### PR TITLE
Updating last synchronization timestamp in agent's DB after a successful checksum comparison

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND wdb_tests_names "test_wdb_integrity")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug1 -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,sqlite3_step -Wl,--wrap,sqlite3_errmsg \
                          -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,EVP_DigestInit_ex -Wl,--wrap,EVP_DigestUpdate -Wl,--wrap,_DigestFinal_ex \
-                         -Wl,--wrap,sqlite3_bind_int64 -Wl,--wrap,sqlite3_column_text -Wl,--wrap,_mdebug2 -Wl,--wrap,wdb_exec_stmt")
+                         -Wl,--wrap,sqlite3_bind_int64 -Wl,--wrap,sqlite3_column_text -Wl,--wrap,_mdebug2 -Wl,--wrap,wdb_exec_stmt -Wl,--wrap,time")
 
 # Add server specific tests to the list
 list(APPEND wdb_tests_names "test_wdb_fim")

--- a/src/unit_tests/wazuh_db/test_wdb_integrity.c
+++ b/src/unit_tests/wazuh_db/test_wdb_integrity.c
@@ -1272,6 +1272,8 @@ void test_wdbi_check_sync_status_data_not_synced_checksum_no_data(void **state)
     assert_int_equal (ret_val, 0);
 }
 
+
+
 void test_wdbi_check_sync_status_data_not_synced_checksum_valid(void **state)
 {
     int ret_val = -1;
@@ -1309,7 +1311,7 @@ void test_wdbi_check_sync_status_data_not_synced_checksum_valid(void **state)
 
     will_return(__wrap_time, timestamp);
 
-    // wdbi_set_last_completion_only
+    // wdbi_set_last_completion
     will_return(__wrap_wdb_stmt_cache, 0);
     will_return(__wrap_sqlite3_bind_int64, 0);
     expect_value(__wrap_sqlite3_bind_int64, index, 1);
@@ -1324,6 +1326,32 @@ void test_wdbi_check_sync_status_data_not_synced_checksum_valid(void **state)
 
     assert_int_equal (ret_val, 1);
 }
+
+// Test wdbi_last_completion
+
+void test_wdbi_last_completion_step_fail(void **state)
+{
+    wdb_t * data = *state;
+    data->id = strdup("000");
+    unsigned int timestamp = 10000;
+
+    will_return(__wrap_wdb_stmt_cache, 0);
+    will_return(__wrap_sqlite3_bind_int64, 0);
+    expect_value(__wrap_sqlite3_bind_int64, index, 1);
+    expect_value(__wrap_sqlite3_bind_int64, value, timestamp);
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "syscollector-packages");
+    will_return(__wrap_sqlite3_step, 0);
+    will_return(__wrap_sqlite3_step, SQLITE_ERROR);
+
+    will_return(__wrap_sqlite3_errmsg, "ERROR_MESSAGE");
+    expect_string(__wrap__mdebug1, formatted_msg, "DB(000) sqlite3_step(): ERROR_MESSAGE");
+
+    wdbi_set_last_completion(data, WDB_SYSCOLLECTOR_PACKAGES, timestamp);
+
+}
+
 
 int main(void) {
     const struct CMUnitTest tests[] = {
@@ -1408,6 +1436,9 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_wdbi_check_sync_status_data_not_synced_error_checksum, setup_wdb_t, teardown_wdb_t),
         cmocka_unit_test_setup_teardown(test_wdbi_check_sync_status_data_not_synced_checksum_no_data, setup_wdb_t, teardown_wdb_t),
         cmocka_unit_test_setup_teardown(test_wdbi_check_sync_status_data_not_synced_checksum_valid, setup_wdb_t, teardown_wdb_t),
+
+        // Test wdbi_last_completion
+        cmocka_unit_test_setup_teardown(test_wdbi_last_completion_step_fail, setup_wdb_t, teardown_wdb_t),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/unit_tests/wazuh_db/test_wdb_integrity.c
+++ b/src/unit_tests/wazuh_db/test_wdb_integrity.c
@@ -1272,8 +1272,6 @@ void test_wdbi_check_sync_status_data_not_synced_checksum_no_data(void **state)
     assert_int_equal (ret_val, 0);
 }
 
