### PR TITLE
Add path_suffix param to aws wodle

### DIFF
--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -25,6 +25,7 @@ static const char *XML_AWS_ORGANIZATION_ID = "aws_organization_id";
 static const char *XML_AWS_ACCOUNT_ID = "aws_account_id";
 static const char *XML_AWS_ACCOUNT_ALIAS = "aws_account_alias";
 static const char *XML_TRAIL_PREFIX = "path";
+static const char *XML_TRAIL_SUFFIX = "path_suffix";
 static const char *XML_ONLY_LOGS_AFTER = "only_logs_after";
 static const char *XML_REGION = "regions";
 static const char *XML_LOG_GROUP = "aws_log_groups";
@@ -254,6 +255,11 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                         if (strlen(children[j]->content) != 0) {
                             free(cur_bucket->trail_prefix);
                             os_strdup(children[j]->content, cur_bucket->trail_prefix);
+                        }
+                    } else if (!strcmp(children[j]->element, XML_TRAIL_SUFFIX)) {
+                        if (strlen(children[j]->content) != 0) {
+                            free(cur_bucket->trail_suffix);
+                            os_strdup(children[j]->content, cur_bucket->trail_suffix);
                         }
                     } else if (!strcmp(children[j]->element, XML_ONLY_LOGS_AFTER)) {
                         if (strlen(children[j]->content) != 0) {

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -90,6 +90,11 @@ void* wm_aws_main(wm_aws *aws_config) {
                 wm_strcat(&log_info, cur_bucket->trail_prefix, ' ');
             }
 
+            if (cur_bucket->trail_suffix) {
+                wm_strcat(&log_info, ", Path suffix:", '\0');
+                wm_strcat(&log_info, cur_bucket->trail_suffix, ' ');
+            }
+
             if (cur_bucket->type) {
                 wm_strcat(&log_info, ", Type:", '\0');
                 wm_strcat(&log_info, cur_bucket->type, ' ');
@@ -190,6 +195,7 @@ cJSON *wm_aws_dump(const wm_aws *aws_config) {
             if (iter->aws_account_id) cJSON_AddStringToObject(buck,"aws_account_id",iter->aws_account_id);
             if (iter->aws_account_alias) cJSON_AddStringToObject(buck,"aws_account_alias",iter->aws_account_alias);
             if (iter->trail_prefix) cJSON_AddStringToObject(buck,"path",iter->trail_prefix);
+            if (iter->trail_suffix) cJSON_AddStringToObject(buck,"path_suffix",iter->trail_suffix);
             if (iter->only_logs_after) cJSON_AddStringToObject(buck,"only_logs_after",iter->only_logs_after);
             if (iter->regions) cJSON_AddStringToObject(buck,"regions",iter->regions);
             if (iter->type) cJSON_AddStringToObject(buck,"type",iter->type);
@@ -348,6 +354,10 @@ void wm_aws_run_s3(wm_aws *aws_config, wm_aws_bucket *exec_bucket) {
     if (exec_bucket->trail_prefix) {
         wm_strcat(&command, "--trail_prefix", ' ');
         wm_strcat(&command, exec_bucket->trail_prefix, ' ');
+    }
+    if (exec_bucket->trail_suffix) {
+        wm_strcat(&command, "--trail_suffix", ' ');
+        wm_strcat(&command, exec_bucket->trail_suffix, ' ');
     }
     if (exec_bucket->only_logs_after) {
         wm_strcat(&command, "--only_logs_after", ' ');

--- a/src/wazuh_modules/wm_aws.h
+++ b/src/wazuh_modules/wm_aws.h
@@ -32,6 +32,7 @@ typedef struct wm_aws_bucket {
     char *aws_account_id;               // AWS account ID(s)
     char *aws_account_alias;            // AWS account alias
     char *trail_prefix;                 // Trail prefix
+    char *trail_suffix;                 // Trail suffix
     char *only_logs_after;              // Date (YYYY-MMM-DD) to only parse logs after
     char *regions;                      // CSV of regions to parse
     char *type;                         // String defining bucket type.

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -474,8 +474,7 @@ class AWSBucket(WazuhIntegration):
         self.prefix = prefix
         self.suffix = suffix
         self.delete_file = delete_file
-        # If not empty, both self.prefix and self.suffix always have a trailing '/'
-        self.bucket_path = f"{self.bucket}/{self.prefix}{self.suffix}"
+        self.bucket_path = self.bucket + '/' + self.prefix
         self.aws_organization_id = aws_organization_id
 
     def already_processed(self, downloaded_file, aws_account_id, aws_region):
@@ -833,6 +832,10 @@ class AWSLogsBucket(AWSBucket):
     """
     Abstract class for logs generated from services such as CloudTrail or Config
     """
+    def __init__(self, **kwargs):
+        AWSBucket.__init__(self, **kwargs)
+        # If not empty, both self.prefix and self.suffix always have a trailing '/'
+        self.bucket_path = f"{self.bucket}/{self.prefix}{self.suffix}"
 
     def get_base_prefix(self):
         base_path = '{}AWSLogs/{}'.format(self.prefix, self.suffix)

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -344,21 +344,22 @@ class AWSBucket(WazuhIntegration):
 
     def __init__(self, reparse, access_key, secret_key, profile, iam_role_arn,
                  bucket, only_logs_after, skip_on_error, account_alias,
-                 prefix, delete_file, aws_organization_id, region):
+                 prefix, suffix, delete_file, aws_organization_id, region):
         """
         AWS Bucket constructor.
 
-        :param reparse: Wether to parse already parsed logs or not
+        :param reparse: Whether to parse already parsed logs or not
         :param access_key: AWS access key id
         :param secret_key: AWS secret access key
         :param profile: AWS profile
         :param iam_role_arn: IAM Role
         :param bucket: Bucket name to extract logs from
         :param only_logs_after: Date after which obtain logs.
-        :param skip_on_error: Wether to continue processing logs or stop when an error takes place
+        :param skip_on_error: Whether to continue processing logs or stop when an error takes place
         :param account_alias: Alias of the AWS account where the bucket is.
         :param prefix: Prefix to filter files in bucket
-        :param delete_file: Wether to delete an already processed file from a bucket or not
+        :param suffix: Suffix to filter files in bucket
+        :param delete_file: Whether to delete an already processed file from a bucket or not
         :param aws_organization_id: The AWS organization ID
         """
 
@@ -471,8 +472,10 @@ class AWSBucket(WazuhIntegration):
         self.skip_on_error = skip_on_error
         self.account_alias = account_alias
         self.prefix = prefix
+        self.suffix = suffix
         self.delete_file = delete_file
-        self.bucket_path = self.bucket + '/' + self.prefix
+        # If not empty, both self.prefix and self.suffix always have a trailing '/'
+        self.bucket_path = f"{self.bucket}/{self.prefix}{self.suffix}"
         self.aws_organization_id = aws_organization_id
 
     def already_processed(self, downloaded_file, aws_account_id, aws_region):
@@ -832,13 +835,13 @@ class AWSLogsBucket(AWSBucket):
     """
 
     def get_base_prefix(self):
-        base_prefix = '{}AWSLogs/'.format(self.prefix)
+        base_path = '{}AWSLogs/{}'.format(self.prefix, self.suffix)
         if self.aws_organization_id:
-            base_prefix = '{base_prefix}{aws_organization_id}/'.format(
-                base_prefix=base_prefix,
+            base_path = '{base_prefix}{aws_organization_id}/'.format(
+                base_prefix=base_path,
                 aws_organization_id=self.aws_organization_id)
 
-        return base_prefix
+        return base_path
 
     def get_service_prefix(self, account_id):
         return '{base_prefix}{aws_account_id}/{aws_service}/'.format(
@@ -2825,6 +2828,9 @@ def get_script_arguments():
     parser.add_argument('-l', '--trail_prefix', dest='trail_prefix',
                         help='Log prefix for S3 key',
                         default='', type=arg_valid_prefix)
+    parser.add_argument('-L', '--trail_suffix', dest='trail_suffix',
+                        help='Log suffix for S3 key',
+                        default='', type=arg_valid_prefix)
     parser.add_argument('-s', '--only_logs_after', dest='only_logs_after',
                         help='Only parse logs after this date - format YYYY-MMM-DD',
                         default=datetime.strftime(datetime.utcnow(), '%Y-%b-%d'), type=arg_valid_date)
@@ -2889,6 +2895,7 @@ def main(argv):
                                  skip_on_error=options.skip_on_error,
                                  account_alias=options.aws_account_alias,
                                  prefix=options.trail_prefix,
+                                 suffix=options.trail_suffix,
                                  delete_file=options.deleteFile,
                                  aws_organization_id=options.aws_organization_id,
                                  region=options.regions[0] if options.regions else None


### PR DESCRIPTION
|Related issue|
|---|
| Closes #7593 |

## Description
Hi team!

This PR adds a new param called `<path_suffix>` to the AWS wodle. Until now, the logs in a S3 bucket had to follow this syntax:
```
<bucket_name>/<prefix>/AWSLogs/<account_id>/CloudTrail/<region>/<year>/<month>/<day>
```

As it can be seen, the <account_id> had to immediately follow the _AWSLogs_ folder. Therefore, structures like the one below were not supported:
```
wazuh-aws-wodle/AWSLogs/test_cloudtrail/<account_id>/CloudTrail/us-east-1/2020/05/06/
```

## New behaviour
Now it is possible when using the `<path_suffix>` option like in this config block:
```XML
<wodle name="aws-s3">
  <disabled>no</disabled>
  <interval>10m</interval>
  <run_on_start>yes</run_on_start>
  <skip_on_error>yes</skip_on_error>

  <bucket type="cloudtrail">
    <name>wazuh-aws-wodle</name>
    <path_suffix>test_cloudtrail/</path_suffix>
    <only_logs_after>2018-JUN-01</only_logs_after>
  </bucket>
</wodle>
```

Therefore, the path where the AWS logs must be stored looks like this now:
```
<bucket_name>/<prefix>/AWSLogs/<suffix>/<account_id>/CloudTrail/<region>/<year>/<month>/<day>
```

## Other cases
When used in services where _AWSLogs_ folder is not expected nor supported (in the path), the `<path_suffix>` param will have no effect at all.

Regards,
Selu.