### PR TITLE
Fix API rule load crash

### DIFF
--- a/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
@@ -320,7 +320,7 @@ stages:
         function: tavern_utils:test_validate_group_configuration
         extra_kwargs:
           expected_field: "query"
-          expected_value: '<QueryList><Query Id="0" Path="System"><Select Path="System">*[System[(Level&lt;=3)]]</Select></Query></QueryList>'
+          expected_value: ' <QueryList> <Query Id="0" Path="System"> <Select Path="System">*[System[(Level&lt;=3)]]</Select> </Query> </QueryList> '
       json:
         error: 0
         data:

--- a/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
@@ -320,7 +320,7 @@ stages:
         function: tavern_utils:test_validate_group_configuration
         extra_kwargs:
           expected_field: "query"
-          expected_value: " <QueryList> <Query Id='0' Path='System'> <Select Path='System'>*[System[(Level&lt;=3)]]</Select> </Query> </QueryList> "
+          expected_value: '<QueryList><Query Id="0" Path="System"><Select Path="System">*[System[(Level&lt;=3)]]</Select></Query></QueryList>'
       json:
         error: 0
         data:

--- a/framework/wazuh/core/configuration.py
+++ b/framework/wazuh/core/configuration.py
@@ -205,9 +205,10 @@ def _read_option(section_name, opt):
     elif section_name == 'localfile' and opt_name == 'query':
         # Remove new lines, empty spaces and backslashes
         regex = rf'<{opt_name}>(.*)</{opt_name}>'
-        opt_value = re.match(regex, re.sub('\s+(?=<)', '',
-                                            tostring(opt, encoding='unicode'
-                                                     ).replace('\\<', '<').replace('\\>', '>')).strip()).group(1)
+        opt_value = re.match(regex,
+                             re.sub('(?:(\n) +)', '',
+                                    tostring(opt, encoding='unicode').replace('\\<', '<').replace('\\>', '>')
+                                    ).strip()).group(1)
     elif section_name == 'remote' and opt_name == 'protocol':
         opt_value = [elem.strip() for elem in opt.text.split(',')]
     else:

--- a/framework/wazuh/core/configuration.py
+++ b/framework/wazuh/core/configuration.py
@@ -12,6 +12,7 @@ import tempfile
 from configparser import RawConfigParser, NoOptionError
 from io import StringIO
 from os import remove, path as os_path
+from xml.etree.ElementTree import tostring
 
 from defusedxml.minidom import parseString
 
@@ -203,7 +204,10 @@ def _read_option(section_name, opt):
             opt_value[a] = opt.attrib[a]
     elif section_name == 'localfile' and opt_name == 'query':
         # Remove new lines, empty spaces and backslashes
-        opt_value = re.sub(r'(?:(\n) +)|.*\n$', '', re.sub(r'\\+<', '<', re.sub(r'\\+>', '>', opt.text)))
+        regex = rf'<{opt_name}>(.*)</{opt_name}>'
+        opt_value = re.match(regex, re.sub('\s+(?=<)', '',
+                                            tostring(opt, encoding='unicode'
+                                                     ).replace('\\<', '<').replace('\\>', '>')).strip()).group(1)
     elif section_name == 'remote' and opt_name == 'protocol':
         opt_value = [elem.strip() for elem in opt.text.split(',')]
     else:

--- a/framework/wazuh/core/tests/data/test_load_wazuh_xml/10000-backslash_rule_test.xml
+++ b/framework/wazuh/core/tests/data/test_load_wazuh_xml/10000-backslash_rule_test.xml
@@ -1,0 +1,14 @@
+<dummy_tag>
+  <root_tag>
+    <var name="TEST_WILDCARD">this is a wildcard</var>
+
+    <group name="dev">
+      <rule id="999999" level="5">
+        <if_sid>60000</if_sid>
+        <field name="win.eventdata.currentDirectory">xyz\\</field>
+        <description>test rule</description>
+      </rule>
+    </group>
+
+  </root_tag>
+</dummy_tag>

