### PR TITLE
Remove authentication_success from groups of rule 60107

### DIFF
--- a/ruleset/rules/0580-win-security_rules.xml
+++ b/ruleset/rules/0580-win-security_rules.xml
@@ -77,7 +77,7 @@
     <mitre>
       <id>T1078</id>
     </mitre>
-    <group>authentication_success,pci_dss_10.2.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.6,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>pci_dss_10.2.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.6,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <!-- Rules based on AUDIT SUCCESS -->


### PR DESCRIPTION
|Related issue|
|---|
|Closes #7839 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Remove authentication_success from groups of rule 60107. No alternative group was found for replacing this one.