### PR TITLE
Fix overreaching sibling decoders

### DIFF
--- a/ruleset/decoders/0051-checkpoint-smart1_decoders.xml
+++ b/ruleset/decoders/0051-checkpoint-smart1_decoders.xml
@@ -1,7 +1,7 @@
 <!--
   -  CheckPoint Smart-1 Firewalls decoders
   -  Created by Wazuh, Inc.
-  -  Copyright (C) 2015-2020, Wazuh Inc.
+  -  Copyright (C) 2015-2021, Wazuh Inc.
   -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
@@ -24,307 +24,289 @@
   <order>timestamp,hostname,ProductVersion</order>
 </decoder>
 
+
 <decoder name="checkpoint-smart1">
   <parent>checkpoint-smart1</parent>
-  <regex>action:"(\.*)";|(\.*)$</regex>
+  <regex>action:"(\.*)";|action:"(\.*)"$|action:(\.*);|action:(\.*)$</regex>
   <order>fw_action</order>
 </decoder>
-
 <decoder name="checkpoint-smart1">
   <parent>checkpoint-smart1</parent>
-  <regex>conn_direction:"(\w*)";|(\.*)$</regex>
-  <order>conn_direction</order>
-</decoder>
-
-<decoder name="checkpoint-smart1">
-  <parent>checkpoint-smart1</parent>
-  <regex>contextnum:"(\d*)";|(\.*)$</regex>
-  <order>contextnum</order>
-</decoder>
-
-<decoder name="checkpoint-smart1">
-  <parent>checkpoint-smart1</parent>
-  <regex>flags:"(\d*)";|(\.*)$</regex>
-  <order>flags</order>
-</decoder>
-
-<decoder name="checkpoint-smart1">
-  <parent>checkpoint-smart1</parent>
-  <regex>ifdir:"(\w*)";|(\.*)$</regex>
-  <order>ifdir</order>
-</decoder>
-
-<decoder name="checkpoint-smart1">
-  <parent>checkpoint-smart1</parent>
-  <regex>ifname:"(\w*)";|(\.*)$</regex>
-  <order>ifname</order>
-</decoder>
-
-<decoder name="checkpoint-smart1">
-  <parent>checkpoint-smart1</parent>
-  <regex>logid:"(\d*)";|(\.*)$</regex>
-  <order>logid</order>
-</decoder>
-
-<decoder name="checkpoint-smart1">
-  <parent>checkpoint-smart1</parent>
-  <regex>loguid:"{(\.*)}";|(\.*)$</regex>
-  <order>loguid</order>
-</decoder>
-
-<decoder name="checkpoint-smart1">
-  <parent>checkpoint-smart1</parent>
-  <regex>origin:"(\d*.\d*.\d*.\d*)";|(\.*)$</regex>
-  <order>origin</order>
-</decoder>
-
-<decoder name="checkpoint-smart1">
-  <parent>checkpoint-smart1</parent>
-  <regex>originsicname:"(\.*)";|(\.*)$</regex>
-  <order>originsicname</order>
-</decoder>
-
-<decoder name="checkpoint-smart1">
-  <parent>checkpoint-smart1</parent>
-  <regex>sequencenum:"(\d*)";|(\.*)$</regex>
-  <order>sequencenum</order>
-</decoder>
-
-<decoder name="checkpoint-smart1">
-  <parent>checkpoint-smart1</parent>
-  <regex>time:"(\d*)";|(\.*)$</regex>
-  <order>time</order>
-</decoder>
-
-<decoder name="checkpoint-smart1">
-  <parent>checkpoint-smart1</parent>
-  <regex>version:"(\d*)";|(\.*)$</regex>
-  <order>version</order>
-</decoder>
-
-<decoder name="checkpoint-smart1">
-  <parent>checkpoint-smart1</parent>
-  <regex>__policy_id_tag:"(\.*)";|(\.*)$</regex>
-  <order>policy_id_tag</order>
-</decoder>
-
-<decoder name="checkpoint-smart1">
-  <parent>checkpoint-smart1</parent>
-  <regex>community:"(\w*)";|(\.*)$</regex>
+  <regex>community:"(\.*)";|community:"(\.*)"$|community:(\.*);|community:(\.*)$</regex>
   <order>community</order>
 </decoder>
-
 <decoder name="checkpoint-smart1">
   <parent>checkpoint-smart1</parent>
-  <regex>cookiei:"(\w*)";|(\.*)$</regex>
-  <order>cookiei</order>
+  <regex>conn_direction:"(\.*)";|conn_direction:"(\.*)"$|conn_direction:(\.*);|conn_direction:(\.*)$</regex>
+  <order>conn_direction</order>
 </decoder>
-
 <decoder name="checkpoint-smart1">
   <parent>checkpoint-smart1</parent>
-  <regex>cookier:"(\w*)";|(\.*)$</regex>
-  <order>cookier</order>
-</decoder>
-
-<decoder name="checkpoint-smart1">
-  <parent>checkpoint-smart1</parent>
-  <regex>context_num:"(\d*)";|(\.*)$</regex>
+  <regex>context_num:"(\.*)";|context_num:"(\.*)"$|context_num:(\.*);|context_num:(\.*)$</regex>
   <order>context_num</order>
 </decoder>
-
 <decoder name="checkpoint-smart1">
   <parent>checkpoint-smart1</parent>
-  <regex>dst:"(\d*.\d*.\d*.\d*)";|(\.*)$</regex>
-  <order>dst</order>
+  <regex>contextnum:"(\.*)";|contextnum:"(\.*)"$|contextnum:(\.*);|contextnum:(\.*)$</regex>
+  <order>contextnum</order>
 </decoder>
