### PR TITLE
Fixing Vulnerability Detector unit tests. 

### DIFF
--- a/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
@@ -38,11 +38,11 @@ int teardown_wdb_agents_helpers(void **state) {
     return 0;
 }
 
-/* Tests wdb_agents_sys_osinfo_check_triaged */
+/* Tests wdb_agents_sys_osinfo_get */
 
-void test_wdb_agents_sys_osinfo_check_triaged_error_wdb_query(void ** state)
+void test_wdb_agents_sys_osinfo_get_error_sql_execution(void ** state)
 {
-    int ret = 0;
+    cJSON *ret = NULL;
     int id = 1;
 
     // Calling Wazuh DB
@@ -55,62 +55,27 @@ void test_wdb_agents_sys_osinfo_check_triaged_error_wdb_query(void ** state)
     //Cleaning  memory
     expect_function_call(__wrap_cJSON_Delete);
 
-    ret = wdb_agents_sys_osinfo_check_triaged(id, NULL);
+    ret = wdb_agents_sys_osinfo_get(id, NULL);
 
-    assert_int_equal(OS_INVALID, ret);
+    assert_null(ret);
 }
 
-void test_wdb_agents_sys_osinfo_check_triaged_error_no_info(void ** state)
+void test_wdb_agents_sys_osinfo_get_success(void ** state)
 {
-    int ret = 0;
+    cJSON *ret = NULL;
     int id = 1;
 
     cJSON *root = __real_cJSON_CreateArray();
     cJSON *row = __real_cJSON_CreateObject();
-    cJSON *triaged = __real_cJSON_CreateNumber(1);
-    __real_cJSON_AddItemToObject(row, "dummy_data", triaged);
     __real_cJSON_AddItemToArray(root, row);
 
     // Calling Wazuh DB
     will_return(__wrap_wdbc_query_parse_json, 0);
     will_return(__wrap_wdbc_query_parse_json, root);
-    will_return(__wrap_cJSON_GetObjectItem, NULL);
 
-    // Handling result
-    expect_string(__wrap__merror, formatted_msg, "No information related to the triaged status of the OS");
+    ret = wdb_agents_sys_osinfo_get(id, NULL);
 
-    //Cleaning  memory
-    expect_function_call(__wrap_cJSON_Delete);
-
-    ret = wdb_agents_sys_osinfo_check_triaged(id, NULL);
-
-    assert_int_equal(OS_INVALID, ret);
-
-    __real_cJSON_Delete(root);
-}
-
-void test_wdb_agents_sys_osinfo_check_triaged_success(void ** state)
-{
-    int ret = 0;
-    int id = 1;
-
-    cJSON *root = __real_cJSON_CreateArray();
-    cJSON *row = __real_cJSON_CreateObject();
-    cJSON *triaged = __real_cJSON_CreateNumber(1);
-    __real_cJSON_AddItemToObject(row, "triaged", triaged);
-    __real_cJSON_AddItemToArray(root, row);
-
-    // Calling Wazuh DB
-    will_return(__wrap_wdbc_query_parse_json, 0);
-    will_return(__wrap_wdbc_query_parse_json, root);
-    will_return(__wrap_cJSON_GetObjectItem, triaged);
-
-    //Cleaning  memory
-    expect_function_call(__wrap_cJSON_Delete);
-
-    ret = wdb_agents_sys_osinfo_check_triaged(id, NULL);
-
-    assert_int_equal(1, ret);
+    assert_ptr_equal(root, ret);
 
     __real_cJSON_Delete(root);
 }
@@ -1260,10 +1225,9 @@ int main()
 {
     const struct CMUnitTest tests[] =
     {
-        /* Tests wdb_agents_sys_osinfo_check_triaged */
-        cmocka_unit_test_setup_teardown(test_wdb_agents_sys_osinfo_check_triaged_error_wdb_query, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_sys_osinfo_check_triaged_error_no_info, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_sys_osinfo_check_triaged_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        /* Tests wdb_agents_sys_osinfo_get */
+        cmocka_unit_test_setup_teardown(test_wdb_agents_sys_osinfo_get_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_sys_osinfo_get_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         /* Tests wdb_agents_vuln_cves_insert*/
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_insert_error_json, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_insert_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/CMakeLists.txt
@@ -44,7 +44,8 @@ list(APPEND vulndetector_flags "-Wl,--wrap,_merror -Wl,--wrap,_mterror -Wl,--wra
                                 -Wl,--wrap,wurl_request_uncompress_bz2_gz -Wl,--wrap,w_uncompress_bz2_gz_file -Wl,--wrap,wstr_replace \
                                 -Wl,--wrap,OSHash_Delete_ex -Wl,--wrap=wstr_split -Wl,--wrap,OSMatch_Execute -Wl,--wrap,OSRegex_Execute_ex \
                                 -Wl,--wrap,fgetpos -Wl,--wrap,wdb_agents_vuln_cves_insert -Wl,--wrap,wdb_agents_vuln_cves_clear -Wl,--wrap,wdb_get_all_agents \
-                                -Wl,--wrap,OS_ClearXML -Wl,--wrap,wdb_agents_vuln_cves_remove_by_status -Wl,--wrap,cJSON_GetStringValue -Wl,--wrap,wm_sendmsg")
+                                -Wl,--wrap,OS_ClearXML -Wl,--wrap,wdb_agents_vuln_cves_remove_by_status -Wl,--wrap,cJSON_GetStringValue -Wl,--wrap,wm_sendmsg \
+                                -Wl,--wrap,wdb_agents_vuln_cves_update_status")
 
 list(APPEND vulndetector_names "test_wm_vuln_detector_evr")
 list(APPEND vulndetector_flags "-Wl,--wrap,_merror -Wl,--wrap,_mterror -Wl,--wrap,_mtdebug1 -Wl,--wrap,_mtdebug2 -Wl,--wrap,OS_ConnectUnixDomain \

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -56,7 +56,7 @@ int wm_vuldet_compare_pkg(cve_vuln_pkg *Pkg1, cve_vuln_pkg *Pkg2);
 int wm_vuldet_add_cve_node(cve_vuln_pkg *newPkg, const char *cve, OSHash *cve_table);
 cJSON *wm_vuldet_get_cvss(const char *scoring_vector);
 void wm_vuldet_free_scan_agent(scan_agent *agent);
-int wm_vuldet_get_os_unix_info(scan_agent *agent);
+int wm_vuldet_build_unix_os_release(scan_agent *agent, const char* os_major, const char* os_minor, const char* os_patch);
 int wm_vuldet_generate_os_and_kernel_package(sqlite3 *db, scan_agent *agent);
 int wm_vuldet_find_agent_vulnerabilities(sqlite3 *db, scan_agent *agent, wm_vuldet_flags *flags, scan_ctx_t* scan_ctx);
 int wm_vuldet_discard_kernel_package(scan_agent *agent, const char *name, const char *version, const char *arch);
@@ -177,9 +177,6 @@ static int build_test_cve_report(vu_report* report, int add_title, int add_condi
     if (!report)
         return OS_INVALID;
 
-    if (1 == add_title)
-        os_strdup("The CVE title.", report->title);
-
     if (1 == add_condition)
         os_strdup("Package less than 4.3-2", report->condition);
 
@@ -224,6 +221,10 @@ static int build_test_cve_report(vu_report* report, int add_title, int add_condi
     report->ref_sources[1] = NULL;
     // Reported software
     os_strdup("libhogweed4", report->software);
+    if (1 == add_title){
+        os_calloc(OS_SIZE_512, sizeof(char), report->title);
+        snprintf(report->title, OS_SIZE_512, "%s affects %s", report->cve, report->software);
+    }
     os_strdup("nettle", report->source);
     os_strdup("o:microsoft:windows_server_2008:r2:sp1::::::", report->generated_cpe);
     os_strdup("3.4-1", report->version);
@@ -608,321 +609,66 @@ static int teardown_info_cves(void **state) {
 
 /* tests */
 
-/* wm_vuldet_get_os_unix_info */
-#if 0 //TODO #7749 Fix UTs
-void test_wm_vuldet_get_os_unix_info (void **state)
+/* wm_vuldet_build_unix_os_release */
+
+void test_wm_vuldet_build_unix_os_release_null_agent(void **state)
 {
     scan_agent *agent = *state;
-
-    const char *query = "agent 000 sql SELECT OS_MAJOR, OS_MINOR, OS_PATCH, RELEASE FROM SYS_OSINFO;";
-    size_t query_size = strlen(query) + 1;
-
-    char *response = "ok [{\"os_major\":\"10.0\",\"os_minor\":\"1\",\"release\":\"4.5.1\"}]";
-    size_t response_size = strlen(response) + 1;
-
-    expect_string(__wrap_OS_ConnectUnixDomain, path, WDB_LOCAL_SOCK);
-    expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
-    expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_SIZE_6144);
-    will_return(__wrap_OS_ConnectUnixDomain, 11111);
-
-    expect_value(__wrap_OS_SendSecureTCP, sock, 11111);
-    expect_value(__wrap_OS_SendSecureTCP, size, query_size);
-    expect_string(__wrap_OS_SendSecureTCP, msg, query);
-    will_return(__wrap_OS_SendSecureTCP, 0);
-
-    expect_value(__wrap_OS_RecvSecureTCP, sock, 11111);
-    expect_value(__wrap_OS_RecvSecureTCP, size, OS_SIZE_128);
-    will_return(__wrap_OS_RecvSecureTCP, response);
-    will_return(__wrap_OS_RecvSecureTCP, response_size);
-
-    cJSON* parsed_json = __real_cJSON_CreateArray();
-    cJSON* object = __real_cJSON_CreateObject();
-    __real_cJSON_AddItemToArray(parsed_json, object);
-    cJSON* os_major = __real_cJSON_CreateString("10.0");
-    cJSON* os_minor = __real_cJSON_CreateString("1");
-    cJSON* release = __real_cJSON_CreateString("4.5.1");
-    __real_cJSON_AddItemToObject(object, "os_major", os_major);
-    __real_cJSON_AddItemToObject(object, "os_minor", os_minor);
-    __real_cJSON_AddItemToObject(object, "release", release);
-
-    will_return(__wrap_cJSON_Parse, parsed_json);
-    will_return(__wrap_cJSON_GetObjectItem, os_major);
-    will_return(__wrap_cJSON_GetObjectItem, os_minor);
-    will_return(__wrap_cJSON_GetObjectItem, NULL);
-    will_return(__wrap_cJSON_GetObjectItem, release);
-
-    expect_function_call(__wrap_cJSON_Delete);
-
-    int ret = wm_vuldet_get_os_unix_info(agent);
-
-    assert_int_equal(ret, 0);
-    assert_string_equal(agent->os_release, "10.0.1");
-    assert_string_equal(agent->kernel_release, "4.5.1");
-
-    __real_cJSON_Delete(parsed_json);
-}
-
-void test_wm_vuldet_get_os_unix_info_only_major(void **state)
-{
-    scan_agent *agent = *state;
-
-    const char *query = "agent 000 sql SELECT OS_MAJOR, OS_MINOR, OS_PATCH, RELEASE FROM SYS_OSINFO;";
-    size_t query_size = strlen(query) + 1;
-
-    char *response = "ok [{\"os_major\":\"10.0 LTS\"}]";
-    size_t response_size = strlen(response) + 1;
-
-    expect_value(__wrap_OS_SendSecureTCP, sock, 11111);
-    expect_value(__wrap_OS_SendSecureTCP, size, query_size);
-    expect_string(__wrap_OS_SendSecureTCP, msg, query);
-    will_return(__wrap_OS_SendSecureTCP, 0);
-
-    expect_value(__wrap_OS_RecvSecureTCP, sock, 11111);
-    expect_value(__wrap_OS_RecvSecureTCP, size, OS_SIZE_128);
-    will_return(__wrap_OS_RecvSecureTCP, response);
-    will_return(__wrap_OS_RecvSecureTCP, response_size);
-
-    cJSON* parsed_json = __real_cJSON_CreateArray();
-    cJSON* object = __real_cJSON_CreateObject();
-    __real_cJSON_AddItemToArray(parsed_json, object);
-    cJSON* os_major = __real_cJSON_CreateString("10.0");
-    __real_cJSON_AddItemToObject(object, "os_major", os_major);
-
-    will_return(__wrap_cJSON_Parse, parsed_json);
-    will_return(__wrap_cJSON_GetObjectItem, os_major);
-    will_return(__wrap_cJSON_GetObjectItem, NULL);
-    will_return(__wrap_cJSON_GetObjectItem, NULL);
-    will_return(__wrap_cJSON_GetObjectItem, NULL);
-
-    expect_function_call(__wrap_cJSON_Delete);
-
-    int ret = wm_vuldet_get_os_unix_info(agent);
-
-    assert_int_equal(ret, 0);
-    assert_string_equal(agent->os_release, "10.0.0");
-    assert_null(agent->kernel_release);
-
-    __real_cJSON_Delete(parsed_json);
-}
-
-void test_wm_vuldet_get_os_unix_info_only_release(void **state)
-{
-    scan_agent *agent = *state;
-
-    const char *query = "agent 000 sql SELECT OS_MAJOR, OS_MINOR, OS_PATCH, RELEASE FROM SYS_OSINFO;";
-    size_t query_size = strlen(query) + 1;
-
-    char *response = "ok [{\"release\":\"4.5.1\"}]";
-    size_t response_size = strlen(response) + 1;
-
-    expect_value(__wrap_OS_SendSecureTCP, sock, 11111);
-    expect_value(__wrap_OS_SendSecureTCP, size, query_size);
-    expect_string(__wrap_OS_SendSecureTCP, msg, query);
-    will_return(__wrap_OS_SendSecureTCP, 0);
-
-    expect_value(__wrap_OS_RecvSecureTCP, sock, 11111);
-    expect_value(__wrap_OS_RecvSecureTCP, size, OS_SIZE_128);
-    will_return(__wrap_OS_RecvSecureTCP, response);
-    will_return(__wrap_OS_RecvSecureTCP, response_size);
-
-    cJSON* parsed_json = __real_cJSON_CreateArray();
-    cJSON* object = __real_cJSON_CreateObject();
-    __real_cJSON_AddItemToArray(parsed_json, object);
-    cJSON* release = __real_cJSON_CreateString("4.5.1");
-    __real_cJSON_AddItemToObject(object, "release", release);
-
-    will_return(__wrap_cJSON_Parse, parsed_json);
-    will_return(__wrap_cJSON_GetObjectItem, NULL);
-    will_return(__wrap_cJSON_GetObjectItem, release);
-
-    expect_function_call(__wrap_cJSON_Delete);
-
-    int ret = wm_vuldet_get_os_unix_info(agent);
-
-    assert_int_equal(ret, 0);
-    assert_null(agent->os_release);
-    assert_string_equal(agent->kernel_release, "4.5.1");
-
-    __real_cJSON_Delete(parsed_json);
-}
-
-void test_wm_vuldet_get_os_unix_info_null_agent(void **state)
-{
-    scan_agent *agent = *state;
+    const char *os_major = NULL;
+    const char *os_minor = NULL;
+    const char *os_patch = NULL;
 
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5566): The agent structure is not initialized.");
 
-    int ret = wm_vuldet_get_os_unix_info(agent);
+    int ret = wm_vuldet_build_unix_os_release(agent, os_major, os_minor, os_patch);
 
     assert_int_equal(ret, -1);
 }
 
-void test_wm_vuldet_get_os_unix_info_request_invalid(void **state)
+void test_wm_vuldet_build_unix_os_release_os_major_null(void **state)
 {
     scan_agent *agent = *state;
-
-    const char *query = "agent 000 sql SELECT OS_MAJOR, OS_MINOR, OS_PATCH, RELEASE FROM SYS_OSINFO;";
-    size_t query_size = strlen(query) + 1;
-
-    expect_value(__wrap_OS_SendSecureTCP, sock, 11111);
-    expect_value(__wrap_OS_SendSecureTCP, size, query_size);
-    expect_string(__wrap_OS_SendSecureTCP, msg, query);
-    will_return(__wrap_OS_SendSecureTCP, 0);
-
-    expect_value(__wrap_OS_RecvSecureTCP, sock, 11111);
-    expect_value(__wrap_OS_RecvSecureTCP, size, OS_SIZE_128);
-    will_return(__wrap_OS_RecvSecureTCP, "");
-    will_return(__wrap_OS_RecvSecureTCP, 0);
+    const char *os_major = NULL;
+    const char *os_minor = NULL;
+    const char *os_patch = NULL;
 
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mterror, formatted_msg, "(5568): Couldn't get the OS information of the agent '000'");
+    expect_string(__wrap__mterror, formatted_msg, "(5568): Invalid OS information of the agent '000'");
 
-    int ret = wm_vuldet_get_os_unix_info(agent);
+    int ret = wm_vuldet_build_unix_os_release(agent, os_major, os_minor, os_patch);
 
     assert_int_equal(ret, -1);
-    assert_null(agent->os_release);
-    assert_null(agent->kernel_release);
 }
 
-void test_wm_vuldet_get_os_unix_info_request_error(void **state)
+void test_wm_vuldet_build_unix_os_release_mac (void **state)
 {
     scan_agent *agent = *state;
-
-    const char *query = "agent 000 sql SELECT OS_MAJOR, OS_MINOR, OS_PATCH, RELEASE FROM SYS_OSINFO;";
-    size_t query_size = strlen(query) + 1;
-
-    expect_string(__wrap_OS_ConnectUnixDomain, path, WDB_LOCAL_SOCK);
-    expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
-    expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_SIZE_6144);
-    will_return(__wrap_OS_ConnectUnixDomain, 11111);
-
-    expect_value(__wrap_OS_SendSecureTCP, sock, 11111);
-    expect_value(__wrap_OS_SendSecureTCP, size, query_size);
-    expect_string(__wrap_OS_SendSecureTCP, msg, query);
-    will_return(__wrap_OS_SendSecureTCP, 0);
-
-    expect_value(__wrap_OS_RecvSecureTCP, sock, 11111);
-    expect_value(__wrap_OS_RecvSecureTCP, size, OS_SIZE_128);
-    will_return(__wrap_OS_RecvSecureTCP, "err");
-    will_return(__wrap_OS_RecvSecureTCP, 3);
-
-    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mterror, formatted_msg, "(5530): Invalid response from wazuh-db: 'err'");
-
-    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mterror, formatted_msg, "(5568): Couldn't get the OS information of the agent '000'");
-
-    int ret = wm_vuldet_get_os_unix_info(agent);
-
-    assert_int_equal(ret, -1);
-    assert_null(agent->os_release);
-    assert_null(agent->kernel_release);
-}
-
-void test_wm_vuldet_get_os_unix_info_request_empty(void **state)
-{
-    scan_agent *agent = *state;
-
-    const char *query = "agent 000 sql SELECT OS_MAJOR, OS_MINOR, OS_PATCH, RELEASE FROM SYS_OSINFO;";
-    size_t query_size = strlen(query) + 1;
-
-    expect_value(__wrap_OS_SendSecureTCP, sock, 11111);
-    expect_value(__wrap_OS_SendSecureTCP, size, query_size);
-    expect_string(__wrap_OS_SendSecureTCP, msg, query);
-    will_return(__wrap_OS_SendSecureTCP, 0);
-
-    expect_value(__wrap_OS_RecvSecureTCP, sock, 11111);
-    expect_value(__wrap_OS_RecvSecureTCP, size, OS_SIZE_128);
-    will_return(__wrap_OS_RecvSecureTCP, "ok []");
-    will_return(__wrap_OS_RecvSecureTCP, 5);
-
-    int ret = wm_vuldet_get_os_unix_info(agent);
-
-    assert_int_equal(ret, 0);
-    assert_null(agent->os_release);
-    assert_null(agent->kernel_release);
-}
-
-void test_wm_vuldet_get_os_unix_info_request_parse_error(void **state)
-{
-    scan_agent *agent = *state;
-
-    const char *query = "agent 000 sql SELECT OS_MAJOR, OS_MINOR, OS_PATCH, RELEASE FROM SYS_OSINFO;";
-    size_t query_size = strlen(query) + 1;
-
-    expect_value(__wrap_OS_SendSecureTCP, sock, 11111);
-    expect_value(__wrap_OS_SendSecureTCP, size, query_size);
-    expect_string(__wrap_OS_SendSecureTCP, msg, query);
-    will_return(__wrap_OS_SendSecureTCP, 0);
-
-    expect_value(__wrap_OS_RecvSecureTCP, sock, 11111);
-    expect_value(__wrap_OS_RecvSecureTCP, size, OS_SIZE_128);
-    will_return(__wrap_OS_RecvSecureTCP, "ok answer");
-    will_return(__wrap_OS_RecvSecureTCP, 9);
-
-    will_return(__wrap_cJSON_Parse, NULL);
-
-    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mterror, formatted_msg, "(5568): Couldn't get the OS information of the agent '000'");
-
-    int ret = wm_vuldet_get_os_unix_info(agent);
-
-    assert_int_equal(ret, -1);
-    assert_null(agent->os_release);
-    assert_null(agent->kernel_release);
-}
-
-void test_wm_vuldet_get_os_unix_info_mac (void **state)
-{
-    scan_agent *agent = *state;
-
-    const char *query = "agent 000 sql SELECT OS_MAJOR, OS_MINOR, OS_PATCH, RELEASE FROM SYS_OSINFO;";
-    size_t query_size = strlen(query) + 1;
-
-    char *response = "ok [{\"os_major\":\"10\",\"os_minor\":\"15\",\"os_patch\":\"1\",\"release\":\"19.0.0\"}]";
-    size_t response_size = strlen(response) + 1;
-
-    expect_value(__wrap_OS_SendSecureTCP, sock, 11111);
-    expect_value(__wrap_OS_SendSecureTCP, size, query_size);
-    expect_string(__wrap_OS_SendSecureTCP, msg, query);
-    will_return(__wrap_OS_SendSecureTCP, 0);
-
-    expect_value(__wrap_OS_RecvSecureTCP, sock, 11111);
-    expect_value(__wrap_OS_RecvSecureTCP, size, OS_SIZE_128);
-    will_return(__wrap_OS_RecvSecureTCP, response);
-    will_return(__wrap_OS_RecvSecureTCP, response_size);
-
-    cJSON* parsed_json = __real_cJSON_CreateArray();
-    cJSON* object = __real_cJSON_CreateObject();
-    __real_cJSON_AddItemToArray(parsed_json, object);
-    cJSON* os_major = __real_cJSON_CreateString("10");
-    cJSON* os_minor = __real_cJSON_CreateString("15");
-    cJSON* os_patch = __real_cJSON_CreateString("1");
-    cJSON* release = __real_cJSON_CreateString("19.0.0");
-    __real_cJSON_AddItemToObject(object, "os_major", os_major);
-    __real_cJSON_AddItemToObject(object, "os_minor", os_minor);
-    __real_cJSON_AddItemToObject(object, "os_patch", os_patch);
-    __real_cJSON_AddItemToObject(object, "release", release);
-
-    will_return(__wrap_cJSON_Parse, parsed_json);
-    will_return(__wrap_cJSON_GetObjectItem, os_major);
-    will_return(__wrap_cJSON_GetObjectItem, os_minor);
-    will_return(__wrap_cJSON_GetObjectItem, os_patch);
-    will_return(__wrap_cJSON_GetObjectItem, release);
-
-    expect_function_call(__wrap_cJSON_Delete);
-
+    const char *os_major = "10";
+    const char *os_minor = "15";
+    const char *os_patch = "1";
     agent->dist = FEED_MAC;
-    int ret = wm_vuldet_get_os_unix_info(agent);
+
+    int ret = wm_vuldet_build_unix_os_release(agent, os_major, os_minor, os_patch);
 
     assert_int_equal(ret, 0);
     assert_string_equal(agent->os_release, "10.15.1");
-    assert_string_equal(agent->kernel_release, "19.0.0");
-
-    __real_cJSON_Delete(parsed_json);
 }
-#endif
+
+void test_wm_vuldet_build_unix_os_release_ubuntu (void **state)
+{
+    scan_agent *agent = *state;
+    const char *os_major = "20";
+    const char *os_minor = "10";
+    const char *os_patch = "1";
+    agent->dist = FEED_UBUNTU;
+
+    int ret = wm_vuldet_build_unix_os_release(agent, os_major, os_minor, os_patch);
+
+    assert_int_equal(ret, 0);
+    assert_string_equal(agent->os_release, "20.10");
+}
+
 /* wm_vuldet_linux_rm_nvd_not_affected_packages */
 
 void test_wm_vuldet_linux_rm_nvd_not_affected_packages_oval()
@@ -17969,6 +17715,8 @@ void test_wm_vuldet_send_removed_cve_report_ip_assigned_success() {
     int retval;
     scan_ctx_t scan_ctx;
     cJSON* j_vuln = NULL;
+    wm_max_eps = 1;
+
     char* alert = "{\"vulnerability\":{\"package\":{\"name\":\"ncurses\",\"version\":\"5.9-14.20130511.el7_4\","
                   "\"architecture\":\"x86_64\"},\"cve\":\"CVE-2019-17594\", \"status\":\"REMOVED\", \"reference\":"
                   "\"fb783b1c771a643f81259a93248e7f61e9a4a597\"}}";
@@ -18044,6 +17792,8 @@ void test_wm_vuldet_send_removed_cve_report_no_ip_success() {
     int retval;
     scan_ctx_t scan_ctx;
     cJSON* j_vuln = NULL;
+    wm_max_eps = 1;
+
     char* alert = "{\"vulnerability\":{\"package\":{\"name\":\"ncurses\",\"version\":\"5.9-14.20130511.el7_4\","
                   "\"architecture\":\"x86_64\"},\"cve\":\"CVE-2019-17594\", \"status\":\"REMOVED\", \"reference\":"
                   "\"fb783b1c771a643f81259a93248e7f61e9a4a597\"}}";
@@ -18113,18 +17863,11 @@ void test_wm_vuldet_send_removed_cve_report_no_ip_success() {
 int main(void)
 {
     const struct CMUnitTest tests[] = {
-        #if 0 //TODO #7749 Fix UTs
-        // Tests wm_vuldet_get_os_unix_info
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_get_os_unix_info, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_get_os_unix_info_only_major, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_get_os_unix_info_only_release, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test(test_wm_vuldet_get_os_unix_info_null_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_get_os_unix_info_request_invalid, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_get_os_unix_info_request_error, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_get_os_unix_info_request_empty, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_get_os_unix_info_request_parse_error, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_get_os_unix_info_mac, setup_scan_agent, teardown_scan_agent),
-        #endif
+        // Tests wm_vuldet_build_unix_os_release
+        cmocka_unit_test(test_wm_vuldet_build_unix_os_release_null_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_build_unix_os_release_os_major_null, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_build_unix_os_release_mac, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_build_unix_os_release_ubuntu, setup_scan_agent, teardown_scan_agent),
         // Tests wm_vuldet_linux_rm_nvd_not_affected_packages
         cmocka_unit_test(test_wm_vuldet_linux_rm_nvd_not_affected_packages_oval),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_linux_rm_nvd_not_affected_packages_vendor_Ubuntu, setup_scan_agent, teardown_scan_agent),
@@ -18304,10 +18047,10 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_error_j_package_create, setup_cve_report, teardown_cve_report),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_error_j_cvss_create, setup_cve_report, teardown_cve_report),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_error_j_cvss_node_create, setup_cve_report, teardown_cve_report),
-        #if 0 //TODO #7749 Fix UTs
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_error_j_advisories_create, setup_cve_report, teardown_cve_report),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_error_j_bug_references_create, setup_cve_report, teardown_cve_report),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_error_j_references_create, setup_cve_report, teardown_cve_report),
+        #if 0 //TODO #7749 Fix UTs
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_without_title, setup_cve_report, teardown_cve_report),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_without_condition, setup_cve_report, teardown_cve_report),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_without_ip, setup_cve_report, teardown_cve_report),
@@ -18567,7 +18310,6 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_MSU_max_attempts, setup_group, teardown_group),
         // Tests wm_vuldet_init
         cmocka_unit_test_setup_teardown(test_wm_vuldet_init_success, setup_group, teardown_group),
