### PR TITLE
Fix segfault when saving state with rotated files

### DIFF
--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -287,4 +287,8 @@
 #define MOD_TASK_TASKS_DB_ERROR_IN_QUERY    "(8208): Tasks DB Error reported in the result of the query, message: '%s'"
 #define MOD_TASK_TASKS_DB_ERROR_EXECUTE     "(8209): Tasks DB Cannot execute SQL query: err database '%s/%s.db'"
 
+/* Logcollector */
+
+#define LOGCOLLECTOR_FILE_NOT_EXIST           "(9000): File '%s' no longer exists."
+
 #endif /* DEBUG_MESSAGES_H */

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -214,6 +214,7 @@
 #define DUP_FILE_INODE  "(1966): Inode for file '%s' already found. Skipping it."
 #define LOCALFILE_REGEX "(1967): Syntax error on multiline_regex: '%s'"
 #define MISS_MULT_REGEX "(1968): Missing 'multiline_regex' element."
+#define FAIL_SHA1_GEN   "(1969): Failure to generate the SHA1 hash from file '%s'"
 
 /* Encryption/auth errors */
 #define INVALID_KEY     "(1401): Error reading authentication key: '%s'."

--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -537,9 +537,10 @@ DWORD FileSizeWin(const char * file);
  * This mode of opening the file allows reading \r\n instead of \n.
  *
  * @param file pathfile to open
+ * @param[out] lpFileInformation  pointer to a BY_HANDLE_FILE_INFORMATION structure that receives the file information
  * @return file descriptor on success, otherwise null.
  */
