### PR TITLE
Remove libwazuhshared from OSSEC_LDFLAGS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -236,7 +236,7 @@ ifeq (${uname_S},HP-UX)
 		DEFINES+=-DHIGHFIRST
 		DEFINES+=-DOS_BIG_ENDIAN
 		OSSEC_CFLAGS+=-pthread
-		OSSEC_LDFLAGS+=-lrt -pthread -L. -lwazuhext -lwazuhshared
+		OSSEC_LDFLAGS+=-lrt -pthread -L. -lwazuhext
 		AR_LDFLAGS+=-lrt -pthread -L. -lwazuhext -lwazuhshared
 ifeq ($(INSTALLDIR),)
 	INSTALLDIR = /var/ossec


### PR DESCRIPTION
|Related issue|
|---|
| Closes #8669 |

## Description
This issue aims, to solve an incorrect library during the linking step.
![imagen](https://user-images.githubusercontent.com/14300208/118224557-ca0ef900-b459-11eb-992f-955982454161.png)

