### PR TITLE
Optimize the flow followed for each API request

### DIFF
--- a/api/api/authentication.py
+++ b/api/api/authentication.py
@@ -166,8 +166,8 @@ def check_token(username, roles, token_nbf_time, run_as):
     ----------
     username : str
         Unique username
-    roles : list
-        List of roles related with the current token
+    roles : tuple
+        Tuple of roles related with the current token
     token_nbf_time : int
         Issued at time of the current token
     run_as : bool

--- a/api/api/authentication.py
+++ b/api/api/authentication.py
@@ -25,7 +25,7 @@ from wazuh.core.cluster.utils import read_config
 from wazuh.rbac.orm import AuthenticationManager, TokenManager, UserRolesManager
 from wazuh.rbac.preprocessor import optimize_resources
 
-pool = ThreadPoolExecutor()
+pool = ThreadPoolExecutor(max_workers=1)
 
 
 def check_user_master(user, password):

--- a/api/api/middlewares.py
+++ b/api/api/middlewares.py
@@ -158,6 +158,6 @@ async def response_postprocessing(request, handler):
             problem = connexion_problem(401, "Unauthorized", type="about:blank",
                                         detail="No authorization token provided")
     finally:
-        if problem:
-            remove_unwanted_fields()
-            return problem
+        problem and remove_unwanted_fields()
+
+    return problem

