### PR TITLE
Eliminate hotfix_config_enabled logic

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -274,7 +274,7 @@ STATIC int wm_vuldet_get_term_condition(char *i_term, char **term, char **comp_f
 STATIC void wm_vuldet_run_scan(wm_vuldet_t *vuldet);
 STATIC void wm_vuldet_run_sleep(wm_vuldet_t *vuldet);
 STATIC void wm_vuldet_init(wm_vuldet_t *vuldet);
-STATIC int wm_vuldet_select_scan_type(char *agent_id, time_t ignore_time, char *hotfix_config_enabled);
+STATIC int wm_vuldet_select_scan_type(char *agent_id, time_t ignore_time);
 STATIC void wm_vuldet_update_last_scan(char *agent_id);
 STATIC char *wm_vuldet_get_hotfix_scan(char *agent_id);
 STATIC int wm_vuldet_get_last_software_scan(char *agent_id, char scan_id[OS_SIZE_128]);
@@ -4381,13 +4381,11 @@ int wm_vuldet_get_software_info(agent_software *agent, sqlite3 *db, time_t ignor
     cpe_list *node_list = NULL;
     const char *jsonErrPtr;
     char hotfix_scan = 0;
-    char package_scan = 1;
-    char hotfix_config_enabled = 0;
 
     mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AGENT_SOFTWARE_REQ, atoi(agent->agent_id));
 
     // Check to see if the scan has already been reported
-    *request = wm_vuldet_select_scan_type(agent->agent_id, ignore_time, &hotfix_config_enabled);
+    *request = wm_vuldet_select_scan_type(agent->agent_id, ignore_time);
     switch (*request) {
         case OS_INVALID:
             goto end;
@@ -4415,7 +4413,6 @@ int wm_vuldet_get_software_info(agent_software *agent, sqlite3 *db, time_t ignor
                 retval = 2;
                 goto end;
             } else {
-                package_scan = 0;
                 mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_NO_PACKAGE_SCAN, atoi(agent->agent_id));
             }
         case 0:
@@ -4494,21 +4491,15 @@ int wm_vuldet_get_software_info(agent_software *agent, sqlite3 *db, time_t ignor
     if (hotfix_scan) {
         // Request the agent hotfixes
         int result;
-        if (result = wm_vuldet_request_hotfixes(db, agent->agent_id), result) {
-            if (result == OS_INVALID) {
-                mterror(WM_VULNDETECTOR_LOGTAG, VU_HOTFIX_REQUEST_ERROR, atoi(agent->agent_id));
-                goto end;
-            } else if (!package_scan && !hotfix_config_enabled) {
-                mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_NO_HOTFIX_AVAIL, atoi(agent->agent_id));
-                retval = 0;
-                goto end;
-            }
+        if (result = wm_vuldet_request_hotfixes(db, agent->agent_id), result == OS_INVALID) {            
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_HOTFIX_REQUEST_ERROR, atoi(agent->agent_id));
+            goto end;
         }
 
         if (wm_vuldet_check_enabled_msu(db) == false) {
             mtwarn(WM_VULNDETECTOR_LOGTAG, VU_NO_HOTFIX_DISABLED, atoi(agent->agent_id));
 
-        } else if (hotfix_config_enabled) {
+        } else {
             // Get the os info
             if (wm_vuldet_get_oswindows_info(agent)) {
                 goto end;
@@ -7187,7 +7178,7 @@ void wm_vuldet_init(wm_vuldet_t * vuldet) {
     vuldet->node_name = get_node_name();
 }
 
-int wm_vuldet_select_scan_type(char *agent_id, time_t ignore_time, char *hotfix_config_enabled) {
+int wm_vuldet_select_scan_type(char *agent_id, time_t ignore_time) {
     int retval = OS_INVALID;
     char request[OS_SIZE_6144];
     cJSON *obj = NULL;
@@ -7213,12 +7204,6 @@ int wm_vuldet_select_scan_type(char *agent_id, time_t ignore_time, char *hotfix_
 
     if (obj = cJSON_Parse(request), !obj) {
         goto end;
-    }
-
-    if ((obj_it = obj->child) &&
-        (obj_it = cJSON_GetObjectItem(obj_it, "hotfix_scan_id")) &&
-        obj_it->valuestring && strcmp(obj_it->valuestring, "0")) {
-        *hotfix_config_enabled = 1;
     }
 
     if (!(obj_it = obj->child) ||


### PR DESCRIPTION
|Related issue|
|---|
|#8273|

## Description
This PR eliminates the logic of checking **hotfix_scan_id** to determine if the Windows OS system scan needs to be performed. As this check is eliminated, and **hotfix_config_enabled** is now obsolete, the logic where it was used was simplified too.
This change is done to fix an error because now **hotfix_scan_id** is always **0** for agents 4.2 and newer. Thus, this check would fail and always bypass the Windows OS scan.
This legacy check was implemented to verify if the **hotfix** section of **sys_collector** was enabled on the agent side, but it also**partially** covers the time windows between the first start of the agent and the complete synchronization of its hotfixes. Thus, with this change, the possibility of having Vulnerability Detector false positives because the agent is still synchronizing the hotfixes is now incremented. On the other hand, the possibility of having this kind of false positives always existed because the agent could be in the middle of synchronization when the manager starts the Vulnerability Detector scan.



## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Package installation
- [X] Source upgrade
- [X] Package upgrade
- [X] Review logs syntax and correct language

