### PR TITLE
Add fix to nlb parsing

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2083,9 +2083,9 @@ class AWSNLBBucket(AWSCustomBucket):
         db_table_name = 'nlb'
         AWSCustomBucket.__init__(self, db_table_name, **kwargs)
 
-    def load_information_from_file(self, file):
-        """Load data from a CLB access log file."""
-        with self.decompress_file(log_key=file) as f:
+    def load_information_from_file(self, log_key):
+        """Load data from a NLB access log file."""
+        with self.decompress_file(log_key=log_key) as f:
             fieldnames = (
                 "type", "version", "time", "elb", "listener", "client_ip", "destination_ip", "connection_time",
                 "tls_handshake_time", "received_bytes", "sent_bytes", "incoming_tls_alert", "chosen_cert_arn",

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2087,7 +2087,7 @@ class AWSNLBBucket(AWSCustomBucket):
         """Load data from a NLB access log file."""
         with self.decompress_file(log_key=log_key) as f:
             fieldnames = (
-                "type", "version", "time", "elb", "listener", "client_ip", "destination_ip", "connection_time",
+                "type", "version", "time", "elb", "listener", "client_port", "destination_port", "connection_time",
                 "tls_handshake_time", "received_bytes", "sent_bytes", "incoming_tls_alert", "chosen_cert_arn",
                 "chosen_cert_serial", "tls_cipher", "tls_protocol_version", "tls_named_group", "domain_name",
                 "alpn_fe_protocol", "alpn_client_preference_list")
@@ -2097,8 +2097,8 @@ class AWSNLBBucket(AWSCustomBucket):
 
             # Split ip_addr:port field into ip_addr and port fields
             for log_entry in tsv_file:
-                log_entry['client_ip'], log_entry['client_port'] = log_entry['client_ip'].split(':')
-                log_entry['destination_ip'], log_entry['destination_port'] = log_entry['destination_ip'].split(':')
+                log_entry['client_ip'], log_entry['client_port'] = log_entry['client_port'].split(':')
+                log_entry['destination_ip'], log_entry['destination_port'] = log_entry['destination_port'].split(':')
 
             return tsv_file
 

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2097,9 +2097,8 @@ class AWSNLBBucket(AWSCustomBucket):
 
             # Split ip_addr:port field into ip_addr and port fields
             for log_entry in tsv_file:
-                fields = log_entry['client_ip'].split(':'), log_entry['destination_ip'].split(':')
-                log_entry['client_ip'], log_entry['client_port'] = fields[0][0], fields[0][1]
-                log_entry['destination_ip'], log_entry['destination_port'] = fields[1][0], fields[1][1]
+                log_entry['client_ip'], log_entry['client_port'] = log_entry['client_ip'].split(':')
+                log_entry['destination_ip'], log_entry['destination_port'] = log_entry['destination_ip'].split(':')
 
             return tsv_file
 

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2080,27 +2080,26 @@ class AWSCLBBucket(AWSCustomBucket):
 class AWSNLBBucket(AWSCustomBucket):
 
     def __init__(self, **kwargs):
-        db_table_name = 'nlb'
-        # AWSCustomBucket.__init__(self, db_table_name, **kwargs)
+        db_table_name = 'clb'
+        AWSCustomBucket.__init__(self, db_table_name, **kwargs)
 
     def load_information_from_file(self, log_key):
-        """Load data from a NLB access log file."""
-        with open(log_key, "r+") as file:
+        """Load data from a CLB access log file."""
+        with self.decompress_file(log_key=log_key) as f:
             fieldnames = (
-                "type", "version", "time", "elb", "listener", "client_ip", "destination_ip", "connection_time",
-                "tls_handshake_time", "received_bytes", "sent_bytes", "incoming_tls_alert", "chosen_cert_arn",
-                "chosen_cert_serial", "tls_cipher", "tls_protocol_version", "tls_named_group", "domain_name",
-                "alpn_fe_protocol", "alpn_client_preference_list")
-            tsv_file = csv.DictReader(file, fieldnames=fieldnames, delimiter=' ')
+                "time", "elb", "client_port", "backend_port", "request_processing_time", "backend_processing_time",
+                "response_processing_time", "elb_status_code", "backend_status_code", "received_bytes", "sent_bytes",
+                "request", "user_agent", "ssl_cipher", "ssl_protocol")
+            tsv_file = csv.DictReader(f, fieldnames=fieldnames, delimiter=' ')
 
