### PR TITLE
Fix race condition when saving localfiles information in logcollector

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -2714,7 +2714,9 @@ STATIC char * w_save_files_status_to_cJSON() {
     OSHashNode * hash_node;
     unsigned int index = 0;
 
+    w_rwlock_rdlock(&files_status->mutex);
     if (hash_node = OSHash_Begin(files_status, &index), !hash_node) {
+        w_rwlock_unlock(&files_status->mutex);
         return NULL;
     }
 
@@ -2737,6 +2739,7 @@ STATIC char * w_save_files_status_to_cJSON() {
 
         hash_node = OSHash_Next(files_status, &index, hash_node);
     }
+    w_rwlock_unlock(&files_status->mutex);
 
     char * global_json_str = cJSON_PrintUnformatted(global_json);
     cJSON_Delete(global_json);

--- a/src/unit_tests/logcollector/CMakeLists.txt
+++ b/src/unit_tests/logcollector/CMakeLists.txt
@@ -26,6 +26,7 @@ list(APPEND logcollector_flags "-Wl,--wrap,OSHash_Add_ex -Wl,--wrap,OSHash_Add -
                                 -Wl,--wrap,cJSON_PrintUnformatted -Wl,--wrap,cJSON_Delete -Wl,--wrap,wfopen -Wl,--wrap,_merror_exit -Wl,--wrap,clearerr \
                                 -Wl,--wrap,cJSON_GetObjectItem -Wl,--wrap,cJSON_GetArraySize -Wl,--wrap,cJSON_GetArrayItem \
                                 -Wl,--wrap,cJSON_GetStringValue -Wl,--wrap,OS_SHA1_File_Nbytes -Wl,--wrap,fileno -Wl,--wrap,fstat \
+                                -Wl,--wrap,pthread_rwlock_rdlock -Wl,--wrap,pthread_rwlock_unlock \
                                 -Wl,--wrap,stat -Wl,--wrap=fgetc -Wl,--wrap=w_fseek -Wl,--wrap,w_ftell")
 
 list(APPEND logcollector_names "test_read_multiline_regex")

--- a/src/unit_tests/logcollector/test_logcollector.c
+++ b/src/unit_tests/logcollector/test_logcollector.c
@@ -53,6 +53,14 @@ static int teardown_group(void **state) {
 
 /* wraps */
 
+int __wrap_pthread_rwlock_rdlock(pthread_mutex_t * mutex) {
+    return mock_type(int);
+}
+
+int __wrap_pthread_rwlock_unlock(pthread_mutex_t * mutex) {
+    return mock_type(int);
+}
+
 /* tests */
 
 /* w_get_hash_context */
@@ -243,8 +251,10 @@ void test_w_save_files_status_to_cJSON_begin_NULL(void ** state) {
 
     OSHashNode *hash_node = NULL;
 
+    will_return(__wrap_pthread_rwlock_rdlock, 0);
     expect_value(__wrap_OSHash_Begin, self, files_status);
     will_return(__wrap_OSHash_Begin, hash_node);
+    will_return(__wrap_pthread_rwlock_unlock, 0);
 
     char * ret = w_save_files_status_to_cJSON();
     assert_null(ret);
@@ -264,6 +274,8 @@ void test_w_save_files_status_to_cJSON_OK(void ** state) {
     hash_node->key = "test";
     hash_node->data = data;
 
+will_return(__wrap_pthread_rwlock_rdlock, 0);
+will_return(__wrap_pthread_rwlock_unlock, 0);
     expect_value(__wrap_OSHash_Begin, self, files_status);
     will_return(__wrap_OSHash_Begin, hash_node);
 
@@ -313,8 +325,10 @@ void test_w_save_file_status_str_NULL(void ** state) {
     //test_w_save_files_status_to_cJSON_begin_NULL
     OSHashNode *hash_node = NULL;
 
+    will_return(__wrap_pthread_rwlock_rdlock, 0);
     expect_value(__wrap_OSHash_Begin, self, files_status);
     will_return(__wrap_OSHash_Begin, hash_node);
+    will_return(__wrap_pthread_rwlock_unlock, 0);
 
     w_save_file_status();
 
@@ -334,6 +348,7 @@ void test_w_save_file_status_wfopen_error(void ** state) {
     hash_node->key = "test";
     hash_node->data = data;
 
+    will_return(__wrap_pthread_rwlock_rdlock, 0);
     expect_value(__wrap_OSHash_Begin, self, files_status);
     will_return(__wrap_OSHash_Begin, hash_node);
 
@@ -361,6 +376,7 @@ void test_w_save_file_status_wfopen_error(void ** state) {
 
     expect_value(__wrap_OSHash_Next, self, files_status);
     will_return(__wrap_OSHash_Next, NULL);
+    will_return(__wrap_pthread_rwlock_unlock, 0);
 
     will_return(__wrap_cJSON_PrintUnformatted, strdup("test_1234"));
 
@@ -393,6 +409,7 @@ void test_w_save_file_status_fwrite_error(void ** state) {
     hash_node->key = "test";
     hash_node->data = data;
 
+    will_return(__wrap_pthread_rwlock_rdlock, 0);
     expect_value(__wrap_OSHash_Begin, self, files_status);
     will_return(__wrap_OSHash_Begin, hash_node);
 
@@ -420,6 +437,7 @@ void test_w_save_file_status_fwrite_error(void ** state) {
 
     expect_value(__wrap_OSHash_Next, self, files_status);
     will_return(__wrap_OSHash_Next, NULL);
+    will_return(__wrap_pthread_rwlock_unlock, 0);
 
     will_return(__wrap_cJSON_PrintUnformatted, strdup("test_1234"));
 
@@ -460,6 +478,7 @@ void test_w_save_file_status_OK(void ** state) {
     hash_node->key = "test";
     hash_node->data = data;
 
+    will_return(__wrap_pthread_rwlock_rdlock, 0);
     expect_value(__wrap_OSHash_Begin, self, files_status);
     will_return(__wrap_OSHash_Begin, hash_node);
 
@@ -487,6 +506,7 @@ void test_w_save_file_status_OK(void ** state) {
 
     expect_value(__wrap_OSHash_Next, self, files_status);
     will_return(__wrap_OSHash_Next, NULL);
+    will_return(__wrap_pthread_rwlock_unlock, 0);
 
     will_return(__wrap_cJSON_PrintUnformatted, strdup("test_1234"));
 

--- a/src/unit_tests/logcollector/test_logcollector.c
+++ b/src/unit_tests/logcollector/test_logcollector.c
@@ -26,6 +26,7 @@
 #include "../wrappers/externals/cJSON/cJSON_wrappers.h"
 #include "../wrappers/wazuh/shared/file_op_wrappers.h"
 #include "../wrappers/wazuh/os_crypto/sha1_op_wrappers.h"
+#include "../wrappers/posix/pthread_wrappers.h"
 
 extern OSHash *files_status;
 
@@ -52,14 +53,6 @@ static int teardown_group(void **state) {
 }
 
 /* wraps */
-
-int __wrap_pthread_rwlock_rdlock(pthread_mutex_t * mutex) {
-    return mock_type(int);
-}
-
-int __wrap_pthread_rwlock_unlock(pthread_mutex_t * mutex) {
-    return mock_type(int);
-}
 
 /* tests */
 
@@ -251,10 +244,10 @@ void test_w_save_files_status_to_cJSON_begin_NULL(void ** state) {
 
     OSHashNode *hash_node = NULL;
 
-    will_return(__wrap_pthread_rwlock_rdlock, 0);
+    expect_function_call(__wrap_pthread_rwlock_rdlock);    
     expect_value(__wrap_OSHash_Begin, self, files_status);
     will_return(__wrap_OSHash_Begin, hash_node);
-    will_return(__wrap_pthread_rwlock_unlock, 0);
+    expect_function_call(__wrap_pthread_rwlock_unlock);
 
     char * ret = w_save_files_status_to_cJSON();
     assert_null(ret);
@@ -274,8 +267,7 @@ void test_w_save_files_status_to_cJSON_OK(void ** state) {
     hash_node->key = "test";
     hash_node->data = data;
 
-will_return(__wrap_pthread_rwlock_rdlock, 0);
-will_return(__wrap_pthread_rwlock_unlock, 0);
+    expect_function_call(__wrap_pthread_rwlock_rdlock);    
     expect_value(__wrap_OSHash_Begin, self, files_status);
     will_return(__wrap_OSHash_Begin, hash_node);
 
@@ -303,6 +295,7 @@ will_return(__wrap_pthread_rwlock_unlock, 0);
 
     expect_value(__wrap_OSHash_Next, self, files_status);
     will_return(__wrap_OSHash_Next, NULL);
+    expect_function_call(__wrap_pthread_rwlock_unlock);
 
     will_return(__wrap_cJSON_PrintUnformatted, "test_1234");
 
@@ -325,10 +318,10 @@ void test_w_save_file_status_str_NULL(void ** state) {
     //test_w_save_files_status_to_cJSON_begin_NULL
     OSHashNode *hash_node = NULL;
 
-    will_return(__wrap_pthread_rwlock_rdlock, 0);
+    expect_function_call(__wrap_pthread_rwlock_rdlock);
     expect_value(__wrap_OSHash_Begin, self, files_status);
     will_return(__wrap_OSHash_Begin, hash_node);
-    will_return(__wrap_pthread_rwlock_unlock, 0);
+    expect_function_call(__wrap_pthread_rwlock_unlock);
 
     w_save_file_status();
 
@@ -348,7 +341,7 @@ void test_w_save_file_status_wfopen_error(void ** state) {
     hash_node->key = "test";
     hash_node->data = data;
 
-    will_return(__wrap_pthread_rwlock_rdlock, 0);
+    expect_function_call(__wrap_pthread_rwlock_rdlock);
     expect_value(__wrap_OSHash_Begin, self, files_status);
     will_return(__wrap_OSHash_Begin, hash_node);
 
@@ -376,7 +369,7 @@ void test_w_save_file_status_wfopen_error(void ** state) {
 
     expect_value(__wrap_OSHash_Next, self, files_status);
     will_return(__wrap_OSHash_Next, NULL);
-    will_return(__wrap_pthread_rwlock_unlock, 0);
+    expect_function_call(__wrap_pthread_rwlock_unlock);
 
     will_return(__wrap_cJSON_PrintUnformatted, strdup("test_1234"));
 
@@ -409,7 +402,7 @@ void test_w_save_file_status_fwrite_error(void ** state) {
     hash_node->key = "test";
     hash_node->data = data;
 
-    will_return(__wrap_pthread_rwlock_rdlock, 0);
+    expect_function_call(__wrap_pthread_rwlock_rdlock);
     expect_value(__wrap_OSHash_Begin, self, files_status);
     will_return(__wrap_OSHash_Begin, hash_node);
 
@@ -437,7 +430,7 @@ void test_w_save_file_status_fwrite_error(void ** state) {
 
     expect_value(__wrap_OSHash_Next, self, files_status);
     will_return(__wrap_OSHash_Next, NULL);
-    will_return(__wrap_pthread_rwlock_unlock, 0);
+    expect_function_call(__wrap_pthread_rwlock_unlock);
 
     will_return(__wrap_cJSON_PrintUnformatted, strdup("test_1234"));
 
@@ -478,7 +471,7 @@ void test_w_save_file_status_OK(void ** state) {
     hash_node->key = "test";
     hash_node->data = data;
 
-    will_return(__wrap_pthread_rwlock_rdlock, 0);
+    expect_function_call(__wrap_pthread_rwlock_rdlock);
     expect_value(__wrap_OSHash_Begin, self, files_status);
     will_return(__wrap_OSHash_Begin, hash_node);
 
@@ -506,7 +499,7 @@ void test_w_save_file_status_OK(void ** state) {
 
     expect_value(__wrap_OSHash_Next, self, files_status);
     will_return(__wrap_OSHash_Next, NULL);
-    will_return(__wrap_pthread_rwlock_unlock, 0);
+    expect_function_call(__wrap_pthread_rwlock_unlock);
 
     will_return(__wrap_cJSON_PrintUnformatted, strdup("test_1234"));
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes #8290 |

## Description

Hi Team!,

This PR adds a mutex to the hash table used to maintain the status of the files read in Wazuh-Logcollector. (Used in the `only-future-events` feature )

The race condition occurred when:
- `w_input_thread` threads read files create a new node with the file hash and offset information (in the `read_*()` functions) 
Then update the node and it frees an old node.
- The main thread of logcollector `LogCollectorStart()`, detects changes in the inodes, looks for new files to track and also dumps the status of the files in a json file. 
For this it iterates in order the hash table of the file status. 


Logcollector crashes if in an iteration the taken node was frees


Regards,
Julian

## Steps to reproduce
1. Install Wazuh manager v4.2.0-rc3 / Master
2. Add the `localfile` config for stress test I.E.:
```
    <log_format>syslog</log_format>
    <location>/root/repos/wazuh-jenkins/quality/tests/stress/scripts/flood*.log</location>
  </localfile>
  <localfile>
    <log_format>syslog</log_format>
    <location>/root/repos/wazuh-jenkins/quality/tests/stress/scripts/date*.log</location>
  </localfile>

```
2. Launch `wazuh-analysisd` and `wazuh-logcollector`
3. Launch logcollector stress script, located here https://github.com/wazuh/wazuh-jenkins/blob/master/quality/tests/stress/scripts/logcollector.py

4. Parameters used:
```
 python3 logcollector.py -t 36000 -l 950 -sc 2 -w 1000 -sw 2 
```
5. Wait until logcollector stops (Estimated crash time between 10 min and 6 hours :eyes::eyes:).

## [UPDATE] Force crash in less than 10 min:

The likelihood of this happening can be improved by changing some internal variables:

```
logcollector.vcheck_files=0
logcollector.reload_delay=10
```

new test param:
```
python3 logcollector.py -t 36000 -l 950 -sc 1 -w 100 -sw 1 
```


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [x] AddressSanitizer
  - [x] ThreadSanitizer
- Memory tests for Windows
  - [x] Scan-build report
  - [x] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [x] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [x] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [x] Stress test for affected components
