### PR TITLE
Implement wdb_exec_stmt_send in WDB

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -79,7 +79,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                              -Wl,--wrap,OSHash_Add_ex -Wl,--wrap,sqlite3_open_v2 -Wl,--wrap,sqlite3_close_v2 -Wl,--wrap,sqlite3_step \
                              -Wl,--wrap,sqlite3_column_count -Wl,--wrap,sqlite3_column_type -Wl,--wrap,sqlite3_column_name -Wl,--wrap,sqlite3_column_double \
                              -Wl,--wrap,sqlite3_column_text -Wl,--wrap,sqlite3_prepare_v2 -Wl,--wrap,sqlite3_finalize -Wl,--wrap,sqlite3_reset \
-                             -Wl,--wrap,sqlite3_clear_bindings -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,sqlite3_sql -Wl,--wrap,OS_SendSecureTCP")
+                             -Wl,--wrap,sqlite3_clear_bindings -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,sqlite3_sql -Wl,--wrap,OS_SendSecureTCP  -Wl,--wrap,OS_SetSendTimeout")
 
 list(APPEND wdb_tests_names "test_wdb_upgrade")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,wdb_metadata_table_check \

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -74,12 +74,12 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                              -Wl,--wrap,cJSON_AddBoolToObject -Wl,--wrap,cJSON_CreateNumber")
 
 list(APPEND wdb_tests_names "test_wdb")
-list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,pthread_mutex_lock \
+list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,strerror -Wl,--wrap,pthread_mutex_lock \
                              -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,OSHash_Get -Wl,--wrap,OSHash_Create -Wl,--wrap,OSHash_Delete_ex \
                              -Wl,--wrap,OSHash_Add_ex -Wl,--wrap,sqlite3_open_v2 -Wl,--wrap,sqlite3_close_v2 -Wl,--wrap,sqlite3_step \
                              -Wl,--wrap,sqlite3_column_count -Wl,--wrap,sqlite3_column_type -Wl,--wrap,sqlite3_column_name -Wl,--wrap,sqlite3_column_double \
                              -Wl,--wrap,sqlite3_column_text -Wl,--wrap,sqlite3_prepare_v2 -Wl,--wrap,sqlite3_finalize -Wl,--wrap,sqlite3_reset \
-                             -Wl,--wrap,sqlite3_clear_bindings -Wl,--wrap,sqlite3_errmsg")
+                             -Wl,--wrap,sqlite3_clear_bindings -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,sqlite3_sql -Wl,--wrap,OS_SendSecureTCP")
 
 list(APPEND wdb_tests_names "test_wdb_upgrade")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,wdb_metadata_table_check \

--- a/src/unit_tests/wazuh_db/test_wdb.c
+++ b/src/unit_tests/wazuh_db/test_wdb.c
@@ -25,6 +25,8 @@
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../wrappers/externals/sqlite/sqlite3_wrappers.h"
 #include "../wrappers/wazuh/wazuh_db/wdb_wrappers.h"
+#include "../wrappers/wazuh/os_net/os_net_wrappers.h"
+#include "../wrappers/libc/string_wrappers.h"
 
 typedef struct test_struct {
     wdb_t *wdb;
@@ -436,6 +438,167 @@ void test_wdb_exec_stmt_silent_invalid(void **state) {
     assert_int_equal(result, OS_INVALID);
 }
 
+/* Tests wdb_exec_stmt_send */
+
+void test_wdb_exec_stmt_send_single_row_success(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+    int peer = 1234;
+    const char* json_str = "COLUMN";
+    double json_value = 10;
+    cJSON* j_query_result = cJSON_CreateObject();
+    cJSON_AddNumberToObject(j_query_result, json_str, json_value);
+    char* str_query_result = cJSON_PrintUnformatted(j_query_result);
+    char* command_result = NULL;
+    os_calloc(OS_MAXSTR, sizeof(char), command_result);
+
+    //Calling wdb_exec_row_stmt
+    expect_sqlite3_step_call(SQLITE_ROW);
+    will_return(__wrap_sqlite3_column_count, 1);
+    expect_any(__wrap_sqlite3_column_type, i);
+    will_return(__wrap_sqlite3_column_type, SQLITE_INTEGER);
+    expect_any(__wrap_sqlite3_column_name, N);
+    will_return(__wrap_sqlite3_column_name, json_str);
+    expect_any(__wrap_sqlite3_column_double, iCol);
+    will_return(__wrap_sqlite3_column_double, json_value);
+    expect_sqlite3_step_call(SQLITE_DONE);
+
+    os_snprintf(command_result, OS_MAXSTR, "due %s", str_query_result);
+    expect_value(__wrap_OS_SendSecureTCP, sock, peer);
+    expect_value(__wrap_OS_SendSecureTCP, size, strlen(command_result));
+    expect_string(__wrap_OS_SendSecureTCP, msg, command_result);
+    will_return(__wrap_OS_SendSecureTCP, 0);
+
+    int result = wdb_exec_stmt_send(*data->wdb->stmt, peer);
+
+    assert_int_equal(result, SQLITE_DONE);
+
+    cJSON_Delete(j_query_result);
+    os_free(str_query_result);
+    os_free(command_result);
+}
+
+void test_wdb_exec_stmt_send_multiple_rows_success(void **state) {
+    int ROWS_RESPONSE = 100;
+    test_struct_t *data  = (test_struct_t *)*state;
+    int peer = 1234;
+    const char* json_str = "COLUMN";
+    double json_value = 10;
+    cJSON* j_query_result = cJSON_CreateObject();
+    cJSON_AddNumberToObject(j_query_result, json_str, json_value);
+    char* str_query_result = cJSON_PrintUnformatted(j_query_result);
+    char* command_result = NULL;
+    os_calloc(OS_MAXSTR, sizeof(char), command_result);
+
+    //Calling wdb_exec_row_stmt
+    expect_sqlite3_step_count(SQLITE_ROW, ROWS_RESPONSE);
+    will_return_count(__wrap_sqlite3_column_count, 1, ROWS_RESPONSE);
+    expect_any_count(__wrap_sqlite3_column_type, i, ROWS_RESPONSE);
+    will_return_count(__wrap_sqlite3_column_type, SQLITE_INTEGER, ROWS_RESPONSE);
+    expect_any_count(__wrap_sqlite3_column_name, N, ROWS_RESPONSE);
+    will_return_count(__wrap_sqlite3_column_name, json_str, ROWS_RESPONSE);
+    expect_any_count(__wrap_sqlite3_column_double, iCol, ROWS_RESPONSE);
+    will_return_count(__wrap_sqlite3_column_double, json_value, ROWS_RESPONSE);
+    expect_sqlite3_step_call(SQLITE_DONE);
+
+    os_snprintf(command_result, OS_MAXSTR, "due %s", str_query_result);
+    expect_value_count(__wrap_OS_SendSecureTCP, sock, peer, ROWS_RESPONSE);
+    expect_value_count(__wrap_OS_SendSecureTCP, size, strlen(command_result), ROWS_RESPONSE);
+    expect_string_count(__wrap_OS_SendSecureTCP, msg, command_result, ROWS_RESPONSE);
+    will_return_count(__wrap_OS_SendSecureTCP, 0, ROWS_RESPONSE);
+
+    int result = wdb_exec_stmt_send(*data->wdb->stmt, peer);
+
+    assert_int_equal(result, SQLITE_DONE);
+
+    cJSON_Delete(j_query_result);
+    os_free(str_query_result);
+    os_free(command_result);
+}
+
+void test_wdb_exec_stmt_send_no_rows_success(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+    int peer = 1234;
+
+    //Calling wdb_exec_row_stmt
+    expect_sqlite3_step_call(SQLITE_DONE);
+
+    int result = wdb_exec_stmt_send(*data->wdb->stmt, peer);
+
+    assert_int_equal(result, SQLITE_DONE);
+}
+
+void test_wdb_exec_stmt_send_row_size_limit_err(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+    int peer = 1234;
+    const char* json_str = "COLUMN";
+    char* json_value = NULL;
+    os_calloc(OS_MAXSTR, sizeof(char), json_value);
+    memset(json_value,'A',OS_MAXSTR-1);
+    cJSON* j_query_result = cJSON_CreateObject();
+    cJSON_AddStringToObject(j_query_result, json_str, json_value);
+    char* str_query_result = cJSON_PrintUnformatted(j_query_result);
+
+    //Calling wdb_exec_row_stmt
+    expect_sqlite3_step_call(SQLITE_ROW);
+    will_return(__wrap_sqlite3_column_count, 1);
+    expect_any(__wrap_sqlite3_column_type, i);
+    will_return(__wrap_sqlite3_column_type, SQLITE_TEXT);
+    expect_any(__wrap_sqlite3_column_name, N);
+    will_return(__wrap_sqlite3_column_name, json_str);
+    expect_any(__wrap_sqlite3_column_text, iCol);
+    will_return(__wrap_sqlite3_column_text, json_value);
+
+    will_return(__wrap_sqlite3_sql, "STATEMENT");
+    expect_string(__wrap__merror, formatted_msg, "SQL row response for statement STATEMENT is too big to be sent");
+
+    int result = wdb_exec_stmt_send(*data->wdb->stmt, peer);
+
+    assert_int_equal(result, SQLITE_ERROR);
+
+    cJSON_Delete(j_query_result);
+    os_free(str_query_result);
+    os_free(json_value);
+}
+
+void test_wdb_exec_stmt_send_socket_err(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+    int peer = 1234;
+    const char* json_str = "COLUMN";
+    double json_value = 10;
+    cJSON* j_query_result = cJSON_CreateObject();
+    cJSON_AddNumberToObject(j_query_result, json_str, json_value);
+    char* str_query_result = cJSON_PrintUnformatted(j_query_result);
+    char* command_result = NULL;
+    os_calloc(OS_MAXSTR, sizeof(char), command_result);
+
+    //Calling wdb_exec_row_stmt
+    expect_sqlite3_step_call(SQLITE_ROW);
+    will_return(__wrap_sqlite3_column_count, 1);
+    expect_any(__wrap_sqlite3_column_type, i);
+    will_return(__wrap_sqlite3_column_type, SQLITE_INTEGER);
+    expect_any(__wrap_sqlite3_column_name, N);
+    will_return(__wrap_sqlite3_column_name, json_str);
+    expect_any(__wrap_sqlite3_column_double, iCol);
+    will_return(__wrap_sqlite3_column_double, json_value);
+
+    os_snprintf(command_result, OS_MAXSTR, "due %s", str_query_result);
+    expect_value(__wrap_OS_SendSecureTCP, sock, peer);
+    expect_value(__wrap_OS_SendSecureTCP, size, strlen(command_result));
+    expect_string(__wrap_OS_SendSecureTCP, msg, command_result);
+    will_return(__wrap_OS_SendSecureTCP, -1);
+
+    will_return(__wrap_strerror, "error");
+    expect_string(__wrap__merror, formatted_msg, "Socket 1234 error: error (0)");
+
+    int result = wdb_exec_stmt_send(*data->wdb->stmt, peer);
+
+    assert_int_equal(result, SQLITE_ERROR);
+
+    cJSON_Delete(j_query_result);
+    os_free(str_query_result);
+    os_free(command_result);
+}
+
 /* Tests wdb_init_stmt_in_cache */
 
 void test_wdb_init_stmt_in_cache_success(void **state) {
@@ -519,6 +682,12 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_exec_stmt_silent_success_sqlite_done, setup_wdb, teardown_wdb),
         cmocka_unit_test_setup_teardown(test_wdb_exec_stmt_silent_success_sqlite_row, setup_wdb, teardown_wdb),
         cmocka_unit_test_setup_teardown(test_wdb_exec_stmt_silent_invalid, setup_wdb, teardown_wdb),
+        //wdb_exec_stmt_send
+        cmocka_unit_test_setup_teardown(test_wdb_exec_stmt_send_single_row_success, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_exec_stmt_send_multiple_rows_success, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_exec_stmt_send_no_rows_success, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_exec_stmt_send_row_size_limit_err, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_exec_stmt_send_socket_err, setup_wdb, teardown_wdb),
         //wdb_init_stmt_in_cache
         cmocka_unit_test_setup_teardown(test_wdb_init_stmt_in_cache_success, setup_wdb, teardown_wdb),
         cmocka_unit_test_setup_teardown(test_wdb_init_stmt_in_cache_invalid_transaction, setup_wdb, teardown_wdb),

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -51,7 +51,7 @@ void test_wdb_parse_global_open_global_fail(void **state)
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: ");
     expect_string(__wrap__mdebug2, formatted_msg, "Couldn't open DB global: queue/db/global.db");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Couldn't open DB global");
     assert_int_equal(ret, OS_INVALID);
@@ -66,7 +66,7 @@ void test_wdb_parse_global_no_space(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Invalid DB query syntax.");
     expect_string(__wrap__mdebug2, formatted_msg, "DB query: global");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'global'");
     assert_int_equal(ret, OS_INVALID);
@@ -84,7 +84,7 @@ void test_wdb_parse_global_substr_fail(void **state)
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: error");
 
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'error'");
     assert_int_equal(ret, OS_INVALID);
@@ -101,7 +101,7 @@ void test_wdb_parse_global_sql_error(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: sql");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'sql'");
     assert_int_equal(ret, OS_INVALID);
@@ -125,7 +125,7 @@ void test_wdb_parse_global_sql_success(void **state)
     will_return(__wrap_wdb_exec,root);
     expect_string(__wrap_wdb_exec, sql, "TEST QUERY");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok [{\"test_field\":\"test_value\"}]");
     assert_int_equal(ret, OS_SUCCESS);
@@ -146,7 +146,7 @@ void test_wdb_parse_global_sql_fail(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db: ERROR MESSAGE");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: TEST QUERY");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
     assert_int_equal(ret, OS_INVALID);
@@ -160,7 +160,7 @@ void test_wdb_parse_global_actor_fail(void **state)
 
     expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Invalid DB query actor: error");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query actor: 'error'");
     assert_int_equal(ret, OS_INVALID);
@@ -179,7 +179,7 @@ void test_wdb_parse_global_insert_agent_syntax_error(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for insert-agent.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: insert-agent");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'insert-agent'");
     assert_int_equal(ret, OS_INVALID);
@@ -196,7 +196,7 @@ void test_wdb_parse_global_insert_agent_invalid_json(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON syntax when inserting agent.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB JSON error near: NVALID_JSON}");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON syntax, near '{INVALID_JSON}'");
     assert_int_equal(ret, OS_INVALID);
@@ -212,7 +212,7 @@ void test_wdb_parse_global_insert_agent_compliant_error(void **state)
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: insert-agent {\"id\":1,\"name\":\"test_name\",\"date_add\":null}");
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON data when inserting agent. Not compliant with constraints defined in the database.");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON data, near '{\"id\":1,\"name\":\"test_name\",\"date'");
     assert_int_equal(ret, OS_INVALID);
@@ -238,7 +238,7 @@ void test_wdb_parse_global_insert_agent_query_error(void **state)
     will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db: ERROR MESSAGE");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
     assert_int_equal(ret, OS_INVALID);
@@ -264,7 +264,7 @@ void test_wdb_parse_global_insert_agent_success(void **state)
     expect_value(__wrap_wdb_global_insert_agent, date_add, 123);
     will_return(__wrap_wdb_global_insert_agent, OS_SUCCESS);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok");
     assert_int_equal(ret, OS_SUCCESS);
@@ -283,7 +283,7 @@ void test_wdb_parse_global_update_agent_name_syntax_error(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for update-agent-name.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: update-agent-name");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'update-agent-name'");
     assert_int_equal(ret, OS_INVALID);
@@ -300,7 +300,7 @@ void test_wdb_parse_global_update_agent_name_invalid_json(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON syntax when updating agent name.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB JSON error near: NVALID_JSON}");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON syntax, near '{INVALID_JSON}'");
     assert_int_equal(ret, OS_INVALID);
@@ -316,7 +316,7 @@ void test_wdb_parse_global_update_agent_name_invalid_data(void **state)
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-agent-name {\"id\":1,\"name\":null}");
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON data when updating agent name.");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON data, near '{\"id\":1,\"name\":null}'");
     assert_int_equal(ret, OS_INVALID);
@@ -336,7 +336,7 @@ void test_wdb_parse_global_update_agent_name_query_error(void **state)
     will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db: ERROR MESSAGE");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
     assert_int_equal(ret, OS_INVALID);
@@ -354,7 +354,7 @@ void test_wdb_parse_global_update_agent_name_success(void **state)
     expect_string(__wrap_wdb_global_update_agent_name, name, "test_name");
     will_return(__wrap_wdb_global_update_agent_name, OS_SUCCESS);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok");
     assert_int_equal(ret, OS_SUCCESS);
@@ -373,7 +373,7 @@ void test_wdb_parse_global_update_agent_data_syntax_error(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for update-agent-data.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: update-agent-data");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'update-agent-data'");
     assert_int_equal(ret, OS_INVALID);
@@ -390,7 +390,7 @@ void test_wdb_parse_global_update_agent_data_invalid_json(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON syntax when updating agent version.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB JSON error near: NVALID_JSON}");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON syntax, near '{INVALID_JSON}'");
     assert_int_equal(ret, OS_INVALID);
@@ -438,7 +438,7 @@ void test_wdb_parse_global_update_agent_data_query_error(void **state)
     will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db: ERROR MESSAGE");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
     assert_int_equal(ret, OS_INVALID);
@@ -464,7 +464,7 @@ void test_wdb_parse_global_update_agent_data_invalid_data(void **state)
 
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON data when updating agent version.");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON data, near '{\"os_name\":\"test_name\",\"os_versi'");
     assert_int_equal(ret, OS_INVALID);
@@ -511,7 +511,7 @@ void test_wdb_parse_global_update_agent_data_success(void **state)
     expect_value(__wrap_wdb_global_del_agent_labels, id, 1);
     will_return(__wrap_wdb_global_del_agent_labels, OS_SUCCESS);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok");
     assert_int_equal(ret, OS_SUCCESS);
@@ -530,7 +530,7 @@ void test_wdb_parse_global_get_agent_labels_syntax_error(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for get-labels.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: get-labels");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'get-labels'");
     assert_int_equal(ret, OS_INVALID);
@@ -548,7 +548,7 @@ void test_wdb_parse_global_get_agent_labels_query_error(void **state)
     will_return(__wrap_wdb_global_get_agent_labels, NULL);
     expect_string(__wrap__mdebug1, formatted_msg, "Error getting agent labels from global.db.");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Error getting agent labels from global.db.");
     assert_int_equal(ret, OS_INVALID);
@@ -574,7 +574,7 @@ void test_wdb_parse_global_get_agent_labels_success(void **state)
     expect_value(__wrap_wdb_global_get_agent_labels, id, 1);
     will_return(__wrap_wdb_global_get_agent_labels, root);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok [{\"id\":1,\"key\":\"test_key\",\"value\":\"test_value\"}]");
     assert_int_equal(ret, OS_SUCCESS);
@@ -594,7 +594,7 @@ void test_wdb_parse_global_set_agent_labels_syntax_error(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for set-labels.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: set-labels");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'set-labels'");
     assert_int_equal(ret, OS_INVALID);
@@ -611,7 +611,7 @@ void test_wdb_parse_global_set_agent_labels_id_error(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Invalid DB query syntax.");
     expect_string(__wrap__mdebug2, formatted_msg, "DB query error near: ");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near ''");
     assert_int_equal(ret, OS_INVALID);
@@ -631,7 +631,7 @@ void test_wdb_parse_global_set_agent_labels_remove_error(void **state)
     will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db: ERROR MESSAGE");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
     assert_int_equal(ret, OS_INVALID);
@@ -655,7 +655,7 @@ void test_wdb_parse_global_set_agent_labels_set_error(void **state)
     will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db: ERROR MESSAGE");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
     assert_int_equal(ret, OS_INVALID);
@@ -685,7 +685,7 @@ void test_wdb_parse_global_set_agent_labels_success(void **state)
     expect_string(__wrap_wdb_global_set_agent_label, value, "test_key4");
     will_return(__wrap_wdb_global_set_agent_label, OS_SUCCESS);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok");
     assert_int_equal(ret, OS_SUCCESS);
@@ -702,7 +702,7 @@ void test_wdb_parse_global_set_agent_labels_success_only_remove(void **state)
     expect_value(__wrap_wdb_global_del_agent_labels, id, 1);
     will_return(__wrap_wdb_global_del_agent_labels, OS_SUCCESS);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok");
     assert_int_equal(ret, OS_SUCCESS);
@@ -721,7 +721,7 @@ void test_wdb_parse_global_update_agent_keepalive_syntax_error(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for update-keepalive.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: update-keepalive");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'update-keepalive'");
     assert_int_equal(ret, OS_INVALID);
@@ -738,7 +738,7 @@ void test_wdb_parse_global_update_agent_keepalive_invalid_json(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON syntax when updating agent keepalive.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB JSON error near: NVALID_JSON}");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON syntax, near '{INVALID_JSON}'");
     assert_int_equal(ret, OS_INVALID);
@@ -754,7 +754,7 @@ void test_wdb_parse_global_update_agent_keepalive_invalid_data(void **state)
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-keepalive {\"id\":1,\"connection_status\":\"active\",\"sync_status\":null}");
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON data when updating agent keepalive.");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON data, near '{\"id\":1,\"connection_status\":\"act'");
     assert_int_equal(ret, OS_INVALID);
@@ -776,7 +776,7 @@ void test_wdb_parse_global_update_agent_keepalive_query_error(void **state)
     will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db: ERROR MESSAGE");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
     assert_int_equal(ret, OS_INVALID);
@@ -796,7 +796,7 @@ void test_wdb_parse_global_update_agent_keepalive_success(void **state)
 
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-keepalive {\"id\":1,\"connection_status\":\"active\",\"sync_status\":\"syncreq\"}");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok");
     assert_int_equal(ret, OS_SUCCESS);
@@ -815,7 +815,7 @@ void test_wdb_parse_global_update_connection_status_syntax_error(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for update-connection-status.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: update-connection-status");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'update-connection-status'");
     assert_int_equal(ret, OS_INVALID);
@@ -832,7 +832,7 @@ void test_wdb_parse_global_update_connection_status_invalid_json(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON syntax when updating agent connection status.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB JSON error near: NVALID_JSON}");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON syntax, near '{INVALID_JSON}'");
     assert_int_equal(ret, OS_INVALID);
@@ -848,7 +848,7 @@ void test_wdb_parse_global_update_connection_status_invalid_data(void **state)
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-connection-status {\"id\":1,\"connection_status\":null}");
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON data when updating agent connection status.");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON data, near '{\"id\":1,\"connection_status\":null'");
     assert_int_equal(ret, OS_INVALID);
@@ -869,7 +869,7 @@ void test_wdb_parse_global_update_connection_status_query_error(void **state)
     will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db: ERROR MESSAGE");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
     assert_int_equal(ret, OS_INVALID);
@@ -888,7 +888,7 @@ void test_wdb_parse_global_update_connection_status_success(void **state)
 
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-connection-status {\"id\":1,\"connection_status\":\"active\",\"sync_status\":\"syncreq\"}");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok");
     assert_int_equal(ret, OS_SUCCESS);
@@ -907,7 +907,7 @@ void test_wdb_parse_global_delete_agent_syntax_error(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for delete-agent.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: delete-agent");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'delete-agent'");
     assert_int_equal(ret, OS_INVALID);
@@ -925,7 +925,7 @@ void test_wdb_parse_global_delete_agent_query_error(void **state)
     will_return(__wrap_wdb_global_delete_agent, OS_INVALID);
     expect_string(__wrap__mdebug1, formatted_msg, "Error deleting agent from agent table in global.db.");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Error deleting agent from agent table in global.db.");
     assert_int_equal(ret, OS_INVALID);
@@ -942,7 +942,7 @@ void test_wdb_parse_global_delete_agent_success(void **state)
     expect_value(__wrap_wdb_global_delete_agent, id, 1);
     will_return(__wrap_wdb_global_delete_agent, OS_SUCCESS);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok");
     assert_int_equal(ret, OS_SUCCESS);
@@ -961,7 +961,7 @@ void test_wdb_parse_global_select_agent_name_syntax_error(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for select-agent-name.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: select-agent-name");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'select-agent-name'");
     assert_int_equal(ret, OS_INVALID);
@@ -979,7 +979,7 @@ void test_wdb_parse_global_select_agent_name_query_error(void **state)
     will_return(__wrap_wdb_global_select_agent_name, NULL);
     expect_string(__wrap__mdebug1, formatted_msg, "Error getting agent name from global.db.");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Error getting agent name from global.db.");
     assert_int_equal(ret, OS_INVALID);
@@ -1000,7 +1000,7 @@ void test_wdb_parse_global_select_agent_name_success(void **state)
     expect_value(__wrap_wdb_global_select_agent_name, id, 1);
     will_return(__wrap_wdb_global_select_agent_name, j_object);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok {\"name\":\"test_name\"}");
     assert_int_equal(ret, OS_SUCCESS);
@@ -1019,7 +1019,7 @@ void test_wdb_parse_global_select_agent_group_syntax_error(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for select-agent-group.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: select-agent-group");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'select-agent-group'");
     assert_int_equal(ret, OS_INVALID);
@@ -1037,7 +1037,7 @@ void test_wdb_parse_global_select_agent_group_query_error(void **state)
     will_return(__wrap_wdb_global_select_agent_group, NULL);
     expect_string(__wrap__mdebug1, formatted_msg, "Error getting agent group from global.db.");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Error getting agent group from global.db.");
     assert_int_equal(ret, OS_INVALID);
@@ -1058,7 +1058,7 @@ void test_wdb_parse_global_select_agent_group_success(void **state)
     expect_value(__wrap_wdb_global_select_agent_group, id, 1);
     will_return(__wrap_wdb_global_select_agent_group, j_object);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok {\"name\":\"test_name\"}");
     assert_int_equal(ret, OS_SUCCESS);
@@ -1077,7 +1077,7 @@ void test_wdb_parse_global_delete_agent_belong_syntax_error(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for delete-agent-belong.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: delete-agent-belong");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'delete-agent-belong'");
     assert_int_equal(ret, OS_INVALID);
@@ -1095,7 +1095,7 @@ void test_wdb_parse_global_delete_agent_belong_query_error(void **state)
     will_return(__wrap_wdb_global_delete_agent_belong, OS_INVALID);
     expect_string(__wrap__mdebug1, formatted_msg, "Error deleting agent from belongs table in global.db.");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Error deleting agent from belongs table in global.db.");
     assert_int_equal(ret, OS_INVALID);
@@ -1112,7 +1112,7 @@ void test_wdb_parse_global_delete_agent_belong_success(void **state)
     expect_value(__wrap_wdb_global_delete_agent_belong, id, 1);
     will_return(__wrap_wdb_global_delete_agent_belong, OS_SUCCESS);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok");
     assert_int_equal(ret, OS_SUCCESS);
@@ -1131,7 +1131,7 @@ void test_wdb_parse_global_find_agent_syntax_error(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for find-agent.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: find-agent");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'find-agent'");
     assert_int_equal(ret, OS_INVALID);
@@ -1148,7 +1148,7 @@ void test_wdb_parse_global_find_agent_invalid_json(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON syntax when finding agent id.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB JSON error near: NVALID_JSON}");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON syntax, near '{INVALID_JSON}'");
     assert_int_equal(ret, OS_INVALID);
@@ -1164,7 +1164,7 @@ void test_wdb_parse_global_find_agent_invalid_data(void **state)
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: find-agent {\"ip\":null,\"name\":\"test_name\"}");
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON data when finding agent id.");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON data, near '{\"ip\":null,\"name\":\"test_name\"}'");
     assert_int_equal(ret, OS_INVALID);
@@ -1184,7 +1184,7 @@ void test_wdb_parse_global_find_agent_query_error(void **state)
     will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db: ERROR MESSAGE");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
     assert_int_equal(ret, OS_INVALID);
@@ -1206,7 +1206,7 @@ void test_wdb_parse_global_find_agent_success(void **state)
     expect_string(__wrap_wdb_global_find_agent, name, "test_name");
     will_return(__wrap_wdb_global_find_agent, j_object);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok {\"id\":1}");
     assert_int_equal(ret, OS_SUCCESS);
@@ -1225,7 +1225,7 @@ void test_wdb_parse_global_update_agent_group_syntax_error(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for update-agent-group.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: update-agent-group");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'update-agent-group'");
     assert_int_equal(ret, OS_INVALID);
@@ -1242,7 +1242,7 @@ void test_wdb_parse_global_update_agent_group_invalid_json(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON syntax when updating agent group.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB JSON error near: NVALID_JSON}");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON syntax, near '{INVALID_JSON}'");
     assert_int_equal(ret, OS_INVALID);
@@ -1258,7 +1258,7 @@ void test_wdb_parse_global_update_agent_group_invalid_data(void **state)
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-agent-group {\"group\":null}");
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON data when updating agent group.");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON data, near '{\"group\":null}'");
     assert_int_equal(ret, OS_INVALID);
@@ -1278,7 +1278,7 @@ void test_wdb_parse_global_update_agent_group_query_error(void **state)
     will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db: ERROR MESSAGE");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
     assert_int_equal(ret, OS_INVALID);
@@ -1296,7 +1296,7 @@ void test_wdb_parse_global_update_agent_group_success(void **state)
     expect_string(__wrap_wdb_global_update_agent_group, group, "test_group");
     will_return(__wrap_wdb_global_update_agent_group, OS_SUCCESS);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok");
     assert_int_equal(ret, OS_SUCCESS);
@@ -1315,7 +1315,7 @@ void test_wdb_parse_global_find_group_syntax_error(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for find-group.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: find-group");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'find-group'");
     assert_int_equal(ret, OS_INVALID);
@@ -1333,7 +1333,7 @@ void test_wdb_parse_global_find_group_query_error(void **state)
     will_return(__wrap_wdb_global_find_group, NULL);
     expect_string(__wrap__mdebug1, formatted_msg, "Error getting group id from global.db.");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Error getting group id from global.db.");
     assert_int_equal(ret, OS_INVALID);
@@ -1354,7 +1354,7 @@ void test_wdb_parse_global_find_group_success(void **state)
     expect_string(__wrap_wdb_global_find_group, group_name, "test_group");
     will_return(__wrap_wdb_global_find_group, j_object);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok {\"id\":1}");
     assert_int_equal(ret, OS_SUCCESS);
@@ -1373,7 +1373,7 @@ void test_wdb_parse_global_insert_agent_group_syntax_error(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for insert-agent-group.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: insert-agent-group");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'insert-agent-group'");
     assert_int_equal(ret, OS_INVALID);
@@ -1391,7 +1391,7 @@ void test_wdb_parse_global_insert_agent_group_query_error(void **state)
     will_return(__wrap_wdb_global_insert_agent_group, OS_INVALID);
     expect_string(__wrap__mdebug1, formatted_msg, "Error inserting group in global.db.");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Error inserting group in global.db.");
     assert_int_equal(ret, OS_INVALID);
