### PR TITLE
Read_oslog for usl support

### DIFF
--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -359,6 +359,14 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
             } else if (strcmp(logf[pl].logformat, OSLOG) == 0) {
                 log_config->oslog_count++;
                 os_calloc(1, sizeof(w_oslog_config_t), logf[pl].oslog);
+                w_calloc_expression_t(&logf[pl].oslog->ctxt.start_log_regex, EXP_TYPE_OSREGEX);
+                if (!w_expression_compile(&logf[pl].oslog->ctxt.start_log_regex, OSLOG_START_REGEX, 0)) {
+                    merror("oslog error osregex");
+                    w_free_expression_t(&logf[pl].oslog->ctxt.start_log_regex);
+                    os_free(logf[pl].oslog);
+                    return (OS_INVALID);
+                }
+
 //endif Darwin
             } else {
                 merror(XML_VALUEERR, node[i]->element, node[i]->content);

--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -359,10 +359,10 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
             } else if (strcmp(logf[pl].logformat, OSLOG) == 0) {
                 log_config->oslog_count++;
                 os_calloc(1, sizeof(w_oslog_config_t), logf[pl].oslog);
-                w_calloc_expression_t(&logf[pl].oslog->ctxt.start_log_regex, EXP_TYPE_OSREGEX);
-                if (!w_expression_compile(&logf[pl].oslog->ctxt.start_log_regex, OSLOG_START_REGEX, 0)) {
-                    merror("oslog error osregex");
-                    w_free_expression_t(&logf[pl].oslog->ctxt.start_log_regex);
+                w_calloc_expression_t(&logf[pl].oslog->start_log_regex, EXP_TYPE_OSREGEX);
+                if (!w_expression_compile(logf[pl].oslog->start_log_regex, OSLOG_START_REGEX, 0)) {
+                    merror(LOGCOLLECTOR_OSLOG_IREGEX_ERROR);
+                    w_free_expression_t(&logf[pl].oslog->start_log_regex);
                     os_free(logf[pl].oslog);
                     return (OS_INVALID);
                 }

--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -141,19 +141,18 @@ typedef struct {
  * An instance of w_oslog_config_t allow save the context of a log that have not yet completely read.
  */
 typedef struct {
-    w_expression_t * start_log_regex; ///< used to check the start of a new log
-    char buffer[OS_MAXSTR];           ///< store current read when os log is in process
-    int newline_offset;            ///< offset of new line, used for regex matching
-    time_t timestamp;  ///< last successful read
+    char buffer[OS_MAXSTR]; ///< store current read when oslog is in process
+    time_t timestamp;       ///< last successful read
 } w_oslog_ctxt_t;
 
 /**
  * @brief An instance of w_oslog_config_t represents a OSlog (ULS) and its state
  */
 typedef struct {
-    w_oslog_ctxt_t ctxt;         ///< store current status when read log is in process
-    char * last_read_timestamp;  ///< timestamp of last log queued (Used for only future event)
-    wfd_t * log_wfd;             ///< `log stream` IPC connector
+    w_expression_t * start_log_regex; ///< used to check the start of a new log
+    w_oslog_ctxt_t ctxt;              ///< store current status when read log is in process
+    char * last_read_timestamp;       ///< timestamp of last log queued (Used for only future event)
+    wfd_t * log_wfd;                  ///< `log stream` IPC connector
     /** Indicates if `log stream` is currently running. if not running, localfiles with oslog format will be ignored */
     bool is_oslog_running;
 } w_oslog_config_t;

--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -54,6 +54,7 @@
                                     x[9]?x[9]:"", x[10]?x[10]:"",   \
                                     x[11]?x[11]:"", x[12]?x[12]:"", \
                                     x[13]?x[13]:""
+
 #define OSLOG_START_REGEX       "^\\d\\d\\d\\d-\\d\\d-\\d\\d \\d+:\\d+:\\d+" ///< regex to determine the start of a log (unchecked)
 #define OSLOG_TIMEOUT_OUT       5
 

--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -25,7 +25,7 @@
 /* oslog configurations */
 #define OSLOG_NAME              "USL_OSLOG_Super_Mc_Darwin" ///< Name to be displayed in the localfile' statistics
 
-#define LOG_CMD_STR             "log"           ///< It is the name of the command used to collect macos' logs
+#define LOG_CMD_STR             "/usr/bin/log"  ///< It is the name of the command used to collect macos' logs
 #define LOG_STREAM_OPT_STR      "stream"        ///< "stream" is the mode in which the "log" command is running
 
 #define STYLE_OPT_STR           "--style"       ///< This precedes the logs' output style to be used by "log stream"
@@ -55,7 +55,8 @@
                                     x[11]?x[11]:"", x[12]?x[12]:"", \
                                     x[13]?x[13]:""
 
-#define OSLOG_START_REGEX       "^\\d\\d\\d\\d-\\d\\d-\\d\\d \\d+:\\d+:\\d+" ///< regex to determine the start of a log (unchecked)
+/** regex to determine the start of a log */
+#define OSLOG_START_REGEX       "^\\d\\d\\d\\d-\\d\\d-\\d\\d \\d\\d:\\d\\d:\\d\\d"
 #define OSLOG_TIMEOUT_OUT       5
 
 #include <pthread.h>

--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -23,7 +23,7 @@
 #define DIFF_MAX_SIZE (2 * 1024 * 1024 * 1024LL)
 
 /* oslog configurations */
-#define OSLOG_NAME              "USL OSLOG Super Mc Darwin" ///< Name to be displayed in the localfile' statistics
+#define OSLOG_NAME              "USL_OSLOG_Super_Mc_Darwin" ///< Name to be displayed in the localfile' statistics
 
 #define LOG_CMD_STR             "log"           ///< It is the name of the command used to collect macos' logs
 #define LOG_STREAM_OPT_STR      "stream"        ///< "stream" is the mode in which the "log" command is running

--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -54,6 +54,8 @@
                                     x[9]?x[9]:"", x[10]?x[10]:"",   \
                                     x[11]?x[11]:"", x[12]?x[12]:"", \
                                     x[13]?x[13]:""
+#define OSLOG_START_REGEX       "^\\d\\d\\d\\d-\\d\\d-\\d\\d \\d+:\\d+:\\d+" ///< regex to determine the start of a log (unchecked)
+#define OSLOG_TIMEOUT_OUT       5
 
 #include <pthread.h>
 
@@ -134,13 +136,24 @@ typedef struct {
 } w_multiline_config_t;
 
 /**
+ * @brief Context of a oslog that was not completely written.
+ *
+ * An instance of w_oslog_config_t allow save the context of a log that have not yet completely read.
+ */
+typedef struct {
+    w_expression_t * start_log_regex; ///< used to check the start of a new log
+    char buffer[OS_MAXSTR];           ///< store current read when os log is in process
+    int newline_offset;            ///< offset of new line, used for regex matching
+    time_t timestamp;  ///< last successful read
+} w_oslog_ctxt_t;
+
+/**
  * @brief An instance of w_oslog_config_t represents a OSlog (ULS) and its state
  */
 typedef struct {
-    char * ctxt_buffer;         ///< store current read when os log is in process
-    int64_t last_read_offset;   ///< absolut stream offset of last complete log processed
-    char * last_read_timestamp; ///< timestamp of last log queued (Used for only future event)
-    wfd_t * log_wfd;            ///< `log stream` IPC connector
+    w_oslog_ctxt_t ctxt;         ///< store current status when read log is in process
+    char * last_read_timestamp;  ///< timestamp of last log queued (Used for only future event)
+    wfd_t * log_wfd;             ///< `log stream` IPC connector
     /** Indicates if `log stream` is currently running. if not running, localfiles with oslog format will be ignored */
     bool is_oslog_running;
 } w_oslog_config_t;

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -138,6 +138,7 @@
 
 /* logcollector */
 #define SYSTEM_ERROR     "(1600): Internal error. Exiting.."
+#define LOGCOLLECTOR_OSLOG_IREGEX_ERROR        "(1601): Invalid internal oslog regex."
 
 /* remoted */
 #define NO_REM_CONN     "(1750): No remote connection configured. Exiting."

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -223,6 +223,7 @@
 #define SET_FLAGS_ERROR "(1974): The flags couldn't be set in the file descriptor: %s (%d)."
 #define WPOPENV_ERROR   "(1975): An error ocurred while calling wpopenv(): %s (%d)."
 #define SNPRINTF_ERROR  "(1976): An error ocurred while calling snprintf(): %s (%d)."
+#define CHILD_ERROR     "(1977): OSLog's process exited, pid: %d, exit value: %d."
 
 /* Encryption/auth errors */
 #define INVALID_KEY     "(1401): Error reading authentication key: '%s'."

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -127,6 +127,12 @@ static pthread_rwlock_t files_update_rwlock;
 static OSHash *excluded_files = NULL;
 static OSHash *excluded_binaries = NULL;
 
+// ifdef DARWIN
+#ifndef WIN32
+static wfd_t * oslog_wfd = NULL;
+#endif
+// endif
+
 /* Handle file management */
 void LogCollectorStart()
 {
@@ -336,7 +342,11 @@ void LogCollectorStart()
         else if (strcmp(current->logformat, OSLOG) == 0) {
             w_logcollector_create_oslog_env(current);
             current->read = read_oslog;
-            if (current->oslog->log_wfd->file) {
+            if (current->oslog->log_wfd->file != NULL) {
+                if (atexit(w_oslog_release)) {
+                    merror(ATEXIT_ERROR);
+                }
+                oslog_wfd = current->oslog->log_wfd;    // OSLog's info needs to be globally reachable to be released
                 for(int tg_idx = 0; current->target[tg_idx]; tg_idx++) {
                     mdebug1("Socket target for '%s' -> %s", OSLOG_NAME, current->target[tg_idx]);
                     w_logcollector_state_add_target(OSLOG_NAME, current->target[tg_idx]);
@@ -2862,3 +2872,18 @@ void w_get_hash_context(const char * path, SHA_CTX * context, int64_t position) 
         *context = data->context;
     }
 }
+
+// ifdef DARWIN
+#ifndef WIN32
+void w_oslog_release(void) {
+    if (oslog_wfd != NULL) {
+        mdebug1("Releasing OSLog resources.");
+        if(oslog_wfd->pid > 0) {
+            kill(oslog_wfd->pid, SIGTERM);
+        }
+        wpclose(oslog_wfd);
+        oslog_wfd = NULL;
+    }
+}
+#endif
+// endif

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -335,12 +335,12 @@ void LogCollectorStart()
 #ifndef WIN32 //todo : remove this when having the right define
         else if (strcmp(current->logformat, OSLOG) == 0) {
             w_logcollector_create_oslog_env(current);
-            if (current->fp) {
+            current->read = read_oslog;
+            if (current->oslog->log_wfd->file) {
                 for(int tg_idx = 0; current->target[tg_idx]; tg_idx++) {
                     mdebug1("Socket target for '%s' -> %s", OSLOG_NAME, current->target[tg_idx]);
                     w_logcollector_state_add_target(OSLOG_NAME, current->target[tg_idx]);
                 }
-                current->read = read_oslog;
             }
         }
 #endif  //todo : remove this when having the right define
@@ -2110,6 +2110,12 @@ void * w_input_thread(__attribute__((unused)) void * t_id){
                             current->read(current, &r, 0);
                         }
                     }
+//#ifdef darwin
+                    /* Read process `log` in stream  (oslog) */
+                    else if (current->oslog != NULL && current->oslog->is_oslog_running) {
+                        current->read(current, &r, 0);
+                    }
+//#endif darwin
                     w_mutex_unlock(&current->mutex);
                     w_rwlock_unlock(&files_update_rwlock);
                     continue;

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -106,6 +106,16 @@ void *read_multiline(logreader *lf, int *rc, int drop_it);
  */
 void *read_multiline_regex(logreader *lf, int *rc, int drop_it);
 
+/**
+ * @brief Read oslog logs
+ *
+ * @param lf status and configuration of the oslog file
+ * @param rc output parameter, returns zero
+ * @param drop_it if drop_it is different from 0, the logs will be read and discarded
+ * @return NULL
+ */
+void *read_oslog(logreader *lf, int *rc, int drop_it);
+
 /* Read DJB multilog format */
 /* Initializes multilog */
 int init_djbmultilog(logreader *lf);

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -274,4 +274,13 @@ extern int OUTPUT_QUEUE_SIZE;
 extern rlim_t nofile;
 #endif
 
+// ifdef DARWIN
+#ifndef WIN32
+/**
+ * @brief This function is called to release oslog's resources
+ */
+void w_oslog_release(void);
+#endif
+// endif
+
 #endif /* LOGREADER_H */

--- a/src/logcollector/oslog_stream.c
+++ b/src/logcollector/oslog_stream.c
@@ -23,6 +23,7 @@
  * @return true if valid, otherwise false
  */
 STATIC bool w_logcollector_validate_oslog_stream_predicate(char * predicate) {
+
     // todo : improve this function
     if (strlen(predicate) > 0) {
         return true;
@@ -38,6 +39,7 @@ STATIC bool w_logcollector_validate_oslog_stream_predicate(char * predicate) {
  * @return A pointer to a fulfilled wfd_t structure, on success, or NULL
  */
 STATIC char ** w_create_oslog_stream_array(char * predicate, char * level, int type) {
+
     char ** oslog_array = NULL;
     size_t oslog_array_idx = 0;
 
@@ -98,6 +100,7 @@ STATIC char ** w_create_oslog_stream_array(char * predicate, char * level, int t
  * @return A pointer to a fulfilled wfd_t structure, on success, or NULL
  */
 STATIC wfd_t * w_logcollector_exec_oslog_stream(char ** oslog_array, u_int32_t flags) {
+
     int oslog_fd = -1;
     int oslog_fd_flags = 0;
     wfd_t * oslog_wfd = wpopenv(*oslog_array, oslog_array, flags);
@@ -136,12 +139,13 @@ STATIC wfd_t * w_logcollector_exec_oslog_stream(char ** oslog_array, u_int32_t f
 }
 
 void w_logcollector_create_oslog_env(logreader * current) {
+
     char ** log_stream_array = NULL;
 
     log_stream_array = w_create_oslog_stream_array(current->query, current->query_level, current->query_type);
 
     // todo: remove testing/developing code lines !!!
-    char * mock_log_stream_array[] = {"/root/readfile.sh", NULL};
+    char * mock_log_stream_array[] = {"/root/oslog.sh", NULL};
     current->oslog->log_wfd = w_logcollector_exec_oslog_stream(mock_log_stream_array, W_BIND_STDOUT | W_BIND_STDERR);
 
     if (current->oslog->log_wfd == NULL) {
@@ -150,7 +154,8 @@ void w_logcollector_create_oslog_env(logreader * current) {
         current->oslog->is_oslog_running = true;
         minfo(LOG_STREAM_INFO, GET_LOG_STREAM_PARAMS(log_stream_array));
     }
-    current->file = NULL;
+
+    os_free(current->file);
     current->fp = NULL;
 
     free_strarray(log_stream_array);

--- a/src/logcollector/oslog_stream.c
+++ b/src/logcollector/oslog_stream.c
@@ -8,9 +8,7 @@
  * Foundation
  */
 
-
 #include "oslog_stream.h"
-
 
 // Remove STATIC qualifier from tests
 #ifdef WAZUH_UNIT_TESTING
@@ -18,17 +16,6 @@
 #else
 #define STATIC static
 #endif
-
-
-// todo: remove this function when read_oslog is implemented, this is just a mock
-void * read_oslog(logreader * lf, int * rc, int drop_it)
-{
-    sleep(1);
-
-    *rc = (lf->duplicated + drop_it) * 0;
-
-    return NULL;
-}
 
 /**
  * @brief Validates whether the predicate is valid or not
@@ -53,7 +40,7 @@ STATIC bool w_logcollector_validate_oslog_stream_predicate(char * predicate) {
 STATIC char ** w_create_oslog_stream_array(char * predicate, char * level, int type) {
     char ** oslog_array = NULL;
     size_t oslog_array_idx = 0;
-    
+
     os_calloc(MAX_LOG_CMD_ARGS + 1, sizeof(char *), oslog_array);
 
     // Adding `log` and `stream` to the array
@@ -89,14 +76,13 @@ STATIC char ** w_create_oslog_stream_array(char * predicate, char * level, int t
     // Log Stream's Predicate section
     if (predicate != NULL) {
         const bool is_predicate_valid = w_logcollector_validate_oslog_stream_predicate(predicate);
-        if (is_predicate_valid)
-        {
+        if (is_predicate_valid) {
             w_strdup(PREDICATE_OPT_STR, oslog_array[oslog_array_idx++]);
 
             const size_t QUERY_STR_LEN = strlen(predicate) + 2 + 1; // The "2" is due to the added chars ''
             os_malloc(QUERY_STR_LEN, oslog_array[oslog_array_idx]);
             const int snprintf_retval = snprintf(oslog_array[oslog_array_idx], QUERY_STR_LEN, "'%s'", predicate);
-            if(snprintf_retval < 0) {
+            if (snprintf_retval < 0) {
                 merror(SNPRINTF_ERROR, strerror(errno), errno);
             }
         }
@@ -156,17 +142,16 @@ void w_logcollector_create_oslog_env(logreader * current) {
 
     // todo: remove testing/developing code lines !!!
     char * mock_log_stream_array[] = {"/root/readfile.sh", NULL};
-    current->oslog->log_wfd = w_logcollector_exec_oslog_stream(mock_log_stream_array, W_BIND_STDOUT|W_BIND_STDERR);
+    current->oslog->log_wfd = w_logcollector_exec_oslog_stream(mock_log_stream_array, W_BIND_STDOUT | W_BIND_STDERR);
 
     if (current->oslog->log_wfd == NULL) {
         current->oslog->is_oslog_running = false;
-        current->fp = NULL;
     } else {
-        current->fp = current->oslog->log_wfd->file;
         current->oslog->is_oslog_running = true;
         minfo(LOG_STREAM_INFO, GET_LOG_STREAM_PARAMS(log_stream_array));
     }
     current->file = NULL;
+    current->fp = NULL;
 
     free_strarray(log_stream_array);
 }

--- a/src/logcollector/oslog_stream.c
+++ b/src/logcollector/oslog_stream.c
@@ -81,12 +81,7 @@ STATIC char ** w_create_oslog_stream_array(char * predicate, char * level, int t
         if (is_predicate_valid) {
             w_strdup(PREDICATE_OPT_STR, oslog_array[oslog_array_idx++]);
 
-            const size_t QUERY_STR_LEN = strlen(predicate) + 2 + 1; // The "2" is due to the added chars ''
-            os_malloc(QUERY_STR_LEN, oslog_array[oslog_array_idx]);
-            const int snprintf_retval = snprintf(oslog_array[oslog_array_idx], QUERY_STR_LEN, "'%s'", predicate);
-            if (snprintf_retval < 0) {
-                merror(SNPRINTF_ERROR, strerror(errno), errno);
-            }
+            w_strdup(predicate, oslog_array[oslog_array_idx++]);
         }
     }
 

--- a/src/logcollector/oslog_stream.c
+++ b/src/logcollector/oslog_stream.c
@@ -144,9 +144,7 @@ void w_logcollector_create_oslog_env(logreader * current) {
 
     log_stream_array = w_create_oslog_stream_array(current->query, current->query_level, current->query_type);
 
-    // todo: remove testing/developing code lines !!!
-    char * mock_log_stream_array[] = {"/root/oslog.sh", NULL};
-    current->oslog->log_wfd = w_logcollector_exec_oslog_stream(mock_log_stream_array, W_BIND_STDOUT | W_BIND_STDERR);
+    current->oslog->log_wfd = w_logcollector_exec_oslog_stream(log_stream_array, W_BIND_STDOUT | W_BIND_STDERR);
 
     if (current->oslog->log_wfd == NULL) {
         current->oslog->is_oslog_running = false;

--- a/src/logcollector/oslog_stream.h
+++ b/src/logcollector/oslog_stream.h
@@ -20,7 +20,5 @@
  */
 void w_logcollector_create_oslog_env(logreader * current);
 
-// todo: remove this function when read_oslog is implemented, this is just a mock
-void * read_oslog(logreader * lf, int * rc, int drop_it);
 
 #endif /* OSLOGSTREAM_H */

--- a/src/logcollector/read_oslog.c
+++ b/src/logcollector/read_oslog.c
@@ -88,11 +88,11 @@ void * read_oslog(logreader * lf, int * rc, int drop_it) {
     read_buffer[OS_MAXSTR] = '\0';
     *rc = 0;
 
-    while (rlog = oslog_getlog(read_buffer, MAX_LINE_LEN, lf->fp, lf->oslog),
+    while (rlog = oslog_getlog(read_buffer, MAX_LINE_LEN, lf->oslog->log_wfd->file, lf->oslog),
            rlog && (maximum_lines == 0 || count_logs < maximum_lines)) {
 
         if (drop_it == 0) {
-            w_msg_hash_queues_push(read_buffer, lf->file, strlen(read_buffer) + 1, lf->log_target, LOCALFILE_MQ);
+            w_msg_hash_queues_push(read_buffer, OSLOG_NAME, strlen(read_buffer) + 1, lf->log_target, LOCALFILE_MQ);
         }
         count_logs++;
     }
@@ -119,7 +119,7 @@ STATIC bool oslog_getlog(char * buffer, int length, FILE * stream, w_oslog_confi
             oslog_ctxt_clean(&oslog_cfg->ctxt);
             /* delete last end-of-line character  */
             if (buffer[offset - 1] == '\n') {
-                buffer[offset - 1] == '0';
+                buffer[offset - 1] = '\0';
             }
             retval = true;
             return retval;
@@ -214,7 +214,7 @@ STATIC bool oslog_getlog(char * buffer, int length, FILE * stream, w_oslog_confi
     return retval;
 }
 
-STATIC bool oslog_ctxt_restore(char * buffer, int * newline_offset, w_oslog_ctxt_t * ctxt) {
+STATIC bool oslog_ctxt_restore(char * buffer, w_oslog_ctxt_t * ctxt) {
 
     if (ctxt->buffer[0] == '\0') {
         return false;

--- a/src/logcollector/read_oslog.c
+++ b/src/logcollector/read_oslog.c
@@ -201,7 +201,7 @@ STATIC bool oslog_getlog(char * buffer, int length, FILE * stream, w_oslog_confi
             *last_line = '\0';
             strncpy(oslog_cfg->ctxt.buffer, last_line + 1, offset - (last_line - buffer) + 1);
             oslog_cfg->ctxt.timestamp = time(NULL);
-        } else {
+        } else if (!full_buffer) {
             oslog_ctxt_backup(buffer, &oslog_cfg->ctxt);
         }
 

--- a/src/logcollector/read_oslog.c
+++ b/src/logcollector/read_oslog.c
@@ -18,61 +18,61 @@
 #endif
 
 /**
- * @brief Get log from `log stream`.
+ * @brief Gets a log from `log stream`
  *
- * @param buffer readed log output
- * @param length buffer max lenth
- * @param stream log file
- * @param oslog_cfg oslog configuration
- * @return  true if a new log was collected.
+ * @param [out] buffer Contains the read log 
+ * @param length Buffer's max length
+ * @param stream File pointer to log stream's output pipe
+ * @param oslog_cfg oslog configuration structure
+ * @return  true if a new log was collected,
  *          false otherwise
  */
 STATIC bool oslog_getlog(char * buffer, int length, FILE * stream, w_oslog_config_t * oslog_cfg);
 
 /**
- * @brief Restore read context from backup
+ * @brief Restores the context from backup
  *
- * Restores the buffer from a context backup
- * `buffer` must be allocated, function does not check, allocate or release memory from the buffer
+ * @warning Notice that `buffer` must be previously allocated, the function does
+ * not verify nor allocate or release the buffer memory
  * @param buffer Destination buffer
- * @param ctxt context backup
- * @return true if a context was restored. Otherwise returns false
+ * @param ctxt Backup context
+ * @return true if the context was restored, otherwise returns false
  */
 STATIC bool oslog_ctxt_restore(char * buffer, w_oslog_ctxt_t * ctxt);
 
 /**
- * @brief Generate a backup of the reading context
+ * @brief Generates a backup of the reading context
  *
- * If the backup exists, the new content is appended and updates the new offset
- * @param buffer to backup
- * @param ctxt backup destination
+ * @param buffer Context to backup
+ * @param ctxt Context's backup destination
  */
 STATIC void oslog_ctxt_backup(char * buffer, w_oslog_ctxt_t * ctxt);
 
 /**
- * @brief Clean a context backup
+ * @brief Cleans the backup context
  *
- * Does not check or release memory from the buffer
+ * @warning Notice that this function does not release the context memory
  * @param ctxt context backup to clean
  */
 STATIC void oslog_ctxt_clean(w_oslog_ctxt_t * ctxt);
 
 /**
- * @brief check if a context in a backup expired
+ * @brief Checks if a backup context has expired
  *
- * @param timeout A timeout that a context without updating is valid.
- * @param ctxt context to check
- * @return true if the context does not exist or expired. Otherwise returns false
+ * @todo  Remove timeout and use a define
+ * @param timeout A timeout that a context without updating is valid
+ * @param ctxt Context to check
+ * @return true if the context has expired, otherwise returns false
  */
 STATIC bool oslog_ctxt_is_expired(time_t timeout, w_oslog_ctxt_t * ctxt);
 
 /**
- * @brief Get pointer to the beginning of the last line in the string str.
+ * @brief Gets the pointer to the beginning of the last line contained in the string
  *
- * @warning If the `str` has one line, return NULL
- * @warning If the `str` ends with a `\n`, it is ignored.
- * @param str to get last line
- * @return pointer to the beginning of the last line
+ * @warning If `str` has one line, returns NULL
+ * @warning If `str` ends with a `\n`, this newline character is ignored
+ * @param str String to be analyzed
+ * @return Pointer to the beginning of the last line, NULL otherwise
  */
 STATIC char * oslog_get_valid_lastline(char * str);
 

--- a/src/logcollector/read_oslog.c
+++ b/src/logcollector/read_oslog.c
@@ -1,0 +1,246 @@
+/* Copyright (C) 2015-2021, Wazuh Inc.
+ * All right reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include "shared.h"
+#include "logcollector.h"
+
+#ifdef WAZUH_UNIT_TESTING
+// Remove STATIC qualifier from tests
+#define STATIC
+#else
+#define STATIC static
+#endif
+
+
+/**
+ * @brief Get log from `log stream`.
+ *
+ * @param buffer readed log output
+ * @param length max lenth
+ * @param stream log file
+ * @param oslog_cfg oslog configuration
+ * @return  true if a new log was collected.
+ *          false otherwise
+ */
+STATIC bool oslog_getlog(char * buffer, int length, FILE * stream, w_oslog_config_t * oslog_cfg);
+
+/**
+ * @brief Restore read context from backup
+ *
+ * Restores the buffer from a context backup
+ * Buffer must be allocated, function does not check, allocate or release memory from the buffer
+ * @param buffer Destination buffer
+ * @param newline_offset output of the last new line offsett
+ * @param ctxt context backup
+ * @return true if a context was restored. Otherwise returns false
+ */
+STATIC bool oslog_ctxt_restore(char * buffer, int * newline_offset, w_oslog_ctxt_t * ctxt);
+
+/**
+ * @brief Generate a backup of the reading context
+ *
+ * If the backup exists, the new content is appended and updates the new offset
+ * @param buffer to backup
+ * @param ctxt backup destination
+ */
+STATIC void oslog_ctxt_backup(char * buffer, w_oslog_ctxt_t * ctxt);
+
+/**
+ * @brief Clean a context backup
+ *
+ * @param ctxt context backup to clean
+ */
+STATIC void oslog_ctxt_clean(w_oslog_ctxt_t * ctxt);
+
+/**
+ * @brief check if a context in a backup expired
+ *
+ * @param timeout A timeout that a context without updating is valid.
+ * @param ctxt context to check
+ * @return true if the context does not exist or expired. Otherwise returns false
+ */
+STATIC bool oslog_ctxt_is_expired(time_t timeout, w_oslog_ctxt_t * ctxt);
+
+void * read_oslog(logreader * lf, int * rc, int drop_it) {
+    char read_buffer[OS_MAXSTR + 1];
+    int count_lines = 0;
+    bool rlog;
+    const int max_line_len = OS_MAXSTR - OS_LOG_HEADER;
+
+    if (can_read() == 0) {
+        return NULL;
+    }
+
+    read_buffer[OS_MAXSTR] = '\0';
+    *rc = 0;
+
+    while (rlog = oslog_getlog(read_buffer, max_line_len, lf->fp, lf->oslog),
+           rlog && (maximum_lines == 0 || count_lines < maximum_lines)) {
+
+        if (drop_it == 0) {
+            w_msg_hash_queues_push(read_buffer, lf->file, strlen(read_buffer) + 1, lf->log_target, LOCALFILE_MQ);
+        }
+        count_lines++;
+    }
+
+    return NULL;
+}
+
+STATIC bool oslog_getlog(char * buffer, int length, FILE * stream, w_oslog_config_t * oslog_cfg) {
+
+    bool retval = false;
+
+    int offset = 0;
+    int newline_offset = 0;
+    char * str = buffer;
+    int chunk_sz = 0;
+    char * retstr;
+
+    *str = '\0';
+
+    /* Check if a context restore is needed for incomplete logs */
+    if (oslog_ctxt_restore(str, &newline_offset, &oslog_cfg->ctxt)) {
+        offset = strlen(str);
+
+        /* If the context it's expired then free it and return log */
+        if (oslog_ctxt_is_expired((time_t) OSLOG_TIMEOUT_OUT, &oslog_cfg->ctxt)) {
+            oslog_ctxt_clean(&oslog_cfg->ctxt);
+            /* delete last end-of-line character  */
+            if (offset == newline_offset) {
+                buffer[newline_offset] = '\0';
+            }
+            retval = true;
+            return retval;
+        }
+
+        str += offset;
+    }
+
+    /* Get stream data, the minimum chunk size of the log is one line */
+    while (can_read() && (retstr = fgets(str, length - offset, stream)) != NULL) {
+
+        chunk_sz = strlen(str);
+        offset += chunk_sz;
+        str += chunk_sz;
+        bool full_buffer = false;
+
+        /* Avoid fgets infinite loop behavior when size parameter is 1
+         * If we didn't get the new line, because the size is large, send what we got so far.
+         */
+        if (offset + 1 == length) {
+            // Clean context and send the log
+            oslog_ctxt_clean(&oslog_cfg->ctxt);
+
+            // Discard the rest of the log, moving the pointer to the next end of line
+            while (true) {
+                char c = fgetc(stream); // if stream its closed ?, check errno and break loop
+                if (c == '\n' || c == '\0' || c == EOF) {
+                    break;
+                }
+            }
+            mdebug2("Max lenght oslog message... The remaining surplus was discarded");
+
+            /* If there is only one log in the buffer it is sent, otherwise,
+               it must be split and send them separately */
+            full_buffer = true;
+        } else if (*(str - 1) != '\n') {
+            mdebug2("Inclomplete oslog message...");
+            /* Save the context */
+            *str = '\0';
+            oslog_ctxt_backup(buffer, &oslog_cfg->ctxt);
+            
+            continue;
+        }
+
+        /* If this point has been reached, it is because:
+            - The buffer is full, one log is incomplete
+            - The buffer is full, there is a full log and an incomplete log.
+            - The buffer is full, there are remnants of one multiline 
+            - The buffer is full, there are remnants of one multiline, and incomplete log
+            - The buffer is not full, there are remnants of one multiline 
+            - The buffer is not full, there are remnants of a multiline and the second one may be multiline
+            - The buffer is not full, there is a complete log and the second one may be a multiline.
+            - The buffer is not full, there is a log that may be multiline.
+        If a new log is received, we store it in the context and send the oldest one.
+        */
+        if (w_expression_match(oslog_cfg->ctxt.start_log_regex, &buffer[newline_offset == 0 ? 0 : newline_offset + 1], NULL, NULL)) {
+            /* split the logs */
+            buffer[newline_offset] = '\0';
+            *str = '\0';
+            strncpy(oslog_cfg->ctxt.buffer, &buffer[newline_offset] + 1, offset - newline_offset + 1);
+            oslog_cfg->ctxt.buffer[offset - newline_offset + 1] = '\0';
+            char * last_nl = strrchr (oslog_cfg->ctxt.buffer, '\n');
+            if(last_nl != NULL) {
+                oslog_cfg->ctxt.newline_offset = last_nl - oslog_cfg->ctxt.buffer;
+            }
+            retval = true;
+            break;
+        } else if (full_buffer) {
+            break;
+        }
+
+        
+
+    }
+
+    /*
+    if (retstr == NULL && errno == EWOULDBLOCK) {
+        // no data in log stream 
+    }
+    */
+
+    return retval;
+}
+
+STATIC bool oslog_ctxt_restore(char * buffer, int * newline_offset, w_oslog_ctxt_t * ctxt) {
+
+    if (ctxt->buffer[0] == '\0') {
+        return false;
+    }
+
+    strcpy(buffer, ctxt->buffer);
+    *newline_offset = ctxt->newline_offset;
+    return true;
+}
+
+STATIC bool oslog_ctxt_is_expired(time_t timeout, w_oslog_ctxt_t * ctxt) {
+
+    if (time(NULL) - ctxt->timestamp > timeout) {
+        return true;
+    }
+
+    return false;
+}
+
+STATIC void oslog_ctxt_clean(w_oslog_ctxt_t * ctxt) {
+
+    ctxt->buffer[0] = '\0';
+    ctxt->newline_offset = 0;
+    ctxt->timestamp = 0;
+
+}
+
+STATIC void oslog_ctxt_backup(char * buffer, w_oslog_ctxt_t * ctxt) {
+
+    size_t current_bsize = strlen(buffer);
+    size_t old_size = strlen(ctxt->buffer);
+    char * last_nl = NULL;
+
+    /* Without new content there is nothing to do */
+    if (old_size == current_bsize) {
+        return;
+    }
+    
+    last_nl = strrchr (ctxt->buffer, '\n');
+
+    /* Backup */
+    strcpy(ctxt->buffer + old_size, buffer + old_size);
+    ctxt->timestamp = time(NULL);
+    ctxt->newline_offset = (last_nl == NULL) ? 0 : last_nl - ctxt->buffer;
+}

--- a/src/logcollector/read_oslog.c
+++ b/src/logcollector/read_oslog.c
@@ -67,13 +67,14 @@ STATIC void oslog_ctxt_clean(w_oslog_ctxt_t * ctxt);
 STATIC bool oslog_ctxt_is_expired(time_t timeout, w_oslog_ctxt_t * ctxt);
 
 /**
- * @brief Get pointer to the beginning of the last line in the string s.
+ * @brief Get pointer to the beginning of the last line in the string str.
  *
+ * @warning If the `str` has one line, return NULL
  * @warning If the `str` ends with a `\n`, it is ignored.
  * @param str to get last line
  * @return pointer to the beginning of the last line
  */
-STATIC char * oslog_get_lastline(char * str);
+STATIC char * oslog_get_valid_lastline(char * str);
 
 void * read_oslog(logreader * lf, int * rc, int drop_it) {
     char read_buffer[OS_MAXSTR + 1];
@@ -187,7 +188,7 @@ STATIC bool oslog_getlog(char * buffer, int length, FILE * stream, w_oslog_confi
         */
 
 
-        last_line = oslog_get_lastline(buffer);
+        last_line = oslog_get_valid_lastline(buffer);
 
         /* If there are 2 logs, they are separated for sending */
         if (str_endline && last_line != NULL) {
@@ -273,7 +274,7 @@ STATIC void oslog_ctxt_backup(char * buffer, w_oslog_ctxt_t * ctxt) {
     ctxt->timestamp = time(NULL);
 }
 
-STATIC char * oslog_get_lastline(char * str) {
+STATIC char * oslog_get_valid_lastline(char * str) {
 
     char * retval = NULL;
     char ignored_char = '\0';

--- a/src/unit_tests/logcollector/CMakeLists.txt
+++ b/src/unit_tests/logcollector/CMakeLists.txt
@@ -69,6 +69,9 @@ list(APPEND logcollector_flags "-Wl,--wrap,wpopenv -Wl,--wrap,fileno -Wl,--wrap,
                                 -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite \
                                 -Wl,--wrap,remove -Wl,--wrap,fgetc -Wl,--wrap,wpclose")
 
+list(APPEND logcollector_names "test_read_oslog")
+list(APPEND logcollector_flags "")
+
 list(LENGTH logcollector_names count)
 math(EXPR count "${count} - 1")
 foreach(counter RANGE ${count})

--- a/src/unit_tests/logcollector/test_oslog_stream.c
+++ b/src/unit_tests/logcollector/test_oslog_stream.c
@@ -63,6 +63,7 @@ static int teardown_file(void **state) {
 
 /* w_logcollector_validate_oslog_stream_predicate */
 void test_w_logcollector_validate_oslog_stream_predicate_empty(void ** state) {
+
     char predicate[] = "";
 
     bool ret = w_logcollector_validate_oslog_stream_predicate(predicate);
@@ -71,6 +72,7 @@ void test_w_logcollector_validate_oslog_stream_predicate_empty(void ** state) {
 }
 
 void test_w_logcollector_validate_oslog_stream_predicate_existing(void ** state) {
+
     char predicate[] = "test";
 
     bool ret = w_logcollector_validate_oslog_stream_predicate(predicate);
@@ -87,7 +89,7 @@ void test_w_create_oslog_stream_array_NULL(void ** state) {
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -107,7 +109,7 @@ void test_w_create_oslog_stream_array_level_default(void ** state) {
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -130,7 +132,7 @@ void test_w_create_oslog_stream_array_level_info(void ** state) {
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -153,7 +155,7 @@ void test_w_create_oslog_stream_array_level_debug(void ** state) {
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -174,7 +176,7 @@ void test_w_create_oslog_stream_array_type_activity(void ** state) {
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -194,7 +196,7 @@ void test_w_create_oslog_stream_array_type_log(void ** state) {
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -214,7 +216,7 @@ void test_w_create_oslog_stream_array_type_trace(void ** state) {
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -234,7 +236,7 @@ void test_w_create_oslog_stream_array_type_activity_log(void ** state) {
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -256,7 +258,7 @@ void test_w_create_oslog_stream_array_type_activity_trace(void ** state) {
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -278,7 +280,7 @@ void test_w_create_oslog_stream_array_type_log_trace(void ** state) {
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -300,7 +302,7 @@ void test_w_create_oslog_stream_array_type_activity_log_trace(void ** state) {
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -326,7 +328,7 @@ void test_w_create_oslog_stream_array_level_default_type_activity(void ** state)
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -351,7 +353,7 @@ void test_w_create_oslog_stream_array_level_default_type_log(void ** state) {
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -376,7 +378,7 @@ void test_w_create_oslog_stream_array_level_default_type_trace(void ** state) {
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -401,7 +403,7 @@ void test_w_create_oslog_stream_array_level_default_type_activity_log(void ** st
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -428,7 +430,7 @@ void test_w_create_oslog_stream_array_level_default_type_activity_trace(void ** 
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -455,7 +457,7 @@ void test_w_create_oslog_stream_array_level_default_type_log_trace(void ** state
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -482,7 +484,7 @@ void test_w_create_oslog_stream_array_level_default_type_activity_log_trace(void
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -511,7 +513,7 @@ void test_w_create_oslog_stream_array_level_info_type_activity(void ** state) {
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -536,7 +538,7 @@ void test_w_create_oslog_stream_array_level_info_type_log(void ** state) {
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -561,7 +563,7 @@ void test_w_create_oslog_stream_array_level_info_type_trace(void ** state) {
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -586,7 +588,7 @@ void test_w_create_oslog_stream_array_level_info_type_activity_log(void ** state
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -613,7 +615,7 @@ void test_w_create_oslog_stream_array_level_info_type_activity_trace(void ** sta
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -640,7 +642,7 @@ void test_w_create_oslog_stream_array_level_info_type_log_trace(void ** state) {
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -667,7 +669,7 @@ void test_w_create_oslog_stream_array_level_info_type_activity_log_trace(void **
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -696,7 +698,7 @@ void test_w_create_oslog_stream_array_level_debug_type_activity(void ** state) {
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -721,7 +723,7 @@ void test_w_create_oslog_stream_array_level_debug_type_log(void ** state) {
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -746,7 +748,7 @@ void test_w_create_oslog_stream_array_level_debug_type_trace(void ** state) {
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -771,7 +773,7 @@ void test_w_create_oslog_stream_array_level_debug_type_activity_log(void ** stat
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -798,7 +800,7 @@ void test_w_create_oslog_stream_array_level_debug_type_activity_trace(void ** st
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -825,7 +827,7 @@ void test_w_create_oslog_stream_array_level_debug_type_log_trace(void ** state) 
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -852,7 +854,7 @@ void test_w_create_oslog_stream_array_level_debug_type_activity_log_trace(void *
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -884,12 +886,12 @@ void test_w_create_oslog_stream_array_predicate(void ** state) {
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
     assert_string_equal(ret[4], "--predicate");
-    assert_string_equal(ret[5], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[5], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[6]);
 
     free_strarray(ret);
@@ -909,14 +911,14 @@ void test_w_create_oslog_stream_array_level_default_predicate(void ** state) {
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
     assert_string_equal(ret[4], "--level");
     assert_string_equal(ret[5], "default");
     assert_string_equal(ret[6], "--predicate");
-    assert_string_equal(ret[7], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[7], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[8]);
 
     free_strarray(ret);
@@ -937,14 +939,14 @@ void test_w_create_oslog_stream_array_level_info_predicate(void ** state) {
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
     assert_string_equal(ret[4], "--level");
     assert_string_equal(ret[5], "info");
     assert_string_equal(ret[6], "--predicate");
-    assert_string_equal(ret[7], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[7], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[8]);
 
     free_strarray(ret);
@@ -965,14 +967,14 @@ void test_w_create_oslog_stream_array_level_debug_predicate(void ** state) {
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
     assert_string_equal(ret[4], "--level");
     assert_string_equal(ret[5], "debug");
     assert_string_equal(ret[6], "--predicate");
-    assert_string_equal(ret[7], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[7], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[8]);
 
     free_strarray(ret);
@@ -991,14 +993,14 @@ void test_w_create_oslog_stream_array_type_activity_predicate(void ** state) {
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
     assert_string_equal(ret[4], "--type");
     assert_string_equal(ret[5], "activity");
     assert_string_equal(ret[6], "--predicate");
-    assert_string_equal(ret[7], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[7], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[8]);
 
     free_strarray(ret);
@@ -1016,14 +1018,14 @@ void test_w_create_oslog_stream_array_type_log_predicate(void ** state) {
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
     assert_string_equal(ret[4], "--type");
     assert_string_equal(ret[5], "log");
     assert_string_equal(ret[6], "--predicate");
-    assert_string_equal(ret[7], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[7], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[8]);
 
     free_strarray(ret);
@@ -1041,14 +1043,14 @@ void test_w_create_oslog_stream_array_type_trace_predicate(void ** state) {
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
     assert_string_equal(ret[4], "--type");
     assert_string_equal(ret[5], "trace");
     assert_string_equal(ret[6], "--predicate");
-    assert_string_equal(ret[7], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[7], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[8]);
 
     free_strarray(ret);
@@ -1066,7 +1068,7 @@ void test_w_create_oslog_stream_array_type_activity_log_predicate(void ** state)
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -1075,7 +1077,7 @@ void test_w_create_oslog_stream_array_type_activity_log_predicate(void ** state)
     assert_string_equal(ret[6], "--type");
     assert_string_equal(ret[7], "log");
     assert_string_equal(ret[8], "--predicate");
-    assert_string_equal(ret[9], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[9], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[10]);
 
     free_strarray(ret);
@@ -1093,7 +1095,7 @@ void test_w_create_oslog_stream_array_type_activity_trace_predicate(void ** stat
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -1102,7 +1104,7 @@ void test_w_create_oslog_stream_array_type_activity_trace_predicate(void ** stat
     assert_string_equal(ret[6], "--type");
     assert_string_equal(ret[7], "trace");
     assert_string_equal(ret[8], "--predicate");
-    assert_string_equal(ret[9], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[9], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[10]);
 
     free_strarray(ret);
@@ -1120,7 +1122,7 @@ void test_w_create_oslog_stream_array_type_log_trace_predicate(void ** state) {
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -1129,7 +1131,7 @@ void test_w_create_oslog_stream_array_type_log_trace_predicate(void ** state) {
     assert_string_equal(ret[6], "--type");
     assert_string_equal(ret[7], "trace");
     assert_string_equal(ret[8], "--predicate");
-    assert_string_equal(ret[9], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[9], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[10]);
 
     free_strarray(ret);
@@ -1147,7 +1149,7 @@ void test_w_create_oslog_stream_array_type_activity_log_trace_predicate(void ** 
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -1158,7 +1160,7 @@ void test_w_create_oslog_stream_array_type_activity_log_trace_predicate(void ** 
     assert_string_equal(ret[8], "--type");
     assert_string_equal(ret[9], "trace");
     assert_string_equal(ret[10], "--predicate");
-    assert_string_equal(ret[11], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[11], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[12]);
 
     free_strarray(ret);
@@ -1178,7 +1180,7 @@ void test_w_create_oslog_stream_array_level_default_type_activity_predicate(void
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -1187,7 +1189,7 @@ void test_w_create_oslog_stream_array_level_default_type_activity_predicate(void
     assert_string_equal(ret[6], "--level");
     assert_string_equal(ret[7], "default");
     assert_string_equal(ret[8], "--predicate");
-    assert_string_equal(ret[9], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[9], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[10]);
 
     free_strarray(ret);
@@ -1208,7 +1210,7 @@ void test_w_create_oslog_stream_array_level_default_type_log_predicate(void ** s
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -1217,7 +1219,7 @@ void test_w_create_oslog_stream_array_level_default_type_log_predicate(void ** s
     assert_string_equal(ret[6], "--level");
     assert_string_equal(ret[7], "default");
     assert_string_equal(ret[8], "--predicate");
-    assert_string_equal(ret[9], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[9], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[10]);
 
     free_strarray(ret);
@@ -1238,7 +1240,7 @@ void test_w_create_oslog_stream_array_level_default_type_trace_predicate(void **
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -1247,7 +1249,7 @@ void test_w_create_oslog_stream_array_level_default_type_trace_predicate(void **
     assert_string_equal(ret[6], "--level");
     assert_string_equal(ret[7], "default");
     assert_string_equal(ret[8], "--predicate");
-    assert_string_equal(ret[9], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[9], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[10]);
 
     free_strarray(ret);
@@ -1268,7 +1270,7 @@ void test_w_create_oslog_stream_array_level_default_type_activity_log_predicate(
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -1279,7 +1281,7 @@ void test_w_create_oslog_stream_array_level_default_type_activity_log_predicate(
     assert_string_equal(ret[8], "--level");
     assert_string_equal(ret[9], "default");
     assert_string_equal(ret[10], "--predicate");
-    assert_string_equal(ret[11], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[11], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[12]);
 
     free_strarray(ret);
@@ -1300,7 +1302,7 @@ void test_w_create_oslog_stream_array_level_default_type_activity_trace_predicat
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -1311,7 +1313,7 @@ void test_w_create_oslog_stream_array_level_default_type_activity_trace_predicat
     assert_string_equal(ret[8], "--level");
     assert_string_equal(ret[9], "default");
     assert_string_equal(ret[10], "--predicate");
-    assert_string_equal(ret[11], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[11], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[12]);
 
     free_strarray(ret);
@@ -1332,7 +1334,7 @@ void test_w_create_oslog_stream_array_level_default_type_log_trace_predicate(voi
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -1343,7 +1345,7 @@ void test_w_create_oslog_stream_array_level_default_type_log_trace_predicate(voi
     assert_string_equal(ret[8], "--level");
     assert_string_equal(ret[9], "default");
     assert_string_equal(ret[10], "--predicate");
-    assert_string_equal(ret[11], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[11], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[12]);
 
     free_strarray(ret);
@@ -1364,7 +1366,7 @@ void test_w_create_oslog_stream_array_level_default_type_activity_log_trace_pred
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -1377,7 +1379,7 @@ void test_w_create_oslog_stream_array_level_default_type_activity_log_trace_pred
     assert_string_equal(ret[10], "--level");
     assert_string_equal(ret[11], "default");
     assert_string_equal(ret[12], "--predicate");
-    assert_string_equal(ret[13], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[13], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[14]);
 
     free_strarray(ret);
@@ -1398,7 +1400,7 @@ void test_w_create_oslog_stream_array_level_info_type_activity_predicate(void **
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -1407,7 +1409,7 @@ void test_w_create_oslog_stream_array_level_info_type_activity_predicate(void **
     assert_string_equal(ret[6], "--level");
     assert_string_equal(ret[7], "info");
     assert_string_equal(ret[8], "--predicate");
-    assert_string_equal(ret[9], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[9], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[10]);
 
     free_strarray(ret);
@@ -1428,7 +1430,7 @@ void test_w_create_oslog_stream_array_level_info_type_log_predicate(void ** stat
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -1437,7 +1439,7 @@ void test_w_create_oslog_stream_array_level_info_type_log_predicate(void ** stat
     assert_string_equal(ret[6], "--level");
     assert_string_equal(ret[7], "info");
     assert_string_equal(ret[8], "--predicate");
-    assert_string_equal(ret[9], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[9], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[10]);
 
     free_strarray(ret);
@@ -1458,7 +1460,7 @@ void test_w_create_oslog_stream_array_level_info_type_trace_predicate(void ** st
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -1467,7 +1469,7 @@ void test_w_create_oslog_stream_array_level_info_type_trace_predicate(void ** st
     assert_string_equal(ret[6], "--level");
     assert_string_equal(ret[7], "info");
     assert_string_equal(ret[8], "--predicate");
-    assert_string_equal(ret[9], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[9], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[10]);
 
     free_strarray(ret);
@@ -1488,7 +1490,7 @@ void test_w_create_oslog_stream_array_level_info_type_activity_log_predicate(voi
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -1499,7 +1501,7 @@ void test_w_create_oslog_stream_array_level_info_type_activity_log_predicate(voi
     assert_string_equal(ret[8], "--level");
     assert_string_equal(ret[9], "info");
     assert_string_equal(ret[10], "--predicate");
-    assert_string_equal(ret[11], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[11], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[12]);
 
     free_strarray(ret);
@@ -1520,7 +1522,7 @@ void test_w_create_oslog_stream_array_level_info_type_activity_trace_predicate(v
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -1531,7 +1533,7 @@ void test_w_create_oslog_stream_array_level_info_type_activity_trace_predicate(v
     assert_string_equal(ret[8], "--level");
     assert_string_equal(ret[9], "info");
     assert_string_equal(ret[10], "--predicate");
-    assert_string_equal(ret[11], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[11], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[12]);
 
     free_strarray(ret);
@@ -1552,7 +1554,7 @@ void test_w_create_oslog_stream_array_level_info_type_log_trace_predicate(void *
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -1563,7 +1565,7 @@ void test_w_create_oslog_stream_array_level_info_type_log_trace_predicate(void *
     assert_string_equal(ret[8], "--level");
     assert_string_equal(ret[9], "info");
     assert_string_equal(ret[10], "--predicate");
-    assert_string_equal(ret[11], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[11], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[12]);
 
     free_strarray(ret);
@@ -1584,7 +1586,7 @@ void test_w_create_oslog_stream_array_level_info_type_activity_log_trace_predica
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -1597,7 +1599,7 @@ void test_w_create_oslog_stream_array_level_info_type_activity_log_trace_predica
     assert_string_equal(ret[10], "--level");
     assert_string_equal(ret[11], "info");
     assert_string_equal(ret[12], "--predicate");
-    assert_string_equal(ret[13], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[13], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[14]);
 
     free_strarray(ret);
@@ -1618,7 +1620,7 @@ void test_w_create_oslog_stream_array_level_debug_type_activity_predicate(void *
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -1627,7 +1629,7 @@ void test_w_create_oslog_stream_array_level_debug_type_activity_predicate(void *
     assert_string_equal(ret[6], "--level");
     assert_string_equal(ret[7], "debug");
     assert_string_equal(ret[8], "--predicate");
-    assert_string_equal(ret[9], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[9], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[10]);
 
     free_strarray(ret);
@@ -1648,7 +1650,7 @@ void test_w_create_oslog_stream_array_level_debug_type_log_predicate(void ** sta
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -1657,7 +1659,7 @@ void test_w_create_oslog_stream_array_level_debug_type_log_predicate(void ** sta
     assert_string_equal(ret[6], "--level");
     assert_string_equal(ret[7], "debug");
     assert_string_equal(ret[8], "--predicate");
-    assert_string_equal(ret[9], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[9], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[10]);
 
     free_strarray(ret);
@@ -1678,7 +1680,7 @@ void test_w_create_oslog_stream_array_level_debug_type_trace_predicate(void ** s
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -1687,7 +1689,7 @@ void test_w_create_oslog_stream_array_level_debug_type_trace_predicate(void ** s
     assert_string_equal(ret[6], "--level");
     assert_string_equal(ret[7], "debug");
     assert_string_equal(ret[8], "--predicate");
-    assert_string_equal(ret[9], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[9], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[10]);
 
     free_strarray(ret);
@@ -1708,7 +1710,7 @@ void test_w_create_oslog_stream_array_level_debug_type_activity_log_predicate(vo
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -1719,7 +1721,7 @@ void test_w_create_oslog_stream_array_level_debug_type_activity_log_predicate(vo
     assert_string_equal(ret[8], "--level");
     assert_string_equal(ret[9], "debug");
     assert_string_equal(ret[10], "--predicate");
-    assert_string_equal(ret[11], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[11], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[12]);
 
     free_strarray(ret);
@@ -1740,7 +1742,7 @@ void test_w_create_oslog_stream_array_level_debug_type_activity_trace_predicate(
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -1751,7 +1753,7 @@ void test_w_create_oslog_stream_array_level_debug_type_activity_trace_predicate(
     assert_string_equal(ret[8], "--level");
     assert_string_equal(ret[9], "debug");
     assert_string_equal(ret[10], "--predicate");
-    assert_string_equal(ret[11], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[11], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[12]);
 
     free_strarray(ret);
@@ -1772,7 +1774,7 @@ void test_w_create_oslog_stream_array_level_debug_type_log_trace_predicate(void 
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -1783,7 +1785,7 @@ void test_w_create_oslog_stream_array_level_debug_type_log_trace_predicate(void 
     assert_string_equal(ret[8], "--level");
     assert_string_equal(ret[9], "debug");
     assert_string_equal(ret[10], "--predicate");
-    assert_string_equal(ret[11], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[11], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[12]);
 
     free_strarray(ret);
@@ -1804,7 +1806,7 @@ void test_w_create_oslog_stream_array_level_debug_type_activity_log_trace_predic
 
     char ** ret = w_create_oslog_stream_array(predicate, level, type);
 
-    assert_string_equal(ret[0], "log");
+    assert_string_equal(ret[0], "/usr/bin/log");
     assert_string_equal(ret[1], "stream");
     assert_string_equal(ret[2], "--style");
     assert_string_equal(ret[3], "syslog");
@@ -1817,7 +1819,7 @@ void test_w_create_oslog_stream_array_level_debug_type_activity_log_trace_predic
     assert_string_equal(ret[10], "--level");
     assert_string_equal(ret[11], "debug");
     assert_string_equal(ret[12], "--predicate");
-    assert_string_equal(ret[13], "'processImagePath CONTAINS[c] 'com.apple.geod''");
+    assert_string_equal(ret[13], "processImagePath CONTAINS[c] 'com.apple.geod'");
     assert_null(ret[14]);
 
     free_strarray(ret);

--- a/src/unit_tests/logcollector/test_read_oslog.c
+++ b/src/unit_tests/logcollector/test_read_oslog.c
@@ -108,6 +108,34 @@ void test_oslog_ctxt_clean_success(void ** state) {
 
 }
 
+/* oslog_ctxt_is_expired */
+
+void test_oslog_ctxt_is_expired_true(void ** state) {
+
+    w_oslog_ctxt_t ctxt;
+    time_t timeout = (time_t) OSLOG_TIMEOUT_OUT;
+
+    ctxt.timestamp = (time_t) 1;
+
+    bool ret = oslog_ctxt_is_expired(timeout, &ctxt);
+
+    assert_true(ret);
+
+}
+
+void test_oslog_ctxt_is_expired_false(void ** state) {
+
+    w_oslog_ctxt_t ctxt;
+    time_t timeout = (time_t) OSLOG_TIMEOUT_OUT;
+
+    ctxt.timestamp = time(NULL);
+
+    bool ret = oslog_ctxt_is_expired(timeout, &ctxt);
+
+    assert_false(ret);
+
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         // Test oslog_ctxt_restore
@@ -117,6 +145,9 @@ int main(void) {
         cmocka_unit_test(test_oslog_ctxt_backup_success),
         // Test oslog_ctxt_clean
         cmocka_unit_test(test_oslog_ctxt_clean_success),
+        // Test oslog_ctxt_is_expired
+        cmocka_unit_test(test_oslog_ctxt_is_expired_true),
+        cmocka_unit_test(test_oslog_ctxt_is_expired_false),
     };
 
     return cmocka_run_group_tests(tests, group_setup, group_teardown);

--- a/src/unit_tests/logcollector/test_read_oslog.c
+++ b/src/unit_tests/logcollector/test_read_oslog.c
@@ -25,7 +25,7 @@ bool oslog_ctxt_restore(char * buffer, w_oslog_ctxt_t * ctxt);
 void oslog_ctxt_backup(char * buffer, w_oslog_ctxt_t * ctxt);
 void oslog_ctxt_clean(w_oslog_ctxt_t * ctxt);
 bool oslog_ctxt_is_expired(time_t timeout, w_oslog_ctxt_t * ctxt);
-char * oslog_get_lastline(char * str);
+char * oslog_get_valid_lastline(char * str);
 
 /* setup/teardown */
 
@@ -136,6 +136,119 @@ void test_oslog_ctxt_is_expired_false(void ** state) {
 
 }
 
+/* oslog_get_valid_lastline */
+
+void test_oslog_get_valid_lastline_str_null(void ** state) {
+
+    char * str = NULL;
+
+    char * ret =oslog_get_valid_lastline(str);
+
+    assert_null(ret);
+
+}
+
+void test_oslog_get_valid_lastline_str_empty(void ** state) {
+
+    char * str = '\0';
+
+    char * ret =oslog_get_valid_lastline(str);
+
+    assert_null(ret);
+
+}
+
+void test_oslog_get_valid_lastline_str_without_new_line(void ** state) {
+
+    char * str = NULL;
+
+    os_strdup("2021-04-22 12:00:00.230270-0700 test", str);
+
+    char * ret =oslog_get_valid_lastline(str);
+
+    assert_null(ret);
+    os_free(str);
+
+}
+
+void test_oslog_get_valid_lastline_str_with_new_line_end(void ** state) {
+
+    char * str = NULL;
+
+    os_strdup("2021-04-22 12:00:00.230270-0700 test\n", str);
+
+    char * ret =oslog_get_valid_lastline(str);
+
+    assert_null(ret);
+    os_free(str);
+
+}
+
+void test_oslog_get_valid_lastline_str_with_new_line_not_end(void ** state) {
+
+    char * str = NULL;
+
+    os_strdup("2021-04-22 12:00:00.230270-0700 test\n2021-04-22 12:00:00.230270-0700 test2", str);
+
+    char * ret =oslog_get_valid_lastline(str);
+
+    assert_string_equal(ret, "\n2021-04-22 12:00:00.230270-0700 test2");
+    os_free(str);
+
+}
+
+void test_oslog_get_valid_lastline_str_with_two_new_lines_end(void ** state) {
+
+    char * str = NULL;
+
+    os_strdup("2021-04-22 12:00:00.230270-0700 test\n2021-04-22 12:00:00.230270-0700 test2\n", str);
+
+    char * ret =oslog_get_valid_lastline(str);
+
+    assert_string_equal(ret, "\n2021-04-22 12:00:00.230270-0700 test2\n");
+    os_free(str);
+
+}
+
+void test_oslog_get_valid_lastline_str_with_two_new_lines_not_end(void ** state) {
+
+    char * str = NULL;
+
+    os_strdup("2021-04-22 12:00:00.230270-0700 test\n2021-04-22 12:00:00.230270-0700 test2\n2021-04-22 12:00:00.230270-0700 test3", str);
+
+    char * ret =oslog_get_valid_lastline(str);
+
+    assert_string_equal(ret, "\n2021-04-22 12:00:00.230270-0700 test3");
+    os_free(str);
+
+}
+
+void test_oslog_get_valid_lastline_str_with_three_new_lines_end(void ** state) {
+
+    char * str = NULL;
+
+    os_strdup("2021-04-22 12:00:00.230270-0700 test\n2021-04-22 12:00:00.230270-0700 test2\n2021-04-22 12:00:00.230270-0700 test3\n", str);
+
+    char * ret =oslog_get_valid_lastline(str);
+
+    assert_string_equal(ret, "\n2021-04-22 12:00:00.230270-0700 test3\n");
+    os_free(str);
+
+}
+
+void test_oslog_get_valid_lastline_str_with_three_new_lines_not_end(void ** state) {
+
+    char * str = NULL;
+
+    os_strdup("2021-04-22 12:00:00.230270-0700 test\n2021-04-22 12:00:00.230270-0700 test2\n2021-04-22 12:00:00.230270-0700 test3\n2021-04-22 12:00:00.230270-0700 test4", str);
+
+    char * ret =oslog_get_valid_lastline(str);
+
+    assert_string_equal(ret, "\n2021-04-22 12:00:00.230270-0700 test4");
+    os_free(str);
+
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         // Test oslog_ctxt_restore
@@ -148,6 +261,15 @@ int main(void) {
         // Test oslog_ctxt_is_expired
         cmocka_unit_test(test_oslog_ctxt_is_expired_true),
         cmocka_unit_test(test_oslog_ctxt_is_expired_false),
+        // Test oslog_get_valid_lastline
+        cmocka_unit_test(test_oslog_get_valid_lastline_str_null),
+        cmocka_unit_test(test_oslog_get_valid_lastline_str_empty),
+        cmocka_unit_test(test_oslog_get_valid_lastline_str_without_new_line),
+        cmocka_unit_test(test_oslog_get_valid_lastline_str_with_new_line_end),
+        cmocka_unit_test(test_oslog_get_valid_lastline_str_with_new_line_not_end),
+        cmocka_unit_test(test_oslog_get_valid_lastline_str_with_two_new_lines_end),
+        cmocka_unit_test(test_oslog_get_valid_lastline_str_with_two_new_lines_not_end),
+        cmocka_unit_test(test_oslog_get_valid_lastline_str_with_three_new_lines_not_end),
     };
 
     return cmocka_run_group_tests(tests, group_setup, group_teardown);

--- a/src/unit_tests/logcollector/test_read_oslog.c
+++ b/src/unit_tests/logcollector/test_read_oslog.c
@@ -79,6 +79,7 @@ void test_oslog_ctxt_backup_success(void ** state) {
 
     w_oslog_ctxt_t ctxt;
     char buffer[OS_MAXSTR + 1];
+
     buffer[OS_MAXSTR] = '\0';
 
     strncpy(buffer,"test",OS_MAXSTR);
@@ -90,13 +91,32 @@ void test_oslog_ctxt_backup_success(void ** state) {
 
 }
 
+/* oslog_ctxt_clean */
+
+void test_oslog_ctxt_clean_success(void ** state) {
+
+    w_oslog_ctxt_t ctxt;
+
+    strncpy(ctxt.buffer,"test",OS_MAXSTR);
+    ctxt.timestamp = time(NULL);
+
+
+    oslog_ctxt_clean(&ctxt);
+
+    assert_int_equal(ctxt.timestamp, 0);
+    assert_string_equal(ctxt.buffer,"\0");
+
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         // Test oslog_ctxt_restore
         cmocka_unit_test(test_oslog_ctxt_restore_false),
         cmocka_unit_test(test_oslog_ctxt_restore_true),
-        // Test
+        // Test oslog_ctxt_backup
         cmocka_unit_test(test_oslog_ctxt_backup_success),
+        // Test oslog_ctxt_clean
+        cmocka_unit_test(test_oslog_ctxt_clean_success),
     };
 
     return cmocka_run_group_tests(tests, group_setup, group_teardown);

--- a/src/unit_tests/logcollector/test_read_oslog.c
+++ b/src/unit_tests/logcollector/test_read_oslog.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2015-2021, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <time.h>
+
+#include "../../logcollector/logcollector.h"
+#include "../../headers/shared.h"
+#include "../wrappers/common.h"
+#include "../wrappers/wazuh/shared/file_op_wrappers.h"
+#include "../wrappers/libc/stdio_wrappers.h"
+#include "../wrappers/linux/socket_wrappers.h"
+
+bool oslog_ctxt_restore(char * buffer, w_oslog_ctxt_t * ctxt);
+void oslog_ctxt_backup(char * buffer, w_oslog_ctxt_t * ctxt);
+void oslog_ctxt_clean(w_oslog_ctxt_t * ctxt);
+bool oslog_ctxt_is_expired(time_t timeout, w_oslog_ctxt_t * ctxt);
+char * oslog_get_lastline(char * str);
+
+/* setup/teardown */
+
+static int group_setup(void ** state) {
+    test_mode = 1;
+    return 0;
+
+}
+
+static int group_teardown(void ** state) {
+    test_mode = 0;
+    return 0;
+
+}
+
+/* wraps */
+
+
+/* tests */
+
+/* oslog_ctxt_restore */
+
+void test_oslog_ctxt_restore_false(void ** state) {
+
+    w_oslog_ctxt_t ctxt;
+    ctxt.buffer[0] = '\0';
+
+    char * buffer = NULL;
+
+    bool ret = oslog_ctxt_restore(buffer, &ctxt);
+    assert_false(ret);
+
+}
+
+void test_oslog_ctxt_restore_true(void ** state) {
+
+    w_oslog_ctxt_t ctxt;
+    strncpy(ctxt.buffer,"test",OS_MAXSTR);
+
+    char buffer[OS_MAXSTR + 1];
+    buffer[OS_MAXSTR] = '\0';
+
+    bool ret = oslog_ctxt_restore(buffer, &ctxt);
+    assert_true(ret);
+
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        // Test w_logcollector_validate_oslog_stream_predicate
+        cmocka_unit_test(test_oslog_ctxt_restore_false),
+        cmocka_unit_test(test_oslog_ctxt_restore_true),
+    };
+
+    return cmocka_run_group_tests(tests, group_setup, group_teardown);
+}

--- a/src/unit_tests/logcollector/test_read_oslog.c
+++ b/src/unit_tests/logcollector/test_read_oslog.c
@@ -73,11 +73,30 @@ void test_oslog_ctxt_restore_true(void ** state) {
 
 }
 
+/* oslog_ctxt_backup */
+
+void test_oslog_ctxt_backup_success(void ** state) {
+
+    w_oslog_ctxt_t ctxt;
+    char buffer[OS_MAXSTR + 1];
+    buffer[OS_MAXSTR] = '\0';
+
+    strncpy(buffer,"test",OS_MAXSTR);
+
+    oslog_ctxt_backup(buffer, &ctxt);
+
+    assert_non_null(ctxt.buffer);
+    assert_non_null(ctxt.timestamp);
+
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
-        // Test w_logcollector_validate_oslog_stream_predicate
+        // Test oslog_ctxt_restore
         cmocka_unit_test(test_oslog_ctxt_restore_false),
         cmocka_unit_test(test_oslog_ctxt_restore_true),
+        // Test
+        cmocka_unit_test(test_oslog_ctxt_backup_success),
     };
 
     return cmocka_run_group_tests(tests, group_setup, group_teardown);


### PR DESCRIPTION
|Related issue|
|---|
|Closes #8133|

## Description

Hi  team,

This PR adds the function to read from the `log` stream. It includes the following cases:

### Test

#### Test overflows

- [X] One log, one line size: 65280 (End with a endline `\n`)  
- [X] One log, Multiline line, total size: 65280 (End with a endline `\n`)
- [X] Multiple los multiline size: 65280 (End with a endline `\n`)  
- [X] Multiple los multiline size: 65280 (las line end without a endline `\n`)  

#### Usual cases

- [X] One log, one line end with a endline
- [X] 2 log, both one line end with a endline
- [X] One log, one line without endline
- [X] One log, one line, but split in two parts (Test context)
- [X] Cut log (case 4) + complete log
- [X] Cut log (case 4) + complete log + cut log


## Logs/Alerts example


## Tests


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
