### PR TITLE
8667 aix libgcc s dep

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1508,7 +1508,7 @@ $(WAZUHEXT_LIB): $(EXTERNAL_LIBS)
 		ar -x libwazuhext/$$lib; \
 		mv *.o libwazuhext/; \
 	done
-	$(OSSEC_SHARED) $(OSSEC_CFLAGS) libwazuhext/*.o -o $@
+	$(OSSEC_SHARED) $(OSSEC_CFLAGS) libwazuhext/*.o -o $@ -static-libgcc
 
 else
 $(WAZUHEXT_LIB): $(EXTERNAL_LIBS)
@@ -1710,7 +1710,7 @@ endif
 else
 ifneq (,$(filter ${uname_S},AIX HP-UX))
 $(WAZUH_LIB): $(WAZUHEXT_LIB) $(AR_PROGRAMS_DEPS)
-	$(OSSEC_SHARED) $(OSSEC_CFLAGS) $^ ${OSSEC_LIBS} -o $@
+	$(OSSEC_SHARED) $(OSSEC_CFLAGS) $^ ${OSSEC_LIBS} -o $@ -static-libgcc
 else
 $(WAZUH_LIB): $(WAZUHEXT_LIB) $(AR_PROGRAMS_DEPS)
 	$(OSSEC_SHARED) $(OSSEC_CFLAGS) -o $@ -Wl,--whole-archive $^ -Wl,--no-whole-archive ${OSSEC_LIBS}


### PR DESCRIPTION
|Related issue|
|---|
|close #8667 |

## Description
This PRs aims to fix the missing dependency of libgcc in AIX platforms.

## DoD
- [X] Modify makefile.
- [X] Manual tests on AIX.