### PR TITLE
[8704] Fixed data provider network interfaces in cases where unsupported net family is present

### DIFF
--- a/src/data_provider/src/network/networkInterfaceBSD.cpp
+++ b/src/data_provider/src/network/networkInterfaceBSD.cpp
@@ -1,6 +1,6 @@
 /*
  * Wazuh SYSINFO
- * Copyright (C) 2015-2020, Wazuh Inc.
+ * Copyright (C) 2015-2021, Wazuh Inc.
  * October 24, 2020.
  *
  * This program is free software; you can redistribute it
@@ -32,10 +32,7 @@ std::shared_ptr<IOSNetwork> FactoryBSDNetwork::create(const std::shared_ptr<INet
         {
             ret = std::make_shared<BSDNetworkImpl<AF_LINK>>(interfaceWrapper);
         }
-        else
-        {
-            throw std::runtime_error { "Error creating BSD network data retriever." };
-        }
+        // else: The current interface family is not supported
     }
     else
     {

--- a/src/data_provider/src/network/networkInterfaceLinux.cpp
+++ b/src/data_provider/src/network/networkInterfaceLinux.cpp
@@ -1,6 +1,6 @@
 /*
  * Wazuh SYSINFO
- * Copyright (C) 2015-2020, Wazuh Inc.
+ * Copyright (C) 2015-2021, Wazuh Inc.
  * October 24, 2020.
  *
  * This program is free software; you can redistribute it
@@ -34,10 +34,7 @@ std::shared_ptr<IOSNetwork> FactoryLinuxNetwork::create(const std::shared_ptr<IN
         {
             ret = std::make_shared<LinuxNetworkImpl<AF_PACKET>>(interfaceWrapper);
         }
-        else
-        {
-            throw std::runtime_error { "Error creating linux network data retriever." };
-        }
+        // else: The current interface family is not supported
     }
     else
     {

--- a/src/data_provider/src/network/networkInterfaceWindows.cpp
+++ b/src/data_provider/src/network/networkInterfaceWindows.cpp
@@ -1,6 +1,6 @@
 /*
  * Wazuh SYSINFO
- * Copyright (C) 2015-2020, Wazuh Inc.
+ * Copyright (C) 2015-2021, Wazuh Inc.
  * November 4, 2020.
  *
  * This program is free software; you can redistribute it
@@ -34,10 +34,7 @@ std::shared_ptr<IOSNetwork> FactoryWindowsNetwork::create(const std::shared_ptr<
         {
             ret = std::make_shared<WindowsNetworkImpl<Utils::NetworkWindowsHelper::COMMON_DATA>>(interfaceWrapper);
         }
-        else
-        {
-            throw std::runtime_error { "Error creating Windows network data retriever." };
-        }
+        // else: The current interface family is not supported
     }
     else
     {

--- a/src/data_provider/src/sysInfoCommonBSD.cpp
+++ b/src/data_provider/src/sysInfoCommonBSD.cpp
@@ -1,6 +1,6 @@
 /*
  * Wazuh SysInfo
- * Copyright (C) 2015-2020, Wazuh Inc.
+ * Copyright (C) 2015-2021, Wazuh Inc.
  * October 7, 2020.
  *
  * This program is free software; you can redistribute it
@@ -85,7 +85,11 @@ nlohmann::json SysInfo::getNetworks() const
         nlohmann::json ifaddr {};
         for (const auto addr : interface.second)
         {
-            FactoryNetworkFamilyCreator<OSType::BSDBASED>::create(std::make_shared<NetworkBSDInterface>(addr))->buildNetworkData(ifaddr);
+            const auto networkInterfacePtr { FactoryNetworkFamilyCreator<OSType::BSDBASED>::create(std::make_shared<NetworkBSDInterface>(addr)) };
+            if (networkInterfacePtr)
+            {
+                networkInterfacePtr->buildNetworkData(ifaddr);
+            }
         }
         networks["iface"].push_back(ifaddr);
     }

--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -1,6 +1,6 @@
 /*
  * Wazuh SysInfo
- * Copyright (C) 2015-2020, Wazuh Inc.
+ * Copyright (C) 2015-2021, Wazuh Inc.
  * October 7, 2020.
  *
  * This program is free software; you can redistribute it
@@ -373,7 +373,11 @@ nlohmann::json SysInfo::getNetworks() const
 
         for (auto addr : interface.second)
         {
-            FactoryNetworkFamilyCreator<OSType::LINUX>::create(std::make_shared<NetworkLinuxInterface>(addr))->buildNetworkData(ifaddr);
+            const auto networkInterfacePtr { FactoryNetworkFamilyCreator<OSType::LINUX>::create(std::make_shared<NetworkLinuxInterface>(addr)) };
+            if (networkInterfacePtr)
+            {
+                networkInterfacePtr->buildNetworkData(ifaddr);
+            }
         }
         networks["iface"].push_back(ifaddr);
     }

--- a/src/data_provider/tests/sysInfoNetworkBSD/sysInfoNetworkBSD_test.cpp
+++ b/src/data_provider/tests/sysInfoNetworkBSD/sysInfoNetworkBSD_test.cpp
@@ -133,14 +133,6 @@ TEST_F(SysInfoNetworkBSDTest, Test_AF_LINK)
     EXPECT_EQ("8.8.4.4",ifaddr.at("gateway").get_ref<const std::string&>());
 }
 
-TEST_F(SysInfoNetworkBSDTest, Test_AF_UNSPEC_THROW)
-{
-    auto mock { std::make_shared<SysInfoNetworkBSDWrapperMock>() };
-    nlohmann::json ifaddr {};
-    EXPECT_CALL(*mock, family()).Times(1).WillOnce(Return(AF_UNSPEC));
-    EXPECT_ANY_THROW(FactoryNetworkFamilyCreator<OSType::BSDBASED>::create(mock)->buildNetworkData(ifaddr));
-}
-
 TEST_F(SysInfoNetworkBSDTest, Test_AF_UNSPEC_THROW_NULLPTR)
 {
     nlohmann::json ifaddr {};

--- a/src/data_provider/tests/sysInfoNetworkLinux/sysInfoNetworkLinux_test.cpp
+++ b/src/data_provider/tests/sysInfoNetworkLinux/sysInfoNetworkLinux_test.cpp
@@ -137,14 +137,6 @@ TEST_F(SysInfoNetworkLinuxTest, Test_AF_PACKET)
     EXPECT_EQ("10.2.2.50",ifaddr.at("gateway").get_ref<const std::string&>());
 }
 
-TEST_F(SysInfoNetworkLinuxTest, Test_AF_UNSPEC_THROW)
-{
-    auto mock { std::make_shared<SysInfoNetworkLinuxWrapperMock>() };
-    nlohmann::json ifaddr {};
-    EXPECT_CALL(*mock, family()).Times(1).WillOnce(Return(AF_UNSPEC));
-    EXPECT_ANY_THROW(FactoryNetworkFamilyCreator<OSType::LINUX>::create(mock)->buildNetworkData(ifaddr));
-}
-
 TEST_F(SysInfoNetworkLinuxTest, Test_AF_UNSPEC_THROW_NULLPTR)
 {
     nlohmann::json ifaddr {};

--- a/src/data_provider/tests/sysInfoNetworkWindows/sysInfoNetworkWindows_test.cpp
+++ b/src/data_provider/tests/sysInfoNetworkWindows/sysInfoNetworkWindows_test.cpp
@@ -64,14 +64,6 @@ TEST_F(SysInfoNetworkWindowsTest, Test_IPV6_THROW)
     EXPECT_ANY_THROW(FactoryNetworkFamilyCreator<OSType::WINDOWS>::create(mock)->buildNetworkData(networkInfo));
 }
 
-TEST_F(SysInfoNetworkWindowsTest, Test_AF_UNSPEC_THROW)
-{
-    auto mock { std::make_shared<SysInfoNetworkWindowsWrapperMock>() };
-    nlohmann::json networkInfo {};
-    EXPECT_CALL(*mock, family()).Times(1).WillOnce(Return(Utils::NetworkWindowsHelper::UNDEF));
-    EXPECT_ANY_THROW(FactoryNetworkFamilyCreator<OSType::WINDOWS>::create(mock)->buildNetworkData(networkInfo));
-}
-
 TEST_F(SysInfoNetworkWindowsTest, Test_AF_UNSPEC_THROW_NULLPTR)
 {
     nlohmann::json networkInfo {};


### PR DESCRIPTION
|Related issue|
|---|
|Closes #8704 |

## Description
This issue has been discovered by @tinachoB, in common usage tests. In scenarios where VPN connections are up and running, the data provider module fails trying to obtain network interfaces information.

**Steps to reproduce.**

1. connect using VPN or any TUN family interface.
2. Installs, register and start the agent.
3. Check logs.

**Actual:**
Exception throw and log printing.

**Expected:**
No exception thrown

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
  - [X] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
