### PR TITLE
Force AWS module to run with Python3

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Import AWS S3
 #


### PR DESCRIPTION
Hello team,

After reviewing the dependencies of the AWS module in a clean Wazuh agent installation in https://github.com/wazuh/wazuh-documentation/issues/3836 we discovered a minor issue in the module itself. The `aws-s3.py` is set to run with python instead of python3. This PR updates it to ensure it will try to run using python3 when running in a Wazuh agent. This does not apply to Wazuh managers as the module is triggered differently in those environments.