### PR TITLE
Update remediation for API error 6004

### DIFF
--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -553,7 +553,7 @@ class WazuhException(Exception):
         6003: {'message': 'Error trying to load the JWT secret',
                'remediation': 'Make sure you have the right permissions: WAZUH_PATH/api/configuration/security/jwt_secret'},
         6004: {'message': 'The current user does not have authentication enabled through authorization context',
-               'remediation': f'You can enable it using the following endpoint: https://documentation.wazuh.com/{WAZUH_VERSION}/user-manual/api/configuration.html#configuration-file'},
+               'remediation': f'You can enable it using the following endpoint: https://documentation.wazuh.com/{WAZUH_VERSION}/user-manual/api/reference.html#operation/api.controllers.security_controller.edit_run_as'},
 
         # Logtest
         7000: {'message': 'Error trying to get logtest response'},


### PR DESCRIPTION
|Related issue|
|---|
| Closes #8248 |

## Description

Hi team!

This PR updates the remediation message for error 6004:
https://github.com/wazuh/wazuh/blob/ec846eb37bb5ccf8ad57c02b5d898c9f8c9fb848/framework/wazuh/core/exception.py#L555-L556

Now, the correct endpoint link is returned:
```JSON
{
  "title": "Permission Denied",
  "detail": "The current user does not have authentication enabled through authorization context",
  "remediation": "You can enable it using the following endpoint: https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.edit_run_as",
  "dapi_errors": {
    "master-node": {
      "error": "The current user does not have authentication enabled through authorization context"
    }
  },
  "error": 6004
}
```

Regards,
Selu.