### PR TITLE
Improve wdb pagination mechanism exceptions

### DIFF
--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -407,6 +407,7 @@ class WazuhException(Exception):
         2007: {'message': 'Error retrieving data from Wazuh DB'},
         2008: {'message': 'Corrupted RBAC database',
                'remediation': 'Restart the Wazuh service to restore the RBAC database to default'},
+        2009: {'message': 'Pagination error. Response from wazuh-db was over the maximum socket buffer size'},
 
         # Cluster
         3000: 'Cluster',

--- a/framework/wazuh/core/tests/test_wdb.py
+++ b/framework/wazuh/core/tests/test_wdb.py
@@ -9,6 +9,7 @@ import pytest
 
 from wazuh.core import exception
 from wazuh.core.wdb import WazuhDBConnection
+from wazuh.core.common import MAX_SOCKET_BUFFER_SIZE
 
 
 def format_msg(msg):
@@ -77,6 +78,11 @@ def test_failed_send_private(send_mock, connect_mock):
         with pytest.raises(exception.WazuhException, match=".* 2003 .*"):
             mywdb._send('test_msg')
 
+    with patch('socket.socket.recv', return_value=b'a' * (MAX_SOCKET_BUFFER_SIZE + 1)):
+        mywdb = WazuhDBConnection()
+        with pytest.raises(exception.WazuhException, match=".* 2009 .*"):
+            mywdb._send('test_msg')
+
 
 @pytest.mark.parametrize('content', [
     b'ok {"agents": {"001": "Ok"}}',
@@ -98,6 +104,7 @@ def test_remove_agents_database(send_mock, connect_mock, content):
         received = mywdb.delete_agents_db(['001', '002'])
         assert(isinstance(received, dict))
         assert("agents" in received)
+
 
 @pytest.mark.parametrize('error_query', [
     'Agent sql select test',
@@ -151,6 +158,23 @@ def test_execute(send_mock, socket_send_mock, connect_mock):
         mywdb.execute("agent 000 sql select test from test offset 1 limit 1")
         mywdb.execute("agent 000 sql select test from test offset 1 limit 1", count=True)
         mywdb.execute("agent 000 sql select test from test offset 1 count")
+
+
+@patch("socket.socket.connect")
+@patch("socket.socket.send")
+def test_execute_pagination(socket_send_mock, connect_mock):
+    mywdb = WazuhDBConnection()
+
+    # Test pagination
+    with patch("wazuh.core.wdb.WazuhDBConnection._send",
+               side_effect=[[{'total': 5}], exception.WazuhInternalError(2009), [{'total': 5}], [{'total': 5}]]):
+        mywdb.execute("agent 000 sql select test from test offset 1 limit 500")
+
+    # Test pagination error
+    with patch("wazuh.core.wdb.WazuhDBConnection._send",
+               side_effect=[[{'total': 5}], exception.WazuhInternalError(2009)]):
+        with pytest.raises(exception.WazuhInternalError, match=".* 2009 .*"):
+            mywdb.execute("agent 000 sql select test from test offset 1 limit 1")
 
 
 @pytest.mark.parametrize('error_query, error_type, expected_exception, delete, update', [


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/8398 |

Closes #8398 

Hello team,

This PR improves the exception handler in the wdb pagination mechanism, as it was covering any possible `ValueError` that could happen. In addition, we have improved the wdb unit tests coverage, as it was very poor.

### Tests performed
#### Unit tests
```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.9.1, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.14.0, metadata-1.10.0
collected 22 items                                                                                                                                                                          

wazuh/core/tests/test_wdb.py ......................                                                                                                                                   [100%]

==================================================================================== 22 passed in 2.25s =====================================================================================

```

#### Manual tests

Forcing the pagination mechanism to reach the critical level (slice = 1), we now get this response:

```json
{
  "title": "Wazuh Internal Error",
  "detail": "Pagination error. Response from wazuh-db was over the maximum socket buffer size",
  "dapi_errors": {
    "master-node": {
      "error": "Pagination error. Response from wazuh-db was over the maximum socket buffer size",
      "logfile": "WAZUH_HOME/logs/api.log"
    }
  },
  "error": 2009
}
```

Previous to this change, we would have obtained a `2007: {'message': 'Error retrieving data from Wazuh DB'}`. Any other captured exception will raise properly.

Regards,
Víctor Fernández