### PR TITLE
modify decoder to include pcre2 and wazuh text

### DIFF
--- a/ruleset/decoders/0225-postgresql_decoders.xml
+++ b/ruleset/decoders/0225-postgresql_decoders.xml
@@ -10,11 +10,15 @@
 
 <!--
   - Examples:
-  - [2007-08-31 18:37:09.454 ADT] 192.168.2.99: LOG:  connection authorized: user=ossec_user database=ossecdb
+  - [2007-08-31 18:37:09.454 ADT] 192.168.2.99: LOG:  connection authorized: user=wazuh_user database=wazuh_db
   - [2007-08-31 18:37:15.525 ADT] 192.168.2.99: ERROR:  relation "alert2" does not exist
+  - Version 13:
+  - 021-04-07 16:48:20.991 EET [8329] FATAL:  password authentication failed for user "testing_user"
+  - 2021-04-07 16:48:20.991 EET [8329] DETAIL:  Password does not match for user "testing_user".
+        Connection matched pg_hba.conf line 90: "host   testing_db      testing_user           0.0.0.0/0                md5"
   -->
 <decoder name="postgresql_log">
-  <prematch>^[\d\d\d\d-\d\d-\d\d \S+ \w+] </prematch>
+  <prematch type="pcre2">^\[?\d\d\d\d-\d\d-\d\d \S+ \w+\]? </prematch>
   <regex offset="after_prematch">^\S+ (\w+): </regex>
   <order>status</order>
 </decoder>


### PR DESCRIPTION
|Related issue|
|---|
|#8189|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR modifies postgreSQL decoder:
.- Replace ossec text with wazuh in sample lines
.- include pcre2 as regex type
<!--
Add a clear description of how the problem has been solved.
-->

