### PR TITLE
8408 monitord clean install and update

### DIFF
--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -924,7 +924,6 @@ InstallLocal()
 
     ${INSTALL} -m 0750 -o root -g 0 wazuh-agentlessd ${INSTALLDIR}/bin
     ${INSTALL} -m 0750 -o root -g 0 wazuh-analysisd ${INSTALLDIR}/bin
-    ${INSTALL} -m 0750 -o root -g 0 wazuh-monitord ${INSTALLDIR}/bin
     ${INSTALL} -m 0750 -o root -g 0 wazuh-reportd ${INSTALLDIR}/bin
     ${INSTALL} -m 0750 -o root -g 0 wazuh-maild ${INSTALLDIR}/bin
     ${INSTALL} -m 0750 -o root -g 0 wazuh-logtest-legacy ${INSTALLDIR}/bin

--- a/src/init/update.sh
+++ b/src/init/update.sh
@@ -403,6 +403,16 @@ UpdateStopOSSEC()
     if [ -d "$PREINSTALLEDDIR/queue/rootcheck" ]; then
         rm -rf $PREINSTALLEDDIR/queue/rootcheck > /dev/null 2>&1
     fi
+
+    # Deleting monitord if exists (it was migrated to Wazuh modules in v5.0)
+    # Version 4.1 and below
+    if [ -f "$PREINSTALLEDDIR/bin/ossec-monitord" ]; then
+        rm -rf $PREINSTALLEDDIR/bin/ossec-monitord > /dev/null 2>&1
+    fi
+    # Version 4.2
+    if [ -f "$PREINSTALLEDDIR/bin/wazuh-monitord" ]; then
+        rm -rf $PREINSTALLEDDIR/bin/wazuh-monitord > /dev/null 2>&1
+    fi
 }
 
 UpdateOldVersions()

--- a/src/init/wazuh-local.sh
+++ b/src/init/wazuh-local.sh
@@ -26,7 +26,7 @@ if [ $? = 0 ]; then
 fi
 
 AUTHOR="Wazuh Inc."
-DAEMONS="wazuh-modulesd wazuh-monitord wazuh-logcollector wazuh-syscheckd wazuh-analysisd wazuh-maild wazuh-execd wazuh-db wazuh-agentlessd wazuh-integratord wazuh-dbd wazuh-csyslogd"
+DAEMONS="wazuh-modulesd wazuh-logcollector wazuh-syscheckd wazuh-analysisd wazuh-maild wazuh-execd wazuh-db wazuh-agentlessd wazuh-integratord wazuh-dbd wazuh-csyslogd"
 
 # Reverse order of daemons
 SDAEMONS=$(echo $DAEMONS | awk '{ for (i=NF; i>1; i--) printf("%s ",$i); print $1; }')

--- a/src/init/wazuh-server.sh
+++ b/src/init/wazuh-server.sh
@@ -27,7 +27,7 @@ fi
 
 AUTHOR="Wazuh Inc."
 USE_JSON=false
-DAEMONS="wazuh-clusterd wazuh-modulesd wazuh-monitord wazuh-logcollector wazuh-remoted wazuh-syscheckd wazuh-analysisd wazuh-maild wazuh-execd wazuh-db wazuh-authd wazuh-agentlessd wazuh-integratord wazuh-dbd wazuh-csyslogd wazuh-apid"
+DAEMONS="wazuh-clusterd wazuh-modulesd wazuh-logcollector wazuh-remoted wazuh-syscheckd wazuh-analysisd wazuh-maild wazuh-execd wazuh-db wazuh-authd wazuh-agentlessd wazuh-integratord wazuh-dbd wazuh-csyslogd wazuh-apid"
 OP_DAEMONS="wazuh-clusterd wazuh-maild wazuh-agentlessd wazuh-integratord wazuh-dbd wazuh-csyslogd"
 
 # Reverse order of daemons


### PR DESCRIPTION
|Related issue|
|---|
|close #8408 |

## Description
This PR aims to remove monitord from install scripts and remove it when an update is being perform.

## DoD
- [X] script changes.
- [X] manual test upgrading from 4.1.
- [X] manual test upgrading from 5.0-dev
- [X] manual tests on fresh install.