### PR TITLE
8703 wrong os name in syscollector scan

### DIFF
--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -281,12 +281,12 @@ static bool getOsInfoFromFiles(nlohmann::json& info)
         {"centos",      CENTOS_RELEASE_FILE     },
         {"fedora",      "/etc/fedora-release"   },
         {"rhel",        "/etc/redhat-release"   },
-        {"ubuntu",      "/etc/lsb-release"      },
         {"gentoo",      "/etc/gentoo-release"   },
         {"suse",        "/etc/SuSE-release"     },
         {"arch",        "/etc/arch-release"     },
         {"debian",      "/etc/debian_version"   },
         {"slackware",   "/etc/slackware-version"},
+        {"ubuntu",      "/etc/lsb-release"      },
     };
     const auto parseFnc
     {

--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -313,7 +313,11 @@ static bool getOsInfoFromFiles(nlohmann::json& info)
     {
         for (const auto& platform : PLATFORMS_RELEASE_FILES)
         {
-            ret |= parseFnc(platform.second, platform.first);
+            if(parseFnc(platform.second, platform.first))
+            {
+                ret = true;
+                break;
+            }
         }
     }
     return ret;


### PR DESCRIPTION
|Related issue|
|---|
|Closes #8703|

## Description
This PR aims to fix the issue found in rhel 6 related to OS name scanning in new syscollector.

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
