### PR TITLE
Add libwazuhshared specialization for aix.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1690,8 +1690,13 @@ ifeq (${uname_P},sparc)
 $(WAZUH_LIB): $(WAZUHEXT_LIB) $(AR_PROGRAMS_DEPS)
 	$(OSSEC_SHARED) $(OSSEC_CFLAGS) -mimpure-text -o $@ -Wl,--whole-archive $^ -Wl,--no-whole-archive ${OSSEC_LIBS}
 else
+ifeq (${uname_S},AIX)
+$(WAZUH_LIB): $(WAZUHEXT_LIB) $(AR_PROGRAMS_DEPS)
+	$(OSSEC_SHARED) $(OSSEC_CFLAGS) $^ ${OSSEC_LIBS} -o $@
+else
 $(WAZUH_LIB): $(WAZUHEXT_LIB) $(AR_PROGRAMS_DEPS)
 	$(OSSEC_SHARED) $(OSSEC_CFLAGS) -o $@ -Wl,--whole-archive $^ -Wl,--no-whole-archive ${OSSEC_LIBS}
+endif
 endif
 endif
 endif


### PR DESCRIPTION
|Related issue|
|---|
| Closes #8523 |

## Description
This issue aims to verify that the post to the creation of the library compiles correctly in this operating system.

If there is a problem, it should be solved here too, this is very likely since AIX treats the directory from which to import dynamic library functions in a special way.

![imagen](https://user-images.githubusercontent.com/14300208/117548750-0df2a000-b00d-11eb-9cd2-887b72b4037a.png)

## DoD
- [x] Check compilation in AIX
- [x] Replace --whole-archive logic not supported in AIX linker.
- [x] PR CI Check
