### PR TITLE
Add GET /mitre/references endpoint to get MITRE references information

### DIFF
--- a/api/api/controllers/mitre_controller.py
+++ b/api/api/controllers/mitre_controller.py
@@ -42,6 +42,65 @@ async def get_metadata(request, pretty=False, wait_for_complete=False):
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+async def get_references(request, reference_ids: list = None, pretty: bool = False, wait_for_complete: bool = False,
+                         offset: int = None, limit: int = None, sort: str = None, search: str = None,
+                         select: list = None, q: str = None):
+    """Get information of specified MITRE's references.
+
+    Parameters
+    ----------
+    request : connexion.request
+    reference_ids : list
+        List of reference ids to be obtained.
+    pretty : bool
+        Show results in human-readable format.
+    wait_for_complete : bool
+        Disable timeout response.
+    offset : int
+        First item to return.
+    limit : int
+        Maximum number of items to return.
+    search : str
+        Looks for elements with the specified string.
+    select : list
+        Select which fields to return (separated by comma).
+    sort : str
+        Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in
+        ascending or descending order.
+    q : str
+        Query to filter by.
+
+    Returns
+    -------
+    MITRE's tactics information.
+    """
+    f_kwargs = {
+        'filters': {
+            'id': reference_ids,
+        },
+        'offset': offset,
+        'limit': limit,
+        'sort_by': parse_api_param(sort, 'sort')['fields'] if sort else None,
+        'sort_ascending': False if not sort or parse_api_param(sort, 'sort')['order'] == 'desc' else True,
+        'search_text': parse_api_param(search, 'search')['value'] if search else None,
+        'complementary_search': parse_api_param(search, 'search')['negation'] if search else None,
+        'select': select,
+        'q': q
+    }
+
+    dapi = DistributedAPI(f=mitre.mitre_references,
+                          f_kwargs=remove_nones_to_dict(f_kwargs),
+                          request_type='local_any',
+                          is_async=False,
+                          wait_for_complete=wait_for_complete,
+                          logger=logger,
+                          rbac_permissions=request['token_info']['rbac_policies']
+                          )
+    data = raise_if_exc(await dapi.distribute_function())
+
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
+
+
 async def get_tactics(request, tactic_ids: list = None, pretty: bool = False, wait_for_complete: bool = False,
                       offset: int = None, limit: int = None, sort: str = None, search: str = None, select: list = None,
                       q: str = None):

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -4072,7 +4072,7 @@ components:
       schema:
         type: array
         items:
-          $ref: '#/components/schemas/MITRE_software_id'
+          $ref: '#/components/schemas/Mitre_software_id'
     mitre_technique_ids:
       in: query
       name: 'technique_ids'

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1721,6 +1721,9 @@ components:
           description: "Event to look for"
 
     # MITRE models
+    Mitre_reference_id:
+      type: string
+      description: "MITRE Reference ID"
     Mitre_mitigation_id:
       type: string
       description: "MITRE mitigation ID"
@@ -4038,6 +4041,14 @@ components:
         type: array
         items:
           $ref: '#/components/schemas/Mitre_mitigation_id'
+    mitre_reference_ids:
+      in: query
+      name: 'reference_ids'
+      description: "List of MITRE's references IDs (separated by comma)"
+      schema:
+        type: array
+        items:
+          $ref: '#/components/schemas/Mitre_reference_id'
     mitre_tactic_ids:
       in: query
       name: 'tactic_ids'
@@ -10698,6 +10709,61 @@ paths:
                   total_failed_items: 0
                   failed_items: [ ]
                 message: "MITRE mitigations information was returned"