--- a/api/api/test/test_authentication.py
+++ b/api/api/test/test_authentication.py
@@ -142,7 +142,8 @@ def test_generate_token(mock_raise_if_exc, mock_submit, mock_distribute_function
 
 @patch('api.authentication.TokenManager')
 def test_check_token(mock_tokenmanager):
-    result = authentication.check_token(username='wazuh_user', roles=[1], token_nbf_time=3600, run_as=False)
+    result = authentication.check_token(username='wazuh_user', roles=tuple([1]), token_nbf_time=3600, run_as=False,
+                                        origin_node_type='master')
     assert result == {'valid': ANY, 'policies': ANY}
 
 
@@ -163,7 +164,8 @@ def test_decode_token(mock_raise_if_exc, mock_submit, mock_distribute_function, 
 
     # Check all functions are called with expected params
     calls = [call(f=ANY, f_kwargs={'username': original_payload['sub'], 'token_nbf_time': original_payload['nbf'],
-                                   'run_as': False, 'roles': original_payload['rbac_roles']},
+                                   'run_as': False, 'roles': tuple(original_payload['rbac_roles']),
+                                   'origin_node_type': 'master'},
                   request_type='local_master', is_async=False, wait_for_complete=False, logger=ANY),
              call(f=ANY, request_type='local_master', is_async=False, wait_for_complete=False, logger=ANY)]
     mock_dapi.assert_has_calls(calls)

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -34,6 +34,8 @@ mutex = threading.Lock()
 lock_file = None
 lock_acquired = False
 
+agent_regex = re.compile(r"^(\d{3,}) [^!].* .* .*$", re.MULTILINE)
+
 
 class WazuhDBQueryAgents(WazuhDBQuery):
 
@@ -1251,7 +1253,6 @@ def send_restart_command(agent_id: str = '', agent_version: str = '') -> str:
 @common.context_cached('system_agents')
 def get_agents_info():
     """Get all agent IDs in the system."""
-    agent_regex = re.compile(r"^([^# ]\d+) [^!].* .* .*$", re.MULTILINE)
     with open(common.client_keys, 'r') as f:
         file_content = f.read()
 

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -6,6 +6,7 @@ import copy
 import fcntl
 import hashlib
 import ipaddress
+import re
 import tempfile
 import threading
 from base64 import b64encode
@@ -1250,10 +1251,11 @@ def send_restart_command(agent_id: str = '', agent_version: str = '') -> str:
 @common.context_cached('system_agents')
 def get_agents_info():
     """Get all agent IDs in the system."""
+    agent_regex = re.compile(r"^([^# ]\d+) [^!].* .* .*$", re.MULTILINE)
     with open(common.client_keys, 'r') as f:
-        file_content = f.readlines()
+        file_content = f.read()
 
-    result = {line.split(' ')[0] for line in file_content}
+    result = set(agent_regex.findall(file_content))
     result.add('000')
 
     return result

--- a/framework/wazuh/core/security.py
+++ b/framework/wazuh/core/security.py
@@ -7,7 +7,6 @@ from functools import lru_cache
 
 import yaml
 
-import api.configuration as configuration
 import api.middlewares as middlewares
 from api import __path__ as api_path
 from api.authentication import change_secret

--- a/framework/wazuh/rbac/orm.py
+++ b/framework/wazuh/rbac/orm.py
@@ -23,6 +23,7 @@ from werkzeug.security import check_password_hash, generate_password_hash
 
 from api.configuration import security_conf
 from api.constants import SECURITY_PATH
+from wazuh.rbac.utils import clear_cache
 
 # Max reserved ID value
 max_id_reserved = 99
@@ -563,6 +564,7 @@ class TokenManager:
                 self.session.add(RunAsTokenBlacklist())
                 self.session.commit()
 
+            clear_cache()
             return True
         except IntegrityError:
             self.session.rollback()

--- a/framework/wazuh/rbac/utils.py
+++ b/framework/wazuh/rbac/utils.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+from functools import wraps
+
+from cachetools import TTLCache, cached
+
+from api.configuration import security_conf
+
+# Tokens cache
+tokens_cache = TTLCache(maxsize=4500, ttl=security_conf['auth_token_exp_timeout'])
+
+
+def clear_cache():
+    """This function clear the authorization tokens cache."""
+    tokens_cache.clear()
+
+
+def token_cache(cache):
+    """Apply cache depending on whether the request comes from the master node or from a worker node.
+
+    Parameters
+    ----------
+    cache : TTLCache
+        Cache object
+
+    Returns
+    -------
+    Requested function
+    """
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            origin_node_type = kwargs.pop('origin_node_type')
+
+            @cached(cache=cache)
+            def f(*_args, **_kwargs):
+                return func(*_args, **_kwargs)
+
+            if origin_node_type == 'master':
+                return f(*args, **kwargs)
+
+            return func(*args, **kwargs)
+        return wrapper
+    return decorator

--- a/framework/wazuh/security.py
+++ b/framework/wazuh/security.py
@@ -15,7 +15,7 @@ from wazuh.core.security import load_spec, update_security_conf
 from wazuh.core.utils import process_array
 from wazuh.rbac.decorators import expose_resources
 from wazuh.rbac.orm import AuthenticationManager, PoliciesManager, RolesManager, RolesPoliciesManager, \
-    TokenManager, UserRolesManager, RolesRulesManager, RulesManager
+    UserRolesManager, RolesRulesManager, RulesManager
 from wazuh.rbac.orm import SecurityError, max_id_reserved
 
 # Minimum eight characters, at least one uppercase letter, one lowercase letter, one number and one special character:
@@ -253,8 +253,7 @@ def remove_users(user_ids):
             elif query == SecurityError.RELATIONSHIP_ERROR:
                 result.add_failed_item(id_=user_id, error=WazuhError(4025))
             elif user:
-                with TokenManager() as tm:
-                    tm.add_user_roles_rules(users={user_id})
+                invalid_users_tokens(users=[user_id])
                 result.affected_items.append(user)
                 result.total_affected_items += 1
 
@@ -917,9 +916,8 @@ def remove_role_policy(role_id, policy_ids):
 
 def revoke_current_user_tokens():
     """Revoke all current user's tokens"""
-    with TokenManager() as tm:
-        with AuthenticationManager() as am:
-            tm.add_user_roles_rules(users={am.get_user(common.current_user.get())['id']})
+    with AuthenticationManager() as am:
+        invalid_users_tokens(users=[am.get_user(common.current_user.get())['id']])
 
     return WazuhResult({'message': f'User {common.current_user.get()} was successfully logged out'})
 

--- a/framework/wazuh/tests/test_security.py
+++ b/framework/wazuh/tests/test_security.py
@@ -211,7 +211,7 @@ def test_invalid_users_tokens(db_setup, user_list, expected_users):
     expected_users : set
         Expected users.
     """
-    with patch('wazuh.security.TokenManager.add_user_roles_rules') as TM_mock:
+    with patch('wazuh.core.security.TokenManager.add_user_roles_rules') as TM_mock:
         _, _, core_security = db_setup
         core_security.invalid_users_tokens(users=[user_id for user_id in user_list])
         related_users = TM_mock.call_args.kwargs['users']
@@ -233,7 +233,7 @@ def test_invalid_roles_tokens(db_setup, role_list, expected_roles):
     expected_roles : set
         Expected roles.
     """
-    with patch('wazuh.security.TokenManager.add_user_roles_rules') as TM_mock:
+    with patch('wazuh.core.security.TokenManager.add_user_roles_rules') as TM_mock:
         _, _, core_security = db_setup
         core_security.invalid_roles_tokens(roles=[role_id for role_id in role_list])
         assert set(TM_mock.call_args.kwargs['roles']) == expected_roles


### PR DESCRIPTION
|Related issue|
|---|
|#8594|

## Description

Hi team,

We have cached the `check_token` function. With this, we have been able to improve the performance of each API call.

### 4.2 (200 request -> `GET /groups/default/agents`)

![old_results](https://user-images.githubusercontent.com/15522808/117781127-973de880-b240-11eb-9d30-7d6171b9fb84.png)

### feature/8594-cache-check-token (200 request -> `GET /groups/default/agents`)

![new_results](https://user-images.githubusercontent.com/15522808/117781155-9e64f680-b240-11eb-9697-be82397251d6.png)

### Size (200 elements)

![size](https://user-images.githubusercontent.com/15522808/117781170-a1f87d80-b240-11eb-95df-305ecae785c6.png)

### Observations

In the case of the request (`GET /groups/default/agents`), almost all the time used by the request corresponds to the `check_token` function. We have executed three consecutive times the script that makes the request with each of the versions and we have obtained the mean time of `check_token` for each execution.

The mean of the three runs in `4.2` is: **0.039297441s**
The mean of the three runs in `feature/8594-cache-check-token` is: **0.001650225s**
Improvement: 0.039297441 / 0.001650225 = **23.81338363** -> About 23 times faster

Finally, we see that the amount of space used by 200 tokens is around 9 KB and this size increases linearly. In addition, **tokens stored in the cache will be invalidated once they expire**. **We have set a maximum of 4500 elements in the cache so the maximum cache size will be 4500 * 9 / 200 = 202.5 KB.**

Regards.