@@ -1408,7 +1408,7 @@ void test_wdb_parse_global_insert_agent_group_success(void **state)
     expect_string(__wrap_wdb_global_insert_agent_group, group_name, "test_group");
     will_return(__wrap_wdb_global_insert_agent_group, OS_SUCCESS);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok");
     assert_int_equal(ret, OS_SUCCESS);
@@ -1427,7 +1427,7 @@ void test_wdb_parse_global_insert_agent_belong_syntax_error(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for insert-agent-belong.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: insert-agent-belong");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'insert-agent-belong'");
     assert_int_equal(ret, OS_INVALID);
@@ -1444,7 +1444,7 @@ void test_wdb_parse_global_insert_agent_belong_invalid_json(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON syntax when inserting agent to belongs table.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB JSON error near: NVALID_JSON}");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON syntax, near '{INVALID_JSON}'");
     assert_int_equal(ret, OS_INVALID);
@@ -1460,7 +1460,7 @@ void test_wdb_parse_global_insert_agent_belong_invalid_data(void **state)
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: insert-agent-belong {\"id_group\":1,\"id_agent\":null}");
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON data when inserting agent to belongs table.");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON data, near '{\"id_group\":1,\"id_agent\":null}'");
     assert_int_equal(ret, OS_INVALID);
@@ -1480,7 +1480,7 @@ void test_wdb_parse_global_insert_agent_belong_query_error(void **state)
     will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db: ERROR MESSAGE");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
     assert_int_equal(ret, OS_INVALID);
@@ -1498,7 +1498,7 @@ void test_wdb_parse_global_insert_agent_belong_success(void **state)
     expect_value(__wrap_wdb_global_insert_agent_belong, id_agent, 2);
     will_return(__wrap_wdb_global_insert_agent_belong, OS_SUCCESS);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok");
     assert_int_equal(ret, OS_SUCCESS);
@@ -1517,7 +1517,7 @@ void test_wdb_parse_global_delete_group_belong_syntax_error(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for delete-group-belong.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: delete-group-belong");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'delete-group-belong'");
     assert_int_equal(ret, OS_INVALID);
@@ -1535,7 +1535,7 @@ void test_wdb_parse_global_delete_group_belong_query_error(void **state)
     will_return(__wrap_wdb_global_delete_group_belong, OS_INVALID);
     expect_string(__wrap__mdebug1, formatted_msg, "Error deleting group from belongs table in global.db.");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Error deleting group from belongs table in global.db.");
     assert_int_equal(ret, OS_INVALID);
@@ -1552,7 +1552,7 @@ void test_wdb_parse_global_delete_group_belong_success(void **state)
     expect_string(__wrap_wdb_global_delete_group_belong, group_name, "test_group");
     will_return(__wrap_wdb_global_delete_group_belong, OS_SUCCESS);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok");
     assert_int_equal(ret, OS_SUCCESS);
@@ -1571,7 +1571,7 @@ void test_wdb_parse_global_delete_group_syntax_error(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for delete-group.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: delete-group");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'delete-group'");
     assert_int_equal(ret, OS_INVALID);
@@ -1589,7 +1589,7 @@ void test_wdb_parse_global_delete_group_query_error(void **state)
     will_return(__wrap_wdb_global_delete_group, OS_INVALID);
     expect_string(__wrap__mdebug1, formatted_msg, "Error deleting group in global.db.");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Error deleting group in global.db.");
     assert_int_equal(ret, OS_INVALID);
@@ -1606,7 +1606,7 @@ void test_wdb_parse_global_delete_group_success(void **state)
     expect_string(__wrap_wdb_global_delete_group, group_name, "test_group");
     will_return(__wrap_wdb_global_delete_group, OS_SUCCESS);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok");
     assert_int_equal(ret, OS_SUCCESS);
@@ -1625,7 +1625,7 @@ void test_wdb_parse_global_select_groups_query_error(void **state)
     will_return(__wrap_wdb_global_select_groups, NULL);
     expect_string(__wrap__mdebug1, formatted_msg, "Error getting groups from global.db.");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Error getting groups from global.db.");
     assert_int_equal(ret, OS_INVALID);
@@ -1646,7 +1646,7 @@ void test_wdb_parse_global_select_groups_success(void **state)
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: select-groups");
     will_return(__wrap_wdb_global_select_groups, j_object);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok {\"id\":1,\"id\":2}");
     assert_int_equal(ret, OS_SUCCESS);
@@ -1665,7 +1665,7 @@ void test_wdb_parse_global_select_agent_keepalive_syntax_error(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for select-keepalive.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: select-keepalive");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'select-keepalive'");
     assert_int_equal(ret, OS_INVALID);
@@ -1682,7 +1682,7 @@ void test_wdb_parse_global_select_agent_keepalive_syntax_error2(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Invalid DB query syntax.");
     expect_string(__wrap__mdebug2, formatted_msg, "DB query error near: test_name");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'test_name'");
     assert_int_equal(ret, OS_INVALID);
@@ -1701,7 +1701,7 @@ void test_wdb_parse_global_select_agent_keepalive_query_error(void **state)
     will_return(__wrap_wdb_global_select_agent_keepalive, NULL);
     expect_string(__wrap__mdebug1, formatted_msg, "Error getting agent keepalive from global.db.");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Error getting agent keepalive from global.db.");
     assert_int_equal(ret, OS_INVALID);
@@ -1723,7 +1723,7 @@ void test_wdb_parse_global_select_agent_keepalive_success(void **state)
     expect_string(__wrap_wdb_global_select_agent_keepalive, ip, "0.0.0.0");
     will_return(__wrap_wdb_global_select_agent_keepalive, j_object);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok {\"keepalive\":1000}");
     assert_int_equal(ret, OS_SUCCESS);
@@ -1744,7 +1744,7 @@ void test_wdb_parse_global_sync_agent_info_get_success(void **state)
     will_return(__wrap_wdb_global_sync_agent_info_get, sync_info);
     will_return(__wrap_wdb_global_sync_agent_info_get, WDBC_OK);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok {SYNC INFO}");
     assert_int_equal(ret, OS_SUCCESS);
@@ -1763,7 +1763,7 @@ void test_wdb_parse_global_sync_agent_info_get_last_id_success(void **state)
     will_return(__wrap_wdb_global_sync_agent_info_get, sync_info);
     will_return(__wrap_wdb_global_sync_agent_info_get, WDBC_OK);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok {SYNC INFO}");
     assert_int_equal(ret, OS_SUCCESS);
@@ -1787,7 +1787,7 @@ void test_wdb_parse_global_sync_agent_info_get_size_limit(void **state)
     will_return(__wrap_wdb_global_sync_agent_info_get, sync_info);
     will_return(__wrap_wdb_global_sync_agent_info_get, WDBC_OK);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     char delims[] = " ";
     char* payload = NULL;
@@ -1812,7 +1812,7 @@ void test_wdb_parse_global_sync_agent_info_set_syntax_error(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for sync-agent-info-set.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: sync-agent-info-set");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'sync-agent-info-set'");
     assert_int_equal(ret, OS_INVALID);
@@ -1829,7 +1829,7 @@ void test_wdb_parse_global_sync_agent_info_set_invalid_json(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON syntax updating unsynced agents.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB JSON error near: NVALID_JSON}");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid JSON syntax, near '{INVALID_JSON}'");
     assert_int_equal(ret, OS_INVALID);
@@ -1851,7 +1851,7 @@ void test_wdb_parse_global_sync_agent_info_set_query_error(void **state)
     will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db: ERROR MESSAGE");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
     assert_int_equal(ret, OS_INVALID);
@@ -1872,7 +1872,7 @@ void test_wdb_parse_global_sync_agent_info_set_id_error(void **state)
     will_return(__wrap_wdb_global_sync_agent_info_set, OS_SUCCESS);
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; incorrect agent id in labels array.");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot update labels due to invalid id.");
     assert_int_equal(ret, OS_INVALID);
