### PR TITLE
Do not insert CPE nor CVE if data parsing was incorrect

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -396,34 +396,36 @@ end:
 void wm_vuldet_free_cpe(cpe *node) {
     int i;
 
-    // CPE fields
-    free(node->part);
-    free(node->vendor);
-    free(node->product);
-    free(node->version);
-    free(node->update);
-    free(node->edition);
-    free(node->language);
-    free(node->sw_edition);
-    free(node->target_sw);
-    free(node->target_hw);
-    free(node->other);
-    // Extra fields
-    free(node->msu_name);
-    free(node->raw);
-    // Multi-fields
-    if (node->cm_product) {
-        for (i = 0; (node->cm_product + i)->translation; i++) {
-            free((void *) (node->cm_product + i)->translation);
-            free((void *) (node->cm_product + i)->field);
-            free((void *) (node->cm_product + i)->condition);
+    if(node != NULL){
+        // CPE fields
+        free(node->part);
+        free(node->vendor);
+        free(node->product);
+        free(node->version);
+        free(node->update);
+        free(node->edition);
+        free(node->language);
+        free(node->sw_edition);
+        free(node->target_sw);
+        free(node->target_hw);
+        free(node->other);
+        // Extra fields
+        free(node->msu_name);
+        free(node->raw);
+        // Multi-fields
+        if (node->cm_product) {
+            for (i = 0; (node->cm_product + i)->translation; i++) {
+                free((void *) (node->cm_product + i)->translation);
+                free((void *) (node->cm_product + i)->field);
+                free((void *) (node->cm_product + i)->condition);
+            }
+
+            free(node->cm_product);
         }
 
-        free(node->cm_product);
+
+        free(node);
     }
-
-
-    free(node);
 }
 
 void wm_vuldet_free_multi_cpe(cpe *node) {
@@ -1494,26 +1496,28 @@ int wm_vuldet_insert_nvd_cve_match(sqlite3 *db, nvd_conf_cpe_match *nvd_data, in
 
     node = nvd_data;
     while(node) {
-        if (cpe_id = wm_vuldet_insert_nvd_cve_cpe(db, node->cpe_node), !cpe_id) {
-            return OS_INVALID;
-        }
+        if(node->cpe_node != NULL){
+            if (cpe_id = wm_vuldet_insert_nvd_cve_cpe(db, node->cpe_node), !cpe_id) {
+                return OS_INVALID;
+            }
 
-        if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_NVD_CVE_MATCHES], -1, &stmt, NULL) != SQLITE_OK) {
-            return wm_vuldet_sql_error(db, stmt);
-        }
-        sqlite3_bind_int(stmt, 1, conf_id);
-        sqlite3_bind_int(stmt, 2, cpe_id);
-        sqlite3_bind_int(stmt, 3, node->vulnerable);
-        sqlite3_bind_text(stmt, 4, node->cpe_uri23, -1, NULL);
-        sqlite3_bind_text(stmt, 5, node->version_start_including, -1, NULL);
-        sqlite3_bind_text(stmt, 6, node->version_start_excluding, -1, NULL);
-        sqlite3_bind_text(stmt, 7, node->version_end_including, -1, NULL);
-        sqlite3_bind_text(stmt, 8, node->version_end_excluding, -1, NULL);
+            if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_NVD_CVE_MATCHES], -1, &stmt, NULL) != SQLITE_OK) {
+                return wm_vuldet_sql_error(db, stmt);
+            }
+            sqlite3_bind_int(stmt, 1, conf_id);
+            sqlite3_bind_int(stmt, 2, cpe_id);
+            sqlite3_bind_int(stmt, 3, node->vulnerable);
+            sqlite3_bind_text(stmt, 4, node->cpe_uri23, -1, NULL);
+            sqlite3_bind_text(stmt, 5, node->version_start_including, -1, NULL);
+            sqlite3_bind_text(stmt, 6, node->version_start_excluding, -1, NULL);
+            sqlite3_bind_text(stmt, 7, node->version_end_including, -1, NULL);
+            sqlite3_bind_text(stmt, 8, node->version_end_excluding, -1, NULL);
 
-        if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
-            return wm_vuldet_sql_error(db, stmt);
+            if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
+                return wm_vuldet_sql_error(db, stmt);
+            }
+            wdb_finalize(stmt);
         }
-        wdb_finalize(stmt);
         node = node->next;
     }
 
@@ -1521,9 +1525,14 @@ int wm_vuldet_insert_nvd_cve_match(sqlite3 *db, nvd_conf_cpe_match *nvd_data, in
 }
 
 int wm_vuldet_insert_nvd_cve_cpe(sqlite3 *db, cpe *cpe_data) {
+    if (cpe_data == NULL) {
+        return 0;
+    }
+
     sqlite3_stmt *stmt = NULL;
     int result;
     unsigned long int cpe_id = 0;
+
 
     if (wm_vuldet_prepare(db, vu_queries[VU_GET_MAX_NVD_CPE_ID], -1, &stmt, NULL) != SQLITE_OK) {
         return wm_vuldet_sql_error(db, stmt);


### PR DESCRIPTION
|Version|Component|
|---|---|
|3.13.0|Vulnerability Detector (Modulesd)|

This PR backports the fix at [4.1.5](https://github.com/wazuh/wazuh/releases/tag/v4.1.5) which prevents Modulesd from crashing when Vulnerability Detector tries to parse a CVE from the NVD database with a missing CPE.

## Rationale

Vulnerability Detector expects every CVE item to define the CPE in the member `cpe23Uri`:

```json
{
    "vulnerable" : true,
    "cpe23Uri" : "cpe:2.3:a:d-bus_project:d-bus:1.5.0:*:*:*:*:*:*:*",
    "cpe_name" : [ ]
}
```

However, there is a particular case ([CVE-2011-2200](https://nvd.nist.gov/vuln/detail/CVE-2011-2200)) which holds no `cpe23Uri`:

```json
{
    "vulnerable" : true,
    "cpe_name" : [ ]
}
```

That makes the internal variable `cpe_node` be `NULL`, and causes Modulesd to crash when attempting to access it.

## Tests

- [X] Compile manager for Linux.
- [X] Update the NVD database feed on Vulnerability Detector to the latest version.

### Updating NVD feed

```
2021/04/23 11:28:21 wazuh-modulesd: INFO: Process started.
2021/04/23 11:28:24 wazuh-modulesd:vulnerability-detector: INFO: (5400): Starting 'National Vulnerability Database' database update.
2021/04/23 11:35:50 wazuh-modulesd:vulnerability-detector: INFO: (5430): The update of the 'National Vulnerability Database' feed finished successfully.
```