### PR TITLE
Fix race condition when using older_than in agent_GET API test

### DIFF
--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -814,7 +814,7 @@ stages:
       verify: False
       <<: *get_agents
       params:
-        older_than: 30s
+        older_than: 1d
     response:
       status_code: 200
       json:


### PR DESCRIPTION
Hi team,

This PR fixes the API integration test failing in the https://github.com/wazuh/wazuh/pull/8323 checks. It includes a minor change to our `test_agent_GET` API integration test.

The test case with name `Filter agents using older_than param` is expecting 4 affected items: **009**, **010**, **011**, **012**.

The filter is `older_than: 30s`, which means the agent's last keep alive was received more than 30 seconds ago from now.

An agent's keepalive is sent each 10 seconds.
It could happen that, with a bad connection, the managers receive the agents' keepalives in periods of more than 10 seconds.

To avoid this race condition, I have changed the filter to `older_than: 1d`. This way, the result will always be the 2 disconnected agents (009 and 010), which had their last keep alive 2 days ago; and the 2 never connected agents (011 and 012).



Regards,
Manuel.