### PR TITLE
Add MITRE's techniques integration tests

### DIFF
--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -145,6 +145,22 @@ def test_save_response_data(response):
     return Box({'response_data': response.json()['data']})
 
 
+def test_save_response_data_mitre(response, fields):
+    response = response.json()['data']
+    fields_response = list()
+    for r in response['affected_items']:
+        fields_response.append({k: r[k] for k in fields})
+
+    return Box({'response_data': fields_response})
+
+
+def test_validate_mitre(response, data, index=0):
+    data = json.loads(data.replace("'", '"'))
+    for element in data:
+        for k, v in element.items():
+            assert v == response.json()['data']['affected_items'][index][k]
+
+
 def test_validate_restart_by_node(response, data):
     data = json.loads(data.replace("'", '"'))
     affected_items = list()

--- a/api/test/integration/test_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_mitre_endpoints.tavern.yaml
@@ -27,3 +27,317 @@ stages:
           total_affected_items: 2
           total_failed_items: 0
           failed_items: [ ]
+
+---
+test_name: GET /mitre/techniques
+
+marks:
+  - base_technique_tests
+
+stages:
+
+  - name: Try to show one technique
+    request: &general_techniques_request
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/mitre/techniques"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: GET
+      params:
+        limit: 1
+        offset: 0
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items: &techniques_response
+            - subtechnique_of: !anything
+              deprecated: !anyint
+              remote_support: !anyint
+              name: !anystr
+              mitre_version: !anystr
+              id: !anystr
+              mitre_detection: !anystr
+              description: !anystr
+              modified_time: !anystr
+              network_requirements: !anyint
+              created_time: !anystr
+              related_tactics: !anything
+              related_mitigations: !anything
+              related_software: !anything
+              related_groups: !anything
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+
+  - name: Try to show one technique with offset = 1
+    request:
+      verify: False
+      <<: *general_techniques_request
+      params:
+        limit: 1
+        offset: 1
+    response:
+      status_code: 200
+      save:
+        $ext:
+          function: tavern_utils:test_save_response_data_mitre
+          extra_kwargs:
+            fields:
+              - id
+              - name
+              - created_time
+              - deprecated
+              - remote_support
+              - related_tactics
+              - related_groups
+              - related_mitigations
+              - related_software
+
+  - name: Check that the offset is working properly, try to show two techniques with offset = 0
+    request:
+      verify: False
+      <<: *general_techniques_request
+      params:
+        limit: 2
+        offset: 0
+    response:
+      status_code: 200
+      json:
+        error: 0
+      verify_response_with:
+        - function: tavern_utils:test_validate_mitre
+          extra_kwargs:
+            data: "{response_data}"
+            index: 1
+
+  - name: Try to show all techniques without limit
+    request:
+      verify: False
+      <<: *general_techniques_request
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          total_affected_items: !anyint
+
+  - name: Try to get all techniques with limit = 0
+    request:
+      verify: False
+      <<: *general_techniques_request
+      params:
+        limit: 0
+    response:
+      status_code: 400
+
+  - name: Get three specified technique (one of them does not exist in the database)
+    request:
+      verify: False
+      <<: *general_techniques_request
+      params:
+        technique_ids:
+          - "attack-pattern--840a987a-99bd-4a80-a5c9-0cb2baa6cade"
+          - "attack-pattern--db8f5003-3b20-48f0-9b76-123e44208120"
+          - "attack-pattern--db8f5003-3b20-48f0-9b76-NOTEXIST"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *techniques_response
+              id: "attack-pattern--840a987a-99bd-4a80-a5c9-0cb2baa6cade"
+            - <<: *techniques_response
+              id: "attack-pattern--db8f5003-3b20-48f0-9b76-123e44208120"
+          failed_items: [ ]
+          total_affected_items: 2
+          total_failed_items: 0
+
+  - name: Sort without limit
+    request:
+      verify: False
+      <<: *general_techniques_request
+      params:
+        sort: -related_mitigations
+    response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "related_mitigations"
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items: !anything
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+
+  - name: Show techniques using valid select
+    request:
+      verify: False
+      <<: *general_techniques_request
+      params:
+        select: 'related_groups,deprecated,name'
+    response:
+      verify_response_with:
+        # Check response item keys are the selected keys
+        function: tavern_utils:test_select_key_affected_items
+        extra_kwargs:
+          select_key: 'id,related_groups,deprecated,name' # required_fields={'id'}
+      status_code: 200
+      json:
+        error: 0
+        data:
+          total_affected_items: !anyint
+          failed_items: []
+          total_failed_items: 0
+
+  - name: Show techniques using invalid select
+    request:
+      verify: False
+      <<: *general_techniques_request
+      params:
+        select: 'noexists'
+    response:
+      status_code: 400
+      json: &invalid_select
+        error: 1724
+
+  - name: Show techniques using invalid select (one select is invalid)
+    request:
+      verify: False
+      <<: *general_techniques_request
+      params:
+        select: 'name,noexists'
+    response:
+      status_code: 400
+      json:
+        <<: *invalid_select
+
+  - name: Show techniques using select and specifying a non-existent id in the technique_ids parameter
+    request:
+      verify: False
+      <<: *general_techniques_request
+      params:
+        select: 'related_software'
+        technique_ids: 'invalid'
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items: []
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+
+  - name: Search in techniques
+    request:
+      verify: False
+      <<: *general_techniques_request
+      params:
+        search: 'Gather Victim Network Information'
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - deprecated: !anyint
+              remote_support: !anyint
+              name: "Gather Victim Network Information"
+              mitre_version: !anystr
+              id: !anystr
+              mitre_detection: !anystr
+              description: !anystr
+              modified_time: !anystr
+              network_requirements: !anyint
+              created_time: !anystr
+              related_tactics: !anything
+              related_mitigations: !anything
+              related_software: !anything
+              related_groups: !anything
+            - <<: *techniques_response
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+      save:
+        json:
+          technique_id: data.affected_items[1].id
+
+  - name: Test search
+    request:
+      verify: False
+      <<: *general_techniques_request
+      params:
+        search: 'Gather Victim Network Information'
+        offset: 1
+        limit: 1
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - id: "{technique_id}"
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+
+  - name: Invalid parameter
+    request:
+      verify: False
+      <<: *general_techniques_request
+      params:
+        noexist: nothing
+    response:
+      status_code: 400
+
+  - name: Invalid parameters - Extra fields
+    request:
+      verify: False
+      <<: *general_techniques_request
+      params:
+        id: "attack-pattern--db8f5003-3b20-48f0-9b76-123e44208120"
+        noexist: True
+    response:
+      status_code: 400
+
+  - name: Test q
+    request:
+      verify: False
+      <<: *general_techniques_request
+      params:
+        q: "id=attack-pattern--db8f5003-3b20-48f0-9b76-123e44208120"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *techniques_response
+              id: "attack-pattern--db8f5003-3b20-48f0-9b76-123e44208120"
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+
+  - name: Test complex q
+    request:
+      verify: False
+      <<: *general_techniques_request
+      params:
+        q: "created_time<2020-02-11 18:42:08;created_time>2020-02-11 18:42:06"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *techniques_response
+              created_time: "2020-02-11 18:42:07.281000"
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0

