### PR TITLE
Stop deprecated ossec-authd before starting Wazuh

### DIFF
--- a/src/init/wazuh-server.sh
+++ b/src/init/wazuh-server.sh
@@ -29,6 +29,7 @@ AUTHOR="Wazuh Inc."
 USE_JSON=false
 DAEMONS="wazuh-clusterd wazuh-modulesd wazuh-monitord wazuh-logcollector wazuh-remoted wazuh-syscheckd wazuh-analysisd wazuh-maild wazuh-execd wazuh-db wazuh-authd wazuh-agentlessd wazuh-integratord wazuh-dbd wazuh-csyslogd wazuh-apid"
 OP_DAEMONS="wazuh-clusterd wazuh-maild wazuh-agentlessd wazuh-integratord wazuh-dbd wazuh-csyslogd"
+DEPRECATED_DAEMONS="ossec-authd"
 
 # Reverse order of daemons
 SDAEMONS=$(echo $DAEMONS | awk '{ for (i=NF; i>1; i--) printf("%s ",$i); print $1; }')
@@ -278,6 +279,16 @@ start_service()
     # Delete all files in temporary folder
     TO_DELETE="$DIR/tmp/*"
     rm -rf $TO_DELETE
+
+    # Stop deprecated daemons that could keep alive on updates
+    for i in ${DEPRECATED_DAEMONS}; do
+        ls ${DIR}/var/run/${i}*.pid > /dev/null 2>&1
+        if [ $? = 0 ]; then
+            pid=`cat ${DIR}/var/run/${i}*.pid`
+            kill $pid
+            rm -f ${DIR}/var/run/${i}-${pid}.pid
+        fi
+    done
 
     # We actually start them now.
     first=true


### PR DESCRIPTION
|Related issue|
|---|
| #8294 |

## Description

Due to the daemons renaming, when updating from < 3.7 when having `ossec-authd` running makes the `wazuh-control` service not to get noticed about its presence.

It has been added a new check when starting the Wazuh manager to kill the `ossec-authd` daemon if found that is running when the manager is updated.
 
## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Update from 3.7.2 to 4.2.0 successfully