### PR TITLE
Add tabulate to Framework requirements

### DIFF
--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -57,6 +57,7 @@ setuptools==46.1.3
 six==1.14.0
 SQLAlchemy==1.3.11
 swagger-ui-bundle==0.0.3
+tabulate==0.8.9
 urllib3==1.25.9
 uvloop==0.15.2
 websocket-client==0.57.0

--- a/src/Makefile
+++ b/src/Makefile
@@ -1032,7 +1032,7 @@ endif
 TAR := tar -xf
 GUNZIP := gunzip
 CURL := curl -so
-DEPS_VERSION = 13
+DEPS_VERSION = 14
 RESOURCES_URL := https://packages.wazuh.com/deps/$(DEPS_VERSION)
 CPYTHON := cpython
 PYTHON_SOURCE := no


### PR DESCRIPTION
|Related issue|
|---|
|#8037|

Hi team,

This PR closes #8037. In this PR we have added the tabulate dependency to our requirements.txt file. We have generated the precompiled Python package and will merge it once we test the package.

Regards
