### PR TITLE
Add hotfix and packages parser legacy actions UTs

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -22,7 +22,9 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                         -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_agents_clear_vuln_cves -Wl,--wrap,wdb_agents_update_vuln_cves_status \
                         -Wl,--wrap,wdb_agents_remove_vuln_cves -Wl,--wrap,wdb_agents_remove_vuln_cves_by_status -Wl,--wrap,cJSON_PrintUnformatted \
                         -Wl,--wrap,wdb_agents_get_sys_osinfo -Wl,--wrap,wdb_agents_set_sys_osinfo_triaged -Wl,--wrap,wdb_osinfo_save \
-                        -Wl,--wrap,wdb_agents_get_packages -Wl,--wrap,wdb_agents_get_hotfixes -Wl,--wrap,close -Wl,--wrap,getpid")
+                        -Wl,--wrap,wdb_agents_get_packages -Wl,--wrap,wdb_agents_get_hotfixes -Wl,--wrap,close -Wl,--wrap,getpid \
+                        -Wl,--wrap,wdb_package_save -Wl,--wrap,wdb_hotfix_save -Wl,--wrap,wdb_package_update -Wl,--wrap,wdb_package_delete -Wl,--wrap,wdb_hotfix_delete \
+                        -Wl,--wrap,time -Wl,--wrap,wdbi_update_attempt  -Wl,--wrap,wdbi_update_completion")
 
 list(APPEND wdb_tests_names "test_wdb_global_parser")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
@@ -153,6 +153,26 @@ int __wrap_wdbi_check_sync_status(__attribute__((unused)) wdb_t *wdb,
     return mock();
 }
 
