### PR TITLE
Exclude purged agents from client.keys in framework

### DIFF
--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -1260,7 +1260,14 @@ def get_agents_info():
     with open(common.client_keys, 'r') as f:
         file_content = f.readlines()
 
-    result = {line.split(' ')[0] for line in file_content}
+    result = set()
+    for line in file_content:
+        split_line = line.split(' ')
+        try:
+            not split_line[1].startswith('!') and result.add(split_line[0])
+        except IndexError:
+            continue
+
     result.add('000')
 
     return result

--- a/framework/wazuh/tests/data/agent/client.keys
+++ b/framework/wazuh/tests/data/agent/client.keys
@@ -8,3 +8,4 @@
 008 linux-agent8 any 2e2d2bd1beb9a94a59a2e8fea1d86c61ff4ec04e93728a805bec4c17021e8e4b
 009 linux-agent9 any 2e2d2bd1beb9a94a59a2e8fea1d86c61ff4ec04e93728a805bec4c17021e8e4b
 010 linux-agent10 any 2e2d2bd1beb9a94a59a2e8fea1d86c61ff4ec04e93728a805bec4c17021e8e4b
+011 !purged-agent any 2e2d2bd1beb9a94a59a2e8fea1d86c61ff4ec04e93728a805bec4c17021e8e4b


### PR DESCRIPTION
|Related issue|
|---|
| #8545 |

Closes #8545 .

Hello team, 
this PR solves the problem with the `get_agents_info` function. Some manual testing can be found in the issue.

## Tests performed
### Unit tests
```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.9.4, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.15.1
collected 251 items                                                                                                                                                                         

wazuh/core/tests/test_agent.py ...................................................................................................................................................... [ 59%]
.....                                                                                                                                                                                 [ 61%]
wazuh/tests/test_agent.py ................................................................................................                                                            [100%]

============================================================================== 251 passed, 2 warnings in 1.14s ==============================================================================

```

Regards,
Víctor Fernández
