### PR TITLE
Fix Macie ipGeoLocation issue

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -1798,7 +1798,7 @@ class AWSCustomBucket(AWSBucket):
                     json_data, json_index = decoder.raw_decode(data)
                 except ValueError as err:
                     match = self.macie_ip_pattern.search(data)
-                    if not match:
+                    if not match or not match.group(1) or not match.group(2):
                         raise err
                     lat = match.group(1)
                     lon = match.group(2)

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -1705,6 +1705,7 @@ class AWSCustomBucket(AWSBucket):
         self.sts_client = self.get_sts_client(access_key, secret_key, profile=profile)
         # get account ID
         self.aws_account_id = self.sts_client.get_caller_identity().get('Account')
+        self.macie_ip_pattern = re.compile(r'"ipGeoLocation":{"lat":(-?\d+\.\d+),"lon":(-?\d+\.\d+)')
         # SQL queries for custom buckets
         self.sql_already_processed = """
                           SELECT
@@ -1793,7 +1794,16 @@ class AWSCustomBucket(AWSBucket):
     def load_information_from_file(self, log_key):
         def json_event_generator(data):
             while data:
-                json_data, json_index = decoder.raw_decode(data)
+                try:
+                    json_data, json_index = decoder.raw_decode(data)
+                except ValueError as err:
+                    match = self.macie_ip_pattern.search(data)
+                    if not match:
+                        raise err
+                    lat = match.group(1)
+                    lon = match.group(2)
+                    new_pattern = f'"ipGeoLocation":{{"lat":"{lat}","lon":"{lon}"'
+                    json_data, json_index = decoder.raw_decode(re.sub(self.macie_ip_pattern, new_pattern, data))
                 data = data[json_index:]
                 yield json_data
 


### PR DESCRIPTION
Hello team,

This PR closes #8393.  As reported in #8393 some Macie events may not be pulled correctly If these Macie logs came from Macie V2 and they contain the `ipGeoLocation`. This is because the `lat` and `lon` fields inside the `ipGeoLocation` are not following the JSON standard and its value is considered to be `undefined` instead of string or numeric.

In this PR we have added a workaround to fix this issue. In case a Macie logs contains a problematic `ipGeoLocation` a `ValueError` will be triggered. If that's the case, then we will cast the value of the `lat` and `lon` values inside `ipGeoLocation` to float, removing any leading `0` before attempting to converting the log into a json.

This solution was tested using the logs provided in #8393 as well as other production logs from the client reporting the issue. Everything worked as expected after the fix.


## Examples

`'ipGeoLocation': {'lat': 00.501, 'lon': -00.4009}}` is changed to `'ipGeoLocation': {'lat': 0.501, 'lon': -0.4009}}`
`'ipGeoLocation': {'lat': 04.501, 'lon': -34.4009}}` is changed to `'ipGeoLocation': {'lat': 4.501, 'lon': -34.4009}}`