-FILE * w_fopen_r(const char *file, const char * mode);
+FILE * w_fopen_r(const char *file, const char * mode, BY_HANDLE_FILE_INFORMATION * lpFileInformation);
 
 #endif // Windows
 

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -2778,7 +2778,7 @@ STATIC int w_set_to_last_line_read(logreader * lf) {
     os_sha1 output;
 
     if (OS_SHA1_File_Nbytes(lf->file, &context, output, OS_BINARY, data->offset) < 0) {
-        merror("Failure to generate the SHA1 hash from file '%s'", lf->file);
+        merror(FAIL_SHA1_GEN, lf->file);
         return -1;
     }
 
@@ -2814,7 +2814,7 @@ STATIC int w_update_hash_node(char * path, int64_t pos) {
     os_sha1 output;
 
     if (OS_SHA1_File_Nbytes(path, &context, output, OS_BINARY, pos) < 0) {
-        merror("Failure to generate the SHA1 hash from file '%s'", path);
+        merror(FAIL_SHA1_GEN, path);
         os_free(data);
         return -1;
     }

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -2836,13 +2836,16 @@ STATIC int64_t w_set_to_pos(logreader * lf, int64_t pos, int mode) {
     return w_ftell(lf->fp);
 }
 
-void w_get_hash_context(const char * path, SHA_CTX * context, int64_t position) {
+bool w_get_hash_context(const char * path, SHA_CTX * context, int64_t position) {
     os_file_status_t * data;
 
     if (data = (os_file_status_t *)OSHash_Get_ex(files_status, path), data == NULL) {
         os_sha1 output;
-        OS_SHA1_File_Nbytes(path, context, output, OS_BINARY, position);
+        if (OS_SHA1_File_Nbytes(path, context, output, OS_BINARY, position) < 0) {
+            return false;
+        }
     } else {
         *context = data->context;
     }
+    return true;
 }

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -2267,7 +2267,7 @@ void * w_input_thread(__attribute__((unused)) void * t_id){
                             w_rwlock_unlock(&files_update_rwlock);
                             continue;
                         }
-    #ifdef WIN32
+#ifdef WIN32
                         if (current->fp != NULL) {
                             if (current->future == 0) {
                                 w_set_to_last_line_read(current);
@@ -2702,6 +2702,7 @@ STATIC void w_load_files_status(cJSON * global_json) {
         os_sha1 output;
 
         if (OS_SHA1_File_Nbytes(path_str, &context, output, OS_BINARY, value_offset) < 0) {
+            mdebug1(LOGCOLLECTOR_FILE_NOT_EXIST, path_str);
             os_free(data);
             return;
         }
@@ -2756,6 +2757,10 @@ STATIC char * w_save_files_status_to_cJSON() {
 STATIC int w_set_to_last_line_read(logreader * lf) {
 
     os_file_status_t * data;
+
+    if (lf->file == NULL) {
+        return 0;
+    }
 
     if (data = (os_file_status_t *)OSHash_Get_ex(files_status, lf->file), data == NULL) {
         w_set_to_pos(lf, 0, SEEK_END);
@@ -2848,9 +2853,10 @@ STATIC int64_t w_set_to_pos(logreader * lf, int64_t pos, int mode) {
 }
 
 bool w_get_hash_context(logreader *lf, SHA_CTX * context, int64_t position) {
-    os_file_status_t * data;
 
-    if (data = (os_file_status_t *)OSHash_Get_ex(files_status, lf->file), data == NULL) {
+    os_file_status_t * data = (os_file_status_t *) OSHash_Get_ex(files_status, lf->file);
+
+    if (data == NULL) {
         os_sha1 output;
         if (OS_SHA1_File_Nbytes_with_fp_check(lf->file, context, output, OS_BINARY, position, lf->fd) < 0) {
             return false;

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -253,7 +253,7 @@ int w_update_file_status(const char * path, int64_t pos, SHA_CTX *context);
  * @param context SHA1 context.
  * @param position end file position.
  */
-bool w_get_hash_context(const char * path, SHA_CTX *context, int64_t position);
+bool w_get_hash_context(logreader *lf, SHA_CTX *context, int64_t position);
 
 extern int sample_log_length;
 extern int lc_debug_level;

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -249,9 +249,10 @@ int w_update_file_status(const char * path, int64_t pos, SHA_CTX *context);
 
 /**
  * @brief Get SHA1 context or initialize it
- * @param path the path is the hash key
+ * @param lf Structure that contains file information, with `fd` and `file` non-null.
  * @param context SHA1 context.
  * @param position end file position.
+ * @return true if returns a valid context, false in otherwise.
  */
 bool w_get_hash_context(logreader *lf, SHA_CTX *context, int64_t position);
 

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -253,7 +253,7 @@ int w_update_file_status(const char * path, int64_t pos, SHA_CTX *context);
  * @param context SHA1 context.
  * @param position end file position.
  */
-void w_get_hash_context(const char * path, SHA_CTX *context, int64_t position);
+bool w_get_hash_context(const char * path, SHA_CTX *context, int64_t position);
 
 extern int sample_log_length;
 extern int lc_debug_level;

--- a/src/logcollector/read_audit.c
+++ b/src/logcollector/read_audit.c
@@ -59,7 +59,7 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     offset = w_ftell(lf->fp);
-    w_get_hash_context(lf->file, &context, offset);
+    bool context_file = w_get_hash_context(lf->file, &context, offset);
 
     for (offset = w_ftell(lf->fp); can_read() && fgets(buffer, OS_MAXSTR, lf->fp) && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
         rbytes = w_ftell(lf->fp) - offset;
@@ -72,7 +72,10 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
         lines++;
 
         if (buffer[rbytes - 1] == '\n') {
-            OS_SHA1_Stream(&context, NULL, buffer);
+            if (context_file) {
+                OS_SHA1_Stream(&context, NULL, buffer);
+            }
+
             buffer[rbytes - 1] = '\0';
 
             if ((int64_t)strlen(buffer) != rbytes - 1)
@@ -90,8 +93,9 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
                     if (rbytes <= 0) {
                         break;
                     }
-
-                    OS_SHA1_Stream(&context, NULL, buffer);
+                    if (context_file) {
+                        OS_SHA1_Stream(&context, NULL, buffer);
+                    }
 
                     if (buffer[rbytes - 1] == '\n') {
                         break;
@@ -138,8 +142,9 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
 
     if (icache > 0)
         audit_send_msg(cache, icache, lf->file, drop_it, lf->log_target);
-
-    w_update_file_status(lf->file, offset, &context);
+    if (context_file) {
+        w_update_file_status(lf->file, offset, &context);
+    }
 
     mdebug2("Read %d lines from %s", lines, lf->file);
     return NULL;

--- a/src/logcollector/read_audit.c
+++ b/src/logcollector/read_audit.c
@@ -59,7 +59,7 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     offset = w_ftell(lf->fp);
-    bool context_file = w_get_hash_context(lf, &context, offset);
+    bool is_valid_context_file = w_get_hash_context(lf, &context, offset);
 
     for (offset = w_ftell(lf->fp); can_read() && fgets(buffer, OS_MAXSTR, lf->fp) && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
         rbytes = w_ftell(lf->fp) - offset;
@@ -72,7 +72,7 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
         lines++;
 
         if (buffer[rbytes - 1] == '\n') {
-            if (context_file) {
+            if (is_valid_context_file) {
                 OS_SHA1_Stream(&context, NULL, buffer);
             }
 
@@ -93,7 +93,7 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
                     if (rbytes <= 0) {
                         break;
                     }
-                    if (context_file) {
+                    if (is_valid_context_file) {
                         OS_SHA1_Stream(&context, NULL, buffer);
                     }
 
@@ -142,7 +142,7 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
 
     if (icache > 0)
         audit_send_msg(cache, icache, lf->file, drop_it, lf->log_target);
-    if (context_file) {
+    if (is_valid_context_file) {
         w_update_file_status(lf->file, offset, &context);
     }
 

--- a/src/logcollector/read_audit.c
+++ b/src/logcollector/read_audit.c
@@ -59,7 +59,7 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     offset = w_ftell(lf->fp);
-    bool context_file = w_get_hash_context(lf->file, &context, offset);
+    bool context_file = w_get_hash_context(lf, &context, offset);
 
     for (offset = w_ftell(lf->fp); can_read() && fgets(buffer, OS_MAXSTR, lf->fp) && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
         rbytes = w_ftell(lf->fp) - offset;

--- a/src/logcollector/read_djb_multilog.c
+++ b/src/logcollector/read_djb_multilog.c
@@ -95,12 +95,14 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    w_get_hash_context(lf->file, &context, current_position);
+    bool context_file = w_get_hash_context(lf->file, &context, current_position);
 
     /* Get new entry */
     while (can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
 
-        OS_SHA1_Stream(&context, NULL, str);
+        if (context_file) {
+            OS_SHA1_Stream(&context, NULL, str);
+        }
 
         lines++;
         /* Get buffer size */
@@ -179,7 +181,10 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
     }
 
     current_position = w_ftell(lf->fp);
-    w_update_file_status(lf->file, current_position, &context);
+
+    if (context_file) {
+        w_update_file_status(lf->file, current_position, &context);
+    }
 
     mdebug2("Read %d lines from %s", lines, lf->file);
     return (NULL);

--- a/src/logcollector/read_djb_multilog.c
+++ b/src/logcollector/read_djb_multilog.c
@@ -95,7 +95,7 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    bool context_file = w_get_hash_context(lf->file, &context, current_position);
+    bool context_file = w_get_hash_context(lf, &context, current_position);
 
     /* Get new entry */
     while (can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {

--- a/src/logcollector/read_djb_multilog.c
+++ b/src/logcollector/read_djb_multilog.c
@@ -95,12 +95,12 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    bool context_file = w_get_hash_context(lf, &context, current_position);
+    bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
     /* Get new entry */
     while (can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
 
-        if (context_file) {
+        if (is_valid_context_file) {
             OS_SHA1_Stream(&context, NULL, str);
         }
 
@@ -182,7 +182,7 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
 
     current_position = w_ftell(lf->fp);
 
-    if (context_file) {
+    if (is_valid_context_file) {
         w_update_file_status(lf->file, current_position, &context);
     }
 

--- a/src/logcollector/read_json.c
+++ b/src/logcollector/read_json.c
@@ -32,7 +32,7 @@ void *read_json(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    bool context_file = w_get_hash_context(lf->file, &context, current_position);
+    bool context_file = w_get_hash_context(lf, &context, current_position);
 
     for (offset = w_ftell(lf->fp); can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
         rbytes = w_ftell(lf->fp) - offset;

--- a/src/logcollector/read_json.c
+++ b/src/logcollector/read_json.c
@@ -32,7 +32,7 @@ void *read_json(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    bool context_file = w_get_hash_context(lf, &context, current_position);
+    bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
     for (offset = w_ftell(lf->fp); can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
         rbytes = w_ftell(lf->fp) - offset;
@@ -45,7 +45,7 @@ void *read_json(logreader *lf, int *rc, int drop_it) {
 
         /* Get the last occurrence of \n */
         if (str[rbytes - 1] == '\n') {
-            if (context_file) {
+            if (is_valid_context_file) {
                 OS_SHA1_Stream(&context, NULL, str);
             }
 
@@ -63,7 +63,7 @@ void *read_json(logreader *lf, int *rc, int drop_it) {
          */
         else if (rbytes == OS_MAXSTR - OS_LOG_HEADER - 1) {
             /* Message size > maximum allowed */
-            if (context_file) {
+            if (is_valid_context_file) {
                 OS_SHA1_Stream(&context, NULL, str);
             }
             __ms = 1;
@@ -136,7 +136,7 @@ void *read_json(logreader *lf, int *rc, int drop_it) {
                     break;
                 }
 
-                if (context_file) {
+                if (is_valid_context_file) {
                     OS_SHA1_Stream(&context, NULL, str);
                 }
 
@@ -151,7 +151,7 @@ void *read_json(logreader *lf, int *rc, int drop_it) {
         current_position = w_ftell(lf->fp);
     }
 
-    if (context_file) {
+    if (is_valid_context_file) {
         w_update_file_status(lf->file, current_position, &context);
     }
 

--- a/src/logcollector/read_json.c
+++ b/src/logcollector/read_json.c
@@ -32,7 +32,7 @@ void *read_json(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    w_get_hash_context(lf->file, &context, current_position);
+    bool context_file = w_get_hash_context(lf->file, &context, current_position);
 
     for (offset = w_ftell(lf->fp); can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
         rbytes = w_ftell(lf->fp) - offset;
@@ -45,7 +45,10 @@ void *read_json(logreader *lf, int *rc, int drop_it) {
 
         /* Get the last occurrence of \n */
         if (str[rbytes - 1] == '\n') {
-            OS_SHA1_Stream(&context, NULL, str);
+            if (context_file) {
+                OS_SHA1_Stream(&context, NULL, str);
+            }
+
             str[rbytes - 1] = '\0';
 
             if ((int64_t)strlen(str) != rbytes - 1)
@@ -60,7 +63,9 @@ void *read_json(logreader *lf, int *rc, int drop_it) {
          */
         else if (rbytes == OS_MAXSTR - OS_LOG_HEADER - 1) {
             /* Message size > maximum allowed */
-            OS_SHA1_Stream(&context, NULL, str);
+            if (context_file) {
+                OS_SHA1_Stream(&context, NULL, str);
+            }
             __ms = 1;
         } else if (feof(lf->fp)) {
             /* Message not complete. Return. */
@@ -131,7 +136,9 @@ void *read_json(logreader *lf, int *rc, int drop_it) {
                     break;
                 }
 
-                OS_SHA1_Stream(&context, NULL, str);
+                if (context_file) {
+                    OS_SHA1_Stream(&context, NULL, str);
+                }
 
                 /* Get the last occurrence of \n */
                 if (str[rbytes - 1] == '\n') {
@@ -144,7 +151,9 @@ void *read_json(logreader *lf, int *rc, int drop_it) {
         current_position = w_ftell(lf->fp);
     }
 
-    w_update_file_status(lf->file, current_position, &context);
+    if (context_file) {
+        w_update_file_status(lf->file, current_position, &context);
+    }
 
     mdebug2("Read %d lines from %s", lines, lf->file);
     return (NULL);

--- a/src/logcollector/read_mssql_log.c
+++ b/src/logcollector/read_mssql_log.c
@@ -40,7 +40,7 @@ void *read_mssql_log(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    w_get_hash_context(lf->file, &context, current_position);
+    bool context_file = w_get_hash_context(lf->file, &context, current_position);
 
     /* Get new entry */
     while (can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
@@ -49,7 +49,9 @@ void *read_mssql_log(logreader *lf, int *rc, int drop_it) {
         /* Get buffer size */
         str_len = strlen(str);
 
-        OS_SHA1_Stream(&context, NULL, str);
+        if (context_file) {
+            OS_SHA1_Stream(&context, NULL, str);
+        }
 
         /* Check str_len size. Very useless, but just to make sure */
         if (str_len >= sizeof(buffer) - 2) {
@@ -144,7 +146,10 @@ void *read_mssql_log(logreader *lf, int *rc, int drop_it) {
     }
 
     current_position = w_ftell(lf->fp);
-    w_update_file_status(lf->file, current_position, &context);
+
+    if (context_file) {
+        w_update_file_status(lf->file, current_position, &context);
+    }
 
     /* Send whatever is stored */
     if (buffer[0] != '\0') {

--- a/src/logcollector/read_mssql_log.c
+++ b/src/logcollector/read_mssql_log.c
@@ -40,7 +40,7 @@ void *read_mssql_log(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    bool context_file = w_get_hash_context(lf, &context, current_position);
+    bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
     /* Get new entry */
     while (can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
@@ -49,7 +49,7 @@ void *read_mssql_log(logreader *lf, int *rc, int drop_it) {
         /* Get buffer size */
         str_len = strlen(str);
 
-        if (context_file) {
+        if (is_valid_context_file) {
             OS_SHA1_Stream(&context, NULL, str);
         }
 
@@ -147,7 +147,7 @@ void *read_mssql_log(logreader *lf, int *rc, int drop_it) {
 
     current_position = w_ftell(lf->fp);
 
-    if (context_file) {
+    if (is_valid_context_file) {
         w_update_file_status(lf->file, current_position, &context);
     }
 

--- a/src/logcollector/read_mssql_log.c
+++ b/src/logcollector/read_mssql_log.c
@@ -40,7 +40,7 @@ void *read_mssql_log(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    bool context_file = w_get_hash_context(lf->file, &context, current_position);
+    bool context_file = w_get_hash_context(lf, &context, current_position);
 
     /* Get new entry */
     while (can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {

--- a/src/logcollector/read_multiline.c
+++ b/src/logcollector/read_multiline.c
@@ -33,7 +33,7 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    bool context_file = w_get_hash_context(lf, &context, current_position);
+    bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
     for (offset = w_ftell(lf->fp); can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
         rbytes = w_ftell(lf->fp) - offset;
@@ -47,7 +47,7 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
 
         /* Get the last occurrence of \n */
         if (str[rbytes - 1] == '\n') {
-            if (context_file) {
+            if (is_valid_context_file) {
                 OS_SHA1_Stream(&context, NULL, str);
             }
             str[rbytes - 1] = '\0';
@@ -64,7 +64,7 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
          */
         else if (rbytes == OS_MAXSTR - OS_LOG_HEADER - 1) {
             /* Message size > maximum allowed */
-            if (context_file) {
+            if (is_valid_context_file) {
                 OS_SHA1_Stream(&context, NULL, str);
             }
             __ms = 1;
@@ -126,7 +126,7 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
                     break;
                 }
 
-                if (context_file) {
+                if (is_valid_context_file) {
                     OS_SHA1_Stream(&context, NULL, str);
                 }
 
@@ -141,7 +141,7 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
         current_position = w_ftell(lf->fp);
     }
 
-    if (context_file) {
+    if (is_valid_context_file) {
         w_update_file_status(lf->file, current_position, &context);
     }
 

--- a/src/logcollector/read_multiline.c
+++ b/src/logcollector/read_multiline.c
@@ -33,7 +33,7 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    w_get_hash_context(lf->file, &context, current_position);
+    bool context_file = w_get_hash_context(lf->file, &context, current_position);
 
     for (offset = w_ftell(lf->fp); can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
         rbytes = w_ftell(lf->fp) - offset;
@@ -47,7 +47,9 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
 
         /* Get the last occurrence of \n */
         if (str[rbytes - 1] == '\n') {
-            OS_SHA1_Stream(&context, NULL, str);
+            if (context_file) {
+                OS_SHA1_Stream(&context, NULL, str);
+            }
             str[rbytes - 1] = '\0';
 
             if ((int64_t)strlen(str) != rbytes - 1)
@@ -62,7 +64,9 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
          */
         else if (rbytes == OS_MAXSTR - OS_LOG_HEADER - 1) {
             /* Message size > maximum allowed */
-            OS_SHA1_Stream(&context, NULL, str);
+            if (context_file) {
+                OS_SHA1_Stream(&context, NULL, str);
+            }
             __ms = 1;
         } else if (feof(lf->fp)) {
             /* Message not complete. Return. */
@@ -122,7 +126,9 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
                     break;
                 }
 
-                OS_SHA1_Stream(&context, NULL, str);
+                if (context_file) {
+                    OS_SHA1_Stream(&context, NULL, str);
+                }
 
                 /* Get the last occurrence of \n */
                 if (str[rbytes - 1] == '\n') {
@@ -135,7 +141,9 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
         current_position = w_ftell(lf->fp);
     }
 
-    w_update_file_status(lf->file, current_position, &context);
+    if (context_file) {
+        w_update_file_status(lf->file, current_position, &context);
+    }
 
     mdebug2("Read %d lines from %s", lines, lf->file);
     return (NULL);

--- a/src/logcollector/read_multiline.c
+++ b/src/logcollector/read_multiline.c
@@ -33,7 +33,7 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    bool context_file = w_get_hash_context(lf->file, &context, current_position);
+    bool context_file = w_get_hash_context(lf, &context, current_position);
 
     for (offset = w_ftell(lf->fp); can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
         rbytes = w_ftell(lf->fp) - offset;

--- a/src/logcollector/read_multiline_regex.c
+++ b/src/logcollector/read_multiline_regex.c
@@ -147,7 +147,7 @@ void * read_multiline_regex(logreader * lf, int * rc, int drop_it) {
         lf->multiline->offset_last_read = w_ftell(lf->fp);
     }
 
-    w_get_hash_context(lf->file, &context, lf->multiline->offset_last_read);
+    bool context_file = w_get_hash_context(lf->file, &context, lf->multiline->offset_last_read);
 
     read_buffer[OS_MAXSTR] = '\0';
     *rc = 0;
@@ -169,10 +169,16 @@ void * read_multiline_regex(logreader * lf, int * rc, int drop_it) {
             continue;
         }
 
-        OS_SHA1_Stream(&context, NULL, raw_data);
+        if (context_file) {
+            OS_SHA1_Stream(&context, NULL, raw_data);
+        }
+
         os_free(raw_data);
     }
-    w_update_file_status(lf->file, lf->multiline->offset_last_read, &context);
+
+    if (context_file) {
+        w_update_file_status(lf->file, lf->multiline->offset_last_read, &context);
+    }
 
     return NULL;
 }

--- a/src/logcollector/read_multiline_regex.c
+++ b/src/logcollector/read_multiline_regex.c
@@ -147,7 +147,7 @@ void * read_multiline_regex(logreader * lf, int * rc, int drop_it) {
         lf->multiline->offset_last_read = w_ftell(lf->fp);
     }
 
-    bool context_file = w_get_hash_context(lf->file, &context, lf->multiline->offset_last_read);
+    bool context_file = w_get_hash_context(lf, &context, lf->multiline->offset_last_read);
 
     read_buffer[OS_MAXSTR] = '\0';
     *rc = 0;

--- a/src/logcollector/read_multiline_regex.c
+++ b/src/logcollector/read_multiline_regex.c
@@ -147,7 +147,7 @@ void * read_multiline_regex(logreader * lf, int * rc, int drop_it) {
         lf->multiline->offset_last_read = w_ftell(lf->fp);
     }
 
-    bool context_file = w_get_hash_context(lf, &context, lf->multiline->offset_last_read);
+    bool is_valid_context_file = w_get_hash_context(lf, &context, lf->multiline->offset_last_read);
 
     read_buffer[OS_MAXSTR] = '\0';
     *rc = 0;
@@ -169,14 +169,14 @@ void * read_multiline_regex(logreader * lf, int * rc, int drop_it) {
             continue;
         }
 
-        if (context_file) {
+        if (is_valid_context_file) {
             OS_SHA1_Stream(&context, NULL, raw_data);
         }
 
         os_free(raw_data);
     }
 
-    if (context_file) {
+    if (is_valid_context_file) {
         w_update_file_status(lf->file, lf->multiline->offset_last_read, &context);
     }
 

--- a/src/logcollector/read_mysql_log.c
+++ b/src/logcollector/read_mysql_log.c
@@ -32,7 +32,7 @@ void *read_mysql_log(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    bool context_file = w_get_hash_context(lf->file, &context, current_position);
+    bool context_file = w_get_hash_context(lf, &context, current_position);
 
     /* Get new entry */
     while (can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {

--- a/src/logcollector/read_mysql_log.c
+++ b/src/logcollector/read_mysql_log.c
@@ -32,7 +32,7 @@ void *read_mysql_log(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    bool context_file = w_get_hash_context(lf, &context, current_position);
+    bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
     /* Get new entry */
     while (can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
@@ -41,7 +41,7 @@ void *read_mysql_log(logreader *lf, int *rc, int drop_it) {
         /* Get buffer size */
         str_len = strlen(str);
 
-        if (context_file) {
+        if (is_valid_context_file) {
             OS_SHA1_Stream(&context, NULL, str);
         }
 
@@ -142,7 +142,7 @@ void *read_mysql_log(logreader *lf, int *rc, int drop_it) {
 
     current_position = w_ftell(lf->fp);
 
-    if (context_file) {
+    if (is_valid_context_file) {
         w_update_file_status(lf->file, current_position, &context);
     }
 

--- a/src/logcollector/read_mysql_log.c
+++ b/src/logcollector/read_mysql_log.c
@@ -32,7 +32,7 @@ void *read_mysql_log(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    w_get_hash_context(lf->file, &context, current_position);
+    bool context_file = w_get_hash_context(lf->file, &context, current_position);
 
     /* Get new entry */
     while (can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
@@ -41,7 +41,9 @@ void *read_mysql_log(logreader *lf, int *rc, int drop_it) {
         /* Get buffer size */
         str_len = strlen(str);
 
-        OS_SHA1_Stream(&context, NULL, str);
+        if (context_file) {
+            OS_SHA1_Stream(&context, NULL, str);
+        }
 
         /* Get the last occurrence of \n */
         if ((p = strrchr(str, '\n')) != NULL) {
@@ -139,7 +141,10 @@ void *read_mysql_log(logreader *lf, int *rc, int drop_it) {
     }
 
     current_position = w_ftell(lf->fp);
-    w_update_file_status(lf->file, current_position, &context);
+
+    if (context_file) {
+        w_update_file_status(lf->file, current_position, &context);
+    }
 
     mdebug2("Read %d lines from %s", lines, lf->file);
     return (NULL);

--- a/src/logcollector/read_nmapg.c
+++ b/src/logcollector/read_nmapg.c
@@ -150,13 +150,13 @@ void *read_nmapg(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    bool context_file = w_get_hash_context(lf, &context, current_position);
+    bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
     while (can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
 
         lines++;
 
-        if (context_file) {
+        if (is_valid_context_file) {
             OS_SHA1_Stream(&context, NULL, str);
         }
 
@@ -266,7 +266,7 @@ file_error:
     }
 
     current_position = w_ftell(lf->fp);
-    if (context_file) {
+    if (is_valid_context_file) {
         w_update_file_status(lf->file, current_position, &context);
     }
 

--- a/src/logcollector/read_nmapg.c
+++ b/src/logcollector/read_nmapg.c
@@ -150,13 +150,15 @@ void *read_nmapg(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    w_get_hash_context(lf->file, &context, current_position);
+    bool context_file = w_get_hash_context(lf->file, &context, current_position);
 
     while (can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
 
         lines++;
 
-        OS_SHA1_Stream(&context, NULL, str);
+        if (context_file) {
+            OS_SHA1_Stream(&context, NULL, str);
+        }
 
         /* If need clear is set, we need to clear the line */
         if (need_clear) {
@@ -264,7 +266,9 @@ file_error:
     }
 
     current_position = w_ftell(lf->fp);
-    w_update_file_status(lf->file, current_position, &context);
+    if (context_file) {
+        w_update_file_status(lf->file, current_position, &context);
+    }
 
     mdebug2("Read %d lines from %s", lines, lf->file);
     return (NULL);

--- a/src/logcollector/read_nmapg.c
+++ b/src/logcollector/read_nmapg.c
@@ -150,7 +150,7 @@ void *read_nmapg(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    bool context_file = w_get_hash_context(lf->file, &context, current_position);
+    bool context_file = w_get_hash_context(lf, &context, current_position);
 
     while (can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
 

--- a/src/logcollector/read_ossecalert.c
+++ b/src/logcollector/read_ossecalert.c
@@ -33,7 +33,7 @@ void *read_ossecalert(logreader *lf, __attribute__((unused)) int *rc, int drop_i
     int64_t current_position = w_ftell(lf->fp);
 
     if (OS_SHA1_File_Nbytes(lf->file, &context, output, OS_BINARY, current_position) < 0) {
-        merror("Failure to generate the SHA1 hash from file '%s'", lf->file);
+        merror(FAIL_SHA1_GEN, lf->file);
     }
 
     w_update_file_status(lf->file, current_position, &context);

--- a/src/logcollector/read_ossecalert.c
+++ b/src/logcollector/read_ossecalert.c
@@ -32,7 +32,10 @@ void *read_ossecalert(logreader *lf, __attribute__((unused)) int *rc, int drop_i
     os_sha1 output;
     int64_t current_position = w_ftell(lf->fp);
 
-    OS_SHA1_File_Nbytes(lf->file, &context, output, OS_BINARY, current_position);
+    if (OS_SHA1_File_Nbytes(lf->file, &context, output, OS_BINARY, current_position) < 0) {
+        merror("Failure to generate the SHA1 hash from file '%s'", lf->file);
+    }
+
     w_update_file_status(lf->file, current_position, &context);
 
     memset(syslog_msg, '\0', OS_SIZE_2048 + 1);

--- a/src/logcollector/read_postgresql_log.c
+++ b/src/logcollector/read_postgresql_log.c
@@ -41,7 +41,7 @@ void *read_postgresql_log(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    bool context_file = w_get_hash_context(lf, &context, current_position);
+    bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
     /* Get new entry */
     while (can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
@@ -50,7 +50,7 @@ void *read_postgresql_log(logreader *lf, int *rc, int drop_it) {
         /* Get buffer size */
         str_len = strlen(str);
 
-        if (context_file) {
+        if (is_valid_context_file) {
             OS_SHA1_Stream(&context, NULL, str);
         }
 
@@ -150,7 +150,7 @@ void *read_postgresql_log(logreader *lf, int *rc, int drop_it) {
     }
 
     current_position = w_ftell(lf->fp);
-    if (context_file) {
+    if (is_valid_context_file) {
         w_update_file_status(lf->file, current_position, &context);
     }
 

--- a/src/logcollector/read_postgresql_log.c
+++ b/src/logcollector/read_postgresql_log.c
@@ -41,7 +41,7 @@ void *read_postgresql_log(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    w_get_hash_context(lf->file, &context, current_position);
+    bool context_file = w_get_hash_context(lf->file, &context, current_position);
 
     /* Get new entry */
     while (can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
@@ -50,7 +50,9 @@ void *read_postgresql_log(logreader *lf, int *rc, int drop_it) {
         /* Get buffer size */
         str_len = strlen(str);
 
-        OS_SHA1_Stream(&context, NULL, str);
+        if (context_file) {
+            OS_SHA1_Stream(&context, NULL, str);
+        }
 
         /* Check str_len size. Very useless, but just to make sure.. */
         if (str_len >= sizeof(buffer) - 2) {
@@ -148,7 +150,9 @@ void *read_postgresql_log(logreader *lf, int *rc, int drop_it) {
     }
 
     current_position = w_ftell(lf->fp);
-    w_update_file_status(lf->file, current_position, &context);
+    if (context_file) {
+        w_update_file_status(lf->file, current_position, &context);
+    }
 
     mdebug2("Read %d lines from %s", lines, lf->file);
     return (NULL);

--- a/src/logcollector/read_postgresql_log.c
+++ b/src/logcollector/read_postgresql_log.c
@@ -41,7 +41,7 @@ void *read_postgresql_log(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    bool context_file = w_get_hash_context(lf->file, &context, current_position);
+    bool context_file = w_get_hash_context(lf, &context, current_position);
 
     /* Get new entry */
     while (can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {

--- a/src/logcollector/read_snortfull.c
+++ b/src/logcollector/read_snortfull.c
@@ -31,7 +31,7 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    bool context_file = w_get_hash_context(lf->file, &context, current_position);
+    bool context_file = w_get_hash_context(lf, &context, current_position);
 
     while (can_read() && fgets(str, OS_MAXSTR, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
 

--- a/src/logcollector/read_snortfull.c
+++ b/src/logcollector/read_snortfull.c
@@ -31,13 +31,13 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    bool context_file = w_get_hash_context(lf, &context, current_position);
+    bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
     while (can_read() && fgets(str, OS_MAXSTR, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
 
         lines++;
 
-        if (context_file) {
+        if (is_valid_context_file) {
             OS_SHA1_Stream(&context, NULL, str);
         }
 
@@ -124,7 +124,7 @@ file_error:
 
     current_position = w_ftell(lf->fp);
 
-    if (context_file) {
+    if (is_valid_context_file) {
         w_update_file_status(lf->file, current_position, &context);
     }
 

--- a/src/logcollector/read_snortfull.c
+++ b/src/logcollector/read_snortfull.c
@@ -31,13 +31,15 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    w_get_hash_context(lf->file, &context, current_position);
+    bool context_file = w_get_hash_context(lf->file, &context, current_position);
 
     while (can_read() && fgets(str, OS_MAXSTR, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
 
         lines++;
 
-        OS_SHA1_Stream(&context, NULL, str);
+        if (context_file) {
+            OS_SHA1_Stream(&context, NULL, str);
+        }
 
         /* Remove \n at the end of the string */
         if ((q = strrchr(str, '\n')) != NULL) {
@@ -121,7 +123,10 @@ file_error:
     }
 
     current_position = w_ftell(lf->fp);
-    w_update_file_status(lf->file, current_position, &context);
+
+    if (context_file) {
+        w_update_file_status(lf->file, current_position, &context);
+    }
 
     mdebug2("Read %d lines from %s", lines, lf->file);
     return (NULL);

--- a/src/logcollector/read_syslog.c
+++ b/src/logcollector/read_syslog.c
@@ -32,7 +32,7 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
     current_position = w_ftell(lf->fp);
 
     SHA_CTX context;
-    bool context_file = w_get_hash_context(lf->file, &context, current_position);
+    bool context_file = w_get_hash_context(lf, &context, current_position);
 
     for (offset = w_ftell(lf->fp); can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
         rbytes = w_ftell(lf->fp) - offset;

--- a/src/logcollector/read_syslog.c
+++ b/src/logcollector/read_syslog.c
@@ -32,7 +32,7 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
     current_position = w_ftell(lf->fp);
 
     SHA_CTX context;
-    w_get_hash_context(lf->file, &context, current_position);
+    bool context_file = w_get_hash_context(lf->file, &context, current_position);
 
     for (offset = w_ftell(lf->fp); can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
         rbytes = w_ftell(lf->fp) - offset;
@@ -45,7 +45,9 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
 
         /* Get the last occurrence of \n */
         if (str[rbytes - 1] == '\n') {
-            OS_SHA1_Stream(&context, NULL, str);
+            if (context_file) {
+                OS_SHA1_Stream(&context, NULL, str);
+            }
             str[rbytes - 1] = '\0';
 
             if ((int64_t)strlen(str) != rbytes - 1)
@@ -61,7 +63,9 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
         else if (rbytes == OS_MAXSTR - OS_LOG_HEADER - 1) {
             /* Message size > maximum allowed */
             __ms = 1;
-            OS_SHA1_Stream(&context, NULL, str);
+            if (context_file) {
+                OS_SHA1_Stream(&context, NULL, str);
+            }
             str[rbytes - 1] = '\0';
         } else {
             /* We may not have gotten a line feed
@@ -123,7 +127,9 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
                     break;
                 }
 
-                OS_SHA1_Stream(&context, NULL, str);
+                if (context_file) {
+                    OS_SHA1_Stream(&context, NULL, str);
+                }
 
                 /* Get the last occurrence of \n */
                 if (str[rbytes - 1] == '\n') {
@@ -135,7 +141,9 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
         current_position = w_ftell(lf->fp);
     }
 
-    w_update_file_status(lf->file, current_position, &context);
+    if (context_file) {
+        w_update_file_status(lf->file, current_position, &context);
+    }
 
     mdebug2("Read %d lines from %s", lines, lf->file);
     return (NULL);

--- a/src/logcollector/read_syslog.c
+++ b/src/logcollector/read_syslog.c
@@ -32,7 +32,7 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
     current_position = w_ftell(lf->fp);
 
     SHA_CTX context;
-    bool context_file = w_get_hash_context(lf, &context, current_position);
+    bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
     for (offset = w_ftell(lf->fp); can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
         rbytes = w_ftell(lf->fp) - offset;
@@ -45,7 +45,7 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
 
         /* Get the last occurrence of \n */
         if (str[rbytes - 1] == '\n') {
-            if (context_file) {
+            if (is_valid_context_file) {
                 OS_SHA1_Stream(&context, NULL, str);
             }
             str[rbytes - 1] = '\0';
@@ -63,7 +63,7 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
         else if (rbytes == OS_MAXSTR - OS_LOG_HEADER - 1) {
             /* Message size > maximum allowed */
             __ms = 1;
-            if (context_file) {
+            if (is_valid_context_file) {
                 OS_SHA1_Stream(&context, NULL, str);
             }
             str[rbytes - 1] = '\0';
@@ -127,7 +127,7 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
                     break;
                 }
 
-                if (context_file) {
+                if (is_valid_context_file) {
                     OS_SHA1_Stream(&context, NULL, str);
                 }
 
@@ -141,7 +141,7 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
         current_position = w_ftell(lf->fp);
     }
 
-    if (context_file) {
+    if (is_valid_context_file) {
         w_update_file_status(lf->file, current_position, &context);
     }
 

--- a/src/logcollector/read_ucs2_be.c
+++ b/src/logcollector/read_ucs2_be.c
@@ -31,7 +31,7 @@ void *read_ucs2_be(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    w_get_hash_context(lf->file, &context, current_position);
+    bool context_file = w_get_hash_context(lf->file, &context, current_position);
 
     for (offset = w_ftell(lf->fp); can_read() && fgets(str, OS_MAXSTR_BE - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
         rbytes = w_ftell(lf->fp) - offset;
@@ -46,7 +46,9 @@ void *read_ucs2_be(logreader *lf, int *rc, int drop_it) {
 
         /* Get the last occurrence of \n */
         if (str[rbytes - 1] == '\n') {
-            OS_SHA1_Stream(&context, NULL, str);
+            if (context_file) {
+                OS_SHA1_Stream(&context, NULL, str);
+            }
             str[rbytes - 1] = '\0';
         }
         /* If we didn't get the new line, because the
@@ -54,7 +56,9 @@ void *read_ucs2_be(logreader *lf, int *rc, int drop_it) {
          */
         else if (rbytes == OS_MAXSTR_BE - OS_LOG_HEADER - 1) {
             /* Message size > maximum allowed */
-            OS_SHA1_Stream(&context, NULL, str);
+            if (context_file) {
+                OS_SHA1_Stream(&context, NULL, str);
+            }
             __ms = 1;
             str[rbytes - 1] = '\0';
         } else {
@@ -139,7 +143,9 @@ void *read_ucs2_be(logreader *lf, int *rc, int drop_it) {
                     break;
                 }
 
-                OS_SHA1_Stream(&context, NULL, str);
+                if (context_file) {
+                    OS_SHA1_Stream(&context, NULL, str);
+                }
 
                 /* Get the last occurrence of \n */
                 if (str[rbytes - 1] == '\n') {
@@ -151,7 +157,9 @@ void *read_ucs2_be(logreader *lf, int *rc, int drop_it) {
         current_position = w_ftell(lf->fp);
     }
 
-    w_update_file_status(lf->file, current_position, &context);
+    if (context_file) {
+        w_update_file_status(lf->file, current_position, &context);
+    }
 
     mdebug2("Read %d lines from %s", lines, lf->file);
     return (NULL);

--- a/src/logcollector/read_ucs2_be.c
+++ b/src/logcollector/read_ucs2_be.c
@@ -31,7 +31,7 @@ void *read_ucs2_be(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    bool context_file = w_get_hash_context(lf, &context, current_position);
+    bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
     for (offset = w_ftell(lf->fp); can_read() && fgets(str, OS_MAXSTR_BE - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
         rbytes = w_ftell(lf->fp) - offset;
@@ -46,7 +46,7 @@ void *read_ucs2_be(logreader *lf, int *rc, int drop_it) {
 
         /* Get the last occurrence of \n */
         if (str[rbytes - 1] == '\n') {
-            if (context_file) {
+            if (is_valid_context_file) {
                 OS_SHA1_Stream(&context, NULL, str);
             }
             str[rbytes - 1] = '\0';
@@ -56,7 +56,7 @@ void *read_ucs2_be(logreader *lf, int *rc, int drop_it) {
          */
         else if (rbytes == OS_MAXSTR_BE - OS_LOG_HEADER - 1) {
             /* Message size > maximum allowed */
-            if (context_file) {
+            if (is_valid_context_file) {
                 OS_SHA1_Stream(&context, NULL, str);
             }
             __ms = 1;
@@ -143,7 +143,7 @@ void *read_ucs2_be(logreader *lf, int *rc, int drop_it) {
                     break;
                 }
 
-                if (context_file) {
+                if (is_valid_context_file) {
                     OS_SHA1_Stream(&context, NULL, str);
                 }
 
@@ -157,7 +157,7 @@ void *read_ucs2_be(logreader *lf, int *rc, int drop_it) {
         current_position = w_ftell(lf->fp);
     }
 
-    if (context_file) {
+    if (is_valid_context_file) {
         w_update_file_status(lf->file, current_position, &context);
     }
 

--- a/src/logcollector/read_ucs2_be.c
+++ b/src/logcollector/read_ucs2_be.c
@@ -31,7 +31,7 @@ void *read_ucs2_be(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    bool context_file = w_get_hash_context(lf->file, &context, current_position);
+    bool context_file = w_get_hash_context(lf, &context, current_position);
 
     for (offset = w_ftell(lf->fp); can_read() && fgets(str, OS_MAXSTR_BE - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
         rbytes = w_ftell(lf->fp) - offset;

--- a/src/logcollector/read_ucs2_le.c
+++ b/src/logcollector/read_ucs2_le.c
@@ -31,7 +31,7 @@ void *read_ucs2_le(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    w_get_hash_context(lf->file, &context, current_position);
+    bool context_file = w_get_hash_context(lf->file, &context, current_position);
 
     for (offset = w_ftell(lf->fp); can_read() && fgetws(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
         rbytes = w_ftell(lf->fp) - offset;
@@ -47,7 +47,9 @@ void *read_ucs2_le(logreader *lf, int *rc, int drop_it) {
         wchar_t * n;
         /* Get the last occurrence of \n */
         if ((n = wcsrchr(str, L'\n')) != NULL) {
-            OS_SHA1_Stream(&context, NULL, (char *) str);
+            if (context_file) {
+                OS_SHA1_Stream(&context, NULL, (char *) str);
+            }
             *n = '\0';
         }
         /* If we didn't get the new line, because the
@@ -55,7 +57,9 @@ void *read_ucs2_le(logreader *lf, int *rc, int drop_it) {
          */
         if (rbytes == OS_MAXSTR - OS_LOG_HEADER - 1) {
             /* Message size > maximum allowed */
-            OS_SHA1_Stream(&context, NULL, (char *) str);
+            if (context_file) {
+                OS_SHA1_Stream(&context, NULL, (char *) str);
+            }
             __ms = 1;
             str[rbytes - 1] = '\0';
         } else {
@@ -132,7 +136,9 @@ void *read_ucs2_le(logreader *lf, int *rc, int drop_it) {
                     break;
                 }
 
-                OS_SHA1_Stream(&context, NULL, (char *) str);
+                if (context_file) {
+                    OS_SHA1_Stream(&context, NULL, (char *) str);
+                }
 
                 /* Get the last occurrence of \n */
                 if (str[rbytes - 2] == '\n') {
@@ -145,7 +151,9 @@ void *read_ucs2_le(logreader *lf, int *rc, int drop_it) {
         current_position = w_ftell(lf->fp);
     }
 
-    w_update_file_status(lf->file, current_position, &context);
+    if (context_file) {
+        w_update_file_status(lf->file, current_position, &context);
+    }
 
     mdebug2("Read %d lines from %s", lines, lf->file);
     return (NULL);

--- a/src/logcollector/read_ucs2_le.c
+++ b/src/logcollector/read_ucs2_le.c
@@ -31,7 +31,7 @@ void *read_ucs2_le(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    bool context_file = w_get_hash_context(lf->file, &context, current_position);
+    bool context_file = w_get_hash_context(lf, &context, current_position);
 
     for (offset = w_ftell(lf->fp); can_read() && fgetws(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
         rbytes = w_ftell(lf->fp) - offset;

--- a/src/logcollector/read_ucs2_le.c
+++ b/src/logcollector/read_ucs2_le.c
@@ -31,7 +31,7 @@ void *read_ucs2_le(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     SHA_CTX context;
     int64_t current_position = w_ftell(lf->fp);
-    bool context_file = w_get_hash_context(lf, &context, current_position);
+    bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
     for (offset = w_ftell(lf->fp); can_read() && fgetws(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
         rbytes = w_ftell(lf->fp) - offset;
@@ -47,7 +47,7 @@ void *read_ucs2_le(logreader *lf, int *rc, int drop_it) {
         wchar_t * n;
         /* Get the last occurrence of \n */
         if ((n = wcsrchr(str, L'\n')) != NULL) {
-            if (context_file) {
+            if (is_valid_context_file) {
                 OS_SHA1_Stream(&context, NULL, (char *) str);
             }
             *n = '\0';
@@ -57,7 +57,7 @@ void *read_ucs2_le(logreader *lf, int *rc, int drop_it) {
          */
         if (rbytes == OS_MAXSTR - OS_LOG_HEADER - 1) {
             /* Message size > maximum allowed */
-            if (context_file) {
+            if (is_valid_context_file) {
                 OS_SHA1_Stream(&context, NULL, (char *) str);
             }
             __ms = 1;
@@ -136,7 +136,7 @@ void *read_ucs2_le(logreader *lf, int *rc, int drop_it) {
                     break;
                 }
 
-                if (context_file) {
+                if (is_valid_context_file) {
                     OS_SHA1_Stream(&context, NULL, (char *) str);
                 }
 
@@ -151,7 +151,7 @@ void *read_ucs2_le(logreader *lf, int *rc, int drop_it) {
         current_position = w_ftell(lf->fp);
     }
 
-    if (context_file) {
+    if (is_valid_context_file) {
         w_update_file_status(lf->file, current_position, &context);
     }
 

--- a/src/os_crypto/sha1/sha1_op.c
+++ b/src/os_crypto/sha1/sha1_op.c
@@ -151,12 +151,14 @@ int OS_SHA1_File_Nbytes_with_fp_check(const char * fname, SHA_CTX * c, os_sha1 o
             merror(FSTAT_ERROR, fname, errno, strerror(errno));
         } else if (fd_check != tmp_stat.st_ino) {
             mdebug1("The inode does not belong to file '%s'. The hash of the file will be ignored.", fname);
+            fclose(fp);
             return -2;
         }
 
 #else
         if (open_fd != 0 && fd_check != open_fd) {
             mdebug1("The inode does not belong to file '%s'. The hash of the file will be ignored.", fname);
+            fclose(fp);
             return -2;
         }
 

--- a/src/os_crypto/sha1/sha1_op.c
+++ b/src/os_crypto/sha1/sha1_op.c
@@ -114,6 +114,8 @@ int OS_SHA1_File_Nbytes(const char *fname, SHA_CTX *c, os_sha1 output, int mode,
     memset(output, 0, sizeof(os_sha1));
     buf[OS_MAXSTR - 1] = '\0';
 
+    SHA1_Init(c);
+
     /* It's important to read \r\n instead of \n to generate the correct hash */
 #ifdef WIN32
     if (fp = w_fopen_r(fname, mode == OS_BINARY ? "rb" : "r"), fp == NULL) {
@@ -124,8 +126,6 @@ int OS_SHA1_File_Nbytes(const char *fname, SHA_CTX *c, os_sha1 output, int mode,
         return -1;
     }
 #endif
-
-    SHA1_Init(c);
 
     for (int64_t bytes_count = 0; bytes_count < nbytes; bytes_count+=2048) {
         if(bytes_count+2048 < nbytes) {

--- a/src/os_crypto/sha1/sha1_op.h
+++ b/src/os_crypto/sha1/sha1_op.h
@@ -40,6 +40,25 @@ void OS_SHA1_Hexdigest(const unsigned char * digest, os_sha1 output);
 int OS_SHA1_File_Nbytes(const char *fname, SHA_CTX *c, os_sha1 output, int mode, int64_t nbytes);
 
 /**
+ * @brief If fp corresponds to fname then calculates the SHA1 of the `fname` file until N byte and save the context
+ *
+ * @param[in] fname File name to calculate SHA1.
+ * @param[out] c SHA1 context.
+ * @param[out] output Output string.
+ * @param[in] nbytes Number of bytes to read.
+ * @param[in] fd_check File serial number, Is checked against `fname`
+ * @retval 0 on success
+ * @retval -1 when failure opening file.
+ * @retval -2 When fp does not correspond to the `fname` file
+ */
+#ifndef WIN32
+int OS_SHA1_File_Nbytes_with_fp_check(const char * fname, SHA_CTX * c, os_sha1 output, int mode, int64_t nbytes,
+                                      ino_t fd_check);
+#else
+int OS_SHA1_File_Nbytes_with_fp_check(const char * fname, SHA_CTX * c, os_sha1 output, int mode, int64_t nbytes,
+                                      DWORD fd_check);
+#endif
+/**
  * @brief update the context and calculates the SHA1
  *
  * @param c[out] SHA1 context.

--- a/src/os_crypto/sha1/sha1_op.h
+++ b/src/os_crypto/sha1/sha1_op.h
@@ -13,6 +13,9 @@
 
 #include <sys/types.h>
 #include <openssl/sha.h>
+#ifdef WIN32
+#include <windef.h>
+#endif
 
 typedef char os_sha1[41];
 

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2011,7 +2011,7 @@ void w_ch_exec_dir() {
     }
 }
 
-FILE * w_fopen_r(const char *file, const char * mode) {
+FILE * w_fopen_r(const char *file, const char * mode, BY_HANDLE_FILE_INFORMATION * lpFileInformation) {
 
     FILE *fp = NULL;
     int fd;
@@ -2021,6 +2021,14 @@ FILE * w_fopen_r(const char *file, const char * mode) {
                    NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
     if (h == INVALID_HANDLE_VALUE) {
         return NULL;
+    }
+
+    if (lpFileInformation != NULL) {
+        memset(lpFileInformation, 0, sizeof(BY_HANDLE_FILE_INFORMATION));
+    }
+
+    if (GetFileInformationByHandle(h, lpFileInformation) == 0) {
+        merror(FILE_ERROR, file);
     }
 
     if (fd = _open_osfhandle((intptr_t)h, 0), fd == -1) {

--- a/src/unit_tests/logcollector/CMakeLists.txt
+++ b/src/unit_tests/logcollector/CMakeLists.txt
@@ -27,7 +27,7 @@ list(APPEND logcollector_flags "-Wl,--wrap,OSHash_Add_ex -Wl,--wrap,OSHash_Add -
                                 -Wl,--wrap,cJSON_GetObjectItem -Wl,--wrap,cJSON_GetArraySize -Wl,--wrap,cJSON_GetArrayItem \
                                 -Wl,--wrap,cJSON_GetStringValue -Wl,--wrap,OS_SHA1_File_Nbytes -Wl,--wrap,fileno -Wl,--wrap,fstat \
                                 -Wl,--wrap,pthread_rwlock_rdlock -Wl,--wrap,pthread_rwlock_unlock \
-                                -Wl,--wrap,stat -Wl,--wrap=fgetc -Wl,--wrap=w_fseek -Wl,--wrap,w_ftell")
+                                -Wl,--wrap,stat -Wl,--wrap=fgetc -Wl,--wrap=w_fseek -Wl,--wrap,w_ftell -Wl,--wrap,OS_SHA1_File_Nbytes_with_fp_check")
 
 list(APPEND logcollector_names "test_read_multiline_regex")
 list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets \

--- a/src/unit_tests/logcollector/test_logcollector.c
+++ b/src/unit_tests/logcollector/test_logcollector.c
@@ -30,7 +30,7 @@
 
 extern OSHash *files_status;
 
-bool w_get_hash_context (const char * path, SHA_CTX *context, ssize_t position);
+bool w_get_hash_context(logreader *lf, SHA_CTX *context, int64_t position);
 void w_initialize_file_status();
 ssize_t w_set_to_pos(logreader *lf, long pos, int mode);
 char * w_save_files_status_to_cJSON();
@@ -63,20 +63,28 @@ void test_w_get_hash_context_NULL_file_exist(void ** state) {
     SHA_CTX * context;
     os_calloc(1, sizeof(SHA_CTX), context);
     int64_t position = 10;
-    const char path[] = "/test_path";
+
+    logreader *lf = NULL;
+    os_calloc(1, sizeof(logreader), lf);
+    lf->fp = (FILE*)1;
+    os_strdup("/test_path", lf->file);
+
     int mode = OS_BINARY;
 
+    ino_t fd_check = 0;
+
     expect_any(__wrap_OSHash_Get_ex, self);
-    expect_string(__wrap_OSHash_Get_ex, key, path);
+    expect_string(__wrap_OSHash_Get_ex, key, lf->file);
     will_return(__wrap_OSHash_Get_ex, NULL);
 
-    expect_string(__wrap_OS_SHA1_File_Nbytes, fname, path);
-    expect_value(__wrap_OS_SHA1_File_Nbytes, mode, mode);
-    expect_value(__wrap_OS_SHA1_File_Nbytes, nbytes, position);
-    will_return(__wrap_OS_SHA1_File_Nbytes, "32bb98743e298dee0a654a654765c765d765ae80");
-    will_return(__wrap_OS_SHA1_File_Nbytes, 1);
+    expect_string(__wrap_OS_SHA1_File_Nbytes_with_fp_check, fname, lf->file);
+    expect_value(__wrap_OS_SHA1_File_Nbytes_with_fp_check, mode, mode);
+    expect_value(__wrap_OS_SHA1_File_Nbytes_with_fp_check, nbytes, position);
+    expect_value(__wrap_OS_SHA1_File_Nbytes_with_fp_check, fd_check, fd_check);
+    will_return(__wrap_OS_SHA1_File_Nbytes_with_fp_check, "32bb98743e298dee0a654a654765c765d765ae80");
+    will_return(__wrap_OS_SHA1_File_Nbytes_with_fp_check, 0);
 
-    bool ret = w_get_hash_context (path, context, position);
+    bool ret = w_get_hash_context (lf, context, position);
 
     assert_true(ret);
 
@@ -88,20 +96,28 @@ void test_w_get_hash_context_NULL_file_not_exist(void ** state) {
     SHA_CTX * context;
     os_calloc(1, sizeof(SHA_CTX), context);
     int64_t position = 10;
-    const char path[] = "/test_path";
+
+    logreader *lf = NULL;
+    os_calloc(1, sizeof(logreader), lf);
+    lf->fp = (FILE*)1;
+    os_strdup("/test_path", lf->file);
+
     int mode = OS_BINARY;
 
+    ino_t fd_check = 0;
+
     expect_any(__wrap_OSHash_Get_ex, self);
-    expect_string(__wrap_OSHash_Get_ex, key, path);
+    expect_string(__wrap_OSHash_Get_ex, key, lf->file);
     will_return(__wrap_OSHash_Get_ex, NULL);
 
-    expect_string(__wrap_OS_SHA1_File_Nbytes, fname, path);
-    expect_value(__wrap_OS_SHA1_File_Nbytes, mode, mode);
-    expect_value(__wrap_OS_SHA1_File_Nbytes, nbytes, position);
-    will_return(__wrap_OS_SHA1_File_Nbytes, "32bb98743e298dee0a654a654765c765d765ae80");
-    will_return(__wrap_OS_SHA1_File_Nbytes, -1);
+    expect_string(__wrap_OS_SHA1_File_Nbytes_with_fp_check, fname, lf->file);
+    expect_value(__wrap_OS_SHA1_File_Nbytes_with_fp_check, mode, mode);
+    expect_value(__wrap_OS_SHA1_File_Nbytes_with_fp_check, nbytes, position);
+    expect_value(__wrap_OS_SHA1_File_Nbytes_with_fp_check, fd_check, 0);
+    will_return(__wrap_OS_SHA1_File_Nbytes_with_fp_check, "32bb98743e298dee0a654a654765c765d765ae80");
+    will_return(__wrap_OS_SHA1_File_Nbytes_with_fp_check, -1);
 
-    bool ret = w_get_hash_context (path, context, position);
+    bool ret = w_get_hash_context (lf, context, position);
 
     assert_false(ret);
 
@@ -113,15 +129,20 @@ void test_w_get_hash_context_done(void ** state) {
     SHA_CTX * context;
     os_calloc(1, sizeof(SHA_CTX), context);
     int64_t position = 10;
-    const char path[] = "/test_path";
+
+    logreader *lf = NULL;
+    os_calloc(1, sizeof(logreader), lf);
+    lf->fp = (FILE*)1;
+    os_strdup("/test_path", lf->file);
+
     os_file_status_t data = {0};
     data.context.num = 123;
 
     expect_any(__wrap_OSHash_Get_ex, self);
-    expect_string(__wrap_OSHash_Get_ex, key, path);
+    expect_string(__wrap_OSHash_Get_ex, key, lf->file);
     will_return(__wrap_OSHash_Get_ex, &data);
 
-    bool ret = w_get_hash_context (path, context, position);
+    bool ret = w_get_hash_context (lf, context, position);
 
     assert_memory_equal(&(data.context), context, sizeof(SHA_CTX));
     assert_true(ret);
@@ -1314,7 +1335,7 @@ void test_w_set_to_last_line_read_OS_SHA1_File_Nbytes_fail(void ** state) {
     will_return(__wrap_OS_SHA1_File_Nbytes, "32bb98743e298dee0a654a654765c765d765ae80");
     will_return(__wrap_OS_SHA1_File_Nbytes, -1);
 
-    expect_string(__wrap__merror, formatted_msg, "Failure to generate the SHA1 hash from file 'test'");
+    expect_string(__wrap__merror, formatted_msg, "(1969): Failure to generate the SHA1 hash from file 'test'");
 
     int ret = w_set_to_last_line_read(lf);
 

--- a/src/unit_tests/wrappers/wazuh/os_crypto/sha1_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/os_crypto/sha1_op_wrappers.c
@@ -38,3 +38,29 @@ void __wrap_OS_SHA1_Stream(__attribute__((unused))SHA_CTX *c, os_sha1 output, ch
     snprintf(output, 41, "%s", mock_type(char *));
 
 }
+
+#ifndef WIN32
+int __wrap_OS_SHA1_File_Nbytes_with_fp_check(const char * fname, __attribute__((unused))SHA_CTX * c, os_sha1 output,
+                                      int mode, int64_t nbytes, ino_t fd_check) {
+    check_expected(fname);
+    check_expected(mode);
+    check_expected(nbytes);
+    check_expected(fd_check);
+
+    snprintf(output, 41, "%s", mock_type(char *));
+
+    return mock();
+}
+#else
+int __wrap_OS_SHA1_File_Nbytes_with_fp_check(const char * fname, __attribute__((unused))SHA_CTX * c, os_sha1 output,
+                                      int mode, int64_t nbytes, DWORD fd_check) {
+    check_expected(fname);
+    check_expected(mode);
+    check_expected(nbytes);
+    check_expected(fd_check);
+
+    snprintf(output, 41, "%s", mock_type(char *));
+
+    return mock();
+}
+#endif

--- a/src/unit_tests/wrappers/wazuh/os_crypto/sha1_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/os_crypto/sha1_op_wrappers.h
@@ -20,5 +20,12 @@ typedef char os_sha1[41];
 int __wrap_OS_SHA1_File(const char *fname, os_sha1 output, int mode);
 int __wrap_OS_SHA1_File_Nbytes(const char *fname, SHA_CTX *c, os_sha1 output, int mode, ssize_t nbytes);
 void __wrap_OS_SHA1_Stream(SHA_CTX *c, os_sha1 output, char * buf);
+#ifndef WIN32
+int __wrap_OS_SHA1_File_Nbytes_with_fp_check(const char * fname, SHA_CTX * c, os_sha1 output, int mode, int64_t nbytes,
+                                      ino_t fd_check);
+#else
+int __wrap_OS_SHA1_File_Nbytes_with_fp_check(const char * fname, SHA_CTX * c, os_sha1 output, int mode, int64_t nbytes,
+                                      DWORD fd_check);
+#endif
 
 #endif


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/8290|

## Description
This PR solves a problem when saving the state of logcollector files, which can cause a segmentation fault if there are many file rotations in a short time.

## Tests
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [x] AddressSanitizer
  - [x] ThreadSanitizer
- Memory tests for Windows
  - [x] Scan-build report
  - [x] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [x] The data flow works as expected (agent-manager-api-app)
- [x] Added unit tests (for new features)
- [x] Stress test for affected components
