### PR TITLE
Add support for S3 Server Access logs in AWS module

### DIFF
--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -47,6 +47,7 @@ static const char *VPCFLOW_BUCKET_TYPE = "vpcflow";
 static const char *CUSTOM_BUCKET_TYPE = "custom";
 static const char *GUARDDUTY_BUCKET_TYPE = "guardduty";
 static const char *WAF_BUCKET_TYPE = "waf";
+static const char *SERVER_ACCESS_BUCKET_TYPE = "server_access";
 static const char *INSPECTOR_SERVICE_TYPE = "inspector";
 static const char *CLOUDWATCHLOGS_SERVICE_TYPE = "cloudwatchlogs";
 static const char *CISCO_UMBRELLA_BUCKET_TYPE = "cisco_umbrella";
@@ -166,13 +167,15 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                         || !strcmp(*nodes[i]->values, CUSTOM_BUCKET_TYPE) || !strcmp(*nodes[i]->values, GUARDDUTY_BUCKET_TYPE)
                         || !strcmp(*nodes[i]->values, VPCFLOW_BUCKET_TYPE) || !strcmp(*nodes[i]->values, CISCO_UMBRELLA_BUCKET_TYPE)
                         || !strcmp(*nodes[i]->values, WAF_BUCKET_TYPE) || !strcmp(*nodes[i]->values, ALB_BUCKET_TYPE)
-                        || !strcmp(*nodes[i]->values, CLB_BUCKET_TYPE) || !strcmp(*nodes[i]->values, NLB_BUCKET_TYPE)) {
+                        || !strcmp(*nodes[i]->values, CLB_BUCKET_TYPE) || !strcmp(*nodes[i]->values, NLB_BUCKET_TYPE)
+                        || !strcmp(*nodes[i]->values, SERVER_ACCESS_BUCKET_TYPE)) {
                         os_strdup(*nodes[i]->values, cur_bucket->type);
                     } else {
                         mterror(WM_AWS_LOGTAG, "Invalid bucket type '%s'. Valid ones are '%s', '%s', '%s', '%s', '%s', "
-                                               "'%s', %s', %s', %s' or '%s'",
+                                               "'%s', %s', %s', %s', %s' or '%s'",
                             *nodes[i]->values, CLOUDTRAIL_BUCKET_TYPE, CONFIG_BUCKET_TYPE, GUARDDUTY_BUCKET_TYPE, VPCFLOW_BUCKET_TYPE,
-                            WAF_BUCKET_TYPE, CISCO_UMBRELLA_BUCKET_TYPE, CUSTOM_BUCKET_TYPE, ALB_BUCKET_TYPE, CLB_BUCKET_TYPE, NLB_BUCKET_TYPE);
+                            WAF_BUCKET_TYPE, CISCO_UMBRELLA_BUCKET_TYPE, CUSTOM_BUCKET_TYPE, ALB_BUCKET_TYPE, CLB_BUCKET_TYPE, NLB_BUCKET_TYPE,
+                            SERVER_ACCESS_BUCKET_TYPE);
                         OS_ClearNode(children);
                         return OS_INVALID;
                     }

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -804,10 +804,10 @@ class AWSBucket(WazuhIntegration):
                     debug("+++ Remove file from S3 Bucket:{0}".format(bucket_file['Key']), 2)
                     self.client.delete_object(Bucket=self.bucket, Key=bucket_file['Key'])
                 self.mark_complete(aws_account_id, aws_region, bucket_file)
-            # optimize DB
+            # Optimize DB
             self.db_maintenance(aws_account_id=aws_account_id, aws_region=aws_region)
             self.db_connector.commit()
-            # iterate if there are more logs
+            # Iterate if there are more logs
             while bucket_files['IsTruncated']:
                 new_s3_args = self.build_s3_filter_args(aws_account_id, aws_region, True)
                 new_s3_args['ContinuationToken'] = bucket_files['NextContinuationToken']