+                error: 0
+        '400':
+          $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDeniedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
+
+  /mitre/references:
+    get:
+      tags:
+        - MITRE
+      summary: "Get MITRE references"
+      description: "Return the references from MITRE database"
+      operationId: api.controllers.mitre_controller.get_references
+      x-rbac-actions:
+        - $ref: '#/x-rbac-catalog/actions/mitre:read'
+      parameters:
+        - $ref: '#/components/parameters/mitre_reference_ids'
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/sort'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/select'
+        - $ref: '#/components/parameters/query'
+      responses:
+        '200':
+          description: "Get MITRE references"
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/AllItemsResponse'
+              example:
+                data:
+                  affected_items:
+                    - description: "Hosseini, A. (2017, July 18). Ten Process Injection Techniques: A Technical Survey Of Common And Trending Process Injection Techniques. Retrieved December 7, 2017."
+                      type: "technique"
+                      source: "Endgame Process Injection July 2017"
+                      url: "https://www.endgame.com/blog/technical-blog/ten-process-injection-techniques-technical-survey-common-and-trending-process"
+                      id: "attack-pattern--0042a9f5-f053-4769-b3ef-9ad018dfa298"
+                  total_affected_items: 5212
+                  failed_items: []
+                  total_failed_items: 0
+                message: "MITRE references information was returned"
                 error: 0
         '400':
           $ref: '#/components/responses/ResponseError'

--- a/api/test/integration/test_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_mitre_endpoints.tavern.yaml
@@ -415,7 +415,7 @@ stages:
       verify: False
       <<: *general_references_request
       params:
-        tactic_ids:
+        reference_ids:
           - "attack-pattern--0042a9f5-f053-4769-b3ef-9ad018dfa298"
           - "attack-pattern--005a06c6-14bf-4118-afa0-ebcd8aebb0c9"
           - "attack-pattern--005a06c6-14bf-4118-afa0-NOTEXIST"
@@ -439,6 +439,7 @@ stages:
       <<: *general_references_request
       params:
         sort: -source
+        limit: 3
     response:
       verify_response_with:
         - function: tavern_utils:test_sort_response
@@ -590,7 +591,7 @@ stages:
           total_affected_items: 6
           total_failed_items: 0
 
-  - name: Filter tactics using q parameter (complex query)
+  - name: Filter references using q parameter (complex query)
     request:
       verify: False
       <<: *general_references_request

--- a/api/test/integration/test_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_mitre_endpoints.tavern.yaml
@@ -322,6 +322,300 @@ stages:
           total_failed_items: 0
 
 ---
