### PR TITLE
Duplicated alerts from case insensitive 32-bit registry values in ossec.conf (winagent)

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -299,7 +299,6 @@ void dump_syscheck_registry(syscheck_config *syscheck,
         syscheck->registry[pl + 1].restrict_key = NULL;
         syscheck->registry[pl + 1].restrict_value = NULL;
         syscheck->registry[pl + 1].diff_size_limit = -1;
-        os_strdup(entry, syscheck->registry[pl].entry);
     } else {
         while (syscheck->registry[pl].entry != NULL) {
             /* Duplicated entry */
@@ -319,7 +318,6 @@ void dump_syscheck_registry(syscheck_config *syscheck,
             syscheck->registry[pl + 1].restrict_key = NULL;
             syscheck->registry[pl + 1].restrict_value = NULL;
             syscheck->registry[pl + 1].diff_size_limit = -1;
-            os_strdup(entry, syscheck->registry[pl].entry);
         } else {
             if (syscheck->registry[pl].restrict_key) {
                 OSMatch_FreePattern(syscheck->registry[pl].restrict_key);
@@ -330,12 +328,16 @@ void dump_syscheck_registry(syscheck_config *syscheck,
                 os_free(syscheck->registry[pl].restrict_value);
             }
             os_free(syscheck->registry[pl].tag);
+            os_free(syscheck->registry[pl].entry);
         }
     }
+
+    os_strdup(entry, syscheck->registry[pl].entry);
     syscheck->registry[pl].recursion_level = recursion_level;
     syscheck->registry[pl].arch = arch;
     syscheck->registry[pl].opts = opts;
     syscheck->registry[pl].diff_size_limit = diff_size;
+
     if (tag) {
         os_strdup(tag, syscheck->registry[pl].tag);
     }

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -302,7 +302,7 @@ void dump_syscheck_registry(syscheck_config *syscheck,
     } else {
         while (syscheck->registry[pl].entry != NULL) {
             /* Duplicated entry */
-            if (strcmp(syscheck->registry[pl].entry, entry) == 0 && arch == syscheck->registry[pl].arch) {
+            if (strcasecmp(syscheck->registry[pl].entry, entry) == 0 && arch == syscheck->registry[pl].arch) {
                 overwrite = pl;
                 mdebug2("Duplicated registration entry: %s", syscheck->registry[pl].entry);
                 break;


### PR DESCRIPTION
|Related issue|
|---|
|#6797|

## Description

The statement evaluating the new registry entry readed from syscheck module in ossec.conf was changed from strcmp to strcasecmp to avoid duplicated entries being monitored and generating duplicated alerts due to windows being case insensitive. 

scan-build : [scan-build-report.zip](https://github.com/wazuh/wazuh/files/6342017/scan-build-report.zip)
windows-report: [windows_report.zip](https://github.com/wazuh/wazuh/files/6363532/windows_report.zip)

Local tier 0 FIM report: 
[local_report_fim_tier_0.zip](https://github.com/wazuh/wazuh/files/7099073/local_report_fim_tier_0.zip)

The tests failing in tier 1 FIM is a known [issue](https://github.com/wazuh/wazuh-qa/issues/1593). In the report posted above the test associated with this PR passes successfully.

## Tests
- Compilation without warnings in every supported platform
  - [X] Windows
- [X] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Windows
  - [X] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory

