### PR TITLE
Allow decoding of empty Windows ACEs

### DIFF
--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -891,8 +891,12 @@ int copy_ace_info(void *ace, char *perm, int perm_size) {
         }
     }
 
-    if (written + 1 < perm_size) {
+    written = snprintf(NULL, 0, "|%s,%d,%d", sid_str ? sid_str : account_name, ace_type, mask);
+
+    if (written > 0 && written + 1 < perm_size) {
         written = snprintf(perm, perm_size, "|%s,%d,%d", sid_str ? sid_str : account_name, ace_type, mask);
+    } else {
+        written = 0;
     }
 
 end:
@@ -1217,9 +1221,7 @@ char *decode_win_permissions(char *raw_perm) {
         if (perm_it = strchr(perm_it, ','), !perm_it) {
             goto error;
         }
-        *perm_it = '\0';
         a_type = *base_it;
-        *perm_it = ',';
 
         // Get the access mask
         base_it = ++perm_it;
@@ -1230,6 +1232,27 @@ char *decode_win_permissions(char *raw_perm) {
         } else {
             // End of the msg
             mask = strtol(base_it, NULL, 10);
+        }
+
+        size = snprintf(NULL, 0, "%s (%s): %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s", account_name,
+                        a_type == '0' ? "allowed" : "denied", mask & GENERIC_READ ? "generic_read|" : "",
+                        mask & GENERIC_WRITE ? "generic_write|" : "", mask & GENERIC_EXECUTE ? "generic_execute|" : "",
+                        mask & GENERIC_ALL ? "generic_all|" : "", mask & DELETE ? "delete|" : "",
+                        mask & READ_CONTROL ? "read_control|" : "", mask & WRITE_DAC ? "write_dac|" : "",
+                        mask & WRITE_OWNER ? "write_owner|" : "", mask & SYNCHRONIZE ? "synchronize|" : "",
+                        mask & FILE_READ_DATA ? "read_data|" : "", mask & FILE_WRITE_DATA ? "write_data|" : "",
+                        mask & FILE_APPEND_DATA ? "append_data|" : "", mask & FILE_READ_EA ? "read_ea|" : "",
+                        mask & FILE_WRITE_EA ? "write_ea|" : "", mask & FILE_EXECUTE ? "execute|" : "",
+                        mask & FILE_READ_ATTRIBUTES ? "read_attributes|" : "",
+                        mask & FILE_WRITE_ATTRIBUTES ? "write_attributes|" : "");
+
+        if (size > perm_size) {
+            os_free(account_name);
+
+            if (perm_it != NULL) {
+                continue;
+            }
+            break;
         }
 
         size = snprintf(decoded_it, perm_size, "%s (%s): %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s",
@@ -1353,10 +1376,11 @@ cJSON *win_perm_to_json(char *perms) {
         }
         *(perm_node++) = '\0';
 
-        perm_node = strchr(perm_node, ' ');
-        if (!perm_node) {
-            goto error;
+        // Remove the colon separator
+        if (*perm_node == ':') {
+            perm_node++;
         }
+
         while (*perm_node == ' ') perm_node++;
 
         // Get the permissions
@@ -1399,6 +1423,12 @@ cJSON *win_perm_to_json(char *perms) {
         cJSON *specific_perms;
         if (specific_perms = cJSON_CreateArray(), !specific_perms) {
             goto error;
+        }
+
+        if (*permissions == '\0') {
+            // Empty ACE
+            cJSON_AddItemToObject(user_obj, perm_type, specific_perms);
+            continue;
         }
 
         char **perms_array = NULL;


### PR DESCRIPTION
|Related issue|
|---|
|closes #8312|

## Description

After some testing, we found that Windows allows ACL entries to be set with no permissions, which was causing an error message on the manager. This PR fixes the problem by changing the function in charge of decoding ACEs and allowing them to be empty. It also fixes a couple of potential buffer overruns found while testing for the previous issue.

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
- Memory tests for Windows
  - [x] Scan-build report
  - [x] Dr. Memory

