### PR TITLE
Removed default name_value assignment in registry monitoring

### DIFF
--- a/src/syscheckd/registry/registry.c
+++ b/src/syscheckd/registry/registry.c
@@ -756,12 +756,6 @@ void fim_read_values(HKEY key_handle,
             break;
         }
 
-        /* Check if no value name is specified */
-        if (value_buffer[0] == '\0') {
-            value_buffer[0] = '@';
-            value_buffer[1] = '\0';
-        }
-
         new->registry_entry.value->name = value_buffer;
         new->registry_entry.value->type = data_type;
         new->registry_entry.value->size = data_size;


### PR DESCRIPTION
|Related issue|
|---|
|#8253|

## Description

Removed if condition that checks for empty value_name and replace it with @

The integrated tests passes with two expections, test_basic_usage_registry_changes.py have two issues reported here ([time travel](https://github.com/wazuh/wazuh-qa/issues/1305) and [registries already created](https://github.com/wazuh/wazuh-qa/issues/1306)) but doesn't seems to be related with the changes in this PR. The same goes for the failures in test_basic_usage_delete_registry.py that also seems to be an isolated error with no relation with this PR, below I'll post the report for test_fim/ and another report for test_basic_usage_delete.py alone.

Report (general) : [report.zip](https://github.com/wazuh/wazuh/files/6472052/report.zip)
Report :  [test_registry_basic_usage_delete_registry_report.zip](https://github.com/wazuh/wazuh/files/6472087/test_registry_basic_usage_delete_registry_report.zip)


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [X] Windows
- [X] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Windows
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory

