### PR TITLE
[8409] Update Makefile and minor changes to get monitor compiled under wazuh modules

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -661,7 +661,6 @@ BUILD_SERVER+=manage_agents
 BUILD_SERVER+=utils
 BUILD_SERVER+=active-responses
 BUILD_SERVER+=wazuh-syscheckd
-#BUILD_SERVER+=wazuh-monitord
 BUILD_SERVER+=wazuh-reportd
 BUILD_SERVER+=wazuh-authd
 BUILD_SERVER+=wazuh-analysisd

--- a/src/Makefile
+++ b/src/Makefile
@@ -661,7 +661,7 @@ BUILD_SERVER+=manage_agents
 BUILD_SERVER+=utils
 BUILD_SERVER+=active-responses
 BUILD_SERVER+=wazuh-syscheckd
-BUILD_SERVER+=wazuh-monitord
+#BUILD_SERVER+=wazuh-monitord
 BUILD_SERVER+=wazuh-reportd
 BUILD_SERVER+=wazuh-authd
 BUILD_SERVER+=wazuh-analysisd
@@ -1365,6 +1365,19 @@ build_syscollector: build_shared_modules build_sysinfo
 	cd ${SYSCOLLECTOR} && mkdir -p build && cd build && cmake ${WIN_CMAKE_OPTS} ${SOLARIS_CMAKE_OPTS} ${SYSCOLLECTOR_TEST} ${SYSCOLLECTOR_RELEASE_TYPE} .. && ${MAKE}
 endif
 
+#### Monitor #######
+
+monitor_c := $(wildcard monitord/*.c)
+monitor_o := $(monitor_c:.c=.o)
+wazuh_monitor_o := ${monitor_o} os_maild/sendcustomemail.o
+
+monitord/%.o: monitord/%.c
+	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"wazuh-modules\" -c $< -o $@
+
+wazuh-monitord: ${wazuh_monitor_o}
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
+
+
 #### Wazuh modules ##
 wmodules_c := $(wildcard wazuh_modules/wm*.c) $(wildcard wazuh_modules/agent_upgrade/*.c)
 
@@ -1383,7 +1396,16 @@ wmodules_o := $(wmodules_c:.c=.o)
 wazuh_modules/%.o: wazuh_modules/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -c $^ -o $@
 
-wmodules_dep := ${wmodules_o} ${wdblib_o}
+
+wmodules_dep_list :=
+ifeq (${TARGET},server)
+# monitor only needs to be added when a server target is being compiled
+wmodules_dep_list := ${wmodules_o} ${wdblib_o} ${wazuh_monitor_o}
+else
+wmodules_dep_list := ${wmodules_o} ${wdblib_o}
+endif
+
+wmodules_dep := ${wmodules_dep_list}
 
 ifeq (${uname_S},HP-UX)
 	wmodules_dep := ${wmodules_dep} ${config_o}
@@ -1730,18 +1752,6 @@ syscheckd/%-event.o: syscheckd/%.c
 
 wazuh-syscheckd: ${syscheck_o} rootcheck.a
 	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
-
-#### Monitor #######
-
-monitor_c := $(wildcard monitord/*.c)
-monitor_o := $(monitor_c:.c=.o)
-
-monitord/%.o: monitord/%.c
-	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"wazuh-monitord\" -c $< -o $@
-
-wazuh-monitord: ${monitor_o} os_maild/sendcustomemail.o
-	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
-
 
 #### reportd #######
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1368,19 +1368,16 @@ endif
 
 wazuh_monitor_o :=
 
-ifeq (${TARGET},server)
-# monitor only needs to be added when a server target is being compiled
 monitor_c := $(wildcard monitord/*.c)
 monitor_o := $(monitor_c:.c=.o)
+
+ifeq (${TARGET},server)
+# monitor only needs to be added when a server target is being compiled
 wazuh_monitor_o := ${monitor_o} os_maild/sendcustomemail.o
+endif # TARGET=server
 
 monitord/%.o: monitord/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"wazuh-modules\" -c $< -o $@
-
-wazuh-monitord: ${wazuh_monitor_o}
-	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
-
-endif # TARGET=server
 
 #### Wazuh modules ##
 wmodules_c := $(wildcard wazuh_modules/wm*.c) $(wildcard wazuh_modules/agent_upgrade/*.c)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1366,6 +1366,10 @@ endif
 
 #### Monitor #######
 
+wazuh_monitor_o :=
+
+ifeq (${TARGET},server)
+# monitor only needs to be added when a server target is being compiled
 monitor_c := $(wildcard monitord/*.c)
 monitor_o := $(monitor_c:.c=.o)
 wazuh_monitor_o := ${monitor_o} os_maild/sendcustomemail.o
@@ -1376,6 +1380,7 @@ monitord/%.o: monitord/%.c
 wazuh-monitord: ${wazuh_monitor_o}
 	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
+endif # TARGET=server
 
 #### Wazuh modules ##
 wmodules_c := $(wildcard wazuh_modules/wm*.c) $(wildcard wazuh_modules/agent_upgrade/*.c)
@@ -1395,16 +1400,7 @@ wmodules_o := $(wmodules_c:.c=.o)
 wazuh_modules/%.o: wazuh_modules/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -c $^ -o $@
 
-
-wmodules_dep_list :=
-ifeq (${TARGET},server)
-# monitor only needs to be added when a server target is being compiled
-wmodules_dep_list := ${wmodules_o} ${wdblib_o} ${wazuh_monitor_o}
-else
-wmodules_dep_list := ${wmodules_o} ${wdblib_o}
-endif
-
-wmodules_dep := ${wmodules_dep_list}
+wmodules_dep := ${wmodules_o} ${wdblib_o} ${wazuh_monitor_o}
 
 ifeq (${uname_S},HP-UX)
 	wmodules_dep := ${wmodules_dep} ${config_o}

--- a/src/config/wmodules-monitor.c
+++ b/src/config/wmodules-monitor.c
@@ -13,18 +13,11 @@
 #include "wazuh_modules/wmodules.h"
 #include "../monitord/monitord.h"
 
-#define DEFAULT_NO_AGENT 0
-#define DEFAULT_DAY_WAIT -1
-
 // Parse XML configuration
 int wm_monitor_read(const OS_XML *xml, XML_NODE node, wmodule *module) {
     if (module) {
         module->context = &WM_MONITOR_CONTEXT;
         module->tag = strdup(module->context->name);
-        /* Reading configuration */
-        if (MonitordConfig(OSSECCONF, &mond, DEFAULT_NO_AGENT, DEFAULT_DAY_WAIT) != OS_SUCCESS ) {
-            merror(CONFIG_ERROR, OSSECCONF);
-        }
     }
     return 0;
 }

