### PR TITLE
Increase the maximum time for integration tests to ~20 minutes

### DIFF
--- a/api/test/integration/conftest.py
+++ b/api/test/integration/conftest.py
@@ -67,7 +67,7 @@ def build_and_up(interval: int = 10, build: bool = True):
     os.chdir(pwd)
     values = {
         'interval': interval,
-        'max_retries': 30,
+        'max_retries': 60,
         'retries': 0
     }
     # Get current branch

--- a/api/test/integration/env/base/agent/new.Dockerfile
+++ b/api/test/integration/env/base/agent/new.Dockerfile
@@ -9,4 +9,4 @@ RUN /wazuh/install.sh
 
 COPY base/agent/entrypoint.sh /scripts/entrypoint.sh
 
-HEALTHCHECK --retries=300 --interval=1s --timeout=30s --start-period=30s CMD /usr/bin/python3 /tmp/healthcheck/healthcheck.py || exit 1
+HEALTHCHECK --retries=600 --interval=1s --timeout=30s --start-period=30s CMD /usr/bin/python3 /tmp/healthcheck/healthcheck.py || exit 1

--- a/api/test/integration/env/base/agent/old.Dockerfile
+++ b/api/test/integration/env/base/agent/old.Dockerfile
@@ -2,4 +2,4 @@ FROM public.ecr.aws/o5x5t0j3/amd64/api_development:integration_test_wazuh-agent_
 
 COPY base/agent/entrypoint.sh /scripts/entrypoint.sh
 
-HEALTHCHECK --retries=300 --interval=1s --timeout=30s --start-period=30s CMD /usr/bin/python3 /tmp/healthcheck/healthcheck.py || exit 1
+HEALTHCHECK --retries=600 --interval=1s --timeout=30s --start-period=30s CMD /usr/bin/python3 /tmp/healthcheck/healthcheck.py || exit 1

--- a/api/test/integration/env/base/manager/manager.Dockerfile
+++ b/api/test/integration/env/base/manager/manager.Dockerfile
@@ -12,4 +12,4 @@ RUN /wazuh/install.sh
 COPY base/manager/entrypoint.sh /scripts/entrypoint.sh
 
 # HEALTHCHECK
-HEALTHCHECK --retries=300 --interval=1s --timeout=30s --start-period=30s CMD /var/ossec/framework/python/bin/python3 /tmp/healthcheck/healthcheck.py || exit 1
+HEALTHCHECK --retries=600 --interval=1s --timeout=30s --start-period=30s CMD /var/ossec/framework/python/bin/python3 /tmp/healthcheck/healthcheck.py || exit 1


### PR DESCRIPTION
Hi team,

Due to the failures detected in Jenkins https://github.com/wazuh/wazuh-jenkins/issues/2500, we have been investigating and we have noticed that the current maximum time to complete the integration tests (10 minutes) is a very tight timeout.

Sometimes, some of the tests fail due to a problem with this timeout. Here we can see some examples of tests that have passed successfully with a timeout close to the environment shutdown, as well as some that have failed due to the environment shutdown:

