### PR TITLE
Move FIM directories configuration to their own struct

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -21,108 +21,6 @@ static void process_option(char ***syscheck_option, xml_node *node);
 /* Set check_all options in a directory/file */
 static void fim_set_check_all(int *opt);
 
-
-void organize_syscheck_dirs(syscheck_config *syscheck)
-{
-    if (syscheck->dir && syscheck->dir[0]) {
-        char **dir;
-        char **symbolic_links;
-        char **tag;
-        OSMatch **filerestrict;
-        int *opts;
-        int *recursion_level;
-        int *diff_size;
-
-        int i;
-        int j;
-        int dirs = 0;
-
-        while (syscheck->dir[dirs] != NULL) {
-            dirs++;
-        }
-
-        os_calloc(dirs + 1, sizeof(char *), dir);
-        os_calloc(dirs + 1, sizeof(char *), symbolic_links);
-        os_calloc(dirs + 1, sizeof(char *), tag);
-        os_calloc(dirs + 1, sizeof(OSMatch *), filerestrict);
-        os_calloc(dirs + 1, sizeof(int), opts);
-        os_calloc(dirs + 1, sizeof(int), recursion_level);
-        os_calloc(dirs + 1, sizeof(int), diff_size);
-
-        for (i = 0; i < dirs; ++i) {
-
-            char *current = NULL;
-            int pos = -1;
-
-            for (j = 0; j < dirs; ++j) {
-
-                if (syscheck->dir[j] == NULL) {
-                    continue;
-                }
-
-                if (current == NULL) {
-                    current = syscheck->dir[j];
-                    pos = j;
-                    continue;
-                }
-
-                if (strcmp(current, syscheck->dir[j]) > 0) {
-                    current = syscheck->dir[j];
-                    pos = j;
-                }
-            }
-
-            dir[i] = current;
-            dir[i + 1] = NULL;
-
-            symbolic_links[i] = (syscheck->symbolic_links[pos]) ? syscheck->symbolic_links[pos] : NULL;
-            symbolic_links[i + 1] = NULL;
-
-            tag[i] = (syscheck->tag[pos]) ? syscheck->tag[pos] : NULL;
-            tag[i + 1] = NULL;
-
-            filerestrict[i] = (syscheck->filerestrict[pos]) ? syscheck->filerestrict[pos] : NULL;
-            filerestrict[i + 1] = NULL;
-
-            opts[i] = syscheck->opts[pos];
-            opts[i + 1] = 0;
-
-            recursion_level[i] = syscheck->recursion_level[pos];
-            recursion_level[i + 1] = 0;
-
-            diff_size[i] = syscheck->diff_size_limit[pos];
-            diff_size[i + 1] = 0;
-
-            syscheck->dir[pos] = NULL;
-
-        }
-
-        os_free(syscheck->dir);
-        syscheck->dir = dir;
-
-        os_free(syscheck->symbolic_links);
-        syscheck->symbolic_links = symbolic_links;
-
-        os_free(syscheck->tag);
-        syscheck->tag = tag;
-
-        os_free(syscheck->filerestrict);
-        syscheck->filerestrict = filerestrict;
-
-        os_free(syscheck->opts);
-        syscheck->opts = opts;
-
-        os_free(syscheck->recursion_level);
-        syscheck->recursion_level = recursion_level;
-
-        os_free(syscheck->diff_size_limit);
-        syscheck->diff_size_limit = diff_size;
-    }
-    else {
-        mdebug2("No directory entries to organize in syscheck configuration.");
-    }
-}
-
 void dump_syscheck_file(syscheck_config *syscheck,
                         char *entry,
                         int vals,
@@ -131,150 +29,63 @@ void dump_syscheck_file(syscheck_config *syscheck,
                         const char *tag,
                         const char *link,
                         int diff_size) {
+    directory_t *new_entry;
+    directory_t *dir_it;
+    int i = 0;
 
-    unsigned int pl = 0;
-    int overwrite = -1;
-    int j;
+    os_calloc(1, sizeof(directory_t), new_entry);
 
-    for (j = 0; syscheck->dir && syscheck->dir[j]; j++) {
-        /* Duplicate entry */
-        if (strcmp(syscheck->dir[j], entry) == 0) {
-            mdebug2("Overwriting the file entry %s", entry);
-            overwrite = j;
-        }
-    }
-
-    /* If overwrite < 0, syscheck entry is added at the end */
-    if (overwrite != -1) {
-        pl = overwrite;
-    }
-
-    if (syscheck->dir == NULL) {
-        os_calloc(2, sizeof(char *), syscheck->dir);
-
-        // If a symbolic link is configured, `link` is the configured path
-        // and `entry` is the resolved path
-        os_strdup(link == NULL ? entry : link, syscheck->dir[pl]);
-
-        syscheck->dir[1] = NULL;
-
-#ifdef WIN32
-        os_calloc(2, sizeof(whodata_dir_status), syscheck->wdata.dirs_status);
-#endif
-        os_calloc(2, sizeof(char *), syscheck->symbolic_links);
-
-        syscheck->symbolic_links[0] = NULL;
-        syscheck->symbolic_links[1] = NULL;
-
-        if (link != NULL && (CHECK_FOLLOW & vals)) {
-            os_strdup(entry, syscheck->symbolic_links[0]);
-        }
-
-        os_calloc(2, sizeof(int), syscheck->opts);
-        syscheck->opts[0] = vals;
-
-        os_calloc(2, sizeof(int), syscheck->diff_size_limit);
-
-        // If diff_size has not been set in read_attr, assign -1 to modify it later with the global value
-        if (diff_size == -1) {
-            syscheck->diff_size_limit[0] = -1;
-        } else {
-            syscheck->diff_size_limit[0] = diff_size;
-        }
-
-        os_calloc(2, sizeof(OSMatch *), syscheck->filerestrict);
-
-        os_calloc(2, sizeof(int), syscheck->recursion_level);
-        syscheck->recursion_level[0] = recursion_limit;
-
-        os_calloc(2, sizeof(char *), syscheck->tag);
-    } else if (overwrite < 0) {
-        while (syscheck->dir[pl] != NULL) {
-            pl++;
-        }
-
-        os_realloc(syscheck->dir, (pl + 2) * sizeof(char *), syscheck->dir);
-
-        os_strdup(link == NULL ? entry : link, syscheck->dir[pl]);
-
-        syscheck->dir[pl + 1] = NULL;
-
-#ifdef WIN32
-        os_realloc(syscheck->wdata.dirs_status, (pl + 2) * sizeof(whodata_dir_status), syscheck->wdata.dirs_status);
-        memset(syscheck->wdata.dirs_status + pl, 0, 2 * sizeof(whodata_dir_status));
-#endif
-
-        os_realloc(syscheck->symbolic_links, (pl + 2) * sizeof(char *), syscheck->symbolic_links);
-
-        syscheck->symbolic_links[pl] = NULL;
-        syscheck->symbolic_links[pl + 1] = NULL;
-
-        if (link != NULL && (CHECK_FOLLOW & vals)) {
-            os_strdup(entry, syscheck->symbolic_links[pl]);
-        }
-
-        os_realloc(syscheck->opts, (pl + 2) * sizeof(int), syscheck->opts);
-        syscheck->opts[pl] = vals;
-        syscheck->opts[pl + 1] = 0;
-
-        os_realloc(syscheck->diff_size_limit, (pl + 2) * sizeof(int), syscheck->diff_size_limit);
-
-        if (diff_size == -1) {
-            syscheck->diff_size_limit[pl] = -1;
-        } else {
-            syscheck->diff_size_limit[pl] = diff_size;
-        }
-
-        syscheck->diff_size_limit[pl + 1] = 0;
-
-        os_realloc(syscheck->filerestrict, (pl + 2) * sizeof(OSMatch *), syscheck->filerestrict);
-        syscheck->filerestrict[pl] = NULL;
-        syscheck->filerestrict[pl + 1] = NULL;
-
-        os_realloc(syscheck->recursion_level, (pl + 2) * sizeof(int), syscheck->recursion_level);
-        syscheck->recursion_level[pl] = recursion_limit;
-        syscheck->recursion_level[pl + 1] = 0;
-
-        os_realloc(syscheck->tag, (pl + 2) * sizeof(char *), syscheck->tag);
-        syscheck->tag[pl] = NULL;
-        syscheck->tag[pl + 1] = NULL;
+    if (link == NULL) {
+        os_strdup(entry, new_entry->path);
     } else {
-        os_free(syscheck->dir[pl]);
-        os_free(syscheck->symbolic_links[pl]);
-
-        os_strdup(link == NULL ? entry : link, syscheck->dir[pl]);
-        if (link != NULL && (CHECK_FOLLOW & vals)) {
-            os_strdup(entry, syscheck->symbolic_links[pl]);
+        os_strdup(link, new_entry->path);
+        if (CHECK_FOLLOW & vals) {
+            os_strdup(entry, new_entry->symbolic_links);
         }
-
-        syscheck->opts[pl] = vals;
-
-        if (diff_size == -1) {
-            syscheck->diff_size_limit[pl] = -1;
-        } else {
-            syscheck->diff_size_limit[pl] = diff_size;
-        }
-
-        os_free(syscheck->filerestrict[pl]);
-        syscheck->recursion_level[pl] = recursion_limit;
-        os_free(syscheck->tag[pl]);
     }
+
+    new_entry->options = vals;
+    new_entry->diff_size_limit = diff_size;
+    new_entry->recursion_level = recursion_limit;
 
     if (restrictfile) {
-        os_calloc(1, sizeof(OSMatch), syscheck->filerestrict[pl]);
-        if (!OSMatch_Compile(restrictfile, syscheck->filerestrict[pl], 0)) {
-            OSMatch *ptm;
-
-            ptm = syscheck->filerestrict[pl];
-
-            merror(REGEX_COMPILE, restrictfile, ptm->error);
-            free(syscheck->filerestrict[pl]);
-            syscheck->filerestrict[pl] = NULL;
+        os_calloc(1, sizeof(OSMatch), new_entry->filerestrict);
+        if (!OSMatch_Compile(restrictfile, new_entry->filerestrict, 0)) {
+            merror(REGEX_COMPILE, restrictfile, new_entry->filerestrict->error);
+            os_free(new_entry->filerestrict);
         }
     }
+
     if (tag) {
-        os_strdup(tag, syscheck->tag[pl]);
+        os_strdup(tag, new_entry->tag);
     }
+
+    // Now we find where to place this new entry
+    if (syscheck->directories == NULL) {
+        os_calloc(2, sizeof(directory_t *), syscheck->directories);
+
+        syscheck->directories[0] = new_entry;
+        return;
+    }
+
+    for (i = 0, dir_it = syscheck->directories[0]; dir_it != NULL; dir_it = syscheck->directories[++i]) {
+        int cmp = strcmp(dir_it->path, new_entry->path);
+        if (cmp == 0) {
+            // Duplicated entry, replace existing with new one
+            free_directory(syscheck->directories[i]);
+            syscheck->directories[i] = new_entry;
+            return;
+        } else if (cmp > 0) {
+            // Replace the current entry and move the one we took next.
+            syscheck->directories[i] = new_entry;
+            new_entry = dir_it;
+        }
+    }
+
+    // Add as new entry
+    os_realloc(syscheck->directories, (i + 2) * sizeof(directory_t *), syscheck->directories);
+    syscheck->directories[i] = new_entry;
+    syscheck->directories[i + 1] = NULL;
 }
 
 #ifdef WIN32
@@ -2185,8 +1996,6 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
         }
     }
 
-    organize_syscheck_dirs(syscheck);
-
     return (0);
 }
 
@@ -2263,12 +2072,26 @@ int Test_Syscheck(const char * path){
     }
 }
 
