### PR TITLE
Fix memory leak in FIM DB

### DIFF
--- a/src/syscheckd/db/fim_db.c
+++ b/src/syscheckd/db/fim_db.c
@@ -376,6 +376,7 @@ fim_entry *fim_db_get_entry_from_sync_msg(fdb_t *fim_sql, fim_type type, const c
     if (entry->registry_entry.key == NULL) {
         free(key_path);
         free(full_path);
+        os_free(value_name);
         fim_registry_free_entry(entry);
         return NULL;
     }
@@ -383,6 +384,7 @@ fim_entry *fim_db_get_entry_from_sync_msg(fdb_t *fim_sql, fim_type type, const c
     if (value_name == NULL || *value_name == '\0') {
         free(key_path);
         free(full_path);
+        os_free(value_name);
         return entry;
     }
 


### PR DESCRIPTION
## Description

This PR fixes a couple memory leaks in FIM DB, as reported by coverity.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Windows
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Windows
  - [x] Scan-build report
