### PR TITLE
Let wcom execute check-manager-config query.

### DIFF
--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -148,6 +148,7 @@ EXECQ = os.path.join(wazuh_path, 'queue', 'alerts', 'execq')
 # Socket
 AUTHD_SOCKET = os.path.join(wazuh_path, 'queue', 'sockets', 'auth')
 REQUEST_SOCKET = os.path.join(wazuh_path, 'queue', 'sockets', 'request')
+WCOM_SOCKET = os.path.join(wazuh_path, 'queue', 'sockets', 'com')
 LOGTEST_SOCKET = os.path.join(wazuh_path, 'queue', 'sockets', 'logtest')
 UPGRADE_SOCKET = os.path.join(wazuh_path, 'queue', 'tasks', 'upgrade')
 

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -374,7 +374,7 @@ class WazuhException(Exception):
         1902: {'message': 'Connection to \'execq\' socket failed'
                },
         1903: 'Error deleting temporary file from API',
-        1904: {'message': 'Bad data from \'execq\''
+        1904: {'message': 'Bad data from \'wcom\''
                },
         1905: {'message': 'File could not be updated, it already exists',
                'remediation': 'Please, provide a different file or set overwrite=True to overwrite actual file'

--- a/framework/wazuh/core/manager.py
+++ b/framework/wazuh/core/manager.py
@@ -10,19 +10,18 @@ import socket
 from collections import OrderedDict
 from datetime import datetime
 from datetime import timezone
-from os import remove
 from os.path import exists, join
 from typing import Dict
 
 from api import configuration
-from wazuh import WazuhInternalError, WazuhError
+from wazuh import WazuhInternalError, WazuhError, WazuhException
 from wazuh.core import common
 from wazuh.core.cluster.utils import get_manager_status
 from wazuh.core.utils import tail
-from wazuh.core.wazuh_socket import create_wazuh_socket_message
+from wazuh.core.wazuh_socket import create_wazuh_socket_message, WazuhSocket
 
 _re_logtest = re.compile(r"^.*(?:ERROR: |CRITICAL: )(?:\[.*\] )?(.*)$")
-execq_lockfile = join(common.wazuh_path, "var", "run", ".api_execq_lock")
+wcom_lockfile = join(common.wazuh_path, "var", "run", ".api_wcom_lock")
 
 
 def status():
@@ -120,70 +119,39 @@ def validate_ossec_conf():
     str
         Status of the configuration.
     """
-    lock_file = open(execq_lockfile, 'a+')
+
+    lock_file = open(wcom_lockfile, 'a+')
     fcntl.lockf(lock_file, fcntl.LOCK_EX)
 
     try:
-        # Sockets path
-        api_socket_relative_path = join('queue', 'alerts', 'execa')
-        api_socket_path = join(common.wazuh_path, api_socket_relative_path)
-        execq_socket_path = common.EXECQ
+        # Socket path
+        wcom_socket_path = common.WCOM_SOCKET
         # Message for checking Wazuh configuration
-        execq_msg = json.dumps(create_wazuh_socket_message(origin={'module': 'api/framework'},
-                                                           command=common.CHECK_CONFIG_COMMAND,
-                                                           parameters={"extra_args": [], "alert": {}}))
+        wcom_msg = common.CHECK_CONFIG_COMMAND
 
-        # Remove api_socket if exists
-        try:
-            remove(api_socket_path)
-        except OSError as e:
-            if exists(api_socket_path):
-                extra_msg = f'Socket: WAZUH_PATH/{api_socket_relative_path}. Error: {e.strerror}'
-                raise WazuhInternalError(1014, extra_message=extra_msg)
-
-        # up API socket
-        try:
-            api_socket = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
-            api_socket.bind(api_socket_path)
-            # Timeout
-            api_socket.settimeout(10)
-        except OSError as e:
-            extra_msg = f'Socket: WAZUH_PATH/{api_socket_relative_path}. Error: {e.strerror}'
-            raise WazuhInternalError(1013, extra_message=extra_msg)
-
-        # Connect to execq socket
-        if exists(execq_socket_path):
+        # Connect to wcom socket
+        if exists(wcom_socket_path):
             try:
-                execq_socket = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
-                execq_socket.connect(execq_socket_path)
-            except OSError as e:
-                extra_msg = f'Socket: WAZUH_PATH/queue/alerts/execq. Error {e.strerror}'
+                wcom_socket = WazuhSocket(wcom_socket_path)
+            except WazuhException as e:
+                extra_msg = f'Socket: WAZUH_PATH/queue/sockets/com. Error {e.message}'
                 raise WazuhInternalError(1013, extra_message=extra_msg)
         else:
             raise WazuhInternalError(1901)
 
-        # Send msg to execq socket
+        # Send msg to wcom socket
         try:
-            execq_socket.send(execq_msg.encode())
-            execq_socket.close()
-        except socket.error as e:
-            raise WazuhInternalError(1014, extra_message=str(e))
-        finally:
-            execq_socket.close()
+            wcom_socket.send(wcom_msg.encode())
 
-        # If api_socket receives a message, configuration is OK
-        try:
             buffer = bytearray()
-            # Receive data
-            datagram = api_socket.recv(4096)
+            datagram = wcom_socket.receive()
             buffer.extend(datagram)
-        except socket.timeout as e:
+
+            wcom_socket.close()
+        except (socket.error, socket.timeout) as e:
             raise WazuhInternalError(1014, extra_message=str(e))
         finally:
-            api_socket.close()
-            # Remove api_socket
-            if exists(api_socket_path):
-                remove(api_socket_path)
+            wcom_socket.close()
 
         try:
             response = parse_execd_output(buffer.decode('utf-8').rstrip('\0'))

--- a/framework/wazuh/core/tests/test_manager.py
+++ b/framework/wazuh/core/tests/test_manager.py
@@ -44,6 +44,7 @@ def get_logs():
     with open(ossec_log_path) as f:
         return f.read()
 
+
 @pytest.mark.parametrize('process_status', [
     'running',
     'stopped',
@@ -69,6 +70,7 @@ def test_get_status(manager_glob, manager_exists, test_manager, process_status):
     process_status : str
         Status to test (valid values: running/stopped/failed/restarting).
     """
+
     def mock_glob(path_to_check):
         return [path_to_check.replace('*', '0234')] if process_status == 'running' else []
 
@@ -76,8 +78,8 @@ def test_get_status(manager_glob, manager_exists, test_manager, process_status):
         if path_to_check == '/proc/0234':
             return process_status == 'running'
         else:
-            return path_to_check.endswith(f'.{process_status.replace("ing","").replace("re", "")}') or \
-                   path_to_check.endswith(f'.{process_status.replace("ing","")}')
+            return path_to_check.endswith(f'.{process_status.replace("ing", "").replace("re", "")}') or \
+                   path_to_check.endswith(f'.{process_status.replace("ing", "")}')
 
     manager_glob.side_effect = mock_glob
     manager_exists.side_effect = mock_exists
@@ -124,75 +126,60 @@ def test_get_logs_summary():
                                                      'debug': 2}
 
 
-@pytest.mark.parametrize('error_flag, error_msg', [
-    (0, ""),
-    (1, "2019/02/27 11:30:07 wazuh-clusterd: ERROR: [Cluster] [Main] Error 3004 - Error in cluster configuration: "
-        "Unspecified key"),
-    (1, "2019/02/27 11:30:24 wazuh-authd: ERROR: (1230): Invalid element in the configuration: "
-        "'use_source_i'.\n2019/02/27 11:30:24 wazuh-authd: ERROR: (1202): Configuration error at "
-        "'/var/ossec/etc/ossec.conf'.")
-])
 @patch('wazuh.core.manager.open')
 @patch('wazuh.core.manager.fcntl')
-@patch("wazuh.core.manager.exists", return_value=True)
-@patch("wazuh.core.manager.remove", return_value=True)
-def test_validate_ossec_conf(mock_remove, mock_exists, mock_fcntl, mock_open, error_flag, error_msg):
+@patch('wazuh.core.manager.exists', return_value=True)
+@patch('wazuh.core.manager.WazuhSocket')
+def test_validate_ossec_conf(mock_wazuhsocket, mock_exists, mock_fcntl, mock_open):
     with patch('socket.socket') as sock:
         # Mock sock response
         json_response = json.dumps({'error': 0, 'message': ""}).encode()
-        sock.return_value.recv.return_value = json_response
+        mock_wazuhsocket.return_value.receive.return_value = json_response
         result = validate_ossec_conf()
 
         assert result == {'status': 'OK'}
         assert mock_fcntl.lockf.call_count == 2
-        mock_remove.assert_called_with(join(common.wazuh_path, 'queue', 'alerts', 'execa'))
-        mock_exists.assert_called_with(join(common.wazuh_path, 'queue', 'alerts', 'execa'))
-        mock_open.assert_called_once_with(join(common.wazuh_path, "var", "run", ".api_execq_lock"), 'a+')
+        mock_exists.assert_called_with(join(common.wazuh_path, 'queue', 'sockets', 'com'))
+        mock_open.assert_called_once_with(join(common.wazuh_path, "var", "run", ".api_wcom_lock"), 'a+')
 
 
 @patch('wazuh.core.manager.open')
 @patch('wazuh.core.manager.fcntl')
 @patch("wazuh.core.manager.exists", return_value=True)
 def test_validation_ko(mosck_exists, mock_lockf, mock_open):
-    # Remove api_socket raise OSError
-    with patch('wazuh.core.manager.remove', side_effect=OSError):
-        with pytest.raises(WazuhInternalError, match='.* 1014 .*'):
+    # Socket creation raise socket.error
+    with patch('socket.socket', side_effect=socket.error):
+        with pytest.raises(WazuhInternalError, match='.* 1013 .*'):
             validate_ossec_conf()
 
-    with patch('wazuh.core.manager.remove'):
-        # Socket creation raise socket.error
-        with patch('socket.socket', side_effect=socket.error):
+    with patch('socket.socket.bind'):
+        # Socket connection raise socket.error
+        with patch('socket.socket.connect', side_effect=socket.error):
             with pytest.raises(WazuhInternalError, match='.* 1013 .*'):
                 validate_ossec_conf()
 
-        with patch('socket.socket.bind'):
-            # Socket connection raise socket.error
-            with patch('socket.socket.connect', side_effect=socket.error):
-                with pytest.raises(WazuhInternalError, match='.* 1013 .*'):
+        # execq_socket_path not exists
+        with patch("wazuh.core.manager.exists", return_value=False):
+            with pytest.raises(WazuhInternalError, match='.* 1901 .*'):
+                validate_ossec_conf()
+
+        with patch('socket.socket.connect'):
+            # Socket send raise socket.error
+            with patch('wazuh.core.manager.WazuhSocket.send', side_effect=socket.error):
+                with pytest.raises(WazuhInternalError, match='.* 1014 .*'):
                     validate_ossec_conf()
 
-            # execq_socket_path not exists
-            with patch("wazuh.core.manager.exists", return_value=False):
-                 with pytest.raises(WazuhInternalError, match='.* 1901 .*'):
-                    validate_ossec_conf()
-
-            with patch('socket.socket.connect'):
-                # Socket send raise socket.error
-                with patch('socket.socket.send', side_effect=socket.error):
+            with patch('socket.socket.send'):
+                # Socket recv raise socket.error
+                with patch('wazuh.core.manager.WazuhSocket.receive', side_effect=socket.timeout):
                     with pytest.raises(WazuhInternalError, match='.* 1014 .*'):
                         validate_ossec_conf()
 
-                with patch('socket.socket.send'):
-                    # Socket recv raise socket.error
-                    with patch('socket.socket.recv', side_effect=socket.timeout):
-                        with pytest.raises(WazuhInternalError, match='.* 1014 .*'):
+                # _parse_execd_output raise KeyError
+                with patch('wazuh.core.manager.WazuhSocket'):
+                    with patch('wazuh.core.manager.parse_execd_output', side_effect=KeyError):
+                        with pytest.raises(WazuhInternalError, match='.* 1904 .*'):
                             validate_ossec_conf()
-
-                    # _parse_execd_output raise KeyError
-                    with patch('socket.socket.recv'):
-                        with patch('wazuh.core.manager.parse_execd_output', side_effect=KeyError):
-                            with pytest.raises(WazuhInternalError, match='.* 1904 .*'):
-                                validate_ossec_conf()
 
 
 @pytest.mark.parametrize('error_flag, error_msg', [

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -181,9 +181,6 @@ https://www.gnu.org/licenses/gpl.html\n"
 /* Security configuration assessment remoted queue */
 #define CFGARQUEUE       "queue/alerts/cfgarq"
 
-/* Exec queue api*/
-#define EXECQUEUEA      "queue/alerts/execa"
-
 /* Active Response queue */
 #define ARQUEUE         "queue/alerts/ar"
 

--- a/src/init/wazuh/wazuh.sh
+++ b/src/init/wazuh/wazuh.sh
@@ -205,4 +205,9 @@ WazuhUpgrade()
         rm -f $DIRECTORY/etc/ossec-init.conf
         rm -f /etc/ossec-init.conf
     fi
+
+    # Remove unnecessary `execa` socket
+    if [ -f "$DIRECTORY/queue/alerts/execa" ]; then
+        rm -f $DIRECTORY/queue/alerts/execa
+    fi
 }

--- a/src/os_execd/execd.c
+++ b/src/os_execd/execd.c
@@ -36,7 +36,6 @@ STATIC void ExecdStart(int q);
 #else
 STATIC void ExecdStart(int q) __attribute__((noreturn));
 #endif
-STATIC int CheckManagerConfiguration(char ** output);
 
 /* Global variables */
 STATIC OSList *timeout_list;
@@ -413,57 +412,6 @@ STATIC void ExecdStart(int q)
             continue;
         }
 
-        /* Check manager configuration */
-        if (!strcmp(name, "check-manager-configuration")) {
-            cJSON_Delete(json_root);
-
-            char *output = NULL;
-            cJSON *result_obj = cJSON_CreateObject();
-
-            if(CheckManagerConfiguration(&output)) {
-                char error_msg[OS_SIZE_4096 - 27] = {0};
-                snprintf(error_msg, OS_SIZE_4096 - 27, "%s", output);
-
-                cJSON_AddNumberToObject(result_obj, "error", 1);
-                cJSON_AddStringToObject(result_obj, "message", error_msg);
-                os_free(output);
-                output = cJSON_PrintUnformatted(result_obj);
-            } else {
-                cJSON_AddNumberToObject(result_obj, "error", 0);
-                cJSON_AddStringToObject(result_obj, "message", "ok");
-                os_free(output);
-                output = cJSON_PrintUnformatted(result_obj);
-            }
-
-            cJSON_Delete(result_obj);
-            mdebug1("Sending configuration check: %s", output);
-
-            int rc;
-            /* Start api socket */
-            int api_sock;
-            if ((api_sock = StartMQ(EXECQUEUEA, WRITE, 1)) < 0) {
-                merror(QUEUE_ERROR, EXECQUEUEA, strerror(errno));
-                os_free(output);
-                continue;
-            }
-
-            if ((rc = OS_SendUnix(api_sock, output, 0)) < 0) {
-                /* Error on the socket */
-                if (rc == OS_SOCKTERR) {
-                    merror("socketerr (not available).");
-                    os_free(output);
-                    close(api_sock);
-                    continue;
-                }
-
-                /* Unable to send. Socket busy */
-                mdebug2("Socket busy, discarding message.");
-            }
-            close(api_sock);
-            os_free(output);
-            continue;
-        }
-
         /* Restart Wazuh */
         if (!strcmp(name, "restart-wazuh")) {
             cJSON_Delete(json_root);
@@ -668,62 +616,6 @@ STATIC void ExecdStart(int q)
     }
     os_free(timeout_list);
 #endif
-}
-
-STATIC int CheckManagerConfiguration(char ** output) {
-    int ret_val;
-    int result_code;
-    int timeout = 2000;
-    char command_in[PATH_MAX] = {0};
-    char *output_msg = NULL;
-    char *daemons[] = { "bin/wazuh-authd", "bin/wazuh-remoted", "bin/wazuh-execd", "bin/wazuh-analysisd", "bin/wazuh-logcollector", "bin/wazuh-integratord",  "bin/wazuh-syscheckd", "bin/wazuh-maild", "bin/wazuh-modulesd", "bin/wazuh-clusterd", "bin/wazuh-agentlessd", "bin/wazuh-integratord", "bin/wazuh-dbd", "bin/wazuh-csyslogd", NULL };
-    int i;
-    ret_val = 0;
-
-    struct timeval start, end;
-    gettimeofday(&start, NULL);
-
-    for (i = 0; daemons[i]; i++) {
-        output_msg = NULL;
-        snprintf(command_in, PATH_MAX, "%s %s", daemons[i], "-t");
-
-        if (wm_exec(command_in, &output_msg, &result_code, timeout, NULL) < 0) {
-            if (result_code == EXECVE_ERROR) {
-                mwarn("Path is invalid or file has insufficient permissions. %s", command_in);
-            } else {
-                mwarn("Error executing [%s]", command_in);
-            }
-
-            goto error;
-        }
-
-        if (output_msg && *output_msg) {
-            // Remove last newline
-            size_t lastchar = strlen(output_msg) - 1;
-            output_msg[lastchar] = output_msg[lastchar] == '\n' ? '\0' : output_msg[lastchar];
-
-            wm_strcat(output, output_msg, ' ');
-        }
-
-        os_free(output_msg);
-
-        if(result_code) {
-            ret_val = result_code;
-            break;
-        }
-    }
-
-    gettimeofday(&end, NULL);
-
-    double elapsed = (end.tv_usec - start.tv_usec) / 1000.0;
-    mdebug1("Elapsed configuration check time: %0.3f milliseconds", elapsed);
-
-    return ret_val;
-
-error:
-
-    ret_val = 1;
-    return ret_val;
 }
 
 #endif /* !WIN32 */