+void free_directory(directory_t *dir) {
+    if (dir == NULL) {
+        return;
+    }
+
+    os_free(dir->path);
+    os_free(dir->symbolic_links);
+    os_free(dir->tag);
+
+    if (dir->filerestrict) {
+        OSMatch_FreePattern(dir->filerestrict);
+        free(dir->filerestrict);
+    }
+
+    free(dir);
+}
+
 void Free_Syscheck(syscheck_config * config) {
     if (config) {
         int i;
-        if (config->opts) {
-            free(config->opts);
-        }
         if (config->scan_day) {
             free(config->scan_day);
         }
@@ -2301,40 +2124,14 @@ void Free_Syscheck(syscheck_config * config) {
             }
             free(config->nodiff_regex);
         }
-        if (config->dir) {
-            for (i=0; config->dir[i] != NULL; i++) {
-                free(config->dir[i]);
-                if(config->filerestrict && config->filerestrict[i]) {
-                    OSMatch_FreePattern(config->filerestrict[i]);
-                    free(config->filerestrict[i]);
-                }
-                if(config->tag && config->tag[i]) {
-                    free(config->tag[i]);
-                }
+        if (config->directories) {
+            for (i = 0; config->directories[i] != NULL; i++) {
+                free_directory(config->directories[i]);
             }
-            free(config->dir);
-            if (config->filerestrict) {
-                free(config->filerestrict);
-            }
-            if (config->tag) {
-                free(config->tag);
-            }
-        }
-        if (config->symbolic_links) {
-            for (i=0; config->symbolic_links[i] != NULL; i++) {
-                free(config->symbolic_links[i]);
-            }
-            free(config->symbolic_links);
-        }
-        if (config->recursion_level) {
-            free(config->recursion_level);
+            free(config->directories);
         }
 
-        if (config->diff_size_limit) {
-            os_free(config->diff_size_limit);
-        }
-
-    #ifdef WIN32
+#ifdef WIN32
         if (config->key_ignore) {
             for (i=0; config->key_ignore[i].entry != NULL; i++) {
                 free(config->key_ignore[i].entry);

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -80,6 +80,12 @@ typedef enum fdb_stmt {
     FIMDB_STMT_SIZE
 } fdb_stmt;
 
+// The following foreach is really hacky, beware!!
+// It will only work with arrays that end on a NULL element
+#define foreach_array(iterator, array)            \
+    iterator = (array != NULL) ? array[0] : NULL; \
+    for (int _i = 0; iterator != NULL; iterator = array[++_i])
+
 #define FIM_MODE(x) (x & WHODATA_ACTIVE ? FIM_WHODATA : x & REALTIME_ACTIVE ? FIM_REALTIME : FIM_SCHEDULED)
 
 #if defined(WIN32) && defined(EVENTCHANNEL_SUPPORT)
@@ -170,6 +176,40 @@ typedef struct _rtfim {
 
 typedef enum fim_type {FIM_TYPE_FILE, FIM_TYPE_REGISTRY} fim_type;
 
+#ifdef WIN32
+
+typedef struct whodata_dir_status {
+    int status;
+    char object_type;
+    SYSTEMTIME last_check;
+} whodata_dir_status;
+
+typedef ULARGE_INTEGER whodata_directory;
+
+typedef struct whodata {
+    OSHash *fd;          // Open file descriptors
+    OSHash *directories; // Directories checked by whodata mode
+    int interval_scan;   // Time interval between scans of the checking thread
+    char **device;        // Hard disk devices
+    char **drive;         // Drive letter
+} whodata;
+
+#endif /* End WIN32*/
+
+typedef struct _directory_s {
+    char *path;
+    int options;
+    int diff_size_limit; /* Apply the file size limit option in a specific directory */
+    char *symbolic_links;
+    OSMatch *filerestrict;
+    int recursion_level;
+    char *tag; /* array of tags for each directory */
+#ifdef WIN32
+    // Windows specific fields
+    whodata_dir_status dirs_status; // Status list
+#endif
+} directory_t;
+
 typedef struct whodata_evt {
     char *user_id;
     char *user_name;
@@ -193,30 +233,9 @@ typedef struct whodata_evt {
     unsigned __int64 process_id;
     unsigned int mask;
     char scan_directory;
-    int config_node;
+    directory_t *config_node;
 #endif
 } whodata_evt;
-
-#ifdef WIN32
-
-typedef struct whodata_dir_status {
-    int status;
-    char object_type;
-    SYSTEMTIME last_check;
-} whodata_dir_status;
-
-typedef ULARGE_INTEGER whodata_directory;
-
-typedef struct whodata {
-    OSHash *fd;                         // Open file descriptors
-    OSHash *directories;                // Directories checked by whodata mode
-    int interval_scan;                  // Time interval between scans of the checking thread
-    whodata_dir_status *dirs_status;    // Status list
-    char **device;                       // Hard disk devices
-    char **drive;                        // Drive letter
-} whodata;
-
-#endif /* End WIN32*/
 
 #ifdef WIN32
 
@@ -347,7 +366,7 @@ typedef struct _config {
     unsigned int enable_synchronization:1;    /* Enable database synchronization */
     unsigned int enable_registry_synchronization:1; /* Enable registry database synchronization */
 
-    int *opts;                      /* attributes set in the <directories> tag element */
+    directory_t **directories; /* List of directories to be monitored */
 
     char *scan_day;                 /* run syscheck on this day */
     char *scan_time;                /* run syscheck at this time */
@@ -362,7 +381,6 @@ typedef struct _config {
     int disk_quota_limit;           /* Controls the increase of the size of the queue/diff/local folder (in KB) */
     int file_size_enabled;          /* Enable diff file size limit */
     int file_size_limit;            /* Avoids generating a backup from a file bigger than this limit (in KB) */
-    int *diff_size_limit;           /* Apply the file size limit option in a specific directory */
     float diff_folder_size;         /* Save size of queue/diff/local folder */
     float comp_estimation_perc;     /* Estimation of the percentage of compression each file will have */
     uint16_t disk_quota_full_msg;   /* Specify if the full disk_quota message can be written (Once per scan) */
@@ -372,12 +390,6 @@ typedef struct _config {
     char **nodiff;                  /* list of files/dirs to never output diff */
     OSMatch **nodiff_regex;         /* regex of files/dirs to never output diff */
 
-    char **dir;                     /* array of directories to be scanned */
-    char **symbolic_links;         /* array of converted links directories */
-    OSMatch **filerestrict;
-    int *recursion_level;
-
-    char **tag;                     /* array of tags for each directory */
     long max_sync_interval;         /* Maximum Synchronization interval (seconds) */
     long sync_interval;             /* Synchronization interval (seconds) */
     long sync_response_timeout;     /* Minimum time between receiving a sync response and starting a new sync session */
@@ -417,13 +429,6 @@ typedef struct _config {
     int process_priority; // Adjusts the priority of the process (or threads in Windows)
     bool allow_remote_prefilter_cmd;
 } syscheck_config;
-
-/**
- * @brief Organizes syscheck directories and related data according to their priority (whodata-realtime-scheduled) and in alphabetical order
- *
- * @param syscheck Syscheck configuration structure
- */
-void organize_syscheck_dirs(syscheck_config *syscheck) __attribute__((nonnull(1)));
 
 /**
  * @brief Converts the value written in the configuration to a determined data unit in KB
@@ -502,6 +507,13 @@ char *syscheck_opts2str(char *buf, int buflen, int opts);
  * @param [out] config The syscheck configuration to free
  */
 void Free_Syscheck(syscheck_config *config);
+
+/**
+ * @brief Frees the memory of a directory_t structure
+ *
+ * @param dir The directory to be free'd
+ */
+void free_directory(directory_t *dir);
 
 /**
  * @brief Transforms an ASCII text to HEX

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -14,7 +14,6 @@
 #include "rootcheck/rootcheck.h"
 
 #ifdef WIN32
-static char *SYSCHECK_EMPTY[] = { NULL };
 static registry REGISTRY_EMPTY[] = { { NULL, 0, 0, 512, 0, NULL, NULL, NULL} };
 #endif
 
@@ -22,7 +21,8 @@ static registry REGISTRY_EMPTY[] = { { NULL, 0, 0, 512, 0, NULL, NULL, NULL} };
 int Read_Syscheck_Config(const char *cfgfile)
 {
     int modules = 0;
-    int it = 0;
+    directory_t *dir_it;
+
     modules |= CSYSCHECK;
 
     syscheck.rootcheck      = 0;
@@ -42,8 +42,7 @@ int Read_Syscheck_Config(const char *cfgfile)
     syscheck.scan_time      = NULL;
     syscheck.file_limit_enabled = true;
     syscheck.file_limit     = 100000;
-    syscheck.dir            = NULL;
-    syscheck.opts           = NULL;
+    syscheck.directories = NULL;
     syscheck.enable_synchronization = 1;
     syscheck.restart_audit  = 1;
     syscheck.enable_whodata = 0;
@@ -99,22 +98,14 @@ int Read_Syscheck_Config(const char *cfgfile)
     ReadConfig(modules, AGENTCONFIG, &syscheck, NULL);
 #endif
 
-    // Check directories options to determine whether to start the whodata thread or not
-    if (syscheck.dir) {
-        for (it = 0; syscheck.dir[it]; it++) {
-            if (syscheck.opts[it] & WHODATA_ACTIVE) {
-                syscheck.enable_whodata = 1;
-
-                break;  // Exit loop with the first whodata directory
-            }
+    foreach_array(dir_it, syscheck.directories) {
+        if (dir_it->diff_size_limit == -1) {
+            dir_it->diff_size_limit = syscheck.file_size_limit;
         }
-    }
 
-    if (syscheck.diff_size_limit) {
-        for (it = 0; syscheck.diff_size_limit[it]; it++) {
-            if (syscheck.diff_size_limit[it] == -1) {
-                syscheck.diff_size_limit[it] = syscheck.file_size_limit;
-            }
+        // Check directories options to determine whether to start the whodata thread or not
+        if (dir_it->options & WHODATA_ACTIVE) {
+            syscheck.enable_whodata = 1;
         }
     }
 
@@ -128,22 +119,19 @@ int Read_Syscheck_Config(const char *cfgfile)
 
 #ifndef WIN32
     /* We must have at least one directory to check */
-    if (!syscheck.dir || syscheck.dir[0] == NULL) {
+    if (syscheck.directories == NULL || syscheck.directories[0] == NULL) {
         return (1);
     }
 #else
-    /* We must have at least one directory or registry key to check. Since
-       it's possible on Windows to have syscheck enabled but only monitoring
-       either the filesystem or the registry, both lists must be valid,
-       even if empty.
+    /* It used to be that we needed to ensure the dir array was not null
+       and had at least a null element, this is no longer the case. In Windows,
+       if syscheck.directories is null nothing will go wrong.
+       syscheck.registry though... That's a different story.
      */
-    if (!syscheck.dir) {
-        syscheck.dir = SYSCHECK_EMPTY;
-    }
     if (!syscheck.registry) {
             syscheck.registry = REGISTRY_EMPTY;
     } else {
-        it = 0;
+        int it = 0;
         while (syscheck.registry[it].entry) {
             if (syscheck.registry[it].diff_size_limit == -1) {
                 syscheck.registry[it].diff_size_limit = syscheck.file_size_limit;
@@ -151,7 +139,7 @@ int Read_Syscheck_Config(const char *cfgfile)
             it++;
         }
     }
-    if ((syscheck.dir[0] == NULL) && (syscheck.registry[0].entry == NULL)) {
+    if ((syscheck.directories == NULL) && (syscheck.registry[0].entry == NULL)) {
         return (1);
     }
     syscheck.max_fd_win_rt = getDefine_Int("syscheck", "max_fd_win_rt", 1, 1024);
@@ -186,9 +174,11 @@ void free_whodata_event(whodata_evt *w_evt) {
 
 cJSON *getSyscheckConfig(void) {
 
-    if (!syscheck.dir) {
+#ifndef WIN32
+    if (!syscheck.directories) {
         return NULL;
     }
+#endif
 
     cJSON *root = cJSON_CreateObject();
     cJSON *syscfg = cJSON_CreateObject();
@@ -224,40 +214,73 @@ cJSON *getSyscheckConfig(void) {
 
     cJSON_AddItemToObject(syscfg, "diff", diff);
 
-    if (syscheck.dir) {
+    if (syscheck.directories) {
+        directory_t *dir_it;
         cJSON *dirs = cJSON_CreateArray();
-        for (i=0;syscheck.dir[i];i++) {
+
+        foreach_array(dir_it, syscheck.directories) {
             cJSON *pair = cJSON_CreateObject();
             cJSON *opts = cJSON_CreateArray();
-            if (syscheck.opts[i] & CHECK_MD5SUM) cJSON_AddItemToArray(opts, cJSON_CreateString("check_md5sum"));
-            if (syscheck.opts[i] & CHECK_SHA1SUM) cJSON_AddItemToArray(opts, cJSON_CreateString("check_sha1sum"));
-            if (syscheck.opts[i] & CHECK_PERM) cJSON_AddItemToArray(opts, cJSON_CreateString("check_perm"));
-            if (syscheck.opts[i] & CHECK_SIZE) cJSON_AddItemToArray(opts, cJSON_CreateString("check_size"));
-            if (syscheck.opts[i] & CHECK_OWNER) cJSON_AddItemToArray(opts, cJSON_CreateString("check_owner"));
-            if (syscheck.opts[i] & CHECK_GROUP) cJSON_AddItemToArray(opts, cJSON_CreateString("check_group"));
-            if (syscheck.opts[i] & CHECK_MTIME) cJSON_AddItemToArray(opts, cJSON_CreateString("check_mtime"));
-            if (syscheck.opts[i] & CHECK_INODE) cJSON_AddItemToArray(opts, cJSON_CreateString("check_inode"));
-            if (syscheck.opts[i] & REALTIME_ACTIVE) cJSON_AddItemToArray(opts, cJSON_CreateString("realtime"));
-            if (syscheck.opts[i] & CHECK_SEECHANGES) cJSON_AddItemToArray(opts, cJSON_CreateString("report_changes"));
-            if (syscheck.opts[i] & CHECK_SHA256SUM) cJSON_AddItemToArray(opts, cJSON_CreateString("check_sha256sum"));
-            if (syscheck.opts[i] & WHODATA_ACTIVE) cJSON_AddItemToArray(opts, cJSON_CreateString("check_whodata"));
-#ifdef WIN32
-            if (syscheck.opts[i] & CHECK_ATTRS) cJSON_AddItemToArray(opts, cJSON_CreateString("check_attrs"));
-#endif
-            if (syscheck.opts[i] & CHECK_FOLLOW) cJSON_AddItemToArray(opts, cJSON_CreateString("follow_symbolic_link"));
-            cJSON_AddItemToObject(pair,"opts",opts);
-            cJSON_AddStringToObject(pair,"dir",syscheck.dir[i]);
-            if (syscheck.symbolic_links[i]) cJSON_AddStringToObject(pair,"symbolic_link",syscheck.symbolic_links[i]);
-            cJSON_AddNumberToObject(pair,"recursion_level",syscheck.recursion_level[i]);
-            if (syscheck.filerestrict && syscheck.filerestrict[i]) {
-                cJSON_AddStringToObject(pair,"restrict",syscheck.filerestrict[i]->raw);
+            if (dir_it->options & CHECK_MD5SUM) {
+                cJSON_AddItemToArray(opts, cJSON_CreateString("check_md5sum"));
             }
-            if (syscheck.tag && syscheck.tag[i]) {
-                cJSON_AddStringToObject(pair,"tags",syscheck.tag[i]);
+            if (dir_it->options & CHECK_SHA1SUM) {
+                cJSON_AddItemToArray(opts, cJSON_CreateString("check_sha1sum"));
+            }
+            if (dir_it->options & CHECK_PERM) {
+                cJSON_AddItemToArray(opts, cJSON_CreateString("check_perm"));
+            }
+            if (dir_it->options & CHECK_SIZE) {
+                cJSON_AddItemToArray(opts, cJSON_CreateString("check_size"));
+            }
+            if (dir_it->options & CHECK_OWNER) {
+                cJSON_AddItemToArray(opts, cJSON_CreateString("check_owner"));
+            }
+            if (dir_it->options & CHECK_GROUP) {
+                cJSON_AddItemToArray(opts, cJSON_CreateString("check_group"));
+            }
+            if (dir_it->options & CHECK_MTIME) {
+                cJSON_AddItemToArray(opts, cJSON_CreateString("check_mtime"));
+            }
+            if (dir_it->options & CHECK_INODE) {
+                cJSON_AddItemToArray(opts, cJSON_CreateString("check_inode"));
+            }
+            if (dir_it->options & REALTIME_ACTIVE) {
+                cJSON_AddItemToArray(opts, cJSON_CreateString("realtime"));
+            }
+            if (dir_it->options & CHECK_SEECHANGES) {
+                cJSON_AddItemToArray(opts, cJSON_CreateString("report_changes"));
+            }
+            if (dir_it->options & CHECK_SHA256SUM) {
+                cJSON_AddItemToArray(opts, cJSON_CreateString("check_sha256sum"));
+            }
+            if (dir_it->options & WHODATA_ACTIVE) {
+                cJSON_AddItemToArray(opts, cJSON_CreateString("check_whodata"));
+            }
+#ifdef WIN32
+            if (dir_it->options & CHECK_ATTRS) {
+                cJSON_AddItemToArray(opts, cJSON_CreateString("check_attrs"));
+            }
+#endif
+            if (dir_it->options & CHECK_FOLLOW) {
+                cJSON_AddItemToArray(opts, cJSON_CreateString("follow_symbolic_link"));
             }
 
-            if (syscheck.file_size_enabled && syscheck.diff_size_limit[i]) {
-                cJSON_AddNumberToObject(pair, "diff_size_limit", syscheck.diff_size_limit[i]);
+            cJSON_AddItemToObject(pair,"opts",opts);
+            cJSON_AddStringToObject(pair, "dir", dir_it->path);
+            if (dir_it->symbolic_links) {
+                cJSON_AddStringToObject(pair, "symbolic_link", dir_it->symbolic_links);
+            }
+            cJSON_AddNumberToObject(pair, "recursion_level", dir_it->recursion_level);
+            if (dir_it->filerestrict) {
+                cJSON_AddStringToObject(pair, "restrict", dir_it->filerestrict->raw);
+            }
+            if (dir_it->tag) {
+                cJSON_AddStringToObject(pair, "tags", dir_it->tag);
+            }
+
+            if (syscheck.file_size_enabled && dir_it->diff_size_limit) {
+                cJSON_AddNumberToObject(pair, "diff_size_limit", dir_it->diff_size_limit);
             }
 
             cJSON_AddItemToArray(dirs, pair);

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -483,8 +483,8 @@ static fim_sanitize_state_t fim_process_file_from_db(const char *path, OSList *s
         configuration = fim_configuration_directory(path);
         if (configuration == NULL) {
             // This should not happen
-            free_entry(entry);
-            return FIM_FILE_ERROR;
+            free_entry(entry);     // LCOV_EXCL_LINE
+            return FIM_FILE_ERROR; // LCOV_EXCL_LINE
         }
 
         *event = _fim_file_force_update(entry, configuration, &evt_data);
@@ -501,8 +501,8 @@ end:
     configuration = fim_configuration_directory(path);
     if (configuration == NULL) {
         // This should not happen
-        free_entry(entry);
-        return FIM_FILE_ERROR;
+        free_entry(entry);     // LCOV_EXCL_LINE
+        return FIM_FILE_ERROR; // LCOV_EXCL_LINE
     }
 
     *event = _fim_file(path, configuration, &evt_data);
@@ -825,9 +825,9 @@ void fim_whodata_event(whodata_evt * w_evt) {
         // Otherwise, it could be a file deleted or a directory moved (or renamed).
         fim_process_missing_entry(w_evt->path, FIM_WHODATA, w_evt);
 #ifndef WIN32
-        char** paths = NULL;
-        const unsigned long int inode = strtoul(w_evt->inode,NULL,10);
-        const unsigned long int dev = strtoul(w_evt->dev,NULL,10);
+        char **paths = NULL;
+        const unsigned long int inode = strtoul(w_evt->inode, NULL, 10);
+        const unsigned long int dev = strtoul(w_evt->dev, NULL, 10);
 
         w_mutex_lock(&syscheck.fim_entry_mutex);
         paths = fim_db_get_paths_from_inode(syscheck.database, inode, dev);
@@ -1136,15 +1136,15 @@ fim_file_data *fim_get_data(const char *file, const directory_t *configuration, 
         }
     }
 
-    if (!(configuration->options & CHECK_MD5SUM)) {
+    if ((configuration->options & CHECK_MD5SUM) == 0) {
         data->hash_md5[0] = '\0';
     }
 
-    if (!(configuration->options & CHECK_SHA1SUM)) {
+    if ((configuration->options & CHECK_SHA1SUM) == 0) {
         data->hash_sha1[0] = '\0';
     }
 
-    if (!(configuration->options & CHECK_SHA256SUM)) {
+    if ((configuration->options & CHECK_SHA256SUM) == 0) {
         data->hash_sha256[0] = '\0';
     }
 

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -47,39 +47,44 @@ static const char *FIM_EVENT_MODE[] = {
     "whodata"
 };
 
-static cJSON *_fim_file(const char *file, fim_element *item, whodata_evt *w_evt);
+static cJSON *
+_fim_file(const char *path, const directory_t *configuration, event_data_t *evt_data, const struct stat *statbuf);
 
 #ifndef WIN32
-static cJSON *_fim_file_force_update(const char *path, const fim_element *item, const fim_entry *saved);
+static cJSON *_fim_file_force_update(const fim_entry *saved,
+                                     const directory_t *configuration,
+                                     event_data_t *evt_data,
+                                     const struct stat *statbuf);
 #endif
 
-void fim_delete_file_event(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex,
-                           __attribute__((unused))void *alert,
-                           __attribute__((unused))void *fim_ev_mode,
-                           __attribute__((unused))void *w_evt) {
-    int *send_alert = (int *) alert;
-    fim_event_mode mode = (fim_event_mode) fim_ev_mode;
+void fim_delete_file_event(fdb_t *fim_sql,
+                           fim_entry *entry,
+                           pthread_mutex_t *mutex,
+                           void *_evt_data,
+                           __attribute__((unused)) void *_unused_field_1,
+                           __attribute__((unused)) void *_unused_field_2) {
+    event_data_t *evt_data = (event_data_t *)_evt_data;
+    const directory_t *configuration = NULL;
     cJSON *json_event = NULL;
-    int pos = -1;
 
-    pos = fim_configuration_directory(entry->file_entry.path);
+    configuration = fim_configuration_directory(entry->file_entry.path);
 
-    if(pos == -1) {
+    if (configuration == NULL) {
         mdebug2(FIM_DELETE_EVENT_PATH_NOCONF, entry->file_entry.path);
         return;
     }
     /* Don't send alert if received mode and mode in configuration aren't the same.
        Scheduled mode events must always be processed to preserve the state of the agent's DB.
     */
-    switch (mode) {
+    switch (evt_data->mode) {
     case FIM_REALTIME:
-        if (!(syscheck.opts[pos] & REALTIME_ACTIVE)) {
+        if (!(configuration->options & REALTIME_ACTIVE)) {
             return;
         }
         break;
 
     case FIM_WHODATA:
-        if (!(syscheck.opts[pos] & WHODATA_ACTIVE)) {
+        if (!(configuration->options & WHODATA_ACTIVE)) {
             return;
         }
         break;
@@ -88,7 +93,7 @@ void fim_delete_file_event(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mu
         break;
     }
 
-    if (syscheck.opts[pos] & CHECK_SEECHANGES) {
+    if (configuration->options & CHECK_SEECHANGES) {
         fim_diff_process_delete_file(entry->file_entry.path);
     }
 
@@ -99,9 +104,8 @@ void fim_delete_file_event(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mu
         return;
     }
 
-    if (send_alert) {
-        json_event =
-        fim_json_event(entry->file_entry.path, NULL, entry->file_entry.data, pos, FIM_DELETE, mode, w_evt, NULL);
+    if (evt_data->report_event) {
+        json_event = fim_json_event(entry, NULL, configuration, evt_data, NULL);
     }
     w_mutex_unlock(mutex);
 
@@ -115,14 +119,13 @@ void fim_delete_file_event(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mu
 
 
 time_t fim_scan() {
-    int it = 0;
     struct timespec start;
     struct timespec end;
     time_t end_of_scan;
     clock_t cputime_start;
     int nodes_count = 0;
-    struct fim_element item;
-    char *real_path = NULL;
+    directory_t *dir_it;
+
     cputime_start = clock();
     gettime(&start);
     minfo(FIM_FREQUENCY_STARTED);
@@ -140,20 +143,17 @@ time_t fim_scan() {
     fim_db_set_all_unscanned(syscheck.database);
     w_mutex_unlock(&syscheck.fim_entry_mutex);
 
-    while (syscheck.dir[it] != NULL) {
-        memset(&item, 0, sizeof(fim_element));
-        item.mode = FIM_SCHEDULED;
-        item.index = it;
-        real_path = fim_get_real_path(it);
+    foreach_array(dir_it, syscheck.directories) {
+        event_data_t evt_data = { .mode = FIM_SCHEDULED, .report_event = true, .w_evt = NULL };
+        char *path = fim_get_real_path(dir_it);
 
-        fim_checker(real_path, &item, NULL, 1);
+        fim_checker(path, &evt_data, dir_it);
 #ifndef WIN32
-        if (syscheck.opts[it] & REALTIME_ACTIVE) {
-            realtime_adddir(real_path, 0, (syscheck.opts[it] & CHECK_FOLLOW) ? 1 : 0);
+        if (dir_it->options & REALTIME_ACTIVE) {
+            realtime_adddir(path, dir_it, (dir_it->options & CHECK_FOLLOW) ? 1 : 0);
         }
 #endif
-        free(real_path);
-        it++;
+        os_free(path);
     }
 
     w_mutex_unlock(&syscheck.fim_scan_mutex);
@@ -171,19 +171,25 @@ time_t fim_scan() {
     check_deleted_files();
 
     if (syscheck.file_limit_enabled && (nodes_count >= syscheck.file_limit)) {
-        it = 0;
-
         w_mutex_lock(&syscheck.fim_scan_mutex);
 
-        while ((syscheck.dir[it] != NULL) && (!syscheck.database->full)) {
-            memset(&item, 0, sizeof(fim_element));
-            item.mode = FIM_SCHEDULED;
-            item.index = it;
-            real_path = fim_get_real_path(it);
+        foreach_array(dir_it, syscheck.directories) {
+            char *path;
+            event_data_t evt_data = { .mode = FIM_SCHEDULED, .report_event = true, .w_evt = NULL };
 
-            fim_checker(real_path, &item, NULL, 0);
-            free(real_path);
-            it++;
+            w_mutex_lock(&syscheck.fim_entry_mutex);
+            if (syscheck.database->full) {
+                w_mutex_unlock(&syscheck.fim_entry_mutex);
+
+                break;
+            }
+            w_mutex_unlock(&syscheck.fim_entry_mutex);
+
+            path = fim_get_real_path(dir_it);
+
+            fim_checker(path, &evt_data, dir_it);
+
+            os_free(path);
         }
 
         w_mutex_unlock(&syscheck.fim_scan_mutex);
@@ -230,9 +236,11 @@ time_t fim_scan() {
     return end_of_scan;
 }
 
-void fim_checker(const char *path, fim_element *item, whodata_evt *w_evt, int report) {
-    int node;
+void fim_checker(const char *path, event_data_t *evt_data, const directory_t *parent_configuration) {
+    directory_t *configuration;
     int depth;
+    fim_entry *saved_entry = NULL;
+    struct stat statbuf;
 
 #ifdef WIN32
     // Ignore the recycle bin.
@@ -241,36 +249,37 @@ void fim_checker(const char *path, fim_element *item, whodata_evt *w_evt, int re
     }
 #endif
 
-    if (item->mode == FIM_SCHEDULED) {
-        // If the directory have another configuration will come back
-        if (node = fim_configuration_directory(path), node < 0 || item->index != node) {
-            return;
-        }
-    } else {
-        if (node = fim_configuration_directory(path), node < 0) {
-            return;
-        }
-    }
-
-    // We need to process every event generated by scheduled scans because we need to
-    // alert about discarded events of real-time and Whodata mode
-    if (item->mode != FIM_SCHEDULED && item->mode != FIM_MODE(syscheck.opts[node])) {
+    configuration = fim_configuration_directory(path);
+    if (configuration == NULL) {
         return;
     }
 
-    depth = fim_check_depth(path, node);
+    if (parent_configuration == NULL) {
+        // First time entering fim_checker
+        // It's dangerous to go alone! Take this.
+        parent_configuration = configuration;
+    }
 
-    if (depth > syscheck.recursion_level[node]) {
-        mdebug2(FIM_MAX_RECURSION_LEVEL, depth, syscheck.recursion_level[node], path);
+    if (evt_data->mode == FIM_SCHEDULED) {
+        // If the directory has another configuration will scan it with that configuration
+        if (parent_configuration != configuration) {
+            return;
+        }
+    } else if (evt_data->mode != FIM_MODE(configuration->options)) {
+        // If this event is not generated by a scan, the mode of the event and
+        // the mode configured must match
         return;
     }
 
-    item->index = node;
-    item->configuration = syscheck.opts[node];
-    fim_entry *saved_entry = NULL;
+    depth = fim_check_depth(path, configuration);
+
+    if (depth > configuration->recursion_level) {
+        mdebug2(FIM_MAX_RECURSION_LEVEL, depth, configuration->recursion_level, path);
+        return;
+    }
 
     // Deleted file. Sending alert.
-    if (w_stat(path, &(item->statbuf)) == -1) {
+    if (w_stat(path, &statbuf) == -1) {
         if(errno != ENOENT) {
             mdebug1(FIM_STAT_FAILED, path, errno, strerror(errno));
             return;
@@ -281,11 +290,11 @@ void fim_checker(const char *path, fim_element *item, whodata_evt *w_evt, int re
         w_mutex_unlock(&syscheck.fim_entry_mutex);
 
         if (saved_entry) {
-            fim_delete_file_event(syscheck.database, saved_entry, &syscheck.fim_entry_mutex, (void *) (int) true,
-                                 (void *) (fim_event_mode) item->mode, (void *) w_evt);
+            evt_data->type = FIM_DELETE;
+            fim_delete_file_event(syscheck.database, saved_entry, &syscheck.fim_entry_mutex, evt_data, NULL, NULL);
             free_entry(saved_entry);
             saved_entry = NULL;
-        } else if (item->configuration & CHECK_SEECHANGES) {
+        } else if (configuration->options & CHECK_SEECHANGES) {
             fim_diff_process_delete_file(path);
         }
 
@@ -293,7 +302,7 @@ void fim_checker(const char *path, fim_element *item, whodata_evt *w_evt, int re
     }
 
 #ifdef WIN_WHODATA
-    if (w_evt && w_evt->scan_directory == 1) {
+    if (evt_data->w_evt && evt_data->w_evt->scan_directory == 1) {
         if (w_update_sacl(path)) {
             mdebug1(FIM_SCAL_NOREFRESH, path);
         }
@@ -304,7 +313,7 @@ void fim_checker(const char *path, fim_element *item, whodata_evt *w_evt, int re
         return;
     }
 
-    switch(item->statbuf.st_mode & S_IFMT) {
+    switch (statbuf.st_mode & S_IFMT) {
 #ifndef WIN32
     case FIM_LINK:
         // Fallthrough
@@ -314,32 +323,32 @@ void fim_checker(const char *path, fim_element *item, whodata_evt *w_evt, int re
             return;
         }
 
-        if (fim_check_restrict (path, syscheck.filerestrict[item->index]) == 1) {
+        if (fim_check_restrict(path, configuration->filerestrict) == 1) {
             return;
         }
 
         check_max_fps();
 
-        fim_file(path, item, w_evt, report);
+        fim_file(path, configuration, evt_data, &statbuf);
         break;
 
     case FIM_DIRECTORY:
-        if (depth == syscheck.recursion_level[node]) {
+        if (depth == configuration->recursion_level) {
             mdebug2(FIM_DIR_RECURSION_LEVEL, path, depth);
             return;
         }
 #ifndef WIN32
-        if (item->configuration & REALTIME_ACTIVE) {
-            realtime_adddir(path, 0, (item->configuration & CHECK_FOLLOW) ? 1 : 0);
+        if (configuration->options & REALTIME_ACTIVE) {
+            realtime_adddir(path, configuration, (configuration->options & CHECK_FOLLOW) ? 1 : 0);
         }
 #endif
-        fim_directory(path, item, w_evt, report);
+        fim_directory(path, evt_data, configuration);
         break;
     }
 }
 
 
-int fim_directory (const char *dir, fim_element *item, whodata_evt *w_evt, int report) {
+int fim_directory(const char *dir, event_data_t *evt_data, const directory_t *configuration) {
     DIR *dp;
     struct dirent *entry;
     char *f_name;
@@ -382,7 +391,7 @@ int fim_directory (const char *dir, fim_element *item, whodata_evt *w_evt, int r
         str_lowercase(f_name);
 #endif
         // Process the event related to f_name
-        fim_checker(f_name, item, w_evt, report);
+        fim_checker(f_name, evt_data, configuration);
     }
 
     os_free(f_name);
@@ -405,8 +414,10 @@ int fim_directory (const char *dir, fim_element *item, whodata_evt *w_evt, int r
  * @retval FIM_FILE_ERROR An error occured while processing the file.
  */
 static fim_sanitize_state_t fim_process_file_from_db(const char *path, OSList *stack, rb_tree *tree, cJSON **event) {
-    fim_element item;
+    event_data_t evt_data = { .mode = FIM_SCHEDULED, .w_evt = NULL, .report_event = true };
+    struct stat statbuf;
     fim_entry *entry;
+    directory_t *configuration = NULL;
 
     assert(path != NULL);
     assert(stack != NULL);
@@ -419,12 +430,7 @@ static fim_sanitize_state_t fim_process_file_from_db(const char *path, OSList *s
         return FIM_FILE_ERROR;
     }
 
-    // Ensure 'item' does not have garbage in case we need it later
-    memset(&item, 0, sizeof(fim_element));
-
-    if (w_stat(entry->file_entry.path, &item.statbuf) == -1) {
-        int configuration;
-
+    if (w_stat(entry->file_entry.path, &statbuf) == -1) {
         if (errno != ENOENT) {
             mdebug1(FIM_STAT_FAILED, entry->file_entry.path, errno, strerror(errno));
             free_entry(entry);
@@ -432,13 +438,13 @@ static fim_sanitize_state_t fim_process_file_from_db(const char *path, OSList *s
         }
 
         configuration = fim_configuration_directory(path);
-        if (configuration == -1) {
+        if (configuration == NULL) {
             // This should not happen
             free_entry(entry);
             return FIM_FILE_ERROR;
         }
 
-        if (syscheck.opts[configuration] & CHECK_SEECHANGES) {
+        if (configuration->options & CHECK_SEECHANGES) {
             fim_diff_process_delete_file(entry->file_entry.path); // LCOV_EXCL_LINE
         }
 
@@ -447,19 +453,20 @@ static fim_sanitize_state_t fim_process_file_from_db(const char *path, OSList *s
             return FIM_FILE_ERROR;
         }
 
-        *event = fim_json_event(entry->file_entry.path, NULL, entry->file_entry.data, configuration, FIM_DELETE,
-                               FIM_SCHEDULED, NULL, NULL);
+        evt_data.type = FIM_DELETE;
+
+        *event = fim_json_event(entry, NULL, configuration, &evt_data, NULL);
         free_entry(entry);
 
         return FIM_FILE_DELETED;
     }
 
-    if (entry->file_entry.data->dev == item.statbuf.st_dev && entry->file_entry.data->inode == item.statbuf.st_ino) {
+    if (entry->file_entry.data->dev == statbuf.st_dev && entry->file_entry.data->inode == statbuf.st_ino) {
         goto end;
     }
 
     // We need to check if the new inode is being used in the DB
-    switch (fim_db_data_exists(syscheck.database, item.statbuf.st_ino, item.statbuf.st_dev)) {
+    switch (fim_db_data_exists(syscheck.database, statbuf.st_ino, statbuf.st_dev)) {
     case FIMDB_ERR:
         free_entry(entry);
         return FIM_FILE_ERROR;
@@ -471,19 +478,17 @@ static fim_sanitize_state_t fim_process_file_from_db(const char *path, OSList *s
     }
 
     // The inode is currently being used, scan those files first
-    if (fim_db_append_paths_from_inode(syscheck.database, item.statbuf.st_ino, item.statbuf.st_dev, stack, tree) == 0) {
+    if (fim_db_append_paths_from_inode(syscheck.database, statbuf.st_ino, statbuf.st_dev, stack, tree) == 0) {
         // We have somehow reached a point an infinite loop could happen, we will need to update the current file
         // forcefully which will generate a false positive alert
-        item.mode = FIM_SCHEDULED;
-        item.index = fim_configuration_directory(entry->file_entry.path);
-        if (item.index == -1) {
+        configuration = fim_configuration_directory(path);
+        if (configuration == NULL) {
             // This should not happen
-            free_entry(entry);     // LCOV_EXCL_LINE
-            return FIM_FILE_ERROR; // LCOV_EXCL_LINE
+            free_entry(entry);
+            return FIM_FILE_ERROR;
         }
-        item.configuration = syscheck.opts[item.index];
 
-        *event = _fim_file_force_update(path, &item, entry);
+        *event = _fim_file_force_update(entry, configuration, &evt_data, &statbuf);
         free_entry(entry);
         return FIM_FILE_UPDATED;
     }
@@ -494,16 +499,14 @@ static fim_sanitize_state_t fim_process_file_from_db(const char *path, OSList *s
 end:
     // Once here, either the used row was cleared and is available or this file is a hardlink to other file
     // either way the only thing left to do is to process the file
-    item.mode = FIM_SCHEDULED;
-    item.index = fim_configuration_directory(entry->file_entry.path);
-    if (item.index == -1) {
+    configuration = fim_configuration_directory(path);
+    if (configuration == NULL) {
         // This should not happen
-        free_entry(entry);     // LCOV_EXCL_LINE
-        return FIM_FILE_ERROR; // LCOV_EXCL_LINE
+        free_entry(entry);
+        return FIM_FILE_ERROR;
     }
-    item.configuration = syscheck.opts[item.index];
 
-    *event = _fim_file(entry->file_entry.path, &item, NULL);
+    *event = _fim_file(path, configuration, &evt_data, &statbuf);
 
     free_entry(entry);
     return FIM_FILE_UPDATED;
@@ -666,17 +669,18 @@ static int fim_update_db_data(const char *path,
  * @brief Processes a file, update the DB entry and return an event. No mutex is used inside this function.
  *
  * @param path The path to the file being processed.
- * @param item Miscellaneous information linked to the event being processed.
- * @param w_evt Whodata information associated with the event.
+ * @param configuration The configuration associated with the file being processed.
+ * @param evt_data Information on how the event was triggered.
+ * @param statbuf A struct stat with the information extracted from the file.
  */
-static cJSON *_fim_file(const char *path, fim_element *item, whodata_evt *w_evt) {
+static cJSON *
+_fim_file(const char *path, const directory_t *configuration, event_data_t *evt_data, const struct stat *statbuf) {
+    fim_entry new;
     fim_entry *saved = NULL;
-    fim_file_data *new = NULL;
     cJSON *json_event = NULL;
     char *diff = NULL;
-    int alert_type;
 
-    if (item->mode == FIM_SCHEDULED) {
+    if (evt_data->mode == FIM_SCHEDULED) {
         // Prevent analysis of the same file twice during the same scan
         switch (fim_db_file_is_scanned(syscheck.database, path)) {
             case FIMDB_ERR:
@@ -690,33 +694,33 @@ static cJSON *_fim_file(const char *path, fim_element *item, whodata_evt *w_evt)
         }
     }
 
-    //Get file attributes
-    new = fim_get_data(path, item);
-    if (new == NULL) {
+    new.file_entry.path = (char *)path;
+    new.file_entry.data = fim_get_data(path, configuration, statbuf);
+    if (new.file_entry.data == NULL) {
         mdebug1(FIM_GET_ATTRIBUTES, path);
         return NULL;
     }
 
-    if (fim_update_db_data(path, new, &saved, item->mode) != 0) {
-        free_file_data(new);
+    if (fim_update_db_data(path, new.file_entry.data, &saved, evt_data->mode) != 0) {
+        free_file_data(new.file_entry.data);
         free_entry(saved);
         return NULL;
     }
 
     if (!saved) {
-        alert_type = FIM_ADD; // New entry
+        evt_data->type = FIM_ADD; // New entry
     } else {
-        alert_type = FIM_MODIFICATION; // Checking for changes
+        evt_data->type = FIM_MODIFICATION; // Checking for changes
     }
 
-    if (item->configuration & CHECK_SEECHANGES) {
+    if (configuration->options & CHECK_SEECHANGES) {
         diff = fim_file_diff(path);
     }
 
-    json_event = fim_json_event(path, saved ? saved->file_entry.data : NULL, new, item->index, alert_type, item->mode, w_evt, diff);
+    json_event = fim_json_event(&new, saved ? saved->file_entry.data : NULL, configuration, evt_data, diff);
 
     os_free(diff);
-    free_file_data(new);
+    free_file_data(new.file_entry.data);
     free_entry(saved);
 
     return json_event;
@@ -726,55 +730,61 @@ static cJSON *_fim_file(const char *path, fim_element *item, whodata_evt *w_evt)
 /**
  * @brief Virtually identical to `_fim_file`, except this function updates the DB with no further validations
  *
- * @param path The path to the file being processed.
- * @param item Miscellaneous information linked to the event being processed.
- * @param saved The data linked to the file that was extracted from the DB in a previous operation.
+ * @param saved Information extracted from FIM DB about the file being processed.
+ * @param configuration The configuration associated with the file being processed.
+ * @param evt_data Information on how the event was triggered.
+ * @param statbuf A struct stat with the information extracted from the file.
+ * @return A JSON event, NULL if no event is triggered.
  */
-static cJSON *_fim_file_force_update(const char *path, const fim_element *item, const fim_entry *saved) {
-    fim_file_data *new = NULL;
+static cJSON *_fim_file_force_update(const fim_entry *saved,
+                                     const directory_t *configuration,
+                                     event_data_t *evt_data,
+                                     const struct stat *statbuf) {
+    fim_entry new;
     cJSON *json_event = NULL;
     char *diff = NULL;
-    int alert_type;
 
-    assert(path != NULL);
-    assert(item != NULL);
     assert(saved != NULL);
+    assert(configuration != NULL);
+    assert(evt_data != NULL);
+    assert(statbuf != NULL);
 
     // Get file attributes
-    new = fim_get_data(path, item);
-    if (new == NULL) {
-        mdebug1(FIM_GET_ATTRIBUTES, path);
+    new.file_entry.path = (char *)saved->file_entry.path;
+    new.file_entry.data = fim_get_data(new.file_entry.path, configuration, statbuf);
+    if (new.file_entry.data == NULL) {
+        mdebug1(FIM_GET_ATTRIBUTES, new.file_entry.path);
         return NULL;
     }
 
-    if (fim_db_insert(syscheck.database, path, new, saved->file_entry.data) != 0) {
-        free_file_data(new);
+    if (fim_db_insert(syscheck.database, new.file_entry.path, new.file_entry.data, saved->file_entry.data) != 0) {
+        free_file_data(new.file_entry.data);
         return NULL;
     }
 
-    alert_type = FIM_MODIFICATION; // Checking for changes
+    evt_data->type = FIM_MODIFICATION; // Checking for changes
 
-    if (item->configuration & CHECK_SEECHANGES) {
-        diff = fim_file_diff(path);
+    if (configuration->options & CHECK_SEECHANGES) {
+        diff = fim_file_diff(new.file_entry.path);
     }
 
-    json_event = fim_json_event(path, saved->file_entry.data, new, item->index, alert_type, item->mode, NULL, diff);
+    json_event = fim_json_event(&new, saved->file_entry.data, configuration, evt_data, diff);
 
     os_free(diff);
-    free_file_data(new);
+    free_file_data(new.file_entry.data);
 
     return json_event;
 }
 #endif
 
-void fim_file(const char *file, fim_element *item, whodata_evt *w_evt, int report) {
+void fim_file(const char *path, const directory_t *configuration, event_data_t *evt_data, const struct stat *statbuf) {
     cJSON *json_event = NULL;
 
     w_mutex_lock(&syscheck.fim_entry_mutex);
-    json_event = _fim_file(file, item, w_evt);
+    json_event = _fim_file(path, configuration, evt_data, statbuf);
     w_mutex_unlock(&syscheck.fim_entry_mutex);
 
-    if (json_event && _base_line && report) {
+    if (json_event && _base_line && evt_data->report_event) {
         send_syscheck_msg(json_event);
     }
 
@@ -783,20 +793,19 @@ void fim_file(const char *file, fim_element *item, whodata_evt *w_evt, int repor
 
 
 void fim_realtime_event(char *file) {
-
     struct stat file_stat;
 
     // If the file exists, generate add or modify events.
     if (w_stat(file, &file_stat) >= 0) {
+        event_data_t evt_data = { .mode = FIM_REALTIME, .w_evt = NULL, .report_event = true };
+
         /* Need a sleep here to avoid triggering on vim
          * (and finding the file removed)
          */
         fim_rt_delay();
 
-        fim_element item = { .mode = FIM_REALTIME };
-        fim_checker(file, &item, NULL, 1);
-    }
-    else {
+        fim_checker(file, &evt_data, NULL);
+    } else {
         // Otherwise, it could be a file deleted or a directory moved (or renamed).
         fim_process_missing_entry(file, FIM_REALTIME, NULL);
     }
@@ -808,31 +817,31 @@ void fim_whodata_event(whodata_evt * w_evt) {
 
     // If the file exists, generate add or modify events.
     if(w_stat(w_evt->path, &file_stat) >= 0) {
+        event_data_t evt_data = { .mode = FIM_WHODATA, .w_evt = w_evt, .report_event = true };
+
         fim_rt_delay();
 
-        fim_element item = { .mode = FIM_WHODATA };
-        fim_checker(w_evt->path, &item, w_evt, 1);
-    }
-    // Otherwise, it could be a file deleted or a directory moved (or renamed).
-    else {
-            fim_process_missing_entry(w_evt->path, FIM_WHODATA, w_evt);
-        #ifndef WIN32
-            char** paths = NULL;
-            const unsigned long int inode = strtoul(w_evt->inode,NULL,10);
-            const unsigned long int dev = strtoul(w_evt->dev,NULL,10);
+        fim_checker(w_evt->path, &evt_data, NULL);
+    } else {
+        // Otherwise, it could be a file deleted or a directory moved (or renamed).
+        fim_process_missing_entry(w_evt->path, FIM_WHODATA, w_evt);
+#ifndef WIN32
+        char** paths = NULL;
+        const unsigned long int inode = strtoul(w_evt->inode,NULL,10);
+        const unsigned long int dev = strtoul(w_evt->dev,NULL,10);
 
-            w_mutex_lock(&syscheck.fim_entry_mutex);
-            paths = fim_db_get_paths_from_inode(syscheck.database, inode, dev);
-            w_mutex_unlock(&syscheck.fim_entry_mutex);
+        w_mutex_lock(&syscheck.fim_entry_mutex);
+        paths = fim_db_get_paths_from_inode(syscheck.database, inode, dev);
+        w_mutex_unlock(&syscheck.fim_entry_mutex);
 
-            if(paths) {
-                for(int i = 0; paths[i]; i++) {
-                    fim_process_missing_entry(paths[i], FIM_WHODATA, w_evt);
-                    os_free(paths[i]);
-                }
-                os_free(paths);
+        if(paths) {
+            for(int i = 0; paths[i]; i++) {
+                fim_process_missing_entry(paths[i], FIM_WHODATA, w_evt);
+                os_free(paths[i]);
             }
-        #endif
+            os_free(paths);
+        }
+#endif
     }
 }
 
@@ -848,8 +857,8 @@ void fim_process_missing_entry(char * pathname, fim_event_mode mode, whodata_evt
 
     // Exists, create event.
     if (saved_data) {
-        fim_element item = { .mode = mode };
-        fim_checker(pathname, &item, w_evt, 1);
+        event_data_t evt_data = { .mode = mode, .w_evt = w_evt, .report_event = true };
+        fim_checker(pathname, &evt_data, NULL);
         free_entry(saved_data);
         return;
     }
@@ -865,9 +874,10 @@ void fim_process_missing_entry(char * pathname, fim_event_mode mode, whodata_evt
     w_mutex_unlock(&syscheck.fim_entry_mutex);
 
     if (files && files->elements) {
-        if (fim_db_process_missing_entry(syscheck.database, files, &syscheck.fim_entry_mutex,
-            syscheck.database_store, mode, w_evt) != FIMDB_OK) {
-                merror(FIM_DB_ERROR_RM_PATTERN, pattern);
+        event_data_t evt_data = { .mode = mode, .w_evt = w_evt, .report_event = true, .type = FIM_DELETE };
+        if (fim_db_process_missing_entry(syscheck.database, files, &syscheck.fim_entry_mutex, syscheck.database_store,
+                                         &evt_data) != FIMDB_OK) {
+            merror(FIM_DB_ERROR_RM_PATTERN, pattern);
         }
     }
 }
@@ -967,54 +977,52 @@ void fim_check_db_state() {
 }
 
 // Returns the position of the path into directories array
-int fim_configuration_directory(const char *path) {
+directory_t *fim_configuration_directory(const char *path) {
     char full_path[OS_SIZE_4096 + 1] = {'\0'};
     char full_entry[OS_SIZE_4096 + 1] = {'\0'};
-    char *real_path = NULL;
-    int it = 0;
+    directory_t *dir_it = NULL;
+    directory_t *dir = NULL;
     int top = 0;
     int match = 0;
-    int position = -1;
 
     if (!path || *path == '\0') {
-        return position;
+        return NULL;
     }
 
     trail_path_separator(full_path, path, sizeof(full_path));
 
-    while(syscheck.dir[it]) {
-        real_path = fim_get_real_path(it);
+    foreach_array(dir_it, syscheck.directories) {
+        char *real_path = fim_get_real_path(dir_it);
+
         trail_path_separator(full_entry, real_path, sizeof(full_entry));
         match = w_compare_str(full_entry, full_path);
 
-        free(real_path);
         if (top < match && full_path[match - 1] == PATH_SEP) {
-            position = it;
+            dir = dir_it;
             top = match;
         }
-        it++;
+
+        os_free(real_path);
     }
 
-    if (position == -1) {
+    if (dir == NULL) {
         mdebug2(FIM_CONFIGURATION_NOTFOUND, "file", path);
     }
 
-    return position;
+    return dir;
 }
 
-int fim_check_depth(const char * path, int dir_position) {
+int fim_check_depth(const char *path, const directory_t *configuration) {
     const char * pos;
     int depth = -1;
+    char *parent_path;
     unsigned int parent_path_size;
-    char *real_path = NULL;
 
-    if (syscheck.dir[dir_position] == NULL && syscheck.symbolic_links[dir_position] == NULL) {
-        return -1;
-    }
+    assert(configuration != NULL);
 
-    real_path = fim_get_real_path(dir_position);
-    parent_path_size = strlen(real_path);
-    free(real_path);
+    parent_path = fim_get_real_path(configuration);
+    parent_path_size = strlen(parent_path);
+    os_free(parent_path);
 
     if (parent_path_size > strlen(path)) {
         return -1;
@@ -1047,17 +1055,17 @@ int fim_check_depth(const char * path, int dir_position) {
 
 
 // Get data from file
-fim_file_data *fim_get_data(const char *file, const fim_element *item) {
-    fim_file_data *data = NULL;
+fim_file_data *fim_get_data(const char *file, const directory_t *configuration, const struct stat *statbuf) {
+    fim_file_data * data = NULL;
 
     os_calloc(1, sizeof(fim_file_data), data);
     init_fim_data_entry(data);
 
-    if (item->configuration & CHECK_SIZE) {
-        data->size = item->statbuf.st_size;
+    if (configuration->options & CHECK_SIZE) {
+        data->size = statbuf->st_size;
     }
 
-    if (item->configuration & CHECK_PERM) {
+    if (configuration->options & CHECK_PERM) {
 #ifdef WIN32
         int error;
         char perm[OS_SIZE_6144 + 1];
@@ -1070,44 +1078,44 @@ fim_file_data *fim_get_data(const char *file, const fim_element *item) {
             data->perm = decode_win_permissions(perm);
         }
 #else
-        data->perm = agent_file_perm(item->statbuf.st_mode);
+        data->perm = agent_file_perm(statbuf->st_mode);
 #endif
     }
 
 #ifdef WIN32
-    if (item->configuration & CHECK_ATTRS) {
+    if (configuration->options & CHECK_ATTRS) {
         os_calloc(OS_SIZE_256, sizeof(char), data->attributes);
         decode_win_attributes(data->attributes, w_get_file_attrs(file));
     }
 #endif
 
-    if (item->configuration & CHECK_MTIME) {
+    if (configuration->options & CHECK_MTIME) {
 #ifdef WIN32
         data->mtime = get_UTC_modification_time(file);
 #else
-        data->mtime = item->statbuf.st_mtime;
+        data->mtime = statbuf->st_mtime;
 #endif
     }
 
 #ifdef WIN32
-    if (item->configuration & CHECK_OWNER) {
+    if (configuration->options & CHECK_OWNER) {
         data->user_name = get_file_user(file, &data->uid);
     }
 #else
-    if (item->configuration & CHECK_OWNER) {
+    if (configuration->options & CHECK_OWNER) {
         char aux[OS_SIZE_64];
-        snprintf(aux, OS_SIZE_64, "%u", item->statbuf.st_uid);
+        snprintf(aux, OS_SIZE_64, "%u", statbuf->st_uid);
         os_strdup(aux, data->uid);
 
-        data->user_name = get_user(item->statbuf.st_uid);
+        data->user_name = get_user(statbuf->st_uid);
     }
 
-    if (item->configuration & CHECK_GROUP) {
+    if (configuration->options & CHECK_GROUP) {
         char aux[OS_SIZE_64];
-        snprintf(aux, OS_SIZE_64, "%u", item->statbuf.st_gid);
+        snprintf(aux, OS_SIZE_64, "%u", statbuf->st_gid);
         os_strdup(aux, data->gid);
 
-        data->group_name = get_group(item->statbuf.st_gid);
+        data->group_name = get_group(statbuf->st_gid);
     }
 #endif
 
@@ -1119,41 +1127,31 @@ fim_file_data *fim_get_data(const char *file, const fim_element *item) {
     data->scanned = 1;
 
     // We won't calculate hash for symbolic links, empty or large files
-    if ((item->statbuf.st_mode & S_IFMT) == FIM_REGULAR)
-        if (item->statbuf.st_size > 0 &&
-                (size_t)item->statbuf.st_size < syscheck.file_max_size &&
-                ( item->configuration & CHECK_MD5SUM ||
-                item->configuration & CHECK_SHA1SUM ||
-                item->configuration & CHECK_SHA256SUM ) ) {
-            if (OS_MD5_SHA1_SHA256_File(file,
-                                        syscheck.prefilter_cmd,
-                                        data->hash_md5,
-                                        data->hash_sha1,
-                                        data->hash_sha256,
-                                        OS_BINARY,
-                                        syscheck.file_max_size) < 0) {
-                mdebug1(FIM_HASHES_FAIL, file);
-                free_file_data(data);
-                return NULL;
+    if (S_ISREG(statbuf->st_mode) && (statbuf->st_size > 0 && (size_t)statbuf->st_size < syscheck.file_max_size) &&
+        (configuration->options & (CHECK_MD5SUM | CHECK_SHA1SUM | CHECK_SHA256SUM))) {
+        if (OS_MD5_SHA1_SHA256_File(file, syscheck.prefilter_cmd, data->hash_md5, data->hash_sha1, data->hash_sha256,
+                                    OS_BINARY, syscheck.file_max_size) < 0) {
+            mdebug1(FIM_HASHES_FAIL, file);
+            free_file_data(data);
+            return NULL;
         }
     }
 
-    if (!(item->configuration & CHECK_MD5SUM)) {
+    if (!(configuration->options & CHECK_MD5SUM)) {
         data->hash_md5[0] = '\0';
     }
 
-    if (!(item->configuration & CHECK_SHA1SUM)) {
+    if (!(configuration->options & CHECK_SHA1SUM)) {
         data->hash_sha1[0] = '\0';
     }
 
-    if (!(item->configuration & CHECK_SHA256SUM)) {
+    if (!(configuration->options & CHECK_SHA256SUM)) {
         data->hash_sha256[0] = '\0';
     }
 
-    data->inode = item->statbuf.st_ino;
-    data->dev = item->statbuf.st_dev;
-    data->mode = item->mode;
-    data->options = item->configuration;
+    data->inode = statbuf->st_ino;
+    data->dev = statbuf->st_dev;
+    data->options = configuration->options;
     data->last_event = time(NULL);
     fim_get_checksum(data);
 
@@ -1231,18 +1229,17 @@ void check_deleted_files() {
     }
 }
 
-cJSON *fim_json_event(const char *file_name,
-                      fim_file_data *old_data,
-                      fim_file_data *new_data,
-                      int pos,
-                      unsigned int type,
-                      fim_event_mode mode,
-                      const whodata_evt *w_evt,
+cJSON *fim_json_event(const fim_entry *new_data,
+                      const fim_file_data *old_data,
+                      const directory_t *configuration,
+                      const event_data_t *evt_data,
                       const char *diff) {
     cJSON * changed_attributes = NULL;
 
+    assert(new_data != NULL);
+
     if (old_data != NULL) {
-        changed_attributes = fim_json_compare_attrs(old_data, new_data);
+        changed_attributes = fim_json_compare_attrs(old_data, new_data->file_entry.data);
 
         // If no such changes, do not send event.
 
@@ -1258,22 +1255,24 @@ cJSON *fim_json_event(const char *file_name,
     cJSON * data = cJSON_CreateObject();
     cJSON_AddItemToObject(json_event, "data", data);
 
-    cJSON_AddStringToObject(data, "path", file_name);
+    cJSON_AddStringToObject(data, "path", new_data->file_entry.path);
     cJSON_AddNumberToObject(data, "version", 2.0);
 
-    cJSON_AddStringToObject(data, "mode", FIM_EVENT_MODE[mode]);
-    cJSON_AddStringToObject(data, "type", FIM_EVENT_TYPE[type]);
-    cJSON_AddNumberToObject(data, "timestamp", new_data->last_event);
+    cJSON_AddStringToObject(data, "mode", FIM_EVENT_MODE[evt_data->mode]);
+    cJSON_AddStringToObject(data, "type", FIM_EVENT_TYPE[evt_data->type]);
+    cJSON_AddNumberToObject(data, "timestamp", new_data->file_entry.data->last_event);
 
 #ifndef WIN32
     char** paths = NULL;
 
-    if (paths = fim_db_get_paths_from_inode(syscheck.database, new_data->inode, new_data->dev), paths){
+    if (paths = fim_db_get_paths_from_inode(syscheck.database, new_data->file_entry.data->inode,
+                                            new_data->file_entry.data->dev),
+        paths) {
         if (paths[0] && paths[1]) {
             cJSON *hard_links = cJSON_CreateArray();
             int i;
             for(i = 0; paths[i]; i++) {
-                if(strcmp(file_name, paths[i])) {
+                if (strcmp(new_data->file_entry.path, paths[i])) {
                     cJSON_AddItemToArray(hard_links, cJSON_CreateString(paths[i]));
                 }
                 os_free(paths[i]);
@@ -1286,7 +1285,7 @@ cJSON *fim_json_event(const char *file_name,
     }
 #endif
 
-    cJSON_AddItemToObject(data, "attributes", fim_attributes_json(new_data));
+    cJSON_AddItemToObject(data, "attributes", fim_attributes_json(new_data->file_entry.data));
 
     if (old_data) {
         cJSON_AddItemToObject(data, "changed_attributes", changed_attributes);
@@ -1294,11 +1293,11 @@ cJSON *fim_json_event(const char *file_name,
     }
 
     char * tags = NULL;
-    if (w_evt) {
-        cJSON_AddItemToObject(data, "audit", fim_audit_json(w_evt));
+    if (evt_data->w_evt) {
+        cJSON_AddItemToObject(data, "audit", fim_audit_json(evt_data->w_evt));
     }
 
-    tags = syscheck.tag[pos];
+    tags = configuration->tag;
 
     if (diff != NULL) {
         cJSON_AddStringToObject(data, "content_changes", diff);
@@ -1598,26 +1597,26 @@ void fim_print_info(struct timespec start, struct timespec end, clock_t cputime_
     return;
 }
 
-char *fim_get_real_path(int position) {
+char *fim_get_real_path(const directory_t *dir) {
     char *real_path = NULL;
 
 #ifndef WIN32
     w_mutex_lock(&syscheck.fim_symlink_mutex);
 
     //Create a safe copy of the path to be used by other threads.
-    if ((syscheck.opts[position] & CHECK_FOLLOW) == 0) {
-        os_strdup(syscheck.dir[position], real_path);
-    } else if (syscheck.symbolic_links[position]) {
-        os_strdup(syscheck.symbolic_links[position], real_path);
-    } else if (IsLink(syscheck.dir[position]) == 0) { // Broken link
+    if ((dir->options & CHECK_FOLLOW) == 0) {
+        os_strdup(dir->path, real_path);
+    } else if (dir->symbolic_links) {
+        os_strdup(dir->symbolic_links, real_path);
+    } else if (IsLink(dir->path) == 0) { // Broken link
         os_strdup("", real_path);
     } else {
-        os_strdup(syscheck.dir[position], real_path);
+        os_strdup(dir->path, real_path);
     }
 
     w_mutex_unlock(&syscheck.fim_symlink_mutex);
 #else // WIN32
-    os_strdup(syscheck.dir[position], real_path);
+    os_strdup(dir->path, real_path);
 #endif
 
     return real_path;

--- a/src/syscheckd/db/fim_db_files.h
+++ b/src/syscheckd/db/fim_db_files.h
@@ -157,13 +157,17 @@ int fim_db_delete_not_scanned(fdb_t *fim_sql, fim_tmp_file *file, pthread_mutex_
  * @param file Structure of the file which contains all the paths.
  * @param mutex FIM database's mutex for thread synchronization.
  * @param storage 1 Store database in memory, disk otherwise.
- * @param mode FIM mode (scheduled, realtime or whodata)
+ * @param evt_data Information on how the event was triggered.
  * @param configuration An integer holding the position of the configuration that corresponds to the entries to be deleted.
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_delete_range(fdb_t * fim_sql, fim_tmp_file *file,
-                        pthread_mutex_t *mutex, int storage, fim_event_mode mode, int *configuration);
+int fim_db_delete_range(fdb_t *fim_sql,
+                        fim_tmp_file *file,
+                        pthread_mutex_t *mutex,
+                        int storage,
+                        event_data_t *evt_data,
+                        directory_t *configuration);
 
 /**
  * @brief Remove a range of paths from database if they have a specific monitoring mode.
@@ -172,13 +176,15 @@ int fim_db_delete_range(fdb_t * fim_sql, fim_tmp_file *file,
  * @param file Structure of the file which contains all the paths.
  * @param mutex FIM database's mutex for thread synchronization.
  * @param storage 1 Store database in memory, disk otherwise.
- * @param mode FIM mode (scheduled, realtime or whodata)
- * @param w_evt Whodata information
+ * @param evt_data Information on how the event was triggered.
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_process_missing_entry(fdb_t *fim_sql, fim_tmp_file *file, pthread_mutex_t *mutex, int storage,
-                                 fim_event_mode mode, whodata_evt * w_evt);
+int fim_db_process_missing_entry(fdb_t *fim_sql,
+                                 fim_tmp_file *file,
+                                 pthread_mutex_t *mutex,
+                                 int storage,
+                                 event_data_t *evt_data);
 
 /**
  * @brief Decodes a row from the database to be saved in a fim_entry structure.

--- a/src/syscheckd/fim_diff_changes.c
+++ b/src/syscheckd/fim_diff_changes.c
@@ -470,8 +470,8 @@ diff_data *initialize_file_diff_data(const char *filename){
     diff->file_size = 0;
 
     if (syscheck.file_size_enabled) {
-        int it = fim_configuration_directory(filename);
-        diff->size_limit = syscheck.diff_size_limit[it];
+        const directory_t *configuration = fim_configuration_directory(filename);
+        diff->size_limit = configuration->diff_size_limit;
     }
 
     // Get absolute path of filename:

--- a/src/syscheckd/main.c
+++ b/src/syscheckd/main.c
@@ -45,6 +45,7 @@ int main(int argc, char **argv)
     const char *cfg = OSSECCONF;
     gid_t gid;
     const char *group = GROUPGLOBAL;
+    directory_t *dir_it = NULL;
 
     /* Set the name */
     OS_SetName(ARGV0);
@@ -113,18 +114,11 @@ int main(int argc, char **argv)
         merror(RCONFIG_ERROR, SYSCHECK, cfg);
         syscheck.disabled = 1;
     } else if ((r == 1) || (syscheck.disabled == 1)) {
-        if (!syscheck.dir) {
-            if (!test_config) {
-                minfo(FIM_DIRECTORY_NOPROVIDED);
-            }
-            dump_syscheck_file(&syscheck, "", 0, NULL, 0, NULL, NULL, -1);
-        } else if (!syscheck.dir[0]) {
+        if (syscheck.directories == NULL || syscheck.directories[0] == NULL) {
             if (!test_config) {
                 minfo(FIM_DIRECTORY_NOPROVIDED);
             }
         }
-
-        os_free(syscheck.dir[0]);
 
         if (!syscheck.ignore) {
             os_calloc(1, sizeof(char *), syscheck.ignore);
@@ -185,25 +179,24 @@ int main(int argc, char **argv)
         minfo(STARTUP_MSG, (int)getpid());
 
         /* Print directories to be monitored */
-        r = 0;
-        while (syscheck.dir[r] != NULL) {
+        foreach_array(dir_it, syscheck.directories) {
             char optstr[ 1024 ];
 
-            if (!syscheck.symbolic_links[r]) {
-                minfo(FIM_MONITORING_DIRECTORY, syscheck.dir[r], syscheck_opts2str(optstr, sizeof( optstr ), syscheck.opts[r]));
+            if (dir_it->symbolic_links == NULL) {
+                minfo(FIM_MONITORING_DIRECTORY, dir_it->path,
+                      syscheck_opts2str(optstr, sizeof(optstr), dir_it->options));
             } else {
-                minfo(FIM_MONITORING_LDIRECTORY, syscheck.dir[r], syscheck.symbolic_links[r], syscheck_opts2str(optstr, sizeof( optstr ), syscheck.opts[r]));
+                minfo(FIM_MONITORING_LDIRECTORY, dir_it->path, dir_it->symbolic_links,
+                      syscheck_opts2str(optstr, sizeof(optstr), dir_it->options));
             }
 
-            if (syscheck.tag && syscheck.tag[r] != NULL)
-                mdebug1(FIM_TAG_ADDED, syscheck.tag[r], syscheck.dir[r]);
+            if (dir_it->tag != NULL)
+                mdebug1(FIM_TAG_ADDED, dir_it->tag, dir_it->path);
 
             // Print diff file size limit
-            if ((syscheck.opts[r] & CHECK_SEECHANGES) && syscheck.file_size_enabled) {
-                mdebug2(FIM_DIFF_FILE_SIZE_LIMIT, syscheck.diff_size_limit[r], syscheck.dir[r]);
+            if ((dir_it->options & CHECK_SEECHANGES) && syscheck.file_size_enabled) {
+                mdebug2(FIM_DIFF_FILE_SIZE_LIMIT, dir_it->diff_size_limit, dir_it->path);
             }
-
-            r++;
         }
 
         if (!syscheck.file_size_enabled) {
@@ -238,19 +231,16 @@ int main(int argc, char **argv)
         }
 
         /* Check directories set for real time */
-        r = 0;
-        while (syscheck.dir[r] != NULL) {
-            if (syscheck.opts[r] & REALTIME_ACTIVE) {
+        foreach_array(dir_it, syscheck.directories) {
+            if (dir_it->options & REALTIME_ACTIVE) {
 #if defined (INOTIFY_ENABLED) || defined (WIN32)
-                minfo(FIM_REALTIME_MONITORING_DIRECTORY, syscheck.dir[r]);
+                minfo(FIM_REALTIME_MONITORING_DIRECTORY, dir_it->path);
 #else
-                mwarn(FIM_WARN_REALTIME_DISABLED, syscheck.dir[r]);
-                syscheck.opts[r] &= ~ REALTIME_ACTIVE;
-                syscheck.opts[r] |= SCHEDULED_ACTIVE;
+                mwarn(FIM_WARN_REALTIME_DISABLED, dir_it->path);
+                dir_it->options &= ~REALTIME_ACTIVE;
+                dir_it->options |= SCHEDULED_ACTIVE;
 #endif
             }
-
-            r++;
         }
     }
 
@@ -259,16 +249,17 @@ int main(int argc, char **argv)
     // Audit events thread
     if (!syscheck.disabled && syscheck.enable_whodata) {
 #ifdef ENABLE_AUDIT
-        int out = audit_init();
-        if (out < 0) {
+        if (audit_init() < 0) {
+            directory_t *dir_it;
+
             mwarn(FIM_WARN_AUDIT_THREAD_NOSTARTED);
 
             // Switch who-data to real-time mode
 
-            for (int i = 0; syscheck.dir[i] != NULL; i++) {
-                if (syscheck.opts[i] & WHODATA_ACTIVE) {
-                    syscheck.opts[i] &= ~WHODATA_ACTIVE;
-                    syscheck.opts[i] |= REALTIME_ACTIVE;
+            foreach_array(dir_it, syscheck.directories) {
+                if (dir_it->options & WHODATA_ACTIVE) {
+                    dir_it->options &= ~WHODATA_ACTIVE;
+                    dir_it->options |= REALTIME_ACTIVE;
                 }
             }
         }

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -55,12 +55,12 @@ STATIC void set_whodata_mode_changes();
 #endif
 #else
 static void *symlink_checker_thread(__attribute__((unused)) void * data);
-STATIC void fim_link_update(int pos, char *new_path);
-STATIC void fim_link_check_delete(int pos);
-STATIC void fim_link_delete_range(int pos);
-STATIC void fim_link_silent_scan(char *path, int pos);
-STATIC void fim_link_reload_broken_link(char *path, int index);
-STATIC void fim_delete_realtime_watches(int pos);
+STATIC void fim_link_update(const char *new_path, directory_t *configuration);
+STATIC void fim_link_check_delete(directory_t *configuration);
+STATIC void fim_link_delete_range(directory_t *configuration);
+STATIC void fim_link_silent_scan(const char *path, directory_t *configuration);
+STATIC void fim_link_reload_broken_link(char *path, directory_t *configuration);
+STATIC void fim_delete_realtime_watches(const directory_t *configuration);
 #endif
 
 // Send a message
@@ -359,19 +359,19 @@ void * fim_run_realtime(__attribute__((unused)) void * args) {
 #endif
 
 #if defined INOTIFY_ENABLED || defined WIN32
-
-static int _base_line = 0;
-
+    static int _base_line = 0;
 #ifdef WIN32
+    directory_t *dir_it;
+
     set_priority_windows_thread();
 #endif
 
     while (1) {
 #ifdef WIN32
         // Directories in Windows configured with real-time add recursive watches
-        for (int i = 0; syscheck.dir[i]; i++) {
-            if (syscheck.opts[i] & REALTIME_ACTIVE) {
-                realtime_adddir(syscheck.dir[i], 0, 0);
+        foreach_array(dir_it, syscheck.directories) {
+            if (dir_it->options & REALTIME_ACTIVE) {
+                realtime_adddir(dir_it->path, dir_it, 0);
             }
         }
 #endif
@@ -464,26 +464,23 @@ void set_priority_windows_thread() {
 }
 #endif
 
-
+#ifdef WIN_WHODATA
 int fim_whodata_initialize() {
     int retval = 0;
+    directory_t *dir_it;
 
-#if defined ENABLE_AUDIT || defined WIN32
-
-#ifdef WIN32
     set_priority_windows_thread();
-#endif
 
-#ifdef WIN_WHODATA // Whodata on Windows
-    for (int i = 0; syscheck.dir[i]; i++) {
-        if (syscheck.opts[i] & WHODATA_ACTIVE) {
-            if(realtime_adddir(syscheck.dir[i], i + 1, 0) == -2) {
-                syscheck.wdata.dirs_status[i].status &= ~WD_CHECK_WHODATA;
-                syscheck.opts[i] &= ~WHODATA_ACTIVE;
-                syscheck.wdata.dirs_status[i].status |= WD_CHECK_REALTIME;
-                syscheck.realtime_change = 1;
-            }
+    foreach_array(dir_it, syscheck.directories) {
+        if ((dir_it->options & WHODATA_ACTIVE) == 0) {
+            continue;
+        }
 
+        if (realtime_adddir(dir_it->path, dir_it, 0) == -2) {
+            dir_it->dirs_status.status &= ~WD_CHECK_WHODATA;
+            dir_it->dirs_status.status |= WD_CHECK_REALTIME;
+            dir_it->options &= ~WHODATA_ACTIVE;
+            syscheck.realtime_change = 1;
         }
     }
     HANDLE t_hdle;
@@ -503,29 +500,49 @@ int fim_whodata_initialize() {
         audit_restore();
 
         // Add proper flags for the realtime thread monitors the directories/files.
-        for (int i = 0; syscheck.dir[i]; i++) {
-            syscheck.wdata.dirs_status[i].status &= ~WD_CHECK_WHODATA;
-            syscheck.opts[i] &= ~WHODATA_ACTIVE;
-            syscheck.wdata.dirs_status[i].status |= WD_CHECK_REALTIME;
+        foreach_array(dir_it, syscheck.directories) {
+            dir_it->dirs_status.status &= ~WD_CHECK_WHODATA;
+            dir_it->dirs_status.status |= WD_CHECK_REALTIME;
+            dir_it->options &= ~WHODATA_ACTIVE;
             syscheck.realtime_change = 1;
         }
 
         retval = -1;
     }
 
-#elif ENABLE_AUDIT
+    return retval;
+}
+
+#elif defined ENABLE_AUDIT
+int fim_whodata_initialize() {
+    directory_t *dir_it;
+
+    foreach_array(dir_it, syscheck.directories) {
+        char *path;
+
+        if ((dir_it->options & WHODATA_ACTIVE) == 0) {
+            continue;
+        }
+
+        path = fim_get_real_path(dir_it);
+        realtime_adddir(path, dir_it, (dir_it->options & CHECK_FOLLOW) ? 1 : 0);
+
+        os_free(path);
+    }
+
     audit_set_db_consistency();
 
-#endif
+    return 0;
+}
 
 #else
+int fim_whodata_initialize() {
     if (syscheck.enable_whodata) {
         mwarn(FIM_WARN_WHODATA_UNSUPPORTED);
     }
-#endif
-
-    return retval;
+    return -1;
 }
+#endif
 
 
 void log_realtime_status(int next) {
@@ -563,7 +580,7 @@ void log_realtime_status(int next) {
 // LCOV_EXCL_START
 static void *symlink_checker_thread(__attribute__((unused)) void * data) {
     char *real_path;
-    int i;
+    directory_t *dir_it;
 
     mdebug1(FIM_LINKCHECK_START, syscheck.sym_checker_interval);
 
@@ -572,39 +589,39 @@ static void *symlink_checker_thread(__attribute__((unused)) void * data) {
         mdebug1(FIM_LINKCHECK_START, syscheck.sym_checker_interval);
 
         w_mutex_lock(&syscheck.fim_scan_mutex);
-        for (i = 0; syscheck.dir[i]; i++) {
-            if (!(CHECK_FOLLOW & syscheck.opts[i])) {
+        foreach_array(dir_it, syscheck.directories) {
+            if ((dir_it->options & CHECK_FOLLOW) == 0) {
                 continue;
             }
 
-            real_path = realpath(syscheck.dir[i], NULL);
+            real_path = realpath(dir_it->path, NULL);
 
-            if (syscheck.symbolic_links[i]) {
+            if (dir_it->symbolic_links) {
                 if (real_path) {
                     // Check if link has changed
-                    if (strcmp(real_path, syscheck.symbolic_links[i])) {
-                        minfo(FIM_LINKCHECK_CHANGED, syscheck.dir[i], syscheck.symbolic_links[i], real_path);
-                        fim_link_update(i, real_path);
+                    if (strcmp(real_path, dir_it->symbolic_links)) {
+                        minfo(FIM_LINKCHECK_CHANGED, dir_it->path, dir_it->symbolic_links, real_path);
+                        fim_link_update(real_path, dir_it);
                     } else {
-                        mdebug1(FIM_LINKCHECK_NOCHANGE, syscheck.symbolic_links[i]);
+                        mdebug1(FIM_LINKCHECK_NOCHANGE, dir_it->symbolic_links);
                     }
                 } else {
                     // Broken link
                     char path[PATH_MAX];
 
-                    snprintf(path, PATH_MAX, "%s", syscheck.symbolic_links[i]);
-                    fim_link_check_delete(i);
+                    snprintf(path, PATH_MAX, "%s", dir_it->symbolic_links);
+                    fim_link_check_delete(dir_it);
 
-                    int config = fim_configuration_directory(path);
+                    directory_t *config = fim_configuration_directory(path);
 
-                    if (config >= 0) {
+                    if (config != NULL) {
                         fim_link_silent_scan(path, config);
                     }
                 }
             } else {
                 // Check real_path to reload broken link.
-                if (real_path && strcmp(real_path, syscheck.dir[i]) != 0) {
-                    fim_link_reload_broken_link(real_path, i);
+                if (real_path && strcmp(real_path, dir_it->path) != 0) {
+                    fim_link_reload_broken_link(real_path, dir_it);
                 }
             }
 
@@ -619,20 +636,20 @@ static void *symlink_checker_thread(__attribute__((unused)) void * data) {
 }
 // LCOV_EXCL_STOP
 
-STATIC void fim_link_update(int pos, char *new_path) {
-    int i;
+STATIC void fim_link_update(const char *new_path, directory_t *configuration) {
     int in_configuration = false;
     int is_new_link = true;
+    directory_t *dir_it;
+
     // Check if the previously pointed folder is in the configuration
     // and delete its database entries if it isn't
-    for (i = 0; syscheck.dir[i] != NULL; i++) {
-        if (i == pos) {
+    foreach_array(dir_it, syscheck.directories) {
+        if (dir_it == configuration) {
             // This is the link being changed
             continue;
         }
 
-        if (strcmp(syscheck.symbolic_links[pos],
-                   syscheck.symbolic_links[i] ? syscheck.symbolic_links[i] : syscheck.dir[i]) == 0) {
+        if (strcmp(configuration->symbolic_links, dir_it->symbolic_links ? dir_it->symbolic_links : dir_it->path) == 0) {
             in_configuration = true;
             break;
         }
@@ -641,133 +658,139 @@ STATIC void fim_link_update(int pos, char *new_path) {
     if (in_configuration == false) {
 #ifdef ENABLE_AUDIT
         // Remove the audit rule for the previous link only if the path is not configured in other entry.
-        if (syscheck.opts[pos] & WHODATA_ACTIVE) {
-            remove_audit_rule_syscheck(syscheck.symbolic_links[pos]);
+        if (configuration->options & WHODATA_ACTIVE) {
+            remove_audit_rule_syscheck(configuration->symbolic_links);
         }
 #endif
-        fim_link_delete_range(pos);
+        fim_link_delete_range(configuration);
     }
 
     // Check if the updated path of the link is already in the configuration
-    for (i = 0; syscheck.dir[i] != NULL; i++) {
-        if (i == pos) {
-            if (strcmp(new_path, syscheck.dir[i]) == 0) {
+    foreach_array(dir_it, syscheck.directories) {
+        if (dir_it == configuration) {
+            if (strcmp(new_path, dir_it->path) == 0) {
                 // We were monitoring a link, now we are monitoring the actual directory
 #ifdef ENABLE_AUDIT
-                if (syscheck.opts[i] & WHODATA_ACTIVE) {
-                    add_whodata_directory(syscheck.dir[i]);
+                if (dir_it->options & WHODATA_ACTIVE) {
+                    add_whodata_directory(dir_it->path);
                 }
 #endif
                 is_new_link = false;
                 break;
             }
-        } else if (strcmp(new_path, syscheck.symbolic_links[i] ? syscheck.symbolic_links[i] : syscheck.dir[i]) == 0) {
-            mdebug1(FIM_LINK_ALREADY_ADDED, syscheck.dir[i]);
+        } else if (strcmp(new_path, dir_it->symbolic_links ? dir_it->symbolic_links : dir_it->path) == 0) {
+            mdebug1(FIM_LINK_ALREADY_ADDED, dir_it->path);
             is_new_link = false;
             break;
         }
     }
 
     w_mutex_lock(&syscheck.fim_symlink_mutex);
-    os_free(syscheck.symbolic_links[pos]);
+    os_free(configuration->symbolic_links);
 
     if (is_new_link) {
-        os_strdup(new_path, syscheck.symbolic_links[pos]);
+        os_strdup(new_path, configuration->symbolic_links);
     }
 
     w_mutex_unlock(&syscheck.fim_symlink_mutex);
     if (is_new_link) {
         // Add new entries without alert.
-        fim_link_silent_scan(new_path, pos);
+        fim_link_silent_scan(new_path, configuration);
     }
 }
 
-STATIC void fim_link_check_delete(int pos) {
+STATIC void fim_link_check_delete(directory_t *configuration) {
     struct stat statbuf;
 
-    if (w_stat(syscheck.symbolic_links[pos], &statbuf) < 0) {
+    if (w_stat(configuration->symbolic_links, &statbuf) < 0) {
         if (errno == ENOENT) {
 #ifdef ENABLE_AUDIT
-            if (syscheck.opts[pos] & WHODATA_ACTIVE) {
-                remove_audit_rule_syscheck(syscheck.symbolic_links[pos]);
+            if (configuration->options & WHODATA_ACTIVE) {
+                remove_audit_rule_syscheck(configuration->symbolic_links);
             }
 #endif
             w_mutex_lock(&syscheck.fim_symlink_mutex);
-            os_free(syscheck.symbolic_links[pos]);
+            os_free(configuration->symbolic_links);
             w_mutex_unlock(&syscheck.fim_symlink_mutex);
             return;
         }
 
-        mdebug1(FIM_STAT_FAILED, syscheck.symbolic_links[pos], errno, strerror(errno));
+        mdebug1(FIM_STAT_FAILED, configuration->symbolic_links, errno, strerror(errno));
     } else {
-        fim_link_delete_range(pos);
+        fim_link_delete_range(configuration);
 
         if (syscheck.realtime && syscheck.realtime->dirtb) {
-            fim_delete_realtime_watches(pos);
+            fim_delete_realtime_watches(configuration);
         }
 #ifdef ENABLE_AUDIT
-        if (syscheck.opts[pos] & WHODATA_ACTIVE) {
-            remove_audit_rule_syscheck(syscheck.symbolic_links[pos]);
+        if (configuration->options & WHODATA_ACTIVE) {
+            remove_audit_rule_syscheck(configuration->symbolic_links);
         }
 #endif
         w_mutex_lock(&syscheck.fim_symlink_mutex);
-        os_free(syscheck.symbolic_links[pos]);
+        os_free(configuration->symbolic_links);
         w_mutex_unlock(&syscheck.fim_symlink_mutex);
     }
 }
 
-STATIC void fim_delete_realtime_watches(__attribute__((unused)) int pos) {
+STATIC void fim_delete_realtime_watches(const directory_t *configuration) {
 #ifdef INOTIFY_ENABLED
     OSHashNode *hash_node;
     char *data;
     W_Vector * watch_to_delete = W_Vector_init(1024);
     unsigned int inode_it = 0;
     int deletion_it = 0;
-    int dir_conf;
-    int watch_conf;
+    directory_t *dir_conf;
+    directory_t *watch_conf;
 
     assert(watch_to_delete != NULL);
-    dir_conf = fim_configuration_directory(syscheck.symbolic_links[pos]);
+    assert(configuration != NULL);
 
-    if (dir_conf > -1) {
-        w_mutex_lock(&syscheck.fim_realtime_mutex);
-        hash_node = OSHash_Begin(syscheck.realtime->dirtb, &inode_it);
-        while(hash_node) {
-            data = hash_node->data;
-            if (data) {
-                watch_conf = fim_configuration_directory(data);
+    dir_conf = fim_configuration_directory(configuration->symbolic_links);
 
-                if (dir_conf == watch_conf) {
-                    W_Vector_insert(watch_to_delete, hash_node->key);
-                    deletion_it++;
-                }
-            }
-            hash_node = OSHash_Next(syscheck.realtime->dirtb, &inode_it, hash_node);
-        }
-
-        deletion_it--;
-        while(deletion_it >= 0) {
-            const char * wd_str = W_Vector_get(watch_to_delete, deletion_it);
-            assert(wd_str != NULL);
-
-            inotify_rm_watch(syscheck.realtime->fd, atol(wd_str));
-            free(OSHash_Delete_ex(syscheck.realtime->dirtb, wd_str));
-            deletion_it--;
-        }
-        w_mutex_unlock(&syscheck.fim_realtime_mutex);
+    if (dir_conf == NULL) {
+        W_Vector_free(watch_to_delete);
+        return;
     }
+
+    w_mutex_lock(&syscheck.fim_realtime_mutex);
+    for (hash_node = OSHash_Begin(syscheck.realtime->dirtb, &inode_it); hash_node;
+         hash_node = OSHash_Next(syscheck.realtime->dirtb, &inode_it, hash_node)) {
+        data = hash_node->data;
+        if (data == NULL) {
+            continue;
+        }
+        watch_conf = fim_configuration_directory(data);
+
+        if (dir_conf == watch_conf) {
+            W_Vector_insert(watch_to_delete, hash_node->key);
+            deletion_it++;
+        }
+    }
+
+    deletion_it--;
+    while(deletion_it >= 0) {
+        const char * wd_str = W_Vector_get(watch_to_delete, deletion_it);
+        assert(wd_str != NULL);
+
+        inotify_rm_watch(syscheck.realtime->fd, atol(wd_str));
+        free(OSHash_Delete_ex(syscheck.realtime->dirtb, wd_str));
+        deletion_it--;
+    }
+    w_mutex_unlock(&syscheck.fim_realtime_mutex);
 
     W_Vector_free(watch_to_delete);
 #endif
     return;
 }
 
-STATIC void fim_link_delete_range(int pos) {
+STATIC void fim_link_delete_range(directory_t *configuration) {
     fim_tmp_file * file = NULL;
+    event_data_t evt_data = { .mode = FIM_SCHEDULED, .report_event = false, .w_evt = NULL, .type = FIM_DELETE };
     char pattern[PATH_MAX] = {0};
 
     // Create the sqlite LIKE pattern.
-    snprintf(pattern, PATH_MAX, "%s%c%%", syscheck.symbolic_links[pos], PATH_SEP);
+    snprintf(pattern, PATH_MAX, "%s%c%%", configuration->symbolic_links, PATH_SEP);
 
     w_mutex_lock(&syscheck.fim_entry_mutex);
 
@@ -778,74 +801,70 @@ STATIC void fim_link_delete_range(int pos) {
     w_mutex_unlock(&syscheck.fim_entry_mutex);
 
     if (file && file->elements) {
-        fim_event_mode mode = FIM_MODE(syscheck.opts[pos]);
-
-        if (fim_db_delete_range(syscheck.database, file,
-                                &syscheck.fim_entry_mutex, syscheck.database_store, mode, &pos) != FIMDB_OK) {
+        if (fim_db_delete_range(syscheck.database, file, &syscheck.fim_entry_mutex, syscheck.database_store,
+                                &evt_data, configuration) != FIMDB_OK) {
             merror(FIM_DB_ERROR_RM_PATTERN, pattern);
         }
     }
 }
 
-STATIC void fim_link_silent_scan(char *path, int pos) {
-    struct fim_element item = { .index = pos, .mode = FIM_SCHEDULED };
+STATIC void fim_link_silent_scan(const char *path, directory_t *configuration) {
+    event_data_t evt_data = { .mode = FIM_SCHEDULED, .w_evt = NULL, .report_event = false };
 
-    fim_checker(path, &item, NULL, 0);
+    fim_checker(path, &evt_data, configuration);
 
-    if (syscheck.opts[pos] & REALTIME_ACTIVE) {
-        realtime_adddir(path, 0, 1);    // This is acting always on links, so `followsl` will always be `1`
-    } else if (syscheck.opts[pos] & WHODATA_ACTIVE) {
+    if (configuration->options & REALTIME_ACTIVE) {
+        realtime_adddir(path, configuration, 1);    // This is acting always on links, so `followsl` will always be `1`
+    } else if (configuration->options & WHODATA_ACTIVE) {
 #ifdef ENABLE_AUDIT
         // Just in case, we need to remove the configured directory if it was previously monitored
-        remove_audit_rule_syscheck(syscheck.dir[pos]);
+        remove_audit_rule_syscheck(configuration->path);
         add_whodata_directory(path);
 #endif
     }
 }
 
-STATIC void fim_link_reload_broken_link(char *path, int index) {
-    int element;
-    int found = 0;
+STATIC void fim_link_reload_broken_link(char *path, directory_t *configuration) {
+    directory_t *dir_it;
 
-    for (element = 0; syscheck.dir[element]; element++) {
-        if (strcmp(path, syscheck.dir[element]) == 0) {
+    foreach_array(dir_it, syscheck.directories) {
+        if (strcmp(path, dir_it->path) == 0) {
             // If a configuration directory exists don't reload
-            mdebug1(FIM_LINK_ALREADY_ADDED, syscheck.dir[element]);
-            found = 1;
+            mdebug1(FIM_LINK_ALREADY_ADDED, dir_it->path);
+            return;
         }
     }
 
     // Reload broken link
-    if (!found) {
-        w_mutex_lock(&syscheck.fim_symlink_mutex);
-        os_free(syscheck.symbolic_links[index]);
-        os_strdup(path, syscheck.symbolic_links[index]);
-        w_mutex_unlock(&syscheck.fim_symlink_mutex);
+    w_mutex_lock(&syscheck.fim_symlink_mutex);
+    os_free(configuration->symbolic_links);
+    os_strdup(path, configuration->symbolic_links);
+    w_mutex_unlock(&syscheck.fim_symlink_mutex);
 
-        // Add new entries without alert.
-        fim_link_silent_scan(path, index);
-    }
+    // Add new entries without alert.
+    fim_link_silent_scan(path, configuration);
 }
 
 #endif
 #ifdef WIN_WHODATA
 void set_whodata_mode_changes() {
+    directory_t *dir_it;
+
     if (!syscheck.realtime) {
         realtime_start();
     }
 
     syscheck.realtime_change = 0;
 
-    int i;
-    for (i = 0; syscheck.dir[i]; i++) {
-        if (syscheck.wdata.dirs_status[i].status & WD_CHECK_REALTIME) {
+    foreach_array(dir_it, syscheck.directories) {
+        if (dir_it->dirs_status.status & WD_CHECK_REALTIME) {
             // At this point the directories in whodata mode that have been deconfigured are added to realtime
-            syscheck.wdata.dirs_status[i].status &= ~WD_CHECK_REALTIME;
-            syscheck.opts[i] |= REALTIME_ACTIVE;
-            if (realtime_adddir(syscheck.dir[i], 0, 0) != 1) {
-                merror(FIM_ERROR_REALTIME_ADDDIR_FAILED, syscheck.dir[i]);
+            dir_it->dirs_status.status &= ~WD_CHECK_REALTIME;
+            dir_it->options |= REALTIME_ACTIVE;
+            if (realtime_adddir(dir_it->path, dir_it, 0) != 1) {
+                merror(FIM_ERROR_REALTIME_ADDDIR_FAILED, dir_it->path);
             } else {
-                mdebug1(FIM_REALTIME_MONITORING, syscheck.dir[i]);
+                mdebug1(FIM_REALTIME_MONITORING, dir_it->path);
             }
         }
     }

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -196,6 +196,8 @@ void start_daemon()
     if (nice(syscheck.process_priority) == -1) {
         merror(NICE_ERROR, strerror(errno), errno);
     }
+#else
+    set_priority_windows_thread();
 #endif
 
 #ifndef WIN32
@@ -469,8 +471,6 @@ int fim_whodata_initialize() {
     int retval = 0;
     directory_t *dir_it;
 
-    set_priority_windows_thread();
-
     foreach_array(dir_it, syscheck.directories) {
         if ((dir_it->options & WHODATA_ACTIVE) == 0) {
             continue;
@@ -515,21 +515,6 @@ int fim_whodata_initialize() {
 
 #elif defined ENABLE_AUDIT
 int fim_whodata_initialize() {
-    directory_t *dir_it;
-
-    foreach_array(dir_it, syscheck.directories) {
-        char *path;
-
-        if ((dir_it->options & WHODATA_ACTIVE) == 0) {
-            continue;
-        }
-
-        path = fim_get_real_path(dir_it);
-        realtime_adddir(path, dir_it, (dir_it->options & CHECK_FOLLOW) ? 1 : 0);
-
-        os_free(path);
-    }
-
     audit_set_db_consistency();
 
     return 0;

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -434,8 +434,10 @@ void * fim_run_realtime(__attribute__((unused)) void * args) {
     }
 
 #else
-    for (int i = 0; syscheck.dir[i]; i++) {
-        if (syscheck.opts[i] & REALTIME_ACTIVE) {
+    directory_t *dir_it;
+
+    foreach_array(dir_it, syscheck.directories) {
+        if (dir_it->options & REALTIME_ACTIVE) {
             mwarn(FIM_WARN_REALTIME_UNSUPPORTED);
             break;
         }

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -636,8 +636,9 @@ int realtime_start()
     return (0);
 }
 
-int realtime_adddir(__attribute__((unused)) const char *dir, __attribute__((unused))int whodata, __attribute__((unused))int followsl)
-{
+int realtime_adddir(__attribute__((unused)) const char *dir,
+                    __attribute__((unused)) directory_t *configuration,
+                    __attribute__((unused)) int followsl) {
     return (0);
 }
 

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -67,12 +67,12 @@ typedef enum fim_state_db {
     FIM_STATE_DB_FULL
 } fim_state_db;
 
-typedef struct fim_element {
-    struct stat statbuf;
-    int index;
-    int configuration;
+typedef struct _event_data_s {
+    int report_event;
     fim_event_mode mode;
-} fim_element;
+    fim_event_type type;
+    whodata_evt *w_evt;
+} event_data_t;
 
 typedef struct fim_tmp_file {
     union { //type_storage
@@ -171,32 +171,30 @@ void check_max_fps();
  * @brief
  *
  * @param [in] path Path of the file to check
- * @param [out] item FIM item
- * @param [in] w_evt Whodata event
- * @param [in] report 0 Dont report alert in the scan, otherwise an alert is generated
+ * @param [in] evt_data Information associated to the triggered event
+ * @param [in] configuration Configuration block associated with a previous event.
  */
-void fim_checker(const char *path, fim_element *item, whodata_evt *w_evt, int report);
+void fim_checker(const char *path, event_data_t *evt_data, const directory_t *configuration);
 
 /**
  * @brief Check file integrity monitoring on a specific folder
  *
  * @param [in] dir
- * @param [out] item FIM item
- * @param [in] w_evt Whodata event
- * @param [in] report 0 Dont report alert in the scan, otherwise an alert is generated
+ * @param [in] evt_data Information associated to the triggered event
+ * @param [in] configuration Configuration block associated with the directory.
  * @return 0 on success, -1 on failure
  */
-int fim_directory (const char *dir, fim_element *item, whodata_evt *w_evt, int report);
+int fim_directory(const char *dir, event_data_t *evt_data, const directory_t *configuration) ;
 
 /**
  * @brief Check file integrity monitoring on a specific file
  *
- * @param [in] file
- * @param [in] item FIM item
- * @param [in] w_evt Whodata event
- * @param [in] report 0 Dont report alert in the scan, otherwise an alert is generated
+ * @param [in] path Path of the file to check
+ * @param [in] configuration Configuration block associated with a previous event.
+ * @param [in] evt_data Information associated to the triggered event
+ * @param [in] statbuf Buffer acquired from a stat command with information linked to 'path'
  */
-void fim_file(const char *file, fim_element *item, whodata_evt *w_evt, int report);
+void fim_file(const char *path, const directory_t *configuration, event_data_t *evt_data, const struct stat *statbuf);
 
 /**
  * @brief Process FIM realtime event
@@ -226,28 +224,29 @@ void fim_process_missing_entry(char * pathname, fim_event_mode mode, whodata_evt
  * @brief Search the position of the path in directories array
  *
  * @param path Path to seek in the directories array
- * @return Returns the position of the path in the directories array, -1 if the path is not found
+ * @return Returns a pointer to the configuration associated with the provided path, NULL if the path is not found
  */
-int fim_configuration_directory(const char *path);
+directory_t *fim_configuration_directory(const char *path);
 
 /**
  * @brief Evaluates the depth of the directory or file to check if it exceeds the configured max_depth value
  *
  * @param path File name of the file/directory to check
- * @param dir_position Position of the file to check in the directories array
+ * @param configuration Configuration associated with the file
  * @return Depth of the directory/file, -1 on error
  */
-int fim_check_depth(const char *path, int dir_position);
+int fim_check_depth(const char *path, const directory_t *configuration);
 
 /**
  * @brief Get data from file
  *
- * @param file_name Name of the file to get the data from
- * @param item FIM item asociated with the file
+ * @param file Name of the file to get the data from
+ * @param [in] configuration Configuration block associated with a previous event.
+ * @param [in] statbuf Buffer acquired from a stat command with information linked to 'path'
  *
  * @return A fim_file_data structure with the data from the file
  */
-fim_file_data * fim_get_data(const char *file_name, const fim_element *item);
+fim_file_data *fim_get_data(const char *file, const directory_t *configuration, const struct stat *statbuf);
 
 /**
  * @brief Initialize a fim_file_data structure
@@ -300,24 +299,18 @@ void check_deleted_files();
  *   }
  * }
  *
- * @param file_name File path.
- * @param old_data Previous file state.
  * @param new_data Current file state.
- * @param dir_position Index of the related configuration stanza.
- * @param type Type of event: added, deleted or modified.
- * @param mode Event source.
- * @param w_evt Audit data structure.
+ * @param old_data Previous file state.
+ * @param configuration Pointer to the related configuration stanza.
+ * @param evt_data Information associated to the triggered event
  * @param diff File diff if applicable.
  * @return File event JSON object.
  * @retval NULL No changes detected. Do not send an event.
  */
-cJSON *fim_json_event(const char *file_name,
-                      fim_file_data *old_data,
-                      fim_file_data *new_data,
-                      int pos,
-                      unsigned int type,
-                      fim_event_mode mode,
-                      const whodata_evt *w_evt,
+cJSON *fim_json_event(const fim_entry *new_data,
+                      const fim_file_data *old_data,
+                      const directory_t *configuration,
+                      const event_data_t *evt_data,
                       const char *diff);
 
 /**
@@ -345,11 +338,11 @@ int realtime_start(void);
  * @brief Add a directory to real time monitoring
  *
  * @param dir Path to file or directory
- * @param whodata If the path is configured with whodata option
+ * @param configuration Configuration associated with the file or directory
  * @param followsl If the path is configured with follow sym link option
  * @return 1 on success, -1 on realtime_start failure, -2 on set_winsacl failure, and 0 on other errors
  */
-int realtime_adddir(const char *dir, int whodata, int followsl) __attribute__((nonnull(1)));
+int realtime_adddir(const char *dir, directory_t *configuration, int followsl);
 
 /**
  * @brief Process events in the real time queue
@@ -579,10 +572,10 @@ int whodata_audit_start();
  * @brief Configure the SACL in a configured folder for Whodata auditing
  *
  * @param dir The name of the folder to configure
- * @param position The position of the folder in the configuration array
+ * @param configuration The configuration associated with the folder.
  * @return 0 on success, 1 on error
  */
-int set_winsacl(const char *dir, int position);
+int set_winsacl(const char *dir, directory_t *configuration);
 
 /**
  * @brief In case SACLs and policies have been set, restore them
@@ -916,24 +909,26 @@ void fim_diff_folder_size();
  * @brief Get the directory that will be effectively monitored depending on configuration the entry configuration and
  * physical object in the filesystem
  *
- * @param position Position of the directory in the structure
+ * @param dir Pointer to the configuration associated with the directory
  * @return A string holding the element being monitored. It must be freed after it's usage.
  */
-char *fim_get_real_path(int position);
+char *fim_get_real_path(const directory_t *dir);
 
 /**
  * @brief Create a delete event and removes the entry from the database.
  *
- * @param fim_sql FIM database struct.
+ * @param fim_sql  FIM database struct.
  * @param entry Entry data to be removed.
  * @param mutex FIM database's mutex for thread synchronization.
- * @param alert False don't send alert, True send delete alert.
- * @param fim_ev_mode FIM Mode (scheduled/realtime/whodata)
- * @param w_evt Whodata information.
+ * @param _evt_data Information associated to the triggered event.
+ * @param _unused_field_1 Unused field, required to use this function as a callback.
+ * @param _unused_field_2 Unused field, required to use this function as a callback.
  *
  */
-void fim_delete_file_event(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex,
-                           __attribute__((unused))void *alert,
-                           __attribute__((unused))void *fim_ev_mode,
-                           __attribute__((unused))void *w_evt);
+void fim_delete_file_event(fdb_t *fim_sql,
+                           fim_entry *entry,
+                           pthread_mutex_t *mutex,
+                           void *_evt_data,
+                           void *_unused_field_1,
+                           void *_unused_field_2);
 #endif /* SYSCHECK_H */

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -71,6 +71,7 @@ typedef struct _event_data_s {
     int report_event;
     fim_event_mode mode;
     fim_event_type type;
+    struct stat statbuf;
     whodata_evt *w_evt;
 } event_data_t;
 
@@ -192,9 +193,8 @@ int fim_directory(const char *dir, event_data_t *evt_data, const directory_t *co
  * @param [in] path Path of the file to check
  * @param [in] configuration Configuration block associated with a previous event.
  * @param [in] evt_data Information associated to the triggered event
- * @param [in] statbuf Buffer acquired from a stat command with information linked to 'path'
  */
-void fim_file(const char *path, const directory_t *configuration, event_data_t *evt_data, const struct stat *statbuf);
+void fim_file(const char *path, const directory_t *configuration, event_data_t *evt_data);
 
 /**
  * @brief Process FIM realtime event

--- a/src/syscheckd/whodata/audit_rule_handling.c
+++ b/src/syscheckd/whodata/audit_rule_handling.c
@@ -79,9 +79,9 @@ void remove_audit_rule_syscheck(const char *path) {
 }
 
 int fim_rules_initial_load() {
-    unsigned int i = 0;
     int retval;
     char *directory = NULL;
+    directory_t *dir_it = NULL;
     int rules_added = 0;
     int auditd_fd = audit_open();
     int res = audit_get_rule_list(auditd_fd);
@@ -93,13 +93,13 @@ int fim_rules_initial_load() {
     }
 
     w_mutex_lock(&rules_mutex);
-    for (i = 0; syscheck.dir[i]; i++) {
+    foreach_array(dir_it, syscheck.directories) {
         // Check if dir[i] is set in whodata mode
-        if ((syscheck.opts[i] & WHODATA_ACTIVE) == 0) {
+        if ((dir_it->options & WHODATA_ACTIVE) == 0) {
             continue; // LCOV_EXCL_LINE
         }
 
-        directory = fim_get_real_path(i);
+        directory = fim_get_real_path(dir_it);
         if (*directory == '\0') {
             free(directory); // LCOV_EXCL_LINE
             continue; // LCOV_EXCL_LINE

--- a/src/syscheckd/whodata/syscheck_audit.c
+++ b/src/syscheckd/whodata/syscheck_audit.c
@@ -185,19 +185,19 @@ int init_auditd_socket(void) {
 void audit_no_rules_to_realtime() {
     int found;
     char *real_path = NULL;
-    int i;
+    directory_t *dir_it = NULL;
 
-    for (i = 0; syscheck.dir[i] != NULL; i++) {
-        if ((syscheck.opts[i] & WHODATA_ACTIVE) == 0) {
+    foreach_array(dir_it, syscheck.directories) {
+        if ((dir_it->options & WHODATA_ACTIVE) == 0) {
             continue;
         }
-        real_path = fim_get_real_path(i);
+        real_path = fim_get_real_path(dir_it);
         found = search_audit_rule(real_path, WHODATA_PERMS, AUDIT_KEY);
 
         if (found == 0) {   // No rule found
             mwarn(FIM_ERROR_WHODATA_ADD_DIRECTORY, real_path);
-            syscheck.opts[i] &= ~WHODATA_ACTIVE;
-            syscheck.opts[i] |= REALTIME_ACTIVE;
+            dir_it->options &= ~WHODATA_ACTIVE;
+            dir_it->options |= REALTIME_ACTIVE;
         }
         free(real_path);
     }
@@ -302,7 +302,7 @@ void audit_set_db_consistency(void) {
 // LCOV_EXCL_START
 void *audit_main(audit_data_t *audit_data) {
     char *path = NULL;
-    int pos;
+    directory_t *dir_it = NULL;
     count_reload_retries = 0;
     audit_thread_active = 0;
 
@@ -333,20 +333,20 @@ void *audit_main(audit_data_t *audit_data) {
     // Clean regexes used for parsing events
     clean_regex();
     // Change Audit monitored folders to Inotify.
-    for (pos = 0; syscheck.dir[pos]; pos++) {
-        if ((syscheck.opts[pos] & WHODATA_ACTIVE) == 0) {
+    foreach_array(dir_it, syscheck.directories) {
+        if ((dir_it->options & WHODATA_ACTIVE) == 0) {
             continue;
         }
-        path = fim_get_real_path(pos);
+        path = fim_get_real_path(dir_it);
         // Check if it's a broken link.
         if (*path == '\0') {
             free(path);
             continue;
         }
-        syscheck.opts[pos] &= ~ WHODATA_ACTIVE;
-        syscheck.opts[pos] |= REALTIME_ACTIVE;
+        dir_it->options &= ~ WHODATA_ACTIVE;
+        dir_it->options |= REALTIME_ACTIVE;
 
-        realtime_adddir(path, 0, (syscheck.opts[pos] & CHECK_FOLLOW) ? 1 : 0);
+        realtime_adddir(path, 0, (dir_it->options & CHECK_FOLLOW) ? 1 : 0);
         free(path);
     }
 

--- a/src/syscheckd/whodata/win_whodata.c
+++ b/src/syscheckd/whodata/win_whodata.c
@@ -139,7 +139,7 @@ int get_volume_names();
 int get_drive_names(wchar_t *volume_name, char *device);
 void replace_device_path(char **path);
 
-int set_winsacl(const char *dir, int position) {
+int set_winsacl(const char *dir, directory_t *configuration) {
     DWORD result = 0;
     PACL old_sacl = NULL, new_sacl = NULL;
     PSECURITY_DESCRIPTOR security_descriptor = NULL;
@@ -151,6 +151,8 @@ int set_winsacl(const char *dir, int position) {
     unsigned long new_sacl_size;
     int retval = 1;
     int privilege_enabled = 0;
+
+    assert(configuration != NULL);
 
     mdebug2(FIM_SACL_CONFIGURE, dir);
 
@@ -174,7 +176,7 @@ int set_winsacl(const char *dir, int position) {
     ZeroMemory(&old_sacl_info, sizeof(ACL_SIZE_INFORMATION));
 
     // Check if the sacl has what the whodata scanner needs
-    int is_file = syscheck.wdata.dirs_status[position].object_type == WD_STATUS_FILE_TYPE ? 1 : 0;
+    int is_file = configuration->dirs_status.object_type == WD_STATUS_FILE_TYPE ? 1 : 0;
 
     switch (is_valid_sacl(old_sacl, is_file)) {
     case 0:
@@ -183,7 +185,7 @@ int set_winsacl(const char *dir, int position) {
         goto end;
     case 1:
         mdebug1(FIM_SACL_CHECK_CONFIGURE, dir);
-        syscheck.wdata.dirs_status[position].status |= WD_IGNORE_REST;
+        configuration->dirs_status.status |= WD_IGNORE_REST;
 
         // Empty SACL
         if (!old_sacl) {
@@ -403,7 +405,6 @@ void audit_restore() {
 
 /* Removes added security audit policies */
 void restore_sacls() {
-    int i;
     PACL sacl_it;
     HANDLE hdle = NULL;
     HANDLE c_process = NULL;
@@ -411,6 +412,7 @@ void restore_sacls() {
     DWORD result = 0;
     PSECURITY_DESCRIPTOR security_descriptor = NULL;
     int privilege_enabled = 0;
+    directory_t *dir_it;
 
     c_process = GetCurrentProcess();
     if (!OpenProcessToken(c_process, TOKEN_ADJUST_PRIVILEGES, &hdle)) {
@@ -425,10 +427,13 @@ void restore_sacls() {
 
     privilege_enabled = 1;
 
-    for (i = 0; syscheck.dir[i] != NULL; i++) {
-        if (syscheck.wdata.dirs_status[i].status & WD_IGNORE_REST) {
+    foreach_array(dir_it, syscheck.directories) {
+        if (dir_it->dirs_status.status & WD_IGNORE_REST) {
             sacl_it = NULL;
-            if (result = GetNamedSecurityInfo(syscheck.dir[i], SE_FILE_OBJECT, SACL_SECURITY_INFORMATION, NULL, NULL, NULL, &sacl_it, &security_descriptor), result != ERROR_SUCCESS) {
+
+            result = GetNamedSecurityInfo(dir_it->path, SE_FILE_OBJECT, SACL_SECURITY_INFORMATION, NULL, NULL, NULL,
+                                          &sacl_it, &security_descriptor);
+            if (result != ERROR_SUCCESS) {
                 merror(FIM_ERROR_SACL_GETSECURITYINFO, result);
                 break;
             }
@@ -440,7 +445,8 @@ void restore_sacls() {
             }
 
             // Set the SACL
-            if (result = SetNamedSecurityInfo((char *) syscheck.dir[i], SE_FILE_OBJECT, SACL_SECURITY_INFORMATION, NULL, NULL, NULL, sacl_it), result != ERROR_SUCCESS) {
+            result = SetNamedSecurityInfo(dir_it->path, SE_FILE_OBJECT, SACL_SECURITY_INFORMATION, NULL, NULL, NULL, sacl_it);
+            if (result != ERROR_SUCCESS) {
                 merror(FIM_ERROR_SACL_SETSECURITYINFO, result);
                 break;
             }
@@ -452,7 +458,7 @@ void restore_sacls() {
             if (security_descriptor) {
                 LocalFree((HLOCAL)security_descriptor);
             }
-            mdebug1(FIM_SACL_RESTORED, syscheck.dir[i]);
+            mdebug1(FIM_SACL_RESTORED, dir_it->path);
         }
     }
 
@@ -666,7 +672,6 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
     unsigned long mask = 0;
 
     if (action == EvtSubscribeActionDeliver) {
-        fim_element *item;
         char hash_id[21];
 
         if (buffer = whodata_event_render(event), !buffer) {
@@ -698,17 +703,18 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
                     free_whodata_event(w_evt);
                     goto clean;
                 }
-                if (w_evt->config_node = fim_configuration_directory(w_evt->path), w_evt->config_node < 0 &&
-                    !(mask & (FILE_APPEND_DATA | FILE_WRITE_DATA))) {
+
+                w_evt->config_node = fim_configuration_directory(w_evt->path);
+                if (w_evt->config_node == NULL && !(mask & (FILE_APPEND_DATA | FILE_WRITE_DATA))) {
                     // Discard the file or directory if its monitoring has not been activated
                     mdebug2(FIM_WHODATA_NOT_ACTIVE, w_evt->path);
                     free_whodata_event(w_evt);
                     goto clean;
                 }
 
-                if (w_evt->config_node >= 0) {
+                if (w_evt->config_node != NULL) {
                     // Ignore the file if belongs to a non-whodata directory
-                    if (!(syscheck.wdata.dirs_status[w_evt->config_node].status & WD_CHECK_WHODATA) &&
+                    if (!(w_evt->config_node->dirs_status.status & WD_CHECK_WHODATA) &&
                         !(mask & (FILE_APPEND_DATA | FILE_WRITE_DATA))) {
                         mdebug2(FIM_WHODATA_CANCELED, w_evt->path);
                         free_whodata_event(w_evt);
@@ -717,8 +723,8 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
 
                     // Ignore any and all events that are beyond the configured recursion level.
                     int depth = fim_check_depth(w_evt->path, w_evt->config_node);
-                    if (depth > syscheck.recursion_level[w_evt->config_node]) {
-                        mdebug2(FIM_MAX_RECURSION_LEVEL, depth, syscheck.recursion_level[w_evt->config_node], w_evt->path);
+                    if (depth > w_evt->config_node->recursion_level) {
+                        mdebug2(FIM_MAX_RECURSION_LEVEL, depth, w_evt->config_node->recursion_level, w_evt->path);
                         free_whodata_event(w_evt);
                         goto clean;
                     }
@@ -804,7 +810,7 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
                 }
 
                 // Check if is a valid directory
-                if (w_evt->config_node < 0) {
+                if (w_evt->config_node == NULL) {
                     mdebug2(FIM_WHODATA_DIRECTORY_DISCARDED, w_evt->path);
                     w_evt->scan_directory = 2;
                     break;
@@ -844,9 +850,6 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
 
             // Close fd
             case 4658:
-                os_calloc(1, sizeof(fim_element), item);
-                item->mode = FIM_WHODATA;
-
                 if (w_evt = OSHash_Delete_ex(syscheck.wdata.fd, hash_id), w_evt && w_evt->path) {
 
                     if (!w_evt->scan_directory) {
@@ -872,8 +875,7 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
                 }
 
                 free_whodata_event(w_evt);
-                os_free(item);
-            break;
+                break;
 
             default:
                 merror(FIM_ERROR_WHODATA_EVENTID);
@@ -906,13 +908,13 @@ int whodata_audit_start() {
 }
 
 long unsigned int WINAPI state_checker(__attribute__((unused)) void *_void) {
-    int i;
     int exists;
     whodata_dir_status *d_status;
     int interval;
     OSHashNode *w_dir_node;
     OSHashNode *w_dir_node_next;
     whodata_directory *w_dir;
+    directory_t *dir_it;
     unsigned int w_dir_it;
     FILETIME current_time;
     ULARGE_INTEGER stale_time;
@@ -926,38 +928,37 @@ long unsigned int WINAPI state_checker(__attribute__((unused)) void *_void) {
     mdebug1(FIM_WHODATA_CHECKTHREAD, interval);
 
     while (FOREVER()) {
-        for (i = 0; syscheck.dir[i]; i++) {
+        foreach_array(dir_it, syscheck.directories) {
             exists = 0;
-            d_status = &syscheck.wdata.dirs_status[i];
+            d_status = &dir_it->dirs_status;
 
             if (!(d_status->status & WD_CHECK_WHODATA)) {
                 // It is not whodata
                 continue;
             }
 
-            switch (check_path_type(syscheck.dir[i])) {
-                case 0:
-                    // Unknown device type or does not exist
-                    exists = 0;
+            switch (check_path_type(dir_it->path)) {
+            case 0:
+                // Unknown device type or does not exist
+                exists = 0;
                 break;
-                case 1:
-                    exists = 1;
-                    d_status->object_type = WD_STATUS_FILE_TYPE;
+            case 1:
+                exists = 1;
+                d_status->object_type = WD_STATUS_FILE_TYPE;
                 break;
-                case 2:
-                    exists = 1;
-                    d_status->object_type = WD_STATUS_DIR_TYPE;
+            case 2:
+                exists = 1;
+                d_status->object_type = WD_STATUS_DIR_TYPE;
                 break;
-
             }
 
             if (exists) {
                 if (!(d_status->status & WD_STATUS_EXISTS)) {
-                    minfo(FIM_WHODATA_READDED, syscheck.dir[i]);
-                    if (set_winsacl(syscheck.dir[i], i)) {
-                        merror(FIM_ERROR_WHODATA_ADD_DIRECTORY, syscheck.dir[i]);
+                    minfo(FIM_WHODATA_READDED, dir_it->path);
+                    if (set_winsacl(dir_it->path, dir_it)) {
+                        merror(FIM_ERROR_WHODATA_ADD_DIRECTORY, dir_it->path);
                         d_status->status &= ~WD_CHECK_WHODATA;
-                        syscheck.opts[i] &= ~WHODATA_ACTIVE;
+                        dir_it->options &= ~WHODATA_ACTIVE;
                         d_status->status |= WD_CHECK_REALTIME;
                         syscheck.realtime_change = 1;
                         continue;
@@ -965,25 +966,25 @@ long unsigned int WINAPI state_checker(__attribute__((unused)) void *_void) {
                     d_status->status |= WD_STATUS_EXISTS;
                 } else {
                     // Check if the SACL is invalid
-                    if (check_object_sacl(syscheck.dir[i], (d_status->object_type == WD_STATUS_FILE_TYPE)) == 1) {
-                        minfo(FIM_WHODATA_SACL_CHANGED, syscheck.dir[i]);
+                    if (check_object_sacl(dir_it->path, (d_status->object_type == WD_STATUS_FILE_TYPE)) == 1) {
+                        minfo(FIM_WHODATA_SACL_CHANGED, dir_it->path);
                         // Mark the directory to prevent its children from
                         // sending partial whodata alerts
                         d_status->status &= ~WD_CHECK_WHODATA;
                         // Removes CHECK_WHODATA from directory properties to prevent from
                         // being found in the whodata callback for Windows
-                        syscheck.opts[i] &= ~WHODATA_ACTIVE;
+                        dir_it->options &= ~WHODATA_ACTIVE;
                         // Mark it to prevent the restoration of its SACL
                         d_status->status &= ~WD_IGNORE_REST;
                         // Mark it to be monitored by Realtime
                         d_status->status |= WD_CHECK_REALTIME;
                         syscheck.realtime_change = 1;
-                        notify_SACL_change(syscheck.dir[i]);
+                        notify_SACL_change(dir_it->path);
                         continue;
                     }
                 }
             } else {
-                mdebug1(FIM_WHODATA_DELETE, syscheck.dir[i]);
+                mdebug1(FIM_WHODATA_DELETE, dir_it->path);
                 d_status->status &= ~WD_STATUS_EXISTS;
                 d_status->object_type = WD_STATUS_UNK_TYPE;
             }

--- a/src/unit_tests/syscheckd/db/test_fim_db_files.c
+++ b/src/unit_tests/syscheckd/db/test_fim_db_files.c
@@ -38,9 +38,9 @@
 void fim_db_remove_validated_path(fdb_t *fim_sql,
                                   fim_entry *entry,
                                   pthread_mutex_t *mutex,
-                                  void *alert,
-                                  void *fim_ev_mode,
-                                  void *configuration);
+                                  void *evt_data,
+                                  void *configuration,
+                                  void *_unused_patameter);
 
 #ifndef TEST_WINAGENT
 extern unsigned long __real_time();
@@ -1111,10 +1111,9 @@ static void test_fim_db_remove_validated_path_invalid_path(void **state) {
 #endif
     fim_entry entry = { .type = FIM_TYPE_FILE, .file_entry.path = entry_path, .file_entry.data = &data };
     fdb_t fim_sql = { .transaction.last_commit = 1, .transaction.interval = 1 };
-    int configuration = fim_configuration_directory(entry_path) + 1;
+    event_data_t evt_data = { .mode = FIM_SCHEDULED, .w_evt = NULL, .report_event = false, .type = FIM_DELETE };
 
-    fim_db_remove_validated_path(&fim_sql, &entry, &syscheck.fim_entry_mutex, (void *)false, (void *)FIM_REALTIME,
-                                 &configuration);
+    fim_db_remove_validated_path(&fim_sql, &entry, &syscheck.fim_entry_mutex, &evt_data, NULL, NULL);
 
     // Last commit time should change
     assert_int_equal(fim_sql.transaction.last_commit, 1);
@@ -1129,7 +1128,8 @@ static void test_fim_db_remove_validated_path_valid_path(void **state) {
 #endif
     fim_entry entry = { .type = FIM_TYPE_FILE, .file_entry.path = entry_path, .file_entry.data = &data };
     fdb_t fim_sql = { .transaction.last_commit = 1, .transaction.interval = 1 };
-    int configuration = fim_configuration_directory(entry_path);
+    event_data_t evt_data = { .mode = FIM_SCHEDULED, .w_evt = NULL, .report_event = false, .type = FIM_DELETE };
+    directory_t *configuration = fim_configuration_directory(entry_path);
 
     syscheck.database = &fim_sql;
 
@@ -1159,8 +1159,7 @@ static void test_fim_db_remove_validated_path_valid_path(void **state) {
 
     expect_fim_db_check_transaction();
 
-    fim_db_remove_validated_path(&fim_sql, &entry, &syscheck.fim_entry_mutex, (void *)false, (void *)FIM_REALTIME,
-                                 &configuration);
+    fim_db_remove_validated_path(&fim_sql, &entry, &syscheck.fim_entry_mutex, &evt_data, configuration, NULL);
 
     // Last commit time should change
     assert_int_equal(fim_sql.transaction.last_commit, 192837465);

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -41,7 +41,7 @@ extern fim_state_db _db_state;
 
 /* auxiliary structs */
 typedef struct __fim_data_s {
-    fim_element *item;
+    event_data_t *evt_data;
     whodata_evt *w_evt;
     fim_entry *fentry;
     fim_file_data *new_data;
@@ -52,6 +52,14 @@ typedef struct __fim_data_s {
     OSList *list;
     rb_tree *tree;
 } fim_data_t;
+
+const struct stat DEFAULT_STATBUF = { .st_mode = S_IFREG | 00444,
+                                      .st_size = 1000,
+                                      .st_uid = 0,
+                                      .st_gid = 0,
+                                      .st_ino = 1234,
+                                      .st_dev = 2345,
+                                      .st_mtime = 3456 };
 
 /* redefinitons/wrapping */
 
@@ -72,7 +80,7 @@ static int setup_fim_data(void **state) {
     if(fim_data == NULL)
         return -1;
 
-    if(fim_data->item = calloc(1, sizeof(fim_element)), fim_data->item == NULL)
+    if (fim_data->evt_data = calloc(1, sizeof(event_data_t)), fim_data->evt_data == NULL)
         return -1;
 
     if(fim_data->w_evt = calloc(1, sizeof(whodata_evt)), fim_data->w_evt == NULL)
@@ -155,7 +163,7 @@ static int setup_fim_data(void **state) {
 static int teardown_fim_data(void **state) {
     fim_data_t *fim_data = *state;
 
-    free(fim_data->item);
+    free(fim_data->evt_data);
     free_whodata_event(fim_data->w_evt);
     free_file_data(fim_data->new_data);
     free_file_data(fim_data->old_data);
@@ -238,15 +246,6 @@ static int setup_fim_entry(void **state) {
 
     fim_data->fentry->file_entry.data = fim_data->local_data;
     fim_data->fentry->file_entry.path = NULL;
-
-    fim_data->item->index = 1;
-    fim_data->item->configuration = CHECK_SIZE |
-                                    CHECK_PERM  |
-                                    CHECK_OWNER |
-                                    CHECK_GROUP |
-                                    CHECK_MD5SUM |
-                                    CHECK_SHA1SUM |
-                                    CHECK_SHA256SUM;
 
     fim_data->fentry->file_entry.path = strdup("file");
     fim_data->fentry->file_entry.data = fim_data->local_data;
@@ -370,15 +369,6 @@ static int setup_fim_scan_realtime(void **state) {
 }
 
 static int teardown_fim_scan_realtime(void **state) {
-    int *dir_opts = *state;
-    int it = 0;
-
-    while (syscheck.dir[it] != NULL) {
-        syscheck.opts[it] = dir_opts[it];
-        it++;
-    }
-
-    free(dir_opts);
     os_free(syscheck.database);
 
     syscheck.realtime = NULL; // Used with local variables in some tests
@@ -524,21 +514,15 @@ void prepare_win_double_scan_success (char *test_file_path, char *dir_file_path,
 /* tests */
 static void test_fim_json_event(void **state) {
     fim_data_t *fim_data = *state;
+    fim_entry entry = { .file_entry.path = "test.file", .file_entry.data = fim_data->new_data };
+    event_data_t evt_data = { .mode = FIM_REALTIME, .w_evt = NULL, .report_event = true, .type = FIM_MODIFICATION };
+    directory_t configuration = { .tag = "tag1,tag2" };
 
 #ifndef TEST_WINAGENT
     expect_wrapper_fim_db_get_paths_from_inode(syscheck.database, 606061, 12345678, NULL);
 #endif
 
-    fim_data->json = fim_json_event(
-                    "test.file",
-                    fim_data->old_data,
-                    fim_data->new_data,
-                    1,
-                    FIM_MODIFICATION,
-                    FIM_REALTIME,
-                    NULL,
-                    NULL
-                );
+    fim_data->json = fim_json_event(&entry, fim_data->old_data, &configuration, &evt_data, NULL);
 
     assert_non_null(fim_data->json);
     cJSON *type = cJSON_GetObjectItem(fim_data->json, "type");
@@ -555,10 +539,8 @@ static void test_fim_json_event(void **state) {
     assert_non_null(timestamp);
     assert_int_equal(timestamp->valueint, 1570184221);
     cJSON *tags = cJSON_GetObjectItem(data, "tags");
-#ifdef TEST_WINAGENT
-    assert_null(tags);
-#else
     assert_string_equal(cJSON_GetStringValue(tags), "tag1,tag2");
+#ifndef TEST_WINAGENT
     cJSON *hard_links = cJSON_GetObjectItem(data, "hard_links");
     assert_null(hard_links);
 #endif
@@ -582,25 +564,21 @@ static void test_fim_json_event(void **state) {
 
 static void test_fim_json_event_whodata(void **state) {
     fim_data_t *fim_data = *state;
+    fim_entry entry = { .file_entry.path = "test.file", .file_entry.data = fim_data->new_data };
+    event_data_t evt_data = {
+        .mode = FIM_WHODATA, .w_evt = fim_data->w_evt, .report_event = true, .type = FIM_MODIFICATION
+    };
+    directory_t configuration = { .tag = "tag1,tag2" };
 
-    syscheck.opts[1] |= CHECK_SEECHANGES;
+    syscheck.directories[1]->options |= CHECK_SEECHANGES;
 
 #ifndef TEST_WINAGENT
     expect_wrapper_fim_db_get_paths_from_inode(syscheck.database, 606061, 12345678, NULL);
 #endif
 
-    fim_data->json = fim_json_event(
-        "test.file",
-        fim_data->old_data,
-        fim_data->new_data,
-        1,
-        FIM_MODIFICATION,
-        FIM_WHODATA,
-        fim_data->w_evt,
-        "diff"
-    );
+    fim_data->json = fim_json_event(&entry, fim_data->old_data, &configuration, &evt_data, "diff");
 
-    syscheck.opts[1] &= ~CHECK_SEECHANGES;
+    syscheck.directories[1]->options &= ~CHECK_SEECHANGES;
 
     assert_non_null(fim_data->json);
     cJSON *type = cJSON_GetObjectItem(fim_data->json, "type");
@@ -617,10 +595,8 @@ static void test_fim_json_event_whodata(void **state) {
     assert_non_null(timestamp);
     assert_int_equal(timestamp->valueint, 1570184221);
     cJSON *tags = cJSON_GetObjectItem(data, "tags");
-#ifdef TEST_WINAGENT
-    assert_null(tags);
-#else
     assert_string_equal(cJSON_GetStringValue(tags), "tag1,tag2");
+#ifndef TEST_WINAGENT
     cJSON *hard_links = cJSON_GetObjectItem(data, "hard_links");
     assert_null(hard_links);
 #endif
@@ -638,24 +614,22 @@ static void test_fim_json_event_whodata(void **state) {
 
 static void test_fim_json_event_no_changes(void **state) {
     fim_data_t *fim_data = *state;
+    fim_entry entry = { .file_entry.path = "test.file", .file_entry.data = fim_data->new_data };
+    event_data_t evt_data = {
+        .mode = FIM_WHODATA, .w_evt = fim_data->w_evt, .report_event = true, .type = FIM_MODIFICATION
+    };
+    directory_t configuration = { .tag = "tag1,tag2" };
 
-    fim_data->json = fim_json_event(
-                        "test.file",
-                        fim_data->new_data,
-                        fim_data->new_data,
-                        1,
-                        FIM_MODIFICATION,
-                        FIM_WHODATA,
-                        NULL,
-                        NULL
-                    );
+    fim_data->json = fim_json_event(&entry, fim_data->new_data, &configuration, &evt_data, NULL);
 
     assert_null(fim_data->json);
 }
 
-
 static void test_fim_json_event_hardlink_one_path(void **state) {
     fim_data_t *fim_data = *state;
+    fim_entry entry = { .file_entry.path = "test.file", .file_entry.data = fim_data->new_data };
+    event_data_t evt_data = { .mode = FIM_REALTIME, .w_evt = NULL, .report_event = true, .type = FIM_MODIFICATION };
+    directory_t configuration = { .tag = NULL };
 
     char **paths = calloc(2, sizeof(char *));
     paths[0] = strdup("test.file");
@@ -665,17 +639,7 @@ static void test_fim_json_event_hardlink_one_path(void **state) {
     expect_wrapper_fim_db_get_paths_from_inode(syscheck.database, 606061, 12345678, paths);
 
 #endif
-
-    fim_data->json = fim_json_event(
-                    "test.file",
-                    fim_data->old_data,
-                    fim_data->new_data,
-                    2,
-                    FIM_MODIFICATION,
-                    FIM_REALTIME,
-                    NULL,
-                    NULL
-                );
+    fim_data->json = fim_json_event(&entry, fim_data->old_data, &configuration, &evt_data, NULL);
 
     assert_non_null(fim_data->json);
     cJSON *type = cJSON_GetObjectItem(fim_data->json, "type");
@@ -692,10 +656,8 @@ static void test_fim_json_event_hardlink_one_path(void **state) {
     assert_non_null(timestamp);
     assert_int_equal(timestamp->valueint, 1570184221);
     cJSON *tags = cJSON_GetObjectItem(data, "tags");
-#ifdef TEST_WINAGENT
-    assert_string_equal(cJSON_GetStringValue(tags), "tag1,tag2");
-#else
     assert_null(tags);
+#ifndef TEST_WINAGENT
     cJSON *hard_links = cJSON_GetObjectItem(data, "hard_links");
     assert_null(hard_links);
 #endif
@@ -718,6 +680,9 @@ static void test_fim_json_event_hardlink_one_path(void **state) {
 
 static void test_fim_json_event_hardlink_two_paths(void **state) {
     fim_data_t *fim_data = *state;
+    fim_entry entry = { .file_entry.path = "test.file", .file_entry.data = fim_data->new_data };
+    event_data_t evt_data = { .mode = FIM_REALTIME, .w_evt = NULL, .report_event = true, .type = FIM_MODIFICATION };
+    directory_t configuration = { .tag = NULL };
 
     char **paths = calloc(3, sizeof(char *));
     paths[0] = strdup("test.file");
@@ -728,16 +693,7 @@ static void test_fim_json_event_hardlink_two_paths(void **state) {
     expect_wrapper_fim_db_get_paths_from_inode(syscheck.database, 606061, 12345678, paths);
 #endif
 
-    fim_data->json = fim_json_event(
-                    "test.file",
-                    fim_data->old_data,
-                    fim_data->new_data,
-                    2,
-                    FIM_MODIFICATION,
-                    FIM_REALTIME,
-                    NULL,
-                    NULL
-                );
+    fim_data->json = fim_json_event(&entry, fim_data->old_data, &configuration, &evt_data, NULL);
 
     assert_non_null(fim_data->json);
     cJSON *type = cJSON_GetObjectItem(fim_data->json, "type");
@@ -754,10 +710,8 @@ static void test_fim_json_event_hardlink_two_paths(void **state) {
     assert_non_null(timestamp);
     assert_int_equal(timestamp->valueint, 1570184221);
     cJSON *tags = cJSON_GetObjectItem(data, "tags");
-#ifdef TEST_WINAGENT
-    assert_string_equal(cJSON_GetStringValue(tags), "tag1,tag2");
-#else
     assert_null(tags);
+#ifndef TEST_WINAGENT
     cJSON *hard_links = cJSON_GetObjectItem(data, "hard_links");
     assert_non_null(hard_links);
 #endif
@@ -1145,71 +1099,73 @@ static void test_fim_get_checksum_wrong_size(void **state) {
 }
 
 static void test_fim_check_depth_success(void **state) {
-    int ret;
-
 #ifndef TEST_WINAGENT
-    // Pos 4 = "/usr/bin"
     char * path = "/usr/bin/folder1/folder2/folder3/file";
+    directory_t configuration = { .path = "/usr/bin", .recursion_level = 4 };
 #else
-    // Pos 4 = "%WINDIR%\\SysNative\\wbem"
-    char *aux_path = "%WINDIR%\\SysNative\\wbem\\folder1\\folder2\\folder3\\path.exe";
+    char *aux_path = "c:\\windows\\sysnative\\wbem\\folder1\\folder2\\folder3\\path.exe";
+    directory_t configuration = { .path = "c:\\windows\\sysnative\\wbem", .recursion_level = 4 };
     char path[OS_MAXSTR];
 
     if(!ExpandEnvironmentStrings(aux_path, path, OS_MAXSTR))
         fail();
 #endif
-    ret = fim_check_depth(path, 4);
+    int ret;
+
+    ret = fim_check_depth(path, &configuration);
 
     assert_int_equal(ret, 3);
 }
 
 
 static void test_fim_check_depth_failure_strlen(void **state) {
-   int ret;
-
     char * path = "fl/fd";
-    // Pos 4 = "/usr/bin"
-    ret = fim_check_depth(path, 4);
+    directory_t configuration = { .path = "/usr/bin", .recursion_level = 4 };
+    int ret;
+
+    ret = fim_check_depth(path, &configuration);
 
     assert_int_equal(ret, -1);
 
 }
 
 static void test_fim_check_depth_failure_null_directory(void **state) {
-   int ret;
-
     char * path = "/usr/bin";
+    directory_t configuration = { .path = "/usr/bin", .recursion_level = 6 };
+    int ret;
+
     // Pos 4 = "/usr/bin"
-    ret = fim_check_depth(path, 6);
+    ret = fim_check_depth(path, &configuration);
 
     assert_int_equal(ret, -1);
 
 }
 
 static void test_fim_configuration_directory_no_path(void **state) {
-    int ret;
+    directory_t *ret;
 
     ret = fim_configuration_directory(NULL);
 
-    assert_int_equal(ret, -1);
+    assert_null(ret);
 }
 
 
 #ifndef TEST_WINAGENT
 static void test_fim_configuration_directory_file(void **state) {
-    int ret;
+    directory_t *ret;
 
     const char * path = "/media";
 
     ret = fim_configuration_directory(path);
 
-    assert_int_equal(ret, 3);
+    assert_non_null(ret);
+    assert_ptr_equal(ret, syscheck.directories[3]);
 }
 #else
 static void test_fim_configuration_directory_file(void **state) {
     char *aux_path = "%WINDIR%\\SysNative\\drivers\\etc";
     char path[OS_MAXSTR];
-    int ret;
+    directory_t *ret;
 
     if(!ExpandEnvironmentStrings(aux_path, path, OS_MAXSTR))
         fail();
@@ -1218,21 +1174,20 @@ static void test_fim_configuration_directory_file(void **state) {
 
     ret = fim_configuration_directory(path);
 
-    assert_int_equal(ret, 3);
+    assert_ptr_equal(ret, syscheck.directories[3]);
 }
 #endif
 
 
 static void test_fim_configuration_directory_not_found(void **state) {
-    int ret;
-
     const char *path = "/invalid";
+    directory_t *ret;
 
     expect_string(__wrap__mdebug2, formatted_msg, "(6319): No configuration found for (file):'/invalid'");
 
     ret = fim_configuration_directory(path);
 
-    assert_int_equal(ret, -1);
+    assert_null(ret);
 }
 
 static void test_init_fim_data_entry(void **state) {
@@ -1267,35 +1222,16 @@ static void expect_fim_db_set_scanned(fdb_t *db, const char *file_path, int ret)
 }
 
 static void test_fim_file_add(void **state) {
-    fim_data_t *fim_data = *state;
-    struct stat buf;
+    event_data_t evt_data = { .mode = FIM_SCHEDULED, .w_evt = NULL, .report_event = true };
+    directory_t configuration = { .options = CHECK_SIZE | CHECK_PERM | CHECK_OWNER | CHECK_GROUP | CHECK_MD5SUM |
+                                             CHECK_SHA1SUM | CHECK_MTIME | CHECK_SHA256SUM | CHECK_SEECHANGES };
+    struct stat statbuf = DEFAULT_STATBUF;
 
 #ifdef TEST_WINAGENT
     char file_path[OS_SIZE_256] = "c:\\windows\\system32\\cmd.exe";
 #else
     char file_path[OS_SIZE_256] = "/bin/ls";
 #endif
-
-    buf.st_mode = S_IFREG | 00444 ;
-    buf.st_size = 1000;
-    buf.st_uid = 0;
-    buf.st_gid = 0;
-    buf.st_ino = 1234;
-    buf.st_dev = 2345;
-    buf.st_mtime = 3456;
-
-    fim_data->item->index = 1;
-    fim_data->item->statbuf = buf;
-    fim_data->item->configuration = CHECK_SIZE |
-                                    CHECK_PERM |
-                                    CHECK_OWNER |
-                                    CHECK_GROUP |
-                                    CHECK_MD5SUM |
-                                    CHECK_SHA1SUM |
-                                    CHECK_MTIME |
-                                    CHECK_SHA256SUM;
-
-    fim_data->item->configuration |= CHECK_SEECHANGES;
 
     expect_string(__wrap_fim_db_file_is_scanned, path, file_path);
     will_return(__wrap_fim_db_file_is_scanned, 0);
@@ -1310,8 +1246,8 @@ static void test_fim_file_add(void **state) {
     will_return(__wrap_fim_db_get_path, NULL);
 
 #ifndef TEST_WINAGENT
-    expect_value(__wrap_fim_db_data_exists, inode, fim_data->item->statbuf.st_ino);
-    expect_value(__wrap_fim_db_data_exists, dev, fim_data->item->statbuf.st_dev);
+    expect_value(__wrap_fim_db_data_exists, inode, statbuf.st_ino);
+    expect_value(__wrap_fim_db_data_exists, dev, statbuf.st_dev);
     will_return(__wrap_fim_db_data_exists, 0);
 
     expect_fim_db_insert(syscheck.database, file_path, FIMDB_OK);
@@ -1326,28 +1262,22 @@ static void test_fim_file_add(void **state) {
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
-    fim_file(file_path, fim_data->item, NULL, 1);
-
-    fim_data->item->configuration &= ~CHECK_SEECHANGES;
+    fim_file(file_path, &configuration, &evt_data, &statbuf);
 }
 
 
 static void test_fim_file_modify(void **state) {
     fim_data_t *fim_data = *state;
+    event_data_t evt_data = { .mode = FIM_SCHEDULED, .w_evt = NULL, .report_event = true };
+    directory_t configuration = { .options = CHECK_SIZE | CHECK_PERM | CHECK_OWNER | CHECK_GROUP | CHECK_MD5SUM |
+                                             CHECK_SHA1SUM | CHECK_SHA256SUM };
+    struct stat statbuf = DEFAULT_STATBUF;
 
 #ifdef TEST_WINAGENT
     char file_path[OS_SIZE_256] = "c:\\windows\\system32\\cmd.exe";
 #else
     char file_path[OS_SIZE_256] = "/bin/ls";
 #endif
-    fim_data->item->index = 1;
-    fim_data->item->configuration = CHECK_SIZE |
-                                    CHECK_PERM  |
-                                    CHECK_OWNER |
-                                    CHECK_GROUP |
-                                    CHECK_MD5SUM |
-                                    CHECK_SHA1SUM |
-                                    CHECK_SHA256SUM;
 
     fim_data->fentry->file_entry.path = strdup("file");
     fim_data->fentry->file_entry.data = fim_data->local_data;
@@ -1397,8 +1327,8 @@ static void test_fim_file_modify(void **state) {
                                         0x400, 0);
 
 #ifndef TEST_WINAGENT
-    expect_value(__wrap_fim_db_data_exists, inode, fim_data->item->statbuf.st_ino);
-    expect_value(__wrap_fim_db_data_exists, dev, fim_data->item->statbuf.st_dev);
+    expect_value(__wrap_fim_db_data_exists, inode, statbuf.st_ino);
+    expect_value(__wrap_fim_db_data_exists, dev, statbuf.st_dev);
     will_return(__wrap_fim_db_data_exists, 0);
 #endif
 
@@ -1414,20 +1344,23 @@ static void test_fim_file_modify(void **state) {
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
-    fim_file(file_path, fim_data->item, NULL, 1);
+
+    fim_file(file_path, &configuration, &evt_data, &statbuf);
 }
 
 static void test_fim_file_no_attributes(void **state) {
-    fim_data_t *fim_data = *state;
     char buffer1[OS_SIZE_256];
     char buffer2[OS_SIZE_256];
+    event_data_t evt_data = { .mode = FIM_SCHEDULED, .w_evt = NULL, .report_event = true };
+    directory_t configuration = { .options = CHECK_SIZE | CHECK_PERM | CHECK_OWNER | CHECK_GROUP | CHECK_MD5SUM |
+                                             CHECK_SHA1SUM | CHECK_SHA256SUM };
+    struct stat statbuf = DEFAULT_STATBUF;
 
 #ifdef TEST_WINAGENT
     char file_path[] = "c:\\windows\\system32\\cmd.exe";
 #else
     char file_path[] = "/bin/ls";
 #endif
-    fim_data->item->index = 1;
 
     expect_string(__wrap_fim_db_file_is_scanned, path, file_path);
     will_return(__wrap_fim_db_file_is_scanned, 0);
@@ -1467,26 +1400,21 @@ static void test_fim_file_no_attributes(void **state) {
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
-    fim_file(file_path, fim_data->item, NULL, 1);
+
+    fim_file(file_path, &configuration, &evt_data, &statbuf);
 }
 
 static void test_fim_file_error_on_insert(void **state) {
     fim_data_t *fim_data = *state;
-
+    event_data_t evt_data = { .mode = FIM_SCHEDULED, .w_evt = NULL, .report_event = true };
+    directory_t configuration = { .options = CHECK_SIZE | CHECK_PERM | CHECK_OWNER | CHECK_GROUP | CHECK_MD5SUM |
+                                             CHECK_SHA1SUM | CHECK_SHA256SUM };
+    struct stat statbuf = DEFAULT_STATBUF;
 #ifdef TEST_WINAGENT
     char file_path[OS_SIZE_256] = "c:\\windows\\system32\\cmd.exe";
 #else
     char file_path[OS_SIZE_256] = "/bin/ls";
 #endif
-
-    fim_data->item->index = 1;
-    fim_data->item->configuration = CHECK_SIZE |
-                                    CHECK_PERM  |
-                                    CHECK_OWNER |
-                                    CHECK_GROUP |
-                                    CHECK_MD5SUM |
-                                    CHECK_SHA1SUM |
-                                    CHECK_SHA256SUM;
 
     fim_data->fentry->file_entry.path = strdup(file_path);
     fim_data->fentry->file_entry.data = fim_data->local_data;
@@ -1545,8 +1473,8 @@ static void test_fim_file_error_on_insert(void **state) {
     will_return(__wrap_fim_db_get_path, fim_data->fentry);
 
 #ifndef TEST_WINAGENT
-    expect_value(__wrap_fim_db_data_exists, inode, fim_data->item->statbuf.st_ino);
-    expect_value(__wrap_fim_db_data_exists, dev, fim_data->item->statbuf.st_dev);
+    expect_value(__wrap_fim_db_data_exists, inode, statbuf.st_ino);
+    expect_value(__wrap_fim_db_data_exists, dev, statbuf.st_dev);
     will_return(__wrap_fim_db_data_exists, 0);
 #endif
 
@@ -1556,106 +1484,69 @@ static void test_fim_file_error_on_insert(void **state) {
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
-    fim_file(file_path, fim_data->item, NULL, 1);
+
+    fim_file(file_path, &configuration, &evt_data, &statbuf);
 }
 
 static void test_fim_checker_scheduled_configuration_directory_error(void **state) {
-    fim_data_t *fim_data = *state;
-
     char * path = "/not/found/test.file";
-    struct stat buf;
-    buf.st_mode = S_IFREG;
-    fim_data->item->index = 3;
-    fim_data->item->statbuf = buf;
-    fim_data->item->mode = FIM_SCHEDULED;
+    event_data_t evt_data = { .mode = FIM_SCHEDULED, .w_evt = NULL, .report_event = true };
 
     expect_string(__wrap__mdebug2, formatted_msg, "(6319): No configuration found for (file):'/not/found/test.file'");
 
-    fim_checker(path, fim_data->item, NULL, 1);
+    fim_checker(path, &evt_data, NULL);
 }
 
 static void test_fim_checker_not_scheduled_configuration_directory_error(void **state) {
-    fim_data_t *fim_data = *state;
-
-    char * path = "/not/found/test.file";
-    struct stat buf;
-    buf.st_mode = S_IFREG;
-    fim_data->item->index = 3;
-    fim_data->item->statbuf = buf;
-    fim_data->item->mode = FIM_REALTIME;
+    event_data_t evt_data = { .mode = FIM_REALTIME, .w_evt = NULL, .report_event = true };
+    const char *path = "/not/found/test.file";
 
     expect_string(__wrap__mdebug2, formatted_msg, "(6319): No configuration found for (file):'/not/found/test.file'");
 
-    fim_checker(path, fim_data->item, NULL, 1);
+    fim_checker(path, &evt_data, NULL);
 }
 
 #ifndef TEST_WINAGENT
-static void test_fim_checker_invalid_fim_mode(void **state) {
-    fim_data_t *fim_data = *state;
-
-    char * path = "/media/test.file";
-    struct stat buf;
-    buf.st_mode = S_IFREG;
-    fim_data->item->index = 3;
-    fim_data->item->statbuf = buf;
-    fim_data->item->mode = -1;
-
-    // Nothing to check on this condition
-
-    fim_checker(path, fim_data->item, NULL, 1);
-}
-
 static void test_fim_checker_over_max_recursion_level(void **state) {
-    fim_data_t *fim_data = *state;
+    event_data_t evt_data = { .mode = FIM_REALTIME, .w_evt = NULL, .report_event = true };
+    const char *path = "/media/a/test.file";
 
-    char * path = "/media/a/test.file";
-    struct stat buf;
-    buf.st_mode = S_IFREG;
-    fim_data->item->index = 3;
-    fim_data->item->statbuf = buf;
-    fim_data->item->mode = FIM_REALTIME;
-
-    syscheck.recursion_level[3] = 0;
+    syscheck.directories[3]->recursion_level = 0;
 
     expect_string(__wrap__mdebug2, formatted_msg,
         "(6217): Maximum level of recursion reached. Depth:1 recursion_level:0 '/media/a/test.file'");
 
-    fim_checker(path, fim_data->item, NULL, 1);
+    fim_checker(path, &evt_data, NULL);
 
-    syscheck.recursion_level[3] = 50;
+    syscheck.directories[3]->recursion_level = 50;
 }
 
 static void test_fim_checker_deleted_file(void **state) {
-    struct stat buf = { .st_mode = S_IFREG };
-    fim_data_t *fim_data = *state;
+    event_data_t evt_data = { .mode = FIM_REALTIME, .w_evt = NULL, .report_event = true };
+    struct stat statbuf = DEFAULT_STATBUF;
+    const char *path = "/media/test.file";
 
-    char * path = "/media/test.file";
-    fim_data->item->index = 3;
-    fim_data->item->mode = FIM_REALTIME;
-
-    expect_string(__wrap__mdebug1, formatted_msg, "(6222): Stat() function failed on: '/media/test.file' due to [(1)-(Operation not permitted)]");
+    expect_string(__wrap__mdebug1, formatted_msg,
+                  "(6222): Stat() function failed on: '/media/test.file' due to [(1)-(Operation not permitted)]");
 
     expect_string(__wrap_lstat, filename, path);
-    will_return(__wrap_lstat, &buf);
+    will_return(__wrap_lstat, &statbuf);
     will_return(__wrap_lstat, -1);
 
     errno = 1;
 
-    fim_checker(path, fim_data->item, NULL, 1);
+    fim_checker(path, &evt_data, NULL);
 
     errno = 0;
-
-    assert_int_equal(fim_data->item->configuration, 33279);
-    assert_int_equal(fim_data->item->index, 3);
 }
 
 static void test_fim_checker_deleted_file_enoent(void **state) {
-    struct stat buf = { .st_mode = S_IFREG };
     fim_data_t *fim_data = *state;
+    event_data_t evt_data = { .mode = FIM_REALTIME, .w_evt = NULL, .report_event = true };
+    struct stat statbuf = DEFAULT_STATBUF;
+    const char *path = "/media/test.file";
 
-    char * path = "/media/test.file";
-    fim_data->item->index = 3;
-    syscheck.opts[3] |= CHECK_SEECHANGES;
+    syscheck.directories[3]->options |= CHECK_SEECHANGES;
 
     fim_data->fentry->file_entry.path = strdup("/media/test.file");
     fim_data->fentry->file_entry.data = fim_data->local_data;
@@ -1680,7 +1571,7 @@ static void test_fim_checker_deleted_file_enoent(void **state) {
     strcpy(fim_data->local_data->checksum, "");
 
     expect_string(__wrap_lstat, filename, path);
-    will_return(__wrap_lstat, &buf);
+    will_return(__wrap_lstat, &statbuf);
     will_return(__wrap_lstat, -1);
     errno = ENOENT;
 
@@ -1692,61 +1583,43 @@ static void test_fim_checker_deleted_file_enoent(void **state) {
 
     expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, FIMDB_ERR);
 
-    fim_checker(path, fim_data->item, NULL, 1);
+    fim_checker(path, &evt_data, NULL);
 
     errno = 0;
-    syscheck.opts[3] &= ~CHECK_SEECHANGES;
-
-    assert_int_equal(fim_data->item->configuration, 41471);
-    assert_int_equal(fim_data->item->index, 3);
+    syscheck.directories[3]->options &= ~CHECK_SEECHANGES;
 }
 
 static void test_fim_checker_no_file_system(void **state) {
-    struct stat buf = { .st_mode = S_IFREG };
-    fim_data_t *fim_data = *state;
-
-    char * path = "/media/test.file";
-    buf.st_mode = S_IFREG;
-    fim_data->item->index = 3;
-    fim_data->item->statbuf = buf;
+    event_data_t evt_data = { .mode = FIM_REALTIME, .w_evt = NULL, .report_event = true };
+    struct stat statbuf = DEFAULT_STATBUF;
+    const char *path = "/media/test.file";
 
     expect_string(__wrap_lstat, filename, path);
-    will_return(__wrap_lstat, &buf);
+    will_return(__wrap_lstat, &statbuf);
     will_return(__wrap_lstat, 0);
 
     expect_string(__wrap_HasFilesystem, path, "/media/test.file");
     will_return(__wrap_HasFilesystem, -1);
 
-    fim_checker(path, fim_data->item, fim_data->w_evt, 1);
-
-    assert_int_equal(fim_data->item->configuration, 33279);
-    assert_int_equal(fim_data->item->index, 3);
+    fim_checker(path, &evt_data, NULL);
 }
 
 static void test_fim_checker_fim_regular(void **state) {
-    struct stat buf = { .st_mode = S_IFREG,
-                        .st_dev = 1,
-                        .st_ino = 999,
-                        .st_uid = 0,
-                        .st_gid = 0,
-                        .st_mtime = 1433395216,
-                        .st_size = 1500 };
-    fim_data_t *fim_data = *state;
-
-    char * path = "/media/test.file";
-    fim_data->item->statbuf.st_dev = 1;
-    fim_data->item->statbuf.st_ino = 999;
-    fim_data->item->statbuf.st_uid = 0;
-    fim_data->item->statbuf.st_gid = 0;
-    fim_data->item->statbuf.st_mtime = 1433395216;
-    fim_data->item->statbuf.st_size = 1500;
-    fim_data->item->index = 3;
+    const char *path = "/media/test.file";
+    event_data_t evt_data = { .mode = FIM_REALTIME, .w_evt = NULL, .report_event = true };
+    struct stat statbuf = { .st_mode = S_IFREG,
+                            .st_dev = 1,
+                            .st_ino = 999,
+                            .st_uid = 0,
+                            .st_gid = 0,
+                            .st_mtime = 1433395216,
+                            .st_size = 1500 };
 
     expect_string(__wrap_lstat, filename, path);
-    will_return(__wrap_lstat, &buf);
+    will_return(__wrap_lstat, &statbuf);
     will_return(__wrap_lstat, 0);
 
-    expect_string(__wrap_HasFilesystem, path, "/media/test.file");
+    expect_string(__wrap_HasFilesystem, path, path);
     will_return(__wrap_HasFilesystem, 0);
 
     // Inside fim_file
@@ -1759,34 +1632,29 @@ static void test_fim_checker_fim_regular(void **state) {
     expect_wrapper_fim_db_get_paths_from_inode(syscheck.database, 999, 1, NULL);
 
     expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_get_path, file_path, "/media/test.file");
+    expect_string(__wrap_fim_db_get_path, file_path, path);
     will_return(__wrap_fim_db_get_path, NULL);
 
     expect_value(__wrap_fim_db_insert, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_insert, file_path, "/media/test.file");
+    expect_string(__wrap_fim_db_insert, file_path, path);
     will_return(__wrap_fim_db_insert, 0);
 
-    fim_checker(path, fim_data->item, fim_data->w_evt, 1);
-
-    assert_int_equal(fim_data->item->configuration, 33279);
-    assert_int_equal(fim_data->item->index, 3);
+    fim_checker(path, &evt_data, NULL);
 }
 
 static void test_fim_checker_fim_regular_warning(void **state) {
-    struct stat buf = { .st_mode = S_IFREG };
-    fim_data_t *fim_data = *state;
+    const char *path = "/media/test.file";
+    event_data_t evt_data = { .mode = FIM_REALTIME, .w_evt = NULL, .report_event = true };
+    struct stat statbuf = { .st_mode = S_IFREG,
+                            .st_dev = 1,
+                            .st_ino = 999,
+                            .st_uid = 0,
+                            .st_gid = 0,
+                            .st_mtime = 1433395216,
+                            .st_size = 1500 };
 
-    char * path = "/media/test.file";
-    fim_data->item->statbuf.st_dev = 1;
-    fim_data->item->statbuf.st_ino = 999;
-    fim_data->item->statbuf.st_uid = 0;
-    fim_data->item->statbuf.st_gid = 0;
-    fim_data->item->statbuf.st_mtime = 1433395216;
-    fim_data->item->statbuf.st_size = 1500;
-
-    fim_data->item->index = 3;
     expect_string(__wrap_lstat, filename, path);
-    will_return(__wrap_lstat, &buf);
+    will_return(__wrap_lstat, &statbuf);
     will_return(__wrap_lstat, 0);
 
     expect_string(__wrap_HasFilesystem, path, "/media/test.file");
@@ -1807,22 +1675,16 @@ static void test_fim_checker_fim_regular_warning(void **state) {
     expect_string(__wrap_fim_db_insert, file_path, "/media/test.file");
     will_return(__wrap_fim_db_insert, -1);
 
-    fim_checker(path, fim_data->item, fim_data->w_evt, 1);
-
-    assert_int_equal(fim_data->item->configuration, 33279);
-    assert_int_equal(fim_data->item->index, 3);
+    fim_checker(path, &evt_data, NULL);
 }
 
 static void test_fim_checker_fim_regular_ignore(void **state) {
-    struct stat buf = { .st_mode = S_IFREG };
-    fim_data_t *fim_data = *state;
-
-    char * path = "/etc/mtab";
-    fim_data->item->index = 3;
-    fim_data->item->mode = FIM_WHODATA;
+    struct stat statbuf = DEFAULT_STATBUF;
+    event_data_t evt_data = { .mode = FIM_WHODATA, .w_evt = NULL, .report_event = true };
+    const char *path = "/etc/mtab";
 
     expect_string(__wrap_lstat, filename, path);
-    will_return(__wrap_lstat, &buf);
+    will_return(__wrap_lstat, &statbuf);
     will_return(__wrap_lstat, 0);
 
     expect_string(__wrap_HasFilesystem, path, "/etc/mtab");
@@ -1830,47 +1692,40 @@ static void test_fim_checker_fim_regular_ignore(void **state) {
 
     expect_string(__wrap__mdebug2, formatted_msg, "(6204): Ignoring 'file' '/etc/mtab' due to '/etc/mtab'");
 
-    fim_checker(path, fim_data->item, fim_data->w_evt, 1);
-
-    assert_int_equal(fim_data->item->configuration, 66047);
-    assert_int_equal(fim_data->item->index, 1);
+    fim_checker(path, &evt_data, NULL);
 }
 
 static void test_fim_checker_fim_regular_restrict(void **state) {
-    struct stat buf = { .st_mode = S_IFREG };
-    fim_data_t *fim_data = *state;
-
-    char * path = "/media/test";
-    fim_data->item->index = 3;
-    fim_data->item->mode = FIM_REALTIME;
+    struct stat statbuf = DEFAULT_STATBUF;
+    event_data_t evt_data = { .mode = FIM_REALTIME, .w_evt = NULL, .report_event = true };
+    const char *path = "/media/test";
 
     expect_string(__wrap_lstat, filename, path);
-    will_return(__wrap_lstat, &buf);
+    will_return(__wrap_lstat, &statbuf);
     will_return(__wrap_lstat, 0);
+
     expect_string(__wrap_HasFilesystem, path, path);
     will_return(__wrap_HasFilesystem, 0);
 
     expect_string(__wrap__mdebug2, formatted_msg, "(6203): Ignoring entry '/media/test' due to restriction 'file$'");
 
-    fim_checker(path, fim_data->item, fim_data->w_evt, 1);
-
-    assert_int_equal(fim_data->item->configuration, 33279);
-    assert_int_equal(fim_data->item->index, 3);
+    fim_checker(path, &evt_data, NULL);
 }
 
 static void test_fim_checker_fim_directory(void **state) {
-    struct stat buf = { .st_mode = S_IFDIR };
     fim_data_t *fim_data = *state;
+    struct stat directory_stat = DEFAULT_STATBUF;
+    event_data_t evt_data = { .mode = FIM_REALTIME, .w_evt = NULL, .report_event = true };
+    const char *path = "/media/";
 
-    char * path = "/media/";
-    fim_data->item->index = 3;
-    fim_data->item->mode = FIM_REALTIME;
+    directory_stat.st_mode = S_IFDIR;
 
     expect_string(__wrap_lstat, filename, "/media/");
-    will_return(__wrap_lstat, &buf);
+    will_return(__wrap_lstat, &directory_stat);
     will_return(__wrap_lstat, 0);
+
     expect_string(__wrap_lstat, filename, "/media/test");
-    will_return(__wrap_lstat, &buf);
+    will_return(__wrap_lstat, &directory_stat);
     will_return(__wrap_lstat, 0);
 
     expect_string(__wrap_HasFilesystem, path, "/media/");
@@ -1878,10 +1733,8 @@ static void test_fim_checker_fim_directory(void **state) {
     will_return_always(__wrap_HasFilesystem, 0);
 
     expect_string(__wrap_realtime_adddir, dir, "/media/");
-    expect_value(__wrap_realtime_adddir, whodata, 0);
     will_return(__wrap_realtime_adddir, 0);
     expect_string(__wrap_realtime_adddir, dir, "/media/test");
-    expect_value(__wrap_realtime_adddir, whodata, 0);
     will_return(__wrap_realtime_adddir, 0);
 
     strcpy(fim_data->entry->d_name, "test");
@@ -1891,29 +1744,27 @@ static void test_fim_checker_fim_directory(void **state) {
     will_return(__wrap_readdir, NULL);
     will_return(__wrap_readdir, NULL);
 
-    fim_checker(path, fim_data->item, NULL, 1);
+    fim_checker(path, &evt_data, NULL);
 }
 
 static void test_fim_checker_fim_directory_on_max_recursion_level(void **state) {
-    struct stat buf = { .st_mode = S_IFDIR };
     fim_data_t *fim_data = *state;
+    struct stat statbuf = DEFAULT_STATBUF;
+    event_data_t evt_data = { .mode = FIM_REALTIME, .w_evt = NULL, .report_event = true };
+    const char *path = "/media";
 
-    char * path = "/media";
-    buf.st_mode = S_IFDIR;
-    fim_data->item->index = 3;
-    fim_data->item->statbuf = buf;
-    fim_data->item->mode = FIM_REALTIME;
+    statbuf.st_mode = S_IFDIR;
 
-    syscheck.recursion_level[3] = 0;
+    syscheck.directories[3]->recursion_level = 0;
 
-    expect_string(__wrap_lstat, filename, "/media");
-    will_return(__wrap_lstat, &buf);
+    expect_string(__wrap_lstat, filename, path);
+    will_return(__wrap_lstat, &statbuf);
     will_return(__wrap_lstat, 0);
-    expect_string(__wrap_HasFilesystem, path, "/media");
+
+    expect_string(__wrap_HasFilesystem, path, path);
     will_return(__wrap_HasFilesystem, 0);
 
-    expect_string(__wrap_realtime_adddir, dir, "/media");
-    expect_value(__wrap_realtime_adddir, whodata, 0);
+    expect_string(__wrap_realtime_adddir, dir, path);
     will_return(__wrap_realtime_adddir, 0);
 
     will_return(__wrap_opendir, 1);
@@ -1921,8 +1772,9 @@ static void test_fim_checker_fim_directory_on_max_recursion_level(void **state) 
     will_return(__wrap_readdir, fim_data->entry);
 
     expect_string(__wrap_lstat, filename, "/media/test");
-    will_return(__wrap_lstat, &buf);
+    will_return(__wrap_lstat, &statbuf);
     will_return(__wrap_lstat, 0);
+
     expect_string(__wrap_HasFilesystem, path, "/media/test");
     will_return(__wrap_HasFilesystem, 0);
 
@@ -1930,42 +1782,34 @@ static void test_fim_checker_fim_directory_on_max_recursion_level(void **state) 
 
     expect_string(__wrap__mdebug2, formatted_msg,
         "(6347): Directory '/media/test' is already on the max recursion_level (0), it will not be scanned.");
-    fim_checker(path, fim_data->item, NULL, 1);
 
-    syscheck.recursion_level[3] = 50;
+    fim_checker(path, &evt_data, NULL);
+
+    syscheck.directories[3]->recursion_level = 50;
 }
 
 static void test_fim_checker_root_ignore_file_under_recursion_level(void **state) {
-    fim_data_t *fim_data = *state;
-
-    char * path = "/media/test.file";
-    struct stat buf;
-    buf.st_mode = S_IFREG;
-    fim_data->item->index = 0;
-    fim_data->item->statbuf = buf;
-    fim_data->item->mode = FIM_REALTIME;
+    event_data_t evt_data = { .mode = FIM_REALTIME, .w_evt = NULL, .report_event = true };
+    const char *path = "/media/test.file";
 
     expect_string(__wrap__mdebug2, formatted_msg,
         "(6217): Maximum level of recursion reached. Depth:1 recursion_level:0 '/media/test.file'");
 
-    fim_checker(path, fim_data->item, NULL, 1);
+    fim_checker(path, &evt_data, NULL);
 }
 
 static void test_fim_checker_root_file_within_recursion_level(void **state) {
-    struct stat buf = { .st_mode = S_IFREG, .st_gid = 0 };
-    fim_data_t *fim_data = *state;
+    struct stat statbuf = DEFAULT_STATBUF;
+    event_data_t evt_data = { .mode = FIM_REALTIME, .w_evt = NULL, .report_event = true };
+    const char *path = "/test.file";
 
-    char * path = "/test.file";
+    statbuf.st_size = 0;
 
-    fim_data->item->index = 0;
-    fim_data->item->statbuf = buf;
-    fim_data->item->mode = FIM_REALTIME;
-
-    expect_string(__wrap_lstat, filename, "/test.file");
-    will_return(__wrap_lstat, &buf);
+    expect_string(__wrap_lstat, filename, path);
+    will_return(__wrap_lstat, &statbuf);
     will_return(__wrap_lstat, 0);
 
-    expect_string(__wrap_HasFilesystem, path, "/test.file");
+    expect_string(__wrap_HasFilesystem, path, path);
     will_return(__wrap_HasFilesystem, 0);
     // Inside fim_file
     expect_value(__wrap_get_user, uid, 0);
@@ -1975,28 +1819,26 @@ static void test_fim_checker_root_file_within_recursion_level(void **state) {
     will_return(__wrap_get_group, strdup("group"));
 
     expect_value(__wrap_fim_db_get_paths_from_inode, fim_sql, syscheck.database);
-    expect_any(__wrap_fim_db_get_paths_from_inode, inode);
-    expect_any(__wrap_fim_db_get_paths_from_inode, dev);
+    expect_value(__wrap_fim_db_get_paths_from_inode, inode, statbuf.st_ino);
+    expect_value(__wrap_fim_db_get_paths_from_inode, dev, statbuf.st_dev);
     will_return(__wrap_fim_db_get_paths_from_inode, NULL);
 
     expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_get_path, file_path, "/test.file");
+    expect_string(__wrap_fim_db_get_path, file_path, path);
     will_return(__wrap_fim_db_get_path, NULL);
 
     expect_value(__wrap_fim_db_insert, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_insert, file_path, "/test.file");
+    expect_string(__wrap_fim_db_insert, file_path, path);
     will_return(__wrap_fim_db_insert, 0);
 
-    fim_checker(path, fim_data->item, fim_data->w_evt, 1);
-
-    assert_int_equal(fim_data->item->configuration, 33279);
-    assert_int_equal(fim_data->item->index, 0);
+    fim_checker(path, &evt_data, NULL);
 }
 
 static void test_fim_scan_db_full_double_scan(void **state) {
     struct stat directory_buf = { .st_mode = S_IFDIR };
     struct stat file_buf = { .st_mode = S_IFREG };
     struct dirent *file = *state;
+    directory_t *dir_it;
 
     expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_STARTED);
 
@@ -2009,24 +1851,22 @@ static void test_fim_scan_db_full_double_scan(void **state) {
 
     expect_string(__wrap__mdebug2, formatted_msg, "(6348): Size of 'queue/diff' folder: 0.00000 KB.");
 
-    int it = 0;
-
     // First scan
-    while (syscheck.dir[it]) {
-        expect_string(__wrap_lstat, filename, syscheck.dir[it]);
+    foreach_array(dir_it, syscheck.directories) {
+        expect_string(__wrap_lstat, filename, dir_it->path);
         will_return(__wrap_lstat, &directory_buf);
         will_return(__wrap_lstat, 0);
-        expect_string(__wrap_HasFilesystem, path, syscheck.dir[it]);
+
+        expect_string(__wrap_HasFilesystem, path, dir_it->path);
         will_return(__wrap_HasFilesystem, 0);
-        if (it == 0 || it == 2 || it == 3){
-            expect_string_count(__wrap_realtime_adddir, dir, syscheck.dir[it], 2);
-            expect_value_count(__wrap_realtime_adddir, whodata, 0, 2);
+
+        if (dir_it->options & REALTIME_ACTIVE) {
+            expect_string_count(__wrap_realtime_adddir, dir, dir_it->path, 2);
             will_return_count(__wrap_realtime_adddir, 0, 2);
         }
+
         will_return(__wrap_opendir, 1);
         will_return(__wrap_readdir, NULL);
-
-        it++;
     }
 
     expect_wrapper_fim_db_get_count_entries(syscheck.database, 50000);
@@ -2041,17 +1881,20 @@ static void test_fim_scan_db_full_double_scan(void **state) {
     expect_string(__wrap_lstat, filename, "/boot");
     will_return(__wrap_lstat, &directory_buf);
     will_return(__wrap_lstat, 0);
+
     expect_string(__wrap_HasFilesystem, path, "/boot");
     will_return(__wrap_HasFilesystem, 0);
+
     expect_string(__wrap_realtime_adddir, dir, "/boot");
-    expect_value(__wrap_realtime_adddir, whodata, 0);
     will_return(__wrap_realtime_adddir, 0);
+
     will_return(__wrap_opendir, 1);
     will_return(__wrap_readdir, file);
 
     expect_string(__wrap_lstat, filename, "/boot/test_file");
     will_return(__wrap_lstat, &file_buf);
     will_return(__wrap_lstat, 0);
+
     expect_string(__wrap_HasFilesystem, path, "/boot/test_file");
     will_return(__wrap_HasFilesystem, 0);
 
@@ -2093,79 +1936,10 @@ static void test_fim_scan_db_full_double_scan(void **state) {
     fim_scan();
 }
 
-static void test_fim_scan_no_realtime(void **state) {
-    struct stat directory_buf = { .st_mode = S_IFDIR };
-    int *dir_opts;
-    int it = 0;
-
-    while (syscheck.dir[it] != NULL) {
-        it++;
-    }
-    dir_opts = calloc(it, sizeof(int));
-
-    if (!dir_opts) {
-        fail();
-    }
-
-    it = 0;
-    while (syscheck.dir[it] != NULL) {
-        dir_opts[it] = syscheck.opts[it];
-        syscheck.opts[it] &= ~REALTIME_ACTIVE;
-        it++;
-    }
-
-    *state = dir_opts;
-
-    expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_STARTED);
-
-    // fim_diff_folder_size
-    expect_string(__wrap_IsDir, file, "queue/diff/local");
-    will_return(__wrap_IsDir, 0);
-
-    expect_string(__wrap_DirSize, path, "queue/diff/local");
-    will_return(__wrap_DirSize, 0.0);
-
-    expect_string(__wrap__mdebug2, formatted_msg, "(6348): Size of 'queue/diff' folder: 0.00000 KB.");
-
-    it = 0;
-    // First scan
-    while (syscheck.dir[it]) {
-        expect_string(__wrap_lstat, filename, syscheck.dir[it]);
-        will_return(__wrap_lstat, &directory_buf);
-        will_return(__wrap_lstat, 0);
-        expect_string(__wrap_HasFilesystem, path, syscheck.dir[it]);
-        will_return(__wrap_HasFilesystem, 0);
-        will_return(__wrap_opendir, 1);
-        will_return(__wrap_readdir, NULL);
-
-        it++;
-    }
-
-    expect_wrapper_fim_db_get_count_entries(syscheck.database, 50000);
-
-    expect_value(__wrap_fim_db_get_not_scanned, fim_sql, syscheck.database);
-    expect_value(__wrap_fim_db_get_not_scanned, storage, FIM_DB_DISK);
-    will_return(__wrap_fim_db_get_not_scanned, NULL);
-    will_return(__wrap_fim_db_get_not_scanned, FIMDB_OK);
-
-    expect_value(__wrap_fim_db_set_all_unscanned, fim_sql, syscheck.database);
-    will_return(__wrap_fim_db_set_all_unscanned, 0);
-
-    expect_wrapper_fim_db_get_count_entries(syscheck.database, 50000);
-
-    expect_string(__wrap__mdebug2, formatted_msg, "(6342): Maximum number of entries to be monitored: '50000'");
-
-    expect_string(__wrap__mwarn, formatted_msg, "(6927): Sending DB 100% full alert.");
-    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":50000,\"alert_type\":\"full\"}");
-    will_return(__wrap_send_log_msg, 1);
-
-    expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_ENDED);
-
-    fim_scan();
-}
 
 static void test_fim_scan_db_full_not_double_scan(void **state) {
     struct stat directory_buf = { .st_mode = S_IFDIR };
+    directory_t *dir_it;
 
     expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_STARTED);
 
@@ -2178,24 +1952,22 @@ static void test_fim_scan_db_full_not_double_scan(void **state) {
 
     expect_string(__wrap__mdebug2, formatted_msg, "(6348): Size of 'queue/diff' folder: 0.00000 KB.");
 
-    int it = 0;
-
     // First scan
-    while (syscheck.dir[it]) {
-        expect_string(__wrap_lstat, filename, syscheck.dir[it]);
+    foreach_array(dir_it, syscheck.directories) {
+        expect_string(__wrap_lstat, filename, dir_it->path);
         will_return(__wrap_lstat, &directory_buf);
         will_return(__wrap_lstat, 0);
-        expect_string(__wrap_HasFilesystem, path, syscheck.dir[it]);
+
+        expect_string(__wrap_HasFilesystem, path, dir_it->path);
         will_return(__wrap_HasFilesystem, 0);
-        if (it == 0 || it == 2 || it == 3){
-            expect_string_count(__wrap_realtime_adddir, dir, syscheck.dir[it], 2);
-            expect_value_count(__wrap_realtime_adddir, whodata, 0, 2);
+
+        if (dir_it->options & REALTIME_ACTIVE) {
+            expect_string_count(__wrap_realtime_adddir, dir, dir_it->path, 2);
             will_return_count(__wrap_realtime_adddir, 0, 2);
         }
+
         will_return(__wrap_opendir, 1);
         will_return(__wrap_readdir, NULL);
-
-        it++;
     }
 
     expect_wrapper_fim_db_get_count_entries(syscheck.database, 50000);
@@ -2222,22 +1994,9 @@ static void test_fim_scan_realtime_enabled(void **state) {
     OSHash dirtb = { .elements = 10, .table = &table, .rows = 0 }; // this hash is not reallistic but works for testing
     rtfim realtime = { .queue_overflow = true, .dirtb = &dirtb };
     struct stat directory_buf = { .st_mode = S_IFDIR };
-    int *dir_opts = calloc(6, sizeof(int));
-    int it = 0;
-
-    if (!dir_opts) {
-        fail();
-    }
+    directory_t *dir_it;
 
     syscheck.realtime = &realtime;
-
-    while (syscheck.dir[it] != NULL) {
-        dir_opts[it] = syscheck.opts[it];
-        syscheck.opts[it] |= REALTIME_ACTIVE;
-        it++;
-    }
-
-    *state = dir_opts;
 
     expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_STARTED);
 
@@ -2250,22 +2009,22 @@ static void test_fim_scan_realtime_enabled(void **state) {
 
     expect_string(__wrap__mdebug2, formatted_msg, "(6348): Size of 'queue/diff' folder: 0.00000 KB.");
 
-    it = 0;
-
     // First scan
-    while (syscheck.dir[it]) {
-        expect_string(__wrap_lstat, filename, syscheck.dir[it]);
+    foreach_array(dir_it, syscheck.directories) {
+        expect_string(__wrap_lstat, filename, dir_it->path);
         will_return(__wrap_lstat, &directory_buf);
         will_return(__wrap_lstat, 0);
-        expect_string(__wrap_HasFilesystem, path, syscheck.dir[it]);
+
+        expect_string(__wrap_HasFilesystem, path, dir_it->path);
         will_return(__wrap_HasFilesystem, 0);
-        expect_string_count(__wrap_realtime_adddir, dir, syscheck.dir[it], 2);
-        expect_value_count(__wrap_realtime_adddir, whodata, 0, 2);
-        will_return_count(__wrap_realtime_adddir, 0, 2);
+
+        if (dir_it->options & REALTIME_ACTIVE) {
+            expect_string_count(__wrap_realtime_adddir, dir, dir_it->path, 2);
+            will_return_count(__wrap_realtime_adddir, 0, 2);
+        }
+
         will_return(__wrap_opendir, 1);
         will_return(__wrap_readdir, NULL);
-
-        it++;
     }
 
     // check_deleted_files
@@ -2291,6 +2050,10 @@ static void test_fim_scan_realtime_enabled(void **state) {
     // fim_scan
     expect_string(__wrap__mdebug2, formatted_msg, "(6345): Folders monitored with real-time engine: 10");
 
+    expect_string(__wrap__mwarn, formatted_msg, "(6927): Sending DB 100% full alert.");
+    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":50000,\"alert_type\":\"full\"}");
+    will_return(__wrap_send_log_msg, 1);
+
     expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_ENDED);
 
     fim_scan();
@@ -2300,6 +2063,7 @@ static void test_fim_scan_realtime_enabled(void **state) {
 
 static void test_fim_scan_db_free(void **state) {
     struct stat directory_buf = { .st_mode = S_IFDIR };
+    directory_t *dir_it;
 
     expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_STARTED);
 
@@ -2312,24 +2076,21 @@ static void test_fim_scan_db_free(void **state) {
 
     expect_string(__wrap__mdebug2, formatted_msg, "(6348): Size of 'queue/diff' folder: 0.00000 KB.");
 
-    int it = 0;
-
     // First scan
-    while (syscheck.dir[it]) {
-        expect_string(__wrap_lstat, filename, syscheck.dir[it]);
+    foreach_array(dir_it, syscheck.directories) {
+        expect_string(__wrap_lstat, filename, dir_it->path);
         will_return(__wrap_lstat, &directory_buf);
         will_return(__wrap_lstat, 0);
-        expect_string(__wrap_HasFilesystem, path, syscheck.dir[it]);
+
+        expect_string(__wrap_HasFilesystem, path, dir_it->path);
         will_return(__wrap_HasFilesystem, 0);
-        if (it == 0 || it == 2 || it == 3){
-            expect_string_count(__wrap_realtime_adddir, dir, syscheck.dir[it], 2);
-            expect_value_count(__wrap_realtime_adddir, whodata, 0, 2);
+
+        if (dir_it->options & REALTIME_ACTIVE) {
+            expect_string_count(__wrap_realtime_adddir, dir, dir_it->path, 2);
             will_return_count(__wrap_realtime_adddir, 0, 2);
         }
         will_return(__wrap_opendir, 1);
         will_return(__wrap_readdir, NULL);
-
-        it++;
     }
 
     expect_wrapper_fim_db_get_count_entries(syscheck.database, 1000);
@@ -2358,6 +2119,7 @@ static void test_fim_scan_db_free(void **state) {
 
 static void test_fim_scan_no_limit(void **state) {
     struct stat directory_buf = { .st_mode = S_IFDIR };
+    directory_t *dir_it;
 
     expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_STARTED);
 
@@ -2370,24 +2132,22 @@ static void test_fim_scan_no_limit(void **state) {
 
     expect_string(__wrap__mdebug2, formatted_msg, "(6348): Size of 'queue/diff' folder: 0.00000 KB.");
 
-    int it = 0;
-
     // First scan
-    while (syscheck.dir[it]) {
-        expect_string(__wrap_lstat, filename, syscheck.dir[it]);
+    foreach_array(dir_it, syscheck.directories) {
+        expect_string(__wrap_lstat, filename, dir_it->path);
         will_return(__wrap_lstat, &directory_buf);
         will_return(__wrap_lstat, 0);
-        expect_string(__wrap_HasFilesystem, path, syscheck.dir[it]);
+
+        expect_string(__wrap_HasFilesystem, path, dir_it->path);
         will_return(__wrap_HasFilesystem, 0);
-        if (it == 0 || it == 2 || it == 3){
-            expect_string_count(__wrap_realtime_adddir, dir, syscheck.dir[it], 2);
-            expect_value_count(__wrap_realtime_adddir, whodata, 0, 2);
+
+        if (dir_it->options & REALTIME_ACTIVE) {
+            expect_string_count(__wrap_realtime_adddir, dir, dir_it->path, 2);
             will_return_count(__wrap_realtime_adddir, 0, 2);
         }
+
         will_return(__wrap_opendir, 1);
         will_return(__wrap_readdir, NULL);
-
-        it++;
     }
 
     // check_deleted_files
@@ -2410,6 +2170,7 @@ static void test_fim_scan_no_limit(void **state) {
 /**** delete_file_event ****/
 void test_fim_delete_file_event_delete_error(void **state) {
     fim_data_t *fim_data = *state;
+    event_data_t evt_data = { .mode = FIM_REALTIME, .w_evt = NULL, .report_event = true, .type = FIM_DELETE };
 
     fim_data->fentry->file_entry.path = strdup("/media/test");
     fim_data->fentry->file_entry.data = fim_data->local_data;
@@ -2436,11 +2197,12 @@ void test_fim_delete_file_event_delete_error(void **state) {
     expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, FIMDB_ERR);
 
 
-    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, (void *)true, NULL, NULL);
+    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, &evt_data, NULL, NULL);
 }
 
 void test_fim_delete_file_event_remove_success(void **state) {
     fim_data_t *fim_data = *state;
+    event_data_t evt_data = { .mode = FIM_REALTIME, .w_evt = NULL, .report_event = true, .type = FIM_DELETE };
 
     fim_data->fentry->file_entry.path = strdup("/media/test");
     fim_data->fentry->file_entry.data = fim_data->local_data;
@@ -2471,12 +2233,13 @@ void test_fim_delete_file_event_remove_success(void **state) {
     snprintf(buffer, OS_SIZE_128, FIM_FILE_MSG_DELETE, fim_data->fentry->file_entry.path);
     expect_string(__wrap__mdebug2, formatted_msg, buffer);
 
-    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, (void *) true, NULL, NULL);
+    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, &evt_data, NULL, NULL);
 }
 
 
 void test_fim_delete_file_event_no_conf(void **state) {
     fim_data_t *fim_data = *state;
+    event_data_t evt_data = { .mode = FIM_REALTIME, .w_evt = NULL, .report_event = true, .type = FIM_DELETE };
 
     fim_data->fentry->file_entry.path = strdup("/a/random/path");
     fim_data->fentry->file_entry.data = fim_data->local_data;
@@ -2511,11 +2274,12 @@ void test_fim_delete_file_event_no_conf(void **state) {
 
     expect_string(__wrap__mdebug2, formatted_msg, buffer_msg);
 
-    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, (void *) true, NULL, NULL);
+    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, &evt_data, NULL, NULL);
 }
 
 void test_fim_delete_file_event_different_mode_scheduled(void **state) {
     fim_data_t *fim_data = *state;
+    event_data_t evt_data = { .mode = FIM_SCHEDULED, .w_evt = NULL, .report_event = true, .type = FIM_DELETE };
 
     fim_data->fentry->file_entry.path = strdup("/media/test");
     fim_data->fentry->file_entry.data = fim_data->local_data;
@@ -2546,12 +2310,12 @@ void test_fim_delete_file_event_different_mode_scheduled(void **state) {
     snprintf(buffer, OS_SIZE_128, FIM_FILE_MSG_DELETE, fim_data->fentry->file_entry.path);
     expect_string(__wrap__mdebug2, formatted_msg, buffer);
 
-    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, (void *) true,
-                          (void *) FIM_SCHEDULED, NULL);
+    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, &evt_data, NULL, NULL);
 }
 
 void test_fim_delete_file_event_different_mode_abort_realtime(void **state) {
     fim_data_t *fim_data = *state;
+    event_data_t evt_data = { .mode = FIM_WHODATA, .w_evt = NULL, .report_event = true, .type = FIM_DELETE };
 
     fim_data->fentry->file_entry.path = strdup("/media/test");
     fim_data->fentry->file_entry.data = fim_data->local_data;
@@ -2576,14 +2340,14 @@ void test_fim_delete_file_event_different_mode_abort_realtime(void **state) {
     strcpy(fim_data->local_data->checksum, "");
 
 
-    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, (void *) true,
-                          (void *) FIM_WHODATA, NULL);
+    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, &evt_data, NULL, NULL);
 }
 
 void test_fim_delete_file_event_different_mode_abort_whodata(void **state) {
     fim_data_t *fim_data = *state;
+    event_data_t evt_data = { .mode = FIM_REALTIME };
 
-    fim_data->fentry->file_entry.path = strdup("/media/test");
+    fim_data->fentry->file_entry.path = strdup("/etc/test");
     fim_data->fentry->file_entry.data = fim_data->local_data;
 
     fim_data->local_data->size = 1500;
@@ -2605,19 +2369,13 @@ void test_fim_delete_file_event_different_mode_abort_whodata(void **state) {
     fim_data->local_data->options = 511;
     strcpy(fim_data->local_data->checksum, "");
 
-    int pos = fim_configuration_directory(fim_data->fentry->file_entry.path);
-    syscheck.opts[pos] |= WHODATA_ACTIVE;
-    syscheck.opts[pos] &= ~REALTIME_ACTIVE;
-
-    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, (void *) true,
-                          (void *) FIM_REALTIME, NULL);
-
-    syscheck.opts[pos] &= ~WHODATA_ACTIVE;
-    syscheck.opts[pos] |= REALTIME_ACTIVE;
+    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, &evt_data, NULL, NULL);
 }
 
 void test_fim_delete_file_event_report_changes(void **state) {
     fim_data_t *fim_data = *state;
+    event_data_t evt_data = { .mode = FIM_REALTIME, .w_evt = NULL, .type = FIM_DELETE, .report_event = true };
+    directory_t *configuration;
 
     fim_data->fentry->file_entry.path = strdup("/media/test");
     fim_data->fentry->file_entry.data = fim_data->local_data;
@@ -2640,8 +2398,9 @@ void test_fim_delete_file_event_report_changes(void **state) {
     fim_data->local_data->scanned = 123456;
     fim_data->local_data->options = 511;
     strcpy(fim_data->local_data->checksum, "");
-    int pos = fim_configuration_directory(fim_data->fentry->file_entry.path);
-    syscheck.opts[pos] |= CHECK_SEECHANGES;
+
+    configuration = fim_configuration_directory(fim_data->fentry->file_entry.path);
+    configuration->options |= CHECK_SEECHANGES;
 
     char buffer[OS_SIZE_128] = {0};
     expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, FIMDB_OK);
@@ -2652,43 +2411,19 @@ void test_fim_delete_file_event_report_changes(void **state) {
     snprintf(buffer, OS_SIZE_128, FIM_FILE_MSG_DELETE, fim_data->fentry->file_entry.path);
     expect_string(__wrap__mdebug2, formatted_msg, buffer);
 
-    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, (void *) true, NULL, NULL);
-    syscheck.opts[pos] &= ~CHECK_SEECHANGES;
+    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, &evt_data, NULL, NULL);
+
+    configuration->options &= ~CHECK_SEECHANGES;
 }
 #else
-static void test_fim_checker_invalid_fim_mode(void **state) {
-    fim_data_t *fim_data = *state;
-
-    char *path = "%WINDIR%\\System32\\drivers\\etc\\test.exe";
-    char expanded_path[OS_MAXSTR];
-    struct stat buf;
-    buf.st_mode = S_IFREG;
-    fim_data->item->index = 3;
-    fim_data->item->statbuf = buf;
-    fim_data->item->mode = -1;
-
-    if(!ExpandEnvironmentStrings(path, expanded_path, OS_MAXSTR))
-        fail();
-
-    str_lowercase(expanded_path);
-
-    // Nothing to check on this condition
-    fim_checker(expanded_path, fim_data->item, NULL, 1);
-}
-
 static void test_fim_checker_over_max_recursion_level(void **state) {
-    fim_data_t *fim_data = *state;
+    event_data_t evt_data = { .mode = FIM_REALTIME, .report_event = true, .w_evt = NULL };
 
     char *path = "%WINDIR%\\System32\\drivers\\etc\\random\\test.exe";
     char expanded_path[OS_MAXSTR];
     char debug_msg[OS_MAXSTR];
-    struct stat buf;
-    buf.st_mode = S_IFREG;
-    fim_data->item->index = 2;
-    fim_data->item->statbuf = buf;
-    fim_data->item->mode = FIM_REALTIME;
 
-    syscheck.recursion_level[2] = 0;
+    syscheck.directories[2]->recursion_level = 0;
     if(!ExpandEnvironmentStrings(path, expanded_path, OS_MAXSTR))
         fail();
 
@@ -2699,17 +2434,14 @@ static void test_fim_checker_over_max_recursion_level(void **state) {
 
     expect_string(__wrap__mdebug2, formatted_msg, debug_msg);
 
-    fim_checker(expanded_path, fim_data->item, NULL, 1);
+    fim_checker(expanded_path, &evt_data, NULL);
 }
 
 static void test_fim_checker_deleted_file(void **state) {
-    fim_data_t *fim_data = *state;
-
+    event_data_t evt_data = { .mode = FIM_REALTIME, .w_evt = NULL, .report_event = true };
     struct stat stat_s = { .st_mode = S_IFREG };
     char *path = "%WINDIR%\\System32\\drivers\\etc\\test.exe";
     char expanded_path[OS_MAXSTR];
-    fim_data->item->index = 7;
-    fim_data->item->mode = FIM_REALTIME;
 
     expect_string(__wrap__mdebug1, formatted_msg, "(6222): Stat() function failed on: 'c:\\windows\\system32\\drivers\\etc\\test.exe' due to [(1)-(Operation not permitted)]");
 
@@ -2724,22 +2456,19 @@ static void test_fim_checker_deleted_file(void **state) {
 
     errno = 1;
 
-    fim_checker(expanded_path, fim_data->item, NULL, 1);
+    fim_checker(expanded_path, &evt_data, NULL);
 
     errno = 0;
-
-    assert_int_equal(fim_data->item->configuration, 37375);
-    assert_int_equal(fim_data->item->index, 7);
 }
 
 static void test_fim_checker_deleted_file_enoent(void **state) {
     fim_data_t *fim_data = *state;
-
     struct stat stat_s = { .st_mode = S_IFREG };
     char *path = "%WINDIR%\\System32\\drivers\\etc\\test.exe";
     char expanded_path[OS_MAXSTR];
-    fim_data->item->index = 7;
-    syscheck.opts[7] |= CHECK_SEECHANGES;
+    event_data_t evt_data = { .mode = FIM_REALTIME, .report_event = true };
+
+    syscheck.directories[7]->options |= CHECK_SEECHANGES;
 
     if(!ExpandEnvironmentStrings(path, expanded_path, OS_MAXSTR))
         fail();
@@ -2786,34 +2515,25 @@ static void test_fim_checker_deleted_file_enoent(void **state) {
     expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, FIMDB_ERR);
     expect_function_call(__wrap_pthread_mutex_unlock);
 
-    fim_checker(expanded_path, fim_data->item, NULL, 1);
+    fim_checker(expanded_path, &evt_data, NULL);
 
     errno = 0;
-    syscheck.opts[7] &= ~CHECK_SEECHANGES;
-
-    assert_int_equal(fim_data->item->configuration, 45567);
-    assert_int_equal(fim_data->item->index, 7);
+    syscheck.directories[7]->options &= ~CHECK_SEECHANGES;
 }
 
 static void test_fim_checker_fim_regular(void **state) {
     fim_data_t *fim_data = *state;
-
     struct stat stat_s = { .st_mode = S_IFREG };
-
-    char *path = "%WINDIR%\\System32\\drivers\\etc\\test.exe";
-
+    char *path = "%WINDIR%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe";
     char expanded_path[OS_SIZE_128];
+    event_data_t evt_data = { .mode = FIM_WHODATA, .w_evt = fim_data->w_evt, .report_event = true };
 
-    fim_data->item->index = 7;
-
-    fim_data->item->statbuf.st_size = 1500;
-
-    if(!ExpandEnvironmentStrings(path, expanded_path, OS_SIZE_128)){
+    if (!ExpandEnvironmentStrings(path, expanded_path, OS_SIZE_128)) {
         fail();
     }
+
     expect_string(__wrap_stat, __file, expanded_path);
     will_return(__wrap_stat, &stat_s);
-
     will_return(__wrap_stat, 0);
 
     str_lowercase(expanded_path);
@@ -2839,21 +2559,15 @@ static void test_fim_checker_fim_regular(void **state) {
     expect_string(__wrap_fim_db_insert, file_path, expanded_path);
     will_return(__wrap_fim_db_insert, 0);
 
-    fim_checker(expanded_path, fim_data->item, fim_data->w_evt, 1);
-
-    assert_int_equal(fim_data->item->configuration, 37375);
-    assert_int_equal(fim_data->item->index, 7);
+    fim_checker(expanded_path, &evt_data, NULL);
 }
 
 static void test_fim_checker_fim_regular_ignore(void **state) {
-    fim_data_t *fim_data = *state;
-
     struct stat stat_s = { .st_mode = S_IFREG };
     char *path = "%WINDIR%\\System32\\drivers\\etc\\ignored.file";
     char expanded_path[OS_MAXSTR];
     char debug_msg[OS_MAXSTR];
-    fim_data->item->index = 7;
-    // fim_data->item->mode = FIM_REALTIME;
+    event_data_t evt_data = { .mode = FIM_REALTIME, .w_evt = NULL, .report_event = true };
 
     if(!ExpandEnvironmentStrings(path, expanded_path, OS_MAXSTR))
         fail();
@@ -2870,21 +2584,15 @@ static void test_fim_checker_fim_regular_ignore(void **state) {
     snprintf(debug_msg, OS_MAXSTR, "(6204): Ignoring 'file' '%s' due to '%s'", expanded_path, expanded_path);
     expect_string(__wrap__mdebug2, formatted_msg, debug_msg);
 
-    fim_checker(expanded_path, fim_data->item, fim_data->w_evt, 1);
-
-    assert_int_equal(fim_data->item->configuration, 37375);
-    assert_int_equal(fim_data->item->index, 7);
+    fim_checker(expanded_path, &evt_data, NULL);
 }
 
 static void test_fim_checker_fim_regular_restrict(void **state) {
-    fim_data_t *fim_data = *state;
-
     struct stat stat_s = { .st_mode = S_IFREG };
     char * path = "%WINDIR%\\System32\\wbem\\restricted.exe";
     char expanded_path[OS_MAXSTR];
     char debug_msg[OS_MAXSTR];
-    fim_data->item->index = 8;
-    fim_data->item->mode = FIM_REALTIME;
+    event_data_t evt_data = { .mode = FIM_REALTIME, .report_event = true };
 
     if(!ExpandEnvironmentStrings(path, expanded_path, OS_MAXSTR))
         fail();
@@ -2901,19 +2609,14 @@ static void test_fim_checker_fim_regular_restrict(void **state) {
     snprintf(debug_msg, OS_MAXSTR, "(6203): Ignoring entry '%s' due to restriction 'wmic.exe$'", expanded_path);
     expect_string(__wrap__mdebug2, formatted_msg, debug_msg);
 
-    fim_checker(expanded_path, fim_data->item, fim_data->w_evt, 1);
-
-    assert_int_equal(fim_data->item->configuration, 37375);
-    assert_int_equal(fim_data->item->index, 8);
+    fim_checker(expanded_path, &evt_data, NULL);
 }
 
 static void test_fim_checker_fim_regular_warning(void **state) {
-    fim_data_t *fim_data = *state;
     struct stat stat_s = { .st_mode = S_IFREG };
     char *path = "%WINDIR%\\System32\\drivers\\etc\\test.exe";
     char expanded_path[OS_MAXSTR];
-    fim_data->item->index = 7;
-    fim_data->item->statbuf.st_size = 1500;
+    event_data_t evt_data = { .mode = FIM_REALTIME, .w_evt = NULL, .report_event = true };
 
     if(!ExpandEnvironmentStrings(path, expanded_path, OS_MAXSTR))
         fail();
@@ -2945,10 +2648,7 @@ static void test_fim_checker_fim_regular_warning(void **state) {
     expect_string(__wrap_fim_db_insert, file_path, expanded_path);
     will_return(__wrap_fim_db_insert, -1);
 
-    fim_checker(expanded_path, fim_data->item, fim_data->w_evt, 1);
-
-    assert_int_equal(fim_data->item->configuration, 37375);
-    assert_int_equal(fim_data->item->index, 7);
+    fim_checker(expanded_path, &evt_data, NULL);
 }
 
 static void test_fim_checker_fim_directory(void **state) {
@@ -2958,8 +2658,7 @@ static void test_fim_checker_fim_directory(void **state) {
     char skip_directory_message[OS_MAXSTR];
     char expanded_path[OS_MAXSTR];
     char expanded_path_test[OS_MAXSTR];
-    fim_data->item->index = 7;
-    fim_data->item->mode = FIM_REALTIME;
+    event_data_t evt_data = { .mode = FIM_REALTIME, .report_event = true };
 
     if(!ExpandEnvironmentStrings(path, expanded_path, OS_MAXSTR))
         fail();
@@ -2990,34 +2689,26 @@ static void test_fim_checker_fim_directory(void **state) {
         "(6347): Directory '%s' is already on the max recursion_level (0), it will not be scanned.", expanded_path_test);
     expect_string(__wrap__mdebug2, formatted_msg, skip_directory_message);
 
-    fim_checker(expanded_path, fim_data->item, NULL, 1);
+    fim_checker(expanded_path, &evt_data, NULL);
 }
 
 
 static void test_fim_checker_root_ignore_file_under_recursion_level(void **state) {
-    fim_data_t *fim_data = *state;
-
     char * path = "c:\\windows\\test.file";
-    struct stat buf;
-    buf.st_mode = S_IFREG;
-    fim_data->item->index = 0;
-    fim_data->item->statbuf = buf;
-    fim_data->item->mode = FIM_REALTIME;
+    event_data_t evt_data = { .mode = FIM_REALTIME, .report_event = true };
 
     expect_string(__wrap__mdebug2, formatted_msg,
         "(6217): Maximum level of recursion reached. Depth:1 recursion_level:0 'c:\\windows\\test.file'");
 
-    fim_checker(path, fim_data->item, NULL, 1);
+    fim_checker(path, &evt_data, NULL);
 }
 
 static void test_fim_checker_root_file_within_recursion_level(void **state) {
-    fim_data_t *fim_data = *state;
-
     char * path = "c:\\test.file";
-    struct stat buf = { .st_mode = S_IFREG };
-    fim_data->item->index = 0;
-    fim_data->item->statbuf = buf;
-    fim_data->item->mode = FIM_REALTIME;
+    struct stat statbuf = DEFAULT_STATBUF;
+    event_data_t evt_data = { .mode = FIM_REALTIME, .report_event = true, .w_evt = NULL };
+
+    statbuf.st_size = 0;
 
     // Inside fim_file
     expect_get_data(strdup("user"), "", path, 0);
@@ -3036,16 +2727,13 @@ static void test_fim_checker_root_file_within_recursion_level(void **state) {
     will_return(__wrap_fim_db_insert, 0);
 
     expect_string(__wrap_stat, __file, "c:\\test.file");
-    will_return(__wrap_stat, &buf);
+    will_return(__wrap_stat, &statbuf);
     will_return(__wrap_stat, 0);
 
     expect_string(__wrap_HasFilesystem, path, "c:\\test.file");
     will_return(__wrap_HasFilesystem, 0);
 
-    fim_checker(path, fim_data->item, fim_data->w_evt, 1);
-
-    assert_int_equal(fim_data->item->configuration, 37375);
-    assert_int_equal(fim_data->item->index, 0);
+    fim_checker(path, &evt_data, NULL);
 }
 
 static void test_fim_scan_db_full_double_scan(void **state) {
@@ -3317,11 +3005,9 @@ static void test_fim_scan_no_limit(void **state) {
 
 void test_fim_delete_file_event_delete_error(void **state) {
     fim_data_t *fim_data = *state;
-
     char *path = "%WINDIR%\\System32\\drivers\\etc\\test.exe";
     char expanded_path[OS_MAXSTR];
-    fim_data->item->index = 7;
-    syscheck.opts[7] |= CHECK_SEECHANGES;
+    event_data_t evt_data = { .mode = FIM_SCHEDULED, .report_event = true, .type=FIM_DELETE };
 
     if(!ExpandEnvironmentStrings(path, expanded_path, OS_MAXSTR))
         fail();
@@ -3348,22 +3034,19 @@ void test_fim_delete_file_event_delete_error(void **state) {
     fim_data->local_data->options = 511;
     strcpy(fim_data->local_data->checksum, "");
 
-    expect_fim_diff_process_delete_file(expanded_path, 0);
-
     expect_function_call(__wrap_pthread_mutex_lock);
     expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, FIMDB_ERR);
     expect_function_call(__wrap_pthread_mutex_unlock);
 
-    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, (void *)true, NULL, NULL);
+    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, &evt_data, NULL, NULL);
 }
 
 void test_fim_delete_file_event_remove_success(void **state) {
     fim_data_t *fim_data = *state;
-
     char *path = "%WINDIR%\\System32\\drivers\\etc\\test.exe";
     char expanded_path[OS_MAXSTR];
-    fim_data->item->index = 7;
-    syscheck.opts[7] |= CHECK_SEECHANGES;
+    event_data_t evt_data = { .mode = FIM_SCHEDULED, .report_event = true };
+
     char buffer[OS_SIZE_128] = {0};
     if(!ExpandEnvironmentStrings(path, expanded_path, OS_MAXSTR))
         fail();
@@ -3390,8 +3073,6 @@ void test_fim_delete_file_event_remove_success(void **state) {
     fim_data->local_data->options = 511;
     strcpy(fim_data->local_data->checksum, "");
 
-    expect_fim_diff_process_delete_file(expanded_path, 0);
-
     expect_function_call(__wrap_pthread_mutex_lock);
     expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, FIMDB_OK);
     expect_function_call(__wrap_pthread_mutex_unlock);
@@ -3399,16 +3080,15 @@ void test_fim_delete_file_event_remove_success(void **state) {
     snprintf(buffer, OS_SIZE_128, FIM_FILE_MSG_DELETE, fim_data->fentry->file_entry.path);
     expect_string(__wrap__mdebug2, formatted_msg, buffer);
 
-    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, (void *) true, NULL, NULL);
+    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, &evt_data, NULL, NULL);
 }
 
 void test_fim_delete_file_event_no_conf(void **state) {
     fim_data_t *fim_data = *state;
-
     char *path = "C:\\A\\random\\path";
     char expanded_path[OS_MAXSTR];
-    fim_data->item->index = 7;
-    syscheck.opts[7] |= CHECK_SEECHANGES;
+    event_data_t evt_data = { .mode = FIM_SCHEDULED, .report_event = true };
+
     if(!ExpandEnvironmentStrings(path, expanded_path, OS_MAXSTR))
         fail();
 
@@ -3443,17 +3123,16 @@ void test_fim_delete_file_event_no_conf(void **state) {
     expect_string(__wrap__mdebug2, formatted_msg, buffer_config);
     expect_string(__wrap__mdebug2, formatted_msg, buffer_msg);
 
-    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, (void *) true, NULL, NULL);
+    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, &evt_data, NULL, NULL);
 }
 
 void test_fim_delete_file_event_different_mode_scheduled(void **state) {
     fim_data_t *fim_data = *state;
-
     char *path = "%WINDIR%\\System32\\drivers\\etc\\test.exe";
     char expanded_path[OS_MAXSTR];
-    fim_data->item->index = 7;
-    syscheck.opts[7] |= CHECK_SEECHANGES;
     char buffer[OS_SIZE_128] = {0};
+    event_data_t evt_data = { .mode = FIM_SCHEDULED, .report_event = true };
+
     if(!ExpandEnvironmentStrings(path, expanded_path, OS_MAXSTR))
         fail();
 
@@ -3478,8 +3157,6 @@ void test_fim_delete_file_event_different_mode_scheduled(void **state) {
     fim_data->local_data->scanned = 123456;
     fim_data->local_data->options = 511;
     strcpy(fim_data->local_data->checksum, "");
-
-    expect_fim_diff_process_delete_file(expanded_path, 0);
 
     expect_function_call(__wrap_pthread_mutex_lock);
     expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, FIMDB_OK);
@@ -3488,17 +3165,15 @@ void test_fim_delete_file_event_different_mode_scheduled(void **state) {
     snprintf(buffer, OS_SIZE_128, FIM_FILE_MSG_DELETE, fim_data->fentry->file_entry.path);
     expect_string(__wrap__mdebug2, formatted_msg, buffer);
 
-    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, (void *) true,
-                          (void *) FIM_SCHEDULED, NULL);
+    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, &evt_data, NULL, NULL);
 }
 
 void test_fim_delete_file_event_different_mode_abort_realtime(void **state) {
     fim_data_t *fim_data = *state;
-
     char *path = "%WINDIR%\\System32\\drivers\\etc\\test.exe";
     char expanded_path[OS_MAXSTR];
-    fim_data->item->index = 7;
-    syscheck.opts[7] |= CHECK_SEECHANGES;
+    event_data_t evt_data = { .mode = FIM_WHODATA, .report_event = true };
+
     if(!ExpandEnvironmentStrings(path, expanded_path, OS_MAXSTR))
         fail();
 
@@ -3524,17 +3199,15 @@ void test_fim_delete_file_event_different_mode_abort_realtime(void **state) {
     fim_data->local_data->options = 511;
     strcpy(fim_data->local_data->checksum, "");
 
-    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, (void *) true,
-                          (void *) FIM_WHODATA, NULL);
+    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, &evt_data, NULL, NULL);
 }
 
 void test_fim_delete_file_event_different_mode_abort_whodata(void **state) {
     fim_data_t *fim_data = *state;
-
     char *path = "%WINDIR%\\System32\\drivers\\etc\\test.exe";
     char expanded_path[OS_MAXSTR];
-    fim_data->item->index = 7;
-    syscheck.opts[7] |= CHECK_SEECHANGES;
+    event_data_t evt_data = { .mode = FIM_REALTIME, .report_event = true };
+
     if(!ExpandEnvironmentStrings(path, expanded_path, OS_MAXSTR))
         fail();
 
@@ -3560,15 +3233,14 @@ void test_fim_delete_file_event_different_mode_abort_whodata(void **state) {
     fim_data->local_data->options = 511;
     strcpy(fim_data->local_data->checksum, "");
 
-    int pos = fim_configuration_directory(fim_data->fentry->file_entry.path);
-    syscheck.opts[pos] |= WHODATA_ACTIVE;
-    syscheck.opts[pos] &= ~REALTIME_ACTIVE;
+    directory_t *configuration = fim_configuration_directory(fim_data->fentry->file_entry.path);
+    configuration->options |= WHODATA_ACTIVE | CHECK_SEECHANGES;
+    configuration->options &= ~REALTIME_ACTIVE;
 
-    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, (void *) true,
-                          (void *) FIM_REALTIME, NULL);
+    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, &evt_data, NULL, NULL);
 
-    syscheck.opts[pos] &= ~WHODATA_ACTIVE;
-    syscheck.opts[pos] |= REALTIME_ACTIVE;
+    configuration->options &= ~(WHODATA_ACTIVE | CHECK_SEECHANGES);
+    configuration->options |= REALTIME_ACTIVE;
 }
 
 #endif
@@ -4077,6 +3749,7 @@ static void test_fim_check_db_state_nodes_count_database_error(void **state) {
 /* fim_directory */
 static void test_fim_directory(void **state) {
     fim_data_t *fim_data = *state;
+    event_data_t evt_data = { .mode = FIM_REALTIME, .w_evt = NULL, .report_event = true, .type = FIM_MODIFICATION };
     int ret;
 
     strcpy(fim_data->entry->d_name, "test");
@@ -4091,15 +3764,14 @@ static void test_fim_directory(void **state) {
     expect_string(__wrap__mdebug2, formatted_msg, "(6319): No configuration found for (file):'test\\test'");
 #endif
 
-    fim_data->item->index = 1;
-
-    ret = fim_directory("test", fim_data->item, NULL, 1);
+    ret = fim_directory("test", &evt_data, NULL);
 
     assert_int_equal(ret, 0);
 }
 
 static void test_fim_directory_ignore(void **state) {
     fim_data_t *fim_data = *state;
+    event_data_t evt_data = { .mode = FIM_REALTIME, .w_evt = NULL, .report_event = true, .type = FIM_MODIFICATION };
     int ret;
 
     strcpy(fim_data->entry->d_name, ".");
@@ -4108,9 +3780,7 @@ static void test_fim_directory_ignore(void **state) {
     will_return(__wrap_readdir, fim_data->entry);
     will_return(__wrap_readdir, NULL);
 
-    fim_data->item->index = 1;
-
-    ret = fim_directory(".", fim_data->item, NULL, 1);
+    ret = fim_directory(".", &evt_data, NULL);
 
     assert_int_equal(ret, 0);
 }
@@ -4120,7 +3790,7 @@ static void test_fim_directory_nodir(void **state) {
 
     expect_string(__wrap__merror, formatted_msg, "(1105): Attempted to use null string.");
 
-    ret = fim_directory(NULL, NULL, NULL, 1);
+    ret = fim_directory(NULL, NULL, NULL);
 
     assert_int_equal(ret, OS_INVALID);
 }
@@ -4134,7 +3804,7 @@ static void test_fim_directory_opendir_error(void **state) {
 
     errno = EACCES;
 
-    ret = fim_directory("test", NULL, NULL, 1);
+    ret = fim_directory("test", NULL, NULL);
 
     errno = 0;
 
@@ -4144,29 +3814,18 @@ static void test_fim_directory_opendir_error(void **state) {
 /* fim_get_data */
 static void test_fim_get_data(void **state) {
     fim_data_t *fim_data = *state;
-    struct stat buf;
-
-    buf.st_mode = S_IFREG | 00444 ;
-    buf.st_size = 1000;
-    buf.st_uid = 0;
-    buf.st_gid = 0;
-    buf.st_ino = 1234;
-    buf.st_dev = 2345;
-    buf.st_mtime = 3456;
-
-    fim_data->item->index = 1;
-    fim_data->item->statbuf = buf;
-    fim_data->item->configuration = CHECK_SIZE |
-                                    CHECK_PERM |
-                                    CHECK_MTIME |
-                                    CHECK_OWNER |
-                                    CHECK_GROUP |
-                                    CHECK_MD5SUM |
-                                    CHECK_SHA1SUM |
-                                    CHECK_SHA256SUM;
+    directory_t configuration = { .options = CHECK_SIZE | CHECK_PERM | CHECK_MTIME | CHECK_OWNER | CHECK_GROUP |
+                                             CHECK_MD5SUM | CHECK_SHA1SUM | CHECK_SHA256SUM };
+    struct stat statbuf = { .st_mode = S_IFREG | 00444,
+                            .st_size = 1000,
+                            .st_uid = 0,
+                            .st_gid = 0,
+                            .st_ino = 1234,
+                            .st_dev = 2345,
+                            .st_mtime = 3456 };
 
     expect_get_data(strdup("user"), strdup("group"), "test", 1);
-    fim_data->local_data = fim_get_data("test", fim_data->item);
+    fim_data->local_data = fim_get_data("test", &configuration, &statbuf);
 
 #ifndef TEST_WINAGENT
     assert_string_equal(fim_data->local_data->perm, "r--r--r--");
@@ -4180,28 +3839,18 @@ static void test_fim_get_data(void **state) {
 
 static void test_fim_get_data_no_hashes(void **state) {
     fim_data_t *fim_data = *state;
-    struct stat buf;
-
-    buf.st_mode = S_IFREG | 00444 ;
-    buf.st_size = 1000;
-    buf.st_uid = 0;
-    buf.st_gid = 0;
-    buf.st_ino = 1234;
-    buf.st_dev = 2345;
-    buf.st_mtime = 3456;
-
-    fim_data->item->index = 1;
-    fim_data->item->statbuf = buf;
-    fim_data->item->configuration = 0 | CHECK_SIZE |
-                                    CHECK_PERM |
-                                    CHECK_MTIME |
-                                    CHECK_OWNER |
-                                    CHECK_GROUP;
+    directory_t configuration = { .options = CHECK_SIZE | CHECK_PERM | CHECK_MTIME | CHECK_OWNER | CHECK_GROUP };
+    struct stat statbuf = { .st_mode = S_IFREG | 00444,
+                            .st_size = 1000,
+                            .st_uid = 0,
+                            .st_gid = 0,
+                            .st_ino = 1234,
+                            .st_dev = 2345,
+                            .st_mtime = 3456 };
 
     expect_get_data(strdup("user"), strdup("group"), "test", 0);
 
-
-    fim_data->local_data = fim_get_data("test", fim_data->item);
+    fim_data->local_data = fim_get_data("test", &configuration, &statbuf);
 
 #ifndef TEST_WINAGENT
     assert_string_equal(fim_data->local_data->perm, "r--r--r--");
@@ -4215,16 +3864,15 @@ static void test_fim_get_data_no_hashes(void **state) {
 
 static void test_fim_get_data_hash_error(void **state) {
     fim_data_t *fim_data = *state;
-
-    fim_data->item->index = 1;
-    fim_data->item->configuration = CHECK_MD5SUM | CHECK_SHA1SUM | CHECK_SHA256SUM | CHECK_MTIME | \
-                          CHECK_SIZE | CHECK_PERM | CHECK_OWNER | CHECK_GROUP;
-    struct stat buf;
-    buf.st_mode = S_IFREG | 00444 ;
-    buf.st_size = 1000;
-    buf.st_uid = 0;
-    buf.st_gid = 0;
-    fim_data->item->statbuf = buf;
+    directory_t configuration = { .options = CHECK_MD5SUM | CHECK_SHA1SUM | CHECK_SHA256SUM | CHECK_MTIME |
+                          CHECK_SIZE | CHECK_PERM | CHECK_OWNER | CHECK_GROUP };
+    struct stat statbuf = { .st_mode = S_IFREG | 00444,
+                            .st_size = 1000,
+                            .st_uid = 0,
+                            .st_gid = 0,
+                            .st_ino = 1234,
+                            .st_dev = 2345,
+                            .st_mtime = 3456 };
 
     expect_get_data(strdup("user"), strdup("group"), "test", 0);
 
@@ -4243,7 +3891,7 @@ static void test_fim_get_data_hash_error(void **state) {
 
     expect_string(__wrap__mdebug1, formatted_msg, "(6324): Couldn't generate hashes for 'test'");
 
-    fim_data->local_data = fim_get_data("test", fim_data->item);
+    fim_data->local_data = fim_get_data("test", &configuration, &statbuf);
 
     assert_null(fim_data->local_data);
 }
@@ -4251,26 +3899,9 @@ static void test_fim_get_data_hash_error(void **state) {
 #ifdef TEST_WINAGENT
 static void test_fim_get_data_fail_to_get_file_premissions(void **state) {
     fim_data_t *fim_data = *state;
-    struct stat buf;
-
-    buf.st_mode = S_IFREG | 00444 ;
-    buf.st_size = 1000;
-    buf.st_uid = 0;
-    buf.st_gid = 0;
-    buf.st_ino = 1234;
-    buf.st_dev = 2345;
-    buf.st_mtime = 3456;
-
-    fim_data->item->index = 1;
-    fim_data->item->statbuf = buf;
-    fim_data->item->configuration = CHECK_SIZE |
-                                    CHECK_PERM |
-                                    CHECK_MTIME |
-                                    CHECK_OWNER |
-                                    CHECK_GROUP |
-                                    CHECK_MD5SUM |
-                                    CHECK_SHA1SUM |
-                                    CHECK_SHA256SUM;
+    directory_t configuration = { .options = CHECK_SIZE | CHECK_PERM | CHECK_MTIME | CHECK_OWNER | CHECK_GROUP |
+                                             CHECK_MD5SUM | CHECK_SHA1SUM | CHECK_SHA256SUM };
+    struct stat statbuf = DEFAULT_STATBUF;
 
     expect_string(__wrap__mdebug1, formatted_msg, "(6325): It was not possible to extract the permissions of 'test'. Error: 5");
 
@@ -4279,7 +3910,7 @@ static void test_fim_get_data_fail_to_get_file_premissions(void **state) {
     will_return(__wrap_w_get_file_permissions, ERROR_ACCESS_DENIED);
 
 
-    fim_data->local_data = fim_get_data("test", fim_data->item);
+    fim_data->local_data = fim_get_data("test", &configuration, &statbuf);
 
     assert_null(fim_data->local_data);
 }
@@ -4545,7 +4176,6 @@ static void test_fim_process_missing_entry_failure(void **state) {
     expect_value(__wrap_fim_db_process_missing_entry, fim_sql, syscheck.database);
     expect_value(__wrap_fim_db_process_missing_entry, file, file);
     expect_value(__wrap_fim_db_process_missing_entry, storage, FIM_DB_DISK);
-    expect_value(__wrap_fim_db_process_missing_entry, mode, FIM_REALTIME);
     will_return(__wrap_fim_db_process_missing_entry, FIMDB_ERR);
 
     expect_string(__wrap__merror, formatted_msg, error_msg);
@@ -5515,7 +5145,7 @@ int main(void) {
         cmocka_unit_test(test_fim_check_db_state_80_percentage_to_normal),
         cmocka_unit_test(test_fim_check_db_state_nodes_count_database_error),
 #ifndef TEST_WINAGENT
-        cmocka_unit_test_setup_teardown(test_fim_scan_no_realtime, setup_fim_scan_realtime, teardown_fim_scan_realtime),
+        // cmocka_unit_test_setup_teardown(test_fim_scan_no_realtime, setup_fim_scan_realtime, teardown_fim_scan_realtime),
         cmocka_unit_test_setup_teardown(test_fim_scan_realtime_enabled, setup_fim_scan_realtime,
                                         teardown_fim_scan_realtime),
 #endif
@@ -5523,7 +5153,7 @@ int main(void) {
         /* fim_checker */
         cmocka_unit_test(test_fim_checker_scheduled_configuration_directory_error),
         cmocka_unit_test(test_fim_checker_not_scheduled_configuration_directory_error),
-        cmocka_unit_test(test_fim_checker_invalid_fim_mode),
+        // cmocka_unit_test(test_fim_checker_invalid_fim_mode),
         cmocka_unit_test(test_fim_checker_over_max_recursion_level),
         cmocka_unit_test(test_fim_checker_deleted_file),
         cmocka_unit_test_setup(test_fim_checker_deleted_file_enoent, setup_fim_entry),

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -1222,11 +1222,9 @@ static void expect_fim_db_set_scanned(fdb_t *db, const char *file_path, int ret)
 }
 
 static void test_fim_file_add(void **state) {
-    event_data_t evt_data = { .mode = FIM_SCHEDULED, .w_evt = NULL, .report_event = true };
+    event_data_t evt_data = { .mode = FIM_SCHEDULED, .w_evt = NULL, .report_event = true, .statbuf = DEFAULT_STATBUF };
     directory_t configuration = { .options = CHECK_SIZE | CHECK_PERM | CHECK_OWNER | CHECK_GROUP | CHECK_MD5SUM |
                                              CHECK_SHA1SUM | CHECK_MTIME | CHECK_SHA256SUM | CHECK_SEECHANGES };
-    struct stat statbuf = DEFAULT_STATBUF;
-
 #ifdef TEST_WINAGENT
     char file_path[OS_SIZE_256] = "c:\\windows\\system32\\cmd.exe";
 #else
@@ -1246,8 +1244,8 @@ static void test_fim_file_add(void **state) {
     will_return(__wrap_fim_db_get_path, NULL);
 
 #ifndef TEST_WINAGENT
-    expect_value(__wrap_fim_db_data_exists, inode, statbuf.st_ino);
-    expect_value(__wrap_fim_db_data_exists, dev, statbuf.st_dev);
+    expect_value(__wrap_fim_db_data_exists, inode, evt_data.statbuf.st_ino);
+    expect_value(__wrap_fim_db_data_exists, dev, evt_data.statbuf.st_dev);
     will_return(__wrap_fim_db_data_exists, 0);
 
     expect_fim_db_insert(syscheck.database, file_path, FIMDB_OK);
@@ -1262,17 +1260,15 @@ static void test_fim_file_add(void **state) {
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
-    fim_file(file_path, &configuration, &evt_data, &statbuf);
+    fim_file(file_path, &configuration, &evt_data);
 }
 
 
 static void test_fim_file_modify(void **state) {
     fim_data_t *fim_data = *state;
-    event_data_t evt_data = { .mode = FIM_SCHEDULED, .w_evt = NULL, .report_event = true };
+    event_data_t evt_data = { .mode = FIM_SCHEDULED, .w_evt = NULL, .report_event = true, .statbuf = DEFAULT_STATBUF };
     directory_t configuration = { .options = CHECK_SIZE | CHECK_PERM | CHECK_OWNER | CHECK_GROUP | CHECK_MD5SUM |
                                              CHECK_SHA1SUM | CHECK_SHA256SUM };
-    struct stat statbuf = DEFAULT_STATBUF;
-
 #ifdef TEST_WINAGENT
     char file_path[OS_SIZE_256] = "c:\\windows\\system32\\cmd.exe";
 #else
@@ -1327,8 +1323,8 @@ static void test_fim_file_modify(void **state) {
                                         0x400, 0);
 
 #ifndef TEST_WINAGENT
-    expect_value(__wrap_fim_db_data_exists, inode, statbuf.st_ino);
-    expect_value(__wrap_fim_db_data_exists, dev, statbuf.st_dev);
+    expect_value(__wrap_fim_db_data_exists, inode, evt_data.statbuf.st_ino);
+    expect_value(__wrap_fim_db_data_exists, dev, evt_data.statbuf.st_dev);
     will_return(__wrap_fim_db_data_exists, 0);
 #endif
 
@@ -1345,17 +1341,15 @@ static void test_fim_file_modify(void **state) {
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
 
-    fim_file(file_path, &configuration, &evt_data, &statbuf);
+    fim_file(file_path, &configuration, &evt_data);
 }
 
 static void test_fim_file_no_attributes(void **state) {
     char buffer1[OS_SIZE_256];
     char buffer2[OS_SIZE_256];
-    event_data_t evt_data = { .mode = FIM_SCHEDULED, .w_evt = NULL, .report_event = true };
+    event_data_t evt_data = { .mode = FIM_SCHEDULED, .w_evt = NULL, .report_event = true, .statbuf = DEFAULT_STATBUF };
     directory_t configuration = { .options = CHECK_SIZE | CHECK_PERM | CHECK_OWNER | CHECK_GROUP | CHECK_MD5SUM |
                                              CHECK_SHA1SUM | CHECK_SHA256SUM };
-    struct stat statbuf = DEFAULT_STATBUF;
-
 #ifdef TEST_WINAGENT
     char file_path[] = "c:\\windows\\system32\\cmd.exe";
 #else
@@ -1401,15 +1395,14 @@ static void test_fim_file_no_attributes(void **state) {
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
 
-    fim_file(file_path, &configuration, &evt_data, &statbuf);
+    fim_file(file_path, &configuration, &evt_data);
 }
 
 static void test_fim_file_error_on_insert(void **state) {
     fim_data_t *fim_data = *state;
-    event_data_t evt_data = { .mode = FIM_SCHEDULED, .w_evt = NULL, .report_event = true };
+    event_data_t evt_data = { .mode = FIM_SCHEDULED, .w_evt = NULL, .report_event = true, .statbuf = DEFAULT_STATBUF };
     directory_t configuration = { .options = CHECK_SIZE | CHECK_PERM | CHECK_OWNER | CHECK_GROUP | CHECK_MD5SUM |
                                              CHECK_SHA1SUM | CHECK_SHA256SUM };
-    struct stat statbuf = DEFAULT_STATBUF;
 #ifdef TEST_WINAGENT
     char file_path[OS_SIZE_256] = "c:\\windows\\system32\\cmd.exe";
 #else
@@ -1473,8 +1466,8 @@ static void test_fim_file_error_on_insert(void **state) {
     will_return(__wrap_fim_db_get_path, fim_data->fentry);
 
 #ifndef TEST_WINAGENT
-    expect_value(__wrap_fim_db_data_exists, inode, statbuf.st_ino);
-    expect_value(__wrap_fim_db_data_exists, dev, statbuf.st_dev);
+    expect_value(__wrap_fim_db_data_exists, inode, evt_data.statbuf.st_ino);
+    expect_value(__wrap_fim_db_data_exists, dev, evt_data.statbuf.st_dev);
     will_return(__wrap_fim_db_data_exists, 0);
 #endif
 
@@ -1485,7 +1478,7 @@ static void test_fim_file_error_on_insert(void **state) {
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
 
-    fim_file(file_path, &configuration, &evt_data, &statbuf);
+    fim_file(file_path, &configuration, &evt_data);
 }
 
 static void test_fim_checker_scheduled_configuration_directory_error(void **state) {

--- a/src/unit_tests/syscheckd/test_fim_diff_changes.c
+++ b/src/unit_tests/syscheckd/test_fim_diff_changes.c
@@ -77,42 +77,20 @@ static OSMatch *syscheck_nodiff_regex[] = { NULL, NULL };
 
 static const char *STR_MORE_CHANGES = "More changes...";
 
-static char *dir_config[] = {
-    "c:\\file\\path",
-    "/path/to/file",
-    "C:\\path\\to\\file",
-    "c:\\file\\nodiff",
-    "/path/to/ignore",
-    NULL,
-};
-
-static char *symbolic_links_config[] = {
-    NULL,
-    NULL,
-    NULL,
-    NULL,
-    NULL,
-    NULL,
-};
-
-static int diff_size_limit_config[] = {
-    1024,
-    1024,
-    1024,
-    1024,
-    1024,
-};
-
 #define DEFAULT_OPTIONS                                                                                    \
     CHECK_MD5SUM | CHECK_SHA1SUM | CHECK_SHA256SUM | CHECK_PERM | CHECK_SIZE | CHECK_OWNER | CHECK_GROUP | \
     CHECK_MTIME | CHECK_INODE
-static int opts_config[] = {
-    DEFAULT_OPTIONS,
-    DEFAULT_OPTIONS,
-    DEFAULT_OPTIONS,
-    DEFAULT_OPTIONS,
-    DEFAULT_OPTIONS
+
+static directory_t DIRECTORIES[] = {
+    [0] = { .path = "c:\\file\\path", .diff_size_limit = 1024, .options = DEFAULT_OPTIONS },
+    [1] = { .path = "/path/to/file", .diff_size_limit = 1024, .options = DEFAULT_OPTIONS },
+    [2] = { .path = "C:\\path\\to\\file", .diff_size_limit = 1024, .options = DEFAULT_OPTIONS },
+    [3] = { .path = "c:\\file\\nodiff", .diff_size_limit = 1024, .options = DEFAULT_OPTIONS },
+    [4] = { .path = "/path/to/ignore", .diff_size_limit = 1024, .options = DEFAULT_OPTIONS },
 };
+
+static directory_t *GLOBAL_CONFIG[] = { [0] = &DIRECTORIES[0], [1] = &DIRECTORIES[1], [2] = &DIRECTORIES[2],
+                                              [3] = &DIRECTORIES[3], [4] = &DIRECTORIES[4], [5] = NULL };
 
 typedef struct gen_diff_struct {
     diff_data *diff;
@@ -278,10 +256,7 @@ static int setup_group(void **state) {
     syscheck.nodiff = syscheck_nodiff;
     syscheck.nodiff_regex = syscheck_nodiff_regex;
 
-    syscheck.dir = dir_config;
-    syscheck.symbolic_links = symbolic_links_config;
-    syscheck.diff_size_limit = diff_size_limit_config;
-    syscheck.opts = opts_config;
+    syscheck.directories = GLOBAL_CONFIG;
 
 #ifdef TEST_WINAGENT
     syscheck.registry = default_reg_config;

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -231,11 +231,6 @@ void test_fim_whodata_initialize(void **state)
         NULL
     };
     char expanded_dirs[1][OS_SIZE_1024];
-    will_return(wrap_GetCurrentThread, (HANDLE)123456);
-
-    expect_SetThreadPriority_call((HANDLE)123456, THREAD_PRIORITY_LOWEST, true);
-
-    expect_string(__wrap__mdebug1, formatted_msg, "(6320): Setting process priority to: '10'");
 
     // Expand directories
     for(i = 0; dirs[i]; i++) {
@@ -320,12 +315,6 @@ void test_fim_whodata_initialize_fail_set_policies(void **state)
         NULL
     };
     char expanded_dirs[1][OS_SIZE_1024];
-
-    will_return(wrap_GetCurrentThread, (HANDLE)123456);
-
-    expect_SetThreadPriority_call((HANDLE)123456, THREAD_PRIORITY_LOWEST, true);
-
-    expect_string(__wrap__mdebug1, formatted_msg, "(6320): Setting process priority to: '10'");
 
     // Expand directories
     for(i = 0; dirs[i]; i++) {
@@ -472,11 +461,6 @@ void test_fim_whodata_initialize_eventchannel(void **state) {
         NULL
     };
     char expanded_dirs[1][OS_SIZE_1024];
-
-    will_return(wrap_GetCurrentThread, (HANDLE)123456);
-    expect_SetThreadPriority_call((HANDLE)123456, THREAD_PRIORITY_LOWEST, true);
-
-    expect_string(__wrap__mdebug1, formatted_msg, "(6320): Setting process priority to: '10'");
 
     // Expand directories
     for(i = 0; dirs[i]; i++) {

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -40,12 +40,12 @@ void set_whodata_mode_changes();
 void fim_send_msg(char mq, const char * location, const char * msg);
 
 #ifndef TEST_WINAGENT
-void fim_link_update(int pos, char *new_path);
-void fim_link_check_delete(int pos);
-void fim_link_delete_range(int pos);
-void fim_link_silent_scan(char *path, int pos);
-void fim_link_reload_broken_link(char *path, int index);
-void fim_delete_realtime_watches(int pos);
+void fim_link_update(const char *new_path, directory_t *configuration);
+void fim_link_check_delete(directory_t *configuration);
+void fim_link_delete_range(const directory_t *configuration);
+void fim_link_silent_scan(char *path, directory_t *configuration);
+void fim_link_reload_broken_link(char *path, directory_t *configuration);
+void fim_delete_realtime_watches(const directory_t *configuration);
 #endif
 
 extern time_t last_time;
@@ -122,16 +122,16 @@ static int setup_group(void ** state) {
 #ifndef TEST_WINAGENT
 
 static int setup_symbolic_links(void **state) {
-    if (syscheck.dir[1] != NULL) {
-        free(syscheck.dir[1]);
-        syscheck.dir[1] = NULL;
+    if (syscheck.directories[1]->path != NULL) {
+        free(syscheck.directories[1]->path);
+        syscheck.directories[1]->path = NULL;
     }
 
-    syscheck.dir[1] = strdup("/link");
-    syscheck.symbolic_links[1] = strdup("/folder");
-    syscheck.opts[1] |= REALTIME_ACTIVE;
+    syscheck.directories[1]->path = strdup("/link");
+    syscheck.directories[1]->symbolic_links = strdup("/folder");
+    syscheck.directories[1]->options |= REALTIME_ACTIVE;
 
-    if (syscheck.dir[1] == NULL || syscheck.symbolic_links[1] == NULL) {
+    if (syscheck.directories[1]->path == NULL || syscheck.directories[1]->symbolic_links == NULL) {
         return -1;
     }
 
@@ -139,20 +139,20 @@ static int setup_symbolic_links(void **state) {
 }
 
 static int teardown_symbolic_links(void **state) {
-    if (syscheck.dir[1] != NULL) {
-        free(syscheck.dir[1]);
-        syscheck.dir[1] = NULL;
+    if (syscheck.directories[1]->path != NULL) {
+        free(syscheck.directories[1]->path);
+        syscheck.directories[1]->path = NULL;
     }
 
-    if (syscheck.symbolic_links[1] != NULL) {
-        free(syscheck.symbolic_links[1]);
-        syscheck.symbolic_links[1] = NULL;
+    if (syscheck.directories[1]->symbolic_links != NULL) {
+        free(syscheck.directories[1]->symbolic_links);
+        syscheck.directories[1]->symbolic_links = NULL;
     }
 
-    syscheck.dir[1] = strdup("/etc");
-    syscheck.opts[1] &= ~REALTIME_ACTIVE;
+    syscheck.directories[1]->path = strdup("/etc");
+    syscheck.directories[1]->options &= ~REALTIME_ACTIVE;
 
-    if (syscheck.dir[1] == NULL) {
+    if (syscheck.directories[1]->path == NULL) {
         return -1;
     }
 
@@ -243,7 +243,7 @@ void test_fim_whodata_initialize(void **state)
             fail();
 
         str_lowercase(expanded_dirs[i]);
-        expect_realtime_adddir_call(expanded_dirs[i], 10, 0);
+        expect_realtime_adddir_call(expanded_dirs[i], 0);
     }
     will_return(__wrap_run_whodata_scan, 0);
     will_return(wrap_CreateThread, (HANDLE)123456);
@@ -333,7 +333,7 @@ void test_fim_whodata_initialize_fail_set_policies(void **state)
             fail();
 
         str_lowercase(expanded_dirs[i]);
-        expect_realtime_adddir_call(expanded_dirs[i], 10, 0);
+        expect_realtime_adddir_call(expanded_dirs[i], 0);
     }
 
     will_return(__wrap_run_whodata_scan, 1);
@@ -441,12 +441,12 @@ void test_set_whodata_mode_changes(void **state) {
     char expanded_dirs[3][OS_SIZE_1024];
 
     // Mark directories to be added in realtime
-    syscheck.wdata.dirs_status[0].status |= WD_CHECK_REALTIME;
-    syscheck.wdata.dirs_status[0].status &= ~WD_CHECK_WHODATA;
-    syscheck.wdata.dirs_status[7].status |= WD_CHECK_REALTIME;
-    syscheck.wdata.dirs_status[7].status &= ~WD_CHECK_WHODATA;
-    syscheck.wdata.dirs_status[8].status |= WD_CHECK_REALTIME;
-    syscheck.wdata.dirs_status[8].status &= ~WD_CHECK_WHODATA;
+    syscheck.directories[0]->dirs_status.status |= WD_CHECK_REALTIME;
+    syscheck.directories[0]->dirs_status.status &= ~WD_CHECK_WHODATA;
+    syscheck.directories[7]->dirs_status.status |= WD_CHECK_REALTIME;
+    syscheck.directories[7]->dirs_status.status &= ~WD_CHECK_WHODATA;
+    syscheck.directories[8]->dirs_status.status |= WD_CHECK_REALTIME;
+    syscheck.directories[8]->dirs_status.status &= ~WD_CHECK_WHODATA;
 
     // Expand directories
     for(i = 0; dirs[i]; i++) {
@@ -454,7 +454,7 @@ void test_set_whodata_mode_changes(void **state) {
             fail();
 
         str_lowercase(expanded_dirs[i]);
-        expect_realtime_adddir_call(expanded_dirs[i], 0, i % 2 == 0);
+        expect_realtime_adddir_call(expanded_dirs[i], i % 2 == 0);
     }
 
     expect_string(__wrap__mdebug1, formatted_msg, "(6225): The 'c:\\programdata\\microsoft\\windows\\start menu\\programs\\startup' directory starts to be monitored in real-time mode.");
@@ -484,8 +484,7 @@ void test_fim_whodata_initialize_eventchannel(void **state) {
             fail();
 
         str_lowercase(expanded_dirs[i]);
-        expect_realtime_adddir_call(expanded_dirs[i], 10, 0);
-
+        expect_realtime_adddir_call(expanded_dirs[i], 0);
     }
 
     will_return(__wrap_run_whodata_scan, 0);
@@ -592,69 +591,57 @@ void test_fim_send_scan_info(void **state) {
 
 #ifndef TEST_WINAGENT
 void test_fim_link_update(void **state) {
-    (void) state;
-
-    int pos = 1;
     char *new_path = "/new_path";
 
     expect_fim_db_get_path_from_pattern(syscheck.database, "/folder/%", NULL, FIM_DB_DISK, FIMDB_OK);
-    expect_string(__wrap_remove_audit_rule_syscheck, path, syscheck.symbolic_links[pos]);
+    expect_string(__wrap_remove_audit_rule_syscheck, path, syscheck.directories[1]->symbolic_links);
 
-    expect_realtime_adddir_call(new_path, 0, 0);
-    expect_fim_checker_call(new_path, 0, 0);
+    expect_realtime_adddir_call(new_path, 0);
+    expect_fim_checker_call(new_path, syscheck.directories[1]);
 
-    fim_link_update(pos, new_path);
+    fim_link_update(new_path, syscheck.directories[1]);
 
-    assert_string_equal(syscheck.dir[pos], "/link");
-    assert_string_equal(syscheck.symbolic_links[pos], new_path);
+    assert_string_equal(syscheck.directories[1]->path, "/link");
+    assert_string_equal(syscheck.directories[1]->symbolic_links, new_path);
 }
 
 void test_fim_link_update_already_added(void **state) {
-    (void) state;
-
-    int pos = 1;
     char *link_path = "/home";
     char error_msg[OS_SIZE_128];
 
-    free(syscheck.symbolic_links[pos]);
-    syscheck.symbolic_links[pos] = strdup("/home");
+    free(syscheck.directories[1]->symbolic_links);
+    syscheck.directories[1]->symbolic_links = strdup("/home");
 
     snprintf(error_msg, OS_SIZE_128, FIM_LINK_ALREADY_ADDED, link_path);
 
     expect_string(__wrap__mdebug1, formatted_msg, error_msg);
 
-    fim_link_update(pos, link_path);
+    fim_link_update(link_path, syscheck.directories[1]);
 
-    assert_string_equal(syscheck.dir[pos], "/link");
-    assert_null(syscheck.symbolic_links[pos]);
+    assert_string_equal(syscheck.directories[1]->path, "/link");
+    assert_null(syscheck.directories[1]->symbolic_links);
 }
 
 void test_fim_link_check_delete(void **state) {
-    (void) state;
-
-    int pos = 1;
     char *link_path = "/link";
     char *pointed_folder = "/folder";
 
-    expect_string(__wrap_lstat, filename, syscheck.symbolic_links[pos]);
+    expect_string(__wrap_lstat, filename, syscheck.directories[1]->symbolic_links);
     will_return(__wrap_lstat, 0);
     will_return(__wrap_lstat, 0);
 
     expect_fim_db_get_path_from_pattern(syscheck.database, "/folder/%", NULL, FIM_DB_DISK, FIMDB_OK);
 
-    expect_string(__wrap_remove_audit_rule_syscheck, path, syscheck.symbolic_links[pos]);
+    expect_string(__wrap_remove_audit_rule_syscheck, path, syscheck.directories[1]->symbolic_links);
 
-    expect_fim_configuration_directory_call(pointed_folder, -1);
-    fim_link_check_delete(pos);
+    expect_fim_configuration_directory_call(pointed_folder, NULL);
+    fim_link_check_delete(syscheck.directories[1]);
 
-    assert_string_equal(syscheck.dir[pos], link_path);
-    assert_null(syscheck.symbolic_links[pos]);
+    assert_string_equal(syscheck.directories[1]->path, link_path);
+    assert_null(syscheck.directories[1]->symbolic_links);
 }
 
 void test_fim_link_check_delete_lstat_error(void **state) {
-    (void) state;
-
-    int pos = 1;
     char *link_path = "/link";
     char *pointed_folder = "/folder";
     char error_msg[OS_SIZE_128];
@@ -668,63 +655,57 @@ void test_fim_link_check_delete_lstat_error(void **state) {
 
     expect_string(__wrap__mdebug1, formatted_msg, error_msg);
 
-    fim_link_check_delete(pos);
+    fim_link_check_delete(syscheck.directories[1]);
 
-    assert_string_equal(syscheck.dir[pos], link_path);
-    assert_string_equal(syscheck.symbolic_links[pos], pointed_folder);
+    assert_string_equal(syscheck.directories[1]->path, link_path);
+    assert_string_equal(syscheck.directories[1]->symbolic_links, pointed_folder);
 }
 
 void test_fim_link_check_delete_noentry_error(void **state) {
-    (void) state;
-
-    int pos = 1;
     char *link_path = "/link";
     char *pointed_folder = "/folder";
 
     expect_string(__wrap_lstat, filename, pointed_folder);
     will_return(__wrap_lstat, 0);
     will_return(__wrap_lstat, -1);
-    expect_string(__wrap_remove_audit_rule_syscheck, path, syscheck.symbolic_links[pos]);
-
+    expect_string(__wrap_remove_audit_rule_syscheck, path, syscheck.directories[1]->symbolic_links);
 
     errno = ENOENT;
 
-    fim_link_check_delete(pos);
+    fim_link_check_delete(syscheck.directories[1]);
 
     errno = 0;
 
-    assert_string_equal(syscheck.dir[pos], link_path);
-    assert_null(syscheck.symbolic_links[pos]);
+    assert_string_equal(syscheck.directories[1]->path, link_path);
+    assert_null(syscheck.directories[1]->symbolic_links);
 }
 
 void test_fim_delete_realtime_watches(void **state) {
     (void) state;
 
-    unsigned int pos = 1;
+    unsigned int pos;
     char *link_path = "/link";
     char *pointed_folder = "/folder";
 
-    expect_fim_configuration_directory_call(pointed_folder, 0);
-    expect_fim_configuration_directory_call("data", 0);
+    expect_fim_configuration_directory_call(pointed_folder, syscheck.directories[0]);
+    expect_fim_configuration_directory_call("data", syscheck.directories[0]);
 
     will_return(__wrap_inotify_rm_watch, 1);
 
-    fim_delete_realtime_watches(pos);
+    fim_delete_realtime_watches(syscheck.directories[1]);
 
     assert_null(OSHash_Begin(syscheck.realtime->dirtb, &pos));
 }
 
 void test_fim_link_delete_range(void **state) {
-    int pos = 1;
     fim_tmp_file *tmp_file = *state;
 
     expect_fim_db_get_path_from_pattern(syscheck.database, "/folder/%", tmp_file, FIM_DB_DISK, FIMDB_OK);
     expect_wrapper_fim_db_delete_range_call(syscheck.database, FIM_DB_DISK, tmp_file, FIMDB_OK);
-    fim_link_delete_range(pos);
+    fim_link_delete_range(syscheck.directories[1]);
 }
 
 void test_fim_link_delete_range_error(void **state) {
-    int pos = 1;
     char error_msg[OS_SIZE_128];
     fim_tmp_file *tmp_file = *state;
 
@@ -734,25 +715,19 @@ void test_fim_link_delete_range_error(void **state) {
     expect_wrapper_fim_db_delete_range_call(syscheck.database, FIM_DB_DISK, tmp_file, FIMDB_ERR);
     expect_string(__wrap__merror, formatted_msg, error_msg);
 
-    fim_link_delete_range(pos);
+    fim_link_delete_range(syscheck.directories[1]);
 }
 
 void test_fim_link_silent_scan(void **state) {
-    (void) state;
-
-    int pos = 3;
     char *link_path = "/link";
 
-    expect_realtime_adddir_call(link_path, 0, 0);
-    expect_fim_checker_call(link_path, 0, 0);
+    expect_realtime_adddir_call(link_path, 0);
+    expect_fim_checker_call(link_path, syscheck.directories[3]);
 
-    fim_link_silent_scan(link_path, pos);
+    fim_link_silent_scan(link_path, syscheck.directories[3]);
 }
 
 void test_fim_link_reload_broken_link_already_monitored(void **state) {
-    (void) state;
-
-    int pos = 1;
     char *link_path = "/link";
     char *pointed_folder = "/folder";
     char error_msg[OS_SIZE_128];
@@ -761,29 +736,25 @@ void test_fim_link_reload_broken_link_already_monitored(void **state) {
 
     expect_string(__wrap__mdebug1, formatted_msg, error_msg);
 
-    fim_link_reload_broken_link(link_path, pos);
+    fim_link_reload_broken_link(link_path, syscheck.directories[1]);
 
-    assert_string_equal(syscheck.dir[pos], link_path);
-    assert_string_equal(syscheck.symbolic_links[pos], pointed_folder);
+    assert_string_equal(syscheck.directories[1]->path, link_path);
+    assert_string_equal(syscheck.directories[1]->symbolic_links, pointed_folder);
 }
 
 void test_fim_link_reload_broken_link_reload_broken(void **state) {
-    (void) state;
-
-    int pos = 1;
     char *link_path = "/link";
     char *pointed_folder = "/new_path";
 
-    expect_fim_checker_call(pointed_folder, 0, 0);
+    expect_fim_checker_call(pointed_folder, syscheck.directories[1]);
 
     expect_string(__wrap_realtime_adddir, dir, pointed_folder);
-    expect_value(__wrap_realtime_adddir, whodata, 0);
     will_return(__wrap_realtime_adddir, 0);
 
-    fim_link_reload_broken_link(pointed_folder, pos);
+    fim_link_reload_broken_link(pointed_folder, syscheck.directories[1]);
 
-    assert_string_equal(syscheck.dir[pos], link_path);
-    assert_string_equal(syscheck.symbolic_links[pos], pointed_folder);
+    assert_string_equal(syscheck.directories[1]->path, link_path);
+    assert_string_equal(syscheck.directories[1]->symbolic_links, pointed_folder);
 }
 #endif
 

--- a/src/unit_tests/syscheckd/test_run_realtime.c
+++ b/src/unit_tests/syscheckd/test_run_realtime.c
@@ -1309,90 +1309,90 @@ void test_free_win32rtfim_data_full_data(void **state) {
 void test_realtime_adddir_whodata_non_existent_file(void **state) {
     int ret;
 
-    syscheck.wdata.dirs_status[0].status &= ~WD_CHECK_WHODATA;
-    syscheck.wdata.dirs_status[0].status |= WD_CHECK_REALTIME;
+    syscheck.directories[9]->dirs_status.status &= ~WD_CHECK_WHODATA;
+    syscheck.directories[9]->dirs_status.status |= WD_CHECK_REALTIME;
 
     expect_string(__wrap_check_path_type, dir, "C:\\a\\path");
     will_return(__wrap_check_path_type, 0);
 
     expect_string(__wrap__mdebug1, formatted_msg, "(6907): 'C:\\a\\path' does not exist. Monitoring discarded.");
 
-    ret = realtime_adddir("C:\\a\\path", 1, 0);
+    ret = realtime_adddir("C:\\a\\path", syscheck.directories[9], 0);
 
     assert_int_equal(ret, 0);
-    assert_non_null(syscheck.wdata.dirs_status[0].status & WD_CHECK_WHODATA);
-    assert_null(syscheck.wdata.dirs_status[0].status & WD_CHECK_REALTIME);
-    assert_int_equal(syscheck.wdata.dirs_status[0].object_type, WD_STATUS_UNK_TYPE);
-    assert_null(syscheck.wdata.dirs_status[0].status & WD_STATUS_EXISTS);
+    assert_non_null(syscheck.directories[9]->dirs_status.status & WD_CHECK_WHODATA);
+    assert_null(syscheck.directories[9]->dirs_status.status & WD_CHECK_REALTIME);
+    assert_int_equal(syscheck.directories[9]->dirs_status.object_type, WD_STATUS_UNK_TYPE);
+    assert_null(syscheck.directories[9]->dirs_status.status & WD_STATUS_EXISTS);
 }
 
 void test_realtime_adddir_whodata_error_adding_whodata_dir(void **state) {
     int ret;
 
-    syscheck.wdata.dirs_status[0].status &= ~WD_CHECK_WHODATA;
-    syscheck.wdata.dirs_status[0].status |= WD_CHECK_REALTIME;
+    syscheck.directories[9]->dirs_status.status &= ~WD_CHECK_WHODATA;
+    syscheck.directories[9]->dirs_status.status |= WD_CHECK_REALTIME;
 
     expect_string(__wrap_check_path_type, dir, "C:\\a\\path");
     will_return(__wrap_check_path_type, 2);
 
     expect_string(__wrap_set_winsacl, dir, "C:\\a\\path");
-    expect_value(__wrap_set_winsacl, position, 0);
+    expect_value(__wrap_set_winsacl, configuration, syscheck.directories[9]);
     will_return(__wrap_set_winsacl, 1);
 
     expect_string(__wrap__merror, formatted_msg,
         "(6619): Unable to add directory to whodata real time monitoring: 'C:\\a\\path'. It will be monitored in Realtime");
 
-    ret = realtime_adddir("C:\\a\\path", 1, 0);
+    ret = realtime_adddir("C:\\a\\path", syscheck.directories[9], 0);
 
     assert_int_equal(ret, -2);
-    assert_non_null(syscheck.wdata.dirs_status[0].status & WD_CHECK_WHODATA);
-    assert_null(syscheck.wdata.dirs_status[0].status & WD_CHECK_REALTIME);
-    assert_int_equal(syscheck.wdata.dirs_status[0].object_type, WD_STATUS_DIR_TYPE);
-    assert_non_null(syscheck.wdata.dirs_status[0].status & WD_STATUS_EXISTS);
+    assert_non_null(syscheck.directories[9]->dirs_status.status & WD_CHECK_WHODATA);
+    assert_null(syscheck.directories[9]->dirs_status.status & WD_CHECK_REALTIME);
+    assert_int_equal(syscheck.directories[9]->dirs_status.object_type, WD_STATUS_DIR_TYPE);
+    assert_non_null(syscheck.directories[9]->dirs_status.status & WD_STATUS_EXISTS);
 }
 
 void test_realtime_adddir_whodata_file_success(void **state) {
     int ret;
 
-    syscheck.wdata.dirs_status[0].status &= ~WD_CHECK_WHODATA;
-    syscheck.wdata.dirs_status[0].status |= WD_CHECK_REALTIME;
+    syscheck.directories[9]->dirs_status.status &= ~WD_CHECK_WHODATA;
+    syscheck.directories[9]->dirs_status.status |= WD_CHECK_REALTIME;
 
     expect_string(__wrap_check_path_type, dir, "C:\\a\\path");
     will_return(__wrap_check_path_type, 1);
 
     expect_string(__wrap_set_winsacl, dir, "C:\\a\\path");
-    expect_value(__wrap_set_winsacl, position, 0);
+    expect_value(__wrap_set_winsacl, configuration, syscheck.directories[9]);
     will_return(__wrap_set_winsacl, 0);
 
-    ret = realtime_adddir("C:\\a\\path", 1, 0);
+    ret = realtime_adddir("C:\\a\\path", syscheck.directories[9], 0);
 
     assert_int_equal(ret, 1);
-    assert_non_null(syscheck.wdata.dirs_status[0].status & WD_CHECK_WHODATA);
-    assert_null(syscheck.wdata.dirs_status[0].status & WD_CHECK_REALTIME);
-    assert_int_equal(syscheck.wdata.dirs_status[0].object_type, WD_STATUS_FILE_TYPE);
-    assert_non_null(syscheck.wdata.dirs_status[0].status & WD_STATUS_EXISTS);
+    assert_non_null(syscheck.directories[9]->dirs_status.status & WD_CHECK_WHODATA);
+    assert_null(syscheck.directories[9]->dirs_status.status & WD_CHECK_REALTIME);
+    assert_int_equal(syscheck.directories[9]->dirs_status.object_type, WD_STATUS_FILE_TYPE);
+    assert_non_null(syscheck.directories[9]->dirs_status.status & WD_STATUS_EXISTS);
 }
 
 void test_realtime_adddir_whodata_dir_success(void **state) {
     int ret;
 
-    syscheck.wdata.dirs_status[0].status &= ~WD_CHECK_WHODATA;
-    syscheck.wdata.dirs_status[0].status |= WD_CHECK_REALTIME;
+    syscheck.directories[9]->dirs_status.status &= ~WD_CHECK_WHODATA;
+    syscheck.directories[9]->dirs_status.status |= WD_CHECK_REALTIME;
 
     expect_string(__wrap_check_path_type, dir, "C:\\a\\path");
     will_return(__wrap_check_path_type, 2);
 
     expect_string(__wrap_set_winsacl, dir, "C:\\a\\path");
-    expect_value(__wrap_set_winsacl, position, 0);
+    expect_value(__wrap_set_winsacl, configuration, syscheck.directories[9]);
     will_return(__wrap_set_winsacl, 0);
 
-    ret = realtime_adddir("C:\\a\\path", 1, 0);
+    ret = realtime_adddir("C:\\a\\path", syscheck.directories[9], 0);
 
     assert_int_equal(ret, 1);
-    assert_non_null(syscheck.wdata.dirs_status[0].status & WD_CHECK_WHODATA);
-    assert_null(syscheck.wdata.dirs_status[0].status & WD_CHECK_REALTIME);
-    assert_int_equal(syscheck.wdata.dirs_status[0].object_type, WD_STATUS_DIR_TYPE);
-    assert_non_null(syscheck.wdata.dirs_status[0].status & WD_STATUS_EXISTS);
+    assert_non_null(syscheck.directories[9]->dirs_status.status & WD_CHECK_WHODATA);
+    assert_null(syscheck.directories[9]->dirs_status.status & WD_CHECK_REALTIME);
+    assert_int_equal(syscheck.directories[9]->dirs_status.object_type, WD_STATUS_DIR_TYPE);
+    assert_non_null(syscheck.directories[9]->dirs_status.status & WD_STATUS_EXISTS);
 }
 
 void test_realtime_adddir_realtime_start_error(void **state) {
@@ -1404,7 +1404,7 @@ void test_realtime_adddir_realtime_start_error(void **state) {
 
     expect_string(__wrap__merror, formatted_msg, "(1102): Could not acquire memory due to [(0)-(Success)].");
 
-    ret = realtime_adddir("C:\\a\\path", 0, 0);
+    ret = realtime_adddir("C:\\a\\path", syscheck.directories[0], 0);
 
     assert_int_equal(ret, -1);
 }
@@ -1421,7 +1421,7 @@ void test_realtime_adddir_max_limit_reached(void **state) {
 
     expect_function_call(__wrap_pthread_mutex_unlock);
 
-    ret = realtime_adddir("C:\\a\\path", 0, 0);
+    ret = realtime_adddir("C:\\a\\path", syscheck.directories[0], 0);
 
     assert_int_equal(ret, 0);
 }
@@ -1443,7 +1443,7 @@ void test_realtime_adddir_duplicate_entry(void **state) {
 
     expect_function_call(__wrap_pthread_mutex_unlock);
 
-    ret = realtime_adddir("C:\\a\\path", 0, 0);
+    ret = realtime_adddir("C:\\a\\path", syscheck.directories[0], 0);
 
     assert_int_equal(ret, 1);
 }
@@ -1468,7 +1468,7 @@ void test_realtime_adddir_duplicate_entry_non_existent_directory_valid_handle(vo
 
     expect_function_call(__wrap_pthread_mutex_unlock);
 
-    ret = realtime_adddir("C:\\a\\path", 0, 0);
+    ret = realtime_adddir("C:\\a\\path", syscheck.directories[0], 0);
 
     assert_int_equal(ret, 1);
 
@@ -1514,7 +1514,7 @@ void test_realtime_adddir_duplicate_entry_non_existent_directory_closed_handle(v
 
     expect_function_call(__wrap_pthread_mutex_unlock);
 
-    ret = realtime_adddir("C:\\a\\path", 0, 0);
+    ret = realtime_adddir("C:\\a\\path", syscheck.directories[0], 0);
 
     assert_int_equal(ret, 1);
 }
@@ -1536,7 +1536,7 @@ void test_realtime_adddir_duplicate_entry_non_existent_directory_invalid_handle(
 
     expect_function_call(__wrap_pthread_mutex_unlock);
 
-    ret = realtime_adddir("C:\\a\\path", 0, 0);
+    ret = realtime_adddir("C:\\a\\path", syscheck.directories[0], 0);
 
     assert_int_equal(ret, 1);
 }
@@ -1560,7 +1560,7 @@ void test_realtime_adddir_handle_error(void **state) {
 
     expect_function_call(__wrap_pthread_mutex_unlock);
 
-    ret = realtime_adddir("C:\\a\\path", 0, 0);
+    ret = realtime_adddir("C:\\a\\path", syscheck.directories[0], 0);
 
     assert_int_equal(ret, 0);
 }
@@ -1585,7 +1585,7 @@ void test_realtime_adddir_success(void **state) {
     expect_function_call(__wrap_pthread_mutex_unlock);
 
     test_mode = 0;
-    ret = realtime_adddir("C:\\a\\path", 0, 0);
+    ret = realtime_adddir("C:\\a\\path", syscheck.directories[0], 0);
     test_mode = 1;
 
     assert_int_equal(ret, 1);

--- a/src/unit_tests/syscheckd/test_syscheck.c
+++ b/src/unit_tests/syscheckd/test_syscheck.c
@@ -112,13 +112,12 @@ void __wrap_read_internal(int debug_level)
     function_called();
 }
 
-void test_Start_win32_Syscheck_no_config_file(void **state)
-{
-    (void) state;
-
-    char *SYSCHECK_EMPTY[] = { NULL };
+void test_Start_win32_Syscheck_no_config_file(void **state) {
+    directory_t EMPTY = { 0 };
+    directory_t *SYSCHECK_EMPTY[] = { &EMPTY };
     registry REGISTRY_EMPTY[] = { { NULL, 0, 0, 0, 0, NULL, NULL } };
-    syscheck.dir = SYSCHECK_EMPTY;
+
+    syscheck.directories = SYSCHECK_EMPTY;
     syscheck.registry = REGISTRY_EMPTY;
     syscheck.disabled = 1;
 
@@ -147,13 +146,12 @@ void test_Start_win32_Syscheck_no_config_file(void **state)
     Start_win32_Syscheck();
 }
 
-void test_Start_win32_Syscheck_corrupted_config_file(void **state)
-{
-    (void) state;
-
-    char *SYSCHECK_EMPTY[] = { NULL };
+void test_Start_win32_Syscheck_corrupted_config_file(void **state) {
+    directory_t EMPTY = { 0 };
+    directory_t *SYSCHECK_EMPTY[] = { &EMPTY };
     registry REGISTRY_EMPTY[] = { { NULL, 0, 0, 0, 0, NULL, NULL } };
-    syscheck.dir = SYSCHECK_EMPTY;
+
+    syscheck.directories = SYSCHECK_EMPTY;
     syscheck.registry = REGISTRY_EMPTY;
     syscheck.disabled = 1;
 
@@ -175,11 +173,8 @@ void test_Start_win32_Syscheck_corrupted_config_file(void **state)
     Start_win32_Syscheck();
 }
 
-void test_Start_win32_Syscheck_syscheck_disabled_1(void **state)
-{
-    (void) state;
-
-    syscheck.dir = NULL;
+void test_Start_win32_Syscheck_syscheck_disabled_1(void **state) {
+    syscheck.directories = NULL;
     syscheck.registry = NULL;
     syscheck.disabled = 0;
     char info_msg[OS_MAXSTR];
@@ -217,15 +212,12 @@ void test_Start_win32_Syscheck_syscheck_disabled_1(void **state)
     Start_win32_Syscheck();
 }
 
-void test_Start_win32_Syscheck_syscheck_disabled_2(void **state)
-{
-    (void) state;
-
-    char *SYSCHECK_EMPTY[] = { NULL };
-
-    syscheck.dir = SYSCHECK_EMPTY;
-
+void test_Start_win32_Syscheck_syscheck_disabled_2(void **state) {
+    directory_t EMPTY = { 0 };
+    directory_t *SYSCHECK_EMPTY[] = { &EMPTY };
     char info_msg[OS_MAXSTR];
+
+    syscheck.directories = SYSCHECK_EMPTY;
 
     will_return_always(__wrap_getDefine_Int, 1);
 
@@ -260,17 +252,15 @@ void test_Start_win32_Syscheck_syscheck_disabled_2(void **state)
     Start_win32_Syscheck();
 }
 
-void test_Start_win32_Syscheck_dirs_and_registry(void **state)
-{
-    (void) state;
-
-    syscheck.disabled = 0;
-
-    char *syscheck_dirs[] = {"Dir1", NULL};
-    syscheck.dir = syscheck_dirs;
-
+void test_Start_win32_Syscheck_dirs_and_registry(void **state) {
+    directory_t BASE_DIRECTORY = { .path = "Dir1", .options = 0 };
+    directory_t *CONFIG[] = { [0] = &BASE_DIRECTORY, [1] = NULL };
     registry syscheck_registry[] = { { "Entry1", 1, 0, 0, 0, NULL, NULL, "Tag1" },
                                      { NULL, 0, 0, 0, 0, NULL, NULL, NULL } };
+    syscheck.disabled = 0;
+
+    syscheck.directories = CONFIG;
+
     syscheck.registry = syscheck_registry;
 
     char *syscheck_ignore[] = {"Dir1", NULL};
@@ -330,17 +320,14 @@ void test_Start_win32_Syscheck_dirs_and_registry(void **state)
     Start_win32_Syscheck();
 }
 
-void test_Start_win32_Syscheck_whodata_active(void **state)
-{
-    (void) state;
+void test_Start_win32_Syscheck_whodata_active(void **state) {
+    directory_t BASE_DIRECTORY = { .path = "Dir1", .options = WHODATA_ACTIVE };
+    directory_t *CONFIG[] = { [0] = &BASE_DIRECTORY, [1] = NULL };
+    registry syscheck_registry[] = { { NULL, 0, 0, 0, 0, NULL, NULL } };
 
     syscheck.disabled = 0;
-    syscheck.opts[0] = WHODATA_ACTIVE;
+    syscheck.directories = CONFIG;
 
-    char *syscheck_dirs[] = { "Dir1", NULL };
-    syscheck.dir = syscheck_dirs;
-
-    registry syscheck_registry[] = { { NULL, 0, 0, 0, 0, NULL, NULL } };
     syscheck.registry = syscheck_registry;
 
     syscheck.ignore = NULL;

--- a/src/unit_tests/syscheckd/test_syscheck_config.c
+++ b/src/unit_tests/syscheckd/test_syscheck_config.c
@@ -63,14 +63,13 @@ void test_Read_Syscheck_Config_success(void **state)
     assert_non_null(syscheck.nodiff_regex);
     assert_null(syscheck.scan_day);
     assert_null(syscheck.scan_time);
-    assert_non_null(syscheck.dir);
+    assert_non_null(syscheck.directories);
     // Directories configuration have 100 directories in one line. It only can monitor 64 per line.
     // With the first 10 directories in other lines, the count should be 74 (75 should be NULL)
     for (int i = 0; i < 74; i++){
-        assert_non_null(syscheck.dir[i]);
+        assert_non_null(syscheck.directories[i]);
     }
-    assert_null(syscheck.dir[74]);
-    assert_non_null(syscheck.opts);
+    assert_null(syscheck.directories[74]);
     assert_int_equal(syscheck.enable_synchronization, 1);
     assert_int_equal(syscheck.restart_audit, 1);
     assert_int_equal(syscheck.enable_whodata, 1);
@@ -88,7 +87,6 @@ void test_Read_Syscheck_Config_success(void **state)
     assert_int_equal(syscheck.file_size_enabled, true);
     assert_int_equal(syscheck.file_size_limit, 50 * 1024);
     assert_int_equal(syscheck.diff_folder_size, 0);
-    assert_non_null(syscheck.diff_size_limit);
 }
 
 void test_Read_Syscheck_Config_invalid(void **state)
@@ -128,8 +126,7 @@ void test_Read_Syscheck_Config_undefined(void **state)
     assert_null(syscheck.nodiff_regex);
     assert_null(syscheck.scan_day);
     assert_null(syscheck.scan_time);
-    assert_non_null(syscheck.dir);
-    assert_non_null(syscheck.opts);
+    assert_non_null(syscheck.directories);
     assert_int_equal(syscheck.enable_synchronization, 0);
     assert_int_equal(syscheck.restart_audit, 0);
     assert_int_equal(syscheck.enable_whodata, 1);
@@ -147,7 +144,6 @@ void test_Read_Syscheck_Config_undefined(void **state)
     assert_int_equal(syscheck.file_size_enabled, true);
     assert_int_equal(syscheck.file_size_limit, 5);
     assert_int_equal(syscheck.diff_folder_size, 0);
-    assert_non_null(syscheck.diff_size_limit);
 }
 
 void test_Read_Syscheck_Config_unparsed(void **state)
@@ -176,12 +172,7 @@ void test_Read_Syscheck_Config_unparsed(void **state)
     assert_null(syscheck.nodiff_regex);
     assert_null(syscheck.scan_day);
     assert_null(syscheck.scan_time);
-#ifndef TEST_WINAGENT
-    assert_null(syscheck.dir);
-#else
-    assert_non_null(syscheck.dir);
-#endif
-    assert_null(syscheck.opts);
+    assert_null(syscheck.directories);
     assert_int_equal(syscheck.enable_synchronization, 1);
     assert_int_equal(syscheck.restart_audit, 1);
     assert_int_equal(syscheck.enable_whodata, 0);
@@ -199,7 +190,6 @@ void test_Read_Syscheck_Config_unparsed(void **state)
     assert_int_equal(syscheck.file_size_enabled, true);
     assert_int_equal(syscheck.file_size_limit, 50 * 1024);
     assert_int_equal(syscheck.diff_folder_size, 0);
-    assert_null(syscheck.diff_size_limit);
 }
 
 void test_getSyscheckConfig(void **state)
@@ -479,7 +469,7 @@ void test_getSyscheckConfig_no_directories(void **state)
     assert_int_equal(cJSON_GetArraySize(ret), 1);
 
     cJSON *sys_items = cJSON_GetObjectItem(ret, "syscheck");
-    assert_int_equal(cJSON_GetArraySize(sys_items), 18);
+    assert_int_equal(cJSON_GetArraySize(sys_items), 17);
     cJSON *disabled = cJSON_GetObjectItem(sys_items, "disabled");
     assert_string_equal(cJSON_GetStringValue(disabled), "yes");
     cJSON *frequency = cJSON_GetObjectItem(sys_items, "frequency");
@@ -515,8 +505,6 @@ void test_getSyscheckConfig_no_directories(void **state)
     assert_string_equal(cJSON_GetStringValue(skip_proc), "yes");
     cJSON *scan_on_start = cJSON_GetObjectItem(sys_items, "scan_on_start");
     assert_string_equal(cJSON_GetStringValue(scan_on_start), "yes");
-    cJSON *directories = cJSON_GetObjectItem(sys_items, "directories");
-    assert_int_equal(cJSON_GetArraySize(directories), 0);
     cJSON *windows_audit_interval = cJSON_GetObjectItem(sys_items, "windows_audit_interval");
     assert_int_equal(windows_audit_interval->valueint, 0);
     cJSON *registry = cJSON_GetObjectItem(sys_items, "registry");
@@ -555,13 +543,13 @@ void test_SyscheckConf_DirectoriesWithCommas(void **state) {
     assert_int_equal(ret, 0);
 
     #ifdef WIN32
-    assert_string_equal(syscheck.dir[0], "c:\\,testcommas");
-    assert_string_equal(syscheck.dir[1], "c:\\test,commas");
-    assert_string_equal(syscheck.dir[2], "c:\\testcommas,");
+    assert_string_equal(syscheck.directories[0]->path, "c:\\,testcommas");
+    assert_string_equal(syscheck.directories[1]->path, "c:\\test,commas");
+    assert_string_equal(syscheck.directories[2]->path, "c:\\testcommas,");
     #else
-    assert_string_equal(syscheck.dir[0], "/,testcommas");
-    assert_string_equal(syscheck.dir[1], "/test,commas");
-    assert_string_equal(syscheck.dir[2], "/testcommas,");
+    assert_string_equal(syscheck.directories[0]->path, "/,testcommas");
+    assert_string_equal(syscheck.directories[1]->path, "/test,commas");
+    assert_string_equal(syscheck.directories[2]->path, "/testcommas,");
     #endif
 }
 

--- a/src/unit_tests/wrappers/wazuh/syscheckd/create_db_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/create_db_wrappers.c
@@ -13,18 +13,15 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-void __wrap_fim_checker(char *path,
-                        __attribute__((unused)) fim_element *item,
-                        whodata_evt *w_evt,
-                        int report) {
+void __wrap_fim_checker(const char *path, event_data_t *evt_data, const directory_t *configuration) {
     check_expected(path);
-    check_expected(w_evt);
-    check_expected(report);
+    check_expected(evt_data);
+    check_expected(configuration);
 }
 
-int __wrap_fim_configuration_directory(const char *path) {
+directory_t *__wrap_fim_configuration_directory(const char *path) {
     check_expected(path);
-    return mock();
+    return mock_type(directory_t *);
 }
 
 cJSON *__wrap_fim_entry_json(const char * path,
@@ -63,13 +60,13 @@ int __wrap_fim_whodata_event(whodata_evt * w_evt)
     return 1;
 }
 
-void expect_fim_checker_call(const char *path, int w_evt, int report) {
+void expect_fim_checker_call(const char *path, const directory_t *configuration) {
     expect_string(__wrap_fim_checker, path, path);
-    expect_value(__wrap_fim_checker, w_evt, w_evt);
-    expect_value(__wrap_fim_checker, report, report);
+    expect_any(__wrap_fim_checker, evt_data);
+    expect_value(__wrap_fim_checker, configuration, configuration);
 }
 
-void expect_fim_configuration_directory_call(const char *path, int ret) {
+void expect_fim_configuration_directory_call(const char *path, directory_t *ret) {
     expect_string(__wrap_fim_configuration_directory, path, path);
     will_return(__wrap_fim_configuration_directory, ret);
 }

--- a/src/unit_tests/wrappers/wazuh/syscheckd/create_db_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/create_db_wrappers.h
@@ -13,12 +13,9 @@
 
 #include "syscheckd/syscheck.h"
 
-void __wrap_fim_checker(char *path,
-                        fim_element *item,
-                        whodata_evt *w_evt,
-                        int report);
+void __wrap_fim_checker(const char *path, event_data_t *evt_data, const directory_t *configuration);
 
-int __wrap_fim_configuration_directory(const char *path);
+directory_t *__wrap_fim_configuration_directory(const char *path);
 
 cJSON *__wrap_fim_entry_json(const char * path,
                              fim_file_data * data);
@@ -34,12 +31,12 @@ int __wrap_fim_whodata_event(whodata_evt * w_evt);
 /**
  * @brief This function loads the expect and will_return calls for the wrapper of fim_configuration_directory
  */
-void expect_fim_configuration_directory_call(const char *path, int ret);
+void expect_fim_configuration_directory_call(const char *path, directory_t *ret);
 
 /**
  * @brief This function loads the expect and will_return calls for the wrapper of fim_checker
  */
-void expect_fim_checker_call(const char *path, int w_evt, int report);
+void expect_fim_checker_call(const char *path, const directory_t *configuration);
 
 void __wrap_free_entry(fim_entry *entry);
 #endif

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
@@ -186,12 +186,10 @@ int __wrap_fim_db_process_missing_entry(fdb_t *fim_sql,
                                         fim_tmp_file *file,
                                         __attribute__((unused)) pthread_mutex_t *mutex,
                                         int storage,
-                                        fim_event_mode mode,
-                                        __attribute__((unused)) whodata_evt * w_evt) {
+                                        __attribute__((unused)) event_data_t *evt_data) {
     check_expected_ptr(fim_sql);
     check_expected_ptr(file);
     check_expected_ptr(storage);
-    check_expected_ptr(mode);
 
     return mock();
 }

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
@@ -82,8 +82,7 @@ int __wrap_fim_db_process_missing_entry(fdb_t *fim_sql,
                                         fim_tmp_file *file,
                                         pthread_mutex_t *mutex,
                                         int storage,
-                                        fim_event_mode mode,
-                                        whodata_evt * w_evt);
+                                        event_data_t *evt_data);
 
 int __wrap_fim_db_remove_path(fdb_t *fim_sql, char *path);
 

--- a/src/unit_tests/wrappers/wazuh/syscheckd/run_realtime_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/run_realtime_wrappers.c
@@ -13,9 +13,10 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-int __wrap_realtime_adddir(const char *dir, int whodata, __attribute__((unused)) int followsl) {
+int __wrap_realtime_adddir(const char *dir,
+                           __attribute__((unused)) directory_t *configuration,
+                           __attribute__((unused)) int followsl) {
     check_expected(dir);
-    check_expected(whodata);
 
     return mock();
 }
@@ -25,8 +26,7 @@ int __wrap_realtime_start() {
     return 0;
 }
 
-void expect_realtime_adddir_call(const char *path, int whodata, int ret) {
+void expect_realtime_adddir_call(const char *path, int ret) {
     expect_string(__wrap_realtime_adddir, dir, path);
-    expect_value(__wrap_realtime_adddir, whodata, whodata);
     will_return(__wrap_realtime_adddir, ret);
 }

--- a/src/unit_tests/wrappers/wazuh/syscheckd/run_realtime_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/run_realtime_wrappers.h
@@ -6,17 +6,19 @@
  * License (version 2) as published by the FSF - Free Software
  * Foundation
  */
-
-
 #ifndef RUN_REALTIME_WRAPPERS_H
 #define RUN_REALTIME_WRAPPERS_H
 
-int __wrap_realtime_adddir(const char *dir, int whodata, int followsl);
+#include "config/syscheck-config.h"
+
+int __wrap_realtime_adddir(const char *dir,
+                           directory_t *configuration,
+                           int followsl);
 
 int __wrap_realtime_start();
 
 /**
  * @brief This function loads the expect and will_return calls for the wrapper of realtime_adddir
  */
-void expect_realtime_adddir_call(const char *path, int whodata, int ret);
+void expect_realtime_adddir_call(const char *path, int ret);
 #endif

--- a/src/unit_tests/wrappers/wazuh/syscheckd/win_whodata_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/win_whodata_wrappers.c
@@ -17,9 +17,9 @@ int __wrap_run_whodata_scan() {
     return mock();
 }
 
-int __wrap_set_winsacl(const char *dir, int position) {
+int __wrap_set_winsacl(const char *dir, directory_t *configuration) {
     check_expected(dir);
-    check_expected(position);
+    check_expected(configuration);
 
     return mock();
 }

--- a/src/unit_tests/wrappers/wazuh/syscheckd/win_whodata_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/win_whodata_wrappers.h
@@ -11,9 +11,11 @@
 #ifndef WIN_WHODATA_WRAPPERS_H
 #define WIN_WHODATA_WRAPPERS_H
 
+#include "config/syscheck-config.h"
+
 int __wrap_run_whodata_scan();
 
-int __wrap_set_winsacl(const char *dir, int position);
+int __wrap_set_winsacl(const char *dir, directory_t *configuration);
 
 int __wrap_whodata_audit_start();
 


### PR DESCRIPTION
|Related issue|
|---|
|#7243|


## Description

This PR closes #7243.

A new `directory_t` struct was created with the purpose of grouping together all configuration data corresponding to a monitored path, as described by the issue. The final struct can be found here:
https://github.com/wazuh/wazuh/blob/7d0da6c153b35f6789a008c3441015f51427282a/src/config/syscheck-config.h#L199-L211
 
In order to further simplify handling of configured directories, an array of pointers to `directory_t` is stored in the global variable `syscheck`, at this time it might not seem like much but if we implement features that need changing the configured directories (hot reload of configuration) having them stored in this way will help reduce complexity when reorganizing, adding or removing this configuration. This can be appreciated in how the `dump_syscheck_file` function's complexity has been reduced.

In addition, having the configuration of a given path accessible through a pointer helped put in evidence that we were holding multiple copies to the same information (`fim_element_t` held both a copy of the `opts` associated to a path as well as the index of the associated configuration itself). Some further changes were made in order to remove duplicate information and improve readability/maintainability of code, the most notable one is the creation of the `event_data_t` structure, meant to held as much information related to the event being processed.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Source upgrade
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer
  - [x] ThreadSanitizer
- Memory tests for Windows
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Dr. Memory