--- a/api/test/integration/test_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_mitre_endpoints.tavern.yaml
@@ -36,7 +36,7 @@ marks:
 
 stages:
 
-  - name: Try to show one technique
+  - name: Show one technique
     request: &general_techniques_request
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/mitre/techniques"
@@ -71,7 +71,7 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Try to show one technique with offset = 1
+  - name: Show one technique with offset = 1
     request:
       verify: False
       <<: *general_techniques_request
@@ -112,7 +112,7 @@ stages:
             data: "{response_data}"
             index: 1
 
-  - name: Try to show all techniques without limit
+  - name: Show all techniques without limit
     request:
       verify: False
       <<: *general_techniques_request
@@ -132,7 +132,7 @@ stages:
     response:
       status_code: 400
 
-  - name: Get three specified technique (one of them does not exist in the database)
+  - name: Get three specified techniques (one of them does not exist in the database)
     request:
       verify: False
       <<: *general_techniques_request
@@ -155,7 +155,7 @@ stages:
           total_affected_items: 2
           total_failed_items: 0
 
-  - name: Sort without limit
+  - name: Sort techniques without limit
     request:
       verify: False
       <<: *general_techniques_request
@@ -175,7 +175,7 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Show techniques using valid select
+  - name: Try to show techniques using valid select
     request:
       verify: False
       <<: *general_techniques_request