@@ -1897,7 +1897,7 @@ void test_wdb_parse_global_sync_agent_info_set_del_label_error(void **state)
     will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db: ERROR MESSAGE");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
     assert_int_equal(ret, OS_INVALID);
@@ -1926,7 +1926,7 @@ void test_wdb_parse_global_sync_agent_info_set_set_label_error(void **state)
     will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db: ERROR MESSAGE");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
     assert_int_equal(ret, OS_INVALID);
@@ -1953,7 +1953,7 @@ void test_wdb_parse_global_sync_agent_info_set_success(void **state)
     expect_string(__wrap_wdb_global_set_agent_label, value, "test_value");
     will_return(__wrap_wdb_global_set_agent_label, OS_SUCCESS);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok");
     assert_int_equal(ret, OS_SUCCESS);
@@ -1972,7 +1972,7 @@ void test_wdb_parse_global_disconnect_agents_syntax_error(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for disconnect-agents.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: disconnect-agents");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'disconnect-agents'");
     assert_int_equal(ret, OS_INVALID);
@@ -1988,7 +1988,7 @@ void test_wdb_parse_global_disconnect_agents_last_id_error(void **state)
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: disconnect-agents ");
     expect_string(__wrap__mdebug1, formatted_msg, "Invalid arguments last id not found.");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid arguments last id not found");
     assert_int_equal(ret, OS_INVALID);
@@ -2004,7 +2004,7 @@ void test_wdb_parse_global_disconnect_agents_keepalive_error(void **state)
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: disconnect-agents 0");
     expect_string(__wrap__mdebug1, formatted_msg, "Invalid arguments keepalive not found.");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid arguments keepalive not found");
     assert_int_equal(ret, OS_INVALID);
@@ -2020,7 +2020,7 @@ void test_wdb_parse_global_disconnect_agents_sync_status_error(void **state)
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: disconnect-agents 0 100");
     expect_string(__wrap__mdebug1, formatted_msg, "Invalid arguments sync_status not found.");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid arguments sync_status not found");
     assert_int_equal(ret, OS_INVALID);
