### PR TITLE
Add delay between vulnerability detectors retry scans

### DIFF
--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -62,6 +62,7 @@ static const char *XML_OS = "os";
 static const char *XML_UPDATE_INTERVAL = "update_interval";
 static const char *XML_RUN_ON_START = "run_on_start";
 static const char *XML_MIN_FULL_SCAN_INTERVAL = "min_full_scan_interval";
+static const char *XML_RETRY_INTERVAL = "retry_interval";
 static const char *XML_URL = "url";
 static const char *XML_PATH = "path";
 static const char *XML_PORT = "port";
@@ -366,6 +367,7 @@ int Read_Vuln(const OS_XML *xml, xml_node **nodes, void *d1, char d2) {
     vuldet->flags.permissive_patch_scan = 0;
     vuldet->flags.enabled = 1;
     vuldet->min_full_scan_interval = VU_DEF_MIN_FULL_SCAN_INTERVAL;
+    vuldet->retry_interval = VU_DEF_RETRY_INTERVAL;
     vuldet->scan_interval = WM_VULNDETECTOR_DEFAULT_INTERVAL;
     vuldet->scan_agents = NULL;
     cur_wmodule->context = &WM_VULNDETECTOR_CONTEXT;
@@ -428,6 +430,11 @@ int Read_Vuln(const OS_XML *xml, xml_node **nodes, void *d1, char d2) {
         } else if (!strcmp(nodes[i]->element, XML_MIN_FULL_SCAN_INTERVAL)) {
             if (wm_vuldet_get_interval(nodes[i]->content, &vuldet->min_full_scan_interval)) {
                 merror("Invalid min_full_scan_interval at module '%s'", WM_VULNDETECTOR_CONTEXT.name);
+                return OS_INVALID;
+            }
+        } else if (!strcmp(nodes[i]->element, XML_RETRY_INTERVAL)) {
+            if (wm_vuldet_get_interval(nodes[i]->content, &vuldet->retry_interval)) {
+                merror("Invalid retry_interval at module '%s'", WM_VULNDETECTOR_CONTEXT.name);
                 return OS_INVALID;
             }
         } else {

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -3611,7 +3611,7 @@ int wdb_parse_packages(wdb_t * wdb, char * input, char * output) {
         return result;
     }
     else if (strcmp(action, "save") == 0) {
-        /* The format of the data is scan_id|scan_time|format|name|priority|section|size|vendor|install_time|version|architecture|multiarch|source|description|location*/
+        /* The format of the data is scan_id|scan_time|format|name|priority|section|size|vendor|install_time|version|architecture|multiarch|source|description|location|item_id*/
         #define SAVE_PACKAGE_FIELDS_AMOUNT 16
         char* fields[SAVE_PACKAGE_FIELDS_AMOUNT] = {NULL};
         char* last = tail;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2343,7 +2343,7 @@ int wm_vuldet_check_agent_vulnerabilities(wm_vuldet_t *vuldet) {
     // Iterate agents to look for vulnerabilities
     do {
         retry_agents = false;
-        time_t last_fail_scan = 0;
+        time_t first_fail_scan = 0;
         for (agents_it = vuldet->scan_agents; agents_it; agents_it = agents_it->next) {
             scan_ctx_t scan_ctx = {0};
             scan_ctx.agent_id = atoi(agents_it->agent_id);
@@ -2400,7 +2400,7 @@ int wm_vuldet_check_agent_vulnerabilities(wm_vuldet_t *vuldet) {
                 agents_it->pending_attempts--;
                 if (agents_it->pending_attempts) {
                     retry_agents = true;
-                    if (!last_fail_scan) last_fail_scan = time(NULL);
+                    if (!first_fail_scan) first_fail_scan = time(NULL);
                 }
                 else {
                     mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_GET_SOFTWARE_ERROR, scan_ctx.agent_id, WM_VULNDETECTOR_MAX_AGENT_SCAN_ATTEMPS);
@@ -2429,14 +2429,16 @@ int wm_vuldet_check_agent_vulnerabilities(wm_vuldet_t *vuldet) {
             mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_FUNCTION_TIME, time(NULL) - start, "scan", scan_ctx.agent_id);
             agents_it->pending_attempts = 0;
         }
+
         if (retry_agents) {
-            time_t sleep_time = last_fail_scan + vuldet->retry_interval - time(NULL);
+            time_t sleep_time = first_fail_scan + vuldet->retry_interval - time(NULL);
             if (sleep_time <= 0) {
                 sleep_time = 1;
             }
             mtdebug1(WM_VULNDETECTOR_LOGTAG, "Going to sleep %ld seconds before retrying pending agents", sleep_time);
             sleep (sleep_time);
         }
+
     } while (retry_agents && !abort_scan);
 
     // Reset the tables

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2343,6 +2343,7 @@ int wm_vuldet_check_agent_vulnerabilities(wm_vuldet_t *vuldet) {
     // Iterate agents to look for vulnerabilities
     do {
         retry_agents = false;
+        time_t last_fail_scan = 0;
         for (agents_it = vuldet->scan_agents; agents_it; agents_it = agents_it->next) {
             scan_ctx_t scan_ctx = {0};
             scan_ctx.agent_id = atoi(agents_it->agent_id);
@@ -2397,10 +2398,13 @@ int wm_vuldet_check_agent_vulnerabilities(wm_vuldet_t *vuldet) {
             // Collect agent software
             if (OS_SUCCESS != wm_vuldet_collect_agent_software(agents_it, db, &scan_ctx)) {
                 agents_it->pending_attempts--;
-                if (agents_it->pending_attempts)
+                if (agents_it->pending_attempts) {
                     retry_agents = true;
-                else
-                    mtwarn(WM_VULNDETECTOR_LOGTAG, VU_GET_SOFTWARE_ERROR, scan_ctx.agent_id, WM_VULNDETECTOR_MAX_AGENT_SCAN_ATTEMPS);
+                    if (!last_fail_scan) last_fail_scan = time(NULL);
+                }
+                else {
+                    mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_GET_SOFTWARE_ERROR, scan_ctx.agent_id, WM_VULNDETECTOR_MAX_AGENT_SCAN_ATTEMPS);
+                }
                 continue;
             }
 
@@ -2424,6 +2428,14 @@ int wm_vuldet_check_agent_vulnerabilities(wm_vuldet_t *vuldet) {
             mtinfo(WM_VULNDETECTOR_LOGTAG, VU_AGENT_FINISH, scan_ctx.agent_id);
             mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_FUNCTION_TIME, time(NULL) - start, "scan", scan_ctx.agent_id);
             agents_it->pending_attempts = 0;
+        }
+        if (retry_agents) {
+            time_t sleep_time = last_fail_scan + vuldet->retry_interval - time(NULL);
+            if (sleep_time <= 0) {
+                sleep_time = 1;
+            }
+            mtdebug1(WM_VULNDETECTOR_LOGTAG, "Going to sleep %ld seconds before retrying pending agents", sleep_time);
+            sleep (sleep_time);
         }
     } while (retry_agents && !abort_scan);
 
@@ -5337,6 +5349,7 @@ cJSON *wm_vuldet_dump(const wm_vuldet_t * vuldet){
     if (vuldet->flags.run_on_start) cJSON_AddStringToObject(wm_vd,"run_on_start","yes"); else cJSON_AddStringToObject(wm_vd,"run_on_start","no");
     cJSON_AddNumberToObject(wm_vd,"interval",vuldet->scan_interval);
     cJSON_AddNumberToObject(wm_vd,"min_full_scan_interval",vuldet->min_full_scan_interval);
+    cJSON_AddNumberToObject(wm_vd,"retry_interval",vuldet->retry_interval);
     cJSON *providers = cJSON_CreateArray();
 
     for (i = 0; i < OS_SUPP_SIZE; i++) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -31,6 +31,7 @@
 #define WM_VULNDETECTOR_MAX_AGENT_SCAN_ATTEMPS 5
 #define WM_VULNDETECTOR_DOWN_ATTEMPTS  5
 #define VU_DEF_MIN_FULL_SCAN_INTERVAL 21600 // 6 hours
+#define VU_DEF_RETRY_INTERVAL 30 // 30 seconds
 #define VU_TEMP_FILE "tmp/vuln-temp"
 #define VU_TEMP_FILE_BZ2 VU_TEMP_FILE ".bz2"
 #define VU_FIT_TEMP_FILE VU_TEMP_FILE "-fitted"
@@ -425,6 +426,7 @@ typedef struct wm_vuldet_t {
     update_node *updates[OS_SUPP_SIZE];
     time_t scan_interval;
     time_t min_full_scan_interval;
+    time_t retry_interval;
     time_t last_scan;
     scan_agent *scan_agents;
     int queue_fd;


### PR DESCRIPTION
|Related issue|
|---|
|#8701|

## Description
This PR implements the required delay logic between retry attempts of scans.
- Adds a new configurable setting `retry_interval` with 30 seconds and hidden by default.
- Adds the logic to wait at least this time before trying to re-scan a pending agent.
 
## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Package installation
- [X] Source upgrade
- [X] Package upgrade
- Memory tests for Linux
  - [X] Scan-build report