-
 <decoder name="checkpoint-smart1">
   <parent>checkpoint-smart1</parent>
-  <regex>fw_subproduct:"(\w*)";|(\.*)$</regex>
-  <order>fw_subproduct</order>
+  <regex>cookiei:"(\.*)";|cookiei:"(\.*)"$|cookiei:(\.*);|cookiei:(\.*)$</regex>
+  <order>cookiei</order>
 </decoder>
-
 <decoder name="checkpoint-smart1">
   <parent>checkpoint-smart1</parent>
-  <regex>hll_key:"(\d*)";|(\.*)$</regex>
-  <order>hll_key</order>
+  <regex>cookier:"(\.*)";|cookier:"(\.*)"$|cookier:(\.*);|cookier:(\.*)$</regex>
+  <order>cookier</order>
 </decoder>
-
 <decoder name="checkpoint-smart1">
   <parent>checkpoint-smart1</parent>
-  <regex>ike::"(\.*)";|(\.*)$</regex>
-  <order>ike</order>
-</decoder>
-
-<decoder name="checkpoint-smart1">
-  <parent>checkpoint-smart1</parent>
-  <regex>Cookies:"(\w*)";|(\.*)$</regex>
+  <regex>Cookies:"(\.*)";|Cookies:"(\.*)"$|Cookies:(\.*);|Cookies:(\.*)$</regex>
   <order>Cookies</order>
 </decoder>
-
 <decoder name="checkpoint-smart1">
   <parent>checkpoint-smart1</parent>
-  <regex>msgid:"(\w*)";|(\.*)$</regex>
+  <regex>dst:"(\.*)";|dst:"(\.*)"$|dst:(\.*);|dst:(\.*)$</regex>
+  <order>dst</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>ESP:"(\.*)";|ESP:"(\.*)"$|ESP:(\.*);|ESP:(\.*)$</regex>
+  <order>ESP</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>flags:"(\.*)";|flags:"(\.*)"$|flags:(\.*);|flags:(\.*)$</regex>
+  <order>flags</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>for:"(\.*)";|for:"(\.*)"$|for:(\.*);|for:(\.*)$</regex>
+  <order>for</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>fw_subproduct:"(\.*)";|fw_subproduct:"(\.*)"$|fw_subproduct:(\.*);|fw_subproduct:(\.*)$</regex>
+  <order>fw_subproduct</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>hll_key:"(\.*)";|hll_key:"(\.*)"$|hll_key:(\.*);|hll_key:(\.*)$</regex>
+  <order>hll_key</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>ifdir:"(\.*)";|ifdir:"(\.*)"$|ifdir:(\.*);|ifdir:(\.*)$</regex>
+  <order>ifdir</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>ifname:"(\.*)";|ifname:"(\.*)"$|ifname:(\.*);|ifname:(\.*)$</regex>
+  <order>ifname</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>ike:"(\.*)";|ike:"(\.*)"$|ike:(\.*);|ike:(\.*)$</regex>
+  <order>ike</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>inzone:"(\.*)";|inzone:"(\.*)"$|inzone:(\.*);|inzone:(\.*)$</regex>
+  <order>inzone</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>layer_name:"(\.*)";|layer_name:"(\.*)"$|layer_name:(\.*);|layer_name:(\.*)$</regex>
+  <order>layer_name</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>layer_uuid:"(\.*)";|layer_uuid:"(\.*)"$|layer_uuid:(\.*);|layer_uuid:(\.*)$</regex>
+  <order>layer_uuid</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>logid:"(\.*)";|logid:"(\.*)"$|logid:(\.*);|logid:(\.*)$</regex>
+  <order>logid</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>loguid:"(\.*)";|loguid:"(\.*)"$|loguid:(\.*);|loguid:(\.*)$</regex>
+  <order>loguid</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>match_id:"(\.*)";|match_id:"(\.*)"$|match_id:(\.*);|match_id:(\.*)$</regex>
+  <order>match_id</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>methods:"(\.*)";|methods:"(\.*)"$|methods:(\.*);|methods:(\.*)$</regex>
+  <order>methods</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>msgid:"(\.*)";|msgid:"(\.*)"$|msgid:(\.*);|msgid:(\.*)$</regex>
   <order>msgid</order>
 </decoder>
 <decoder name="checkpoint-smart1">
   <parent>checkpoint-smart1</parent>
