### PR TITLE
Add MITRE techniques unittest

### DIFF
--- a/framework/wazuh/core/tests/test_mitre.py
+++ b/framework/wazuh/core/tests/test_mitre.py
@@ -25,6 +25,7 @@ def test_WazuhDBQueryMitreMetadata(mock_wdb):
 
 @pytest.mark.parametrize('wdb_query_class', [
     # TODO: add the rest of wdb query classes
+    WazuhDBQueryMitreTechniques
 ])
 @patch('wazuh.core.utils.WazuhDBConnection', return_value=InitWDBSocketMock(sql_schema_file='schema_mitre_test.sql'))
 def test_WazuhDBQueryMitre_classes(mock_wdb, wdb_query_class):
@@ -45,6 +46,7 @@ def test_WazuhDBQueryMitre_classes(mock_wdb, wdb_query_class):
 
 @pytest.mark.parametrize('mitre_get_function, mitre_wdb_query_class', [
     # TODO: add the rest of wdb query classes
+    (get_techniques, WazuhDBQueryMitreTechniques)
 ])
 @patch('wazuh.core.utils.WazuhDBConnection')
 def test_mitre_get_functions(mock_wdb, mitre_get_function, mitre_wdb_query_class):


### PR DESCRIPTION
|Related issue|
|---|
|#7824|

Hi team,

This PR closes #7824. In this PR we have added the MITRE techniques unittests.

### Test results
```
adriiiprodri@wazuh pytest -x framework/wazuh/core/tests/test_mitre.py
================================================================================================ test session starts =================================================================================================
platform linux -- Python 3.9.2, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /home/adriiiprodri/git/wazuh/framework
plugins: tavern-1.14.0, metadata-1.11.0, html-3.1.1
collected 3 items                                                                                                                                                                                                    

framework/wazuh/core/tests/test_mitre.py ...                                                                                                                                                                   [100%]

=========================================================================================== 3 passed, 3 warnings in 1.27s ============================================================================================
```
```
adriiiprodri@wazuh pytest -x framework/wazuh/tests/test_mitre.py
================================================================================================ test session starts =================================================================================================
platform linux -- Python 3.9.2, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /home/adriiiprodri/git/wazuh/framework
plugins: tavern-1.14.0, metadata-1.11.0, html-3.1.1
collected 2 items                                                                                                                                                                                                    

framework/wazuh/tests/test_mitre.py ..                                                                                                                                                                         [100%]

=========================================================================================== 2 passed, 3 warnings in 1.79s ============================================================================================
```

Regards
