### PR TITLE
Fixing winagent override warning when compiling

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1007,12 +1007,14 @@ endif
 
 #### libarchive ######
 
+ifneq (${TARGET},winagent)
 ifeq (${uname_S},Linux)
 ${LIBARCHIVE_LIB}: $(EXTERNAL_LIBARCHIVE)Makefile
 	 ${MAKE} -C $(EXTERNAL_LIBARCHIVE)
 
 $(EXTERNAL_LIBARCHIVE)Makefile:
 	cd ${EXTERNAL_LIBARCHIVE} && CPPFLAGS=-fPIC ./configure --disable-acl --without-expat --without-iconv --without-xml2 --without-lz4 --without-lzma --without-zstd --without-bz2lib --without-openssl
+endif
 endif
 
 #### libalpm ######


### PR DESCRIPTION


## Description

Hi team,

This PR is intended to avoid a warning caused by an override in the Makefile for the `TARGET winagent`.

This problem occurs because the condition for not compiling the _libarchive_ library is that the machine where the Makefile is compiled is _Linux_. And because we compiled the `winagent` on a _Linux_ machine, this condition is met and causes the override.

To avoid this, a condition has been added in case `TARGET equals winagent` then _libarchive_ is not compiled.

## Logs/Alerts example

With the changes made we avoid these two warnings:
```
Makefile:1015: warning: overriding recipe for target 'Makefile'
Makefile:1005: warning: ignoring old recipe for target 'Makefile'
```

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Winagent
