### PR TITLE
Run and fix all 4.2.0 API integration tests

### DIFF
--- a/api/test/integration/env/configurations/vulnerability/manager/configuration_files/ossec_module.conf
+++ b/api/test/integration/env/configurations/vulnerability/manager/configuration_files/ossec_module.conf
@@ -1,7 +1,7 @@
 <root>
     <vulnerability-detector>
         <enabled>yes</enabled>
-        <interval>1h</interval>
+        <interval>1m</interval>
         <ignore_time>6h</ignore_time>
         <run_on_start>yes</run_on_start>
 

--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -56,7 +56,8 @@ def test_select_key_affected_items(response, select_key):
         set1 = main_keys.symmetric_difference(set(item.keys()))
         # Check if there are keys in response that were not specified in 'select_keys', apart from those which can be
         # mandatory (id, agent_id, etc).
-        assert (set1 == set() or set1 == set1.intersection({'id', 'agent_id', 'file'} | main_keys)), \
+        assert (set1 == set() or set1 == set1.intersection({'id', 'agent_id', 'file', 'task_id', 'agent_id', 'status',
+                                                            'command', 'create_time'} | main_keys)), \
             f'Select keys are {main_keys}, but the response contains these keys: {set1}'
 
         for nested_key in nested_keys.items():


### PR DESCRIPTION
|Related issue|
|---|
| #8595 |

Hi team,

This PR closes #8595.

In this pull request, I have fixed 2 API integration tests failing in 4.2.0. These tests are the **vulnerability** tests and the **task** test.

More comments and all the API integration tests passed in this PR's related issue.

The tests have also been passed  by Jenkins here: https://ci.wazuh.info/job/Test_integration_endpoints/720/.

Regards,
Manuel.