### PR TITLE
Prevent the agent installation from getting corrupted after a macOS upgrade

### DIFF
--- a/src/init/wazuh-client.sh
+++ b/src/init/wazuh-client.sh
@@ -126,6 +126,23 @@ testconfig()
     done
 }
 
+# Check folders
+check_folders()
+{
+    ALERTS_FOLDER="../queue/alerts"
+
+    if [ ! -d $ALERTS_FOLDER ]
+    then
+        if rm -rf $ALERTS_FOLDER && mkdir -p $ALERTS_FOLDER && chown ossec:ossec $ALERTS_FOLDER && chmod 770 $ALERTS_FOLDER
+        then
+            echo "WARNING: missing folder 'queue/alerts'. Restored back."
+        else
+            echo "ERROR: missing folder 'queue/alerts', and could not restore back."
+            exit 1
+        fi
+    fi
+}
+
 # Start function
 start_service()
 {
@@ -272,6 +289,7 @@ arg=$2
 case "$1" in
 start)
     testconfig
+    check_folders
     lock
     start_service
     unlock


### PR DESCRIPTION
|Related issue|
|---|
|Closes #7793|

macOS is removing the folder `queue/alerts` when upgrading from Catalina to Big Sur.

## Proposed fix

If the folder won't exist, the script tries to restore it, and shows this message:

```
WARNING: missing folder 'queue/alerts'. Restored back.
```

On the other hand, if the agent fails to set up that, it print this message:

```
ERROR: missing folder 'queue/alerts', and could not restore back.
```

## Tests

### On Linux

- [X] Start the agent normally.
- [X] Delete `folder/alerts` and start the agent.

### On macOS

Install on macOS Catalina, and upgrade to Big Sur.

- [ ] Let the agent start automatically.