-  <regex>Reason:"(\.*)";|(\.*)$</regex>
-  <order>Reason</order>
-</decoder>
-
-<decoder name="checkpoint-smart1">
-  <parent>checkpoint-smart1</parent>
-  <regex>inzone:"(\w*)";|(\.*)$</regex>
-  <order>inzone</order>
-</decoder>
-
-<decoder name="checkpoint-smart1">
-  <parent>checkpoint-smart1</parent>
-  <regex>layer_name:"(\.*)";|(\.*)$</regex>
-  <order>layer_name</order>
-</decoder>
-
-<decoder name="checkpoint-smart1">
-  <parent>checkpoint-smart1</parent>
-  <regex>layer_uuid:"(\w*)";|(\.*)$</regex>
-  <order>layer_uuid</order>
-</decoder>
-
-<decoder name="checkpoint-smart1">
-  <parent>checkpoint-smart1</parent>
-  <regex>match_id:"(\d*)";|(\.*)$</regex>
-  <order>match_id</order>
-</decoder>
-
-<decoder name="checkpoint-smart1">
-  <parent>checkpoint-smart1</parent>
-  <regex>parent_rule:"(\d*)";|(\.*)$</regex>
-  <order>parent_rule</order>
-</decoder>
-
-<decoder name="checkpoint-smart1">
-  <parent>checkpoint-smart1</parent>
-  <regex>rule_action:"(\w*)";|(\.*)$</regex>
-  <order>rule_action</order>
-</decoder>
-
-<decoder name="checkpoint-smart1">
-  <parent>checkpoint-smart1</parent>
-  <regex>rule_name:"(\.*)";|(\.*)$</regex>
-  <order>rule_name</order>
-</decoder>
-
-<decoder name="checkpoint-smart1">
-  <parent>checkpoint-smart1</parent>
-  <regex>rule_uid:"(\w*)";|(\.*)$</regex>
-  <order>rule_uid</order>
-</decoder>
-
-<decoder name="checkpoint-smart1">
-  <parent>checkpoint-smart1</parent>
-  <regex>methods:"(\.*)";|(\.*)$</regex>
-  <order>methods</order>
-</decoder>
-
-<decoder name="checkpoint-smart1">
-  <parent>checkpoint-smart1</parent>
-  <regex>nat_addtnl_rulenum:"(\d*)";|(\.*)$</regex>
+  <regex>nat_addtnl_rulenum:"(\.*)";|nat_addtnl_rulenum:"(\.*)"$|nat_addtnl_rulenum:(\.*);|nat_addtnl_rulenum:(\.*)$</regex>
   <order>nat_addtnl_rulenum</order>
 </decoder>
-
 <decoder name="checkpoint-smart1">
   <parent>checkpoint-smart1</parent>
-  <regex>nat_rulenum:"(\d*)";|(\.*)$</regex>
+  <regex>nat_rulenum:"(\.*)";|nat_rulenum:"(\.*)"$|nat_rulenum:(\.*);|nat_rulenum:(\.*)$</regex>
   <order>nat_rulenum</order>
 </decoder>
-
 <decoder name="checkpoint-smart1">
   <parent>checkpoint-smart1</parent>
-  <regex>outzone:"(\w*)";|(\.*)$</regex>
+  <regex>origin:"(\.*)";|origin:"(\.*)"$|origin:(\.*);|origin:(\.*)$</regex>
+  <order>origin</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>originsicname:"(\.*)";|originsicname:"(\.*)"$|originsicname:(\.*);|originsicname:(\.*)$</regex>
+  <order>originsicname</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>outzone:"(\.*)";|outzone:"(\.*)"$|outzone:(\.*);|outzone:(\.*)$</regex>
   <order>outzone</order>
 </decoder>
-
 <decoder name="checkpoint-smart1">
   <parent>checkpoint-smart1</parent>
-  <regex>product:"(\.*)";|(\.*)$</regex>
-  <order>product</order>
+  <regex>parent_rule:"(\.*)";|parent_rule:"(\.*)"$|parent_rule:(\.*);|parent_rule:(\.*)$</regex>
+  <order>parent_rule</order>
 </decoder>
- 
 <decoder name="checkpoint-smart1">
   <parent>checkpoint-smart1</parent>
-  <regex>peer_gateway:"(\d*.\d*.\d*.\d*)";|(\.*)$</regex>
+  <regex>Peer:"(\.*)";|Peer:"(\.*)"$|Peer:(\.*);|Peer:(\.*)$</regex>
+  <order>Peer</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>peer_gateway:"(\.*)";|peer_gateway:"(\.*)"$|peer_gateway:(\.*);|peer_gateway:(\.*)$</regex>
   <order>peer_gateway</order>
 </decoder>
-
 <decoder name="checkpoint-smart1">
   <parent>checkpoint-smart1</parent>
-  <regex>reject_category:"(\.*)";|(\.*)$</regex>
-  <order>reject_category</order>
+  <regex>__policy_id_tag:"(\.*)";|__policy_id_tag:"(\.*)"$|__policy_id_tag:(\.*);|__policy_id_tag:(\.*)$</regex>
+  <order>policy_id_tag</order>
 </decoder>
-
 <decoder name="checkpoint-smart1">
   <parent>checkpoint-smart1</parent>
-  <regex>scheme::"(\w*)";|(\.*)$</regex>
-  <order>scheme</order>
+  <regex>product:"(\.*)";|product:"(\.*)"$|product:(\.*);|product:(\.*)$</regex>
+  <order>product</order>
 </decoder>
-
 <decoder name="checkpoint-smart1">
   <parent>checkpoint-smart1</parent>
-  <regex>proto:"(\d*)";|(\.*)$</regex>
+  <regex>proposal:"(\.*)";|proposal:"(\.*)"$|proposal:(\.*);|proposal:(\.*)$</regex>
+  <order>proposal</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>proto:"(\.*)";|proto:"(\.*)"$|proto:(\.*);|proto:(\.*)$</regex>
   <order>proto</order>
 </decoder>
-
 <decoder name="checkpoint-smart1">
   <parent>checkpoint-smart1</parent>
-  <regex>s_port:"(\d*)";|(\.*)$</regex>
-  <order>s_port</order>
+  <regex>Reason:"(\.*)";|Reason:"(\.*)"$|Reason:(\.*);|Reason:(\.*)$</regex>
+  <order>Reason</order>
 </decoder>
-
 <decoder name="checkpoint-smart1">
   <parent>checkpoint-smart1</parent>
