### PR TITLE
[8402] Removed unneeded modules debug log settings from internal_options.conf

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -409,9 +409,6 @@ auth.timeout_microseconds=0
 # Windows debug (used by the Windows agent)
 windows.debug=0
 
-# Syscheck (local, server and Unix agent)
-syscheck.debug=0
-
 # Remoted (server debug)
 remoted.debug=0
 
@@ -421,14 +418,8 @@ analysisd.debug=0
 # Auth daemon debug (server)
 authd.debug=0
 
-# Exec daemon debug (server, local or Unix agent)
-execd.debug=0
-
 # Monitor daemon debug (server, local or Unix agent)
 monitord.debug=0
-
-# Log collector (server, local or Unix agent)
-logcollector.debug=0
 
 # Integrator daemon debug (server, local or Unix agent)
 integrator.debug=0
@@ -439,6 +430,11 @@ agent.debug=0
 # Wazuh DB debug level
 wazuh_db.debug=0
 
+# This will set the following debug log modules:
+# - syscollector
+# - logcollector
+# - syscheck
+# - execd
 wazuh_modules.debug=0
 
 # Wazuh Cluster debug level


### PR DESCRIPTION
|Related issue|
|---|
|Closes #8402 |

## Description
This issue aims to eliminate from the default configuration the assignment of a debug level, this is because these processes no longer exist, and now the configuration of wazuh_modules.debug is respected since they are modules (thread) and not processes as before.

**Branch destination:** dev-agent-process-unification

## DoD
- [X] Modify default internal configuration.
- [X] Test clean install.
- [X] Test upgrades from 4.2.
- [x] CI-Check.
