### PR TITLE
Fix chmod_r function in framework

### DIFF
--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -449,8 +449,6 @@ def chmod_r(filepath, mode):
     :param filepath: Path to the file.
     :param mode: file mode in octal.
     """
-    chmod(filepath, mode)
-
     if path.isdir(filepath):
         for item in listdir(filepath):
             itempath = path.join(filepath, item)
@@ -458,6 +456,8 @@ def chmod_r(filepath, mode):
                 chmod(itempath, mode)
             elif path.isdir(itempath):
                 chmod_r(itempath, mode)
+
+    chmod(filepath, mode)
 
 
 def chown_r(filepath, uid, gid):


### PR DESCRIPTION
|Related issue|
|---|
| Closes #3750 |

**Note:** Merge after https://github.com/wazuh/wazuh/pull/8378 is merged. Some unittests are failing in master branch.

## Description

Hi team!

As explained in #3750, when `chmod_r` function was used to set, for instance, 0o660 permissions to a directory, the files inside were not updated. 

https://github.com/wazuh/wazuh/blob/d6119bb49306ea1dea3231ee1817be9a2e50f68b/framework/wazuh/core/utils.py#L446-L460

The reason is that once the permissions of the directory are changed (and `x` permissions are removed), the `path.isfile()` method always returns False, so chmod was not applied:
```
/var/ossec/etc/shared/test_group# ll
total 20
drwxrwx--- 2 wazuh wazuh 4096 Apr 28 07:20 ./
drwxrwx--- 1 root  wazuh 4096 Apr 28 07:20 ../
-rw-r--r-- 1 wazuh wazuh   76 Apr 28 07:20 agent.conf
-rw-rw---- 1 wazuh wazuh  344 Apr 28 07:20 merged.mg
```

After this PR, the permissions of the directory are changed in the last step, so files can be correctly modified:
```
/var/ossec/etc/shared/test4_group# ll
total 20
drwxrwx--- 2 wazuh wazuh 4096 Apr 28 07:33 ./
drwxrwx--- 1 root  wazuh 4096 Apr 28 07:33 ../
-rw-rw---- 1 wazuh wazuh   76 Apr 28 07:33 agent.conf
-rw-rw---- 1 wazuh wazuh  345 Apr 28 07:33 merged.mg
```

Regards,
Selu.