+test_name: GET /mitre/references
+
+marks:
+  - base_reference_tests
+
+stages:
+
+  - name: Show one reference
+    request: &general_references_request
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/mitre/references"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: GET
+      params:
+        limit: 1
+        offset: 0
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items: &references_response
+            - id: !anystr
+              source: !anystr
+              url: !anystr
+              type: !anystr
+              # description or external_id
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+
+  - name: Show one reference with offset = 1
+    request:
+      verify: False
+      <<: *general_references_request
+      params:
+        limit: 1
+        offset: 1
+    response:
+      status_code: 200
+      save:
+        $ext:
+          function: tavern_utils:test_save_response_data_mitre
+          extra_kwargs:
+            fields:
+              - id
+              - source
+              - url
+              - type
+
+  - name: Check that the offset is working properly, try to show two references with offset = 0
+    request:
+      verify: False
+      <<: *general_references_request
+      params:
+        limit: 2
+        offset: 0
+    response:
+      status_code: 200
+      json:
+        error: 0
+      verify_response_with:
+        - function: tavern_utils:test_validate_mitre
+          extra_kwargs:
+            data: "{response_data}"
+            index: 1
+
+  - name: Show all references without limit
+    request:
+      verify: False
+      <<: *general_references_request
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          total_affected_items: !anyint
+
+  - name: Try to get all references with limit = 0
+    request:
+      verify: False
+      <<: *general_references_request
+      params:
+        limit: 0
+    response:
+      status_code: 400
+
+  - name: Get three specified references (one of them does not exist in the database)
+    request:
+      verify: False
+      <<: *general_references_request
+      params:
+        tactic_ids:
+          - "attack-pattern--0042a9f5-f053-4769-b3ef-9ad018dfa298"
+          - "attack-pattern--005a06c6-14bf-4118-afa0-ebcd8aebb0c9"
+          - "attack-pattern--005a06c6-14bf-4118-afa0-NOTEXIST"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *references_response
+              id: "attack-pattern--0042a9f5-f053-4769-b3ef-9ad018dfa298"
+            - <<: *references_response
+              id: "attack-pattern--005a06c6-14bf-4118-afa0-ebcd8aebb0c9"
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+
+  - name: Sort references without limit
+    request:
+      verify: False
+      <<: *general_references_request
+      params:
+        sort: -source
+    response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "source"
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items: !anything
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+
+  - name: Try to show references using valid select
+    request:
+      verify: False
+      <<: *general_references_request
+      params:
+        select: 'url,source,type'
+    response:
+      verify_response_with:
+        # Check response item keys are the selected keys
+        function: tavern_utils:test_select_key_affected_items
+        extra_kwargs:
+          select_key: 'url,source,type' # required_fields={'id'}
+      status_code: 200
+      json:
+        error: 0
+        data:
+          total_affected_items: !anyint
+          failed_items: []
+          total_failed_items: 0
+
+  - name: Show references using invalid select
+    request:
+      verify: False
+      <<: *general_references_request
+      params:
+        select: 'noexists'
+    response:
+      status_code: 400
+      json: &invalid_select
+        error: 1724
+
+  - name: Try to show references using invalid select (one select is invalid)
+    request:
+      verify: False
+      <<: *general_references_request
+      params:
+        select: 'source,noexists'
+    response:
+      status_code: 400
+      json:
+        <<: *invalid_select
+
+  - name: Show references using select and specifying a non-existent id in the reference_ids parameter
+    request:
+      verify: False
+      <<: *general_references_request
+      params:
+        select: 'url'
+        reference_ids: 'invalid'
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items: []
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+
+  - name: Search in references
+    request:
+      verify: False
+      <<: *general_references_request
+      params:
+        search: 'TechNet RPC'
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          failed_items: []
+          total_affected_items: 3
+          total_failed_items: 0
+      verify_response_with:
+        function: tavern_utils:test_validate_search
+        extra_kwargs:
+          search_param: 'TechNet RPC'
+      save:
+        json:
+          reference_id: data.affected_items[1].id
+
+  - name: Search references using offset and limit
+    request:
+      verify: False
+      <<: *general_references_request
+      params:
+        search: 'TechNet RPC'
+        offset: 1
+        limit: 1
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - id: "{reference_id}"
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+
+  - name: Try to show references using an invalid parameter
+    request:
+      verify: False
+      <<: *general_references_request
+      params:
+        noexist: nothing
+    response:
+      status_code: 400
+
+  - name: Try to show references using an invalid with an extra field
+    request:
+      verify: False
+      <<: *general_references_request
+      params:
+        id: "attack-pattern--01a5a209-b94c-450b-b7f9-946497d91055"
+        noexist: True
+    response:
+      status_code: 400
+
+  - name: Filter references using q parameter
+    request:
+      verify: False
+      <<: *general_references_request
+      params:
+        q: "id=attack-pattern--01a5a209-b94c-450b-b7f9-946497d91055"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *references_response
+              id: "attack-pattern--01a5a209-b94c-450b-b7f9-946497d91055"
+          failed_items: []
+          total_affected_items: 6
+          total_failed_items: 0
+
+  - name: Filter tactics using q parameter (complex query)
+    request:
+      verify: False
+      <<: *general_references_request
+      params:
+        q: "source~Wikipedia;type!=technique;type!=mitigation"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *references_response
+              source: "Wikipedia Ifconfig"
+              type: "software"
+            - <<: *references_response
+              source: "Wikipedia pwdump"
+              type: "software"
+            - <<: *references_response
+              source: "Wikipedia FTP"
+              type: "software"
+          failed_items: []
+          total_affected_items: 3
+          total_failed_items: 0
+
+---
 test_name: GET /mitre/tactics
 
 marks:

