### PR TITLE
Let DB sync module erase agent-related files on syncing

### DIFF
--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -302,6 +302,10 @@ void wm_sync_agents() {
             if (OS_IsAllowedID(&keys, id) == -1) {
                 if (wdb_remove_agent(agents[i], &wdb_wmdb_sock) < 0) {
                     mtdebug1(WM_DATABASE_LOGTAG, "Couldn't remove agent %s", id);
+                } else {
+                    // Remove agent-related files
+                    OS_RemoveCounter(id);
+                    OS_RemoveAgentGroup(id);
                 }
             }
         }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #8497|

As described in #8497, the manager deletes agent-related files when removing an agent. The agent may still be connected to the manager until Remoted reloads the keys (_etc/client.keys_).

On the other hand, the database-sync module can delete files that it detects as changed, if such files belong to an unexisting agent. However, if Remoted saves a file for an agent before the database-sync module updates the DB, the file may remain in the manager.

These are the agent-related files we're considering:

- Message counters (remote ids): _queue/rids/<id>_.
- Agent group assignation files: _queue/agent_groups/<id>_.

## Proposed fix

Despite Authd (which manages the agent keys) erases the agent-related files when removing an agent, we will let the database-sync module remove such agents again (if they exist) when synchronizing an agent deletion.

## Tests

- [X] Remove an agent that exists in the database, create an agent-group file, and then synchronize.
- [X] Cluster stress test by @wazuh/framework.