### PR TITLE
Allow cluster to send and receive messages higher than request_chunk

### DIFF
--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -423,10 +423,11 @@ class Handler(asyncio.Protocol):
 
         while parsed:
             if self.in_msg.received == self.in_msg.total:
-                # Decrypt received message if it is not a divided one
+                # Decrypt received message if it is not a part of a divided message
                 try:
                     decrypted_payload = self.my_fernet.decrypt(bytes(self.in_msg.payload)) if self.my_fernet is not \
-                        None and not self.in_msg.flag_divided else bytes(self.in_msg.payload)
+                        None and not self.in_msg.flag_divided and self.in_msg.counter not in self.div_msg_box \
+                        else bytes(self.in_msg.payload)
                 except cryptography.fernet.InvalidToken:
                     raise exception.WazuhClusterError(3025)
                 yield self.in_msg.cmd, self.in_msg.counter, decrypted_payload, self.in_msg.flag_divided

--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -57,6 +57,9 @@ class InBuffer:
     Define a buffer to receive incoming requests.
     """
 
+    divide_flag = b' d'  # flag used to indicate the message is divided
+    end_divide_flag = b' e'  # flag used to indicate the message is the end of a big message
+
     def __init__(self, total=0):
         """Class constructor.
 
@@ -69,6 +72,7 @@ class InBuffer:
         self.total = total  # total of bytes to receive
         self.received = 0  # number of received bytes
         self.cmd = ''  # request's command in header
+        self.flag_divided = b''  # request's command flag to indicate a msg division
         self.counter = 0  # request's counter in the box
 
     def get_info_from_header(self, header: bytes, header_format: str, header_size: int) -> bytes:
@@ -89,7 +93,10 @@ class InBuffer:
             Buffer without the content of the header.
         """
         self.counter, self.total, cmd = struct.unpack(header_format, header[:header_size])
-        self.cmd = cmd.split(b' ')[0]
+        cmd_split = cmd.split(b' ')
+        self.cmd = cmd_split[0]
+        self.flag_divided = cmd_split[-1] if cmd_split[-1] in [InBuffer.divide_flag.strip(),
+                                                               InBuffer.end_divide_flag.strip()] else b''
         self.payload = bytearray(self.total)
         return header[header_size:]
 
@@ -255,8 +262,10 @@ class Handler(asyncio.Protocol):
         self.counter = random.SystemRandom().randint(0, 2 ** 32 - 1)
         # The box stores all sent messages IDs.
         self.box = {}
+        # The div_msg_box stores all divided messages under its IDs.
+        self.div_msg_box = {}
         # Defines command length.
-        self.cmd_len = 12
+        self.cmd_len = 12 + max(len(InBuffer.divide_flag), len(InBuffer.end_divide_flag))
         # Defines header length.
         self.header_len = self.cmd_len + 8  # 4 bytes of counter and 4 bytes of message size
         # Defines header format.
@@ -304,11 +313,11 @@ class Handler(asyncio.Protocol):
         self.counter = (self.counter + 1) % (2 ** 32)
         return self.counter
 
-    def msg_build(self, command: bytes, counter: int, data: bytes) -> bytes:
-        """Build a message with header + payload.
+    def msg_build(self, command: bytes, counter: int, data: bytes) -> list[bytearray]:
+        """Build messages with header + payload.
 
-        It contains a header in self.header_format format that includes self.counter, the data size and the command.
-        The data is also encrypted and added to the bytearray starting from the position self.header_len.
+        Each message contains a header in self.header_format format that includes self.counter, the data size and the
+        command. The data is also encrypted and added to the bytearray starting from the position self.header_len.
 
         Parameters
         ----------
@@ -321,21 +330,51 @@ class Handler(asyncio.Protocol):
 
         Returns
         -------
-        bytes
-            Built message.
+        list
+            List of Bytes, built messages.
         """
         cmd_len = len(command)
-        if cmd_len > self.cmd_len:
+        # 2 B reserved for the divided msg case
+        if cmd_len > self.cmd_len - 2:
             raise exception.WazuhClusterError(3024, extra_message=command)
 
-        # adds - to command until it reaches cmd length
+        # Adds - to command until it reaches cmd length
         command = command + b' ' + b'-' * (self.cmd_len - cmd_len - 1)
         encrypted_data = self.my_fernet.encrypt(data) if self.my_fernet is not None else data
-        out_msg = bytearray(self.header_len + len(encrypted_data))
-        out_msg[:self.header_len] = struct.pack(self.header_format, counter, len(encrypted_data), command)
-        out_msg[self.header_len:self.header_len + len(encrypted_data)] = encrypted_data
+        message_size = self.header_len + len(encrypted_data)
 