-        #if 0 //TODO #7749 Fix UTs
         // Tests wm_vuldet_update_last_scan
         cmocka_unit_test_setup_teardown(test_wm_vuldet_update_last_scan_full_success, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_update_last_scan_partial_success, setup_scan_agent, teardown_scan_agent),
@@ -18583,15 +18325,12 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_feed_changed_windows, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_feed_changed_nvd, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_feed_changed_updated, setup_scan_agent, teardown_scan_agent),
-        #endif
-        #if 0 //TODO #7749 Fix UTs
         // Tests wm_vuldet_find_obsolete_vulnerabilities
         cmocka_unit_test_setup_teardown(test_wm_vuldet_find_obsolete_vulnerabilities_baseline_success, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_find_obsolete_vulnerabilities_pending_status_fail, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_find_obsolete_vulnerabilities_obsolete_status_fail, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_find_obsolete_vulnerabilities_empty_success, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_find_obsolete_vulnerabilities_report_fail, setup_group, teardown_group),
-        #endif
         // Tests wm_vuldet_send_removed_cve_report
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_removed_cve_report_fail, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_removed_cve_report_ip_assigned_success, setup_group, teardown_group),

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -58,9 +58,9 @@ cJSON *wm_vuldet_get_cvss(const char *scoring_vector);
 void wm_vuldet_free_scan_agent(scan_agent *agent);
 int wm_vuldet_get_os_unix_info(scan_agent *agent);
 int wm_vuldet_generate_os_and_kernel_package(sqlite3 *db, scan_agent *agent);
-int wm_vuldet_report_agent_vulnerabilities(sqlite3 *db, scan_agent *agent, wm_vuldet_flags *flags);
+int wm_vuldet_find_agent_vulnerabilities(sqlite3 *db, scan_agent *agent, wm_vuldet_flags *flags, scan_ctx_t* scan_ctx);
 int wm_vuldet_discard_kernel_package(scan_agent *agent, const char *name, const char *version, const char *arch);
-int wm_vuldet_send_agent_report(sqlite3 *db, OSHash *cve_table, scan_agent *agents_it);
+int wm_vuldet_process_agent_vulnerabilities(sqlite3 *db, OSHash *cve_table, scan_agent *agents_it, scan_ctx_t *scan_ctx);
 int wm_vuldet_linux_rm_nvd_not_affected_packages(sqlite3 *db, scan_agent *agent, const char *cve, cve_vuln_pkg *first, int *vuln_discarded);
 void wm_vuldet_linux_rm_nvd_not_dependencies_met_packages(const char *cve, cve_vuln_pkg *first, int *vuln_discarded);
 void wm_vuldet_linux_rm_nvd_not_vulnerable_packages(const char *cve, cve_vuln_pkg *first, int *vuln_discarded);
@@ -607,8 +607,9 @@ static int teardown_info_cves(void **state) {
 }
 
 /* tests */
-#if 0 //TODO 7749 Fix UT
+
 /* wm_vuldet_get_os_unix_info */
+#if 0 //TODO #7749 Fix UTs
 void test_wm_vuldet_get_os_unix_info (void **state)
 {
     scan_agent *agent = *state;
@@ -921,7 +922,7 @@ void test_wm_vuldet_get_os_unix_info_mac (void **state)
 
     __real_cJSON_Delete(parsed_json);
 }
-
+#endif
 /* wm_vuldet_linux_rm_nvd_not_affected_packages */
 
 void test_wm_vuldet_linux_rm_nvd_not_affected_packages_oval()
@@ -1904,6 +1905,7 @@ void test_wm_vuldet_generate_os_and_kernel_package_ubuntu(void **state)
     agent->os_release = strdup("18.04");
     agent->kernel_release = strdup("3.10");
     agent->arch = strdup("x86_64");
+    agent->os_reference = strdup("94b6f7b3c1d905aae22a652448df6372da98e5b8");
 
     will_return_count(__wrap_sqlite3_prepare_v2, SQLITE_OK, 2);
     will_return_always(__wrap_sqlite3_bind_text, 0);
@@ -1928,6 +1930,10 @@ void test_wm_vuldet_generate_os_and_kernel_package_ubuntu(void **state)
     expect_value(__wrap_sqlite3_bind_text, pos, 9);
     expect_value(__wrap_sqlite3_bind_text, pos, 10);
     expect_string(__wrap_sqlite3_bind_text, buffer, "x86_64");
+    expect_value(__wrap_sqlite3_bind_text, pos, 11);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "94b6f7b3c1d905aae22a652448df6372da98e5b8");
+    expect_value(__wrap_sqlite3_bind_text, pos, 12);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "OS");
 
     // Kernel package
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
@@ -1946,6 +1952,10 @@ void test_wm_vuldet_generate_os_and_kernel_package_ubuntu(void **state)
     expect_value(__wrap_sqlite3_bind_text, pos, 9);
     expect_value(__wrap_sqlite3_bind_text, pos, 10);
     expect_string(__wrap_sqlite3_bind_text, buffer, "x86_64");
+    expect_value(__wrap_sqlite3_bind_text, pos, 11);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "94b6f7b3c1d905aae22a652448df6372da98e5b8");
+    expect_value(__wrap_sqlite3_bind_text, pos, 12);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "PACKAGE");
 
     int ret = wm_vuldet_generate_os_and_kernel_package(db, agent);
 
@@ -1962,6 +1972,7 @@ void test_wm_vuldet_generate_os_and_kernel_package_debian(void **state)
     agent->os_release = strdup("10");
     agent->kernel_release = strdup("4.11");
     agent->arch = strdup("x86_64");
+    agent->os_reference = strdup("94b6f7b3c1d905aae22a652448df6372da98e5b8");
 
     will_return_count(__wrap_sqlite3_prepare_v2, SQLITE_OK, 2);
     will_return_always(__wrap_sqlite3_bind_text, 0);
@@ -1986,6 +1997,10 @@ void test_wm_vuldet_generate_os_and_kernel_package_debian(void **state)
     expect_value(__wrap_sqlite3_bind_text, pos, 9);
     expect_value(__wrap_sqlite3_bind_text, pos, 10);
     expect_string(__wrap_sqlite3_bind_text, buffer, "x86_64");
+    expect_value(__wrap_sqlite3_bind_text, pos, 11);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "94b6f7b3c1d905aae22a652448df6372da98e5b8");
+    expect_value(__wrap_sqlite3_bind_text, pos, 12);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "OS");
 
     // Kernel package
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
@@ -2004,6 +2019,10 @@ void test_wm_vuldet_generate_os_and_kernel_package_debian(void **state)
     expect_value(__wrap_sqlite3_bind_text, pos, 9);
     expect_value(__wrap_sqlite3_bind_text, pos, 10);
     expect_string(__wrap_sqlite3_bind_text, buffer, "x86_64");
+    expect_value(__wrap_sqlite3_bind_text, pos, 11);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "94b6f7b3c1d905aae22a652448df6372da98e5b8");
+    expect_value(__wrap_sqlite3_bind_text, pos, 12);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "PACKAGE");
 
     int ret = wm_vuldet_generate_os_and_kernel_package(db, agent);
 
@@ -2020,6 +2039,7 @@ void test_wm_vuldet_generate_os_and_kernel_package_redhat(void **state)
     agent->os_release = strdup("7.2");
     agent->kernel_release = strdup("5.1.0");
     agent->arch = strdup("x86_64");
+    agent->os_reference = strdup("94b6f7b3c1d905aae22a652448df6372da98e5b8");
 
     will_return_count(__wrap_sqlite3_prepare_v2, SQLITE_OK, 2);
     will_return_always(__wrap_sqlite3_bind_text, 0);
@@ -2044,6 +2064,10 @@ void test_wm_vuldet_generate_os_and_kernel_package_redhat(void **state)
     expect_value(__wrap_sqlite3_bind_text, pos, 9);
     expect_value(__wrap_sqlite3_bind_text, pos, 10);
     expect_string(__wrap_sqlite3_bind_text, buffer, "x86_64");
+    expect_value(__wrap_sqlite3_bind_text, pos, 11);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "94b6f7b3c1d905aae22a652448df6372da98e5b8");
+    expect_value(__wrap_sqlite3_bind_text, pos, 12);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "OS");
 
     // Kernel package
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
@@ -2062,6 +2086,10 @@ void test_wm_vuldet_generate_os_and_kernel_package_redhat(void **state)
     expect_value(__wrap_sqlite3_bind_text, pos, 9);
     expect_value(__wrap_sqlite3_bind_text, pos, 10);
     expect_string(__wrap_sqlite3_bind_text, buffer, "x86_64");
+    expect_value(__wrap_sqlite3_bind_text, pos, 11);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "94b6f7b3c1d905aae22a652448df6372da98e5b8");
+    expect_value(__wrap_sqlite3_bind_text, pos, 12);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "PACKAGE");
 
     int ret = wm_vuldet_generate_os_and_kernel_package(db, agent);
 
@@ -2172,6 +2200,7 @@ void test_wm_vuldet_generate_os_and_kernel_package_release_end(void **state)
     agent->os_release = strdup("18.04");
     agent->kernel_release = strdup("3.10-0.0.0");
     agent->arch = strdup("x86_64");
+    agent->os_reference = strdup("94b6f7b3c1d905aae22a652448df6372da98e5b8");
 
     will_return_count(__wrap_sqlite3_prepare_v2, SQLITE_OK, 2);
     will_return_always(__wrap_sqlite3_bind_text, 0);
@@ -2196,6 +2225,10 @@ void test_wm_vuldet_generate_os_and_kernel_package_release_end(void **state)
     expect_value(__wrap_sqlite3_bind_text, pos, 9);
     expect_value(__wrap_sqlite3_bind_text, pos, 10);
     expect_string(__wrap_sqlite3_bind_text, buffer, "x86_64");
+    expect_value(__wrap_sqlite3_bind_text, pos, 11);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "94b6f7b3c1d905aae22a652448df6372da98e5b8");
+    expect_value(__wrap_sqlite3_bind_text, pos, 12);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "OS");
 
     // Kernel package
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
@@ -2214,6 +2247,10 @@ void test_wm_vuldet_generate_os_and_kernel_package_release_end(void **state)
     expect_value(__wrap_sqlite3_bind_text, pos, 9);
     expect_value(__wrap_sqlite3_bind_text, pos, 10);
     expect_string(__wrap_sqlite3_bind_text, buffer, "x86_64");
+    expect_value(__wrap_sqlite3_bind_text, pos, 11);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "94b6f7b3c1d905aae22a652448df6372da98e5b8");
+    expect_value(__wrap_sqlite3_bind_text, pos, 12);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "PACKAGE");
 
     int ret = wm_vuldet_generate_os_and_kernel_package(db, agent);
 
@@ -2490,12 +2527,14 @@ void test_wm_vuldel_truncate_revision(void ** state) {
 
 /* wm_vuldet_linux_oval_vulnerabilities */
 // TO DO #7749: Fix UT
-#if 0
+
 void test_wm_vuldet_linux_oval_vulnerabilities_error_prepare_nvd_configured_year(void **state)
 {
     sqlite3 *db = (sqlite3 *)1;
     scan_agent *agent = *state;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx;
+    scan_ctx.agent_id = 0;
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug1, formatted_msg, "(5456): Analyzing OVAL vulnerabilities for agent '000'");
@@ -2514,7 +2553,7 @@ void test_wm_vuldet_linux_oval_vulnerabilities_error_prepare_nvd_configured_year
 
     will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
-    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table);
+    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
 
     assert_int_equal(OS_INVALID, ret);
 }
@@ -2524,6 +2563,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_error_no_nvd_year(void **state)
     sqlite3 *db = (sqlite3 *)1;
     scan_agent *agent = *state;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx;
+    scan_ctx.agent_id = 0;
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug1, formatted_msg, "(5456): Analyzing OVAL vulnerabilities for agent '000'");
@@ -2537,7 +2578,7 @@ void test_wm_vuldet_linux_oval_vulnerabilities_error_no_nvd_year(void **state)
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5585): Couldn't get the NVD configured year.");
 
-    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table);
+    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
 
     assert_int_equal(OS_INVALID, ret);
 }
@@ -2547,6 +2588,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_error_prepare(void **state)
     sqlite3 *db = (sqlite3 *)1;
     scan_agent *agent = *state;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx;
+    scan_ctx.agent_id = 0;
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug1, formatted_msg, "(5456): Analyzing OVAL vulnerabilities for agent '000'");
@@ -2572,7 +2615,7 @@ void test_wm_vuldet_linux_oval_vulnerabilities_error_prepare(void **state)
 
     will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
-    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table);
+    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
 
     assert_int_equal(OS_INVALID, ret);
 }
@@ -2582,6 +2625,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_error_prepare_rh(void **state)
     sqlite3 *db = (sqlite3 *)1;
     scan_agent *agent = *state;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx;
+    scan_ctx.agent_id = 0;
 
     agent->dist = FEED_REDHAT;
 
@@ -2609,7 +2654,7 @@ void test_wm_vuldet_linux_oval_vulnerabilities_error_prepare_rh(void **state)
 
     will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
-    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table);
+    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
 
     assert_int_equal(OS_INVALID, ret);
 }
@@ -2619,6 +2664,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_error_prepare_deb(void **state)
     sqlite3 *db = (sqlite3 *)1;
     scan_agent *agent = *state;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx;
+    scan_ctx.agent_id = 0;
 
     agent->dist = FEED_DEBIAN;
 
@@ -2646,7 +2693,7 @@ void test_wm_vuldet_linux_oval_vulnerabilities_error_prepare_deb(void **state)
 
     will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
-    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table);
+    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
 
     assert_int_equal(OS_INVALID, ret);
 }
@@ -2656,6 +2703,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_error_step(void **state)
     sqlite3 *db = (sqlite3 *)1;
     scan_agent *agent = *state;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx;
+    scan_ctx.agent_id = 0;
 
     agent->dist = FEED_DEBIAN;
     agent->dist_ver = FEED_BUSTER;
@@ -2691,7 +2740,7 @@ void test_wm_vuldet_linux_oval_vulnerabilities_error_step(void **state)
 
     will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
-    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table);
+    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
 
     assert_int_equal(OS_INVALID, ret);
 }
@@ -2701,6 +2750,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_step_done(void **state)
     sqlite3 *db = (sqlite3 *)1;
     scan_agent *agent = *state;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx;
+    scan_ctx.agent_id = 0;
 
     agent->dist = FEED_DEBIAN;
     agent->dist_ver = FEED_BUSTER;
@@ -2732,7 +2783,7 @@ void test_wm_vuldet_linux_oval_vulnerabilities_step_done(void **state)
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug1, formatted_msg, "(5590): No vulnerabilities could be found in the OVAL for agent '000'");
 
-    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table);
+    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
 
     assert_int_equal(0, ret);
 }
@@ -2742,6 +2793,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_no_data(void **state)
     sqlite3 *db = (sqlite3 *)1;
     scan_agent *agent = *state;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx;
+    scan_ctx.agent_id = 0;
 
     agent->dist = FEED_DEBIAN;
     agent->dist_ver = FEED_BUSTER;
@@ -2790,6 +2843,10 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_no_data(void **state)
     will_return(__wrap_sqlite3_column_text, "10");
     expect_value(__wrap_sqlite3_column_text, iCol, 8);
     will_return(__wrap_sqlite3_column_text, NULL);
+    expect_value(__wrap_sqlite3_column_text, iCol, 9);
+    will_return(__wrap_sqlite3_column_text, NULL);
+    expect_value(__wrap_sqlite3_column_text, iCol, 10);
+    will_return(__wrap_sqlite3_column_text, NULL);
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -2799,7 +2856,7 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_no_data(void **state)
     will_return(__wrap_time, (time_t)1);
     expect_string(__wrap__mtdebug1, formatted_msg, "(5470): It took '0' seconds to 'find OVAL' vulnerabilities in agent '000'");
 
-    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table);
+    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
 
     assert_int_equal(OS_SUCCESS, ret);
 }
@@ -2809,6 +2866,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_bad_version(void **state)
     sqlite3 *db = (sqlite3 *)1;
     scan_agent *agent = *state;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx;
+    scan_ctx.agent_id = 0;
 
     agent->dist = FEED_DEBIAN;
     agent->dist_ver = FEED_BUSTER;
@@ -2863,8 +2922,12 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_bad_version(void **state)
     will_return(__wrap_sqlite3_column_text, "10");
     expect_value(__wrap_sqlite3_column_text, iCol, 8);
     will_return(__wrap_sqlite3_column_text, NULL);
+    expect_value(__wrap_sqlite3_column_text, iCol, 9);
+    will_return(__wrap_sqlite3_column_text, NULL);
+    expect_value(__wrap_sqlite3_column_text, iCol, 10);
+    will_return(__wrap_sqlite3_column_text, NULL);
 
-    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table);
+    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
 
     assert_int_equal(OS_INVALID, ret);
 
@@ -2876,6 +2939,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_not_fixed(void **state)
     sqlite3 *db = (sqlite3 *)1;
     scan_agent *agent = *state;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx;
+    scan_ctx.agent_id = 0;
 
     agent->dist = FEED_DEBIAN;
     agent->dist_ver = FEED_BUSTER;
@@ -2922,6 +2987,10 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_not_fixed(void **state)
     will_return(__wrap_sqlite3_column_text, NULL);
     expect_value(__wrap_sqlite3_column_text, iCol, 8);
     will_return(__wrap_sqlite3_column_text, NULL);
+    expect_value(__wrap_sqlite3_column_text, iCol, 9);
+    will_return(__wrap_sqlite3_column_text, "94b6f7b3c1d905aae22a652448df6372da98e5b8");
+    expect_value(__wrap_sqlite3_column_text, iCol, 10);
+    will_return(__wrap_sqlite3_column_text, "PACKAGE");
 
     // Adding cve node
     cve_vuln_pkg *Pkg = NULL;
@@ -2930,6 +2999,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_not_fixed(void **state)
         return;
 
     os_strdup("src_name1", Pkg->src_name);
+    os_strdup("94b6f7b3c1d905aae22a652448df6372da98e5b8", Pkg->reference);
+    os_strdup("PACKAGE", Pkg->type);
 
     expect_string(__wrap_OSHash_Add, key, "CVE-2020-1234");
     will_return(__wrap_OSHash_Add, 1);
@@ -2949,7 +3020,7 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_not_fixed(void **state)
     will_return(__wrap_time, (time_t)1);
     expect_string(__wrap__mtdebug1, formatted_msg, "(5470): It took '0' seconds to 'find OVAL' vulnerabilities in agent '000'");
 
-    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table);
+    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
 
     assert_int_equal(OS_SUCCESS, ret);
 
