### PR TITLE
8319 check macos log before execution

### DIFF
--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -107,6 +107,7 @@
 #define TCP_NOT_SUPPORT "(1247): TCP not supported for this operating system."
 #define TCP_EPIPE       "(1248): Unable to send message. Connection has been closed by remote server."
 #define CONN_REF        "(1249): Unable to send message. Connection with remote server refused."
+#define ACCESS_ERROR    "(1250): Error trying to execute \"%s\": %s (%d)."
 
 #define MAILQ_ERROR     "(1221): No Mail queue at %s"
 #define IMSG_ERROR      "(1222): Invalid msg: %s"

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -339,7 +339,7 @@ void LogCollectorStart()
         else if (strcmp(current->logformat, OSLOG) == 0) {
             w_logcollector_create_oslog_env(current);
             current->read = read_oslog;
-            if (current->oslog->log_wfd->file != NULL) {
+            if (current->oslog->is_oslog_running) {
                 if (atexit(w_oslog_release)) {
                     merror(ATEXIT_ERROR);
                 }


### PR DESCRIPTION
|Closes|
|---|
|#8319|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hi team!

In this PR, which closes #8319, we added the code that checks whether the macOS' log command can be executed or not before doing so.

By using the C `access()` function it is possible to verify whether `/usr/bin/log` exists and has execution permission for the process' user and group. Given the output of this function, proper actions are taken to allow "logcollector" to continue performing well.

<!--
Add a clear description of how the problem has been solved.
-->

## Logs/Alerts example

In the case that `access()` determines that `/usr/bin/log` cannot be executed, an error is raised and an entry like the following one can be found in the ossec.log:

```
2021/04/22 16:54:31 wazuh-logcollector: ERROR: (1250): Error executing access() to check "/usr/bin/log" with flags 1. Error: No such file or directory (2).
```

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

Best Regards,

Mariano Koremblum