### PR TITLE
Generate OS and Kernel packages for Amazon Linux to match NVD vulnerabilities

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -2064,7 +2064,7 @@ void test_wm_vuldet_generate_os_and_kernel_package_amazon_linux(void **state)
     sqlite3 *db = (sqlite3 *)1;
 
     agent->dist = FEED_ALAS;
-    agent->dist_ver = FEED_AL2;
+    agent->dist_ver = FEED_ALAS2;
     agent->os_release = strdup("2");
     agent->kernel_release = strdup("4.14.194");
     agent->arch = strdup("x86_64");

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -2058,6 +2058,64 @@ void test_wm_vuldet_generate_os_and_kernel_package_redhat(void **state)
     assert_int_equal(ret, 0);
 }
 
+void test_wm_vuldet_generate_os_and_kernel_package_amazon_linux(void **state)
+{
+    agent_software *agent = *state;
+    sqlite3 *db = (sqlite3 *)1;
+
+    agent->dist = FEED_ALAS;
+    agent->dist_ver = FEED_AL2;
+    agent->os_release = strdup("2");
+    agent->kernel_release = strdup("4.14.194");
+    agent->arch = strdup("x86_64");
+
+    will_return_count(__wrap_sqlite3_prepare_v2, SQLITE_OK, 2);
+    will_return_always(__wrap_sqlite3_bind_text, 0);
+    will_return_always(__wrap_sqlite3_bind_int, 0);
+    expect_sqlite3_step_call(SQLITE_DONE);
+    expect_sqlite3_step_call(SQLITE_DONE);
+
+    // OS package
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "000");
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_value(__wrap_sqlite3_bind_text, pos, 3);
+    expect_value(__wrap_sqlite3_bind_int, index, 4);
+    expect_value(__wrap_sqlite3_bind_int, value, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 5);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "amazon");
+    expect_value(__wrap_sqlite3_bind_text, pos, 6);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "linux_2");
+    expect_value(__wrap_sqlite3_bind_text, pos, 7);
+    expect_value(__wrap_sqlite3_bind_text, pos, 8);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "*");
+    expect_value(__wrap_sqlite3_bind_text, pos, 9);
+    expect_value(__wrap_sqlite3_bind_text, pos, 10);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "x86_64");
+
+    // Kernel package
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "000");
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_value(__wrap_sqlite3_bind_text, pos, 3);
+    expect_value(__wrap_sqlite3_bind_int, index, 4);
+    expect_value(__wrap_sqlite3_bind_int, value, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 5);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "linux");
+    expect_value(__wrap_sqlite3_bind_text, pos, 6);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "linux_kernel");
+    expect_value(__wrap_sqlite3_bind_text, pos, 7);
+    expect_value(__wrap_sqlite3_bind_text, pos, 8);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "4.14.194");
+    expect_value(__wrap_sqlite3_bind_text, pos, 9);
+    expect_value(__wrap_sqlite3_bind_text, pos, 10);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "x86_64");
+
+    int ret = wm_vuldet_generate_os_and_kernel_package(db, agent);
+
+    assert_int_equal(ret, 0);
+}
+
 void test_wm_vuldet_generate_os_and_kernel_package_null_db(void **state)
 {
     (void) state;
@@ -17336,6 +17394,7 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_generate_os_and_kernel_package_ubuntu, setup_agent_software, teardown_agent_software),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_generate_os_and_kernel_package_debian, setup_agent_software, teardown_agent_software),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_generate_os_and_kernel_package_redhat, setup_agent_software, teardown_agent_software),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_generate_os_and_kernel_package_amazon_linux, setup_agent_software, teardown_agent_software),
         cmocka_unit_test(test_wm_vuldet_generate_os_and_kernel_package_null_db),
         cmocka_unit_test(test_wm_vuldet_generate_os_and_kernel_package_null_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_generate_os_and_kernel_package_invalid_agent, setup_agent_software, teardown_agent_software),

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5374,14 +5374,16 @@ int wm_vuldet_generate_os_and_kernel_package(sqlite3 *db, agent_software *agent)
                 product_name[2] = "macos";
             }
         break;
-        case FEED_AL1:
+        case FEED_ALAS1:
             product_name[0] = "linux_1";
-            product_name[1] = V_KERNEL;
+            product_name[1] = "linux";
             vendor = V_AMAZON;