@@ -2961,6 +3032,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_not_vulnerable(void **sta
     sqlite3 *db = (sqlite3 *)1;
     scan_agent *agent = *state;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx;
+    scan_ctx.agent_id = 0;
 
     agent->dist = FEED_DEBIAN;
     agent->dist_ver = FEED_BUSTER;
@@ -3007,6 +3080,10 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_not_vulnerable(void **sta
     will_return(__wrap_sqlite3_column_text, "10");
     expect_value(__wrap_sqlite3_column_text, iCol, 8);
     will_return(__wrap_sqlite3_column_text, NULL);
+    expect_value(__wrap_sqlite3_column_text, iCol, 9);
+    will_return(__wrap_sqlite3_column_text, NULL);
+    expect_value(__wrap_sqlite3_column_text, iCol, 10);
+    will_return(__wrap_sqlite3_column_text, NULL);
 
     // Adding cve node
     cve_vuln_pkg *Pkg = NULL;
@@ -3030,7 +3107,7 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_not_vulnerable(void **sta
     will_return(__wrap_time, (time_t)1);
     expect_string(__wrap__mtdebug1, formatted_msg, "(5470): It took '0' seconds to 'find OVAL' vulnerabilities in agent '000'");
 
-    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table);
+    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
 
     assert_int_equal(OS_SUCCESS, ret);
 
@@ -3042,6 +3119,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_centos_not_vulnerable(voi
     sqlite3 *db = (sqlite3 *)1;
     scan_agent *agent = *state;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx;
+    scan_ctx.agent_id = 0;
 
     agent->dist = FEED_REDHAT;
     agent->dist_ver = FEED_RHEL8;
@@ -3089,6 +3168,10 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_centos_not_vulnerable(voi
     will_return(__wrap_sqlite3_column_text, "5.1.2-3.el8_1");
     expect_value(__wrap_sqlite3_column_text, iCol, 8);
     will_return(__wrap_sqlite3_column_text, "CentOS");
+    expect_value(__wrap_sqlite3_column_text, iCol, 9);
+    will_return(__wrap_sqlite3_column_text, NULL);
+    expect_value(__wrap_sqlite3_column_text, iCol, 10);
+    will_return(__wrap_sqlite3_column_text, NULL);
 
     // Adding cve node
     cve_vuln_pkg *Pkg = NULL;
@@ -3112,7 +3195,7 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_centos_not_vulnerable(voi
     will_return(__wrap_time, (time_t)1);
     expect_string(__wrap__mtdebug1, formatted_msg, "(5470): It took '0' seconds to 'find OVAL' vulnerabilities in agent '000'");
 
-    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table);
+    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
 
     assert_int_equal(OS_SUCCESS, ret);
 
@@ -3124,6 +3207,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_error_comparing(void **st
     sqlite3 *db = (sqlite3 *)1;
     scan_agent *agent = *state;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx;
+    scan_ctx.agent_id = 0;
 
     agent->dist = FEED_DEBIAN;
     agent->dist_ver = FEED_BUSTER;
@@ -3170,6 +3255,10 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_error_comparing(void **st
     will_return(__wrap_sqlite3_column_text, "10");
     expect_value(__wrap_sqlite3_column_text, iCol, 8);
     will_return(__wrap_sqlite3_column_text, NULL);
+    expect_value(__wrap_sqlite3_column_text, iCol, 9);
+    will_return(__wrap_sqlite3_column_text, NULL);
+    expect_value(__wrap_sqlite3_column_text, iCol, 10);
+    will_return(__wrap_sqlite3_column_text, NULL);
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5487): Unknown relation 'unexisting relation' between versions '10' and '5.1.1' for package 'package'");
@@ -3182,7 +3271,7 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_error_comparing(void **st
     will_return(__wrap_time, (time_t)1);
     expect_string(__wrap__mtdebug1, formatted_msg, "(5470): It took '0' seconds to 'find OVAL' vulnerabilities in agent '000'");
 
-    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table);
+    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
 
     assert_int_equal(OS_SUCCESS, ret);
 
@@ -3193,6 +3282,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_vulnerable(void **state)
     sqlite3 *db = (sqlite3 *)1;
     scan_agent *agent = *state;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx;
+    scan_ctx.agent_id = 0;
 
     agent->dist = FEED_DEBIAN;
     agent->dist_ver = FEED_BUSTER;
@@ -3239,6 +3330,10 @@ void test_wm_vuldet_linux_oval_vulnerabilities_vulnerable(void **state)
     will_return(__wrap_sqlite3_column_text, "5.1.0");
     expect_value(__wrap_sqlite3_column_text, iCol, 8);
     will_return(__wrap_sqlite3_column_text, NULL);
+    expect_value(__wrap_sqlite3_column_text, iCol, 9);
+    will_return(__wrap_sqlite3_column_text, "94b6f7b3c1d905aae22a652448df6372da98e5b8");
+    expect_value(__wrap_sqlite3_column_text, iCol, 10);
+    will_return(__wrap_sqlite3_column_text, "PACKAGE");
 
     // Adding cve node
     cve_vuln_pkg *Pkg2 = NULL;
@@ -3250,6 +3345,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_vulnerable(void **state)
     os_strdup("package2", Pkg2->bin_name);
     os_strdup("5.1.2", Pkg2->version);
     os_strdup("x64", Pkg2->arch);
+    os_strdup("94b6f7b3c1d905aae22a652448df6372da98e5b8", Pkg2->reference);
+    os_strdup("PACKAGE", Pkg2->type);
 
     expect_value(__wrap_pkg_version_relate, rel, PKG_RELATION_LT);
     will_return(__wrap_pkg_version_relate, true);
@@ -3272,7 +3369,7 @@ void test_wm_vuldet_linux_oval_vulnerabilities_vulnerable(void **state)
     will_return(__wrap_time, (time_t)1);
     expect_string(__wrap__mtdebug1, formatted_msg, "(5470): It took '0' seconds to 'find OVAL' vulnerabilities in agent '000'");
 
-    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table);
+    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
 
     assert_int_equal(OS_SUCCESS, ret);
 
@@ -3284,6 +3381,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_insert_package_error(void **state
     sqlite3 *db = (sqlite3 *)1;
     scan_agent *agent = *state;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx;
+    scan_ctx.agent_id = 0;
 
     agent->dist = FEED_DEBIAN;
     agent->dist_ver = FEED_BUSTER;
@@ -3330,6 +3429,10 @@ void test_wm_vuldet_linux_oval_vulnerabilities_insert_package_error(void **state
     will_return(__wrap_sqlite3_column_text, "10");
     expect_value(__wrap_sqlite3_column_text, iCol, 8);
     will_return(__wrap_sqlite3_column_text, NULL);
+    expect_value(__wrap_sqlite3_column_text, iCol, 9);
+    will_return(__wrap_sqlite3_column_text, "94b6f7b3c1d905aae22a652448df6372da98e5b8");
+    expect_value(__wrap_sqlite3_column_text, iCol, 10);
+    will_return(__wrap_sqlite3_column_text, "PACKAGE");
 
     // wm_checks_package_vulnerability
     expect_value(__wrap_pkg_version_relate, rel, PKG_RELATION_GT);
@@ -3345,6 +3448,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_insert_package_error(void **state
     os_strdup("package2", Pkg2->bin_name);
     os_strdup("5.1.2", Pkg2->version);
     os_strdup("x64", Pkg2->arch);
+    os_strdup("94b6f7b3c1d905aae22a652448df6372da98e5b8", Pkg2->reference);
+    os_strdup("PACKAGE", Pkg2->type);
 
     expect_string(__wrap_OSHash_Add, key, "CVE-2020-1234");
     will_return(__wrap_OSHash_Add, 0);
@@ -3360,7 +3465,7 @@ void test_wm_vuldet_linux_oval_vulnerabilities_insert_package_error(void **state
     will_return(__wrap_time, (time_t)1);
     expect_string(__wrap__mtdebug1, formatted_msg, "(5470): It took '0' seconds to 'find OVAL' vulnerabilities in agent '000'");
 
-    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table);
+    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
 
     assert_int_equal(OS_SUCCESS, ret);
 
@@ -3372,6 +3477,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_duplicated_package(void **state)
     sqlite3 *db = (sqlite3 *)1;
     scan_agent *agent = *state;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx;
+    scan_ctx.agent_id = 0;
 
     agent->dist = FEED_DEBIAN;
     agent->dist_ver = FEED_BUSTER;
@@ -3418,6 +3525,10 @@ void test_wm_vuldet_linux_oval_vulnerabilities_duplicated_package(void **state)
     will_return(__wrap_sqlite3_column_text, "4.0.0");
     expect_value(__wrap_sqlite3_column_text, iCol, 8);
     will_return(__wrap_sqlite3_column_text, NULL);
+    expect_value(__wrap_sqlite3_column_text, iCol, 9);
+    will_return(__wrap_sqlite3_column_text, "94b6f7b3c1d905aae22a652448df6372da98e5b8");
+    expect_value(__wrap_sqlite3_column_text, iCol, 10);
+    will_return(__wrap_sqlite3_column_text, "PACKAGE");
 
     // wm_checks_package_vulnerability
     expect_value(__wrap_pkg_version_relate, rel, PKG_RELATION_LT);
@@ -3433,6 +3544,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_duplicated_package(void **state)
     w_strdup("source", vuln_pkg->src_name);
     os_strdup("4.0.0", vuln_pkg->version);
     os_strdup("x64", vuln_pkg->arch);
+    os_strdup("94b6f7b3c1d905aae22a652448df6372da98e5b8", vuln_pkg->reference);
+    os_strdup("PACKAGE", vuln_pkg->type);
 
     os_calloc(1, sizeof(cve_vuln_cond), vuln_pkg->vuln_cond);
 
@@ -3459,7 +3572,7 @@ void test_wm_vuldet_linux_oval_vulnerabilities_duplicated_package(void **state)
     will_return(__wrap_time, (time_t)1);
     expect_string(__wrap__mtdebug1, formatted_msg, "(5470): It took '0' seconds to 'find OVAL' vulnerabilities in agent '000'");
 
-    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table);
+    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
 
     assert_int_equal(OS_SUCCESS, ret);
 
@@ -3471,6 +3584,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_external_vendor(void **state)
     sqlite3 *db = (sqlite3 *)1;
     scan_agent *agent = *state;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx;
+    scan_ctx.agent_id = 0;
 
     agent->dist = FEED_REDHAT;
     agent->dist_ver = FEED_RHEL7;
@@ -3517,6 +3632,10 @@ void test_wm_vuldet_linux_oval_vulnerabilities_external_vendor(void **state)
     will_return(__wrap_sqlite3_column_text, "10");
     expect_value(__wrap_sqlite3_column_text, iCol, 8);
     will_return(__wrap_sqlite3_column_text, "third-party");
+    expect_value(__wrap_sqlite3_column_text, iCol, 9);
+    will_return(__wrap_sqlite3_column_text, NULL);
+    expect_value(__wrap_sqlite3_column_text, iCol, 10);
+    will_return(__wrap_sqlite3_column_text, NULL);
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5486): Discarded package 'package' from a third-party source ('third-party') for agent '000'");
@@ -3529,11 +3648,10 @@ void test_wm_vuldet_linux_oval_vulnerabilities_external_vendor(void **state)
     will_return(__wrap_time, (time_t)1);
     expect_string(__wrap__mtdebug1, formatted_msg, "(5470): It took '0' seconds to 'find OVAL' vulnerabilities in agent '000'");
 
-    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table);
+    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table, &scan_ctx);
 
     assert_int_equal(OS_SUCCESS, ret);
 }
-#endif
 
 /* wm_vuldet_build_nvd_report_condition */
 
@@ -4572,14 +4690,16 @@ void test_wm_vuldet_fill_report_oval_data(void **state)
     wm_vuldet_free_report(report);
 }
 
-/* wm_vuldet_send_agent_report */
-// TO DO #7749: Fix UT
-#if 0
-void test_wm_vuldet_send_agent_report_no_hash_node_rh(void **state)
+/* wm_vuldet_process_agent_vulnerabilities */
+
+void test_wm_vuldet_process_agent_vulnerabilities_no_hash_node_rh(void **state)
 {
     scan_agent *agent = *state;
     sqlite3 *db = (sqlite3 *)1;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx;
+    scan_ctx.scan_type = VU_BASELINE_SCAN;
+    scan_ctx.agent_id = 0;
 
     agent->dist = FEED_REDHAT;
 
@@ -4603,16 +4723,19 @@ void test_wm_vuldet_send_agent_report_no_hash_node_rh(void **state)
     expect_value(__wrap_OSHash_Begin, self, cve_table);
     will_return(__wrap_OSHash_Begin, NULL);
 
-    int ret = wm_vuldet_send_agent_report(db, cve_table, agent);
+    int ret = wm_vuldet_process_agent_vulnerabilities(db, cve_table, agent, &scan_ctx);
 
     assert_int_equal(ret, OS_SUCCESS);
 }
 
-void test_wm_vuldet_send_agent_report_no_hash_node_ubuntu(void **state)
+void test_wm_vuldet_process_agent_vulnerabilities_no_hash_node_ubuntu(void **state)
 {
     scan_agent *agent = *state;
     sqlite3 *db = (sqlite3 *)1;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx;
+    scan_ctx.scan_type = VU_BASELINE_SCAN;
+    scan_ctx.agent_id = 0;
 
     agent->dist = FEED_UBUNTU;
     agent->dist_ver = FEED_FOCAL;
@@ -4637,16 +4760,19 @@ void test_wm_vuldet_send_agent_report_no_hash_node_ubuntu(void **state)
     expect_value(__wrap_OSHash_Begin, self, cve_table);
     will_return(__wrap_OSHash_Begin, NULL);
 
-    int ret = wm_vuldet_send_agent_report(db, cve_table, agent);
+    int ret = wm_vuldet_process_agent_vulnerabilities(db, cve_table, agent, &scan_ctx);
 
     assert_int_equal(ret, OS_SUCCESS);
 }
 
-void test_wm_vuldet_send_agent_report_fill_report_nvd_cve_info_error(void **state)
+void test_wm_vuldet_process_agent_vulnerabilities_fill_report_nvd_cve_info_error(void **state)
 {
     scan_agent *agent = *state;
     sqlite3 *db = (sqlite3 *)1;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx;
+    scan_ctx.scan_type = VU_BASELINE_SCAN;
+    scan_ctx.agent_id = 0;
 
     agent->dist = FEED_UBUNTU;
     agent->dist_ver = FEED_FOCAL;
@@ -4673,7 +4799,7 @@ void test_wm_vuldet_send_agent_report_fill_report_nvd_cve_info_error(void **stat
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
     will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
-    int ret = wm_vuldet_send_agent_report(db, cve_table, agent);
+    int ret = wm_vuldet_process_agent_vulnerabilities(db, cve_table, agent, &scan_ctx);
 
     assert_int_equal(ret, OS_INVALID);
 
@@ -4682,11 +4808,14 @@ void test_wm_vuldet_send_agent_report_fill_report_nvd_cve_info_error(void **stat
     os_free(node);
 }
 
-void test_wm_vuldet_send_agent_report_fill_report_nvd_references_error(void **state)
+void test_wm_vuldet_process_agent_vulnerabilities_fill_report_nvd_references_error(void **state)
 {
     scan_agent *agent = *state;
     sqlite3 *db = (sqlite3 *)1;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx;
+    scan_ctx.scan_type = VU_BASELINE_SCAN;
+    scan_ctx.agent_id = 0;
 
     agent->dist = FEED_UBUNTU;
     agent->dist_ver = FEED_FOCAL;
@@ -4733,7 +4862,7 @@ void test_wm_vuldet_send_agent_report_fill_report_nvd_references_error(void **st
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
     will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
-    int ret = wm_vuldet_send_agent_report(db, cve_table, agent);
+    int ret = wm_vuldet_process_agent_vulnerabilities(db, cve_table, agent, &scan_ctx);
 
     assert_int_equal(ret, OS_INVALID);
 
@@ -4742,11 +4871,14 @@ void test_wm_vuldet_send_agent_report_fill_report_nvd_references_error(void **st
     os_free(node);
 }
 
-void test_wm_vuldet_send_agent_report_fill_report_nvd_scoring_error(void **state)
+void test_wm_vuldet_process_agent_vulnerabilities_fill_report_nvd_scoring_error(void **state)
 {
     scan_agent *agent = *state;
     sqlite3 *db = (sqlite3 *)1;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx;
+    scan_ctx.scan_type = VU_BASELINE_SCAN;
+    scan_ctx.agent_id = 0;
 
     agent->dist = FEED_UBUNTU;
     agent->dist_ver = FEED_FOCAL;
@@ -4804,7 +4936,7 @@ void test_wm_vuldet_send_agent_report_fill_report_nvd_scoring_error(void **state
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
     will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
-    int ret = wm_vuldet_send_agent_report(db, cve_table, agent);
+    int ret = wm_vuldet_process_agent_vulnerabilities(db, cve_table, agent, &scan_ctx);
 
     assert_int_equal(ret, OS_INVALID);
 
@@ -4813,11 +4945,14 @@ void test_wm_vuldet_send_agent_report_fill_report_nvd_scoring_error(void **state
     os_free(node);
 }
 
-void test_wm_vuldet_send_agent_report_fill_report_oval_error(void **state)
+void test_wm_vuldet_process_agent_vulnerabilities_fill_report_oval_error(void **state)
 {
     scan_agent *agent = *state;
     sqlite3 *db = (sqlite3 *)1;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx;
+    scan_ctx.scan_type = VU_BASELINE_SCAN;
+    scan_ctx.agent_id = 0;
 
     agent->dist = FEED_UBUNTU;
     agent->dist_ver = FEED_FOCAL;
@@ -4844,7 +4979,7 @@ void test_wm_vuldet_send_agent_report_fill_report_oval_error(void **state)
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
     will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
-    int ret = wm_vuldet_send_agent_report(db, cve_table, agent);
+    int ret = wm_vuldet_process_agent_vulnerabilities(db, cve_table, agent, &scan_ctx);
 
     assert_int_equal(ret, OS_INVALID);
 
@@ -4853,11 +4988,14 @@ void test_wm_vuldet_send_agent_report_fill_report_oval_error(void **state)
     os_free(node);
 }
 
-void test_wm_vuldet_send_agent_report_vuln_cves_insert_error(void **state)
+void test_wm_vuldet_process_agent_vulnerabilities_vuln_cves_insert_error(void **state)
 {
     scan_agent *agent = *state;
     sqlite3 *db = (sqlite3 *)1;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx;
+    scan_ctx.scan_type = VU_BASELINE_SCAN;
+    scan_ctx.agent_id = 0;
 
     wm_max_eps = 1000000;
 
@@ -5017,7 +5155,7 @@ void test_wm_vuldet_send_agent_report_vuln_cves_insert_error(void **state)
     will_return(__wrap_time, (time_t)1);
     expect_string(__wrap__mtdebug1, formatted_msg, "(5470): It took '0' seconds to 'report' vulnerabilities in agent '000'");
 
-    int ret = wm_vuldet_send_agent_report(db, cve_table, agent);
+    int ret = wm_vuldet_process_agent_vulnerabilities(db, cve_table, agent, &scan_ctx);
 
     assert_int_equal(ret, OS_SUCCESS);
 
@@ -5026,11 +5164,14 @@ void test_wm_vuldet_send_agent_report_vuln_cves_insert_error(void **state)
     os_free(node);
 }
 
-void test_wm_vuldet_send_agent_report_send_cve_report_error(void **state)
+void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_error(void **state)
 {
     scan_agent *agent = *state;
     sqlite3 *db = (sqlite3 *)1;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx;
+    scan_ctx.scan_type = VU_BASELINE_SCAN;
+    scan_ctx.agent_id = 0;
 
     wm_max_eps = 1000000;
 
@@ -5186,7 +5327,7 @@ void test_wm_vuldet_send_agent_report_send_cve_report_error(void **state)
     will_return(__wrap_time, (time_t)1);
     expect_string(__wrap__mtdebug1, formatted_msg, "(5470): It took '0' seconds to 'report' vulnerabilities in agent '000'");
 
-    int ret = wm_vuldet_send_agent_report(db, cve_table, agent);
+    int ret = wm_vuldet_process_agent_vulnerabilities(db, cve_table, agent, &scan_ctx);
 
     assert_int_equal(ret, OS_SUCCESS);
 
@@ -5195,11 +5336,14 @@ void test_wm_vuldet_send_agent_report_send_cve_report_error(void **state)
     os_free(node);
 }
 
-void test_wm_vuldet_send_agent_report_send_cve_report_negative_version(void **state)
+void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_negative_version(void **state)
 {
     scan_agent *agent = *state;
     sqlite3 *db = (sqlite3 *)1;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx;
+    scan_ctx.scan_type = VU_BASELINE_SCAN;
+    scan_ctx.agent_id = 0;
 
     wm_max_eps = 1000000;
 
@@ -5359,7 +5503,7 @@ void test_wm_vuldet_send_agent_report_send_cve_report_negative_version(void **st
     will_return(__wrap_time, (time_t)1);
     expect_string(__wrap__mtdebug1, formatted_msg, "(5470): It took '0' seconds to 'report' vulnerabilities in agent '000'");
 
-    int ret = wm_vuldet_send_agent_report(db, cve_table, agent);
+    int ret = wm_vuldet_process_agent_vulnerabilities(db, cve_table, agent, &scan_ctx);
 
     assert_int_equal(ret, OS_SUCCESS);
 
@@ -5368,11 +5512,14 @@ void test_wm_vuldet_send_agent_report_send_cve_report_negative_version(void **st
     os_free(node);
 }
 
-void test_wm_vuldet_send_agent_report_send_cve_report_adding_data_from_OVAL_error(void **state)
+void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_adding_data_from_OVAL_error(void **state)
 {
     scan_agent *agent = *state;
     sqlite3 *db = (sqlite3 *)1;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx;
+    scan_ctx.scan_type = VU_BASELINE_SCAN;
+    scan_ctx.agent_id = 0;
 
     wm_max_eps = 1000000;
 
@@ -5496,7 +5643,7 @@ void test_wm_vuldet_send_agent_report_send_cve_report_adding_data_from_OVAL_erro
     expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
     will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
-    int ret = wm_vuldet_send_agent_report(db, cve_table, agent);
+    int ret = wm_vuldet_process_agent_vulnerabilities(db, cve_table, agent, &scan_ctx);
 
     assert_int_equal(ret, -1);
 
@@ -5505,10 +5652,13 @@ void test_wm_vuldet_send_agent_report_send_cve_report_adding_data_from_OVAL_erro
     os_free(node);
 }
 
-void test_wm_vuldet_send_agent_report_send_cve_report_without_errors_OVAL(void **state)
+void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_without_errors_OVAL(void **state)
 {
     // wm_vuldet_init
     wm_vuldet_t *vuldet = calloc(1, sizeof(wm_vuldet_t));
+    scan_ctx_t scan_ctx;
+    scan_ctx.scan_type = VU_BASELINE_SCAN;
+    scan_ctx.agent_id = 0;
 
     if (!vuldet) {
         return;
@@ -5842,7 +5992,7 @@ void test_wm_vuldet_send_agent_report_send_cve_report_without_errors_OVAL(void *
     will_return(__wrap_time, (time_t)1);
     expect_string(__wrap__mtdebug1, formatted_msg, "(5470): It took '0' seconds to 'report' vulnerabilities in agent '000'");
 
-    int ret = wm_vuldet_send_agent_report(db, cve_table, agent);
+    int ret = wm_vuldet_process_agent_vulnerabilities(db, cve_table, agent, &scan_ctx);
 
     assert_int_equal(ret, OS_SUCCESS);
 
@@ -5852,10 +6002,13 @@ void test_wm_vuldet_send_agent_report_send_cve_report_without_errors_OVAL(void *
     os_free(vuldet);
 }
 
-void test_wm_vuldet_send_agent_report_send_cve_report_without_errors_NVD(void **state)
+void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_without_errors_NVD(void **state)
 {
     // wm_vuldet_init
     wm_vuldet_t *vuldet = calloc(1, sizeof(wm_vuldet_t));
+    scan_ctx_t scan_ctx;
+    scan_ctx.scan_type = VU_BASELINE_SCAN;
+    scan_ctx.agent_id = 0;
 
     if (!vuldet) {
         return;
@@ -6189,7 +6342,7 @@ void test_wm_vuldet_send_agent_report_send_cve_report_without_errors_NVD(void **
     will_return(__wrap_time, (time_t)1);
     expect_string(__wrap__mtdebug1, formatted_msg, "(5470): It took '0' seconds to 'report' vulnerabilities in agent '000'");
 
-    int ret = wm_vuldet_send_agent_report(db, cve_table, agent);
+    int ret = wm_vuldet_process_agent_vulnerabilities(db, cve_table, agent, &scan_ctx);
 
     assert_int_equal(ret, OS_SUCCESS);
 
@@ -6198,7 +6351,7 @@ void test_wm_vuldet_send_agent_report_send_cve_report_without_errors_NVD(void **
     os_free(node);
     os_free(vuldet);
 }
-#endif
+
 /* wm_vuldet_get_cvss */
 
 void test_wm_vuldet_get_cvss_null(void ** state)
@@ -6823,7 +6976,7 @@ void test_wm_vuldet_get_cvss_v3(void ** state)
 
 /* wm_vuldet_send_cve_report */
 // TO DO #7749: Fix UT
-#if 0
+
 void test_wm_vuldet_send_cve_report_error_alert_create(void **state)
 {
     vu_report* report = state[REPORT_CVE_REPORT_POS];
@@ -8382,7 +8535,7 @@ void test_wm_vuldet_send_cve_report_sendmsg_error(void **state)
 
     os_free(strerr);
 }
-#endif
+
 /* wm_vuldet_extract_advisories */
 
 void test_wm_vuldet_extract_advisories_no_advisories(void **state)
@@ -8775,59 +8928,69 @@ void test_wm_vuldet_free_cve_node(void **state)
     next_pkg = NULL;
 }
 
-/* wm_vuldet_report_agent_vulnerabilities */
+/* wm_vuldet_find_agent_vulnerabilities */
 // TO DO #7749: Fix UT
-#if 0
-void test_wm_vuldet_report_agent_vulnerabilities_agent_info_NULL(void **state)
+
+void test_wm_vuldet_find_agent_vulnerabilities_agent_info_NULL(void **state)
 {
     sqlite3 *db = (sqlite3 *)1;
     scan_agent *agent = *state;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx = {0};
+    scan_ctx.agent_id = 0;
+    scan_ctx.scan_type = VU_FULL_SCAN;
 
-    int ret = wm_vuldet_report_agent_vulnerabilities(db, agent, NULL);
+
+    int ret = wm_vuldet_find_agent_vulnerabilities(db, agent, NULL, &scan_ctx);
     assert_int_equal(ret, 0);
 
 }
 
-void test_wm_vuldet_report_agent_vulnerabilities_agent_windows_error(void **state)
+void test_wm_vuldet_find_agent_vulnerabilities_agent_windows_error(void **state)
 {
     sqlite3 *db = (sqlite3 *)1;
     scan_agent *agent = *state;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx = {0};
+    scan_ctx.agent_id = 0;
+    scan_ctx.scan_type = VU_FULL_SCAN;
 
-    agent->info = 'T';
     agent->dist = FEED_WIN;
 
     will_return(__wrap_wm_vuldet_win_nvd_vulnerabilities, -1);
 
-    int ret = wm_vuldet_report_agent_vulnerabilities(db, agent, NULL);
+    int ret = wm_vuldet_find_agent_vulnerabilities(db, agent, NULL, &scan_ctx);
     assert_int_equal(ret, -1);
 
 }
 
-void test_wm_vuldet_report_agent_vulnerabilities_agent_windows_OK(void **state)
+void test_wm_vuldet_find_agent_vulnerabilities_agent_windows_OK(void **state)
 {
     sqlite3 *db = (sqlite3 *)1;
     scan_agent *agent = *state;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx = {0};
+    scan_ctx.agent_id = 0;
+    scan_ctx.scan_type = VU_FULL_SCAN;
 
-    agent->info = 'T';
     agent->dist = FEED_WIN;
 
     will_return(__wrap_wm_vuldet_win_nvd_vulnerabilities, 0);
 
-    int ret = wm_vuldet_report_agent_vulnerabilities(db, agent, NULL);
+    int ret = wm_vuldet_find_agent_vulnerabilities(db, agent, NULL, &scan_ctx);
     assert_int_equal(ret, 0);
 
 }
 
-void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_create_hash_error(void **state)
+void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_create_hash_error(void **state)
 {
     sqlite3 *db = (sqlite3 *)1;
     scan_agent *agent = *state;
     OSHash *cve_table = NULL;
+    scan_ctx_t scan_ctx = {0};
+    scan_ctx.agent_id = 0;
+    scan_ctx.scan_type = VU_FULL_SCAN;
 
-    agent->info = 'T';
     agent->dist = FEED_CANONICAL;
 
     expect_function_call(__wrap_OSHash_Create);
@@ -8835,18 +8998,20 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_create_hash_error(v
 
     expect_string(__wrap__merror, formatted_msg, "(1290): Unable to create a new list (calloc).");
 
-    int ret = wm_vuldet_report_agent_vulnerabilities(db, agent, NULL);
+    int ret = wm_vuldet_find_agent_vulnerabilities(db, agent, NULL, &scan_ctx);
     assert_int_equal(ret, -1);
 
 }
 
-void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_setSize_hash_error(void **state)
+void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_setSize_hash_error(void **state)
 {
     sqlite3 *db = (sqlite3 *)1;
     scan_agent *agent = *state;
     OSHash *cve_table = NULL;
+    scan_ctx_t scan_ctx = {0};
+    scan_ctx.agent_id = 0;
+    scan_ctx.scan_type = VU_FULL_SCAN;
 
-    agent->info = 'T';
     agent->dist = FEED_CANONICAL;
 
     expect_function_call(__wrap_OSHash_Create);
@@ -8857,18 +9022,20 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_setSize_hash_error(
 
     expect_string(__wrap__merror, formatted_msg, "(1290): Unable to create a new list (calloc).");
 
-    int ret = wm_vuldet_report_agent_vulnerabilities(db, agent, NULL);
+    int ret = wm_vuldet_find_agent_vulnerabilities(db, agent, NULL, &scan_ctx);
     assert_int_equal(ret, -1);
 
 }
 
-void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_oval_vulnerabilities_error(void **state)
+void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_oval_vulnerabilities_error(void **state)
 {
     sqlite3 *db = (sqlite3 *)1;
     scan_agent *agent = *state;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx = {0};
+    scan_ctx.agent_id = 0;
+    scan_ctx.scan_type = VU_FULL_SCAN;
 
-    agent->info = 'T';
     agent->dist = FEED_CANONICAL;
 
     expect_function_call(__wrap_OSHash_Create);
@@ -8902,18 +9069,20 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_oval_vulnerabilitie
 
     will_return(__wrap_OSHash_Clean, 0);
 
-    int ret = wm_vuldet_report_agent_vulnerabilities(db, agent, NULL);
+    int ret = wm_vuldet_find_agent_vulnerabilities(db, agent, NULL, &scan_ctx);
     assert_int_equal(ret, -1);
 
 }
 
-void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_nvd_vulnerabilities_error(void **state)
+void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_nvd_vulnerabilities_error(void **state)
 {
     sqlite3 *db = (sqlite3 *)1;
     scan_agent *agent = *state;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx = {0};
+    scan_ctx.agent_id = 0;
+    scan_ctx.scan_type = VU_FULL_SCAN;
 
-    agent->info = 'T';
     agent->dist = FEED_DEBIAN;
     agent->dist_ver = FEED_BUSTER;
 
@@ -8979,23 +9148,25 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_nvd_vulnerabilities
 
     will_return(__wrap_OSHash_Clean, 0);
 
-    int ret = wm_vuldet_report_agent_vulnerabilities(db, agent, NULL);
+    int ret = wm_vuldet_find_agent_vulnerabilities(db, agent, NULL, &scan_ctx);
     assert_int_equal(ret, -1);
 
 }
 
-void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_rm_false_positivies_error(void **state)
+void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_rm_false_positivies_error(void **state)
 {
     sqlite3 *db = (sqlite3 *)1;
     scan_agent *agent = *state;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx = {0};
+    scan_ctx.agent_id = 0;
+    scan_ctx.scan_type = VU_FULL_SCAN;
 
     OSHashNode* node = NULL;
     os_calloc(1, sizeof(OSHashNode), node);
     if (!node || (OS_INVALID == build_test_hash_node(node, VU_SRC_NVD)))
         return;
 
-    agent->info = 'T';
     agent->dist = FEED_DEBIAN;
     agent->dist_ver = FEED_BUSTER;
 
@@ -9083,7 +9254,7 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_rm_false_positivies
 
     will_return(__wrap_OSHash_Clean, 0);
 
-    int ret = wm_vuldet_report_agent_vulnerabilities(db, agent, NULL);
+    int ret = wm_vuldet_find_agent_vulnerabilities(db, agent, NULL, &scan_ctx);
     assert_int_equal(ret, -1);
 
     wm_vuldet_free_cve_node(node->data);
@@ -9091,11 +9262,14 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_rm_false_positivies
     os_free(node);
 }
 
-void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_send_agent_report_error(void **state)
+void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_send_agent_report_error(void **state)
 {
     sqlite3 *db = (sqlite3 *)1;
     scan_agent *agent = *state;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx = {0};
+    scan_ctx.agent_id = 0;
+    scan_ctx.scan_type = VU_FULL_SCAN;
 
     OSHashNode* node = NULL;
     os_calloc(1, sizeof(OSHashNode), node);
@@ -9107,7 +9281,6 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_send_agent_report_e
         return;
     }
 
-    agent->info = 'T';
     agent->dist = FEED_DEBIAN;
     agent->dist_ver = FEED_BUSTER;
 
@@ -9214,7 +9387,7 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_send_agent_report_e
     will_return(__wrap_time, (time_t)1);
     expect_string(__wrap__mtdebug1, formatted_msg, "(5470): It took '0' seconds to 'filter' vulnerabilities in agent '000'");
 
-    //wm_vuldet_send_agent_report_fill_report_nvd_cve_info_error()
+    //wm_vuldet_process_agent_vulnerabilities_fill_report_nvd_cve_info_error()
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug1, formatted_msg, "(5466): Sending vulnerabilities report for agent '000'");
 
@@ -9233,7 +9406,7 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_send_agent_report_e
 
     will_return(__wrap_OSHash_Clean, 0);
 
-    int ret = wm_vuldet_report_agent_vulnerabilities(db, agent, flags);
+    int ret = wm_vuldet_find_agent_vulnerabilities(db, agent, flags, &scan_ctx);
     assert_int_equal(ret, -1);
 
     wm_vuldet_free_cve_node(node->data);
@@ -9242,18 +9415,20 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_send_agent_report_e
     os_free(flags);
 }
 
-void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_OK(void **state)
+void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_OK(void **state)
 {
     sqlite3 *db = (sqlite3 *)1;
     scan_agent *agent = *state;
     OSHash *cve_table = (OSHash *)1;
+    scan_ctx_t scan_ctx = {0};
+    scan_ctx.agent_id = 0;
+    scan_ctx.scan_type = VU_FULL_SCAN;
 
     OSHashNode* node = NULL;
     os_calloc(1, sizeof(OSHashNode), node);
     if (!node || (OS_INVALID == build_test_hash_node(node, VU_SRC_NVD)))
         return;
 
-    agent->info = 'T';
     agent->dist = FEED_DEBIAN;
     agent->dist_ver = FEED_BUSTER;
 
@@ -9363,7 +9538,7 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_OK(void **state)
     will_return(__wrap_time, (time_t)1);
     expect_string(__wrap__mtdebug1, formatted_msg, "(5470): It took '0' seconds to 'filter' vulnerabilities in agent '000'");
 
-    //wm_vuldet_send_agent_report_fill_report_nvd_cve_info_error()
+    //wm_vuldet_process_agent_vulnerabilities_fill_report_nvd_cve_info_error()
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug1, formatted_msg, "(5466): Sending vulnerabilities report for agent '000'");
 
@@ -9387,7 +9562,7 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_OK(void **state)
 
     will_return(__wrap_OSHash_Clean, 0);
 
-    int ret = wm_vuldet_report_agent_vulnerabilities(db, agent, NULL);
+    int ret = wm_vuldet_find_agent_vulnerabilities(db, agent, NULL, &scan_ctx);
     assert_int_equal(ret, 0);
 
     wm_vuldet_free_cve_node(node->data);
@@ -9395,7 +9570,7 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_OK(void **state)
     os_free(node);
 
 }
-#endif
+
 /* wm_vuldet_discard_kernel_package */
 
 void test_wm_vuldet_discard_kernel_package_null_kernel(void **state)
@@ -17319,8 +17494,6 @@ void test_wm_vuldet_init_success(void **state)
     os_free(vuldet);
 }
 
-#endif
-
 // Tests wm_vuldet_update_last_scan
 
 void test_wm_vuldet_update_last_scan_full_success(void **state)
@@ -17778,6 +17951,7 @@ void test_wm_vuldet_send_removed_cve_report_fail() {
     int retval;
     scan_ctx_t scan_ctx;
     cJSON* j_vuln = NULL;
+    wm_max_eps = 1;
 
     will_return_count(__wrap_cJSON_GetObjectItem, NULL, -1);
     will_return_count(__wrap_cJSON_GetStringValue, NULL, -1);
@@ -17939,7 +18113,7 @@ void test_wm_vuldet_send_removed_cve_report_no_ip_success() {
 int main(void)
 {
     const struct CMUnitTest tests[] = {
-        #if 0 //TODO #7749 Fix UT
+        #if 0 //TODO #7749 Fix UTs
         // Tests wm_vuldet_get_os_unix_info
         cmocka_unit_test_setup_teardown(test_wm_vuldet_get_os_unix_info, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_get_os_unix_info_only_major, setup_scan_agent, teardown_scan_agent),
@@ -17950,14 +18124,7 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_get_os_unix_info_request_empty, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_get_os_unix_info_request_parse_error, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_get_os_unix_info_mac, setup_scan_agent, teardown_scan_agent),
-        // Tests wm_vuldet_discard_kernel_package
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_discard_kernel_package_null_kernel, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_discard_kernel_package_redhat_no_kernel, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_discard_kernel_package_redhat_kernel, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_discard_kernel_package_debian_family_no_linux_image, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_discard_kernel_package_debian_family_linux_image, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_discard_kernel_package_discard_kernel, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_discard_kernel_package_OK, setup_scan_agent, teardown_scan_agent),
+        #endif
         // Tests wm_vuldet_linux_rm_nvd_not_affected_packages
         cmocka_unit_test(test_wm_vuldet_linux_rm_nvd_not_affected_packages_oval),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_linux_rm_nvd_not_affected_packages_vendor_Ubuntu, setup_scan_agent, teardown_scan_agent),
@@ -17989,6 +18156,14 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_linux_rm_false_positivies_error_removing_nvd_not_affected, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_linux_rm_false_positivies_error_removing_oval_not_affected, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_linux_rm_false_positivies_ok, setup_scan_agent, teardown_scan_agent),
+        // Tests wm_vuldet_discard_kernel_package
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_discard_kernel_package_null_kernel, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_discard_kernel_package_redhat_no_kernel, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_discard_kernel_package_redhat_kernel, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_discard_kernel_package_debian_family_no_linux_image, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_discard_kernel_package_debian_family_linux_image, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_discard_kernel_package_discard_kernel, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_discard_kernel_package_OK, setup_scan_agent, teardown_scan_agent),
         // Tests vuldet_generate_os_and_kernel_package
         cmocka_unit_test_setup_teardown(test_wm_vuldet_generate_os_and_kernel_package_ubuntu, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_generate_os_and_kernel_package_debian, setup_scan_agent, teardown_scan_agent),
@@ -18020,8 +18195,6 @@ int main(void)
         cmocka_unit_test(test_wm_vuldel_truncate_revision_null),
         cmocka_unit_test(test_wm_vuldel_truncate_revision),
         // Tests wm_vuldet_linux_oval_vulnerabilities
-        // TO DO #7749: Fix UT
-        #if 0
         cmocka_unit_test_setup_teardown(test_wm_vuldet_linux_oval_vulnerabilities_error_prepare_nvd_configured_year, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_linux_oval_vulnerabilities_error_no_nvd_year, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_linux_oval_vulnerabilities_error_prepare, setup_scan_agent, teardown_scan_agent),
@@ -18039,7 +18212,6 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_linux_oval_vulnerabilities_insert_package_error, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_linux_oval_vulnerabilities_duplicated_package, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_linux_oval_vulnerabilities_external_vendor, setup_scan_agent, teardown_scan_agent),
-        #endif
         // Tests wm_vuldet_build_nvd_report
         cmocka_unit_test(test_wm_vuldet_build_nvd_report_condition_both_including),
         cmocka_unit_test(test_wm_vuldet_build_nvd_report_condition_both_excluding),
@@ -18072,21 +18244,20 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_fill_report_oval_data_bugzilla_references_error, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_fill_report_oval_data_advisories_error, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_fill_report_oval_data, setup_scan_agent, teardown_scan_agent),
-        // Tests wm_vuldet_send_agent_report
-        // TO DO #7749: Fix UT
-        #if 0
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_send_agent_report_no_hash_node_rh, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_send_agent_report_no_hash_node_ubuntu, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_send_agent_report_fill_report_nvd_cve_info_error, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_send_agent_report_fill_report_nvd_references_error, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_send_agent_report_fill_report_nvd_scoring_error, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_send_agent_report_fill_report_oval_error, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_send_agent_report_vuln_cves_insert_error, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_send_agent_report_send_cve_report_error, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_send_agent_report_send_cve_report_negative_version, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_send_agent_report_send_cve_report_adding_data_from_OVAL_error, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_send_agent_report_send_cve_report_without_errors_OVAL, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_send_agent_report_send_cve_report_without_errors_NVD, setup_scan_agent, teardown_scan_agent),
+        #if 0 //TODO #7749 Fix UTs
+        // Tests wm_vuldet_process_agent_vulnerabilities
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_process_agent_vulnerabilities_no_hash_node_rh, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_process_agent_vulnerabilities_no_hash_node_ubuntu, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_process_agent_vulnerabilities_fill_report_nvd_cve_info_error, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_process_agent_vulnerabilities_fill_report_nvd_references_error, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_process_agent_vulnerabilities_fill_report_nvd_scoring_error, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_process_agent_vulnerabilities_fill_report_oval_error, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_process_agent_vulnerabilities_vuln_cves_insert_error, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_error, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_negative_version, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_adding_data_from_OVAL_error, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_without_errors_OVAL, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_without_errors_NVD, setup_scan_agent, teardown_scan_agent),
         #endif
         // Tests test_wm_vuldet_get_cvss
         cmocka_unit_test(test_wm_vuldet_get_cvss_null),
@@ -18128,13 +18299,12 @@ int main(void)
         cmocka_unit_test(test_wm_vuldet_get_cvss_v2),
         cmocka_unit_test(test_wm_vuldet_get_cvss_v3),
         // Tests wm_vuldet_send_cve_report
-        // TO DO #7749: Fix UT
-        #if 0
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_error_alert_create, setup_cve_report, teardown_cve_report),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_error_alert_cve_create, setup_cve_report, teardown_cve_report),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_error_j_package_create, setup_cve_report, teardown_cve_report),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_error_j_cvss_create, setup_cve_report, teardown_cve_report),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_error_j_cvss_node_create, setup_cve_report, teardown_cve_report),
+        #if 0 //TODO #7749 Fix UTs
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_error_j_advisories_create, setup_cve_report, teardown_cve_report),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_error_j_bug_references_create, setup_cve_report, teardown_cve_report),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_error_j_references_create, setup_cve_report, teardown_cve_report),
@@ -18169,19 +18339,18 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_add_cve_node_not_found, setup_package_comparison, teardown_package_comparison),
         // Tests wm_vuldet_free_cve_node
         cmocka_unit_test(test_wm_vuldet_free_cve_node),
