### PR TITLE
Check NSpredicates and errors in log_format oslog 

### DIFF
--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -475,7 +475,7 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
         merror(MISS_LOG_FORMAT);
         return (OS_INVALID);
     }
-//ifdef Darwin
+//#if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
     /* Verify oslog config*/
     if (log_config->oslog_count > 1) {
         merror(DUP_OSLOG);
@@ -487,7 +487,7 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
         merror(INV_OSLOG);
         return (OS_INVALID);
     }
-//endif Darwin
+//#endif
     /* Verify Multiline Regex Config */
     if (strcmp(logf[pl].logformat, MULTI_LINE_REGEX) == 0) {
 

--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -57,7 +57,7 @@
 
 /** regex to determine the start of a log */
 #define OSLOG_START_REGEX       "^\\d\\d\\d\\d-\\d\\d-\\d\\d \\d\\d:\\d\\d:\\d\\d"
-#define OSLOG_TIMEOUT_OUT       5
+#define OSLOG_TIMEOUT           5
 
 #include <pthread.h>
 
@@ -152,6 +152,7 @@ typedef struct {
  */
 typedef struct {
     w_expression_t * start_log_regex; ///< used to check the start of a new log
+    bool processed_header;            ///< True if the stream header was processed
     w_oslog_ctxt_t ctxt;              ///< store current status when read log is in process
     char * last_read_timestamp;       ///< timestamp of last log queued (Used for only future event)
     wfd_t * log_wfd;                  ///< `log stream` IPC connector

--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -152,7 +152,7 @@ typedef struct {
  */
 typedef struct {
     w_expression_t * start_log_regex; ///< used to check the start of a new log
-    bool processed_header;            ///< True if the stream header was processed
+    bool is_header_processed;            ///< True if the stream header was processed
     w_oslog_ctxt_t ctxt;              ///< store current status when read log is in process
     char * last_read_timestamp;       ///< timestamp of last log queued (Used for only future event)
     wfd_t * log_wfd;                  ///< `log stream` IPC connector

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -139,6 +139,7 @@
 /* logcollector */
 #define SYSTEM_ERROR     "(1600): Internal error. Exiting.."
 #define LOGCOLLECTOR_OSLOG_IREGEX_ERROR        "(1601): Invalid internal oslog regex."
+#define LOGCOLLECTOR_OSLOG_ERROR_AFTER_EXEC    "(1602): error execution %s"
 
 /* remoted */
 #define NO_REM_CONN     "(1750): No remote connection configured. Exiting."

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -139,7 +139,7 @@
 /* logcollector */
 #define SYSTEM_ERROR     "(1600): Internal error. Exiting.."
 #define LOGCOLLECTOR_OSLOG_IREGEX_ERROR        "(1601): Invalid internal oslog regex."
-#define LOGCOLLECTOR_OSLOG_ERROR_AFTER_EXEC    "(1602): error execution %s"
+#define LOGCOLLECTOR_OSLOG_ERROR_AFTER_EXEC    "(1602): Execution error '%s'"
 
 /* remoted */
 #define NO_REM_CONN     "(1750): No remote connection configured. Exiting."

--- a/src/headers/expression.h
+++ b/src/headers/expression.h
@@ -13,7 +13,6 @@
 #define PCRE2_CODE_UNIT_WIDTH 8
 
 #include "external/libpcre2/include/pcre2.h"
-#include "shared.h"
 #include "os_regex/os_regex.h"
 #include "validate_op.h"
 

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -127,11 +127,9 @@ static pthread_rwlock_t files_update_rwlock;
 static OSHash *excluded_files = NULL;
 static OSHash *excluded_binaries = NULL;
 
-// ifdef DARWIN
-#ifndef WIN32
+#if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
 static wfd_t * oslog_wfd = NULL;
 #endif
-// endif
 
 /* Handle file management */
 void LogCollectorStart()
@@ -337,8 +335,7 @@ void LogCollectorStart()
                 merror("Missing command argument. Ignoring it.");
             }
         }
-//ifdef Darwin
-#ifndef WIN32 //todo : remove this when having the right define
+#if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
         else if (strcmp(current->logformat, OSLOG) == 0) {
             w_logcollector_create_oslog_env(current);
             current->read = read_oslog;
@@ -353,8 +350,7 @@ void LogCollectorStart()
                 }
             }
         }
-#endif  //todo : remove this when having the right define
-//endif Darwin
+#endif
         else if (j < 0) {
             set_read(current, i, j);
             if (current->file) {
@@ -2120,12 +2116,12 @@ void * w_input_thread(__attribute__((unused)) void * t_id){
                             current->read(current, &r, 0);
                         }
                     }
-//#ifdef darwin
+#if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
                     /* Read process `log` in stream  (oslog) */
                     else if (current->oslog != NULL && current->oslog->is_oslog_running) {
                         current->read(current, &r, 0);
                     }
-//#endif darwin
+#endif
                     w_mutex_unlock(&current->mutex);
                     w_rwlock_unlock(&files_update_rwlock);
                     continue;
@@ -2873,8 +2869,7 @@ void w_get_hash_context(const char * path, SHA_CTX * context, int64_t position) 
     }
 }
 