-        return out_msg
+        # Message size is <= request_chunk, send the message
+        if message_size <= self.request_chunk:
+            msg = bytearray(message_size)
+            msg[:self.header_len] = struct.pack(self.header_format, counter, len(encrypted_data), command)
+            msg[self.header_len:message_size] = encrypted_data
+            return [msg]
+
+        # Message size > request_chunk, send the message divided
+        else:
+            # Command with the flag d (divided)
+            command = command[:-len(InBuffer.divide_flag)] + InBuffer.divide_flag
+            msg_list = []
+            partial_data_size = 0
+            data_size = len(encrypted_data)
+            while partial_data_size < data_size:
+                message_size = self.request_chunk \
+                    if data_size - partial_data_size + self.header_len >= self.request_chunk \
+                    else data_size - partial_data_size + self.header_len
+
+                # Last divided message, change flag to e (end)
+                if message_size == data_size - partial_data_size + self.header_len:
+                    command = command[:-len(InBuffer.end_divide_flag)] + InBuffer.end_divide_flag
+
+                msg = bytearray(message_size)
+                msg[:self.header_len] = struct.pack(self.header_format, counter, message_size - self.header_len,
+                                                    command)
+                msg[self.header_len:message_size] = encrypted_data[
+                                                    partial_data_size:partial_data_size + message_size - self.header_len]
+                partial_data_size += message_size - self.header_len
+                msg_list.append(msg)
+
+            return msg_list
 
     def msg_parse(self) -> bool:
         """Parse an incoming message.
@@ -360,8 +399,8 @@ class Handler(asyncio.Protocol):
 
         return False
 
-    def get_messages(self) -> Tuple[bytes, int, bytes]:
-        """Get received command, counter and payload.
+    def get_messages(self) -> Tuple[bytes, int, bytes, bytes]:
+        """Get received command, counter, payload and flag_divided.
 
         Called when data is received in the transport. It decrypts the received data and returns it using generators.
         If the data received in the transport contains multiple separated messages, it will return all of them in
@@ -375,18 +414,20 @@ class Handler(asyncio.Protocol):
             Counter.
         bytes
             Payload.
+        bytes
+            Flag_divided.
         """
         parsed = self.msg_parse()
 
         while parsed:
             if self.in_msg.received == self.in_msg.total:
-                # Decrypt received message
+                # Decrypt received message if it is not a divided one
                 try:
-                    decrypted_payload = self.my_fernet.decrypt(bytes(self.in_msg.payload)) if self.my_fernet is not None \
-                        else bytes(self.in_msg.payload)
+                    decrypted_payload = self.my_fernet.decrypt(bytes(self.in_msg.payload)) if self.my_fernet is not \
+                        None and not self.in_msg.flag_divided else bytes(self.in_msg.payload)
                 except cryptography.fernet.InvalidToken:
                     raise exception.WazuhClusterError(3025)
-                yield self.in_msg.cmd, self.in_msg.counter, decrypted_payload
+                yield self.in_msg.cmd, self.in_msg.counter, decrypted_payload, self.in_msg.flag_divided
                 self.in_msg = InBuffer()
             else:
                 break
@@ -407,14 +448,13 @@ class Handler(asyncio.Protocol):
         response_data : bytes
             Response from peer.
         """
-        if len(data) > self.request_chunk:
-            raise exception.WazuhClusterError(3033)
-
         response = Response()
         msg_counter = self.next_counter()
         self.box[msg_counter] = response
         try:
-            self.push(self.msg_build(command, msg_counter, data))
+            msgs = self.msg_build(command, msg_counter, data)
+            for msg in msgs:
+                self.push(msg)
         except MemoryError:
             self.request_chunk //= 2
             raise exception.WazuhClusterError(3026)
@@ -553,17 +593,37 @@ class Handler(asyncio.Protocol):
             Received data.
         """
         self.in_buffer += message