-  <regex>service:"(\d*)";|(\.*)$</regex>
+  <regex>reject_category:"(\.*)";|reject_category:"(\.*)"$|reject_category:(\.*);|reject_category:(\.*)$</regex>
+  <order>reject_category</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>rule_action:"(\.*)";|rule_action:"(\.*)"$|rule_action:(\.*);|rule_action:(\.*)$</regex>
+  <order>rule_action</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>rule_name:"(\.*)";|rule_name:"(\.*)"$|rule_name:(\.*);|rule_name:(\.*)$</regex>
+  <order>rule_name</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>rule_uid:"(\.*)";|rule_uid:"(\.*)"$|rule_uid:(\.*);|rule_uid:(\.*)$</regex>
+  <order>rule_uid</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>scheme:"(\.*)";|scheme:"(\.*)"$|scheme:(\.*);|scheme:(\.*)$</regex>
+  <order>scheme</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>sequencenum:"(\.*)";|sequencenum:"(\.*)"$|sequencenum:(\.*);|sequencenum:(\.*)$</regex>
+  <order>sequencenum</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>service:"(\.*)";|service:"(\.*)"$|service:(\.*);|service:(\.*)$</regex>
   <order>service</order>
 </decoder>
-
 <decoder name="checkpoint-smart1">
   <parent>checkpoint-smart1</parent>
-  <regex>service_id:"(\w*)";|(\.*)$</regex>
+  <regex>service_id:"(\.*)";|service_id:"(\.*)"$|service_id:(\.*);|service_id:(\.*)$</regex>
   <order>service_id</order>
 </decoder>
-
 <decoder name="checkpoint-smart1">
   <parent>checkpoint-smart1</parent>
-  <regex>src:"(\d*.\d*.\d*.\d*)";|(\.*)$</regex>
+  <regex>s_port:"(\.*)";|s_port:"(\.*)"$|s_port:(\.*);|s_port:(\.*)$</regex>
+  <order>s_port</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>src:"(\.*)";|src:"(\.*)"$|src:(\.*);|src:(\.*)$</regex>
   <order>src</order>
 </decoder>
-
 <decoder name="checkpoint-smart1">
   <parent>checkpoint-smart1</parent>
-  <regex>vpn_feature_name:"(\w*)";|(\.*)$</regex>
+  <regex>time:"(\.*)";|time:"(\.*)"$|time:(\.*);|time:(\.*)$</regex>
+  <order>time</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>Transform:"(\.*)";|Transform:"(\.*)"$|Transform:(\.*);|Transform:(\.*)$</regex>
+  <order>Transform</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>version:"(\.*)";|version:"(\.*)"$|version:(\.*);|version:(\.*)$</regex>
+  <order>version</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>vpn_feature_name:"(\.*)";|vpn_feature_name:"(\.*)"$|vpn_feature_name:(\.*);|vpn_feature_name:(\.*)$</regex>
   <order>vpn_feature_name</order>
 </decoder>
-
 <decoder name="checkpoint-smart1">
   <parent>checkpoint-smart1</parent>
-  <regex>xlatedport:"(\d*)";|(\.*)$</regex>
+  <regex>xlatedport:"(\.*)";|xlatedport:"(\.*)"$|xlatedport:(\.*);|xlatedport:(\.*)$</regex>
   <order>xlatedport</order>
 </decoder>
-
 <decoder name="checkpoint-smart1">
   <parent>checkpoint-smart1</parent>
-  <regex>xlateds:"(\d*.\d*.\d*.\d*)";|(\.*)$</regex>
+  <regex>xlateds:"(\.*)";|xlateds:"(\.*)"$|xlateds:(\.*);|xlateds:(\.*)$</regex>
   <order>xlateds</order>
 </decoder>
-
 <decoder name="checkpoint-smart1">
   <parent>checkpoint-smart1</parent>
-  <regex>xlatesport:"(\d*)";|(\.*)$</regex>
+  <regex>xlatedst:"(\.*)";|xlatedst:"(\.*)"$|xlatedst:(\.*);|xlatedst:(\.*)$</regex>
+  <order>xlatedst</order>
+</decoder>
+<decoder name="checkpoint-smart1">
+  <parent>checkpoint-smart1</parent>
+  <regex>xlatesport:"(\.*)";|xlatesport:"(\.*)"$|xlatesport:(\.*);|xlatesport:(\.*)$</regex>
   <order>xlatesport</order>
 </decoder>
-
 <decoder name="checkpoint-smart1">
   <parent>checkpoint-smart1</parent>
-  <regex>xlatesrc:"(\d*.\d*.\d*.\d*)";|(\.*)$</regex>
+  <regex>xlatesrc:"(\.*)";|xlatesrc:"(\.*)"$|xlatesrc:(\.*);|xlatesrc:(\.*)$</regex>
   <order>xlatesrc</order>
 </decoder>

--- a/ruleset/decoders/0470-panda-paps_decoders.xml
+++ b/ruleset/decoders/0470-panda-paps_decoders.xml
@@ -1,7 +1,7 @@
 <!--
   -  Panda Advanced Protection Service (PAPS) decoders
   -  Created by Wazuh, Inc.
-  -  Copyright (C) 2015-2020, Wazuh Inc.
+  -  Copyright (C) 2015-2021, Wazuh Inc.
   -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
@@ -504,7 +504,7 @@ LEEF:1.0|Panda Security|paps|02.47.00.0000|exec|sev=4	devTime=2019-05-09 22:00:5
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>MWName=\t*(\.*)\t|(\.*)$</regex>
+  <regex>MWName=\t*(\.*)\t|MWName=\t*(\.*)$</regex>
   <order>MWName</order>
 </decoder>
 

--- a/ruleset/decoders/0510-sophos_fw_decoders.xml
+++ b/ruleset/decoders/0510-sophos_fw_decoders.xml
@@ -1,7 +1,7 @@
 <!--
   -  Sophos XG210 Firewall decoders
   -  Created by Wazuh, Inc.