@@ -206,7 +206,7 @@ stages:
       json: &invalid_select
         error: 1724
 
-  - name: Show techniques using invalid select (one select is invalid)
+  - name: Tey to show techniques using invalid select (one select is invalid)
     request:
       verify: False
       <<: *general_techniques_request
@@ -268,7 +268,7 @@ stages:
         json:
           technique_id: data.affected_items[1].id
 
-  - name: Test search
+  - name: Search techniques using offset and limit
     request:
       verify: False
       <<: *general_techniques_request
@@ -287,7 +287,7 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Invalid parameter
+  - name: Try to show techniques using an invalid parameter
     request:
       verify: False
       <<: *general_techniques_request
@@ -296,7 +296,7 @@ stages:
     response:
       status_code: 400
 
-  - name: Invalid parameters - Extra fields
+  - name: Try to show techniques using an invalid with an extra field
     request:
       verify: False
       <<: *general_techniques_request
@@ -306,7 +306,7 @@ stages:
     response:
       status_code: 400
 
-  - name: Test q
+  - name: Filter techniques using q parameter
     request:
       verify: False
       <<: *general_techniques_request
@@ -324,7 +324,7 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Test complex q
+  - name: Filter techniques using q parameter (complex query)
     request:
       verify: False
       <<: *general_techniques_request

--- a/api/test/integration/test_rbac_black_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_mitre_endpoints.tavern.yaml
@@ -18,3 +18,22 @@ stages:
       status_code: 403
       json:
         error: 4000
+
+---
+test_name: GET /mitre/techniques
+
+marks:
+  - base_technique_tests
+
+stages:
+
+  # GET /mitre/techniques
+  - name: Request MITRE techniques (Denied)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/mitre/techniques"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      <<: *permission_denied

--- a/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
@@ -1782,6 +1782,21 @@ stages:
       <<: *permission_denied
 
 ---
+test_name: GET /mitre/techniques
+
+stages:
+
+  - name: Try to get MITRE techniques
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/mitre/techniques"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      <<: *permission_denied
+
+---
 test_name: GET /overview/agents
 
 stages:

--- a/api/test/integration/test_rbac_white_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_mitre_endpoints.tavern.yaml
@@ -17,7 +17,23 @@ stages:
     response: &permission_allowed
       status_code: 200
       json:
-        error: !anyint
-        data:
-          affected_items: !anything
-          total_failed_items: 0
+        error: 0
+
+---
+test_name: GET /mitre/techniques
+
+marks:
+  - base_technique_tests
+
+stages:
+
+  # GET /mitre/techniques
+  - name: Request MITRE techniques (Allowed)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/mitre/techniques"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      <<: *permission_allowed


### PR DESCRIPTION
|Related issue|
|---|
|#7824|

Hi team,

This PR is related with #7824. In this PR we have added the integrated tests related to the technique endpoints. These will provide the general outline for the following integration tests.

### Test results
```
adriiiprodri@wazuh python3 run_tests.py -rbac both -k mitre             
Collected tests [3]:
test_mitre_endpoints.tavern.yaml, test_rbac_black_mitre_endpoints.tavern.yaml, test_rbac_white_mitre_endpoints.tavern.yaml


test_mitre_endpoints.tavern.yaml 
	 2 passed, 5 warnings

test_rbac_black_mitre_endpoints.tavern.yaml 
	 2 passed, 5 warnings

test_rbac_white_mitre_endpoints.tavern.yaml 
	 2 passed, 5 warnings
```

```
adriiiprodri@wazuh pytest -x test_rbac_white_all_endpoints.tavern.yaml  
================================================================================================ test session starts =================================================================================================
platform linux -- Python 3.9.2, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /home/adriiiprodri/git/wazuh/api/test/integration, configfile: pytest.ini
plugins: tavern-1.14.0, metadata-1.11.0, html-3.1.1
collected 154 items                                                                                                                                                                                                  

test_rbac_white_all_endpoints.tavern.yaml ..................................................................................................................................x..xx...................           [100%]

============================================================================== 151 passed, 3 xfailed, 156 warnings in 156.08s (0:02:36) ==============================================================================
```

Regards