### PR TITLE
[8382] Fixed old binary removal condition for update scenarios

### DIFF
--- a/src/init/update.sh
+++ b/src/init/update.sh
@@ -405,17 +405,32 @@ UpdateStopOSSEC()
     fi
 
     # Deleting syscheckd if exists (it was migrated to Wazuh modules in v5.0)
-    if [ -d "$PREINSTALLEDDIR/bin/wazuh-syscheckd" ]; then
+    # Version 4.1 and below
+    if [ -f "$PREINSTALLEDDIR/bin/ossec-syscheckd" ]; then
+        rm -rf $PREINSTALLEDDIR/bin/ossec-syscheckd > /dev/null 2>&1
+    fi
+    # Version 4.2
+    if [ -f "$PREINSTALLEDDIR/bin/wazuh-syscheckd" ]; then
         rm -rf $PREINSTALLEDDIR/bin/wazuh-syscheckd > /dev/null 2>&1
     fi
 
-    # Deleting wazuh-logcollector if exists (it was migrated to Wazuh modules in v5.0)
-    if [ -d "$PREINSTALLEDDIR/bin/wazuh-logcollector" ]; then
+    # Deleting logcollector if exists (it was migrated to Wazuh modules in v5.0)
+    # Version 4.1 and below
+    if [ -f "$PREINSTALLEDDIR/bin/ossec-logcollector" ]; then
+        rm -rf $PREINSTALLEDDIR/bin/ossec-logcollector > /dev/null 2>&1
+    fi
+    # Version 4.2
+    if [ -f "$PREINSTALLEDDIR/bin/wazuh-logcollector" ]; then
         rm -rf $PREINSTALLEDDIR/bin/wazuh-logcollector > /dev/null 2>&1
     fi
 
-    # Deleting wazuh-execd if exists (it was migrated to Wazuh modules in v5.0)
-    if [ -d "$PREINSTALLEDDIR/bin/wazuh-execd" ]; then
+    # Deleting execd if exists (it was migrated to Wazuh modules in v5.0)
+    # Version 4.1 and below
+    if [ -f "$PREINSTALLEDDIR/bin/ossec-execd" ]; then
+        rm -rf $PREINSTALLEDDIR/bin/ossec-execd > /dev/null 2>&1
+    fi
+    # Version 4.2
+    if [ -f "$PREINSTALLEDDIR/bin/wazuh-execd" ]; then
         rm -rf $PREINSTALLEDDIR/bin/wazuh-execd > /dev/null 2>&1
     fi
 }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #8382 |

## Description
Having a lower Wazuh version than 5.0 installed, and, executing an product update the following binaries are still present eventhougth they shouldn't. 
- ossec-execd / wazuh-execd
- ossec-syscheckd / wazuh-syscheckd
- ossec-logcollector / wazuh-logcollector

**Expected:** binaries deleted after upgrade
**Actual:** binaries not deleted after upgrade

## DoD
- [X] Modify update.sh
- [X] Manual test upgrade, from 4.1(ossec-*) to 5.0, from 4.2(wazuh-*) to 5.0.
- [ ] CI tests