-        // Tests wm_vuldet_report_agent_vulnerabilities
-        // TO DO #7749: Fix UT
-        #if 0
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_report_agent_vulnerabilities_agent_info_NULL, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_report_agent_vulnerabilities_agent_windows_error, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_report_agent_vulnerabilities_agent_windows_OK, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_report_agent_vulnerabilities_agent_linux_create_hash_error, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_report_agent_vulnerabilities_agent_linux_setSize_hash_error, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_report_agent_vulnerabilities_agent_linux_oval_vulnerabilities_error, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_report_agent_vulnerabilities_agent_linux_nvd_vulnerabilities_error, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_report_agent_vulnerabilities_agent_linux_rm_false_positivies_error, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_report_agent_vulnerabilities_agent_linux_send_agent_report_error, setup_scan_agent, teardown_scan_agent),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_report_agent_vulnerabilities_agent_linux_OK, setup_scan_agent, teardown_scan_agent),
+        #if 0 //TODO #7749 Fix UTs
+        // Tests wm_vuldet_find_agent_vulnerabilities
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_find_agent_vulnerabilities_agent_info_NULL, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_find_agent_vulnerabilities_agent_windows_error, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_find_agent_vulnerabilities_agent_windows_OK, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_find_agent_vulnerabilities_agent_linux_create_hash_error, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_find_agent_vulnerabilities_agent_linux_setSize_hash_error, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_find_agent_vulnerabilities_agent_linux_oval_vulnerabilities_error, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_find_agent_vulnerabilities_agent_linux_nvd_vulnerabilities_error, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_find_agent_vulnerabilities_agent_linux_rm_false_positivies_error, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_find_agent_vulnerabilities_agent_linux_send_agent_report_error, setup_scan_agent, teardown_scan_agent),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_find_agent_vulnerabilities_agent_linux_OK, setup_scan_agent, teardown_scan_agent),
         #endif
         // Tests wm_vuldet_fetch_redhat
         cmocka_unit_test(test_wm_vuldet_fetch_redhat_multi_url_no_valid_response),
@@ -18398,7 +18567,7 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_MSU_max_attempts, setup_group, teardown_group),
         // Tests wm_vuldet_init
         cmocka_unit_test_setup_teardown(test_wm_vuldet_init_success, setup_group, teardown_group),
-        #endif
+        #if 0 //TODO #7749 Fix UTs
         // Tests wm_vuldet_update_last_scan
         cmocka_unit_test_setup_teardown(test_wm_vuldet_update_last_scan_full_success, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_update_last_scan_partial_success, setup_scan_agent, teardown_scan_agent),
@@ -18414,12 +18583,15 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_feed_changed_windows, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_feed_changed_nvd, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_feed_changed_updated, setup_scan_agent, teardown_scan_agent),
+        #endif
+        #if 0 //TODO #7749 Fix UTs
         // Tests wm_vuldet_find_obsolete_vulnerabilities
         cmocka_unit_test_setup_teardown(test_wm_vuldet_find_obsolete_vulnerabilities_baseline_success, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_find_obsolete_vulnerabilities_pending_status_fail, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_find_obsolete_vulnerabilities_obsolete_status_fail, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_find_obsolete_vulnerabilities_empty_success, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_find_obsolete_vulnerabilities_report_fail, setup_group, teardown_group),
+        #endif
         // Tests wm_vuldet_send_removed_cve_report
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_removed_cve_report_fail, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_removed_cve_report_ip_assigned_success, setup_group, teardown_group),

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -9059,6 +9059,10 @@ void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_nvd_vulnerabilities_e
     will_return(__wrap_sqlite3_column_text, "10");
     expect_value(__wrap_sqlite3_column_text, iCol, 8);
     will_return(__wrap_sqlite3_column_text, NULL);
+    expect_value(__wrap_sqlite3_column_text, iCol, 9);
+    will_return(__wrap_sqlite3_column_text, NULL);
+    expect_value(__wrap_sqlite3_column_text, iCol, 10);
+    will_return(__wrap_sqlite3_column_text, NULL);
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -9149,6 +9153,10 @@ void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_rm_false_positivies_e
     will_return(__wrap_sqlite3_column_text, "5.4.2");
     expect_value(__wrap_sqlite3_column_text, iCol, 8);
     will_return(__wrap_sqlite3_column_text, NULL);
+    expect_value(__wrap_sqlite3_column_text, iCol, 9);
+    will_return(__wrap_sqlite3_column_text, NULL);
+    expect_value(__wrap_sqlite3_column_text, iCol, 10);
+    will_return(__wrap_sqlite3_column_text, NULL);
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -9201,6 +9209,8 @@ void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_send_agent_report_err
     scan_ctx.agent_id = 0;
     scan_ctx.os_scan = 1;
     scan_ctx.scan_type = VU_FULL_SCAN;
+    cJSON* j_status = __real_cJSON_CreateString("SUCCESS");
+    cJSON* j_action = __real_cJSON_CreateString("INSERT");
 
     OSHashNode* node = NULL;
     os_calloc(1, sizeof(OSHashNode), node);
@@ -9269,6 +9279,10 @@ void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_send_agent_report_err
     will_return(__wrap_sqlite3_column_text, "5.4.2");
     expect_value(__wrap_sqlite3_column_text, iCol, 8);
     will_return(__wrap_sqlite3_column_text, NULL);
+    expect_value(__wrap_sqlite3_column_text, iCol, 9);
+    will_return(__wrap_sqlite3_column_text, NULL);
+    expect_value(__wrap_sqlite3_column_text, iCol, 10);
+    will_return(__wrap_sqlite3_column_text, NULL);
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -9332,6 +9346,22 @@ void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_send_agent_report_err
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5578): Could not fill the report with the CVE info from the NVD for agent '000'");
 
+    // wdb_agents_vuln_cves_insert
+    will_return(__wrap_wdb_agents_vuln_cves_insert, (cJSON*)1);
+    expect_value(__wrap_wdb_agents_vuln_cves_insert, id, 0);
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, name, "test-wazuh");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, version, "5.3.4");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, architecture, "x86_64");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, cve, "CVE-2016-6489");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, reference, "e91d3dd01b9214df53c8f3985f028112268d2173");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, type, VULN_CVES_TYPE_PACKAGE);
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, status, VULN_CVES_STATUS_VALID);
+    expect_value(__wrap_wdb_agents_vuln_cves_insert, check_pkg_existence, TRUE);
+
+    will_return(__wrap_cJSON_GetObjectItem, j_status);
+    will_return(__wrap_cJSON_GetObjectItem, j_action);
+    expect_function_call(__wrap_cJSON_Delete);
+
     expect_value(__wrap_OSHash_Begin, self, cve_table);
     will_return(__wrap_OSHash_Begin, node);
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_ERROR);
@@ -9349,6 +9379,8 @@ void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_send_agent_report_err
     os_free(node->key);
     os_free(node);
     os_free(flags);
+    __real_cJSON_Delete(j_action);
+    __real_cJSON_Delete(j_status);
 }
 
 void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_OK(void **state)
@@ -9422,6 +9454,10 @@ void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_OK(void **state)
     expect_value(__wrap_sqlite3_column_text, iCol, 7);
     will_return(__wrap_sqlite3_column_text, "5.4.2");
     expect_value(__wrap_sqlite3_column_text, iCol, 8);
+    will_return(__wrap_sqlite3_column_text, NULL);
+    expect_value(__wrap_sqlite3_column_text, iCol, 9);
+    will_return(__wrap_sqlite3_column_text, NULL);
+    expect_value(__wrap_sqlite3_column_text, iCol, 10);
     will_return(__wrap_sqlite3_column_text, NULL);
 
     expect_sqlite3_step_call(SQLITE_DONE);
@@ -17452,17 +17488,12 @@ void test_wm_vuldet_update_last_scan_full_success(void **state)
 
     will_return(__wrap_time, (time_t)1);
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, WDB_LOCAL_SOCK);
-    expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
-    expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_SIZE_6144);
-    will_return(__wrap_OS_ConnectUnixDomain, 11111);
-
-    expect_value(__wrap_OS_SendSecureTCP, sock, 11111);
+    expect_value(__wrap_OS_SendSecureTCP, sock, 1);
     expect_value(__wrap_OS_SendSecureTCP, size, query_size);
     expect_string(__wrap_OS_SendSecureTCP, msg, query);
     will_return(__wrap_OS_SendSecureTCP, 0);
 
-    expect_value(__wrap_OS_RecvSecureTCP, sock, 11111);
+    expect_value(__wrap_OS_RecvSecureTCP, sock, 1);
     expect_value(__wrap_OS_RecvSecureTCP, size, OS_SIZE_256);
     will_return(__wrap_OS_RecvSecureTCP, response);
     will_return(__wrap_OS_RecvSecureTCP, response_size);
@@ -17484,12 +17515,12 @@ void test_wm_vuldet_update_last_scan_partial_success(void **state)
 
     will_return(__wrap_time, (time_t)1);
 
-    expect_value(__wrap_OS_SendSecureTCP, sock, 11111);
+    expect_value(__wrap_OS_SendSecureTCP, sock, 1);
     expect_value(__wrap_OS_SendSecureTCP, size, query_size);
     expect_string(__wrap_OS_SendSecureTCP, msg, query);
     will_return(__wrap_OS_SendSecureTCP, 0);
 
-    expect_value(__wrap_OS_RecvSecureTCP, sock, 11111);
+    expect_value(__wrap_OS_RecvSecureTCP, sock, 1);
     expect_value(__wrap_OS_RecvSecureTCP, size, OS_SIZE_256);
     will_return(__wrap_OS_RecvSecureTCP, response);
     will_return(__wrap_OS_RecvSecureTCP, response_size);
@@ -17508,12 +17539,12 @@ void test_wm_vuldet_update_last_scan_fail(void **state)
 
     will_return(__wrap_time, (time_t)1);
 
-    expect_value(__wrap_OS_SendSecureTCP, sock, 11111);
+    expect_value(__wrap_OS_SendSecureTCP, sock, 1);
     expect_value(__wrap_OS_SendSecureTCP, size, query_size);
     expect_string(__wrap_OS_SendSecureTCP, msg, query);
     will_return(__wrap_OS_SendSecureTCP, 0);
 