@@ -836,7 +836,7 @@ class AWSBucket(WazuhIntegration):
                         debug("+++ Remove file from S3 Bucket:{0}".format(bucket_file['Key']), 2)
                         self.client.delete_object(Bucket=self.bucket, Key=bucket_file['Key'])
                     self.mark_complete(aws_account_id, aws_region, bucket_file)
-                # optimize DB
+                # Optimize DB
                 self.db_maintenance(aws_account_id=aws_account_id, aws_region=aws_region)
                 self.db_connector.commit()
         except SystemExit:
@@ -1149,10 +1149,10 @@ class AWSConfigBucket(AWSLogsBucket):
                     debug("+++ Remove file from S3 Bucket:{0}".format(bucket_file['Key']), 2)
                     self.client.delete_object(Bucket=self.bucket, Key=bucket_file['Key'])
                 self.mark_complete(aws_account_id, aws_region, bucket_file)
-            # optimize DB
+            # Optimize DB
             self.db_maintenance(aws_account_id=aws_account_id, aws_region=aws_region)
             self.db_connector.commit()
-            # iterate if there are more logs
+            # Iterate if there are more logs
             while bucket_files['IsTruncated']:
                 new_s3_args = self.build_s3_filter_args(aws_account_id, aws_region, date, True)
                 new_s3_args['ContinuationToken'] = bucket_files['NextContinuationToken']
@@ -1181,7 +1181,7 @@ class AWSConfigBucket(AWSLogsBucket):
                         debug("+++ Remove file from S3 Bucket:{0}".format(bucket_file['Key']), 2)
                         self.client.delete_object(Bucket=self.bucket, Key=bucket_file['Key'])
                     self.mark_complete(aws_account_id, aws_region, bucket_file)
-                # optimize DB
+                # Optimize DB
                 self.db_maintenance(aws_account_id=aws_account_id, aws_region=aws_region)
                 self.db_connector.commit()
         except SystemExit:
@@ -1618,11 +1618,11 @@ class AWSVPCFlowBucket(AWSLogsBucket):
                     debug("+++ Remove file from S3 Bucket:{0}".format(bucket_file['Key']), 2)
                     self.client.delete_object(Bucket=self.bucket, Key=bucket_file['Key'])
                 self.mark_complete(aws_account_id, aws_region, bucket_file, flow_log_id)
-            # optimize DB
+            # Optimize DB
             self.db_maintenance(aws_account_id=aws_account_id, aws_region=aws_region,
                                 flow_log_id=flow_log_id)
             self.db_connector.commit()
-            # iterate if there are more logs
+            # Iterate if there are more logs
             while bucket_files['IsTruncated']:
                 new_s3_args = self.build_s3_filter_args(aws_account_id, aws_region, date, flow_log_id, True)
                 new_s3_args['ContinuationToken'] = bucket_files['NextContinuationToken']
@@ -1653,7 +1653,7 @@ class AWSVPCFlowBucket(AWSLogsBucket):
                         debug("+++ Remove file from S3 Bucket:{0}".format(bucket_file['Key']), 2)
                         self.client.delete_object(Bucket=self.bucket, Key=bucket_file['Key'])
                     self.mark_complete(aws_account_id, aws_region, bucket_file, flow_log_id)
-                # optimize DB
+                # Optimize DB
                 self.db_maintenance(aws_account_id=aws_account_id, aws_region=aws_region,
                                     flow_log_id=flow_log_id)
                 self.db_connector.commit()
@@ -2187,10 +2187,10 @@ class AWSServerAccess(AWSCustomBucket):
                     debug("+++ Remove file from S3 Bucket:{0}".format(bucket_file['Key']), 2)
                     self.client.delete_object(Bucket=self.bucket, Key=bucket_file['Key'])
                 self.mark_complete(aws_account_id, aws_region, bucket_file)
-            # optimize DB
+            # Optimize DB
             self.db_maintenance(aws_account_id=aws_account_id, aws_region=aws_region)
             self.db_connector.commit()
