### PR TITLE
Change min_select_fields for WazuhDBQueryTask

### DIFF
--- a/framework/wazuh/core/task.py
+++ b/framework/wazuh/core/task.py
@@ -25,7 +25,7 @@ class WazuhDBQueryTask(WazuhDBQuery):
         if filters is None:
             filters = {}
         if min_select_fields is None:
-            min_select_fields = {'task_id', 'agent_id', 'status', 'command', 'create_time'}
+            min_select_fields = {'task_id'}
         if fields is None:
             fields = tasks_fields
 

--- a/framework/wazuh/task.py
+++ b/framework/wazuh/task.py
@@ -50,7 +50,7 @@ def get_task_status(filters: dict = None, select: list = None, search: dict = No
                                       none_msg='No status was returned')
 
     db_query = WazuhDBQueryTask(filters=filters, offset=offset, limit=limit, query=q, sort=sort, search=search,
-                                 select=select)
+                                select=select)
     data = db_query.run()
 
     # Sort result array
@@ -59,7 +59,10 @@ def get_task_status(filters: dict = None, select: list = None, search: dict = No
 
     # Add zeros to agent IDs
     for element in data['items']:
-        element['agent_id'] = str(element['agent_id']).zfill(3)
+        try:
+            element['agent_id'] = str(element['agent_id']).zfill(3)
+        except KeyError:
+            pass
 
     result.affected_items.extend(data['items'])
     result.total_affected_items = data['totalItems']

--- a/framework/wazuh/task.py
+++ b/framework/wazuh/task.py
@@ -53,11 +53,7 @@ def get_task_status(filters: dict = None, select: list = None, search: dict = No
                                 select=select)
     data = db_query.run()
 
-    # Sort result array
-    if sort and 'json' not in sort['fields']:
-        data['items'] = sort_array(data['items'], sort_by=sort['fields'], sort_ascending=sort['order'] == 'asc')
-
-    # Add zeros to agent IDs
+    # Fill with zeros the agent_id
     for element in data['items']:
         try:
             element['agent_id'] = str(element['agent_id']).zfill(3)


### PR DESCRIPTION
Hi team,

Recently we have detected that the task endpoint does not follow the same schema as the other endpoints. In other endpoints, the select parameter will return only what you specify in it, in the task endpoint this is not true. For example, if in the GET /agents endpoint we use the select indicating "agent_id", this will be the only field that comes in the response.

However, in the task endpoint, if we apply the select parameter with the value "task_id", the fields that come are the following:

```
{'task_id', 'agent_id', 'status', 'command', 'create_time'}
```

In this PR we have fixed this behavior to be the same as in the rest of the endpoints.


## Tests

### Integration tests

```
adriiiprodri@wazuh python3 run_tests.py -rbac both -k task              
Collected tests [3]:
test_rbac_black_task_endpoints.tavern.yaml, test_rbac_white_task_endpoints.tavern.yaml, test_task_endpoints.tavern.yaml


test_rbac_black_task_endpoints.tavern.yaml 
	 1 passed, 3 warnings

test_rbac_white_task_endpoints.tavern.yaml 
	 1 passed, 3 warnings

test_task_endpoints.tavern.yaml 
	 2 passed, 4 warnings
```

### Unittests

```
adriiiprodri@wazuh pytest -x framework/wazuh/tests --disable-warnings     
=========================================== test session starts ===========================================
platform linux -- Python 3.9.2, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /home/adriiiprodri/git/wazuh/framework
plugins: tavern-1.14.0, metadata-1.11.0, html-3.1.1
collected 707 items                                                                                       

framework/wazuh/tests/test_active_response.py ............                                          [  1%]
framework/wazuh/tests/test_agent.py ............................................................... [ 10%]
....................................                                                                [ 15%]
framework/wazuh/tests/test_ciscat.py .................................                              [ 20%]
framework/wazuh/tests/test_cluster.py .....ss                                                       [ 21%]
framework/wazuh/tests/test_decoder.py ...................................                           [ 26%]
framework/wazuh/tests/test_group.py ........                                                        [ 27%]
framework/wazuh/tests/test_logtest.py ......                                                        [ 28%]
framework/wazuh/tests/test_manager.py .................................                             [ 32%]
framework/wazuh/tests/test_mitre.py ............................................................... [ 41%]
................................................................................................... [ 55%]
..................                                                                                  [ 58%]
framework/wazuh/tests/test_rootcheck.py .................................................           [ 65%]
framework/wazuh/tests/test_rule.py ........................................................         [ 73%]
framework/wazuh/tests/test_sca.py .......                                                           [ 74%]
framework/wazuh/tests/test_security.py ............................................................ [ 82%]
................                                                                                    [ 85%]
framework/wazuh/tests/test_stats.py ................                                                [ 87%]
framework/wazuh/tests/test_syscheck.py ........................                                     [ 90%]
framework/wazuh/tests/test_syscollector.py ............                                             [ 92%]
framework/wazuh/tests/test_task.py ............................                                     [ 96%]
framework/wazuh/tests/test_vulnerability.py ..........................                              [100%]

========================= 705 passed, 2 skipped, 930 warnings in 72.67s (0:01:12) =========================
```