### PR TITLE
8646 openbsd testtool compilation

### DIFF
--- a/src/data_provider/testtool/CMakeLists.txt
+++ b/src/data_provider/testtool/CMakeLists.txt
@@ -37,6 +37,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     )
 elseif (CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
     target_link_libraries(sysinfo_test_tool
+        sysinfo
         pthread)
 elseif (CMAKE_SYSTEM_NAME STREQUAL "AIX")
     target_link_libraries(sysinfo_test_tool

--- a/src/shared_modules/utils/timeHelper.h
+++ b/src/shared_modules/utils/timeHelper.h
@@ -15,6 +15,7 @@
 #include <string>
 #include <ctime>
 #include <iomanip>
+#include <sstream>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"


### PR DESCRIPTION
|Related issue|
|---|
|Closes #8646 |
## Description
This PR aims to fix the compilation issue found in data providers testtool compilation in open BSD.

## DoD
- [X] manual tests on openBSD
![image](https://user-images.githubusercontent.com/54002291/118146541-1835e500-b3e5-11eb-9669-566ac5ed9dce.png)