-            tsv_file = [dict(x, source='nlb') for x in tsv_file]
+            [dict(x, source='clb') for x in tsv_file]
 
             # Split ip_addr:port field into ip_addr and port fields
             for log_entry in tsv_file:
                 fields = log_entry['client_ip'].split(':'), log_entry['destination_ip'].split(':')
                 log_entry['client_ip'], log_entry['client_port'] = fields[0][0], fields[0][1]
                 log_entry['destination_ip'], log_entry['destination_port'] = fields[1][0], fields[1][1]
-                print(log_entry)
+
             return tsv_file
 
 
@@ -2949,19 +2948,11 @@ def main(argv):
         sys.exit(12)
 
 
-def main_de_enrique():
-    bucket_type = AWSNLBBucket()
-
-    file = './166157441623_elasticloadbalancing_us-west-1_net.demo-3130-prod-Wazuh.f279b3dd67f9c98e_20200801T0050Z_256f6bdd.log'
-
-    bucket_type.load_information_from_file(file)
-
 if __name__ == '__main__':
     try:
         debug('Args: {args}'.format(args=str(sys.argv)), 2)
         signal.signal(signal.SIGINT, handler)
-        # main(sys.argv[1:])
-        main_de_enrique()
+        main(sys.argv[1:])
         sys.exit(0)
     except Exception as e:
         print("Unknown error: {}".format(e))

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -676,10 +676,8 @@ class AWSBucket(WazuhIntegration):
                 # Python 2
                 return gzip.GzipFile(fileobj=raw_object, mode='r')
 
-        print('dec hola')
         raw_object = io.BytesIO(self.client.get_object(Bucket=self.bucket, Key=log_key)['Body'].read())
         if log_key[-3:] == '.gz':
-            print('dec hola')
             return decompress_gzip(raw_object)
         elif log_key[-4:] == '.zip':
             zipfile_object = zipfile.ZipFile(raw_object, compression=zipfile.ZIP_DEFLATED)
@@ -2083,7 +2081,7 @@ class AWSNLBBucket(AWSCustomBucket):
 
     def __init__(self, **kwargs):
         db_table_name = 'nlb'
-        AWSCustomBucket.__init__(self, db_table_name, **kwargs)
+        # AWSCustomBucket.__init__(self, db_table_name, **kwargs)
 
     def load_information_from_file(self, log_key):
         """Load data from a NLB access log file."""
@@ -2102,7 +2100,7 @@ class AWSNLBBucket(AWSCustomBucket):
                 fields = log_entry['client_ip'].split(':'), log_entry['destination_ip'].split(':')
                 log_entry['client_ip'], log_entry['client_port'] = fields[0][0], fields[0][1]
                 log_entry['destination_ip'], log_entry['destination_port'] = fields[1][0], fields[1][1]
-
+                print(log_entry)
             return tsv_file
 
 
@@ -2951,11 +2949,19 @@ def main(argv):
         sys.exit(12)
 
 
+def main_de_enrique():
+    bucket_type = AWSNLBBucket()
+
+    file = './166157441623_elasticloadbalancing_us-west-1_net.demo-3130-prod-Wazuh.f279b3dd67f9c98e_20200801T0050Z_256f6bdd.log'
+
+    bucket_type.load_information_from_file(file)
+
 if __name__ == '__main__':
     try:
         debug('Args: {args}'.format(args=str(sys.argv)), 2)
         signal.signal(signal.SIGINT, handler)
-        main(sys.argv[1:])
+        # main(sys.argv[1:])
+        main_de_enrique()
         sys.exit(0)
     except Exception as e:
         print("Unknown error: {}".format(e))

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2097,8 +2097,13 @@ class AWSNLBBucket(AWSCustomBucket):
 
             # Split ip_addr:port field into ip_addr and port fields
             for log_entry in tsv_file:
-                log_entry['client_ip'], log_entry['client_port'] = log_entry['client_port'].split(':')
-                log_entry['destination_ip'], log_entry['destination_port'] = log_entry['destination_port'].split(':')
+                try:
+                    log_entry['client_ip'], log_entry['client_port'] = log_entry['client_port'].split(':')
+                    log_entry['destination_ip'], log_entry['destination_port'] = \
+                        log_entry['destination_port'].split(':')
+                except ValueError:
+                    log_entry['client_ip'] = log_entry['client_port']
+                    log_entry['destination_ip'] = log_entry['destination_port']
 
             return tsv_file
 

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2080,19 +2080,20 @@ class AWSCLBBucket(AWSCustomBucket):
 class AWSNLBBucket(AWSCustomBucket):
 
     def __init__(self, **kwargs):
