### PR TITLE
Fixes memleak in logcollector

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -661,7 +661,11 @@ void LogCollectorStart()
                         mdebug1("File inode changed. %s",
                                current->file);
 
-                        OSHash_Delete_ex(files_status,current->file);
+                        os_file_status_t * old_file_status = OSHash_Delete_ex(files_status, current->file);
+                        if (old_file_status != NULL) {
+                            os_free(old_file_status);
+                        }
+
                         fclose(current->fp);
 
 #ifdef WIN32
@@ -693,7 +697,11 @@ void LogCollectorStart()
                                 current->file);
 
                         /* Get new file */
-                        OSHash_Delete_ex(files_status,current->file);
+                        os_file_status_t * old_file_status = OSHash_Delete_ex(files_status, current->file);
+                        if (old_file_status != NULL) {
+                            os_free(old_file_status);
+                        }
+
                         fclose(current->fp);
 
 #ifdef WIN32


### PR DESCRIPTION
|Related issue|
|---|
|Closes #8710|


Hi Team!,

This PR fixes memory leaks in logcollector when a file is truncated or rotated, frees memory from the state table node.

[Valgrind Report](https://github.com/wazuh/wazuh/files/6497338/Valgrind_PR.log)


Regards,
Julian

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