--- a/api/test/integration/test_rbac_black_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_mitre_endpoints.tavern.yaml
@@ -40,6 +40,25 @@ stages:
       <<: *permission_denied
 
 ---
+test_name: GET /mitre/references
+
+marks:
+  - base_reference_tests
+
+stages:
+
+  # GET /mitre/references
+  - name: Request MITRE references (Denied)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/mitre/references"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      <<: *permission_denied
+
+---
 test_name: GET /mitre/techniques
 
 marks:

--- a/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
@@ -1797,6 +1797,21 @@ stages:
       <<: *permission_denied
 
 ---
+test_name: GET /mitre/tactics
+
+stages:
+
+  - name: Try to get MITRE references
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/mitre/references"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      <<: *permission_denied
+
+---
 test_name: GET /mitre/techniques
 
 stages:

--- a/api/test/integration/test_rbac_white_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_mitre_endpoints.tavern.yaml
@@ -39,6 +39,25 @@ stages:
       <<: *permission_allowed
 
 ---
+test_name: GET /mitre/references
+
+marks:
+  - base_reference_tests
+
+stages:
+
+  # GET /mitre/references
+  - name: Request MITRE references (Allowed)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/mitre/references"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      <<: *permission_allowed
+
+---
 test_name: GET /mitre/techniques
 
 marks:

--- a/framework/wazuh/core/tests/test_mitre.py
+++ b/framework/wazuh/core/tests/test_mitre.py
@@ -27,6 +27,7 @@ def test_WazuhDBQueryMitreMetadata(mock_wdb):
     # TODO: add the rest of wdb query classes
     WazuhDBQueryMitreGroups,
     WazuhDBQueryMitreMitigations,
+    WazuhDBQueryMitreReferences,
     WazuhDBQueryMitreTactics,
     WazuhDBQueryMitreTechniques,
     WazuhDBQueryMitreSoftware
@@ -53,6 +54,7 @@ def test_WazuhDBQueryMitre_classes(mock_wdb, wdb_query_class):
     # TODO: add the rest of wdb query classes
     (get_groups, WazuhDBQueryMitreGroups),
     (get_mitigations, WazuhDBQueryMitreMitigations),
+    (get_references, WazuhDBQueryMitreReferences),
     (get_tactics, WazuhDBQueryMitreTactics),
     (get_techniques, WazuhDBQueryMitreTechniques),
     (get_software, WazuhDBQueryMitreSoftware)

