### PR TITLE
Revert "Clean src/win32 folder"

### DIFF
--- a/src/win32/license.rtf
+++ b/src/win32/license.rtf
@@ -1,0 +1,479 @@
+{\rtf1\ansi\ansicpg1252\deff0{\fonttbl{\f0\fnil\fcharset0 Tahoma;}}
+{\colortbl ;\red0\green0\blue0;\red0\green0\blue255;}
+{\*\generator Msftedit 5.41.21.2510;}\viewkind4\uc1\pard\sl280\slmult0\cf1\lang10\f0\fs18\par
+ Portions Copyright (C) 2015-2021, Wazuh Inc.\par
+ Based on work Copyright (C) 2003 - 2013 Trend Micro, Inc.\par
+\par
+ This program is free software; you can redistribute it and/or modify\par
+ it under the terms of the GNU General Public License (version 2) as\par
+ published by the FSF - Free Software Foundation.\par
+\par
+ In addition, certain source files in this program permit linking with the\par
+ OpenSSL library ({\field{\*\fldinst{HYPERLINK "http://www.openssl.org"}}{\fldrslt{\ul\cf2 http://www.openssl.org}}}\f0\fs18 ), which otherwise wouldn't be allowed\par
+ under the GPL.  For purposes of identifying OpenSSL, most source files giving\par
+ this permission limit it to versions of OpenSSL having a license identical to\par
+ that listed in this file (see section "OpenSSL LICENSE" below). It is not\par
+ necessary for the copyright years to match between this file and the OpenSSL\par
+ version in question.  However, note that because this file is an extension of\par
+ the license statements of these source files, this file may not be changed\par
+ except with permission from all copyright holders of source files in this\par
+ program which reference this file.\par
+\par
+ Note that this license applies to the source code, as well as\par
+ decoders, rules and any other data file included with OSSEC (unless\par
+ otherwise specified).\par
+\par
+ For the purpose of this license, we consider an application to constitute a\par
+ "derivative work" or a work based on this program if it does any of the\par
+ following (list not exclusive):\par
+\par
+  * Integrates source code/data files from OSSEC.\par
+  * Includes OSSEC copyrighted material.\par
+  * Includes/integrates OSSEC into a proprietary executable installer.\par
+  * Links to a library or executes a program that does any of the above.\par
+\par
+ This list is not exclusive, but just a clarification of our interpretation\par
+ of derived works. These restrictions only apply if you actually redistribute\par
+ OSSEC (or parts of it).\par
+\par
+ We don't consider these to be added restrictions on top of the GPL,\par
+ but just a clarification of how we interpret "derived works" as it\par
+ applies to OSSEC. This is similar to the way Linus Torvalds has\par
+ announced his interpretation of how "derived works" applies to Linux kernel\par
+ modules. Our interpretation refers only to OSSEC - we don't speak\par
+ for any other GPL products.\par
+\par
+  * As a special exception, the copyright holders give\par
+  * permission to link the code of portions of this program with the\par
+  * OpenSSL library under certain conditions as described in each\par
+  * individual source file, and distribute linked combinations\par
+  * including the two.\par
+  * You must obey the GNU General Public License in all respects\par
+  * for all of the code used other than OpenSSL.  If you modify\par
+  * file(s) with this exception, you may extend this exception to your\par
+  * version of the file(s), but you are not obligated to do so.  If you\par
+  * do not wish to do so, delete this exception statement from your\par
+  * version.  If you delete this exception statement from all source\par
+  * files in the program, then also delete it here.\par
+\par
+ OSSEC HIDS is distributed in the hope that it will be useful, but WITHOUT\par
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or\par
+ FITNESS FOR A PARTICULAR PURPOSE.\par
+ See the GNU General Public License Version 2 below for more details.\par
+\par
+-----------------------------------------------------------------------------\par
+\par
+\tab\tab     GNU GENERAL PUBLIC LICENSE\par
+\tab\tab        Version 2, June 1991\par
+\par
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,\par
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA\par
+ Everyone is permitted to copy and distribute verbatim copies\par
+ of this license document, but changing it is not allowed.\par
+\par
+\tab\tab\tab     Preamble\par
+\par
+  The licenses for most software are designed to take away your\par
+freedom to share and change it.  By contrast, the GNU General Public\par
+License is intended to guarantee your freedom to share and change free\par
+software--to make sure the software is free for all its users.  This\par
+General Public License applies to most of the Free Software\par
+Foundation's software and to any other program whose authors commit to\par
+using it.  (Some other Free Software Foundation software is covered by\par
+the GNU Lesser General Public License instead.)  You can apply it to\par
+your programs, too.\par
+\par
+  When we speak of free software, we are referring to freedom, not\par
+price.  Our General Public Licenses are designed to make sure that you\par
+have the freedom to distribute copies of free software (and charge for\par
+this service if you wish), that you receive source code or can get it\par
+if you want it, that you can change the software or use pieces of it\par
+in new free programs; and that you know you can do these things.\par
+\par
+  To protect your rights, we need to make restrictions that forbid\par
+anyone to deny you these rights or to ask you to surrender the rights.\par
+These restrictions translate to certain responsibilities for you if you\par
+distribute copies of the software, or if you modify it.\par
+\par
+  For example, if you distribute copies of such a program, whether\par
+gratis or for a fee, you must give the recipients all the rights that\par
+you have.  You must make sure that they, too, receive or can get the\par
+source code.  And you must show them these terms so they know their\par
+rights.\par
+\par
+  We protect your rights with two steps: (1) copyright the software, and\par
+(2) offer you this license which gives you legal permission to copy,\par
+distribute and/or modify the software.\par
+\par
+  Also, for each author's protection and ours, we want to make certain\par
+that everyone understands that there is no warranty for this free\par
+software.  If the software is modified by someone else and passed on, we\par
+want its recipients to know that what they have is not the original, so\par
+that any problems introduced by others will not reflect on the original\par
+authors' reputations.\par
+\par
+  Finally, any free program is threatened constantly by software\par
+patents.  We wish to avoid the danger that redistributors of a free\par
+program will individually obtain patent licenses, in effect making the\par
+program proprietary.  To prevent this, we have made it clear that any\par
+patent must be licensed for everyone's free use or not licensed at all.\par
+\par
+  The precise terms and conditions for copying, distribution and\par
+modification follow.\par
+\par
+\tab\tab     GNU GENERAL PUBLIC LICENSE\par
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION\par
+\par
+  0. This License applies to any program or other work which contains\par
+a notice placed by the copyright holder saying it may be distributed\par
+under the terms of this General Public License.  The "Program", below,\par
+refers to any such program or work, and a "work based on the Program"\par
+means either the Program or any derivative work under copyright law:\par
+that is to say, a work containing the Program or a portion of it,\par
+either verbatim or with modifications and/or translated into another\par
+language.  (Hereinafter, translation is included without limitation in\par
+the term "modification".)  Each licensee is addressed as "you".\par
+\par
+Activities other than copying, distribution and modification are not\par
+covered by this License; they are outside its scope.  The act of\par
+running the Program is not restricted, and the output from the Program\par
+is covered only if its contents constitute a work based on the\par
+Program (independent of having been made by running the Program).\par
+Whether that is true depends on what the Program does.\par
+\par
+  1. You may copy and distribute verbatim copies of the Program's\par
+source code as you receive it, in any medium, provided that you\par
+conspicuously and appropriately publish on each copy an appropriate\par
+copyright notice and disclaimer of warranty; keep intact all the\par
+notices that refer to this License and to the absence of any warranty;\par
+and give any other recipients of the Program a copy of this License\par
+along with the Program.\par
+\par
+You may charge a fee for the physical act of transferring a copy, and\par
+you may at your option offer warranty protection in exchange for a fee.\par
+\par
+  2. You may modify your copy or copies of the Program or any portion\par
+of it, thus forming a work based on the Program, and copy and\par
+distribute such modifications or work under the terms of Section 1\par
+above, provided that you also meet all of these conditions:\par
+\par
+    a) You must cause the modified files to carry prominent notices\par
+    stating that you changed the files and the date of any change.\par
+\par
+    b) You must cause any work that you distribute or publish, that in\par
+    whole or in part contains or is derived from the Program or any\par
+    part thereof, to be licensed as a whole at no charge to all third\par
+    parties under the terms of this License.\par
+\par
+    c) If the modified program normally reads commands interactively\par
+    when run, you must cause it, when started running for such\par
+    interactive use in the most ordinary way, to print or display an\par
+    announcement including an appropriate copyright notice and a\par
+    notice that there is no warranty (or else, saying that you provide\par
+    a warranty) and that users may redistribute the program under\par
+    these conditions, and telling the user how to view a copy of this\par
+    License.  (Exception: if the Program itself is interactive but\par
+    does not normally print such an announcement, your work based on\par
+    the Program is not required to print an announcement.)\par
+\par
+These requirements apply to the modified work as a whole.  If\par
+identifiable sections of that work are not derived from the Program,\par
+and can be reasonably considered independent and separate works in\par
+themselves, then this License, and its terms, do not apply to those\par
+sections when you distribute them as separate works.  But when you\par
+distribute the same sections as part of a whole which is a work based\par
+on the Program, the distribution of the whole must be on the terms of\par
+this License, whose permissions for other licensees extend to the\par
+entire whole, and thus to each and every part regardless of who wrote it.\par
+\par
+Thus, it is not the intent of this section to claim rights or contest\par
+your rights to work written entirely by you; rather, the intent is to\par
+exercise the right to control the distribution of derivative or\par
+collective works based on the Program.\par
+\par
+In addition, mere aggregation of another work not based on the Program\par
+with the Program (or with a work based on the Program) on a volume of\par
+a storage or distribution medium does not bring the other work under\par
+the scope of this License.\par
+\par
+  3. You may copy and distribute the Program (or a work based on it,\par
+under Section 2) in object code or executable form under the terms of\par
+Sections 1 and 2 above provided that you also do one of the following:\par
+\par
+    a) Accompany it with the complete corresponding machine-readable\par
+    source code, which must be distributed under the terms of Sections\par
+    1 and 2 above on a medium customarily used for software interchange; or,\par
+\par
+    b) Accompany it with a written offer, valid for at least three\par
+    years, to give any third party, for a charge no more than your\par
+    cost of physically performing source distribution, a complete\par
+    machine-readable copy of the corresponding source code, to be\par
+    distributed under the terms of Sections 1 and 2 above on a medium\par
+    customarily used for software interchange; or,\par
+\par
+    c) Accompany it with the information you received as to the offer\par
+    to distribute corresponding source code.  (This alternative is\par
+    allowed only for noncommercial distribution and only if you\par
+    received the program in object code or executable form with such\par
+    an offer, in accord with Subsection b above.)\par
+\par
+The source code for a work means the preferred form of the work for\par
+making modifications to it.  For an executable work, complete source\par
+code means all the source code for all modules it contains, plus any\par
+associated interface definition files, plus the scripts used to\par
+control compilation and installation of the executable.  However, as a\par
+special exception, the source code distributed need not include\par
+anything that is normally distributed (in either source or binary\par
+form) with the major components (compiler, kernel, and so on) of the\par
+operating system on which the executable runs, unless that component\par
+itself accompanies the executable.\par
+\par
+If distribution of executable or object code is made by offering\par
+access to copy from a designated place, then offering equivalent\par
+access to copy the source code from the same place counts as\par
+distribution of the source code, even though third parties are not\par
+compelled to copy the source along with the object code.\par
+\par
+  4. You may not copy, modify, sublicense, or distribute the Program\par
+except as expressly provided under this License.  Any attempt\par
+otherwise to copy, modify, sublicense or distribute the Program is\par
+void, and will automatically terminate your rights under this License.\par
+However, parties who have received copies, or rights, from you under\par
+this License will not have their licenses terminated so long as such\par
+parties remain in full compliance.\par
+\par
+  5. You are not required to accept this License, since you have not\par
+signed it.  However, nothing else grants you permission to modify or\par
+distribute the Program or its derivative works.  These actions are\par
+prohibited by law if you do not accept this License.  Therefore, by\par
+modifying or distributing the Program (or any work based on the\par
+Program), you indicate your acceptance of this License to do so, and\par
+all its terms and conditions for copying, distributing or modifying\par
+the Program or works based on it.\par
+\par
+  6. Each time you redistribute the Program (or any work based on the\par
+Program), the recipient automatically receives a license from the\par
+original licensor to copy, distribute or modify the Program subject to\par
+these terms and conditions.  You may not impose any further\par
+restrictions on the recipients' exercise of the rights granted herein.\par
+You are not responsible for enforcing compliance by third parties to\par
+this License.\par
+\par
+  7. If, as a consequence of a court judgment or allegation of patent\par
+infringement or for any other reason (not limited to patent issues),\par
+conditions are imposed on you (whether by court order, agreement or\par
+otherwise) that contradict the conditions of this License, they do not\par
+excuse you from the conditions of this License.  If you cannot\par
+distribute so as to satisfy simultaneously your obligations under this\par
+License and any other pertinent obligations, then as a consequence you\par
+may not distribute the Program at all.  For example, if a patent\par
+license would not permit royalty-free redistribution of the Program by\par
+all those who receive copies directly or indirectly through you, then\par
+the only way you could satisfy both it and this License would be to\par
+refrain entirely from distribution of the Program.\par
+\par
+If any portion of this section is held invalid or unenforceable under\par
+any particular circumstance, the balance of the section is intended to\par
+apply and the section as a whole is intended to apply in other\par
+circumstances.\par
+\par
+It is not the purpose of this section to induce you to infringe any\par
+patents or other property right claims or to contest validity of any\par
+such claims; this section has the sole purpose of protecting the\par
+integrity of the free software distribution system, which is\par
+implemented by public license practices.  Many people have made\par
+generous contributions to the wide range of software distributed\par
+through that system in reliance on consistent application of that\par
+system; it is up to the author/donor to decide if he or she is willing\par
+to distribute software through any other system and a licensee cannot\par
+impose that choice.\par
+\par
+This section is intended to make thoroughly clear what is believed to\par
+be a consequence of the rest of this License.\par
+\par
+  8. If the distribution and/or use of the Program is restricted in\par
+certain countries either by patents or by copyrighted interfaces, the\par
+original copyright holder who places the Program under this License\par
+may add an explicit geographical distribution limitation excluding\par
+those countries, so that distribution is permitted only in or among\par
+countries not thus excluded.  In such case, this License incorporates\par
+the limitation as if written in the body of this License.\par
+\par
+  9. The Free Software Foundation may publish revised and/or new versions\par
+of the General Public License from time to time.  Such new versions will\par
+be similar in spirit to the present version, but may differ in detail to\par
+address new problems or concerns.\par
+\par
+Each version is given a distinguishing version number.  If the Program\par
+specifies a version number of this License which applies to it and "any\par
+later version", you have the option of following the terms and conditions\par
+either of that version or of any later version published by the Free\par
+Software Foundation.  If the Program does not specify a version number of\par
+this License, you may choose any version ever published by the Free Software\par
+Foundation.\par
+\par
+  10. If you wish to incorporate parts of the Program into other free\par
+programs whose distribution conditions are different, write to the author\par
+to ask for permission.  For software which is copyrighted by the Free\par
+Software Foundation, write to the Free Software Foundation; we sometimes\par
+make exceptions for this.  Our decision will be guided by the two goals\par
+of preserving the free status of all derivatives of our free software and\par
+of promoting the sharing and reuse of software generally.\par
+\par
+\tab\tab\tab     NO WARRANTY\par
+\par
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY\par
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN\par
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES\par
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED\par
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF\par
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS\par
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE\par
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,\par
+REPAIR OR CORRECTION.\par
+\par
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING\par
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR\par
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,\par
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING\par
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED\par
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY\par
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER\par
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE\par
+POSSIBILITY OF SUCH DAMAGES.\par
+\par
+\tab\tab      END OF TERMS AND CONDITIONS\par
+\par
+\par
+-------------------------------------------------------------------------------\par
+\par
+OpenSSL License\par
+---------------\par
+\par
+  LICENSE ISSUES\par
+  ==============\par
+\par
+  The OpenSSL toolkit stays under a dual license, i.e. both the conditions of\par
+  the OpenSSL License and the original SSLeay license apply to the toolkit.\par
+  See below for the actual license texts. Actually both licenses are BSD-style\par
+  Open Source licenses. In case of any license issues related to OpenSSL\par
+  please contact openssl-core@openssl.org.\par
+\par
+  OpenSSL License\par
+  ---------------\par
+\par
+/* ====================================================================\par
+ * Copyright (c) 1998-2001 The OpenSSL Project.  All rights reserved.\par
+ *\par
+ * Redistribution and use in source and binary forms, with or without\par
+ * modification, are permitted provided that the following conditions\par
+ * are met:\par
+ *\par
+ * 1. Redistributions of source code must retain the above copyright\par
+ *    notice, this list of conditions and the following disclaimer.\par
+ *\par
+ * 2. Redistributions in binary form must reproduce the above copyright\par
+ *    notice, this list of conditions and the following disclaimer in\par
+ *    the documentation and/or other materials provided with the\par
+ *    distribution.\par
+ *\par
+ * 3. All advertising materials mentioning features or use of this\par
+ *    software must display the following acknowledgment:\par
+ *    "This product includes software developed by the OpenSSL Project\par
+ *    for use in the OpenSSL Toolkit. ({\field{\*\fldinst{HYPERLINK "http://www.openssl.org/"}}{\fldrslt{\ul\cf2 http://www.openssl.org/}}}\f0\fs18 )"\par
+ *\par
+ * 4. The names "OpenSSL Toolkit" and "OpenSSL Project" must not be used to\par
+ *    endorse or promote products derived from this software without\par
+ *    prior written permission. For written permission, please contact\par
+ *    openssl-core@openssl.org.\par
+ *\par
+ * 5. Products derived from this software may not be called "OpenSSL"\par
+ *    nor may "OpenSSL" appear in their names without prior written\par
+ *    permission of the OpenSSL Project.\par
+ *\par
+ * 6. Redistributions of any form whatsoever must retain the following\par
+ *    acknowledgment:\par
+ *    "This product includes software developed by the OpenSSL Project\par
+ *    for use in the OpenSSL Toolkit ({\field{\*\fldinst{HYPERLINK "http://www.openssl.org/"}}{\fldrslt{\ul\cf2 http://www.openssl.org/}}}\f0\fs18 )"\par
+ *\par
+ * THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT ``AS IS'' AND ANY\par
+ * EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE\par
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR\par
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR\par
+ * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\par
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\par
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;\par
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)\par
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,\par
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)\par
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED\par
+ * OF THE POSSIBILITY OF SUCH DAMAGE.\par
+ * ====================================================================\par
+ *\par
+ * This product includes cryptographic software written by Eric Young\par
+ * (eay@cryptsoft.com).  This product includes software written by Tim\par
+ * Hudson (tjh@cryptsoft.com).\par
+ *\par
+ */\par
+\par
+ Original SSLeay License\par
+ -----------------------\par
+\par
+/* Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)\par
+ * All rights reserved.\par
+ *\par
+ * This package is an SSL implementation written\par
+ * by Eric Young (eay@cryptsoft.com).\par
+ * The implementation was written so as to conform with Netscapes SSL.\par
+ *\par
+ * This library is free for commercial and non-commercial use as long as\par
+ * the following conditions are aheared to.  The following conditions\par
+ * apply to all code found in this distribution, be it the RC4, RSA,\par
+ * lhash, DES, etc., code; not just the SSL code.  The SSL documentation\par
+ * included with this distribution is covered by the same copyright terms\par
+ * except that the holder is Tim Hudson (tjh@cryptsoft.com).\par
+ *\par
+ * Copyright remains Eric Young's, and as such any Copyright notices in\par
+ * the code are not to be removed.\par
+ * If this package is used in a product, Eric Young should be given attribution\par
+ * as the author of the parts of the library used.\par
+ * This can be in the form of a textual message at program startup or\par
+ * in documentation (online or textual) provided with the package.\par
+ *\par
+ * Redistribution and use in source and binary forms, with or without\par
+ * modification, are permitted provided that the following conditions\par
+ * are met:\par
+ * 1. Redistributions of source code must retain the copyright\par
+ *    notice, this list of conditions and the following disclaimer.\par
+ * 2. Redistributions in binary form must reproduce the above copyright\par
+ *    notice, this list of conditions and the following disclaimer in the\par
+ *    documentation and/or other materials provided with the distribution.\par
+ * 3. All advertising materials mentioning features or use of this software\par
+ *    must display the following acknowledgement:\par
+ *    "This product includes cryptographic software written by\par
+ *     Eric Young (eay@cryptsoft.com)"\par
+ *    The word 'cryptographic' can be left out if the routines from the library\par
+ *    being used are not cryptographic related :-).\par
+ * 4. If you include any Windows specific code (or a derivative thereof) from\par
+ *    the apps directory (application code) you must include an acknowledgement:\par
+ *    "This product includes software written by Tim Hudson (tjh@cryptsoft.com)"\par
+ *\par
+ * THIS SOFTWARE IS PROVIDED BY ERIC YOUNG ``AS IS'' AND\par
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE\par
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE\par
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE\par
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\par
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS\par
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)\par
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT\par
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY\par
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF\par
+ * SUCH DAMAGE.\par
+ *\par
+ * The licence and distribution terms for any publically available version or\par
+ * derivative of this code cannot be changed.  i.e. this code cannot simply be\par
+ * copied and put under another distribution licence\par
+ * [including the GNU Public Licence.]\par
+ */\par
+}
+ 

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -61,6 +61,7 @@
         <Property Id="WixAppFolder" Value="WixPerMachineFolder" />
         <WixVariable Id="WixUISupportPerUser" Value="0" />
         <Property Id="ALLUSERS" Value="1" />
+        <WixVariable Id="WixUILicenseRtf" Value="license.rtf" />
         <WixVariable Id="WixUIBannerBmp" Value="ui\bannrbmp.jpg" />
         <WixVariable Id="WixUIDialogBmp" Value="ui\dlgbmp.jpg" />
         <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="Run Agent configuration interface" />


### PR DESCRIPTION
|Related issue|
|---|
|Closes #8460|

This PR restores the file "license.rtf", used by the MSI installer to show the license message.