-        for command, counter, payload in self.get_messages():
-            # If the message is the response of a previously sent request.
-            if counter in self.box:
-                if self.box[counter] is None:
-                    # Delete entry for previously expired request, just in case is received too late.
-                    del self.box[counter]
+        for command, counter, payload, flag_divided in self.get_messages():
+            # If the message is a divided one
+            if flag_divided == InBuffer.divide_flag.strip():
+                try:
+                    self.div_msg_box[counter] = self.div_msg_box[counter] + payload
+                except KeyError:
+                    self.div_msg_box[counter] = payload
+            # If the message is the last part of a division
+            elif flag_divided == InBuffer.end_divide_flag.strip():
+                payload = self.div_msg_box[counter] + payload
+                del self.div_msg_box[counter]
+                flag_divided = b''
+                # Decrypt the joined payload
+                try:
+                    payload = self.my_fernet.decrypt(bytes(payload)) if self.my_fernet is not \
+                        None else bytes(payload)
+                except cryptography.fernet.InvalidToken:
+                    raise exception.WazuhClusterError(3025)
+
+            # If the message is not a divided one or it has been already joint
+            if not flag_divided:
+                # If the message is the response of a previously sent request.
+                if counter in self.box:
+                    if self.box[counter] is None:
+                        # Delete entry for previously expired request, just in case is received too late.
+                        del self.box[counter]
+                    else:
+                        self.box[counter].write(self.process_response(command, payload))
+                # If the message is not related to any previously sent request.
                 else:
-                    self.box[counter].write(self.process_response(command, payload))
-            # If the message is not related to any previously sent request.
-            else:
-                self.dispatch(command, counter, payload)
+                    self.dispatch(command, counter, payload)
 
     def dispatch(self, command: bytes, counter: int, payload: bytes) -> None:
         """Process a received message and send a response.
@@ -587,7 +647,9 @@ class Handler(asyncio.Protocol):
             command, payload = b'err', json.dumps(exception.WazuhInternalError(1000, extra_message=str(e)),
                                                   cls=WazuhJSONEncoder).encode()
         if command is not None:
-            self.push(self.msg_build(command, counter, payload))
+            msgs = self.msg_build(command, counter, payload)
+            for msg in msgs:
+                self.push(msg)
 
     def close(self):
         """Close the connection."""

--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -93,13 +93,7 @@ class InBuffer:
         header : bytes
             Buffer without the content of the header.
         """
