### PR TITLE
New unit tests for packages and hotfixes helper methods in vulnerability detector

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/CMakeLists.txt
@@ -45,7 +45,7 @@ list(APPEND vulndetector_flags "-Wl,--wrap,_merror -Wl,--wrap,_mterror -Wl,--wra
                                 -Wl,--wrap,OSHash_Delete_ex -Wl,--wrap=wstr_split -Wl,--wrap,OSMatch_Execute -Wl,--wrap,OSRegex_Execute_ex \
                                 -Wl,--wrap,fgetpos -Wl,--wrap,wdb_insert_vuln_cves -Wl,--wrap,wdb_clear_vuln_cves -Wl,--wrap,wdb_get_all_agents \
                                 -Wl,--wrap,OS_ClearXML -Wl,--wrap,wdb_remove_vuln_cves_by_status -Wl,--wrap,cJSON_GetStringValue -Wl,--wrap,wm_sendmsg \
-                                -Wl,--wrap,wdb_update_vuln_cves_status")
+                                -Wl,--wrap,wdb_update_vuln_cves_status -Wl,--wrap,cJSON_ParseWithOpts")
 
 list(APPEND vulndetector_names "test_wm_vuln_detector_evr")
 list(APPEND vulndetector_flags "-Wl,--wrap,_merror -Wl,--wrap,_mterror -Wl,--wrap,_mtdebug1 -Wl,--wrap,_mtdebug2 -Wl,--wrap,OS_ConnectUnixDomain \

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -18635,8 +18635,9 @@ void test_wm_vuldet_recv_wdb_by_row_recv_error() {
 
 void test_wm_vuldet_recv_wdb_by_row_json_syntax_error() {
     int result;
-    cJSON* array = __real_cJSON_CreateArray();
     char* response = "ok {";
+    cJSON* array = __real_cJSON_CreateArray();
+    cJSON* j_object = __real_cJSON_Parse(response + 3);
 
     wdb_vuldet_sock = 1;
 
@@ -18647,22 +18648,26 @@ void test_wm_vuldet_recv_wdb_by_row_json_syntax_error() {
     will_return(__wrap_OS_RecvSecureTCP, response);
     will_return(__wrap_OS_RecvSecureTCP, strlen(response));
 
+    will_return(__wrap_cJSON_ParseWithOpts, j_object);
+
     expect_string(__wrap__mdebug1, formatted_msg, "Invalid JSON syntax in vulnerability detector database request.");
-    expect_string(__wrap__mdebug2, formatted_msg, "JSON error near: ");
+    expect_string(__wrap__mdebug2, formatted_msg, "JSON error near: (null)");
 
     expect_function_calls(__wrap_cJSON_Delete, 2);
 
     result = wm_vuldet_recv_wdb_by_row(&array);
 
     __real_cJSON_Delete(array);
+    __real_cJSON_Delete(j_object);
     assert_int_equal(result, OS_INVALID);
 }
 
 void test_wm_vuldet_recv_wdb_by_row_not_synced() {
     int result;
+    char* response = "ok {\"status\":\"NOT_SYNCED\"}";
     cJSON* array = __real_cJSON_CreateArray();
     cJSON* j_status = __real_cJSON_CreateString("NOT_SYNCED");
-    char* response = "ok {\"status\":\"NOT_SYNCED\"}";
+    cJSON* j_object = __real_cJSON_Parse(response + 3);
 
     wdb_vuldet_sock = 1;
 
@@ -18672,6 +18677,8 @@ void test_wm_vuldet_recv_wdb_by_row_not_synced() {
     expect_value(__wrap_OS_RecvSecureTCP, size, OS_MAXSTR);
     will_return(__wrap_OS_RecvSecureTCP, response);
     will_return(__wrap_OS_RecvSecureTCP, strlen(response));
+
+    will_return(__wrap_cJSON_ParseWithOpts, j_object);
 
     will_return(__wrap_cJSON_GetObjectItem, j_status);
     will_return_count(__wrap_cJSON_GetStringValue, "NOT_SYNCED", 2);
@@ -18680,14 +18687,17 @@ void test_wm_vuldet_recv_wdb_by_row_not_synced() {
     result = wm_vuldet_recv_wdb_by_row(&array);
 
     __real_cJSON_Delete(array);
+    __real_cJSON_Delete(j_object);
+    __real_cJSON_Delete(j_status);
     assert_int_equal(result, OS_SUCCESS);
 }
 
 void test_wm_vuldet_recv_wdb_by_row_error_status() {
     int result;
+    char* response = "ok {\"status\":\"ERROR\"}";
     cJSON* array = __real_cJSON_CreateArray();
     cJSON* j_status = __real_cJSON_CreateString("ERROR");
-    char* response = "ok {\"status\":\"ERROR\"}";
+    cJSON* j_object = __real_cJSON_Parse(response + 3);
 
     wdb_vuldet_sock = 1;
 
@@ -18697,6 +18707,8 @@ void test_wm_vuldet_recv_wdb_by_row_error_status() {
     expect_value(__wrap_OS_RecvSecureTCP, size, OS_MAXSTR);
     will_return(__wrap_OS_RecvSecureTCP, response);
     will_return(__wrap_OS_RecvSecureTCP, strlen(response));
+
+    will_return(__wrap_cJSON_ParseWithOpts, j_object);
 
     will_return(__wrap_cJSON_GetObjectItem, j_status);
     will_return_count(__wrap_cJSON_GetStringValue, "ERROR", 2);
@@ -18705,14 +18717,17 @@ void test_wm_vuldet_recv_wdb_by_row_error_status() {
     result = wm_vuldet_recv_wdb_by_row(&array);
 
     __real_cJSON_Delete(array);
+    __real_cJSON_Delete(j_status);
+    __real_cJSON_Delete(j_object);
     assert_int_equal(result, OS_INVALID);
 }
 
 void test_wm_vuldet_recv_wdb_by_row_success_empty() {
     int result;
+    char* response = "ok {\"status\":\"SUCCESS\"}";
     cJSON* array = __real_cJSON_CreateArray();
     cJSON* j_status = __real_cJSON_CreateString("SUCCESS");
-    char* response = "ok {\"status\":\"SUCCESS\"}";
+    cJSON* j_object = __real_cJSON_Parse(response + 3);
 
     wdb_vuldet_sock = 1;
 
@@ -18722,6 +18737,8 @@ void test_wm_vuldet_recv_wdb_by_row_success_empty() {
     expect_value(__wrap_OS_RecvSecureTCP, size, OS_MAXSTR);
     will_return(__wrap_OS_RecvSecureTCP, response);
     will_return(__wrap_OS_RecvSecureTCP, strlen(response));
+
+    will_return(__wrap_cJSON_ParseWithOpts, j_object);
 
     will_return(__wrap_cJSON_GetObjectItem, j_status);
     will_return_count(__wrap_cJSON_GetStringValue, "SUCCESS", 1);
@@ -18730,13 +18747,16 @@ void test_wm_vuldet_recv_wdb_by_row_success_empty() {
     result = wm_vuldet_recv_wdb_by_row(&array);
 
     __real_cJSON_Delete(array);
+    __real_cJSON_Delete(j_status);
+    __real_cJSON_Delete(j_object);
     assert_int_equal(result, OS_SUCCESS);
 }
 
 void test_wm_vuldet_recv_wdb_by_row_no_status() {
     int result;
-    cJSON* array = __real_cJSON_CreateArray();
     char* response = "ok {}";
+    cJSON* array = __real_cJSON_CreateArray();
+    cJSON* j_object = __real_cJSON_Parse(response + 3);
 
     wdb_vuldet_sock = 1;
 
@@ -18747,21 +18767,26 @@ void test_wm_vuldet_recv_wdb_by_row_no_status() {
     will_return(__wrap_OS_RecvSecureTCP, response);
     will_return(__wrap_OS_RecvSecureTCP, strlen(response));
 
+    will_return(__wrap_cJSON_ParseWithOpts, j_object);
+
     will_return(__wrap_cJSON_GetObjectItem, NULL);
     expect_function_calls(__wrap_cJSON_Delete, 2);
 
     result = wm_vuldet_recv_wdb_by_row(&array);
 
     __real_cJSON_Delete(array);
+    __real_cJSON_Delete(j_object);
     assert_int_equal(result, OS_INVALID);
 }
 
 void test_wm_vuldet_recv_wdb_by_row_success() {
     int result;
-    cJSON* array = __real_cJSON_CreateArray();
-    cJSON* j_status = __real_cJSON_CreateString("SUCCESS");
     char* response = "due {\"name\":\"package1\"}";
     char* response2 = "ok {\"status\":\"SUCCESS\"}";
+    cJSON* array = __real_cJSON_CreateArray();
+    cJSON* j_status = __real_cJSON_CreateString("SUCCESS");
+    cJSON* j_object = __real_cJSON_Parse(response + 4);
+    cJSON* j_object2 = __real_cJSON_Parse(response2 + 3);
 
     wdb_vuldet_sock = 1;
 
@@ -18772,6 +18797,7 @@ void test_wm_vuldet_recv_wdb_by_row_success() {
     expect_value(__wrap_OS_RecvSecureTCP, size, OS_MAXSTR);
     will_return(__wrap_OS_RecvSecureTCP, response);
     will_return(__wrap_OS_RecvSecureTCP, strlen(response));
+    will_return(__wrap_cJSON_ParseWithOpts, j_object);
 
     expect_function_call(__wrap_cJSON_AddItemToArray);
     will_return(__wrap_cJSON_AddItemToArray, TRUE);
@@ -18781,6 +18807,7 @@ void test_wm_vuldet_recv_wdb_by_row_success() {
     expect_value(__wrap_OS_RecvSecureTCP, size, OS_MAXSTR);
     will_return(__wrap_OS_RecvSecureTCP, response2);
     will_return(__wrap_OS_RecvSecureTCP, strlen(response2));
+    will_return(__wrap_cJSON_ParseWithOpts, j_object2);
 
     will_return(__wrap_cJSON_GetObjectItem, j_status);
     will_return_count(__wrap_cJSON_GetStringValue, "SUCCESS", 1);
@@ -18789,7 +18816,77 @@ void test_wm_vuldet_recv_wdb_by_row_success() {
     result = wm_vuldet_recv_wdb_by_row(&array);
 
     __real_cJSON_Delete(array);
+    __real_cJSON_Delete(j_status);
+    __real_cJSON_Delete(j_object);
+    __real_cJSON_Delete(j_object2);
     assert_int_equal(result, OS_SUCCESS);
+}
+
+// Tests wm_vuldet_get_hotfixes
+
+void test_wm_vuldet_get_hotfixes_send_error() {
+    int result;
+    int agent_id = 1;
+    char* query = "agent 1 hotfix get";
+    cJSON* requested_items;
+
+    wdb_vuldet_sock = 1;
+
+    expect_value(__wrap_OS_SendSecureTCP, sock, 1);
+    expect_value(__wrap_OS_SendSecureTCP, size, strlen(query) + 1);
+    expect_string(__wrap_OS_SendSecureTCP, msg, query);
+    will_return(__wrap_OS_SendSecureTCP, OS_INVALID);
+
+    expect_string(__wrap__mterror, tag, WM_VULNDETECTOR_LOGTAG);
+    expect_string(__wrap__mterror, formatted_msg, "(5550): The hotfixes of the agent '001' could not be requested.");
+
+    result = wm_vuldet_get_hotfixes(agent_id, &requested_items);
+
+    assert_int_equal(result, OS_INVALID);
+}
+
+// Tests wm_vuldet_get_software
+
+void test_wm_vuldet_get_software_send_error() {
+    int result;
+    int agent_id = 1;
+    char* query = "agent 1 package get ";
+    cJSON* requested_items;
+
+    wdb_vuldet_sock = 1;
+
+    expect_value(__wrap_OS_SendSecureTCP, sock, 1);
+    expect_value(__wrap_OS_SendSecureTCP, size, strlen(query) + 1);
+    expect_string(__wrap_OS_SendSecureTCP, msg, query);
+    will_return(__wrap_OS_SendSecureTCP, OS_INVALID);
+
+    expect_string(__wrap__mterror, tag, WM_VULNDETECTOR_LOGTAG);
+    expect_string(__wrap__mterror, formatted_msg, "(5515): Agent '001' software could not be requested.");
+
+    result = wm_vuldet_get_software(agent_id, FALSE, &requested_items);
+
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_wm_vuldet_get_software_not_triaged_send_error() {
+    int result;
+    int agent_id = 1;
+    char* query = "agent 1 package get not_triaged";
+    cJSON* requested_items;
+
+    wdb_vuldet_sock = 1;
+
+    expect_value(__wrap_OS_SendSecureTCP, sock, 1);
+    expect_value(__wrap_OS_SendSecureTCP, size, strlen(query) + 1);
+    expect_string(__wrap_OS_SendSecureTCP, msg, query);
+    will_return(__wrap_OS_SendSecureTCP, OS_INVALID);
+
+    expect_string(__wrap__mterror, tag, WM_VULNDETECTOR_LOGTAG);
+    expect_string(__wrap__mterror, formatted_msg, "(5515): Agent '001' software could not be requested.");
+
+    result = wm_vuldet_get_software(agent_id, TRUE, &requested_items);
+
+    assert_int_equal(result, OS_INVALID);
 }
 
 int main(void)
@@ -19287,6 +19384,11 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_recv_wdb_by_row_success_empty, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_recv_wdb_by_row_no_status, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_recv_wdb_by_row_success, setup_group, teardown_group),
+        // Tests wm_vuldet_get_hotfixes
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_get_hotfixes_send_error, setup_group, teardown_group),
+        // Tests wm_vuldet_get_software
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_get_software_send_error, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_get_software_not_triaged_send_error, setup_group, teardown_group),
         };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -38,6 +38,7 @@
 #include "../../../wazuh_modules/vulnerability_detector/wm_vuln_detector_db.h"
 #include "../../headers/shared.h"
 #include "cJSON.h"
+#include "defs.h"
 #include "mocks_wm_vuln_detector.h"
 #include "os_err.h"
 #include "wazuh_db/wdb.h"
@@ -18609,6 +18610,188 @@ void test_wm_vuldet_send_removed_cve_report_no_ip_success() {
     os_free(vuldet);
 }
 
+// Tests wm_vuldet_recv_wdb_by_row
+
+void test_wm_vuldet_recv_wdb_by_row_recv_error() {
+    int result;
+    cJSON* array = __real_cJSON_CreateArray();
+    wdb_vuldet_sock = 1;
+
+    will_return(__wrap_cJSON_CreateArray, array);
+
+    expect_value(__wrap_OS_RecvSecureTCP, sock, 1);
+    expect_value(__wrap_OS_RecvSecureTCP, size, OS_MAXSTR);
+    will_return(__wrap_OS_RecvSecureTCP, "");
+    will_return(__wrap_OS_RecvSecureTCP, OS_INVALID);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Error receiveing requested data from Wazuh-DB");
+    expect_function_calls(__wrap_cJSON_Delete, 2);
+
+    result = wm_vuldet_recv_wdb_by_row(&array);
+
+    __real_cJSON_Delete(array);
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_wm_vuldet_recv_wdb_by_row_json_syntax_error() {
+    int result;
+    cJSON* array = __real_cJSON_CreateArray();
+    char* response = "ok {";
+
+    wdb_vuldet_sock = 1;
+
+    will_return(__wrap_cJSON_CreateArray, array);
+
+    expect_value(__wrap_OS_RecvSecureTCP, sock, 1);
+    expect_value(__wrap_OS_RecvSecureTCP, size, OS_MAXSTR);
+    will_return(__wrap_OS_RecvSecureTCP, response);
+    will_return(__wrap_OS_RecvSecureTCP, strlen(response));
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid JSON syntax in vulnerability detector database request.");
+    expect_string(__wrap__mdebug2, formatted_msg, "JSON error near: ");
+
+    expect_function_calls(__wrap_cJSON_Delete, 2);
+
+    result = wm_vuldet_recv_wdb_by_row(&array);
+
+    __real_cJSON_Delete(array);
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_wm_vuldet_recv_wdb_by_row_not_synced() {
+    int result;
+    cJSON* array = __real_cJSON_CreateArray();
+    cJSON* j_status = __real_cJSON_CreateString("NOT_SYNCED");
+    char* response = "ok {\"status\":\"NOT_SYNCED\"}";
+
+    wdb_vuldet_sock = 1;
+
+    will_return(__wrap_cJSON_CreateArray, array);
+
+    expect_value(__wrap_OS_RecvSecureTCP, sock, 1);
+    expect_value(__wrap_OS_RecvSecureTCP, size, OS_MAXSTR);
+    will_return(__wrap_OS_RecvSecureTCP, response);
+    will_return(__wrap_OS_RecvSecureTCP, strlen(response));
+
+    will_return(__wrap_cJSON_GetObjectItem, j_status);
+    will_return_count(__wrap_cJSON_GetStringValue, "NOT_SYNCED", 2);
+    expect_function_calls(__wrap_cJSON_Delete, 2);
+
+    result = wm_vuldet_recv_wdb_by_row(&array);
+
+    __real_cJSON_Delete(array);
+    assert_int_equal(result, OS_SUCCESS);
+}
+
+void test_wm_vuldet_recv_wdb_by_row_error_status() {
+    int result;
+    cJSON* array = __real_cJSON_CreateArray();
+    cJSON* j_status = __real_cJSON_CreateString("ERROR");
+    char* response = "ok {\"status\":\"ERROR\"}";
+
+    wdb_vuldet_sock = 1;
+
+    will_return(__wrap_cJSON_CreateArray, array);
+
+    expect_value(__wrap_OS_RecvSecureTCP, sock, 1);
+    expect_value(__wrap_OS_RecvSecureTCP, size, OS_MAXSTR);
+    will_return(__wrap_OS_RecvSecureTCP, response);
+    will_return(__wrap_OS_RecvSecureTCP, strlen(response));
+
+    will_return(__wrap_cJSON_GetObjectItem, j_status);
+    will_return_count(__wrap_cJSON_GetStringValue, "ERROR", 2);
+    expect_function_calls(__wrap_cJSON_Delete, 2);
+
+    result = wm_vuldet_recv_wdb_by_row(&array);
+
+    __real_cJSON_Delete(array);
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_wm_vuldet_recv_wdb_by_row_success_empty() {
+    int result;
+    cJSON* array = __real_cJSON_CreateArray();
+    cJSON* j_status = __real_cJSON_CreateString("SUCCESS");
+    char* response = "ok {\"status\":\"SUCCESS\"}";
+
+    wdb_vuldet_sock = 1;
+
+    will_return(__wrap_cJSON_CreateArray, array);
+
+    expect_value(__wrap_OS_RecvSecureTCP, sock, 1);
+    expect_value(__wrap_OS_RecvSecureTCP, size, OS_MAXSTR);
+    will_return(__wrap_OS_RecvSecureTCP, response);
+    will_return(__wrap_OS_RecvSecureTCP, strlen(response));
+
+    will_return(__wrap_cJSON_GetObjectItem, j_status);
+    will_return_count(__wrap_cJSON_GetStringValue, "SUCCESS", 1);
+    expect_function_calls(__wrap_cJSON_Delete, 1);
+
+    result = wm_vuldet_recv_wdb_by_row(&array);
+
+    __real_cJSON_Delete(array);
+    assert_int_equal(result, OS_SUCCESS);
+}
+
+void test_wm_vuldet_recv_wdb_by_row_no_status() {
+    int result;
+    cJSON* array = __real_cJSON_CreateArray();
+    char* response = "ok {}";
+
+    wdb_vuldet_sock = 1;
+
+    will_return(__wrap_cJSON_CreateArray, array);
+
+    expect_value(__wrap_OS_RecvSecureTCP, sock, 1);
+    expect_value(__wrap_OS_RecvSecureTCP, size, OS_MAXSTR);
+    will_return(__wrap_OS_RecvSecureTCP, response);
+    will_return(__wrap_OS_RecvSecureTCP, strlen(response));
+
+    will_return(__wrap_cJSON_GetObjectItem, NULL);
+    expect_function_calls(__wrap_cJSON_Delete, 2);
+
+    result = wm_vuldet_recv_wdb_by_row(&array);
+
+    __real_cJSON_Delete(array);
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_wm_vuldet_recv_wdb_by_row_success() {
+    int result;
+    cJSON* array = __real_cJSON_CreateArray();
+    cJSON* j_status = __real_cJSON_CreateString("SUCCESS");
+    char* response = "due {\"name\":\"package1\"}";
+    char* response2 = "ok {\"status\":\"SUCCESS\"}";
+
+    wdb_vuldet_sock = 1;
+
+    will_return(__wrap_cJSON_CreateArray, array);
+
+    // First message
+    expect_value(__wrap_OS_RecvSecureTCP, sock, 1);
+    expect_value(__wrap_OS_RecvSecureTCP, size, OS_MAXSTR);
+    will_return(__wrap_OS_RecvSecureTCP, response);
+    will_return(__wrap_OS_RecvSecureTCP, strlen(response));
+
+    expect_function_call(__wrap_cJSON_AddItemToArray);
+    will_return(__wrap_cJSON_AddItemToArray, TRUE);
+
+    // Final message
+    expect_value(__wrap_OS_RecvSecureTCP, sock, 1);
+    expect_value(__wrap_OS_RecvSecureTCP, size, OS_MAXSTR);
+    will_return(__wrap_OS_RecvSecureTCP, response2);
+    will_return(__wrap_OS_RecvSecureTCP, strlen(response2));
+
+    will_return(__wrap_cJSON_GetObjectItem, j_status);
+    will_return_count(__wrap_cJSON_GetStringValue, "SUCCESS", 1);
+    expect_function_calls(__wrap_cJSON_Delete, 1);
+
+    result = wm_vuldet_recv_wdb_by_row(&array);
+
+    __real_cJSON_Delete(array);
+    assert_int_equal(result, OS_SUCCESS);
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -19096,6 +19279,14 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_removed_cve_report_fail, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_removed_cve_report_ip_assigned_success, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_removed_cve_report_no_ip_success, setup_group, teardown_group),
+        // Tests wm_vuldet_recv_wdb_by_row
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_recv_wdb_by_row_recv_error, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_recv_wdb_by_row_json_syntax_error, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_recv_wdb_by_row_not_synced, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_recv_wdb_by_row_error_status, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_recv_wdb_by_row_success_empty, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_recv_wdb_by_row_no_status, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_recv_wdb_by_row_success, setup_group, teardown_group),
         };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -18845,6 +18845,59 @@ void test_wm_vuldet_get_hotfixes_send_error() {
     assert_int_equal(result, OS_INVALID);
 }
 
+void test_wm_vuldet_get_hotfixes_success() {
+    int result;
+    int agent_id = 1;
+    char* query = "agent 1 hotfix get";
+    cJSON* requested_items;
+
+    wdb_vuldet_sock = 1;
+
+    expect_value(__wrap_OS_SendSecureTCP, sock, 1);
+    expect_value(__wrap_OS_SendSecureTCP, size, strlen(query) + 1);
+    expect_string(__wrap_OS_SendSecureTCP, msg, query);
+    will_return(__wrap_OS_SendSecureTCP, OS_SUCCESS);
+
+    // wm_vuldet_recv_wdb_by_row call
+    char* response = "due {\"name\":\"package1\"}";
+    char* response2 = "ok {\"status\":\"SUCCESS\"}";
+    cJSON* array = __real_cJSON_CreateArray();
+    cJSON* j_status = __real_cJSON_CreateString("SUCCESS");
+    cJSON* j_object = __real_cJSON_Parse(response + 4);
+    cJSON* j_object2 = __real_cJSON_Parse(response2 + 3);
+
+    will_return(__wrap_cJSON_CreateArray, array);
+
+    // First message
+    expect_value(__wrap_OS_RecvSecureTCP, sock, 1);
+    expect_value(__wrap_OS_RecvSecureTCP, size, OS_MAXSTR);
+    will_return(__wrap_OS_RecvSecureTCP, response);
+    will_return(__wrap_OS_RecvSecureTCP, strlen(response));
+    will_return(__wrap_cJSON_ParseWithOpts, j_object);
+
+    expect_function_call(__wrap_cJSON_AddItemToArray);
+    will_return(__wrap_cJSON_AddItemToArray, TRUE);
+
+    // Final message
+    expect_value(__wrap_OS_RecvSecureTCP, sock, 1);
+    expect_value(__wrap_OS_RecvSecureTCP, size, OS_MAXSTR);
+    will_return(__wrap_OS_RecvSecureTCP, response2);
+    will_return(__wrap_OS_RecvSecureTCP, strlen(response2));
+    will_return(__wrap_cJSON_ParseWithOpts, j_object2);
+
+    will_return(__wrap_cJSON_GetObjectItem, j_status);
+    will_return_count(__wrap_cJSON_GetStringValue, "SUCCESS", 1);
+    expect_function_calls(__wrap_cJSON_Delete, 1);
+
+    result = wm_vuldet_get_hotfixes(agent_id, &requested_items);
+
+    __real_cJSON_Delete(requested_items);
+    __real_cJSON_Delete(j_status);
+    __real_cJSON_Delete(j_object);
+    __real_cJSON_Delete(j_object2);
+    assert_int_equal(result, OS_SUCCESS);
+}
+
 // Tests wm_vuldet_get_software
 
 void test_wm_vuldet_get_software_send_error() {
@@ -18887,6 +18940,59 @@ void test_wm_vuldet_get_software_not_triaged_send_error() {
     result = wm_vuldet_get_software(agent_id, TRUE, &requested_items);
 
     assert_int_equal(result, OS_INVALID);
+}
+
+void test_wm_vuldet_get_software_success() {
+    int result;
+    int agent_id = 1;
+    char* query = "agent 1 package get ";
+    cJSON* requested_items;
+
+    wdb_vuldet_sock = 1;
+
+    expect_value(__wrap_OS_SendSecureTCP, sock, 1);
+    expect_value(__wrap_OS_SendSecureTCP, size, strlen(query) + 1);
+    expect_string(__wrap_OS_SendSecureTCP, msg, query);
+    will_return(__wrap_OS_SendSecureTCP, OS_SUCCESS);
+
+    // wm_vuldet_recv_wdb_by_row call
+    char* response = "due {\"name\":\"package1\"}";
+    char* response2 = "ok {\"status\":\"SUCCESS\"}";
+    cJSON* array = __real_cJSON_CreateArray();
+    cJSON* j_status = __real_cJSON_CreateString("SUCCESS");
+    cJSON* j_object = __real_cJSON_Parse(response + 4);
+    cJSON* j_object2 = __real_cJSON_Parse(response2 + 3);
+
+    will_return(__wrap_cJSON_CreateArray, array);
+
+    // First message
+    expect_value(__wrap_OS_RecvSecureTCP, sock, 1);
+    expect_value(__wrap_OS_RecvSecureTCP, size, OS_MAXSTR);
+    will_return(__wrap_OS_RecvSecureTCP, response);
+    will_return(__wrap_OS_RecvSecureTCP, strlen(response));
+    will_return(__wrap_cJSON_ParseWithOpts, j_object);
+
+    expect_function_call(__wrap_cJSON_AddItemToArray);
+    will_return(__wrap_cJSON_AddItemToArray, TRUE);
+
+    // Final message
+    expect_value(__wrap_OS_RecvSecureTCP, sock, 1);
+    expect_value(__wrap_OS_RecvSecureTCP, size, OS_MAXSTR);
+    will_return(__wrap_OS_RecvSecureTCP, response2);
+    will_return(__wrap_OS_RecvSecureTCP, strlen(response2));
+    will_return(__wrap_cJSON_ParseWithOpts, j_object2);
+
+    will_return(__wrap_cJSON_GetObjectItem, j_status);
+    will_return_count(__wrap_cJSON_GetStringValue, "SUCCESS", 1);
+    expect_function_calls(__wrap_cJSON_Delete, 1);
+
+    result = wm_vuldet_get_software(agent_id, FALSE, &requested_items);
+
+    __real_cJSON_Delete(requested_items);
+    __real_cJSON_Delete(j_status);
+    __real_cJSON_Delete(j_object);
+    __real_cJSON_Delete(j_object2);
+    assert_int_equal(result, OS_SUCCESS);
 }
 
 int main(void)
@@ -19386,9 +19492,11 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_recv_wdb_by_row_success, setup_group, teardown_group),
         // Tests wm_vuldet_get_hotfixes
         cmocka_unit_test_setup_teardown(test_wm_vuldet_get_hotfixes_send_error, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_get_hotfixes_success, setup_group, teardown_group),
         // Tests wm_vuldet_get_software
         cmocka_unit_test_setup_teardown(test_wm_vuldet_get_software_send_error, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_get_software_not_triaged_send_error, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_get_software_success, setup_group, teardown_group),
         };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -8103,7 +8103,7 @@ int wm_vuldet_get_hotfixes(int agent_id, cJSON** requested_items) {
     snprintf(query, OS_SIZE_128, vu_queries[VU_HOTFIXES_GET], agent_id);
 
     if (wm_vuldet_send_wdb(query) != OS_SUCCESS) {
-        mterror(WM_VULNDETECTOR_LOGTAG, VU_SOFTWARE_REQUEST_ERROR, agent_id);
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_HOTFIX_REQUEST_ERROR, agent_id);
     } else {
         result = wm_vuldet_recv_wdb_by_row(requested_items);
     }


### PR DESCRIPTION
|Related issue|
|---|
|#8555 #8570|

## Description

This PR adds UT for the following methods:
- **wm_vuldet_get_software**
- **wm_vuldet_get_hotfixes**
- **wm_vuldet_recv_wdb_by_row**

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Review logs syntax and correct language
<!-- Depending on the affected OS -->
- Memory tests for Linux
   - [x] Valgrind (memcheck and descriptor leaks check)
- [x] Added unit tests (for new features)
