### PR TITLE
Add postgre sql13 decoder

### DIFF
--- a/ruleset/decoders/0225-postgresql_decoders.xml
+++ b/ruleset/decoders/0225-postgresql_decoders.xml
@@ -18,3 +18,9 @@
   <regex offset="after_prematch">^\S+ (\w+): </regex>
   <order>status</order>
 </decoder>
+
+<decoder name="postgresql_log">
+  <prematch>^\d\d\d\d-\d\d-\d\d \S+ \w+ </prematch>
+  <regex offset="after_prematch">^\S+ (\w+): </regex>
+  <order>status</order>
+</decoder>

--- a/ruleset/decoders/0225-postgresql_decoders.xml
+++ b/ruleset/decoders/0225-postgresql_decoders.xml
@@ -12,15 +12,13 @@
   - Examples:
   - [2007-08-31 18:37:09.454 ADT] 192.168.2.99: LOG:  connection authorized: user=wazuh_user database=wazuh_db
   - [2007-08-31 18:37:15.525 ADT] 192.168.2.99: ERROR:  relation "alert2" does not exist
+  - Version 13:
+  - 021-04-07 16:48:20.991 EET [8329] FATAL:  password authentication failed for user "testing_user"
+  - 2021-04-07 16:48:20.991 EET [8329] DETAIL:  Password does not match for user "testing_user".
+        Connection matched pg_hba.conf line 90: "host   testing_db      testing_user           0.0.0.0/0                md5"
   -->
 <decoder name="postgresql_log">
-  <prematch>^[\d\d\d\d-\d\d-\d\d \S+ \w+] </prematch>
-  <regex offset="after_prematch">^\S+ (\w+): </regex>
-  <order>status</order>
-</decoder>
-
-<decoder name="postgresql_log">
-  <prematch>^\d\d\d\d-\d\d-\d\d \S+ \w+ </prematch>
+  <prematch type="pecre2">^\[?\d\d\d\d-\d\d-\d\d \S+ \w+\]? </prematch>
   <regex offset="after_prematch">^\S+ (\w+): </regex>
   <order>status</order>
 </decoder>


### PR DESCRIPTION
|#8189|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Added support for PostgreSQL13 logs, the only difference is that date is not enclosed with brackets.  
Changed regex type to pcre2, and made the brackets optional.  
Added log examples.
<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example
2021-04-07 16:48:20.991 EET [8329] FATAL: password authentication failed for user "testing_user"  
2021-04-07 16:48:20.991 EET [8329] DETAIL: Password does not match for user "testing_user".
<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