-
-
 void test_wdbi_check_sync_status_data_not_synced_checksum_valid(void **state)
 {
     int ret_val = -1;
@@ -1351,7 +1349,6 @@ void test_wdbi_last_completion_step_fail(void **state)
     wdbi_set_last_completion(data, WDB_SYSCOLLECTOR_PACKAGES, timestamp);
 
 }
-
 
 int main(void) {
     const struct CMUnitTest tests[] = {

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -122,6 +122,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_SYNC_UPDATE_ATTEMPT_LEGACY] = "UPDATE sync_info SET last_attempt = ? WHERE component = ?;",
     [WDB_STMT_SYNC_UPDATE_ATTEMPT] = "UPDATE sync_info SET last_attempt = ?, last_agent_checksum = ?, n_attempts = n_attempts + 1 WHERE component = ?;",
     [WDB_STMT_SYNC_UPDATE_COMPLETION] = "UPDATE sync_info SET last_attempt = ?, last_completion = ?, last_agent_checksum = ?, n_attempts = n_attempts + 1, n_completions = n_completions + 1 WHERE component = ?;",
+    [WDB_STMT_SYNC_SET_COMPLETION] = "UPDATE sync_info SET last_completion = ? WHERE component = ?;",
     [WDB_STMT_SYNC_GET_INFO] = "SELECT * FROM sync_info WHERE component = ?;",
     [WDB_STMT_MITRE_NAME_GET] = "SELECT name FROM attack WHERE id = ?;",
     [WDB_STMT_FIM_FILE_SELECT_CHECKSUM] = "SELECT checksum FROM fim_entry WHERE type='file' ORDER BY file;",

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -1271,7 +1271,7 @@ void wdbi_update_attempt(wdb_t * wdb, wdb_component_t component, long timestamp,
 
 void wdbi_update_completion(wdb_t * wdb, wdb_component_t component, long timestamp, os_sha1 checksum);
 
-void wdbi_set_last_completion_only(wdb_t * wdb, wdb_component_t component, long timestamp);
+void wdbi_set_last_completion(wdb_t * wdb, wdb_component_t component, long timestamp);
 
 int wdbi_check_sync_status(wdb_t *wdb, wdb_component_t component);
 

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -149,6 +149,7 @@ typedef enum wdb_stmt {
     WDB_STMT_SYNC_UPDATE_ATTEMPT_LEGACY,
     WDB_STMT_SYNC_UPDATE_ATTEMPT,
     WDB_STMT_SYNC_UPDATE_COMPLETION,
+    WDB_STMT_SYNC_SET_COMPLETION,
     WDB_STMT_SYNC_GET_INFO,
     WDB_STMT_MITRE_NAME_GET,
     WDB_STMT_FIM_FILE_SELECT_CHECKSUM,
@@ -1269,6 +1270,8 @@ int wdbi_delete(wdb_t * wdb, wdb_component_t component, const char * begin, cons
 void wdbi_update_attempt(wdb_t * wdb, wdb_component_t component, long timestamp, bool legacy, os_sha1 checksum);
 
 void wdbi_update_completion(wdb_t * wdb, wdb_component_t component, long timestamp, os_sha1 checksum);
+
+void wdbi_set_last_completion_only(wdb_t * wdb, wdb_component_t component, long timestamp);
 
 int wdbi_check_sync_status(wdb_t *wdb, wdb_component_t component);
 

--- a/src/wazuh_db/wdb_integrity.c
+++ b/src/wazuh_db/wdb_integrity.c
@@ -299,7 +299,8 @@ void wdbi_update_attempt(wdb_t * wdb, wdb_component_t component, long timestamp,
  *
  * @param wdb Database node.
  * @param component Name of the component.
- * @param timestamp Synchronization event timestamp (field "id");
+ * @param timestamp Synchronization event timestamp (field "id").
+ * @param last_agent_checksum The last global checksum received from the agent.
  */
 
 void wdbi_update_completion(wdb_t * wdb, wdb_component_t component, long timestamp, os_sha1 last_agent_checksum) {
@@ -316,6 +317,34 @@ void wdbi_update_completion(wdb_t * wdb, wdb_component_t component, long timesta
     sqlite3_bind_int64(stmt, 2, timestamp);
     sqlite3_bind_text(stmt, 3, last_agent_checksum, -1, NULL);
     sqlite3_bind_text(stmt, 4, COMPONENT_NAMES[component], -1, NULL);
+
+    if (sqlite3_step(stmt) != SQLITE_DONE) {
+        mdebug1("DB(%s) sqlite3_step(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+    }
+}
+
+/**
+ * @brief This methods updates only the "last_completion" column.
+ *
+ * The rest of the columns, "last_attempt", "n_attempts" and "n_completions", are not modified.
+ * It should be called after a positive checksum comparison to avoid repeated calculations.
+ *
+ * @param wdb Database node.
+ * @param component Name of the component.
+ * @param timestamp Synchronization event timestamp.
+ */
+void wdbi_set_last_completion_only(wdb_t * wdb, wdb_component_t component, long timestamp) {
+
+    assert(wdb != NULL);
+
+    if (wdb_stmt_cache(wdb, WDB_STMT_SYNC_SET_COMPLETION) == -1) {
+        return;
+    }
+
+    sqlite3_stmt * stmt = wdb->stmt[WDB_STMT_SYNC_SET_COMPLETION];
+
+    sqlite3_bind_int64(stmt, 1, timestamp);
+    sqlite3_bind_text(stmt, 2, COMPONENT_NAMES[component], -1, NULL);
 
     if (sqlite3_step(stmt) != SQLITE_DONE) {
         mdebug1("DB(%s) sqlite3_step(): %s", wdb->id, sqlite3_errmsg(wdb->db));
@@ -579,7 +608,7 @@ int wdbi_check_sync_status(wdb_t *wdb, wdb_component_t component) {
         char *checksum = cJSON_GetStringValue(j_checksum);
 
         // Return 0 if there was not at least one successful syncronization or
-        // if the syncronization is in process or there was an error in the syncronization
+        // if the syncronization is in progress or there was an error in the syncronization
         if (last_completion != 0 && last_attempt <= last_completion) {
             result = 1;
         }
@@ -598,6 +627,10 @@ int wdbi_check_sync_status(wdb_t *wdb, wdb_component_t component) {
 
             case 1:
                 result = !strcmp(hexdigest, checksum);
+                // Updating last_completion timestamp to avoid calculating the checksum again
+                if (1 == result) {
+                    wdbi_set_last_completion_only(wdb, component, (unsigned)time(NULL));
+                }
             }
         }
     } else {

--- a/src/wazuh_db/wdb_integrity.c
+++ b/src/wazuh_db/wdb_integrity.c
@@ -324,16 +324,15 @@ void wdbi_update_completion(wdb_t * wdb, wdb_component_t component, long timesta
 }
 
 /**
- * @brief This methods updates only the "last_completion" column.
+ * @brief This methods updates the "last_completion" value.
  *
- * The rest of the columns, "last_attempt", "n_attempts" and "n_completions", are not modified.
  * It should be called after a positive checksum comparison to avoid repeated calculations.
  *
  * @param wdb Database node.
  * @param component Name of the component.
  * @param timestamp Synchronization event timestamp.
  */
-void wdbi_set_last_completion_only(wdb_t * wdb, wdb_component_t component, long timestamp) {
+void wdbi_set_last_completion(wdb_t * wdb, wdb_component_t component, long timestamp) {
 
     assert(wdb != NULL);
 
@@ -629,7 +628,7 @@ int wdbi_check_sync_status(wdb_t *wdb, wdb_component_t component) {
                 result = !strcmp(hexdigest, checksum);
                 // Updating last_completion timestamp to avoid calculating the checksum again
                 if (1 == result) {
-                    wdbi_set_last_completion_only(wdb, component, (unsigned)time(NULL));
+                    wdbi_set_last_completion(wdb, component, (unsigned)time(NULL));
                 }
             }
         }

--- a/src/wazuh_db/wdb_integrity.c
+++ b/src/wazuh_db/wdb_integrity.c
@@ -324,7 +324,7 @@ void wdbi_update_completion(wdb_t * wdb, wdb_component_t component, long timesta
 }
 
 /**
- * @brief This methods updates the "last_completion" value.
+ * @brief This method updates the "last_completion" value.
  *
  * It should be called after a positive checksum comparison to avoid repeated calculations.
  *


### PR DESCRIPTION
|Related issue|
|---|
|#8694|

## Description

This PR adds another method to update the `last_completion` timestamp in `sync_info` table.
It is called after performing a global checksum calculation to avoid repeating this process.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Source installation
- Memory tests for Linux
  - [x] Valgrind (memcheck and descriptor leaks check)
- [x] Added unit tests (for new features)