-// ifdef DARWIN
-#ifndef WIN32
+#if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
 void w_oslog_release(void) {
     if (oslog_wfd != NULL) {
         mdebug1("Releasing OSLog resources.");
@@ -2886,4 +2881,3 @@ void w_oslog_release(void) {
     }
 }
 #endif
-// endif

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -106,6 +106,7 @@ void *read_multiline(logreader *lf, int *rc, int drop_it);
  */
 void *read_multiline_regex(logreader *lf, int *rc, int drop_it);
 
+#if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
 /**
  * @brief Read oslog logs
  *
@@ -115,6 +116,7 @@ void *read_multiline_regex(logreader *lf, int *rc, int drop_it);
  * @return NULL
  */
 void *read_oslog(logreader *lf, int *rc, int drop_it);
+#endif
 
 /* Read DJB multilog format */
 /* Initializes multilog */
@@ -274,8 +276,7 @@ extern int OUTPUT_QUEUE_SIZE;
 extern rlim_t nofile;
 #endif
 
-// ifdef DARWIN
-#ifndef WIN32
+#if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
 /**
  * @brief This function is called to release oslog's resources
  */

--- a/src/logcollector/oslog_stream.c
+++ b/src/logcollector/oslog_stream.c
@@ -7,7 +7,7 @@
  * License (version 2) as published by the FSF - Free Software
  * Foundation
  */
-
+#if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
 #include "oslog_stream.h"
 
 // Remove STATIC qualifier from tests
@@ -153,3 +153,5 @@ void w_logcollector_create_oslog_env(logreader * current) {
 
     free_strarray(log_stream_array);
 }
+
+#endif

--- a/src/logcollector/read_oslog.c
+++ b/src/logcollector/read_oslog.c
@@ -6,7 +6,7 @@
  * License (version 2) as published by the FSF - Free Software
  * Foundation
  */
-
+#if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
 #include "shared.h"
 #include "logcollector.h"
 
@@ -338,3 +338,5 @@ STATIC bool oslog_header_check(w_oslog_config_t * oslog_cfg, char * buffer) {
 
     return retval;
 }
+
+#endif

--- a/src/unit_tests/logcollector/CMakeLists.txt
+++ b/src/unit_tests/logcollector/CMakeLists.txt
@@ -70,7 +70,7 @@ list(APPEND logcollector_flags "-Wl,--wrap,wpopenv -Wl,--wrap,fileno -Wl,--wrap,
                                 -Wl,--wrap,remove -Wl,--wrap,fgetc -Wl,--wrap,wpclose")
 
 list(APPEND logcollector_names "test_read_oslog")
-list(APPEND logcollector_flags "")
+list(APPEND logcollector_flags "-Wl,--wrap,w_expression_match")
 
 list(LENGTH logcollector_names count)
 math(EXPR count "${count} - 1")

--- a/src/unit_tests/logcollector/test_read_oslog.c
+++ b/src/unit_tests/logcollector/test_read_oslog.c
@@ -20,12 +20,14 @@
 #include "../wrappers/wazuh/shared/file_op_wrappers.h"
 #include "../wrappers/libc/stdio_wrappers.h"
 #include "../wrappers/linux/socket_wrappers.h"
+#include "../wrappers/wazuh/shared/expression_wrappers.h"
 
 bool oslog_ctxt_restore(char * buffer, w_oslog_ctxt_t * ctxt);
 void oslog_ctxt_backup(char * buffer, w_oslog_ctxt_t * ctxt);
 void oslog_ctxt_clean(w_oslog_ctxt_t * ctxt);
 bool oslog_ctxt_is_expired(time_t timeout, w_oslog_ctxt_t * ctxt);
 char * oslog_get_valid_lastline(char * str);
+bool oslog_header_check(w_oslog_config_t * oslog_cfg, char * buffer);
 
 /* setup/teardown */
 

--- a/src/unit_tests/logcollector/test_read_oslog.c
+++ b/src/unit_tests/logcollector/test_read_oslog.c
@@ -113,7 +113,7 @@ void test_oslog_ctxt_clean_success(void ** state) {
 void test_oslog_ctxt_is_expired_true(void ** state) {
 
     w_oslog_ctxt_t ctxt;
-    time_t timeout = (time_t) OSLOG_TIMEOUT_OUT;
+    time_t timeout = (time_t) OSLOG_TIMEOUT;
 
     ctxt.timestamp = (time_t) 1;
 
@@ -126,7 +126,7 @@ void test_oslog_ctxt_is_expired_true(void ** state) {
 void test_oslog_ctxt_is_expired_false(void ** state) {
 
     w_oslog_ctxt_t ctxt;
-    time_t timeout = (time_t) OSLOG_TIMEOUT_OUT;
+    time_t timeout = (time_t) OSLOG_TIMEOUT;
 
     ctxt.timestamp = time(NULL);
 

--- a/src/unit_tests/wrappers/wazuh/shared/expression_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/expression_wrappers.c
@@ -1,0 +1,19 @@
+/* Copyright (C) 2015-2021, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include "expression_wrappers.h"
+#include <stddef.h>
+#include <stdarg.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+bool __wrap_w_expression_match(__attribute__((unused))w_expression_t * expression, __attribute__((unused))const char * str_test, 
+                               __attribute__((unused))const char ** end_match, __attribute__((unused))regex_matching * regex_match) {
+    return mock_type(bool);
+}

--- a/src/unit_tests/wrappers/wazuh/shared/expression_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/expression_wrappers.h
@@ -1,0 +1,19 @@
+/* Copyright (C) 2015-2021, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#ifndef EXPRESSION_WRAPPERS_H
+#define EXPRESSION_WRAPPERS_H
+
+#include <stdbool.h>
+#include "headers/expression.h"
+
+bool __wrap_w_expression_match(__attribute__((unused))w_expression_t * expression, __attribute__((unused))const char * str_test, 
+                               __attribute__((unused))const char ** end_match, __attribute__((unused))regex_matching * regex_match);
+
+#endif


### PR DESCRIPTION
|Related issue|
|---|
| Closes #8258 |

## Description

This PR adds a mechanism to check [NSPredicate](https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/Predicates/AdditionalChapters/Introduction.html) predicates during `wazuh-logcollector` startup process when a `localfile` with `oslog` as `log_format` and predicate defined in `query` option is declared.

Currently there's no library for C/C++ to check NSPredicate syntax,.

Regards,
Julian

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