-  -  Copyright (C) 2015-2019, Wazuh Inc.
+  -  Copyright (C) 2015-2021, Wazuh Inc.
   -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 

--- a/ruleset/decoders/0510-sophos_fw_decoders.xml
+++ b/ruleset/decoders/0510-sophos_fw_decoders.xml
@@ -243,7 +243,7 @@ device="SFW" date=2019-10-09 time=17:19:06 timezone="+08" device_name="XG210" de
 <decoder name="sophos-fw">
   <parent>sophos-fw</parent>
   <regex>status="(\.*)"\s+|status="(\.*)"$|status=(\.*)\s+|status=(\.*)$</regex>
-  <order>status</order>
+  <order>sophos_fw_status_msg</order>
 </decoder>
 <decoder name="sophos-fw">
   <parent>sophos-fw</parent>

--- a/ruleset/decoders/0510-sophos_fw_decoders.xml
+++ b/ruleset/decoders/0510-sophos_fw_decoders.xml
@@ -22,300 +22,276 @@ device="SFW" date=2019-10-09 time=17:19:06 timezone="+08" device_name="XG210" de
 </decoder>
 <decoder name="sophos-fw">
   <parent>sophos-fw</parent>
-  <regex>device_name="(\.*)"\s+|(\.*)$</regex>
-  <order>device_name</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>device_id=(\w*)\s+|(\.*)$</regex>
-  <order>device_id</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>log_id=(\s*)\s+|(\.*)$</regex>
-  <order>log_id</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>log_type="(\w*)"\s+|(\.*)$</regex>
-  <order>log_type</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>log_component="(\.*)"\s+|(\.*)$</regex>
-  <order>log_component</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>log_subtype="(\w*)"\s+|(\.*)$</regex>
-  <order>log_subtype</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>status="(\.*)"\s+|(\.*)$</regex>
-  <order>sophos_fw_status_msg</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>priority=(\w*)\s+|(\.*)$</regex>
-  <order>priority</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>duration=(\d*)\s+|(\.*)$</regex>
-  <order>duration</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>fw_rule_id=(\d*)\s+|(\.*)$</regex>
-  <order>fw_rule_id</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>policy_type=(\d*)\s+|(\.*)$</regex>
-  <order>policy_type</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>user_name="(\w*)"\s+|(\.*)$</regex>
-  <order>user_name</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>user_gp="(\w*)"\s+|(\.*)$</regex>
-  <order>user_group</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>iap=(\d*)\s+|(\.*)$</regex>
-  <order>iap</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>ips_policy_id=(\d*)\s+|(\.*)$</regex>
-  <order>ips_policy_id</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>appfilter_policy_id=(\d*)\s+|(\.*)$</regex>
+  <regex>appfilter_policy_id="(\.*)"\s+|appfilter_policy_id="(\.*)"$|appfilter_policy_id=(\.*)\s+|appfilter_policy_id=(\.*)$</regex>
   <order>appfilter_policy_id</order>
 </decoder>
-
 <decoder name="sophos-fw">
   <parent>sophos-fw</parent>
-  <regex>application="(\w*)"\s+|(\.*)$</regex>
+  <regex>application="(\.*)"\s+|application="(\.*)"$|application=(\.*)\s+|application=(\.*)$</regex>
   <order>application</order>
 </decoder>
-
 <decoder name="sophos-fw">
   <parent>sophos-fw</parent>
-  <regex>application_risk=(\d*)\s+|(\.*)$</regex>
-  <order>application_risk</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>application_technology="(\w*)"\s+|(\.*)$</regex>
-  <order>application_technology</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>application_category="(\w*)"\s+|(\.*)$</regex>
+  <regex>application_category="(\.*)"\s+|application_category="(\.*)"$|application_category=(\.*)\s+|application_category=(\.*)$</regex>
   <order>application_category</order>
 </decoder>
-
 <decoder name="sophos-fw">
   <parent>sophos-fw</parent>
-  <regex>in_interface="(\w*)"\s+|(\.*)$</regex>
-  <order>in_interface</order>
+  <regex>application_risk="(\.*)"\s+|application_risk="(\.*)"$|application_risk=(\.*)\s+|application_risk=(\.*)$</regex>
+  <order>application_risk</order>
 </decoder>
-
 <decoder name="sophos-fw">
   <parent>sophos-fw</parent>
-  <regex>out_interface="(\w*)"\s+|(\.*)$</regex>
-  <order>out_interface</order>
+  <regex>application_technology="(\.*)"\s+|application_technology="(\.*)"$|application_technology=(\.*)\s+|application_technology=(\.*)$</regex>
+  <order>application_technology</order>
 </decoder>
-
 <decoder name="sophos-fw">
   <parent>sophos-fw</parent>
