### PR TITLE
Add functionality to get_unix_version to AIX OS

### DIFF
--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -746,7 +746,20 @@ os_info *get_unix_version()
                     }
                     pclose(cmd_output_ver);
                 }
-            } else if (strcmp(strtok_r(buff, "\n", &save_ptr),"Linux") == 0){ // Linux undefined
+            } else if (strcmp(strtok_r(buff, "\n", &save_ptr), "AIX") == 0) { // AIX
+                info->os_name = strdup("AIX");
+                info->os_platform = strdup("aix");
+
+                if (cmd_output_ver = popen("oslevel", "r"), cmd_output_ver) {
+                    if (fgets(buff, sizeof(buff) - 1, cmd_output_ver)) {
+                        buff[strlen(buff) - 1] = '\0';
+                        os_strdup(buff, info->os_version);
+                    } else {
+                        mdebug1("Cannot read from command output (oslevel).");
+                    }
+                    pclose(cmd_output_ver);
+                }
+            } else if (strcmp(strtok_r(buff, "\n", &save_ptr), "Linux") == 0) { // Linux undefined
                 info->os_name = strdup("Linux");
                 info->os_platform = strdup("linux");
             }

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -747,13 +747,16 @@ os_info *get_unix_version()
                     pclose(cmd_output_ver);
                 }
             } else if (strcmp(strtok_r(buff, "\n", &save_ptr), "AIX") == 0) { // AIX
-                info->os_name = strdup("AIX");
-                info->os_platform = strdup("aix");
+                os_strdup("AIX", info->os_name);
+                os_strdup("aix", info->os_platform);
 
                 if (cmd_output_ver = popen("oslevel", "r"), cmd_output_ver) {
                     if (fgets(buff, sizeof(buff) - 1, cmd_output_ver)) {
-                        buff[strlen(buff) - 1] = '\0';
-                        os_strdup(buff, info->os_version);
+                        int buff_len = strlen(buff);
+                        if (buff_len > 0) {
+                            buff[buff_len - 1] = '\0';
+                            os_strdup(buff, info->os_version);
+                        }
                     } else {
                         mdebug1("Cannot read from command output (oslevel).");
                     }

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -36,7 +36,7 @@ list(APPEND shared_tests_flags "-Wl,--wrap,OS_IsValidIP -Wl,--wrap,OSMatch_Execu
 list(APPEND shared_tests_names "test_version_op")
 set(VERSION_OP_BASE_FLAGS "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fread \
                            -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fprintf -Wl,--wrap,fgets \
-                           -Wl,--wrap,fgetpos -Wl,--wrap=fgetc")
+                           -Wl,--wrap,fgetpos -Wl,--wrap,fgetc -Wl,--wrap,popen -Wl,--wrap,pclose")
 list(APPEND shared_tests_flags "${VERSION_OP_BASE_FLAGS}")
 
 list(APPEND shared_tests_names "test_queue_op")

--- a/src/unit_tests/shared/test_version_op.c
+++ b/src/unit_tests/shared/test_version_op.c
@@ -77,6 +77,1230 @@ void test_get_unix_version_Ubuntu1904(void **state)
     assert_string_equal(ret->sysname, "Linux");
 }
 
+void test_get_unix_version_centos(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // Fail to open /etc/os-release
+    expect_string(__wrap_fopen, path, "/etc/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Open /usr/lib/os-release
+    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "NAME=\"CentOS Linux\"");
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "VERSION=\"7 (Core)\"");
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "ID=centos");
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "EOF");
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, NULL);
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+
+    // Open /etc/centos-release
+    expect_string(__wrap_fopen, path, "/etc/centos-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "CentOS Linux release 7.5.1804 (Core)");
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_name, "CentOS Linux");
+    assert_string_equal(ret->os_major, "7");
+    assert_string_equal(ret->os_minor, "5");
+    assert_string_equal(ret->os_version, "7.5");
+    assert_string_equal(ret->os_platform, "centos");
+    assert_string_equal(ret->sysname, "Linux");
+}
+
+void test_get_unix_version_fail_os_release_centos(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // Fail to open /etc/os-release
+    expect_string(__wrap_fopen, path, "/etc/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /usr/lib/os-release
+    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Open /etc/centos-release
+    expect_string(__wrap_fopen, path, "/etc/centos-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "CentOS Linux release 6.2.1604 (Core)");
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_name, "CentOS Linux");
+    assert_string_equal(ret->os_major, "6");
+    assert_string_equal(ret->os_minor, "2");
+    assert_string_equal(ret->os_version, "6.2");
+    assert_string_equal(ret->os_platform, "centos");
+    assert_string_equal(ret->sysname, "Linux");
+}
+
+void test_get_unix_version_fail_os_release_fedora(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // Fail to open /etc/os-release
+    expect_string(__wrap_fopen, path, "/etc/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /usr/lib/os-release
+    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/centos-release
+    expect_string(__wrap_fopen, path, "/etc/centos-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Open /etc/fedora-release
+    expect_string(__wrap_fopen, path, "/etc/fedora-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "Fedora release 7 (Moonshine)");
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_name, "Fedora");
+    assert_string_equal(ret->os_major, "7");
+    assert_string_equal(ret->os_version, "7");
+    assert_string_equal(ret->os_platform, "fedora");
+    assert_string_equal(ret->sysname, "Linux");
+}
+
+void test_get_unix_version_fail_os_release_redhat_centos(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // Fail to open /etc/os-release
+    expect_string(__wrap_fopen, path, "/etc/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /usr/lib/os-release
+    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/centos-release
+    expect_string(__wrap_fopen, path, "/etc/centos-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/fedora-release
+    expect_string(__wrap_fopen, path, "/etc/fedora-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Open /etc/redhat-release
+    expect_string(__wrap_fopen, path, "/etc/redhat-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "CentOS Linux Server release 7.2 (Maipo)");
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_name, "CentOS Linux");
+    assert_string_equal(ret->os_major, "7");
+    assert_string_equal(ret->os_minor, "2");
+    assert_string_equal(ret->os_version, "7.2");
+    assert_string_equal(ret->os_platform, "centos");
+    assert_string_equal(ret->sysname, "Linux");
+}
+
+void test_get_unix_version_fail_os_release_redhat_fedora(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // Fail to open /etc/os-release
+    expect_string(__wrap_fopen, path, "/etc/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /usr/lib/os-release
+    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/centos-release
+    expect_string(__wrap_fopen, path, "/etc/centos-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/fedora-release
+    expect_string(__wrap_fopen, path, "/etc/fedora-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Open /etc/redhat-release
+    expect_string(__wrap_fopen, path, "/etc/redhat-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "Fedora Linux Server release 7.2 (Maipo)");
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_name, "Fedora");
+    assert_string_equal(ret->os_major, "7");
+    assert_string_equal(ret->os_minor, "2");
+    assert_string_equal(ret->os_version, "7.2");
+    assert_string_equal(ret->os_platform, "fedora");
+    assert_string_equal(ret->sysname, "Linux");
+}
+
+void test_get_unix_version_fail_os_release_redhat_rhel(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // Fail to open /etc/os-release
+    expect_string(__wrap_fopen, path, "/etc/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /usr/lib/os-release
+    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/centos-release
+    expect_string(__wrap_fopen, path, "/etc/centos-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/fedora-release
+    expect_string(__wrap_fopen, path, "/etc/fedora-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Open /etc/redhat-release
+    expect_string(__wrap_fopen, path, "/etc/redhat-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "Red Hat Enterprise Linux release 7.2 (Maipo)");
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_name, "Red Hat Enterprise Linux");
+    assert_string_equal(ret->os_major, "7");
+    assert_string_equal(ret->os_minor, "2");
+    assert_string_equal(ret->os_version, "7.2");
+    assert_string_equal(ret->os_platform, "rhel");
+    assert_string_equal(ret->sysname, "Linux");
+}
+
+void test_get_unix_version_fail_os_release_redhat_rhel_server(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // Fail to open /etc/os-release
+    expect_string(__wrap_fopen, path, "/etc/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /usr/lib/os-release
+    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/centos-release
+    expect_string(__wrap_fopen, path, "/etc/centos-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/fedora-release
+    expect_string(__wrap_fopen, path, "/etc/fedora-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Open /etc/redhat-release
+    expect_string(__wrap_fopen, path, "/etc/redhat-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "Red Hat Enterprise Linux Server release 7.2 (Maipo)");
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_name, "Red Hat Enterprise Linux Server");
+    assert_string_equal(ret->os_major, "7");
+    assert_string_equal(ret->os_minor, "2");
+    assert_string_equal(ret->os_version, "7.2");
+    assert_string_equal(ret->os_platform, "rhel");
+    assert_string_equal(ret->sysname, "Linux");
+}
+
+void test_get_unix_version_fail_os_release_ubuntu(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // Fail to open /etc/os-release
+    expect_string(__wrap_fopen, path, "/etc/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /usr/lib/os-release
+    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/centos-release
+    expect_string(__wrap_fopen, path, "/etc/centos-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/fedora-release
+    expect_string(__wrap_fopen, path, "/etc/fedora-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/redhat-release
+    expect_string(__wrap_fopen, path, "/etc/redhat-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Open /etc/lsb-release
+    expect_string(__wrap_fopen, path, "/etc/lsb-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "DISTRIB_RELEASE=20.04");
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_name, "Ubuntu");
+    assert_string_equal(ret->os_major, "20");
+    assert_string_equal(ret->os_minor, "04");
+    assert_string_equal(ret->os_version, "20.04");
+    assert_string_equal(ret->os_platform, "ubuntu");
+    assert_string_equal(ret->sysname, "Linux");
+}
+
+void test_get_unix_version_fail_os_release_gentoo(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // Fail to open /etc/os-release
+    expect_string(__wrap_fopen, path, "/etc/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /usr/lib/os-release
+    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/centos-release
+    expect_string(__wrap_fopen, path, "/etc/centos-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/fedora-release
+    expect_string(__wrap_fopen, path, "/etc/fedora-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/redhat-release
+    expect_string(__wrap_fopen, path, "/etc/redhat-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/lsb-release
+    expect_string(__wrap_fopen, path, "/etc/lsb-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Open /etc/gentoo-release
+    expect_string(__wrap_fopen, path, "/etc/gentoo-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "Gentoo Base System version 1.6.12");
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_name, "Gentoo");
+    assert_string_equal(ret->os_major, "1");
+    assert_string_equal(ret->os_minor, "6");
+    assert_string_equal(ret->os_version, "1.6");
+    assert_string_equal(ret->os_platform, "gentoo");
+    assert_string_equal(ret->sysname, "Linux");
+}
+
+void test_get_unix_version_fail_os_release_suse(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // Fail to open /etc/os-release
+    expect_string(__wrap_fopen, path, "/etc/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /usr/lib/os-release
+    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/centos-release
+    expect_string(__wrap_fopen, path, "/etc/centos-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/fedora-release
+    expect_string(__wrap_fopen, path, "/etc/fedora-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/redhat-release
+    expect_string(__wrap_fopen, path, "/etc/redhat-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/lsb-release
+    expect_string(__wrap_fopen, path, "/etc/lsb-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/gentoo-release
+    expect_string(__wrap_fopen, path, "/etc/gentoo-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Open /etc/SuSE-release
+    expect_string(__wrap_fopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "VERSION = 3.5");
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_name, "SuSE Linux");
+    assert_string_equal(ret->os_major, "3");
+    assert_string_equal(ret->os_version, "3");
+    assert_string_equal(ret->os_platform, "suse");
+    assert_string_equal(ret->sysname, "Linux");
+}
+
+void test_get_unix_version_fail_os_release_arch(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // Fail to open /etc/os-release
+    expect_string(__wrap_fopen, path, "/etc/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /usr/lib/os-release
+    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/centos-release
+    expect_string(__wrap_fopen, path, "/etc/centos-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/fedora-release
+    expect_string(__wrap_fopen, path, "/etc/fedora-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/redhat-release
+    expect_string(__wrap_fopen, path, "/etc/redhat-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/lsb-release
+    expect_string(__wrap_fopen, path, "/etc/lsb-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/gentoo-release
+    expect_string(__wrap_fopen, path, "/etc/gentoo-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/SuSE-release
+    expect_string(__wrap_fopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Open /etc/arch-release
+    expect_string(__wrap_fopen, path, "/etc/arch-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "3.5.14");
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_name, "Arch Linux");
+    assert_string_equal(ret->os_major, "3");
+    assert_string_equal(ret->os_minor, "5");
+    assert_string_equal(ret->os_version, "3.5");
+    assert_string_equal(ret->os_platform, "arch");
+    assert_string_equal(ret->sysname, "Linux");
+}
+
+void test_get_unix_version_fail_os_release_debian(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // Fail to open /etc/os-release
+    expect_string(__wrap_fopen, path, "/etc/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /usr/lib/os-release
+    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/centos-release
+    expect_string(__wrap_fopen, path, "/etc/centos-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/fedora-release
+    expect_string(__wrap_fopen, path, "/etc/fedora-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/redhat-release
+    expect_string(__wrap_fopen, path, "/etc/redhat-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/lsb-release
+    expect_string(__wrap_fopen, path, "/etc/lsb-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/gentoo-release
+    expect_string(__wrap_fopen, path, "/etc/gentoo-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/SuSE-release
+    expect_string(__wrap_fopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/arch-release
+    expect_string(__wrap_fopen, path, "/etc/arch-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Open /etc/debian_version
+    expect_string(__wrap_fopen, path, "/etc/debian_version");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "3.5.14");
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_name, "Debian GNU/Linux");
+    assert_string_equal(ret->os_major, "3");
+    assert_string_equal(ret->os_minor, "5");
+    assert_string_equal(ret->os_version, "3.5");
+    assert_string_equal(ret->os_platform, "debian");
+    assert_string_equal(ret->sysname, "Linux");
+}
+
+void test_get_unix_version_fail_os_release_slackware(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // Fail to open /etc/os-release
+    expect_string(__wrap_fopen, path, "/etc/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /usr/lib/os-release
+    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/centos-release
+    expect_string(__wrap_fopen, path, "/etc/centos-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/fedora-release
+    expect_string(__wrap_fopen, path, "/etc/fedora-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/redhat-release
+    expect_string(__wrap_fopen, path, "/etc/redhat-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/lsb-release
+    expect_string(__wrap_fopen, path, "/etc/lsb-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/gentoo-release
+    expect_string(__wrap_fopen, path, "/etc/gentoo-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/SuSE-release
+    expect_string(__wrap_fopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/arch-release
+    expect_string(__wrap_fopen, path, "/etc/arch-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/debian_version
+    expect_string(__wrap_fopen, path, "/etc/debian_version");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Open /etc/slackware-version
+    expect_string(__wrap_fopen, path, "/etc/slackware-version");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "Slackware 14.2");
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_name, "Slackware");
+    assert_string_equal(ret->os_major, "14");
+    assert_string_equal(ret->os_minor, "2");
+    assert_string_equal(ret->os_version, "14.2");
+    assert_string_equal(ret->os_platform, "slackware");
+    assert_string_equal(ret->sysname, "Linux");
+}
+
+void test_get_unix_version_fail_os_release_uname_darwin(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // Fail to open /etc/os-release
+    expect_string(__wrap_fopen, path, "/etc/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /usr/lib/os-release
+    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/centos-release
+    expect_string(__wrap_fopen, path, "/etc/centos-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/fedora-release
+    expect_string(__wrap_fopen, path, "/etc/fedora-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/redhat-release
+    expect_string(__wrap_fopen, path, "/etc/redhat-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/lsb-release
+    expect_string(__wrap_fopen, path, "/etc/lsb-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/gentoo-release
+    expect_string(__wrap_fopen, path, "/etc/gentoo-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/SuSE-release
+    expect_string(__wrap_fopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/arch-release
+    expect_string(__wrap_fopen, path, "/etc/arch-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/debian_version
+    expect_string(__wrap_fopen, path, "/etc/debian_version");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/slackware-version
+    expect_string(__wrap_fopen, path, "/etc/slackware-version");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // uname
+    expect_string(__wrap_popen, command, "uname");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "Darwin\n");
+
+    // sw_vers -productName
+    expect_string(__wrap_popen, command, "sw_vers -productName");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "macOS Catalina\n");
+
+    expect_value(__wrap_pclose, stream, 1);
+    will_return(__wrap_pclose, 1);
+
+    // sw_vers -productVersion
+    expect_string(__wrap_popen, command, "sw_vers -productVersion");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "10.2\n");
+
+    expect_value(__wrap_pclose, stream, 1);
+    will_return(__wrap_pclose, 1);
+
+    // sw_vers -buildVersion
+    expect_string(__wrap_popen, command, "sw_vers -buildVersion");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "10\n");
+
+    expect_value(__wrap_pclose, stream, 1);
+    will_return(__wrap_pclose, 1);
+
+    // uname -r
+    expect_string(__wrap_popen, command, "uname -r");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "macos\n");
+
+    expect_value(__wrap_pclose, stream, 1);
+    will_return(__wrap_pclose, 1);
+
+
+    expect_value(__wrap_pclose, stream, 1);
+    will_return(__wrap_pclose, 1);
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_name, "macOS Catalina");
+    assert_string_equal(ret->os_major, "10");
+    assert_string_equal(ret->os_minor, "2");
+    assert_string_equal(ret->os_version, "10.2");
+    assert_string_equal(ret->os_platform, "darwin");
+    assert_string_equal(ret->sysname, "Linux");
+}
+
+void test_get_unix_version_fail_os_release_uname_sunos(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // Fail to open /etc/os-release
+    expect_string(__wrap_fopen, path, "/etc/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /usr/lib/os-release
+    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/centos-release
+    expect_string(__wrap_fopen, path, "/etc/centos-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/fedora-release
+    expect_string(__wrap_fopen, path, "/etc/fedora-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/redhat-release
+    expect_string(__wrap_fopen, path, "/etc/redhat-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/lsb-release
+    expect_string(__wrap_fopen, path, "/etc/lsb-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/gentoo-release
+    expect_string(__wrap_fopen, path, "/etc/gentoo-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/SuSE-release
+    expect_string(__wrap_fopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/arch-release
+    expect_string(__wrap_fopen, path, "/etc/arch-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/debian_version
+    expect_string(__wrap_fopen, path, "/etc/debian_version");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/slackware-version
+    expect_string(__wrap_fopen, path, "/etc/slackware-version");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // uname
+    expect_string(__wrap_popen, command, "uname");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "SunOS\n");
+
+    // Open /etc/release
+    expect_string(__wrap_fopen, path, "/etc/release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "Oracle Solaris 11.1 SPARC");
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+
+
+    expect_value(__wrap_pclose, stream, 1);
+    will_return(__wrap_pclose, 1);
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_name, "SunOS");
+    assert_string_equal(ret->os_major, "11");
+    assert_string_equal(ret->os_minor, "1");
+    assert_string_equal(ret->os_version, "11.1");
+    assert_string_equal(ret->os_platform, "sunos");
+    assert_string_equal(ret->sysname, "Linux");
+}
+
+void test_get_unix_version_fail_os_release_uname_hp_ux(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // Fail to open /etc/os-release
+    expect_string(__wrap_fopen, path, "/etc/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /usr/lib/os-release
+    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/centos-release
+    expect_string(__wrap_fopen, path, "/etc/centos-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/fedora-release
+    expect_string(__wrap_fopen, path, "/etc/fedora-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/redhat-release
+    expect_string(__wrap_fopen, path, "/etc/redhat-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/lsb-release
+    expect_string(__wrap_fopen, path, "/etc/lsb-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/gentoo-release
+    expect_string(__wrap_fopen, path, "/etc/gentoo-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/SuSE-release
+    expect_string(__wrap_fopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/arch-release
+    expect_string(__wrap_fopen, path, "/etc/arch-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/debian_version
+    expect_string(__wrap_fopen, path, "/etc/debian_version");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/slackware-version
+    expect_string(__wrap_fopen, path, "/etc/slackware-version");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // uname
+    expect_string(__wrap_popen, command, "uname");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "HP-UX\n");
+
+    // uname - r
+    expect_string(__wrap_popen, command, "uname -r");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "B.3.5");
+
+    expect_value(__wrap_pclose, stream, 1);
+    will_return(__wrap_pclose, 1);
+
+
+    expect_value(__wrap_pclose, stream, 1);
+    will_return(__wrap_pclose, 1);
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_name, "HP-UX");
+    assert_string_equal(ret->os_major, "3");
+    assert_string_equal(ret->os_minor, "5");
+    assert_string_equal(ret->os_version, "3.5");
+    assert_string_equal(ret->os_platform, "hp-ux");
+    assert_string_equal(ret->sysname, "Linux");
+}
+
+void test_get_unix_version_fail_os_release_uname_bsd(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // Fail to open /etc/os-release
+    expect_string(__wrap_fopen, path, "/etc/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /usr/lib/os-release
+    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/centos-release
+    expect_string(__wrap_fopen, path, "/etc/centos-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/fedora-release
+    expect_string(__wrap_fopen, path, "/etc/fedora-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/redhat-release
+    expect_string(__wrap_fopen, path, "/etc/redhat-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/lsb-release
+    expect_string(__wrap_fopen, path, "/etc/lsb-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/gentoo-release
+    expect_string(__wrap_fopen, path, "/etc/gentoo-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/SuSE-release
+    expect_string(__wrap_fopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/arch-release
+    expect_string(__wrap_fopen, path, "/etc/arch-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/debian_version
+    expect_string(__wrap_fopen, path, "/etc/debian_version");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/slackware-version
+    expect_string(__wrap_fopen, path, "/etc/slackware-version");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // uname
+    expect_string(__wrap_popen, command, "uname");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "OpenBSD\n");
+
+    // uname - r
+    expect_string(__wrap_popen, command, "uname -r");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "10.3.5");
+
+    expect_value(__wrap_pclose, stream, 1);
+    will_return(__wrap_pclose, 1);
+
+
+    expect_value(__wrap_pclose, stream, 1);
+    will_return(__wrap_pclose, 1);
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_name, "BSD");
+    assert_string_equal(ret->os_major, "10");
+    assert_string_equal(ret->os_minor, "3");
+    assert_string_equal(ret->os_version, "10.3");
+    assert_string_equal(ret->os_platform, "bsd");
+    assert_string_equal(ret->sysname, "Linux");
+}
+
+void test_get_unix_version_fail_os_release_uname_aix(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // Fail to open /etc/os-release
+    expect_string(__wrap_fopen, path, "/etc/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /usr/lib/os-release
+    expect_string(__wrap_fopen, path, "/usr/lib/os-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/centos-release
+    expect_string(__wrap_fopen, path, "/etc/centos-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/fedora-release
+    expect_string(__wrap_fopen, path, "/etc/fedora-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/redhat-release
+    expect_string(__wrap_fopen, path, "/etc/redhat-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/lsb-release
+    expect_string(__wrap_fopen, path, "/etc/lsb-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/gentoo-release
+    expect_string(__wrap_fopen, path, "/etc/gentoo-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/SuSE-release
+    expect_string(__wrap_fopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/arch-release
+    expect_string(__wrap_fopen, path, "/etc/arch-release");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/debian_version
+    expect_string(__wrap_fopen, path, "/etc/debian_version");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // Fail to open /etc/slackware-version
+    expect_string(__wrap_fopen, path, "/etc/slackware-version");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
+
+    // uname
+    expect_string(__wrap_popen, command, "uname");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "AIX\n");
+
+    // oslevel
+    expect_string(__wrap_popen, command, "oslevel");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "7.1\n");
+
+    expect_value(__wrap_pclose, stream, 1);
+    will_return(__wrap_pclose, 1);
+
+
+    expect_value(__wrap_pclose, stream, 1);
+    will_return(__wrap_pclose, 1);
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_name, "AIX");
+    assert_string_equal(ret->os_major, "7");
+    assert_string_equal(ret->os_minor, "1");
+    assert_string_equal(ret->os_version, "7.1");
+    assert_string_equal(ret->os_platform, "aix");
+    assert_string_equal(ret->sysname, "Linux");
+}
+
 void test_OSX_ReleaseName(void **state) {
     (void)state;
 
@@ -101,6 +1325,24 @@ int main(void) {
     const struct CMUnitTest tests[] = {
 #ifdef __linux__
             cmocka_unit_test_teardown(test_get_unix_version_Ubuntu1904, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_centos, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_centos, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_fedora, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_redhat_centos, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_redhat_fedora, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_redhat_rhel, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_redhat_rhel_server, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_ubuntu, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_gentoo, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_suse, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_arch, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_debian, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_slackware, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_darwin, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_sunos, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_hp_ux, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_bsd, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_aix, delete_os_info),
             cmocka_unit_test(test_OSX_ReleaseName),
 #endif
     };

--- a/src/unit_tests/wrappers/libc/stdio_wrappers.c
+++ b/src/unit_tests/wrappers/libc/stdio_wrappers.c
@@ -199,3 +199,14 @@ int __wrap__fseeki64(__attribute__ ((__unused__)) FILE *stream, \
                      __attribute__ ((__unused__)) long offset, __attribute__ ((__unused__)) int whence){
      return mock();
 }
+
+FILE *__wrap_popen(const char *command, const char *type) {
+    check_expected(command);
+    check_expected(type);
+    return mock_ptr_type(FILE*);
+}
+
+int __wrap_pclose(FILE *stream) {
+    check_expected(stream);
+    return mock();
+}

--- a/src/unit_tests/wrappers/libc/stdio_wrappers.h
+++ b/src/unit_tests/wrappers/libc/stdio_wrappers.h
@@ -53,4 +53,8 @@ int __wrap_fgetc(FILE * stream);
 
 int __wrap__fseeki64(FILE *stream, long offset, int whence);
 
+FILE *__wrap_popen(const char *command, const char *type);
+
+int __wrap_pclose(FILE *stream);
+
 #endif


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/6132|


## Description
Hello team,
This PR adds the AIX OS code inside the get_unix_version() function, which is in charge of extracting the operating system information.
In AIX the data related to the system name, version, and platform were missing.
Now, we can check it with the Wazuh API.
`curl -u 'wazuh:wazuh' -k -X GET "https://localhost:55000/agents" -H "Authorization: Bearer $TOKEN"`

```
                "os": {
                    "arch": "AIX",
                    "major": "7",
                    "minor": "1",
                    "name": "AIX",
                    "platform": "aix",
                    "uname": "AIX |soaxp176 |1 |7 |00CADA644C00",
                    "version": "7.1.0.0"
                },
```

I have also added the unit tests related to this function for the rest of the operating systems.

## Tests


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] AIX
- [x] Source installation
