### PR TITLE
Avoided some false warnings due to duplicated ignore paths options

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -2552,15 +2552,19 @@ static void process_option(char ***syscheck_option, xml_node *node) {
     }
 
     for (int i = 0; new_opt[i]; i++) {
-        if(*new_opt[i] != '\0') {
+        if (*new_opt[i] != '\0') {
             clean_path = format_path(new_opt[i]);
-            if (clean_path && !os_IsStrOnArray(dir, syscheck_option[0])) {
+            if (clean_path == NULL) {
+                mwarn(FIM_WARN_FORMAT_PATH, new_opt[i]);
+                os_free(new_opt[i]);
+                continue;
+            }
+
+            if (!os_IsStrOnArray(dir, syscheck_option[0])) {
                 os_realloc(syscheck_option[0], sizeof(char *) * (counter_opt + 2), syscheck_option[0]);
                 os_strdup(clean_path, syscheck_option[0][counter_opt]);
                 syscheck_option[0][counter_opt + 1] = NULL;
                 counter_opt++;
-            } else {
-                mwarn(FIM_WARN_FORMAT_PATH, new_opt[i]);
             }
             os_free(clean_path);
         }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/8257|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Fixed a problem in `process_option` function, where some false warnings (`Error formatting path`) were showing when ignore paths options were just being duplicated, and it was necessary to discard them.

## Fix
To fix it I have separated the check that the path to ignore was duplicated, so that the warning only appears when there is an error formatting the path.

## Test
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