-  <regex>src_mac=(\.+:\.+:\.+:\.+:\.+:\.+)\s+|(\.*)$</regex>
-  <order>src_mac</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>src_ip=(\.*)\s+|(\.*)$</regex>
-  <order>src_ip</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>src_country_code=(\w*)\s+|(\.*)$</regex>
-  <order>src_country_code</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>dst_ip=(\.*)\s+|(\.*)$</regex>
-  <order>dst_ip</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>dst_country_code=(\w*)\s+|(\.*)$</regex>
-  <order>dst_country_code</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>protocol="(\w*)"\s+|(\.*)$</regex>
-  <order>protocol</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>src_port=(\d*)\s+|(\.*)$</regex>
-  <order>src_port</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>dst_port=(\d*)\s+|(\.*)$</regex>
-  <order>dst_port</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>sent_pkts=(\d*)\s+|(\.*)$</regex>
-  <order>sent_pkts</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>recv_pkts=(\d*)\s+|(\.*)$</regex>
-  <order>recv_pkts</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>sent_bytes=(\d*)\s+|(\.*)$</regex>
-  <order>sent_bytes</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>recv_bytes=(\d*)\s+|(\.*)$</regex>
-  <order>recv_bytes</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>tran_src_ip=(\.*)\s+|(\.*)$</regex>
-  <order>tran_src_ip</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>tran_src_port=(\d*)\s+|(\.*)$</regex>
-  <order>tran_src_port</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>tran_src_ip=(\.*)\s+|(\.*)$</regex>
-  <order>tran_src_ip</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>tran_dst_ip=(\.*)\s+|(\.*)$</regex>
-  <order>tran_dst_ip</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>srczonetype="(\.*)"\s+|(\.*)$</regex>
-  <order>srczonetype</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>srczone="(\.*)"\s+|(\.*)$</regex>
-  <order>srczone</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>dstzonetype="(\.*)"\s+|(\.*)$</regex>
-  <order>dstzonetype</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>dstzone="(\.*)"\s+|(\.*)$</regex>
-  <order>dstzone</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>dir_disp="(\.*)"\s+|(\.*)$</regex>
-  <order>dir_disp</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>connevent="(\.*)"\s+|(\.*)$</regex>
-  <order>connevent</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>connid="(\.*)"\s+|(\.*)$</regex>
-  <order>connid</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>vconnid="(\.*)"\s+|(\.*)$</regex>
-  <order>vconnid</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>hb_health="(\.*)"\s+|(\.*)$</regex>
-  <order>hb_health</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>message="(\.*)"\s+|(\.*)$</regex>
-  <order>message</order>
-</decoder>
-
-<decoder name="sophos-fw">
-  <parent>sophos-fw</parent>
-  <regex>appresolvedby="(\w*)"\s*|(\.*)$</regex>
+  <regex>appresolvedby="(\.*)"\s+|appresolvedby="(\.*)"$|appresolvedby=(\.*)\s+|appresolvedby=(\.*)$</regex>
   <order>appresolvedby</order>
 </decoder>
-
 <decoder name="sophos-fw">
   <parent>sophos-fw</parent>
