### PR TITLE
Change AR decoder absolute path to relative path

### DIFF
--- a/ruleset/decoders/0010-active-response_decoders.xml
+++ b/ruleset/decoders/0010-active-response_decoders.xml
@@ -44,6 +44,6 @@ Tue 08/28/2018 09:27:23.14 "active-response/bin/netsh.cmd" add "-" "1.2.3.4" "15
 </decoder>
 
 <decoder name="ar_log_json">
-    <prematch>^\d\d\d\d/\d\d/\d\d \d\d:\d\d:\d\d /\S+/active-response/bin/\S+: </prematch>
+    <prematch>^\d\d\d\d/\d\d/\d\d \d\d:\d\d:\d\d active-response/bin/\S+: </prematch>
     <plugin_decoder offset="after_prematch">JSON_Decoder</plugin_decoder>
 </decoder>


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/8441|

## Description

The AR decoder was expecting to receive an alert with the absolute path of the `active-reponse/bin` directory.

Since WAZUH_HOME, now all paths are relative paths and this decoder was not updated, which was the reason why AR logs weren't matching any decoder.

This is the AR decoder after changing the path from absolute to relative:

```xml
<decoder name="ar_log_json">
    <prematch>^\d\d\d\d/\d\d/\d\d \d\d:\d\d:\d\d active-response/bin/\S+: </prematch>
    <plugin_decoder offset="after_prematch">JSON_Decoder</plugin_decoder>
</decoder>
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language