### PR TITLE
Revert "Relocation of the cve.db database to the Wazuh DB databases folder"

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -16605,7 +16605,7 @@ void test_wm_vuldet_get_package_os_rhel8(void **state)
 
 void test_wm_vuldet_get_hash_open_fail(void **state)
 {
-    expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/cve.db");
+    expect_string(__wrap_sqlite3_open_v2, filename, "queue/vulnerabilities/cve.db");
     expect_value(__wrap_sqlite3_open_v2, flags, 2);
     will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
     will_return(__wrap_sqlite3_open_v2, SQLITE_ERROR);
@@ -16621,7 +16621,7 @@ void test_wm_vuldet_get_hash_open_fail(void **state)
 
 void test_wm_vuldet_get_hash_prepare_fail(void **state)
 {
-    expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/cve.db");
+    expect_string(__wrap_sqlite3_open_v2, filename, "queue/vulnerabilities/cve.db");
     expect_value(__wrap_sqlite3_open_v2, flags, 2);
     will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
     will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
@@ -16638,7 +16638,7 @@ void test_wm_vuldet_get_hash_prepare_fail(void **state)
 
 void test_wm_vuldet_get_hash_one_row(void **state)
 {
-    expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/cve.db");
+    expect_string(__wrap_sqlite3_open_v2, filename, "queue/vulnerabilities/cve.db");
     expect_value(__wrap_sqlite3_open_v2, flags, 2);
     will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
     will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
@@ -16666,7 +16666,7 @@ void test_wm_vuldet_get_hash_one_row(void **state)
 
 void test_wm_vuldet_get_hash_no_row(void **state)
 {
-    expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/cve.db");
+    expect_string(__wrap_sqlite3_open_v2, filename, "queue/vulnerabilities/cve.db");
     expect_value(__wrap_sqlite3_open_v2, flags, 2);
     will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
     will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
@@ -16787,7 +16787,7 @@ void test_wm_vuldet_check_enabled_msu_one_row(void **state)
 
 void test_wm_insert_MSU_metadata_open_fail(void **state)
 {
-    expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/cve.db");
+    expect_string(__wrap_sqlite3_open_v2, filename, "queue/vulnerabilities/cve.db");
     expect_value(__wrap_sqlite3_open_v2, flags, 2);
     will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
     will_return(__wrap_sqlite3_open_v2, SQLITE_ERROR);
@@ -16803,7 +16803,7 @@ void test_wm_insert_MSU_metadata_open_fail(void **state)
 
 void test_wm_insert_MSU_metadata_prepare_fail(void **state)
 {
-    expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/cve.db");
+    expect_string(__wrap_sqlite3_open_v2, filename, "queue/vulnerabilities/cve.db");
     expect_value(__wrap_sqlite3_open_v2, flags, 2);
     will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
     will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
@@ -16831,7 +16831,7 @@ void test_wm_insert_MSU_metadata_one_row(void **state)
     msu->sha256 = "123456";
 
     // open DB
-    expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/cve.db");
+    expect_string(__wrap_sqlite3_open_v2, filename, "queue/vulnerabilities/cve.db");
     expect_value(__wrap_sqlite3_open_v2, flags, 2);
     will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
     will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
@@ -16891,7 +16891,7 @@ void test_wm_insert_MSU_metadata_no_row(void **state)
     msu->sha256 = "123456";
 
     // open DB
-    expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/cve.db");
+    expect_string(__wrap_sqlite3_open_v2, filename, "queue/vulnerabilities/cve.db");
     expect_value(__wrap_sqlite3_open_v2, flags, 2);
     will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
     will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
@@ -17799,7 +17799,7 @@ void test_wm_vuldet_feed_changed_updated(void **state)
 
 void test_wm_vuldet_get_last_feed_update_success(void **state)
 {
-    expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/cve.db");
+    expect_string(__wrap_sqlite3_open_v2, filename, "queue/vulnerabilities/cve.db");
     expect_value(__wrap_sqlite3_open_v2, flags, 1);
     will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
     will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
@@ -17818,7 +17818,7 @@ void test_wm_vuldet_get_last_feed_update_success(void **state)
 
 void test_wm_vuldet_get_last_feed_update_NVD_success(void **state)
 {
-    expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/cve.db");
+    expect_string(__wrap_sqlite3_open_v2, filename, "queue/vulnerabilities/cve.db");
     expect_value(__wrap_sqlite3_open_v2, flags, 1);
     will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
     will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
@@ -17834,7 +17834,7 @@ void test_wm_vuldet_get_last_feed_update_NVD_success(void **state)
 
 void test_wm_vuldet_get_last_feed_update_open_error(void **state)
 {
-    expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/cve.db");
+    expect_string(__wrap_sqlite3_open_v2, filename, "queue/vulnerabilities/cve.db");
     expect_value(__wrap_sqlite3_open_v2, flags, 1);
     will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
     will_return(__wrap_sqlite3_open_v2, SQLITE_ERROR);
@@ -17849,7 +17849,7 @@ void test_wm_vuldet_get_last_feed_update_open_error(void **state)
 
 void test_wm_vuldet_get_last_feed_update_prepare_error(void **state)
 {
-    expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/cve.db");
+    expect_string(__wrap_sqlite3_open_v2, filename, "queue/vulnerabilities/cve.db");
     expect_value(__wrap_sqlite3_open_v2, flags, 1);
     will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
     will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
@@ -17865,7 +17865,7 @@ void test_wm_vuldet_get_last_feed_update_prepare_error(void **state)
 
 void test_wm_vuldet_get_last_feed_update_NVD_prepare_error(void **state)
 {
-    expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/cve.db");
+    expect_string(__wrap_sqlite3_open_v2, filename, "queue/vulnerabilities/cve.db");
     expect_value(__wrap_sqlite3_open_v2, flags, 1);
     will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
     will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
@@ -17881,7 +17881,7 @@ void test_wm_vuldet_get_last_feed_update_NVD_prepare_error(void **state)
 
 void test_wm_vuldet_get_last_feed_update_step_empty(void **state)
 {
-    expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/cve.db");
+    expect_string(__wrap_sqlite3_open_v2, filename, "queue/vulnerabilities/cve.db");
     expect_value(__wrap_sqlite3_open_v2, flags, 1);
     will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
     will_return(__wrap_sqlite3_open_v2, SQLITE_OK);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_db.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_db.h
@@ -12,7 +12,7 @@
 #ifndef WM_VUNALIZER_DB
 #define WM_VUNALIZER_DB
 
-#define CVE_DBS_PATH            "queue/db/"
+#define CVE_DBS_PATH            "queue/vulnerabilities/"
 #define CVE_DB CVE_DBS_PATH     "cve.db"
 
 #define AGENTS_TABLE            "AGENTS"


### PR DESCRIPTION
### Description

Considering the changes on the desing of the epic https://github.com/wazuh/wazuh/issues/8315 explained in [this comment](https://github.com/wazuh/wazuh/issues/8316#issuecomment-828834093) of the analysis that we performed, the `cve.db` database shouldn't be relocated. So, this pull request reverts the changes merged as part of the pull https://github.com/wazuh/wazuh/pull/8336.