-            # iterate if there are more logs
+            # Iterate if there are more logs
             while bucket_files['IsTruncated']:
                 new_s3_args = self.build_s3_filter_args(aws_account_id, aws_region, True)
                 new_s3_args['ContinuationToken'] = bucket_files['NextContinuationToken']
@@ -2223,7 +2223,7 @@ class AWSServerAccess(AWSCustomBucket):
                         debug("+++ Remove file from S3 Bucket:{0}".format(bucket_file['Key']), 2)
                         self.client.delete_object(Bucket=self.bucket, Key=bucket_file['Key'])
                     self.mark_complete(aws_account_id, aws_region, bucket_file)
-                # optimize DB
+                # Optimize DB
                 self.db_maintenance(aws_account_id=aws_account_id, aws_region=aws_region)
                 self.db_connector.commit()
         except SystemExit:
@@ -2471,7 +2471,7 @@ class AWSInspector(AWSService):
                                                                          {'beginDate': datetime_last_scan,
                                                                           'endDate': datetime_current}})
         self.send_describe_findings(response['findingArns'])
-        # iterate if there are more elements
+        # Iterate if there are more elements
         while 'nextToken' in response:
             response = self.client.list_findings(maxResults=100, nextToken=response['nextToken'],
                                                  filter={'creationTimeRange': {'beginDate': datetime_last_scan,

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -41,7 +41,6 @@ import gzip
 import zipfile
 import re
 import io
-import shlex
 from os import path
 import operator
 from datetime import datetime

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2153,7 +2153,6 @@ class AWSServerAccess(AWSCustomBucket):
         def skip_if_old(downloaded_file):
             date = re.search(r'(\d{4}-\d{2}-\d{2}).*', downloaded_file)
             if date:
-                from datetime import datetime
                 date = datetime.strptime(date.group(1), '%Y-%m-%d')
                 return date < self.only_logs_after
             return False
@@ -2259,7 +2258,7 @@ class AWSServerAccess(AWSCustomBucket):
                     try:
                         if next_[-1] == delimiter:
                             if remove:
-                                value_list[-1] = value_list[-1][1:-2]
+                                value_list[-1] = value_list[-1][1:-1]
                             break
                     except TypeError:
                         pass
@@ -2280,6 +2279,10 @@ class AWSServerAccess(AWSCustomBucket):
                         value_list[-1] = value_list[-1][1:-1]
                 except TypeError:
                     pass
+            try:
+                value_list[-1] = value_list[-1].replace("\n", "")
+            except TypeError:
+                pass
             return value_list
 
         with self.decompress_file(log_key=log_key) as f:


### PR DESCRIPTION
|Related issue|
|---|
| #7811|

## Description

Hi team,

This PR adds support to `S3 Server Access` buckets as explained in #7811. The new bucket type is called `server_access` and works in the same way as the rest of the supported bucket types.

A new class called `AWSServiceAccess` which inherits from `AWSCustomBucket` has been added. This class contains custom `check_bucket` and `load_information_from_file` functions. The former was added to ensure the user could provide a preffix for their logs using the `path` tag while the latter is in charge of parsing and cleaning the AWS logs, as some fields may contain problematic characters such as empty spaces or `[`. The details are explained in the issue.

## Configuration example
```
<wodle name="aws-s3">
  <disabled>no</disabled>
  <interval>5m</interval>
  <bucket type="server_access">
    <name>wazuh-aws-wodle</name>
    <aws_profile>default</aws_profile>
    <path>access_logs</path>
    <only_logs_after>2020-JAN-01</only_logs_after>
  </bucket>
</wodle>
```
Note: the `path` tag is optional.

## Manual usage

In the same way as the rest of the buckets and services supported by our AWS module, this integration can be manually tested by using the following command:

```
/var/ossec/wodles/aws/aws-s3 -t server_access -b wazuh-aws-wodle-access-logs -a $ACCESS -k $KEY -d 2 -s 2021-APR-28
```