### PR TITLE
8283 windows agent stop and leak

### DIFF
--- a/src/os_execd/win_execd.c
+++ b/src/os_execd/win_execd.c
@@ -98,7 +98,11 @@ int WinExecd_Start()
 // Create a thread to run windows AR simultaneous
 DWORD WINAPI win_exec_main(__attribute__((unused)) void * args) {
     while(1) {
-        WinExecdRun(queue_pop_ex(winexec_queue));
+        char* exec_msg = queue_pop_ex(winexec_queue);
+        if (exec_msg) {
+            WinExecdRun(exec_msg);
+            os_free(exec_msg);
+        }
     }
 }
 

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -465,6 +465,7 @@ void SQLiteDBEngine::initialize(const std::string& path,
                     m_sqliteConnection = m_sqliteFactory->createConnection(dbPath);
                     const auto createDBQueryList { Utils::split(tableStmtCreation,';') };
                     m_sqliteConnection->execute("PRAGMA temp_store = memory;");
+                    m_sqliteConnection->execute("PRAGMA journal_mode = memory;");
                     m_sqliteConnection->execute("PRAGMA synchronous = OFF;");
                     for (const auto& query : createDBQueryList)
                     {

--- a/src/shared_modules/dbsync/tests/dbengine/dbengine_test.cpp
+++ b/src/shared_modules/dbsync/tests/dbengine/dbengine_test.cpp
@@ -37,6 +37,7 @@ static void initNoMetaDataMocks(std::unique_ptr<SQLiteDBEngine>& spEngine)
         .WillOnce(Return(ByMove(std::move(mockStatement_1))));
 
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
 
     EXPECT_NO_THROW(spEngine = std::make_unique<SQLiteDBEngine>(
@@ -62,11 +63,12 @@ TEST_F(DBEngineTest, Initialization)
     EXPECT_CALL(*mockStatement, step()).WillOnce(Return(SQLITE_DONE));
     EXPECT_CALL(*mockFactory, createStatement(_,_)).WillOnce(Return(ByMove(std::move(mockStatement))));
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
 
     EXPECT_NO_THROW(std::make_unique<SQLiteDBEngine>(
         mockFactory,
-        "1", 
+        "1",
         "NNN"));
 }
 
@@ -80,6 +82,7 @@ TEST_F(DBEngineTest, InitializationSQLError)
     EXPECT_CALL(*mockStatement, step()).WillOnce(Return(SQLITE_ERROR));
     EXPECT_CALL(*mockFactory, createStatement(_,_)).WillOnce(Return(ByMove(std::move(mockStatement))));
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
 
     EXPECT_THROW(std::make_unique<SQLiteDBEngine>(
@@ -95,11 +98,12 @@ TEST_F(DBEngineTest, InitializationEmptyQuery)
 
     EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
 
     EXPECT_NO_THROW(std::make_unique<SQLiteDBEngine>(
         mockFactory,
-        "1", 
+        "1",
         ""));
 }
 
@@ -107,7 +111,7 @@ TEST_F(DBEngineTest, InitializationEmptyFileName)
 {
     EXPECT_THROW(std::make_unique<SQLiteDBEngine>(
         nullptr,
-        "", 
+        "",
         "NNN"), dbengine_error);
 }
 
@@ -115,27 +119,28 @@ TEST_F(DBEngineTest, InitializeStatusField)
 {
     const auto& mockFactory { std::make_shared<MockSQLiteFactory>() };
     const auto& mockConnection { std::make_shared<MockConnection>() };
-    
+
     auto mockTransaction { std::make_unique<MockTransaction>() };
 
     EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
     EXPECT_CALL(*mockTransaction, commit()).Times(1);
     EXPECT_CALL(*mockFactory, createTransaction(_)).WillOnce(Return(ByMove(std::move(mockTransaction))));
-    
+
     auto mockStatement_1 { std::make_unique<MockStatement>() };
     EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(SQLITE_DONE));
-    EXPECT_CALL(*mockFactory, 
+    EXPECT_CALL(*mockFactory,
         createStatement(_,"NNN"))
         .WillOnce(Return(ByMove(std::move(mockStatement_1))));
 
-    
+
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
 
     std::unique_ptr<SQLiteDBEngine> spEngine;
     EXPECT_NO_THROW(spEngine = std::make_unique<SQLiteDBEngine>(
         mockFactory,
-        "1", 
+        "1",
         "NNN"));
 
     auto mockColumn_1 { std::make_unique<MockColumn>() };
@@ -154,7 +159,7 @@ TEST_F(DBEngineTest, InitializeStatusField)
     auto mockStatement_2 { std::make_unique<MockStatement>() };
     EXPECT_CALL(*mockStatement_2, step())
         .WillOnce(Return(SQLITE_ROW))
-        .WillOnce(Return(SQLITE_DONE));      
+        .WillOnce(Return(SQLITE_DONE));
     EXPECT_CALL(*mockStatement_2, column(0))
         .WillOnce(Return(ByMove(std::move(mockColumn_1))));
     EXPECT_CALL(*mockStatement_2, column(1))
@@ -163,27 +168,27 @@ TEST_F(DBEngineTest, InitializeStatusField)
         .WillOnce(Return(ByMove(std::move(mockColumn_3))));
     EXPECT_CALL(*mockStatement_2, column(5))
         .WillOnce(Return(ByMove(std::move(mockColumn_4))));
-    EXPECT_CALL(*mockFactory, 
+    EXPECT_CALL(*mockFactory,
         createStatement(_,"PRAGMA table_info(dummy);"))
         .WillOnce(Return(ByMove(std::move(mockStatement_2))));
 
     auto mockStatement_3 { std::make_unique<MockStatement>() };
-    EXPECT_CALL(*mockStatement_3, 
+    EXPECT_CALL(*mockStatement_3,
         step())
         .WillOnce(Return(0));
-    EXPECT_CALL(*mockFactory, 
+    EXPECT_CALL(*mockFactory,
         createStatement(_,"ALTER TABLE dummy ADD COLUMN db_status_field_dm INTEGER DEFAULT 1;"))
         .WillOnce(Return(ByMove(std::move(mockStatement_3))));
 
     auto mockStatement_4 { std::make_unique<MockStatement>() };
-    EXPECT_CALL(*mockStatement_4, 
+    EXPECT_CALL(*mockStatement_4,
         step())
         .WillOnce(Return(0));
 
-    EXPECT_CALL(*mockFactory, 
+    EXPECT_CALL(*mockFactory,
         createStatement(_,"UPDATE dummy SET db_status_field_dm=0;"))
         .WillOnce(Return(ByMove(std::move(mockStatement_4))));
- 
+
 
     EXPECT_NO_THROW(spEngine->initializeStatusField(std::vector<std::string> {"dummy"}));
 }
@@ -192,35 +197,36 @@ TEST_F(DBEngineTest, InitializeStatusFieldNoMetadata)
 {
     const auto& mockFactory { std::make_shared<MockSQLiteFactory>() };
     const auto& mockConnection { std::make_shared<MockConnection>() };
-    
+
     auto mockTransaction { std::make_unique<MockTransaction>() };
 
     EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
     EXPECT_CALL(*mockFactory, createTransaction(_)).WillOnce(Return(ByMove(std::move(mockTransaction))));
-    
+
     auto mockStatement_1 { std::make_unique<MockStatement>() };
     EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(SQLITE_DONE));
-    EXPECT_CALL(*mockFactory, 
+    EXPECT_CALL(*mockFactory,
         createStatement(_,"NNN"))
         .WillOnce(Return(ByMove(std::move(mockStatement_1))));
 
-    
+
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
 
     std::unique_ptr<SQLiteDBEngine> spEngine;
     EXPECT_NO_THROW(spEngine = std::make_unique<SQLiteDBEngine>(
         mockFactory,
-        "1", 
+        "1",
         "NNN"));
 
     auto mockStatement_2 { std::make_unique<MockStatement>() };
     EXPECT_CALL(*mockStatement_2, step())
-        .WillOnce(Return(SQLITE_DONE));    
-    EXPECT_CALL(*mockFactory, 
+        .WillOnce(Return(SQLITE_DONE));
+    EXPECT_CALL(*mockFactory,
         createStatement(_,"PRAGMA table_info(dummy);"))
         .WillOnce(Return(ByMove(std::move(mockStatement_2))));
- 
+
     EXPECT_THROW(spEngine->initializeStatusField(std::vector<std::string> {"dummy"}), dbengine_error);
 }
 
@@ -228,27 +234,28 @@ TEST_F(DBEngineTest, InitializeStatusFieldPreExistent)
 {
     const auto& mockFactory { std::make_shared<MockSQLiteFactory>() };
     const auto& mockConnection { std::make_shared<MockConnection>() };
-    
+
     auto mockTransaction { std::make_unique<MockTransaction>() };
 
     EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
     EXPECT_CALL(*mockTransaction, commit()).Times(1);
     EXPECT_CALL(*mockFactory, createTransaction(_)).WillOnce(Return(ByMove(std::move(mockTransaction))));
-    
+
     auto mockStatement_1 { std::make_unique<MockStatement>() };
     EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(SQLITE_DONE));
-    EXPECT_CALL(*mockFactory, 
+    EXPECT_CALL(*mockFactory,
         createStatement(_,"NNN"))
         .WillOnce(Return(ByMove(std::move(mockStatement_1))));
 
-    
+
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
 
     std::unique_ptr<SQLiteDBEngine> spEngine;
     EXPECT_NO_THROW(spEngine = std::make_unique<SQLiteDBEngine>(
         mockFactory,
-        "1", 
+        "1",
         "NNN"));
 
     auto mockColumn_1 { std::make_unique<MockColumn>() };
@@ -281,7 +288,7 @@ TEST_F(DBEngineTest, InitializeStatusFieldPreExistent)
     EXPECT_CALL(*mockStatement_2, step())
         .WillOnce(Return(SQLITE_ROW))
         .WillOnce(Return(SQLITE_ROW))
-        .WillOnce(Return(SQLITE_DONE));      
+        .WillOnce(Return(SQLITE_DONE));
     EXPECT_CALL(*mockStatement_2, column(0))
         .WillOnce(Return(ByMove(std::move(mockColumn_1))))
         .WillOnce(Return(ByMove(std::move(mockColumn_5))));
@@ -294,19 +301,19 @@ TEST_F(DBEngineTest, InitializeStatusFieldPreExistent)
     EXPECT_CALL(*mockStatement_2, column(5))
         .WillOnce(Return(ByMove(std::move(mockColumn_4))))
         .WillOnce(Return(ByMove(std::move(mockColumn_8))));
-    EXPECT_CALL(*mockFactory, 
+    EXPECT_CALL(*mockFactory,
         createStatement(_,"PRAGMA table_info(dummy);"))
         .WillOnce(Return(ByMove(std::move(mockStatement_2))));
 
     auto mockStatement_4 { std::make_unique<MockStatement>() };
-    EXPECT_CALL(*mockStatement_4, 
+    EXPECT_CALL(*mockStatement_4,
         step())
         .WillOnce(Return(0));
-        
-    EXPECT_CALL(*mockFactory, 
+
+    EXPECT_CALL(*mockFactory,
         createStatement(_,"UPDATE dummy SET db_status_field_dm=0;"))
         .WillOnce(Return(ByMove(std::move(mockStatement_4))));
- 
+
     EXPECT_NO_THROW(spEngine->initializeStatusField(std::vector<std::string> {"dummy"}));
 }
 
@@ -314,26 +321,27 @@ TEST_F(DBEngineTest, DeleteRowsByStatusField)
 {
     const auto& mockFactory { std::make_shared<MockSQLiteFactory>() };
     const auto& mockConnection { std::make_shared<MockConnection>() };
-    
+
     auto mockTransaction { std::make_unique<MockTransaction>() };
 
     EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
     EXPECT_CALL(*mockTransaction, commit()).Times(1);
     EXPECT_CALL(*mockFactory, createTransaction(_)).WillOnce(Return(ByMove(std::move(mockTransaction))));
-    
+
     auto mockStatement_1 { std::make_unique<MockStatement>() };
     EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(SQLITE_DONE));
-    EXPECT_CALL(*mockFactory, 
+    EXPECT_CALL(*mockFactory,
         createStatement(_,"NNN"))
         .WillOnce(Return(ByMove(std::move(mockStatement_1))));
 
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
 
     std::unique_ptr<SQLiteDBEngine> spEngine;
     EXPECT_NO_THROW(spEngine = std::make_unique<SQLiteDBEngine>(
         mockFactory,
-        "1", 
+        "1",
         "NNN"));
 
     auto mockColumn_1 { std::make_unique<MockColumn>() };
@@ -366,7 +374,7 @@ TEST_F(DBEngineTest, DeleteRowsByStatusField)
     EXPECT_CALL(*mockStatement_2, step())
         .WillOnce(Return(SQLITE_ROW))
         .WillOnce(Return(SQLITE_ROW))
-        .WillOnce(Return(SQLITE_DONE));      
+        .WillOnce(Return(SQLITE_DONE));
     EXPECT_CALL(*mockStatement_2, column(0))
         .WillOnce(Return(ByMove(std::move(mockColumn_1))))
         .WillOnce(Return(ByMove(std::move(mockColumn_5))));
@@ -379,19 +387,19 @@ TEST_F(DBEngineTest, DeleteRowsByStatusField)
     EXPECT_CALL(*mockStatement_2, column(5))
         .WillOnce(Return(ByMove(std::move(mockColumn_4))))
         .WillOnce(Return(ByMove(std::move(mockColumn_8))));
-    EXPECT_CALL(*mockFactory, 
+    EXPECT_CALL(*mockFactory,
         createStatement(_,"PRAGMA table_info(dummy);"))
         .WillOnce(Return(ByMove(std::move(mockStatement_2))));
 
     auto mockStatement_3 { std::make_unique<MockStatement>() };
-    EXPECT_CALL(*mockStatement_3, 
+    EXPECT_CALL(*mockStatement_3,
         step())
         .WillOnce(Return(0));
-        
-    EXPECT_CALL(*mockFactory, 
+
+    EXPECT_CALL(*mockFactory,
         createStatement(_,"DELETE FROM dummy WHERE db_status_field_dm=0;"))
         .WillOnce(Return(ByMove(std::move(mockStatement_3))));
- 
+
     EXPECT_NO_THROW(spEngine->deleteRowsByStatusField(std::vector<std::string> {"dummy"}));
 }
 
@@ -399,31 +407,32 @@ TEST_F(DBEngineTest, DeleteRowsByStatusFieldNoMetadata)
 {
     const auto& mockFactory { std::make_shared<MockSQLiteFactory>() };
     const auto& mockConnection { std::make_shared<MockConnection>() };
-    
+
     auto mockTransaction { std::make_unique<MockTransaction>() };
 
     EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
     EXPECT_CALL(*mockFactory, createTransaction(_)).WillOnce(Return(ByMove(std::move(mockTransaction))));
-    
+
     auto mockStatement_1 { std::make_unique<MockStatement>() };
     EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(SQLITE_DONE));
-    EXPECT_CALL(*mockFactory, 
+    EXPECT_CALL(*mockFactory,
         createStatement(_,"NNN"))
         .WillOnce(Return(ByMove(std::move(mockStatement_1))));
-    
+
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
 
     std::unique_ptr<SQLiteDBEngine> spEngine;
     EXPECT_NO_THROW(spEngine = std::make_unique<SQLiteDBEngine>(
         mockFactory,
-        "1", 
+        "1",
         "NNN"));
 
     auto mockStatement_2 { std::make_unique<MockStatement>() };
     EXPECT_CALL(*mockStatement_2, step())
-        .WillOnce(Return(SQLITE_DONE));     
-    EXPECT_CALL(*mockFactory, 
+        .WillOnce(Return(SQLITE_DONE));
+    EXPECT_CALL(*mockFactory,
         createStatement(_,"PRAGMA table_info(dummy);"))
         .WillOnce(Return(ByMove(std::move(mockStatement_2))));
 
@@ -434,28 +443,29 @@ TEST_F(DBEngineTest, GetRowsToBeDeletedByStatusFieldNoMetadata)
 {
     const auto& mockFactory { std::make_shared<MockSQLiteFactory>() };
     const auto& mockConnection { std::make_shared<MockConnection>() };
-    
+
     EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
-    
+
     auto mockStatement_1 { std::make_unique<MockStatement>() };
     EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(SQLITE_DONE));
-    EXPECT_CALL(*mockFactory, 
+    EXPECT_CALL(*mockFactory,
         createStatement(_,"NNN"))
         .WillOnce(Return(ByMove(std::move(mockStatement_1))));
-    
+
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
 
     std::unique_ptr<SQLiteDBEngine> spEngine;
     EXPECT_NO_THROW(spEngine = std::make_unique<SQLiteDBEngine>(
         mockFactory,
-        "1", 
+        "1",
         "NNN"));
 
     auto mockStatement_2 { std::make_unique<MockStatement>() };
     EXPECT_CALL(*mockStatement_2, step())
-        .WillOnce(Return(SQLITE_DONE));     
-    EXPECT_CALL(*mockFactory, 
+        .WillOnce(Return(SQLITE_DONE));
+    EXPECT_CALL(*mockFactory,
         createStatement(_,"PRAGMA table_info(dummy);"))
         .WillOnce(Return(ByMove(std::move(mockStatement_2))));
 
@@ -466,23 +476,24 @@ TEST_F(DBEngineTest, GetRowsToBeDeletedByStatusField)
 {
     const auto& mockFactory { std::make_shared<MockSQLiteFactory>() };
     const auto& mockConnection { std::make_shared<MockConnection>() };
-    
+
     EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
-    
+
     auto mockStatement_1 { std::make_unique<MockStatement>() };
     EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(SQLITE_DONE));
-    EXPECT_CALL(*mockFactory, 
+    EXPECT_CALL(*mockFactory,
         createStatement(_,"NNN"))
         .WillOnce(Return(ByMove(std::move(mockStatement_1))));
 
-    
+
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
 
     std::unique_ptr<SQLiteDBEngine> spEngine;
     EXPECT_NO_THROW(spEngine = std::make_unique<SQLiteDBEngine>(
         mockFactory,
-        "1", 
+        "1",
         "NNN"));
 
     auto mockColumn_1 { std::make_unique<MockColumn>() };
@@ -515,7 +526,7 @@ TEST_F(DBEngineTest, GetRowsToBeDeletedByStatusField)
     EXPECT_CALL(*mockStatement_2, step())
         .WillOnce(Return(SQLITE_ROW))
         .WillOnce(Return(SQLITE_ROW))
-        .WillOnce(Return(SQLITE_DONE));      
+        .WillOnce(Return(SQLITE_DONE));
     EXPECT_CALL(*mockStatement_2, column(0))
         .WillOnce(Return(ByMove(std::move(mockColumn_1))))
         .WillOnce(Return(ByMove(std::move(mockColumn_5))));
@@ -528,15 +539,15 @@ TEST_F(DBEngineTest, GetRowsToBeDeletedByStatusField)
     EXPECT_CALL(*mockStatement_2, column(5))
         .WillOnce(Return(ByMove(std::move(mockColumn_4))))
         .WillOnce(Return(ByMove(std::move(mockColumn_8))));
-    EXPECT_CALL(*mockFactory, 
+    EXPECT_CALL(*mockFactory,
         createStatement(_,"PRAGMA table_info(dummy);"))
         .WillOnce(Return(ByMove(std::move(mockStatement_2))));
 
     auto mockStatement_3 { std::make_unique<MockStatement>() };
-    EXPECT_CALL(*mockStatement_3, 
+    EXPECT_CALL(*mockStatement_3,
         step())
         .WillOnce(Return(SQLITE_ROW))
-        .WillOnce(Return(SQLITE_DONE));  
+        .WillOnce(Return(SQLITE_DONE));
 
     auto mockColumn_9 { std::make_unique<MockColumn>() };
     EXPECT_CALL(*mockColumn_9, value(An<const int32_t&>()))
@@ -545,7 +556,7 @@ TEST_F(DBEngineTest, GetRowsToBeDeletedByStatusField)
     EXPECT_CALL(*mockStatement_3, column(0))
         .WillOnce(Return(ByMove(std::move(mockColumn_9))));
 
-    EXPECT_CALL(*mockFactory, 
+    EXPECT_CALL(*mockFactory,
         createStatement(_,"SELECT PID FROM dummy WHERE db_status_field_dm=0;"))
         .WillOnce(Return(ByMove(std::move(mockStatement_3))));
 
@@ -591,15 +602,15 @@ TEST_F(DBEngineTest, AddTableRelationship)
 {
     const auto& mockFactory { std::make_shared<MockSQLiteFactory>() };
     const auto& mockConnection { std::make_shared<MockConnection>() };
-    const auto& relationshipJSON { nlohmann::json::parse( 
+    const auto& relationshipJSON { nlohmann::json::parse(
         R"(
-            {  
+            {
                 "base_table":"dummy",
                 "relationed_tables":
                 [
                     {
                         "table": "dummy_relationed_1",
-                        "field_match": 
+                        "field_match":
                         {
                             "field_n_1": "field_m_1",
                             "field_n_2": "field_m_2"
@@ -607,7 +618,7 @@ TEST_F(DBEngineTest, AddTableRelationship)
                     },
                     {
                         "table": "dummy_relationed_2",
-                        "field_match": 
+                        "field_match":
                         {
                             "field_n_1": "field_m_1",
                             "field_n_2": "field_m_2"
@@ -617,23 +628,24 @@ TEST_F(DBEngineTest, AddTableRelationship)
             }
         )"
     )};
-    
+
     EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
-    
+
     auto mockStatement_1 { std::make_unique<MockStatement>() };
     EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(SQLITE_DONE));
-    EXPECT_CALL(*mockFactory, 
+    EXPECT_CALL(*mockFactory,
         createStatement(_,"NNN"))
         .WillOnce(Return(ByMove(std::move(mockStatement_1))));
 
-    
+
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
 
     std::unique_ptr<SQLiteDBEngine> spEngine;
     EXPECT_NO_THROW(spEngine = std::make_unique<SQLiteDBEngine>(
         mockFactory,
-        "1", 
+        "1",
         "NNN"));
 
     auto mockColumn_1 { std::make_unique<MockColumn>() };
@@ -680,7 +692,7 @@ TEST_F(DBEngineTest, AddTableRelationship)
         .WillOnce(Return(SQLITE_ROW))
         .WillOnce(Return(SQLITE_ROW))
         .WillOnce(Return(SQLITE_ROW))
-        .WillOnce(Return(SQLITE_DONE));      
+        .WillOnce(Return(SQLITE_DONE));
     EXPECT_CALL(*mockStatement_2, column(0))
         .WillOnce(Return(ByMove(std::move(mockColumn_1))))
         .WillOnce(Return(ByMove(std::move(mockColumn_5))))
@@ -697,7 +709,7 @@ TEST_F(DBEngineTest, AddTableRelationship)
         .WillOnce(Return(ByMove(std::move(mockColumn_4))))
         .WillOnce(Return(ByMove(std::move(mockColumn_8))))
         .WillOnce(Return(ByMove(std::move(mockColumn_12))));
-    EXPECT_CALL(*mockFactory, 
+    EXPECT_CALL(*mockFactory,
         createStatement(_,"PRAGMA table_info(dummy);"))
         .WillOnce(Return(ByMove(std::move(mockStatement_2))));
 
@@ -711,15 +723,15 @@ TEST_F(DBEngineTest, AddTableRelationshipNoMetadata)
 {
     const auto& mockFactory { std::make_shared<MockSQLiteFactory>() };
     const auto& mockConnection { std::make_shared<MockConnection>() };
-    const auto& relationshipJSON { nlohmann::json::parse( 
+    const auto& relationshipJSON { nlohmann::json::parse(
         R"(
-            {  
+            {
                 "base_table":"dummy",
                 "relationed_tables":
                 [
                     {
                         "table": "dummy_relationed_1",
-                        "field_match": 
+                        "field_match":
                         {
                             "field_n_1": "field_m_1",
                             "field_n_2": "field_m_2"
@@ -727,7 +739,7 @@ TEST_F(DBEngineTest, AddTableRelationshipNoMetadata)
                     },
                     {
                         "table": "dummy_relationed_2",
-                        "field_match": 
+                        "field_match":
                         {
                             "field_n_1": "field_m_1",
                             "field_n_2": "field_m_2"
@@ -737,30 +749,31 @@ TEST_F(DBEngineTest, AddTableRelationshipNoMetadata)
             }
         )"
     )};
-    
+
     EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
-    
+
     auto mockStatement_1 { std::make_unique<MockStatement>() };
     EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(SQLITE_DONE));
-    EXPECT_CALL(*mockFactory, 
+    EXPECT_CALL(*mockFactory,
         createStatement(_,"NNN"))
         .WillOnce(Return(ByMove(std::move(mockStatement_1))));
 
-    
+
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA journal_mode = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
 
     std::unique_ptr<SQLiteDBEngine> spEngine;
     EXPECT_NO_THROW(spEngine = std::make_unique<SQLiteDBEngine>(
         mockFactory,
-        "1", 
+        "1",
         "NNN"));
 
     auto mockStatement_2 { std::make_unique<MockStatement>() };
     EXPECT_CALL(*mockStatement_2, step())
-        .WillOnce(Return(SQLITE_DONE));      
+        .WillOnce(Return(SQLITE_DONE));
 
-    EXPECT_CALL(*mockFactory, 
+    EXPECT_CALL(*mockFactory,
         createStatement(_,"PRAGMA table_info(dummy);"))
         .WillOnce(Return(ByMove(std::move(mockStatement_2))));
 

--- a/src/shared_modules/rsync/src/messageRowData.h
+++ b/src/shared_modules/rsync/src/messageRowData.h
@@ -37,19 +37,22 @@ namespace RSync
         // LCOV_EXCL_STOP
         void send(const ResultCallback callback, const nlohmann::json& config, const nlohmann::json& data) override
         {
-            nlohmann::json outputMessage;
-            outputMessage["component"] = config.at("component");
-            outputMessage["type"] = "state";
+            if(!data.empty())
+            {
+                nlohmann::json outputMessage;
+                outputMessage["component"] = config.at("component");
+                outputMessage["type"] = "state";
 
-            nlohmann::json outputData;
-            outputData["index"] = data.at(config.at("index").get_ref<const std::string&>());
-            const auto lastEvent{config.find("last_event")};
-            outputData["timestamp"] = (lastEvent != config.end()) ? data.at(lastEvent->get_ref<const std::string&>()) : "";
-            outputData["attributes"] = data;
+                nlohmann::json outputData;
+                outputData["index"] = data.at(config.at("index").get_ref<const std::string&>());
+                const auto lastEvent{config.find("last_event")};
+                outputData["timestamp"] = (lastEvent != config.end()) ? data.at(lastEvent->get_ref<const std::string&>()) : "";
+                outputData["attributes"] = data;
 
-            outputMessage["data"] = outputData;
+                outputMessage["data"] = outputData;
 
-            callback(outputMessage.dump());
+                callback(outputMessage.dump());
+            }
         }
     };
 };// namespace RSync


### PR DESCRIPTION
|Related issue|
|---|
|Closes #8283|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
1- Fix memory leak.
![imagen](https://user-images.githubusercontent.com/14300208/115640686-ee116b80-a2ed-11eb-8f62-ad6f94227fd6.png)
2- Change DB Journal mode to avoid disk io operations and journaldb locked.
3- Avoid RSync verbose logging for delete rows in the middle of manager-agent synchronization.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