### 10:17 minutes (Passed very close to the limit ~10 minutes)
```
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-1029-aws-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.9.0', 'pluggy': '0.13.1'}, 'Plugins': {'tavern': '1.0.0', 'metadata': '1.10.0', 'html': '2.0.1'}}
rootdir: /tmp/Test_integration_endpoints_B597_test_files/api/test/integration, inifile: pytest.ini
plugins: tavern-1.0.0, metadata-1.10.0, html-2.0.1
collecting ... collected 45 items

test_cluster_endpoints.tavern.yaml::GET /cluster/local/config PASSED     [  2%]
test_cluster_endpoints.tavern.yaml::GET /cluster/healthcheck PASSED      [  4%]
test_cluster_endpoints.tavern.yaml::GET /cluster/local/info PASSED       [  6%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes PASSED            [  8%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[master-node] PASSED [ 11%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker1] PASSED   [ 13%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker2] PASSED   [ 15%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[ip] PASSED [ 17%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[name] PASSED [ 20%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[type] PASSED [ 22%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[version] PASSED [ 24%]
test_cluster_endpoints.tavern.yaml::GET /cluster/status PASSED           [ 26%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration PASSED [ 28%]
test_cluster_endpoints.tavern.yaml::GET /cluster/configuration/validation XPASS [ 31%]
test_cluster_endpoints.tavern.yaml::GET /cluster/api/config PASSED       [ 33%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration/{component}/{configuration} PASSED [ 35%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[master-node] PASSED [ 37%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker1] PASSED [ 40%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker2] PASSED [ 42%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[master-node] PASSED [ 44%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker1] PASSED [ 46%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker2] PASSED [ 48%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker1] PASSED [ 51%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker2] PASSED [ 53%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[master-node] PASSED [ 55%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker1] PASSED [ 57%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker2] PASSED [ 60%]
test_cluster_endpoints.tavern.yaml::GET /cluster/wrong_node/stats PASSED [ 62%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[master-node] PASSED [ 64%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker1] PASSED [ 66%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker2] PASSED [ 68%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[master-node] PASSED [ 71%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker1] PASSED [ 73%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker2] PASSED [ 75%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[master-node] PASSED [ 77%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker1] PASSED [ 80%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker2] PASSED [ 82%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[master-node] PASSED [ 84%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker1] PASSED [ 86%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker2] PASSED [ 88%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[master-node] PASSED [ 91%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker1] PASSED [ 93%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker2] PASSED [ 95%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/restart PASSED          [ 97%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/configuration PASSED [100%]

=============================== warnings summary ===============================
/usr/local/lib/python3.8/dist-packages/tavern/testutils/pytesthook/hooks.py:83
  /usr/local/lib/python3.8/dist-packages/tavern/testutils/pytesthook/hooks.py:83: PytestDeprecationWarning: direct construction of YamlFile has been deprecated, please use YamlFile.from_parent
    return YamlFile(path, parent)

/usr/local/lib/python3.8/dist-packages/tavern/testutils/pytesthook/file.py:233: 23 tests with warnings
  /usr/local/lib/python3.8/dist-packages/tavern/testutils/pytesthook/file.py:233: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
    item = YamlItem(test_spec["test_name"], self, test_spec, self.fspath)

/usr/local/lib/python3.8/dist-packages/tavern/testutils/pytesthook/file.py:61
  /usr/local/lib/python3.8/dist-packages/tavern/testutils/pytesthook/file.py:61: PytestUnknownMarkWarning: Unknown pytest.mark.base_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    pytest_marks.append(getattr(pytest.mark, m))

/usr/local/lib/python3.8/dist-packages/tavern/testutils/pytesthook/file.py:182: 33 tests with warnings
  /usr/local/lib/python3.8/dist-packages/tavern/testutils/pytesthook/file.py:182: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
    item_new = YamlItem(spec_new["test_name"], self, spec_new, self.fspath)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
- generated html file: file:///tmp/Test_integration_endpoints_B597_test_files/api/test/integration/Test_integration_endpoints_B597_test_cluster_endpoints.html -
============ 44 passed, 1 xpassed, 58 warnings in 617.81s (0:10:17) ============
```