+void __wrap_wdbi_update_attempt(__attribute__((unused))wdb_t * wdb,
+                                wdb_component_t component,
+                                long timestamp,
+                                bool legacy,
+                                os_sha1 last_agent_checksum) {
+    check_expected(component);
+    check_expected(timestamp);
+    check_expected(legacy);
+    check_expected(last_agent_checksum);
+}
+
+void __wrap_wdbi_update_completion(__attribute__((unused))wdb_t * wdb,
+                                wdb_component_t component,
+                                long timestamp,
+                                os_sha1 last_agent_checksum) {
+    check_expected(component);
+    check_expected(timestamp);
+    check_expected(last_agent_checksum);
+}
+
 cJSON* __wrap_wdbc_query_parse_json(__attribute__((unused)) int *sock,
                                     __attribute__((unused)) const char *query,
                                     char *response,
@@ -240,5 +260,77 @@ int __wrap_wdb_exec_stmt_silent(__attribute__((unused)) sqlite3_stmt* stmt) {
 
 int __wrap_wdb_exec_stmt_send(__attribute__((unused)) sqlite3_stmt* stmt, int peer) {
     check_expected(peer);
+    return mock();
+}
+
+int  __wrap_wdb_package_save(__attribute__((unused))wdb_t * wdb,
+                             const char* scan_id,
+                             const char* scan_time,
+                             const char* format,
+                             const char* name,
+                             const char* priority,
+                             const char* section,
+                             long size,
+                             const char* vendor,
+                             const char* install_time,
+                             const char* version,
+                             const char* architecture,
+                             const char* multiarch,
+                             const char* source,
+                             const char* description,
+                             const char* location,
+                             const char* checksum,
+                             const char* item_id,
+                             const bool replace) {
+    check_expected(scan_id);
+    check_expected(scan_time);
+    check_expected(format);
+    check_expected(name);
+    check_expected(priority);
+    check_expected(section);
+    check_expected(size);
+    check_expected(vendor);
+    check_expected(install_time);
+    check_expected(version);
+    check_expected(architecture);
+    check_expected(multiarch);
+    check_expected(source);
+    check_expected(description);
+    check_expected(location);
+    check_expected(checksum);
+    check_expected(item_id);
+    check_expected(replace);
+    return mock();
+}
+
+int __wrap_wdb_hotfix_save(__attribute__((unused))wdb_t * wdb,
+                           const char* scan_id,
+                           const char* scan_time,
+                           const char* hotfix,
+                           const char* checksum,
+                           const bool replace) {
+    check_expected(scan_id);
+    check_expected(scan_time);
+    check_expected(hotfix);
+    check_expected(checksum);
+    check_expected(replace);
+    return mock();
+}
+
+int __wrap_wdb_package_update(__attribute__((unused))wdb_t * wdb,
+                              const char * scan_id) {
+    check_expected(scan_id);
+    return mock();
+}
+
+int __wrap_wdb_package_delete(__attribute__((unused))wdb_t * wdb,
+                              const char * scan_id) {
+    check_expected(scan_id);
+    return mock();
+}
+
+int __wrap_wdb_hotfix_delete(__attribute__((unused))wdb_t * wdb,
+                              const char * scan_id) {
+    check_expected(scan_id);
     return mock();
 }

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -3604,7 +3604,13 @@ int wdb_parse_packages(wdb_t * wdb, char * input, char * output) {
     char* tail = NULL;
     char* action = strtok_r(input, " ", &tail);
 
-    if (strcmp(action, "save") == 0) {
+    if (!action) {
+        mdebug1("Invalid package info query syntax. Missing action");
+        mdebug2("DB query error. Missing action");
+        snprintf(output, OS_MAXSTR + 1, "err Invalid package info query syntax. Missing action");
+        return result;
+    }
+    else if (strcmp(action, "save") == 0) {
         /* The format of the data is scan_id|scan_time|format|name|priority|section|size|vendor|install_time|version|architecture|multiarch|source|description|location*/
         #define SAVE_PACKAGE_FIELDS_AMOUNT 16
         char* fields[SAVE_PACKAGE_FIELDS_AMOUNT] = {NULL};
@@ -3649,7 +3655,6 @@ int wdb_parse_packages(wdb_t * wdb, char * input, char * output) {
 
         if (result = wdb_package_update(wdb, scan_id), result < 0) {
             mdebug1("Cannot update scanned packages.");
-            snprintf(output, OS_MAXSTR + 1, "err Cannot save scanned packages before delete old package information.");
         }
 
         if (result = wdb_package_delete(wdb, scan_id), result < 0) {
@@ -3698,7 +3703,7 @@ int wdb_parse_packages(wdb_t * wdb, char * input, char * output) {
         mdebug1("Invalid package info query syntax.");
         mdebug2("DB query error near: %s", input);
         snprintf(output, OS_MAXSTR + 1, "err Invalid package info query syntax, near '%.32s'", input);
-        return -1;
+        return result;
     }
 }
 
@@ -3708,7 +3713,13 @@ int wdb_parse_hotfixes(wdb_t * wdb, char * input, char * output) {
     char* tail = NULL;
     char* action = strtok_r(input, " ", &tail);
 
-    if (strcmp(action, "save") == 0) {
+    if (!action) {
+        mdebug1("Invalid hotfix info query syntax. Missing action");
+        mdebug2("DB query error. Missing action");
+        snprintf(output, OS_MAXSTR + 1, "err Invalid hotfix info query syntax. Missing action");
+        return result;
+    }
+    else if (strcmp(action, "save") == 0) {
         /* The format of the data is scan_id|scan_time|hotfix */
         #define SAVE_HOTFIX_FIELDS_AMOUNT 3
         char* fields[SAVE_HOTFIX_FIELDS_AMOUNT] = {NULL};
@@ -3717,8 +3728,8 @@ int wdb_parse_hotfixes(wdb_t * wdb, char * input, char * output) {
         for (int i = 0; i < SAVE_HOTFIX_FIELDS_AMOUNT; i++) {
             if (!(next = strtok_r(NULL, "|", &tail))) {
                 mdebug1("Invalid hotfix info query syntax.");
-                mdebug2("Package info query: %s", last);
-                snprintf(output, OS_MAXSTR + 1, "err Invalid Package info query syntax, near '%.32s'", last);
+                mdebug2("Hotfix info query: %s", last);
+                snprintf(output, OS_MAXSTR + 1, "err Invalid hotfix info query syntax, near '%.32s'", last);
                 return OS_INVALID;
             }
             last = next;
@@ -3785,7 +3796,7 @@ int wdb_parse_hotfixes(wdb_t * wdb, char * input, char * output) {
         mdebug1("Invalid hotfix info query syntax.");
         mdebug2("DB query error near: %s", input);
         snprintf(output, OS_MAXSTR + 1, "err Invalid hotfix info query syntax, near '%.32s'", input);
-        return -1;
+        return result;
     }
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|#8637|

## Description
This PR adds several UTs for legacy actions of the hotfix and package parsing methods:
- Save package
- Delete package
- Invalid action package
- Save Hotfix
- Delete hotfix
- Invalid action hotfix

It also fix some minor strings error found with the UTs. 

>

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux

- Memory tests for Linux
  - [X] Valgrind (memcheck and descriptor leaks check)
