### PR TITLE
Add testing tools for MITRE unit tests

### DIFF
--- a/framework/wazuh/tests/test_mitre.py
+++ b/framework/wazuh/tests/test_mitre.py
@@ -4,10 +4,14 @@
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
-from unittest.mock import patch
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
 
 with patch('wazuh.common.ossec_uid'):
     with patch('wazuh.common.ossec_gid'):
+        sys.modules['wazuh.rbac.orm'] = MagicMock()
         import wazuh.rbac.decorators
 
         from wazuh.tests.util import get_fake_database_data, RBAC_bypasser, InitWDBSocketMock
@@ -18,18 +22,56 @@ with patch('wazuh.common.ossec_uid'):
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 
 
+# Fixtures
+@pytest.fixture(scope='module')
+def mitre_db():
+    """Get fake MITRE database cursor."""
+    return get_fake_database_data('schema_mitre_test.sql').cursor()
+
+
+# Functions
+class CursorByName:
+    """Class to return query result including the column name as key."""
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        row = self._cursor.__next__()
+        return {description[0]: row[col] for col, description in enumerate(self._cursor.description)}
+
+
+def mitre_query(cursor, query):
+    """Return list of dictionaries with the query results."""
+    cursor.execute(query)
+    return [row for row in CursorByName(cursor)]
+
+
+def sort_entries(entries, sort_key='id'):
+    """Sort a list of dictionaries by one their keys."""
+    return sorted(entries, key=lambda k: k[sort_key])
+
+
 # Tests
 
 @patch('wazuh.core.utils.WazuhDBConnection', return_value=InitWDBSocketMock(sql_schema_file='schema_mitre_test.sql'))
-def test_get_mitre_metadata(mock_mitre_db):
-    """Check MITRE metadata
-    """
+def test_mitre_metadata(mock_mitre_dbmitre, mitre_db):
+    """Check MITRE metadata."""
     result = mitre.mitre_metadata()
-    cur = get_fake_database_data('schema_mitre_test.sql').cursor()
-    cur.execute("SELECT * FROM metadata")
-    rows = cur.fetchall()
+    rows = mitre_query(mitre_db, 'SELECT * FROM metadata')
 
-    assert result.affected_items[0]['key'] == rows[0][0]
-    assert result.affected_items[1]['key'] == rows[1][0]
-    assert result.affected_items[0]['value'] == rows[0][1]
-    assert result.affected_items[1]['value'] == rows[1][1]
+    assert result.affected_items
+    assert all(item[key] == row[key] for item, row in zip(result.affected_items, rows) for key in row)
+
+
+@patch('wazuh.core.utils.WazuhDBConnection', return_value=InitWDBSocketMock(sql_schema_file='schema_mitre_test.sql'))
+def test_mitre_techniques(mock_mitre_db, mitre_db):
+    """Check MITRE groups."""
+    result = mitre.mitre_techniques()
+    rows = mitre_query(mitre_db, "SELECT * FROM technique")
+
+    assert result.affected_items
+    assert all(item[key] == row[key] for item, row in zip(sort_entries(result.affected_items), sort_entries(rows))
+               for key in row)


### PR DESCRIPTION
Hello team,

as part of each MITRE endpoint development we need to implement new unit tests. This PR adds some common tools to do that.

## Tests results

### SDK MITRE
```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.9.1, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.14.0, metadata-1.10.0
collected 2 items                                                                                                                                                                           

wazuh/tests/test_mitre.py ..                                                                                                                                                          [100%]

=============================================================================== 2 passed, 2 warnings in 1.69s ===============================================================================
```

### CORE MITRE

Core MITRE unit tests updated with templates to test wach `WazuhDBQueryMitre` class and MITRE function. Refactored `WazuhDBQueryMitreMetadata` test.

```
pytest framework/wazuh/core/tests/test_mitre.py --disable-warnings
========================================================= test session starts ==========================================================
platform linux -- Python 3.9.2, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /home/manuel/git/wazuh/framework
plugins: asyncio-0.14.0
collected 3 items                                                                                                                      

framework/wazuh/core/tests/test_mitre.py .ss                                                                                     [100%]

=============================================== 1 passed, 2 skipped, 2 warnings in 0.40s ===============================================

```

Regards,
Víctor Fernández 