-        db_table_name = 'clb'
+        db_table_name = 'nlb'
         AWSCustomBucket.__init__(self, db_table_name, **kwargs)
 
-    def load_information_from_file(self, log_key):
+    def load_information_from_file(self, file):
         """Load data from a CLB access log file."""
-        with self.decompress_file(log_key=log_key) as f:
+        with self.decompress_file(log_key=file) as f:
             fieldnames = (
-                "time", "elb", "client_port", "backend_port", "request_processing_time", "backend_processing_time",
-                "response_processing_time", "elb_status_code", "backend_status_code", "received_bytes", "sent_bytes",
-                "request", "user_agent", "ssl_cipher", "ssl_protocol")
+                "type", "version", "time", "elb", "listener", "client_ip", "destination_ip", "connection_time",
+                "tls_handshake_time", "received_bytes", "sent_bytes", "incoming_tls_alert", "chosen_cert_arn",
+                "chosen_cert_serial", "tls_cipher", "tls_protocol_version", "tls_named_group", "domain_name",
+                "alpn_fe_protocol", "alpn_client_preference_list")
             tsv_file = csv.DictReader(f, fieldnames=fieldnames, delimiter=' ')
 
-            [dict(x, source='clb') for x in tsv_file]
+            tsv_file = [dict(x, source='nlb') for x in tsv_file]
 
             # Split ip_addr:port field into ip_addr and port fields
             for log_entry in tsv_file:


### PR DESCRIPTION
|Related issue|
|--|
|#7168|

## Description

Hello team!

In this issue we fix the parsing of the LB logs files for the aws wodle. The IP address and the port were being read in the same field.

Now a post-processing of the dictionary is carried out after reading the file, where the ```client_port``` and ```destination_port``` keys are modified and the keys ```client_ip``` and ```destination_ip``` are added.

```python
# Split ip_addr:port field into ip_addr and port fields
for log_entry in tsv_file:
    log_entry['client_ip'], log_entry['client_port'] = log_entry['client_port'].split(':')
    log_entry['destination_ip'], log_entry['destination_port'] = log_entry['destination_port'].split(':')
```

## Logs example

To test the fix, the module has been manually executed, having previously activated the ```logall``` option. The log information has been modified for security reasons.

### Log file

```
tls 2.0 2020-08-01T00:49:02 net/echo-3456-prod-Test/fffffffffd66t i9k2b2c4556k5111 88.11.77.55:66666 10.20.4.220:666 1111 5555 11 222 - ttt www sss us-west-1 100150001675 certificate/es03tt20-111d-1f11-a11e-11111f281t20 - GGFFF-RSA-AES256-TTT-SHA128 tlsv12 - - - - -
```
### Command used

```
/var/ossec/framework/python/bin/python3 /var/ossec/wodles/aws/aws-s3.py -d 2 -a ACCESS -k SECRET -r us-east-1 -t nlb -b wzaccesslogslb
```

### Log output from /var/ossec/logs/archives/archives.log
```
2021 Apr 26 10:46:21 wazuh-master->Wazuh-AWS {"integration": "aws", "aws": {"log_info": {"aws_account_alias": "", 
"log_file": "AWSLogs/1111111111/elasticloadbalancing/us-west-1/2020/07/22/111111111111_elasticloadbalancing_us-west-1_net.demo-3130-prod-Wazuh.gggggggggg_20200722F1950F_2cg47b57.log.gz",
"s3bucket": "wzaccesslogslb"}, "type": "tls", "version": "2.0", "time": "2020-07-22T19:49:15",
 "elb": "net/demo-3130-prod-Wazuh/f279b3dd67f9c98e", "listener": "c3c3c3c3c3c3c3c3c3", 
"client_ip": "88.11.77.55", "destination_ip": "10.20.4.220", "connection_time": "111919", 
"tls_handshake_time": "225", "received_bytes": "32982", "sent_bytes": "69819", "incoming_tls_alert": "-", 
"chosen_cert_arn": "arn:aws:acm:us-west-1:11111111:certificate/7111111111111111111",
 "chosen_cert_serial": "-", "tls_cipher": "TTHHH-FTT-PTT256-GCM-SHA128", 
"tls_protocol_version": "tlsv12", "tls_named_group": "-", "domain_name": "test.test.com", 
"alpn_fe_protocol": "-", "alpn_client_preference_list": "-", "null": "-", "source": "nlb",
"client_port": "66666", "destination_port": "666"}}
```
