### PR TITLE
Fix API remediation message

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -621,7 +621,7 @@ components:
             $ref: '#/components/schemas/RequestError'
           example:
             title: "Wazuh Error"
-            detail: "Maximum number of request per minute reached"
+            detail: "Maximum number of requests per minute reached"
             remediation: "This limit can be changed in api.yaml file. More information here:
             https://documentation.wazuh.com/4.3/user-manual/api/security/configuration.html"
             code: 6001

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -622,7 +622,7 @@ components:
           example:
             title: "Wazuh Error"
             detail: "Maximum number of request per minute reached"
-            remediation: "This limit can be changed in security.yaml file. More information here:
+            remediation: "This limit can be changed in api.yaml file. More information here:
             https://documentation.wazuh.com/4.3/user-manual/api/security/configuration.html"
             code: 6001
 

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -549,7 +549,7 @@ class WazuhException(Exception):
         6000: {'message': 'Limit of login attempts reached. '
                           'The current IP has been blocked due to a high number of login attempts'},
         6001: {'message': 'Maximum number of request per minute reached',
-               'remediation': f'This limit can be changed in security.yaml file. More information here: https://documentation.wazuh.com/{WAZUH_VERSION}/user-manual/api/configuration.html#configuration-file'},
+               'remediation': f'This limit can be changed in api.yaml file. More information here: https://documentation.wazuh.com/{WAZUH_VERSION}/user-manual/api/configuration.html#configuration-file'},
         6002: {'message': 'The body type is not the one specified in the content-type'},
         6003: {'message': 'Error trying to load the JWT secret',
                'remediation': 'Make sure you have the right permissions: WAZUH_PATH/api/configuration/security/jwt_secret'},

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -548,7 +548,7 @@ class WazuhException(Exception):
         # Security issues
         6000: {'message': 'Limit of login attempts reached. '
                           'The current IP has been blocked due to a high number of login attempts'},
-        6001: {'message': 'Maximum number of request per minute reached',
+        6001: {'message': 'Maximum number of requests per minute reached',
                'remediation': f'This limit can be changed in api.yaml file. More information here: https://documentation.wazuh.com/{WAZUH_VERSION}/user-manual/api/configuration.html#configuration-file'},
         6002: {'message': 'The body type is not the one specified in the content-type'},
         6003: {'message': 'Error trying to load the JWT secret',


### PR DESCRIPTION
|Related issue|
|---|
| Closes #8534 |

## Description

Hi team!

This PR the `6001` remediation message:
https://github.com/wazuh/wazuh/blob/0a320a0aedf3c113317b044f365ee916fd3249f0/framework/wazuh/core/exception.py#L552

The `maximum number of requests per minute ` that the API allows can be defined in the `api.yaml`, not in the `security.yaml`.

Regards,
Selu. 