### PR TITLE
Upgrade python-jose to latest stable and add tabulate

### DIFF
--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -57,6 +57,7 @@ setuptools==46.1.3
 six==1.14.0
 SQLAlchemy==1.3.11
 swagger-ui-bundle==0.0.3
+tabulate==0.8.9
 urllib3==1.25.9
 uvloop==0.15.2
 websocket-client==0.57.0

--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -47,7 +47,7 @@ pyasn1-modules==0.2.8
 pyasn1==0.4.8
 pycparser==2.20
 python-dateutil==2.8.1
-python-jose==3.2.0
+python-jose==3.1.0
 pytz==2020.1
 requests==2.23.0
 rsa==4.7.2

--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -47,7 +47,7 @@ pyasn1-modules==0.2.8
 pyasn1==0.4.8
 pycparser==2.20
 python-dateutil==2.8.1
-python-jose==3.0.1
+python-jose==3.2.0
 pytz==2020.1
 requests==2.23.0
 rsa==4.7.2

--- a/src/Makefile
+++ b/src/Makefile
@@ -1032,7 +1032,7 @@ endif
 TAR := tar -xf
 GUNZIP := gunzip
 CURL := curl -so
-DEPS_VERSION = 13
+DEPS_VERSION = 14
 RESOURCES_URL := https://packages.wazuh.com/deps/$(DEPS_VERSION)
 CPYTHON := cpython
 PYTHON_SOURCE := no


### PR DESCRIPTION
|Related issue|
|---|
|#8054|

Hi team,

This PR closes #8037 and #8054. In this PR we have upgraded the python-jose dependency to the latest stable version (3.2.0) and we have added a new dependency (tabulate). We have generated the precompiled Python package and will merge it once we test the package.

Regards