### PR TITLE
Stop raising exception when an invalid path is found

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -515,7 +515,6 @@ class AWSBucket(WazuhIntegration):
                 ))
             except Exception as e:
                 debug("+++ Error marking log {} as completed: {}".format(log_file['Key'], e), 2)
-                raise e
 
     def create_table(self):
         try:
@@ -1682,7 +1681,6 @@ class AWSVPCFlowBucket(AWSLogsBucket):
                 ))
             except Exception as e:
                 debug("+++ Error marking log {} as completed: {}".format(log_file['Key'], e), 2)
-                raise e
 
 
 class AWSCustomBucket(AWSBucket):
@@ -1894,7 +1892,6 @@ class AWSCustomBucket(AWSBucket):
                 ))
             except Exception as e:
                 debug("+++ Error marking log {} as completed: {}".format(log_file['Key'], e), 2)
-                raise e
 
     def db_count_custom(self):
         """Counts the number of rows in DB for a region


### PR DESCRIPTION
|Related issue|
|---|
| Closes #8349 |

## Description

Hi team!

It turns out that AWS does not treat directories inside a bucket as folders. Moreover, there are some differences when a "folder" is created in the console vs in the CLI. It is better explained in [this issue update](https://github.com/wazuh/wazuh/issues/8349#issuecomment-826729562). 

In the (rare) occasions where a user creates a path like `.../us-east-1/CloudTrail/2020/05/01/` to store files using the Console, a 0-bytes object will be created for each folder. Thefore, when the AWS wodle lists all the objects inside `AWSLogs/<account_id>/CloudTrail/us-east-1/`, this will be returned:
- `AWSLogs/test_cloudtrail_suffix/<account_id>/Cloudtrail/us-east-1/2020/` (0-bytes object)
- `AWSLogs/test_cloudtrail_suffix/<account_id>/Cloudtrail/us-east-1/2020/05/` (0-bytes object)
- `AWSLogs/test_cloudtrail_suffix/<account_id>/Cloudtrail/us-east-1/2020/05/06/` (0-bytes object)
- `AWSLogs/<account_id>/CloudTrail/us-east-1/2020/05/06/<account_id>_CloudTrail_us-east-1_20200506T1115Z_WXBxpSwm2u3s7lxQ.json.gz` (n-bytes object)

However, the wodle tries to split the filenames by `_`:
https://github.com/wazuh/wazuh/blob/ae7d0ea8b5e78cb6169f34cc2b0cab2127f3c5da/wodles/aws/aws_s3.py#L897
which when no filename is found, raises an exception that is handled:
https://github.com/wazuh/wazuh/blob/ae7d0ea8b5e78cb6169f34cc2b0cab2127f3c5da/wodles/aws/aws_s3.py#L507-L518

The problem is that it is raised (`#L518`) even after handling the exception, so the wodle stops running and the remaining logs are not processed. On top of that, all queries marking the previous logs as processed are not sent to the db (they are not commited), but the logs were sent to analysisd. Therefore, next time the wodle is run the same logs will be processed and sent to analysisd, but never stored in the db.

This PR removes the `raise e` code so, if an invalid filename is processed, the wodle does not stop working. The error message will still be printed:
```
DEBUG: +++ Marker: AWSLogs/test_cloudtrail_suffix/<account_id>/CloudTrail/us-east-1/2018/06/01
DEBUG: ++ Found new log: AWSLogs/test_cloudtrail_suffix/<account_id>/CloudTrail/us-east-1/2020/
DEBUG: ++ Failed to parse file AWSLogs/test_cloudtrail_suffix/<account_id>/CloudTrail/us-east-1/2020/: Expecting value: line 1 column 1 (char 0); skipping...
DEBUG: +++ Error marking log AWSLogs/test_cloudtrail_suffix/<account_id>/CloudTrail/us-east-1/2020/ as completed: list index out of range
DEBUG: ++ Found new log: AWSLogs/test_cloudtrail_suffix/<account_id>/CloudTrail/us-east-1/2020/05/
DEBUG: ++ Failed to parse file AWSLogs/test_cloudtrail_suffix/<account_id>/CloudTrail/us-east-1/2020/05/: Expecting value: line 1 column 1 (char 0); skipping...
DEBUG: +++ Error marking log AWSLogs/test_cloudtrail_suffix/<account_id>/CloudTrail/us-east-1/2020/05/ as completed: list index out of range
DEBUG: ++ Found new log: AWSLogs/test_cloudtrail_suffix/<account_id>/CloudTrail/us-east-1/2020/05/06/
DEBUG: ++ Failed to parse file AWSLogs/test_cloudtrail_suffix/<account_id>/CloudTrail/us-east-1/2020/05/06/: Expecting value: line 1 column 1 (char 0); skipping...
DEBUG: +++ Error marking log AWSLogs/test_cloudtrail_suffix/<account_id>/CloudTrail/us-east-1/2020/05/06/ as completed: list index out of range
DEBUG: ++ Found new log: AWSLogs/test_cloudtrail_suffix/<account_id>/CloudTrail/us-east-1/2020/05/06/<account_id>_CloudTrail_us-east-1_20200506T1115Z_WXBxpSwm2u3s7lxQ.json.gz
DEBUG: ++ Found new log: AWSLogs/test_cloudtrail_suffix/<account_id>/CloudTrail/us-east-1/2020/05/06/<account_id>_CloudTrail_us-east-1_20200506T1115Z_iPfeDdpoI46Gw5lc.json.gz
DEBUG: ++ Found new log: AWSLogs/test_cloudtrail_suffix/<account_id>/CloudTrail/us-east-1/2020/05/06/<account_id>_CloudTrail_us-east-1_20200506T1120Z_4UcVcNPIGVrUKCeh.json.gz
```

Regards,
Selu. 