### PR TITLE
Fix/7397 disordered sort fields in all endpoints

### DIFF
--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -1167,8 +1167,7 @@ class WazuhDBQuery(object):
                 # check every element in sort['fields'] is in allowed_sort_fields
                 if not self._check_allowed_sort_fields(allowed_sort_fields):
                     raise WazuhError(1403, "Allowed sort fields: {}. Fields: {}".format(
-                        sorted(allowed_sort_fields, key=str), ', '.join(self.sort['fields'] - allowed_sort_fields)
-                    ))
+                        sorted(allowed_sort_fields, key=str), sorted(self.sort['fields'])))
                 self.query += ' ORDER BY ' + ','.join([self._sort_query(i) for i in self.sort['fields']])
             else:
                 self.query += ' ORDER BY {0} {1}'.format(self.default_sort_field, self.sort['order'])

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -1153,16 +1153,23 @@ class WazuhDBQuery(object):
     def _sort_query(self, field):
         return '{} {}'.format(self.fields[field], self.sort['order'])
 
+    def _check_allowed_sort_fields(self, allowed_sort_fields):
+
+        for field in self.sort['fields']:
+            if field not in allowed_sort_fields:
+                return False
+        return True
+
     def _add_sort_to_query(self):
         if self.sort:
             if self.sort['fields']:
-                sort_fields, allowed_sort_fields = set(self.sort['fields']), set(self.fields.keys())
+                allowed_sort_fields = set(self.fields.keys())
                 # check every element in sort['fields'] is in allowed_sort_fields
