### PR TITLE
Remove wmodules logic from shared helpers.

### DIFF
--- a/src/headers/exec_op.h
+++ b/src/headers/exec_op.h
@@ -15,7 +15,6 @@
 #define W_BIND_STDOUT   001
 #define W_BIND_STDERR   002
 #define W_CHECK_WRITE   004
-#define W_APPEND_POOL   010
 #define W_BIND_STDIN    020
 
 #ifdef WIN32

--- a/src/wazuh_modules/wm_docker.c
+++ b/src/wazuh_modules/wm_docker.c
@@ -60,12 +60,20 @@ void* wm_docker_main(wm_docker_t *docker_conf) {
 
         mtdebug1(WM_DOCKER_LOGTAG, "Launching command '%s'", command);
 
-        wfd_t * wfd = wpopenl(command, W_BIND_STDERR | W_APPEND_POOL, command, NULL);
+        wfd_t * wfd = wpopenl(command, W_BIND_STDERR, command, NULL);
 
         if (wfd == NULL) {
             mterror(WM_DOCKER_LOGTAG, "Cannot launch Docker integration due to an internal error.");
             pthread_exit(NULL);
         }
+
+#ifdef WIN32
+        wm_append_handle(wfd->pinfo.hProcess);
+#else
+        if (0 <= wfd->pid) {
+            wm_append_sid(wfd->pid);
+        }
+#endif
 
         char buffer[4096];
 
@@ -79,7 +87,13 @@ void* wm_docker_main(wm_docker_t *docker_conf) {
         }
 
         // At this point, DockerListener terminated
-
+#ifdef WIN32
+        wm_remove_handle(wfd->pinfo.hProcess);
+#else
+        if (0 <= wfd->pid) {
+            wm_remove_sid(wfd->pid);
+        }
+#endif
         status = wpclose(wfd);
         int exitcode = WEXITSTATUS(status);
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes #8506 |

|Branch|
|---|
|[8506-normalize-shared-code](https://github.com/wazuh/wazuh/tree/8506-normalize-shared-code)|

## Description

This issue aims to solve a responsibility error between a shared function and a specific module.

The problem here is that in the compilation of something shared, a link is needed and specific functions of a wazuh helper are used.

for this case wpopenv and wpclose uses wm_append_sid and wm_remove_sid functions located in wazuh-modulesd wm_exec.c

## DoD 
- [x] Remove modules d logic from exec_op.c
- [x] Add exec_op.c specialization.
- [x] Add/modify unit tests.
- [x] Manual test osquery/docker/install test. Win / Docker
- [ ] PR CI Checks
