### PR TITLE
Migrate agent info files on agent updates

### DIFF
--- a/src/init/wazuh/wazuh.sh
+++ b/src/init/wazuh/wazuh.sh
@@ -129,18 +129,26 @@ WazuhUpgrade()
     rm -f $DIRECTORY/wodles/cve.db
     rm -f $DIRECTORY/queue/vulnerabilities/cve.db
 
-    # Remove existing socket folder
+    # Migrate .agent_info and .wait files before removing deprecated socket folder
 
-    rm -rf $DIRECTORY/queue/ossec
+    if [ -d $DIRECTORY/queue/ossec ]; then
+        if [ -f $DIRECTORY/queue/ossec/.agent_info ]; then
+            mv -f $DIRECTORY/queue/ossec/.agent_info $DIRECTORY/queue/sockets/.agent_info
+        fi
+        if [ -f $DIRECTORY/queue/ossec/.wait ]; then
+            mv -f $DIRECTORY/queue/ossec/.wait $DIRECTORY/queue/sockets/.wait
+        fi
+        rm -rf $DIRECTORY/queue/ossec
+    fi
 
-	# Move rotated logs to new folder and remove the existing one
-	
-	if [ -d $DIRECTORY/logs/ossec ]; then
-		if [ "$(ls -A $DIRECTORY/logs/ossec)" ]; then
-			mv -f $DIRECTORY/logs/ossec/* $DIRECTORY/logs/wazuh
-		fi
-		rm -rf $DIRECTORY/logs/ossec
-	fi
+    # Move rotated logs to new folder and remove the existing one
+
+    if [ -d $DIRECTORY/logs/ossec ]; then
+        if [ "$(ls -A $DIRECTORY/logs/ossec)" ]; then
+            mv -f $DIRECTORY/logs/ossec/* $DIRECTORY/logs/wazuh
+        fi
+        rm -rf $DIRECTORY/logs/ossec
+    fi
 
     # Remove deprecated Wazuh tools
 
@@ -150,8 +158,8 @@ WazuhUpgrade()
     rm -f $DIRECTORY/bin/ossec-makelists
     rm -f $DIRECTORY/bin/util.sh
     rm -f $DIRECTORY/bin/rootcheck_control
-	rm -f $DIRECTORY/bin/syscheck_control
-	rm -f $DIRECTORY/bin/syscheck_update
+    rm -f $DIRECTORY/bin/syscheck_control
+    rm -f $DIRECTORY/bin/syscheck_update
 
     # Remove old Wazuh daemons
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes #8263 |

## Description

This pull request migrates the files `.agent_info` and `.wait` if they exist on agent updates, due to the rename of the sockets folder from `ossec` to `sockets`.

The rename of this folder was removing the `.agent_info` files when updating an agent, leading to the following errors when starting it again.

```
2021/04/19 17:59:35 wazuh-agentd: ERROR: (1103): Could not open file 'queue/sockets/.agent_info' due to [(2)-(No such file or directory)].
```

To keep these files when updating the agent avoid this error.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