### Limit reached ~10 minutes
```
E   StopIteration
_ ERROR at setup of /tmp/Test_integration_endpoints_B597_test_files/api/test/integration/test_cdb_list_endpoints.tavern.yaml::DELETE /lists/files/{filename} _
/usr/local/lib/python3.8/dist-packages/_pytest/runner.py:244: in from_call
    result = func()
/usr/local/lib/python3.8/dist-packages/_pytest/runner.py:217: in <lambda>
    lambda: ihook(item=item, **kwds), when=when, reraise=reraise
/usr/local/lib/python3.8/dist-packages/pluggy/hooks.py:286: in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
/usr/local/lib/python3.8/dist-packages/pluggy/manager.py:93: in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
/usr/local/lib/python3.8/dist-packages/pluggy/manager.py:84: in <lambda>
    self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
/usr/local/lib/python3.8/dist-packages/pluggy/callers.py:208: in _multicall
    return outcome.get_result()
/usr/local/lib/python3.8/dist-packages/pluggy/callers.py:80: in get_result
    raise ex[1].with_traceback(ex[2])
/usr/local/lib/python3.8/dist-packages/pluggy/callers.py:187: in _multicall
    res = hook_impl.function(*args)
/usr/local/lib/python3.8/dist-packages/_pytest/runner.py:123: in pytest_runtest_setup
    item.session._setupstate.prepare(item)
/usr/local/lib/python3.8/dist-packages/_pytest/runner.py:376: in prepare
    raise e
/usr/local/lib/python3.8/dist-packages/_pytest/runner.py:373: in prepare
    col.setup()
/usr/local/lib/python3.8/dist-packages/tavern/testutils/pytesthook/item.py:59: in setup
    fixtures.fillfixtures(self)
/usr/local/lib/python3.8/dist-packages/_pytest/fixtures.py:297: in fillfixtures
    request._fillfixtures()
/usr/local/lib/python3.8/dist-packages/_pytest/fixtures.py:477: in _fillfixtures
    item.funcargs[argname] = self.getfixturevalue(argname)
/usr/local/lib/python3.8/dist-packages/_pytest/fixtures.py:487: in getfixturevalue
    return self._get_active_fixturedef(argname).cached_result[0]
/usr/local/lib/python3.8/dist-packages/_pytest/fixtures.py:503: in _get_active_fixturedef
    self._compute_fixture_value(fixturedef)
/usr/local/lib/python3.8/dist-packages/_pytest/fixtures.py:584: in _compute_fixture_value
    fixturedef.execute(request=subrequest)
/usr/local/lib/python3.8/dist-packages/_pytest/fixtures.py:905: in execute
    raise val.with_traceback(tb)
/usr/local/lib/python3.8/dist-packages/_pytest/fixtures.py:964: in pytest_fixture_setup
    result = call_fixture_func(fixturefunc, request, kwargs)
/usr/local/lib/python3.8/dist-packages/_pytest/fixtures.py:788: in call_fixture_func
    res = next(it)
E   StopIteration
=============================== warnings summary ===============================
/usr/local/lib/python3.8/dist-packages/tavern/testutils/pytesthook/hooks.py:83
  /usr/local/lib/python3.8/dist-packages/tavern/testutils/pytesthook/hooks.py:83: PytestDeprecationWarning: direct construction of YamlFile has been deprecated, please use YamlFile.from_parent
    return YamlFile(path, parent)

/usr/local/lib/python3.8/dist-packages/tavern/testutils/pytesthook/file.py:233
/usr/local/lib/python3.8/dist-packages/tavern/testutils/pytesthook/file.py:233
/usr/local/lib/python3.8/dist-packages/tavern/testutils/pytesthook/file.py:233
/usr/local/lib/python3.8/dist-packages/tavern/testutils/pytesthook/file.py:233
/usr/local/lib/python3.8/dist-packages/tavern/testutils/pytesthook/file.py:233
  /usr/local/lib/python3.8/dist-packages/tavern/testutils/pytesthook/file.py:233: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
    item = YamlItem(test_spec["test_name"], self, test_spec, self.fspath)

/usr/local/lib/python3.8/dist-packages/tavern/testutils/pytesthook/file.py:61
  /usr/local/lib/python3.8/dist-packages/tavern/testutils/pytesthook/file.py:61: PytestUnknownMarkWarning: Unknown pytest.mark.base_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    pytest_marks.append(getattr(pytest.mark, m))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
- generated html file: file:///tmp/Test_integration_endpoints_B597_test_files/api/test/integration/Test_integration_endpoints_B597_test_cdb_list_endpoints.html -
=========================== short test summary info ============================
ERROR test_cdb_list_endpoints.tavern.yaml::GET /lists - StopIteration
ERROR test_cdb_list_endpoints.tavern.yaml::GET /lists/files - StopIteration
ERROR test_cdb_list_endpoints.tavern.yaml::GET /lists/files/{filename} - Stop...
ERROR test_cdb_list_endpoints.tavern.yaml::PUT /lists/files/{filename} - Stop...
ERROR test_cdb_list_endpoints.tavern.yaml::DELETE /lists/files/{filename} - S...
================== 7 warnings, 5 errors in 644.29s (0:10:44) ===================
```

In this PR we have increased this limit to approximately 20 minutes, in this way we will try to avoid this type of errors. This is the maximum limit so the average test time should not be highly affected.

Best regards,

Adrián Peña