+            agent->os_release = "*";
         break;
-        case FEED_AL2:
+        case FEED_ALAS2:
             product_name[0] = "linux_2";
             vendor = V_AMAZON;
+            agent->os_release = "*";
         break;
         default:
             return 1;
@@ -5389,13 +5391,7 @@ int wm_vuldet_generate_os_and_kernel_package(sqlite3 *db, agent_software *agent)
 
     for (int i = 0; product_name[i] != NULL; i++) {
         // Generate os package
-        if (agent->dist == FEED_ALAS){
-            if (wm_vuldet_insert_agent_data(db, agent, NULL, vendor, product_name[i], NULL, "*", NULL, agent->arch, NULL, NULL)) {
-                mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_INSERT_DATA_ERR, product_name[i]);
-                return OS_INVALID;
-            }
-        }
-        else if (agent->os_release) {
+        if (agent->os_release) {
             if (wm_vuldet_insert_agent_data(db, agent, NULL, vendor, product_name[i], NULL, agent->os_release, NULL, agent->arch, NULL, NULL)) {
                 mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_INSERT_DATA_ERR, product_name[i]);
                 return OS_INVALID;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -323,6 +323,7 @@ static const char *V_UBUNTU = "canonical";
 static const char *V_DEBIAN = "debian";
 static const char *V_REDHAT = "redhat";
 static const char *V_KERNEL = "linux";
+static const char *V_AMAZON = "amazon";
 
 const char *vu_vendor_list_ubuntu_debian[] = {
     "canonical",
@@ -5373,13 +5374,28 @@ int wm_vuldet_generate_os_and_kernel_package(sqlite3 *db, agent_software *agent)
                 product_name[2] = "macos";
             }
         break;
+        case FEED_AL1:
+            product_name[0] = "linux_1";
+            product_name[1] = V_KERNEL;
+            vendor = V_AMAZON;
+        break;
+        case FEED_AL2:
+            product_name[0] = "linux_2";
+            vendor = V_AMAZON;
+        break;
         default:
             return 1;
     }
 
     for (int i = 0; product_name[i] != NULL; i++) {
         // Generate os package
-        if (agent->os_release) {
+        if (agent->dist == FEED_ALAS){
+            if (wm_vuldet_insert_agent_data(db, agent, NULL, vendor, product_name[i], NULL, "*", NULL, agent->arch, NULL, NULL)) {
+                mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_INSERT_DATA_ERR, product_name[i]);
+                return OS_INVALID;
+            }
+        }
+        else if (agent->os_release) {
             if (wm_vuldet_insert_agent_data(db, agent, NULL, vendor, product_name[i], NULL, agent->os_release, NULL, agent->arch, NULL, NULL)) {
                 mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_INSERT_DATA_ERR, product_name[i]);
                 return OS_INVALID;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5378,12 +5378,14 @@ int wm_vuldet_generate_os_and_kernel_package(sqlite3 *db, agent_software *agent)
             product_name[0] = "linux_1";
             product_name[1] = "linux";
             vendor = V_AMAZON;
-            agent->os_release = "*";
+            os_free(agent->os_release);
+            os_strdup(agent->os_release, "*");
         break;
         case FEED_ALAS2:
             product_name[0] = "linux_2";
             vendor = V_AMAZON;
-            agent->os_release = "*";
+            os_free(agent->os_release);
+            os_strdup(agent->os_release, "*");
         break;
         default:
             return 1;


### PR DESCRIPTION
|Related issue|
|---|
|#8369|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR aims to generate the OS and kernel packages for Amazon Linux, so that they match with the NVD.

In the case of the generation of the OS package, currently we can only see cases in the NVD with the following format:
`cpe:2.3:o:amazon:linux_2:20180925:*:*:*:*:*:*:*`

So to address all possible cases that could be added in the future within the NVD, we have added the following formats:
```
Amazon Linux 1:
cpe:2.3:o:amazon:linux:*:*:*:*:*:*:*:*
cpe:2.3:o:amazon:linux_1:*:*:*:*:*:*:*:*
```
```
Amazon Linux 2:
cpe:2.3:o:amazon:linux_2:*:*:*:*:*:*:*:*
```
Also, in the event that the Amazon Linux feed is detected, we will try to detect all possible CPEs, because where the `os_release` should go is the date of the release notes.

