### PR TITLE
Fix KeyError when handling error command in cluster

### DIFF
--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -916,7 +916,7 @@ class WazuhCommon:
         """
         task_id, error_details = task_id_and_error_details.split(' ', 1)
         error_details_json = json.loads(error_details, object_hook=as_wazuh_object)
-        if task_id != 'None':
+        if task_id in self.sync_tasks:
             # Remove filename if exists
             if os.path.exists(self.sync_tasks[task_id].filename):
                 try:


### PR DESCRIPTION
|Related issue|
|---|
| Closes #8601 |

## Description

Hey team,

This PR fixes the KeyError reported in #8601. Now, it is checked if the received `task_id` is in the `sync_tasks` list before trying to access any field of said item. 

Regards,
Selu.