### PR TITLE
Remove active-response check from agents restart

### DIFF
--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -467,11 +467,6 @@ class Agent:
         if self.status.lower() != 'active':
             raise WazuhError(1707, extra_message='{0}'.format(self.status))
 
-        # Check if agent has active-response enabled
-        agent_conf = self.getconfig('com', 'active-response', self.version)
-        if agent_conf['active-response']['disabled'] == 'yes':
-            raise WazuhError(1750)
-
         return send_restart_command(self.id, self.version)
 
     def remove(self, backup=False, purge=False, use_only_authd=False):

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -454,8 +454,6 @@ class Agent:
         ------
         WazuhError(1707)
             If the agent to be restarted is not active.
-        WazuhError(1750)
-            If the agent has active response disabled.
 
         Returns
         -------

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -565,14 +565,11 @@ def test_agent_get_key_ko(socket_mock, send_mock):
 @patch('socket.socket.connect')
 def test_agent_restart(socket_mock, send_mock, mock_queue):
     """Test if method restart calls other methods with correct params."""
-    with patch('wazuh.core.agent.Agent.getconfig', return_value={'active-response': {'disabled': 'no'}}) as \
-            mock_config:
-        agent = Agent(0)
-        agent.restart()
+    agent = Agent(0)
+    agent.restart()
 
-        # Assert methods are called with correct params
-        mock_config.assert_called_once_with('com', 'active-response', 'Wazuh v3.9.0')
-        mock_queue.assert_called_once()
+    # Assert methods are called with correct params
+    mock_queue.assert_called_once()
 
 
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
@@ -580,16 +577,9 @@ def test_agent_restart(socket_mock, send_mock, mock_queue):
 def test_agent_restart_ko(socket_mock, send_mock):
     """Test if method restart raises exception."""
     # Assert exception is raised when status of agent is not 'active'
-    with patch('wazuh.core.agent.Agent.getconfig', return_value={'active-response': {'disabled': 'no'}}):
-        with pytest.raises(WazuhError, match='.* 1707 .*'):
-            agent = Agent(3)
-            agent.restart()
-
-    # Assert exception is raised when active-response is disabled
-    with patch('wazuh.core.agent.Agent.getconfig', return_value={'active-response': {'disabled': 'yes'}}):
-        with pytest.raises(WazuhException, match='.* 1750 .*'):
-            agent = Agent(0)
-            agent.restart()
+    with pytest.raises(WazuhError, match='.* 1707 .*'):
+        agent = Agent(3)
+        agent.restart()
 
 
 @pytest.mark.parametrize('status', [


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/8448 |

Closes #8448 

Hello team,

this PR improves the agents restart function by removing the active-response check. As the response message indicates, this function will send the active-response command to restart the desired agents. If active-response is not enabled on said agent, it will not restart but the API response must be an affected item as the command was correctly sent.

## Tests performed
### Unit tests
```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.9.4, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.15.1
collected 96 items                                                                                                                                                                          

framework/wazuh/tests/test_agent.py ................................................................................................                                                  [100%]

============================================================================== 96 passed, 2 warnings in 0.67s ===============================================================================

==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.9.4, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.15.1
collected 155 items                                                                                                                                                                         

framework/wazuh/core/tests/test_agent.py ............................................................................................................................................ [ 90%]
...............                                                                                                                                                                       [100%]

============================================================================== 155 passed, 2 warnings in 0.87s ==============================================================================
```

Regards,
Víctor Fernández 