### PR TITLE
Update API integration tests

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -3541,7 +3541,6 @@ components:
       schema:
         type: string
         format: symbols_alphanumeric_param
-#        format: alphanumeric
     component:
       in: path
       name: component

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -3540,7 +3540,8 @@ components:
       description: "Filter by command"
       schema:
         type: string
-        format: alphanumeric
+        format: symbols_alphanumeric_param
+#        format: alphanumeric
     component:
       in: path
       name: component

--- a/api/test/integration/env/docker-compose.yml
+++ b/api/test/integration/env/docker-compose.yml
@@ -24,8 +24,6 @@ services:
       dockerfile: base/manager/manager.Dockerfile
     image: integration_test_wazuh-manager
     hostname: wazuh-worker1
-    ports:
-      - "55001:55000"
     volumes:
       - ./configurations/tmp/manager:/tmp
       - ./tools/:/tools
@@ -41,8 +39,6 @@ services:
       dockerfile: base/manager/manager.Dockerfile
     image: integration_test_wazuh-manager
     hostname: wazuh-worker2
-    ports:
-      - "55002:55000"
     volumes:
       - ./configurations/tmp/manager:/tmp
       - ./tools/:/tools

--- a/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
@@ -415,11 +415,13 @@ stages:
         data:
           affected_items:
             - agent_id: '002'
+            - agent_id: '002'
+            - agent_id: '004'
             - agent_id: '004'
             - agent_id: '006'
             - agent_id: '008'
           failed_items: []
-          total_affected_items: 4
+          total_affected_items: 6
           total_failed_items: 0
 
 ---

--- a/api/test/integration/test_rbac_black_syscollector_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_syscollector_endpoints.tavern.yaml
@@ -68,8 +68,7 @@ stages:
         error: !anyint
         data:
           affected_items:
-            - board_serial: !anything
-              cpu:
+            - cpu:
                 cores: !anything
                 mhz: !anything
                 name: !anything

--- a/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
@@ -2047,7 +2047,6 @@ stages:
       json:
         username: newUser
         password: stringA1!
-        allow_run_as: true
       headers:
         Authorization: "Bearer {test_login_token}"
     response:

--- a/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
@@ -419,11 +419,13 @@ stages:
         data:
           affected_items:
             - agent_id: '001'
+            - agent_id: '001'
+            - agent_id: '003'
             - agent_id: '003'
             - agent_id: '005'
             - agent_id: '007'
           failed_items: []
-          total_affected_items: 4
+          total_affected_items: 6
           total_failed_items: 0
 
   - name: Request
@@ -442,11 +444,13 @@ stages:
         data:
           affected_items:
             - agent_id: '001'
+            - agent_id: '001'
+            - agent_id: '003'
             - agent_id: '003'
             - agent_id: '005'
             - agent_id: '007'
           failed_items: []
-          total_affected_items: 4
+          total_affected_items: 6
           total_failed_items: 0
 
 ---

--- a/api/test/integration/test_rbac_white_syscollector_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_syscollector_endpoints.tavern.yaml
@@ -71,8 +71,7 @@ stages:
         error: !anyint
         data:
           affected_items:
-            - board_serial: !anything
-              cpu:
+            - cpu:
                 cores: !anything
                 mhz: !anything
                 name: !anything

--- a/api/test/integration/test_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_sca_endpoints.tavern.yaml
@@ -50,6 +50,10 @@ stages:
           total_affected_items: 1
           failed_items: []
           total_failed_items: 0
+      save:
+        json:
+          expected_name: data.affected_items[0].name
+          expected_description: data.affected_items[0].description
 
   - name: Parameters -> offset=1,limit=1
     request:
@@ -92,7 +96,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Parameters -> q=score>40,limit=1
+  - name: Parameters -> q=score>0,limit=1
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/sca/001"
@@ -101,7 +105,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
       params:
         limit: 1
-        q: score>40
+        q: score>0
     response:
       status_code: 200
       json:
