### PR TITLE
Fix bugs in CIS-CAT module when using relative paths

### DIFF
--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -115,6 +115,8 @@ void* wm_ciscat_main(wm_ciscat *ciscat) {
     // Define path where CIS-CAT is installed
 
     if (ciscat->ciscat_path) {
+        char pwd[PATH_MAX];
+
         switch (wm_relative_path(ciscat->ciscat_path)) {
             case 0:
                 // Full path
@@ -127,7 +129,12 @@ void* wm_ciscat_main(wm_ciscat *ciscat) {
                     snprintf(cis_path, OS_MAXSTR - 1, "%s\\%s", current, ciscat->ciscat_path);
                 }
             #else
-                snprintf(cis_path, OS_MAXSTR - 1, "%s", ciscat->ciscat_path);
+                if (getcwd(pwd, sizeof(pwd)) == NULL) {
+                    mterror(WM_CISCAT_LOGTAG, "Could not get the current working directory: %s (%d)", strerror(errno), errno);
+                    ciscat->flags.error = 1;
+                } else {
+                    os_snprintf(cis_path, OS_MAXSTR - 1, "%s/%s", pwd, ciscat->ciscat_path);
+                }
             #endif
                 break;
             default:

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -427,6 +427,12 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char * java_p
     char msg[OS_MAXSTR];
     char *ciscat_script = "./CIS-CAT.sh";
     wm_scan_data *scan_info = NULL;
+    char pwd[PATH_MAX];
+
+    if (getcwd(pwd, sizeof(pwd)) == NULL) {
+        mterror(WM_CISCAT_LOGTAG, "Could not get the current working directory: %s (%d)", strerror(errno), errno);
+        pthread_exit(NULL);
+    }
 
     // Create arguments
 
@@ -460,7 +466,9 @@ void wm_ciscat_run(wm_ciscat_eval *eval, char *path, int id, const char * java_p
     // Specify location for reports
 
     wm_strcat(&command, "-r", ' ');
-    wm_strcat(&command, WM_CISCAT_REPORTS, ' ');
+    char reports_path[PATH_MAX];
+    os_snprintf(reports_path, sizeof(reports_path), "%s/%s", pwd, WM_CISCAT_REPORTS);
+    wm_strcat(&command, reports_path, ' ');
 
     // Set reports file name
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #8745|

This PR aims to fix two problems related to the CIS-CAT module

1. The module prepended the `<ciscat_path>` multiple times when that was a relative path.
```
ERROR: Failed reading scan results for policy 'wodles/cis-cat/benchmarks/CIS_Google_Chrome_Benchmark_v1.2.0-xccdf.xml'
ERROR: Benchmark file 'wodles/cis-cat/wodles/cis-cat/benchmarks/CIS_Google_Chrome_Benchmark_v1.2.0-xccdf.xml' not found.
ERROR: Benchmark file 'wodles/cis-cat/wodles/cis-cat/wodles/cis-cat/benchmarks/CIS_Google_Chrome_Benchmark_v1.2.0-xccdf.xml' not found.
```
2. The module set the report path (`-r`) to a relative path (`/tmp` instead of `/var/ossec/tmp`), which let the CIS-CAT tool try to save the report file into a `tmp` folder inside `<ciscat_path>`.
```
ERROR: Ignoring content 'wodles/cis-cat/benchmarks/CIS_Google_Chrome_Benchmark_v1.2.0-xccdf.xml' due to error (232).
ERROR: OUTPUT: This is CIS-CAT-Pro Assessor version 3.0.43
An error occurred configuring the reports directory.  The directory 'tmp' does not exist.  Either create this directory or specify a valid directory.
CIS-CAT will now exit -- Error Code: ERR-CLI-0004
```

## Testing the fix

### Configuration

```xml
<wodle name="cis-cat">
  <disabled>no</disabled>
  <timeout>1800</timeout>
  <interval>10s</interval>
  <scan-on-start>yes</scan-on-start>
  <java_path>/usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/bin</java_path>
  <ciscat_path>wodles/cis-cat</ciscat_path>
  <content path="benchmarks/CIS_Google_Chrome_Benchmark_v1.2.0-xccdf.xml" type="xccdf">
    <profile>xccdf_org.cisecurity.benchmarks_profile_Level_2</profile>
  </content>
</wodle>
```

### Logs

```
2021/05/20 14:19:21 wazuh-modulesd:ciscat: INFO: Starting evaluation.
2021/05/20 14:19:21 wazuh-modulesd:osquery: INFO: Module disabled. Exiting...
2021/05/20 14:19:21 sca: INFO: Module disabled. Exiting.
INFO: Starting evaluation.
INFO: Scan finished successfully. File: /var/ossec/wodles/cis-cat/benchmarks/CIS_Google_Chrome_Benchmark_v1.2.0-xccdf.xml
INFO: Evaluation finished.
INFO: Starting evaluation.
INFO: Scan finished successfully. File: /var/ossec/wodles/cis-cat/benchmarks/CIS_Google_Chrome_Benchmark_v1.2.0-xccdf.xml
INFO: Evaluation finished.
```

### Sample alert
```
** Alert 1621513173.294056: - ciscat,pci_dss_2.2,nist_800_53_CM.1,gdpr_IV_35.7.d,
2021 May 20 14:19:33 Rocket->wodle_cis-cat
Rule: 87418 (level 7) -> 'CIS-CAT: (L1) Ensure 'Enable the password manager' is set to 'Disabled' (failed)'
{"type":"scan_result","scan_id":423859713,"cis":{"rule_id":"1.11.1","rule_title":"(L1) Ensure 'Enable the password manager' is set to 'Disabled'","group":"Computer Configuration ","description":"Chrome will memorize passwords and automatically provide them when a user logs into a site. By disabling this feature the user will be prompted to enter their password each time they visit a website.","rationale":"If this setting is enabled, users can have Google Chrome memorize passwords and provide them automatically the next time they log in to a site. An intruder who has unrestricted access to your computer for even a minute can view and copy all of your saved passwords just by visiting an easy-to-remember settings page: chrome://settings/passwords.","remediation":"To establish the recommended configuration via Group Policy, set the following UI path to Disabled. Computer Configuration\\Administrative Templates\\Classic Administrative Template (ADM)\\Google\\Google Chrome\\Password manager\\Enable the password manager  Impact: If this setting is disable, users are not able to save passwords or use previously saved passwords.","result":"fail"}}
type: scan_result
scan_id: 423859713
cis.rule_id: 1.11.1
cis.rule_title: (L1) Ensure 'Enable the password manager' is set to 'Disabled'
cis.group: Computer Configuration
cis.description: Chrome will memorize passwords and automatically provide them when a user logs into a site. By disabling this feature the user will be prompted to enter their password each time they visit a website.
cis.rationale: If this setting is enabled, users can have Google Chrome memorize passwords and provide them automatically the next time they log in to a site. An intruder who has unrestricted access to your computer for even a minute can view and copy all of your saved passwords just by visiting an easy-to-remember settings page: chrome://settings/passwords.
cis.remediation: To establish the recommended configuration via Group Policy, set the following UI path to Disabled. Computer Configuration\Administrative Templates\Classic Administrative Template (ADM)\Google\Google Chrome\Password manager\Enable the password manager  Impact: If this setting is disable, users are not able to save passwords or use previously saved passwords.
cis.result: fail
```

## Tests

- [X] Build manager for Linux.
- [X] Test CIS-CAT scan on Ubuntu.
- [X] Run Modulesd on Valgrind.