--- a/src/os_execd/execd.h
+++ b/src/os_execd/execd.h
@@ -54,6 +54,7 @@ size_t wcom_restart(char **output);
 size_t wcom_dispatch(char *command, char **output);
 size_t lock_restart(int timeout);
 size_t wcom_getconfig(const char * section, char ** output);
+size_t wcom_check_manager_config(char **output);
 
 #ifndef WIN32
 // Com request thread dispatcher


### PR DESCRIPTION
|Related issue|
|---|
|#8356|

## Description
This PR aims to avoid `execd` to execute `check-manager-config` and `restart-manager` API requests. Now, these requests that were executed by `execd` will be executed by the `wcom` thread. This will avoid the problems described in #7968 once this development is completed.

If the `check-manager-config` request is sent to execd after the change, the following error will appear:
```
2021/04/26 06:57:29 wazuh-execd: ERROR: (1311): Invalid command name 'check-manager-configuration' provided.
```
Closes #8356
## Test active response disabled
```
root@ubuntumanager:/vagrant/Scripts# python3 test_execq.py e
Traceback (most recent call last):
  File "test_execq.py", line 135, in <module>
    response = test_exec()
  File "test_execq.py", line 89, in test_exec
    raise e
  File "test_execq.py", line 86, in test_exec
    datagram = api_socket.recv(4096)
socket.timeout: timed out
root@ubuntumanager:/vagrant/Scripts# python3 test_execq.py w
/var/ossec/queue/sockets/com
b'{"error":0,"message":"ok"}'
root@ubuntumanager:/vagrant/Scripts# 
```
## Test active response enabled
```
root@ubuntumanager:/vagrant/Scripts# python3 test_execq.py e
Traceback (most recent call last):
  File "test_execq.py", line 135, in <module>
    response = test_exec()
  File "test_execq.py", line 89, in test_exec
    raise e
  File "test_execq.py", line 86, in test_exec
    datagram = api_socket.recv(4096)
socket.timeout: timed out
root@ubuntumanager:/vagrant/Scripts# python3 test_execq.py w
/var/ossec/queue/sockets/com
b'{"error":0,"message":"ok"}'
root@ubuntumanager:/vagrant/Scripts# 
```
The exception that is raised is because the API was expecting to connect to the `alerts/execa` sockets, which is no longer used and it won't be created.
## Valgrind report 
```
==29915== LEAK SUMMARY:
==29915==    definitely lost: 0 bytes in 0 blocks
==29915==    indirectly lost: 0 bytes in 0 blocks
==29915==      possibly lost: 272 bytes in 1 blocks
==29915==    still reachable: 144 bytes in 1 blocks
==29915==         suppressed: 0 bytes in 0 blocks
```
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [X] Valgrind (memcheck and descriptor leaks check)