### PR TITLE
Wazuh-modulesd stop/start error

### DIFF
--- a/src/logcollector/config.c
+++ b/src/logcollector/config.c
@@ -169,6 +169,7 @@ cJSON *getLogcollectorInternalOptions(void) {
     cJSON_AddNumberToObject(logcollector,"reload_delay",reload_delay);
     cJSON_AddNumberToObject(logcollector, "exclude_files_interval", free_excluded_files_interval);
     cJSON_AddNumberToObject(logcollector, "state_interval", state_interval);
+    cJSON_AddNumberToObject(logcollector, "debug",wm_debug_level);
 
 #ifndef WIN32
     cJSON_AddNumberToObject(logcollector,"rlimit_nofile",nofile);

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -260,6 +260,7 @@ extern int sample_log_length;
 extern int accept_remote;
 extern int N_INPUT_THREADS;
 extern int OUTPUT_QUEUE_SIZE;
+extern int wm_debug_level;
 #ifndef WIN32
 extern rlim_t nofile;
 #endif

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -372,7 +372,7 @@ cJSON *getSyscheckInternalOptions(void) {
     cJSON_AddNumberToObject(syscheckd,"rt_delay",syscheck.rt_delay);
     cJSON_AddNumberToObject(syscheckd,"default_max_depth",syscheck.max_depth);
     cJSON_AddNumberToObject(syscheckd,"symlink_scan_interval",syscheck.sym_checker_interval);
-    cJSON_AddNumberToObject(syscheckd,"debug",sys_debug_level);
+    cJSON_AddNumberToObject(syscheckd,"debug",wm_debug_level);
     cJSON_AddNumberToObject(syscheckd,"file_max_size",syscheck.file_max_size);
 #ifdef WIN32
     cJSON_AddNumberToObject(syscheckd,"max_fd_win_rt",syscheck.max_fd_win_rt);

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -20,8 +20,6 @@
 // Global variables
 syscheck_config syscheck;
 
-int sys_debug_level;
-
 #ifdef USE_MAGIC
 #include <magic.h>
 magic_t magic_cookie = 0;
@@ -58,20 +56,6 @@ void read_internal(int debug_level)
 #ifndef WIN32
     syscheck.max_audit_entries = getDefine_Int("syscheck", "max_audit_entries", 1, 4096);
 #endif
-    sys_debug_level = getDefine_Int("syscheck", "debug", 0, 2);
-
-    /* Check current debug_level
-     * Command line setting takes precedence
-     */
-    if (debug_level == 0) {
-        int debug_level = sys_debug_level;
-        while (debug_level != 0) {
-            nowDebug();
-            debug_level--;
-        }
-    }
-
-    return;
 }
 
 

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -45,7 +45,7 @@
 
 /* Global config */
 extern syscheck_config syscheck;
-extern int sys_debug_level;
+extern int wm_debug_level;
 
 typedef enum fim_event_type {
     FIM_ADD,


### PR DESCRIPTION
|Related issue|
|---|
|Closes #8432 |

## Description
When deployed the agent in CentOS7 and Debian 9 I've found weird behavior with `wazuh-control`. I've set debug 2 to `wazuh_modules`. Also, as you can see the folder `/var/ossec/var/run` is empty and apparently, there is no wazuh process running, here is the trace:

```
[root@ip-10-0-1-100 run]# /var/ossec/bin/wazuh-control stop
wazuh-modulesd not running...
Killing wazuh-agentd... 
Wazuh v5.0.0 Stopped
[root@ip-10-0-1-100 run]# rm -rf /var/ossec/var/run/*
[root@ip-10-0-1-100 run]# ls -la /var/ossec/var/run/
total 0
drwxrwx---. 2 root ossec  6 abr 29 08:30 .
drwxr-x---. 7 root ossec 77 abr 29 08:30 ..
[root@ip-10-0-1-100 run]# ps -aux | grep ossec
root     15897  0.0  0.0 112708   984 pts/0    R+   08:30   0:00 grep --color=auto ossec
[root@ip-10-0-1-100 run]# ps -aux | grep wazuh
root     14209  0.0  0.5 158760  5704 ?        Ss   08:05   0:00 sshd: wazuh [priv]
wazuh    14212  0.0  0.2 158892  2556 ?        S    08:05   0:00 sshd: wazuh@pts/0
wazuh    14213  0.0  0.1 115440  2016 pts/0    Ss   08:05   0:00 -bash
root     15899  0.0  0.0 112708   980 pts/0    R+   08:30   0:00 grep --color=auto wazuh
[root@ip-10-0-1-100 run]# /var/ossec/bin/wazuh-control start
2021/04/29 08:30:58 wazuh-modulesd[15908] debug_op.c:70 at _log(): DEBUG: Logging module auto-initialized
2021/04/29 08:30:58 wazuh-modulesd[15908] main.c:76 at main(): DEBUG: Wazuh home directory: /var/ossec
2021/04/29 08:30:58 wazuh-modulesd[15908] wmodules-osquery-monitor.c:78 at wm_osquery_monitor_read(): DEBUG: Logpath read: /var/log/osquery/osqueryd.results.log
2021/04/29 08:30:58 wazuh-modulesd[15908] wmodules-osquery-monitor.c:84 at wm_osquery_monitor_read(): DEBUG: configPath read: /etc/osquery/osquery.conf
2021/04/29 08:30:58 wazuh-modulesd[15908] syscheck-config.c:2515 at process_option_regex(): DEBUG: Found ignore regex node .log$|.swp$
2021/04/29 08:30:58 wazuh-modulesd[15908] syscheck-config.c:2522 at process_option_regex(): DEBUG: Found ignore regex node .log$|.swp$ OK?
2021/04/29 08:30:58 wazuh-modulesd[15908] syscheck-config.c:2523 at process_option_regex(): DEBUG: Found ignore regex size 0
Starting Wazuh v5.0.0...
Started wazuh-agentd...
2021/04/29 08:30:59 wazuh-modulesd[15931] debug_op.c:70 at _log(): DEBUG: Logging module auto-initialized
2021/04/29 08:30:59 wazuh-modulesd[15931] main.c:76 at main(): DEBUG: Wazuh home directory: /var/ossec
2021/04/29 08:30:59 wazuh-modulesd[15931] wmodules-osquery-monitor.c:78 at wm_osquery_monitor_read(): DEBUG: Logpath read: /var/log/osquery/osqueryd.results.log
2021/04/29 08:30:59 wazuh-modulesd[15931] wmodules-osquery-monitor.c:84 at wm_osquery_monitor_read(): DEBUG: configPath read: /etc/osquery/osquery.conf
2021/04/29 08:30:59 wazuh-modulesd[15931] syscheck-config.c:2515 at process_option_regex(): DEBUG: Found ignore regex node .log$|.swp$
2021/04/29 08:30:59 wazuh-modulesd[15931] syscheck-config.c:2522 at process_option_regex(): DEBUG: Found ignore regex node .log$|.swp$ OK?
2021/04/29 08:30:59 wazuh-modulesd[15931] syscheck-config.c:2523 at process_option_regex(): DEBUG: Found ignore regex size 0
wazuh-modulesd: Process 15934 not used by Wazuh, removing ..
wazuh-modulesd did not start
```

However, this behaviour is not 100% reproducible, sometimes `wazuh-control` just works fine:

```
root@ip-10-0-1-247:/home/wazuh# /var/ossec/bin/wazuh-control start
Starting Wazuh v5.0.0...
Started wazuh-agentd...
Started wazuh-modulesd...
Completed.
root@ip-10-0-1-247:/home/wazuh# /var/ossec/bin/wazuh-control stop
Killing wazuh-modulesd... 
Killing wazuh-agentd... 
Wazuh v5.0.0 Stopped
root@ip-10-0-1-247:/home/wazuh# /var/ossec/bin/wazuh-control info
WAZUH_VERSION="v5.0.0"
WAZUH_REVISION="50000"
WAZUH_TYPE="agent"
```