### PR TITLE
Fix API unittests so tmp files are not created

### DIFF
--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -12,7 +12,7 @@ import random
 import struct
 import traceback
 from importlib import import_module
-from typing import Tuple, Dict, Callable
+from typing import Tuple, Dict, Callable, List
 from uuid import uuid4
 
 import cryptography.fernet
@@ -314,7 +314,7 @@ class Handler(asyncio.Protocol):
         self.counter = (self.counter + 1) % (2 ** 32)
         return self.counter
 
-    def msg_build(self, command: bytes, counter: int, data: bytes) -> list[bytearray]:
+    def msg_build(self, command: bytes, counter: int, data: bytes) -> List[bytearray]:
         """Build messages with header + payload.
 
         Each message contains a header in self.header_format format that includes self.counter, the data size and the

--- a/framework/wazuh/core/tests/test_configuration.py
+++ b/framework/wazuh/core/tests/test_configuration.py
@@ -268,7 +268,8 @@ def test_get_internal_options_value():
         assert configuration.get_internal_options_value('ossec', 'python', 5, 1) == 1
 
 
-def test_upload_group_configuration():
+@patch('builtins.open')
+def test_upload_group_configuration(mock_open):
     with pytest.raises(WazuhError, match=".* 1710 .*"):
         configuration.upload_group_configuration('noexists', 'noexists')
 

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -424,11 +424,12 @@ def test_agent_delete_agents(socket_mock, send_mock, mock_remove, agent_list, fi
 @patch('wazuh.core.agent.chmod')
 @patch('wazuh.core.agent.common.wazuh_uid')
 @patch('wazuh.core.agent.common.wazuh_gid')
+@patch('wazuh.core.agent.tempfile.mkstemp', return_value=['handle', 'output'])
 @patch('wazuh.core.agent.safe_move')
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
-def test_agent_add_agent(socket_mock, send_mock, safe_move_mock, common_gid_mock, common_uid_mock, chmod_mock,
-                         chown_mock, release_mock, acquire_mock, fcntl_mock, name, agent_id, key):
+def test_agent_add_agent(socket_mock, send_mock, safe_move_mock, tempfile_mock, common_gid_mock, common_uid_mock,
+                         chmod_mock, chown_mock, release_mock, acquire_mock, fcntl_mock, name, agent_id, key):
     """Test `add_agent` from agent module.
 
     Parameters

--- a/framework/wazuh/tests/test_cdb_list.py
+++ b/framework/wazuh/tests/test_cdb_list.py
@@ -365,10 +365,11 @@ def test_upload_list_file_ko(mock_remove, mock_lists_path):
             assert result.render()['data']['failed_items'][0]['error']['code'] == 1019
 
         # Exception while trying to create list file
-        with patch('wazuh.cdb_list.exists', return_value=False):
-            with patch('wazuh.core.configuration.tempfile.mkstemp', return_value=['mock_handle', 'mock_tmp_file']):
-                with pytest.raises(WazuhInternalError, match=r'\b1005\b'):
-                    upload_list_file(filename='test', content='test:content', overwrite=False)
+        with patch('builtins.open'):
+            with patch('wazuh.cdb_list.exists', return_value=False):
+                with patch('wazuh.core.configuration.tempfile.mkstemp', return_value=['mock_handle', 'mock_tmp_file']):
+                    with pytest.raises(WazuhInternalError, match=r'\b1005\b'):
+                        upload_list_file(filename='test', content='test:content', overwrite=False)
 
 
 @patch('wazuh.core.cdb_list.delete_wazuh_file')


### PR DESCRIPTION
|Related issue|
|---|
| Closes #8539 |

## Description

Hello team!

This PR fixes the unittests that, as reported in #8539, were leaving some tmp files behind when run. 

The problem was that some functions like `tempfile.mkstemp` or `builtins.open` were not mocked, so the files were actually being created. Now it is working as expected.

Regards,
Selu.