--- a/src/monitord/monitord.h
+++ b/src/monitord/monitord.h
@@ -13,7 +13,7 @@
 
 #include "hash_op.h"
 #ifndef ARGV0
-#define ARGV0 "wazuh-monitord"
+#define ARGV0 "wazuh-modules"
 #endif
 
 #include "../headers/store_op.h"

--- a/src/monitord/monitord.h
+++ b/src/monitord/monitord.h
@@ -16,6 +16,7 @@
 #define ARGV0 "wazuh-monitord"
 #endif
 
+#include "../headers/store_op.h"
 #include "config/reports-config.h"
 #include "config/global-config.h"
 

--- a/src/wazuh_modules/wm_monitor.c
+++ b/src/wazuh_modules/wm_monitor.c
@@ -9,18 +9,20 @@
  * Foundation.
  */
 #include <stdlib.h>
-#include "../../wmodules_def.h"
-#include "wmodules.h"
 #include "wm_monitor.h"
+#include "wmodules.h"
 #include "defs.h"
+
+#define DEFAULT_NO_AGENT 0
+#define DEFAULT_DAY_WAIT -1
 
 static void* wm_monitor_main(wm_monitor_t *data);        // Module main function. It won't return
 static void wm_monitor_destroy(wm_monitor_t *data);      // Destroy data
-const char *WM_MONITOR_LOCATION = "monitor";            // Location field for event sending
+const char *WM_MONITOR_LOCATION = "monitor";             // Location field for event sending
 cJSON *wm_monitor_dump(const wm_monitor_t *data);
 
 const wm_context WM_MONITOR_CONTEXT = {
-    WM_MONITOR_LOCATION,
+    "monitor",
     (wm_routine)wm_monitor_main,
     (wm_routine)(void *)wm_monitor_destroy,
     (cJSON * (*)(const void *))wm_monitor_dump,
@@ -45,6 +47,11 @@ void* wm_monitor_main(wm_monitor_t *data) {
         mtinfo(WM_MONITOR_LOGTAG, "Module disabled. Exiting...");
         pthread_exit(NULL);
     }*/
+
+    /* Reading configuration */
+    if (MonitordConfig(OSSECCONF, &mond, DEFAULT_NO_AGENT, DEFAULT_DAY_WAIT) != OS_SUCCESS ) {
+        mterror(WM_MONITOR_LOGTAG, CONFIG_ERROR, OSSECCONF);
+    }
 
     mtinfo(WM_MONITOR_LOGTAG, "Module finished.");
 

--- a/src/wazuh_modules/wm_monitor.c
+++ b/src/wazuh_modules/wm_monitor.c
@@ -8,6 +8,7 @@
  * License (version 2) as published by the FSF - Free Software
  * Foundation.
  */
+
 #include <stdlib.h>
 #include "wm_monitor.h"
 #include "wmodules.h"
@@ -16,13 +17,15 @@
 #define DEFAULT_NO_AGENT 0
 #define DEFAULT_DAY_WAIT -1
 
+// Location field for event sending
+#define WM_MONITOR_LOCATION "monitor"
+
 static void* wm_monitor_main(wm_monitor_t *data);        // Module main function. It won't return
 static void wm_monitor_destroy(wm_monitor_t *data);      // Destroy data
-const char *WM_MONITOR_LOCATION = "monitor";             // Location field for event sending
 cJSON *wm_monitor_dump(const wm_monitor_t *data);
 
 const wm_context WM_MONITOR_CONTEXT = {
-    "monitor",
+    WM_MONITOR_LOCATION,
     (wm_routine)wm_monitor_main,
     (wm_routine)(void *)wm_monitor_destroy,
     (cJSON * (*)(const void *))wm_monitor_dump,

--- a/src/wazuh_modules/wm_monitor.h
+++ b/src/wazuh_modules/wm_monitor.h
@@ -16,7 +16,7 @@
 #ifndef WM_MONITOR
 #define WM_MONITOR
 
-extern const wm_context WM_MONITOR_CONTEXT;     // Context
+extern const wm_context WM_MONITOR_CONTEXT; // Context
 
 #define WM_MONITOR_LOGTAG ARGV0 ":monitor"  // Tag for log messages
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #8409 |

## Description
This issue aims to eliminate the generation of the old process, and thus also add to the linking process the wazuh-modulesd binary dependency to the compiled monitord files objects.


## DoD
- [X] Remove linking of monitord process.
- [X] Add dependency of object files to modulesd rule.
- [X] Manual test on all build possibilities.
- [x] CI building PASS