--- a/framework/wazuh/core/tests/data/test_load_wazuh_xml/agent_backslash_query.conf
+++ b/framework/wazuh/core/tests/data/test_load_wazuh_xml/agent_backslash_query.conf
@@ -1,0 +1,15 @@
+<dummy_tag>
+    <agent_config>
+        <localfile>
+            <location>System</location>
+            <log_format>eventchannel</log_format>
+            <query>
+               \<QueryList>
+                    \<Query Id="0" Path="System">
+                        \<Select Path="System">*[System[(Level=3)]]\</Select>
+                    \</Query>
+                \</QueryList>
+            </query>
+        </localfile>
+    </agent_config>
+</dummy_tag>

--- a/framework/wazuh/core/tests/data/test_load_wazuh_xml/agent_new_line_query.conf
+++ b/framework/wazuh/core/tests/data/test_load_wazuh_xml/agent_new_line_query.conf
@@ -1,0 +1,12 @@
+<dummy_tag>
+    <agent_config profile="database">
+        <localfile>
+          <location>Security</location>
+          <log_format>eventchannel</log_format>
+          <query>Event/System[EventID != 5145 and EventID != 5156 and EventID != 5447 and
+            EventID != 4656 and EventID != 4658 and EventID != 4663 and EventID != 4660 and
+            EventID != 4670 and EventID != 4690 and EventID != 4703 and EventID != 4907 and
+            EventID != 5152 and EventID != 5157]</query>
+        </localfile>
+    </agent_config>
+</dummy_tag>

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -783,8 +783,8 @@ def load_wazuh_xml(xml_path, data=None):
     # < characters should be escaped as &lt; unless < is starting a <tag> or a comment
     data = re.sub(r"<(?!/?\w+.+>|!--)", "&lt;", data)
 
-    # replace \< by &lt;
-    data = re.sub(r'&backslash;<', '&backslash;&lt;', data)
+    # replace \< by &lt, only outside xml tags;
+    data = re.sub(r'^&backslash;<(.*[^>])$', '&backslash;&lt;\g<1>', data)
 
     # replace \> by &gt;
     data = re.sub(r'&backslash;>', '&backslash;&gt;', data)


### PR DESCRIPTION
|Related issue|
|---|
|#8387|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

Hi team,

This PR closes #8387. In this PR we have fixed a problem related to the loading of XML files by the API. We have fixed this use case without breaking the use case that caused this error: https://github.com/wazuh/wazuh/commit/654aa15fa6d64c1378810bbd44c712f5c5f4b3f9.

In addition to this, we have added an initial set of unit tests for the load_wazuh_xml function.

### load_wazuh_xml unittest

```
adriiiprodri@wazuh pytest -xs -vv framework/wazuh/core/tests/test_utils.py --disable-warnings -k test_load_wazuh_xml
================================================================================================ test session starts =================================================================================================
platform linux -- Python 3.9.2, pytest-5.4.3, py-1.10.0, pluggy-0.13.1 -- /home/adriiiprodri/.virtualenvs/wazuh/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.9.2', 'Platform': 'Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32', 'Packages': {'pytest': '5.4.3', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.11.0', 'html': '2.1.1', 'cov': '2.10.1', 'asyncio': '0.12.0', 'tavern': '1.0.0', 'testinfra': '6.3.0'}}
rootdir: /home/adriiiprodri/git/wazuh/framework
plugins: metadata-1.11.0, html-2.1.1, cov-2.10.1, asyncio-0.12.0, tavern-1.0.0, testinfra-6.3.0
collected 221 items / 220 deselected / 1 selected                                                                                                                                                                    

framework/wazuh/core/tests/test_utils.py::test_load_wazuh_xml PASSED

=================================================================================== 1 passed, 220 deselected, 3 warnings in 0.20s ====================================================================================

```

### Integration tests (rules)
```
adriiiprodri@wazuh python3 run_tests.py -rbac both -k rule       
Collected tests [3]:
test_rbac_black_rule_endpoints.tavern.yaml, test_rbac_white_rule_endpoints.tavern.yaml, test_rule_endpoints.tavern.yaml


test_rbac_black_rule_endpoints.tavern.yaml 
	 8 passed, 10 warnings

test_rbac_white_rule_endpoints.tavern.yaml 
	 8 passed, 10 warnings

test_rule_endpoints.tavern.yaml 
	 15 passed, 17 warnings
```