### PR TITLE
Add discard_regex option to AWS buckets and services

### DIFF
--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -200,6 +200,8 @@ cJSON *wm_aws_dump(const wm_aws *aws_config) {
             if (iter->regions) cJSON_AddStringToObject(buck,"regions",iter->regions);
             if (iter->type) cJSON_AddStringToObject(buck,"type",iter->type);
             if (iter->remove_from_bucket) cJSON_AddStringToObject(buck,"remove_from_bucket","yes"); else cJSON_AddStringToObject(buck,"remove_from_bucket","no");
+            if (iter->discard_field) cJSON_AddStringToObject(buck,"discard_field",iter->discard_field);
+            if (iter->discard_regex) cJSON_AddStringToObject(buck,"discard_regex",iter->discard_regex);
             cJSON_AddItemToArray(arr_buckets,buck);
         }
         if (cJSON_GetArraySize(arr_buckets) > 0) {
@@ -224,6 +226,8 @@ cJSON *wm_aws_dump(const wm_aws *aws_config) {
             if (iter->regions) cJSON_AddStringToObject(service,"regions",iter->regions);
             if (iter->aws_log_groups) cJSON_AddStringToObject(service,"aws_log_groups",iter->aws_log_groups);
             if (iter->remove_log_streams) cJSON_AddStringToObject(service,"remove_log_streams","yes"); else cJSON_AddStringToObject(service,"remove_log_streams","no");
+            if (iter->discard_field) cJSON_AddStringToObject(service,"discard_field",iter->discard_field);
+            if (iter->discard_regex) cJSON_AddStringToObject(service,"discard_regex",iter->discard_regex);
             cJSON_AddItemToArray(arr_services,service);
         }
         if (cJSON_GetArraySize(arr_services) > 0) {
@@ -366,6 +370,14 @@ void wm_aws_run_s3(wm_aws *aws_config, wm_aws_bucket *exec_bucket) {
     if (exec_bucket->regions) {
         wm_strcat(&command, "--regions", ' ');
         wm_strcat(&command, exec_bucket->regions, ' ');
+    }
+    if (exec_bucket->discard_field) {
+        wm_strcat(&command, "--discard-field", ' ');
+        wm_strcat(&command, exec_bucket->discard_field, ' ');
+    }
+    if (exec_bucket->discard_regex) {
+        wm_strcat(&command, "--discard-regex", ' ');
+        wm_strcat(&command, exec_bucket->discard_regex, ' ');
     }
     if (exec_bucket->type) {
         wm_strcat(&command, "--type", ' ');
@@ -517,6 +529,14 @@ void wm_aws_run_service(wm_aws *aws_config, wm_aws_service *exec_service) {
     }
     if (exec_service->remove_log_streams) {
         wm_strcat(&command, "--remove-log-streams", ' ');
+    }
+    if (exec_service->discard_field) {
+        wm_strcat(&command, "--discard-field", ' ');
+        wm_strcat(&command, exec_service->discard_field, ' ');
+    }
+    if (exec_service->discard_regex) {
+        wm_strcat(&command, "--discard-regex", ' ');
+        wm_strcat(&command, exec_service->discard_regex, ' ');
     }
     if (isDebug()) {
         wm_strcat(&command, "--debug", ' ');

--- a/src/wazuh_modules/wm_aws.h
+++ b/src/wazuh_modules/wm_aws.h
@@ -36,6 +36,8 @@ typedef struct wm_aws_bucket {
     char *only_logs_after;              // Date (YYYY-MMM-DD) to only parse logs after
     char *regions;                      // CSV of regions to parse
     char *type;                         // String defining bucket type.
+    char *discard_field;                // Name of the event's field to apply the discard_regex on
+    char *discard_regex;                // REGEX to determine if an event should be skipped
     unsigned int remove_from_bucket:1;  // Remove the logs from the bucket
     struct wm_aws_bucket *next;     // Pointer to next
 } wm_aws_bucket;
@@ -52,6 +54,8 @@ typedef struct wm_aws_service {
     char *only_logs_after;              // Date (YYYY-MMM-DD) to only parse logs after
     char *regions;                      // CSV of regions to parse
     char *aws_log_groups;               // CSV of log groups to parse
+    char *discard_field;                // Name of the event's field to apply the discard_regex on
+    char *discard_regex;                // REGEX to determine if an event should be skipped
     unsigned int remove_log_streams:1;  // Remove the log stream from the log group
     struct wm_aws_service *next;     // Pointer to next
 } wm_aws_service;

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2150,7 +2150,8 @@ class AWSService(WazuhIntegration):
     """
 
     def __init__(self, access_key, secret_key, aws_profile, iam_role_arn,
-                 service_name, only_logs_after, region, aws_log_groups=None, remove_log_streams=None):
+                 service_name, only_logs_after, region, aws_log_groups=None, remove_log_streams=None,
+                 discard_field=None, discard_regex=None):
         # DB name
         self.db_name = 'aws_services'
         # table name
@@ -2158,7 +2159,8 @@ class AWSService(WazuhIntegration):
 
         WazuhIntegration.__init__(self, access_key=access_key, secret_key=secret_key,
                                   aws_profile=aws_profile, iam_role_arn=iam_role_arn,
-                                  service_name=service_name, region=region)
+                                  service_name=service_name, region=region, discard_field=discard_field,
+                                  discard_regex=discard_regex)
 
         # get sts client (necessary for getting account ID)
         self.sts_client = self.get_sts_client(access_key, secret_key, aws_profile)
@@ -2254,7 +2256,7 @@ class AWSInspector(AWSService):
 
     def __init__(self, reparse, access_key, secret_key, aws_profile,
                  iam_role_arn, only_logs_after, region, aws_log_groups=None,
-                 remove_log_streams=None):
+                 remove_log_streams=None, discard_field=None, discard_regex=None):
 
         self.service_name = 'inspector'
         self.inspector_region = region
@@ -2262,7 +2264,8 @@ class AWSInspector(AWSService):
         AWSService.__init__(self, access_key=access_key, secret_key=secret_key,
                             aws_profile=aws_profile, iam_role_arn=iam_role_arn, only_logs_after=only_logs_after,
                             service_name=self.service_name, region=region, aws_log_groups=aws_log_groups,
-                            remove_log_streams=remove_log_streams)
+                            remove_log_streams=remove_log_streams, discard_field=discard_field,
+                            discard_regex=discard_regex)
 
         # max DB records for region
         self.retain_db_records = 5
@@ -2374,7 +2377,7 @@ class AWSCloudWatchLogs(AWSService):
 
     def __init__(self, reparse, access_key, secret_key, aws_profile,
                  iam_role_arn, only_logs_after, region, aws_log_groups,
-                 remove_log_streams):
+                 remove_log_streams, discard_field=None, discard_regex=None):
 
         self.sql_cloudwatch_create_table = """
                                 CREATE TABLE
@@ -2447,7 +2450,7 @@ class AWSCloudWatchLogs(AWSService):
         AWSService.__init__(self, access_key=access_key, secret_key=secret_key,
                             aws_profile=aws_profile, iam_role_arn=iam_role_arn, only_logs_after=only_logs_after,
                             region=region, aws_log_groups=aws_log_groups, remove_log_streams=remove_log_streams,
-                            service_name='cloudwatchlogs')
+                            service_name='cloudwatchlogs', discard_field=discard_field, discard_regex=discard_regex)
 
         self.region = region
         self.db_table_name = 'cloudwatch_logs'
@@ -2980,7 +2983,8 @@ def main(argv):
                                        region=region,
                                        aws_log_groups=options.aws_log_groups,
                                        remove_log_streams=options.deleteLogStreams,
-                                       filter_conditions=options.filter_conditions
+                                       discard_field=options.discard_field,
+                                       discard_regex=options.discard_regex
                                        )
                 service.get_alerts()
 

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -768,7 +768,7 @@ class AWSBucket(WazuhIntegration):
             for event in event_list:
                 if event_should_be_skipped(event):
                     debug(f'+++ The "{self.discard_regex.pattern}" regex found a match in the "{self.discard_field}" field. '
-                          f'The event will be skipped.', 1)
+                          f'The event will be skipped.', 2)
                     continue
                 event_msg = self.get_alert_msg(aws_account_id, log_key, event)
                 # Change dynamic fields to strings; truncate values as needed

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -79,7 +79,7 @@ class WazuhIntegration:
     """
 
     def __init__(self, access_key, secret_key, aws_profile, iam_role_arn,
-                 service_name=None, region=None, bucket=None):
+                 service_name=None, region=None, bucket=None, discard_field=None, discard_regex=None):
         # SQL queries
         self.sql_find_table_names = """
                             SELECT
@@ -163,6 +163,8 @@ class WazuhIntegration:
             self.bucket = bucket
         self.old_version = None  # for DB migration if it is necessary
         self.check_metadata_version()
+        self.discard_field = discard_field
+        self.discard_regex = re.compile(fr'{discard_regex}')
 
     def migrate_from_38(self, **kwargs):
         self.db_maintenance(**kwargs)
@@ -279,7 +281,7 @@ class WazuhIntegration:
         Sends an AWS event to the Wazuh Queue
 
         :param msg: JSON message to be sent.
-        :para dump_json: If json.dumps should be applied to the msg
+        :param dump_json: If json.dumps should be applied to the msg
         """
         try:
             json_msg = json.dumps(msg, default=str)
@@ -344,7 +346,8 @@ class AWSBucket(WazuhIntegration):
 
     def __init__(self, reparse, access_key, secret_key, profile, iam_role_arn,
                  bucket, only_logs_after, skip_on_error, account_alias,
-                 prefix, suffix, delete_file, aws_organization_id, region):
+                 prefix, suffix, delete_file, aws_organization_id, region,
+                 discard_field, discard_regex):
         """
         AWS Bucket constructor.
 
@@ -361,6 +364,8 @@ class AWSBucket(WazuhIntegration):
         :param suffix: Suffix to filter files in bucket
         :param delete_file: Whether to delete an already processed file from a bucket or not
         :param aws_organization_id: The AWS organization ID
+        :param discard_field: Name of the event field to apply the regex value on
+        :param discard_regex: REGEX value to determine whether an event should be skipped
         """
 
         # common SQL queries
@@ -464,7 +469,9 @@ class AWSBucket(WazuhIntegration):
                                   iam_role_arn=iam_role_arn,
                                   bucket=bucket,
                                   service_name='s3',
-                                  region=region
+                                  region=region,
+                                  discard_field=discard_field,
+                                  discard_regex=discard_regex
                                   )
         self.retain_db_records = 500
         self.reparse = reparse
@@ -734,9 +741,44 @@ class AWSBucket(WazuhIntegration):
         raise NotImplementedError
 
     def iter_events(self, event_list, log_key, aws_account_id):
+        def check_recursive(json_item=None, nested_field: str = '', regex: str = ''):
+            field_list = nested_field.split('.', 1)
+            try:
+                expression_to_evaluate = json_item[field_list[0]]
+            except TypeError:
+                if isinstance(json_item, list):
+                    for i in json_item:
+                        if check_recursive(i, field_list[0], regex=regex):
+                            return True
+                return False
+            except KeyError:
+                return False
+            if len(field_list) == 1:
+                def check_regex(exp):
+                    try:
+                        return re.match(regex, exp) is not None
+                    except TypeError:
+                        if isinstance(exp, list):
+                            for ex in exp:
+                                if check_regex(ex):
+                                    return True
+                    return False
+
+                return check_regex(expression_to_evaluate)
+            return check_recursive(expression_to_evaluate, field_list[1], regex=regex)
+
+        def event_should_be_skipped():
+            if self.discard_field and self.discard_regex:
+                if check_recursive(event, nested_field=self.discard_field, regex=self.discard_regex):
+                    return True
+            return False
+
         if event_list is not None:
             for event in event_list:
-                # Parse out all the values of 'None'
+                if event_should_be_skipped():
+                    debug(f'+++ The "{self.discard_regex}" regex found a match in the "{self.discard_field}" field. '
+                          f'The event will be skipped.', 1)
+                    continue
                 event_msg = self.get_alert_msg(aws_account_id, log_key, event)
                 # Change dynamic fields to strings; truncate values as needed
                 event_msg = self.reformat_msg(event_msg)
@@ -2848,6 +2890,11 @@ def get_script_arguments():
                         default='')
     parser.add_argument('-P', '--remove-log-streams', action='store_true', dest='deleteLogStreams',
                         help='Remove processed log streams from the log group', default=False)
+    parser.add_argument('-df', '--discard-field', type=str, dest='discard_field', default=None,
+                        help='The name of the event field where the discard_regex should be applied to determine if '
+                             'an event should be skipped.', )
+    parser.add_argument('-dr', '--discard-regex', type=str, dest='discard_regex', default=None,
+                        help='REGEX value to be applied to determine whether an event should be skipped.', )
 
     return parser.parse_args()
 
@@ -2901,7 +2948,9 @@ def main(argv):
                                  suffix=options.trail_suffix,
                                  delete_file=options.deleteFile,
                                  aws_organization_id=options.aws_organization_id,
-                                 region=options.regions[0] if options.regions else None
+                                 region=options.regions[0] if options.regions else None,
+                                 discard_field=options.discard_field,
+                                 discard_regex=options.discard_regex
                                  )
             # check if bucket is empty or credentials are wrong
             bucket.check_bucket()
@@ -2930,7 +2979,9 @@ def main(argv):
                                        only_logs_after=options.only_logs_after,
                                        region=region,
                                        aws_log_groups=options.aws_log_groups,
-                                       remove_log_streams=options.deleteLogStreams)
+                                       remove_log_streams=options.deleteLogStreams,
+                                       filter_conditions=options.filter_conditions
+                                       )
                 service.get_alerts()
 
     except Exception as err:


### PR DESCRIPTION
Hello team,

This PR closes #8055.

A new option called `<discard_regex>` has been added to every supported AWS Bucket and Service. This new option allows the user to skip events if a given `regex` condition is matched for the specified field. Skipped events won't be sent to `analysisd`.

Here is the syntax for the new option and an usage example
```
<discard_regex field="name-of-the-field"> regex </discard_regex>
```
```
<wodle name="aws-s3">
  <disabled>no</disabled>
  <interval>5m</interval>
  <run_on_start>yes</run_on_start>
  <skip_on_error>no</skip_on_error>
  <remove_from_bucket>no</remove_from_bucket>
  <bucket type="cloudtrail">
    <name>wazuh-aws-wodle</name>
    <aws_profile>default</aws_profile>
    <discard_regex field="resources.accountId">.*157441.*</discard_regex>
  </bucket>
</wodle>
```

When an event is skipped the following message will appear if the debug mode is enabled:
```
+++ The "re.compile('.*157441.*')" regex found a match in the "resources.accountId" field. The event will be skipped.
```

A new recursive function have been implemented in the `aws-s3.py` module to apply the speficied regex to the field provided. This applies to every supported bucket and services.

To add support to the new `discard_regex` option several changes needed to be applied in Wazuh core. This implementation will ensure both the value of the `discard_regex` and its `field` attribute must be present and must not be empty.  If the `field` attribute is not present the following warning will be shown and the `discard_regex` will be ignored:

```
Required attribute 'field' is missing in 'discard_regex'. No event will be skipped.
```

If the `discard_regex` value is empty, the following warning will be shown:
```
No value was provided for 'discard_regex'. No event will be skipped.
```
## Testing

To ensure everything still works after the implemented changes I have checked manually every bucket and service supported. Everything looks to be running as expected.

