### PR TITLE
Join cluster messages when they have been divided

### DIFF
--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -597,13 +597,13 @@ class Handler(asyncio.Protocol):
         self.in_buffer += message
         for command, counter, payload, flag_divided in self.get_messages():
             # If the message is a divided one
-            if flag_divided == b'd':
+            if flag_divided == InBuffer.divide_flag.strip():
                 try:
                     self.div_msg_box[counter] = self.div_msg_box[counter] + payload
                 except KeyError:
                     self.div_msg_box[counter] = payload
             # If the message is the last part of a division
-            elif flag_divided == b'e':
+            elif flag_divided == InBuffer.end_divide_flag.strip():
                 payload = self.div_msg_box[counter] + payload
                 del self.div_msg_box[counter]
                 flag_divided = b''

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -465,7 +465,6 @@ class WazuhException(Exception):
                'remediation': f"[Update](https://documentation.wazuh.com/{WAZUH_VERSION}/upgrade-guide/index.html)"
                               " master and workers to the same version."},
         3032: "Could not forward DAPI request. Connection not available.",
-        3033: "Payload length exceeds limit defined in wazuh.cluster.common.Handler.request_chunk.",
         3034: "Error sending file. File not found.",
         3035: "String couldn't be found",
         3036: "JSON couldn't be loaded",


### PR DESCRIPTION
|Related issue|
|---|
| #7137 |

Hi team,

This PR closes #7137.

In this pull request, I have added a new mechanism in the `data_received` function of `core/cluster/common.py` to join messages that have been divided because their sizes were bigger than `request_chunk`.

I have included a `dict` type variable called `div_msg_box` to save parts of divided messages. This parts are merged when a new message with same ID (counter) is received. When the last part of the message is received (see #7136), the whole message is joined and the process continues as it used to.

Regards,
Manuel.