### PR TITLE
Fix architecture detection in Makefile for downloading dependencies

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -13,6 +13,7 @@ uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 uname_P := $(shell sh -c 'uname -p 2>/dev/null || echo not')
 uname_R := $(shell sh -c 'uname -r 2>/dev/null || echo not')
 uname_V := $(shell sh -c 'uname -v 2>/dev/null || echo not')
+uname_M := $(shell sh -c 'uname -m 2>/dev/null || echo not')
 HAS_CHECKMODULE = $(shell command -v checkmodule > /dev/null && echo YES)
 HAS_SEMODULE_PACKAGE = $(shell command -v semodule_package > /dev/null && echo YES)
 CHECK_ARCHLINUX := $(shell sh -c 'grep "Arch Linux" /etc/os-release > /dev/null && echo YES || echo not')
@@ -1031,6 +1032,7 @@ endif
 
 TAR := tar -xf
 GUNZIP := gunzip
+GZIP := gzip
 CURL := curl -so
 DEPS_VERSION = 13
 RESOURCES_URL := https://packages.wazuh.com/deps/$(DEPS_VERSION)
@@ -1039,8 +1041,11 @@ PYTHON_SOURCE := no
 
 ifneq (${TARGET}, winagent)
 cpu_arch := ${uname_P}
-ifneq (,$(filter ${cpu_arch},unknown Unknown))
+ifneq (,$(filter ${cpu_arch},unknown Unknown not))
 	cpu_arch := $(shell sh -c 'arch 2>/dev/null || echo not')
+endif
+ifneq (,$(filter ${cpu_arch},unknown Unknown not))
+	cpu_arch := ${uname_M}
 endif
 ifneq (,$(filter ${cpu_arch},x86_64 amd64))
 PRECOMPILED_ARCH := /amd64
@@ -1066,7 +1071,7 @@ PRECOMPILED_OS := el5
 endif
 
 ifeq (,$(filter ${EXTERNAL_SRC_ONLY},YES yes y Y 1))
-# If EXTERNAL_SRC_ONLY=YES is not defined, lets look for the precompiled libs
+# If EXTERNAL_SRC_ONLY=YES is not defined, lets look for the precompiled lib
 PRECOMPILED_RES := $(PRECOMPILED_OS)$(PRECOMPILED_ARCH)
 endif
 
@@ -1086,10 +1091,18 @@ deps: $(EXTERNAL_TAR)
 
 # Python interpreter
 ifeq (,$(filter ${PYTHON_SOURCE},YES yes y Y 1))
-external/$(CPYTHON).tar.gz:
 ifneq (,$(PRECOMPILED_RES))
-	$(CURL) $@ $(RESOURCES_URL)/libraries/$(PRECOMPILED_RES)/$(patsubst external/%,%,$@)
+external/$(CPYTHON).tar.gz: external-precompiled/$(CPYTHON).tar.gz
+	test -e $(patsubst %.gz,%,$@) ||\
+	($(CURL) $@ $(RESOURCES_URL)/libraries/sources/$(patsubst external/%,%,$@) &&\
+	cd external && $(GUNZIP) $(patsubst external/%,%,$@) && $(TAR) $(patsubst external/%.gz,%,$@) && rm $(patsubst external/%.gz,%,$@))
+	test -d $(patsubst %.tar.gz,%,$@) || (cd external && $(GZIP) $(patsubst external/%.gz,%,$@))
+
+external-precompiled/$(CPYTHON).tar.gz:
+	-$(CURL) external/$(patsubst external-precompiled/%,%,$@) $(RESOURCES_URL)/libraries/$(PRECOMPILED_RES)/$(patsubst external-precompiled/%,%,$@) || true
+	-cd external && test -e $(patsubst external-precompiled/%,%,$@) && $(GUNZIP) $(patsubst external-precompiled/%,%,$@) || true
 else
+external/$(CPYTHON).tar.gz:
 	$(CURL) $@ $(RESOURCES_URL)/libraries/sources/$(patsubst external/%,%,$@)
 	cd external && $(GUNZIP) $(patsubst external/%,%,$@)
 	cd external && $(TAR) $(patsubst external/%.gz,%,$@)


### PR DESCRIPTION
|Related issue|
|---|
| N/A |

## Description

This pull request fixes the following items:

- When building in Arch Linux the Makefile was not able to detect the OS architecture, generating a malformed URL when downloading the Wazuh deps.

- When the python package was not able for the detected architecture, the compilation fails due to the downloaded package is garbage. Now, sources are downloaded when the architecture is other than expected.

## Logs/Alerts example

When the architecture is unable to be guessed, the download of the Python package follows these steps:

```
curl -so external/cpython.tar.gz https://packages.wazuh.com/deps/13/libraries/linux/not/cpython.tar.gz || true
cd external && test -e cpython.tar.gz && gunzip cpython.tar.gz || true

gzip: cpython.tar.gz: not in gzip format
test -e external/cpython.tar ||\
(curl -so external/cpython.tar.gz https://packages.wazuh.com/deps/13/libraries/sources/cpython.tar.gz &&\
cd external && gunzip cpython.tar.gz && tar -xf cpython.tar && rm cpython.tar)
test -d external/cpython || (cd external && gzip cpython.tar)
```

And finally, the `cpython` folder contains the sources of the python interpreter.

```
# ls external/
audit-userspace  cJSON    curl        libdb   libpcre2  libyaml  nlohmann  procps  zlib
bzip2            cpython  googletest  libffi  libplist  msgpack  openssl   sqlite
```

Otherwise, the preinstalled python package is downloading for the detected architecture:

```
curl -so external/cpython.tar.gz https://packages.wazuh.com/deps/13/libraries/linux/amd64/cpython.tar.gz || true
cd external && test -e cpython.tar.gz && gunzip cpython.tar.gz || true
test -e external/cpython.tar ||\
(curl -so external/cpython.tar.gz https://packages.wazuh.com/deps/13/libraries/sources/cpython.tar.gz &&\
cd external && gunzip cpython.tar.gz && tar -xf cpython.tar && rm cpython.tar)
test -d external/cpython || (cd external && gzip cpython.tar)
```

The result is the package `cpython.tar.gz`:

```
# ls external/
audit-userspace  cJSON           curl        libdb   libpcre2  libyaml  nlohmann  procps  zlib
bzip2            cpython.tar.gz  googletest  libffi  libplist  msgpack  openssl   sqlite
```


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
