### PR TITLE
Fix manager API integration tests

### DIFF
--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -1146,31 +1146,6 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-
----
-test_name: PUT /manager/restart
-
-stages:
-
-  # PUT /manager/restart
-  - name: Restart manager
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/restart"
-      method: PUT
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          affected_items:
-            - !anystr
-          failed_items: []
-          total_affected_items: 1
-          total_failed_items: 0
-
 ---
 test_name: PUT /manager/configuration
 
@@ -1288,6 +1263,30 @@ stages:
           affected_items:
             - alerts:
                 log_alert_level: '300'
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+
+---
+test_name: PUT /manager/restart
+
+stages:
+
+  # PUT /manager/restart
+  - name: Restart manager
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/restart"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - !anystr
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0

--- a/api/test/integration/test_rbac_black_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_manager_endpoints.tavern.yaml
@@ -97,22 +97,6 @@ stages:
       <<: *permission_allowed
 
 ---
-test_name: PUT /manager/restart
-
-stages:
-
-  - name: Restart manager (Allowed) (Allowed)
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/restart"
-      method: PUT
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      <<: *permission_allowed
-    delay_after: !float "{restart_delay}"
-
----
 test_name: GET /manager/stats
 
 stages:
@@ -237,3 +221,18 @@ stages:
         content-type: application/octet-stream
     response:
       <<: *permission_denied
+
+---
+test_name: PUT /manager/restart
+
+stages:
+
+  - name: Restart manager (Allowed) (Allowed)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/restart"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      <<: *permission_allowed


### PR DESCRIPTION
Hi team,

This PR fixes some manager API integrations.

There was a race condition. When restarting the manager, sometimes the API wasn't listening and the tests after the restart one were failing.

- Test results:

```
test_manager_endpoints.tavern.yaml 
	 31 passed, 33 warnings

test_rbac_black_manager_endpoints.tavern.yaml 
	 15 passed, 17 warnings

test_rbac_white_manager_endpoints.tavern.yaml 
	 15 passed, 17 warnings
```

Regards,
Manuel.