### PR TITLE
Fixing MSSQL log source

### DIFF
--- a/ruleset/rules/0580-win-security_rules.xml
+++ b/ruleset/rules/0580-win-security_rules.xml
@@ -1039,26 +1039,6 @@
     <group>authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
-  <!-- MS SQL rules -->
-  <rule id="60198" level="5">
-    <if_sid>60104</if_sid>
-    <field name="win.system.eventID">^18456$</field>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-    <description>MS SQL Server Logon Failure</description>
-    <options>no_full_log</options>
-  </rule>
-
-  <rule id="60199" level="3">
-    <if_sid>60103</if_sid>
-    <field name="win.system.eventID">^18454$|^18453$</field>
-    <description>MS SQL Server Logon Success</description>
-    <options>no_full_log</options>
-    <mitre>
-      <id>T1078</id>
-    </mitre>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-  </rule>
-
 <!-- Detail logon rules -->
   <rule id="60200" level="3">
     <if_sid>60106</if_sid>

--- a/ruleset/rules/0585-win-application_rules.xml
+++ b/ruleset/rules/0585-win-application_rules.xml
@@ -3433,5 +3433,44 @@
     <options>no_full_log</options>
   </rule>
 
+  <rule id="61069" level="0">
+    <if_sid>60003</if_sid>
+    <field name="win.system.severityValue">^AUDIT_FAILURE$</field>
+    <description>Windows Application audit failure event</description>
+    <options>no_full_log</options>
+    <group>gpg13_4.12,</group>
+  </rule>
+
+  <rule id="61070" level="0">
+    <if_sid>60003</if_sid>
+    <field name="win.system.severityValue">^AUDIT_SUCCESS$</field>
+    <description>Windows Application audit success event</description>
+    <options>no_full_log</options>
+    <group>gpg13_4.12,</group>
+  </rule>
+
+
+  <!-- MS SQL rules -->
+
+  <!-- Sample: {"win":{"system":{"providerName":"MSSQL$SQLEXPRESS","eventID":"18456","level":"0","task":"4","keywords":"0x90000000000000","systemTime":"2021-05-04T00:14:02.000000000Z","eventRecordID":"11930713","channel":"Application","computer":"IPASRV-VPS001","severityValue":"AUDIT_FAILURE","message":"\"Login failed for user 'user'. Reason: Password did not match that for the login provided. [CLIENT: 192.168.0.5]\""},"eventdata":{"binary":"184800000E000000190000004900500041005300520056002D005600500053003000300031005C00530051004C0045005800500052004500530053000000070000006D00610073007400650072000000","data":"user,  Reason: Password did not match that for the login provided.,  [CLIENT: 192.168.0.5]"}}} -->
+  <rule id="61071" level="5">
+    <if_sid>61069</if_sid>
+    <field name="win.system.eventID">^18456$</field>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <description>MS SQL Server Logon Failure</description>
+    <options>no_full_log</options>
+  </rule>
+
+  <!-- Sample: {"win":{"system":{"providerName":"MSSQL$SQLEXPRESS","eventID":"18453","level":"0","task":"4","keywords":"0xa0000000000000","systemTime":"2021-03-19T22:14:38.786376900Z","eventRecordID":"2530","channel":"Application","computer":"WIN2019.wazuh.local","severityValue":"AUDIT_SUCCESS","message":"\"Login succeeded for user 'WAZUH\\Administrator'. Connection made using Integrated authentication. [CLIENT: <local machine>]\""},"eventdata":{"binary":"154800000A00000013000000570049004E0032003000310039005C00530051004C0045005800500052004500530053000000070000006D00610073007400650072000000","data":"WAZUH\\\\Administrator,  [CLIENT: &lt;local machine&gt;]"}}} -->
+  <rule id="61072" level="3">
+    <if_sid>61070</if_sid>
+    <field name="win.system.eventID">^18454$|^18453$</field>
+    <description>MS SQL Server Logon Success</description>
+    <options>no_full_log</options>
+    <mitre>
+      <id>T1078</id>
+    </mitre>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
 </group>
 


### PR DESCRIPTION
|Related issue|
|---|
| closes #7976 |

## Description

As indicated in #7976 and in [this community question](https://groups.google.com/g/wazuh/c/uDtSqFlkgGg), there is a bug when MSSQL Windows Event Logs are parsed as they use Application channel instead of Security channel.
Rule numeration is a bit suboptimal but I am not sure of the impact a major refactor may have across the rulesset


## Logs/Alerts example

Log Failure:
```
{"win":{"system":{"providerName":"MSSQL$SQLEXPRESS","eventID":"18456","level":"0","task":"4","keywords":"0x90000000000000","systemTime":"2021-05-04T00:14:02.000000000Z","eventRecordID":"11930713","channel":"Application","computer":"IPASRV-VPS001","severityValue":"AUDIT_FAILURE","message":"\"Login failed for user 'user'. Reason: Password did not match that for the login provided. [CLIENT: 192.168.0.5]\""},"eventdata":{"binary":"184800000E000000190000004900500041005300520056002D005600500053003000300031005C00530051004C0045005800500052004500530053000000070000006D00610073007400650072000000","data":"user,  Reason: Password did not match that for the login provided.,  [CLIENT: 192.168.0.5]"}}}
``` 
Log success:
``` 
{"win":{"system":{"providerName":"MSSQL$SQLEXPRESS","eventID":"18453","level":"0","task":"4","keywords":"0xa0000000000000","systemTime":"2021-03-19T22:14:38.786376900Z","eventRecordID":"2530","channel":"Application","computer":"WIN2019.wazuh.local","severityValue":"AUDIT_SUCCESS","message":"\"Login succeeded for user 'WAZUH\\Administrator'. Connection made using Integrated authentication. [CLIENT: <local machine>]\""},"eventdata":{"binary":"154800000A00000013000000570049004E0032003000310039005C00530051004C0045005800500052004500530053000000070000006D00610073007400650072000000","data":"WAZUH\\\\Administrator,  [CLIENT: &lt;local machine&gt;]"}}}
``` 