### PR TITLE
Fix removal of service OssecSvc on Windows on agent upgrade

### DIFF
--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -179,7 +179,7 @@
 
         <!-- Explicitely stopping and deleting the OSSEC service to install new Wazuh service -->
         <CustomAction Id="StopOssecService" Directory="APPLICATIONFOLDER" ExeCommand="NET STOP &quot;OssecSvc&quot;" Execute="immediate" Return="ignore" />
-        <CustomAction Id="DeleteOssecService" Directory="APPLICATIONFOLDER" ExeCommand="SC DELETE &quot;OssecSvc&quot;" Execute="immediate" Return="ignore" />
+        <CustomAction Id="DeleteOssecService" Directory="APPLICATIONFOLDER" ExeCommand="SC DELETE &quot;OssecSvc&quot;" Execute="deferred" Return="ignore" Impersonate="no" />
 
         <UI>
             <UIRef Id="WixUI_Advanced" />


### PR DESCRIPTION
|Related issue|
|---|
|#8631|

Upgrading to 4.2.0 was not deleting the service "OssecSvc". That was because the installer was not interpreting `&quot;` properly. Maybe it was including the quotes as the service name.

## Proposed fix

Disable execution impersonation for the command `SC DELETE OssecSvc`.

By the [`CustomAction` documentation](https://wixtoolset.org/documentation/manual/v3/xsd/wix/customaction.html):

> This attribute specifies whether the Windows Installer, which executes as LocalSystem, should impersonate the user context of the installing user when executing this custom action. Typically the value should be 'yes', except when the custom action needs elevated privileges to apply changes to the machine.

On the other hand, this [thread at StackOverflow](https://stackoverflow.com/questions/24484478/run-execommand-in-customaction-as-administrator-mode-in-wix-installer) adds:
> Any immediate custom actions impersonate the invoking user. Before Windows Vista this wasn't a problem since at this point the installing administrative user had a privileged token. With the introduction of UAC in Windows Vista the default administrative token with UAC enabled is a filtered token and does not hold all privileges. Since immediate custom actions are not supposed to modify machine state - only to gather state data and schedule custom actions to run deferred - this still shouldn't be a problem. After all, at this point the generation of the installation and rollback scripts is all that should be going on.

## Tests

- [X] Upgrade from 4.1.5 to 4.2.0 on Windows 10, in Administrator mode.
- [X] Upgrade from 4.1.5 to 4.2.0 on Windows 10, in User mode.
- [X] Upgrade from 4.2.0 to 4.2.1 on Windows 10, in User mode.