### PR TITLE
Fix bug running wazuh-cluster process when it was already running

### DIFF
--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -133,6 +133,11 @@ if __name__ == '__main__':
 
     from api import configuration
 
+    cluster_status = wazuh.core.cluster.utils.get_cluster_status()
+    if cluster_status['running'] == 'yes':
+        main_logger.error("Cluster is already running.")
+        sys.exit(1)
+
     configuration.api_conf.update(configuration.read_yaml_config())
 
     # clean


### PR DESCRIPTION
|Related issue|
|---|
| Closes #7189 |

## Description

Hi team!

There was a bug that leads the Wazuh cluster to stop working until the manager was restarted. If `wazuh-clusterd` was running and the `/var/ossec/bin/wazuh-clusterd` was used, the socket was redefined and the process stopped working.

A condition has been added to the wazuh-clusterd.py script in order to check if the process is running before trying to launch it. In that case, the script is exited:
```
root@wazuh-master:/# /var/ossec/bin/wazuh-clusterd -f
2021/04/27 12:49:59 ERROR: [Cluster] [Main] Cluster is already running.
```

Regards,
Selu.