-                if not sort_fields.issubset(allowed_sort_fields):
-                    raise WazuhError(1403, "Allowerd sort fields: {}. Fields: {}".format(
-                        sorted(allowed_sort_fields, key=str), ', '.join(sort_fields - allowed_sort_fields)
+                if not self._check_allowed_sort_fields(allowed_sort_fields):
+                    raise WazuhError(1403, "Allowed sort fields: {}. Fields: {}".format(
+                        sorted(allowed_sort_fields, key=str), ', '.join(self.sort['fields'] - allowed_sort_fields)
                     ))
-                self.query += ' ORDER BY ' + ','.join([self._sort_query(i) for i in sort_fields])
+                self.query += ' ORDER BY ' + ','.join([self._sort_query(i) for i in self.sort['fields']])
             else:
                 self.query += ' ORDER BY {0} {1}'.format(self.default_sort_field, self.sort['order'])
         else:

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2115,26 +2115,26 @@ class AWSCLBBucket(AWSCustomBucket):
 class AWSNLBBucket(AWSCustomBucket):
 
     def __init__(self, **kwargs):
-        db_table_name = 'nlb'
-        # AWSCustomBucket.__init__(self, db_table_name, **kwargs)
+        db_table_name = 'clb'
+        AWSCustomBucket.__init__(self, db_table_name, **kwargs)
 
     def load_information_from_file(self, log_key):
-        """Load data from a NLB access log file."""
-        with open(log_key, "r+") as file:
+        """Load data from a CLB access log file."""
+        with self.decompress_file(log_key=log_key) as f:
             fieldnames = (
-                "type", "version", "time", "elb", "listener", "client_ip", "destination_ip", "connection_time",
-                "tls_handshake_time", "received_bytes", "sent_bytes", "incoming_tls_alert", "chosen_cert_arn",
-                "chosen_cert_serial", "tls_cipher", "tls_protocol_version", "tls_named_group", "domain_name",
-                "alpn_fe_protocol", "alpn_client_preference_list")
-            tsv_file = csv.DictReader(file, fieldnames=fieldnames, delimiter=' ')
+                "time", "elb", "client_port", "backend_port", "request_processing_time", "backend_processing_time",
+                "response_processing_time", "elb_status_code", "backend_status_code", "received_bytes", "sent_bytes",
+                "request", "user_agent", "ssl_cipher", "ssl_protocol")
+            tsv_file = csv.DictReader(f, fieldnames=fieldnames, delimiter=' ')
 
-            tsv_file = [dict(x, source='nlb') for x in tsv_file]
+            [dict(x, source='clb') for x in tsv_file]
 
             # Split ip_addr:port field into ip_addr and port fields
             for log_entry in tsv_file:
                 fields = log_entry['client_ip'].split(':'), log_entry['destination_ip'].split(':')
                 log_entry['client_ip'], log_entry['client_port'] = fields[0][0], fields[0][1]
                 log_entry['destination_ip'], log_entry['destination_port'] = fields[1][0], fields[1][1]
+<<<<<<< HEAD
 <<<<<<< HEAD
 
 <<<<<<< HEAD
@@ -2155,6 +2155,9 @@ class AWSNLBBucket(AWSCustomBucket):
 =======
                 print(log_entry)
 >>>>>>> Change files to offline testing
+=======
+
+>>>>>>> Change code to online version with the new parsing
             return tsv_file
 
 
@@ -3016,19 +3019,11 @@ def main(argv):
         sys.exit(12)
 
 
-def main_de_enrique():
-    bucket_type = AWSNLBBucket()
-
-    file = './166157441623_elasticloadbalancing_us-west-1_net.demo-3130-prod-Wazuh.f279b3dd67f9c98e_20200801T0050Z_256f6bdd.log'
-
-    bucket_type.load_information_from_file(file)
-
 if __name__ == '__main__':
     try:
         debug('Args: {args}'.format(args=str(sys.argv)), 2)
         signal.signal(signal.SIGINT, handler)
-        # main(sys.argv[1:])
-        main_de_enrique()
+        main(sys.argv[1:])
         sys.exit(0)
     except Exception as e:
         print("Unknown error: {}".format(e))

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2118,9 +2118,9 @@ class AWSNLBBucket(AWSCustomBucket):
         db_table_name = 'nlb'
         AWSCustomBucket.__init__(self, db_table_name, **kwargs)
 
-    def load_information_from_file(self, file):
-        """Load data from a CLB access log file."""
-        with self.decompress_file(log_key=file) as f:
+    def load_information_from_file(self, log_key):
+        """Load data from a NLB access log file."""
+        with self.decompress_file(log_key=log_key) as f:
             fieldnames = (
                 "type", "version", "time", "elb", "listener", "client_ip", "destination_ip", "connection_time",
                 "tls_handshake_time", "received_bytes", "sent_bytes", "incoming_tls_alert", "chosen_cert_arn",

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2132,6 +2132,7 @@ class AWSNLBBucket(AWSCustomBucket):
 
             # Split ip_addr:port field into ip_addr and port fields
             for log_entry in tsv_file:
+<<<<<<< HEAD
                 fields = log_entry['client_ip'].split(':'), log_entry['destination_ip'].split(':')
                 log_entry['client_ip'], log_entry['client_port'] = fields[0][0], fields[0][1]
                 log_entry['destination_ip'], log_entry['destination_port'] = fields[1][0], fields[1][1]
@@ -2140,6 +2141,10 @@ class AWSNLBBucket(AWSCustomBucket):
 
 <<<<<<< HEAD
             tsv_file = [dict(x, source='nlb') for x in tsv_file]
+=======
+                log_entry['client_ip'], log_entry['client_port'] = log_entry['client_ip'].split(':')
+                log_entry['destination_ip'], log_entry['destination_port'] = log_entry['destination_ip'].split(':')
+>>>>>>> Enhance code
 
             # Split ip_addr:port field into ip_addr and port fields
             for log_entry in tsv_file:

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2122,49 +2122,13 @@ class AWSNLBBucket(AWSCustomBucket):
         """Load data from a NLB access log file."""
         with self.decompress_file(log_key=log_key) as f:
             fieldnames = (
-                "type", "version", "time", "elb", "listener", "client_ip", "destination_ip", "connection_time",
+                "type", "version", "time", "elb", "listener", "client_port", "destination_port", "connection_time",
                 "tls_handshake_time", "received_bytes", "sent_bytes", "incoming_tls_alert", "chosen_cert_arn",
                 "chosen_cert_serial", "tls_cipher", "tls_protocol_version", "tls_named_group", "domain_name",
                 "alpn_fe_protocol", "alpn_client_preference_list")
             tsv_file = csv.DictReader(f, fieldnames=fieldnames, delimiter=' ')
 
-            tsv_file = [dict(x, source='nlb') for x in tsv_file]
-
-            # Split ip_addr:port field into ip_addr and port fields
-            for log_entry in tsv_file:
-<<<<<<< HEAD
-                fields = log_entry['client_ip'].split(':'), log_entry['destination_ip'].split(':')
-                log_entry['client_ip'], log_entry['client_port'] = fields[0][0], fields[0][1]
-                log_entry['destination_ip'], log_entry['destination_port'] = fields[1][0], fields[1][1]
-<<<<<<< HEAD
-<<<<<<< HEAD
-
-<<<<<<< HEAD
-            tsv_file = [dict(x, source='nlb') for x in tsv_file]
-=======
-                log_entry['client_ip'], log_entry['client_port'] = log_entry['client_ip'].split(':')
-                log_entry['destination_ip'], log_entry['destination_port'] = log_entry['destination_ip'].split(':')
->>>>>>> Enhance code
-
-            # Split ip_addr:port field into ip_addr and port fields
-            for log_entry in tsv_file:
-                try:
-                    log_entry['client_ip'], log_entry['client_port'] = log_entry['client_port'].split(':')
-                    log_entry['destination_ip'], log_entry['destination_port'] = \
-                        log_entry['destination_port'].split(':')
-                except ValueError:
-                    log_entry['client_ip'] = log_entry['client_port']
-                    log_entry['destination_ip'] = log_entry['destination_port']
-
-=======
->>>>>>> Add fix to nlb parsing
-=======
-                print(log_entry)
->>>>>>> Change files to offline testing
-=======
-
->>>>>>> Change code to online version with the new parsing
-            return tsv_file
+            return [dict(x, source='nlb') for x in tsv_file]
 
 
 class AWSService(WazuhIntegration):

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -682,10 +682,8 @@ class AWSBucket(WazuhIntegration):
                 # Python 2
                 return gzip.GzipFile(fileobj=raw_object, mode='r')
 
-        print('dec hola')
         raw_object = io.BytesIO(self.client.get_object(Bucket=self.bucket, Key=log_key)['Body'].read())
         if log_key[-3:] == '.gz':
-            print('dec hola')
             return decompress_gzip(raw_object)
         elif log_key[-4:] == '.zip':
             zipfile_object = zipfile.ZipFile(raw_object, compression=zipfile.ZIP_DEFLATED)
@@ -2118,7 +2116,7 @@ class AWSNLBBucket(AWSCustomBucket):
 
     def __init__(self, **kwargs):
         db_table_name = 'nlb'
-        AWSCustomBucket.__init__(self, db_table_name, **kwargs)
+        # AWSCustomBucket.__init__(self, db_table_name, **kwargs)
 
     def load_information_from_file(self, log_key):
         """Load data from a NLB access log file."""
@@ -2137,6 +2135,7 @@ class AWSNLBBucket(AWSCustomBucket):
                 fields = log_entry['client_ip'].split(':'), log_entry['destination_ip'].split(':')
                 log_entry['client_ip'], log_entry['client_port'] = fields[0][0], fields[0][1]
                 log_entry['destination_ip'], log_entry['destination_port'] = fields[1][0], fields[1][1]
+<<<<<<< HEAD
 
 <<<<<<< HEAD
             tsv_file = [dict(x, source='nlb') for x in tsv_file]
@@ -2153,6 +2152,9 @@ class AWSNLBBucket(AWSCustomBucket):
 
 =======
 >>>>>>> Add fix to nlb parsing
+=======
+                print(log_entry)
+>>>>>>> Change files to offline testing
             return tsv_file
 
 
@@ -3014,11 +3016,19 @@ def main(argv):
         sys.exit(12)
 
 
+def main_de_enrique():
+    bucket_type = AWSNLBBucket()
+
+    file = './166157441623_elasticloadbalancing_us-west-1_net.demo-3130-prod-Wazuh.f279b3dd67f9c98e_20200801T0050Z_256f6bdd.log'
+
+    bucket_type.load_information_from_file(file)
+
 if __name__ == '__main__':
     try:
         debug('Args: {args}'.format(args=str(sys.argv)), 2)
         signal.signal(signal.SIGINT, handler)
-        main(sys.argv[1:])
+        # main(sys.argv[1:])
+        main_de_enrique()
         sys.exit(0)
     except Exception as e:
         print("Unknown error: {}".format(e))

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -682,8 +682,10 @@ class AWSBucket(WazuhIntegration):
                 # Python 2
                 return gzip.GzipFile(fileobj=raw_object, mode='r')
 
+        print('dec hola')
         raw_object = io.BytesIO(self.client.get_object(Bucket=self.bucket, Key=log_key)['Body'].read())
         if log_key[-3:] == '.gz':
+            print('dec hola')
             return decompress_gzip(raw_object)
         elif log_key[-4:] == '.zip':
             zipfile_object = zipfile.ZipFile(raw_object, compression=zipfile.ZIP_DEFLATED)
@@ -2120,14 +2122,23 @@ class AWSNLBBucket(AWSCustomBucket):
 
     def load_information_from_file(self, log_key):
         """Load data from a NLB access log file."""
-        with self.decompress_file(log_key=log_key) as f:
+        with open(log_key, "r+") as file:
             fieldnames = (
-                "type", "version", "time", "elb", "listener", "client_port", "destination_port", "connection_time",
+                "type", "version", "time", "elb", "listener", "client_ip", "destination_ip", "connection_time",
                 "tls_handshake_time", "received_bytes", "sent_bytes", "incoming_tls_alert", "chosen_cert_arn",
                 "chosen_cert_serial", "tls_cipher", "tls_protocol_version", "tls_named_group", "domain_name",
                 "alpn_fe_protocol", "alpn_client_preference_list")
-            tsv_file = csv.DictReader(f, fieldnames=fieldnames, delimiter=' ')
+            tsv_file = csv.DictReader(file, fieldnames=fieldnames, delimiter=' ')
 
+            tsv_file = [dict(x, source='nlb') for x in tsv_file]
+
+            # Split ip_addr:port field into ip_addr and port fields
+            for log_entry in tsv_file:
+                fields = log_entry['client_ip'].split(':'), log_entry['destination_ip'].split(':')
+                log_entry['client_ip'], log_entry['client_port'] = fields[0][0], fields[0][1]
+                log_entry['destination_ip'], log_entry['destination_port'] = fields[1][0], fields[1][1]
+
+<<<<<<< HEAD
             tsv_file = [dict(x, source='nlb') for x in tsv_file]
 
             # Split ip_addr:port field into ip_addr and port fields
@@ -2140,6 +2151,8 @@ class AWSNLBBucket(AWSCustomBucket):
                     log_entry['client_ip'] = log_entry['client_port']
                     log_entry['destination_ip'] = log_entry['destination_port']
 
+=======
+>>>>>>> Add fix to nlb parsing
             return tsv_file
 
 

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2115,19 +2115,20 @@ class AWSCLBBucket(AWSCustomBucket):
 class AWSNLBBucket(AWSCustomBucket):
 
     def __init__(self, **kwargs):
-        db_table_name = 'clb'
+        db_table_name = 'nlb'
         AWSCustomBucket.__init__(self, db_table_name, **kwargs)
 
-    def load_information_from_file(self, log_key):
+    def load_information_from_file(self, file):
         """Load data from a CLB access log file."""
-        with self.decompress_file(log_key=log_key) as f:
+        with self.decompress_file(log_key=file) as f:
             fieldnames = (
-                "time", "elb", "client_port", "backend_port", "request_processing_time", "backend_processing_time",
-                "response_processing_time", "elb_status_code", "backend_status_code", "received_bytes", "sent_bytes",
-                "request", "user_agent", "ssl_cipher", "ssl_protocol")
+                "type", "version", "time", "elb", "listener", "client_ip", "destination_ip", "connection_time",
+                "tls_handshake_time", "received_bytes", "sent_bytes", "incoming_tls_alert", "chosen_cert_arn",
+                "chosen_cert_serial", "tls_cipher", "tls_protocol_version", "tls_named_group", "domain_name",
+                "alpn_fe_protocol", "alpn_client_preference_list")
             tsv_file = csv.DictReader(f, fieldnames=fieldnames, delimiter=' ')
 
-            [dict(x, source='clb') for x in tsv_file]
+            tsv_file = [dict(x, source='nlb') for x in tsv_file]
 
             # Split ip_addr:port field into ip_addr and port fields
             for log_entry in tsv_file:


### PR DESCRIPTION
|Related issue|
|---|
|#7397|


## Description

### Affected endpoints

```python
- /agents
- /groups
- /groups/{group_id}/agents
- /groups/{group_id}/files
- /agents/no_group
- /agetns/outdated
- /agents/stats/distinct 
- /ciscat/{agent_id}/results
- /cluster/nodes
- /cluster/{node_id}/logs
- /lists
- /lists/files
- /manager/logs 
- /mitre
- /rootcheck/{agent_id}
- /rules
- /rules/groups
- /rules/requirement/{requirement}
- /rules/files
- /sca/{agent_id}
- /sca/{agent_id}/checks/{policy_id}
- /syscheck/{agent_id}
- /decoders
- /decoders/files
- /decoders/parents
- /experimental/ciscat/results
- /experimental/syscollector/hardware
- /experimental/syscollector/netaddr
- /experimental/syscollector/netiface
- /experimental/syscollector/netproto
- /experimental/syscollector/os
- /experimental/syscollector/packages
- /experimental/syscollector/ports
- /experimental/syscollector/processes
- /experimental/syscollector/hotfixes
- /syscollector/{agent_id}/hotfixes
- /syscollector/{agent_id}/netaddr
- /syscollector/{agent_id}/netiface
- /syscollector/{agent_id}/netproto
- /syscollector/{agent_id}/packages
- /syscollector/{agent_id}/ports
- /syscollector/{agent_id}/processes
- /security/users
- /security/rules
- /security/policies
- /tasks/status
- /vulnerability/{agent_id}
```
## Tests

- Unit tests without failures. Updated and/or expanded if there are new functions/methods/outputs:
  - [x] Cluster (`framework/wazuh/core/cluster/tests/` & `framework/wazuh/core/cluster/dapi/tests/`)
  - [x] Core (`framework/wazuh/core/tests/`) 
  - [x] SDK (`framework/wazuh/tests/`)
  - [x] RBAC (`framework/wazuh/rbac/tests/`)
  - [x] API (`api/api/tests/`)
- API tavern integration tests without failures. Updated and/or expanded if needed (`api/test/integration/`):
  - [ ] Affected tests 
  - [ ] Affected RBAC (black and white) tests
- [ ] Review integration test mapping using the script (`api/test/integration/mapping/integration_test_api_endpoints.json`)
- [ ] Review of spec.yaml examples and schemas (`api/api/spec/spec.yaml`)
- [ ] Review exceptions remediation when any endpoint path changes or is removed (`framework/wazuh/core/exception.py`)
- [ ] Changelog (`CHANGELOG.md`)
<!-- If changes are made to any of the following components, uncomment the corresponding line 
- [ ] **Integration tests** without failures for API configuration (`/wazuh-qa/tests/integration/test_api/test_config/`)
- [ ] **System tests** for agent enrollment process (`/wazuh-qa/tests/system/test_cluster/test_agent_enrollment`)
- [ ] **System tests** for agent info sync process in cluster (`/wazuh-qa/tests/system/test_cluster/test_agent_info_sync`)
- [ ] **System tests** for agent key polling (`/wazuh-qa/tests/system/test_cluster/test_agent_key_polling`)
- [ ] **System tests** for JWT invalidation (`/wazuh-qa/tests/system/test_jwt_invalidation`)
-->
