### PR TITLE
Change test_select_key mandatory fields

### DIFF
--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -75,8 +75,7 @@ def test_select_key_affected_items(response, select_key):
 
         # Check if there are keys in response that were not specified in 'select_keys', apart from those which can be
         # mandatory (id, agent_id, etc).
-        assert (set1 == set() or set1 == set1.intersection({'id', 'agent_id', 'file', 'task_id', 'agent_id', 'status',
-                                                            'command', 'create_time'} | main_keys)), \
+        assert (set1 == set() or set1 == set1.intersection({'id', 'agent_id', 'file', 'task_id'} | main_keys)), \
             f'Select keys are {main_keys}, but the response contains these keys: {set1}'
 
         for nested_key in nested_keys.items():


### PR DESCRIPTION
Hi team,

This PR fixes the Task API integration tests after the merge of 4.2 into master.

In 4.2, the task's **min_select_fields** were the following:

`min_select_fields = {'task_id', 'agent_id', 'status', 'command', 'create_time'}
`

In master, the **min_select_fields** are these:

`min_select_fields = {'task_id'}`


A change is needed in the `test_select_key_affected_items` function of `tavern_utils` due to this change. It does not affect the task tests now, but it could be a problem in the future.

```
assert (set1 == set() or set1 == set1.intersection({'id', 'agent_id', 'file', 'task_id', 'agent_id', 'status',
                                                    'command', 'create_time'} | main_keys)), \
	f'Select keys are {main_keys}, but the response contains these keys: {set1}'
```
	
To:

```
assert (set1 == set() or set1 == set1.intersection({'id', 'agent_id', 'file', 'task_id'} | main_keys)), \
	f'Select keys are {main_keys}, but the response contains these keys: {set1}'
```
	
- Test result:

```
test_task_endpoints.tavern.yaml 
	 2 passed, 4 warnings
```



Regards,
Manuel.
