### PR TITLE
Fix NULL address access hazard in Vulnerability Detector

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -1958,6 +1958,10 @@ int wm_vuldet_get_vuln_nvd_cpe(sqlite3 *db, agent_software *agent, wm_vuldet_fla
 
                             cpe_node = wm_vuldet_decode_cpe(uri + strlen(CPE_VER_TAG));
 
+                            if (cpe_node == NULL) {
+                                continue;
+                            }
+
                             nvd_report_node = wm_vuldet_check_nvd_vulnerability(db, agent, flags, agent_cpe, cve_id, nvd_cve_conf, vulnerable,
                                                                                 operator, parent, cpe_node->version,
                                                                                 v_start_inc, v_start_exc, v_end_inc, v_end_exc);
@@ -3935,7 +3939,7 @@ void wm_vuldet_free_cpe_list(cpe_list *node_list) {
 }
 
 void wm_vuldet_adapt_os_cpe(cpe *ag_cpe) {
-    if (*ag_cpe->part != 'o') {
+    if (ag_cpe == NULL || *ag_cpe->part != 'o') {
         return;
     }
 


### PR DESCRIPTION
|Related issue|
|---|
|#8324|

This PR aims to fix two vulnerabilities in Vulnerability Detector that may happen when parsing a CPE string with an unknown format while:

1. Fetching a CVE item from NVD:
```
Thread 9 "wazuh-modulesd" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffdf7fe700 (LWP 24334)]
0x0000555555626895 in wm_vuldet_adapt_os_cpe (ag_cpe=0x0) at wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c:3941
3941        if (*ag_cpe->part != 'o') {
```

2. Reading a previously fetched NVD item from the internal database on a Windows agent scan:
```
[Switching to Thread 0x7fffdf318700 (LWP 26021)]
0x000055555561d2af in wm_vuldet_get_vuln_nvd_cpe (db=0x7fffec04b518, agent=0x7fffec069740, flags=0x555555741440, agent_cpe=0x7fffec29e030,
    raw_product=0x7fffec086618 "Oracle VM VirtualBox 6.1.22", raw_version=0x7fffec087d88 "6.1.22", raw_arch=0x7fffec084ea8 "x86_64", nvd_report_list=0x7fffdf317da8)
    at wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c:1967
warning: Source file is more recent than executable.
```

## Proposed fix

- Discard that item and continue the scan.

## Tests

- [x] Build manager for Linux.
- [x] Force a corrupt CPE string condition when fetching the NVD feed.
- [x]  Force a corrupt CPE string condition when scanning a Windows agent.