### PR TITLE
Changes to the MITRE endpoints implementations and minor changes

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -10670,11 +10670,11 @@ paths:
                         [APT38](https://attack.mitre.org/groups/G0082) is a financially-motivated threat group that is backed by the North Korean regime. The group mainly targets banks and financial institutions and has targeted more than 16 organizations in at least 13 countries since at least 2014.(Citation: FireEye APT38 Oct 2018)
 
                         North Korean group definitions are known to have significant overlap, and the name [Lazarus Group](https://attack.mitre.org/groups/G0032) is known to encompass a broad range of activity. Some organizations use the name Lazarus Group to refer to any activity attributed to North Korea.(Citation: US-CERT HIDDEN COBRA June 2017) Some organizations track North Korean clusters or groups such as Bluenoroff,(Citation: Kaspersky Lazarus Under The Hood Blog 2017) [APT37](https://attack.mitre.org/groups/G0067), and [APT38](https://attack.mitre.org/groups/G0082) separately, while other organizations may track some activity associated with those group names by the name Lazarus Group.
-                      related_software:
+                      software:
                         - tool--03342581-f790-4f03-ba41-e82e67392e23
                         - tool--afc079f3-c0ea-4096-b75d-3f05338b7f60
                         - malware--53ab35c2-d00e-491a-8753-41d35ae7e547
-                      related_techniques:
+                      techniques:
                         - attack-pattern--df8b2a25-8bdf-4856-953c-a04372b1c161
                         - attack-pattern--09a60ea3-a8d1-4ae5-976e-5783248b72a4
                         - attack-pattern--8f4a33ec-8b1f-4b80-a2f6-642b2e479580
@@ -10788,7 +10788,7 @@ paths:
                       description: "This category is used for any applicable mitigation activities that
                         apply to techniques occurring before an adversary gains Initial Access, such
                         as Reconnaissance and Resource Development techniques."
-                      related_techniques: [ ]
+                      techniques: [ ]
                   total_affected_items: 267
                   total_failed_items: 0
                   failed_items: [ ]
@@ -10903,9 +10903,9 @@ paths:
                       description: "[HDoor](https://attack.mitre.org/software/S0061) is malware that
                         has been customized and used by the [Naikon](https://attack.mitre.org/groups/G0019)
                         group. (Citation: Baumgartner Naikon 2015)"
-                      related_groups:
+                      groups:
                         - intrusion-set--2a158b0a-7ef8-43cb-9985-bf34d1e12050
-                      related_techniques:
+                      techniques:
                         - attack-pattern--ac08589e-ee59-4935-8667-d845e38fe579
                         - attack-pattern--e3a12395-188d-4051-9a16-ea8e14d07b88
                   total_affected_items: 444
@@ -10964,7 +10964,7 @@ paths:
                       description: "The adversary is trying to move through your environment.\n\nLateral Movement consists of techniques that adversaries use to enter and control remote systems on a network. Following through on their primary objective often requires exploring the network to find their target and subsequently gaining access to it. Reaching their objective often involves pivoting through multiple systems and accounts to gain. Adversaries might install their own remote access tools to accomplish Lateral Movement or use legitimate credentials with native network and operating system tools, which may be stealthier. "
                       name: "Lateral Movement"
                       short_name: "lateral-movement"
-                      related_techniques:
+                      techniques:
                         - "attack-pattern--01327cde-66c4-4123-bf34-5f258d59457b"
                         - "attack-pattern--246fd3c7-f5e3-466d-8787-4c13d9e3b61c"
                         - "attack-pattern--2db31dcd-54da-405d-acef-b9129b816ed6"
@@ -11054,10 +11054,10 @@ paths:
                         Before compromising a victim, adversaries may gather information about the victim's networks that can be used during targeting. Information about networks may include a variety of details, including administrative data (ex: IP ranges, domain names, etc.) as well as specifics regarding its topology and operations.
 
                         Adversaries may gather this information in various ways, such as direct collection actions via [Active Scanning](https://attack.mitre.org/techniques/T1595) or [Phishing for Information](https://attack.mitre.org/techniques/T1598). Information about networks may also be exposed to adversaries via online or other accessible data sets (ex: [Search Open Technical Databases](https://attack.mitre.org/techniques/T1596)).(Citation: WHOIS)(Citation: DNS Dumpster)(Citation: Circl Passive DNS) Gathering this information may reveal opportunities for other forms of reconnaissance (ex: [Active Scanning](https://attack.mitre.org/techniques/T1595) or [Search Open Websites/Domains](https://attack.mitre.org/techniques/T1593)), establishing operational resources (ex: [Acquire Infrastructure](https://attack.mitre.org/techniques/T1583) or [Compromise Infrastructure](https://attack.mitre.org/techniques/T1584)), and/or initial access (ex: [Trusted Relationship](https://attack.mitre.org/techniques/T1199)).
-                      related_tactics: [ ]
-                      related_mitigations: [ ]
-                      related_software: [ ]
-                      related_groups: [ ]
+                      tactics: [ ]
+                      mitigations: [ ]
+                      software: [ ]
+                      groups: [ ]
                   total_affected_items: 1
                   total_failed_items: 0
                   failed_items: [ ]

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -10626,6 +10626,90 @@ paths:
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
 
+  /mitre/groups:
+    get:
+      tags:
+        - MITRE
+      summary: "Get MITRE groups"
+      description: "Return the groups from MITRE database"
+      operationId: api.controllers.mitre_controller.get_groups
+      x-rbac-actions:
+        - $ref: '#/x-rbac-catalog/actions/mitre:read'
+      parameters:
+        - $ref: '#/components/parameters/mitre_group_ids'
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/sort'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/select'
+        - $ref: '#/components/parameters/query'
+      responses:
+        '200':
+          description: "Get MITRE groups information"
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/AllItemsResponse'
+              example:
+                data:
+                  affected_items:
+                    - mitre_version: '1.2'
+                      deprecated: 0
+                      name: APT38
+                      id: intrusion-set--00f67a77-86a4-4adf-be26-1a54fc713340
+                      modified_time: '2020-03-30 18:50:43.737000'
+                      created_time: '2019-01-29 21:27:24.793000'
+                      description: |-
+                        [APT38](https://attack.mitre.org/groups/G0082) is a financially-motivated threat group that is backed by the North Korean regime. The group mainly targets banks and financial institutions and has targeted more than 16 organizations in at least 13 countries since at least 2014.(Citation: FireEye APT38 Oct 2018)
+
+                        North Korean group definitions are known to have significant overlap, and the name [Lazarus Group](https://attack.mitre.org/groups/G0032) is known to encompass a broad range of activity. Some organizations use the name Lazarus Group to refer to any activity attributed to North Korea.(Citation: US-CERT HIDDEN COBRA June 2017) Some organizations track North Korean clusters or groups such as Bluenoroff,(Citation: Kaspersky Lazarus Under The Hood Blog 2017) [APT37](https://attack.mitre.org/groups/G0067), and [APT38](https://attack.mitre.org/groups/G0082) separately, while other organizations may track some activity associated with those group names by the name Lazarus Group.
+                      related_software:
+                        - tool--03342581-f790-4f03-ba41-e82e67392e23
+                        - tool--afc079f3-c0ea-4096-b75d-3f05338b7f60
+                        - malware--53ab35c2-d00e-491a-8753-41d35ae7e547
+                      related_techniques:
+                        - attack-pattern--df8b2a25-8bdf-4856-953c-a04372b1c161
+                        - attack-pattern--09a60ea3-a8d1-4ae5-976e-5783248b72a4
+                        - attack-pattern--8f4a33ec-8b1f-4b80-a2f6-642b2e479580
+                        - attack-pattern--57340c81-c025-4189-8fa0-fc7ede51bae4
+                        - attack-pattern--d742a578-d70e-4d0e-96a6-02a9c30204e6
+                        - attack-pattern--30973a08-aed9-4edf-8604-9084ce1b5c4f
+                        - attack-pattern--deb98323-e13f-4b0c-8d94-175379069062
+                        - attack-pattern--d1fcf083-a721-4223-aedf-bf8960798d62
+                        - attack-pattern--e6919abc-99f9-4c6c-95a5-14761e7b2add
+                        - attack-pattern--d63a3fb8-9452-4e9d-a60a-54be68d5998c
+                        - attack-pattern--6495ae23-3ab4-43c5-a94f-5638a2c31fd2
+                        - attack-pattern--32ad5c86-2bcf-47d8-8fdc-d7f3d79a7490
+                        - attack-pattern--d0613359-5781-4fd2-b5be-c269270be1f6
+                        - attack-pattern--1cfcb312-b8d7-47a4-b560-4b16cc677292
+                        - attack-pattern--0af0ca99-357d-4ba1-805f-674fdfb7bef9
+                        - attack-pattern--b80d107d-fa0d-4b60-9684-b0433e8bdba0
+                        - attack-pattern--d45a3d09-b3cf-48f4-9f0f-f521ee5cb05c
+                        - attack-pattern--7e150503-88e7-4861-866b-ff1ac82c4475
+                        - attack-pattern--ff73aa03-0090-4464-83ac-f89e233c02bc
+                  total_affected_items: 111
+                  total_failed_items: 0
+                  failed_items: [ ]
+                message: MITRE groups information was returned
+                error: 0
+        '400':
+          $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDeniedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
+
   /mitre/metadata:
     get:
       tags:
@@ -10764,6 +10848,70 @@ paths:
                   failed_items: []
                   total_failed_items: 0
                 message: "MITRE references information was returned"
+                error: 0
+        '400':
+          $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDeniedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
+
+  /mitre/software:
+    get:
+      tags:
+        - MITRE
+      summary: "Get MITRE software"
+      description: "Return the software from MITRE database"
+      operationId: api.controllers.mitre_controller.get_software
+      x-rbac-actions:
+        - $ref: '#/x-rbac-catalog/actions/mitre:read'
+      parameters:
+        - $ref: '#/components/parameters/mitre_software_ids'
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/sort'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/select'
+        - $ref: '#/components/parameters/query'
+      responses:
+        '200':
+          description: "Get MITRE software information"
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/AllItemsResponse'
+              example:
+                data:
+                  affected_items:
+                    - deprecated: 0
+                      mitre_version: '1.0'
+                      created_time: '2017-05-31 21:32:40.801000'
+                      id: malware--007b44b6-e4c5-480b-b5b9-56f2081b1b7b
+                      name: HDoor
+                      modified_time: '2019-04-25 02:33:53.419000'
+                      description: "[HDoor](https://attack.mitre.org/software/S0061) is malware that
+                        has been customized and used by the [Naikon](https://attack.mitre.org/groups/G0019)
+                        group. (Citation: Baumgartner Naikon 2015)"
+                      related_groups:
+                        - intrusion-set--2a158b0a-7ef8-43cb-9985-bf34d1e12050
+                      related_techniques:
+                        - attack-pattern--ac08589e-ee59-4935-8667-d845e38fe579
+                        - attack-pattern--e3a12395-188d-4051-9a16-ea8e14d07b88
+                  total_affected_items: 444
+                  total_failed_items: 0
+                  failed_items: [ ]
+                message: MITRE software information was returned
                 error: 0
         '400':
           $ref: '#/components/responses/ResponseError'
@@ -10915,155 +11063,6 @@ paths:
                   failed_items: [ ]
                 message: MITRE techniques information was returned
                 error: 0
-        '400':
-          $ref: '#/components/responses/ResponseError'
-        '401':
-          $ref: '#/components/responses/UnauthorizedResponse'
-        '403':
-          $ref: '#/components/responses/PermissionDeniedResponse'
-        '405':
-          $ref: '#/components/responses/InvalidHTTPMethodResponse'
-        '429':
-          $ref: '#/components/responses/TooManyRequestsResponse'
-
-  /mitre/groups:
-    get:
-      tags:
-        - MITRE
-      summary: "Get MITRE groups"
-      description: "Return the groups from MITRE database"
-      operationId: api.controllers.mitre_controller.get_groups
-      x-rbac-actions:
-        - $ref: '#/x-rbac-catalog/actions/mitre:read'
-      parameters:
-        - $ref: '#/components/parameters/mitre_group_ids'
-        - $ref: '#/components/parameters/pretty'
-        - $ref: '#/components/parameters/wait_for_complete'
-        - $ref: '#/components/parameters/offset'
-        - $ref: '#/components/parameters/limit'
-        - $ref: '#/components/parameters/sort'
-        - $ref: '#/components/parameters/search'
-        - $ref: '#/components/parameters/select'
-        - $ref: '#/components/parameters/query'
-      responses:
-        '200':
-          description: "Get MITRE groups information"
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
-                  - type: object
-                    properties:
-                      data:
-                        $ref: '#/components/schemas/AllItemsResponse'
-              example:
-                data:
-                  affected_items:
-                    - mitre_version: '1.2'
-                      deprecated: 0
-                      name: APT38
-                      id: intrusion-set--00f67a77-86a4-4adf-be26-1a54fc713340
-                      modified_time: '2020-03-30 18:50:43.737000'
-                      created_time: '2019-01-29 21:27:24.793000'
-                      description: |-
-                        [APT38](https://attack.mitre.org/groups/G0082) is a financially-motivated threat group that is backed by the North Korean regime. The group mainly targets banks and financial institutions and has targeted more than 16 organizations in at least 13 countries since at least 2014.(Citation: FireEye APT38 Oct 2018)
-
-                        North Korean group definitions are known to have significant overlap, and the name [Lazarus Group](https://attack.mitre.org/groups/G0032) is known to encompass a broad range of activity. Some organizations use the name Lazarus Group to refer to any activity attributed to North Korea.(Citation: US-CERT HIDDEN COBRA June 2017) Some organizations track North Korean clusters or groups such as Bluenoroff,(Citation: Kaspersky Lazarus Under The Hood Blog 2017) [APT37](https://attack.mitre.org/groups/G0067), and [APT38](https://attack.mitre.org/groups/G0082) separately, while other organizations may track some activity associated with those group names by the name Lazarus Group.
-                      related_software:
-                        - tool--03342581-f790-4f03-ba41-e82e67392e23
-                        - tool--afc079f3-c0ea-4096-b75d-3f05338b7f60
-                        - malware--53ab35c2-d00e-491a-8753-41d35ae7e547
-                      related_techniques:
-                        - attack-pattern--df8b2a25-8bdf-4856-953c-a04372b1c161
-                        - attack-pattern--09a60ea3-a8d1-4ae5-976e-5783248b72a4
-                        - attack-pattern--8f4a33ec-8b1f-4b80-a2f6-642b2e479580
-                        - attack-pattern--57340c81-c025-4189-8fa0-fc7ede51bae4
-                        - attack-pattern--d742a578-d70e-4d0e-96a6-02a9c30204e6
-                        - attack-pattern--30973a08-aed9-4edf-8604-9084ce1b5c4f
-                        - attack-pattern--deb98323-e13f-4b0c-8d94-175379069062
-                        - attack-pattern--d1fcf083-a721-4223-aedf-bf8960798d62
-                        - attack-pattern--e6919abc-99f9-4c6c-95a5-14761e7b2add
-                        - attack-pattern--d63a3fb8-9452-4e9d-a60a-54be68d5998c
-                        - attack-pattern--6495ae23-3ab4-43c5-a94f-5638a2c31fd2
-                        - attack-pattern--32ad5c86-2bcf-47d8-8fdc-d7f3d79a7490
-                        - attack-pattern--d0613359-5781-4fd2-b5be-c269270be1f6
-                        - attack-pattern--1cfcb312-b8d7-47a4-b560-4b16cc677292
-                        - attack-pattern--0af0ca99-357d-4ba1-805f-674fdfb7bef9
-                        - attack-pattern--b80d107d-fa0d-4b60-9684-b0433e8bdba0
-                        - attack-pattern--d45a3d09-b3cf-48f4-9f0f-f521ee5cb05c
-                        - attack-pattern--7e150503-88e7-4861-866b-ff1ac82c4475
-                        - attack-pattern--ff73aa03-0090-4464-83ac-f89e233c02bc
-                  total_affected_items: 111
-                  total_failed_items: 0
-                  failed_items: [ ]
-                message: MITRE groups information was returned
-                error: 0
-        '400':
-          $ref: '#/components/responses/ResponseError'
-        '401':
-          $ref: '#/components/responses/UnauthorizedResponse'
-        '403':
-          $ref: '#/components/responses/PermissionDeniedResponse'
-        '405':
-          $ref: '#/components/responses/InvalidHTTPMethodResponse'
-        '429':
-          $ref: '#/components/responses/TooManyRequestsResponse'
-
-  /mitre/software:
-    get:
-      tags:
-        - MITRE
-      summary: "Get MITRE software"
-      description: "Return the software from MITRE database"
-      operationId: api.controllers.mitre_controller.get_software
-      x-rbac-actions:
-        - $ref: '#/x-rbac-catalog/actions/mitre:read'
-      parameters:
-        - $ref: '#/components/parameters/mitre_software_ids'
-        - $ref: '#/components/parameters/pretty'
-        - $ref: '#/components/parameters/wait_for_complete'
-        - $ref: '#/components/parameters/offset'
-        - $ref: '#/components/parameters/limit'
-        - $ref: '#/components/parameters/sort'
-        - $ref: '#/components/parameters/search'
-        - $ref: '#/components/parameters/select'
-        - $ref: '#/components/parameters/query'
-      responses:
-        '200':
-          description: "Get MITRE software information"
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
-                  - type: object
-                    properties:
-                      data:
-                        $ref: '#/components/schemas/AllItemsResponse'
-              example:
-                data:
-                  affected_items:
-                    - deprecated: 0
-                      mitre_version: '1.0'
-                      created_time: '2017-05-31 21:32:40.801000'
-                      id: malware--007b44b6-e4c5-480b-b5b9-56f2081b1b7b
-                      name: HDoor
-                      modified_time: '2019-04-25 02:33:53.419000'
-                      description: "[HDoor](https://attack.mitre.org/software/S0061) is malware that
-                      has been customized and used by the [Naikon](https://attack.mitre.org/groups/G0019)
-                      group. (Citation: Baumgartner Naikon 2015)"
-                      related_groups:
-                        - intrusion-set--2a158b0a-7ef8-43cb-9985-bf34d1e12050
-                      related_techniques:
-                        - attack-pattern--ac08589e-ee59-4935-8667-d845e38fe579
-                        - attack-pattern--e3a12395-188d-4051-9a16-ea8e14d07b88
-                  total_affected_items: 444
-                  total_failed_items: 0
-                  failed_items: [ ]
-                message: MITRE software information was returned
-                error: 0
-
         '400':
           $ref: '#/components/responses/ResponseError'
         '401':

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -10694,6 +10694,19 @@ paths:
                         - attack-pattern--d45a3d09-b3cf-48f4-9f0f-f521ee5cb05c
                         - attack-pattern--7e150503-88e7-4861-866b-ff1ac82c4475
                         - attack-pattern--ff73aa03-0090-4464-83ac-f89e233c02bc
+                      references:
+                        - url: "https://content.fireeye.com/apt/rpt-apt38"
+                          description: "FireEye. (2018, October 03). APT38: Un-usual Suspects. Retrieved November 6, 2018."
+                          source: "FireEye APT38 Oct 2018"
+                        - url: "https://securelist.com/lazarus-under-the-hood/77908/"
+                          description: "GReAT. (2017, April 3). Lazarus Under the Hood. Retrieved April 17, 2019."
+                          source: "Kaspersky Lazarus Under The Hood Blog 2017"
+                        - url: "https://www.us-cert.gov/ncas/alerts/TA17-164A"
+                          description: "US-CERT. (2017, June 13). Alert (TA17-164A) HIDDEN COBRA – North Korea’s DDoS Botnet Infrastructure. Retrieved July 13, 2017."
+                          source: "US-CERT HIDDEN COBRA June 2017"
+                        - url: "https://attack.mitre.org/groups/G0082"
+                          external_id: "G0082"
+                          source: "mitre-attack"
                   total_affected_items: 111
                   total_failed_items: 0
                   failed_items: [ ]
@@ -10734,6 +10747,18 @@ paths:
                     properties:
                       data:
                         $ref: '#/components/schemas/AllItemsResponse'
+              example:
+                data:
+                  affected_items:
+                    - value: "1"
+                      key: "db_version"
+                    - value: "2.0"
+                      key: "mitre_version"
+                  total_affected_items: 2
+                  failed_items: [2]
+                  total_failed_items: 0
+                message: "Metadata information was returned"
+                error: 0
         '400':
           $ref: '#/components/responses/ResponseError'
         '401':
@@ -10779,16 +10804,22 @@ paths:
               example:
                 data:
                   affected_items:
-                    - id: "course-of-action--78bb71be-92b4-46de-acd6-5f998fedf1cc"
-                      modified_time: '2020-10-20 19:52:32.439000'
-                      deprecated: 0
-                      created_time: '2020-10-19 14:57:58.771000'
-                      name: "Pre-compromise"
+                    - id: "course-of-action--00d7d21b-69d6-4797-88a2-c86f3fc97651"
+                      modified_time: '2019-07-25 11:22:19.139000'
+                      deprecated: 1
+                      created_time: '2018-10-17 00:14:20.652000'
+                      name: "Password Filter DLL Mitigation"
                       mitre_version: "1.0"
-                      description: "This category is used for any applicable mitigation activities that
-                        apply to techniques occurring before an adversary gains Initial Access, such
-                        as Reconnaissance and Resource Development techniques."
-                      techniques: [ ]
+                      description: "Ensure only valid password filters are registered. Filter DLLs must be present in Windows installation directory (<code>C:\\Windows\\System32\\</code> by default) of a domain controller and/or local computer with a corresponding entry in <code>HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Lsa\\Notification Packages</code>. (Citation: Microsoft Install Password Filter n.d)"
+                      techniques:
+                        - "attack-pattern--b8c5c9dd-a662-479d-9428-ae745872537c"
+                      references:
+                        - source: "Microsoft Install Password Filter n.d"
+                          description: "Microsoft. (n.d.). Installing and Registering a Password Filter DLL. Retrieved November 21, 2017."
+                          url": "https://msdn.microsoft.com/library/windows/desktop/ms721766.aspx"
+                        - source: "mitre-attack"
+                          external_id: "T1174"
+                          url: "https://attack.mitre.org/mitigations/T1174"
                   total_affected_items: 267
                   total_failed_items: 0
                   failed_items: [ ]
@@ -10908,6 +10939,13 @@ paths:
                       techniques:
                         - attack-pattern--ac08589e-ee59-4935-8667-d845e38fe579
                         - attack-pattern--e3a12395-188d-4051-9a16-ea8e14d07b88
+                      references:
+                        - source: "Baumgartner Naikon 2015"
+                          description: "Baumgartner, K., Golovkin, M.. (2015, May). The MsnMM Campaigns: The Earliest Naikon APT Campaigns. Retrieved April 10, 2019."
+                          url: "https://media.kasperskycontenthub.com/wp-content/uploads/sites/43/2018/03/07205555/TheNaikonAPT-MsnMM1.pdf"
+                        - source: "mitre-attack"
+                          external_id: "S0061"
+                          url: "https://attack.mitre.org/software/S0061"
                   total_affected_items: 444
                   total_failed_items: 0
                   failed_items: [ ]
@@ -10988,6 +11026,10 @@ paths:
                         - "attack-pattern--e624264c-033a-424d-9fd7-fc9c3bbdb03e"
                         - "attack-pattern--eb062747-2193-45de-8fa2-e62549c37ddf"
                         - "attack-pattern--f005e783-57d4-4837-88ad-dbe7faee1c51"
+                      references:
+                        - source: "mitre-attack"
+                          external_id: "TA0008"
+                          url: "https://attack.mitre.org/tactics/TA0008"
                   total_affected_items: 14
                   failed_items: []
                   total_failed_items: 0
@@ -11054,10 +11096,25 @@ paths:
                         Before compromising a victim, adversaries may gather information about the victim's networks that can be used during targeting. Information about networks may include a variety of details, including administrative data (ex: IP ranges, domain names, etc.) as well as specifics regarding its topology and operations.
 
                         Adversaries may gather this information in various ways, such as direct collection actions via [Active Scanning](https://attack.mitre.org/techniques/T1595) or [Phishing for Information](https://attack.mitre.org/techniques/T1598). Information about networks may also be exposed to adversaries via online or other accessible data sets (ex: [Search Open Technical Databases](https://attack.mitre.org/techniques/T1596)).(Citation: WHOIS)(Citation: DNS Dumpster)(Citation: Circl Passive DNS) Gathering this information may reveal opportunities for other forms of reconnaissance (ex: [Active Scanning](https://attack.mitre.org/techniques/T1595) or [Search Open Websites/Domains](https://attack.mitre.org/techniques/T1593)), establishing operational resources (ex: [Acquire Infrastructure](https://attack.mitre.org/techniques/T1583) or [Compromise Infrastructure](https://attack.mitre.org/techniques/T1584)), and/or initial access (ex: [Trusted Relationship](https://attack.mitre.org/techniques/T1199)).
-                      tactics: [ ]
-                      mitigations: [ ]
-                      software: [ ]
-                      groups: [ ]
+                      tactics:
+                        - "x-mitre-tactic--daa4cbb1-b4f4-4723-a824-7f1efd6e0592"
+                      mitigations:
+                        - "course-of-action--78bb71be-92b4-46de-acd6-5f998fedf1cc"
+                      software: []
+                      groups: []
+                      references:
+                        - source: "Circl Passive DNS"
+                          description: "CIRCL Computer Incident Response Center. (n.d.). Passive DNS. Retrieved October 20, 2020."
+                          url: "https://www.circl.lu/services/passive-dns/"
+                        - source: "DNS Dumpster"
+                          description: "Hacker Target. (n.d.). DNS Dumpster. Retrieved October 20, 2020."
+                          url: "https://dnsdumpster.com/"
+                        - source: "WHOIS"
+                          description: "NTT America. (n.d.). Whois Lookup. Retrieved October 20, 2020."
+                          url: "https://www.whois.net/"
+                        - source: "mitre-attack"
+                          external_id: "T1590"
+                          url: "https://attack.mitre.org/techniques/T1590"
                   total_affected_items: 1
                   total_failed_items: 0
                   failed_items: [ ]

--- a/api/test/integration/test_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_mitre_endpoints.tavern.yaml
@@ -482,8 +482,8 @@ stages:
         select: 'noexists'
     response:
       status_code: 400
-      json: &invalid_select
-        error: 1724
+      json:
+        <<: *invalid_select
 
   - name: Try to show references using invalid select (one select is invalid)
     request:

--- a/api/test/integration/test_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_mitre_endpoints.tavern.yaml
@@ -59,7 +59,7 @@ stages:
               modified_time: !anystr
               mitre_version: !anystr
               deprecated: !anyint
-              related_techniques: !anything
+              techniques: !anything
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
@@ -84,7 +84,7 @@ stages:
               - created_time
               - modified_time
               - deprecated
-              - related_techniques
+              - techniques
 
   - name: Check that the offset is working properly, try to show two mitigations with offset = 0
     request:
@@ -151,12 +151,12 @@ stages:
       verify: False
       <<: *general_mitigations_request
       params:
-        sort: -related_techniques
+        sort: -techniques
     response:
       verify_response_with:
         - function: tavern_utils:test_sort_response
           extra_kwargs:
-            key: "related_techniques"
+            key: "techniques"
       status_code: 200
       json:
         error: 0
@@ -171,13 +171,13 @@ stages:
       verify: False
       <<: *general_mitigations_request
       params:
-        select: 'related_techniques,deprecated,name'
+        select: 'techniques,deprecated,name'
     response:
       verify_response_with:
         # Check response item keys are the selected keys
         function: tavern_utils:test_select_key_affected_items
         extra_kwargs:
-          select_key: 'id,name,deprecated,related_techniques' # required_fields={'id'}
+          select_key: 'id,name,deprecated,techniques' # required_fields={'id'}
       status_code: 200
       json:
         error: 0
@@ -213,7 +213,7 @@ stages:
       verify: False
       <<: *general_mitigations_request
       params:
-        select: 'related_techniques'
+        select: 'techniques'
         mitigation_ids: 'invalid'
     response:
       status_code: 200
@@ -646,7 +646,7 @@ stages:
               created_time: !anystr
               modified_time: !anystr
               id: !anystr
-              related_techniques: !anything
+              techniques: !anything
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
@@ -671,7 +671,7 @@ stages:
               - description
               - created_time
               - modified_time
-              - related_techniques
+              - techniques
 
   - name: Check that the offset is working properly, try to show two tactics with offset = 0
     request:
@@ -738,12 +738,12 @@ stages:
       verify: False
       <<: *general_tactics_request
       params:
-        sort: -related_techniques
+        sort: -techniques
     response:
       verify_response_with:
         - function: tavern_utils:test_sort_response
           extra_kwargs:
-            key: "related_techniques"
+            key: "techniques"
       status_code: 200
       json:
         error: 0
@@ -758,13 +758,13 @@ stages:
       verify: False
       <<: *general_tactics_request
       params:
-        select: 'related_techniques,short_name,name'
+        select: 'techniques,short_name,name'
     response:
       verify_response_with:
         # Check response item keys are the selected keys
         function: tavern_utils:test_select_key_affected_items
         extra_kwargs:
-          select_key: 'id,name,short_name,related_techniques' # required_fields={'id'}
+          select_key: 'id,name,short_name,techniques' # required_fields={'id'}
       status_code: 200
       json:
         error: 0
@@ -800,7 +800,7 @@ stages:
       verify: False
       <<: *general_tactics_request
       params:
-        select: 'related_techniques'
+        select: 'techniques'
         tactic_ids: 'invalid'
     response:
       status_code: 200
@@ -943,10 +943,10 @@ stages:
               modified_time: !anystr
               network_requirements: !anyint
               created_time: !anystr
-              related_tactics: !anything
-              related_mitigations: !anything
-              related_software: !anything
-              related_groups: !anything
+              tactics: !anything
+              mitigations: !anything
+              software: !anything
+              groups: !anything
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
@@ -970,10 +970,10 @@ stages:
               - created_time
               - deprecated
               - remote_support
-              - related_tactics
-              - related_groups
-              - related_mitigations
-              - related_software
+              - tactics
+              - groups
+              - mitigations
+              - software
 
   - name: Check that the offset is working properly, try to show two techniques with offset = 0
     request:
@@ -1040,12 +1040,12 @@ stages:
       verify: False
       <<: *general_techniques_request
       params:
-        sort: -related_mitigations
+        sort: -mitigations
     response:
       verify_response_with:
         - function: tavern_utils:test_sort_response
           extra_kwargs:
-            key: "related_mitigations"
+            key: "mitigations"
       status_code: 200
       json:
         error: 0
@@ -1060,13 +1060,13 @@ stages:
       verify: False
       <<: *general_techniques_request
       params:
-        select: 'related_groups,deprecated,name'
+        select: 'groups,deprecated,name'
     response:
       verify_response_with:
         # Check response item keys are the selected keys
         function: tavern_utils:test_select_key_affected_items
         extra_kwargs:
-          select_key: 'id,related_groups,deprecated,name' # required_fields={'id'}
+          select_key: 'id,groups,deprecated,name' # required_fields={'id'}
       status_code: 200
       json:
         error: 0
@@ -1102,7 +1102,7 @@ stages:
       verify: False
       <<: *general_techniques_request
       params:
-        select: 'related_software'
+        select: 'software'
         technique_ids: 'invalid'
     response:
       status_code: 200
@@ -1238,8 +1238,8 @@ stages:
               modified_time: !anystr
               created_time: !anystr
               description: !anystr
-              related_software: !anything
-              related_techniques: !anything
+              software: !anything
+              techniques: !anything
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
@@ -1265,8 +1265,8 @@ stages:
               - modified_time
               - created_time
               - description
-              - related_software
-              - related_techniques
+              - software
+              - techniques
 
   - name: Check that the offset is working properly, show two groups with offset = 0
     request:
@@ -1333,12 +1333,12 @@ stages:
       verify: False
       <<: *general_groups_request
       params:
-        sort: -related_software
+        sort: -software
     response:
       verify_response_with:
         - function: tavern_utils:test_sort_response
           extra_kwargs:
-            key: "related_software"
+            key: "software"
       status_code: 200
       json:
         error: 0
@@ -1395,7 +1395,7 @@ stages:
       verify: False
       <<: *general_groups_request
       params:
-        select: 'related_software'
+        select: 'software'
         group_ids: 'invalid'
     response:
       status_code: 200
@@ -1531,8 +1531,8 @@ stages:
               modified_time: !anystr
               created_time: !anystr
               description: !anystr
-              related_groups: !anything
-              related_techniques: !anything
+              groups: !anything
+              techniques: !anything
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
@@ -1558,8 +1558,8 @@ stages:
               - modified_time
               - created_time
               - description
-              - related_groups
-              - related_techniques
+              - groups
+              - techniques
 
   - name: Check that the offset is working properly, show two softwares with offset = 0
     request:
@@ -1626,12 +1626,12 @@ stages:
       verify: False
       <<: *general_software_request
       params:
-        sort: -related_groups
+        sort: -groups
     response:
       verify_response_with:
         - function: tavern_utils:test_sort_response
           extra_kwargs:
-            key: "related_groups"
+            key: "groups"
       status_code: 200
       json:
         error: 0
@@ -1688,7 +1688,7 @@ stages:
       verify: False
       <<: *general_software_request
       params:
-        select: 'related_groups'
+        select: 'groups'
         software_ids: 'invalid'
     response:
       status_code: 200

--- a/framework/wazuh/core/mitre.py
+++ b/framework/wazuh/core/mitre.py
@@ -156,7 +156,7 @@ class WazuhDBQueryMitreMitigations(WazuhDBQueryMitre):
                                    select=list(set(self.fields.values()).intersection(set(select))),
                                    request_slice=MITIGATIONS_REQUEST_SLICE)
 
-        self.relation_fields = {'related_techniques', 'references'}
+        self.relation_fields = {'techniques', 'references'}
 
     def _filter_status(self, status_filter):
         pass
@@ -170,7 +170,7 @@ class WazuhDBQueryMitreMitigations(WazuhDBQueryMitre):
         for mitigation in self._data:
             mitigation_ids.add(mitigation['id'])
 
-        related_techniques = WazuhDBQueryMitreRelational(table='mitigate', filters={'source_id': list(mitigation_ids)},
+        techniques = WazuhDBQueryMitreRelational(table='mitigate', filters={'source_id': list(mitigation_ids)},
                                                          dict_key='source_id', limit=None).run()
 
         references = WazuhDBQueryMitreReferences(limit=None, filters={'type': 'mitigation'},
@@ -180,7 +180,7 @@ class WazuhDBQueryMitreMitigations(WazuhDBQueryMitre):
             row.pop('id')
 
         for mitigation in self._data:
-            mitigation['related_techniques'] = related_techniques.get(mitigation['id'], list())
+            mitigation['techniques'] = techniques.get(mitigation['id'], list())
             mitigation['references'] = [row_no_id for row, row_no_id in
                                         zip(references['items'], references_no_id['items']) if
                                         row['id'] == mitigation['id']]
@@ -241,7 +241,7 @@ class WazuhDBQueryMitreTactics(WazuhDBQueryMitre):
                                    default_sort_order=default_sort_order, search=search,
                                    select=list(set(self.fields.values()).intersection(set(select))))
 
-        self.relation_fields = {'related_techniques', 'references'}
+        self.relation_fields = {'techniques', 'references'}
 
     def _filter_status(self, status_filter):
         pass
@@ -254,7 +254,7 @@ class WazuhDBQueryMitreTactics(WazuhDBQueryMitre):
         for tactic in self._data:
             tactic_ids.add(tactic['id'])
 
-        related_techniques = WazuhDBQueryMitreRelational(table='phase', filters={'tactic_id': list(tactic_ids)},
+        techniques = WazuhDBQueryMitreRelational(table='phase', filters={'tactic_id': list(tactic_ids)},
                                                          dict_key='tactic_id', limit=None).run()
 
         references = WazuhDBQueryMitreReferences(limit=None, filters={'type': 'tactic'},
@@ -264,7 +264,7 @@ class WazuhDBQueryMitreTactics(WazuhDBQueryMitre):
             row.pop('id')
 
         for tactic in self._data:
-            tactic['related_techniques'] = related_techniques.get(tactic['id'], list())
+            tactic['techniques'] = techniques.get(tactic['id'], list())
             tactic['references'] = [row_no_id for row, row_no_id in
                                     zip(references['items'], references_no_id['items']) if
                                     row['id'] == tactic['id']]
@@ -299,7 +299,7 @@ class WazuhDBQueryMitreTechniques(WazuhDBQueryMitre):
                                    select=list(set(self.fields.values()).intersection(set(select))),
                                    request_slice=TECHNIQUES_REQUEST_SLICE)
 
-        self.relation_fields = {'related_tactics', 'related_mitigations', 'related_software', 'related_groups',
+        self.relation_fields = {'tactics', 'mitigations', 'software', 'groups',
                                 'references'}
 
     def _filter_status(self, status_filter):
@@ -315,16 +315,16 @@ class WazuhDBQueryMitreTechniques(WazuhDBQueryMitre):
         for technique in self._data:
             technique_ids.add(technique['id'])
 
-        related_tactics = WazuhDBQueryMitreRelational(table='phase', filters={'tech_id': list(technique_ids)},
+        tactics = WazuhDBQueryMitreRelational(table='phase', filters={'tech_id': list(technique_ids)},
                                                       dict_key='tech_id', limit=None).run()
-        related_mitigations = WazuhDBQueryMitreRelational(table='mitigate', filters={'target_id': list(technique_ids)},
+        mitigations = WazuhDBQueryMitreRelational(table='mitigate', filters={'target_id': list(technique_ids)},
                                                           dict_key='target_id', limit=None).run()
-        related_software = WazuhDBQueryMitreRelational(table='use',
+        software = WazuhDBQueryMitreRelational(table='use',
                                                        filters={'target_id': list(technique_ids),
                                                                 'target_type': 'technique', 'source_type': 'software'},
                                                        dict_key='target_id',
                                                        limit=None).run()
-        related_groups = WazuhDBQueryMitreRelational(table='use',
+        groups = WazuhDBQueryMitreRelational(table='use',
                                                      filters={'target_id': list(technique_ids),
                                                               'target_type': 'technique', 'source_type': 'group'},
                                                      dict_key='target_id',
@@ -337,10 +337,10 @@ class WazuhDBQueryMitreTechniques(WazuhDBQueryMitre):
             row.pop('id')
 
         for technique in self._data:
-            technique['related_tactics'] = related_tactics.get(technique['id'], list())
-            technique['related_mitigations'] = related_mitigations.get(technique['id'], list())
-            technique['related_software'] = related_software.get(technique['id'], list())
-            technique['related_groups'] = related_groups.get(technique['id'], list())
+            technique['tactics'] = tactics.get(technique['id'], list())
+            technique['mitigations'] = mitigations.get(technique['id'], list())
+            technique['software'] = software.get(technique['id'], list())
+            technique['groups'] = groups.get(technique['id'], list())
             technique['references'] = [row_no_id for row, row_no_id in
                                        zip(references['items'], references_no_id['items']) if
                                        row['id'] == technique['id']]
@@ -373,7 +373,7 @@ class WazuhDBQueryMitreGroups(WazuhDBQueryMitre):
                                    select=list(set(self.fields.values()).intersection(set(select))),
                                    request_slice=GROUPS_REQUEST_SLICE)
 
-        self.relation_fields = {'related_software', 'related_techniques', 'references'}
+        self.relation_fields = {'software', 'techniques', 'references'}
 
     def _filter_status(self, status_filter):
         pass
@@ -386,12 +386,12 @@ class WazuhDBQueryMitreGroups(WazuhDBQueryMitre):
         for group in self._data:
             group_ids.add(group['id'])
 
-        related_software = WazuhDBQueryMitreRelational(table='use',
+        software = WazuhDBQueryMitreRelational(table='use',
                                                        filters={'source_id': list(group_ids),
                                                                 'target_type': 'software', 'source_type': 'group'},
                                                        dict_key='source_id',
                                                        limit=None).run()
-        related_techniques = WazuhDBQueryMitreRelational(table='use',
+        techniques = WazuhDBQueryMitreRelational(table='use',
                                                          filters={'source_id': list(group_ids),
                                                                   'target_type': 'technique', 'source_type': 'group'},
                                                          dict_key='source_id',
@@ -404,8 +404,8 @@ class WazuhDBQueryMitreGroups(WazuhDBQueryMitre):
             row.pop('id')
 
         for group in self._data:
-            group['related_software'] = related_software.get(group['id'], list())
-            group['related_techniques'] = related_techniques.get(group['id'], list())
+            group['software'] = software.get(group['id'], list())
+            group['techniques'] = techniques.get(group['id'], list())
             group['references'] = [row_no_id for row, row_no_id in
                                    zip(references['items'], references_no_id['items']) if
                                    row['id'] == group['id']]
@@ -438,7 +438,7 @@ class WazuhDBQueryMitreSoftware(WazuhDBQueryMitre):
                                    select=list(set(self.fields.values()).intersection(set(select))),
                                    request_slice=SOFTWARE_REQUEST_SLICE)
 
-        self.relation_fields = {'related_groups', 'related_techniques', 'references'}
+        self.relation_fields = {'groups', 'techniques', 'references'}
 
     def _filter_status(self, status_filter):
         pass
@@ -451,13 +451,13 @@ class WazuhDBQueryMitreSoftware(WazuhDBQueryMitre):
         for group in self._data:
             software_ids.add(group['id'])
 
-        related_groups = WazuhDBQueryMitreRelational(table='use',
+        groups = WazuhDBQueryMitreRelational(table='use',
                                                      filters={'target_id': list(software_ids),
                                                               'target_type': 'software',
                                                               'source_type': 'group'},
                                                      dict_key='target_id',
                                                      limit=None).run()
-        related_techniques = WazuhDBQueryMitreRelational(table='use',
+        techniques = WazuhDBQueryMitreRelational(table='use',
                                                          filters={'source_id': list(software_ids),
                                                                   'target_type': 'technique',
                                                                   'source_type': 'software'},
@@ -471,8 +471,8 @@ class WazuhDBQueryMitreSoftware(WazuhDBQueryMitre):
             row.pop('id')
 
         for software in self._data:
-            software['related_groups'] = related_groups.get(software['id'], list())
-            software['related_techniques'] = related_techniques.get(software['id'], list())
+            software['groups'] = groups.get(software['id'], list())
+            software['techniques'] = techniques.get(software['id'], list())
             software['references'] = [row_no_id for row, row_no_id in
                                       zip(references['items'], references_no_id['items']) if
                                       row['id'] == software['id']]

--- a/framework/wazuh/core/mitre.py
+++ b/framework/wazuh/core/mitre.py
@@ -171,7 +171,7 @@ class WazuhDBQueryMitreMitigations(WazuhDBQueryMitre):
             mitigation_ids.add(mitigation['id'])
 
         techniques = WazuhDBQueryMitreRelational(table='mitigate', filters={'source_id': list(mitigation_ids)},
-                                                         dict_key='source_id', limit=None).run()
+                                                 dict_key='source_id', limit=None).run()
 
         references = WazuhDBQueryMitreReferences(limit=None, filters={'type': 'mitigation'},
                                                  select=SELECT_FIELDS_REFERENCES).run()
@@ -255,7 +255,7 @@ class WazuhDBQueryMitreTactics(WazuhDBQueryMitre):
             tactic_ids.add(tactic['id'])
 
         techniques = WazuhDBQueryMitreRelational(table='phase', filters={'tactic_id': list(tactic_ids)},
-                                                         dict_key='tactic_id', limit=None).run()
+                                                 dict_key='tactic_id', limit=None).run()
 
         references = WazuhDBQueryMitreReferences(limit=None, filters={'type': 'tactic'},
                                                  select=SELECT_FIELDS_REFERENCES).run()
@@ -316,19 +316,19 @@ class WazuhDBQueryMitreTechniques(WazuhDBQueryMitre):
             technique_ids.add(technique['id'])
 
         tactics = WazuhDBQueryMitreRelational(table='phase', filters={'tech_id': list(technique_ids)},
-                                                      dict_key='tech_id', limit=None).run()
+                                              dict_key='tech_id', limit=None).run()
         mitigations = WazuhDBQueryMitreRelational(table='mitigate', filters={'target_id': list(technique_ids)},
-                                                          dict_key='target_id', limit=None).run()
+                                                  dict_key='target_id', limit=None).run()
         software = WazuhDBQueryMitreRelational(table='use',
-                                                       filters={'target_id': list(technique_ids),
-                                                                'target_type': 'technique', 'source_type': 'software'},
-                                                       dict_key='target_id',
-                                                       limit=None).run()
+                                               filters={'target_id': list(technique_ids),
+                                                        'target_type': 'technique', 'source_type': 'software'},
+                                               dict_key='target_id',
+                                               limit=None).run()
         groups = WazuhDBQueryMitreRelational(table='use',
-                                                     filters={'target_id': list(technique_ids),
-                                                              'target_type': 'technique', 'source_type': 'group'},
-                                                     dict_key='target_id',
-                                                     limit=None).run()
+                                             filters={'target_id': list(technique_ids),
+                                                      'target_type': 'technique', 'source_type': 'group'},
+                                             dict_key='target_id',
+                                             limit=None).run()
 
         references = WazuhDBQueryMitreReferences(limit=None, filters={'type': 'technique'},
                                                  select=SELECT_FIELDS_REFERENCES).run()
@@ -387,15 +387,15 @@ class WazuhDBQueryMitreGroups(WazuhDBQueryMitre):
             group_ids.add(group['id'])
 
         software = WazuhDBQueryMitreRelational(table='use',
-                                                       filters={'source_id': list(group_ids),
-                                                                'target_type': 'software', 'source_type': 'group'},
-                                                       dict_key='source_id',
-                                                       limit=None).run()
+                                               filters={'source_id': list(group_ids),
+                                                        'target_type': 'software', 'source_type': 'group'},
+                                               dict_key='source_id',
+                                               limit=None).run()
         techniques = WazuhDBQueryMitreRelational(table='use',
-                                                         filters={'source_id': list(group_ids),
-                                                                  'target_type': 'technique', 'source_type': 'group'},
-                                                         dict_key='source_id',
-                                                         limit=None).run()
+                                                 filters={'source_id': list(group_ids),
+                                                          'target_type': 'technique', 'source_type': 'group'},
+                                                 dict_key='source_id',
+                                                 limit=None).run()
 
         references = WazuhDBQueryMitreReferences(limit=None, filters={'type': 'group'},
                                                  select=SELECT_FIELDS_REFERENCES).run()
@@ -452,17 +452,17 @@ class WazuhDBQueryMitreSoftware(WazuhDBQueryMitre):
             software_ids.add(group['id'])
 
         groups = WazuhDBQueryMitreRelational(table='use',
-                                                     filters={'target_id': list(software_ids),
-                                                              'target_type': 'software',
-                                                              'source_type': 'group'},
-                                                     dict_key='target_id',
-                                                     limit=None).run()
+                                             filters={'target_id': list(software_ids),
+                                                      'target_type': 'software',
+                                                      'source_type': 'group'},
+                                             dict_key='target_id',
+                                             limit=None).run()
         techniques = WazuhDBQueryMitreRelational(table='use',
-                                                         filters={'source_id': list(software_ids),
-                                                                  'target_type': 'technique',
-                                                                  'source_type': 'software'},
-                                                         dict_key='source_id',
-                                                         limit=None).run()
+                                                 filters={'source_id': list(software_ids),
+                                                          'target_type': 'technique',
+                                                          'source_type': 'software'},
+                                                 dict_key='source_id',
+                                                 limit=None).run()
 
         references = WazuhDBQueryMitreReferences(limit=None, filters={'type': 'software'},
                                                  select=SELECT_FIELDS_REFERENCES).run()
@@ -479,18 +479,23 @@ class WazuhDBQueryMitreSoftware(WazuhDBQueryMitre):
 
 
 @lru_cache(maxsize=None)
-def get_mitigations():
-    """This function loads the mitigation data in order to speed up the use of the Framework function.
+def get_mitre_items(mitre_class: callable):
+    """This function loads the MITRE data in order to speed up the use of the Framework function.
     It also provides information about the min_select_fields for the select parameter and the
     allowed_fields for the sort parameter.
+
+    Parameters
+    ----------
+    mitre_class : callable
+        WazuhDBQueryMitre class used to obtain certain MITRE resources.
 
     Returns
     -------
     dict
-        Dictionary with information about the fields of the mitigation objects and the mitigations obtained.
+        Dictionary with information about the fields of the MITRE objects and the items obtained.
     """
     info = {'min_select_fields': None, 'allowed_fields': None}
-    db_query = WazuhDBQueryMitreMitigations(limit=None)
+    db_query = mitre_class(limit=None)
     info['allowed_fields'] = set(db_query.fields.keys()).union(set(db_query.relation_fields))
     info['min_select_fields'] = set(db_query.min_select_fields)
     data = db_query.run()
@@ -498,114 +503,14 @@ def get_mitigations():
     return info, data
 
 
-@lru_cache(maxsize=None)
-def get_references():
-    """This function loads the reference data in order to speed up the use of the Framework function.
-    It also provides information about the min_select_fields for the select parameter and the
-    allowed_fields for the sort parameter.
-
-    Returns
-    -------
-    dict
-        Dictionary with information about the fields of the reference objects and the references obtained.
-    """
-    info = {'min_select_fields': None, 'allowed_fields': None}
-    db_query = WazuhDBQueryMitreReferences(limit=None)
-    info['allowed_fields'] = set(db_query.fields.keys()).union(set(db_query.relation_fields))
-    info['min_select_fields'] = set(db_query.min_select_fields)
-    data = db_query.run()
-
-    return info, data
-
-
-@lru_cache(maxsize=None)
-def get_tactics():
-    """This function loads the tactic data in order to speed up the use of the Framework function.
-    It also provides information about the min_select_fields for the select parameter and the
-    allowed_fields for the sort parameter.
-
-    Returns
-    -------
-    dict
-        Dictionary with information about the fields of the tactic objects and the tactics obtained.
-    """
-    info = {'min_select_fields': None, 'allowed_fields': None}
-    db_query = WazuhDBQueryMitreTactics(limit=None)
-    info['allowed_fields'] = set(db_query.fields.keys()).union(set(db_query.relation_fields))
-    info['min_select_fields'] = set(db_query.min_select_fields)
-    data = db_query.run()
-
-    return info, data
-
-
-@lru_cache(maxsize=None)
-def get_techniques():
-    """This function loads the technique data in order to speed up the use of the Framework function.
-    It also provides information about the min_select_fields for the select parameter and the
-    allowed_fields for the sort parameter.
-
-    Returns
-    -------
-    dict
-        Dictionary with information about the fields of the technique objects and the techniques obtained.
-    """
-    info = {'min_select_fields': None, 'allowed_fields': None}
-    db_query = WazuhDBQueryMitreTechniques(limit=None)
-    info['allowed_fields'] = set(db_query.fields.keys()).union(set(db_query.relation_fields))
-    info['min_select_fields'] = set(db_query.min_select_fields)
-    data = db_query.run()
-
-    return info, data
-
-
-@lru_cache(maxsize=None)
-def get_groups():
-    """This function loads the MITRE groups data in order to speed up the use of the Framework function.
-    It also provides information about the min_select_fields for the select parameter and the
-    allowed_fields for the sort parameter.
-
-    Returns
-    -------
-    dict
-        Dictionary with information about the fields of the group objects and the MITRE groups obtained.
-    """
-    info = {'min_select_fields': None, 'allowed_fields': None}
-    db_query = WazuhDBQueryMitreGroups(limit=None)
-    info['allowed_fields'] = set(db_query.fields.keys()).union(set(db_query.relation_fields))
-    info['min_select_fields'] = set(db_query.min_select_fields)
-    data = db_query.run()
-
-    return info, data
-
-
-@lru_cache(maxsize=None)
-def get_software():
-    """This function loads the MITRE groups data in order to speed up the use of the Framework function.
-    It also provides information about the min_select_fields for the select parameter and the
-    allowed_fields for the sort parameter.
-
-    Returns
-    -------
-    dict
-        Dictionary with information about the fields of the software objects and the MITRE software obtained.
-    """
-    info = {'min_select_fields': None, 'allowed_fields': None}
-    db_query = WazuhDBQueryMitreSoftware(limit=None)
-    info['allowed_fields'] = set(db_query.fields.keys()).union(set(db_query.relation_fields))
-    info['min_select_fields'] = set(db_query.min_select_fields)
-    data = db_query.run()
-
-    return info, data
-
-
-def get_results_with_select(mitre_function, filters, select, offset, limit, sort_by, sort_ascending, search_text,
+def get_results_with_select(mitre_class, filters, select, offset, limit, sort_by, sort_ascending, search_text,
                             complementary_search, search_in_fields, q):
     """Sanitize the select parameter and processes the list of MITRE resources.
 
     Parameters
     ----------
-    mitre_function : callable
-        Cached function to obtain certain MITRE resources.
+    mitre_class : callable
+        WazuhDBQueryMitre class used to obtain certain MITRE resources.
     filters : str
         Define field filters required by the user. Format: {"field1":"value1", "field2":["value2","value3"]}
     select : list
@@ -633,7 +538,7 @@ def get_results_with_select(mitre_function, filters, select, offset, limit, sort
     list
         Processed MITRE resources array.
     """
-    fields_info, data = mitre_function()
+    fields_info, data = get_mitre_items(mitre_class)
 
     return process_array(data['items'], filters=filters, search_text=search_text, search_in_fields=search_in_fields,
                          complementary_search=complementary_search, sort_by=sort_by, select=select,

--- a/framework/wazuh/core/tests/test_mitre.py
+++ b/framework/wazuh/core/tests/test_mitre.py
@@ -24,7 +24,6 @@ def test_WazuhDBQueryMitreMetadata(mock_wdb):
 
 
 @pytest.mark.parametrize('wdb_query_class', [
-    # TODO: add the rest of wdb query classes
     WazuhDBQueryMitreGroups,
     WazuhDBQueryMitreMitigations,
     WazuhDBQueryMitreReferences,
@@ -50,19 +49,18 @@ def test_WazuhDBQueryMitre_classes(mock_wdb, wdb_query_class):
         pytest.fail("Related item not found in data obtained from query")
 
 
-@pytest.mark.parametrize('mitre_get_function, mitre_wdb_query_class', [
-    # TODO: add the rest of wdb query classes
-    (get_groups, WazuhDBQueryMitreGroups),
-    (get_mitigations, WazuhDBQueryMitreMitigations),
-    (get_references, WazuhDBQueryMitreReferences),
-    (get_tactics, WazuhDBQueryMitreTactics),
-    (get_techniques, WazuhDBQueryMitreTechniques),
-    (get_software, WazuhDBQueryMitreSoftware)
+@pytest.mark.parametrize('mitre_wdb_query_class', [
+    WazuhDBQueryMitreGroups,
+    WazuhDBQueryMitreMitigations,
+    WazuhDBQueryMitreReferences,
+    WazuhDBQueryMitreTactics,
+    WazuhDBQueryMitreTechniques,
+    WazuhDBQueryMitreSoftware
 ])
 @patch('wazuh.core.utils.WazuhDBConnection')
-def test_mitre_get_functions(mock_wdb, mitre_get_function, mitre_wdb_query_class):
+def test_get_mitre_items(mock_wdb, mitre_wdb_query_class):
     """Test get_tactics function."""
-    info, data = mitre_get_function()
+    info, data = get_mitre_items(mitre_wdb_query_class)
 
     db_query_to_compare = mitre_wdb_query_class()
 

--- a/framework/wazuh/core/tests/test_mitre.py
+++ b/framework/wazuh/core/tests/test_mitre.py
@@ -59,7 +59,7 @@ def test_WazuhDBQueryMitre_classes(mock_wdb, wdb_query_class):
 ])
 @patch('wazuh.core.utils.WazuhDBConnection')
 def test_get_mitre_items(mock_wdb, mitre_wdb_query_class):
-    """Test get_tactics function."""
+    """Test get_mitre_items function."""
     info, data = get_mitre_items(mitre_wdb_query_class)
 
     db_query_to_compare = mitre_wdb_query_class()

--- a/framework/wazuh/mitre.py
+++ b/framework/wazuh/mitre.py
@@ -66,7 +66,7 @@ def mitre_mitigations(filters: dict = None, offset=0, limit=common.database_limi
     dict
         Dictionary with the information of the specified mitigations and their relationships
     """
-    data = mitre.get_results_with_select(mitre.get_mitigations, **locals())
+    data = mitre.get_results_with_select(mitre.WazuhDBQueryMitreMitigations, **locals())
 
     result = AffectedItemsWazuhResult(none_msg='No MITRE mitigations information was returned',
                                       all_msg='MITRE mitigations information was returned')
@@ -110,7 +110,7 @@ def mitre_references(filters: dict = None, offset=0, limit=common.database_limit
     dict
         Dictionary with the information of the specified references.
     """
-    data = mitre.get_results_with_select(mitre.get_references, **locals())
+    data = mitre.get_results_with_select(mitre.WazuhDBQueryMitreReferences, **locals())
 
     result = AffectedItemsWazuhResult(none_msg='No MITRE references information was returned',
                                       all_msg='MITRE references information was returned')
@@ -154,7 +154,7 @@ def mitre_techniques(filters: dict = None, offset=0, limit=common.database_limit
     dict
         Dictionary with the information of the specified techniques and their relationships
     """
-    data = mitre.get_results_with_select(mitre.get_techniques, **locals())
+    data = mitre.get_results_with_select(mitre.WazuhDBQueryMitreTechniques, **locals())
 
     result = AffectedItemsWazuhResult(none_msg='No MITRE techniques information was returned',
                                       all_msg='MITRE techniques information was returned')
@@ -198,7 +198,7 @@ def mitre_tactics(filters: dict = None, offset: int = 0, limit: int = common.dat
     dict
         Dictionary with the information of the specified tactics and their relationships.
     """
-    data = mitre.get_results_with_select(mitre.get_tactics, **locals())
+    data = mitre.get_results_with_select(mitre.WazuhDBQueryMitreTactics, **locals())
 
     result = AffectedItemsWazuhResult(none_msg='No tactics information was returned',
                                       all_msg='All tactics information was returned')
@@ -242,7 +242,7 @@ def mitre_groups(filters: dict = None, offset: int = 0, limit: int = common.data
     dict
         Dictionary with the information of the specified groups and their relationships.
     """
-    data = mitre.get_results_with_select(mitre.get_groups, **locals())
+    data = mitre.get_results_with_select(mitre.WazuhDBQueryMitreGroups, **locals())
 
     result = AffectedItemsWazuhResult(none_msg='No MITRE groups information was returned',
                                       all_msg='MITRE groups information was returned')
@@ -286,7 +286,7 @@ def mitre_software(filters: dict = None, offset: int = 0, limit: int = common.da
     dict
         Dictionary with the information of the specified software and their relationships.
     """
-    data = mitre.get_results_with_select(mitre.get_software, **locals())
+    data = mitre.get_results_with_select(mitre.WazuhDBQueryMitreSoftware, **locals())
 
     result = AffectedItemsWazuhResult(none_msg='No MITRE software information was returned',
                                       all_msg='MITRE software information was returned')

--- a/framework/wazuh/tests/data/security/rbac_catalog.yml
+++ b/framework/wazuh/tests/data/security/rbac_catalog.yml
@@ -473,13 +473,13 @@ get_rbac_actions:
             - "*:*:*"
           effect: allow
         related_endpoints:
+          - GET /mitre/groups
           - GET /mitre/metadata
           - GET /mitre/mitigations
-          - GET /mitre/tactics
-          - GET /mitre/techniques
-          - GET /mitre/groups
           - GET /mitre/references
           - GET /mitre/software
+          - GET /mitre/tactics
+          - GET /mitre/techniques
       rootcheck:clear:
         description: Clear the agents rootcheck database
         resources:

--- a/framework/wazuh/tests/test_mitre.py
+++ b/framework/wazuh/tests/test_mitre.py
@@ -27,11 +27,7 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
 @pytest.fixture(scope='module')
 def mitre_db():
     """Get fake MITRE database cursor."""
-    core_mitre.get_groups.cache_clear()
-    core_mitre.get_mitigations.cache_clear()
-    core_mitre.get_techniques.cache_clear()
-    core_mitre.get_tactics.cache_clear()
-    core_mitre.get_software.cache_clear()
+    core_mitre.get_mitre_items.cache_clear()
     return get_fake_database_data('schema_mitre_test.sql').cursor()
 
 


### PR DESCRIPTION
|Related issue|
|---|
| #7819 |

Hi team,

In this PR, I have made some changes to the new MITRE endpoints and related functions.

1.- I have updated the spec and rbac_catalog to avoid errors in a SDK unittest. Reviewed spec examples.
2.- Updated `WazuhDBQueryMitre` classes docstrings and added `limit=None` to relational classes.
3.- Add related references to each MITRE endpoint.
4.- I have tested all `WazuhDBQueries` to optimize the `request_slice` values.
5.- Changed `related_items` names to `items`. Updated spec examples.
6.- I have unified all MITRE callables in one function.
7.- RAM consumption test after caching all functions: 

Before caching: 
`MiB Mem :  15944.3 total,   1760.5 free,   8194.9 used,   5988.9 buff/cache
`

After caching:
`MiB Mem :  15944.3 total,   1752.7 free,   8185.0 used,   6006.5 buff/cache
`

10-20 MiB are being cached after testing all functions (mitigations, references, groups, software, metadata, tactics, techniques and its respective relations)

- Test results:

```
framework/wazuh/core/tests/
============== 664 passed, 1 xfailed, 2 xpassed, 9 warnings in 4.86s ==============

framework/wazuh/tests/
============== 586 passed, 13 warnings in 62.47s (0:01:02) ==============
```

```
test_mitre_endpoints.tavern.yaml 
	 7 passed, 13 warnings

test_rbac_black_mitre_endpoints.tavern.yaml 
	 7 passed, 13 warnings

test_rbac_white_mitre_endpoints.tavern.yaml 
	 7 passed, 13 warnings
```

Regards,
Manuel.