### PR TITLE
Adds predecoder support uls syslog

### DIFF
--- a/src/analysisd/cleanevent.c
+++ b/src/analysisd/cleanevent.c
@@ -82,6 +82,7 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
      *   or  2007-06-14T15:48:55-04:00 for syslog-ng isodate
      *   or  2009-05-22T09:36:46.214994-07:00 for rsyslog )
      *   or  2015-04-16 21:51:02,805 (proftpd 1.3.5)
+     *   or  2021-04-21 10:16:09.404756-0700 (for macos ULS --syslog output)
      */
     if (
         (
@@ -132,6 +133,19 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
             (pieces[14] == ':') &&
             (pieces[17] == ':') &&
             (pieces[20] == ' ') && (lf->log += 21)
+        )
+     ||
+        (
+            (loglen > 33) &&
+            (isdigit(pieces[0])) &&
+            (pieces[4] == '-') &&
+            (pieces[7] == '-') &&
+            (pieces[10] == ' ') &&
+            (pieces[13] == ':') &&
+            (pieces[16] == ':') &&
+            (pieces[19] == '.') &&
+            (pieces[26] == '-') &&
+            (pieces[31] == ' ') && (lf->log += 32)
         )
 
     ) {


### PR DESCRIPTION
|Related issue|
|---|
| Closes #8427 |

## Description

Hi team!,

This PR adds support for the pre-decoding stage of the logs obtained from the Unify Loggin System (ULS) of macOS.

Regards,
Julian


<!--
Add a clear description of how the problem has been solved.
-->


### Output of this PR in kibana:

The output in kibana guarantees that the current [filebeat template ](https://github.com/wazuh/wazuh/blob/d44d2c49e3e0dd40c3e7c04e6a1a31c526dd869c/extensions/filebeat/7.x/wazuh-module/alerts/ingest/pipeline.json#L44)is working correctly for this format.

log: 
```
2021-04-28 12:59:31.633600-0700  localhost sshd[51281]: error: PAM: unknown user for illegal user vagrant123 from 10.0.2.2
```

![image](https://user-images.githubusercontent.com/1891958/116467808-7b9d1000-a846-11eb-9e8c-152e024c12a1.png)


## Logs/Alerts example

```
{
      "timestamp": "2021-04-28T19:59:18.095+0000",
      "rule": {
            "level": 5,
            "description": "sshd: Attempt to login using a non-existent user",
            "id": "5710",
            "mitre": {
                  "id": [
                        "T1110"
                  ],
                  "tactic": [
                        "Credential Access"
                  ],
                  "technique": [
                        "Brute Force"
                  ]
            },
            "firedtimes": 1,
            "mail": false,
            "groups": [
                  "syslog",
                  "sshd",
                  "invalid_login",
                  "authentication_failed"
            ],
            "pci_dss": [
                  "10.2.4",
                  "10.2.5",
                  "10.6.1"
            ],
            "gpg13": [
                  "7.1"
            ],
            "gdpr": [
                  "IV_35.7.d",
                  "IV_32.2"
            ],
            "hipaa": [
                  "164.312.b"
            ],
            "nist_800_53": [
                  "AU.14",
                  "AC.7",
                  "AU.6"
            ],
            "tsc": [
                  "CC6.1",
                  "CC6.8",
                  "CC7.2",
                  "CC7.3"
            ]
      },
      "agent": {
            "id": "003",
            "name": "macos-1100",
            "ip": "10.0.2.15"
      },
      "manager": {
            "name": "35-u20-manager4"
      },
      "id": "1619639958.806834",
      "full_log": "2021-04-28 12:59:16.813135-0700  localhost sshd[51281]: error: PAM: unknown user for illegal user vagrant123 from 10.0.2.2",
      "predecoder": {
            "program_name": "sshd",
            "timestamp": "2021-04-28 12:59:16.813135-0700"
      },
      "decoder": {
            "parent": "sshd",
            "name": "sshd"
      },
      "data": {
            "srcip": "10.0.2.2",
            "dstuser": "vagrant123"
      },
      "location": "USL_OSLOG_Super_Mc_Darwin"
}
```

## Warning

This predecoder prepends the sshd-mac decoders of the `0500-macos-sshd_decoders.xml` file and also its rules.

## Tests



<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
  - [x] ThreadSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [x] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