@@ -147,7 +151,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Parameters -> description=This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux 9.,limit=1
+  - name: Parameters -> description,limit=1
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/sca/001"
@@ -155,7 +159,7 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
-        description: This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux 9.
+        description: "{expected_description:s}"
         limit: 1
     response:
       status_code: 200
@@ -178,7 +182,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
       params:
         limit: 1
-        name: CIS Benchmark for Debian/Linux 9
+        name: "{expected_name:s}"
     response:
       status_code: 200
       json:
@@ -186,7 +190,7 @@ stages:
         data:
           affected_items:
             - <<: *sca_agent_result_001
-              name: CIS Benchmark for Debian/Linux 9
+              name: "{expected_name:s}"
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
@@ -275,6 +279,10 @@ stages:
           total_affected_items: 2
           failed_items: []
           total_failed_items: 0
+      save:
+        json:
+          expected_name: data.affected_items[0].name
+          expected_description: data.affected_items[0].description
 
   - name: Parameters -> offset=1,limit=1
     request:
@@ -318,7 +326,7 @@ stages:
           total_affected_items: 2
           total_failed_items: 0
 
-  - name: Parameters -> q=score>40,limit=1
+  - name: Parameters -> q=score>0,limit=1
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/sca/006"
@@ -327,7 +335,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
       params:
         limit: 1
-        q: score>40
+        q: score>0
     response:
       status_code: 200
       json:
@@ -373,7 +381,7 @@ stages:
           total_affected_items: 2
           total_failed_items: 0
 
-  - name: Parameters -> description=This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux 9.,limit=1
+  - name: Parameters -> description,limit=1
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/sca/006"
@@ -381,7 +389,7 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
-        description: This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux 9.
+        description: "{expected_description:s}"
         limit: 1
     response:
       status_code: 200
@@ -452,11 +460,25 @@ stages:
 test_name: GET /sca/001/checks/cis_debian9 (001 is an agent with version >=4.2.0)
 
 stages:
+  - name: Parameters -> limit=1
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 1
+    response:
+      status_code: 200
+      save:
+        json:
+          expected_policy_id: data.affected_items[0].policy_id
 
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -469,7 +491,7 @@ stages:
   - name: Parameters -> limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -495,11 +517,15 @@ stages:
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
+      save:
+        json:
+          expected_check_id: data.affected_items[0].id
+          expected_command: data.affected_items[0].command
 
   - name: Parameters -> limit=4
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -522,7 +548,7 @@ stages:
   - name: Parameters -> sort=-id,limit=2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -548,7 +574,7 @@ stages:
   - name: Parameters -> search=passwd,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -566,15 +592,15 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Parameters -> q=id=2003
+  - name: Parameters -> q=id
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
-        q: id=2003
+        q: "id={expected_check_id}"
     response:
       status_code: 200
       json:
@@ -582,7 +608,7 @@ stages:
         data:
           affected_items:
             - <<: *sca_check_result_001
-              id: 2003
+              id: !int "{expected_check_id}"
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
@@ -590,7 +616,7 @@ stages:
   - name: Parameters -> result=failed,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -612,7 +638,7 @@ stages:
   - name: Parameters -> file=/etc/shadow,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -634,7 +660,7 @@ stages:
   - name: Parameters -> limit=2500
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -646,7 +672,7 @@ stages:
   - name: Parameters -> title="Ensure shadow group is empty",limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -668,7 +694,7 @@ stages:
   - name: Parameters -> title="Ensure address space layout randomization (ASLR) is enabled",limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -689,7 +715,7 @@ stages:
   - name: Parameters -> title="non-existent"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -709,7 +735,7 @@ stages:
   - name: Parameters -> description="The /etc/ssh/sshd_config file contains configuration specifications for sshd. The command below sets the owner and group of the file to root.",limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -731,7 +757,7 @@ stages:
   - name: Parameters -> remediation=Remove any legacy + entries from /etc/group if they exist.,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -753,7 +779,7 @@ stages:
   - name: Parameters -> rationale with apostrophe and parenthesis"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -774,7 +800,7 @@ stages:
   - name: Parameters -> rationale with word "count"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -803,7 +829,7 @@ stages:
   - name: Parameters -> rationale with word "offset"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -820,16 +846,16 @@ stages:
           failed_items: []
           total_failed_items: 0
 