--- a/framework/wazuh/mitre.py
+++ b/framework/wazuh/mitre.py
@@ -77,6 +77,50 @@ def mitre_mitigations(filters: dict = None, offset=0, limit=common.database_limi
 
 
 @expose_resources(actions=["mitre:read"], resources=["*:*:*"])
+def mitre_references(filters: dict = None, offset=0, limit=common.database_limit, select=None, sort_by=None,
+                     sort_ascending=True, search_text=None, complementary_search=False,
+                     search_in_fields=None, q='') -> Dict:
+    """Get information of specified MITRE's references.
+
+    Parameters
+    ----------
+    filters : str
+        Define field filters required by the user. Format: {"field1":"value1", "field2":["value2","value3"]}
+    offset : int
+        First item to return
+    limit : int
+        Maximum number of items to return
+    select : list
+        Select which fields to return (separated by comma).
+    sort_by : dict
+        Fields to sort the items by. Format: {"fields":["field1","field2"],"order":"asc|desc"}
+    sort_ascending : bool
+        Sort in ascending (true) or descending (false) order
+    search_text : str
+        Text to search
+    complementary_search : bool
+        Find items without the text to search
+    search_in_fields : list
+        Fields to search in
+    q : str
+        Query for filtering a list of results.
+
+    Returns
+    -------
+    dict
+        Dictionary with the information of the specified references.
+    """
+    data = mitre.get_results_with_select(mitre.get_references, **locals())
+
+    result = AffectedItemsWazuhResult(none_msg='No MITRE references information was returned',
+                                      all_msg='MITRE references information was returned')
+    result.affected_items.extend(data['items'])
+    result.total_affected_items = data['totalItems']
+
+    return result
+
+
+@expose_resources(actions=["mitre:read"], resources=["*:*:*"])
 def mitre_techniques(filters: dict = None, offset=0, limit=common.database_limit, select=None, sort_by=None,
                      sort_ascending=True, search_text=None, complementary_search=False,
                      search_in_fields=None, q='') -> Dict:
@@ -152,7 +196,7 @@ def mitre_tactics(filters: dict = None, offset: int = 0, limit: int = common.dat
     Returns
     -------
     dict
-        Dictionary with the information of the specified tactics and their relationships
+        Dictionary with the information of the specified tactics and their relationships.
     """
     data = mitre.get_results_with_select(mitre.get_tactics, **locals())
 

--- a/framework/wazuh/tests/data/security/rbac_catalog.yml
+++ b/framework/wazuh/tests/data/security/rbac_catalog.yml
@@ -478,6 +478,7 @@ get_rbac_actions:
           - GET /mitre/tactics
           - GET /mitre/techniques
           - GET /mitre/groups
+          - GET /mitre/references
           - GET /mitre/software
       rootcheck:clear:
         description: Clear the agents rootcheck database

--- a/framework/wazuh/tests/test_mitre.py
+++ b/framework/wazuh/tests/test_mitre.py
@@ -38,6 +38,7 @@ def mitre_db():
 # Functions
 class CursorByName:
     """Class to return query result including the column name as key."""
+
     def __init__(self, cursor):
         self._cursor = cursor
 
@@ -56,7 +57,7 @@ def mitre_query(cursor, query):
 
 
 def sort_entries(entries, sort_key='id'):
-    """Sort a list of dictionaries by one their keys."""
+    """Sort a list of dictionaries by one of their keys."""
     return sorted(entries, key=lambda k: k[sort_key])
 
 
@@ -80,6 +81,20 @@ def test_mitre_mitigations(mock_mitre_db, mitre_db):
 
     assert all(item[key] == row[key] for item, row in zip(sort_entries(result.affected_items), sort_entries(rows))
                for key in row)
+
+
+@patch('wazuh.core.utils.WazuhDBConnection', return_value=InitWDBSocketMock(sql_schema_file='schema_mitre_test.sql'))
+def test_mitre_references(mock_mitre_dbmitre, mitre_db):
+    """Check MITRE metadata."""
+    result = mitre.mitre_references(limit=None)
+    rows = mitre_query(mitre_db, 'SELECT * FROM reference')
+
+    sorted_result = sort_entries(sort_entries(sort_entries(result.affected_items, sort_key='id'), sort_key='source'),
+                                 sort_key='url')
+    sorted_rows = sort_entries(sort_entries(sort_entries(rows, sort_key='id'), sort_key='source'), sort_key='url')
+
+    assert result.affected_items
+    assert all(item[key] == row[key] for item, row in zip(sorted_result, sorted_rows) for key in row)
 
 
 @patch('wazuh.core.utils.WazuhDBConnection', return_value=InitWDBSocketMock(sql_schema_file='schema_mitre_test.sql'))


### PR DESCRIPTION
|Related issue|
|---|
| #7828 |

Hi team,

This PR closes #7828.

In this pull request, I have added the new `GET /mitre/references` endpoint.

I have also updated the mitre unittests and API integration tests.

- Test results:

```
test_rbac_black_mitre_endpoints.tavern.yaml 
	 5 passed, 10 warnings

test_rbac_white_mitre_endpoints.tavern.yaml 
	 5 passed, 10 warnings

test_mitre_endpoints.tavern.yaml 
	 5 passed, 10 warnings

test_rbac_white_all_endpoints.tavern.yaml 
	 154 passed, 3 xfailed, 159 warnings

framework/wazuh/tests/test_mitre.py
========================== 5 passed, 2 warnings in 2.42s ==========================

framework/wazuh/core/tests/test_mitre.py
========================== 9 passed, 2 warnings in 1.45s ==========================
```

Regards,
Manuel.
