### PR TITLE
macOS ULS - coverity report fixes

### DIFF
--- a/src/logcollector/read_macos.c
+++ b/src/logcollector/read_macos.c
@@ -267,7 +267,7 @@ STATIC bool w_macos_log_getlog(char * buffer, int length, FILE * stream, w_macos
              */
             if (!is_endline) {
                 if (last_line == NULL) {
-                    char c;
+                    int c;
                     // Discards the rest of the log, up to the end of line
                     do {
                         c = fgetc(stream);
@@ -332,7 +332,7 @@ STATIC INLINE void w_macos_log_ctxt_clean(w_macos_log_ctxt_t * ctxt) {
 STATIC INLINE void w_macos_log_ctxt_backup(char * buffer, w_macos_log_ctxt_t * ctxt) {
 
     /* Backup */
-    strcpy(ctxt->buffer, buffer);
+    strncpy(ctxt->buffer, buffer, OS_MAXSTR - 1);
     ctxt->timestamp = time(NULL);
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #8635||

Hi Team!,

This PR fixes 2 coverity issues:

![image](https://user-images.githubusercontent.com/1791430/118033097-ca66a180-b33e-11eb-8332-ed34f214f1a5.png)
![image](https://user-images.githubusercontent.com/1791430/118033213-eec27e00-b33e-11eb-96e6-5c54bdd91a5e.png)


Regards,



## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
