### PR TITLE
Add log message when cluster is stopped

### DIFF
--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -31,7 +31,6 @@ def print_version():
 def exit_handler(signum, frame):
     main_logger.info(f'SIGNAL [({signum})-({Signals(signum).name})] received. Exit...')
 
-    global original_sig_handler
     if callable(original_sig_handler):
         original_sig_handler(signum, frame)
     elif original_sig_handler == SIG_DFL:


### PR DESCRIPTION
|Related issue|
|---|
| Closes #8718 |

## Description

Hi team!

Before, when any cluster node was stopped/restarted, no related information was shown in the `cluster.log` file. This is an example where the last log says nothing about the cluster process being stopped.
```
2021/05/20 11:21:53 INFO: [Master] [Local integrity] Starting.
2021/05/20 11:21:53 INFO: [Master] [Local integrity] Finished in 0.005s. Calculated metadata of 11 files.
2021/05/20 11:21:53 DEBUG: [Worker worker2] [Main] Command received: b'sync_a_w_m_p'
```

After this PR and as requested in #8718, a message following the same pattern that those in the `ossec.log` is shown, in both workers and master:
```
2021/05/20 12:32:28 DEBUG: [Cluster] [D API] Starting to execute request locally
2021/05/20 12:32:28 DEBUG: [Cluster] [D API] Finished executing request locally
2021/05/20 12:32:28 DEBUG: [Worker worker2] [D API] Time calculating request result: 0.003s
2021/05/20 12:32:28 INFO: [Cluster] [Main] SIGNAL [(15)-(SIGTERM)] received. Exit...
```

The signal is being handled in the [wazuh-clusterd.py](https://github.com/wazuh/wazuh/blob/master/framework/scripts/wazuh-clusterd.py) script so it is common for both types of nodes. It will handle SIGTERM singals whatever its procedence is (API requset, using binary, etc).

Although the issue suggested show it as a `DEBUG` message, I decided to make it `INFO` so it is consistent with those in the `ossec.log`:
```
2021/05/20 12:36:26 wazuh-logcollector: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
```

Regards,
Selu.