### PR TITLE
Improve check_token function

### DIFF
--- a/api/api/authentication.py
+++ b/api/api/authentication.py
@@ -182,7 +182,7 @@ def check_token(username, roles, token_nbf_time, run_as):
         user_id = user['id']
 
         with UserRolesManager() as urm:
-            user_roles = [role['id'] for role in map(Roles.to_dict, urm.get_all_roles_from_user(user_id=user_id))]
+            user_roles = [role.id for role in urm.get_all_roles_from_user(user_id=user_id)]
             if not am.user_allow_run_as(user['username']) and set(user_roles) != set(roles):
                 return {'valid': False}
             with TokenManager() as tm:


### PR DESCRIPTION
Hi team,

In this PR we have improved the function check_token. We have removed the **map function** from the code since in this case, it was not necessary. We can use the role object as such, it is not necessary to transform it to a dictionary.

This way we achieve an improvement in the performance of this part of the code, now it consumes about 4 times less time. This is added to the fact that this function is executed in each of the calls that are made to the API and that this time is only checking 4 roles. 

The higher the number of roles, the longer the time, it scales in a logarithmic way.

## Comparison 

### Before
![image](https://user-images.githubusercontent.com/15522808/117262405-8280df80-ae51-11eb-8175-534a2baa135e.png)

### After
![image](https://user-images.githubusercontent.com/15522808/117262473-93c9ec00-ae51-11eb-8922-3e7f12ad1d4b.png)


Regards