-    expect_value(__wrap_OS_RecvSecureTCP, sock, 11111);
+    expect_value(__wrap_OS_RecvSecureTCP, sock, 1);
     expect_value(__wrap_OS_RecvSecureTCP, size, OS_SIZE_256);
     will_return(__wrap_OS_RecvSecureTCP, "err");
     will_return(__wrap_OS_RecvSecureTCP, OS_INVALID);

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -173,7 +173,6 @@ const char *redhat_feed_mock_num_score = "[ {\n \
 
 static int build_test_cve_report(vu_report* report, int add_title, int add_condition, int add_ip, int is_hotfix)
 {
-
     if (!report)
         return OS_INVALID;
 
@@ -6906,7 +6905,7 @@ void test_wm_vuldet_send_cve_report_error_j_cvss_create(void **state)
 {
     vu_report* report = state[REPORT_CVE_REPORT_POS];
 
-    if (OS_INVALID == build_test_cve_report(report, 1, 1, 1, 1))
+    if (OS_INVALID == build_test_cve_report(report, 0, 1, 1, 1))
         return;
 
     cJSON* alert = (cJSON *)1;
@@ -6948,7 +6947,7 @@ void test_wm_vuldet_send_cve_report_error_j_cvss_node_create(void **state)
 {
     vu_report* report = state[REPORT_CVE_REPORT_POS];
 
-    if (OS_INVALID == build_test_cve_report(report, 1, 1, 1, 1))
+    if (OS_INVALID == build_test_cve_report(report, 0, 1, 1, 1))
         return;
 
     cJSON* alert = (cJSON *)1;
@@ -6994,7 +6993,7 @@ void test_wm_vuldet_send_cve_report_error_j_advisories_create(void **state)
 {
     vu_report* report = state[REPORT_CVE_REPORT_POS];
 
-    if (OS_INVALID == build_test_cve_report(report, 1, 1, 1, 1))
+    if (OS_INVALID == build_test_cve_report(report, 0, 1, 1, 1))
         return;
 
     cJSON* alert = (cJSON *)1;
@@ -7098,7 +7097,7 @@ void test_wm_vuldet_send_cve_report_error_j_advisories_create(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, name, "cve");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->cve);
     expect_string(__wrap_cJSON_AddStringToObject, name, "title");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->title);
+    expect_string(__wrap_cJSON_AddStringToObject, string, "CVE-2016-6489 affects libhogweed4");
     expect_string(__wrap_cJSON_AddStringToObject, name, "rationale");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->rationale);
     expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
@@ -7142,7 +7141,7 @@ void test_wm_vuldet_send_cve_report_error_j_bug_references_create(void **state)
 {
     vu_report* report = state[REPORT_CVE_REPORT_POS];
 
-    if (OS_INVALID == build_test_cve_report(report, 1, 1, 1, 1))
+    if (OS_INVALID == build_test_cve_report(report, 0, 1, 1, 1))
         return;
 
     cJSON* alert = (cJSON *)1;
@@ -7247,7 +7246,7 @@ void test_wm_vuldet_send_cve_report_error_j_bug_references_create(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, name, "cve");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->cve);
     expect_string(__wrap_cJSON_AddStringToObject, name, "title");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->title);
+    expect_string(__wrap_cJSON_AddStringToObject, string, "CVE-2016-6489 affects libhogweed4");
     expect_string(__wrap_cJSON_AddStringToObject, name, "rationale");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->rationale);
     expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
@@ -7299,7 +7298,7 @@ void test_wm_vuldet_send_cve_report_error_j_references_create(void **state)
 {
     vu_report* report = state[REPORT_CVE_REPORT_POS];
 
-    if (OS_INVALID == build_test_cve_report(report, 1, 1, 1, 1))
+    if (OS_INVALID == build_test_cve_report(report, 0, 1, 1, 1))
         return;
 
     cJSON* alert = (cJSON *)1;
@@ -7404,7 +7403,7 @@ void test_wm_vuldet_send_cve_report_error_j_references_create(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, name, "cve");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->cve);
     expect_string(__wrap_cJSON_AddStringToObject, name, "title");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->title);
+    expect_string(__wrap_cJSON_AddStringToObject, string, "CVE-2016-6489 affects libhogweed4");
     expect_string(__wrap_cJSON_AddStringToObject, name, "rationale");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->rationale);
     expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
@@ -7654,7 +7653,7 @@ void test_wm_vuldet_send_cve_report_without_condition(void **state)
 {
     vu_report* report = state[REPORT_CVE_REPORT_POS];
 
-    if (OS_INVALID == build_test_cve_report(report, 1, 0, 1, 1))
+    if (OS_INVALID == build_test_cve_report(report, 0, 0, 1, 1))
         return;
 
     cJSON* alert = (cJSON *)1;
@@ -7762,7 +7761,7 @@ void test_wm_vuldet_send_cve_report_without_condition(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, name, "cve");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->cve);
     expect_string(__wrap_cJSON_AddStringToObject, name, "title");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->title);
+    expect_string(__wrap_cJSON_AddStringToObject, string, "CVE-2016-6489 affects libhogweed4");
     expect_string(__wrap_cJSON_AddStringToObject, name, "rationale");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->rationale);
     expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
@@ -7845,7 +7844,7 @@ void test_wm_vuldet_send_cve_report_without_ip(void **state)
 {
     vu_report* report = state[REPORT_CVE_REPORT_POS];
 
-    if (OS_INVALID == build_test_cve_report(report, 1, 1, 0, 1))
+    if (OS_INVALID == build_test_cve_report(report, 0, 1, 0, 1))
         return;
 
     cJSON* alert = (cJSON *)1;
@@ -7953,7 +7952,7 @@ void test_wm_vuldet_send_cve_report_without_ip(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, name, "cve");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->cve);
     expect_string(__wrap_cJSON_AddStringToObject, name, "title");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->title);
+    expect_string(__wrap_cJSON_AddStringToObject, string, "CVE-2016-6489 affects libhogweed4");
     expect_string(__wrap_cJSON_AddStringToObject, name, "rationale");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->rationale);
     expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
@@ -8035,7 +8034,7 @@ void test_wm_vuldet_send_cve_report_without_hotfix(void **state)
 {
     vu_report* report = state[REPORT_CVE_REPORT_POS];
 
-    if (OS_INVALID == build_test_cve_report(report, 1, 1, 1, 0))
+    if (OS_INVALID == build_test_cve_report(report, 0, 1, 1, 0))
         return;
 
     cJSON* alert = (cJSON *)1;
@@ -8143,7 +8142,7 @@ void test_wm_vuldet_send_cve_report_without_hotfix(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, name, "cve");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->cve);
     expect_string(__wrap_cJSON_AddStringToObject, name, "title");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->title);
+    expect_string(__wrap_cJSON_AddStringToObject, string, "CVE-2016-6489 affects libhogweed4");
     expect_string(__wrap_cJSON_AddStringToObject, name, "rationale");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->rationale);
     expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
@@ -8225,7 +8224,7 @@ void test_wm_vuldet_send_cve_report_sendmsg_error(void **state)
 {
     vu_report* report = state[REPORT_CVE_REPORT_POS];
 
-    if (OS_INVALID == build_test_cve_report(report, 1, 1, 1, 0))
+    if (OS_INVALID == build_test_cve_report(report, 0, 1, 1, 0))
         return;
 
     cJSON* alert = (cJSON *)1;
@@ -8333,7 +8332,7 @@ void test_wm_vuldet_send_cve_report_sendmsg_error(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, name, "cve");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->cve);
     expect_string(__wrap_cJSON_AddStringToObject, name, "title");
-    expect_string(__wrap_cJSON_AddStringToObject, string, report->title);
+    expect_string(__wrap_cJSON_AddStringToObject, string, "CVE-2016-6489 affects libhogweed4");
     expect_string(__wrap_cJSON_AddStringToObject, name, "rationale");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->rationale);
     expect_string(__wrap_cJSON_AddStringToObject, name, "severity");

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -267,6 +267,8 @@ static int build_test_hash_node(OSHashNode* node, uint8_t feed) {
     w_strdup("libhogweed4", next->bin_name);
     w_strdup("5.3.4", next->version);
     w_strdup("x86_64", next->arch);
+    w_strdup(VULN_CVES_TYPE_PACKAGE, next->type);
+    w_strdup("e91d3dd01b9214df53c8f3985f028112268d2173", next->reference);
     next->feed |= feed;
 
     cve_vuln_cond_NVD* nvd_cond = NULL;
@@ -2272,7 +2274,6 @@ void test_wm_vuldel_truncate_revision(void ** state) {
 }
 
 /* wm_vuldet_linux_oval_vulnerabilities */
-// TO DO #7749: Fix UT
 
 void test_wm_vuldet_linux_oval_vulnerabilities_error_prepare_nvd_configured_year(void **state)
 {
@@ -4447,6 +4448,12 @@ void test_wm_vuldet_process_agent_vulnerabilities_no_hash_node_rh(void **state)
     scan_ctx.scan_type = VU_BASELINE_SCAN;
     scan_ctx.agent_id = 0;
 
+    // wm_vuldet_get_wdb_socket
+    will_return(__wrap_OS_ConnectUnixDomain, 1);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, WDB_LOCAL_SOCK);
+    expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
+    expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_SIZE_6144);
+
     agent->dist = FEED_REDHAT;
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
@@ -4517,8 +4524,10 @@ void test_wm_vuldet_process_agent_vulnerabilities_fill_report_nvd_cve_info_error
     sqlite3 *db = (sqlite3 *)1;
     OSHash *cve_table = (OSHash *)1;
     scan_ctx_t scan_ctx;
-    scan_ctx.scan_type = VU_BASELINE_SCAN;
+    scan_ctx.scan_type = VU_FULL_SCAN;
     scan_ctx.agent_id = 0;
+    cJSON* j_status = __real_cJSON_CreateString("SUCCESS");
+    cJSON* j_action = __real_cJSON_CreateString("INSERT");
 
     agent->dist = FEED_UBUNTU;
     agent->dist_ver = FEED_FOCAL;
@@ -4527,6 +4536,22 @@ void test_wm_vuldet_process_agent_vulnerabilities_fill_report_nvd_cve_info_error
     os_calloc(1, sizeof(OSHashNode), node);
     if (!node || (OS_INVALID == build_test_hash_node(node, VU_SRC_NVD|VU_SRC_OVAL)))
         return;
+
+    // wdb_agents_vuln_cves_insert
+    will_return(__wrap_wdb_agents_vuln_cves_insert, (cJSON*)1);
+    expect_value(__wrap_wdb_agents_vuln_cves_insert, id, 0);
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, name, "libhogweed4");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, version, "5.3.4");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, architecture, "x86_64");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, cve, "CVE-2016-6489");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, reference, "e91d3dd01b9214df53c8f3985f028112268d2173");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, type, VULN_CVES_TYPE_PACKAGE);
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, status, VULN_CVES_STATUS_VALID);
+    expect_value(__wrap_wdb_agents_vuln_cves_insert, check_pkg_existence, TRUE);
+
+    will_return(__wrap_cJSON_GetObjectItem, j_status);
+    will_return(__wrap_cJSON_GetObjectItem, j_action);
+    expect_function_call(__wrap_cJSON_Delete);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug1, formatted_msg, "(5466): Sending vulnerabilities report for agent '000'");
@@ -4552,6 +4577,8 @@ void test_wm_vuldet_process_agent_vulnerabilities_fill_report_nvd_cve_info_error
     wm_vuldet_free_cve_node(node->data);
     os_free(node->key);
     os_free(node);
+    __real_cJSON_Delete(j_action);
+    __real_cJSON_Delete(j_status);
 }
 
 void test_wm_vuldet_process_agent_vulnerabilities_fill_report_nvd_references_error(void **state)
@@ -4560,8 +4587,10 @@ void test_wm_vuldet_process_agent_vulnerabilities_fill_report_nvd_references_err
     sqlite3 *db = (sqlite3 *)1;
     OSHash *cve_table = (OSHash *)1;
     scan_ctx_t scan_ctx;
-    scan_ctx.scan_type = VU_BASELINE_SCAN;
+    scan_ctx.scan_type = VU_FULL_SCAN;
     scan_ctx.agent_id = 0;
+    cJSON* j_status = __real_cJSON_CreateString("SUCCESS");
+    cJSON* j_action = __real_cJSON_CreateString("INSERT");
 
     agent->dist = FEED_UBUNTU;
     agent->dist_ver = FEED_FOCAL;
@@ -4570,6 +4599,22 @@ void test_wm_vuldet_process_agent_vulnerabilities_fill_report_nvd_references_err
     os_calloc(1, sizeof(OSHashNode), node);
     if (!node || (OS_INVALID == build_test_hash_node(node, VU_SRC_NVD|VU_SRC_OVAL)))
         return;
+
+    // wdb_agents_vuln_cves_insert
+    will_return(__wrap_wdb_agents_vuln_cves_insert, (cJSON*)1);
+    expect_value(__wrap_wdb_agents_vuln_cves_insert, id, 0);
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, name, "libhogweed4");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, version, "5.3.4");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, architecture, "x86_64");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, cve, "CVE-2016-6489");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, reference, "e91d3dd01b9214df53c8f3985f028112268d2173");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, type, VULN_CVES_TYPE_PACKAGE);
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, status, VULN_CVES_STATUS_VALID);
+    expect_value(__wrap_wdb_agents_vuln_cves_insert, check_pkg_existence, TRUE);
+
+    will_return(__wrap_cJSON_GetObjectItem, j_status);
+    will_return(__wrap_cJSON_GetObjectItem, j_action);
+    expect_function_call(__wrap_cJSON_Delete);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug1, formatted_msg, "(5466): Sending vulnerabilities report for agent '000'");
@@ -4615,6 +4660,8 @@ void test_wm_vuldet_process_agent_vulnerabilities_fill_report_nvd_references_err
     wm_vuldet_free_cve_node(node->data);
     os_free(node->key);
     os_free(node);
+    __real_cJSON_Delete(j_action);
+    __real_cJSON_Delete(j_status);
 }
 
 void test_wm_vuldet_process_agent_vulnerabilities_fill_report_nvd_scoring_error(void **state)
@@ -4623,8 +4670,10 @@ void test_wm_vuldet_process_agent_vulnerabilities_fill_report_nvd_scoring_error(
     sqlite3 *db = (sqlite3 *)1;
     OSHash *cve_table = (OSHash *)1;
     scan_ctx_t scan_ctx;
-    scan_ctx.scan_type = VU_BASELINE_SCAN;
+    scan_ctx.scan_type = VU_FULL_SCAN;
     scan_ctx.agent_id = 0;
+    cJSON* j_status = __real_cJSON_CreateString("SUCCESS");
+    cJSON* j_action = __real_cJSON_CreateString("INSERT");
 
     agent->dist = FEED_UBUNTU;
     agent->dist_ver = FEED_FOCAL;
@@ -4633,6 +4682,22 @@ void test_wm_vuldet_process_agent_vulnerabilities_fill_report_nvd_scoring_error(
     os_calloc(1, sizeof(OSHashNode), node);
     if (!node || (OS_INVALID == build_test_hash_node(node, VU_SRC_NVD)))
         return;
+
+    // wdb_agents_vuln_cves_insert
+    will_return(__wrap_wdb_agents_vuln_cves_insert, (cJSON*)1);
+    expect_value(__wrap_wdb_agents_vuln_cves_insert, id, 0);
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, name, "libhogweed4");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, version, "5.3.4");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, architecture, "x86_64");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, cve, "CVE-2016-6489");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, reference, "e91d3dd01b9214df53c8f3985f028112268d2173");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, type, VULN_CVES_TYPE_PACKAGE);
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, status, VULN_CVES_STATUS_VALID);
+    expect_value(__wrap_wdb_agents_vuln_cves_insert, check_pkg_existence, TRUE);
+
+    will_return(__wrap_cJSON_GetObjectItem, j_status);
+    will_return(__wrap_cJSON_GetObjectItem, j_action);
+    expect_function_call(__wrap_cJSON_Delete);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug1, formatted_msg, "(5466): Sending vulnerabilities report for agent '000'");
@@ -4689,6 +4754,8 @@ void test_wm_vuldet_process_agent_vulnerabilities_fill_report_nvd_scoring_error(
     wm_vuldet_free_cve_node(node->data);
     os_free(node->key);
     os_free(node);
+    __real_cJSON_Delete(j_action);
+    __real_cJSON_Delete(j_status);
 }
 
 void test_wm_vuldet_process_agent_vulnerabilities_fill_report_oval_error(void **state)
@@ -4697,8 +4764,10 @@ void test_wm_vuldet_process_agent_vulnerabilities_fill_report_oval_error(void **
     sqlite3 *db = (sqlite3 *)1;
     OSHash *cve_table = (OSHash *)1;
     scan_ctx_t scan_ctx;
-    scan_ctx.scan_type = VU_BASELINE_SCAN;
+    scan_ctx.scan_type = VU_FULL_SCAN;
     scan_ctx.agent_id = 0;
+    cJSON* j_status = __real_cJSON_CreateString("SUCCESS");
+    cJSON* j_action = __real_cJSON_CreateString("INSERT");
 
     agent->dist = FEED_UBUNTU;
     agent->dist_ver = FEED_FOCAL;
@@ -4707,6 +4776,22 @@ void test_wm_vuldet_process_agent_vulnerabilities_fill_report_oval_error(void **
     os_calloc(1, sizeof(OSHashNode), node);
     if (!node || (OS_INVALID == build_test_hash_node(node, VU_SRC_OVAL)))
         return;
+
+    // wdb_agents_vuln_cves_insert
+    will_return(__wrap_wdb_agents_vuln_cves_insert, (cJSON*)1);
+    expect_value(__wrap_wdb_agents_vuln_cves_insert, id, 0);
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, name, "libhogweed4");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, version, "5.3.4");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, architecture, "x86_64");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, cve, "CVE-2016-6489");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, reference, "e91d3dd01b9214df53c8f3985f028112268d2173");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, type, VULN_CVES_TYPE_PACKAGE);
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, status, VULN_CVES_STATUS_VALID);
+    expect_value(__wrap_wdb_agents_vuln_cves_insert, check_pkg_existence, TRUE);
+
+    will_return(__wrap_cJSON_GetObjectItem, j_status);
+    will_return(__wrap_cJSON_GetObjectItem, j_action);
+    expect_function_call(__wrap_cJSON_Delete);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug1, formatted_msg, "(5466): Sending vulnerabilities report for agent '000'");
@@ -4732,6 +4817,8 @@ void test_wm_vuldet_process_agent_vulnerabilities_fill_report_oval_error(void **
     wm_vuldet_free_cve_node(node->data);
     os_free(node->key);
     os_free(node);
+    __real_cJSON_Delete(j_action);
+    __real_cJSON_Delete(j_status);
 }
 
 void test_wm_vuldet_process_agent_vulnerabilities_vuln_cves_insert_error(void **state)
@@ -4740,7 +4827,7 @@ void test_wm_vuldet_process_agent_vulnerabilities_vuln_cves_insert_error(void **
     sqlite3 *db = (sqlite3 *)1;
     OSHash *cve_table = (OSHash *)1;
     scan_ctx_t scan_ctx;
-    scan_ctx.scan_type = VU_BASELINE_SCAN;
+    scan_ctx.scan_type = VU_FULL_SCAN;
     scan_ctx.agent_id = 0;
 
     wm_max_eps = 1000000;
@@ -4869,13 +4956,13 @@ void test_wm_vuldet_process_agent_vulnerabilities_vuln_cves_insert_error(void **
     expect_string(__wrap_wdb_agents_vuln_cves_insert, version, "5.3.4");
     expect_string(__wrap_wdb_agents_vuln_cves_insert, architecture, "x86_64");
     expect_string(__wrap_wdb_agents_vuln_cves_insert, cve, "CVE-2016-6489");
-    expect_string(__wrap_wdb_agents_vuln_cves_insert, reference, "UNDEFINED");
-    expect_string(__wrap_wdb_agents_vuln_cves_insert, type, "OS");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, reference, "e91d3dd01b9214df53c8f3985f028112268d2173");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, type, VULN_CVES_TYPE_PACKAGE);
     expect_string(__wrap_wdb_agents_vuln_cves_insert, status, "VALID");
     expect_value(__wrap_wdb_agents_vuln_cves_insert, check_pkg_existence, TRUE);
     will_return(__wrap_wdb_agents_vuln_cves_insert, NULL);
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Failed to insert CVE-2016-6489 for package libhogweed4 in the agent 000 database");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Failed to insert CVE-2016-6489 for package e91d3dd01b9214df53c8f3985f028112268d2173 in the agent 000 database");
     // Sending CVE report
     will_return(__wrap_cJSON_CreateObject, NULL);
 
@@ -4884,9 +4971,6 @@ void test_wm_vuldet_process_agent_vulnerabilities_vuln_cves_insert_error(void **
 
     expect_value(__wrap_OSHash_Next, self, cve_table);
     will_return(__wrap_OSHash_Next, NULL);
-
-    expect_string(__wrap__mtwarn, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtwarn, formatted_msg, "Failed to insert vulnerabilities in the agent 000 database");
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5482): A total of '0' vulnerabilities have been reported for agent '000' thanks to the 'NVD' feed.");
@@ -4916,8 +5000,10 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_error(void **s
     sqlite3 *db = (sqlite3 *)1;
     OSHash *cve_table = (OSHash *)1;
     scan_ctx_t scan_ctx;
-    scan_ctx.scan_type = VU_BASELINE_SCAN;
+    scan_ctx.scan_type = VU_FULL_SCAN;
     scan_ctx.agent_id = 0;
+    cJSON* j_status = __real_cJSON_CreateString("SUCCESS");
+    cJSON* j_action = __real_cJSON_CreateString("INSERT");
 
     wm_max_eps = 1000000;
 
@@ -5045,12 +5131,16 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_error(void **s
     expect_string(__wrap_wdb_agents_vuln_cves_insert, version, "5.3.4");
     expect_string(__wrap_wdb_agents_vuln_cves_insert, architecture, "x86_64");
     expect_string(__wrap_wdb_agents_vuln_cves_insert, cve, "CVE-2016-6489");
-    expect_string(__wrap_wdb_agents_vuln_cves_insert, reference, "UNDEFINED");
-    expect_string(__wrap_wdb_agents_vuln_cves_insert, type, "OS");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, reference, "e91d3dd01b9214df53c8f3985f028112268d2173");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, type, "PACKAGE");
     expect_string(__wrap_wdb_agents_vuln_cves_insert, status, "VALID");
     expect_value(__wrap_wdb_agents_vuln_cves_insert, check_pkg_existence, TRUE);
     will_return(__wrap_wdb_agents_vuln_cves_insert, (cJSON *)1);
+
+    will_return(__wrap_cJSON_GetObjectItem, j_status);
+    will_return(__wrap_cJSON_GetObjectItem, j_action);
     expect_function_call(__wrap_cJSON_Delete);
+
     // Sending CVE report
     will_return(__wrap_cJSON_CreateObject, NULL);
 
@@ -5080,6 +5170,8 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_error(void **s
     wm_vuldet_free_cve_node(node->data);
     os_free(node->key);
     os_free(node);
+    __real_cJSON_Delete(j_action);
+    __real_cJSON_Delete(j_status);
 }
 
 void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_negative_version(void **state)
@@ -5088,8 +5180,10 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_negative_versi
     sqlite3 *db = (sqlite3 *)1;
     OSHash *cve_table = (OSHash *)1;
     scan_ctx_t scan_ctx;
-    scan_ctx.scan_type = VU_BASELINE_SCAN;
+    scan_ctx.scan_type = VU_FULL_SCAN;
     scan_ctx.agent_id = 0;
+    cJSON* j_status = __real_cJSON_CreateString("SUCCESS");
+    cJSON* j_action = __real_cJSON_CreateString("INSERT");
 
     wm_max_eps = 1000000;
 
@@ -5218,14 +5312,17 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_negative_versi
     //Save the vulnerability in the agent database
     expect_value(__wrap_wdb_agents_vuln_cves_insert, id, 0);
     expect_string(__wrap_wdb_agents_vuln_cves_insert, name, "libhogweed4");
-    expect_string(__wrap_wdb_agents_vuln_cves_insert, version, "");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, version, "-1:");
     expect_string(__wrap_wdb_agents_vuln_cves_insert, architecture, "x86_64");
     expect_string(__wrap_wdb_agents_vuln_cves_insert, cve, "CVE-2016-6489");
-    expect_string(__wrap_wdb_agents_vuln_cves_insert, reference, "UNDEFINED");
-    expect_string(__wrap_wdb_agents_vuln_cves_insert, type, "OS");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, reference, "e91d3dd01b9214df53c8f3985f028112268d2173");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, type, "PACKAGE");
     expect_string(__wrap_wdb_agents_vuln_cves_insert, status, "VALID");
     expect_value(__wrap_wdb_agents_vuln_cves_insert, check_pkg_existence, TRUE);
     will_return(__wrap_wdb_agents_vuln_cves_insert, (cJSON *)1);
+
+    will_return(__wrap_cJSON_GetObjectItem, j_status);
+    will_return(__wrap_cJSON_GetObjectItem, j_action);
     expect_function_call(__wrap_cJSON_Delete);
     // Sending CVE report
     will_return(__wrap_cJSON_CreateObject, NULL);
@@ -5256,6 +5353,8 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_negative_versi
     wm_vuldet_free_cve_node(node->data);
     os_free(node->key);
     os_free(node);
+    __real_cJSON_Delete(j_action);
+    __real_cJSON_Delete(j_status);
 }
 
 void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_adding_data_from_OVAL_error(void **state)
@@ -5264,8 +5363,10 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_adding_data_fr
     sqlite3 *db = (sqlite3 *)1;
     OSHash *cve_table = (OSHash *)1;
     scan_ctx_t scan_ctx;
-    scan_ctx.scan_type = VU_BASELINE_SCAN;
+    scan_ctx.scan_type = VU_FULL_SCAN;
     scan_ctx.agent_id = 0;
+    cJSON* j_status = __real_cJSON_CreateString("SUCCESS");
+    cJSON* j_action = __real_cJSON_CreateString("INSERT");
 
     wm_max_eps = 1000000;
 
@@ -5276,6 +5377,22 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_adding_data_fr
     os_calloc(1, sizeof(OSHashNode), node);
     if (!node || (OS_INVALID == build_test_hash_node(node, VU_SRC_OVAL)))
         return;
