### PR TITLE
Add environment information when a StopIteration error raise

### DIFF
--- a/api/test/integration/conftest.py
+++ b/api/test/integration/conftest.py
@@ -21,6 +21,7 @@ login_url = f"{common['protocol']}://{common['host']}:{common['port']}/{common['
 basic_auth = f"{common['user']}:{common['pass']}".encode()
 login_headers = {'Content-Type': 'application/json',
                  'Authorization': f'Basic {b64encode(basic_auth).decode()}'}
+environment_status = None
 
 
 def pytest_addoption(parser):
@@ -294,7 +295,28 @@ def api_test(request):
     clean_tmp_folder()
     if request.session.testsfailed > 0:
         save_logs(f"{rbac_mode}_{module.split('.')[0]}" if rbac_mode else f"{module.split('.')[0]}")
+
+    # Get the environment current status
+    global environment_status
+    environment_status = get_health()
     down_env()
+
+
+def get_health():
+    """Get the current status of the integration environment
+
+    Returns
+    -------
+    str
+        Current status
+    """
+    health = "\nEnvironment final status\n"
+    health += subprocess.check_output(
+        "docker ps --format 'table {{.Names}}\t{{.RunningFor}}\t{{.Status}}' --filter name=^env_wazuh",
+        shell=True).decode()
+    health += '\n'
+
+    return health
 
 
 # HTML report
@@ -382,6 +404,11 @@ def pytest_runtest_makereport(item, call):
 
     elif report.outcome == 'failed':
         results[report.location[0]]['error'] += 1
+
+    if report.when == 'setup' and \
+            report.longrepr and ('api_test did not yield a value' in report.longrepr.reprcrash.message or
+                                 'StopIteration' in report.longrepr.reprcrash.message):
+        report.sections.append(('Environment section', environment_status))
 
 
 def pytest_html_results_summary(prefix, summary, postfix):


### PR DESCRIPTION
Hi team,

In this PR we have added new functionality to the API integrated tests. Due to the type of problems reported in this comment: https://github.com/wazuh/wazuh-jenkins/issues/2500#issuecomment-829892538.

we have decided to implement the functionality to show the environment status when the "StopIteration" error occurs.

### Example
```
...

/home/adriiiprodri/.virtualenvs/wazuh/lib/python3.9/site-packages/_pytest/fixtures.py:905: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

fixturedef = <FixtureDef argname='api_test' scope='session' baseid=''>, request = <SubRequest 'api_test' for <YamlItem GET /security/roles>>

    def pytest_fixture_setup(fixturedef, request):
        """ Execution of fixture setup. """
        kwargs = {}
        for argname in fixturedef.argnames:
            fixdef = request._get_active_fixturedef(argname)
            assert fixdef.cached_result is not None
            result, arg_cache_key, exc = fixdef.cached_result
            request._check_scope(argname, request.scope, fixdef.scope)
            kwargs[argname] = result
    
        fixturefunc = resolve_fixture_function(fixturedef, request)
        my_cache_key = fixturedef.cache_key(request)
        try:
>           result = call_fixture_func(fixturefunc, request, kwargs)

/home/adriiiprodri/.virtualenvs/wazuh/lib/python3.9/site-packages/_pytest/fixtures.py:964: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

fixturefunc = <function api_test at 0x7fdbb473b310>, request = <SubRequest 'api_test' for <YamlItem GET /security/roles>>, kwargs = {'request': <SubRequest 'api_test' for <YamlItem GET /security/roles>>}

    def call_fixture_func(fixturefunc, request, kwargs):
        yieldctx = is_generator(fixturefunc)
        if yieldctx:
            it = fixturefunc(**kwargs)
>           res = next(it)
E           StopIteration

/home/adriiiprodri/.virtualenvs/wazuh/lib/python3.9/site-packages/_pytest/fixtures.py:788: StopIteration
------------------------------------------------------------------------------------------------ Environment section -------------------------------------------------------------------------------------------------

Environment final status
NAMES                 CREATED          STATUS
env_wazuh-agent8_1    21 seconds ago   Up 20 seconds (healthy)
env_wazuh-agent7_1    22 seconds ago   Up 21 seconds (healthy)
env_wazuh-agent6_1    23 seconds ago   Up 21 seconds (healthy)
env_wazuh-agent5_1    23 seconds ago   Up 22 seconds (healthy)
env_wazuh-agent4_1    24 seconds ago   Up 23 seconds (healthy)
env_wazuh-agent3_1    25 seconds ago   Up 23 seconds (healthy)
env_wazuh-agent2_1    25 seconds ago   Up 24 seconds (healthy)
env_wazuh-agent1_1    26 seconds ago   Up 25 seconds (unhealthy)
env_wazuh-worker2_1   27 seconds ago   Up 25 seconds (healthy)
env_wazuh-worker1_1   27 seconds ago   Up 26 seconds (healthy)
env_wazuh-master_1    27 seconds ago   Up 25 seconds (healthy)

...
```

Regards