### PR TITLE
Vulnerability Detector atomic query exploratory testing fixes

### DIFF
--- a/src/wazuh_db/schema_upgrade_v8.sql
+++ b/src/wazuh_db/schema_upgrade_v8.sql
@@ -38,8 +38,6 @@ CREATE TABLE IF NOT EXISTS vuln_metadata (
 );
 
 INSERT INTO vuln_metadata (LAST_PARTIAL_SCAN, LAST_FULL_SCAN) VALUES (0, 0);
-INSERT INTO sync_info (component) VALUES ('syscollector-packages');
-INSERT INTO sync_info (component) VALUES ('syscollector-hotfixes');
 
 CREATE TRIGGER obsolete_vulnerabilities
     AFTER DELETE ON sys_programs

--- a/src/wazuh_db/wdb_integrity.c
+++ b/src/wazuh_db/wdb_integrity.c
@@ -441,14 +441,6 @@ int wdbi_query_clear(wdb_t * wdb, wdb_component_t component, const char * payloa
         goto end;
     }
 
-    item = cJSON_GetObjectItem(data, "checksum");
-    char * checksum = cJSON_GetStringValue(item);
-
-    if (checksum == NULL) {
-        mdebug1("No such string 'checksum' in JSON payload.");
-        goto end;
-    }
-
     long timestamp = item->valuedouble;
 
     if (wdb_stmt_cache(wdb, INDEXES[component]) == -1) {
@@ -462,7 +454,7 @@ int wdbi_query_clear(wdb_t * wdb, wdb_component_t component, const char * payloa
         goto end;
     }
 
-    wdbi_update_completion(wdb, component, timestamp, checksum);
+    wdbi_update_completion(wdb, component, timestamp, "");
     retval = 0;
 
 end:

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2348,10 +2348,11 @@ int wm_vuldet_check_agent_vulnerabilities(wm_vuldet_t *vuldet) {
             scan_ctx.agent_id = atoi(agents_it->agent_id);
             scan_ctx.agent_name = agents_it->agent_name;
             scan_ctx.agent_ip = agents_it->agent_ip;
-            mtinfo(WM_VULNDETECTOR_LOGTAG, VU_START_AG_AN, scan_ctx.agent_id);
-            time_t start = time(NULL);
 
             if (agents_it->pending_attempts == 0) continue;
+
+            mtinfo(WM_VULNDETECTOR_LOGTAG, VU_START_AG_AN, scan_ctx.agent_id);
+            time_t start = time(NULL);
 
             // Check if there are available vulnerabilities for this agent
             if (agents_it->dist != FEED_WIN && agents_it->dist != FEED_MAC) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -4802,84 +4802,86 @@ int wm_vuldet_collect_agent_software(scan_agent *agent, sqlite3 *db, scan_ctx_t*
         goto end;
     }
 
-    sqlite3_exec(db, vu_queries[BEGIN_T], NULL, NULL, NULL);
+    if (package_list->child) { //JSON array not empty
+        sqlite3_exec(db, vu_queries[BEGIN_T], NULL, NULL, NULL);
 
-    for (cJSON *package_it = package_list->child; package_it; package_it = package_it->next) {
-        char *name = (char *) wm_vuldet_get_json_value(package_it, "name");
-        char *version = (char *) wm_vuldet_get_json_value(package_it, "version");
-        char *architecture = (char *) wm_vuldet_get_json_value(package_it, "architecture");
-        char *cpe_str = (char *) wm_vuldet_get_json_value(package_it, "cpe");
-        char *vendor = (char *) wm_vuldet_get_json_value(package_it, "vendor");
-        char *msu_name = (char *) wm_vuldet_get_json_value(package_it, "msu_name");
-        char *source = (char *) wm_vuldet_get_json_value(package_it, "source");
-        char *item_id = (char *) wm_vuldet_get_json_value(package_it, "item_id");
-        char *src_version = NULL;
+        for (cJSON *package_it = package_list->child; package_it; package_it = package_it->next) {
+            char *name = (char *) wm_vuldet_get_json_value(package_it, "name");
+            char *version = (char *) wm_vuldet_get_json_value(package_it, "version");
+            char *architecture = (char *) wm_vuldet_get_json_value(package_it, "architecture");
+            char *cpe_str = (char *) wm_vuldet_get_json_value(package_it, "cpe");
+            char *vendor = (char *) wm_vuldet_get_json_value(package_it, "vendor");
+            char *msu_name = (char *) wm_vuldet_get_json_value(package_it, "msu_name");
+            char *source = (char *) wm_vuldet_get_json_value(package_it, "source");
+            char *item_id = (char *) wm_vuldet_get_json_value(package_it, "item_id");
+            char *src_version = NULL;
 
-        if (!architecture  && agent->dist == FEED_MAC) {
-            architecture = agent->arch;
-        }
-
-        if (name && version && architecture) {
-            struct cpe *s_cpe = NULL;
-            char success = 1;
-
-            if (cpe_str) {
-                s_cpe = wm_vuldet_decode_cpe(cpe_str);
-                w_strdup(msu_name, s_cpe->msu_name);
+            if (!architecture  && agent->dist == FEED_MAC) {
+                architecture = agent->arch;
             }
 
-            if (agent->dist != FEED_WIN && agent->dist != FEED_MAC) {
-                if (wm_vuldet_discard_kernel_package(agent, name, version, architecture)) {
-                    continue;
+            if (name && version && architecture) {
+                struct cpe *s_cpe = NULL;
+                char success = 1;
+
+                if (cpe_str) {
+                    s_cpe = wm_vuldet_decode_cpe(cpe_str);
+                    w_strdup(msu_name, s_cpe->msu_name);
                 }
-            }
 
-            if (source) {
-                if (agent->dist == FEED_REDHAT || agent->dist == FEED_MAC) {
-                    source = NULL;
-                } else {
-                    // Separate version from source
-                    char *source_end = strstr(source, " ");
-                    char *source_version_start;
-                    char *source_version_end;
-                    if (source_end) {
-                        source_version_start = strstr(source_end, "(");
-                        if (source_version_start) {
-                            source_version_end = strstr(source_version_start, ")");
-                            if (source_version_end) {
-                                src_version = source_version_start + 1;
-                                *source_version_end = '\0';
-                            }
-                        }
-                        *source_end = '\0';
+                if (agent->dist != FEED_WIN && agent->dist != FEED_MAC) {
+                    if (wm_vuldet_discard_kernel_package(agent, name, version, architecture)) {
+                        continue;
                     }
                 }
-            }
 
-            if (agent->dist == FEED_MAC) {
-                wchr_replace(name, ' ', '_');
-                if (vendor) wchr_replace(vendor, ' ', '_');
-            }
+                if (source) {
+                    if (agent->dist == FEED_REDHAT || agent->dist == FEED_MAC) {
+                        source = NULL;
+                    } else {
+                        // Separate version from source
+                        char *source_end = strstr(source, " ");
+                        char *source_version_start;
+                        char *source_version_end;
+                        if (source_end) {
+                            source_version_start = strstr(source_end, "(");
+                            if (source_version_start) {
+                                source_version_end = strstr(source_version_start, ")");
+                                if (source_version_end) {
+                                    src_version = source_version_start + 1;
+                                    *source_version_end = '\0';
+                                }
+                            }
+                            *source_end = '\0';
+                        }
+                    }
+                }
 
-            // Generate the node_list structure with those packages
-            // that have associated CPE
-            if (wm_vuldet_insert_agent_data(db, agent, &min_cpe_index, vendor, name, source, version,
-                                            src_version, architecture, item_id, VULN_CVES_TYPE_PACKAGE, s_cpe, &node_list)) {
-                mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_INSERT_DATA_ERR, cpe_str ? cpe_str : name);
-                success = 0;
-            }
+                if (agent->dist == FEED_MAC) {
+                    wchr_replace(name, ' ', '_');
+                    if (vendor) wchr_replace(vendor, ' ', '_');
+                }
 
-            if (s_cpe) {
-                wm_vuldet_free_cpe(s_cpe);
-            }
+                // Generate the node_list structure with those packages
+                // that have associated CPE
+                if (wm_vuldet_insert_agent_data(db, agent, &min_cpe_index, vendor, name, source, version,
+                                                src_version, architecture, item_id, VULN_CVES_TYPE_PACKAGE, s_cpe, &node_list)) {
+                    mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_INSERT_DATA_ERR, cpe_str ? cpe_str : name);
+                    success = 0;
+                }
 
-            if (!success) {
-                goto end;
+                if (s_cpe) {
+                    wm_vuldet_free_cpe(s_cpe);
+                }
+
+                if (!success) {
+                    goto end;
+                }
             }
         }
+        sqlite3_exec(db, vu_queries[END_T], NULL, NULL, NULL);
+        scan_ctx->package_scan = TRUE;
     }
-    sqlite3_exec(db, vu_queries[END_T], NULL, NULL, NULL);
-    scan_ctx->package_scan = TRUE;
 
     // Operating System
     if (VU_PARTIAL_SCAN != scan_ctx->scan_type  || 0 == agent->os_triaged) {
@@ -6721,32 +6723,34 @@ int wm_vuldet_request_hotfixes(sqlite3 *db, const char *agent_id) {
         goto end;
     }
 
-    sqlite3_exec(db, vu_queries[BEGIN_T], NULL, NULL, NULL);
+    if (hotfixes->child) { //JSON array not empty
+        sqlite3_exec(db, vu_queries[BEGIN_T], NULL, NULL, NULL);
 
-    for (cJSON *hotfixes_it = hotfixes->child; hotfixes_it; hotfixes_it = hotfixes_it->next) {
-        if (!hotfixes_it->child || !hotfixes_it->child->valuestring) {
-            retval = OS_INVALID;
-            goto end;
+        for (cJSON *hotfixes_it = hotfixes->child; hotfixes_it; hotfixes_it = hotfixes_it->next) {
+            if (!hotfixes_it->child || !hotfixes_it->child->valuestring) {
+                retval = OS_INVALID;
+                goto end;
+            }
+
+            if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_AGENT_HOTFIXES], -1, &stmt, NULL) != SQLITE_OK) {
+                mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                retval = OS_INVALID;
+                goto end;
+            }
+
+            sqlite3_bind_text(stmt, 1, agent_id, -1, NULL);
+            sqlite3_bind_text(stmt, 2, hotfixes_it->child->valuestring, -1, NULL);
+
+            if (wm_vuldet_step(stmt) != SQLITE_DONE) {
+                mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
+                retval = OS_INVALID;
+                goto end;
+            }
+            wdb_finalize(stmt);
         }
 
-        if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_AGENT_HOTFIXES], -1, &stmt, NULL) != SQLITE_OK) {
-            mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
-            retval = OS_INVALID;
-            goto end;
-        }
-
-        sqlite3_bind_text(stmt, 1, agent_id, -1, NULL);
-        sqlite3_bind_text(stmt, 2, hotfixes_it->child->valuestring, -1, NULL);
-
-        if (wm_vuldet_step(stmt) != SQLITE_DONE) {
-            mterror(WM_VULNDETECTOR_LOGTAG, VU_SQL_ERROR, sqlite3_errmsg(db));
-            retval = OS_INVALID;
-            goto end;
-        }
-        wdb_finalize(stmt);
+        sqlite3_exec(db, vu_queries[END_T], NULL, NULL, NULL);
     }
-
-    sqlite3_exec(db, vu_queries[END_T], NULL, NULL, NULL);
 
     retval = OS_SUCCESS;
 


### PR DESCRIPTION
|Related issue|
|---|
|#8573|

## Description
This PR implements the fixes for the following issues found during the exploratory testing of epic #8529.
- Scans are executed even if the package list is empty ([link](https://github.com/wazuh/wazuh/issues/8573#issuecomment-841290924)).
  - Fix: The empty status of the JSON array response is evaluated before triggering the data insertion and setting the package_scan flag.
- Sync_info table has a checksum column to reflect the last received checksum from the agent. The default value of this column is **""** but during a clear query of the component, this column wasn´t re-set to the default value.
  - Fix: Clear query command now set the checksum column to **""**.
- The log that informs that an agent is attempted to be scanned was printed even if the agent was already scanned.
  - The log was moved after the check of scanning attempts.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Package installation
- [X] Source upgrade
- [X] Package upgrade
- 
<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Valgrind (memcheck and descriptor leaks check)