+
+    //Save the vulnerability in the agent database
+    expect_value(__wrap_wdb_agents_vuln_cves_insert, id, 0);
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, name, "libhogweed4");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, version, "5.3.4");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, architecture, "x86_64");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, cve, "CVE-2016-6489");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, reference, "e91d3dd01b9214df53c8f3985f028112268d2173");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, type, "PACKAGE");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, status, "VALID");
+    expect_value(__wrap_wdb_agents_vuln_cves_insert, check_pkg_existence, TRUE);
+    will_return(__wrap_wdb_agents_vuln_cves_insert, (cJSON *)1);
+
+    will_return(__wrap_cJSON_GetObjectItem, j_status);
+    will_return(__wrap_cJSON_GetObjectItem, j_action);
+    expect_function_call(__wrap_cJSON_Delete);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug1, formatted_msg, "(5466): Sending vulnerabilities report for agent '000'");
@@ -5396,6 +5513,8 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_adding_data_fr
     wm_vuldet_free_cve_node(node->data);
     os_free(node->key);
     os_free(node);
+    __real_cJSON_Delete(j_action);
+    __real_cJSON_Delete(j_status);
 }
 
 void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_without_errors_OVAL(void **state)
@@ -5403,8 +5522,10 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_without_errors
     // wm_vuldet_init
     wm_vuldet_t *vuldet = calloc(1, sizeof(wm_vuldet_t));
     scan_ctx_t scan_ctx;
-    scan_ctx.scan_type = VU_BASELINE_SCAN;
+    scan_ctx.scan_type = VU_FULL_SCAN;
     scan_ctx.agent_id = 0;
+    cJSON* j_status = __real_cJSON_CreateString("SUCCESS");
+    cJSON* j_action = __real_cJSON_CreateString("INSERT");
 
     if (!vuldet) {
         return;
@@ -5424,7 +5545,6 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_without_errors
     will_return(__wrap_OS_GetOneContentforElement, "node01");
 
     wm_vuldet_init(vuldet);
-
 
     scan_agent *agent = *state;
     sqlite3 *db = (sqlite3 *)1;
@@ -5557,11 +5677,14 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_without_errors
     expect_string(__wrap_wdb_agents_vuln_cves_insert, version, "5.3.4");
     expect_string(__wrap_wdb_agents_vuln_cves_insert, architecture, "x86_64");
     expect_string(__wrap_wdb_agents_vuln_cves_insert, cve, "CVE-2016-6489");
-    expect_string(__wrap_wdb_agents_vuln_cves_insert, reference, "UNDEFINED");
-    expect_string(__wrap_wdb_agents_vuln_cves_insert, type, "OS");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, reference, "e91d3dd01b9214df53c8f3985f028112268d2173");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, type, "PACKAGE");
     expect_string(__wrap_wdb_agents_vuln_cves_insert, status, "VALID");
     expect_value(__wrap_wdb_agents_vuln_cves_insert, check_pkg_existence, TRUE);
     will_return(__wrap_wdb_agents_vuln_cves_insert, (cJSON *)1);
+
+    will_return(__wrap_cJSON_GetObjectItem, j_status);
+    will_return(__wrap_cJSON_GetObjectItem, j_action);
     expect_function_call(__wrap_cJSON_Delete);
 
     // Sending the CVE report
@@ -5713,10 +5836,12 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_without_errors
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5468): The 'libhogweed4' package (5.3.4) from agent '000' is vulnerable to 'CVE-2016-6489'. Condition: 'Package less than 4.3-2'");
 
-    expect_string(__wrap_SendMSG, message, "{\"title\": \"vulnerability detector alert json\"}");
-    expect_string(__wrap_SendMSG, locmsg, "vulnerability-detector");
-    expect_value(__wrap_SendMSG, loc, LOCALFILE_MQ);
-    will_return(__wrap_SendMSG, OS_SUCCESS);
+    will_return(__wrap_wm_sendmsg, 0);
+    expect_value(__wrap_wm_sendmsg, usec, 1000000 / wm_max_eps);
+    expect_value(__wrap_wm_sendmsg, queue, 1);
+    expect_string(__wrap_wm_sendmsg, message, "{\"title\": \"vulnerability detector alert json\"}");
+    expect_string(__wrap_wm_sendmsg, locmsg, "vulnerability-detector");
+    expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
 
     expect_function_call(__wrap_cJSON_Delete);
 
@@ -5746,6 +5871,8 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_without_errors
     os_free(node->key);
     os_free(node);
     os_free(vuldet);
+    __real_cJSON_Delete(j_action);
+    __real_cJSON_Delete(j_status);
 }
 
 void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_without_errors_NVD(void **state)
@@ -5753,8 +5880,10 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_without_errors
     // wm_vuldet_init
     wm_vuldet_t *vuldet = calloc(1, sizeof(wm_vuldet_t));
     scan_ctx_t scan_ctx;
-    scan_ctx.scan_type = VU_BASELINE_SCAN;
+    scan_ctx.scan_type = VU_FULL_SCAN;
     scan_ctx.agent_id = 0;
+    cJSON* j_status = __real_cJSON_CreateString("SUCCESS");
+    cJSON* j_action = __real_cJSON_CreateString("INSERT");
 
     if (!vuldet) {
         return;
@@ -5907,11 +6036,14 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_without_errors
     expect_string(__wrap_wdb_agents_vuln_cves_insert, version, "5.3.4");
     expect_string(__wrap_wdb_agents_vuln_cves_insert, architecture, "x86_64");
     expect_string(__wrap_wdb_agents_vuln_cves_insert, cve, "CVE-2016-6489");
-    expect_string(__wrap_wdb_agents_vuln_cves_insert, reference, "UNDEFINED");
-    expect_string(__wrap_wdb_agents_vuln_cves_insert, type, "OS");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, reference, "e91d3dd01b9214df53c8f3985f028112268d2173");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, type, "PACKAGE");
     expect_string(__wrap_wdb_agents_vuln_cves_insert, status, "VALID");
     expect_value(__wrap_wdb_agents_vuln_cves_insert, check_pkg_existence, TRUE);
     will_return(__wrap_wdb_agents_vuln_cves_insert, (cJSON *)1);
+
+    will_return(__wrap_cJSON_GetObjectItem, j_status);
+    will_return(__wrap_cJSON_GetObjectItem, j_action);
     expect_function_call(__wrap_cJSON_Delete);
 
     // Sending the CVE report
@@ -6063,10 +6195,12 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_without_errors
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5468): The 'libhogweed4' package (5.3.4) from agent '000' is vulnerable to 'CVE-2016-6489'. Condition: 'Package matches a vulnerable version'");
 
-    expect_string(__wrap_SendMSG, message, "{\"title\": \"vulnerability detector alert json\"}");
-    expect_string(__wrap_SendMSG, locmsg, "vulnerability-detector");
-    expect_value(__wrap_SendMSG, loc, LOCALFILE_MQ);
-    will_return(__wrap_SendMSG, OS_SUCCESS);
+    will_return(__wrap_wm_sendmsg, 0);
+    expect_value(__wrap_wm_sendmsg, usec, 1000000 / wm_max_eps);
+    expect_value(__wrap_wm_sendmsg, queue, 1);
+    expect_string(__wrap_wm_sendmsg, message, "{\"title\": \"vulnerability detector alert json\"}");
+    expect_string(__wrap_wm_sendmsg, locmsg, "vulnerability-detector");
+    expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
 
     expect_function_call(__wrap_cJSON_Delete);
 
@@ -6096,6 +6230,8 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_without_errors
     os_free(node->key);
     os_free(node);
     os_free(vuldet);
+    __real_cJSON_Delete(j_action);
+    __real_cJSON_Delete(j_status);
 }
 
 /* wm_vuldet_get_cvss */
@@ -6721,7 +6857,6 @@ void test_wm_vuldet_get_cvss_v3(void ** state)
 }
 
 /* wm_vuldet_send_cve_report */
-// TO DO #7749: Fix UT
 
 void test_wm_vuldet_send_cve_report_error_alert_create(void **state)
 {
@@ -7436,6 +7571,8 @@ void test_wm_vuldet_send_cve_report_without_title(void **state)
     // Adding CVE information
     expect_string(__wrap_cJSON_AddStringToObject, name, "cve");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->cve);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "title");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "CVE-2016-6489 affects libhogweed4");
     expect_string(__wrap_cJSON_AddStringToObject, name, "rationale");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->rationale);
     expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
@@ -7499,10 +7636,12 @@ void test_wm_vuldet_send_cve_report_without_title(void **state)
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5467): Agent '001' is vulnerable to 'CVE-2016-6489'. Condition: 'Package less than 4.3-2'");
 
-    expect_string(__wrap_SendMSG, message, "1:vulnerability-detector:{\"title\": \"vulnerability detector alert json\"}");
-    expect_string(__wrap_SendMSG, locmsg, "[001] (Ubuntu_WAgent) 192.168.0.125");
-    expect_value(__wrap_SendMSG, loc, SECURE_MQ);
-    will_return(__wrap_SendMSG, OS_SUCCESS);
+    will_return(__wrap_wm_sendmsg, 0);
+    expect_value(__wrap_wm_sendmsg, usec, 1000000 / wm_max_eps);
+    expect_value(__wrap_wm_sendmsg, queue, 1);
+    expect_string(__wrap_wm_sendmsg, message, "1:vulnerability-detector:{\"title\": \"vulnerability detector alert json\"}");
+    expect_string(__wrap_wm_sendmsg, locmsg, "[001] (Ubuntu_WAgent) 192.168.0.125");
+    expect_value(__wrap_wm_sendmsg, loc, SECURE_MQ);
 
     expect_function_call(__wrap_cJSON_Delete);
 
@@ -7687,10 +7826,13 @@ void test_wm_vuldet_send_cve_report_without_condition(void **state)
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5467): Agent '001' is vulnerable to 'CVE-2016-6489'. Condition: 'Package CVE-2016-6489 reports as vulnerable all the versions of this package 4.3-2'");
 
-    expect_string(__wrap_SendMSG, message, "1:vulnerability-detector:{\"title\": \"vulnerability detector alert json\"}");
-    expect_string(__wrap_SendMSG, locmsg, "[001] (Ubuntu_WAgent) 192.168.0.125");
-    expect_value(__wrap_SendMSG, loc, SECURE_MQ);
-    will_return(__wrap_SendMSG, OS_SUCCESS);
+    will_return(__wrap_wm_sendmsg, 0);
+    expect_value(__wrap_wm_sendmsg, usec, 1000000 / wm_max_eps);
+    expect_value(__wrap_wm_sendmsg, queue, 1);
+    expect_string(__wrap_wm_sendmsg, message, "1:vulnerability-detector:{\"title\": \"vulnerability detector alert json\"}");
+    expect_string(__wrap_wm_sendmsg, locmsg, "[001] (Ubuntu_WAgent) 192.168.0.125");
+    expect_value(__wrap_wm_sendmsg, loc, SECURE_MQ);
+
 
     expect_function_call(__wrap_cJSON_Delete);
 
@@ -7875,10 +8017,12 @@ void test_wm_vuldet_send_cve_report_without_ip(void **state)
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5467): Agent '001' is vulnerable to 'CVE-2016-6489'. Condition: 'Package less than 4.3-2'");
 
-    expect_string(__wrap_SendMSG, message, "{\"title\": \"vulnerability detector alert json\"}");
-    expect_string(__wrap_SendMSG, locmsg, "vulnerability-detector");
-    expect_value(__wrap_SendMSG, loc, LOCALFILE_MQ);
-    will_return(__wrap_SendMSG, OS_SUCCESS);
+    will_return(__wrap_wm_sendmsg, 0);
+    expect_value(__wrap_wm_sendmsg, usec, 1000000 / wm_max_eps);
+    expect_value(__wrap_wm_sendmsg, queue, 1);
+    expect_string(__wrap_wm_sendmsg, message, "{\"title\": \"vulnerability detector alert json\"}");
+    expect_string(__wrap_wm_sendmsg, locmsg, "vulnerability-detector");
+    expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
 
     expect_function_call(__wrap_cJSON_Delete);
 
@@ -8063,10 +8207,12 @@ void test_wm_vuldet_send_cve_report_without_hotfix(void **state)
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5468): The 'libhogweed4' package (3.4-1) from agent '001' is vulnerable to 'CVE-2016-6489'. Condition: 'Package less than 4.3-2'");
 
-    expect_string(__wrap_SendMSG, message, "1:vulnerability-detector:{\"title\": \"vulnerability detector alert json\"}");
-    expect_string(__wrap_SendMSG, locmsg, "[001] (Ubuntu_WAgent) 192.168.0.125");
-    expect_value(__wrap_SendMSG, loc, SECURE_MQ);
-    will_return(__wrap_SendMSG, OS_SUCCESS);
+    will_return(__wrap_wm_sendmsg, 0);
+    expect_value(__wrap_wm_sendmsg, usec, 1000000 / wm_max_eps);
+    expect_value(__wrap_wm_sendmsg, queue, 1);
+    expect_string(__wrap_wm_sendmsg, message, "1:vulnerability-detector:{\"title\": \"vulnerability detector alert json\"}");
+    expect_string(__wrap_wm_sendmsg, locmsg, "[001] (Ubuntu_WAgent) 192.168.0.125");
+    expect_value(__wrap_wm_sendmsg, loc, SECURE_MQ);
 
     expect_function_call(__wrap_cJSON_Delete);
 
@@ -8251,18 +8397,17 @@ void test_wm_vuldet_send_cve_report_sendmsg_error(void **state)
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5468): The 'libhogweed4' package (3.4-1) from agent '001' is vulnerable to 'CVE-2016-6489'. Condition: 'Package less than 4.3-2'");
 
-    expect_string(__wrap_SendMSG, message, "1:vulnerability-detector:{\"title\": \"vulnerability detector alert json\"}");
-    expect_string(__wrap_SendMSG, locmsg, "[001] (Ubuntu_WAgent) 192.168.0.125");
-    expect_value(__wrap_SendMSG, loc, SECURE_MQ);
-    will_return(__wrap_SendMSG, OS_INVALID);
+    will_return(__wrap_wm_sendmsg, OS_INVALID);
+    expect_value(__wrap_wm_sendmsg, usec, 1000000 / wm_max_eps);
+    expect_value(__wrap_wm_sendmsg, queue, 1);
+    expect_string(__wrap_wm_sendmsg, message, "1:vulnerability-detector:{\"title\": \"vulnerability detector alert json\"}");
+    expect_string(__wrap_wm_sendmsg, locmsg, "[001] (Ubuntu_WAgent) 192.168.0.125");
+    expect_value(__wrap_wm_sendmsg, loc, SECURE_MQ);
 
     char* strerr = NULL;
     os_strdup("Error sending message", strerr);
     will_return(__wrap_strerror, strerr);
 
-    expect_string(__wrap__merror, formatted_msg, "At wm_sendmsg(): Unable to send message to queue: (Error sending message)");
-
-    will_return(__wrap_strerror, strerr);
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(1210): Queue 'queue/sockets/queue' not accessible: 'Error sending message'");
 
@@ -8675,7 +8820,6 @@ void test_wm_vuldet_free_cve_node(void **state)
 }
 
 /* wm_vuldet_find_agent_vulnerabilities */
-// TO DO #7749: Fix UT
 
 void test_wm_vuldet_find_agent_vulnerabilities_agent_info_NULL(void **state)
 {
@@ -8699,10 +8843,15 @@ void test_wm_vuldet_find_agent_vulnerabilities_agent_windows_error(void **state)
     OSHash *cve_table = (OSHash *)1;
     scan_ctx_t scan_ctx = {0};
     scan_ctx.agent_id = 0;
+    scan_ctx.os_scan = 1;
     scan_ctx.scan_type = VU_FULL_SCAN;
 
     agent->dist = FEED_WIN;
 
+    will_return(__wrap_wdb_agents_vuln_cves_update_status, OS_SUCCESS);
+    expect_value(__wrap_wdb_agents_vuln_cves_update_status, id, 0);
+    expect_string(__wrap_wdb_agents_vuln_cves_update_status, old_status, "*");
+    expect_string(__wrap_wdb_agents_vuln_cves_update_status, new_status, VULN_CVES_STATUS_PENDING);
     will_return(__wrap_wm_vuldet_win_nvd_vulnerabilities, -1);
 
     int ret = wm_vuldet_find_agent_vulnerabilities(db, agent, NULL, &scan_ctx);
@@ -8717,10 +8866,15 @@ void test_wm_vuldet_find_agent_vulnerabilities_agent_windows_OK(void **state)
     OSHash *cve_table = (OSHash *)1;
     scan_ctx_t scan_ctx = {0};
     scan_ctx.agent_id = 0;
+    scan_ctx.os_scan = 1;
     scan_ctx.scan_type = VU_FULL_SCAN;
 
     agent->dist = FEED_WIN;
 
+    will_return(__wrap_wdb_agents_vuln_cves_update_status, OS_SUCCESS);
+    expect_value(__wrap_wdb_agents_vuln_cves_update_status, id, 0);
+    expect_string(__wrap_wdb_agents_vuln_cves_update_status, old_status, "*");
+    expect_string(__wrap_wdb_agents_vuln_cves_update_status, new_status, VULN_CVES_STATUS_PENDING);
     will_return(__wrap_wm_vuldet_win_nvd_vulnerabilities, 0);
 
     int ret = wm_vuldet_find_agent_vulnerabilities(db, agent, NULL, &scan_ctx);
@@ -8735,9 +8889,15 @@ void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_create_hash_error(voi
     OSHash *cve_table = NULL;
     scan_ctx_t scan_ctx = {0};
     scan_ctx.agent_id = 0;
+    scan_ctx.os_scan = 1;
     scan_ctx.scan_type = VU_FULL_SCAN;
 
     agent->dist = FEED_CANONICAL;
+
+    will_return(__wrap_wdb_agents_vuln_cves_update_status, OS_SUCCESS);
+    expect_value(__wrap_wdb_agents_vuln_cves_update_status, id, 0);
+    expect_string(__wrap_wdb_agents_vuln_cves_update_status, old_status, "*");
+    expect_string(__wrap_wdb_agents_vuln_cves_update_status, new_status, VULN_CVES_STATUS_PENDING);
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, 0);
@@ -8756,9 +8916,15 @@ void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_setSize_hash_error(vo
     OSHash *cve_table = NULL;
     scan_ctx_t scan_ctx = {0};
     scan_ctx.agent_id = 0;
+    scan_ctx.os_scan = 1;
     scan_ctx.scan_type = VU_FULL_SCAN;
 
     agent->dist = FEED_CANONICAL;
+
+    will_return(__wrap_wdb_agents_vuln_cves_update_status, OS_SUCCESS);
+    expect_value(__wrap_wdb_agents_vuln_cves_update_status, id, 0);
+    expect_string(__wrap_wdb_agents_vuln_cves_update_status, old_status, "*");
+    expect_string(__wrap_wdb_agents_vuln_cves_update_status, new_status, VULN_CVES_STATUS_PENDING);
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, 1);
@@ -8780,9 +8946,15 @@ void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_oval_vulnerabilities_
     OSHash *cve_table = (OSHash *)1;
     scan_ctx_t scan_ctx = {0};
     scan_ctx.agent_id = 0;
+    scan_ctx.os_scan = 1;
     scan_ctx.scan_type = VU_FULL_SCAN;
 
     agent->dist = FEED_CANONICAL;
+
+    will_return(__wrap_wdb_agents_vuln_cves_update_status, OS_SUCCESS);
+    expect_value(__wrap_wdb_agents_vuln_cves_update_status, id, 0);
+    expect_string(__wrap_wdb_agents_vuln_cves_update_status, old_status, "*");
+    expect_string(__wrap_wdb_agents_vuln_cves_update_status, new_status, VULN_CVES_STATUS_PENDING);
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, cve_table);
@@ -8827,10 +8999,16 @@ void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_nvd_vulnerabilities_e
     OSHash *cve_table = (OSHash *)1;
     scan_ctx_t scan_ctx = {0};
     scan_ctx.agent_id = 0;
+    scan_ctx.os_scan = 1;
     scan_ctx.scan_type = VU_FULL_SCAN;
 
     agent->dist = FEED_DEBIAN;
     agent->dist_ver = FEED_BUSTER;
+
+    will_return(__wrap_wdb_agents_vuln_cves_update_status, OS_SUCCESS);
+    expect_value(__wrap_wdb_agents_vuln_cves_update_status, id, 0);
+    expect_string(__wrap_wdb_agents_vuln_cves_update_status, old_status, "*");
+    expect_string(__wrap_wdb_agents_vuln_cves_update_status, new_status, VULN_CVES_STATUS_PENDING);
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, cve_table);
@@ -8906,6 +9084,7 @@ void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_rm_false_positivies_e
     OSHash *cve_table = (OSHash *)1;
     scan_ctx_t scan_ctx = {0};
     scan_ctx.agent_id = 0;
+    scan_ctx.os_scan = 1;
     scan_ctx.scan_type = VU_FULL_SCAN;
 
     OSHashNode* node = NULL;
@@ -8915,6 +9094,11 @@ void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_rm_false_positivies_e
 
     agent->dist = FEED_DEBIAN;
     agent->dist_ver = FEED_BUSTER;
+
+    will_return(__wrap_wdb_agents_vuln_cves_update_status, OS_SUCCESS);
+    expect_value(__wrap_wdb_agents_vuln_cves_update_status, id, 0);
+    expect_string(__wrap_wdb_agents_vuln_cves_update_status, old_status, "*");
+    expect_string(__wrap_wdb_agents_vuln_cves_update_status, new_status, VULN_CVES_STATUS_PENDING);
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, cve_table);
@@ -9015,6 +9199,7 @@ void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_send_agent_report_err
     OSHash *cve_table = (OSHash *)1;
     scan_ctx_t scan_ctx = {0};
     scan_ctx.agent_id = 0;
+    scan_ctx.os_scan = 1;
     scan_ctx.scan_type = VU_FULL_SCAN;
 
     OSHashNode* node = NULL;
@@ -9029,6 +9214,11 @@ void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_send_agent_report_err
 
     agent->dist = FEED_DEBIAN;
     agent->dist_ver = FEED_BUSTER;
+
+    will_return(__wrap_wdb_agents_vuln_cves_update_status, OS_SUCCESS);
+    expect_value(__wrap_wdb_agents_vuln_cves_update_status, id, 0);
+    expect_string(__wrap_wdb_agents_vuln_cves_update_status, old_status, "*");
+    expect_string(__wrap_wdb_agents_vuln_cves_update_status, new_status, VULN_CVES_STATUS_PENDING);
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, cve_table);
@@ -9168,6 +9358,7 @@ void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_OK(void **state)
     OSHash *cve_table = (OSHash *)1;
     scan_ctx_t scan_ctx = {0};
     scan_ctx.agent_id = 0;
+    scan_ctx.os_scan = 1;
     scan_ctx.scan_type = VU_FULL_SCAN;
 
     OSHashNode* node = NULL;
@@ -9177,6 +9368,11 @@ void test_wm_vuldet_find_agent_vulnerabilities_agent_linux_OK(void **state)
 
     agent->dist = FEED_DEBIAN;
     agent->dist_ver = FEED_BUSTER;
+
+    will_return(__wrap_wdb_agents_vuln_cves_update_status, OS_SUCCESS);
+    expect_value(__wrap_wdb_agents_vuln_cves_update_status, id, 0);
+    expect_string(__wrap_wdb_agents_vuln_cves_update_status, old_status, "*");
+    expect_string(__wrap_wdb_agents_vuln_cves_update_status, new_status, VULN_CVES_STATUS_PENDING);
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, cve_table);
@@ -17987,7 +18183,6 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_fill_report_oval_data_bugzilla_references_error, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_fill_report_oval_data_advisories_error, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_fill_report_oval_data, setup_scan_agent, teardown_scan_agent),
-        #if 0 //TODO #7749 Fix UTs
         // Tests wm_vuldet_process_agent_vulnerabilities
         cmocka_unit_test_setup_teardown(test_wm_vuldet_process_agent_vulnerabilities_no_hash_node_rh, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_process_agent_vulnerabilities_no_hash_node_ubuntu, setup_scan_agent, teardown_scan_agent),
@@ -18001,7 +18196,6 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_adding_data_from_OVAL_error, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_without_errors_OVAL, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_without_errors_NVD, setup_scan_agent, teardown_scan_agent),
-        #endif
         // Tests test_wm_vuldet_get_cvss
         cmocka_unit_test(test_wm_vuldet_get_cvss_null),
         cmocka_unit_test(test_wm_vuldet_get_cvss_error_cvss_json),
@@ -18050,13 +18244,11 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_error_j_advisories_create, setup_cve_report, teardown_cve_report),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_error_j_bug_references_create, setup_cve_report, teardown_cve_report),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_error_j_references_create, setup_cve_report, teardown_cve_report),
-        #if 0 //TODO #7749 Fix UTs
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_without_title, setup_cve_report, teardown_cve_report),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_without_condition, setup_cve_report, teardown_cve_report),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_without_ip, setup_cve_report, teardown_cve_report),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_without_hotfix, setup_cve_report, teardown_cve_report),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_cve_report_sendmsg_error, setup_cve_report, teardown_cve_report),
-        #endif
         // Tests wm_vuldet_extract_advisories
         cmocka_unit_test(test_wm_vuldet_extract_advisories_no_advisories),
         cmocka_unit_test(test_wm_vuldet_extract_advisories),
@@ -18082,7 +18274,6 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_add_cve_node_not_found, setup_package_comparison, teardown_package_comparison),
         // Tests wm_vuldet_free_cve_node
         cmocka_unit_test(test_wm_vuldet_free_cve_node),
-        #if 0 //TODO #7749 Fix UTs
         // Tests wm_vuldet_find_agent_vulnerabilities
         cmocka_unit_test_setup_teardown(test_wm_vuldet_find_agent_vulnerabilities_agent_info_NULL, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_find_agent_vulnerabilities_agent_windows_error, setup_scan_agent, teardown_scan_agent),
