### PR TITLE
Change level of cluster log message

### DIFF
--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -233,7 +233,7 @@ def walk_dir(dirname, recursive, files, excluded_files, excluded_extensions, get
                                            get_cluster_item_key, get_md5))
 
         except Exception as e:
-            logger.error(f"Could not get checksum of file {entry}: {e}")
+            logger.debug(f"Could not get checksum of file {entry}: {e}")
 
     return walk_files
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes #8463 |

## Description

Hey team!

This PR contains a small change so that, in case of iterating a file listed and already deleted as described in X, it is not logged as an error but as a debug message.

**Before:**
```
2021/05/04 09:34:39 DEBUG: [Local Server] [Main] Calculating.
2021/05/04 09:34:39 DEBUG: [Local Server] [Main] Calculated.
2021/05/04 09:34:39 INFO: [Worker worker1] [Main] Sucessful response from master: keepalive
2021/05/04 09:40:24 ERROR: [Worker worker1] [Main] Could not get checksum of file test_rule.xml: [Errno 2] No such file or directory: '/var/ossec/etc/rules/test_rule.xml'
Traceback (most recent call last):
  File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.2.0-py3.9.egg/wazuh/core/cluster/cluster.py", line 205, in walk_dir
    file_mod_time = datetime.utcfromtimestamp(stat(os.path.join(common.wazuh_path, full_path)).st_mtime)
FileNotFoundError: [Errno 2] No such file or directory: '/var/ossec/etc/rules/test_rule.xml'
```

**Now:**
```
2021/05/04 09:41:08 DEBUG: [Local Server] [Main] Calculating.
2021/05/04 09:41:08 DEBUG: [Local Server] [Main] Calculated.
2021/05/04 09:41:08 INFO: [Worker worker1] [Main] Sucessfully connected to master.
2021/05/04 09:42:04 DEBUG: [Worker worker1] [Main] Could not get checksum of file test_rule.xml: [Errno 2] No such file or directory: '/var/ossec/etc/rules/test_rule.xml'
```

Regards,
Selu.