### PR TITLE
Set package revision to 0 when missing in Vulnerability Detector

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -2326,18 +2326,18 @@ void test_wm_checks_package_vulnerability_no_revision_rpm(void **state)
 
     int ret = wm_checks_package_vulnerability(version_a, operation, version_b, VER_TYPE_RPM);
 
-    assert_int_equal(VU_ERROR_CMP, ret);
+    assert_int_equal(VU_VULNERABLE, ret);
 }
 
 void test_wm_checks_package_vulnerability_no_revision_rpm_centos(void **state)
 {
     char *version_a = "5.3.2";
-    char *version_b = "6.1.1-23";
+    char *version_b = "6.1.1";
     char *operation = "less than";
 
     int ret = wm_checks_package_vulnerability(version_a, operation, version_b, VER_TYPE_RPM_CENTOS);
 
-    assert_int_equal(VU_ERROR_CMP, ret);
+    assert_int_equal(VU_VULNERABLE, ret);
 }
 
 void test_wm_checks_package_vulnerability_lt_no_revision(void **state)

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -660,10 +660,10 @@ int wm_checks_package_vulnerability(char *version_a, const char *operation, cons
         os_calloc(1, sizeof(struct pkg_version), package_feed_version);
         package_version->epoch = epoch;
         package_version->version = version_it;
-        package_version->revision = release_it;
+        package_version->revision = release_it ? release_it : "0";
         package_feed_version->epoch = c_epoch;
         package_feed_version->version = cversion_it;
-        package_feed_version->revision = crelease_it;
+        package_feed_version->revision = crelease_it ? crelease_it : "0";
 
         if (!strcmp(operation, vu_package_comp[VU_COMP_L])) {
             feed_condition = PKG_RELATION_LT;
@@ -682,7 +682,7 @@ int wm_checks_package_vulnerability(char *version_a, const char *operation, cons
 
         // This sanity is included since you cannot always expect a revision to come,
         // since it is a data provided by the agent.
-        if ((vertype == VER_TYPE_RPM_CENTOS || vertype == VER_TYPE_RPM) && (NULL == package_version->version || NULL == package_version->revision)) {
+        if ((vertype == VER_TYPE_RPM_CENTOS || vertype == VER_TYPE_RPM) && (NULL == package_version->version)) {
             ret = VU_ERROR_CMP;
             goto clean;
         }


### PR DESCRIPTION
## Description

This pull request imports https://github.com/wazuh/wazuh/pull/8474 to 4.2.

The aim of this pull request is to set a default value for the revision part of the version compared by Vulnerability Detector when they are missing.

That avoids skipping the comparison setting the error value `VU_ERROR_CMP` when versions to be compared doesn't contain a revision. To avoid the segmentation fault, they are set to 0 since it doesn't change the comparison result in case any of them is missing.

This was making the integration tests fail because the sample data include packages with simple versions: https://github.com/wazuh/wazuh-qa/blob/e216afb4c1580cc0ae6ecf2577b110dcf10f1232/tests/integration/test_vulnerability_detector/test_scan_results/data/vulnerabilities.json#L64

Triggering the following error:

```
2021/04/30 18:41:48 wazuh-modulesd:vulnerability-detector[16931] wm_vuln_detector.c:1978 at wm_vuldet_linux_oval_vulnerabilities(): DEBUG: (5487): Unknown relation 'less than' between versions '0.9' and '1.0.0' for package 'wazuhintegrationpackage-5'
```

## Logs/Alerts example

**Before**

```
Tier 0:
=========================== short test summary info ============================
FAILED test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.py::test_run_on_start[run_on_start_yes]
FAILED test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py::test_redhat_vulnerabilities_report[redhat_scan_configuration-RHEL8]
FAILED test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py::test_redhat_vulnerabilities_report[redhat_scan_configuration-RHEL7]
FAILED test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py::test_redhat_vulnerabilities_report[redhat_scan_configuration-RHEL6]
FAILED test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py::test_redhat_vulnerabilities_report[redhat_scan_configuration-RHEL5]
FAILED test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL8]
FAILED test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL7]
FAILED test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL6]
FAILED test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL5]

Tier 1:
=========================== short test summary info ============================
FAILED test_vulnerability_detector/test_scan_results/test_scan_different_cves.py::test_vulnerabilities_report[test_different_cves-RHEL8]
FAILED test_vulnerability_detector/test_scan_results/test_scan_different_cves.py::test_vulnerabilities_report[test_different_cves-RHEL7]
FAILED test_vulnerability_detector/test_scan_results/test_scan_different_cves.py::test_vulnerabilities_report[test_different_cves-RHEL6]
FAILED test_vulnerability_detector/test_scan_results/test_scan_different_cves.py::test_vulnerabilities_report[test_different_cves-RHEL5]
```

**After**

```
Tier 0:
test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.py::test_run_on_start[run_on_start_yes] PASSED [ 50%]
test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py::test_redhat_vulnerabilities_report[redhat_scan_configuration-RHEL8] PASSED [ 25%]
test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py::test_redhat_vulnerabilities_report[redhat_scan_configuration-RHEL7] PASSED [ 50%]
test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py::test_redhat_vulnerabilities_report[redhat_scan_configuration-RHEL6] PASSED [ 75%]
test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py::test_redhat_vulnerabilities_report[redhat_scan_configuration-RHEL5] PASSED [100%]
test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL8] PASSED [ 11%]
test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL7] PASSED [ 22%]
test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL6] PASSED [ 33%]
test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL5] PASSED [ 44%]

Tier 1:
test_vulnerability_detector/test_scan_results/test_scan_different_cves.py::test_vulnerabilities_report[test_different_cves-RHEL8] PASSED [ 11%]
test_vulnerability_detector/test_scan_results/test_scan_different_cves.py::test_vulnerabilities_report[test_different_cves-RHEL7] PASSED [ 22%]
test_vulnerability_detector/test_scan_results/test_scan_different_cves.py::test_vulnerabilities_report[test_different_cves-RHEL6] PASSED [ 33%]
test_vulnerability_detector/test_scan_results/test_scan_different_cves.py::test_vulnerabilities_report[test_different_cves-RHEL5] PASSED [ 44%]
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Added unit tests (for new features)
