### PR TITLE
Let Remoted lock the keystore in writing mode when closing RIDs

### DIFF
--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -182,7 +182,7 @@ void HandleSecure()
     }
 
     while (1) {
-        
+
         /* It waits for a socket event */
         if (n_events = wnotify_wait(notify, EPOLL_MILLIS), n_events < 0) {
             if (errno != EINTR) {
@@ -260,7 +260,7 @@ void HandleSecure()
 #if ETIMEDOUT
                     case ETIMEDOUT:
 #endif
-                        mdebug2("TCP peer [%d] at %s: %s (%d)", sock_client, 
+                        mdebug2("TCP peer [%d] at %s: %s (%d)", sock_client,
                                 inet_ntoa(peer_info.sin_addr), strerror(errno), errno);
                         break;
                     default:
@@ -328,7 +328,7 @@ STATIC void * close_fp_main(void * args) {
 
     while (1) {
         sleep(seconds);
-        key_lock_read();
+        key_lock_write();
         flag = 1;
         while (flag) {
             w_linked_queue_node_t * first_node = keys->opened_fp_queue->first;

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -26,7 +26,7 @@ list(APPEND remoted_flags "-W")
 list(APPEND remoted_names "test_secure")
 list(APPEND remoted_flags "-Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,fclose -Wl,--wrap,remove \
                             -Wl,--wrap,_mdebug2 -Wl,--wrap,sleep -Wl,--wrap,fgets -Wl,--wrap,fflush -Wl,--wrap,fseek \
-                            -Wl,--wrap,stat -Wl,--wrap,getpid -Wl,--wrap=key_lock_read -Wl,--wrap=key_unlock -Wl,--wrap=time \
+                            -Wl,--wrap,stat -Wl,--wrap,getpid -Wl,--wrap=key_lock_write -Wl,--wrap=key_unlock -Wl,--wrap=time \
                             -Wl,--wrap,fgetpos -Wl,--wrap=fgetc")
 
 list(APPEND remoted_names "test_remote-config")

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -55,7 +55,7 @@ time_t __wrap_time(int time) {
     return mock();
 }
 
-void __wrap_key_lock_read(){
+void __wrap_key_lock_write(){
     function_called();
 }
 
@@ -73,7 +73,7 @@ void test_close_fp_main_queue_empty(void **state)
     expect_value(__wrap_sleep, seconds, 10);
 
     // key_lock
-    expect_function_call(__wrap_key_lock_read);
+    expect_function_call(__wrap_key_lock_write);
 
     expect_string(__wrap__mdebug2, formatted_msg, "Opened rids queue size: 0");
 
@@ -103,7 +103,7 @@ void test_close_fp_main_first_node_no_close_first(void **state)
     expect_value(__wrap_sleep, seconds, 10);
 
     // key_lock
-    expect_function_call(__wrap_key_lock_read);
+    expect_function_call(__wrap_key_lock_write);
 
     expect_string(__wrap__mdebug2, formatted_msg, "Opened rids queue size: 1");
 
@@ -142,7 +142,7 @@ void test_close_fp_main_close_first(void **state)
     expect_value(__wrap_sleep, seconds, 10);
 
     // key_lock
-    expect_function_call(__wrap_key_lock_read);
+    expect_function_call(__wrap_key_lock_write);
 
     expect_string(__wrap__mdebug2, formatted_msg, "Opened rids queue size: 1");
 
@@ -195,7 +195,7 @@ void test_close_fp_main_close_first_queue_2(void **state)
     expect_value(__wrap_sleep, seconds, 10);
 
     // key_lock
-    expect_function_call(__wrap_key_lock_read);
+    expect_function_call(__wrap_key_lock_write);
 
     expect_string(__wrap__mdebug2, formatted_msg, "Opened rids queue size: 2");
 
@@ -258,7 +258,7 @@ void test_close_fp_main_close_first_queue_2_close_2(void **state)
     expect_value(__wrap_sleep, seconds, 10);
 
     // key_lock
-    expect_function_call(__wrap_key_lock_read);
+    expect_function_call(__wrap_key_lock_write);
 
     expect_string(__wrap__mdebug2, formatted_msg, "Opened rids queue size: 2");
 
@@ -321,7 +321,7 @@ void test_close_fp_main_close_fp_null(void **state)
     expect_value(__wrap_sleep, seconds, 10);
 
     // key_lock
-    expect_function_call(__wrap_key_lock_read);
+    expect_function_call(__wrap_key_lock_write);
 
     expect_string(__wrap__mdebug2, formatted_msg, "Opened rids queue size: 1");
 


### PR DESCRIPTION
|Related issue|
|---|
|#8203|

This PR aims to fix a race condition between `StoreCounter()` and `close_fp_main()`. As described at https://github.com/wazuh/wazuh/issues/8203#issuecomment-820268709, Remoted is crashing due to a corrupt RIDs file descriptors queue, and Thread Sanitizer detected many race conditions near that part of the code.

## Tests

- [X] Build manager for Linux.
- [X] Check that ThreadSanitizer stops reporting the race condition at `close_fp_main()`.

However, we have not been able to reproduce the same crash as we were reported. On the other hand, there are further race conditions that this PR won't fix, but the impact is lower.