@@ -2044,7 +2044,7 @@ void test_wdb_parse_global_disconnect_agents_success(void **state)
     will_return(__wrap_wdb_global_get_agents_to_disconnect, WDBC_OK);
     will_return(__wrap_wdb_global_get_agents_to_disconnect, root);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok [{\"id\":10}]");
     assert_int_equal(ret, OS_SUCCESS);
@@ -2063,7 +2063,7 @@ void test_wdb_parse_global_get_all_agents_syntax_error(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for get-all-agents.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: get-all-agents");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'get-all-agents'");
     assert_int_equal(ret, OS_INVALID);
@@ -2079,7 +2079,7 @@ void test_wdb_parse_global_get_all_agents_argument_error(void **state)
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-all-agents invalid");
     expect_string(__wrap__mdebug1, formatted_msg, "Invalid arguments 'last_id' not found.");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid arguments 'last_id' not found");
     assert_int_equal(ret, OS_INVALID);
@@ -2095,7 +2095,7 @@ void test_wdb_parse_global_get_all_agents_argument2_error(void **state)
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-all-agents last_id");
     expect_string(__wrap__mdebug1, formatted_msg, "Invalid arguments 'last_id' not found.");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid arguments 'last_id' not found");
     assert_int_equal(ret, OS_INVALID);
@@ -2117,7 +2117,7 @@ void test_wdb_parse_global_get_all_agents_success(void **state)
     will_return(__wrap_wdb_global_get_all_agents, WDBC_OK);
     will_return(__wrap_wdb_global_get_all_agents, root);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok [{\"id\":10}]");
     assert_int_equal(ret, OS_SUCCESS);
@@ -2136,7 +2136,7 @@ void test_wdb_parse_global_get_agent_info_syntax_error(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for get-agent-info.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: get-agent-info");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'get-agent-info'");
     assert_int_equal(ret, OS_INVALID);
@@ -2154,7 +2154,7 @@ void test_wdb_parse_global_get_agent_info_query_error(void **state)
     will_return(__wrap_wdb_global_get_agent_info, NULL);
     expect_string(__wrap__mdebug1, formatted_msg, "Error getting agent information from global.db.");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Error getting agent information from global.db.");
     assert_int_equal(ret, OS_INVALID);
@@ -2175,7 +2175,7 @@ void test_wdb_parse_global_get_agent_info_success(void **state)
     expect_value(__wrap_wdb_global_get_agent_info, id, 1);
     will_return(__wrap_wdb_global_get_agent_info, j_object);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok {\"name\":\"test_name\"}");
     assert_int_equal(ret, OS_SUCCESS);
@@ -2194,7 +2194,7 @@ void test_wdb_parse_reset_agents_connection_syntax_error(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for reset-agents-connection.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: reset-agents-connection");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'reset-agents-connection'");
     assert_int_equal(ret, OS_INVALID);
@@ -2213,7 +2213,7 @@ void test_wdb_parse_reset_agents_connection_query_error(void **state)
     will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db: ERROR MESSAGE");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
     assert_int_equal(ret, OS_INVALID);
@@ -2230,7 +2230,7 @@ void test_wdb_parse_reset_agents_connection_success(void **state)
     expect_string(__wrap_wdb_global_reset_agents_connection, sync_status, "syncreq");
     will_return(__wrap_wdb_global_reset_agents_connection, OS_SUCCESS);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok");
     assert_int_equal(ret, OS_SUCCESS);
@@ -2249,7 +2249,7 @@ void test_wdb_parse_global_get_agents_by_connection_status_syntax_error(void **s
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for get-agents-by-connection-status.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: get-agents-by-connection-status");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'get-agents-by-connection-status'");
     assert_int_equal(ret, OS_INVALID);
@@ -2265,7 +2265,7 @@ void test_wdb_parse_global_get_agents_by_connection_status_status_error(void **s
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-agents-by-connection-status 0 ");
     expect_string(__wrap__mdebug1, formatted_msg, "Invalid arguments 'connection_status' not found.");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid arguments 'connection_status' not found");
     assert_int_equal(ret, OS_INVALID);
@@ -2289,7 +2289,7 @@ void test_wdb_parse_global_get_agents_by_connection_status_query_success(void **
     will_return(__wrap_wdb_global_get_agents_by_connection_status, WDBC_OK);
     will_return(__wrap_wdb_global_get_agents_by_connection_status, root);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "ok [{\"id\":10}]");
     assert_int_equal(ret, OS_SUCCESS);

--- a/src/unit_tests/wazuh_db/test_wdb_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_parser.c
@@ -758,7 +758,7 @@ void test_osinfo_syntax_error(void **state) {
     expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Invalid DB query syntax.");
     expect_string(__wrap__mdebug2, formatted_msg, "DB(000) query error near: osinfo");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'osinfo'");
     assert_int_equal(ret, OS_INVALID);
@@ -776,7 +776,7 @@ void test_osinfo_invalid_action(void **state) {
     will_return(__wrap_wdb_open_agent2, (wdb_t*)1); // Returning any value
     expect_string(__wrap__mdebug2, formatted_msg, "Agent 000 query: osinfo invalid");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid osinfo action: invalid");
     assert_int_equal(ret, OS_INVALID);
@@ -1249,7 +1249,7 @@ void test_vuln_cves_syntax_error(void **state) {
     expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Invalid vuln_cves query syntax.");
     expect_string(__wrap__mdebug2, formatted_msg, "DB(000) vuln_cves query error near: vuln_cves");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid vuln_cves query syntax, near 'vuln_cves'");
     assert_int_equal(ret, OS_INVALID);
@@ -1267,7 +1267,7 @@ void test_vuln_cves_invalid_action(void **state) {
     will_return(__wrap_wdb_open_agent2, (wdb_t*)1); // Returning any value
     expect_string(__wrap__mdebug2, formatted_msg, "Agent 000 query: vuln_cves invalid");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid vuln_cves action: invalid");
     assert_int_equal(ret, OS_INVALID);

--- a/src/unit_tests/wazuh_db/test_wdb_task_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_task_parser.c
@@ -61,7 +61,7 @@ void test_wdb_parse_task_open_tasks_fail(void **state)
     expect_string(__wrap__mdebug2, formatted_msg, "Task query: ");
     expect_string(__wrap__mdebug2, formatted_msg, "Couldn't open DB task: queue/tasks/tasks.db");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Couldn't open DB task");
     assert_int_equal(ret, OS_INVALID);
@@ -76,7 +76,7 @@ void test_wdb_parse_task_no_space(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Invalid DB query syntax.");
     expect_string(__wrap__mdebug2, formatted_msg, "DB query: task");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'task'");
     assert_int_equal(ret, OS_INVALID);
@@ -95,7 +95,7 @@ void test_wdb_parse_task_invalid_command(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Invalid DB query syntax.");
     expect_string(__wrap__mdebug2, formatted_msg, "Task DB query error near: invalid");
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid DB query syntax, near 'invalid'");
     assert_int_equal(ret, OS_INVALID);
@@ -111,7 +111,7 @@ void test_wdb_parse_task_upgrade_invalid_parameters(void **state)
 
     will_return(__wrap_wdb_open_tasks, data->wdb);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid command parameters, near 'no_json'");
     assert_int_equal(ret, OS_INVALID);
@@ -127,7 +127,7 @@ void test_wdb_parse_task_upgrade_custom_invalid_parameters(void **state)
 
     will_return(__wrap_wdb_open_tasks, data->wdb);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid command parameters, near 'no_json'");
     assert_int_equal(ret, OS_INVALID);
@@ -143,7 +143,7 @@ void test_wdb_parse_task_upgrade_get_status_invalid_parameters(void **state)
 
     will_return(__wrap_wdb_open_tasks, data->wdb);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid command parameters, near 'no_json'");
     assert_int_equal(ret, OS_INVALID);
@@ -159,7 +159,7 @@ void test_wdb_parse_task_upgrade_update_status_invalid_parameters(void **state)
 
     will_return(__wrap_wdb_open_tasks, data->wdb);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid command parameters, near 'no_json'");
     assert_int_equal(ret, OS_INVALID);
@@ -175,7 +175,7 @@ void test_wdb_parse_task_upgrade_result_invalid_parameters(void **state)
 
     will_return(__wrap_wdb_open_tasks, data->wdb);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid command parameters, near 'no_json'");
     assert_int_equal(ret, OS_INVALID);
@@ -191,7 +191,7 @@ void test_wdb_parse_task_upgrade_cancel_tasks_invalid_parameters(void **state)
 
     will_return(__wrap_wdb_open_tasks, data->wdb);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid command parameters, near 'no_json'");
     assert_int_equal(ret, OS_INVALID);
@@ -207,7 +207,7 @@ void test_wdb_parse_task_delete_old_invalid_parameters(void **state)
 
     will_return(__wrap_wdb_open_tasks, data->wdb);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid command parameters, near 'no_json'");
     assert_int_equal(ret, OS_INVALID);
@@ -223,7 +223,7 @@ void test_wdb_parse_task_set_timeout_invalid_parameters(void **state)
 
     will_return(__wrap_wdb_open_tasks, data->wdb);
 
-    ret = wdb_parse(query, data->output);
+    ret = wdb_parse(query, data->output, 0);
 
     assert_string_equal(data->output, "err Invalid command parameters, near 'no_json'");
     assert_int_equal(ret, OS_INVALID);

--- a/src/unit_tests/wrappers/externals/sqlite/sqlite3_wrappers.c
+++ b/src/unit_tests/wrappers/externals/sqlite/sqlite3_wrappers.c
@@ -196,3 +196,7 @@ const char* __wrap_sqlite3_column_name(__attribute__((unused)) sqlite3_stmt *pSt
 int __wrap_sqlite3_changes(__attribute__((unused)) sqlite3 * db){
     return mock();
 }
+
+const char*  __wrap_sqlite3_sql(__attribute__((unused)) sqlite3_stmt *pStmt){
+    return mock_ptr_type(char*);
+}

--- a/src/unit_tests/wrappers/externals/sqlite/sqlite3_wrappers.h
+++ b/src/unit_tests/wrappers/externals/sqlite/sqlite3_wrappers.h
@@ -90,4 +90,6 @@ int __wrap_sqlite3_column_type(sqlite3_stmt *pStmt, int i);
 
 const char* __wrap_sqlite3_column_name(sqlite3_stmt *pStmt, int N);
 
+const char* __wrap_sqlite3_sql(sqlite3_stmt *pStmt);
+
 #endif

--- a/src/unit_tests/wrappers/wazuh/os_net/os_net_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/os_net/os_net_wrappers.c
@@ -102,6 +102,11 @@ int __wrap_OS_SetRecvTimeout(__attribute__((unused)) int socket,
     return mock();
 }
 
+int __wrap_OS_SetSendTimeout(__attribute__((unused)) int socket,
+                             __attribute__((unused)) int seconds) {
+    return mock();
+}
+
 
 int __wrap_wnet_select(__attribute__((unused)) int sock,
                        __attribute__((unused)) int timeout) {

--- a/src/unit_tests/wrappers/wazuh/os_net/os_net_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/os_net/os_net_wrappers.h
@@ -43,6 +43,8 @@ int __wrap_OS_ConnectUDP(u_int16_t _port, const char *_ip, int ipv6);
 
 int __wrap_OS_SetRecvTimeout(int socket, long seconds, long useconds);
 
+int __wrap_OS_SetSendTimeout(int socket, int seconds);
+
 int __wrap_wnet_select(int sock, int timeout);
 
 #endif

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -363,7 +363,7 @@ void * run_worker(__attribute__((unused)) void * args) {
             }
 
             *response = '\0';
-            wdb_parse(buffer, response);
+            wdb_parse(buffer, response, peer);
             if (length = strlen(response), length > 0) {
                 if (terminal && length < OS_MAXSTR - 1) {
                     response[length++] = '\n';

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -1063,12 +1063,16 @@ int wdb_exec_stmt_send(sqlite3_stmt* stmt, int peer) {
     int sql_status = SQLITE_ERROR;
     cJSON * row = NULL;
     char* response = NULL;
-    char* header = "due ";
+    // Every row will be the payload of a message with the format "due {payload}"
+    const char* header = "due ";
     int header_size = strlen(header);
+    // Allocating the memory where all the responses will be dumped, it will contain the header+payload
     os_calloc(OS_MAXSTR, sizeof(char), response);
+    // Coping the "due" header into the response buffer
     memcpy(response, header, header_size);
-    char* payload = response+header_size;
-    int payload_size = OS_MAXSTR-header_size;
+    // Each row is dumped into the payload section of the buffer, so the pointer and the tailing available space for the payload are obtained
+    char* payload = response + header_size;
+    int payload_size = OS_MAXSTR - header_size;
 
     while ((row = wdb_exec_row_stmt(stmt, &sql_status))) {
         bool row_fits = cJSON_PrintPreallocated(row, payload, payload_size, FALSE);

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -1050,11 +1050,17 @@ cJSON* wdb_exec_stmt_sized(sqlite3_stmt * stmt, const size_t max_size, int* stat
 }
 
 int wdb_exec_stmt_send(sqlite3_stmt* stmt, int peer) {
-    int status = SQLITE_ERROR;
     if (!stmt) {
         mdebug1("Invalid SQL statement.");
-        return status;
+        return OS_INVALID;
     }
+    if (OS_SetSendTimeout(peer, WDB_BLOCK_SEND_TIMEOUT_S) < 0) {
+        merror("Could not set timeout to network socket: %s (%d)", strerror(errno), errno);
+        return OS_SOCKTERR;
+    }
+
+    int status = OS_SUCCESS;
+    int sql_status = SQLITE_ERROR;
     cJSON * row = NULL;
     char* response = NULL;
     char* header = "due ";
@@ -1064,21 +1070,24 @@ int wdb_exec_stmt_send(sqlite3_stmt* stmt, int peer) {
     char* payload = response+header_size;
     int payload_size = OS_MAXSTR-header_size;
 
-    while ((row = wdb_exec_row_stmt(stmt, &status))) {
+    while ((row = wdb_exec_row_stmt(stmt, &sql_status))) {
         bool row_fits = cJSON_PrintPreallocated(row, payload, payload_size, FALSE);
         cJSON_Delete(row);
         if (row_fits) {
             if (OS_SendSecureTCP(peer, strlen(response), response) < 0) {
                 merror("Socket %d error: %s (%d)", peer, strerror(errno), errno);
-                status = SQLITE_ERROR;
+                status = OS_SOCKTERR;
                 break;
             }
         }
         else {
             merror("SQL row response for statement %s is too big to be sent", sqlite3_sql(stmt));
-            status = SQLITE_ERROR;
+            status = OS_SIZELIM;
             break;
         }
+    }
+    if (status == OS_SUCCESS && sql_status != SQLITE_DONE) {
+        status = OS_INVALID;
     }
 
     os_free(response);

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -1055,7 +1055,7 @@ int wdb_exec_stmt_send(sqlite3_stmt* stmt, int peer) {
         return OS_INVALID;
     }
     if (OS_SetSendTimeout(peer, WDB_BLOCK_SEND_TIMEOUT_S) < 0) {
-        merror("Could not set timeout to network socket: %s (%d)", strerror(errno), errno);
+        merror("Socket %d error setting timeout: %s (%d)", peer, strerror(errno), errno);
         return OS_SOCKTERR;
     }
 

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -1049,6 +1049,43 @@ cJSON* wdb_exec_stmt_sized(sqlite3_stmt * stmt, const size_t max_size, int* stat
     return result;
 }
 
+int wdb_exec_stmt_send(sqlite3_stmt* stmt, int peer) {
+    int status = SQLITE_ERROR;
+    if (!stmt) {
+        mdebug1("Invalid SQL statement.");
+        return status;
+    }
+    cJSON * row = NULL;
+    char* response = NULL;
+    char* header = "due ";
+    int header_size = strlen(header);
+    os_calloc(OS_MAXSTR, sizeof(char), response);
+    memcpy(response, header, header_size);
+    char* payload = response+header_size;
+    int payload_size = OS_MAXSTR-header_size;
+
+    while ((row = wdb_exec_row_stmt(stmt, &status))) {
+        bool row_fits = cJSON_PrintPreallocated(row, payload, payload_size, FALSE);
+        cJSON_Delete(row);
+        if (row_fits) {
+            if (OS_SendSecureTCP(peer, strlen(response), response) < 0) {
+                merror("Socket %d error: %s (%d)", peer, strerror(errno), errno);
+                status = SQLITE_ERROR;
+                break;
+            }
+        }
+        else {
+            merror("SQL row response for statement %s is too big to be sent", sqlite3_sql(stmt));
+            status = SQLITE_ERROR;
+            break;
+        }
+    }
+
+    os_free(response);
+
+    return status;
+}
+
 cJSON * wdb_exec_stmt(sqlite3_stmt * stmt) {
     cJSON * result;
     cJSON * row;

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -776,6 +776,18 @@ int wdb_exec_stmt_silent(sqlite3_stmt* stmt);
 cJSON * wdb_exec_stmt_sized(sqlite3_stmt * stmt, const size_t max_size, int* status);
 
 /**
+ * @brief Function to execute a SQL statement and send the result thru a TCP socket.
+ *        Each row of the SQL response will be sent in a different command.
+ *        This method will continue until SQL_DONE or an error is obtained.
+ *        This method could be blocking if the receiver lasts longer in receiving the information.
+ *
+ * @param [in] stmt The SQL statement to be executed.
+ * @param [in] peer The peer where the result will be sent.
+ * @return SQL error code of the last step.
+ */
+int wdb_exec_stmt_send(sqlite3_stmt* stmt, int peer);
+
+/**
  * @brief Function to execute a SQL statement and save the result in a JSON array.
  *
  * @param [in] stmt The SQL statement to be executed.
@@ -803,7 +815,7 @@ wdb_t * wdb_pool_find_prev(wdb_t * wdb);
 
 int wdb_stmt_cache(wdb_t * wdb, int index);
 
-int wdb_parse(char * input, char * output);
+int wdb_parse(char * input, char * output, int peer);
 
 int wdb_parse_syscheck(wdb_t * wdb, wdb_component_t component, char * input, char * output);
 int wdb_parse_syscollector(wdb_t * wdb, const char * query, char * input, char * output);

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -59,6 +59,8 @@
 #define VULN_CVES_TYPE_OS         "OS"
 #define VULN_CVES_TYPE_PACKAGE    "PACKAGE"
 
+#define WDB_BLOCK_SEND_TIMEOUT_S   1 /* Max time in seconds waiting for the client to receive the information sent with a blocking method*/
+
 typedef enum wdb_stmt {
     WDB_STMT_FIM_LOAD,
     WDB_STMT_FIM_FIND_ENTRY,
@@ -779,11 +781,15 @@ cJSON * wdb_exec_stmt_sized(sqlite3_stmt * stmt, const size_t max_size, int* sta
  * @brief Function to execute a SQL statement and send the result thru a TCP socket.
  *        Each row of the SQL response will be sent in a different command.
  *        This method will continue until SQL_DONE or an error is obtained.
- *        This method could be blocking if the receiver lasts longer in receiving the information.
+ *        This method could block if the receiver lasts longer in receiving the information.
+ *        The block will timeout after the time defined in WDB_BLOCK_SEND_TIMEOUT_S.
  *
  * @param [in] stmt The SQL statement to be executed.
  * @param [in] peer The peer where the result will be sent.
- * @return SQL error code of the last step.
+ * @return OS_SUCCESS on success.
+ *         OS_INVALID on errors executing SQL statement.
+ *         OS_SOCKTERR on errors handling the socket.
+ *         OS_SIZELIM on error trying to fit the row response into the socket buffer.
  */
 int wdb_exec_stmt_send(sqlite3_stmt* stmt, int peer);
 

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -778,7 +778,7 @@ int wdb_exec_stmt_silent(sqlite3_stmt* stmt);
 cJSON * wdb_exec_stmt_sized(sqlite3_stmt * stmt, const size_t max_size, int* status);
 
 /**
- * @brief Function to execute a SQL statement and send the result thru a TCP socket.
+ * @brief Function to execute a SQL statement and send the result via TCP socket.
  *        Each row of the SQL response will be sent in a different command.
  *        This method will continue until SQL_DONE or an error is obtained.
  *        This method could block if the receiver lasts longer in receiving the information.

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -187,7 +187,7 @@ static struct kv_list const TABLE_MAP[] = {
 };
 
 
-int wdb_parse(char * input, char * output) {
+int wdb_parse(char * input, char * output, int peer) {
     char * actor;
     char * id;
     char * query;


### PR DESCRIPTION
|Related issue|
|---|
|#8550|

## Description
This PR implements a method named **wdb_exec_stmt_send()** to execute an SQL statement and send the result of each row in an independent command.
Each of these responses will use the Wazuh TCP format (with a leading 4 bytes identifying the package size) and the payload is preceded with a "due" string.
i.e.:
`SIZE due {PAYLOAD}`

In case of error, this method will return the latest SQL error or a generic SQL_ERROR and will not send an error command.
The reason for this is to let the parser of WazuhDB create a final command with "ok" or "err" to identify if the query ended successfully. This standardizes the way every Wazuh-DB command is parsed and responded to.
UT for this method and fixes for **wdb_parse()** UT are implemented too.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Package installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report
  - [X] Valgrind (memcheck and descriptor leaks check)