-  <regex>th="(\.*)"\s*|(\.*)$</regex>
+  <regex>connevent="(\.*)"\s+|connevent="(\.*)"$|connevent=(\.*)\s+|connevent=(\.*)$</regex>
+  <order>connevent</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>connid="(\.*)"\s+|connid="(\.*)"$|connid=(\.*)\s+|connid=(\.*)$</regex>
+  <order>connid</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>date="(\.*)"\s+|date="(\.*)"$|date=(\.*)\s+|date=(\.*)$</regex>
+  <order>date</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>device="(\.*)"\s+|device="(\.*)"$|device=(\.*)\s+|device=(\.*)$</regex>
+  <order>device</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>device_id="(\.*)"\s+|device_id="(\.*)"$|device_id=(\.*)\s+|device_id=(\.*)$</regex>
+  <order>device_id</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>device_name="(\.*)"\s+|device_name="(\.*)"$|device_name=(\.*)\s+|device_name=(\.*)$</regex>
+  <order>device_name</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>dir_disp="(\.*)"\s+|dir_disp="(\.*)"$|dir_disp=(\.*)\s+|dir_disp=(\.*)$</regex>
+  <order>dir_disp</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>dst_country_code="(\.*)"\s+|dst_country_code="(\.*)"$|dst_country_code=(\.*)\s+|dst_country_code=(\.*)$</regex>
+  <order>dst_country_code</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>dst_ip="(\.*)"\s+|dst_ip="(\.*)"$|dst_ip=(\.*)\s+|dst_ip=(\.*)$</regex>
+  <order>dst_ip</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>dst_port="(\.*)"\s+|dst_port="(\.*)"$|dst_port=(\.*)\s+|dst_port=(\.*)$</regex>
+  <order>dst_port</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>dstzone="(\.*)"\s+|dstzone="(\.*)"$|dstzone=(\.*)\s+|dstzone=(\.*)$</regex>
+  <order>dstzone</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>dstzonetype="(\.*)"\s+|dstzonetype="(\.*)"$|dstzonetype=(\.*)\s+|dstzonetype=(\.*)$</regex>
+  <order>dstzonetype</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>duration="(\.*)"\s+|duration="(\.*)"$|duration=(\.*)\s+|duration=(\.*)$</regex>
+  <order>duration</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>fw_rule_id="(\.*)"\s+|fw_rule_id="(\.*)"$|fw_rule_id=(\.*)\s+|fw_rule_id=(\.*)$</regex>
+  <order>fw_rule_id</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>hb_health="(\.*)"\s+|hb_health="(\.*)"$|hb_health=(\.*)\s+|hb_health=(\.*)$</regex>
+  <order>hb_health</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>iap="(\.*)"\s+|iap="(\.*)"$|iap=(\.*)\s+|iap=(\.*)$</regex>
+  <order>iap</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>in_interface="(\.*)"\s+|in_interface="(\.*)"$|in_interface=(\.*)\s+|in_interface=(\.*)$</regex>
+  <order>in_interface</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>ips_policy_id="(\.*)"\s+|ips_policy_id="(\.*)"$|ips_policy_id=(\.*)\s+|ips_policy_id=(\.*)$</regex>
+  <order>ips_policy_id</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>log_component="(\.*)"\s+|log_component="(\.*)"$|log_component=(\.*)\s+|log_component=(\.*)$</regex>
+  <order>log_component</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>log_id="(\.*)"\s+|log_id="(\.*)"$|log_id=(\.*)\s+|log_id=(\.*)$</regex>
+  <order>log_id</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>log_subtype="(\.*)"\s+|log_subtype="(\.*)"$|log_subtype=(\.*)\s+|log_subtype=(\.*)$</regex>
+  <order>log_subtype</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>log_type="(\.*)"\s+|log_type="(\.*)"$|log_type=(\.*)\s+|log_type=(\.*)$</regex>
+  <order>log_type</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>message="(\.*)"\s+|message="(\.*)"$|message=(\.*)\s+|message=(\.*)$</regex>
+  <order>message</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>name="(\.*)"\s+|name="(\.*)"$|name=(\.*)\s+|name=(\.*)$</regex>
+  <order>name</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>out_interface="(\.*)"\s+|out_interface="(\.*)"$|out_interface=(\.*)\s+|out_interface=(\.*)$</regex>
+  <order>out_interface</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>policy_type="(\.*)"\s+|policy_type="(\.*)"$|policy_type=(\.*)\s+|policy_type=(\.*)$</regex>
+  <order>policy_type</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>priority="(\.*)"\s+|priority="(\.*)"$|priority=(\.*)\s+|priority=(\.*)$</regex>
+  <order>priority</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>protocol="(\.*)"\s+|protocol="(\.*)"$|protocol=(\.*)\s+|protocol=(\.*)$</regex>
+  <order>protocol</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>recv_bytes="(\.*)"\s+|recv_bytes="(\.*)"$|recv_bytes=(\.*)\s+|recv_bytes=(\.*)$</regex>
+  <order>recv_bytes</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>recv_pkts="(\.*)"\s+|recv_pkts="(\.*)"$|recv_pkts=(\.*)\s+|recv_pkts=(\.*)$</regex>
+  <order>recv_pkts</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>sent_bytes="(\.*)"\s+|sent_bytes="(\.*)"$|sent_bytes=(\.*)\s+|sent_bytes=(\.*)$</regex>
+  <order>sent_bytes</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>sent_pkts="(\.*)"\s+|sent_pkts="(\.*)"$|sent_pkts=(\.*)\s+|sent_pkts=(\.*)$</regex>
+  <order>sent_pkts</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>src_country_code="(\.*)"\s+|src_country_code="(\.*)"$|src_country_code=(\.*)\s+|src_country_code=(\.*)$</regex>
+  <order>src_country_code</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>src_ip="(\.*)"\s+|src_ip="(\.*)"$|src_ip=(\.*)\s+|src_ip=(\.*)$</regex>
+  <order>src_ip</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>src_mac="(\.*)"\s+|src_mac="(\.*)"$|src_mac=(\.*)\s+|src_mac=(\.*)$</regex>
+  <order>src_mac</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>src_port="(\.*)"\s+|src_port="(\.*)"$|src_port=(\.*)\s+|src_port=(\.*)$</regex>
+  <order>src_port</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>srczone="(\.*)"\s+|srczone="(\.*)"$|srczone=(\.*)\s+|srczone=(\.*)$</regex>
+  <order>srczone</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>srczonetype="(\.*)"\s+|srczonetype="(\.*)"$|srczonetype=(\.*)\s+|srczonetype=(\.*)$</regex>
+  <order>srczonetype</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>status="(\.*)"\s+|status="(\.*)"$|status=(\.*)\s+|status=(\.*)$</regex>
+  <order>status</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>th="(\.*)"\s+|th="(\.*)"$|th=(\.*)\s+|th=(\.*)$</regex>
   <order>th</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>time="(\.*)"\s+|time="(\.*)"$|time=(\.*)\s+|time=(\.*)$</regex>
+  <order>time</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>timezone="(\.*)"\s+|timezone="(\.*)"$|timezone=(\.*)\s+|timezone=(\.*)$</regex>
+  <order>timezone</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>tran_dst_ip="(\.*)"\s+|tran_dst_ip="(\.*)"$|tran_dst_ip=(\.*)\s+|tran_dst_ip=(\.*)$</regex>
+  <order>tran_dst_ip</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>tran_dst_port="(\.*)"\s+|tran_dst_port="(\.*)"$|tran_dst_port=(\.*)\s+|tran_dst_port=(\.*)$</regex>
+  <order>tran_dst_port</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>tran_src_ip="(\.*)"\s+|tran_src_ip="(\.*)"$|tran_src_ip=(\.*)\s+|tran_src_ip=(\.*)$</regex>
+  <order>tran_src_ip</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>tran_src_port="(\.*)"\s+|tran_src_port="(\.*)"$|tran_src_port=(\.*)\s+|tran_src_port=(\.*)$</regex>
+  <order>tran_src_port</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>user_gp="(\.*)"\s+|user_gp="(\.*)"$|user_gp=(\.*)\s+|user_gp=(\.*)$</regex>
+  <order>user_gp</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>user_name="(\.*)"\s+|user_name="(\.*)"$|user_name=(\.*)\s+|user_name=(\.*)$</regex>
+  <order>user_name</order>
+</decoder>
+<decoder name="sophos-fw">
+  <parent>sophos-fw</parent>
+  <regex>vconnid="(\.*)"\s+|vconnid="(\.*)"$|vconnid=(\.*)\s+|vconnid=(\.*)$</regex>
+  <order>vconnid</order>
 </decoder>

--- a/ruleset/rules/0705-sophos_fw_rules.xml
+++ b/ruleset/rules/0705-sophos_fw_rules.xml
@@ -13,61 +13,61 @@
 
   <rule id="70021" level="5">
     <if_sid>70020</if_sid>
