### PR TITLE
Use integration field for GitHub rules matching

### DIFF
--- a/ruleset/rules/0750-github_rules.xml
+++ b/ruleset/rules/0750-github_rules.xml
@@ -14,7 +14,7 @@ ID: 91100 - 91449
     <!-- GitHub wodle -->
     <rule id="91100" level="0">
         <decoded_as>json</decoded_as>
-        <field name="github.source">github</field>
+        <field name="integration">github</field>
         <description>GitHub alert.</description>
         <options>no_full_log</options>
     </rule>
@@ -3203,7 +3203,7 @@ ID: 91100 - 91449
     </rule>
 
     <!-- This rule capture internal event, 3 request fail.
-        {"github":{"actor":"wazuh","organization":"wazuh","response":"@response","source":"github"}}
+        {"integration":"github","github":{"actor":"wazuh","organization":"wazuh","response":"@response"}}
     -->
     <rule id="91448" level="3">
         <if_sid>91100</if_sid>

--- a/ruleset/testing/tests/github.ini
+++ b/ruleset/testing/tests/github.ini
@@ -1,5 +1,5 @@
 [GitHub Account Category.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"account.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"account."}}
 
 rule =91101
 alert = 3
@@ -7,7 +7,7 @@ decoder = json
 
 
 [GitHub Account billing plan change.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"account.billing_plan_change","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"account.billing_plan_change"}}
 
 rule =91102
 alert = 9
@@ -15,7 +15,7 @@ decoder = json
 
 
 [GitHub Account plan change.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"account.plan_change","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"account.plan_change"}}
 
 rule =91103
 alert = 9
@@ -23,7 +23,7 @@ decoder = json
 
 
 [GitHub Account pending plan change.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"account.pending_plan_change","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"account.pending_plan_change"}}
 
 rule =91104
 alert = 9
@@ -31,7 +31,7 @@ decoder = json
 
 
 [GitHub Account pending subscription change.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"account.pending_subscription_change","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"account.pending_subscription_change"}}
 
 rule =91105
 alert = 9
@@ -39,7 +39,7 @@ decoder = json
 
 
 [GitHub Advisory credit.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"advisory_credit.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"advisory_credit."}}
 
 rule =91106
 alert = 3
@@ -47,7 +47,7 @@ decoder = json
 
 
 [GitHub Advisory credit accept.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"advisory_credit.accept","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"advisory_credit.accept"}}
 
 rule =91107
 alert = 7
@@ -55,7 +55,7 @@ decoder = json
 
 
 [GitHub Advisory credit create.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"advisory_credit.create","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"advisory_credit.create"}}
 
 rule =91108
 alert = 7
@@ -63,7 +63,7 @@ decoder = json
 
 
 [GitHub Advisory credit decline.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"advisory_credit.decline","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"advisory_credit.decline"}}
 
 rule =91109
 alert = 7
@@ -71,7 +71,7 @@ decoder = json
 
 
 [GitHub Advisory credit destroy.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"advisory_credit.destroy","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"advisory_credit.destroy"}}
 
 rule =91110
 alert = 7
@@ -79,7 +79,7 @@ decoder = json
 
 
 [GitHub Billing.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"billing.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"billing."}}
 
 rule =91111
 alert = 3
@@ -87,7 +87,7 @@ decoder = json
 
 
 [GitHub Billing change billing type.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"billing.change_billing_type","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"billing.change_billing_type"}}
 
 rule =91112
 alert = 9
@@ -95,7 +95,7 @@ decoder = json
 
 
 [GitHub Billing change billing email.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"billing.change_billing_email","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"billing.change_billing_email"}}
 
 rule =91113
 alert = 9
@@ -103,7 +103,7 @@ decoder = json
 
 
 [GitHub Dependabot alerts.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependabot_alerts.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependabot_alerts."}}
 
 rule =91114
 alert = 3
@@ -111,7 +111,7 @@ decoder = json
 
 
 [GitHub Dependabot alerts disable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependabot_alerts.disable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependabot_alerts.disable"}}
 
 rule =91115
 alert = 12
@@ -119,7 +119,7 @@ decoder = json
 
 
 [GitHub Dependabot alerts enable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependabot_alerts.enable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependabot_alerts.enable"}}
 
 rule =91116
 alert = 3
@@ -127,7 +127,7 @@ decoder = json
 
 
 [GitHub Dependabot alerts new repos.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependabot_alerts_new_repos.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependabot_alerts_new_repos."}}
 
 rule =91117
 alert = 3
@@ -135,7 +135,7 @@ decoder = json
 
 
 [GitHub Dependabot alerts new repos disable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependabot_alerts_new_repos.disable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependabot_alerts_new_repos.disable"}}
 
 rule =91118
 alert = 12
@@ -143,7 +143,7 @@ decoder = json
 
 
 [GitHub Dependabot alerts new repos enable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependabot_alerts_new_repos.enable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependabot_alerts_new_repos.enable"}}
 
 rule =91119
 alert = 3
@@ -151,7 +151,7 @@ decoder = json
 
 
 [GitHub Dependabot security updates.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependabot_security_updates.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependabot_security_updates."}}
 
 rule =91120
 alert = 3
@@ -159,7 +159,7 @@ decoder = json
 
 
 [GitHub Dependabot security updates disable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependabot_security_updates.disable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependabot_security_updates.disable"}}
 
 rule =91121
 alert = 12
@@ -167,7 +167,7 @@ decoder = json
 
 
 [GitHub Dependabot security updates enable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependabot_security_updates.enable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependabot_security_updates.enable"}}
 
 rule =91122
 alert = 3
@@ -175,7 +175,7 @@ decoder = json
 
 
 [GitHub Dependabot security updates new repos.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependabot_security_updates_new_repos.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependabot_security_updates_new_repos."}}
 
 rule =91123
 alert = 3
@@ -183,7 +183,7 @@ decoder = json
 
 
 [GitHub Dependabot security updates new repos disable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependabot_security_updates_new_repos.disable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependabot_security_updates_new_repos.disable"}}
 
 rule =91124
 alert = 12
@@ -191,7 +191,7 @@ decoder = json
 
 
 [GitHub Dependabot security updates new repos enable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependabot_security_updates_new_repos.enable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependabot_security_updates_new_repos.enable"}}
 
 rule =91125
 alert = 3
@@ -199,7 +199,7 @@ decoder = json
 
 
 [GitHub Dependency graph.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependency_graph.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependency_graph."}}
 
 rule =91126
 alert = 3
@@ -207,7 +207,7 @@ decoder = json
 
 
 [GitHub Dependency graph disable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependency_graph.disable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependency_graph.disable"}}
 
 rule =91127
 alert = 12
@@ -215,7 +215,7 @@ decoder = json
 
 
 [GitHub Dependency graph enable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependency_graph.enable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependency_graph.enable"}}
 
 rule =91128
 alert = 3
@@ -223,7 +223,7 @@ decoder = json
 
 
 [GitHub Dependency graph new repos.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependency_graph_new_repos.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependency_graph_new_repos."}}
 
 rule =91129
 alert = 3
@@ -231,7 +231,7 @@ decoder = json
 
 
 [GitHub Dependency graph new repos disable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependency_graph_new_repos.disable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependency_graph_new_repos.disable"}}
 
 rule =91130
 alert = 12
@@ -239,7 +239,7 @@ decoder = json
 
 
 [GitHub Dependency graph new repos enable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependency_graph_new_repos.enable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"dependency_graph_new_repos.enable"}}
 
 rule =91131
 alert = 3
@@ -247,7 +247,7 @@ decoder = json
 
 
 [GitHub Discussion post.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"discussion_post.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"discussion_post."}}
 
 rule =91132
 alert = 3
@@ -255,7 +255,7 @@ decoder = json
 
 
 [GitHub Discussion post update.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"discussion_post.update","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"discussion_post.update"}}
 
 rule =91133
 alert = 5
@@ -263,7 +263,7 @@ decoder = json
 
 
 [GitHub Discussion post destroy.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"discussion_post.destroy","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"discussion_post.destroy"}}
 
 rule =91134
 alert = 5
@@ -271,7 +271,7 @@ decoder = json
 
 
 [GitHub Discussion post reply.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"discussion_post_reply.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"discussion_post_reply."}}
 
 rule =91135
 alert = 3
@@ -279,7 +279,7 @@ decoder = json
 
 
 [GitHub Discussion post replay update.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"discussion_post_reply.update","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"discussion_post_reply.update"}}
 
 rule =91136
 alert = 5
@@ -287,7 +287,7 @@ decoder = json
 
 
 [GitHub Discussion post replay destroy.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"discussion_post_reply.destroy","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"discussion_post_reply.destroy"}}
 
 rule =91137
 alert = 5
@@ -295,7 +295,7 @@ decoder = json
 
 
 [GitHub Enterprise.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"enterprise.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"enterprise."}}
 
 rule =91139
 alert = 3
@@ -303,7 +303,7 @@ decoder = json
 
 
 [GitHub Enterprise Remove self hosted runner.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"enterprise.remove_self_hosted_runner","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"enterprise.remove_self_hosted_runner"}}
 
 rule =91140
 alert = 3
@@ -311,7 +311,7 @@ decoder = json
 
 
 [GitHub Enterprise Register self hosted runner.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"enterprise.register_self_hosted_runner","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"enterprise.register_self_hosted_runner"}}
 
 rule =91141
 alert = 3
@@ -319,7 +319,7 @@ decoder = json
 
 
 [GitHub Enterprise Runner group created.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"enterprise.runner_group_created","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"enterprise.runner_group_created"}}
 
 rule =91142
 alert = 5
@@ -327,7 +327,7 @@ decoder = json
 
 
 [GitHub Enterprise Runner group removed.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"enterprise.runner_group_removed","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"enterprise.runner_group_removed"}}
 
 rule =91143
 alert = 7
@@ -335,7 +335,7 @@ decoder = json
 
 
 [GitHub Enterprise Runner group runner removed.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"enterprise.runner_group_runner_removed","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"enterprise.runner_group_runner_removed"}}
 
 rule =91144
 alert = 7
@@ -343,7 +343,7 @@ decoder = json
 
 
 [GitHub Enterprise Runner group runners added.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"enterprise.runner_group_runners_added","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"enterprise.runner_group_runners_added"}}
 
 rule =91145
 alert = 5
@@ -351,7 +351,7 @@ decoder = json
 
 
 [GitHub Enterprise Runner group runners updated.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"enterprise.runner_group_runners_updated","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"enterprise.runner_group_runners_updated"}}
 
 rule =91146
 alert = 5
@@ -359,7 +359,7 @@ decoder = json
 
 
 [GitHub Enterprise Runner group updated.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"enterprise.runner_group_updated","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"enterprise.runner_group_updated"}}
 
 rule =91147
 alert = 5
@@ -367,7 +367,7 @@ decoder = json
 
 
 [GitHub Enterprise Self hosted runner updated.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"enterprise.self_hosted_runner_updated","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"enterprise.self_hosted_runner_updated"}}
 
 rule =91148
 alert = 3
@@ -375,7 +375,7 @@ decoder = json
 
 
 [GitHub Environment.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"environment.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"environment."}}
 
 rule =91149
 alert = 3
@@ -383,7 +383,7 @@ decoder = json
 
 
 [GitHub Environment Create actions secret.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"environment.create_actions_secret","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"environment.create_actions_secret"}}
 
 rule =91150
 alert = 7
@@ -391,7 +391,7 @@ decoder = json
 
 
 [GitHub Environment Delete.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"environment.delete","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"environment.delete"}}
 
 rule =91151
 alert = 7
@@ -399,7 +399,7 @@ decoder = json
 
 
 [GitHub Environment Remove actions secret.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"environment.remove_actions_secret","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"environment.remove_actions_secret"}}
 
 rule =91152
 alert = 9
@@ -407,7 +407,7 @@ decoder = json
 
 
 [GitHub Environment Update actions secret.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"environment.update_actions_secret","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"environment.update_actions_secret"}}
 
 rule =91153
 alert = 7
@@ -415,7 +415,7 @@ decoder = json
 
 
 [GitHub Environment Add protection rule.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"environment.add_protection_rule","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"environment.add_protection_rule"}}
 
 rule =91154
 alert = 7
@@ -423,7 +423,7 @@ decoder = json
 
 
 [GitHub Environment Update protection rule.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"environment.update_protection_rule","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"environment.update_protection_rule"}}
 
 rule =91155
 alert = 7
@@ -431,7 +431,7 @@ decoder = json
 
 
 [GitHub Environment Remove protection rule.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"environment.remove_protection_rule","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"environment.remove_protection_rule"}}
 
 rule =91156
 alert = 9
@@ -439,7 +439,7 @@ decoder = json
 
 
 [GitHub Git.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"git.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"git."}}
 
 rule =91157
 alert = 3
@@ -447,7 +447,7 @@ decoder = json
 
 
 [GitHub Git clone.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"git.clone","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"git.clone"}}
 
 rule =91158
 alert = 3
@@ -455,7 +455,7 @@ decoder = json
 
 
 [GitHub Git fetch.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"git.fetch","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"git.fetch"}}
 
 rule =91159
 alert = 3
@@ -463,7 +463,7 @@ decoder = json
 
 
 [GitHub Git push.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"git.push","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"git.push"}}
 
 rule =91160
 alert = 3
@@ -471,7 +471,7 @@ decoder = json
 
 
 [GitHub Hook.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"hook.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"hook."}}
 
 rule =91161
 alert = 3
@@ -479,7 +479,7 @@ decoder = json
 
 
 [GitHub Hook create.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"hook.create","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"hook.create"}}
 
 rule =91162
 alert = 5
@@ -487,7 +487,7 @@ decoder = json
 
 
 [GitHub Hook config changed.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"hook.config_changed","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"hook.config_changed"}}
 
 rule =91163
 alert = 5
@@ -495,7 +495,7 @@ decoder = json
 
 
 [GitHub Hook destroy.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"hook.destroy","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"hook.destroy"}}
 
 rule =91164
 alert = 7
@@ -503,7 +503,7 @@ decoder = json
 
 
 [GitHub Hook events changed.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"hook.events_changed","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"hook.events_changed"}}
 
 rule =91165
 alert = 5
@@ -511,8 +511,8 @@ decoder = json
 
 
 [GitHub Integration installation.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"integration_installation.","source":"github"}}
-log 2 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"integration_installation_request.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"integration_installation."}}
+log 2 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"integration_installation_request."}}
 
 rule =91166
 alert = 3
@@ -520,7 +520,7 @@ decoder = json
 
 
 [GitHub Integration installation create.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"integration_installation.create","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"integration_installation.create"}}
 
 rule =91167
 alert = 5
@@ -528,7 +528,7 @@ decoder = json
 
 
 [GitHub Integration installation close.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"integration_installation.close","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"integration_installation.close"}}
 
 rule =91168
 alert = 5
@@ -536,8 +536,8 @@ decoder = json
 
 
 [GitHub Issues.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"issue.","source":"github"}}
-log 2 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"issues.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"issue."}}
+log 2 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"issues."}}
 
 rule =91169
 alert = 3
@@ -545,7 +545,7 @@ decoder = json
 
 
 [GitHub Issues destroy.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"issues.destroy","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"issues.destroy"}}
 
 rule =91170
 alert = 5
@@ -553,7 +553,7 @@ decoder = json
 
 
 [GitHub Marketplace agreement signature.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"marketplace_agreement_signature.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"marketplace_agreement_signature."}}
 
 rule =91171
 alert = 3
@@ -561,7 +561,7 @@ decoder = json
 
 
 [GitHub Marketplace agreement signature create.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"marketplace_agreement_signature.create","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"marketplace_agreement_signature.create"}}
 
 rule =91172
 alert = 7
@@ -569,7 +569,7 @@ decoder = json
 
 
 [GitHub Marketplace listing.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"marketplace_listing.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"marketplace_listing."}}
 
 rule =91173
 alert = 3
@@ -577,7 +577,7 @@ decoder = json
 
 
 [GitHub Marketplace listing approve.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"marketplace_listing.approve","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"marketplace_listing.approve"}}
 
 rule =91174
 alert = 5
@@ -585,7 +585,7 @@ decoder = json
 
 
 [GitHub Marketplace listing create.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"marketplace_listing.create","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"marketplace_listing.create"}}
 
 rule =91175
 alert = 5
@@ -593,7 +593,7 @@ decoder = json
 
 
 [GitHub Marketplace listing delist.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"marketplace_listing.delist","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"marketplace_listing.delist"}}
 
 rule =91176
 alert = 5
@@ -601,7 +601,7 @@ decoder = json
 
 
 [GitHub Marketplace listing redraft.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"marketplace_listing.redraft","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"marketplace_listing.redraft"}}
 
 rule =91177
 alert = 5
@@ -609,7 +609,7 @@ decoder = json
 
 
 [GitHub Marketplace listing reject.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"marketplace_listing.reject","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"marketplace_listing.reject"}}
 
 rule =91178
 alert = 5
@@ -617,7 +617,7 @@ decoder = json
 
 
 [GitHub Members can create pages.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"members_can_create_pages.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"members_can_create_pages."}}
 
 rule =91179
 alert = 3
@@ -625,7 +625,7 @@ decoder = json
 
 
 [GitHub Members can create pages enable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"members_can_create_pages.enable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"members_can_create_pages.enable"}}
 
 rule =91180
 alert = 3
@@ -633,7 +633,7 @@ decoder = json
 
 
 [GitHub Members can create pages disable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"members_can_create_pages.disable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"members_can_create_pages.disable"}}
 
 rule =91181
 alert = 3
@@ -641,7 +641,7 @@ decoder = json
 
 
 [GitHub Oauth application.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"oauth_application.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"oauth_application."}}
 
 rule =91182
 alert = 3
@@ -649,7 +649,7 @@ decoder = json
 
 
 [GitHub Oauth application create.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"oauth_application.create","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"oauth_application.create"}}
 
 rule =91183
 alert = 5
@@ -657,7 +657,7 @@ decoder = json
 
 
 [GitHub Oauth application destroy.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"oauth_application.destroy","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"oauth_application.destroy"}}
 
 rule =91184
 alert = 7
@@ -665,7 +665,7 @@ decoder = json
 
 
 [GitHub Oauth application reset secret.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"oauth_application.reset_secret","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"oauth_application.reset_secret"}}
 
 rule =91185
 alert = 7
@@ -673,7 +673,7 @@ decoder = json
 
 
 [GitHub Oauth application revoke tokens.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"oauth_application.revoke_tokens","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"oauth_application.revoke_tokens"}}
 
 rule =91186
 alert = 7
@@ -681,7 +681,7 @@ decoder = json
 
 
 [GitHub Oauth application transfer.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"oauth_application.transfer","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"oauth_application.transfer"}}
 
 rule =91187
 alert = 5
@@ -689,7 +689,7 @@ decoder = json
 
 
 [GitHub Organization.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org."}}
 
 rule =91188
 alert = 3
@@ -697,7 +697,7 @@ decoder = json
 
 
 [GitHub Organization add billing manager.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.add_billing_manager","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.add_billing_manager"}}
 
 rule =91189
 alert = 9
@@ -705,7 +705,7 @@ decoder = json
 
 
 [GitHub Organization add member.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.add_member","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.add_member"}}
 
 rule =91190
 alert = 5
@@ -713,7 +713,7 @@ decoder = json
 
 
 [GitHub Organization advanced security policy selected member disabled.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.advanced_security_policy_selected_member_disabled","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.advanced_security_policy_selected_member_disabled"}}
 
 rule =91191
 alert = 9
@@ -721,7 +721,7 @@ decoder = json
 
 
 [GitHub Organization advanced security policy selected member enabled.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.advanced_security_policy_selected_member_enabled","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.advanced_security_policy_selected_member_enabled"}}
 
 rule =91192
 alert = 5
@@ -729,8 +729,8 @@ decoder = json
 
 
 [GitHub Organization audit log export.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.audit_log_export","source":"github"}}
-log 2 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.audit_log_git_event_export","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.audit_log_export"}}
+log 2 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.audit_log_git_event_export"}}
 
 rule =91193
 alert = 5
@@ -738,7 +738,7 @@ decoder = json
 
 
 [GitHub Organization block user.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.block_user","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.block_user"}}
 
 rule =91194
 alert = 9
@@ -746,7 +746,7 @@ decoder = json
 
 
 [GitHub Organization cancel invitation.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.cancel_invitation","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.cancel_invitation"}}
 
 rule =91195
 alert = 5
@@ -754,7 +754,7 @@ decoder = json
 
 
 [GitHub Organization create.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.create","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.create"}}
 
 rule =91196
 alert = 5
@@ -762,7 +762,7 @@ decoder = json
 
 
 [GitHub Organization create actions secret.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.create_actions_secret","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.create_actions_secret"}}
 
 rule =91197
 alert = 7
@@ -770,7 +770,7 @@ decoder = json
 
 
 [GitHub Organization disable member team creation permission.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.disable_member_team_creation_permission","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.disable_member_team_creation_permission"}}
 
 rule =91198
 alert = 9
@@ -778,7 +778,7 @@ decoder = json
 
 
 [GitHub Organization disable oauth app restrictions.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.disable_oauth_app_restrictions","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.disable_oauth_app_restrictions"}}
 
 rule =91199
 alert = 12
@@ -786,7 +786,7 @@ decoder = json
 
 
 [GitHub Organization disable saml.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.disable_saml","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.disable_saml"}}
 
 rule =91200
 alert = 12
@@ -794,7 +794,7 @@ decoder = json
 
 
 [GitHub Organization disable two factor requirement.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.disable_two_factor_requirement","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.disable_two_factor_requirement"}}
 
 rule =91201
 alert = 12
@@ -802,7 +802,7 @@ decoder = json
 
 
 [GitHub Organization display commenter full name enabled.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.display_commenter_full_name_enabled","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.display_commenter_full_name_enabled"}}
 
 rule =91202
 alert = 5
@@ -810,7 +810,7 @@ decoder = json
 
 
 [GitHub Organization enable member team creation permission.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.enable_member_team_creation_permission","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.enable_member_team_creation_permission"}}
 
 rule =91203
 alert = 5
@@ -818,7 +818,7 @@ decoder = json
 
 
 [GitHub Organization enable oauth app restrictions.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.enable_oauth_app_restrictions","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.enable_oauth_app_restrictions"}}
 
 rule =91204
 alert = 7
@@ -826,7 +826,7 @@ decoder = json
 
 
 [GitHub Organization enable saml.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.enable_saml","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.enable_saml"}}
 
 rule =91205
 alert = 7
@@ -834,7 +834,7 @@ decoder = json
 
 
 [GitHub Organization enable two factor requirement.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.enable_two_factor_requirement","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.enable_two_factor_requirement"}}
 
 rule =91206
 alert = 7
@@ -842,7 +842,7 @@ decoder = json
 
 
 [GitHub Organization invite member.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.invite_member","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.invite_member"}}
 
 rule =91207
 alert = 5
@@ -850,7 +850,7 @@ decoder = json
 
 
 [GitHub Organization oauth app access approved.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.oauth_app_access_approved","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.oauth_app_access_approved"}}
 
 rule =91208
 alert = 7
@@ -858,7 +858,7 @@ decoder = json
 
 
 [GitHub Organization oauth app access denied.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.oauth_app_access_denied","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.oauth_app_access_denied"}}
 
 rule =91209
 alert = 12
@@ -866,7 +866,7 @@ decoder = json
 
 
 [GitHub Organization oauth app access requested.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.oauth_app_access_requested","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.oauth_app_access_requested"}}
 
 rule =91210
 alert = 7
@@ -874,7 +874,7 @@ decoder = json
 
 
 [GitHub Organization register self hosted runner.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.register_self_hosted_runner","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.register_self_hosted_runner"}}
 
 rule =91211
 alert = 3
@@ -882,7 +882,7 @@ decoder = json
 
 
 [GitHub Organization remove actions secret.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.remove_actions_secret","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.remove_actions_secret"}}
 
 rule =91212
 alert = 9
@@ -890,7 +890,7 @@ decoder = json
 
 
 [GitHub Organization remove billing manager.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.remove_billing_manager","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.remove_billing_manager"}}
 
 rule =91213
 alert = 9
@@ -898,7 +898,7 @@ decoder = json
 
 
 [GitHub Organization remove member.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.remove_member","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.remove_member"}}
 
 rule =91214
 alert = 7
@@ -906,7 +906,7 @@ decoder = json
 
 
 [GitHub Organization remove outside collaborator.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.remove_outside_collaborator","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.remove_outside_collaborator"}}
 
 rule =91215
 alert = 7
@@ -914,7 +914,7 @@ decoder = json
 
 
 [GitHub Organization remove self hosted runner.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.remove_self_hosted_runner","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.remove_self_hosted_runner"}}
 
 rule =91216
 alert = 3
@@ -922,7 +922,7 @@ decoder = json
 
 
 [GitHub Organization restore member.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.restore_member","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.restore_member"}}
 
 rule =91217
 alert = 5
@@ -930,7 +930,7 @@ decoder = json
 
 
 [GitHub Organization revoke external identity.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.revoke_external_identity","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.revoke_external_identity"}}
 
 rule =91218
 alert = 9
@@ -938,7 +938,7 @@ decoder = json
 
 
 [GitHub Organization revoke sso session.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.revoke_sso_session","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.revoke_sso_session"}}
 
 rule =91219
 alert = 9
@@ -946,7 +946,7 @@ decoder = json
 
 
 [GitHub Organization runner group created.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.runner_group_created","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.runner_group_created"}}
 
 rule =91220
 alert = 5
@@ -954,7 +954,7 @@ decoder = json
 
 
 [GitHub Organization runner group removed.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.runner_group_removed","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.runner_group_removed"}}
 
 rule =91221
 alert = 7
@@ -962,7 +962,7 @@ decoder = json
 
 
 [GitHub Organization runner group runner removed.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.runner_group_runner_removed","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.runner_group_runner_removed"}}
 
 rule =91222
 alert = 7
@@ -970,7 +970,7 @@ decoder = json
 
 
 [GitHub Organization runner group runners added.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.runner_group_runners_added","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.runner_group_runners_added"}}
 
 rule =91223
 alert = 5
@@ -978,7 +978,7 @@ decoder = json
 
 
 [GitHub Organization runner group runners updated.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.runner_group_runners_updated","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.runner_group_runners_updated"}}
 
 rule =91224
 alert = 5
@@ -986,7 +986,7 @@ decoder = json
 
 
 [GitHub Organization runner group updated.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.runner_group_updated","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.runner_group_updated"}}
 
 rule =91225
 alert = 5
@@ -994,7 +994,7 @@ decoder = json
 
 
 [GitHub Organization self hosted runner updated.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.self_hosted_runner_updated","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.self_hosted_runner_updated"}}
 
 rule =91226
 alert = 3
@@ -1002,7 +1002,7 @@ decoder = json
 
 
 [GitHub Organization set actions retention limit.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.set_actions_retention_limit","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.set_actions_retention_limit"}}
 
 rule =91227
 alert = 5
@@ -1010,7 +1010,7 @@ decoder = json
 
 
 [GitHub Organization unblock user.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.unblock_user","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.unblock_user"}}
 
 rule =91228
 alert = 7
@@ -1018,7 +1018,7 @@ decoder = json
 
 
 [GitHub Organization update actions secret.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.update_actions_secret","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.update_actions_secret"}}
 
 rule =91229
 alert = 7
@@ -1026,7 +1026,7 @@ decoder = json
 
 
 [GitHub Organization update actions settings.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.update_actions_settings","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.update_actions_settings"}}
 
 rule =91230
 alert = 7
@@ -1034,7 +1034,7 @@ decoder = json
 
 
 [GitHub Organization update default repository permission.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.update_default_repository_permission","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.update_default_repository_permission"}}
 
 rule =91231
 alert = 7
@@ -1042,7 +1042,7 @@ decoder = json
 
 
 [GitHub Organization update member.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.update_member","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.update_member"}}
 
 rule =91232
 alert = 5
@@ -1050,7 +1050,7 @@ decoder = json
 
 
 [GitHub Organization update member repository creation permission.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.update_member_repository_creation_permission","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.update_member_repository_creation_permission"}}
 
 rule =91233
 alert = 7
@@ -1058,7 +1058,7 @@ decoder = json
 
 
 [GitHub Organization update new repository default branch setting.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.update_new_repository_default_branch_setting","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.update_new_repository_default_branch_setting"}}
 
 rule =91234
 alert = 7
@@ -1066,7 +1066,7 @@ decoder = json
 
 
 [GitHub Organization update saml provider settings.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.update_saml_provider_settings","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.update_saml_provider_settings"}}
 
 rule =91235
 alert = 7
@@ -1074,7 +1074,7 @@ decoder = json
 
 
 [GitHub Organization update terms of service.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.update_terms_of_service","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org.update_terms_of_service"}}
 
 rule =91236
 alert = 7
@@ -1082,7 +1082,7 @@ decoder = json
 
 
 [GitHub Organization credential authorization.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org_credential_authorization.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org_credential_authorization."}}
 
 rule =91239
 alert = 3
@@ -1090,7 +1090,7 @@ decoder = json
 
 
 [GitHub Organization credential authorization grant.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org_credential_authorization.grant","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org_credential_authorization.grant"}}
 
 rule =91240
 alert = 7
@@ -1098,7 +1098,7 @@ decoder = json
 
 
 [GitHub Organization credential authorization deauthorized.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org_credential_authorization.deauthorized","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org_credential_authorization.deauthorized"}}
 
 rule =91241
 alert = 12
@@ -1106,7 +1106,7 @@ decoder = json
 
 
 [GitHub Organization credential authorization revoke.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org_credential_authorization.revoke","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"org_credential_authorization.revoke"}}
 
 rule =91242
 alert = 9
@@ -1114,8 +1114,8 @@ decoder = json
 
 
 [GitHub Organization default label.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"organization_default_label.","source":"github"}}
-log 2 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"organization_label.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"organization_default_label."}}
+log 2 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"organization_label."}}
 
 rule =91243
 alert = 3
@@ -1123,7 +1123,7 @@ decoder = json
 
 
 [GitHub Organization default label create.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"organization_default_label.create","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"organization_default_label.create"}}
 
 rule =91244
 alert = 5
@@ -1131,7 +1131,7 @@ decoder = json
 
 
 [GitHub Organization default label update.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"organization_default_label.update","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"organization_default_label.update"}}
 
 rule =91245
 alert = 5
@@ -1139,7 +1139,7 @@ decoder = json
 
 
 [GitHub Organization default label destroy.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"organization_default_label.destroy","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"organization_default_label.destroy"}}
 
 rule =91246
 alert = 5
@@ -1147,7 +1147,7 @@ decoder = json
 
 
 [GitHub Packages.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"packages.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"packages."}}
 
 rule =91247
 alert = 3
@@ -1155,7 +1155,7 @@ decoder = json
 
 
 [GitHub Package version published.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"packages.package_version_published","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"packages.package_version_published"}}
 
 rule =91248
 alert = 5
@@ -1163,7 +1163,7 @@ decoder = json
 
 
 [GitHub Package version deleted.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"packages.package_version_deleted","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"packages.package_version_deleted"}}
 
 rule =91249
 alert = 7
@@ -1171,7 +1171,7 @@ decoder = json
 
 
 [GitHub Package deleted.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"packages.package_deleted","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"packages.package_deleted"}}
 
 rule =91250
 alert = 7
@@ -1179,7 +1179,7 @@ decoder = json
 
 
 [GitHub Package version restored.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"packages.package_version_restored","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"packages.package_version_restored"}}
 
 rule =91251
 alert = 5
@@ -1187,7 +1187,7 @@ decoder = json
 
 
 [GitHub Package restored.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"packages.package_restored","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"packages.package_restored"}}
 
 rule =91252
 alert = 5
@@ -1195,7 +1195,7 @@ decoder = json
 
 
 [GitHub Payment method.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"payment_method.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"payment_method."}}
 
 rule =91253
 alert = 3
@@ -1203,7 +1203,7 @@ decoder = json
 
 
 [GitHub Payment method clear.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"payment_method.clear","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"payment_method.clear"}}
 
 rule =91254
 alert = 7
@@ -1211,7 +1211,7 @@ decoder = json
 
 
 [GitHub Payment method create.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"payment_method.create","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"payment_method.create"}}
 
 rule =91255
 alert = 7
@@ -1219,7 +1219,7 @@ decoder = json
 
 
 [GitHub Payment method update.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"payment_method.update","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"payment_method.update"}}
 
 rule =91256
 alert = 7
@@ -1227,7 +1227,7 @@ decoder = json
 
 
 [GitHub Profile picture.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"profile_picture.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"profile_picture."}}
 
 rule =91257
 alert = 3
@@ -1235,7 +1235,7 @@ decoder = json
 
 
 [GitHub Profile picture update.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"profile_picture.update","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"profile_picture.update"}}
 
 rule =91258
 alert = 5
@@ -1243,7 +1243,7 @@ decoder = json
 
 
 [GitHub Project.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"project.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"project."}}
 
 rule =91259
 alert = 3
@@ -1251,7 +1251,7 @@ decoder = json
 
 
 [GitHub Project create.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"project.create","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"project.create"}}
 
 rule =91260
 alert = 5
@@ -1259,7 +1259,7 @@ decoder = json
 
 
 [GitHub Project link.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"project.link","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"project.link"}}
 
 rule =91261
 alert = 5
@@ -1267,7 +1267,7 @@ decoder = json
 
 
 [GitHub Project rename.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"project.rename","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"project.rename"}}
 
 rule =91262
 alert = 5
@@ -1275,7 +1275,7 @@ decoder = json
 
 
 [GitHub Project update.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"project.update","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"project.update"}}
 
 rule =91263
 alert = 5
@@ -1283,7 +1283,7 @@ decoder = json
 
 
 [GitHub Project delete.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"project.delete","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"project.delete"}}
 
 rule =91264
 alert = 7
@@ -1291,7 +1291,7 @@ decoder = json
 
 
 [GitHub Project unlink.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"project.unlink","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"project.unlink"}}
 
 rule =91265
 alert = 7
@@ -1299,7 +1299,7 @@ decoder = json
 
 
 [GitHub Project update org permission.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"project.update_org_permission","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"project.update_org_permission"}}
 
 rule =91266
 alert = 5
@@ -1307,7 +1307,7 @@ decoder = json
 
 
 [GitHub Project update team permission.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"project.update_team_permission","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"project.update_team_permission"}}
 
 rule =91267
 alert = 5
@@ -1315,7 +1315,7 @@ decoder = json
 
 
 [GitHub Project update user permission.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"project.update_user_permission","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"project.update_user_permission"}}
 
 rule =91268
 alert = 5
@@ -1323,7 +1323,7 @@ decoder = json
 
 
 [GitHub Organization domain.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"organization_domain.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"organization_domain."}}
 
 rule =91269
 alert = 3
@@ -1331,7 +1331,7 @@ decoder = json
 
 
 [GitHub Organization domain create.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"organization_domain.create","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"organization_domain.create"}}
 
 rule =91270
 alert = 5
@@ -1339,7 +1339,7 @@ decoder = json
 
 
 [GitHub Organization domain delete.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"organization_domain.delete","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"organization_domain.delete"}}
 
 rule =91271
 alert = 5
@@ -1347,7 +1347,7 @@ decoder = json
 
 
 [GitHub Private repository forking.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"private_repository_forking.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"private_repository_forking."}}
 
 rule =91272
 alert = 3
@@ -1355,7 +1355,7 @@ decoder = json
 
 
 [GitHub Private repository forking enable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"private_repository_forking.enable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"private_repository_forking.enable"}}
 
 rule =91273
 alert = 9
@@ -1363,7 +1363,7 @@ decoder = json
 
 
 [GitHub Private repository forking disable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"private_repository_forking.disable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"private_repository_forking.disable"}}
 
 rule =91274
 alert = 5
@@ -1371,7 +1371,7 @@ decoder = json
 
 
 [GitHub Protected branch.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch."}}
 
 rule =91275
 alert = 3
@@ -1379,7 +1379,7 @@ decoder = json
 
 
 [GitHub Protected branch create.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.create","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.create"}}
 
 rule =91276
 alert = 5
@@ -1387,7 +1387,7 @@ decoder = json
 
 
 [GitHub Protected branch destroy.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.destroy","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.destroy"}}
 
 rule =91277
 alert = 7
@@ -1395,7 +1395,7 @@ decoder = json
 
 
 [GitHub Protected branch update admin enforced.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.update_admin_enforced","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.update_admin_enforced"}}
 
 rule =91278
 alert = 5
@@ -1403,7 +1403,7 @@ decoder = json
 
 
 [GitHub Protected branch update require code owner review.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.update_require_code_owner_review","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.update_require_code_owner_review"}}
 
 rule =91279
 alert = 5
@@ -1411,7 +1411,7 @@ decoder = json
 
 
 [GitHub Protected branch dismissal restricted users teams.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.dismissal_restricted_users_teams","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.dismissal_restricted_users_teams"}}
 
 rule =91280
 alert = 5
@@ -1419,7 +1419,7 @@ decoder = json
 
 
 [GitHub Protected branch dismiss stale reviews.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.dismiss_stale_reviews","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.dismiss_stale_reviews"}}
 
 rule =91281
 alert = 5
@@ -1427,7 +1427,7 @@ decoder = json
 
 
 [GitHub Protected branch update signature requirement enforcement level.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.update_signature_requirement_enforcement_level","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.update_signature_requirement_enforcement_level"}}
 
 rule =91282
 alert = 5
@@ -1435,7 +1435,7 @@ decoder = json
 
 
 [GitHub Protected branch update pull request reviews enforcement level.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.update_pull_request_reviews_enforcement_level","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.update_pull_request_reviews_enforcement_level"}}
 
 rule =91283
 alert = 5
@@ -1443,7 +1443,7 @@ decoder = json
 
 
 [GitHub Protected branch update required status checks enforcement level.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.update_required_status_checks_enforcement_level","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.update_required_status_checks_enforcement_level"}}
 
 rule =91284
 alert = 5
@@ -1451,7 +1451,7 @@ decoder = json
 
 
 [GitHub Protected branch update strict required status checks policy.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.update_strict_required_status_checks_policy","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.update_strict_required_status_checks_policy"}}
 
 rule =91285
 alert = 5
@@ -1459,7 +1459,7 @@ decoder = json
 
 
 [GitHub Protected branch rejected ref update.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.rejected_ref_update","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.rejected_ref_update"}}
 
 rule =91286
 alert = 5
@@ -1467,7 +1467,7 @@ decoder = json
 
 
 [GitHub Protected branch policy override.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.policy_override","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.policy_override"}}
 
 rule =91287
 alert = 5
@@ -1475,7 +1475,7 @@ decoder = json
 
 
 [GitHub Protected branch update allow force pushes enforcement level.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.update_allow_force_pushes_enforcement_level","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.update_allow_force_pushes_enforcement_level"}}
 
 rule =91288
 alert = 5
@@ -1483,7 +1483,7 @@ decoder = json
 
 
 [GitHub Protected branch update allow deletions enforcement level.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.update_allow_deletions_enforcement_level","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.update_allow_deletions_enforcement_level"}}
 
 rule =91289
 alert = 5
@@ -1491,7 +1491,7 @@ decoder = json
 
 
 [GitHub Protected branch update linear history requirement enforcement level.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.update_linear_history_requirement_enforcement_level","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"protected_branch.update_linear_history_requirement_enforcement_level"}}
 
 rule =91290
 alert = 5
@@ -1499,7 +1499,7 @@ decoder = json
 
 
 [GitHub Pull request.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request."}}
 
 rule =91292
 alert = 3
@@ -1507,7 +1507,7 @@ decoder = json
 
 
 [GitHub Pull request create.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request.create","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request.create"}}
 
 rule =91293
 alert = 5
@@ -1515,7 +1515,7 @@ decoder = json
 
 
 [GitHub Pull request close.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request.close","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request.close"}}
 
 rule =91294
 alert = 5
@@ -1523,7 +1523,7 @@ decoder = json
 
 
 [GitHub Pull request reopen.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request.reopen","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request.reopen"}}
 
 rule =91295
 alert = 5
@@ -1531,7 +1531,7 @@ decoder = json
 
 
 [GitHub Pull request merge.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request.merge","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request.merge"}}
 
 rule =91296
 alert = 5
@@ -1539,7 +1539,7 @@ decoder = json
 
 
 [GitHub Pull request indirect merge.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request.indirect_merge","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request.indirect_merge"}}
 
 rule =91297
 alert = 5
@@ -1547,7 +1547,7 @@ decoder = json
 
 
 [GitHub Pull request ready for review.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request.ready_for_review","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request.ready_for_review"}}
 
 rule =91298
 alert = 5
@@ -1555,7 +1555,7 @@ decoder = json
 
 
 [GitHub Pull request converted to draft.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request.converted_to_draft","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request.converted_to_draft"}}
 
 rule =91299
 alert = 5
@@ -1563,7 +1563,7 @@ decoder = json
 
 
 [GitHub Pull request create review request.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request.create_review_request","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request.create_review_request"}}
 
 rule =91300
 alert = 5
@@ -1571,7 +1571,7 @@ decoder = json
 
 
 [GitHub Pull request remove review request.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request.remove_review_request","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request.remove_review_request"}}
 
 rule =91301
 alert = 5
@@ -1579,7 +1579,7 @@ decoder = json
 
 
 [GitHub Pull request review.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request_review.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request_review."}}
 
 rule =91302
 alert = 3
@@ -1587,7 +1587,7 @@ decoder = json
 
 
 [GitHub Pull request review submit.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request_review.submit","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request_review.submit"}}
 
 rule =91303
 alert = 5
@@ -1595,7 +1595,7 @@ decoder = json
 
 
 [GitHub Pull request review dismiss.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request_review.dismiss","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request_review.dismiss"}}
 
 rule =91304
 alert = 5
@@ -1603,7 +1603,7 @@ decoder = json
 
 
 [GitHub Pull request review delete.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request_review.delete","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request_review.delete"}}
 
 rule =91305
 alert = 5
@@ -1611,7 +1611,7 @@ decoder = json
 
 
 [GitHub Pull request review comment.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request_review_comment.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request_review_comment."}}
 
 rule =91306
 alert = 3
@@ -1619,7 +1619,7 @@ decoder = json
 
 
 [GitHub Pull request review comment create.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request_review_comment.create","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request_review_comment.create"}}
 
 rule =91307
 alert = 5
@@ -1627,7 +1627,7 @@ decoder = json
 
 
 [GitHub Pull request review comment update.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request_review_comment.update","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request_review_comment.update"}}
 
 rule =91308
 alert = 5
@@ -1635,7 +1635,7 @@ decoder = json
 
 
 [GitHub Pull request review comment delete.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request_review_comment.delete","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"pull_request_review_comment.delete"}}
 
 rule =91309
 alert = 5
@@ -1643,7 +1643,7 @@ decoder = json
 
 
 [GitHub Repo.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo."}}
 
 rule =91310
 alert = 3
@@ -1651,7 +1651,7 @@ decoder = json
 
 
 [GitHub Repo access.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.access","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.access"}}
 
 rule =91311
 alert = 7
@@ -1659,7 +1659,7 @@ decoder = json
 
 
 [GitHub Repo actions enabled.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.actions_enabled","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.actions_enabled"}}
 
 rule =91312
 alert = 5
@@ -1667,7 +1667,7 @@ decoder = json
 
 
 [GitHub Repo add member.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.add_member","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.add_member"}}
 
 rule =91313
 alert = 5
@@ -1675,7 +1675,7 @@ decoder = json
 
 
 [GitHub Repo add topic.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.add_topic","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.add_topic"}}
 
 rule =91314
 alert = 5
@@ -1683,7 +1683,7 @@ decoder = json
 
 
 [GitHub Repo advanced security disabled.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.advanced_security_disabled","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.advanced_security_disabled"}}
 
 rule =91315
 alert = 12
@@ -1691,7 +1691,7 @@ decoder = json
 
 
 [GitHub Repo advanced security enabled.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.advanced_security_enabled","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.advanced_security_enabled"}}
 
 rule =91316
 alert = 7
@@ -1699,7 +1699,7 @@ decoder = json
 
 
 [GitHub Repo archived.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.archived","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.archived"}}
 
 rule =91317
 alert = 9
@@ -1707,7 +1707,7 @@ decoder = json
 
 
 [GitHub Repo create.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.create","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.create"}}
 
 rule =91318
 alert = 5
@@ -1715,7 +1715,7 @@ decoder = json
 
 
 [GitHub Repo create actions secret.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.create_actions_secret","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.create_actions_secret"}}
 
 rule =91319
 alert = 7
@@ -1723,7 +1723,7 @@ decoder = json
 
 
 [GitHub Repo destroy.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.destroy","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.destroy"}}
 
 rule =91320
 alert = 9
@@ -1731,7 +1731,7 @@ decoder = json
 
 
 [GitHub Repo disable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.disable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.disable"}}
 
 rule =91321
 alert = 9
@@ -1739,7 +1739,7 @@ decoder = json
 
 
 [GitHub Repo enable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.enable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.enable"}}
 
 rule =91322
 alert = 5
@@ -1747,7 +1747,7 @@ decoder = json
 
 
 [GitHub Repo pages create.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.pages_create","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.pages_create"}}
 
 rule =91323
 alert = 5
@@ -1755,7 +1755,7 @@ decoder = json
 
 
 [GitHub Repo pages https redirect enabled.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.pages_https_redirect_enabled","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.pages_https_redirect_enabled"}}
 
 rule =91324
 alert = 5
@@ -1763,7 +1763,7 @@ decoder = json
 
 
 [GitHub Repo pages private.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.pages_private","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.pages_private"}}
 
 rule =91325
 alert = 5
@@ -1771,7 +1771,7 @@ decoder = json
 
 
 [GitHub Repo pages public.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.pages_public","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.pages_public"}}
 
 rule =91326
 alert = 5
@@ -1779,7 +1779,7 @@ decoder = json
 
 
 [GitHub Repo pages source.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.pages_source","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.pages_source"}}
 
 rule =91327
 alert = 5
@@ -1787,7 +1787,7 @@ decoder = json
 
 
 [GitHub Repo remove actions secret.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.remove_actions_secret","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.remove_actions_secret"}}
 
 rule =91328
 alert = 9
@@ -1795,7 +1795,7 @@ decoder = json
 
 
 [GitHub Repo remove member.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.remove_member","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.remove_member"}}
 
 rule =91329
 alert = 7
@@ -1803,7 +1803,7 @@ decoder = json
 
 
 [GitHub Repo register self hosted runner.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.register_self_hosted_runner","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.register_self_hosted_runner"}}
 
 rule =91330
 alert = 3
@@ -1811,7 +1811,7 @@ decoder = json
 
 
 [GitHub Repo remove self hosted runner.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.remove_self_hosted_runner","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.remove_self_hosted_runner"}}
 
 rule =91331
 alert = 3
@@ -1819,7 +1819,7 @@ decoder = json
 
 
 [GitHub Repo remove topic.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.remove_topic","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.remove_topic"}}
 
 rule =91332
 alert = 5
@@ -1827,7 +1827,7 @@ decoder = json
 
 
 [GitHub Repo rename.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.rename","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.rename"}}
 
 rule =91333
 alert = 5
@@ -1835,7 +1835,7 @@ decoder = json
 
 
 [GitHub Repo self hosted runner updated.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.self_hosted_runner_updated","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.self_hosted_runner_updated"}}
 
 rule =91334
 alert = 3
@@ -1843,7 +1843,7 @@ decoder = json
 
 
 [GitHub Repo set actions retention limit.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.set_actions_retention_limit","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.set_actions_retention_limit"}}
 
 rule =91335
 alert = 5
@@ -1851,7 +1851,7 @@ decoder = json
 
 
 [GitHub Repo transfer.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.transfer","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.transfer"}}
 
 rule =91336
 alert = 5
@@ -1859,7 +1859,7 @@ decoder = json
 
 
 [GitHub Repo transfer start.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.transfer_start","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.transfer_start"}}
 
 rule =91337
 alert = 5
@@ -1867,7 +1867,7 @@ decoder = json
 
 
 [GitHub Repo unarchived.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.unarchived","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.unarchived"}}
 
 rule =91338
 alert = 5
@@ -1875,7 +1875,7 @@ decoder = json
 
 
 [GitHub Repo update actions secret.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.update_actions_secret","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repo.update_actions_secret"}}
 
 rule =91339
 alert = 7
@@ -1883,7 +1883,7 @@ decoder = json
 
 
 [GitHub Repository advisory.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_advisory.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_advisory."}}
 
 rule =91340
 alert = 3
@@ -1891,7 +1891,7 @@ decoder = json
 
 
 [GitHub Repository advisory close.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_advisory.close","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_advisory.close"}}
 
 rule =91341
 alert = 7
@@ -1899,7 +1899,7 @@ decoder = json
 
 
 [GitHub Repository advisory cve request.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_advisory.cve_request","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_advisory.cve_request"}}
 
 rule =91342
 alert = 9
@@ -1907,7 +1907,7 @@ decoder = json
 
 
 [GitHub Repository advisory github broadcast.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_advisory.github_broadcast","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_advisory.github_broadcast"}}
 
 rule =91343
 alert = 9
@@ -1915,7 +1915,7 @@ decoder = json
 
 
 [GitHub Repository advisory github withdraw.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_advisory.github_withdraw","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_advisory.github_withdraw"}}
 
 rule =91344
 alert = 9
@@ -1923,7 +1923,7 @@ decoder = json
 
 
 [GitHub Repository advisory open.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_advisory.open","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_advisory.open"}}
 
 rule =91345
 alert = 7
@@ -1931,7 +1931,7 @@ decoder = json
 
 
 [GitHub Repository advisory publish.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_advisory.publish","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_advisory.publish"}}
 
 rule =91346
 alert = 7
@@ -1939,7 +1939,7 @@ decoder = json
 
 
 [GitHub Repository advisory reopen.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_advisory.reopen","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_advisory.reopen"}}
 
 rule =91347
 alert = 7
@@ -1947,7 +1947,7 @@ decoder = json
 
 
 [GitHub Repository advisory update.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_advisory.update","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_advisory.update"}}
 
 rule =91348
 alert = 7
@@ -1955,7 +1955,7 @@ decoder = json
 
 
 [GitHub Repository content analysis.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_content_analysis.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_content_analysis."}}
 
 rule =91349
 alert = 3
@@ -1963,7 +1963,7 @@ decoder = json
 
 
 [GitHub Repository content analysis enable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_content_analysis.enable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_content_analysis.enable"}}
 
 rule =91350
 alert = 5
@@ -1971,7 +1971,7 @@ decoder = json
 
 
 [GitHub Repository content analysis disable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_content_analysis.disable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_content_analysis.disable"}}
 
 rule =91351
 alert = 9
@@ -1979,7 +1979,7 @@ decoder = json
 
 
 [GitHub Repository dependency graph.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_dependency_graph.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_dependency_graph."}}
 
 rule =91352
 alert = 3
@@ -1987,7 +1987,7 @@ decoder = json
 
 
 [GitHub Repository dependency graph disable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_dependency_graph.disable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_dependency_graph.disable"}}
 
 rule =91353
 alert = 9
@@ -1995,7 +1995,7 @@ decoder = json
 
 
 [GitHub Repository dependency graph enable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_dependency_graph.enable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_dependency_graph.enable"}}
 
 rule =91354
 alert = 5
@@ -2003,7 +2003,7 @@ decoder = json
 
 
 [GitHub Repository projects change.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_projects_change.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_projects_change."}}
 
 rule =91355
 alert = 3
@@ -2011,7 +2011,7 @@ decoder = json
 
 
 [GitHub Repository projects change disable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_projects_change.disable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_projects_change.disable"}}
 
 rule =91356
 alert = 9
@@ -2019,7 +2019,7 @@ decoder = json
 
 
 [GitHub Repository projects change enable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_projects_change.enable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_projects_change.enable"}}
 
 rule =91357
 alert = 5
@@ -2027,7 +2027,7 @@ decoder = json
 
 
 [GitHub Repository secret scanning.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_secret_scanning.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_secret_scanning."}}
 
 rule =91358
 alert = 3
@@ -2035,7 +2035,7 @@ decoder = json
 
 
 [GitHub Repository secret scanning disable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_secret_scanning.disable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_secret_scanning.disable"}}
 
 rule =91359
 alert = 9
@@ -2043,7 +2043,7 @@ decoder = json
 
 
 [GitHub Repository secret scanning enable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_secret_scanning.enable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_secret_scanning.enable"}}
 
 rule =91360
 alert = 5
@@ -2051,7 +2051,7 @@ decoder = json
 
 
 [GitHub Repository vulnerability alert.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_vulnerability_alert.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_vulnerability_alert."}}
 
 rule =91361
 alert = 3
@@ -2059,7 +2059,7 @@ decoder = json
 
 
 [GitHub Repository vulnerability alert create.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_vulnerability_alert.create","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_vulnerability_alert.create"}}
 
 rule =91362
 alert = 12
@@ -2067,7 +2067,7 @@ decoder = json
 
 
 [GitHub Repository vulnerability alert dismiss.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_vulnerability_alert.dismiss","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_vulnerability_alert.dismiss"}}
 
 rule =91363
 alert = 9
@@ -2075,7 +2075,7 @@ decoder = json
 
 
 [GitHub Repository vulnerability alert resolve.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_vulnerability_alert.resolve","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_vulnerability_alert.resolve"}}
 
 rule =91364
 alert = 7
@@ -2083,7 +2083,7 @@ decoder = json
 
 
 [GitHub Repository vulnerability alerts.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_vulnerability_alerts.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_vulnerability_alerts."}}
 
 rule =91365
 alert = 3
@@ -2091,7 +2091,7 @@ decoder = json
 
 
 [GitHub Repository vulnerability alerts authorized users teams.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_vulnerability_alerts.authorized_users_teams","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_vulnerability_alerts.authorized_users_teams"}}
 
 rule =91366
 alert = 7
@@ -2099,7 +2099,7 @@ decoder = json
 
 
 [GitHub Repository vulnerability alerts disable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_vulnerability_alerts.disable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_vulnerability_alerts.disable"}}
 
 rule =91367
 alert = 12
@@ -2107,7 +2107,7 @@ decoder = json
 
 
 [GitHub Repository vulnerability alerts enable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_vulnerability_alerts.enable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"repository_vulnerability_alerts.enable"}}
 
 rule =91368
 alert = 5
@@ -2115,7 +2115,7 @@ decoder = json
 
 
 [GitHub Secret scanning.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"secret_scanning.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"secret_scanning."}}
 
 rule =91369
 alert = 3
@@ -2123,7 +2123,7 @@ decoder = json
 
 
 [GitHub Secret scanning disable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"secret_scanning.disable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"secret_scanning.disable"}}
 
 rule =91370
 alert = 9
@@ -2131,7 +2131,7 @@ decoder = json
 
 
 [GitHub Secret scanning enable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"secret_scanning.enable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"secret_scanning.enable"}}
 
 rule =91371
 alert = 5
@@ -2139,7 +2139,7 @@ decoder = json
 
 
 [GitHub Secret scanning new repos.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"secret_scanning_new_repos.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"secret_scanning_new_repos."}}
 
 rule =91372
 alert = 3
@@ -2147,7 +2147,7 @@ decoder = json
 
 
 [GitHub Secret scanning new repos disable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"secret_scanning_new_repos.disable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"secret_scanning_new_repos.disable"}}
 
 rule =91373
 alert = 9
@@ -2155,7 +2155,7 @@ decoder = json
 
 
 [GitHub Secret scanning new repos enable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"secret_scanning_new_repos.enable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"secret_scanning_new_repos.enable"}}
 
 rule =91374
 alert = 5
@@ -2163,7 +2163,7 @@ decoder = json
 
 
 [GitHub Sponsors.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors."}}
 
 rule =91375
 alert = 3
@@ -2171,7 +2171,7 @@ decoder = json
 
 
 [GitHub Sponsors custom amount settings change.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.custom_amount_settings_change","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.custom_amount_settings_change"}}
 
 rule =91376
 alert = 5
@@ -2179,7 +2179,7 @@ decoder = json
 
 
 [GitHub Sponsors repo funding links file action.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.repo_funding_links_file_action","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.repo_funding_links_file_action"}}
 
 rule =91377
 alert = 5
@@ -2187,7 +2187,7 @@ decoder = json
 
 
 [GitHub Sponsors sponsorship cancel.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.sponsor_sponsorship_cancel","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.sponsor_sponsorship_cancel"}}
 
 rule =91378
 alert = 5
@@ -2195,7 +2195,7 @@ decoder = json
 
 
 [GitHub Sponsors sponsorship create.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.sponsor_sponsorship_create","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.sponsor_sponsorship_create"}}
 
 rule =91379
 alert = 5
@@ -2203,7 +2203,7 @@ decoder = json
 
 
 [GitHub Sponsors sponsorship preference change.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.sponsor_sponsorship_preference_change","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.sponsor_sponsorship_preference_change"}}
 
 rule =91380
 alert = 5
@@ -2211,7 +2211,7 @@ decoder = json
 
 
 [GitHub Sponsors sponsorship tier change.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.sponsor_sponsorship_tier_change","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.sponsor_sponsorship_tier_change"}}
 
 rule =91381
 alert = 5
@@ -2219,7 +2219,7 @@ decoder = json
 
 
 [GitHub Sponsors sponsored developer approve.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.sponsored_developer_approve","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.sponsored_developer_approve"}}
 
 rule =91382
 alert = 5
@@ -2227,7 +2227,7 @@ decoder = json
 
 
 [GitHub Sponsors sponsored developer create.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.sponsored_developer_create","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.sponsored_developer_create"}}
 
 rule =91383
 alert = 5
@@ -2235,7 +2235,7 @@ decoder = json
 
 
 [GitHub Sponsors sponsored developer disable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.sponsored_developer_disable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.sponsored_developer_disable"}}
 
 rule =91384
 alert = 5
@@ -2243,7 +2243,7 @@ decoder = json
 
 
 [GitHub Sponsors sponsored developer redraft.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.sponsored_developer_redraft","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.sponsored_developer_redraft"}}
 
 rule =91385
 alert = 5
@@ -2251,7 +2251,7 @@ decoder = json
 
 
 [GitHub Sponsors sponsored developer profile update.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.sponsored_developer_profile_update","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.sponsored_developer_profile_update"}}
 
 rule =91386
 alert = 5
@@ -2259,7 +2259,7 @@ decoder = json
 
 
 [GitHub Sponsors sponsored developer request approval.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.sponsored_developer_request_approval","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.sponsored_developer_request_approval"}}
 
 rule =91387
 alert = 5
@@ -2267,7 +2267,7 @@ decoder = json
 
 
 [GitHub Sponsors sponsored developer tier description update.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.sponsored_developer_tier_description_update","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.sponsored_developer_tier_description_update"}}
 
 rule =91388
 alert = 5
@@ -2275,7 +2275,7 @@ decoder = json
 
 
 [GitHub Sponsors sponsored developer update newsletter send.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.sponsored_developer_update_newsletter_send","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.sponsored_developer_update_newsletter_send"}}
 
 rule =91389
 alert = 5
@@ -2283,7 +2283,7 @@ decoder = json
 
 
 [GitHub Sponsors waitlist invite sponsored developer.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.waitlist_invite_sponsored_developer","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.waitlist_invite_sponsored_developer"}}
 
 rule =91390
 alert = 5
@@ -2291,7 +2291,7 @@ decoder = json
 
 
 [GitHub Sponsors waitlist join.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.waitlist_join","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"sponsors.waitlist_join"}}
 
 rule =91391
 alert = 5
@@ -2299,7 +2299,7 @@ decoder = json
 
 
 [GitHub Team.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"team.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"team."}}
 
 rule =91392
 alert = 3
@@ -2307,7 +2307,7 @@ decoder = json
 
 
 [GitHub Team add member.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"team.add_member","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"team.add_member"}}
 
 rule =91393
 alert = 5
@@ -2315,7 +2315,7 @@ decoder = json
 
 
 [GitHub Team add repository.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"team.add_repository","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"team.add_repository"}}
 
 rule =91394
 alert = 5
@@ -2323,7 +2323,7 @@ decoder = json
 
 
 [GitHub Team change parent team.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"team.change_parent_team","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"team.change_parent_team"}}
 
 rule =91395
 alert = 7
@@ -2331,7 +2331,7 @@ decoder = json
 
 
 [GitHub Team change privacy.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"team.change_privacy","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"team.change_privacy"}}
 
 rule =91396
 alert = 7
@@ -2339,7 +2339,7 @@ decoder = json
 
 
 [GitHub Team create.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"team.create","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"team.create"}}
 
 rule =91397
 alert = 5
@@ -2347,7 +2347,7 @@ decoder = json
 
 
 [GitHub Team demote maintainer.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"team.demote_maintainer","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"team.demote_maintainer"}}
 
 rule =91398
 alert = 7
@@ -2355,7 +2355,7 @@ decoder = json
 
 
 [GitHub Team destroy.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"team.destroy","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"team.destroy"}}
 
 rule =91399
 alert = 7
@@ -2363,7 +2363,7 @@ decoder = json
 
 
 [GitHub Team promote maintainer.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"team.promote_maintainer","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"team.promote_maintainer"}}
 
 rule =91400
 alert = 7
@@ -2371,7 +2371,7 @@ decoder = json
 
 
 [GitHub Team remove member.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"team.remove_member","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"team.remove_member"}}
 
 rule =91401
 alert = 7
@@ -2379,7 +2379,7 @@ decoder = json
 
 
 [GitHub Team remove repository.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"team.remove_repository","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"team.remove_repository"}}
 
 rule =91402
 alert = 7
@@ -2387,7 +2387,7 @@ decoder = json
 
 
 [GitHub Team discussions.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"team_discussions.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"team_discussions."}}
 
 rule =91403
 alert = 3
@@ -2395,7 +2395,7 @@ decoder = json
 
 
 [GitHub Team discussions disable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"team_discussions.disable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"team_discussions.disable"}}
 
 rule =91404
 alert = 3
@@ -2403,7 +2403,7 @@ decoder = json
 
 
 [GitHub Team discussions enable.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"team_discussions.enable","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"team_discussions.enable"}}
 
 rule =91405
 alert = 3
@@ -2411,7 +2411,7 @@ decoder = json
 
 
 [GitHub Workflows.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"workflows.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"workflows."}}
 
 rule =91406
 alert = 3
@@ -2419,7 +2419,7 @@ decoder = json
 
 
 [GitHub Workflows cancel workflow run.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"workflows.cancel_workflow_run","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"workflows.cancel_workflow_run"}}
 
 rule =91407
 alert = 5
@@ -2427,7 +2427,7 @@ decoder = json
 
 
 [GitHub Workflows completed workflow run.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"workflows.completed_workflow_run","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"workflows.completed_workflow_run"}}
 
 rule =91408
 alert = 5
@@ -2435,7 +2435,7 @@ decoder = json
 
 
 [GitHub Workflows created workflow run.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"workflows.created_workflow_run","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"workflows.created_workflow_run"}}
 
 rule =91409
 alert = 5
@@ -2443,7 +2443,7 @@ decoder = json
 
 
 [GitHub Workflows delete workflow run.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"workflows.delete_workflow_run","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"workflows.delete_workflow_run"}}
 
 rule =91410
 alert = 5
@@ -2451,7 +2451,7 @@ decoder = json
 
 
 [GitHub Workflows disable workflow.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"workflows.disable_workflow","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"workflows.disable_workflow"}}
 
 rule =91411
 alert = 5
@@ -2459,7 +2459,7 @@ decoder = json
 
 
 [GitHub Workflows enable workflow.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"workflows.enable_workflow","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"workflows.enable_workflow"}}
 
 rule =91412
 alert = 5
@@ -2467,7 +2467,7 @@ decoder = json
 
 
 [GitHub Workflows rerun workflow run.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"workflows.rerun_workflow_run","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"workflows.rerun_workflow_run"}}
 
 rule =91413
 alert = 5
@@ -2475,7 +2475,7 @@ decoder = json
 
 
 [GitHub Workflows prepared workflow job.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"workflows.prepared_workflow_job","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"workflows.prepared_workflow_job"}}
 
 rule =91414
 alert = 5
@@ -2483,7 +2483,7 @@ decoder = json
 
 
 [GitHub Codespaces.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"codespaces.","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"codespaces."}}
 
 rule =91415
 alert = 3
@@ -2491,7 +2491,7 @@ decoder = json
 
 
 [GitHub Codespaces create.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"codespaces.create","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"codespaces.create"}}
 
 rule =91416
 alert = 5
@@ -2499,7 +2499,7 @@ decoder = json
 
 
 [GitHub Codespaces resume.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"codespaces.resume","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"codespaces.resume"}}
 
 rule =91417
 alert = 5
@@ -2507,7 +2507,7 @@ decoder = json
 
 
 [GitHub Codespaces delete.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"codespaces.delete","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"codespaces.delete"}}
 
 rule =91418
 alert = 7
@@ -2515,7 +2515,7 @@ decoder = json
 
 
 [GitHub Codespaces create an org secret.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"codespaces.create_an_org_secret","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"codespaces.create_an_org_secret"}}
 
 rule =91419
 alert = 5
@@ -2523,7 +2523,7 @@ decoder = json
 
 
 [GitHub Codespaces update an org secret.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"codespaces.update_an_org_secret","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"codespaces.update_an_org_secret"}}
 
 rule =91420
 alert = 7
@@ -2531,7 +2531,7 @@ decoder = json
 
 
 [GitHub Codespaces remove an org secret.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"codespaces.remove_an_org_secret","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"codespaces.remove_an_org_secret"}}
 
 rule =91421
 alert = 9
@@ -2539,7 +2539,7 @@ decoder = json
 
 
 [GitHub Codespaces manage access and security.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"codespaces.manage_access_and_security","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"codespaces.manage_access_and_security"}}
 
 rule =91422
 alert = 9
@@ -2547,7 +2547,7 @@ decoder = json
 
 
 [GitHub module internal event, 3 request fail.]
-log 1 pass = {"github":{"actor":"wazuh","created_at":1619032221869,"request":"request","response":"response","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"wazuh","created_at":1619032221869,"request":"request","response":"response"}}
 
 rule =91448
 alert = 3
@@ -2555,7 +2555,7 @@ decoder = json
 
 
 [GitHub Generic rule.]
-log 1 pass = {"github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"unknown","source":"github"}}
+log 1 pass = {"integration":"github","github":{"actor":"user","org":"organization","created_at":1619032221869,"action":"unknown"}}
 
 rule =91449
 alert = 3

--- a/src/unit_tests/wazuh_modules/github/test_wm_github.c
+++ b/src/unit_tests/wazuh_modules/github/test_wm_github.c
@@ -244,13 +244,13 @@ void test_github_scan_failure_action_2(void **state) {
 
     expect_value(__wrap_wm_sendmsg, usec, 1000000);
     expect_value(__wrap_wm_sendmsg, queue, 1);
-    expect_string(__wrap_wm_sendmsg, message, "{\"github\":{\"actor\":\"wazuh\",\"source\":\"github\",\"organization\":\"test_org\",\"response\":\"Unknown error\"}}");
+    expect_string(__wrap_wm_sendmsg, message, "{\"integration\":\"github\",\"github\":{\"actor\":\"wazuh\",\"organization\":\"test_org\",\"response\":\"Unknown error\"}}");
     expect_string(__wrap_wm_sendmsg, locmsg, "github");
     expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
     will_return(__wrap_wm_sendmsg, result);
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:github");
-    expect_string(__wrap__mtdebug2, formatted_msg, "Sending GitHub internal message: '{\"github\":{\"actor\":\"wazuh\",\"source\":\"github\",\"organization\":\"test_org\",\"response\":\"Unknown error\"}}'");
+    expect_string(__wrap__mtdebug2, formatted_msg, "Sending GitHub internal message: '{\"integration\":\"github\",\"github\":{\"actor\":\"wazuh\",\"organization\":\"test_org\",\"response\":\"Unknown error\"}}'");
 
     wm_github_scan_failure_action(&data->github_config->fails, org_name, error_msg, queue_fd);
 
@@ -273,13 +273,13 @@ void test_github_scan_failure_action_error(void **state) {
 
     expect_value(__wrap_wm_sendmsg, usec, 1000000);
     expect_value(__wrap_wm_sendmsg, queue, 1);
-    expect_string(__wrap_wm_sendmsg, message, "{\"github\":{\"actor\":\"wazuh\",\"source\":\"github\",\"organization\":\"test_org\",\"response\":\"Unknown error\"}}");
+    expect_string(__wrap_wm_sendmsg, message, "{\"integration\":\"github\",\"github\":{\"actor\":\"wazuh\",\"organization\":\"test_org\",\"response\":\"Unknown error\"}}");
     expect_string(__wrap_wm_sendmsg, locmsg, "github");
     expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
     will_return(__wrap_wm_sendmsg, result);
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:github");
-    expect_string(__wrap__mtdebug2, formatted_msg, "Sending GitHub internal message: '{\"github\":{\"actor\":\"wazuh\",\"source\":\"github\",\"organization\":\"test_org\",\"response\":\"Unknown error\"}}'");
+    expect_string(__wrap__mtdebug2, formatted_msg, "Sending GitHub internal message: '{\"integration\":\"github\",\"github\":{\"actor\":\"wazuh\",\"organization\":\"test_org\",\"response\":\"Unknown error\"}}'");
 
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:github");
     expect_string(__wrap__mterror, formatted_msg, "(1210): Queue 'queue/sockets/queue' not accessible: 'Success'");
@@ -530,13 +530,13 @@ void test_github_execute_scan_status_code_200_null(void **state) {
 
     expect_value(__wrap_wm_sendmsg, usec, 1000000);
     expect_value(__wrap_wm_sendmsg, queue, 0);
-    expect_string(__wrap_wm_sendmsg, message, "{\"github\":{\"actor\":\"wazuh\",\"source\":\"github\"}}");
+    expect_string(__wrap_wm_sendmsg, message, "{\"integration\":\"github\",\"github\":{\"actor\":\"wazuh\"}}");
     expect_string(__wrap_wm_sendmsg, locmsg, "github");
     expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
     will_return(__wrap_wm_sendmsg, 0);
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:github");
-    expect_string(__wrap__mtdebug2, formatted_msg, "Sending GitHub log: '{\"github\":{\"actor\":\"wazuh\",\"source\":\"github\"}}'");
+    expect_string(__wrap__mtdebug2, formatted_msg, "Sending GitHub log: '{\"integration\":\"github\",\"github\":{\"actor\":\"wazuh\"}}'");
 
     expect_string(__wrap_wm_state_io, tag, "github-test_org");
     expect_value(__wrap_wm_state_io, op, WM_IO_WRITE);

--- a/src/wazuh_modules/wm_github.c
+++ b/src/wazuh_modules/wm_github.c
@@ -254,7 +254,7 @@ STATIC int wm_github_execute_scan(wm_github *github_config, int initial_scan) {
                             if (subitem) {
                                 cJSON * github = cJSON_CreateObject();
 
-                                cJSON_AddStringToObject(subitem, "source", WM_GITHUB_CONTEXT.name);
+                                cJSON_AddStringToObject(github, "integration", WM_GITHUB_CONTEXT.name);
                                 cJSON_AddItemToObject(github, "github", cJSON_Duplicate(subitem, true));
 
                                 payload = cJSON_PrintUnformatted(github);
@@ -407,7 +407,6 @@ STATIC void wm_github_scan_failure_action(wm_github_fail **current_fails, char *
             cJSON *fail_github = cJSON_CreateObject();
 
             cJSON_AddStringToObject(fail_object, "actor", "wazuh");
-            cJSON_AddStringToObject(fail_object, "source", WM_GITHUB_CONTEXT.name);
             cJSON_AddStringToObject(fail_object, "organization", org_name);
 
             if (msg_obj) {
@@ -418,6 +417,7 @@ STATIC void wm_github_scan_failure_action(wm_github_fail **current_fails, char *
                 cJSON_AddStringToObject(fail_object, "response", "Unknown error");
             }
 
+            cJSON_AddStringToObject(fail_github, "integration", WM_GITHUB_CONTEXT.name);
             cJSON_AddItemToObject(fail_github, "github", fail_object);
 
             payload = cJSON_PrintUnformatted(fail_github);


### PR DESCRIPTION
## Description

This issue modifies the way that GitHub audit-logs match rules.

The main field to detect GitHub logs was renamed from `github.source` to `integration`, just to be the same as the other integrations of Wazuh.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
