### PR TITLE
Adding unit tests for check sync status method

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND wdb_tests_names "test_wdb_integrity")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug1 -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,sqlite3_step -Wl,--wrap,sqlite3_errmsg \
                          -Wl,--wrap,EVP_DigestInit_ex -Wl,--wrap,EVP_DigestUpdate -Wl,--wrap,_DigestFinal_ex \
-                         -Wl,--wrap,sqlite3_column_text -Wl,--wrap,_mdebug2")
+                         -Wl,--wrap,sqlite3_column_text -Wl,--wrap,_mdebug2 -Wl,--wrap,wdb_exec_stmt")
 
 # Add server specific tests to the list
 list(APPEND wdb_tests_names "test_wdb_fim")

--- a/src/wazuh_db/wdb_integrity.c
+++ b/src/wazuh_db/wdb_integrity.c
@@ -13,6 +13,7 @@
  * Foundation.
  */
 
+#include "os_err.h"
 #include "wdb.h"
 #include "os_crypto/sha1/sha1_op.h"
 #include <openssl/evp.h>
@@ -475,13 +476,14 @@ int wdbi_check_sync_status (wdb_t *wdb, wdb_component_t component) {
     cJSON* j_sync_info = NULL;
     int result = 1;
 
-    sqlite3_stmt* stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_SYNC_GET_INFO);
-
-    if (stmt == NULL) {
+    if (wdb_stmt_cache(wdb, WDB_STMT_SYNC_GET_INFO) == -1) {
+        mdebug1("Cannot cache statement");
         return OS_INVALID;
     }
 
+    sqlite3_stmt * stmt = wdb->stmt[WDB_STMT_SYNC_GET_INFO];
     sqlite3_bind_text(stmt, 1, COMPONENT_NAMES[component], -1, NULL);
+
     j_sync_info = wdb_exec_stmt(stmt);
 
     if (!j_sync_info) {


### PR DESCRIPTION
|Related issue|
|---|
|#8546|

## Description

This PR add UT for the new method `wdbi_check_sync_status`.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Valgrind (memcheck and descriptor leaks check)
 - [x] Added unit tests (for new features)

