### PR TITLE
Update force_time description in spec.yaml

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -5687,7 +5687,8 @@ paths:
                     type: string
                     format: alphanumeric
                   force_time:
-                    description: "Remove the old agent with the same IP if disconnected since <force_time> seconds"
+                    description: "Remove the old agent with the same name or IP if disconnected for <force_time>
+                    seconds"
                     type: integer
                     format: int32
                     minimum: 0
@@ -7033,8 +7034,8 @@ paths:
       tags:
         - Agents
       summary: "Add agent full"
-      description: "Add an agent specifying its name, ID and IP. If an agent with the same ID already exists, replace
-      it using `force` parameter"
+      description: "Add an agent specifying its name, ID and IP. If an agent with the same name, the same ID or the
+      same IP already exists, replace it using `force_time` parameter"
       operationId: api.controllers.agent_controller.insert_agent
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/agent:create'
@@ -7065,7 +7066,8 @@ paths:
                     type: string
                     format: alphanumeric
                   force_time:
-                    description: "Remove the old agent with the same IP if disconnected for <force_time> seconds"
+                    description: "Remove the old agent with the same name, ID or IP if disconnected for <force_time>
+                    seconds"
                     type: integer
                     format: int32
                     minimum: 0


### PR DESCRIPTION
|Related issue|
|---|
| Closes #8597 |

## Description

Hey team,

This PR updates the `foce_time` description given in the API `spec.yaml` file. As reported in #8597, the terms used were not the same everywhere. 

In addition, the way it works was not correctly explained. According to the original description, `force_time` could be used in case IP field was repetead. However, any agent with a repeated ID, name or IP can be replaced.

Regards,
Selu.