-    <field name="sophos_fw_status_msg">Deny</field>
+    <status>Deny</status>
     <description>Traffic Denied: from $(src_ip) to $(dst_ip)</description>
   </rule>
 
   <rule id="70022" level="3">
     <if_sid>70020</if_sid>
-    <field name="sophos_fw_status_msg">Allow</field>
+    <status>Allow</status>
     <description>Traffic Allowed: from $(src_ip) to $(dst_ip)</description>
   </rule>
 
   <rule id="70023" level="3">
     <if_sid>70020</if_sid>
-    <field name="sophos_fw_status_msg">Detect</field>
+    <status>Detect</status>
     <description>Traffic Detected: from $(src_ip) to $(dst_ip)</description>
   </rule>
 
   <rule id="70024" level="3">
     <if_sid>70020</if_sid>
-    <field name="sophos_fw_status_msg">Drop</field>
+    <status>Drop</status>
     <description>Traffic Dropped: from $(src_ip) to $(dst_ip)</description>
   </rule>
 
   <rule id="70025" level="3">
     <if_sid>70020</if_sid>
-    <field name="sophos_fw_status_msg">Clean</field>
+    <status>Clean</status>
     <description>Traffic Cleaned: from $(src_ip) to $(dst_ip)</description>
   </rule>
 
   <rule id="70026" level="7">
     <if_sid>70020</if_sid>
-    <field name="sophos_fw_status_msg">Virus</field>
+    <status>Virus</status>
     <description>Virus detected: source IP $(src_ip)</description>
   </rule>
 
   <rule id="70027" level="5">
     <if_sid>70020</if_sid>
-    <field name="sophos_fw_status_msg">Spam</field>
+    <status>Spam</status>
     <description>Spam: source IP $(src_ip)</description>
   </rule>
 
   <rule id="70028" level="3">
     <if_sid>70020</if_sid>
-    <field name="sophos_fw_status_msg">Admin</field>
+    <status>Admin</status>
     <description>Admin Traffic: from $(src_ip) to $(dst_ip)</description>
   </rule>
   
   <rule id="70029" level="5">
     <if_sid>70020</if_sid>
-    <field name="sophos_fw_status_msg">Authentication</field>
+    <status>Authentication</status>
     <description>Authentication Traffic: from $(src_ip) to $(dst_ip)</description>
   </rule>
   
   <rule id="70030" level="3">
     <if_sid>70020</if_sid>
-    <field name="sophos_fw_status_msg">System</field>
+    <status>System</status>
     <description>System Traffic : from $(src_ip) to $(dst_ip)</description>
   </rule>
 

--- a/ruleset/rules/0705-sophos_fw_rules.xml
+++ b/ruleset/rules/0705-sophos_fw_rules.xml
@@ -13,61 +13,61 @@
 
   <rule id="70021" level="5">
     <if_sid>70020</if_sid>
-    <status>Deny</status>
+    <field name="sophos_fw_status_msg">Deny</field>
     <description>Traffic Denied: from $(src_ip) to $(dst_ip)</description>
   </rule>
 
   <rule id="70022" level="3">
     <if_sid>70020</if_sid>
-    <status>Allow</status>
+    <field name="sophos_fw_status_msg">Allow</field>
     <description>Traffic Allowed: from $(src_ip) to $(dst_ip)</description>
   </rule>
 
   <rule id="70023" level="3">
     <if_sid>70020</if_sid>
-    <status>Detect</status>
+    <field name="sophos_fw_status_msg">Detect</field>
     <description>Traffic Detected: from $(src_ip) to $(dst_ip)</description>
   </rule>
 
   <rule id="70024" level="3">
     <if_sid>70020</if_sid>
-    <status>Drop</status>
+    <field name="sophos_fw_status_msg">Drop</field>
     <description>Traffic Dropped: from $(src_ip) to $(dst_ip)</description>
   </rule>
 
   <rule id="70025" level="3">
     <if_sid>70020</if_sid>
-    <status>Clean</status>
+    <field name="sophos_fw_status_msg">Clean</field>
     <description>Traffic Cleaned: from $(src_ip) to $(dst_ip)</description>
   </rule>
 
   <rule id="70026" level="7">
     <if_sid>70020</if_sid>
-    <status>Virus</status>
+    <field name="sophos_fw_status_msg">Virus</field>
     <description>Virus detected: source IP $(src_ip)</description>
   </rule>
 
   <rule id="70027" level="5">
     <if_sid>70020</if_sid>
-    <status>Spam</status>
+    <field name="sophos_fw_status_msg">Spam</field>
     <description>Spam: source IP $(src_ip)</description>
   </rule>
 
   <rule id="70028" level="3">
     <if_sid>70020</if_sid>
-    <status>Admin</status>
+    <field name="sophos_fw_status_msg">Admin</field>
     <description>Admin Traffic: from $(src_ip) to $(dst_ip)</description>
   </rule>
   
   <rule id="70029" level="5">
     <if_sid>70020</if_sid>
-    <status>Authentication</status>
+    <field name="sophos_fw_status_msg">Authentication</field>
     <description>Authentication Traffic: from $(src_ip) to $(dst_ip)</description>
   </rule>
   
   <rule id="70030" level="3">
     <if_sid>70020</if_sid>
-    <status>System</status>
+    <field name="sophos_fw_status_msg">System</field>
     <description>System Traffic : from $(src_ip) to $(dst_ip)</description>
   </rule>
 


### PR DESCRIPTION
|Related issue|
|---|
|#8675 |


## Description

As mentioned in #8675  in 4.2 some sibling decoders were wrongly configured which would lead to the full event being assigned to several decoded fields.

This PR re-created these decoders with the correct logic and each decoder was tested on the latest RC of 4.2.
