### PR TITLE
Update inst-functions to fix API integration tests errors regarding shared.conf

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -511,7 +511,7 @@ def create_group(group_id):
     try:
         mkdir_with_mode(group_path)
         copyfile(group_def_path, path.join(group_path, 'shared.conf'))
-        chown_r(group_path, common.ossec_uid(), common.wazuh_gid())
+        chown_r(group_path, common.wazuh_uid(), common.wazuh_gid())
         chmod_r(group_path, 0o660)
         chmod(group_path, 0o770)
         msg = f"Group '{group_id}' created."

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -973,11 +973,11 @@ InstallServer()
     ${INSTALL} -m 0660 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ../ruleset/rootcheck/db/*.txt ${INSTALLDIR}/etc/shared/default
 
     if [ ! -f ${INSTALLDIR}/etc/shared/default/shared.conf ]; then
-        ${INSTALL} -m 0660 -o ossec -g ${WAZUH_GROUP} ../etc/shared.conf ${INSTALLDIR}/etc/shared/default
+        ${INSTALL} -m 0660 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ../etc/shared.conf ${INSTALLDIR}/etc/shared/default
     fi
 
     if [ ! -f ${INSTALLDIR}/etc/shared/shared-template.conf ]; then
-        ${INSTALL} -m 0660 -o ossec -g ${WAZUH_GROUP} ../etc/shared.conf ${INSTALLDIR}/etc/shared/shared-template.conf
+        ${INSTALL} -m 0660 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ../etc/shared.conf ${INSTALLDIR}/etc/shared/shared-template.conf
     fi
 
     # Install the plugins files


### PR DESCRIPTION
Hi team,

This PR is related to https://github.com/wazuh/wazuh/pull/8072.

In this pull request, I have investigated the errors found in the related PR jenkins checks. I have investigated API integration tests errors and I have found more errors:

1.- Problem found when installing:

```
Installed /var/ossec/framework/python/lib/python3.9/site-packages/api-5.0.0-py3.9.egg
Processing dependencies for api==5.0.0
Finished processing dependencies for api==5.0.0
cd ../tools/mitre && /var/ossec/framework/python/bin/python3 mitredb.py -d /var/ossec/var/db/mitre.db

install: invalid user 'ossec'            <--------
install: invalid user 'ossec'            <--------

Generating self-signed certificate for wazuh-authd...


 - System is Debian (Ubuntu or derivative).
 - Init script modified to start Wazuh during boot.

 - Configuration finished properly.

 - To start Wazuh:
      /var/ossec/bin/wazuh-control start

 - To stop Wazuh:
      /var/ossec/bin/wazuh-control stop

 - The configuration can be viewed or modified at:
      /var/ossec/etc/manager.conf
      /var/ossec/etc/agent.conf


   Thanks for using Wazuh.
   Please don't hesitate to contact us if you need help or find
   any bugs.

   Use our public Mailing List at:
          https://groups.google.com/forum/#!forum/wazuh

   More information can be found at:
          - http://www.wazuh.com

    ---  Press ENTER to finish (maybe more information below). ---
```
   
When installing, we have no `shared-template.conf` in the `/var/ossec/etc` folder, as we used to.
After investigating the error, I have realized the `inst-functions.sh` script has a wrong and hardcoded user:

https://github.com/wazuh/wazuh/blob/cf95951eef0f0fec40d6986347498766ee25115a/src/init/inst-functions.sh#L975-L981

I have changed it as we need to use the variable `WAZUH_USER`, as it is done in `master`:

https://github.com/wazuh/wazuh/blob/e733d239fad6f88fe188c00006d171d3b1d35ca6/src/init/inst-functions.sh#L1049-L1055
    
Manual test, installation with the fix:

```
root@wazuh-master:/# cat /var/ossec/etc/shared/
default/              shared-template.conf  
root@wazuh-master:/# cat /var/ossec/etc/shared/shared-template.conf 
<agent_config>

  <!-- Shared agent configuration here -->

</agent_config>  
```
  
2.- Problem in some API Integration tests: Agent 004 is unhealthy.

Why only agent 004??

The healthcheck expects a restart due to shared configuration changes, but `wazuh-agentd` gives an error.
Agent's `ossec.log` has this error:

`2021/04/27 09:12:36 wazuh-agentd: ERROR: (1207): Syscheck remote configuration in 'etc/shared/shared.conf' is corrupted.
`
Agent 004 doesn't have `shared.conf`. 004 is the only agent in group `default` that doesn't belong to other groups.

When installing (no api tests environment), the master `shared/default` folder doesn't have the `shared.conf` file.

This error is caused by 1.


3.- I have changed `ossec_uid` in `create_group` function of `agent.py`, to `wazuh_uid`. This fixes an error when trying to create groups via Wazuh API.

- Test results:

```
test_rbac_black_security_endpoints.tavern.yaml 
	 25 passed, 27 warnings

test_rbac_white_security_endpoints.tavern.yaml 
	 25 passed, 27 warnings

test_security_DELETE_endpoints.tavern.yaml 
	 15 passed, 17 warnings

test_security_GET_endpoints.tavern.yaml 
	 11 passed, 13 warnings

test_security_POST_endpoints.tavern.yaml 
	 7 passed, 9 warnings

test_security_PUT_endpoints.tavern.yaml 
	 9 passed, 11 warnings

test_agent_GET_endpoints.tavern.yaml 
	 91 passed, 93 warnings

test_agent_PUT_endpoints.tavern.yaml 
	 10 passed, 12 warnings
```

- All framework and API unittests **passing**

Regards,
Manuel.