-  - name: Parameters -> command="dpkg -s libpam-pwquality"
+  - name: Parameters -> command
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
         limit: 1
-        command: dpkg -s libpam-pwquality
+        command: "{expected_command:s}"
     response:
       status_code: 200
       json:
@@ -837,14 +863,14 @@ stages:
         data:
           total_affected_items: !anyint
           affected_items:
-            - command: dpkg -s libpam-pwquality
+            - command: "{expected_command:s}"
           failed_items: []
           total_failed_items: 0
 
   - name: Parameters -> status="Not applicable"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -865,7 +891,7 @@ stages:
   - name: Parameters -> reason="Invalid path or wrong permissions to run command 'ip6tables -L'"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -886,7 +912,7 @@ stages:
   - name: Parameters -> command="systemctl is-enabled autofs"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1227,7 +1253,7 @@ stages:
   - name: Parameters -> rationale with word "count"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1256,7 +1282,7 @@ stages:
   - name: Parameters -> rationale with word "offset"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1276,7 +1302,7 @@ stages:
   - name: Parameters -> command="dpkg -s libpam-pwquality"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1297,7 +1323,7 @@ stages:
   - name: Parameters -> reason="Invalid path or wrong permissions to run command 'ip6tables -L'"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_syscollector_endpoints.tavern.yaml
+++ b/api/test/integration/test_syscollector_endpoints.tavern.yaml
@@ -88,7 +88,7 @@ stages:
       status_code: 200
       verify_response_with:
         # Check response item keys are the selected keys
-        function: tavern_utils:test_select_key_affected_items_with_agent_id
+        function: tavern_utils:test_select_key_affected_items
         extra_kwargs:
           select_key: "{field:s}"
 
@@ -167,7 +167,7 @@ stages:
       status_code: 200
       verify_response_with:
         # Check response item keys are the selected keys
-        function: tavern_utils:test_select_key_affected_items_with_agent_id
+        function: tavern_utils:test_select_key_affected_items
         extra_kwargs:
           select_key: "{field:s}"
 
@@ -562,7 +562,7 @@ stages:
       status_code: 200
       verify_response_with:
         # Check response item keys are the selected keys
-        function: tavern_utils:test_select_key_affected_items_with_agent_id
+        function: tavern_utils:test_select_key_affected_items
         extra_kwargs:
           select_key: "{field:s}"
 
@@ -1057,7 +1057,7 @@ stages:
       status_code: 200
       verify_response_with:
         # Check response item keys are the selected keys
-        function: tavern_utils:test_select_key_affected_items_with_agent_id
+        function: tavern_utils:test_select_key_affected_items
         extra_kwargs:
           select_key: "{field:s}"
 
@@ -1298,7 +1298,7 @@ stages:
       status_code: 200
       verify_response_with:
         # Check response item keys are the selected keys
-        function: tavern_utils:test_select_key_affected_items_with_agent_id
+        function: tavern_utils:test_select_key_affected_items
         extra_kwargs:
           select_key: "{field:s}"
       json:
@@ -1690,7 +1690,7 @@ stages:
       status_code: 200
       verify_response_with:
         # Check response item keys are the selected keys
-        function: tavern_utils:test_select_key_affected_items_with_agent_id
+        function: tavern_utils:test_select_key_affected_items
         extra_kwargs:
           select_key: "{field:s}"
       json:
@@ -2020,7 +2020,7 @@ stages:
       status_code: 200
       verify_response_with:
         # Check response item keys are the selected keys
-        function: tavern_utils:test_select_key_affected_items_with_agent_id
+        function: tavern_utils:test_select_key_affected_items
         extra_kwargs:
           select_key: "{field:s}"
       json:
