### PR TITLE
[8685] scan-build fix win

### DIFF
--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -82,8 +82,12 @@ bool connect_server(int server_id, bool verbose)
 
     /* The hostname was not resolved correctly */
     if (tmp_str == NULL || *tmp_str == '\0') {
-        int rip_l = strlen(agt->server[server_id].rip);
-        mdebug2("Could not resolve hostname '%.*s'", agt->server[server_id].rip[rip_l - 1] == '/' ? rip_l - 1 : rip_l, agt->server[server_id].rip);
+        if (agt->server[server_id].rip != NULL) {
+            const int rip_l = strlen(agt->server[server_id].rip);
+            mdebug2("Could not resolve hostname '%.*s'", agt->server[server_id].rip[rip_l - 1] == '/' ? rip_l - 1 : rip_l, agt->server[server_id].rip);
+        } else {
+            mdebug2("Could not resolve hostname");
+        }
 
         return false;
     }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #8685 |

## Description

Execute scanbuild and coverity in dev-footprint-reduction branch.

scan-build in Windows reported the following error:
![image](https://user-images.githubusercontent.com/22640902/118561361-3da65400-b741-11eb-904b-dc9bbc7ca40b.png)

With the current fix:
![image](https://user-images.githubusercontent.com/22640902/118561436-57479b80-b741-11eb-96ee-36af8235bdfb.png)

## DoD:
- [X] Implement scan-build fix
- [ ] PR Checks