### PR TITLE
8521 change dependencies of active response binaries

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1621,7 +1621,7 @@ manage_agents: ${addagent_o}
 
 active_response_programs = default-firewall-drop pf npf ipfw firewalld-drop disable-account host-deny ip-customblock restart-wazuh route-null kaspersky wazuh-slack
 
-$(active_response_programs): ${BUILD_LIBS} ${WAZUH_LIB}
+$(active_response_programs): ${WAZUH_LIB} ${WAZUHEXT_LIB}
 
 # Minimal dependencies for building active responses programs
 AR_PROGRAMS_DEPS = shared/validate_op.o shared/regex_op.o shared/string_op.o shared/exec_op.o shared/file_op.o shared/debug_op_proc.o shared/time_op.o shared/privsep_op.o shared/version_op.o os_xml/os_xml.o os_xml/os_xml_access.o os_regex/os_regex_strbreak.o


### PR DESCRIPTION
|Related issue|
|---|
| close #8521  |

## Description
This PR aims to change dependencies of active response binaries for unix based systems.

## DoD
- [X] changes in makefile
- [X] tests on ubuntu.
- [X] test on macos.
- [X] tests on solaris11.
- [X] tests on centos5.

Ubuntu AR binaries list:
![image](https://user-images.githubusercontent.com/54002291/117515626-2f03b400-af6d-11eb-8a69-20f44c206e04.png)
MacOs binaries list:
![image](https://user-images.githubusercontent.com/54002291/117515675-50fd3680-af6d-11eb-9843-2ef5c6370c2e.png)
Solaris 11 binaries list:
![image](https://user-images.githubusercontent.com/54002291/117515716-6d00d800-af6d-11eb-8e22-fe2e90009105.png)
Centos5 binaries list:
![image](https://user-images.githubusercontent.com/54002291/117515748-86098900-af6d-11eb-92b6-aad1e9d81092.png)
