### PR TITLE
Update localfile active config retrieving for macOS ULS

### DIFF
--- a/src/logcollector/config.c
+++ b/src/logcollector/config.c
@@ -115,12 +115,12 @@ void _getLocalfilesListJSON(logreader *list, cJSON *array, int gl) {
         if (list[i].command) cJSON_AddStringToObject(file,"command",list[i].command);
         if (list[i].djb_program_name) cJSON_AddStringToObject(file,"djb_program_name",list[i].djb_program_name);
         if (list[i].alias) cJSON_AddStringToObject(file,"alias",list[i].alias);
-        if (list[i].query) {
+        if (list[i].query != NULL) {
             cJSON * query = cJSON_CreateObject();
-            if (list[i].query) {
+            if (*list[i].query != '\0') {
                 cJSON_AddStringToObject(query, "value", list[i].query);
             }
-            if (list[i].query_level) {
+            if (list[i].query_level != NULL) {
                 cJSON_AddStringToObject(query, "level", list[i].query_level);
             }
             if (list[i].query_type > 0) {

--- a/src/logcollector/config.c
+++ b/src/logcollector/config.c
@@ -115,7 +115,29 @@ void _getLocalfilesListJSON(logreader *list, cJSON *array, int gl) {
         if (list[i].command) cJSON_AddStringToObject(file,"command",list[i].command);
         if (list[i].djb_program_name) cJSON_AddStringToObject(file,"djb_program_name",list[i].djb_program_name);
         if (list[i].alias) cJSON_AddStringToObject(file,"alias",list[i].alias);
-        if (list[i].query) cJSON_AddStringToObject(file,"query",list[i].query);
+        if (list[i].query) {
+            cJSON * query = cJSON_CreateObject();
+            if (list[i].query) {
+                cJSON_AddStringToObject(query, "value", list[i].query);
+            }
+            if (list[i].query_level) {
+                cJSON_AddStringToObject(query, "level", list[i].query_level);
+            }
+            if (list[i].query_type > 0) {
+                cJSON *type = cJSON_CreateArray();
+                if (list[i].query_type & OSLOG_TYPE_LOG) {
+                    cJSON_AddItemToArray(type, cJSON_CreateString(OSLOG_TYPE_LOG_STR));
+                }
+                if (list[i].query_type & OSLOG_TYPE_ACTIVITY) {
+                    cJSON_AddItemToArray(type, cJSON_CreateString(OSLOG_TYPE_ACTIVITY_STR));
+                }
+                if (list[i].query_type & OSLOG_TYPE_TRACE) {
+                    cJSON_AddItemToArray(type, cJSON_CreateString(OSLOG_TYPE_TRACE_STR));
+                }
+                cJSON_AddItemToObject(query, "type", type);
+            }
+            cJSON_AddItemToObject(file, "query", query);
+        }
         cJSON_AddStringToObject(file,"ignore_binaries",list[i].filter_binary ? "yes" : "no");
         if (list[i].age_str) cJSON_AddStringToObject(file,"age",list[i].age_str);
         if (list[i].exclude) cJSON_AddStringToObject(file,"exclude",list[i].exclude);


### PR DESCRIPTION
|Related issue|
|---|
|Close #8137|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hi team!

This PR aims to implement #8137 by updating active configuration support for localfile configuration block for Unified Logging System (ULS), returning `query` attribute values.

## Configuration options

```xml
<localfile>
  <log_format>oslog</log_format>
  <location>oslog</location>
  <query type="trace" level="debug">processImagePath CONTAINS[c] "com.apple.geod"</query>
</localfile>
```
<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

```
echo -n "getconfig localfile" | ./wazuh-tools/utils/secure-tcp.py /var/ossec/queue/sockets/logcollector
```
```json
{
  "localfile": [
    {
      "file": "/var/log/audit/audit.log",
      "logformat": "audit",
      "ignore_binaries": "no",
      "only-future-events": "yes",
      "target": [
        "agent"
      ]
    },
    {
      "file": "/var/log/test.log",
      "logformat": "syslog",
      "ignore_binaries": "no",
      "only-future-events": "yes",
      "target": [
        "agent"
      ]
    },
    {
      "logformat": "oslog",
      "query": {
        "value": "processImagePath CONTAINS[c] \"com.apple.geod\"",
        "level": "debug",
        "type": [
          "trace"
        ]
      },
      "ignore_binaries": "no",
      "only-future-events": "yes",
      "target": [
        "agent"
      ]
    },
    {
      "file": "/var/ossec/logs/active-responses.log",
      "logformat": "syslog",
      "ignore_binaries": "no",
      "only-future-events": "yes",
      "target": [
        "agent"
      ]
    },
    {
      "file": "/var/log/auth.log",
      "logformat": "syslog",
      "ignore_binaries": "no",
      "only-future-events": "yes",
      "target": [
        "agent"
      ]
    },
    {
      "file": "/var/log/syslog",
      "logformat": "syslog",
      "ignore_binaries": "no",
      "only-future-events": "yes",
      "target": [
        "agent"
      ]
    },
    {
      "file": "/var/log/vsftpd.log",
      "logformat": "syslog",
      "ignore_binaries": "no",
      "only-future-events": "yes",
      "target": [
        "agent"
      ]
    },
    {
      "file": "/var/log/dpkg.log",
      "logformat": "syslog",
      "ignore_binaries": "no",
      "only-future-events": "yes",
      "target": [
        "agent"
      ]
    },
    {
      "file": "/var/log/kern.log",
      "logformat": "syslog",
      "ignore_binaries": "no",
      "only-future-events": "yes",
      "target": [
        "agent"
      ]
    },
    {
      "logformat": "command",
      "command": "df -P",
      "alias": "df -P",
      "ignore_binaries": "no",
      "only-future-events": "yes",
      "target": [
        "agent"
      ],
      "frequency": 360
    },
    {
      "logformat": "full_command",
      "command": "netstat -tulpn | sed 's/\\([[:alnum:]]\\+\\)\\ \\+[[:digit:]]\\+\\ \\+[[:digit:]]\\+\\ \\+\\(.*\\):\\([[:digit:]]*\\)\\ \\+\\([0-9\\.\\:\\*]\\+\\).\\+\\ \\([[:digit:]]*\\/[[:alnum:]\\-]*\\).*/\\1 \\2 == \\3 == \\4 \\5/' | sort -k 4 -g | sed 's/ == \\(.*\\) ==/:\\1/' | sed 1,2d",
      "alias": "netstat listening ports",
      "ignore_binaries": "no",
      "only-future-events": "yes",
      "target": [
        "agent"
      ],
      "frequency": 360
    },
    {
      "logformat": "full_command",
      "command": "last -n 20",
      "alias": "last -n 20",
      "ignore_binaries": "no",
      "only-future-events": "yes",
      "target": [
        "agent"
      ],
      "frequency": 360
    }
  ]
}
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

Regards,
Nico