@@ -18094,7 +18285,6 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_find_agent_vulnerabilities_agent_linux_rm_false_positivies_error, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_find_agent_vulnerabilities_agent_linux_send_agent_report_error, setup_scan_agent, teardown_scan_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_find_agent_vulnerabilities_agent_linux_OK, setup_scan_agent, teardown_scan_agent),
-        #endif
         // Tests wm_vuldet_fetch_redhat
         cmocka_unit_test(test_wm_vuldet_fetch_redhat_multi_url_no_valid_response),
         cmocka_unit_test(test_wm_vuldet_fetch_redhat_single_url_no_valid_response),

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -171,7 +171,7 @@ const char *redhat_feed_mock_num_score = "[ {\n \
     \"cvss3_score\":8.6\n \
   } ]";
 
-static int build_test_cve_report(vu_report* report, int add_title, int add_condition, int add_ip, int is_hotfix)
+static int build_test_cve_report(vu_report* report, int add_condition, int add_ip, int is_hotfix)
 {
     if (!report)
         return OS_INVALID;
@@ -220,10 +220,6 @@ static int build_test_cve_report(vu_report* report, int add_title, int add_condi
     report->ref_sources[1] = NULL;
     // Reported software
     os_strdup("libhogweed4", report->software);
-    if (1 == add_title){
-        os_calloc(OS_SIZE_512, sizeof(char), report->title);
-        snprintf(report->title, OS_SIZE_512, "%s affects %s", report->cve, report->software);
-    }
     os_strdup("nettle", report->source);
     os_strdup("o:microsoft:windows_server_2008:r2:sp1::::::", report->generated_cpe);
     os_strdup("3.4-1", report->version);
@@ -6905,7 +6901,7 @@ void test_wm_vuldet_send_cve_report_error_j_cvss_create(void **state)
 {
     vu_report* report = state[REPORT_CVE_REPORT_POS];
 
-    if (OS_INVALID == build_test_cve_report(report, 0, 1, 1, 1))
+    if (OS_INVALID == build_test_cve_report(report, 1, 1, 1))
         return;
 
     cJSON* alert = (cJSON *)1;
@@ -6947,7 +6943,7 @@ void test_wm_vuldet_send_cve_report_error_j_cvss_node_create(void **state)
 {
     vu_report* report = state[REPORT_CVE_REPORT_POS];
 
-    if (OS_INVALID == build_test_cve_report(report, 0, 1, 1, 1))
+    if (OS_INVALID == build_test_cve_report(report, 1, 1, 1))
         return;
 
     cJSON* alert = (cJSON *)1;
@@ -6993,7 +6989,7 @@ void test_wm_vuldet_send_cve_report_error_j_advisories_create(void **state)
 {
     vu_report* report = state[REPORT_CVE_REPORT_POS];
 
-    if (OS_INVALID == build_test_cve_report(report, 0, 1, 1, 1))
+    if (OS_INVALID == build_test_cve_report(report, 1, 1, 1))
         return;
 
     cJSON* alert = (cJSON *)1;
@@ -7141,7 +7137,7 @@ void test_wm_vuldet_send_cve_report_error_j_bug_references_create(void **state)
 {
     vu_report* report = state[REPORT_CVE_REPORT_POS];
 
-    if (OS_INVALID == build_test_cve_report(report, 0, 1, 1, 1))
+    if (OS_INVALID == build_test_cve_report(report, 1, 1, 1))
         return;
 
     cJSON* alert = (cJSON *)1;
@@ -7298,7 +7294,7 @@ void test_wm_vuldet_send_cve_report_error_j_references_create(void **state)
 {
     vu_report* report = state[REPORT_CVE_REPORT_POS];
 
-    if (OS_INVALID == build_test_cve_report(report, 0, 1, 1, 1))
+    if (OS_INVALID == build_test_cve_report(report, 1, 1, 1))
         return;
 
     cJSON* alert = (cJSON *)1;
@@ -7463,7 +7459,7 @@ void test_wm_vuldet_send_cve_report_without_title(void **state)
 {
     vu_report* report = state[REPORT_CVE_REPORT_POS];
 
-    if (OS_INVALID == build_test_cve_report(report, 0, 1, 1, 1))
+    if (OS_INVALID == build_test_cve_report(report, 1, 1, 1))
         return;
 
     cJSON* alert = (cJSON *)1;
@@ -7653,7 +7649,7 @@ void test_wm_vuldet_send_cve_report_without_condition(void **state)
 {
     vu_report* report = state[REPORT_CVE_REPORT_POS];
 
-    if (OS_INVALID == build_test_cve_report(report, 0, 0, 1, 1))
+    if (OS_INVALID == build_test_cve_report(report, 0, 1, 1))
         return;
 
     cJSON* alert = (cJSON *)1;
@@ -7844,7 +7840,7 @@ void test_wm_vuldet_send_cve_report_without_ip(void **state)
 {
     vu_report* report = state[REPORT_CVE_REPORT_POS];
 
-    if (OS_INVALID == build_test_cve_report(report, 0, 1, 0, 1))
+    if (OS_INVALID == build_test_cve_report(report, 1, 0, 1))
         return;
 
     cJSON* alert = (cJSON *)1;
@@ -8034,7 +8030,7 @@ void test_wm_vuldet_send_cve_report_without_hotfix(void **state)
 {
     vu_report* report = state[REPORT_CVE_REPORT_POS];
 
-    if (OS_INVALID == build_test_cve_report(report, 0, 1, 1, 0))
+    if (OS_INVALID == build_test_cve_report(report, 1, 1, 0))
         return;
 
     cJSON* alert = (cJSON *)1;
@@ -8224,7 +8220,7 @@ void test_wm_vuldet_send_cve_report_sendmsg_error(void **state)
 {
     vu_report* report = state[REPORT_CVE_REPORT_POS];
 
-    if (OS_INVALID == build_test_cve_report(report, 0, 1, 1, 0))
+    if (OS_INVALID == build_test_cve_report(report, 1, 1, 0))
         return;
 
     cJSON* alert = (cJSON *)1;

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector_nvd.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector_nvd.c
@@ -23,8 +23,30 @@ void wm_vuldet_free_scan_agent(scan_agent *agent);
 
 char *wm_vuldet_clean_version(const char *version);
 int vw_vuldet_filter_vulnerabilities(vu_feed feed, const char *vendor, const char *target_sw);
-int wm_vuldet_check_generic_package(sqlite3 *dbCVE, vu_feed feed, char *pkg_name, char *pkg_source, char *pkg_version, char *pkg_arch, char *pkg_vendor, OSHash *cve_table, int8_t name_type, int *vuln_count);
-int wm_vuldet_check_specific_package(sqlite3 *dbCVE, vu_feed feed, char *pkg_name, char *pkg_source, char *pkg_version, char *pkg_arch, char *pkg_vendor, OSHash *cve_table, int8_t name_type, int *vuln_count);
+int wm_vuldet_check_generic_package(sqlite3 *dbCVE,
+                                    vu_feed feed,
+                                    char *pkg_name,
+                                    char *pkg_source,
+                                    char *pkg_version,
+                                    char *pkg_arch,
+                                    char *pkg_vendor,
+                                    char *pkg_reference,
+                                    char *pkg_type,
+                                    OSHash *cve_table,
+                                    int8_t name_type,
+                                    int *vuln_count);
+int wm_vuldet_check_specific_package(sqlite3 *dbCVE,
+                                     vu_feed feed,
+                                     char *pkg_name,
+                                     char *pkg_source,
+                                     char *pkg_version,
+                                     char *pkg_arch,
+                                     char *pkg_vendor,
+                                     char *pkg_reference,
+                                     char *pkg_type,
+                                     OSHash *cve_table,
+                                     int8_t name_type,
+                                     int *vuln_count);
 int wm_vuldet_get_children(sqlite3 * dbCVE, int configuration_id, int package_id, int *children);
 int wm_vuldet_get_siblings(sqlite3 * dbCVE, int parent, int configuration_id, int *siblings);
 
@@ -445,6 +467,8 @@ void test_wm_vuldet_check_generic_package_prepare_error(void **state)
     char *pkg_version = NULL;
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = NULL;
     int8_t name_type = PACKAGE_SOURCE;
     int *vuln_count = NULL;
@@ -458,7 +482,18 @@ void test_wm_vuldet_check_generic_package_prepare_error(void **state)
 
     will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_DEBIAN,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, -1);
 }
 
@@ -472,6 +507,8 @@ void test_wm_vuldet_check_generic_package_done(void **state)
     char *pkg_version = NULL;
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = NULL;
     int8_t name_type = PACKAGE_SOURCE;
     int *vuln_count = NULL;
@@ -484,7 +521,18 @@ void test_wm_vuldet_check_generic_package_done(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_DEBIAN,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 0);
 }
 
@@ -498,6 +546,8 @@ void test_wm_vuldet_check_generic_package_skip(void **state)
     char *pkg_version = NULL;
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = NULL;
     int8_t name_type = PACKAGE_SOURCE;
     int *vuln_count = NULL;
@@ -537,7 +587,18 @@ void test_wm_vuldet_check_generic_package_skip(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_DEBIAN,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 0);
 }
 
@@ -551,6 +612,8 @@ void test_wm_vuldet_check_generic_package_start_including_no_vulnerable(void **s
     char *pkg_version = "0.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = NULL;
     int8_t name_type = PACKAGE_SOURCE;
     int *vuln_count = NULL;
@@ -595,7 +658,18 @@ void test_wm_vuldet_check_generic_package_start_including_no_vulnerable(void **s
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_DEBIAN,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 0);
 }
 
@@ -609,6 +683,8 @@ void test_wm_vuldet_check_generic_package_start_including_vulnerable(void **stat
     char *pkg_version = "0.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -655,7 +731,18 @@ void test_wm_vuldet_check_generic_package_start_including_vulnerable(void **stat
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_DEBIAN,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -669,6 +756,8 @@ void test_wm_vuldet_check_generic_package_start_excluding_no_vulnerable(void **s
     char *pkg_version = "0.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = NULL;
     int8_t name_type = PACKAGE_SOURCE;
     int *vuln_count = NULL;
@@ -713,7 +802,18 @@ void test_wm_vuldet_check_generic_package_start_excluding_no_vulnerable(void **s
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_DEBIAN,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 0);
 }
 
@@ -727,6 +827,8 @@ void test_wm_vuldet_check_generic_package_start_excluding_vulnerable(void **stat
     char *pkg_version = "0.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -773,7 +875,18 @@ void test_wm_vuldet_check_generic_package_start_excluding_vulnerable(void **stat
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_DEBIAN,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -787,6 +900,8 @@ void test_wm_vuldet_check_generic_package_no_starts_no_vulnerable(void **state)
     char *pkg_version = "2.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = NULL;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -832,7 +947,18 @@ void test_wm_vuldet_check_generic_package_no_starts_no_vulnerable(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_DEBIAN,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 0);
 }
 
@@ -846,6 +972,8 @@ void test_wm_vuldet_check_generic_package_no_starts_vulnerable(void **state)
     char *pkg_version = "0.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -892,7 +1020,18 @@ void test_wm_vuldet_check_generic_package_no_starts_vulnerable(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_DEBIAN,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -906,6 +1045,8 @@ void test_wm_vuldet_check_generic_package_end_including_no_vulnerable(void **sta
     char *pkg_version = "2.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = NULL;
     int8_t name_type = PACKAGE_SOURCE;
     int *vuln_count = NULL;
@@ -950,7 +1091,18 @@ void test_wm_vuldet_check_generic_package_end_including_no_vulnerable(void **sta
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_DEBIAN,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 0);
 }
 
@@ -964,6 +1116,8 @@ void test_wm_vuldet_check_generic_package_end_including_vulnerable(void **state)
     char *pkg_version = "0.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -1010,7 +1164,18 @@ void test_wm_vuldet_check_generic_package_end_including_vulnerable(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_DEBIAN,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -1024,6 +1189,8 @@ void test_wm_vuldet_check_generic_package_end_excluding_no_vulnerable(void **sta
     char *pkg_version = "2.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = NULL;
     int8_t name_type = PACKAGE_SOURCE;
     int *vuln_count = NULL;
@@ -1068,7 +1235,18 @@ void test_wm_vuldet_check_generic_package_end_excluding_no_vulnerable(void **sta
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_DEBIAN,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 0);
 }
 
@@ -1082,6 +1260,8 @@ void test_wm_vuldet_check_generic_package_end_excluding_vulnerable(void **state)
     char *pkg_version = "0.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -1128,7 +1308,18 @@ void test_wm_vuldet_check_generic_package_end_excluding_vulnerable(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_DEBIAN,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -1142,6 +1333,8 @@ void test_wm_vuldet_check_generic_package_no_ends_no_vulnerable(void **state)
     char *pkg_version = "1.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = NULL;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -1187,7 +1380,18 @@ void test_wm_vuldet_check_generic_package_no_ends_no_vulnerable(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_DEBIAN,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 0);
 }
 
@@ -1201,6 +1405,8 @@ void test_wm_vuldet_check_generic_package_no_ends_vulnerable(void **state)
     char *pkg_version = "1.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -1247,7 +1453,18 @@ void test_wm_vuldet_check_generic_package_no_ends_vulnerable(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_DEBIAN,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -1261,6 +1478,8 @@ void test_wm_vuldet_check_generic_package_no_starts_no_ends_children(void **stat
     char *pkg_version = "0.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -1322,7 +1541,18 @@ void test_wm_vuldet_check_generic_package_no_starts_no_ends_children(void **stat
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_DEBIAN,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -1336,6 +1566,8 @@ void test_wm_vuldet_check_generic_package_no_children_no_siblings(void **state)
     char *pkg_version = "1.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -1384,7 +1616,18 @@ void test_wm_vuldet_check_generic_package_no_children_no_siblings(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_DEBIAN,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -1398,6 +1641,8 @@ void test_wm_vuldet_check_generic_package_children_invalid(void **state)
     char *pkg_version = "1.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = NULL;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -1450,7 +1695,18 @@ void test_wm_vuldet_check_generic_package_children_invalid(void **state)
 
     will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_DEBIAN,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, -1);
 }
 
@@ -1464,6 +1720,8 @@ void test_wm_vuldet_check_generic_package_children_OK(void **state)
     char *pkg_version = "1.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -1529,7 +1787,18 @@ void test_wm_vuldet_check_generic_package_children_OK(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_DEBIAN,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -1543,6 +1812,8 @@ void test_wm_vuldet_check_generic_package_siblings_invalid(void **state)
     char *pkg_version = "1.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = NULL;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -1595,7 +1866,18 @@ void test_wm_vuldet_check_generic_package_siblings_invalid(void **state)
 
     will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_DEBIAN,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, -1);
 }
 
@@ -1609,6 +1891,8 @@ void test_wm_vuldet_check_generic_package_siblings_OK(void **state)
     char *pkg_version = "1.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -1674,7 +1958,18 @@ void test_wm_vuldet_check_generic_package_siblings_OK(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_DEBIAN,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -1688,6 +1983,8 @@ void test_wm_vuldet_check_generic_package_ignore_package(void **state)
     char *pkg_version = "1.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = NULL;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -1728,8 +2025,18 @@ void test_wm_vuldet_check_generic_package_ignore_package(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
-
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_DEBIAN,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -1743,6 +2050,8 @@ void test_wm_vuldet_check_generic_package_insert_package_error(void **state)
     char *pkg_version = "1.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = NULL;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -1808,8 +2117,18 @@ void test_wm_vuldet_check_generic_package_insert_package_error(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
-
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_DEBIAN,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -1823,6 +2142,8 @@ void test_wm_vuldet_check_generic_package_duplicated_package(void **state)
     char *pkg_version = "1.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = NULL;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -1888,7 +2209,18 @@ void test_wm_vuldet_check_generic_package_duplicated_package(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_DEBIAN,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -1902,6 +2234,8 @@ void test_wm_vuldet_check_generic_package_insert_package_OK(void **state)
     char *pkg_version = "1.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -1967,7 +2301,18 @@ void test_wm_vuldet_check_generic_package_insert_package_OK(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_DEBIAN,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -1981,6 +2326,8 @@ void test_wm_vuldet_check_generic_package_insert_package_Ubuntu(void **state)
     char *pkg_version = "1.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -2049,7 +2396,18 @@ void test_wm_vuldet_check_generic_package_insert_package_Ubuntu(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_DEBIAN,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -2063,6 +2421,8 @@ void test_wm_vuldet_check_generic_package_insert_package_Debian(void **state)
     char *pkg_version = "1.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -2131,7 +2491,18 @@ void test_wm_vuldet_check_generic_package_insert_package_Debian(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_DEBIAN,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -2145,6 +2516,8 @@ void test_wm_vuldet_check_generic_package_insert_package_RedHat(void **state)
     char *pkg_version = "1.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -2213,7 +2586,18 @@ void test_wm_vuldet_check_generic_package_insert_package_RedHat(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_DEBIAN,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -2227,6 +2611,8 @@ void test_wm_vuldet_check_generic_package_insert_package_linux_kernel(void **sta
     char *pkg_version = "1.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -2295,7 +2681,18 @@ void test_wm_vuldet_check_generic_package_insert_package_linux_kernel(void **sta
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_DEBIAN,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -2309,6 +2706,8 @@ void test_wm_vuldet_check_generic_package_insert_package_mac_os_x(void **state)
     char *pkg_version = "10.15.1";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -2374,7 +2773,18 @@ void test_wm_vuldet_check_generic_package_insert_package_mac_os_x(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_MAC, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_MAC,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -2388,6 +2798,8 @@ void test_wm_vuldet_check_generic_package_insert_package_mac_os_x_server(void **
     char *pkg_version = "10.15.1";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -2453,7 +2865,18 @@ void test_wm_vuldet_check_generic_package_insert_package_mac_os_x_server(void **
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_MAC, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_MAC,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -2467,6 +2890,8 @@ void test_wm_vuldet_check_generic_package_insert_package_mac_os(void **state)
     char *pkg_version = "10.15.1";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -2532,7 +2957,18 @@ void test_wm_vuldet_check_generic_package_insert_package_mac_os(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_MAC, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_MAC,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -2546,6 +2982,8 @@ void test_wm_vuldet_check_generic_package_insert_package_macos(void **state)
     char *pkg_version = "10.15.1";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -2611,7 +3049,18 @@ void test_wm_vuldet_check_generic_package_insert_package_macos(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_MAC, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_MAC,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -2625,6 +3074,8 @@ void test_wm_vuldet_check_generic_package_insert_package_mac_no_vendor(void **st
     char *pkg_version = "2.1.3";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -2696,7 +3147,18 @@ void test_wm_vuldet_check_generic_package_insert_package_mac_no_vendor(void **st
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_MAC, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_MAC,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -2710,6 +3172,8 @@ void test_wm_vuldet_check_generic_package_insert_package_mac_with_vendor(void **
     char *pkg_version = "2.1.3";
     char *pkg_arch = NULL;
     char *pkg_vendor = "apple";
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -2781,7 +3245,18 @@ void test_wm_vuldet_check_generic_package_insert_package_mac_with_vendor(void **
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_generic_package(db, FEED_MAC, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_generic_package(db,
+                                              FEED_MAC,
+                                              pkg_name,
+                                              pkg_source,
+                                              pkg_version,
+                                              pkg_arch,
+                                              pkg_vendor,
+                                              pkg_reference,
+                                              pkg_type,
+                                              cve_table,
+                                              name_type,
+                                              vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -2797,6 +3272,8 @@ void test_wm_vuldet_check_specific_package_pkg_version_NULL(void **state)
     char *pkg_version = NULL;
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = NULL;
     int8_t name_type = PACKAGE_SOURCE;
     int *vuln_count = NULL;
@@ -2804,7 +3281,18 @@ void test_wm_vuldet_check_specific_package_pkg_version_NULL(void **state)
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5576): Missing version for package 'test' of the inventory.");
 
-    int ret = wm_vuldet_check_specific_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_specific_package(db,
+                                               FEED_DEBIAN,
+                                               pkg_name,
+                                               pkg_source,
+                                               pkg_version,
+                                               pkg_arch,
+                                               pkg_vendor,
+                                               pkg_reference,
+                                               pkg_type,
+                                               cve_table,
+                                               name_type,
+                                               vuln_count);
     assert_int_equal(ret, 0);
 }
 
@@ -2818,6 +3306,8 @@ void test_wm_vuldet_check_specific_package_pkg_version_empty(void **state)
     char *pkg_version = "";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = NULL;
     int8_t name_type = PACKAGE_SOURCE;
     int *vuln_count = NULL;
@@ -2825,7 +3315,18 @@ void test_wm_vuldet_check_specific_package_pkg_version_empty(void **state)
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mterror, formatted_msg, "(5591): Invalid version for package 'test' of the inventory: ''");
 
-    int ret = wm_vuldet_check_specific_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_specific_package(db,
+                                               FEED_DEBIAN,
+                                               pkg_name,
+                                               pkg_source,
+                                               pkg_version,
+                                               pkg_arch,
+                                               pkg_vendor,
+                                               pkg_reference,
+                                               pkg_type,
+                                               cve_table,
+                                               name_type,
+                                               vuln_count);
     assert_int_equal(ret, 0);
 }
 
@@ -2839,6 +3340,8 @@ void test_wm_vuldet_check_specific_package_prepare_error(void **state)
     char *pkg_version = "0.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = NULL;
     int8_t name_type = PACKAGE_SOURCE;
     int *vuln_count = NULL;
@@ -2852,7 +3355,18 @@ void test_wm_vuldet_check_specific_package_prepare_error(void **state)
 
     will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
-    int ret = wm_vuldet_check_specific_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_specific_package(db,
+                                               FEED_DEBIAN,
+                                               pkg_name,
+                                               pkg_source,
+                                               pkg_version,
+                                               pkg_arch,
+                                               pkg_vendor,
+                                               pkg_reference,
+                                               pkg_type,
+                                               cve_table,
+                                               name_type,
+                                               vuln_count);
     assert_int_equal(ret, -1);
 }
 
@@ -2866,6 +3380,8 @@ void test_wm_vuldet_check_specific_package_done(void **state)
     char *pkg_version = "0.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = NULL;
     int8_t name_type = PACKAGE_SOURCE;
     int *vuln_count = NULL;
@@ -2881,7 +3397,18 @@ void test_wm_vuldet_check_specific_package_done(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_specific_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_specific_package(db,
+                                               FEED_DEBIAN,
+                                               pkg_name,
+                                               pkg_source,
+                                               pkg_version,
+                                               pkg_arch,
+                                               pkg_vendor,
+                                               pkg_reference,
+                                               pkg_type,
+                                               cve_table,
+                                               name_type,
+                                               vuln_count);
     assert_int_equal(ret, 0);
 }
 
@@ -2895,6 +3422,8 @@ void test_wm_vuldet_check_specific_package_skip(void **state)
     char *pkg_version = "0.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = NULL;
     int8_t name_type = PACKAGE_SOURCE;
     int *vuln_count = NULL;
@@ -2931,7 +3460,18 @@ void test_wm_vuldet_check_specific_package_skip(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_specific_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_specific_package(db,
+                                               FEED_DEBIAN,
+                                               pkg_name,
+                                               pkg_source,
+                                               pkg_version,
+                                               pkg_arch,
+                                               pkg_vendor,
+                                               pkg_reference,
+                                               pkg_type,
+                                               cve_table,
+                                               name_type,
+                                               vuln_count);
     assert_int_equal(ret, 0);
 }
 
@@ -2945,6 +3485,8 @@ void test_wm_vuldet_check_specific_package_no_vulnerable(void **state)
     char *pkg_version = "0.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = NULL;
     int8_t name_type = PACKAGE_SOURCE;
     int *vuln_count = NULL;
@@ -2986,7 +3528,18 @@ void test_wm_vuldet_check_specific_package_no_vulnerable(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_specific_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_specific_package(db,
+                                               FEED_DEBIAN,
+                                               pkg_name,
+                                               pkg_source,
+                                               pkg_version,
+                                               pkg_arch,
+                                               pkg_vendor,
+                                               pkg_reference,
+                                               pkg_type,
+                                               cve_table,
+                                               name_type,
+                                               vuln_count);
     assert_int_equal(ret, 0);
 }
 
@@ -3000,6 +3553,8 @@ void test_wm_vuldet_check_specific_package_vulnerable(void **state)
     char *pkg_version = "0.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -3043,7 +3598,18 @@ void test_wm_vuldet_check_specific_package_vulnerable(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_specific_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_specific_package(db,
+                                               FEED_DEBIAN,
+                                               pkg_name,
+                                               pkg_source,
+                                               pkg_version,
+                                               pkg_arch,
+                                               pkg_vendor,
+                                               pkg_reference,
+                                               pkg_type,
+                                               cve_table,
+                                               name_type,
+                                               vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -3057,6 +3623,8 @@ void test_wm_vuldet_check_specific_package_no_children_no_siblings(void **state)
     char *pkg_version = "0.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -3100,7 +3668,18 @@ void test_wm_vuldet_check_specific_package_no_children_no_siblings(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_specific_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_specific_package(db,
+                                               FEED_DEBIAN,
+                                               pkg_name,
+                                               pkg_source,
+                                               pkg_version,
+                                               pkg_arch,
+                                               pkg_vendor,
+                                               pkg_reference,
+                                               pkg_type,
+                                               cve_table,
+                                               name_type,
+                                               vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -3114,6 +3693,8 @@ void test_wm_vuldet_check_specific_package_children_invalid(void **state)
     char *pkg_version = "0.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = NULL;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -3161,7 +3742,18 @@ void test_wm_vuldet_check_specific_package_children_invalid(void **state)
 
     will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
-    int ret = wm_vuldet_check_specific_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_specific_package(db,
+                                               FEED_DEBIAN,
+                                               pkg_name,
+                                               pkg_source,
+                                               pkg_version,
+                                               pkg_arch,
+                                               pkg_vendor,
+                                               pkg_reference,
+                                               pkg_type,
+                                               cve_table,
+                                               name_type,
+                                               vuln_count);
     assert_int_equal(ret, -1);
 }
 
@@ -3175,6 +3767,8 @@ void test_wm_vuldet_check_specific_package_children_OK(void **state)
     char *pkg_version = "0.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -3235,7 +3829,18 @@ void test_wm_vuldet_check_specific_package_children_OK(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_specific_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_specific_package(db,
+                                               FEED_DEBIAN,
+                                               pkg_name,
+                                               pkg_source,
+                                               pkg_version,
+                                               pkg_arch,
+                                               pkg_vendor,
+                                               pkg_reference,
+                                               pkg_type,
+                                               cve_table,
+                                               name_type,
+                                               vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -3249,6 +3854,8 @@ void test_wm_vuldet_check_specific_package_siblings_invalid(void **state)
     char *pkg_version = "0.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = NULL;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -3296,7 +3903,18 @@ void test_wm_vuldet_check_specific_package_siblings_invalid(void **state)
 
     will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
 
-    int ret = wm_vuldet_check_specific_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_specific_package(db,
+                                               FEED_DEBIAN,
+                                               pkg_name,
+                                               pkg_source,
+                                               pkg_version,
+                                               pkg_arch,
+                                               pkg_vendor,
+                                               pkg_reference,
+                                               pkg_type,
+                                               cve_table,
+                                               name_type,
+                                               vuln_count);
     assert_int_equal(ret, -1);
 }
 
@@ -3310,6 +3928,8 @@ void test_wm_vuldet_check_specific_package_siblings_OK(void **state)
     char *pkg_version = "0.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -3370,7 +3990,18 @@ void test_wm_vuldet_check_specific_package_siblings_OK(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_specific_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_specific_package(db,
+                                               FEED_DEBIAN,
+                                               pkg_name,
+                                               pkg_source,
+                                               pkg_version,
+                                               pkg_arch,
+                                               pkg_vendor,
+                                               pkg_reference,
+                                               pkg_type,
+                                               cve_table,
+                                               name_type,
+                                               vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -3384,6 +4015,8 @@ void test_wm_vuldet_check_specific_package_os_package_valid(void **state)
     char *pkg_version = "0.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = NULL;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -3447,7 +4080,18 @@ void test_wm_vuldet_check_specific_package_os_package_valid(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_specific_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_specific_package(db,
+                                               FEED_DEBIAN,
+                                               pkg_name,
+                                               pkg_source,
+                                               pkg_version,
+                                               pkg_arch,
+                                               pkg_vendor,
+                                               pkg_reference,
+                                               pkg_type,
+                                               cve_table,
+                                               name_type,
+                                               vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -3461,6 +4105,8 @@ void test_wm_vuldet_check_specific_package_ignore_package(void **state)
     char *pkg_version = "0.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = NULL;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -3503,7 +4149,18 @@ void test_wm_vuldet_check_specific_package_ignore_package(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_specific_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_specific_package(db,
+                                               FEED_DEBIAN,
+                                               pkg_name,
+                                               pkg_source,
+                                               pkg_version,
+                                               pkg_arch,
+                                               pkg_vendor,
+                                               pkg_reference,
+                                               pkg_type,
+                                               cve_table,
+                                               name_type,
+                                               vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -3517,6 +4174,8 @@ void test_wm_vuldet_check_specific_package_insert_package_error(void **state)
     char *pkg_version = "0.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = NULL;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -3577,7 +4236,18 @@ void test_wm_vuldet_check_specific_package_insert_package_error(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_specific_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_specific_package(db,
+                                               FEED_DEBIAN,
+                                               pkg_name,
+                                               pkg_source,
+                                               pkg_version,
+                                               pkg_arch,
+                                               pkg_vendor,
+                                               pkg_reference,
+                                               pkg_type,
+                                               cve_table,
+                                               name_type,
+                                               vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -3591,6 +4261,8 @@ void test_wm_vuldet_check_specific_package_duplicated_package(void **state)
     char *pkg_version = "0.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = NULL;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -3651,7 +4323,18 @@ void test_wm_vuldet_check_specific_package_duplicated_package(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_specific_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_specific_package(db,
+                                               FEED_DEBIAN,
+                                               pkg_name,
+                                               pkg_source,
+                                               pkg_version,
+                                               pkg_arch,
+                                               pkg_vendor,
+                                               pkg_reference,
+                                               pkg_type,
+                                               cve_table,
+                                               name_type,
+                                               vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -3665,6 +4348,8 @@ void test_wm_vuldet_check_specific_package_insert_package_OK(void **state)
     char *pkg_version = "0.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -3725,7 +4410,18 @@ void test_wm_vuldet_check_specific_package_insert_package_OK(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_specific_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_specific_package(db,
+                                               FEED_DEBIAN,
+                                               pkg_name,
+                                               pkg_source,
+                                               pkg_version,
+                                               pkg_arch,
+                                               pkg_vendor,
+                                               pkg_reference,
+                                               pkg_type,
+                                               cve_table,
+                                               name_type,
+                                               vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -3739,6 +4435,8 @@ void test_wm_vuldet_check_specific_package_insert_package_Ubuntu(void **state)
     char *pkg_version = "0.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -3802,7 +4500,18 @@ void test_wm_vuldet_check_specific_package_insert_package_Ubuntu(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_specific_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_specific_package(db,
+                                               FEED_DEBIAN,
+                                               pkg_name,
+                                               pkg_source,
+                                               pkg_version,
+                                               pkg_arch,
+                                               pkg_vendor,
+                                               pkg_reference,
+                                               pkg_type,
+                                               cve_table,
+                                               name_type,
+                                               vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -3816,6 +4525,8 @@ void test_wm_vuldet_check_specific_package_insert_package_Debian(void **state)
     char *pkg_version = "0.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -3879,7 +4590,18 @@ void test_wm_vuldet_check_specific_package_insert_package_Debian(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_specific_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_specific_package(db,
+                                               FEED_DEBIAN,
+                                               pkg_name,
+                                               pkg_source,
+                                               pkg_version,
+                                               pkg_arch,
+                                               pkg_vendor,
+                                               pkg_reference,
+                                               pkg_type,
+                                               cve_table,
+                                               name_type,
+                                               vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -3893,6 +4615,8 @@ void test_wm_vuldet_check_specific_package_insert_package_RedHat(void **state)
     char *pkg_version = "0.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -3956,7 +4680,18 @@ void test_wm_vuldet_check_specific_package_insert_package_RedHat(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_specific_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_specific_package(db,
+                                               FEED_DEBIAN,
+                                               pkg_name,
+                                               pkg_source,
+                                               pkg_version,
+                                               pkg_arch,
+                                               pkg_vendor,
+                                               pkg_reference,
+                                               pkg_type,
+                                               cve_table,
+                                               name_type,
+                                               vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -3970,6 +4705,8 @@ void test_wm_vuldet_check_specific_package_insert_package_linux_kernel(void **st
     char *pkg_version = "0.0.0";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -4033,7 +4770,18 @@ void test_wm_vuldet_check_specific_package_insert_package_linux_kernel(void **st
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_specific_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_specific_package(db,
+                                               FEED_DEBIAN,
+                                               pkg_name,
+                                               pkg_source,
+                                               pkg_version,
+                                               pkg_arch,
+                                               pkg_vendor,
+                                               pkg_reference,
+                                               pkg_type,
+                                               cve_table,
+                                               name_type,
+                                               vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -4047,6 +4795,8 @@ void test_wm_vuldet_check_specific_package_insert_package_mac_os_x(void **state)
     char *pkg_version = "10.15.1";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -4107,7 +4857,18 @@ void test_wm_vuldet_check_specific_package_insert_package_mac_os_x(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_specific_package(db, FEED_MAC, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_specific_package(db,
+                                               FEED_MAC,
+                                               pkg_name,
+                                               pkg_source,
+                                               pkg_version,
+                                               pkg_arch,
+                                               pkg_vendor,
+                                               pkg_reference,
+                                               pkg_type,
+                                               cve_table,
+                                               name_type,
+                                               vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -4121,6 +4882,8 @@ void test_wm_vuldet_check_specific_package_insert_package_mac_os_x_server(void *
     char *pkg_version = "10.15.1";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -4181,7 +4944,18 @@ void test_wm_vuldet_check_specific_package_insert_package_mac_os_x_server(void *
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_specific_package(db, FEED_MAC, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_specific_package(db,
+                                               FEED_MAC,
+                                               pkg_name,
+                                               pkg_source,
+                                               pkg_version,
+                                               pkg_arch,
+                                               pkg_vendor,
+                                               pkg_reference,
+                                               pkg_type,
+                                               cve_table,
+                                               name_type,
+                                               vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -4195,6 +4969,8 @@ void test_wm_vuldet_check_specific_package_insert_package_mac_os(void **state)
     char *pkg_version = "10.15.1";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -4255,7 +5031,18 @@ void test_wm_vuldet_check_specific_package_insert_package_mac_os(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_specific_package(db, FEED_MAC, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_specific_package(db,
+                                               FEED_MAC,
+                                               pkg_name,
+                                               pkg_source,
+                                               pkg_version,
+                                               pkg_arch,
+                                               pkg_vendor,
+                                               pkg_reference,
+                                               pkg_type,
+                                               cve_table,
+                                               name_type,
+                                               vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -4269,6 +5056,8 @@ void test_wm_vuldet_check_specific_package_insert_package_macos(void **state)
     char *pkg_version = "10.15.1";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -4329,7 +5118,18 @@ void test_wm_vuldet_check_specific_package_insert_package_macos(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_specific_package(db, FEED_MAC, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_specific_package(db,
+                                               FEED_MAC,
+                                               pkg_name,
+                                               pkg_source,
+                                               pkg_version,
+                                               pkg_arch,
+                                               pkg_vendor,
+                                               pkg_reference,
+                                               pkg_type,
+                                               cve_table,
+                                               name_type,
+                                               vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -4343,6 +5143,8 @@ void test_wm_vuldet_check_specific_package_insert_package_mac_no_vendor(void **s
     char *pkg_version = "2.1.3";
     char *pkg_arch = NULL;
     char *pkg_vendor = NULL;
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -4409,7 +5211,18 @@ void test_wm_vuldet_check_specific_package_insert_package_mac_no_vendor(void **s
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_specific_package(db, FEED_MAC, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_specific_package(db,
+                                               FEED_MAC,
+                                               pkg_name,
+                                               pkg_source,
+                                               pkg_version,
+                                               pkg_arch,
+                                               pkg_vendor,
+                                               pkg_reference,
+                                               pkg_type,
+                                               cve_table,
+                                               name_type,
+                                               vuln_count);
     assert_int_equal(ret, 1);
 }
 
@@ -4423,6 +5236,8 @@ void test_wm_vuldet_check_specific_package_insert_package_mac_with_vendor(void *
     char *pkg_version = "2.1.3";
     char *pkg_arch = NULL;
     char *pkg_vendor = "apple";
+    char *pkg_reference = NULL;
+    char *pkg_type = NULL;
     OSHash *cve_table = (OSHash *)1;
     int8_t name_type = PACKAGE_SOURCE;
     int i = 1;
@@ -4489,11 +5304,23 @@ void test_wm_vuldet_check_specific_package_insert_package_mac_with_vendor(void *
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    int ret = wm_vuldet_check_specific_package(db, FEED_MAC, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    int ret = wm_vuldet_check_specific_package(db,
+                                               FEED_MAC,
+                                               pkg_name,
+                                               pkg_source,
+                                               pkg_version,
+                                               pkg_arch,
+                                               pkg_vendor,
+                                               pkg_reference,
+                                               pkg_type,
+                                               cve_table,
+                                               name_type,
+                                               vuln_count);
     assert_int_equal(ret, 1);
 }
 
 /* wm_vuldet_linux_nvd_vulnerabilities */
+
 void test_wm_vuldet_linux_nvd_vulnerabilities_prepare_error(void **state)
 {
     scan_agent *agent = *state;
@@ -4578,6 +5405,10 @@ void test_wm_vuldet_linux_nvd_vulnerabilities_no_source_no_name(void **state)
     will_return_count(__wrap_sqlite3_column_text, "x32", 2);       //architecture
     expect_value_count(__wrap_sqlite3_column_text, iCol, 5, 1);
     will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //vendor
+    expect_value_count(__wrap_sqlite3_column_text, iCol, 6, 1);
+    will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //reference
+    expect_value_count(__wrap_sqlite3_column_text, iCol, 7, 1);
+    will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //type
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -4622,6 +5453,10 @@ void test_wm_vuldet_linux_nvd_vulnerabilities_source_generic_invalid(void **stat
     will_return_count(__wrap_sqlite3_column_text, "x32", 2);       //architecture
     expect_value_count(__wrap_sqlite3_column_text, iCol, 5, 1);
     will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //vendor
+    expect_value_count(__wrap_sqlite3_column_text, iCol, 6, 1);
+    will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //reference
+    expect_value_count(__wrap_sqlite3_column_text, iCol, 7, 1);
+    will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //type
 
     //test_wm_vuldet_check_generic_package_prepare_error
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_ERROR);
@@ -4668,6 +5503,10 @@ void test_wm_vuldet_linux_nvd_vulnerabilities_source_specific_invalid(void **sta
     will_return_count(__wrap_sqlite3_column_text, "x32", 2);       //architecture
     expect_value_count(__wrap_sqlite3_column_text, iCol, 5, 1);
     will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //vendor
+    expect_value_count(__wrap_sqlite3_column_text, iCol, 6, 1);
+    will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //reference
+    expect_value_count(__wrap_sqlite3_column_text, iCol, 7, 1);
+    will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //type
 
     //test_wm_vuldet_check_generic_package_siblings_OK
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
@@ -4775,6 +5614,10 @@ void test_wm_vuldet_linux_nvd_vulnerabilities_source_no_vulnerable(void **state)
     will_return_count(__wrap_sqlite3_column_text, "x32", 2);       //architecture
     expect_value_count(__wrap_sqlite3_column_text, iCol, 5, 1);
     will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //vendor
+    expect_value_count(__wrap_sqlite3_column_text, iCol, 6, 1);
+    will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //reference
+    expect_value_count(__wrap_sqlite3_column_text, iCol, 7, 1);
+    will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //type
 
     //test_wm_vuldet_check_generic_package_end_including_no_vulnerable()
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
@@ -4898,6 +5741,10 @@ void test_wm_vuldet_linux_nvd_vulnerabilities_source_vulnerable(void **state)
     will_return_count(__wrap_sqlite3_column_text, "x32", 2);       //architecture
     expect_value_count(__wrap_sqlite3_column_text, iCol, 5, 1);
     will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //vendor
+    expect_value_count(__wrap_sqlite3_column_text, iCol, 6, 1);
+    will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //reference
+    expect_value_count(__wrap_sqlite3_column_text, iCol, 7, 1);
+    will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //type
 
     //test_wm_vuldet_check_generic_package_siblings_OK
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
@@ -5043,6 +5890,10 @@ void test_wm_vuldet_linux_nvd_vulnerabilities_name_generic_invalid(void **state)
     will_return_count(__wrap_sqlite3_column_text, "x32", 2);       //architecture
     expect_value_count(__wrap_sqlite3_column_text, iCol, 5, 1);
     will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //vendor
+    expect_value_count(__wrap_sqlite3_column_text, iCol, 6, 1);
+    will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //reference
+    expect_value_count(__wrap_sqlite3_column_text, iCol, 7, 1);
+    will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //type
 
     //test_wm_vuldet_check_generic_package_prepare_error
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_ERROR);
@@ -5089,6 +5940,10 @@ void test_wm_vuldet_linux_nvd_vulnerabilities_name_specific_invalid(void **state
     will_return_count(__wrap_sqlite3_column_text, "x32", 2);       //architecture
     expect_value_count(__wrap_sqlite3_column_text, iCol, 5, 1);
     will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //vendor
+    expect_value_count(__wrap_sqlite3_column_text, iCol, 6, 1);
+    will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //reference
+    expect_value_count(__wrap_sqlite3_column_text, iCol, 7, 1);
+    will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //type
 
     //test_wm_vuldet_check_generic_package_siblings_OK
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
@@ -5196,6 +6051,10 @@ void test_wm_vuldet_linux_nvd_vulnerabilities_name_no_vulnerable(void **state)
     will_return_count(__wrap_sqlite3_column_text, "x32", 2);       //architecture
     expect_value_count(__wrap_sqlite3_column_text, iCol, 5, 1);
     will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //vendor
+    expect_value_count(__wrap_sqlite3_column_text, iCol, 6, 1);
+    will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //reference
+    expect_value_count(__wrap_sqlite3_column_text, iCol, 7, 1);
+    will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //type
 
     //test_wm_vuldet_check_generic_package_end_including_no_vulnerable()
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
@@ -5319,6 +6178,10 @@ void test_wm_vuldet_linux_nvd_vulnerabilities_name_vulnerable(void **state)
     will_return_count(__wrap_sqlite3_column_text, "x32", 2);       //architecture
     expect_value_count(__wrap_sqlite3_column_text, iCol, 5, 1);
     will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //vendor
+    expect_value_count(__wrap_sqlite3_column_text, iCol, 6, 1);
+    will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //reference
+    expect_value_count(__wrap_sqlite3_column_text, iCol, 7, 1);
+    will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //type
 
     //test_wm_vuldet_check_generic_package_siblings_OK
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
@@ -5464,6 +6327,10 @@ void test_wm_vuldet_linux_nvd_vulnerabilities_pkg_source_version_NULL(void **sta
     will_return_count(__wrap_sqlite3_column_text, "x32", 2);       //architecture
     expect_value_count(__wrap_sqlite3_column_text, iCol, 5, 1);
     will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //vendor
+    expect_value_count(__wrap_sqlite3_column_text, iCol, 6, 1);
+    will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //reference
+    expect_value_count(__wrap_sqlite3_column_text, iCol, 7, 1);
+    will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //type
 
     //test_wm_vuldet_check_generic_package_siblings_OK
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
@@ -5610,6 +6477,10 @@ void test_wm_vuldet_linux_nvd_vulnerabilities_os_pkg_mac(void **state)
     will_return_count(__wrap_sqlite3_column_text, "x64", 2);       //architecture
     expect_value_count(__wrap_sqlite3_column_text, iCol, 5, 1);
     will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //vendor
+    expect_value_count(__wrap_sqlite3_column_text, iCol, 6, 1);
+    will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //reference
+    expect_value_count(__wrap_sqlite3_column_text, iCol, 7, 1);
+    will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //type
 
     //test_wm_vuldet_check_generic_package_siblings_OK
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
@@ -5752,6 +6623,10 @@ void test_wm_vuldet_linux_nvd_vulnerabilities_app_pkg_mac_no_vendor(void **state
     will_return_count(__wrap_sqlite3_column_text, "x64", 2);       //architecture
     expect_value_count(__wrap_sqlite3_column_text, iCol, 5, 1);
     will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //vendor
+    expect_value_count(__wrap_sqlite3_column_text, iCol, 6, 1);
+    will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //reference
+    expect_value_count(__wrap_sqlite3_column_text, iCol, 7, 1);
+    will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //type
 
     //test_wm_vuldet_check_generic_package_siblings_OK
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
@@ -5910,6 +6785,10 @@ void test_wm_vuldet_linux_nvd_vulnerabilities_app_pkg_mac_with_vendor(void **sta
     will_return_count(__wrap_sqlite3_column_text, "x64", 2);       //architecture
     expect_value_count(__wrap_sqlite3_column_text, iCol, 5, 2);
     will_return_count(__wrap_sqlite3_column_text, "apple", 2);        //vendor
+    expect_value_count(__wrap_sqlite3_column_text, iCol, 6, 1);
+    will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //reference
+    expect_value_count(__wrap_sqlite3_column_text, iCol, 7, 1);
+    will_return_count(__wrap_sqlite3_column_text, NULL, 1);        //type
 
     //test_wm_vuldet_check_generic_package_siblings_OK
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.c
@@ -14,16 +14,16 @@
 #include <cmocka.h>
 #include <stdlib.h>
 
-int __wrap_wdb_agents_vuln_cves_insert(int id,
-                                      const char *name,
-                                      const char *version,
-                                      const char *architecture,
-                                      const char *cve,
-                                      const char *reference,
-                                      const char *type,
-                                      const char *status,
-                                      bool check_pkg_existence,
-                                      __attribute__((unused)) int *sock) {
+cJSON* __wrap_wdb_agents_vuln_cves_insert(int id,
+                                          const char *name,
+                                          const char *version,
+                                          const char *architecture,
+                                          const char *cve,
+                                          const char *reference,
+                                          const char *type,
+                                          const char *status,
+                                          bool check_pkg_existence,
+                                          __attribute__((unused)) int *sock) {
     check_expected(id);
     check_expected(name);
     check_expected(version);
@@ -33,7 +33,7 @@ int __wrap_wdb_agents_vuln_cves_insert(int id,
     check_expected(type);
     check_expected(status);
     check_expected(check_pkg_existence);
-    return mock_type(int);
+    return mock_ptr_type(cJSON*);
 }
 
 int __wrap_wdb_agents_vuln_cves_clear(int id,
@@ -48,4 +48,14 @@ cJSON* __wrap_wdb_agents_vuln_cves_remove_by_status(int id,
     check_expected(id);
     check_expected(status);
     return mock_ptr_type(cJSON*);
+}
+
+int __wrap_wdb_agents_vuln_cves_update_status(int id,
+                                       const char *old_status,
+                                       const char *new_status,
+                                       __attribute__((unused)) int *sock) {
+    check_expected(id);
+    check_expected(old_status);
+    check_expected(new_status);
+    return mock_type(int);
 }

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.c
@@ -51,9 +51,9 @@ cJSON* __wrap_wdb_agents_vuln_cves_remove_by_status(int id,
 }
 
 int __wrap_wdb_agents_vuln_cves_update_status(int id,
-                                       const char *old_status,
-                                       const char *new_status,
-                                       __attribute__((unused)) int *sock) {
+                                              const char *old_status,
+                                              const char *new_status,
+                                              __attribute__((unused)) int *sock) {
     check_expected(id);
     check_expected(old_status);
     check_expected(new_status);

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.h
@@ -13,16 +13,16 @@
 
 #include "wazuh_db/wdb.h"
 
-int __wrap_wdb_agents_vuln_cves_insert(int id,
-                                      const char *name,
-                                      const char *version,
-                                      const char *architecture,
-                                      const char *cve,
-                                      const char *reference,
-                                      const char *type,
-                                      const char *status,
-                                      bool check_pkg_existence,
-                                      __attribute__((unused)) int *sock);
+cJSON* __wrap_wdb_agents_vuln_cves_insert(int id,
+                                          const char *name,
+                                          const char *version,
+                                          const char *architecture,
+                                          const char *cve,
+                                          const char *reference,
+                                          const char *type,
+                                          const char *status,
+                                          bool check_pkg_existence,
+                                          __attribute__((unused)) int *sock);
 
 int __wrap_wdb_agents_vuln_cves_clear(int id,
                                      __attribute__((unused)) int *sock);
@@ -30,5 +30,10 @@ int __wrap_wdb_agents_vuln_cves_clear(int id,
 cJSON* __wrap_wdb_agents_vuln_cves_remove_by_status(int id,
                                              const char *status,
                                              __attribute__((unused)) int *sock);
+
+int __wrap_wdb_agents_vuln_cves_update_status(int id,
+                                       const char *old_status,
+                                       const char *new_status,
+                                       __attribute__((unused)) int *sock);
 
 #endif

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.h
@@ -32,8 +32,8 @@ cJSON* __wrap_wdb_agents_vuln_cves_remove_by_status(int id,
                                              __attribute__((unused)) int *sock);
 
 int __wrap_wdb_agents_vuln_cves_update_status(int id,
-                                       const char *old_status,
-                                       const char *new_status,
-                                       __attribute__((unused)) int *sock);
+                                              const char *old_status,
+                                              const char *new_status,
+                                              __attribute__((unused)) int *sock);
 
 #endif

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -908,6 +908,8 @@ void wm_vuldet_free_cve_node(void *data){
             os_free(pkg->version);
             os_free(pkg->type);
             os_free(pkg->reference);
+            os_free(pkg->type);
+            os_free(pkg->reference);
 
             if (pkg->nvd_cond) {
                 os_free(pkg->nvd_cond->operator);


### PR DESCRIPTION
|Related issue|
|---|
|#7926|
## Description
Adding and fixing UTs for the changes introduced as part of #7749 that affected the Vulnerability Detector module.
## DoD
#### ctest
![image](https://user-images.githubusercontent.com/13010397/115065439-852c8c80-9ec4-11eb-843b-2ae8ffa53b6e.png)
![image](https://user-images.githubusercontent.com/13010397/115065808-02f09800-9ec5-11eb-9666-b93734459a36.png)
#### Valgrind
`valgrind -s --leak-check=full --show-leak-kinds=all --num-callers=20 --trace-children=yes --track-origins=yes`
##### Results
[valgrind.txt](https://github.com/wazuh/wazuh/files/6327035/valgrind.txt)
## Tests
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Source upgrade
- [X] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [X] Added unit tests (for new features)