### PR TITLE
Refactor send_request usage with the new cluster msg chunk feature

### DIFF
--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -279,7 +279,7 @@ class Handler(asyncio.Protocol):
         # Stores incoming string information from string commands.
         self.in_str = {}
         # Maximum message length to send in a single request.
-        self.request_chunk = 200
+        self.request_chunk = 5242880
         # Object use to encrypt and decrypt requests.
         self.my_fernet = cryptography.fernet.Fernet(base64.b64encode(fernet_key.encode())) if fernet_key else None
         # Logging.Logger object used to write logs.


### PR DESCRIPTION
|Related issue|
|---|
| #7187 |

Hi team,

This PR closes https://github.com/wazuh/wazuh/issues/7187.

In this pull request, I have fixed errors regarding the cluster messages division and union. I have also refactored places where we were manually dividing the messages into chunks.

Errors found when testing the division + union:

**1.- First error:**

```
2021/05/04 07:01:44 ERROR: [Local 765665] [Main] Internal error processing request 'b'dapi_forward'': Error 3022 - Unknown node ID
2021/05/04 07:01:44 ERROR: [Local 765665] [Main] Error during connection with '765665': [Errno 32] Broken pipe.
  File "/var/ossec/framework/python/lib/python3.9/asyncio/selector_events.py", line 918, in write
    n = self._sock.send(data)
```

With verbose, we can see the message was divided but the flag is not `b'd'` (the flag is the **Byte** shown at the end of each log):

```
2021/05/04 07:13:40 INFO: [Client] [Main] ---- (b'dapi_forward', 1652790332, b'worker2 {"f": {"__callable__": {"__name__": "restart_agents", "__module__": "wazuh.agent", "__qualname__": "restart_agents", "__type__": "function"}}, "f_kwargs": {"agent_list": ', b'')
...
2021/05/04 07:13:40 INFO: [Local 761608] [Main] ---- (b'dapi_forward', 1652790332, b'ow"}, "rbac_mode": "white"}, "current_user": "", "broadcasting": true, "nodes": []}', b'')
2021/05/04 07:13:40 ERROR: [Local 761608] [Main] Internal error processing request 'b'dapi_forward'': Error 3022 - Unknown node ID
2021/05/04 07:13:40 ERROR: [Local 761608] [Main] Error during connection with '761608': [Errno 32] Broken pipe.
  File "/var/ossec/framework/python/lib/python3.9/asyncio/selector_events.py", line 918, in write
    n = self._sock.send(data)
```

    
The problem is the command doesn't have any `'-'`, so the flag position is not `cmd_split[2]`.

**Example:** 

`dapi_forward e`
    
The solution is a new `flag_divided` variable declaration (in `get_info_from_header` method of `InBuffer` Class):

`self.flag_divided = cmd_split[len(cmd_split)-1] if cmd_split[len(cmd_split)-1] in [b'd', b'e'] else b''`


**2.- Second error:**

```
2021/05/04 12:21:00 ERROR: [Worker worker1] [Main] Error during connection with 'worker1': Error 3025 - Could not decrypt message: .
  File "/var/ossec/framework/python/lib/python3.9/asyncio/selector_events.py", line 870, in _read_ready__data_received
    self._protocol.data_received(data)
  File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.3.0-py3.9.egg/wazuh/core/cluster/common.py", line 595, in data_received
    for command, counter, payload, flag_divided in self.get_messages():
  File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.3.0-py3.9.egg/wazuh/core/cluster/common.py", line 428, in get_messages
    raise exception.WazuhClusterError(3025, extra_message=e)
```
    
I was trying to decrypt divided messages. This wasn't correct as messages were encrypted when they were together. Solution: decrypt the message once it has been joined.

**3.- Refactor needed:**

Conflict with the old chunk division of `new_file` and `file_upd`.
The error appears with splitted command: `[b'new_file', b'---', b'd']`

**Refactor:**

I have changed the `new_file` and `file_upd` requests, now it is not necessary to divide in chunks as the `send_request` function does it.
`file_end` command is necessary as we are checking the file was correctly passed.
Similar changes to `str_upd`.

### Tests:

- Cluster working:

I have tested the cluster with a `request_chunk=200`. This means a lot of messages are divided into chunks and joined using the new feature.
File updates are tested when running the cluster.
API calls, example: restart agents (requires more than 200B) is done properly.

- API integration tests and unittests:

I have left request_chunk to 200B.

```
framework/wazuh/core/cluster/dapi/tests/
======== 23 passed, 9 warnings in 0.59s ========

framework/wazuh/core/cluster/tests/
======== 56 passed, 4 warnings in 0.43s ========
```

Rest of unittests passing.

```
test_cluster_endpoints.tavern.yaml 
	 44 passed, 1 xpassed, 47 warnings

test_rbac_black_cluster_endpoints.tavern.yaml 
	 17 passed, 19 warnings

test_rbac_white_cluster_endpoints.tavern.yaml 
	 17 passed, 19 warnings

test_security_DELETE_endpoints.tavern.yaml 
	 15 passed, 17 warnings

test_security_GET_endpoints.tavern.yaml 
	 11 passed, 13 warnings

test_security_POST_endpoints.tavern.yaml 
	 7 passed, 9 warnings
```