@@ -2689,7 +2689,7 @@ stages:
       status_code: 200
       verify_response_with:
         # Check response item keys are the selected keys
-        function: tavern_utils:test_select_key_affected_items_with_agent_id
+        function: tavern_utils:test_select_key_affected_items
         extra_kwargs:
           select_key: "{field:s}"
       json:
@@ -2794,7 +2794,7 @@ stages:
       status_code: 200
       verify_response_with:
         # Check response item keys are the selected keys
-        function: tavern_utils:test_select_key_affected_items_with_agent_id
+        function: tavern_utils:test_select_key_affected_items
         extra_kwargs:
           select_key: "{field:s}"
 
@@ -2869,7 +2869,7 @@ stages:
       status_code: 200
       verify_response_with:
         # Check response item keys are the selected keys
-        function: tavern_utils:test_select_key_affected_items_with_agent_id
+        function: tavern_utils:test_select_key_affected_items
         extra_kwargs:
           select_key: "{field:s}"
 
@@ -3222,7 +3222,7 @@ stages:
       status_code: 200
       verify_response_with:
         # Check response item keys are the selected keys
-        function: tavern_utils:test_select_key_affected_items_with_agent_id
+        function: tavern_utils:test_select_key_affected_items
         extra_kwargs:
           select_key: "{field:s}"
       json:
@@ -3567,7 +3567,7 @@ stages:
       status_code: 200
       verify_response_with:
         # Check response item keys are the selected keys
-        function: tavern_utils:test_select_key_affected_items_with_agent_id
+        function: tavern_utils:test_select_key_affected_items
         extra_kwargs:
           select_key: "{field:s}"
       json:
@@ -4219,7 +4219,7 @@ stages:
       status_code: 200
       verify_response_with:
         # Check response item keys are the selected keys
-        function: tavern_utils:test_select_key_affected_items_with_agent_id
+        function: tavern_utils:test_select_key_affected_items
         extra_kwargs:
           select_key: "{field:s}"
       json:

--- a/api/test/integration/test_syscollector_endpoints.tavern.yaml
+++ b/api/test/integration/test_syscollector_endpoints.tavern.yaml
@@ -110,8 +110,7 @@ stages:
         error: !anyint
         data:
           affected_items:
-            - board_serial: !anything
-              cpu:
+            - cpu:
                 cores: !anything
                 mhz: !anything
                 name: !anything
@@ -128,7 +127,6 @@ stages:
         message: !anystr
       save:
         json:
-          board_serial: data.affected_items[0].board_serial
           cpu_name: data.affected_items[0].cpu.name
           ram_total: data.affected_items[0].ram.total
 
@@ -148,7 +146,6 @@ marks:
   - parametrize:
       key: field
       vals:
-        - board_serial
         - cpu.cores
         - cpu.mhz
         - cpu.name
@@ -2819,8 +2816,7 @@ stages:
         error: !anyint
         data:
           affected_items:
-            - board_serial: !anything
-              cpu:
+            - cpu:
                 cores: !anything
                 mhz: !anything
                 name: !anything
@@ -2833,7 +2829,6 @@ stages:
                 time: !anything
       save:
         json:
-          board_serial: data.affected_items[0].board_serial
           cpu_name: data.affected_items[0].cpu.name
           ram_total: data.affected_items[0].ram.total
 
@@ -2853,7 +2848,6 @@ marks:
   - parametrize:
       key: field
       vals:
-        - board_serial
         - cpu.cores
         - cpu.mhz
         - cpu.name


### PR DESCRIPTION
## Description

Hi team!

This PR updates the API integration tests that were failing in 4.2. Those tests are:
- test_rbac_black_experimental_endpoints
- test_rbac_black_syscollector_endpoints
- test_rbac_white_all_endpoints
- test_rbac_white_experimental_endpoints
- test_rbac_white_syscollector_endpoints
- test_sca_endpoints
- test_syscollector_endpoints
 
Regards,
Selu.