-        # Check if command has 14 B (from cluster) or 12 B (from local socket)
-        try:
-            # Base case: header received from cluster (header length = 22 B)
-            self.counter, self.total, cmd = struct.unpack(header_format, header[:header_size])
-        except struct.error:
-            # Header received from socket (no flag divided, header length = 20 B)
-            self.counter, self.total, cmd = struct.unpack(self.header_format_local_server, header[:header_size])
+        self.counter, self.total, cmd = struct.unpack(header_format, header[:header_size])
         cmd_split = cmd.split(b' ')
         self.cmd = cmd_split[0]
         self.flag_divided = cmd_split[-1] if cmd_split[-1] in [InBuffer.divide_flag.strip(),

--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -495,9 +495,9 @@ class Handler(asyncio.Protocol):
         # Send each chunk so it is updated in the destination.
         file_hash = hashlib.sha256()
         with open(filename, 'rb') as f:
-            for chunk in iter(lambda: f.read(self.request_chunk - len(relative_path) - 1), b''):
-                await self.send_request(command=b'file_upd', data=relative_path + b' ' + chunk)
-                file_hash.update(chunk)
+            data = f.read()
+            await self.send_request(command=b'file_upd', data=relative_path + b' ' + data)
+            file_hash.update(data)
 
         # Close the destination file descriptor so the file in memory is dumped to disk.
         await self.send_request(command=b'file_end', data=relative_path + b' ' + file_hash.digest())
@@ -521,10 +521,8 @@ class Handler(asyncio.Protocol):
         total = len(my_str)
         task_id = await self.send_request(command=b'new_str', data=str(total).encode())
 
-        # Send chunks of the string to the destination node, indicating the ID of the string.
-        local_req_chunk = self.request_chunk - len(task_id) - 1
-        for c in range(0, total, local_req_chunk):
-            await self.send_request(command=b'str_upd', data=task_id + b' ' + my_str[c:c + local_req_chunk])
+        # Send the string to the destination node, indicating the ID of the string.
+        await self.send_request(command=b'str_upd', data=task_id + b' ' + my_str)
 
         return task_id
 
@@ -745,12 +743,12 @@ class Handler(asyncio.Protocol):
         return b"ok ", b"Ready to receive new file"
 
     def update_file(self, data: bytes) -> Tuple[bytes, bytes]:
-        """Extend file content.
+        """Update file content.
 
         Parameters
         ----------
         data : bytes
-            Bytes containing filepath and chunk of data separated by ' '.
+            Bytes containing filepath and data separated by ' '.
 
         Returns
         -------
@@ -759,9 +757,9 @@ class Handler(asyncio.Protocol):
         bytes
             Response message.
         """
-        name, chunk = data.split(b' ', 1)
-        self.in_file[name]['fd'].write(chunk)
-        self.in_file[name]['checksum'].update(chunk)
+        name, file_content = data.split(b' ', 1)
+        self.in_file[name]['fd'].write(file_content)
+        self.in_file[name]['checksum'].update(file_content)
         return b"ok", b"File updated"
 
     def end_file(self, data: bytes) -> Tuple[bytes, bytes]:
@@ -813,7 +811,7 @@ class Handler(asyncio.Protocol):
         Parameters
         ----------
         data : bytes
-            Bytes containing string ID and chunk of data separated by ' '.
+            Bytes containing string ID and data separated by ' '.
 
         Returns
         -------
@@ -824,7 +822,7 @@ class Handler(asyncio.Protocol):
         """
         name, str_data = data.split(b' ', 1)
         self.in_str[name].receive_data(str_data)
-        return b"ok", b"Chunk received"
+        return b"ok", b"String updated"
 
     def process_unknown_cmd(self, command: bytes) -> Tuple[bytes, bytes]:
         """Define message when an unknown command is received.

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -410,7 +410,7 @@ class DistributedAPI:
                     kcopy = deepcopy(self.to_dict())
                     if agent_list:
                         kcopy['f_kwargs']['agent_id' if 'agent_id' in kcopy['f_kwargs'] else 'agent_list'] = agent_list
-                    result = json.loads(await client.execute(b'dapi_forward',
+                    result = json.loads(await client.execute(b'dapi_fwd',
                                                              "{} {}".format(node_name,
                                                                             json.dumps(kcopy,
                                                                                        cls=c_common.WazuhJSONEncoder)
@@ -697,8 +697,8 @@ class SendSyncRequestQueue(WazuhRequestQueue):
 
             if task_id.startswith(b'Error'):
                 self.logger.error(task_id.decode())
-                result = await node.send_request(b'sendsync_err', name_2.encode() + task_id)
+                result = await node.send_request(b'sendsyn_err', name_2.encode() + task_id)
             else:
-                result = await node.send_request(b'sendsync_res', name_2.encode() + task_id)
+                result = await node.send_request(b'sendsyn_res', name_2.encode() + task_id)
             if isinstance(result, WazuhException):
                 self.logger.error(result.message)

--- a/framework/wazuh/core/cluster/local_client.py
+++ b/framework/wazuh/core/cluster/local_client.py
@@ -175,7 +175,7 @@ class LocalClient(client.AbstractClientManager):
         else:
             # Wait for expected data if it is not returned by send_request(),
             # which occurs when the following commands are used.
-            if command == b'dapi' or command == b'dapi_forward' or command == b'send_file' or command == b'sendasync' \
+            if command == b'dapi' or command == b'dapi_fwd' or command == b'send_file' or command == b'sendasync' \
                     or result == 'Sent request to master node':
                 try:
                     timeout = None if wait_for_complete \

--- a/framework/wazuh/core/cluster/local_server.py
+++ b/framework/wazuh/core/cluster/local_server.py
@@ -7,13 +7,15 @@ import functools
 import json
 import os
 import random
+import struct
 from datetime import datetime
 from typing import Tuple, Union
 
 import uvloop
 
-from wazuh.core import common
+from wazuh.core import common, exception
 from wazuh.core.cluster import common as c_common, server, client
+from wazuh.core.cluster.common import InBuffer
 from wazuh.core.cluster.dapi import dapi
 from wazuh.core.cluster.utils import context_tag
 from wazuh.core.exception import WazuhClusterError
@@ -166,6 +168,44 @@ class LocalServerHandler(server.AbstractServerHandler):
             if exc:
                 self.logger.error(exc)
 
+    def msg_build(self, command: bytes, counter: int, data: bytes) -> list[bytearray]:
+        """Build messages with header + payload to be sent from the local server.
+
+        Each message contains a header in self.header_format format that includes self.counter, the data size and the
+        command. The data is also encrypted and added to the bytearray starting from the position self.header_len.
+
+        Parameters
+        ----------
+        command : bytes
+            Command to send to peer.
+        counter : int
+            Message ID.
+        data : bytes
+            Data to send to peer.
+
+        Returns
+        -------
+        list
+            List of Bytes, built messages.
+        """
+        if len(data) > self.request_chunk:
+            raise exception.WazuhClusterError(3033)
+
+        bytes_divided = max(len(InBuffer.divide_flag), len(InBuffer.end_divide_flag))
+        self.header_format = f'!2I{self.cmd_len - bytes_divided}s'
+        cmd_len = len(command)
+        if cmd_len > self.cmd_len - bytes_divided:
+            raise exception.WazuhClusterError(3024, extra_message=command)
+
+        # Adds - to command until it reaches cmd length (no flag_divided from sockets)
+        command = command + b' ' + b'-' * (self.cmd_len - cmd_len - 1 - bytes_divided)
+        encrypted_data = self.my_fernet.encrypt(data) if self.my_fernet is not None else data
+        message_size = self.header_len - bytes_divided + len(encrypted_data)
+
+        msg = bytearray(message_size)
+        msg[:self.header_len - bytes_divided] = struct.pack(self.header_format, counter, len(encrypted_data), command)
+        msg[self.header_len - bytes_divided:message_size] = encrypted_data
+        return [msg]
 
 class LocalServer(server.AbstractServer):
     """

--- a/framework/wazuh/core/cluster/local_server.py
+++ b/framework/wazuh/core/cluster/local_server.py
@@ -166,6 +166,7 @@ class LocalServerHandler(server.AbstractServerHandler):
             if exc:
                 self.logger.error(exc)
 
+
 class LocalServer(server.AbstractServer):
     """
     Create the server, manage multiple client connections. It's connected to the cluster TCP transports.

--- a/framework/wazuh/core/cluster/local_server.py
+++ b/framework/wazuh/core/cluster/local_server.py
@@ -244,7 +244,7 @@ class LocalServerHandlerMaster(LocalServerHandler):
         if command == b'dapi':
             self.server.dapi.add_request(self.name.encode() + b' ' + data)
             return b'ok', b'Added request to API requests queue'
-        elif command == b'dapi_forward':
+        elif command == b'dapi_fwd':
             node_name, request = data.split(b' ', 1)
             node_name = node_name.decode()
             if node_name in self.server.node.clients:

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -200,13 +200,13 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             Response message.
         """
         self.logger.debug(f"Command received: {command}")
-        if command == b'sync_i_w_m_p' or command == b'sync_e_w_m_p' or command == b'sync_a_w_m_p':
+        if command == b'syn_i_w_m_p' or command == b'syn_e_w_m_p' or command == b'syn_a_w_m_p':
             return self.get_permission(command)
-        elif command == b'sync_i_w_m' or command == b'sync_e_w_m' or command == b'sync_a_w_m':
+        elif command == b'syn_i_w_m' or command == b'syn_e_w_m' or command == b'syn_a_w_m':
             return self.setup_sync_integrity(command, data)
-        elif command == b'sync_i_w_m_e' or command == b'sync_e_w_m_e':
+        elif command == b'syn_i_w_m_e' or command == b'syn_e_w_m_e':
             return self.end_receiving_integrity_checksums(data.decode())
-        elif command == b'sync_i_w_m_r' or command == b'sync_e_w_m_r':
+        elif command == b'syn_i_w_m_r' or command == b'syn_e_w_m_r':
             return self.process_sync_error_from_worker(command, data)
         elif command == b'dapi':
             self.server.dapi.add_request(self.name.encode() + b'*' + data)
@@ -257,7 +257,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         self.server.pending_api_requests[request_id] = {'Event': asyncio.Event(), 'Response': ''}
 
         # If forward request to other worker, get destination client and request.
-        if command == b'dapi_forward':
+        if command == b'dapi_fwd':
             client, request = data.split(b' ', 1)
             client = client.decode()
             if client in self.server.clients:
@@ -271,8 +271,8 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         else:
             result = self.process_request(command=command, data=data)
 
-        # If command was dapi or dapi_forward, wait for response.
-        if command == b'dapi' or command == b'dapi_forward':
+        # If command was dapi or dapi_fwd, wait for response.
+        if command == b'dapi' or command == b'dapi_fwd':
             try:
                 timeout = None if wait_for_complete \
                                else self.cluster_items['intervals']['communication']['timeout_api_request']
@@ -420,11 +420,11 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         bytes
             Response message.
         """
-        if sync_type == b'sync_i_w_m_p':
+        if sync_type == b'syn_i_w_m_p':
             permission = self.sync_integrity_free
-        elif sync_type == b'sync_e_w_m_p':
+        elif sync_type == b'syn_e_w_m_p':
             permission = self.sync_extra_valid_free
-        elif sync_type == b'sync_a_w_m_p':
+        elif sync_type == b'syn_a_w_m_p':
             permission = self.sync_agent_info_free
         else:
             permission = False
@@ -476,9 +476,9 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         bytes
             Response message.
         """
-        if command == b'sync_i_w_m_r':
+        if command == b'syn_i_w_m_r':
             sync_type, self.sync_integrity_free = "Integrity", True
-        else:  # command == b'sync_e_w_m_r':
+        else:  # command == b'syn_e_w_m_r':
             sync_type, self.sync_extra_valid_free = "Extra valid", True
 
         return super().error_receiving_file(error_msg.decode())

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -212,26 +212,26 @@ async def test_SyncWazuhdb(create_log, caplog):
 
     worker_handler = get_worker_handler()
 
-    sync_worker = worker.SyncWazuhdb(worker=worker_handler, logger=logger, cmd=b'sync_a_w_m', data_retriever=MagicMock(),
+    sync_worker = worker.SyncWazuhdb(worker=worker_handler, logger=logger, cmd=b'syn_a_w_m', data_retriever=MagicMock(),
                                      get_data_command='test-get', set_data_command='test-set')
     await check_message(mock=KeyError(1), expected_messages=["Error asking for permission: 1"])
     await check_message(mock=b'False', expected_messages=["Master didn't grant permission to synchronize."])
 
-    sync_worker = worker.SyncWazuhdb(worker=worker_handler, logger=logger, cmd=b'sync_a_w_m',
+    sync_worker = worker.SyncWazuhdb(worker=worker_handler, logger=logger, cmd=b'syn_a_w_m',
                                      get_data_command='test-get', set_data_command='test-set',
                                      data_retriever=lambda x: [])
     await check_message(mock=b'True', expected_messages=["(0 chunks sent)",
                                                          "Obtained 0 chunks of data in",
                                                          "Permission to synchronize granted."])
 
-    sync_worker = worker.SyncWazuhdb(worker=worker_handler, logger=logger, cmd=b'sync_a_w_m',
+    sync_worker = worker.SyncWazuhdb(worker=worker_handler, logger=logger, cmd=b'syn_a_w_m',
                                      get_data_command='test-get', set_data_command='test-set',
                                      data_retriever=lambda x: ['test0', 'test1'])
     await check_message(mock=b'True', expected_messages=["All chunks sent.",
                                                          "Obtained 2 chunks of data in",
                                                          "Permission to synchronize granted."])
 
-    sync_worker = worker.SyncWazuhdb(worker=worker_handler, logger=logger, cmd=b'sync_a_w_m',
+    sync_worker = worker.SyncWazuhdb(worker=worker_handler, logger=logger, cmd=b'syn_a_w_m',
                                      get_data_command='test-get', set_data_command='test-set',
                                      data_retriever=lambda x: exec('raise(WazuhException(1000))'))
     await check_message(mock=b'True', expected_messages=["Error obtaining data from wazuh-db",
@@ -286,17 +286,17 @@ async def test_RetrieveAndSendToMaster(caplog):
     # Test unsuccessful workflow for 1 chunks
     sync_worker = worker.RetrieveAndSendToMaster(worker=worker_handler, destination_daemon='test', logger=logger,
                                                  expected_res='test_res', n_retries=1, data_retriever=lambda: ['test1'],
-                                                 cmd=b'sync_a_m_w')
+                                                 cmd=b'syn_a_m_w')
     with patch('wazuh.core.cluster.local_client.LocalClient.execute', return_value='ok') as mock_lc:
         with patch('wazuh.core.cluster.common.Handler.send_request', return_value='ok'):
             await check_message(expected_messages=["Finished sending information to test in",
-                                                   "Master response for b'sync_a_m_w_e' command: ok",
+                                                   "Master response for b'syn_a_m_w_e' command: ok",
                                                    "Master's test response: ok.",
                                                    "Error sending chunk to master's test. Response does not start with"
                                                    " test_res (Response: ok). Retrying... 0",
                                                    "Master's test response: ok.",
                                                    "Starting to send information to test.",
-                                                   "Master response for b'sync_a_m_w_s' command: ok",
+                                                   "Master response for b'syn_a_m_w_s' command: ok",
                                                    "Obtained 1 chunks of data to be sent.",
                                                    "Obtaining data to be sent to master's test."])
             calls = [
@@ -314,18 +314,18 @@ def test_WorkerHandler():
                 worker_handler.connected = True
                 worker_handler.connection_result(future_result=None)
 
-    assert worker_handler.process_request(command=b'sync_m_c_ok', data=b'Testing') == (b'ok', b'Thanks')
+    assert worker_handler.process_request(command=b'syn_m_c_ok', data=b'Testing') == (b'ok', b'Thanks')
 
     with patch('wazuh.core.cluster.common.WazuhCommon.setup_receive_file', side_effect=(b'ok', b'Thanks')):
-        assert worker_handler.process_request(command=b'sync_m_c', data=b'Testing') == b'ok'
+        assert worker_handler.process_request(command=b'syn_m_c', data=b'Testing') == b'ok'
 
     with patch('wazuh.core.cluster.common.WazuhCommon.end_receiving_file',
                side_effect=(b'ok', b'File correctly received')):
-        assert worker_handler.process_request(command=b'sync_m_c_e', data=b'Testing First') == b'ok'
+        assert worker_handler.process_request(command=b'syn_m_c_e', data=b'Testing First') == b'ok'
 
     with patch('wazuh.core.cluster.common.WazuhCommon.error_receiving_file',
                side_effect=(b'ok', b'File correctly received')):
-        assert worker_handler.process_request(command=b'sync_m_c_r', data=b'Testing') == b'ok'
+        assert worker_handler.process_request(command=b'syn_m_c_r', data=b'Testing') == b'ok'
 
     with patch('asyncio.create_task', side_effect=None):
         assert worker_handler.process_request(command=b'dapi_res', data=b'Testing') == \

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -387,17 +387,17 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
             Response message.
         """
         self.logger.debug(f"Command received: '{command}'")
-        if command == b'sync_m_c_ok':
+        if command == b'syn_m_c_ok':
             return self.sync_integrity_ok_from_master()
-        elif command == b'sync_m_c':
+        elif command == b'syn_m_c':
             return self.setup_receive_files_from_master()
-        elif command == b'sync_m_c_e':
+        elif command == b'syn_m_c_e':
             return self.end_receiving_integrity(data.decode())
-        elif command == b'sync_m_c_r':
+        elif command == b'syn_m_c_r':
             return self.error_receiving_integrity(data.decode())
-        elif command == b'sync_m_a_e':
+        elif command == b'syn_m_a_e':
             return self.sync_agent_info_from_master(data.decode())
-        elif command == b'sync_m_a_err':
+        elif command == b'syn_m_a_err':
             return self.error_receiving_agent_info(data.decode())
         elif command == b'dapi_res':
             asyncio.create_task(self.forward_dapi_response(data))
@@ -490,7 +490,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         return super().error_receiving_file(taskname_and_error_details)
 
     def sync_integrity_ok_from_master(self) -> Tuple[bytes, bytes]:
-        """Function called when the master sends the "sync_m_c_ok" command.
+        """Function called when the master sends the "syn_m_c_ok" command.
 
         Returns
         -------
@@ -505,7 +505,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         return b'ok', b'Thanks'
 
     def sync_agent_info_from_master(self, response) -> Tuple[bytes, bytes]:
-        """Function called when the master sends the "sync_m_a_e" command.
+        """Function called when the master sends the "syn_m_a_e" command.
 
         This method is called once the master finishes processing the agent-info. It logs
         information like the number of chunks that were updated and any error message.
@@ -532,7 +532,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         return b'ok', b'Thanks'
 
     def error_receiving_agent_info(self, response):
-        """Function called when the master sends the "sync_m_a_err" command.
+        """Function called when the master sends the "syn_m_a_err" command.
 
         Parameters
         ----------
@@ -567,7 +567,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                 if self.connected:
                     logger.info("Starting.")
                     start_time = time.time()
-                    if await SyncWorker(cmd=b'sync_i_w_m', files_to_sync={}, logger=logger, worker=self,
+                    if await SyncWorker(cmd=b'syn_i_w_m', files_to_sync={}, logger=logger, worker=self,
                                         files_metadata=wazuh.core.cluster.cluster.get_files_status()).sync():
                         self.integrity_check_status['date_start'] = start_time
             # If exception is raised during sync process, notify the master so it removes the file if received.
@@ -595,7 +595,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         logger = self.task_loggers["Agent-info sync"]
         wdb_conn = WazuhDBConnection()
         synced = True
-        agent_info = SyncWazuhdb(worker=self, logger=logger, cmd=b'sync_a_w_m', data_retriever=wdb_conn.run_wdb_command,
+        agent_info = SyncWazuhdb(worker=self, logger=logger, cmd=b'syn_a_w_m', data_retriever=wdb_conn.run_wdb_command,
                                  get_data_command='global sync-agent-info-get ',
                                  set_data_command='global sync-agent-info-set')
 
@@ -634,7 +634,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                                                       node_name=self.name)
             files_to_sync = {merged_file: {'merged': True, 'merge_type': 'agent-groups', 'merge_name': merged_file,
                                            'cluster_item_key': 'queue/agent-groups/'}} if n_files else {}
-            await SyncWorker(cmd=b'sync_e_w_m', files_to_sync=files_to_sync, files_metadata=files_to_sync,
+            await SyncWorker(cmd=b'syn_e_w_m', files_to_sync=files_to_sync, files_metadata=files_to_sync,
                              logger=logger, worker=self).sync()
             after = time.time()
             logger.debug(f"Finished sending extra valid files in {(after - before):.3f}s.")

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -402,7 +402,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         elif command == b'dapi_res':
             asyncio.create_task(self.forward_dapi_response(data))
             return b'ok', b'Response forwarded to worker'
-        elif command == b'sendsync_res':
+        elif command == b'sendsyn_res':
             asyncio.create_task(self.forward_sendsync_response(data))
             return b'ok', b'Response forwarded to worker'
         elif command == b'dapi_err':
@@ -413,7 +413,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
             except WazuhClusterError as e:
                 raise WazuhClusterError(3025)
             return b'ok', b'DAPI error forwarded to worker'
-        elif command == b'sendsync_err':
+        elif command == b'sendsyn_err':
             sendsync_client, error_msg = data.split(b' ', 1)
             try:
                 asyncio.create_task(
@@ -573,13 +573,13 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
             # If exception is raised during sync process, notify the master so it removes the file if received.
             except exception.WazuhException as e:
                 logger.error(f"Error synchronizing integrity: {e}")
-                await self.send_request(command=b'sync_i_w_m_r', data=b'None ' +
+                await self.send_request(command=b'syn_i_w_m_r', data=b'None ' +
                                         json.dumps(e, cls=c_common.WazuhJSONEncoder).encode())
             except Exception as e:
                 logger.error(f"Error synchronizing integrity: {e}")
                 exc_info = json.dumps(exception.WazuhClusterError(code=1000, extra_message=str(e)),
                                       cls=c_common.WazuhJSONEncoder)
-                await self.send_request(command=b'sync_i_w_m_r', data=b'None ' + exc_info.encode())
+                await self.send_request(command=b'syn_i_w_m_r', data=b'None ' + exc_info.encode())
 
             await asyncio.sleep(self.cluster_items['intervals']['worker']['sync_integrity'])
 
@@ -643,13 +643,13 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         # If exception is raised during sync process, notify the master so it removes the file if received.
         except exception.WazuhException as e:
             logger.error(f"Error synchronizing extra valid files: {e}")
-            await self.send_request(command=b'sync_e_w_m_r',
+            await self.send_request(command=b'syn_e_w_m_r',
                                     data=b'None ' + json.dumps(e, cls=c_common.WazuhJSONEncoder).encode())
         except Exception as e:
             logger.error(f"Error synchronizing extra valid files: {e}")
             exc_info = json.dumps(exception.WazuhClusterError(code=1000, extra_message=str(e)),
                                   cls=c_common.WazuhJSONEncoder)
-            await self.send_request(command=b'sync_e_w_m_r', data=b'None ' + exc_info.encode())
+            await self.send_request(command=b'syn_e_w_m_r', data=b'None ' + exc_info.encode())
 
     async def process_files_from_master(self, name: str, file_received: asyncio.Event):
         """Perform relevant actions for each file according to its status.

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -465,7 +465,6 @@ class WazuhException(Exception):
                'remediation': f"[Update](https://documentation.wazuh.com/{WAZUH_VERSION}/upgrade-guide/index.html)"
                               " master and workers to the same version."},
         3032: "Could not forward DAPI request. Connection not available.",
-        3033: "Payload length exceeds limit defined in wazuh.cluster.common.Handler.request_chunk.",
         3034: "Error sending file. File not found.",
         3035: "String couldn't be found",
         3036: "JSON couldn't be loaded",

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -465,6 +465,7 @@ class WazuhException(Exception):
                'remediation': f"[Update](https://documentation.wazuh.com/{WAZUH_VERSION}/upgrade-guide/index.html)"
                               " master and workers to the same version."},
         3032: "Could not forward DAPI request. Connection not available.",
+        3033: "Payload length exceeds limit defined in wazuh.cluster.common.Handler.request_chunk.",
         3034: "Error sending file. File not found.",
         3035: "String couldn't be found",
         3036: "JSON couldn't be loaded",


### PR DESCRIPTION
|Related issue|
|---|
| #6820 |

This PR closes #6820.

This PR includes the changes done for the send_request update to generalize the cluster message division:
- [Divide messages](https://github.com/wazuh/wazuh/issues/7136)
- [Join messages](https://github.com/wazuh/wazuh/pull/8492)
- [General refactor](https://github.com/wazuh/wazuh/pull/8504)

Now it is not necessary to divide messages and strings as this functionality is included in the functions used to send and receive.
We have also removed the limitation of messages via API.

Regards,
Manuel.