### PR TITLE
Fix uninitialized value in the os_crypto library

### DIFF
--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -662,7 +662,7 @@ int OS_AddSocket(keystore * keys, unsigned int i, int sock) {
 int OS_DeleteSocket(keystore * keys, int sock) {
     char strsock[16] = "";
     keyentry * entry;
-    int retval;
+    int retval = 0;
 
     snprintf(strsock, sizeof(strsock), "%d", sock);
     w_mutex_lock(&keys->keytree_sock_mutex);


### PR DESCRIPTION
This PR aims to fix the following defect reported by Coverity:

```
** CID 220944:  Uninitialized variables  (UNINIT)
/os_crypto/shared/keys.c: 681 in OS_DeleteSocket()
________________________________________________________________________________________________________
*** CID 220944:  Uninitialized variables  (UNINIT)
/os_crypto/shared/keys.c: 681 in OS_DeleteSocket()
675             rbtree_delete(keys->keytree_sock, strsock);
676         } else {
677             retval = -1;
678         }
679     
680         w_mutex_unlock(&keys->keytree_sock_mutex);
>>>     CID 220944:  Uninitialized variables  (UNINIT)
>>>     Using uninitialized value "retval".
681         return retval;
682     }
683     
684     int w_get_agent_net_protocol_from_keystore(keystore * keys, const char * agent_id) {
685     
686         const int key_id = OS_IsAllowedID(keys, agent_id);
687     
688         return (key_id >= 0 ? keys->keyentries[key_id]->net_protocol : key_id);
```