### PR TITLE
Wildcards configuration update in FIM Scan

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1316,6 +1316,9 @@ wrappers_wazuh_addagent_o := $(wrappers_wazuh_addagent_c:.c=.o)
 wrappers_client_agent_c := $(wildcard unit_tests/wrappers/wazuh/client-agent/*.c)
 wrappers_client_agent_o := $(wrappers_client_agent_c:.c=.o)
 
+wrappers_wazuh_config_c := $(wildcard unit_tests/wrappers/wazuh/config/*.c)
+wrappers_wazuh_config_o := $(wrappers_wazuh_config_c:.c=.o)
+
 wrappers_windows_c := $(wildcard unit_tests/wrappers/windows/*.c)
 wrappers_windows_o := $(wrappers_windows_c:.c=.o)
 
@@ -1354,6 +1357,7 @@ ifneq (,$(filter ${TEST},YES yes y Y 1))
 	UNIT_TEST_WRAPPERS+=${wrappers_wazuh_monitord_o}
 	UNIT_TEST_WRAPPERS+=${wrappers_wazuh_os_auth_o}
 	UNIT_TEST_WRAPPERS+=${wrappers_wazuh_addagent_o}
+	UNIT_TEST_WRAPPERS+=${wrappers_wazuh_config_o}
 	UNIT_TEST_WRAPPERS+=${wrappers_client_agent_o}
 
 	ifeq (${TARGET},winagent)
@@ -2148,6 +2152,9 @@ unit_tests/wrappers/wazuh/os_auth/%.o: unit_tests/wrappers/wazuh/os_auth/%.c
 unit_tests/wrappers/wazuh/addagent/%.o: unit_tests/wrappers/wazuh/addagent/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} ${DEFINES_EVENTCHANNEL} -c $^ -o $@
 
+unit_tests/wrappers/wazuh/config/%.o: unit_tests/wrappers/wazuh/config/%.c
+	${OSSEC_CC} ${OSSEC_CFLAGS} ${DEFINES_EVENTCHANNEL} -c $^ -o $@
+
 unit_tests/wrappers/windows/%.o: unit_tests/wrappers/windows/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} ${DEFINES_EVENTCHANNEL} -c $^ -o $@
 
@@ -2348,6 +2355,7 @@ clean-unit-tests:
 	rm -f ${wrappers_wazuh_monitord_o}
 	rm -f ${wrappers_wazuh_os_auth_o}
 	rm -f ${wrappers_wazuh_addagent_o}
+	rm -f ${wrappers_wazuh_config_o}
 	rm -f ${wrappers_windows_o}
 	rm -f ${wrappers_windows_lib_o}
 	rm -f ${wrappers_windows_posix_o}

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -70,6 +70,15 @@ void fim_insert_directory(OSList *config_list,
         if (cmp == 0) {
             // Duplicated entry, replace existing with new one
             if (dir_it->is_wildcard == new_entry->is_wildcard || new_entry->is_wildcard == 0) {
+                // Before replacing the configuration, we will keep the previous symbolic_links,
+                // this value should only be changed by symlink_checker_thread.
+                // TODO: unify symlink update logic with wildcards.
+                os_free(new_entry->symbolic_links);
+
+                if (dir_it->symbolic_links != NULL) {
+                    os_strdup(dir_it->symbolic_links, new_entry->symbolic_links);
+                }
+
                 free_directory(dir_it);
                 node_it->data = new_entry;
             } else {

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -93,11 +93,9 @@ directory_t *fim_copy_directory(const directory_t *_dir) {
     }
     char *filerestrict = NULL;
 
-#ifndef WIN32
     if (_dir->filerestrict) {
         filerestrict = _dir->filerestrict->raw;
     }
-#endif
 
     return fim_create_directory(_dir->path, _dir->options, filerestrict, _dir->recursion_level,
                                 _dir->tag, _dir->diff_size_limit, _dir->is_wildcard);
@@ -1029,6 +1027,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                         merror(MEM_ERROR, errno, strerror(errno));
                         continue;
                     }
+                    OSList_SetFreeDataPointer(syscheck->wildcards, (void (*)(void *))free_directory);
                 }
 
                 // Create the wildcard directory
@@ -2117,8 +2116,6 @@ void free_directory(directory_t *dir) {
 }
 
 void Free_Syscheck(syscheck_config * config) {
-    OSListNode *node_it;
-
     if (config) {
         int i;
         if (config->scan_day) {
@@ -2154,18 +2151,10 @@ void Free_Syscheck(syscheck_config * config) {
             free(config->nodiff_regex);
         }
         if (config->directories) {
-            OSList_foreach(node_it, config->directories) {
-                free_directory(node_it->data);
-                node_it->data = NULL;
-            }
             OSList_Destroy(config->directories);
             config->directories = NULL;
         }
         if (config->wildcards) {
-            OSList_foreach(node_it, config->wildcards) {
-                free_directory(node_it->data);
-                node_it->data = NULL;
-            }
             OSList_Destroy(config->wildcards);
             config->wildcards = NULL;
         }

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1022,29 +1022,28 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
 
             // Fill wildcards array
             if (strchr(clean_path, '*') || strchr(clean_path, '?') || strchr(clean_path, '[')) {
-                directory_t *wildcard = fim_create_directory(clean_path, opts, restrictfile, recursion_limit,
-                                                             clean_tag, tmp_diff_size, 1);
                 if (syscheck->wildcards == NULL) {
                     syscheck->wildcards = OSList_Create();
                     if (syscheck->wildcards == NULL) {
-                        free_directory(wildcard);
                         os_free(clean_path);
                         merror(MEM_ERROR, errno, strerror(errno));
                         continue;
                     }
                 }
-
-                // Check directories options to determine whether to start the whodata thread or not
-                if (wildcard->options & WHODATA_ACTIVE) {
-                    syscheck->enable_whodata = 1;
-                }
-
-                fim_insert_directory(syscheck->wildcards, wildcard);
                 paths = expand_wildcards(clean_path);
 
                 if (paths == NULL) {
                     os_free(clean_path);
                     continue;
+                }
+
+                // Create the wildcard directory
+                directory_t *wildcard = fim_create_directory(clean_path, opts, restrictfile, recursion_limit,
+                                                             clean_tag, tmp_diff_size, 1);
+
+                // Check directories options to determine whether to start the whodata thread or not
+                if (wildcard->options & WHODATA_ACTIVE) {
+                    syscheck->enable_whodata = 1;
                 }
 
                 for (int j = 0; paths[j]; j++) {
@@ -1062,8 +1061,9 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
 
                     fim_insert_directory(syscheck->directories, new_entry);
                 }
-
                 os_free(paths);
+
+                fim_insert_directory(syscheck->wildcards, wildcard);
             } else {
                 new_entry = fim_create_directory(clean_path, opts, restrictfile, recursion_limit,
                                      clean_tag, tmp_diff_size, 0);

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -69,8 +69,12 @@ void fim_insert_directory(OSList *config_list,
         int cmp = strcmp(dir_it->path, new_entry->path);
         if (cmp == 0) {
             // Duplicated entry, replace existing with new one
-            free_directory(dir_it);
-            node_it->data = new_entry;
+            if (dir_it->is_wildcard == new_entry->is_wildcard || new_entry->is_wildcard == 0) {
+                free_directory(dir_it);
+                node_it->data = new_entry;
+            } else {
+                free_directory(new_entry);
+            }
             return;
         } else if (cmp > 0) {
             // Insert the new entry before the current node.

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -366,7 +366,8 @@ typedef struct _config {
     unsigned int enable_synchronization:1;    /* Enable database synchronization */
     unsigned int enable_registry_synchronization:1; /* Enable registry database synchronization */
 
-    directory_t **directories; /* List of directories to be monitored */
+    directory_t **directories;      /* List of directories to be monitored */
+    directory_t **wildcards;        /* List of wildcards to be monitored */
 
     char *scan_day;                 /* run syscheck on this day */
     char *scan_time;                /* run syscheck at this time */
@@ -451,20 +452,44 @@ int read_data_unit(const char *content);
 void parse_diff(const OS_XML *xml, syscheck_config * syscheck, XML_NODE node);
 
 /**
- * @brief Adds (or overwrite if exists) an entry to the syscheck configuration structure
+ * @brief Creates a directory_t object from defined values
  *
- * @param syscheck Syscheck configuration structure
- * @param entry Entry to be dumped
- * @param vals Indicates the attributes for folders or registries to be set
- * @param restrictfile The restrict regex to be set
+ * @param path Path to be dumped
+ * @param options Indicates the attributes for folders or registries to be set
+ * @param filerestrict The restrict string to be set
  * @param recursion_level The recursion level to be set
  * @param tag The tag to be set
- * @param link If the added entry is pointed by a symbolic link for folders and arch for registries
- * @param diff_size Maximum size to calculate diff for files in the directory
+ * @param diff_size_limit Maximum size to calculate diff for files in the directory
  */
-void dump_syscheck_file(syscheck_config *syscheck, char *entry, int vals, const char *restrictfile,
-                            int recursion_level, const char *tag, const char *link,
-                            int diff_size) __attribute__((nonnull(1, 2)));
+directory_t *fim_create_directory(const char *path,
+                                  int options,
+                                  const char *filerestrict,
+                                  int recursion_level,
+                                  const char *tag,
+                                  int diff_size_limit);
+
+/**
+ * @brief Inserts the directory_t 'config_object' into the directory_t array 'config_array'
+ *
+ * @param config_array directory_t array from the syscheck configuration, passed by reference
+ * @param config_object directory_t object to be inserted
+ */
+void fim_insert_directory(directory_t ***config_array,
+                          directory_t *config_object);
+
+/**
+ * @brief Copies a given directory_t object and returns a reference to the copy.
+ *
+ * @param _dir directory_t object to be copied
+ */
+directory_t *fim_copy_directory(const directory_t *_dir);
+
+/**
+ * @brief Expands wildcards in the given path
+ *
+ * @param path Path to be expanded
+ */
+char **expand_wildcards(const char *path);
 
 #ifdef WIN32
 /**

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -80,10 +80,6 @@ typedef enum fdb_stmt {
     FIMDB_STMT_SIZE
 } fdb_stmt;
 
-#define OSList_foreach(node_it, list)                                                  \
-    for (node_it = (list != NULL) ? OSList_GetFirstNode(list) : NULL; node_it != NULL; \
-         node_it = OSList_GetNext(list, node_it))
-
 #define FIM_MODE(x) (x & WHODATA_ACTIVE ? FIM_WHODATA : x & REALTIME_ACTIVE ? FIM_REALTIME : FIM_SCHEDULED)
 
 #if defined(WIN32) && defined(EVENTCHANNEL_SUPPORT)

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -417,6 +417,7 @@ typedef struct _config {
     int audit_healthcheck;          // Startup health-check for whodata
     int sym_checker_interval;
 
+    pthread_rwlock_t directories_lock;
     pthread_mutex_t fim_entry_mutex;
     pthread_mutex_t fim_scan_mutex;
     pthread_mutex_t fim_realtime_mutex;
@@ -493,15 +494,6 @@ directory_t *fim_copy_directory(const directory_t *_dir);
  * @param path Path to be expanded
  */
 char **expand_wildcards(const char *path);
-
-/**
- * @brief Update directories configuration with the wildcard list
- *
- * @param OSList List of directories to be updated
- * @param OSList List wildcards to expand
- */
-void update_wildcards_config(OSList *directories,
-                             OSList *wildcards);
 
 #ifdef WIN32
 /**

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -230,7 +230,6 @@ typedef struct whodata_evt {
     unsigned __int64 process_id;
     unsigned int mask;
     char scan_directory;
-    directory_t *config_node;
 #endif
 } whodata_evt;
 

--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -256,6 +256,9 @@
 #define FIM_DIFF_FOLDER_DELETED             "(6358): Folder '%s' has been deleted."
 #define GLOB_NO_MATCH                       "(6359): No matches found for the glob pattern: '%s'"
 #define FIM_DB_FAIL_TO_GET_SCANNED_FILE     "(6360): Failed to get scanned value of '%s' - %s"
+#define FIM_WILDCARDS_UPDATE_START          "(6361): Starting configuration wildcards update."
+#define FIM_WILDCARDS_REMOVE_DIRECTORY      "(6362): Removing entry '%s' due to it has not been expanded by the wildcards"
+#define FIM_WILDCARDS_UPDATE_FINALIZE       "(6363): Configuration wildcards update finalize."
 
 /* Modules messages */
 #define WM_UPGRADE_RESULT_AGENT_INFO         "(8151): Agent Information obtained: '%s'"

--- a/src/headers/list_op.h
+++ b/src/headers/list_op.h
@@ -73,4 +73,21 @@ void OSList_CleanNodes(OSList *list);
  */
 void OSList_CleanOnlyNodes(OSList *list);
 
+/**
+ * @brief Get the next node to a given node
+ *
+ * @param list List where to get the node from
+ * @param node Node reference to get next
+ */
+OSListNode *OSList_GetNext(OSList *list, OSListNode *node);
+
+/**
+ * @brief Insert data in the place of a given node
+ *
+ * @param list List where to get the node from
+ * @param node Node reference to insert new node with data
+ * @param node Data to be insert
+ */
+int OSList_InsertData(OSList *list, OSListNode *node, void *data);
+
 #endif /* OS_LIST */

--- a/src/headers/list_op.h
+++ b/src/headers/list_op.h
@@ -86,8 +86,16 @@ OSListNode *OSList_GetNext(OSList *list, OSListNode *node);
  *
  * @param list List where to get the node from
  * @param node Node reference to insert new node with data
- * @param node Data to be insert
+ * @param data Data to be insert
  */
 int OSList_InsertData(OSList *list, OSListNode *node, void *data);
+
+/**
+ * @brief Get the pointer to data from the node placed in index position
+ *
+ * @param list List where to get the node from
+ * @param index Index that indicate the position of the node required
+ */
+void *OSList_GetDataFromIndex(OSList *list, int index);
 
 #endif /* OS_LIST */

--- a/src/headers/list_op.h
+++ b/src/headers/list_op.h
@@ -102,4 +102,12 @@ int OSList_InsertData(OSList *list, OSListNode *node, void *data);
  */
 void *OSList_GetDataFromIndex(OSList *list, int index);
 
+/**
+ * @brief Insert data at the beggining of a list
+ *
+ * @param list List where the node will be inserted into
+ * @param data Data to be inserted
+ */
+int OSList_PushData(OSList *list, void *data);
+
 #endif /* OS_LIST */

--- a/src/headers/list_op.h
+++ b/src/headers/list_op.h
@@ -13,6 +13,10 @@
 #ifndef OS_LIST
 #define OS_LIST
 
+#define OSList_foreach(node_it, list)                                                  \
+    for (node_it = (list != NULL) ? OSList_GetFirstNode(list) : NULL; node_it != NULL; \
+         node_it = OSList_GetNext(list, node_it))
+
 typedef struct _OSListNode {
     struct _OSListNode *next;
     struct _OSListNode *prev;

--- a/src/shared/list_op.c
+++ b/src/shared/list_op.c
@@ -425,10 +425,12 @@ OSListNode *OSList_GetNext(OSList *list, OSListNode *node) {
 
 void *OSList_GetDataFromIndex(OSList *list, int index) {
     int count = 0;
-    OSListNode *current = list->first_node;
+    OSListNode *current;
 
     w_rwlock_rdlock((pthread_rwlock_t *)&list->wr_mutex);
     w_mutex_lock((pthread_mutex_t *)&list->mutex);
+
+    current = list->first_node;
 
     while (current != NULL) {
         if (count == index) {
@@ -452,19 +454,17 @@ void *OSList_GetDataFromIndex(OSList *list, int index) {
 int OSList_InsertData(OSList *list, OSListNode *node, void *data) {
     OSListNode *newnode;
 
-    w_rwlock_wrlock((pthread_rwlock_t *)&list->wr_mutex);
-    w_mutex_lock((pthread_mutex_t *)&list->mutex);
-
     /* Allocate memory for new node */
     newnode = (OSListNode *) calloc(1, sizeof(OSListNode));
     if (newnode == NULL) {
         // LCOV_EXCL_START
         merror(MEM_ERROR, errno, strerror(errno));
-        w_mutex_unlock((pthread_mutex_t *)&list->mutex);
-        w_rwlock_unlock((pthread_rwlock_t *)&list->wr_mutex);
         return 1;
         // LCOV_EXCL_STOP
     }
+
+    w_rwlock_wrlock((pthread_rwlock_t *)&list->wr_mutex);
+    w_mutex_lock((pthread_mutex_t *)&list->mutex);
 
     newnode->data = data;
 

--- a/src/shared/list_op.c
+++ b/src/shared/list_op.c
@@ -447,7 +447,7 @@ void *OSList_GetDataFromIndex(OSList *list, int index) {
 }
 
 /* Add data to the list
- * Returns 1 on success and 0 on failure
+ * Returns 0 on success and 1 on failure
  */
 int OSList_InsertData(OSList *list, OSListNode *node, void *data) {
     OSListNode *newnode;

--- a/src/shared/list_op.c
+++ b/src/shared/list_op.c
@@ -458,10 +458,12 @@ int OSList_InsertData(OSList *list, OSListNode *node, void *data) {
     /* Allocate memory for new node */
     newnode = (OSListNode *) calloc(1, sizeof(OSListNode));
     if (newnode == NULL) {
+        // LCOV_EXCL_START
         merror(MEM_ERROR, errno, strerror(errno));
         w_mutex_unlock((pthread_mutex_t *)&list->mutex);
         w_rwlock_unlock((pthread_rwlock_t *)&list->wr_mutex);
         return 1;
+        // LCOV_EXCL_STOP
     }
 
     newnode->data = data;

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -43,6 +43,7 @@ int Read_Syscheck_Config(const char *cfgfile)
     syscheck.file_limit_enabled = true;
     syscheck.file_limit     = 100000;
     syscheck.directories = NULL;
+    syscheck.wildcards = NULL;
     syscheck.enable_synchronization = 1;
     syscheck.restart_audit  = 1;
     syscheck.enable_whodata = 0;

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -179,9 +179,9 @@ void free_whodata_event(whodata_evt *w_evt) {
 }
 
 cJSON *getSyscheckConfig(void) {
-
+    w_rwlock_rdlock(&syscheck.directories_lock);
 #ifndef WIN32
-    if (!syscheck.directories) {
+    if (OSList_GetFirstNode(syscheck.directories) == NULL) {
         return NULL;
     }
 #endif
@@ -220,7 +220,6 @@ cJSON *getSyscheckConfig(void) {
 
     cJSON_AddItemToObject(syscfg, "diff", diff);
 
-    w_rwlock_rdlock(&syscheck.directories_lock);
     if (syscheck.directories) {
         directory_t *dir_it;
         cJSON *dirs = cJSON_CreateArray();

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -47,6 +47,7 @@ int Read_Syscheck_Config(const char *cfgfile)
     if (syscheck.directories == NULL) {
         return (OS_INVALID);
     }
+    OSList_SetFreeDataPointer(syscheck.directories, (void (*)(void *))free_directory);
     syscheck.wildcards = NULL;
     syscheck.enable_synchronization = 1;
     syscheck.restart_audit  = 1;

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -220,7 +220,7 @@ cJSON *getSyscheckConfig(void) {
 
     cJSON_AddItemToObject(syscfg, "diff", diff);
 
-    if (syscheck.directories) {
+    if (OSList_GetFirstNode(syscheck.directories) != NULL) {
         directory_t *dir_it;
         cJSON *dirs = cJSON_CreateArray();
         OSListNode *node_it;

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -365,10 +365,12 @@ void fim_checker(const char *path, event_data_t *evt_data, const directory_t *pa
         }
         fim_directory(path, evt_data, configuration);
 
-#ifndef WIN32
-        w_mutex_lock(&syscheck.fim_realtime_mutex);
-        realtime_adddir(path, configuration);
-        w_mutex_unlock(&syscheck.fim_realtime_mutex);
+#ifdef INOTIFY_ENABLED
+        if (FIM_MODE(configuration->options) == FIM_REALTIME) {
+            w_mutex_lock(&syscheck.fim_realtime_mutex);
+            fim_add_inotify_watch(path, configuration);
+            w_mutex_unlock(&syscheck.fim_realtime_mutex);
+        }
 #endif
         break;
     }

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -530,7 +530,6 @@ static fim_sanitize_state_t fim_process_file_from_db(const char *path, OSList *s
         configuration = fim_configuration_directory(path);
         if (configuration == NULL) {
             // This should not happen
-            w_rwlock_unlock(&syscheck.directories_lock);
             free_entry(entry);     // LCOV_EXCL_LINE
             return FIM_FILE_ERROR; // LCOV_EXCL_LINE
         }
@@ -552,7 +551,6 @@ end:
     configuration = fim_configuration_directory(path);
     if (configuration == NULL) {
         // This should not happen
-        w_rwlock_unlock(&syscheck.directories_lock);
         free_entry(entry);     // LCOV_EXCL_LINE
         return FIM_FILE_ERROR; // LCOV_EXCL_LINE
     }
@@ -1705,11 +1703,7 @@ void update_wildcards_config() {
             os_free(new_entry->path);
 
             new_entry->path = paths[i];
-#ifndef WIN32
-            if (CHECK_FOLLOW & new_entry->options) {
-                new_entry->symbolic_links = realpath(new_entry->path, NULL);
-            }
-#else
+#ifdef WIN32
             str_lowercase(new_entry->path);
 #endif
             new_entry->is_expanded = 1;

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -480,7 +480,6 @@ static fim_sanitize_state_t fim_process_file_from_db(const char *path, OSList *s
         configuration = fim_configuration_directory(path);
         if (configuration == NULL) {
             // This should not happen
-            w_rwlock_unlock(&syscheck.directories_lock);
             free_entry(entry);
             return FIM_FILE_ERROR;
         }
@@ -490,7 +489,6 @@ static fim_sanitize_state_t fim_process_file_from_db(const char *path, OSList *s
         }
 
         if (fim_db_remove_path(syscheck.database, entry->file_entry.path) == FIMDB_ERR) {
-            w_rwlock_unlock(&syscheck.directories_lock);
             free_entry(entry);
             return FIM_FILE_ERROR;
         }

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -1652,13 +1652,17 @@ void update_wildcards_config(){
         for (int i = 0; paths[i]; i++) {
             new_entry = fim_copy_directory(dir_it);
             os_free(new_entry->path);
-            new_entry->path = paths[i];
-            new_entry->is_expanded = 1;
+
 #ifndef WIN32
             if (CHECK_FOLLOW & new_entry->options) {
                 new_entry->symbolic_links = realpath(new_entry->path, NULL);
             }
+#else
+            str_lowercase(paths[i]);
 #endif
+            new_entry->path = paths[i];
+            new_entry->is_expanded = 1;
+
             if (new_entry->diff_size_limit == -1) {
                 new_entry->diff_size_limit = syscheck.file_size_limit;
             }

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -1738,8 +1738,9 @@ void update_wildcards_config() {
                 remove_audit_rule_syscheck(dir_it->path);
             }
 #endif
-            // Add node to delete list
-            OSList_AddData(removed_entries, dir_it);
+            // Inserting like this will cause the new list to have the order reversed to the one in syscheck.directories
+            // This will cause the following loop to delete "inner" directories before "outer" ones
+            OSList_PushData(removed_entries, dir_it);
 
             // Delete node
             aux_it = OSList_GetNext(syscheck.directories, node_it);

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -1653,14 +1653,14 @@ void update_wildcards_config(){
             new_entry = fim_copy_directory(dir_it);
             os_free(new_entry->path);
 
+            new_entry->path = paths[i];
 #ifndef WIN32
             if (CHECK_FOLLOW & new_entry->options) {
                 new_entry->symbolic_links = realpath(new_entry->path, NULL);
             }
 #else
-            str_lowercase(paths[i]);
+            str_lowercase(new_entry->path);
 #endif
-            new_entry->path = paths[i];
             new_entry->is_expanded = 1;
 
             if (new_entry->diff_size_limit == -1) {

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -1683,6 +1683,17 @@ void update_wildcards_config(){
             // Send event if needed before delete this node entry
             fim_process_missing_entry(dir_it->path, FIM_SCHEDULED, NULL);
 
+#if INOTIFY_ENABLED
+            if (FIM_MODE(dir_it->options) == FIM_REALTIME) {
+                fim_delete_realtime_watches(dir_it);
+            }
+#endif
+#if ENABLE_AUDIT
+            if (FIM_MODE(dir_it->options) == FIM_WHODATA) {
+                remove_audit_rule_syscheck(dir_it->path);
+            }
+#endif
+
             // Delete node
             mdebug2(FIM_WILDCARDS_REMOVE_DIRECTORY, dir_it->path);
             aux_it = OSList_GetNext(syscheck.directories, node_it);

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -834,6 +834,7 @@ void fim_whodata_event(whodata_evt * w_evt) {
 
     struct stat file_stat;
 
+    w_rwlock_rdlock(&syscheck.directories_lock);
     // If the file exists, generate add or modify events.
     if(w_stat(w_evt->path, &file_stat) >= 0) {
         event_data_t evt_data = { .mode = FIM_WHODATA, .w_evt = w_evt, .report_event = true };
@@ -862,6 +863,7 @@ void fim_whodata_event(whodata_evt * w_evt) {
         }
 #endif
     }
+    w_rwlock_unlock(&syscheck.directories_lock);
 }
 
 
@@ -1638,11 +1640,14 @@ void update_wildcards_config(OSList *directories,
                 new_entry->diff_size_limit = syscheck.file_size_limit;
             }
 
-#ifdef WIN_WHODATA
             if (FIM_MODE(new_entry->options) == FIM_WHODATA) {
+#ifdef WIN32
                 realtime_adddir(new_entry->path, new_entry, 0);
-            }
+#else
+                add_whodata_directory(new_entry->path);
 #endif
+            }
+
             fim_insert_directory(directories, new_entry);
         }
         os_free(paths);

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -172,9 +172,7 @@ time_t fim_scan() {
         fim_checker(path, &evt_data, dir_it);
 
 #ifndef WIN32
-        w_mutex_lock(&syscheck.fim_realtime_mutex);
         realtime_adddir(path, dir_it);
-        w_mutex_unlock(&syscheck.fim_realtime_mutex);
 #elif defined WIN_WHODATA
         if (FIM_MODE(dir_it->options) == FIM_WHODATA) {
             realtime_adddir(path, dir_it);
@@ -379,9 +377,7 @@ void fim_checker(const char *path, event_data_t *evt_data, const directory_t *pa
 
 #ifdef INOTIFY_ENABLED
         if (FIM_MODE(configuration->options) == FIM_REALTIME) {
-            w_mutex_lock(&syscheck.fim_realtime_mutex);
             fim_add_inotify_watch(path, configuration);
-            w_mutex_unlock(&syscheck.fim_realtime_mutex);
         }
 #endif
         break;

--- a/src/syscheckd/db/fim_db_files.c
+++ b/src/syscheckd/db/fim_db_files.c
@@ -109,6 +109,22 @@ void fim_db_remove_validated_path(fdb_t *fim_sql,
                                   void *configuration,
                                   void *_unused_patameter);
 
+/**
+ * @brief Removes paths from the FIM DB if its configuration matches with the one provided
+ *
+ * @param fim_sql FIM database structure.
+ * @param entry Entry data to be removed.
+ * @param mutex FIM database's mutex for thread synchronization.
+ * @param evt_data Information on how the event was triggered.
+ * @param _configuration Position of the configuration that triggered the deletion of entries.
+ * @param _unused_parameter Needed for this function to be a valid FIM DB callback.
+ */
+void fim_db_wildcard_delete_event(fdb_t *fim_sql,
+                                  fim_entry *entry,
+                                  pthread_mutex_t *mutex,
+                                  void *evt_data,
+                                  void *_configuration,
+                                  void *_unused_patameter);
 
 int fim_db_get_not_scanned(fdb_t * fim_sql, fim_tmp_file **file, int storage) {
     if ((*file = fim_db_create_temp_file(storage)) == NULL) {
@@ -158,7 +174,7 @@ int fim_db_remove_wildcard_entry(fdb_t *fim_sql,
                                  int storage,
                                  event_data_t *evt_data,
                                  directory_t *configuration) {
-    return fim_db_process_read_file(fim_sql, file, FIM_TYPE_FILE, mutex, fim_generate_delete_event, storage, evt_data,
+    return fim_db_process_read_file(fim_sql, file, FIM_TYPE_FILE, mutex, fim_db_wildcard_delete_event, storage, evt_data,
                                     configuration, NULL);
 }
 // LCOV_EXCL_STOP
@@ -526,6 +542,18 @@ void fim_db_remove_validated_path(fdb_t *fim_sql,
     if (validated_configuration == original_configuration) {
         fim_delete_file_event(fim_sql, entry, mutex, evt_data, NULL, NULL);
     }
+}
+
+void fim_db_wildcard_delete_event(fdb_t *fim_sql,
+                                  fim_entry *entry,
+                                  pthread_mutex_t *mutex,
+                                  void *evt_data,
+                                  void *_configuration,
+                                  __attribute__((unused)) void *_unused_patameter) {
+    if (fim_configuration_directory(entry->file_entry.path) != NULL) {
+        return;
+    }
+    fim_generate_delete_event(fim_sql, entry, mutex, evt_data, _configuration, NULL);
 }
 
 int fim_db_set_all_unscanned(fdb_t *fim_sql) {

--- a/src/syscheckd/db/fim_db_files.c
+++ b/src/syscheckd/db/fim_db_files.c
@@ -151,6 +151,16 @@ int fim_db_process_missing_entry(fdb_t *fim_sql,
     return fim_db_process_read_file(fim_sql, file, FIM_TYPE_FILE, mutex, fim_delete_file_event, storage, evt_data, NULL,
                                     NULL);
 }
+
+int fim_db_remove_wildcard_entry(fdb_t *fim_sql,
+                                 fim_tmp_file *file,
+                                 pthread_mutex_t *mutex,
+                                 int storage,
+                                 event_data_t *evt_data,
+                                 directory_t *configuration) {
+    return fim_db_process_read_file(fim_sql, file, FIM_TYPE_FILE, mutex, fim_generate_delete_event, storage, evt_data,
+                                    configuration, NULL);
+}
 // LCOV_EXCL_STOP
 
 fim_entry *fim_db_decode_full_row(sqlite3_stmt *stmt) {

--- a/src/syscheckd/db/fim_db_files.c
+++ b/src/syscheckd/db/fim_db_files.c
@@ -550,9 +550,12 @@ void fim_db_wildcard_delete_event(fdb_t *fim_sql,
                                   void *evt_data,
                                   void *_configuration,
                                   __attribute__((unused)) void *_unused_patameter) {
+    w_rwlock_rdlock(&syscheck.directories_lock);
     if (fim_configuration_directory(entry->file_entry.path) != NULL) {
+        w_rwlock_unlock(&syscheck.directories_lock);
         return;
     }
+    w_rwlock_unlock(&syscheck.directories_lock);
     fim_generate_delete_event(fim_sql, entry, mutex, evt_data, _configuration, NULL);
 }
 

--- a/src/syscheckd/db/fim_db_files.h
+++ b/src/syscheckd/db/fim_db_files.h
@@ -187,6 +187,25 @@ int fim_db_process_missing_entry(fdb_t *fim_sql,
                                  event_data_t *evt_data);
 
 /**
+ * @brief Remove a wildcard directory that were not expanded from the configuration
+ *
+ * @param fim_sql FIM database struct.
+ * @param file Structure of the file which contains all the paths.
+ * @param mutex FIM database's mutex for thread synchronization.
+ * @param storage 1 Store database in memory, disk otherwise.
+ * @param evt_data Information on how the event was triggered.
+ * @param configuration An integer holding the position of the configuration that corresponds to the entries to be deleted.
+ *
+ * @return FIMDB_OK on success, FIMDB_ERR otherwise.
+ */
+int fim_db_remove_wildcard_entry(fdb_t *fim_sql,
+                                 fim_tmp_file *file,
+                                 pthread_mutex_t *mutex,
+                                 int storage,
+                                 event_data_t *evt_data,
+                                 directory_t *configuration);
+
+/**
  * @brief Decodes a row from the database to be saved in a fim_entry structure.
  *
  * @param stmt The statement to be decoded.

--- a/src/syscheckd/fim_diff_changes.c
+++ b/src/syscheckd/fim_diff_changes.c
@@ -470,8 +470,10 @@ diff_data *initialize_file_diff_data(const char *filename){
     diff->file_size = 0;
 
     if (syscheck.file_size_enabled) {
+        w_rwlock_rdlock(&syscheck.directories_lock);
         const directory_t *configuration = fim_configuration_directory(filename);
         diff->size_limit = configuration->diff_size_limit;
+        w_rwlock_unlock(&syscheck.directories_lock);
     }
 
     // Get absolute path of filename:

--- a/src/syscheckd/main.c
+++ b/src/syscheckd/main.c
@@ -268,7 +268,7 @@ int main(int argc, char **argv)
             // Switch who-data to real-time mode
 
             OSList_foreach(node_it, syscheck.directories) {
-            dir_it = node_it->data;
+                dir_it = node_it->data;
                 if (dir_it->options & WHODATA_ACTIVE) {
                     dir_it->options &= ~WHODATA_ACTIVE;
                     dir_it->options |= REALTIME_ACTIVE;

--- a/src/syscheckd/main.c
+++ b/src/syscheckd/main.c
@@ -115,7 +115,7 @@ int main(int argc, char **argv)
         merror(RCONFIG_ERROR, SYSCHECK, cfg);
         syscheck.disabled = 1;
     } else if ((r == 1) || (syscheck.disabled == 1)) {
-        if (syscheck.directories == NULL || syscheck.directories[0] == NULL) {
+        if (syscheck.directories == NULL || syscheck.directories->first_node == NULL) {
             if (!test_config) {
                 minfo(FIM_DIRECTORY_NOPROVIDED);
             }
@@ -176,11 +176,14 @@ int main(int argc, char **argv)
     }
 
     if (!syscheck.disabled) {
+        OSListNode *node_it;
+
         /* Start up message */
         minfo(STARTUP_MSG, (int)getpid());
 
         /* Print directories to be monitored */
-        foreach_array(dir_it, syscheck.directories) {
+        OSList_foreach(node_it, syscheck.directories) {
+            dir_it = node_it->data;
             char optstr[ 1024 ];
 
             if (dir_it->symbolic_links == NULL) {
@@ -232,7 +235,8 @@ int main(int argc, char **argv)
         }
 
         /* Check directories set for real time */
-        foreach_array(dir_it, syscheck.directories) {
+        OSList_foreach(node_it, syscheck.directories) {
+            dir_it = node_it->data;
             if (dir_it->options & REALTIME_ACTIVE) {
 #if defined (INOTIFY_ENABLED) || defined (WIN32)
                 minfo(FIM_REALTIME_MONITORING_DIRECTORY, dir_it->path);
@@ -257,12 +261,14 @@ int main(int argc, char **argv)
 #ifdef ENABLE_AUDIT
         if (audit_init() < 0) {
             directory_t *dir_it;
+            OSListNode *node_it;
 
             mwarn(FIM_WARN_AUDIT_THREAD_NOSTARTED);
 
             // Switch who-data to real-time mode
 
-            foreach_array(dir_it, syscheck.directories) {
+            OSList_foreach(node_it, syscheck.directories) {
+            dir_it = node_it->data;
                 if (dir_it->options & WHODATA_ACTIVE) {
                     dir_it->options &= ~WHODATA_ACTIVE;
                     dir_it->options |= REALTIME_ACTIVE;

--- a/src/syscheckd/main.c
+++ b/src/syscheckd/main.c
@@ -253,8 +253,8 @@ int main(int argc, char **argv)
             dir_it = node_it->data;
             if (dir_it->options & REALTIME_ACTIVE) {
 #if defined (INOTIFY_ENABLED) || defined (WIN32)
-                minfo(FIM_REALTIME_MONITORING_DIRECTORY, dir_it->path);
                 start_realtime = 1;
+                break;
 #else
                 mwarn(FIM_WARN_REALTIME_DISABLED, dir_it->path);
                 dir_it->options &= ~REALTIME_ACTIVE;

--- a/src/syscheckd/main.c
+++ b/src/syscheckd/main.c
@@ -115,7 +115,7 @@ int main(int argc, char **argv)
         merror(RCONFIG_ERROR, SYSCHECK, cfg);
         syscheck.disabled = 1;
     } else if ((r == 1) || (syscheck.disabled == 1)) {
-        if (syscheck.directories == NULL || syscheck.directories->first_node == NULL) {
+        if (syscheck.directories == NULL || OSList_GetFirstNode(syscheck.directories) == NULL) {
             if (!test_config) {
                 minfo(FIM_DIRECTORY_NOPROVIDED);
             }

--- a/src/syscheckd/main.c
+++ b/src/syscheckd/main.c
@@ -248,6 +248,20 @@ int main(int argc, char **argv)
 #endif
             }
         }
+
+        OSList_foreach(node_it, syscheck.wildcards) {
+            dir_it = node_it->data;
+            if (dir_it->options & REALTIME_ACTIVE) {
+#if defined (INOTIFY_ENABLED) || defined (WIN32)
+                minfo(FIM_REALTIME_MONITORING_DIRECTORY, dir_it->path);
+                start_realtime = 1;
+#else
+                mwarn(FIM_WARN_REALTIME_DISABLED, dir_it->path);
+                dir_it->options &= ~REALTIME_ACTIVE;
+                dir_it->options |= SCHEDULED_ACTIVE;
+#endif
+            }
+        }
     }
 
     fim_initialize();

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -373,7 +373,7 @@ void * fim_run_realtime(__attribute__((unused)) void * args) {
     while (1) {
 #ifdef WIN32
         // Directories in Windows configured with real-time add recursive watches
-        w_rwlock_rdlock(&syscheck.directories_lock);
+        w_rwlock_wrlock(&syscheck.directories_lock);
         OSList_foreach(node_it, syscheck.directories) {
             dir_it = node_it->data;
             if (dir_it->options & REALTIME_ACTIVE) {

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -60,7 +60,6 @@ STATIC void fim_link_check_delete(directory_t *configuration);
 STATIC void fim_link_delete_range(directory_t *configuration);
 STATIC void fim_link_silent_scan(const char *path, directory_t *configuration);
 STATIC void fim_link_reload_broken_link(char *path, directory_t *configuration);
-STATIC void fim_delete_realtime_watches(const directory_t *configuration);
 #endif
 
 // Send a message
@@ -769,7 +768,7 @@ STATIC void fim_link_check_delete(directory_t *configuration) {
     }
 }
 
-STATIC void fim_delete_realtime_watches(__attribute__((unused)) const directory_t *configuration) {
+void fim_delete_realtime_watches(__attribute__((unused)) const directory_t *configuration) {
 #ifdef INOTIFY_ENABLED
     OSHashNode *hash_node;
     char *data;

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -536,7 +536,7 @@ int fim_whodata_initialize() {
         // In case SACLs and policies have been set, restore them.
         audit_restore();
 
-        w_rwlock_rdlock(&syscheck.directories_lock);
+        w_rwlock_wrlock(&syscheck.directories_lock);
         // Add proper flags for the realtime thread monitors the directories/files.
         OSList_foreach(node_it, syscheck.directories) {
             dir_it = node_it->data;

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -430,12 +430,12 @@ void CALLBACK RTCallBack(DWORD dwerror, DWORD dwBytes, LPOVERLAPPED overlap)
             w_rwlock_rdlock(&syscheck.directories_lock);
             directory_t *index = fim_configuration_directory(wdchar);
             directory_t *file_index = fim_configuration_directory(final_path);
+            w_rwlock_unlock(&syscheck.directories_lock);
 
             if (index == file_index) {
                 /* Check the change */
                 fim_realtime_event(final_path);
             }
-            w_rwlock_unlock(&syscheck.directories_lock);
 
         } while (pinfo->NextEntryOffset != 0);
     }

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -221,11 +221,9 @@ void realtime_process() {
 
     char ** paths = rbtree_keys(tree);
 
-    w_rwlock_rdlock(&syscheck.directories_lock);
     for (int i = 0; paths[i] != NULL; i++) {
         fim_realtime_event(paths[i]);
     }
-    w_rwlock_unlock(&syscheck.directories_lock);
 
     free_strarray(paths);
     rbtree_destroy(tree);

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -146,10 +146,12 @@ int Start_win32_Syscheck()
 
     if (!syscheck.disabled) {
         directory_t *dir_it;
+        OSListNode *node_it;
 #ifndef WIN_WHODATA
         int whodata_notification = 0;
         /* Remove whodata attributes */
-        foreach_array(dir_it, syscheck.directories) {
+        OSList_foreach(node_it, syscheck.directories) {
+            dir_it = node_it->data;
             if (dir_it->options & WHODATA_ACTIVE) {
                 if (!whodata_notification) {
                     whodata_notification = 1;
@@ -176,7 +178,8 @@ int Start_win32_Syscheck()
         }
 
         /* Print directories to be monitored */
-        foreach_array(dir_it, syscheck.directories) {
+        OSList_foreach(node_it, syscheck.directories) {
+            dir_it = node_it->data;
             char optstr[ 1024 ];
 
             minfo(FIM_MONITORING_DIRECTORY, dir_it->path, syscheck_opts2str(optstr, sizeof(optstr), dir_it->options));

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -83,7 +83,7 @@ void fim_initialize() {
         merror_exit(FIM_CRITICAL_DATA_CREATE, "sqlite3 db");
     }
 
-    w_mutex_init(&syscheck.directories_lock, NULL);
+    w_rwlock_init(&syscheck.directories_lock, NULL);
     w_mutex_init(&syscheck.fim_entry_mutex, NULL);
     w_mutex_init(&syscheck.fim_scan_mutex, NULL);
     w_mutex_init(&syscheck.fim_realtime_mutex, NULL);

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -257,7 +257,6 @@ int Start_win32_Syscheck() {
 
         /* Start up message */
         minfo(STARTUP_MSG, getpid());
-        w_rwlock_rdlock(&syscheck.directories_lock);
         OSList_foreach(node_it, syscheck.directories) {
             dir_it = node_it->data;
             if (dir_it->options & REALTIME_ACTIVE) {
@@ -265,7 +264,17 @@ int Start_win32_Syscheck() {
                 break;
             }
         }
-        w_rwlock_unlock(&syscheck.directories_lock);
+
+        if (syscheck.realtime == NULL) {
+            // Check if a wildcard might require realtime later
+            OSList_foreach(node_it, syscheck.wildcards) {
+                dir_it = node_it->data;
+                if (dir_it->options & REALTIME_ACTIVE) {
+                    realtime_start();
+                    break;
+                }
+            }
+        }
     }
 
     /* Some sync time */

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -257,12 +257,15 @@ int Start_win32_Syscheck() {
 
         /* Start up message */
         minfo(STARTUP_MSG, getpid());
-        foreach_array(dir_it, syscheck.directories) {
+        w_rwlock_rdlock(&syscheck.directories_lock);
+        OSList_foreach(node_it, syscheck.directories) {
+            dir_it = node_it->data;
             if (dir_it->options & REALTIME_ACTIVE) {
                 realtime_start();
                 break;
             }
         }
+        w_rwlock_unlock(&syscheck.directories_lock);
     }
 
     /* Some sync time */

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -344,6 +344,8 @@ int realtime_start(void);
  */
 int realtime_adddir(const char *dir, directory_t *configuration, int followsl);
 
+void fim_delete_realtime_watches(const directory_t *configuration);
+
 /**
  * @brief Process events in the real time queue
  *

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -343,6 +343,22 @@ int realtime_start(void);
  */
 int realtime_adddir(const char *dir, directory_t *configuration);
 
+#ifdef INOTIFY_ENABLED
+/**
+ * @brief Add an inotify watch to monitoring directory
+ *
+ * @param dir Path to file or directory
+ * @param configuration Configuration associated with the file or directory
+ * @return 1 on success, -1 on failure
+ */
+int fim_add_inotify_watch(const char *dir, const directory_t *configuration);
+#endif
+
+/**
+ * @brief Remove an inotify watch
+ *
+ * @param configuration Configuration associated with the file or directory
+ */
 void fim_delete_realtime_watches(const directory_t *configuration);
 
 /**

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -339,10 +339,9 @@ int realtime_start(void);
  *
  * @param dir Path to file or directory
  * @param configuration Configuration associated with the file or directory
- * @param followsl If the path is configured with follow sym link option
  * @return 1 on success, -1 on realtime_start failure, -2 on set_winsacl failure, and 0 on other errors
  */
-int realtime_adddir(const char *dir, directory_t *configuration, int followsl);
+int realtime_adddir(const char *dir, directory_t *configuration);
 
 void fim_delete_realtime_watches(const directory_t *configuration);
 

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -932,13 +932,4 @@ void fim_delete_file_event(fdb_t *fim_sql,
                            void *_unused_field_1,
                            void *_unused_field_2);
 
-/**
- * @brief Update directories configuration with the wildcard list
- *
- * @param OSList List of directories to be updated
- * @param OSList List wildcards to expand
- */
-void update_wildcards_config(OSList *directories,
-                             OSList *wildcards);
-
 #endif /* SYSCHECK_H */

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -949,4 +949,22 @@ void fim_delete_file_event(fdb_t *fim_sql,
                            void *_unused_field_1,
                            void *_unused_field_2);
 
+/**
+ * @brief Create a delete event and removes the entry from the database.
+ *
+ * @param fim_sql  FIM database struct.
+ * @param entry Entry data to be removed.
+ * @param mutex FIM database's mutex for thread synchronization.
+ * @param evt_data Information associated to the triggered event.
+ * @param configuration Directory configuration to be deleted.
+ * @param _unused_field Unused field, required to use this function as a callback.
+ *
+ */
+void fim_generate_delete_event(fdb_t *fim_sql,
+                               fim_entry *entry,
+                               pthread_mutex_t *mutex,
+                               void *evt_data,
+                               void *configuration,
+                               void *_unused_field);
+
 #endif /* SYSCHECK_H */

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -931,4 +931,14 @@ void fim_delete_file_event(fdb_t *fim_sql,
                            void *_evt_data,
                            void *_unused_field_1,
                            void *_unused_field_2);
+
+/**
+ * @brief Update directories configuration with the wildcard list
+ *
+ * @param OSList List of directories to be updated
+ * @param OSList List wildcards to expand
+ */
+void update_wildcards_config(OSList *directories,
+                             OSList *wildcards);
+
 #endif /* SYSCHECK_H */

--- a/src/syscheckd/whodata/audit_parse.c
+++ b/src/syscheckd/whodata/audit_parse.c
@@ -640,7 +640,9 @@ void audit_parse(char *buffer) {
                                 (w_evt->process_name) ? w_evt->process_name : "");
 
                         if (w_evt->inode) {
+                            w_rwlock_rdlock(&syscheck.directories_lock);
                             fim_whodata_event(w_evt);
+                            w_rwlock_unlock(&syscheck.directories_lock);
                         }
                     }
                 }
@@ -664,7 +666,9 @@ void audit_parse(char *buffer) {
                         free(file_path);
 
                         if (w_evt->inode) {
+                            w_rwlock_rdlock(&syscheck.directories_lock);
                             fim_whodata_event(w_evt);
+                            w_rwlock_unlock(&syscheck.directories_lock);
                         }
                     }
                 }
@@ -699,7 +703,9 @@ void audit_parse(char *buffer) {
                                 (w_evt->process_name) ? w_evt->process_name : "");
 
                         if (w_evt->inode) {
+                            w_rwlock_rdlock(&syscheck.directories_lock);
                             fim_whodata_event(w_evt);
+                            w_rwlock_unlock(&syscheck.directories_lock);
                         }
                     }
                 }
@@ -755,7 +761,9 @@ void audit_parse(char *buffer) {
                                 (w_evt->process_name) ? w_evt->process_name : "");
 
                         if (w_evt->inode) {
+                            w_rwlock_rdlock(&syscheck.directories_lock);
                             fim_whodata_event(w_evt);
+                            w_rwlock_unlock(&syscheck.directories_lock);
                         }
                         free(file_path1);
                         w_evt->path = NULL;
@@ -773,7 +781,9 @@ void audit_parse(char *buffer) {
                                 (w_evt->process_name) ? w_evt->process_name : "");
 
                         if (w_evt->inode) {
+                            w_rwlock_rdlock(&syscheck.directories_lock);
                             fim_whodata_event(w_evt);
+                            w_rwlock_unlock(&syscheck.directories_lock);
                         }
                     }
                 }
@@ -811,7 +821,9 @@ void audit_parse(char *buffer) {
                                 (w_evt->process_name) ? w_evt->process_name : "");
 
                         if (w_evt->inode) {
+                            w_rwlock_rdlock(&syscheck.directories_lock);
                             fim_whodata_event(w_evt);
+                            w_rwlock_unlock(&syscheck.directories_lock);
                         }
                     }
                 }

--- a/src/syscheckd/whodata/audit_parse.c
+++ b/src/syscheckd/whodata/audit_parse.c
@@ -640,9 +640,7 @@ void audit_parse(char *buffer) {
                                 (w_evt->process_name) ? w_evt->process_name : "");
 
                         if (w_evt->inode) {
-                            w_rwlock_rdlock(&syscheck.directories_lock);
                             fim_whodata_event(w_evt);
-                            w_rwlock_unlock(&syscheck.directories_lock);
                         }
                     }
                 }
@@ -666,9 +664,7 @@ void audit_parse(char *buffer) {
                         free(file_path);
 
                         if (w_evt->inode) {
-                            w_rwlock_rdlock(&syscheck.directories_lock);
                             fim_whodata_event(w_evt);
-                            w_rwlock_unlock(&syscheck.directories_lock);
                         }
                     }
                 }
@@ -703,9 +699,7 @@ void audit_parse(char *buffer) {
                                 (w_evt->process_name) ? w_evt->process_name : "");
 
                         if (w_evt->inode) {
-                            w_rwlock_rdlock(&syscheck.directories_lock);
                             fim_whodata_event(w_evt);
-                            w_rwlock_unlock(&syscheck.directories_lock);
                         }
                     }
                 }
@@ -761,9 +755,7 @@ void audit_parse(char *buffer) {
                                 (w_evt->process_name) ? w_evt->process_name : "");
 
                         if (w_evt->inode) {
-                            w_rwlock_rdlock(&syscheck.directories_lock);
                             fim_whodata_event(w_evt);
-                            w_rwlock_unlock(&syscheck.directories_lock);
                         }
                         free(file_path1);
                         w_evt->path = NULL;
@@ -781,9 +773,7 @@ void audit_parse(char *buffer) {
                                 (w_evt->process_name) ? w_evt->process_name : "");
 
                         if (w_evt->inode) {
-                            w_rwlock_rdlock(&syscheck.directories_lock);
                             fim_whodata_event(w_evt);
-                            w_rwlock_unlock(&syscheck.directories_lock);
                         }
                     }
                 }
@@ -821,9 +811,7 @@ void audit_parse(char *buffer) {
                                 (w_evt->process_name) ? w_evt->process_name : "");
 
                         if (w_evt->inode) {
-                            w_rwlock_rdlock(&syscheck.directories_lock);
                             fim_whodata_event(w_evt);
-                            w_rwlock_unlock(&syscheck.directories_lock);
                         }
                     }
                 }

--- a/src/syscheckd/whodata/audit_rule_handling.c
+++ b/src/syscheckd/whodata/audit_rule_handling.c
@@ -82,6 +82,7 @@ int fim_rules_initial_load() {
     int retval;
     char *directory = NULL;
     directory_t *dir_it = NULL;
+    OSListNode *node_it;
     int rules_added = 0;
     int auditd_fd = audit_open();
     int res = audit_get_rule_list(auditd_fd);
@@ -93,7 +94,8 @@ int fim_rules_initial_load() {
     }
 
     w_mutex_lock(&rules_mutex);
-    foreach_array(dir_it, syscheck.directories) {
+    OSList_foreach(node_it, syscheck.directories) {
+        dir_it = node_it->data;
         // Check if dir[i] is set in whodata mode
         if ((dir_it->options & WHODATA_ACTIVE) == 0) {
             continue; // LCOV_EXCL_LINE

--- a/src/syscheckd/whodata/audit_rule_handling.c
+++ b/src/syscheckd/whodata/audit_rule_handling.c
@@ -93,6 +93,7 @@ int fim_rules_initial_load() {
         merror(FIM_ERROR_WHODATA_READ_RULE); // LCOV_EXCL_LINE
     }
 
+    w_rwlock_rdlock(&syscheck.directories_lock);
     w_mutex_lock(&rules_mutex);
     OSList_foreach(node_it, syscheck.directories) {
         dir_it = node_it->data;
@@ -140,8 +141,9 @@ int fim_rules_initial_load() {
         // real_path can't be NULL
         free(directory);
     }
-
     w_mutex_unlock(&rules_mutex);
+    w_rwlock_unlock(&syscheck.directories_lock);
+
     return rules_added;
 }
 

--- a/src/syscheckd/whodata/syscheck_audit.c
+++ b/src/syscheckd/whodata/syscheck_audit.c
@@ -182,6 +182,7 @@ void audit_no_rules_to_realtime() {
     directory_t *dir_it = NULL;
     OSListNode *node_it;
 
+    w_rwlock_rdlock(&syscheck.directories_lock);
     OSList_foreach(node_it, syscheck.directories) {
         dir_it = node_it->data;
         if ((dir_it->options & WHODATA_ACTIVE) == 0) {
@@ -197,6 +198,7 @@ void audit_no_rules_to_realtime() {
         }
         free(real_path);
     }
+    w_rwlock_unlock(&syscheck.directories_lock);
 }
 
 // LCOV_EXCL_START

--- a/src/syscheckd/whodata/syscheck_audit.c
+++ b/src/syscheckd/whodata/syscheck_audit.c
@@ -180,8 +180,10 @@ void audit_no_rules_to_realtime() {
     int found;
     char *real_path = NULL;
     directory_t *dir_it = NULL;
+    OSListNode *node_it;
 
-    foreach_array(dir_it, syscheck.directories) {
+    OSList_foreach(node_it, syscheck.directories) {
+        dir_it = node_it->data;
         if ((dir_it->options & WHODATA_ACTIVE) == 0) {
             continue;
         }
@@ -298,6 +300,7 @@ void audit_set_db_consistency(void) {
 void *audit_main(audit_data_t *audit_data) {
     char *path = NULL;
     directory_t *dir_it = NULL;
+    OSListNode *node_it;
     count_reload_retries = 0;
     atomic_int_set(&audit_thread_active,0);
 
@@ -328,7 +331,8 @@ void *audit_main(audit_data_t *audit_data) {
     // Clean regexes used for parsing events
     clean_regex();
     // Change Audit monitored folders to Inotify.
-    foreach_array(dir_it, syscheck.directories) {
+    OSList_foreach(node_it, syscheck.directories) {
+        dir_it = node_it->data;
         if ((dir_it->options & WHODATA_ACTIVE) == 0) {
             continue;
         }

--- a/src/syscheckd/whodata/syscheck_audit.c
+++ b/src/syscheckd/whodata/syscheck_audit.c
@@ -331,6 +331,7 @@ void *audit_main(audit_data_t *audit_data) {
     // Clean regexes used for parsing events
     clean_regex();
     // Change Audit monitored folders to Inotify.
+    w_rwlock_rdlock(&syscheck.directories_lock);
     OSList_foreach(node_it, syscheck.directories) {
         dir_it = node_it->data;
         if ((dir_it->options & WHODATA_ACTIVE) == 0) {
@@ -353,6 +354,7 @@ void *audit_main(audit_data_t *audit_data) {
         realtime_adddir(path, 0, (dir_it->options & CHECK_FOLLOW) ? 1 : 0);
         free(path);
     }
+    w_rwlock_unlock(&syscheck.directories_lock);
 
     // Clean Audit added rules.
     if (audit_data->mode == AUDIT_ENABLED) {

--- a/src/syscheckd/whodata/syscheck_audit.c
+++ b/src/syscheckd/whodata/syscheck_audit.c
@@ -352,8 +352,8 @@ void *audit_main(audit_data_t *audit_data) {
         if (syscheck.realtime == NULL) {
             realtime_start();
         }
+        realtime_adddir(path, dir_it);
         w_mutex_unlock(&syscheck.fim_realtime_mutex);
-        realtime_adddir(path, 0, (dir_it->options & CHECK_FOLLOW) ? 1 : 0);
         free(path);
     }
     w_rwlock_unlock(&syscheck.directories_lock);

--- a/src/syscheckd/whodata/win_whodata.c
+++ b/src/syscheckd/whodata/win_whodata.c
@@ -413,6 +413,7 @@ void restore_sacls() {
     PSECURITY_DESCRIPTOR security_descriptor = NULL;
     int privilege_enabled = 0;
     directory_t *dir_it;
+    OSListNode *node_it;
 
     c_process = GetCurrentProcess();
     if (!OpenProcessToken(c_process, TOKEN_ADJUST_PRIVILEGES, &hdle)) {
@@ -427,7 +428,8 @@ void restore_sacls() {
 
     privilege_enabled = 1;
 
-    foreach_array(dir_it, syscheck.directories) {
+    OSList_foreach(node_it, syscheck.directories) {
+        dir_it = node_it->data;
         if (dir_it->dirs_status.status & WD_IGNORE_REST) {
             sacl_it = NULL;
 
@@ -915,6 +917,7 @@ long unsigned int WINAPI state_checker(__attribute__((unused)) void *_void) {
     OSHashNode *w_dir_node_next;
     whodata_directory *w_dir;
     directory_t *dir_it;
+    OSListNode *node_it;
     unsigned int w_dir_it;
     FILETIME current_time;
     ULARGE_INTEGER stale_time;
@@ -928,7 +931,8 @@ long unsigned int WINAPI state_checker(__attribute__((unused)) void *_void) {
     mdebug1(FIM_WHODATA_CHECKTHREAD, interval);
 
     while (FOREVER()) {
-        foreach_array(dir_it, syscheck.directories) {
+        OSList_foreach(node_it, syscheck.directories) {
+            dir_it = node_it->data;
             exists = 0;
             d_status = &dir_it->dirs_status;
 

--- a/src/syscheckd/whodata/win_whodata.c
+++ b/src/syscheckd/whodata/win_whodata.c
@@ -862,21 +862,15 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
                 if (w_evt = OSHash_Delete_ex(syscheck.wdata.fd, hash_id), w_evt && w_evt->path) {
 
                     if (!w_evt->scan_directory) {
-                        w_rwlock_rdlock(&syscheck.directories_lock);
                         fim_whodata_event(w_evt);
-                        w_rwlock_unlock(&syscheck.directories_lock);
                     } else if (w_evt->scan_directory == 1) {
                         // Directory scan has been aborted if scan_directory is 2
                         if (w_evt->mask & DELETE) {
-                            w_rwlock_rdlock(&syscheck.directories_lock);
                             fim_whodata_event(w_evt);
-                            w_rwlock_unlock(&syscheck.directories_lock);
 
                         } else if(w_evt->mask & FILE_APPEND_DATA || w_evt->mask & FILE_WRITE_DATA) {
                             // Find new files
-                            w_rwlock_rdlock(&syscheck.directories_lock);
                             fim_whodata_event(w_evt);
-                            w_rwlock_unlock(&syscheck.directories_lock);
 
                         } else {
                             mdebug2(FIM_WHODATA_NO_NEW_FILES, w_evt->path, w_evt->mask);
@@ -944,7 +938,6 @@ long unsigned int WINAPI state_checker(__attribute__((unused)) void *_void) {
     while (FOREVER()) {
         w_rwlock_rdlock(&syscheck.directories_lock);
         OSList_foreach(node_it, syscheck.directories) {
-            minfo("inside whodata scan");
             dir_it = node_it->data;
             exists = 0;
             d_status = &dir_it->dirs_status;
@@ -1010,7 +1003,6 @@ long unsigned int WINAPI state_checker(__attribute__((unused)) void *_void) {
         }
         w_rwlock_unlock(&syscheck.directories_lock);
 
-        minfo("after whodata scan");
         // Go through syscheck.wdata.directories and remove stale entries
         GetSystemTimeAsFileTime(&current_time);
 
@@ -1023,7 +1015,6 @@ long unsigned int WINAPI state_checker(__attribute__((unused)) void *_void) {
         w_dir_it = 0;
         w_rwlock_wrlock(&syscheck.wdata.directories->mutex);
 
-        minfo("whodata scan 2");
         while (w_dir_it <= syscheck.wdata.directories->rows) {
             w_dir_node = syscheck.wdata.directories->table[w_dir_it];
             w_dir_node_next = w_dir_node;
@@ -1042,7 +1033,6 @@ long unsigned int WINAPI state_checker(__attribute__((unused)) void *_void) {
             w_dir_it++;
         }
 
-        minfo("whodata scan 3");
         w_rwlock_unlock(&syscheck.wdata.directories->mutex);
 
         sleep(interval);

--- a/src/syscheckd/whodata/win_whodata.c
+++ b/src/syscheckd/whodata/win_whodata.c
@@ -724,7 +724,7 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
                         !(mask & (FILE_APPEND_DATA | FILE_WRITE_DATA))) {
                         mdebug2(FIM_WHODATA_CANCELED, w_evt->path);
                         free_whodata_event(w_evt);
-                    w_rwlock_unlock(&syscheck.directories_lock);
+                        w_rwlock_unlock(&syscheck.directories_lock);
                         goto clean;
                     }
 
@@ -733,7 +733,7 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
                     if (depth > w_evt->config_node->recursion_level) {
                         mdebug2(FIM_MAX_RECURSION_LEVEL, depth, w_evt->config_node->recursion_level, w_evt->path);
                         free_whodata_event(w_evt);
-                    w_rwlock_unlock(&syscheck.directories_lock);
+                        w_rwlock_unlock(&syscheck.directories_lock);
                         goto clean;
                     }
                 }
@@ -936,7 +936,7 @@ long unsigned int WINAPI state_checker(__attribute__((unused)) void *_void) {
     mdebug1(FIM_WHODATA_CHECKTHREAD, interval);
 
     while (FOREVER()) {
-        w_rwlock_rdlock(&syscheck.directories_lock);
+        w_rwlock_wrlock(&syscheck.directories_lock);
         OSList_foreach(node_it, syscheck.directories) {
             dir_it = node_it->data;
             exists = 0;

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -1,6 +1,11 @@
 
 # Tests list and flags
 
+list(APPEND shared_tests_flags "-Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,pthread_mutex_lock \
+    -Wl,--wrap,pthread_rwlock_rdlock -Wl,--wrap,pthread_rwlock_unlock -Wl,--wrap,_merror \
+    -Wl,--wrap,pthread_rwlock_wrlock")
+list(APPEND shared_tests_names "test_list_op")
+
 list(APPEND shared_tests_names "test_file_op")
 if(NOT ${TARGET} STREQUAL "winagent")
     set(FILE_OP_BASE_FLAGS "-Wl,--wrap,stat,--wrap,chmod,--wrap,getpid,--wrap,_mdebug1 \

--- a/src/unit_tests/shared/test_list_op.c
+++ b/src/unit_tests/shared/test_list_op.c
@@ -1,0 +1,211 @@
+/*
+ * Copyright (C) 2015-2021, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+
+#include "../wrappers/common.h"
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+#include "../../headers/shared.h"
+
+void test_OSList_GetNext_null_return(void **state) {
+
+    OSList list;
+    OSListNode *node = NULL;
+    OSListNode *node_returned;
+
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+
+    node_returned = OSList_GetNext(&list, node);
+
+    assert_null(node_returned);
+
+}
+
+void test_OSList_GetNext_node_return(void **state) {
+
+    OSList list;
+    OSListNode node;
+    OSListNode *node_returned = NULL;
+
+    node.next = (OSListNode*) malloc(sizeof(OSListNode));
+
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+
+    node_returned = OSList_GetNext(&list, &node);
+
+    assert_non_null(node_returned);
+
+}
+
+void test_OSList_GetDataFromIndex_null_return(void **state) {
+
+    OSList list;
+    int data_index = 0;
+    void* data_return;
+
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+
+    data_return = OSList_GetDataFromIndex(&list, data_index);
+
+    assert_null(data_return);
+
+}
+
+void test_OSList_GetDataFromIndex_data_return(void **state) {
+
+    OSList list;
+    int data_index = 0;
+    void* data_return;
+    char data[5] = "data\0";
+
+    list.first_node = (OSListNode*) malloc(sizeof(OSListNode));
+    list.first_node->data = &data;
+
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+
+    data_return = OSList_GetDataFromIndex(&list, data_index);
+
+    assert_ptr_equal(data_return, list.first_node->data);
+
+}
+
+void test_OSList_InsertData_insert_at_first_position(void **state) {
+
+    OSList list;
+    list.first_node = NULL;
+    list.last_node = NULL;
+    OSListNode *node = NULL;
+    void *data = NULL;
+    int return_code;
+    int success_code = 0;
+    int list_size_after_insertion = list.currently_size + 1;
+
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+
+    return_code = OSList_InsertData(&list, node, data);
+
+    assert_int_equal(return_code, success_code);
+    assert_non_null(list.first_node);
+    assert_non_null(list.last_node);
+    assert_int_equal(list.currently_size,list_size_after_insertion);
+
+}
+
+void test_OSList_InsertData_insert_at_last_position(void **state) {
+
+    OSList list;
+    OSListNode *node = NULL;
+    char data[5] = "data\0";
+    int return_code;
+    int success_code = 0;
+    int list_size_after_insertion = 1;
+
+    list.first_node = (OSListNode*) malloc(sizeof(OSListNode));
+    list.last_node = list.first_node;
+    list.last_node->data = &data;
+
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+
+    return_code = OSList_InsertData(&list, node, &data);
+
+    assert_int_equal(return_code, success_code);
+    assert_ptr_equal(list.last_node->data, &data);
+    assert_int_equal(list.currently_size,list_size_after_insertion);
+
+}
+
+void test_OSList_InsertData_insert_at_first_position_before_node(void **state) {
+
+    OSList list;
+    OSListNode *node;
+    char data[5] = "data\0";
+    int return_code;
+    int success_code = 0;
+    int list_size_after_insertion = 1;
+
+    node = (OSListNode*) malloc(sizeof(OSListNode));
+    list.first_node = node;
+    list.last_node = list.first_node;
+
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+
+    return_code = OSList_InsertData(&list, node, &data);
+
+    assert_int_equal(return_code, success_code);
+    assert_ptr_equal(list.first_node->next, node);
+    assert_int_equal(list.currently_size,list_size_after_insertion);
+
+}
+
+void test_OSList_InsertData_insert_at_n_position_before_node(void **state) {
+
+    OSList list;
+    OSListNode *node;
+    char data[5] = "data\0";
+    int return_code;
+    int success_code = 0;
+    int list_size_after_insertion = 1;
+
+    node = (OSListNode*) malloc(sizeof(OSListNode));
+    node->prev = (OSListNode*) malloc(sizeof(OSListNode));
+    list.first_node = node->prev;
+    list.last_node = node;
+
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+
+    return_code = OSList_InsertData(&list, node, &data);
+
+    assert_int_equal(return_code, success_code);
+    assert_ptr_equal(list.first_node->next, node->prev);
+    assert_int_equal(list.currently_size,list_size_after_insertion);
+
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_OSList_GetNext_null_return),
+        cmocka_unit_test(test_OSList_GetNext_node_return),
+        cmocka_unit_test(test_OSList_GetDataFromIndex_null_return),
+        cmocka_unit_test(test_OSList_GetDataFromIndex_data_return),
+        cmocka_unit_test(test_OSList_InsertData_insert_at_first_position),
+        cmocka_unit_test(test_OSList_InsertData_insert_at_last_position),
+        cmocka_unit_test(test_OSList_InsertData_insert_at_first_position_before_node),
+        cmocka_unit_test(test_OSList_InsertData_insert_at_n_position_before_node)
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -127,7 +127,8 @@ set(CREATE_DB_BASE_FLAGS "-Wl,--wrap,_minfo -Wl,--wrap,_merror -Wl,--wrap,_mwarn
                           -Wl,--wrap,fim_db_append_paths_from_inode -Wl,--wrap,pthread_rwlock_wrlock \
                           -Wl,--wrap,pthread_rwlock_unlock -Wl,--wrap,pthread_rwlock_rdlock \
                           -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_mutex_unlock \
-                          -Wl,--wrap,expand_wildcards -Wl,--wrap,fim_add_inotify_watch")
+                          -Wl,--wrap,expand_wildcards -Wl,--wrap,fim_add_inotify_watch \
+                          -Wl,--wrap,fim_db_remove_wildcard_entry")
 
 target_link_libraries(test_create_db SYSCHECK_O ${TEST_DEPS} fim_shared)
 if(${TARGET} STREQUAL "winagent")

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -138,7 +138,7 @@ if(${TARGET} STREQUAL "winagent")
 else()
     target_link_libraries(test_create_db "${CREATE_DB_BASE_FLAGS} -Wl,--wrap=lstat -Wl,--wrap=count_watches \
                                           -Wl,--wrap,get_user -Wl,--wrap,realpath -Wl,--wrap,add_whodata_directory \
-                                          -Wl,--wrap,atexit")
+                                          -Wl,--wrap,atexit -Wl,--wrap,remove_audit_rule_syscheck")
 endif()
 
 add_test(NAME test_create_db COMMAND test_create_db)

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -132,8 +132,7 @@ set(CREATE_DB_BASE_FLAGS "-Wl,--wrap,_minfo -Wl,--wrap,_merror -Wl,--wrap,_mwarn
 target_link_libraries(test_create_db SYSCHECK_O ${TEST_DEPS} fim_shared)
 if(${TARGET} STREQUAL "winagent")
     target_link_libraries(test_create_db "${CREATE_DB_BASE_FLAGS} -Wl,--wrap=w_get_file_permissions -Wl,--wrap,getpid \
-                                          -Wl,--wrap=decode_win_permissions,--wrap=pthread_mutex_lock \
-                                          -Wl,--wrap=pthread_mutex_unlock,--wrap=w_get_file_attrs,--wrap=os_winreg_check \
+                                          -Wl,--wrap=decode_win_permissions,--wrap=w_get_file_attrs,--wrap=os_winreg_check \
                                           -Wl,--wrap,get_file_user -Wl,--wrap,fim_registry_scan \
                                           -Wl,--wrap,get_UTC_modification_time -Wl,--wrap,realtime_adddir")
 else()
@@ -153,7 +152,7 @@ set(FIM_DIFF_CHANGES_BASE_FLAGS "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap
                            -Wl,--wrap=fgets -Wl,--wrap,atexit -Wl,--wrap,getpid,--wrap=_mdebug2,--wrap=rmdir_ex,--wrap=rename_ex \
                            -Wl,--wrap,_minfo,--wrap=DirSize,--wrap=remove_empty_folders,--wrap=abspath,--wrap=getpid \
                            -Wl,--wrap,fgetpos -Wl,--wrap=fgetc -Wl,--wrap=pthread_rwlock_wrlock -Wl,--wrap=pthread_mutex_lock \
-                           -Wl,--wrap=pthread_mutex_unlock -Wl,--wrap=pthread_rwlock_unlock")
+                           -Wl,--wrap=pthread_mutex_unlock -Wl,--wrap=pthread_rwlock_unlock -Wl,--wrap=pthread_rwlock_rdlock")
 
 list(APPEND syscheckd_tests_names "test_fim_diff_changes")
 if(${TARGET} STREQUAL "agent")
@@ -211,7 +210,10 @@ if(${TARGET} STREQUAL "winagent")
                                     -Wl,--wrap=rootcheck_init \
                                     -Wl,--wrap=start_daemon \
                                     -Wl,--wrap=File_DateofChange \
-                                    -Wl,--wrap,getpid, -Wl,--wrap,realtime_start")
+                                    -Wl,--wrap,getpid, -Wl,--wrap,realtime_start \
+                                    -Wl,--wrap,pthread_rwlock_rdlock -Wl,--wrap,pthread_rwlock_unlock \
+                                    -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_rwlock_wrlock \
+                                    -Wl,--wrap,pthread_mutex_unlock")
 
 else()
   list(APPEND syscheckd_tests_flags "${SYSCHECK_BASE_FLAGS}")
@@ -253,7 +255,8 @@ elseif(${TARGET} STREQUAL "winagent")
   # Create event channel tests for run_check
   list(APPEND syscheckd_event_tests_names "test_run_check_event")
   list(APPEND syscheckd_event_tests_flags "${RUN_CHECK_BASE_FLAGS} -Wl,--wrap=realtime_start,--wrap=run_whodata_scan \
-                                                                    -Wl,--wrap=audit_restore")
+                                                                    -Wl,--wrap=audit_restore -Wl,--wrap,pthread_rwlock_rdlock -Wl,--wrap,pthread_rwlock_unlock \
+                                                                    -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_rwlock_wrlock -Wl,--wrap,pthread_mutex_unlock")
 else()
   list(APPEND syscheckd_tests_flags "${RUN_CHECK_BASE_FLAGS} -Wl,--wrap=sleep,--wrap,time")
 endif()

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -186,7 +186,10 @@ else()
   list(APPEND syscheckd_tests_flags "${RUN_REALTIME_BASE_FLAGS}")
 endif()
 
-set(SYSCHECK_CONFIG_BASE_FLAGS "-Wl,--wrap,_merror -Wl,--wrap,_mdebug1 -Wl,--wrap,_mwarn")
+set(SYSCHECK_CONFIG_BASE_FLAGS "-Wl,--wrap,_merror -Wl,--wrap,_mdebug1 -Wl,--wrap,_mwarn -Wl,--wrap,OSMatch_Compile \
+                                -Wl,--wrap,pthread_rwlock_rdlock -Wl,--wrap,pthread_rwlock_unlock \
+                                -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_rwlock_wrlock \
+                                -Wl,--wrap,pthread_mutex_unlock")
 
 list(APPEND syscheckd_tests_names "test_syscheck_config")
 if(${TARGET} STREQUAL "agent")

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -126,7 +126,8 @@ set(CREATE_DB_BASE_FLAGS "-Wl,--wrap,_minfo -Wl,--wrap,_merror -Wl,--wrap,_mwarn
                           -Wl,--wrap,fim_db_file_is_scanned -Wl,--wrap,fim_db_data_exists \
                           -Wl,--wrap,fim_db_append_paths_from_inode -Wl,--wrap,pthread_rwlock_wrlock \
                           -Wl,--wrap,pthread_rwlock_unlock -Wl,--wrap,pthread_rwlock_rdlock \
-                          -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_mutex_unlock")
+                          -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_mutex_unlock \
+                          -Wl,--wrap,expand_wildcards")
 
 target_link_libraries(test_create_db SYSCHECK_O ${TEST_DEPS} fim_shared)
 if(${TARGET} STREQUAL "winagent")
@@ -134,10 +135,11 @@ if(${TARGET} STREQUAL "winagent")
                                           -Wl,--wrap=decode_win_permissions,--wrap=pthread_mutex_lock \
                                           -Wl,--wrap=pthread_mutex_unlock,--wrap=w_get_file_attrs,--wrap=os_winreg_check \
                                           -Wl,--wrap,get_file_user -Wl,--wrap,fim_registry_scan \
-                                          -Wl,--wrap,get_UTC_modification_time")
+                                          -Wl,--wrap,get_UTC_modification_time -Wl,--wrap,realtime_adddir")
 else()
     target_link_libraries(test_create_db "${CREATE_DB_BASE_FLAGS} -Wl,--wrap=lstat -Wl,--wrap=count_watches \
-                                          -Wl,--wrap,get_user")
+                                          -Wl,--wrap,get_user -Wl,--wrap,realpath -Wl,--wrap,add_whodata_directory \
+                                          -Wl,--wrap,atexit")
 endif()
 
 add_test(NAME test_create_db COMMAND test_create_db)
@@ -170,7 +172,8 @@ set(RUN_REALTIME_BASE_FLAGS "-Wl,--wrap,inotify_init -Wl,--wrap,inotify_add_watc
                              -Wl,--wrap,rbtree_keys -Wl,--wrap,fim_realtime_event -Wl,--wrap,OSHash_Delete_ex \
                              -Wl,--wrap=OSHash_Begin -Wl,--wrap=OSHash_Next -Wl,--wrap=pthread_mutex_lock \
                              -Wl,--wrap=pthread_mutex_unlock -Wl,--wrap=getpid -Wl,--wrap=atexit -Wl,--wrap=os_random \
-                             -Wl,--wrap,inotify_rm_watch")
+                             -Wl,--wrap,inotify_rm_watch -Wl,--wrap,pthread_rwlock_wrlock -Wl,--wrap,pthread_rwlock_unlock \
+                             -Wl,--wrap,pthread_rwlock_rdlock")
 
 list(APPEND syscheckd_tests_names "test_run_realtime")
 if(${TARGET} STREQUAL "agent")
@@ -189,7 +192,8 @@ endif()
 set(SYSCHECK_CONFIG_BASE_FLAGS "-Wl,--wrap,_merror -Wl,--wrap,_mdebug1 -Wl,--wrap,_mwarn -Wl,--wrap,OSMatch_Compile \
                                 -Wl,--wrap,pthread_rwlock_rdlock -Wl,--wrap,pthread_rwlock_unlock \
                                 -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_rwlock_wrlock \
-                                -Wl,--wrap,pthread_mutex_unlock")
+                                -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,OSRegex_Compile -Wl,--wrap,OSRegex_Execute \
+                                -Wl,--wrap,OSMatch_Execute -Wl,--wrap,OSRegex_Execute_ex")
 
 list(APPEND syscheckd_tests_names "test_syscheck_config")
 if(${TARGET} STREQUAL "agent")

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -124,7 +124,9 @@ set(CREATE_DB_BASE_FLAGS "-Wl,--wrap,_minfo -Wl,--wrap,_merror -Wl,--wrap,_mwarn
                           -Wl,--wrap,fim_file_diff -Wl,--wrap,fim_diff_process_delete_file \
                           -Wl,--wrap,fim_db_get_count_entries -Wl,--wrap,fim_db_get_path_from_pattern \
                           -Wl,--wrap,fim_db_file_is_scanned -Wl,--wrap,fim_db_data_exists \
-                          -Wl,--wrap,fim_db_append_paths_from_inode")
+                          -Wl,--wrap,fim_db_append_paths_from_inode -Wl,--wrap,pthread_rwlock_wrlock \
+                          -Wl,--wrap,pthread_rwlock_unlock -Wl,--wrap,pthread_rwlock_rdlock \
+                          -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_mutex_unlock")
 
 target_link_libraries(test_create_db SYSCHECK_O ${TEST_DEPS} fim_shared)
 if(${TARGET} STREQUAL "winagent")
@@ -148,7 +150,8 @@ set(FIM_DIFF_CHANGES_BASE_FLAGS "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap
                            -Wl,--wrap,rename -Wl,--wrap,system -Wl,--wrap,fseek -Wl,--wrap,remove,--wrap=fprintf \
                            -Wl,--wrap=fgets -Wl,--wrap,atexit -Wl,--wrap,getpid,--wrap=_mdebug2,--wrap=rmdir_ex,--wrap=rename_ex \
                            -Wl,--wrap,_minfo,--wrap=DirSize,--wrap=remove_empty_folders,--wrap=abspath,--wrap=getpid \
-                           -Wl,--wrap,fgetpos -Wl,--wrap=fgetc")
+                           -Wl,--wrap,fgetpos -Wl,--wrap=fgetc -Wl,--wrap=pthread_rwlock_wrlock -Wl,--wrap=pthread_mutex_lock \
+                           -Wl,--wrap=pthread_mutex_unlock -Wl,--wrap=pthread_rwlock_unlock")
 
 list(APPEND syscheckd_tests_names "test_fim_diff_changes")
 if(${TARGET} STREQUAL "agent")

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -189,11 +189,10 @@ else()
   list(APPEND syscheckd_tests_flags "${RUN_REALTIME_BASE_FLAGS}")
 endif()
 
-set(SYSCHECK_CONFIG_BASE_FLAGS "-Wl,--wrap,_merror -Wl,--wrap,_mdebug1 -Wl,--wrap,_mwarn -Wl,--wrap,OSMatch_Compile \
+set(SYSCHECK_CONFIG_BASE_FLAGS "-Wl,--wrap,_merror -Wl,--wrap,_mdebug1 -Wl,--wrap,_mwarn \
                                 -Wl,--wrap,pthread_rwlock_rdlock -Wl,--wrap,pthread_rwlock_unlock \
                                 -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_rwlock_wrlock \
-                                -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,OSRegex_Compile -Wl,--wrap,OSRegex_Execute \
-                                -Wl,--wrap,OSMatch_Execute -Wl,--wrap,OSRegex_Execute_ex")
+                                -Wl,--wrap,pthread_mutex_unlock")
 
 list(APPEND syscheckd_tests_names "test_syscheck_config")
 if(${TARGET} STREQUAL "agent")

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -127,14 +127,14 @@ set(CREATE_DB_BASE_FLAGS "-Wl,--wrap,_minfo -Wl,--wrap,_merror -Wl,--wrap,_mwarn
                           -Wl,--wrap,fim_db_append_paths_from_inode -Wl,--wrap,pthread_rwlock_wrlock \
                           -Wl,--wrap,pthread_rwlock_unlock -Wl,--wrap,pthread_rwlock_rdlock \
                           -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_mutex_unlock \
-                          -Wl,--wrap,expand_wildcards")
+                          -Wl,--wrap,expand_wildcards -Wl,--wrap,fim_add_inotify_watch")
 
 target_link_libraries(test_create_db SYSCHECK_O ${TEST_DEPS} fim_shared)
 if(${TARGET} STREQUAL "winagent")
     target_link_libraries(test_create_db "${CREATE_DB_BASE_FLAGS} -Wl,--wrap=w_get_file_permissions -Wl,--wrap,getpid \
                                           -Wl,--wrap=decode_win_permissions,--wrap=w_get_file_attrs,--wrap=os_winreg_check \
                                           -Wl,--wrap,get_file_user -Wl,--wrap,fim_registry_scan \
-                                          -Wl,--wrap,get_UTC_modification_time -Wl,--wrap,realtime_adddir")
+                                          -Wl,--wrap,get_UTC_modification_time")
 else()
     target_link_libraries(test_create_db "${CREATE_DB_BASE_FLAGS} -Wl,--wrap=lstat -Wl,--wrap=count_watches \
                                           -Wl,--wrap,get_user -Wl,--wrap,realpath -Wl,--wrap,add_whodata_directory \

--- a/src/unit_tests/syscheckd/db/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/db/CMakeLists.txt
@@ -17,7 +17,8 @@ set(FIM_DB_BASE_FLAGS "-Wl,--wrap=w_is_file,--wrap=remove,--wrap=sqlite3_open_v2
                        -Wl,--wrap=sqlite3_column_int64,--wrap=fread,--wrap=fwrite,--wrap=_mwarn \
                        -Wl,--wrap=fprintf,--wrap=fgets,--wrap=stat,--wrap=wstr_split,--wrap=os_random \
                        -Wl,--wrap=DirSize,--wrap=IsDir,--wrap=sqlite3_column_count,--wrap=getDefine_Int,--wrap=wfopen \
-                       -Wl,--wrap=fgetpos,--wrap=fgetc")
+                       -Wl,--wrap=fgetpos,--wrap=fgetc,--wrap=pthread_rwlock_rdlock,--wrap=pthread_rwlock_unlock \
+                       -Wl,--wrap=pthread_rwlock_wrlock")
 
 target_link_libraries(test_fim_db SYSCHECK_O ${TEST_DEPS} fim_shared)
 if(${TARGET} STREQUAL "winagent")

--- a/src/unit_tests/syscheckd/db/expect_fim_db.c
+++ b/src/unit_tests/syscheckd/db/expect_fim_db.c
@@ -161,6 +161,9 @@ int setup_fim_db_group(void **state) {
     (void)state;
 
     expect_any_always(__wrap__mdebug1, formatted_msg);
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
 #ifndef TEST_SERVER
     will_return_always(__wrap_getDefine_Int, 0);
@@ -179,6 +182,9 @@ int setup_fim_db_group(void **state) {
 }
 
 int teardown_fim_db_group(void **state) {
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+
     Free_Syscheck(&syscheck);
     w_mutex_destroy(&syscheck.fim_entry_mutex);
     test_mode = 0;

--- a/src/unit_tests/syscheckd/db/test_fim_db_files.c
+++ b/src/unit_tests/syscheckd/db/test_fim_db_files.c
@@ -121,6 +121,9 @@ static int teardown_append_inode(void **state) {
         return 0;
     }
 
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+
     teardown_os_list((void **)&(data->list));
     teardown_rb_tree((void **)&(data->tree));
 
@@ -1116,6 +1119,11 @@ static void test_fim_db_remove_validated_path_invalid_path(void **state) {
 #else
     char *entry_path = "c:\\windows\\system32\\wbem\\some\\path";
 #endif
+
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+
     fim_entry entry = { .type = FIM_TYPE_FILE, .file_entry.path = entry_path, .file_entry.data = &data };
     fdb_t fim_sql = { .transaction.last_commit = 1, .transaction.interval = 1 };
     event_data_t evt_data = { .mode = FIM_SCHEDULED, .w_evt = NULL, .report_event = false, .type = FIM_DELETE };
@@ -1133,6 +1141,11 @@ static void test_fim_db_remove_validated_path_valid_path(void **state) {
 #else
     char *entry_path = "c:\\windows\\system32\\wbem\\some\\path";
 #endif
+
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+
     fim_entry entry = { .type = FIM_TYPE_FILE, .file_entry.path = entry_path, .file_entry.data = &data };
     fdb_t fim_sql = { .transaction.last_commit = 1, .transaction.interval = 1 };
     event_data_t evt_data = { .mode = FIM_SCHEDULED, .w_evt = NULL, .report_event = false, .type = FIM_DELETE };
@@ -1180,6 +1193,11 @@ static void test_fim_db_wildcard_delete_event_path_founded_in_config(void **stat
 #else
     char *entry_path = "c:\\windows\\system32\\wbem\\some\\path";
 #endif
+
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+
     fim_entry entry = { .type = FIM_TYPE_FILE, .file_entry.path = entry_path, .file_entry.data = &data };
     fdb_t fim_sql = { .transaction.last_commit = 1, .transaction.interval = 1 };
     event_data_t evt_data = { .mode = FIM_SCHEDULED, .w_evt = NULL, .report_event = false, .type = FIM_DELETE };
@@ -1197,6 +1215,11 @@ static void test_fim_db_wildcard_delete_event_path_not_founded(void **state) {
 #else
     char *entry_path = "c:\\not\\exists\\path";
 #endif
+
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+
     fim_entry entry = { .type = FIM_TYPE_FILE, .file_entry.path = entry_path, .file_entry.data = &data };
     fdb_t fim_sql = { .transaction.last_commit = 1, .transaction.interval = 1 };
     event_data_t evt_data = { .mode = FIM_SCHEDULED, .w_evt = NULL, .report_event = false, .type = FIM_DELETE };
@@ -1281,6 +1304,9 @@ static void test_fim_db_append_paths_from_inode_append_paths(void **state) {
     OSList *list = ((append_inode_t *)*state)->list;
     rb_tree *tree = ((append_inode_t *)*state)->tree;
     int ret, i;
+
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
     expect_fim_db_clean_stmt();
     expect_fim_db_bind_get_inode();

--- a/src/unit_tests/syscheckd/db/test_fim_db_files.c
+++ b/src/unit_tests/syscheckd/db/test_fim_db_files.c
@@ -42,13 +42,6 @@ void fim_db_remove_validated_path(fdb_t *fim_sql,
                                   void *configuration,
                                   void *_unused_patameter);
 
-void fim_db_wildcard_delete_event(fdb_t *fim_sql,
-                                  fim_entry *entry,
-                                  pthread_mutex_t *mutex,
-                                  void *evt_data,
-                                  void *_configuration,
-                                  void *_unused_patameter);
-
 #ifndef TEST_WINAGENT
 extern unsigned long __real_time();
 unsigned long __wrap_time() {
@@ -1185,87 +1178,6 @@ static void test_fim_db_remove_validated_path_valid_path(void **state) {
     assert_int_equal(fim_sql.transaction.last_commit, 192837465);
 }
 
-/*----------fim_db_wildcard_delete_event()------------*/
-static void test_fim_db_wildcard_delete_event_path_founded_in_config(void **state) {
-    fim_file_data data = DEFAULT_FILE_DATA;
-#ifndef TEST_WINAGENT
-    char *entry_path = "/media/some/path";
-#else
-    char *entry_path = "c:\\windows\\system32\\wbem\\some\\path";
-#endif
-
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
-    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
-    expect_function_call_any(__wrap_pthread_rwlock_unlock);
-
-    fim_entry entry = { .type = FIM_TYPE_FILE, .file_entry.path = entry_path, .file_entry.data = &data };
-    fdb_t fim_sql = { .transaction.last_commit = 1, .transaction.interval = 1 };
-    event_data_t evt_data = { .mode = FIM_SCHEDULED, .w_evt = NULL, .report_event = false, .type = FIM_DELETE };
-
-    fim_db_wildcard_delete_event(&fim_sql, &entry, &syscheck.fim_entry_mutex, &evt_data, NULL, NULL);
-
-    // Last commit time should not change
-    assert_int_equal(fim_sql.transaction.last_commit, 1);
-}
-
-static void test_fim_db_wildcard_delete_event_path_not_founded(void **state) {
-    fim_file_data data = DEFAULT_FILE_DATA;
-#ifndef TEST_WINAGENT
-    char *entry_path = "/not/exists/path";
-#else
-    char *entry_path = "c:\\not\\exists\\path";
-#endif
-
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
-    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
-    expect_function_call_any(__wrap_pthread_rwlock_unlock);
-
-    fim_entry entry = { .type = FIM_TYPE_FILE, .file_entry.path = entry_path, .file_entry.data = &data };
-    fdb_t fim_sql = { .transaction.last_commit = 1, .transaction.interval = 1 };
-    event_data_t evt_data = { .mode = FIM_SCHEDULED, .w_evt = NULL, .report_event = false, .type = FIM_DELETE };
-#ifndef TEST_WINAGENT
-    directory_t *configuration = fim_create_directory("/media/some/path", REALTIME_ACTIVE, NULL, 512, NULL, -1, 1);
-    expect_string(__wrap__mdebug2, formatted_msg, "(6319): No configuration found for (file):'/not/exists/path'");
-#else
-    directory_t *configuration = fim_create_directory("c:\\windows\\system32\\wbem\\some\\path", REALTIME_ACTIVE, NULL, 512, NULL, -1, 1);
-    expect_string(__wrap__mdebug2, formatted_msg, "(6319): No configuration found for (file):'c:\\not\\exists\\path'");
-#endif
-
-    syscheck.database = &fim_sql;
-
-    for (int i = 0; i < 3; i++) {
-        expect_fim_db_clean_stmt();
-    }
-
-    expect_fim_db_bind_path(entry_path);
-
-    will_return(__wrap_sqlite3_step, 0);
-    will_return(__wrap_sqlite3_step, SQLITE_ROW);
-
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, 1);
-    expect_value(__wrap_sqlite3_column_int, iCol, 1);
-    will_return(__wrap_sqlite3_column_int, 1);
-
-    expect_fim_db_bind_delete_data_id(1);
-
-    will_return(__wrap_sqlite3_step, 0);
-    will_return(__wrap_sqlite3_step, SQLITE_DONE);
-
-    expect_fim_db_bind_path(entry_path);
-
-    will_return(__wrap_sqlite3_step, 0);
-    will_return(__wrap_sqlite3_step, SQLITE_DONE);
-
-    expect_fim_db_check_transaction();
-
-    fim_db_wildcard_delete_event(&fim_sql, &entry, &syscheck.fim_entry_mutex, &evt_data, configuration, NULL);
-
-    free_directory(configuration);
-    // Last commit time should change
-    assert_int_equal(fim_sql.transaction.last_commit, 192837465);
-}
-
 #ifndef TEST_WINAGENT
 static void test_fim_db_append_paths_from_inode_null_list(void **state) {
     fdb_t fim_sql = { .transaction.last_commit = 1, .transaction.interval = 1 };
@@ -1543,10 +1455,6 @@ int main(void) {
         // fim_db_remove_validated_path
         cmocka_unit_test(test_fim_db_remove_validated_path_invalid_path),
         cmocka_unit_test(test_fim_db_remove_validated_path_valid_path),
-
-        // fim_db_wildcard_delete_event
-        cmocka_unit_test(test_fim_db_wildcard_delete_event_path_founded_in_config),
-        cmocka_unit_test(test_fim_db_wildcard_delete_event_path_not_founded),
 
         // fim_db_append_paths_from_inode
 #ifndef TEST_WINAGENT

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -1832,6 +1832,7 @@ static void test_fim_scan_db_full_double_scan(void **state) {
     struct stat file_buf = { .st_mode = S_IFREG };
     struct dirent *file = *state;
     directory_t *dir_it;
+    OSListNode *node_it;
 
     expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_STARTED);
 
@@ -1845,7 +1846,8 @@ static void test_fim_scan_db_full_double_scan(void **state) {
     expect_string(__wrap__mdebug2, formatted_msg, "(6348): Size of 'queue/diff' folder: 0.00000 KB.");
 
     // First scan
-    foreach_array(dir_it, syscheck.directories) {
+    OSList_foreach(node_it, syscheck.directories) {
+        dir_it = node_it->data;
         expect_string(__wrap_lstat, filename, dir_it->path);
         will_return(__wrap_lstat, &directory_buf);
         will_return(__wrap_lstat, 0);
@@ -1933,6 +1935,7 @@ static void test_fim_scan_db_full_double_scan(void **state) {
 static void test_fim_scan_db_full_not_double_scan(void **state) {
     struct stat directory_buf = { .st_mode = S_IFDIR };
     directory_t *dir_it;
+    OSListNode *node_it;
 
     expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_STARTED);
 
@@ -1946,7 +1949,8 @@ static void test_fim_scan_db_full_not_double_scan(void **state) {
     expect_string(__wrap__mdebug2, formatted_msg, "(6348): Size of 'queue/diff' folder: 0.00000 KB.");
 
     // First scan
-    foreach_array(dir_it, syscheck.directories) {
+    OSList_foreach(node_it, syscheck.directories) {
+        dir_it = node_it->data;
         expect_string(__wrap_lstat, filename, dir_it->path);
         will_return(__wrap_lstat, &directory_buf);
         will_return(__wrap_lstat, 0);
@@ -1988,6 +1992,7 @@ static void test_fim_scan_realtime_enabled(void **state) {
     rtfim realtime = { .queue_overflow = true, .dirtb = &dirtb };
     struct stat directory_buf = { .st_mode = S_IFDIR };
     directory_t *dir_it;
+    OSListNode *node_it;
 
     syscheck.realtime = &realtime;
 
@@ -2003,7 +2008,8 @@ static void test_fim_scan_realtime_enabled(void **state) {
     expect_string(__wrap__mdebug2, formatted_msg, "(6348): Size of 'queue/diff' folder: 0.00000 KB.");
 
     // First scan
-    foreach_array(dir_it, syscheck.directories) {
+    OSList_foreach(node_it, syscheck.directories) {
+        dir_it = node_it->data;
         expect_string(__wrap_lstat, filename, dir_it->path);
         will_return(__wrap_lstat, &directory_buf);
         will_return(__wrap_lstat, 0);
@@ -2057,6 +2063,7 @@ static void test_fim_scan_realtime_enabled(void **state) {
 static void test_fim_scan_db_free(void **state) {
     struct stat directory_buf = { .st_mode = S_IFDIR };
     directory_t *dir_it;
+    OSListNode *node_it;
 
     expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_STARTED);
 
@@ -2070,7 +2077,8 @@ static void test_fim_scan_db_free(void **state) {
     expect_string(__wrap__mdebug2, formatted_msg, "(6348): Size of 'queue/diff' folder: 0.00000 KB.");
 
     // First scan
-    foreach_array(dir_it, syscheck.directories) {
+    OSList_foreach(node_it, syscheck.directories) {
+        dir_it = node_it->data;
         expect_string(__wrap_lstat, filename, dir_it->path);
         will_return(__wrap_lstat, &directory_buf);
         will_return(__wrap_lstat, 0);
@@ -2113,6 +2121,7 @@ static void test_fim_scan_db_free(void **state) {
 static void test_fim_scan_no_limit(void **state) {
     struct stat directory_buf = { .st_mode = S_IFDIR };
     directory_t *dir_it;
+    OSListNode *node_it;
 
     expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_STARTED);
 
@@ -2126,7 +2135,8 @@ static void test_fim_scan_no_limit(void **state) {
     expect_string(__wrap__mdebug2, formatted_msg, "(6348): Size of 'queue/diff' folder: 0.00000 KB.");
 
     // First scan
-    foreach_array(dir_it, syscheck.directories) {
+    OSList_foreach(node_it, syscheck.directories) {
+        dir_it = node_it->data;
         expect_string(__wrap_lstat, filename, dir_it->path);
         will_return(__wrap_lstat, &directory_buf);
         will_return(__wrap_lstat, 0);

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -4300,6 +4300,8 @@ static void test_check_deleted_files(void **state) {
 
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
     expect_value(__wrap_fim_db_get_not_scanned, fim_sql, syscheck.database);
     expect_value(__wrap_fim_db_get_not_scanned, storage, FIM_DB_DISK);
@@ -4947,11 +4949,11 @@ static void test_fim_process_file_from_db_file_without_conflict(void **state) {
         fail_msg("Failed to set an invalid path.");
     }
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
     expect_string(__wrap_fim_db_get_path, file_path, entry->file_entry.path);
@@ -4987,11 +4989,11 @@ static void test_fim_process_file_from_db_conflicting_file_current_inode_free_in
         fail_msg("Failed to set an invalid path.");
     }
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
     expect_string(__wrap_fim_db_get_path, file_path, entry->file_entry.path);
@@ -5076,11 +5078,11 @@ static void test_fim_process_file_from_db_conflicting_file_infinite_loop(void **
         fail_msg("Failed to set an invalid path.");
     }
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     entry->file_entry.data->perm = strdup("rw-r--r--");
 

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -5682,8 +5682,8 @@ static void test_update_wildcards_config_remove_config() {
     snprintf(error_msg2, OS_MAXSTR, FIM_WILDCARDS_REMOVE_DIRECTORY, resolvedpath2);
 
     expect_string(__wrap__mdebug2, formatted_msg, FIM_WILDCARDS_UPDATE_START);
-    expect_string(__wrap__mdebug2, formatted_msg, error_msg);
     expect_string(__wrap__mdebug2, formatted_msg, error_msg2);
+    expect_string(__wrap__mdebug2, formatted_msg, error_msg);
     expect_string(__wrap__mdebug2, formatted_msg, FIM_WILDCARDS_UPDATE_FINALIZE);
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
@@ -5703,16 +5703,16 @@ static void test_update_wildcards_config_remove_config() {
 
     // Remove configuration loop
     expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_get_path, file_path, resolvedpath1);
-    will_return(__wrap_fim_db_get_path, NULL);
-
-    expect_fim_db_get_path_from_pattern(syscheck.database, pattern1, NULL, FIM_DB_DISK, FIMDB_ERR);
-
-    expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
     expect_string(__wrap_fim_db_get_path, file_path, resolvedpath2);
     will_return(__wrap_fim_db_get_path, NULL);
 
     expect_fim_db_get_path_from_pattern(syscheck.database, pattern2, NULL, FIM_DB_DISK, FIMDB_ERR);
+
+    expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
+    expect_string(__wrap_fim_db_get_path, file_path, resolvedpath1);
+    will_return(__wrap_fim_db_get_path, NULL);
+
+    expect_fim_db_get_path_from_pattern(syscheck.database, pattern1, NULL, FIM_DB_DISK, FIMDB_ERR);
 
     update_wildcards_config();
 

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -5645,14 +5645,8 @@ static void test_update_wildcards_config() {
     will_return(__wrap_expand_wildcards, NULL);
 
 #ifndef WIN32
-    expect_string(__wrap_realpath, path, wildcard1);
-    will_return(__wrap_realpath, NULL);
-    expect_string(__wrap_realpath, path, resolvedpath1);
-    will_return(__wrap_realpath, NULL);
-    expect_string(__wrap_realpath, path, wildcard1);
-    will_return(__wrap_realpath, NULL);
-    expect_string(__wrap_realpath, path, resolvedpath2);
-    will_return(__wrap_realpath, NULL);
+    expect_string_count(__wrap_realpath, path, wildcard1, 2);
+    will_return_count(__wrap_realpath, NULL, 2);
 #endif
 
     update_wildcards_config();

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -1929,10 +1929,10 @@ static void test_fim_checker_fim_directory(void **state) {
     expect_string(__wrap_HasFilesystem, path, "/media/test");
     will_return_always(__wrap_HasFilesystem, 0);
 
-    expect_string(__wrap_realtime_adddir, dir, "/media/test");
-    will_return(__wrap_realtime_adddir, 0);
-    expect_string(__wrap_realtime_adddir, dir, "/media/");
-    will_return(__wrap_realtime_adddir, 0);
+    expect_string(__wrap_fim_add_inotify_watch, dir, "/media/test");
+    will_return(__wrap_fim_add_inotify_watch, 0);
+    expect_string(__wrap_fim_add_inotify_watch, dir, "/media/");
+    will_return(__wrap_fim_add_inotify_watch, 0);
 
     strcpy(fim_data->entry->d_name, "test");
 
@@ -1967,8 +1967,8 @@ static void test_fim_checker_fim_directory_on_max_recursion_level(void **state) 
     expect_string(__wrap_HasFilesystem, path, path);
     will_return(__wrap_HasFilesystem, 0);
 
-    expect_string(__wrap_realtime_adddir, dir, path);
-    will_return(__wrap_realtime_adddir, 0);
+    expect_string(__wrap_fim_add_inotify_watch, dir, path);
+    will_return(__wrap_fim_add_inotify_watch, 0);
 
     will_return(__wrap_opendir, 1);
     strcpy(fim_data->entry->d_name, "test");
@@ -2083,8 +2083,13 @@ static void test_fim_scan_db_full_double_scan(void **state) {
         expect_string(__wrap_HasFilesystem, path, dir_it->path);
         will_return(__wrap_HasFilesystem, 0);
 
-        expect_string_count(__wrap_realtime_adddir, dir, dir_it->path, 2);
-        will_return_count(__wrap_realtime_adddir, 0, 2);
+        if (FIM_MODE(dir_it->options) == FIM_REALTIME) {
+            expect_string(__wrap_fim_add_inotify_watch, dir, dir_it->path);
+            will_return(__wrap_fim_add_inotify_watch, 0);
+        }
+
+        expect_string(__wrap_realtime_adddir, dir, dir_it->path);
+        will_return(__wrap_realtime_adddir, 0);
 
         will_return(__wrap_opendir, 1);
         will_return(__wrap_readdir, NULL);
@@ -2106,8 +2111,10 @@ static void test_fim_scan_db_full_double_scan(void **state) {
     expect_string(__wrap_HasFilesystem, path, "/boot");
     will_return(__wrap_HasFilesystem, 0);
 
-    expect_string_count(__wrap_realtime_adddir, dir, "/boot", 2);
-    will_return_count(__wrap_realtime_adddir, 0, 2);
+    expect_string(__wrap_fim_add_inotify_watch, dir, "/boot");
+    will_return(__wrap_fim_add_inotify_watch, 0);
+    expect_string(__wrap_realtime_adddir, dir, "/boot");
+    will_return(__wrap_realtime_adddir, 0);
 
     will_return(__wrap_opendir, 1);
     will_return(__wrap_readdir, file);
@@ -2190,8 +2197,13 @@ static void test_fim_scan_db_full_not_double_scan(void **state) {
         expect_string(__wrap_HasFilesystem, path, dir_it->path);
         will_return(__wrap_HasFilesystem, 0);
 
-        expect_string_count(__wrap_realtime_adddir, dir, dir_it->path, 2);
-        will_return_count(__wrap_realtime_adddir, 0, 2);
+        if (FIM_MODE(dir_it->options) == FIM_REALTIME) {
+            expect_string(__wrap_fim_add_inotify_watch, dir, dir_it->path);
+            will_return(__wrap_fim_add_inotify_watch, 0);
+        }
+
+        expect_string(__wrap_realtime_adddir, dir, dir_it->path);
+        will_return(__wrap_realtime_adddir, 0);
 
         will_return(__wrap_opendir, 1);
         will_return(__wrap_readdir, NULL);
@@ -2253,8 +2265,13 @@ static void test_fim_scan_realtime_enabled(void **state) {
         expect_string(__wrap_HasFilesystem, path, dir_it->path);
         will_return(__wrap_HasFilesystem, 0);
 
-        expect_string_count(__wrap_realtime_adddir, dir, dir_it->path, 2);
-        will_return_count(__wrap_realtime_adddir, 0, 2);
+        if (FIM_MODE(dir_it->options) == FIM_REALTIME) {
+            expect_string(__wrap_fim_add_inotify_watch, dir, dir_it->path);
+            will_return(__wrap_fim_add_inotify_watch, 0);
+        }
+
+        expect_string(__wrap_realtime_adddir, dir, dir_it->path);
+        will_return(__wrap_realtime_adddir, 0);
 
         will_return(__wrap_opendir, 1);
         will_return(__wrap_readdir, NULL);
@@ -2326,8 +2343,13 @@ static void test_fim_scan_db_free(void **state) {
         expect_string(__wrap_HasFilesystem, path, dir_it->path);
         will_return(__wrap_HasFilesystem, 0);
 
-        expect_string_count(__wrap_realtime_adddir, dir, dir_it->path, 2);
-        will_return_count(__wrap_realtime_adddir, 0, 2);
+        if (FIM_MODE(dir_it->options) == FIM_REALTIME) {
+            expect_string(__wrap_fim_add_inotify_watch, dir, dir_it->path);
+            will_return(__wrap_fim_add_inotify_watch, 0);
+        }
+
+        expect_string(__wrap_realtime_adddir, dir, dir_it->path);
+        will_return(__wrap_realtime_adddir, 0);
 
         will_return(__wrap_opendir, 1);
         will_return(__wrap_readdir, NULL);
@@ -2389,8 +2411,13 @@ static void test_fim_scan_no_limit(void **state) {
         expect_string(__wrap_HasFilesystem, path, dir_it->path);
         will_return(__wrap_HasFilesystem, 0);
 
-        expect_string_count(__wrap_realtime_adddir, dir, dir_it->path, 2);
-        will_return_count(__wrap_realtime_adddir, 0, 2);
+        if (FIM_MODE(dir_it->options) == FIM_REALTIME) {
+            expect_string(__wrap_fim_add_inotify_watch, dir, dir_it->path);
+            will_return(__wrap_fim_add_inotify_watch, 0);
+        }
+
+        expect_string(__wrap_realtime_adddir, dir, dir_it->path);
+        will_return(__wrap_realtime_adddir, 0);
 
         will_return(__wrap_opendir, 1);
         will_return(__wrap_readdir, NULL);

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -5474,8 +5474,12 @@ static void test_fim_update_db_data_modified() {
 #endif
 
 static void test_update_wildcards_config_list_null() {
-    // Do nothing
-    update_wildcards_config(syscheck.directories, NULL);
+    if (syscheck.wildcards) {
+        OSList_SetFreeDataPointer(syscheck.wildcards, (void (*)(void *))free_directory);
+        OSList_Destroy(syscheck.wildcards);
+        syscheck.wildcards = NULL;
+    }
+    update_wildcards_config();
 }
 
 static void test_update_wildcards_config() {
@@ -5530,7 +5534,7 @@ static void test_update_wildcards_config() {
     expect_string(__wrap_add_whodata_directory, path, resolvedpath2);
 #endif
 
-    update_wildcards_config(syscheck.directories, syscheck.wildcards);
+    update_wildcards_config();
 
     // Filled config
     directory_t *directory0 = (directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0);
@@ -5588,7 +5592,7 @@ static void test_update_wildcards_config_remove_config() {
     will_return(__wrap_fim_db_get_path, NULL);
     expect_fim_db_get_path_from_pattern(syscheck.database, pattern2, NULL, FIM_DB_DISK, FIMDB_ERR);
 
-    update_wildcards_config(syscheck.directories, syscheck.wildcards);
+    update_wildcards_config();
 
     // Empty config
     directory_t *directory0 = (directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0);
@@ -5806,9 +5810,9 @@ int main(void) {
     };
     const struct CMUnitTest wildcards_tests[] = {
         /* update_wildcards_config */
-        cmocka_unit_test(test_update_wildcards_config_list_null),
         cmocka_unit_test(test_update_wildcards_config),
         cmocka_unit_test(test_update_wildcards_config_remove_config),
+        cmocka_unit_test(test_update_wildcards_config_list_null),
     };
     int retval;
 

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -272,10 +272,9 @@ static int teardown_group(void **state) {
     test_mode = 0;
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
-    expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
     if(teardown_fim_data(state) != 0)
         return -1;
@@ -4698,11 +4697,11 @@ static void test_fim_process_file_from_db_deleted_file_not_in_configuration(void
         fail_msg("Failed to set an invalid path.");
     }
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
     expect_string(__wrap_fim_db_get_path, file_path, entry->file_entry.path);
@@ -4740,11 +4739,11 @@ static void test_fim_process_file_from_db_deleted_file_fail_to_remove_entry_from
         fail_msg("Failed to set an invalid path.");
     }
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
     expect_string(__wrap_fim_db_get_path, file_path, entry->file_entry.path);
@@ -4781,11 +4780,11 @@ static void test_fim_process_file_from_db_deleted_file_event_generated(void **st
         fail_msg("Failed to set an invalid path.");
     }
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
     expect_string(__wrap_fim_db_get_path, file_path, entry->file_entry.path);
@@ -5582,23 +5581,15 @@ static void test_update_wildcards_config_remove_config() {
     will_return(__wrap_expand_wildcards, NULL);
     expect_string(__wrap_expand_wildcards, path, wildcard2);
     will_return(__wrap_expand_wildcards, NULL);
-
-    // Inside fim_process_missing_entry
-    expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_get_path, file_path, resolvedpath1);
-    will_return(__wrap_fim_db_get_path, NULL);
 #ifndef TEST_WINAGENT
     expect_string(__wrap_remove_audit_rule_syscheck, path, resolvedpath1);
-#endif
-    expect_fim_db_get_path_from_pattern(syscheck.database, pattern1, NULL, FIM_DB_DISK, FIMDB_ERR);
-
-    expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_get_path, file_path, resolvedpath2);
-    will_return(__wrap_fim_db_get_path, NULL);
-    expect_fim_db_get_path_from_pattern(syscheck.database, pattern2, NULL, FIM_DB_DISK, FIMDB_ERR);
-#ifndef TEST_WINAGENT
     expect_string(__wrap_remove_audit_rule_syscheck, path, resolvedpath2);
 #endif
+
+    // Remove configuration loop
+    expect_fim_db_get_path_from_pattern(syscheck.database, pattern1, NULL, FIM_DB_DISK, FIMDB_ERR);
+    expect_fim_db_get_path_from_pattern(syscheck.database, pattern2, NULL, FIM_DB_DISK, FIMDB_ERR);
+
     update_wildcards_config();
 
     // Empty config

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -204,11 +204,11 @@ static int setup_root_group(void **state) {
     test_mode = 0;
     expect_any_always(__wrap__mdebug1, formatted_msg);
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
-    expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     // Read and setup global values.
     Read_Syscheck_Config("test_syscheck_top_level.conf");
@@ -227,9 +227,9 @@ static int teardown_group(void **state) {
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     if(teardown_fim_data(state) != 0)
         return -1;
@@ -1689,11 +1689,11 @@ static void test_fim_checker_no_file_system(void **state) {
     struct stat statbuf = DEFAULT_STATBUF;
     const char *path = "/media/test.file";
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     expect_string(__wrap_lstat, filename, path);
     will_return(__wrap_lstat, &statbuf);
@@ -1716,11 +1716,11 @@ static void test_fim_checker_fim_regular(void **state) {
                             .st_mtime = 1433395216,
                             .st_size = 1500 };
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     expect_string(__wrap_lstat, filename, path);
     will_return(__wrap_lstat, &statbuf);
@@ -1760,11 +1760,11 @@ static void test_fim_checker_fim_regular_warning(void **state) {
                             .st_mtime = 1433395216,
                             .st_size = 1500 };
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     expect_string(__wrap_lstat, filename, path);
     will_return(__wrap_lstat, &statbuf);
@@ -1796,11 +1796,11 @@ static void test_fim_checker_fim_regular_ignore(void **state) {
     event_data_t evt_data = { .mode = FIM_WHODATA, .w_evt = NULL, .report_event = true };
     const char *path = "/etc/mtab";
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     expect_string(__wrap_lstat, filename, path);
     will_return(__wrap_lstat, &statbuf);
@@ -1819,11 +1819,11 @@ static void test_fim_checker_fim_regular_restrict(void **state) {
     event_data_t evt_data = { .mode = FIM_REALTIME, .w_evt = NULL, .report_event = true };
     const char *path = "/media/test";
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     expect_string(__wrap_lstat, filename, path);
     will_return(__wrap_lstat, &statbuf);
@@ -1843,11 +1843,11 @@ static void test_fim_checker_fim_directory(void **state) {
     event_data_t evt_data = { .mode = FIM_REALTIME, .w_evt = NULL, .report_event = true };
     const char *path = "/media/";
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     directory_stat.st_mode = S_IFDIR;
 
@@ -1888,6 +1888,7 @@ static void test_fim_checker_fim_directory_on_max_recursion_level(void **state) 
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
 
     statbuf.st_mode = S_IFDIR;
 
@@ -1930,9 +1931,9 @@ static void test_fim_checker_root_ignore_file_under_recursion_level(void **state
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     expect_string(__wrap__mdebug2, formatted_msg,
         "(6217): Maximum level of recursion reached. Depth:1 recursion_level:0 '/media/test.file'");
@@ -1947,9 +1948,9 @@ static void test_fim_checker_root_file_within_recursion_level(void **state) {
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     statbuf.st_size = 0;
 
@@ -2384,9 +2385,9 @@ void test_fim_delete_file_event_delete_error(void **state) {
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, FIMDB_ERR);
 
@@ -2422,9 +2423,9 @@ void test_fim_delete_file_event_remove_success(void **state) {
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     char buffer[OS_SIZE_128] = {0};
     expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, FIMDB_OK);
@@ -2468,9 +2469,9 @@ void test_fim_delete_file_event_no_conf(void **state) {
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     snprintf(buffer_msg, OS_SIZE_128, FIM_DELETE_EVENT_PATH_NOCONF, fim_data->fentry->file_entry.path);
     snprintf(buffer_config, OS_SIZE_128, FIM_CONFIGURATION_NOTFOUND, "file", fim_data->fentry->file_entry.path);
@@ -2511,9 +2512,9 @@ void test_fim_delete_file_event_different_mode_scheduled(void **state) {
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     char buffer[OS_SIZE_128] = {0};
     expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, FIMDB_OK);
@@ -2553,9 +2554,9 @@ void test_fim_delete_file_event_different_mode_abort_realtime(void **state) {
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, &evt_data, NULL, NULL);
 }
@@ -2588,9 +2589,9 @@ void test_fim_delete_file_event_different_mode_abort_whodata(void **state) {
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, &evt_data, NULL, NULL);
 }
@@ -2624,9 +2625,9 @@ void test_fim_delete_file_event_report_changes(void **state) {
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     configuration = fim_configuration_directory(fim_data->fentry->file_entry.path);
     configuration->options |= CHECK_SEECHANGES;
@@ -4119,9 +4120,9 @@ static void test_fim_directory(void **state) {
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     strcpy(fim_data->entry->d_name, "test");
 
@@ -4335,9 +4336,9 @@ static void test_fim_realtime_event_file_exists(void **state) {
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     fim_data->fentry->file_entry.path = strdup("file");
     fim_data->fentry->file_entry.data = fim_data->local_data;
@@ -4426,9 +4427,9 @@ static void test_fim_whodata_event_file_exists(void **state) {
     fim_data_t *fim_data = *state;
     struct stat buf = { .st_mode = 0 };
 
-    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
-    expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
 
@@ -4451,8 +4452,10 @@ static void test_fim_whodata_event_file_missing(void **state) {
     fim_data_t *fim_data = *state;
     struct stat buf = { .st_mode = 0 };
 
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
 #ifndef TEST_WINAGENT
     expect_string(__wrap_lstat, filename, fim_data->w_evt->path);
@@ -4619,8 +4622,9 @@ static void test_fim_process_missing_entry_data_exists(void **state) {
 
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
@@ -4752,9 +4756,9 @@ static void test_fim_process_file_from_db_deleted_file_not_in_configuration(void
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
     expect_string(__wrap_fim_db_get_path, file_path, entry->file_entry.path);
@@ -4794,9 +4798,9 @@ static void test_fim_process_file_from_db_deleted_file_fail_to_remove_entry_from
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
     expect_string(__wrap_fim_db_get_path, file_path, entry->file_entry.path);
@@ -4835,9 +4839,9 @@ static void test_fim_process_file_from_db_deleted_file_event_generated(void **st
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
     expect_string(__wrap_fim_db_get_path, file_path, entry->file_entry.path);
@@ -4883,9 +4887,9 @@ static void test_fim_process_file_from_db_file_without_conflict(void **state) {
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
     expect_string(__wrap_fim_db_get_path, file_path, entry->file_entry.path);
@@ -4923,9 +4927,9 @@ static void test_fim_process_file_from_db_conflicting_file_current_inode_free_in
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
     expect_string(__wrap_fim_db_get_path, file_path, entry->file_entry.path);
@@ -5012,9 +5016,9 @@ static void test_fim_process_file_from_db_conflicting_file_infinite_loop(void **
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     entry->file_entry.data->perm = strdup("rw-r--r--");
 

--- a/src/unit_tests/syscheckd/test_fim_diff_changes.c
+++ b/src/unit_tests/syscheckd/test_fim_diff_changes.c
@@ -301,6 +301,7 @@ static int teardown_group(void **state) {
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
 
@@ -1556,7 +1557,13 @@ void test_fim_registry_value_diff_generate_diff_str(void **state) {
 
 void test_fim_file_diff_wrong_initialize(void **state) {
     const char *filename = GENERIC_PATH;
-
+#ifdef TEST_WINAGENT
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+#endif
     expect_initialize_file_diff_data(filename, 0);
 
     char *diff_str = fim_file_diff(filename);
@@ -1567,6 +1574,7 @@ void test_fim_file_diff_wrong_initialize(void **state) {
 void test_fim_file_diff_wrong_too_big_file(void **state) {
     const char *filename = GENERIC_PATH;
 
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
@@ -1619,6 +1627,7 @@ void test_fim_file_diff_uncompress_fail(void **state) {
     syscheck.comp_estimation_perc = 0.4;
     syscheck.diff_folder_size = 512;
 
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
@@ -1651,6 +1660,7 @@ void test_fim_file_diff_create_compress_fail(void **state) {
     syscheck.comp_estimation_perc = 0.4;
     syscheck.diff_folder_size = 512;
 
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
@@ -1689,6 +1699,7 @@ void test_fim_file_diff_compare_fail(void **state) {
     syscheck.comp_estimation_perc = 0.4;
     syscheck.diff_folder_size = 512;
 
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
@@ -1726,6 +1737,7 @@ void test_fim_file_diff_nodiff(void **state) {
     syscheck.comp_estimation_perc = 0.4;
     syscheck.diff_folder_size = 512;
 
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
@@ -1760,6 +1772,7 @@ void test_fim_file_diff_nodiff(void **state) {
     syscheck.comp_estimation_perc = 0.4;
     syscheck.diff_folder_size = 512;
 
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
@@ -1795,6 +1808,7 @@ void test_fim_file_diff_generate_fail(void **state) {
     syscheck.comp_estimation_perc = 0.4;
     syscheck.diff_folder_size = 512;
 
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
@@ -1847,6 +1861,7 @@ void test_fim_file_diff_generate_diff_str(void **state) {
     syscheck.comp_estimation_perc = 0.4;
     syscheck.diff_folder_size = 512;
 
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
@@ -1895,6 +1910,7 @@ void test_fim_file_diff_generate_diff_str_too_long(void **state) {
     syscheck.comp_estimation_perc = 0.4;
     syscheck.diff_folder_size = 512;
 
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -68,6 +68,13 @@ time_t __wrap_time(time_t *timer) {
 
 static int setup_group(void ** state) {
 #ifdef TEST_WINAGENT
+#ifdef WIN_WHODATA
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+#endif
     expect_string(__wrap__mdebug1, formatted_msg, "(6287): Reading configuration file: 'test_syscheck.conf'");
     expect_string(__wrap__mdebug1, formatted_msg, "Found ignore regex node .log$|.htm$|.jpg$|.png$|.chm$|.pnf$|.evtx$|.swp$");
     expect_string(__wrap__mdebug1, formatted_msg, "Found ignore regex node .log$|.htm$|.jpg$|.png$|.chm$|.pnf$|.evtx$|.swp$ OK?");
@@ -187,6 +194,14 @@ static int teardown_tmp_file(void **state) {
 
 static int teardown_group(void **state) {
 #ifdef TEST_WINAGENT
+#ifdef WIN_WHODATA
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+#endif
+
     if (syscheck.realtime) {
         if (syscheck.realtime->dirtb) {
             OSHash_Free(syscheck.realtime->dirtb);
@@ -225,6 +240,12 @@ void test_fim_whodata_initialize(void **state)
 {
     int ret;
 #ifdef TEST_WINAGENT
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+
     int i;
     char *dirs[] = {
         "%WINDIR%\\System32\\WindowsPowerShell\\v1.0",
@@ -315,6 +336,12 @@ void test_fim_whodata_initialize_fail_set_policies(void **state)
         NULL
     };
     char expanded_dirs[1][OS_SIZE_1024];
+
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
 
     // Expand directories
     for(i = 0; dirs[i]; i++) {
@@ -429,6 +456,12 @@ void test_set_whodata_mode_changes(void **state) {
     };
     char expanded_dirs[3][OS_SIZE_1024];
 
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+
     // Mark directories to be added in realtime
     ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.status |= WD_CHECK_REALTIME;
     ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.status &= ~WD_CHECK_WHODATA;
@@ -461,6 +494,12 @@ void test_fim_whodata_initialize_eventchannel(void **state) {
         NULL
     };
     char expanded_dirs[1][OS_SIZE_1024];
+
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
 
     // Expand directories
     for(i = 0; dirs[i]; i++) {

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -122,16 +122,16 @@ static int setup_group(void ** state) {
 #ifndef TEST_WINAGENT
 
 static int setup_symbolic_links(void **state) {
-    if (syscheck.directories[1]->path != NULL) {
-        free(syscheck.directories[1]->path);
-        syscheck.directories[1]->path = NULL;
+    if (((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path != NULL) {
+        free(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path);
+        ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path = NULL;
     }
 
-    syscheck.directories[1]->path = strdup("/link");
-    syscheck.directories[1]->symbolic_links = strdup("/folder");
-    syscheck.directories[1]->options |= REALTIME_ACTIVE;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path = strdup("/link");
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links = strdup("/folder");
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->options |= REALTIME_ACTIVE;
 
-    if (syscheck.directories[1]->path == NULL || syscheck.directories[1]->symbolic_links == NULL) {
+    if (((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path == NULL || ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links == NULL) {
         return -1;
     }
 
@@ -139,20 +139,20 @@ static int setup_symbolic_links(void **state) {
 }
 
 static int teardown_symbolic_links(void **state) {
-    if (syscheck.directories[1]->path != NULL) {
-        free(syscheck.directories[1]->path);
-        syscheck.directories[1]->path = NULL;
+    if (((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path != NULL) {
+        free(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path);
+        ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path = NULL;
     }
 
-    if (syscheck.directories[1]->symbolic_links != NULL) {
-        free(syscheck.directories[1]->symbolic_links);
-        syscheck.directories[1]->symbolic_links = NULL;
+    if (((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links != NULL) {
+        free(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links);
+        ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links = NULL;
     }
 
-    syscheck.directories[1]->path = strdup("/etc");
-    syscheck.directories[1]->options &= ~REALTIME_ACTIVE;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path = strdup("/etc");
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->options &= ~REALTIME_ACTIVE;
 
-    if (syscheck.directories[1]->path == NULL) {
+    if (((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path == NULL) {
         return -1;
     }
 
@@ -430,12 +430,12 @@ void test_set_whodata_mode_changes(void **state) {
     char expanded_dirs[3][OS_SIZE_1024];
 
     // Mark directories to be added in realtime
-    syscheck.directories[0]->dirs_status.status |= WD_CHECK_REALTIME;
-    syscheck.directories[0]->dirs_status.status &= ~WD_CHECK_WHODATA;
-    syscheck.directories[7]->dirs_status.status |= WD_CHECK_REALTIME;
-    syscheck.directories[7]->dirs_status.status &= ~WD_CHECK_WHODATA;
-    syscheck.directories[8]->dirs_status.status |= WD_CHECK_REALTIME;
-    syscheck.directories[8]->dirs_status.status &= ~WD_CHECK_WHODATA;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.status |= WD_CHECK_REALTIME;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.status &= ~WD_CHECK_WHODATA;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 7))->dirs_status.status |= WD_CHECK_REALTIME;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 7))->dirs_status.status &= ~WD_CHECK_WHODATA;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 8))->dirs_status.status |= WD_CHECK_REALTIME;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 8))->dirs_status.status &= ~WD_CHECK_WHODATA;
 
     // Expand directories
     for(i = 0; dirs[i]; i++) {
@@ -578,51 +578,51 @@ void test_fim_link_update(void **state) {
     char *new_path = "/new_path";
 
     expect_fim_db_get_path_from_pattern(syscheck.database, "/folder/%", NULL, FIM_DB_DISK, FIMDB_OK);
-    expect_string(__wrap_remove_audit_rule_syscheck, path, syscheck.directories[1]->symbolic_links);
+    expect_string(__wrap_remove_audit_rule_syscheck, path, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links);
 
     expect_realtime_adddir_call(new_path, 0);
-    expect_fim_checker_call(new_path, syscheck.directories[1]);
+    expect_fim_checker_call(new_path, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1)));
 
-    fim_link_update(new_path, syscheck.directories[1]);
+    fim_link_update(new_path, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1)));
 
-    assert_string_equal(syscheck.directories[1]->path, "/link");
-    assert_string_equal(syscheck.directories[1]->symbolic_links, new_path);
+    assert_string_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path, "/link");
+    assert_string_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links, new_path);
 }
 
 void test_fim_link_update_already_added(void **state) {
     char *link_path = "/home";
     char error_msg[OS_SIZE_128];
 
-    free(syscheck.directories[1]->symbolic_links);
-    syscheck.directories[1]->symbolic_links = strdup("/home");
+    free(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links);
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links = strdup("/home");
 
     snprintf(error_msg, OS_SIZE_128, FIM_LINK_ALREADY_ADDED, link_path);
 
     expect_string(__wrap__mdebug1, formatted_msg, error_msg);
 
-    fim_link_update(link_path, syscheck.directories[1]);
+    fim_link_update(link_path, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1)));
 
-    assert_string_equal(syscheck.directories[1]->path, "/link");
-    assert_null(syscheck.directories[1]->symbolic_links);
+    assert_string_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path, "/link");
+    assert_null(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links);
 }
 
 void test_fim_link_check_delete(void **state) {
     char *link_path = "/link";
     char *pointed_folder = "/folder";
 
-    expect_string(__wrap_lstat, filename, syscheck.directories[1]->symbolic_links);
+    expect_string(__wrap_lstat, filename, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links);
     will_return(__wrap_lstat, 0);
     will_return(__wrap_lstat, 0);
 
     expect_fim_db_get_path_from_pattern(syscheck.database, "/folder/%", NULL, FIM_DB_DISK, FIMDB_OK);
 
-    expect_string(__wrap_remove_audit_rule_syscheck, path, syscheck.directories[1]->symbolic_links);
+    expect_string(__wrap_remove_audit_rule_syscheck, path, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links);
 
     expect_fim_configuration_directory_call(pointed_folder, NULL);
-    fim_link_check_delete(syscheck.directories[1]);
+    fim_link_check_delete(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1)));
 
-    assert_string_equal(syscheck.directories[1]->path, link_path);
-    assert_null(syscheck.directories[1]->symbolic_links);
+    assert_string_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path, link_path);
+    assert_null(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links);
 }
 
 void test_fim_link_check_delete_lstat_error(void **state) {
@@ -639,10 +639,10 @@ void test_fim_link_check_delete_lstat_error(void **state) {
 
     expect_string(__wrap__mdebug1, formatted_msg, error_msg);
 
-    fim_link_check_delete(syscheck.directories[1]);
+    fim_link_check_delete(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1)));
 
-    assert_string_equal(syscheck.directories[1]->path, link_path);
-    assert_string_equal(syscheck.directories[1]->symbolic_links, pointed_folder);
+    assert_string_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path, link_path);
+    assert_string_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links, pointed_folder);
 }
 
 void test_fim_link_check_delete_noentry_error(void **state) {
@@ -652,16 +652,16 @@ void test_fim_link_check_delete_noentry_error(void **state) {
     expect_string(__wrap_lstat, filename, pointed_folder);
     will_return(__wrap_lstat, 0);
     will_return(__wrap_lstat, -1);
-    expect_string(__wrap_remove_audit_rule_syscheck, path, syscheck.directories[1]->symbolic_links);
+    expect_string(__wrap_remove_audit_rule_syscheck, path, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links);
 
     errno = ENOENT;
 
-    fim_link_check_delete(syscheck.directories[1]);
+    fim_link_check_delete(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1)));
 
     errno = 0;
 
-    assert_string_equal(syscheck.directories[1]->path, link_path);
-    assert_null(syscheck.directories[1]->symbolic_links);
+    assert_string_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path, link_path);
+    assert_null(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links);
 }
 
 void test_fim_delete_realtime_watches(void **state) {
@@ -671,12 +671,12 @@ void test_fim_delete_realtime_watches(void **state) {
     char *link_path = "/link";
     char *pointed_folder = "/folder";
 
-    expect_fim_configuration_directory_call(pointed_folder, syscheck.directories[0]);
-    expect_fim_configuration_directory_call("data", syscheck.directories[0]);
+    expect_fim_configuration_directory_call(pointed_folder, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)));
+    expect_fim_configuration_directory_call("data", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)));
 
     will_return(__wrap_inotify_rm_watch, 1);
 
-    fim_delete_realtime_watches(syscheck.directories[1]);
+    fim_delete_realtime_watches(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1)));
 
     assert_null(OSHash_Begin(syscheck.realtime->dirtb, &pos));
 }
@@ -686,7 +686,7 @@ void test_fim_link_delete_range(void **state) {
 
     expect_fim_db_get_path_from_pattern(syscheck.database, "/folder/%", tmp_file, FIM_DB_DISK, FIMDB_OK);
     expect_wrapper_fim_db_delete_range_call(syscheck.database, FIM_DB_DISK, tmp_file, FIMDB_OK);
-    fim_link_delete_range(syscheck.directories[1]);
+    fim_link_delete_range(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1)));
 }
 
 void test_fim_link_delete_range_error(void **state) {
@@ -699,16 +699,16 @@ void test_fim_link_delete_range_error(void **state) {
     expect_wrapper_fim_db_delete_range_call(syscheck.database, FIM_DB_DISK, tmp_file, FIMDB_ERR);
     expect_string(__wrap__merror, formatted_msg, error_msg);
 
-    fim_link_delete_range(syscheck.directories[1]);
+    fim_link_delete_range(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1)));
 }
 
 void test_fim_link_silent_scan(void **state) {
     char *link_path = "/link";
 
     expect_realtime_adddir_call(link_path, 0);
-    expect_fim_checker_call(link_path, syscheck.directories[3]);
+    expect_fim_checker_call(link_path, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 3)));
 
-    fim_link_silent_scan(link_path, syscheck.directories[3]);
+    fim_link_silent_scan(link_path, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 3)));
 }
 
 void test_fim_link_reload_broken_link_already_monitored(void **state) {
@@ -720,25 +720,25 @@ void test_fim_link_reload_broken_link_already_monitored(void **state) {
 
     expect_string(__wrap__mdebug1, formatted_msg, error_msg);
 
-    fim_link_reload_broken_link(link_path, syscheck.directories[1]);
+    fim_link_reload_broken_link(link_path, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1)));
 
-    assert_string_equal(syscheck.directories[1]->path, link_path);
-    assert_string_equal(syscheck.directories[1]->symbolic_links, pointed_folder);
+    assert_string_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path, link_path);
+    assert_string_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links, pointed_folder);
 }
 
 void test_fim_link_reload_broken_link_reload_broken(void **state) {
     char *link_path = "/link";
     char *pointed_folder = "/new_path";
 
-    expect_fim_checker_call(pointed_folder, syscheck.directories[1]);
+    expect_fim_checker_call(pointed_folder, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1)));
 
     expect_string(__wrap_realtime_adddir, dir, pointed_folder);
     will_return(__wrap_realtime_adddir, 0);
 
-    fim_link_reload_broken_link(pointed_folder, syscheck.directories[1]);
+    fim_link_reload_broken_link(pointed_folder, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1)));
 
-    assert_string_equal(syscheck.directories[1]->path, link_path);
-    assert_string_equal(syscheck.directories[1]->symbolic_links, pointed_folder);
+    assert_string_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path, link_path);
+    assert_string_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links, pointed_folder);
 }
 #endif
 

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -129,16 +129,18 @@ static int setup_group(void ** state) {
 #ifndef TEST_WINAGENT
 
 static int setup_symbolic_links(void **state) {
-    if (((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path != NULL) {
-        free(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path);
-        ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path = NULL;
+    directory_t *config = (directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1);
+
+    if (config->path != NULL) {
+        free(config->path);
+        config->path = NULL;
     }
 
-    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path = strdup("/link");
-    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links = strdup("/folder");
-    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->options |= REALTIME_ACTIVE;
+    config->path = strdup("/link");
+    config->symbolic_links = strdup("/folder");
+    config->options |= REALTIME_ACTIVE;
 
-    if (((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path == NULL || ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links == NULL) {
+    if (config->path == NULL || config->symbolic_links == NULL) {
         return -1;
     }
 
@@ -146,20 +148,21 @@ static int setup_symbolic_links(void **state) {
 }
 
 static int teardown_symbolic_links(void **state) {
-    if (((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path != NULL) {
-        free(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path);
-        ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path = NULL;
+    directory_t *config = (directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1);
+    if (config->path != NULL) {
+        free(config->path);
+        config->path = NULL;
     }
 
-    if (((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links != NULL) {
-        free(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links);
-        ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links = NULL;
+    if (config->symbolic_links != NULL) {
+        free(config->symbolic_links);
+        config->symbolic_links = NULL;
     }
 
-    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path = strdup("/etc");
-    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->options &= ~REALTIME_ACTIVE;
+    config->path = strdup("/etc");
+    config->options &= ~REALTIME_ACTIVE;
 
-    if (((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path == NULL) {
+    if (config->path == NULL) {
         return -1;
     }
 
@@ -615,59 +618,64 @@ void test_fim_send_scan_info(void **state) {
 #ifndef TEST_WINAGENT
 void test_fim_link_update(void **state) {
     char *new_path = "/new_path";
+    directory_t *affected_config = (directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1);
 
     expect_fim_db_get_path_from_pattern(syscheck.database, "/folder/%", NULL, FIM_DB_DISK, FIMDB_OK);
-    expect_string(__wrap_remove_audit_rule_syscheck, path, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links);
+    expect_string(__wrap_remove_audit_rule_syscheck, path, affected_config->symbolic_links);
 
+    expect_fim_checker_call(new_path, affected_config);
     expect_realtime_adddir_call(new_path, 0);
-    expect_fim_checker_call(new_path, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1)));
+    expect_string(__wrap_remove_audit_rule_syscheck, path, affected_config->path);
 
-    fim_link_update(new_path, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1)));
+    fim_link_update(new_path, affected_config);
 
-    assert_string_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path, "/link");
-    assert_string_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links, new_path);
+    assert_string_equal(affected_config->path, "/link");
+    assert_string_equal(affected_config->symbolic_links, new_path);
 }
 
 void test_fim_link_update_already_added(void **state) {
     char *link_path = "/home";
     char error_msg[OS_SIZE_128];
+    directory_t *affected_config = (directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1);
 
-    free(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links);
-    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links = strdup("/home");
+    free(affected_config->symbolic_links);
+    affected_config->symbolic_links = strdup("/home");
 
     snprintf(error_msg, OS_SIZE_128, FIM_LINK_ALREADY_ADDED, link_path);
 
     expect_string(__wrap__mdebug1, formatted_msg, error_msg);
 
-    fim_link_update(link_path, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1)));
+    fim_link_update(link_path, affected_config);
 
-    assert_string_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path, "/link");
-    assert_null(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links);
+    assert_string_equal(affected_config->path, "/link");
+    assert_null(affected_config->symbolic_links);
 }
 
 void test_fim_link_check_delete(void **state) {
     char *link_path = "/link";
     char *pointed_folder = "/folder";
+    directory_t *affected_config = (directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1);
 
-    expect_string(__wrap_lstat, filename, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links);
+    expect_string(__wrap_lstat, filename, affected_config->symbolic_links);
     will_return(__wrap_lstat, 0);
     will_return(__wrap_lstat, 0);
 
     expect_fim_db_get_path_from_pattern(syscheck.database, "/folder/%", NULL, FIM_DB_DISK, FIMDB_OK);
 
-    expect_string(__wrap_remove_audit_rule_syscheck, path, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links);
+    expect_string(__wrap_remove_audit_rule_syscheck, path, affected_config->symbolic_links);
 
     expect_fim_configuration_directory_call(pointed_folder, NULL);
-    fim_link_check_delete(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1)));
+    fim_link_check_delete(affected_config);
 
-    assert_string_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path, link_path);
-    assert_null(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links);
+    assert_string_equal(affected_config->path, link_path);
+    assert_null(affected_config->symbolic_links);
 }
 
 void test_fim_link_check_delete_lstat_error(void **state) {
     char *link_path = "/link";
     char *pointed_folder = "/folder";
     char error_msg[OS_SIZE_128];
+    directory_t *affected_config = (directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1);
 
     expect_string(__wrap_lstat, filename, pointed_folder);
     will_return(__wrap_lstat, 0);
@@ -678,34 +686,33 @@ void test_fim_link_check_delete_lstat_error(void **state) {
 
     expect_string(__wrap__mdebug1, formatted_msg, error_msg);
 
-    fim_link_check_delete(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1)));
+    fim_link_check_delete(affected_config);
 
-    assert_string_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path, link_path);
-    assert_string_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links, pointed_folder);
+    assert_string_equal(affected_config->path, link_path);
+    assert_string_equal(affected_config->symbolic_links, pointed_folder);
 }
 
 void test_fim_link_check_delete_noentry_error(void **state) {
     char *link_path = "/link";
     char *pointed_folder = "/folder";
+    directory_t *affected_config = (directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1);
 
     expect_string(__wrap_lstat, filename, pointed_folder);
     will_return(__wrap_lstat, 0);
     will_return(__wrap_lstat, -1);
-    expect_string(__wrap_remove_audit_rule_syscheck, path, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links);
+    expect_string(__wrap_remove_audit_rule_syscheck, path, affected_config->symbolic_links);
 
     errno = ENOENT;
 
-    fim_link_check_delete(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1)));
+    fim_link_check_delete(affected_config);
 
     errno = 0;
 
-    assert_string_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path, link_path);
-    assert_null(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links);
+    assert_string_equal(affected_config->path, link_path);
+    assert_null(affected_config->symbolic_links);
 }
 
 void test_fim_delete_realtime_watches(void **state) {
-    (void) state;
-
     unsigned int pos;
     char *link_path = "/link";
     char *pointed_folder = "/folder";
@@ -743,41 +750,46 @@ void test_fim_link_delete_range_error(void **state) {
 
 void test_fim_link_silent_scan(void **state) {
     char *link_path = "/link";
+    directory_t *affected_config = (directory_t *)OSList_GetDataFromIndex(syscheck.directories, 3);
 
     expect_realtime_adddir_call(link_path, 0);
-    expect_fim_checker_call(link_path, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 3)));
+    expect_fim_checker_call(link_path, affected_config);
 
-    fim_link_silent_scan(link_path, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 3)));
+    fim_link_silent_scan(link_path, affected_config);
 }
 
 void test_fim_link_reload_broken_link_already_monitored(void **state) {
     char *link_path = "/link";
     char *pointed_folder = "/folder";
     char error_msg[OS_SIZE_128];
+    directory_t *affected_config = (directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1);
 
     snprintf(error_msg, OS_SIZE_128, FIM_LINK_ALREADY_ADDED, link_path);
 
     expect_string(__wrap__mdebug1, formatted_msg, error_msg);
 
-    fim_link_reload_broken_link(link_path, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1)));
+    fim_link_reload_broken_link(link_path, affected_config);
 
-    assert_string_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path, link_path);
-    assert_string_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links, pointed_folder);
+    assert_string_equal(affected_config->path, link_path);
+    assert_string_equal(affected_config->symbolic_links, pointed_folder);
 }
 
 void test_fim_link_reload_broken_link_reload_broken(void **state) {
     char *link_path = "/link";
     char *pointed_folder = "/new_path";
+    directory_t *affected_config = (directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1);
 
-    expect_fim_checker_call(pointed_folder, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1)));
+    expect_fim_checker_call(pointed_folder, affected_config);
 
     expect_string(__wrap_realtime_adddir, dir, pointed_folder);
     will_return(__wrap_realtime_adddir, 0);
 
-    fim_link_reload_broken_link(pointed_folder, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1)));
+    expect_string(__wrap_remove_audit_rule_syscheck, path, link_path);
 
-    assert_string_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path, link_path);
-    assert_string_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->symbolic_links, pointed_folder);
+    fim_link_reload_broken_link(pointed_folder, affected_config);
+
+    assert_string_equal(affected_config->path, link_path);
+    assert_string_equal(affected_config->symbolic_links, pointed_folder);
 }
 #endif
 

--- a/src/unit_tests/syscheckd/test_run_realtime.c
+++ b/src/unit_tests/syscheckd/test_run_realtime.c
@@ -1292,90 +1292,90 @@ void test_free_win32rtfim_data_full_data(void **state) {
 void test_realtime_adddir_whodata_non_existent_file(void **state) {
     int ret;
 
-    syscheck.directories[9]->dirs_status.status &= ~WD_CHECK_WHODATA;
-    syscheck.directories[9]->dirs_status.status |= WD_CHECK_REALTIME;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.status &= ~WD_CHECK_WHODATA;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.status |= WD_CHECK_REALTIME;
 
     expect_string(__wrap_check_path_type, dir, "C:\\a\\path");
     will_return(__wrap_check_path_type, 0);
 
     expect_string(__wrap__mdebug1, formatted_msg, "(6907): 'C:\\a\\path' does not exist. Monitoring discarded.");
 
-    ret = realtime_adddir("C:\\a\\path", syscheck.directories[9], 0);
+    ret = realtime_adddir("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9)), 0);
 
     assert_int_equal(ret, 0);
-    assert_non_null(syscheck.directories[9]->dirs_status.status & WD_CHECK_WHODATA);
-    assert_null(syscheck.directories[9]->dirs_status.status & WD_CHECK_REALTIME);
-    assert_int_equal(syscheck.directories[9]->dirs_status.object_type, WD_STATUS_UNK_TYPE);
-    assert_null(syscheck.directories[9]->dirs_status.status & WD_STATUS_EXISTS);
+    assert_non_null(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.status & WD_CHECK_WHODATA);
+    assert_null(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.status & WD_CHECK_REALTIME);
+    assert_int_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.object_type, WD_STATUS_UNK_TYPE);
+    assert_null(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.status & WD_STATUS_EXISTS);
 }
 
 void test_realtime_adddir_whodata_error_adding_whodata_dir(void **state) {
     int ret;
 
-    syscheck.directories[9]->dirs_status.status &= ~WD_CHECK_WHODATA;
-    syscheck.directories[9]->dirs_status.status |= WD_CHECK_REALTIME;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.status &= ~WD_CHECK_WHODATA;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.status |= WD_CHECK_REALTIME;
 
     expect_string(__wrap_check_path_type, dir, "C:\\a\\path");
     will_return(__wrap_check_path_type, 2);
 
     expect_string(__wrap_set_winsacl, dir, "C:\\a\\path");
-    expect_value(__wrap_set_winsacl, configuration, syscheck.directories[9]);
+    expect_value(__wrap_set_winsacl, configuration, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9)));
     will_return(__wrap_set_winsacl, 1);
 
     expect_string(__wrap__merror, formatted_msg,
         "(6619): Unable to add directory to whodata real time monitoring: 'C:\\a\\path'. It will be monitored in Realtime");
 
-    ret = realtime_adddir("C:\\a\\path", syscheck.directories[9], 0);
+    ret = realtime_adddir("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9)), 0);
 
     assert_int_equal(ret, -2);
-    assert_non_null(syscheck.directories[9]->dirs_status.status & WD_CHECK_WHODATA);
-    assert_null(syscheck.directories[9]->dirs_status.status & WD_CHECK_REALTIME);
-    assert_int_equal(syscheck.directories[9]->dirs_status.object_type, WD_STATUS_DIR_TYPE);
-    assert_non_null(syscheck.directories[9]->dirs_status.status & WD_STATUS_EXISTS);
+    assert_non_null(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.status & WD_CHECK_WHODATA);
+    assert_null(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.status & WD_CHECK_REALTIME);
+    assert_int_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.object_type, WD_STATUS_DIR_TYPE);
+    assert_non_null(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.status & WD_STATUS_EXISTS);
 }
 
 void test_realtime_adddir_whodata_file_success(void **state) {
     int ret;
 
-    syscheck.directories[9]->dirs_status.status &= ~WD_CHECK_WHODATA;
-    syscheck.directories[9]->dirs_status.status |= WD_CHECK_REALTIME;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.status &= ~WD_CHECK_WHODATA;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.status |= WD_CHECK_REALTIME;
 
     expect_string(__wrap_check_path_type, dir, "C:\\a\\path");
     will_return(__wrap_check_path_type, 1);
 
     expect_string(__wrap_set_winsacl, dir, "C:\\a\\path");
-    expect_value(__wrap_set_winsacl, configuration, syscheck.directories[9]);
+    expect_value(__wrap_set_winsacl, configuration, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9)));
     will_return(__wrap_set_winsacl, 0);
 
-    ret = realtime_adddir("C:\\a\\path", syscheck.directories[9], 0);
+    ret = realtime_adddir("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9)), 0);
 
     assert_int_equal(ret, 1);
-    assert_non_null(syscheck.directories[9]->dirs_status.status & WD_CHECK_WHODATA);
-    assert_null(syscheck.directories[9]->dirs_status.status & WD_CHECK_REALTIME);
-    assert_int_equal(syscheck.directories[9]->dirs_status.object_type, WD_STATUS_FILE_TYPE);
-    assert_non_null(syscheck.directories[9]->dirs_status.status & WD_STATUS_EXISTS);
+    assert_non_null(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.status & WD_CHECK_WHODATA);
+    assert_null(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.status & WD_CHECK_REALTIME);
+    assert_int_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.object_type, WD_STATUS_FILE_TYPE);
+    assert_non_null(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.status & WD_STATUS_EXISTS);
 }
 
 void test_realtime_adddir_whodata_dir_success(void **state) {
     int ret;
 
-    syscheck.directories[9]->dirs_status.status &= ~WD_CHECK_WHODATA;
-    syscheck.directories[9]->dirs_status.status |= WD_CHECK_REALTIME;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.status &= ~WD_CHECK_WHODATA;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.status |= WD_CHECK_REALTIME;
 
     expect_string(__wrap_check_path_type, dir, "C:\\a\\path");
     will_return(__wrap_check_path_type, 2);
 
     expect_string(__wrap_set_winsacl, dir, "C:\\a\\path");
-    expect_value(__wrap_set_winsacl, configuration, syscheck.directories[9]);
+    expect_value(__wrap_set_winsacl, configuration, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9)));
     will_return(__wrap_set_winsacl, 0);
 
-    ret = realtime_adddir("C:\\a\\path", syscheck.directories[9], 0);
+    ret = realtime_adddir("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9)), 0);
 
     assert_int_equal(ret, 1);
-    assert_non_null(syscheck.directories[9]->dirs_status.status & WD_CHECK_WHODATA);
-    assert_null(syscheck.directories[9]->dirs_status.status & WD_CHECK_REALTIME);
-    assert_int_equal(syscheck.directories[9]->dirs_status.object_type, WD_STATUS_DIR_TYPE);
-    assert_non_null(syscheck.directories[9]->dirs_status.status & WD_STATUS_EXISTS);
+    assert_non_null(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.status & WD_CHECK_WHODATA);
+    assert_null(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.status & WD_CHECK_REALTIME);
+    assert_int_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.object_type, WD_STATUS_DIR_TYPE);
+    assert_non_null(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.status & WD_STATUS_EXISTS);
 }
 
 void test_realtime_adddir_max_limit_reached(void **state) {
@@ -1386,7 +1386,9 @@ void test_realtime_adddir_max_limit_reached(void **state) {
     expect_string(__wrap__merror, formatted_msg,
         "(6616): Unable to add directory to real time monitoring: 'C:\\a\\path' - Maximum size permitted.");
 
-    ret = realtime_adddir("C:\\a\\path", syscheck.directories[0], 0);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    ret = realtime_adddir("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)), 0);
 
     assert_int_equal(ret, 0);
 }
@@ -1404,7 +1406,9 @@ void test_realtime_adddir_duplicate_entry(void **state) {
     expect_string(__wrap_w_directory_exists, path, "C:\\a\\path");
     will_return(__wrap_w_directory_exists, 1);
 
-    ret = realtime_adddir("C:\\a\\path", syscheck.directories[0], 0);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    ret = realtime_adddir("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)), 0);
 
     assert_int_equal(ret, 1);
 }
@@ -1425,7 +1429,9 @@ void test_realtime_adddir_duplicate_entry_non_existent_directory_valid_handle(vo
     expect_value(wrap_CloseHandle, hObject, 1234);
     will_return(wrap_CloseHandle, 0);
 
-    ret = realtime_adddir("C:\\a\\path", syscheck.directories[0], 0);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    ret = realtime_adddir("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)), 0);
 
     assert_int_equal(ret, 1);
 
@@ -1467,7 +1473,9 @@ void test_realtime_adddir_duplicate_entry_non_existent_directory_closed_handle(v
     snprintf(debug_msg, OS_SIZE_128, FIM_REALTIME_CALLBACK, "C:\\a\\path");
     expect_string(__wrap__mdebug1, formatted_msg, debug_msg);
 
-    ret = realtime_adddir("C:\\a\\path", syscheck.directories[0], 0);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    ret = realtime_adddir("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)), 0);
 
     assert_int_equal(ret, 1);
 }
@@ -1485,7 +1493,9 @@ void test_realtime_adddir_duplicate_entry_non_existent_directory_invalid_handle(
     expect_string(__wrap_w_directory_exists, path, "C:\\a\\path");
     will_return(__wrap_w_directory_exists, 0);
 
-    ret = realtime_adddir("C:\\a\\path", syscheck.directories[0], 0);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    ret = realtime_adddir("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)), 0);
 
     assert_int_equal(ret, 1);
 }
@@ -1505,7 +1515,9 @@ void test_realtime_adddir_handle_error(void **state) {
     expect_string(__wrap__mdebug2, formatted_msg,
         "(6290): Unable to add directory to real time monitoring: 'C:\\a\\path'");
 
-    ret = realtime_adddir("C:\\a\\path", syscheck.directories[0], 0);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    ret = realtime_adddir("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)), 0);
 
     assert_int_equal(ret, 0);
 }
@@ -1527,7 +1539,7 @@ void test_realtime_adddir_success(void **state) {
                   "(6227): Directory added for real time monitoring: 'C:\\a\\path'");
 
     test_mode = 0;
-    ret = realtime_adddir("C:\\a\\path", syscheck.directories[0], 0);
+    ret = realtime_adddir("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)), 0);
     test_mode = 1;
 
     assert_int_equal(ret, 1);

--- a/src/unit_tests/syscheckd/test_run_realtime.c
+++ b/src/unit_tests/syscheckd/test_run_realtime.c
@@ -607,10 +607,8 @@ void test_realtime_process_len(void **state) {
     char **paths = NULL;
     paths = os_AddStrArray("/test", paths);
 
-    expect_function_call(__wrap_pthread_rwlock_rdlock);
     will_return(__wrap_rbtree_keys, paths);
     expect_string(__wrap_fim_realtime_event, file, "/test");
-    expect_function_call(__wrap_pthread_rwlock_unlock);
 
     test_mode = 1;
     realtime_process();
@@ -646,10 +644,8 @@ void test_realtime_process_len_zero(void **state) {
     char **paths = NULL;
     paths = os_AddStrArray("/test", paths);
 
-    expect_function_call(__wrap_pthread_rwlock_rdlock);
     will_return(__wrap_rbtree_keys, paths);
     expect_string(__wrap_fim_realtime_event, file, "/test");
-    expect_function_call(__wrap_pthread_rwlock_unlock);
 
     test_mode = 1;
     realtime_process();
@@ -683,10 +679,8 @@ void test_realtime_process_len_path_separator(void **state) {
     char **paths = NULL;
     paths = os_AddStrArray("/test", paths);
 
-    expect_function_call(__wrap_pthread_rwlock_rdlock);
     will_return(__wrap_rbtree_keys, paths);
     expect_string(__wrap_fim_realtime_event, file, "/test");
-    expect_function_call(__wrap_pthread_rwlock_unlock);
 
     test_mode = 1;
     realtime_process();
@@ -715,10 +709,8 @@ void test_realtime_process_overflow(void **state) {
     char **paths = NULL;
     paths = os_AddStrArray("/test", paths);
 
-    expect_function_call(__wrap_pthread_rwlock_rdlock);
     will_return(__wrap_rbtree_keys, paths);
     expect_string(__wrap_fim_realtime_event, file, "/test");
-    expect_function_call(__wrap_pthread_rwlock_unlock);
 
     realtime_process();
 
@@ -759,10 +751,8 @@ void test_realtime_process_delete(void **state) {
     char **paths = NULL;
     paths = os_AddStrArray("/test", paths);
 
-    expect_function_call(__wrap_pthread_rwlock_rdlock);
     will_return(__wrap_rbtree_keys, paths);
     expect_string(__wrap_fim_realtime_event, file, "/test");
-    expect_function_call(__wrap_pthread_rwlock_unlock);
 
     test_mode = 1;
     realtime_process();
@@ -823,10 +813,8 @@ void test_realtime_process_move_self(void **state) {
     char **paths = NULL;
     paths = os_AddStrArray("/test", paths);
 
-    expect_function_call(__wrap_pthread_rwlock_rdlock);
     will_return(__wrap_rbtree_keys, paths);
     expect_string(__wrap_fim_realtime_event, file, "/test");
-    expect_function_call(__wrap_pthread_rwlock_unlock);
 
     test_mode = 1;
     realtime_process();

--- a/src/unit_tests/syscheckd/test_run_realtime.c
+++ b/src/unit_tests/syscheckd/test_run_realtime.c
@@ -1359,6 +1359,11 @@ void test_free_win32rtfim_data_full_data(void **state) {
 void test_realtime_adddir_whodata_non_existent_file(void **state) {
     int ret;
 
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+
     ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.status &= ~WD_CHECK_WHODATA;
     ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.status |= WD_CHECK_REALTIME;
 
@@ -1378,6 +1383,11 @@ void test_realtime_adddir_whodata_non_existent_file(void **state) {
 
 void test_realtime_adddir_whodata_error_adding_whodata_dir(void **state) {
     int ret;
+
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
     ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.status &= ~WD_CHECK_WHODATA;
     ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.status |= WD_CHECK_REALTIME;
@@ -1404,6 +1414,11 @@ void test_realtime_adddir_whodata_error_adding_whodata_dir(void **state) {
 void test_realtime_adddir_whodata_file_success(void **state) {
     int ret;
 
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+
     ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.status &= ~WD_CHECK_WHODATA;
     ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.status |= WD_CHECK_REALTIME;
 
@@ -1425,6 +1440,11 @@ void test_realtime_adddir_whodata_file_success(void **state) {
 
 void test_realtime_adddir_whodata_dir_success(void **state) {
     int ret;
+
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
     ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.status &= ~WD_CHECK_WHODATA;
     ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9))->dirs_status.status |= WD_CHECK_REALTIME;
@@ -1448,12 +1468,15 @@ void test_realtime_adddir_whodata_dir_success(void **state) {
 void test_realtime_adddir_max_limit_reached(void **state) {
     int ret;
 
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+
     syscheck.realtime->fd = 1024;
 
     expect_string(__wrap__merror, formatted_msg,
         "(6616): Unable to add directory to real time monitoring: 'C:\\a\\path' - Maximum size permitted.");
-
-    expect_function_call(__wrap_pthread_mutex_unlock);
 
     ret = realtime_adddir("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)), 0);
 
@@ -1464,6 +1487,11 @@ void test_realtime_adddir_duplicate_entry(void **state) {
     win32rtfim rtlocald = { .dir = "C:\\a\\path" };
     int ret;
 
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+
     syscheck.realtime->fd = 128;
 
     expect_value(__wrap_OSHash_Get_ex, self, syscheck.realtime->dirtb);
@@ -1473,8 +1501,6 @@ void test_realtime_adddir_duplicate_entry(void **state) {
     expect_string(__wrap_w_directory_exists, path, "C:\\a\\path");
     will_return(__wrap_w_directory_exists, 1);
 
-    expect_function_call(__wrap_pthread_mutex_unlock);
-
     ret = realtime_adddir("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)), 0);
 
     assert_int_equal(ret, 1);
@@ -1483,6 +1509,11 @@ void test_realtime_adddir_duplicate_entry(void **state) {
 void test_realtime_adddir_duplicate_entry_non_existent_directory_valid_handle(void **state) {
     win32rtfim rtlocald = { .dir = "C:\\a\\path", .watch_status = FIM_RT_HANDLE_OPEN, .h = (HANDLE)1234 };
     int ret;
+
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
     syscheck.realtime->fd = 128;
 
@@ -1496,8 +1527,6 @@ void test_realtime_adddir_duplicate_entry_non_existent_directory_valid_handle(vo
     expect_value(wrap_CloseHandle, hObject, 1234);
     will_return(wrap_CloseHandle, 0);
 
-    expect_function_call(__wrap_pthread_mutex_unlock);
-
     ret = realtime_adddir("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)), 0);
 
     assert_int_equal(ret, 1);
@@ -1508,6 +1537,11 @@ void test_realtime_adddir_duplicate_entry_non_existent_directory_closed_handle(v
     win32rtfim *rtlocald = calloc(1, sizeof(win32rtfim));
     char debug_msg[OS_SIZE_128];
     int ret;
+
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
     if (rtlocald == NULL) {
         fail_msg("Failed to allocate 'rtlocald'");
@@ -1540,8 +1574,6 @@ void test_realtime_adddir_duplicate_entry_non_existent_directory_closed_handle(v
     snprintf(debug_msg, OS_SIZE_128, FIM_REALTIME_CALLBACK, "C:\\a\\path");
     expect_string(__wrap__mdebug1, formatted_msg, debug_msg);
 
-    expect_function_call(__wrap_pthread_mutex_unlock);
-
     ret = realtime_adddir("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)), 0);
 
     assert_int_equal(ret, 1);
@@ -1550,6 +1582,11 @@ void test_realtime_adddir_duplicate_entry_non_existent_directory_closed_handle(v
 void test_realtime_adddir_duplicate_entry_non_existent_directory_invalid_handle(void **state) {
     win32rtfim rtlocald = { .dir = "C:\\a\\path", .watch_status = FIM_RT_HANDLE_OPEN, .h = INVALID_HANDLE_VALUE };
     int ret;
+
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
     syscheck.realtime->fd = 128;
 
@@ -1560,8 +1597,6 @@ void test_realtime_adddir_duplicate_entry_non_existent_directory_invalid_handle(
     expect_string(__wrap_w_directory_exists, path, "C:\\a\\path");
     will_return(__wrap_w_directory_exists, 0);
 
-    expect_function_call(__wrap_pthread_mutex_unlock);
-
     ret = realtime_adddir("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)), 0);
 
     assert_int_equal(ret, 1);
@@ -1569,6 +1604,11 @@ void test_realtime_adddir_duplicate_entry_non_existent_directory_invalid_handle(
 
 void test_realtime_adddir_handle_error(void **state) {
     int ret;
+
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
     syscheck.realtime->fd = 128;
 
@@ -1582,8 +1622,6 @@ void test_realtime_adddir_handle_error(void **state) {
     expect_string(__wrap__mdebug2, formatted_msg,
         "(6290): Unable to add directory to real time monitoring: 'C:\\a\\path'");
 
-    expect_function_call(__wrap_pthread_mutex_unlock);
-
     ret = realtime_adddir("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)), 0);
 
     assert_int_equal(ret, 0);
@@ -1592,6 +1630,12 @@ void test_realtime_adddir_handle_error(void **state) {
 void test_realtime_adddir_success(void **state) {
     int ret;
     syscheck.realtime->dirtb = *state;
+
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
 
     expect_value(__wrap_OSHash_Get_ex, self, syscheck.realtime->dirtb);
     expect_string(__wrap_OSHash_Get_ex, key, "C:\\a\\path");
@@ -1656,6 +1700,9 @@ void test_RTCallBack_acquired_changes_null_dir(void **state) {
     OVERLAPPED ov;
     PFILE_NOTIFY_INFORMATION pinfo;
 
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+
     // Fill the win32rtfim struct with testing data
     pinfo = (PFILE_NOTIFY_INFORMATION) rt->buffer;
     wcscpy(pinfo->FileName, L"C:\\a\\path");
@@ -1690,6 +1737,9 @@ void test_RTCallBack_acquired_changes(void **state) {
     win32rtfim *rt = *state;
     OVERLAPPED ov;
     PFILE_NOTIFY_INFORMATION pinfo;
+
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
     // Fill the win32rtfim struct with testing data
     pinfo = (PFILE_NOTIFY_INFORMATION) rt->buffer;

--- a/src/unit_tests/syscheckd/test_syscheck_config.c
+++ b/src/unit_tests/syscheckd/test_syscheck_config.c
@@ -225,7 +225,7 @@ void test_Read_Syscheck_Config_unparsed(void **state)
     assert_null(syscheck.scan_day);
     assert_null(syscheck.scan_time);
     assert_non_null(syscheck.directories);
-    assert_null(syscheck.directories->first_node);
+    assert_null(OSList_GetFirstNode(syscheck.directories));
     assert_int_equal(syscheck.enable_synchronization, 1);
     assert_int_equal(syscheck.restart_audit, 1);
     assert_int_equal(syscheck.enable_whodata, 0);

--- a/src/unit_tests/syscheckd/test_syscheck_config.c
+++ b/src/unit_tests/syscheckd/test_syscheck_config.c
@@ -26,18 +26,10 @@
 
 static int restart_syscheck(void **state)
 {
-    if(syscheck.directories->first_node){
-        expect_function_call_any(__wrap_pthread_rwlock_wrlock);
-        expect_function_call_any(__wrap_pthread_rwlock_unlock);
-        expect_function_call_any(__wrap_pthread_rwlock_rdlock);
-        expect_function_call_any(__wrap_pthread_mutex_lock);
-        expect_function_call_any(__wrap_pthread_mutex_unlock);
-    }else{
-        expect_function_call_any(__wrap_pthread_rwlock_wrlock);
-        expect_function_call_any(__wrap_pthread_rwlock_unlock);
-        expect_function_call_any(__wrap_pthread_mutex_lock);
-        expect_function_call_any(__wrap_pthread_mutex_unlock);
-    }
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
     cJSON *data = *state;
     if (data) {

--- a/src/unit_tests/syscheckd/test_syscheck_config.c
+++ b/src/unit_tests/syscheckd/test_syscheck_config.c
@@ -18,12 +18,38 @@
 #include "../config/syscheck-config.h"
 
 #include "../wrappers/common.h"
+//#include "../wrappers/posix/pthread_wrappers.h"
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 
 /* redefinitons/wrapping */
 
+
+
+int __wrap_OSMatch_Compile(const char *pattern, OSMatch *reg, int flags) {
+
+    int max_size = 20;
+
+    if (strlen(pattern) > max_size) {
+        reg->error = OS_REGEX_MAXSIZE;
+        return mock();
+    }
+}
+
 static int restart_syscheck(void **state)
 {
+    if(syscheck.directories->first_node){
+        expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+        expect_function_call_any(__wrap_pthread_rwlock_unlock);
+        expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+        expect_function_call_any(__wrap_pthread_mutex_lock);
+        expect_function_call_any(__wrap_pthread_mutex_unlock);
+    }else{
+        expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+        expect_function_call_any(__wrap_pthread_rwlock_unlock);
+        expect_function_call_any(__wrap_pthread_mutex_lock);
+        expect_function_call_any(__wrap_pthread_mutex_unlock);
+    }
+
     cJSON *data = *state;
     if (data) {
         cJSON_Delete(data);
@@ -40,6 +66,12 @@ void test_Read_Syscheck_Config_success(void **state)
 {
     (void) state;
     int ret;
+
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     expect_any_always(__wrap__mdebug1, formatted_msg);
     expect_any_always(__wrap__mwarn, formatted_msg);
@@ -96,6 +128,14 @@ void test_Read_Syscheck_Config_invalid(void **state)
 
     expect_any_always(__wrap__mdebug1, formatted_msg);
     expect_string(__wrap__merror, formatted_msg, "(1226): Error reading XML file 'invalid.conf': XMLERR: File 'invalid.conf' not found. (line 0).");
+
+ /* expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+*/
+
     ret = Read_Syscheck_Config("invalid.conf");
 
     assert_int_equal(ret, OS_INVALID);
@@ -105,6 +145,12 @@ void test_Read_Syscheck_Config_undefined(void **state)
 {
     (void) state;
     int ret;
+
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     expect_any_always(__wrap__mdebug1, formatted_msg);
 
@@ -151,6 +197,9 @@ void test_Read_Syscheck_Config_unparsed(void **state)
     (void) state;
     int ret;
 
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+
     expect_any_always(__wrap__mdebug1, formatted_msg);
 
     ret = Read_Syscheck_Config("test_empty_config.conf");
@@ -172,7 +221,8 @@ void test_Read_Syscheck_Config_unparsed(void **state)
     assert_null(syscheck.nodiff_regex);
     assert_null(syscheck.scan_day);
     assert_null(syscheck.scan_time);
-    assert_null(syscheck.directories);
+    assert_non_null(syscheck.directories);
+    assert_null(syscheck.directories->first_node);
     assert_int_equal(syscheck.enable_synchronization, 1);
     assert_int_equal(syscheck.restart_audit, 1);
     assert_int_equal(syscheck.enable_whodata, 0);
@@ -196,6 +246,12 @@ void test_getSyscheckConfig(void **state)
 {
     (void) state;
     cJSON * ret;
+
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     expect_any_always(__wrap__mdebug1, formatted_msg);
 
@@ -332,6 +388,12 @@ void test_getSyscheckConfig_no_audit(void **state)
     (void) state;
     cJSON * ret;
 
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+
     expect_any_always(__wrap__mdebug1, formatted_msg);
 
     Read_Syscheck_Config("test_syscheck2.conf");
@@ -444,6 +506,10 @@ void test_getSyscheckConfig_no_directories(void **state)
     (void) state;
     cJSON * ret;
 
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+
     expect_any_always(__wrap__mdebug1, formatted_msg);
 
     Read_Syscheck_Config("test_empty_config.conf");
@@ -457,6 +523,12 @@ void test_getSyscheckConfig_no_directories(void **state)
 {
     (void) state;
     cJSON * ret;
+
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     expect_any_always(__wrap__mdebug1, formatted_msg);
 
@@ -537,6 +609,12 @@ void test_SyscheckConf_DirectoriesWithCommas(void **state) {
     (void) state;
     int ret;
 
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+
     expect_any_always(__wrap__mdebug1, formatted_msg);
 
     ret = Read_Syscheck_Config("test_syscheck3.conf");
@@ -558,6 +636,12 @@ void test_getSyscheckInternalOptions(void **state)
     (void) state;
     cJSON * ret;
 
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+
     expect_any_always(__wrap__mdebug1, formatted_msg);
 
     Read_Syscheck_Config("test_syscheck.conf");
@@ -575,6 +659,150 @@ void test_getSyscheckInternalOptions(void **state)
     assert_int_equal(cJSON_GetArraySize(root_items), 1);
 }
 
+void test_fim_create_directory_add_new_entry(void **state) {
+    const char *path = "./mock_path";
+    int options = CHECK_FOLLOW;
+    const char *filerestrict = "<>";
+    int recursion_level = 0;
+    const char *tag = "mock_tag";
+    int diff_size_limit = 0;
+    unsigned int is_wildcard = 0;
+    directory_t *new_entry;
+
+    new_entry = fim_create_directory(path, options, filerestrict, recursion_level, tag, diff_size_limit, is_wildcard);
+
+    assert_non_null(new_entry);
+    assert_string_equal(tag, new_entry->tag);
+    assert_string_equal(path, new_entry->path);
+    assert_int_equal(is_wildcard, new_entry->is_wildcard);
+
+}
+
+void test_fim_create_directory_OSMatch_Compile_fail_maxsize(void **state) {
+    const char *path = "./mock_path";
+    char *filerestrict = "aaaaaaaaaaaaaaaaaaaaaaaaa";
+    int filerestrict_expr_size = 25;
+    int recursion_level = 0;
+    const char *tag = "mock_tag";
+    int options = CHECK_FOLLOW;
+    int diff_size_limit = 0;
+    unsigned int is_wildcard = 0;
+    directory_t *new_entry;
+    char error_msg[OS_MAXSTR];
+
+    snprintf(error_msg, OS_MAXSTR, REGEX_COMPILE, filerestrict, OS_REGEX_MAXSIZE);
+
+    will_return(__wrap_OSMatch_Compile, 0);
+    expect_string(__wrap__merror, formatted_msg, error_msg);
+
+    new_entry = fim_create_directory(path, options, filerestrict, recursion_level, tag, diff_size_limit, is_wildcard);
+
+    assert_non_null(new_entry);
+    assert_string_equal(tag, new_entry->tag);
+
+}
+
+void test_fim_insert_directory_duplicate_entry(void **state) {
+    OSList list;
+    OSListNode first_list_node;
+    directory_t *old_entry = (directory_t*) malloc(sizeof(directory_t));
+    old_entry->symbolic_links = NULL;
+    old_entry->tag = NULL;
+    old_entry->filerestrict = NULL;
+    directory_t new_entry;
+    new_entry.path = "same_path";
+    new_entry.tag = "new_entry_tag";
+    first_list_node.data = old_entry;
+    list.first_node = &first_list_node;
+
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+
+    old_entry->path = strdup(new_entry.path);
+    fim_insert_directory(&list, &new_entry);
+
+    assert_string_equal(new_entry.tag, ((directory_t*)(list.first_node->data))->tag);
+
+}
+
+void test_fim_insert_directory_insert_entry_before(void **state) {
+    OSList list;
+    OSListNode first_list_node;
+    directory_t *old_entry = (directory_t*) malloc(sizeof(directory_t));
+    old_entry->symbolic_links = NULL;
+    old_entry->tag = NULL;
+    old_entry->filerestrict = NULL;
+    directory_t new_entry;
+    old_entry->path = "BPath";
+    new_entry.path = "APath";
+    new_entry.tag = "new_entry_tag";
+    first_list_node.data = old_entry;
+    list.first_node = &first_list_node;
+
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+
+    fim_insert_directory(&list, &new_entry);
+
+    assert_string_equal(new_entry.tag, ((directory_t*)(list.first_node->data))->tag);
+
+}
+
+void test_fim_insert_directory_insert_entry_last(void **state) {
+    OSList list;
+    OSListNode first_list_node;
+    directory_t *old_entry = (directory_t*) malloc(sizeof(directory_t));
+    directory_t new_entry;
+    old_entry->path = "APath";
+    new_entry.path = "BPath";
+    new_entry.tag = "new_entry_tag";
+    first_list_node.data = old_entry;
+    list.first_node = &first_list_node;
+    list.last_node = &first_list_node;
+
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+
+    fim_insert_directory(&list, &new_entry);
+
+    assert_string_equal(new_entry.tag, ((directory_t*)(list.last_node->data))->tag);
+
+}
+
+void test_fim_copy_directory_null(void **state) {
+    directory_t *dir = NULL;
+    directory_t *return_dir;
+
+    return_dir = fim_copy_directory(dir);
+
+    assert_null(return_dir);
+
+}
+
+void test_fim_copy_directory_return_dir_copied(void **state) {
+    directory_t directory_copied;
+    directory_t *new_entry;
+    directory_copied.filerestrict = NULL;
+    directory_copied.path = "mock_path";
+    directory_copied.options = 0;
+    directory_copied.recursion_level = 3;
+    directory_copied.tag = "mock_tag";
+    directory_copied.diff_size_limit = 10;
+    directory_copied.is_wildcard = 0;
+
+    new_entry = fim_copy_directory(&directory_copied);
+
+    assert_non_null(new_entry);
+    assert_string_equal(directory_copied.tag, new_entry->tag);
+    assert_string_equal(directory_copied.path, new_entry->path);
+    assert_int_equal(directory_copied.is_wildcard, new_entry->is_wildcard);
+
+}
 
 int main(void) {
     const struct CMUnitTest tests[] = {
@@ -587,6 +815,13 @@ int main(void) {
         cmocka_unit_test_teardown(test_getSyscheckConfig_no_directories, restart_syscheck),
         cmocka_unit_test_teardown(test_getSyscheckInternalOptions, restart_syscheck),
         cmocka_unit_test_teardown(test_SyscheckConf_DirectoriesWithCommas, restart_syscheck),
+        cmocka_unit_test(test_fim_create_directory_add_new_entry),
+        cmocka_unit_test(test_fim_create_directory_OSMatch_Compile_fail_maxsize),
+        cmocka_unit_test(test_fim_insert_directory_duplicate_entry),
+        cmocka_unit_test(test_fim_insert_directory_insert_entry_before),
+        cmocka_unit_test(test_fim_insert_directory_insert_entry_last),
+        cmocka_unit_test(test_fim_copy_directory_null),
+        cmocka_unit_test(test_fim_copy_directory_return_dir_copied)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/syscheckd/test_syscheck_config.c
+++ b/src/unit_tests/syscheckd/test_syscheck_config.c
@@ -67,9 +67,9 @@ void test_Read_Syscheck_Config_success(void **state)
     // Directories configuration have 100 directories in one line. It only can monitor 64 per line.
     // With the first 10 directories in other lines, the count should be 74 (75 should be NULL)
     for (int i = 0; i < 74; i++){
-        assert_non_null(syscheck.directories[i]);
+        assert_non_null(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, i)));
     }
-    assert_null(syscheck.directories[74]);
+    assert_null(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 74)));
     assert_int_equal(syscheck.enable_synchronization, 1);
     assert_int_equal(syscheck.restart_audit, 1);
     assert_int_equal(syscheck.enable_whodata, 1);
@@ -543,13 +543,13 @@ void test_SyscheckConf_DirectoriesWithCommas(void **state) {
     assert_int_equal(ret, 0);
 
     #ifdef WIN32
-    assert_string_equal(syscheck.directories[0]->path, "c:\\,testcommas");
-    assert_string_equal(syscheck.directories[1]->path, "c:\\test,commas");
-    assert_string_equal(syscheck.directories[2]->path, "c:\\testcommas,");
+    assert_string_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->path, "c:\\,testcommas");
+    assert_string_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path, "c:\\test,commas");
+    assert_string_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 2))->path, "c:\\testcommas,");
     #else
-    assert_string_equal(syscheck.directories[0]->path, "/,testcommas");
-    assert_string_equal(syscheck.directories[1]->path, "/test,commas");
-    assert_string_equal(syscheck.directories[2]->path, "/testcommas,");
+    assert_string_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->path, "/,testcommas");
+    assert_string_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->path, "/test,commas");
+    assert_string_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 2))->path, "/testcommas,");
     #endif
 }
 

--- a/src/unit_tests/syscheckd/whodata/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/whodata/CMakeLists.txt
@@ -57,7 +57,9 @@ if(NOT ${TARGET} STREQUAL "winagent")
                               -Wl,--wrap,select -Wl,--wrap,audit_parse -Wl,--wrap,symlink -Wl,--wrap,SendMSG \
                               -Wl,--wrap,audit_get_rule_list -Wl,--wrap,fim_audit_reload_rules \
                               -Wl,--wrap,search_audit_rule -Wl,--wrap,abspath -Wl,--wrap,atomic_int_get \
-                              -Wl,--wrap,atomic_int_set -Wl,--wrap,atomic_int_dec -Wl,--wrap,atomic_int_inc")
+                              -Wl,--wrap,atomic_int_set -Wl,--wrap,atomic_int_dec -Wl,--wrap,atomic_int_inc \
+                              -Wl,--wrap,pthread_rwlock_wrlock -Wl,--wrap,pthread_rwlock_unlock \
+                              -Wl,--wrap,pthread_rwlock_rdlock")
 
     target_link_libraries(test_syscheck_audit SYSCHECK_O ${TEST_DEPS})
 

--- a/src/unit_tests/syscheckd/whodata/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/whodata/CMakeLists.txt
@@ -102,7 +102,8 @@ else()
                            -Wl,--wrap,convert_windows_string -Wl,--wrap,OSHash_Get_ex -Wl,--wrap,FOREVER \
                            -Wl,--wrap,fflush -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,fprintf \
                            -Wl,--wrap,fgets -Wl,--wrap,wstr_split -Wl,--wrap,pthread_rwlock_wrlock \
-                           -Wl,--wrap,fgetpos -Wl,--wrap,fgetc -Wl,--wrap,getDefine_Int -Wl,--wrap,pthread_rwlock_rdlock")
+                           -Wl,--wrap,fgetpos -Wl,--wrap,fgetc -Wl,--wrap,getDefine_Int -Wl,--wrap,pthread_rwlock_rdlock \
+                           -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_mutex_unlock")
     target_link_libraries(test_win_whodata SYSCHECK_EVENT_O ${TEST_EVENT_DEPS})
 
     target_link_libraries(test_win_whodata "${WIN_WHODATA_FLAGS}")

--- a/src/unit_tests/syscheckd/whodata/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/whodata/CMakeLists.txt
@@ -81,7 +81,8 @@ if(NOT ${TARGET} STREQUAL "winagent")
                            -Wl,--wrap,audit_close -Wl,--wrap,fim_manipulated_audit_rules \
                            -Wl,--wrap,fim_audit_reload_rules -Wl,--wrap,remove_audit_rule_syscheck \
                            -Wl,--wrap,atomic_int_get -Wl,--wrap,atomic_int_set -Wl,--wrap,atomic_int_dec \
-                           -Wl,--wrap,atomic_int_inc")
+                           -Wl,--wrap,atomic_int_inc -Wl,--wrap,pthread_rwlock_wrlock -Wl,--wrap,pthread_rwlock_unlock \
+                           -Wl,--wrap,pthread_rwlock_rdlock")
 
     target_link_libraries(test_audit_parse SYSCHECK_O ${TEST_DEPS})
 
@@ -101,7 +102,7 @@ else()
                            -Wl,--wrap,convert_windows_string -Wl,--wrap,OSHash_Get_ex -Wl,--wrap,FOREVER \
                            -Wl,--wrap,fflush -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,fprintf \
                            -Wl,--wrap,fgets -Wl,--wrap,wstr_split -Wl,--wrap,pthread_rwlock_wrlock \
-                           -Wl,--wrap,fgetpos -Wl,--wrap,fgetc -Wl,--wrap,getDefine_Int")
+                           -Wl,--wrap,fgetpos -Wl,--wrap,fgetc -Wl,--wrap,getDefine_Int -Wl,--wrap,pthread_rwlock_rdlock")
     target_link_libraries(test_win_whodata SYSCHECK_EVENT_O ${TEST_EVENT_DEPS})
 
     target_link_libraries(test_win_whodata "${WIN_WHODATA_FLAGS}")

--- a/src/unit_tests/syscheckd/whodata/test_audit_parse.c
+++ b/src/unit_tests/syscheckd/whodata/test_audit_parse.c
@@ -71,11 +71,11 @@ static int setup_config(void **state) {
 static int teardown_config(void **state) {
     OSListNode *node_it;
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
 
     if (syscheck.directories) {
         OSList_foreach(node_it, syscheck.directories) {

--- a/src/unit_tests/syscheckd/whodata/test_audit_rule_handling.c
+++ b/src/unit_tests/syscheckd/whodata/test_audit_rule_handling.c
@@ -33,34 +33,9 @@
     (CHECK_MD5SUM | CHECK_SHA1SUM | CHECK_SHA256SUM | CHECK_PERM | CHECK_SIZE | CHECK_OWNER | CHECK_GROUP | \
      CHECK_MTIME | CHECK_INODE)
 
-static directory_t DIRECTORIES[] = {
-    [0] = { .path = "/testdir0", .options = CHECK_ALL | WHODATA_ACTIVE },
-    [1] = { .path = "/testdir1", .options = CHECK_ALL | WHODATA_ACTIVE },
-    [2] = { .path = "/testdir2", .options = CHECK_ALL | WHODATA_ACTIVE },
-    [3] = { .path = "/testdir3", .options = CHECK_ALL | WHODATA_ACTIVE },
-    [4] = { .path = "/etc", .options = CHECK_ALL | WHODATA_ACTIVE },
-};
-
-static directory_t *GENERAL_CONFIG[] = { [0] = &DIRECTORIES[0], [1] = &DIRECTORIES[1], [2] = &DIRECTORIES[2],
-                                         [3] = &DIRECTORIES[3], [4] = &DIRECTORIES[4], NULL };
-
-
-static directory_t DIRECTORIES_RELOAD[] = {
-    [0] = { .path = "/testdir0", .options = CHECK_ALL | WHODATA_ACTIVE },
-    [1] = { .path = "/testdir1", .options = CHECK_ALL | WHODATA_ACTIVE },
-    [2] = { .path = "/testdir2", .options = CHECK_ALL | WHODATA_ACTIVE },
-    [3] = { .path = "/testdir3", .options = CHECK_ALL | WHODATA_ACTIVE },
-    [4] = { .path = "/testdir4", .options = CHECK_ALL | WHODATA_ACTIVE },
-    [5] = { .path = "/testdir5", .options = CHECK_ALL | WHODATA_ACTIVE },
-    [6] = { .path = "/etc", .options = CHECK_ALL | WHODATA_ACTIVE },
-};
-
-static directory_t *RELOAD_CONFIG[] = { [0] = &DIRECTORIES_RELOAD[0], [1] = &DIRECTORIES_RELOAD[1],
-                                        [2] = &DIRECTORIES_RELOAD[2], [3] = &DIRECTORIES_RELOAD[3],
-                                        [4] = &DIRECTORIES_RELOAD[4], [5] = &DIRECTORIES_RELOAD[5],
-                                        [6] = &DIRECTORIES_RELOAD[6], NULL };
-
 extern OSList *whodata_directories;
+OSList *GENERAL_CONFIG;
+OSList *RELOAD_CONFIG;
 
 extern int audit_rule_manipulation;
 
@@ -68,6 +43,47 @@ extern atomic_int_t audit_thread_active;
 
 /* setup/teardown */
 static int setup_group(void **state) {
+
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+
+    directory_t *directory0 = fim_create_directory("/testdir0", CHECK_ALL | WHODATA_ACTIVE, NULL, 512, NULL, 1024, 0);
+    directory_t *directory1 = fim_create_directory("/testdir1", CHECK_ALL | WHODATA_ACTIVE, NULL, 512, NULL, 1024, 0);
+    directory_t *directory2 = fim_create_directory("/testdir2", CHECK_ALL | WHODATA_ACTIVE, NULL, 512, NULL, 1024, 0);
+    directory_t *directory3 = fim_create_directory("/testdir3", CHECK_ALL | WHODATA_ACTIVE, NULL, 512, NULL, 1024, 0);
+    directory_t *directory4 = fim_create_directory("/testdir4", CHECK_ALL | WHODATA_ACTIVE, NULL, 512, NULL, 1024, 0);
+    directory_t *directory5 = fim_create_directory("/testdir5", CHECK_ALL | WHODATA_ACTIVE, NULL, 512, NULL, 1024, 0);
+    directory_t *directory6 = fim_create_directory("/etc", CHECK_ALL | WHODATA_ACTIVE, NULL, 512, NULL, 1024, 0);
+
+    directory_t *general_directory0 = fim_copy_directory(directory0);
+    directory_t *general_directory1 = fim_copy_directory(directory1);
+    directory_t *general_directory2 = fim_copy_directory(directory2);
+    directory_t *general_directory3 = fim_copy_directory(directory3);
+    directory_t *general_directory4 = fim_copy_directory(directory4);
+
+    // Initialize directories list
+    GENERAL_CONFIG = OSList_Create();
+    RELOAD_CONFIG = OSList_Create();
+    if (GENERAL_CONFIG == NULL || RELOAD_CONFIG == NULL) {
+        return -1;
+    }
+
+    OSList_InsertData(GENERAL_CONFIG, NULL, general_directory0);
+    OSList_InsertData(GENERAL_CONFIG, NULL, general_directory1);
+    OSList_InsertData(GENERAL_CONFIG, NULL, general_directory2);
+    OSList_InsertData(GENERAL_CONFIG, NULL, general_directory3);
+    OSList_InsertData(GENERAL_CONFIG, NULL, general_directory4);
+
+    OSList_InsertData(RELOAD_CONFIG, NULL, directory0);
+    OSList_InsertData(RELOAD_CONFIG, NULL, directory1);
+    OSList_InsertData(RELOAD_CONFIG, NULL, directory2);
+    OSList_InsertData(RELOAD_CONFIG, NULL, directory3);
+    OSList_InsertData(RELOAD_CONFIG, NULL, directory4);
+    OSList_InsertData(RELOAD_CONFIG, NULL, directory5);
+    OSList_InsertData(RELOAD_CONFIG, NULL, directory6);
+
     syscheck.directories = GENERAL_CONFIG;
 
     // The basic list needs to be created, we won't test this function.
@@ -77,6 +93,32 @@ static int setup_group(void **state) {
 }
 
 static int teardown_group(void **state) {
+    OSListNode *node_it;
+
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+
+    if (GENERAL_CONFIG) {
+        OSList_foreach(node_it, GENERAL_CONFIG) {
+            free_directory(node_it->data);
+            node_it->data = NULL;
+        }
+        OSList_Destroy(GENERAL_CONFIG);
+        GENERAL_CONFIG = NULL;
+    }
+
+    if (RELOAD_CONFIG) {
+        OSList_foreach(node_it, RELOAD_CONFIG) {
+            free_directory(node_it->data);
+            node_it->data = NULL;
+        }
+        OSList_Destroy(RELOAD_CONFIG);
+        RELOAD_CONFIG = NULL;
+    }
+
     return 0;
 }
 
@@ -95,13 +137,16 @@ static int setup_add_directories_to_whodata_list(void **state) {
     directory_t *dir_it;
     OSListNode *node_it;
 
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+
+    syscheck.directories = RELOAD_CONFIG;
 
     OSList_foreach(node_it, syscheck.directories) {
-        dir_it = node_it->data;(dir_it, RELOAD_CONFIG) {
+        dir_it = node_it->data;
         whodata_directory_t *dir = calloc(1, sizeof(whodata_directory_t));
 
         if (dir == NULL) {
@@ -118,8 +163,6 @@ static int setup_add_directories_to_whodata_list(void **state) {
     }
 
     syscheck.max_audit_entries = whodata_directories->currently_size;
-
-    syscheck.directories = RELOAD_CONFIG;
 
     return 0;
 }
@@ -211,33 +254,33 @@ void test_rules_initial_load_new_rules(void **state) {
     will_return(__wrap_audit_get_rule_list, 1);
     will_return(__wrap_audit_close, 1);
 
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
 
     // First directory will be added
     will_return(__wrap_search_audit_rule, 0);
     will_return(__wrap_audit_add_rule, 15);
-    snprintf(log_messages[0], OS_SIZE_512, FIM_AUDIT_NEWRULE, GENERAL_CONFIG[0]->path);
+    snprintf(log_messages[0], OS_SIZE_512, FIM_AUDIT_NEWRULE, ((directory_t *)OSList_GetDataFromIndex(GENERAL_CONFIG, 0))->path);
     expect_string(__wrap__mdebug1, formatted_msg, log_messages[0]);
 
     // Second directory will have the rule already configured
     will_return(__wrap_search_audit_rule, 0);
     will_return(__wrap_audit_add_rule, -EEXIST);
-    snprintf(log_messages[1], OS_SIZE_512, FIM_AUDIT_ALREADY_ADDED, GENERAL_CONFIG[1]->path);
+    snprintf(log_messages[1], OS_SIZE_512, FIM_AUDIT_ALREADY_ADDED, ((directory_t *)OSList_GetDataFromIndex(GENERAL_CONFIG, 1))->path);
     expect_string(__wrap__mdebug1, formatted_msg, log_messages[1]);
 
     // Third directory will encounter an error
     will_return(__wrap_search_audit_rule, 0);
     will_return(__wrap_audit_add_rule, -1);
-    snprintf(log_messages[2], OS_SIZE_512, FIM_WARN_WHODATA_ADD_RULE, GENERAL_CONFIG[2]->path);
+    snprintf(log_messages[2], OS_SIZE_512, FIM_WARN_WHODATA_ADD_RULE, ((directory_t *)OSList_GetDataFromIndex(GENERAL_CONFIG, 2))->path);
     expect_string(__wrap__mwarn, formatted_msg, log_messages[2]);
 
     // Fourth directory will be duplicated on the audit_op list
     will_return(__wrap_search_audit_rule, 1);
-    snprintf(log_messages[3], OS_SIZE_512, FIM_AUDIT_RULEDUP, GENERAL_CONFIG[3]->path);
+    snprintf(log_messages[3], OS_SIZE_512, FIM_AUDIT_RULEDUP, ((directory_t *)OSList_GetDataFromIndex(GENERAL_CONFIG, 3))->path);
     expect_string(__wrap__mdebug1, formatted_msg, log_messages[3]);
 
     // Fifth directory will encounter an error
@@ -259,20 +302,20 @@ void test_rules_initial_load_max_audit_entries(void **state) {
     will_return(__wrap_audit_get_rule_list, 1);
     will_return(__wrap_audit_close, 1);
 
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
 
     // First directory will be added
     will_return(__wrap_search_audit_rule, 0);
     will_return(__wrap_audit_add_rule, 15);
-    snprintf(log_messages[0], OS_SIZE_512, FIM_AUDIT_NEWRULE, GENERAL_CONFIG[0]->path);
+    snprintf(log_messages[0], OS_SIZE_512, FIM_AUDIT_NEWRULE, ((directory_t *)OSList_GetDataFromIndex(GENERAL_CONFIG, 0))->path);
     expect_string(__wrap__mdebug1, formatted_msg, log_messages[0]);
 
     // Second directory will be ignored, since we have room for 1 entry
-    snprintf(log_messages[1], OS_SIZE_512, FIM_ERROR_WHODATA_MAXNUM_WATCHES, GENERAL_CONFIG[1]->path,
+    snprintf(log_messages[1], OS_SIZE_512, FIM_ERROR_WHODATA_MAXNUM_WATCHES, ((directory_t *)OSList_GetDataFromIndex(GENERAL_CONFIG, 1))->path,
              syscheck.max_audit_entries);
     expect_string(__wrap__merror, formatted_msg, log_messages[1]);
 
@@ -326,11 +369,11 @@ static void test_fim_audit_reload_rules(void **state) {
     will_return(__wrap_audit_get_rule_list, 1);
     will_return(__wrap_audit_close, 1);
 
-    expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
-    expect_function_call_any(__wrap_pthread_mutex_unlock);
 
     // First directory won't have a configured rule
     will_return(__wrap_search_audit_rule, 0);
@@ -338,31 +381,31 @@ static void test_fim_audit_reload_rules(void **state) {
     // Second directory will be added to audit
     will_return(__wrap_search_audit_rule, 0);
     will_return(__wrap_audit_add_rule, 15);
-    snprintf(log_messages[1], OS_SIZE_512, FIM_AUDIT_NEWRULE, RELOAD_CONFIG[1]->path);
+    snprintf(log_messages[1], OS_SIZE_512, FIM_AUDIT_NEWRULE, ((directory_t *)OSList_GetDataFromIndex(RELOAD_CONFIG, 1))->path);
     expect_string(__wrap__mdebug1, formatted_msg, log_messages[1]);
 
     // Third directory will be removed from audit
     will_return(__wrap_search_audit_rule, 1);
-    expect_string(__wrap_audit_delete_rule, path, RELOAD_CONFIG[2]->path);
+    expect_string(__wrap_audit_delete_rule, path, ((directory_t *)OSList_GetDataFromIndex(RELOAD_CONFIG, 2))->path);
     expect_value(__wrap_audit_delete_rule, perms, PERMS);
     expect_string(__wrap_audit_delete_rule, key, AUDIT_KEY);
     will_return(__wrap_audit_delete_rule, 1);
 
     // Fourth directory will be a rule that is already added to audit
     will_return(__wrap_search_audit_rule, 1);
-    snprintf(log_messages[3], OS_SIZE_512, FIM_AUDIT_RULEDUP, RELOAD_CONFIG[3]->path);
+    snprintf(log_messages[3], OS_SIZE_512, FIM_AUDIT_RULEDUP, ((directory_t *)OSList_GetDataFromIndex(RELOAD_CONFIG, 3))->path);
     expect_string(__wrap__mdebug1, formatted_msg, log_messages[3]);
 
     // Fifth directory will fail to be added
     will_return(__wrap_search_audit_rule, 0);
     will_return(__wrap_audit_add_rule, -1);
-    snprintf(log_messages[4], OS_SIZE_512, FIM_WARN_WHODATA_ADD_RULE, RELOAD_CONFIG[4]->path);
+    snprintf(log_messages[4], OS_SIZE_512, FIM_WARN_WHODATA_ADD_RULE, ((directory_t *)OSList_GetDataFromIndex(RELOAD_CONFIG, 4))->path);
     expect_string(__wrap__mdebug1, formatted_msg, log_messages[4]);
 
     // Sixth directory will attempt to be added, but find it's duplicated
     will_return(__wrap_search_audit_rule, 0);
     will_return(__wrap_audit_add_rule, -EEXIST);
-    snprintf(log_messages[5], OS_SIZE_512, FIM_AUDIT_ALREADY_ADDED, RELOAD_CONFIG[5]->path);
+    snprintf(log_messages[5], OS_SIZE_512, FIM_AUDIT_ALREADY_ADDED, ((directory_t *)OSList_GetDataFromIndex(RELOAD_CONFIG, 5))->path);
     expect_string(__wrap__mdebug1, formatted_msg, log_messages[5]);
 
     // Seventh directory will encounter an error when searching the rule
@@ -380,7 +423,9 @@ static void test_fim_audit_reload_rules(void **state) {
 static void test_fim_audit_reload_rules_full(void **state) {
     char log_messages[7][OS_SIZE_512];
     int initial_rules = whodata_directories->currently_size;
-    int i;
+    int i = 0;
+    OSListNode *node_it;
+    directory_t *dir_it;
 
     // We trick fim_audit_reload_rules() into thinking it already has added all possible rules.
     syscheck.max_audit_entries = 0;
@@ -393,21 +438,24 @@ static void test_fim_audit_reload_rules_full(void **state) {
     will_return(__wrap_audit_get_rule_list, 1);
     will_return(__wrap_audit_close, 1);
 
-    expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
 
     will_return_always(__wrap_search_audit_rule, 0);
 
-    // First directory will cause an error message
-    snprintf(log_messages[0], OS_SIZE_512, FIM_ERROR_WHODATA_MAXNUM_WATCHES, RELOAD_CONFIG[0]->path, 0);
-    expect_string(__wrap__merror, formatted_msg, log_messages[0]);
-
-    // The rest of them will trigger debug messages
-    for (i = 1; RELOAD_CONFIG[i]; i++) {
-        snprintf(log_messages[i], OS_SIZE_512, FIM_ERROR_WHODATA_MAXNUM_WATCHES, RELOAD_CONFIG[i]->path, 0);
-        expect_string(__wrap__mdebug1, formatted_msg, log_messages[i]);
+    OSList_foreach(node_it, RELOAD_CONFIG) {
+        dir_it = node_it->data;
+        snprintf(log_messages[i], OS_SIZE_512, FIM_ERROR_WHODATA_MAXNUM_WATCHES, dir_it->path, 0);
+        if (i == 0) {
+            // First directory will cause an error message
+            expect_string(__wrap__merror, formatted_msg, log_messages[i]);
+        } else {
+            // The rest of them will trigger debug messages
+            expect_string(__wrap__mdebug1, formatted_msg, log_messages[i]);
+        }
+        i++;
     }
 
     expect_any(__wrap__mdebug1, formatted_msg);

--- a/src/unit_tests/syscheckd/whodata/test_audit_rule_handling.c
+++ b/src/unit_tests/syscheckd/whodata/test_audit_rule_handling.c
@@ -93,13 +93,15 @@ static int teardown_clean_rules_list(void **state) {
 
 static int setup_add_directories_to_whodata_list(void **state) {
     directory_t *dir_it;
+    OSListNode *node_it;
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
-    foreach_array(dir_it, RELOAD_CONFIG) {
+    OSList_foreach(node_it, syscheck.directories) {
+        dir_it = node_it->data;(dir_it, RELOAD_CONFIG) {
         whodata_directory_t *dir = calloc(1, sizeof(whodata_directory_t));
 
         if (dir == NULL) {

--- a/src/unit_tests/syscheckd/whodata/test_audit_rule_handling.c
+++ b/src/unit_tests/syscheckd/whodata/test_audit_rule_handling.c
@@ -95,11 +95,11 @@ static int setup_group(void **state) {
 static int teardown_group(void **state) {
     OSListNode *node_it;
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
 
     if (GENERAL_CONFIG) {
         OSList_foreach(node_it, GENERAL_CONFIG) {
@@ -137,11 +137,11 @@ static int setup_add_directories_to_whodata_list(void **state) {
     directory_t *dir_it;
     OSListNode *node_it;
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
-    expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     syscheck.directories = RELOAD_CONFIG;
 
@@ -184,10 +184,10 @@ static void test_add_whodata_directory(void **state) {
     assert_int_equal(whodata_directories->currently_size, 0);
 
     expect_function_call_any(__wrap_pthread_mutex_lock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
-    expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+
     add_whodata_directory(test_string);
 
     assert_int_equal(whodata_directories->currently_size, 1);
@@ -226,7 +226,6 @@ static void test_remove_audit_rule_syscheck(void **state) {
         fail_msg("Failed to add directory to the whodata rules list");
     }
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     remove_audit_rule_syscheck("/some/path");
 
     assert_int_equal(dir->pending_removal, 1);
@@ -329,9 +328,8 @@ static void test_clean_rules(void **state) {
     assert_int_not_equal(whodata_directories->currently_size, 0);
 
     expect_function_call_any(__wrap_pthread_mutex_lock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
-    expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
 
     expect_string(__wrap__mdebug2, formatted_msg, FIM_AUDIT_DELETE_RULE);
@@ -438,8 +436,9 @@ static void test_fim_audit_reload_rules_full(void **state) {
     will_return(__wrap_audit_get_rule_list, 1);
     will_return(__wrap_audit_close, 1);
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
 

--- a/src/unit_tests/syscheckd/whodata/test_syscheck_audit.c
+++ b/src/unit_tests/syscheckd/whodata/test_syscheck_audit.c
@@ -102,11 +102,11 @@ static int setup_syscheck_dir_links(void **state) {
 static int teardown_syscheck_dir_links(void **state) {
     OSListNode *node_it;
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
 
     if (syscheck.directories) {
         OSList_foreach(node_it, syscheck.directories) {
@@ -1045,10 +1045,11 @@ void test_audit_no_rules_to_realtime(void **state) {
     char error_msg[OS_SIZE_128];
 
     // Mutex
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     will_return(__wrap_search_audit_rule, 0);
 

--- a/src/unit_tests/syscheckd/whodata/test_syscheck_audit.c
+++ b/src/unit_tests/syscheckd/whodata/test_syscheck_audit.c
@@ -1045,11 +1045,11 @@ void test_audit_no_rules_to_realtime(void **state) {
     char error_msg[OS_SIZE_128];
 
     // Mutex
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     will_return(__wrap_search_audit_rule, 0);
 

--- a/src/unit_tests/syscheckd/whodata/test_win_whodata.c
+++ b/src/unit_tests/syscheckd/whodata/test_win_whodata.c
@@ -3480,8 +3480,10 @@ void test_restore_sacls_set_privilege_failed(void **state){
 
 int setup_restore_sacls(void **state) {
     directory_t *dir_it;
+    OSListNode *node_it;
 
-    foreach_array(dir_it, syscheck.directories) {
+    OSList_foreach(node_it, syscheck.directories) {
+        dir_it = node_it->data;
         dir_it->dirs_status.status &= ~WD_IGNORE_REST;
     }
 
@@ -3492,8 +3494,10 @@ int setup_restore_sacls(void **state) {
 
 int teardown_restore_sacls(void **state) {
     directory_t *dir_it;
+    OSListNode *node_it;
 
-    foreach_array(dir_it, syscheck.directories) {
+    OSList_foreach(node_it, syscheck.directories) {
+        dir_it = node_it->data;
         if (FIM_MODE(dir_it->options) == FIM_WHODATA) {
             syscheck.directories[0]->dirs_status.status |= WD_IGNORE_REST;
         }

--- a/src/unit_tests/syscheckd/whodata/test_win_whodata.c
+++ b/src/unit_tests/syscheckd/whodata/test_win_whodata.c
@@ -5400,7 +5400,12 @@ void test_whodata_callback_4663_non_monitored_directory(void **state) {
         fail();
 
     w_evt->scan_directory = 1;
-    w_evt->config_node = NULL;
+
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
 
     successful_whodata_event_render(event, raw_data);
 
@@ -5408,6 +5413,8 @@ void test_whodata_callback_4663_non_monitored_directory(void **state) {
     expect_string(__wrap_OSHash_Get, key, "1193046");
     will_return(__wrap_OSHash_Get, w_evt);
 
+    expect_string(__wrap__mdebug2, formatted_msg,
+        "(6319): No configuration found for (file):'c:\\a\\path'");
     expect_string(__wrap__mdebug2, formatted_msg,
         "(6243): The 'c:\\a\\path' directory has been discarded because it is not being monitored in whodata mode.");
 
@@ -5434,18 +5441,16 @@ void test_whodata_callback_4663_fail_to_add_new_directory(void **state) {
     unsigned long result;
     whodata_evt *w_evt = *state;
 
-    if(w_evt->path = strdup("c:\\a\\path"), !w_evt->path)
+    if(w_evt->path = strdup("c:\\windows"), !w_evt->path)
         fail();
 
     w_evt->scan_directory = 1;
 
     expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
-
-    w_evt->config_node = ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0));
 
     successful_whodata_event_render(event, raw_data);
 
@@ -5454,17 +5459,17 @@ void test_whodata_callback_4663_fail_to_add_new_directory(void **state) {
     will_return(__wrap_OSHash_Get, w_evt);
 
     expect_value(__wrap_OSHash_Get, self, syscheck.wdata.directories);
-    expect_string(__wrap_OSHash_Get, key, "c:\\a\\path");
+    expect_string(__wrap_OSHash_Get, key, "c:\\windows");
     will_return(__wrap_OSHash_Get, NULL);
 
     // Inside whodata_hash_add
     {
         expect_value(__wrap_OSHash_Add_ex, self, syscheck.wdata.directories);
-        expect_string(__wrap_OSHash_Add_ex, key, "c:\\a\\path");
+        expect_string(__wrap_OSHash_Add_ex, key, "c:\\windows");
         will_return(__wrap_OSHash_Add_ex, 0);
 
         expect_string(__wrap__merror, formatted_msg,
-            "(6631): The event could not be added to the 'directories' hash table. Target: 'c:\\a\\path'.");
+            "(6631): The event could not be added to the 'directories' hash table. Target: 'c:\\windows'.");
     }
 
     result = whodata_callback(action, NULL, event);
@@ -5490,17 +5495,16 @@ void test_whodata_callback_4663_new_files_added(void **state) {
     unsigned long result;
     whodata_evt *w_evt = *state;
 
-    if(w_evt->path = strdup("c:\\a\\path"), !w_evt->path)
+    if(w_evt->path = strdup("c:\\windows"), !w_evt->path)
         fail();
 
     expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
 
     w_evt->scan_directory = 1;
-    w_evt->config_node = ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0));
 
     successful_whodata_event_render(event, raw_data);
 
@@ -5509,18 +5513,18 @@ void test_whodata_callback_4663_new_files_added(void **state) {
     will_return(__wrap_OSHash_Get, w_evt);
 
     expect_value(__wrap_OSHash_Get, self, syscheck.wdata.directories);
-    expect_string(__wrap_OSHash_Get, key, "c:\\a\\path");
+    expect_string(__wrap_OSHash_Get, key, "c:\\windows");
     will_return(__wrap_OSHash_Get, NULL);
 
     // Inside whodata_hash_add
     {
         expect_value(__wrap_OSHash_Add_ex, self, syscheck.wdata.directories);
-        expect_string(__wrap_OSHash_Add_ex, key, "c:\\a\\path");
+        expect_string(__wrap_OSHash_Add_ex, key, "c:\\windows");
         will_return(__wrap_OSHash_Add_ex, 2);
     }
 
     expect_string(__wrap__mdebug2, formatted_msg,
-        "(6244): New files have been detected in the 'c:\\a\\path' directory and will be scanned.");
+        "(6244): New files have been detected in the 'c:\\windows' directory and will be scanned.");
 
     result = whodata_callback(action, NULL, event);
     assert_int_equal(result, 0);
@@ -5545,7 +5549,7 @@ void test_whodata_callback_4663_wrong_time_type(void **state) {
     unsigned long result;
     whodata_evt *w_evt = *state;
 
-    if(w_evt->path = strdup("c:\\a\\path"), !w_evt->path)
+    if(w_evt->path = strdup("c:\\windows"), !w_evt->path)
         fail();
 
     w_evt->scan_directory = 1;
@@ -5582,17 +5586,17 @@ void test_whodata_callback_4663_abort_scan(void **state) {
     whodata_evt *w_evt = *state;
     whodata_directory w_dir;
 
-    if(w_evt->path = strdup("c:\\a\\path"), !w_evt->path)
+    if(w_evt->path = strdup("c:\\windows"), !w_evt->path)
         fail();
 
     expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
 
     w_evt->scan_directory = 1;
-    w_evt->config_node = ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0));
+
     memset(&w_dir, 0, sizeof(whodata_directory));
     w_dir.QuadPart = 133022717170000000;
 
@@ -5603,10 +5607,10 @@ void test_whodata_callback_4663_abort_scan(void **state) {
     will_return(__wrap_OSHash_Get, w_evt);
 
     expect_value(__wrap_OSHash_Get, self, syscheck.wdata.directories);
-    expect_string(__wrap_OSHash_Get, key, "c:\\a\\path");
+    expect_string(__wrap_OSHash_Get, key, "c:\\windows");
     will_return(__wrap_OSHash_Get, &w_dir);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "(6241): The 'c:\\a\\path' directory has been scanned. It does not need to be scanned again.");
+    expect_string(__wrap__mdebug2, formatted_msg, "(6241): The 'c:\\windows' directory has been scanned. It does not need to be scanned again.");
 
     result = whodata_callback(action, NULL, event);
     assert_int_equal(result, 0);
@@ -5632,17 +5636,17 @@ void test_whodata_callback_4663_directory_will_be_scanned(void **state) {
     whodata_evt *w_evt = *state;
     whodata_directory w_dir;
 
-    if(w_evt->path = strdup("c:\\a\\path"), !w_evt->path)
+    if(w_evt->path = strdup("c:\\windows"), !w_evt->path)
         fail();
 
     expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
 
     w_evt->scan_directory = 1;
-    w_evt->config_node = ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0));
+
     memset(&w_dir, 0, sizeof(whodata_directory));
 
     successful_whodata_event_render(event, raw_data);
@@ -5652,10 +5656,10 @@ void test_whodata_callback_4663_directory_will_be_scanned(void **state) {
     will_return(__wrap_OSHash_Get, w_evt);
 
     expect_value(__wrap_OSHash_Get, self, syscheck.wdata.directories);
-    expect_string(__wrap_OSHash_Get, key, "c:\\a\\path");
+    expect_string(__wrap_OSHash_Get, key, "c:\\windows");
     will_return(__wrap_OSHash_Get, &w_dir);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "(6244): New files have been detected in the 'c:\\a\\path' directory and will be scanned.");
+    expect_string(__wrap__mdebug2, formatted_msg, "(6244): New files have been detected in the 'c:\\windows' directory and will be scanned.");
 
     result = whodata_callback(action, NULL, event);
     assert_int_equal(result, 0);

--- a/src/unit_tests/syscheckd/whodata/test_win_whodata.c
+++ b/src/unit_tests/syscheckd/whodata/test_win_whodata.c
@@ -108,12 +108,9 @@ static void successful_whodata_event_render(EVT_HANDLE event, PEVT_VARIANT raw_d
 int syscheck_teardown(void ** state) {
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
-    expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    if (syscheck.directories->first_node != NULL) {
-        expect_function_call_any(__wrap_pthread_rwlock_rdlock);
-    }
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
     // Free wdata
     if (syscheck.wdata.fd) {

--- a/src/unit_tests/syscheckd/whodata/test_win_whodata.c
+++ b/src/unit_tests/syscheckd/whodata/test_win_whodata.c
@@ -6704,7 +6704,6 @@ void test_state_checker_no_files_to_check(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
     OSList_CleanNodes(syscheck.directories);
     expect_string(__wrap__mdebug1, formatted_msg, "(6233): Checking thread set to '300' seconds.");
@@ -6754,9 +6753,9 @@ void test_state_checker_file_does_not_exist(void **state) {
     st.wMonth = 3;
     st.wDay = 3;
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
 
@@ -6791,9 +6790,9 @@ void test_state_checker_file_with_invalid_sacl(void **state) {
 
     acl.AceCount = 1;
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
 
@@ -6899,9 +6898,9 @@ void test_state_checker_file_with_valid_sacl(void **state) {
 
     acl.AceCount = 1;
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
 
@@ -7193,7 +7192,6 @@ void test_state_checker_dir_readded_succesful(void **state) {
 void test_state_checker_dirs_cleanup_no_nodes(void ** state) {
     int ret;
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
@@ -7215,7 +7213,6 @@ void test_state_checker_dirs_cleanup_single_non_stale_node(void ** state) {
     whodata_directory * w_dir;
     FILETIME current_time;
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
@@ -7248,7 +7245,6 @@ void test_state_checker_dirs_cleanup_single_stale_node(void ** state) {
     int ret;
     whodata_directory * w_dir;
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
@@ -7280,7 +7276,6 @@ void test_state_checker_dirs_cleanup_multiple_nodes_none_stale(void ** state) {
     FILETIME current_time;
     int i;
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
@@ -7323,7 +7318,6 @@ void test_state_checker_dirs_cleanup_multiple_nodes_some_stale(void ** state) {
     FILETIME current_time;
     int i;
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
@@ -7370,7 +7364,6 @@ void test_state_checker_dirs_cleanup_multiple_nodes_all_stale(void ** state) {
     int ret;
     int i;
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
 

--- a/src/unit_tests/syscheckd/whodata/test_win_whodata.c
+++ b/src/unit_tests/syscheckd/whodata/test_win_whodata.c
@@ -194,22 +194,22 @@ static int setup_whodata_callback_group(void ** state) {
         return -1;
     }
 
-    syscheck.directories[0] = calloc(1, sizeof(directory_t));
-    if (syscheck.directories[0] == NULL) {
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)) = calloc(1, sizeof(directory_t));
+    if (((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)) == NULL) {
         return -1;
     }
 
-    syscheck.directories[0]->path = strdup("c:\\windows");
-    if (syscheck.directories[0]->path == NULL) {
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->path = strdup("c:\\windows");
+    if (((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->path == NULL) {
         return -1;
     }
 
-    syscheck.directories[0]->options = CHECK_SIZE | CHECK_PERM | CHECK_OWNER | CHECK_GROUP | CHECK_MTIME | CHECK_INODE |
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->options = CHECK_SIZE | CHECK_PERM | CHECK_OWNER | CHECK_GROUP | CHECK_MTIME | CHECK_INODE |
                                        CHECK_MD5SUM | CHECK_SHA1SUM | CHECK_SHA256SUM | CHECK_ATTRS | WHODATA_ACTIVE;
 
-    syscheck.directories[0]->dirs_status.status = WD_CHECK_WHODATA;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.status = WD_CHECK_WHODATA;
 
-    syscheck.directories[0]->recursion_level = 50;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->recursion_level = 50;
 
     OSHash_Add_ex_check_data = 0;
     SIZE_EVENTS = sizeof(EVT_VARIANT) * NUM_EVENTS;
@@ -291,13 +291,13 @@ static int setup_state_checker(void ** state) {
         return -1;
     }
 
-    syscheck.directories[0] = calloc(1, sizeof(directory_t));
-    if (syscheck.directories[0] == NULL) {
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)) = calloc(1, sizeof(directory_t));
+    if (((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)) == NULL) {
         return -1;
     }
 
-    syscheck.directories[0]->path = strdup("c:\\a\\path");
-    if (syscheck.directories[0]->path == NULL) {
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->path = strdup("c:\\a\\path");
+    if (((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->path == NULL) {
         return -1;
     }
 
@@ -311,10 +311,10 @@ static int setup_state_checker(void ** state) {
 
     __real_OSHash_SetFreeDataPointer(syscheck.wdata.directories, free);
 
-    syscheck.directories[0]->dirs_status.object_type = WD_STATUS_DIR_TYPE;
-    syscheck.directories[0]->dirs_status.status = WD_CHECK_WHODATA | WD_STATUS_EXISTS;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.object_type = WD_STATUS_DIR_TYPE;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.status = WD_CHECK_WHODATA | WD_STATUS_EXISTS;
 
-    syscheck.directories[0]->options = WHODATA_ACTIVE;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->options = WHODATA_ACTIVE;
 
     test_mode = 1;
 
@@ -357,26 +357,26 @@ static int teardown_win_whodata_evt(void **state) {
 }
 
 static int teardown_whodata_callback_restore_globals(void ** state) {
-    syscheck.directories[0]->dirs_status.status |= WD_CHECK_WHODATA;
-    syscheck.directories[0]->recursion_level = 50;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.status |= WD_CHECK_WHODATA;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->recursion_level = 50;
     return 0;
 }
 
 static int teardown_state_checker_restore_globals(void ** state) {
-    syscheck.directories[0] = calloc(1, sizeof(directory_t));
-    if (syscheck.directories[0] == NULL) {
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)) = calloc(1, sizeof(directory_t));
+    if (((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)) == NULL) {
         return -1;
     }
 
-    syscheck.directories[0]->path = strdup("c:\\a\\path");
-    if (syscheck.directories[0]->path == NULL) {
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->path = strdup("c:\\a\\path");
+    if (((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->path == NULL) {
         return -1;
     }
 
-    syscheck.directories[0]->dirs_status.object_type = WD_STATUS_DIR_TYPE;
-    syscheck.directories[0]->dirs_status.status = WD_CHECK_WHODATA | WD_STATUS_EXISTS;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.object_type = WD_STATUS_DIR_TYPE;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.status = WD_CHECK_WHODATA | WD_STATUS_EXISTS;
 
-    syscheck.directories[0]->options = WHODATA_ACTIVE;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->options = WHODATA_ACTIVE;
     return 0;
 }
 
@@ -413,7 +413,7 @@ int __wrap_pthread_rwlock_unlock(pthread_rwlock_t * rwlock) {
 /***************************set_winsacl************************************/
 void test_set_winsacl_failed_opening(void **state) {
     char debug_msg[OS_MAXSTR];
-    snprintf(debug_msg, OS_MAXSTR, FIM_SACL_CONFIGURE, syscheck.directories[0]->path);
+    snprintf(debug_msg, OS_MAXSTR, FIM_SACL_CONFIGURE, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->path);
     expect_string(__wrap__mdebug2, formatted_msg, debug_msg);
 
     will_return(wrap_GetCurrentProcess, (HANDLE)4321);
@@ -424,12 +424,12 @@ void test_set_winsacl_failed_opening(void **state) {
     will_return(wrap_GetLastError, (unsigned int) 500);
     expect_string(__wrap__merror, formatted_msg, "(6648): OpenProcessToken() failed. Error '500'.");
 
-    set_winsacl(syscheck.directories[0]->path, syscheck.directories[0]);
+    set_winsacl(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->path, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)));
 }
 
 void test_set_winsacl_failed_privileges(void **state) {
     char debug_msg[OS_MAXSTR];
-    snprintf(debug_msg, OS_MAXSTR, FIM_SACL_CONFIGURE, syscheck.directories[0]->path);
+    snprintf(debug_msg, OS_MAXSTR, FIM_SACL_CONFIGURE, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->path);
     expect_string(__wrap__mdebug2, formatted_msg, debug_msg);
 
     will_return(wrap_GetCurrentProcess, (HANDLE)4321);
@@ -449,12 +449,12 @@ void test_set_winsacl_failed_privileges(void **state) {
 
     expect_value(wrap_CloseHandle, hObject, (HANDLE)123456);
     will_return(wrap_CloseHandle, 0);
-    set_winsacl(syscheck.directories[0]->path, syscheck.directories[0]);
+    set_winsacl(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->path, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)));
 }
 
 void test_set_winsacl_failed_security_descriptor(void **state) {
     char debug_msg[OS_MAXSTR];
-    snprintf(debug_msg, OS_MAXSTR, FIM_SACL_CONFIGURE, syscheck.directories[0]->path);
+    snprintf(debug_msg, OS_MAXSTR, FIM_SACL_CONFIGURE, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->path);
     expect_string(__wrap__mdebug2, formatted_msg, debug_msg);
 
     will_return(wrap_GetCurrentProcess, (HANDLE)4321);
@@ -473,7 +473,7 @@ void test_set_winsacl_failed_security_descriptor(void **state) {
     expect_string(__wrap__mdebug2, formatted_msg, "(6268): The 'SeSecurityPrivilege' privilege has been added.");
 
     // GetNamedSecurity
-    expect_string(wrap_GetNamedSecurityInfo, pObjectName, syscheck.directories[0]->path);
+    expect_string(wrap_GetNamedSecurityInfo, pObjectName, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->path);
     expect_value(wrap_GetNamedSecurityInfo, ObjectType, SE_FILE_OBJECT);
     expect_value(wrap_GetNamedSecurityInfo, SecurityInfo, SACL_SECURITY_INFORMATION);
     will_return(wrap_GetNamedSecurityInfo, NULL);
@@ -493,7 +493,7 @@ void test_set_winsacl_failed_security_descriptor(void **state) {
     expect_value(wrap_CloseHandle, hObject, (HANDLE)123456);
     will_return(wrap_CloseHandle, 0);
 
-    set_winsacl(syscheck.directories[0]->path, syscheck.directories[0]);
+    set_winsacl(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->path, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)));
 }
 
 void test_set_winsacl_no_need_to_configure_acl(void **state) {
@@ -566,7 +566,7 @@ void test_set_winsacl_no_need_to_configure_acl(void **state) {
     expect_value(wrap_CloseHandle, hObject, (HANDLE)123456);
     will_return(wrap_CloseHandle, 0);
 
-    ret = set_winsacl("C:\\a\\path", syscheck.directories[9]);
+    ret = set_winsacl("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9)));
 
     assert_int_equal(ret, 0);
 }
@@ -642,7 +642,7 @@ void test_set_winsacl_unable_to_get_acl_info(void **state) {
     expect_value(wrap_CloseHandle, hObject, (HANDLE)123456);
     will_return(wrap_CloseHandle, 0);
 
-    ret = set_winsacl("C:\\a\\path", syscheck.directories[9]);
+    ret = set_winsacl("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9)));
 
     assert_int_equal(ret, 1);
 }
@@ -723,7 +723,7 @@ void test_set_winsacl_fail_to_alloc_new_sacl(void **state) {
     expect_value(wrap_CloseHandle, hObject, (HANDLE)123456);
     will_return(wrap_CloseHandle, 0);
 
-    ret = set_winsacl("C:\\a\\path", syscheck.directories[9]);
+    ret = set_winsacl("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9)));
 
     assert_int_equal(ret, 1);
 }
@@ -809,7 +809,7 @@ void test_set_winsacl_fail_to_initialize_new_sacl(void **state) {
     expect_value(wrap_CloseHandle, hObject, (HANDLE)123456);
     will_return(wrap_CloseHandle, 0);
 
-    ret = set_winsacl("C:\\a\\path", syscheck.directories[9]);
+    ret = set_winsacl("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9)));
 
     assert_int_equal(ret, 1);
 }
@@ -899,7 +899,7 @@ void test_set_winsacl_fail_getting_ace_from_old_sacl(void **state) {
     expect_value(wrap_CloseHandle, hObject, (HANDLE)123456);
     will_return(wrap_CloseHandle, 0);
 
-    ret = set_winsacl("C:\\a\\path", syscheck.directories[9]);
+    ret = set_winsacl("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9)));
 
     assert_int_equal(ret, 1);
 }
@@ -993,7 +993,7 @@ void test_set_winsacl_fail_adding_old_ace_into_new_sacl(void **state) {
     expect_value(wrap_CloseHandle, hObject, (HANDLE)123456);
     will_return(wrap_CloseHandle, 0);
 
-    ret = set_winsacl("C:\\a\\path", syscheck.directories[9]);
+    ret = set_winsacl("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9)));
 
     assert_int_equal(ret, 1);
 }
@@ -1089,7 +1089,7 @@ void test_set_winsacl_fail_to_alloc_new_ace(void **state) {
     expect_value(wrap_CloseHandle, hObject, (HANDLE)123456);
     will_return(wrap_CloseHandle, 0);
 
-    ret = set_winsacl("C:\\a\\path", syscheck.directories[9]);
+    ret = set_winsacl("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9)));
 
     assert_int_equal(ret, 1);
 }
@@ -1187,7 +1187,7 @@ void test_set_winsacl_fail_to_copy_sid(void **state) {
     expect_value(wrap_CloseHandle, hObject, (HANDLE)123456);
     will_return(wrap_CloseHandle, 0);
 
-    ret = set_winsacl("C:\\a\\path", syscheck.directories[9]);
+    ret = set_winsacl("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9)));
 
     assert_int_equal(ret, 1);
     assert_int_equal(ace.Header.AceType, SYSTEM_AUDIT_ACE_TYPE);
@@ -1294,7 +1294,7 @@ void test_set_winsacl_fail_to_add_ace(void **state) {
     expect_value(wrap_CloseHandle, hObject, (HANDLE)123456);
     will_return(wrap_CloseHandle, 0);
 
-    ret = set_winsacl("C:\\a\\path", syscheck.directories[9]);
+    ret = set_winsacl("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9)));
 
     assert_int_equal(ret, 1);
     assert_int_equal(ace.Header.AceType, SYSTEM_AUDIT_ACE_TYPE);
@@ -1410,7 +1410,7 @@ void test_set_winsacl_fail_to_set_security_info(void **state) {
     expect_value(wrap_CloseHandle, hObject, (HANDLE)123456);
     will_return(wrap_CloseHandle, 0);
 
-    ret = set_winsacl("C:\\a\\path", syscheck.directories[9]);
+    ret = set_winsacl("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9)));
 
     assert_int_equal(ret, 1);
     assert_int_equal(ace.Header.AceType, SYSTEM_AUDIT_ACE_TYPE);
@@ -1524,7 +1524,7 @@ void test_set_winsacl_success(void **state) {
     expect_value(wrap_CloseHandle, hObject, (HANDLE)123456);
     will_return(wrap_CloseHandle, 0);
 
-    ret = set_winsacl("C:\\a\\path", syscheck.directories[9]);
+    ret = set_winsacl("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9)));
 
     assert_int_equal(ret, 0);
     assert_int_equal(ace.Header.AceType, SYSTEM_AUDIT_ACE_TYPE);
@@ -3487,7 +3487,7 @@ int setup_restore_sacls(void **state) {
         dir_it->dirs_status.status &= ~WD_IGNORE_REST;
     }
 
-    syscheck.directories[0]->dirs_status.status |= WD_IGNORE_REST;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.status |= WD_IGNORE_REST;
 
     return 0;
 }
@@ -3499,7 +3499,7 @@ int teardown_restore_sacls(void **state) {
     OSList_foreach(node_it, syscheck.directories) {
         dir_it = node_it->data;
         if (FIM_MODE(dir_it->options) == FIM_WHODATA) {
-            syscheck.directories[0]->dirs_status.status |= WD_IGNORE_REST;
+            ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.status |= WD_IGNORE_REST;
         }
     }
 
@@ -3524,7 +3524,7 @@ void test_restore_sacls_securityNameInfo_failed(void **state){
         expect_string(__wrap__mdebug2, formatted_msg, "(6268): The 'SeSecurityPrivilege' privilege has been added.");
     }
     // GetNamedSecurity
-    expect_string(wrap_GetNamedSecurityInfo, pObjectName, syscheck.directories[0]->path);
+    expect_string(wrap_GetNamedSecurityInfo, pObjectName, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->path);
     expect_value(wrap_GetNamedSecurityInfo, ObjectType, SE_FILE_OBJECT);
     expect_value(wrap_GetNamedSecurityInfo, SecurityInfo, SACL_SECURITY_INFORMATION);
     will_return(wrap_GetNamedSecurityInfo, NULL);
@@ -3571,7 +3571,7 @@ void test_restore_sacls_deleteAce_failed(void **state){
         expect_string(__wrap__mdebug2, formatted_msg, "(6268): The 'SeSecurityPrivilege' privilege has been added.");
     }
     // GetNamedSecurity
-    expect_string(wrap_GetNamedSecurityInfo, pObjectName, syscheck.directories[0]->path);
+    expect_string(wrap_GetNamedSecurityInfo, pObjectName, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->path);
     ACL acl;
     expect_value(wrap_GetNamedSecurityInfo, ObjectType, SE_FILE_OBJECT);
     expect_value(wrap_GetNamedSecurityInfo, SecurityInfo, SACL_SECURITY_INFORMATION);
@@ -3623,7 +3623,7 @@ void test_restore_sacls_SetNamedSecurityInfo_failed(void **state){
         expect_string(__wrap__mdebug2, formatted_msg, "(6268): The 'SeSecurityPrivilege' privilege has been added.");
     }
     // GetNamedSecurity
-    expect_string(wrap_GetNamedSecurityInfo, pObjectName, syscheck.directories[0]->path);
+    expect_string(wrap_GetNamedSecurityInfo, pObjectName, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->path);
     ACL acl;
     expect_value(wrap_GetNamedSecurityInfo, ObjectType, SE_FILE_OBJECT);
     expect_value(wrap_GetNamedSecurityInfo, SecurityInfo, SACL_SECURITY_INFORMATION);
@@ -3635,7 +3635,7 @@ void test_restore_sacls_SetNamedSecurityInfo_failed(void **state){
     expect_value(wrap_DeleteAce, dwAceIndex, 0);
     will_return(wrap_DeleteAce, 1);
 
-    expect_string(wrap_SetNamedSecurityInfo, pObjectName, syscheck.directories[0]->path);
+    expect_string(wrap_SetNamedSecurityInfo, pObjectName, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->path);
     expect_value(wrap_SetNamedSecurityInfo, ObjectType, SE_FILE_OBJECT);
     expect_value(wrap_SetNamedSecurityInfo, SecurityInfo, SACL_SECURITY_INFORMATION);
     expect_value(wrap_SetNamedSecurityInfo, psidOwner, NULL);
@@ -3684,7 +3684,7 @@ void test_restore_sacls_success(void **state){
         expect_string(__wrap__mdebug2, formatted_msg, "(6268): The 'SeSecurityPrivilege' privilege has been added.");
     }
     // GetNamedSecurity
-    expect_string(wrap_GetNamedSecurityInfo, pObjectName, syscheck.directories[0]->path);
+    expect_string(wrap_GetNamedSecurityInfo, pObjectName, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->path);
     ACL acl;
     expect_value(wrap_GetNamedSecurityInfo, ObjectType, SE_FILE_OBJECT);
     expect_value(wrap_GetNamedSecurityInfo, SecurityInfo, SACL_SECURITY_INFORMATION);
@@ -3696,7 +3696,7 @@ void test_restore_sacls_success(void **state){
     expect_value(wrap_DeleteAce, dwAceIndex, 0);
     will_return(wrap_DeleteAce, 1);
 
-    expect_string(wrap_SetNamedSecurityInfo, pObjectName, syscheck.directories[0]->path);
+    expect_string(wrap_SetNamedSecurityInfo, pObjectName, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->path);
     expect_value(wrap_SetNamedSecurityInfo, ObjectType, SE_FILE_OBJECT);
     expect_value(wrap_SetNamedSecurityInfo, SecurityInfo, SACL_SECURITY_INFORMATION);
     expect_value(wrap_SetNamedSecurityInfo, psidOwner, NULL);
@@ -3706,7 +3706,7 @@ void test_restore_sacls_success(void **state){
     will_return(wrap_SetNamedSecurityInfo, ERROR_SUCCESS);
 
     char debug_msg[OS_MAXSTR];
-    snprintf(debug_msg, OS_MAXSTR, FIM_SACL_RESTORED, syscheck.directories[0]->path);
+    snprintf(debug_msg, OS_MAXSTR, FIM_SACL_RESTORED, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->path);
     expect_string(__wrap__mdebug1, formatted_msg, debug_msg);
 
     /* Inside set_privilege */
@@ -3825,7 +3825,7 @@ void test_audit_restore(void **state) {
             expect_string(__wrap__mdebug2, formatted_msg, "(6268): The 'SeSecurityPrivilege' privilege has been added.");
         }
         // GetNamedSecurity
-        expect_string(wrap_GetNamedSecurityInfo, pObjectName, syscheck.directories[0]->path);
+        expect_string(wrap_GetNamedSecurityInfo, pObjectName, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->path);
         ACL acl;
         expect_value(wrap_GetNamedSecurityInfo, ObjectType, SE_FILE_OBJECT);
         expect_value(wrap_GetNamedSecurityInfo, SecurityInfo, SACL_SECURITY_INFORMATION);
@@ -3837,7 +3837,7 @@ void test_audit_restore(void **state) {
         expect_value(wrap_DeleteAce, dwAceIndex, 0);
         will_return(wrap_DeleteAce, 1);
 
-        expect_string(wrap_SetNamedSecurityInfo, pObjectName, syscheck.directories[0]->path);
+        expect_string(wrap_SetNamedSecurityInfo, pObjectName, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->path);
         expect_value(wrap_SetNamedSecurityInfo, ObjectType, SE_FILE_OBJECT);
         expect_value(wrap_SetNamedSecurityInfo, SecurityInfo, SACL_SECURITY_INFORMATION);
         expect_value(wrap_SetNamedSecurityInfo, psidOwner, NULL);
@@ -3847,7 +3847,7 @@ void test_audit_restore(void **state) {
         will_return(wrap_SetNamedSecurityInfo, ERROR_SUCCESS);
 
         char debug_msg[OS_MAXSTR];
-        snprintf(debug_msg, OS_MAXSTR, FIM_SACL_RESTORED, syscheck.directories[0]->path);
+        snprintf(debug_msg, OS_MAXSTR, FIM_SACL_RESTORED, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->path);
         expect_string(__wrap__mdebug1, formatted_msg, debug_msg);
 
         /* Inside set_privilege */
@@ -4738,7 +4738,7 @@ void test_whodata_callback_4656_non_whodata_directory(void **state) {
 
     unsigned long result;
 
-    syscheck.directories[0]->dirs_status.status &= ~WD_CHECK_WHODATA;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.status &= ~WD_CHECK_WHODATA;
 
     successful_whodata_event_render(event, raw_data);
 
@@ -4788,7 +4788,7 @@ void test_whodata_callback_4656_path_above_recursion_level(void ** state) {
     };
     unsigned long result;
 
-    syscheck.directories[0]->recursion_level = 0;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->recursion_level = 0;
 
     successful_whodata_event_render(event, raw_data);
 
@@ -5282,7 +5282,7 @@ void test_whodata_callback_4663_fail_to_add_new_directory(void **state) {
         fail();
 
     w_evt->scan_directory = 1;
-    w_evt->config_node = syscheck.directories[8];
+    w_evt->config_node = ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 8));
 
     successful_whodata_event_render(event, raw_data);
 
@@ -5339,7 +5339,7 @@ void test_whodata_callback_4663_new_files_added(void **state) {
         fail();
 
     w_evt->scan_directory = 1;
-    w_evt->config_node = syscheck.directories[8];
+    w_evt->config_node = ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 8));
 
     successful_whodata_event_render(event, raw_data);
 
@@ -5433,7 +5433,7 @@ void test_whodata_callback_4663_abort_scan(void **state) {
         fail();
 
     w_evt->scan_directory = 1;
-    w_evt->config_node = syscheck.directories[9];
+    w_evt->config_node = ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9));
     memset(&w_dir, 0, sizeof(whodata_directory));
     w_dir.QuadPart = 133022717170000000;
 
@@ -5485,7 +5485,7 @@ void test_whodata_callback_4663_directory_will_be_scanned(void **state) {
         fail();
 
     w_evt->scan_directory = 1;
-    w_evt->config_node = syscheck.directories[9];
+    w_evt->config_node = ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 9));
     memset(&w_dir, 0, sizeof(whodata_directory));
 
     successful_whodata_event_render(event, raw_data);
@@ -6548,11 +6548,11 @@ void test_state_checker_no_files_to_check(void **state) {
     int ret;
     void *input = NULL;
 
-    if(syscheck.directories[0]) {
-        free_directory(syscheck.directories[0]);
+    if(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))) {
+        free_directory(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)));
     }
 
-    syscheck.directories[0] = NULL;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)) = NULL;
 
     expect_string(__wrap__mdebug1, formatted_msg, "(6233): Checking thread set to '300' seconds.");
 
@@ -6579,7 +6579,7 @@ void test_state_checker_file_not_whodata(void **state) {
     void *input = NULL;
 
     // Leverage Free_Syscheck not free the wdata struct
-    syscheck.directories[0]->dirs_status.status &= ~WD_CHECK_WHODATA;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.status &= ~WD_CHECK_WHODATA;
 
     expect_string(__wrap__mdebug1, formatted_msg, "(6233): Checking thread set to '300' seconds.");
 
@@ -6637,9 +6637,9 @@ void test_state_checker_file_does_not_exist(void **state) {
     ret = state_checker(input);
 
     assert_int_equal(ret, 0);
-    assert_memory_equal(&syscheck.directories[0]->dirs_status.last_check, &st, sizeof(SYSTEMTIME));
-    assert_int_equal(syscheck.directories[0]->dirs_status.object_type, WD_STATUS_UNK_TYPE);
-    assert_null(syscheck.directories[0]->dirs_status.status & WD_STATUS_EXISTS);
+    assert_memory_equal(&((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.last_check, &st, sizeof(SYSTEMTIME));
+    assert_int_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.object_type, WD_STATUS_UNK_TYPE);
+    assert_null(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.status & WD_STATUS_EXISTS);
 }
 
 void test_state_checker_file_with_invalid_sacl(void **state) {
@@ -6742,9 +6742,9 @@ void test_state_checker_file_with_invalid_sacl(void **state) {
     ret = state_checker(input);
 
     assert_int_equal(ret, 0);
-    assert_int_equal(syscheck.directories[0]->dirs_status.object_type, WD_STATUS_FILE_TYPE);
-    assert_non_null(syscheck.directories[0]->dirs_status.status & WD_STATUS_EXISTS);
-    assert_null(syscheck.directories[0]->options & WHODATA_ACTIVE);
+    assert_int_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.object_type, WD_STATUS_FILE_TYPE);
+    assert_non_null(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.status & WD_STATUS_EXISTS);
+    assert_null(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->options & WHODATA_ACTIVE);
 }
 
 void test_state_checker_file_with_valid_sacl(void **state) {
@@ -6849,10 +6849,10 @@ void test_state_checker_file_with_valid_sacl(void **state) {
     ret = state_checker(input);
 
     assert_int_equal(ret, 0);
-    assert_memory_equal(&syscheck.directories[0]->dirs_status.last_check, &st, sizeof(SYSTEMTIME));
-    assert_int_equal(syscheck.directories[0]->dirs_status.object_type, WD_STATUS_FILE_TYPE);
-    assert_non_null(syscheck.directories[0]->dirs_status.status & WD_STATUS_EXISTS);
-    assert_non_null(syscheck.directories[0]->options & WHODATA_ACTIVE);
+    assert_memory_equal(&((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.last_check, &st, sizeof(SYSTEMTIME));
+    assert_int_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.object_type, WD_STATUS_FILE_TYPE);
+    assert_non_null(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.status & WD_STATUS_EXISTS);
+    assert_non_null(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->options & WHODATA_ACTIVE);
 }
 
 void test_state_checker_dir_readded_error(void **state) {
@@ -6860,7 +6860,7 @@ void test_state_checker_dir_readded_error(void **state) {
     void *input = NULL;
     char debug_msg[OS_MAXSTR];
 
-    syscheck.directories[0]->dirs_status.status &= ~WD_STATUS_EXISTS;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.status &= ~WD_STATUS_EXISTS;
 
     expect_string(__wrap__mdebug1, formatted_msg, "(6233): Checking thread set to '300' seconds.");
 
@@ -6877,7 +6877,7 @@ void test_state_checker_dir_readded_error(void **state) {
 
     // Inside set_winsacl
     {
-        snprintf(debug_msg, OS_MAXSTR, FIM_SACL_CONFIGURE, syscheck.directories[0]->path);
+        snprintf(debug_msg, OS_MAXSTR, FIM_SACL_CONFIGURE, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->path);
         expect_string(__wrap__mdebug2, formatted_msg, debug_msg);
 
         will_return(wrap_GetCurrentProcess, (HANDLE)4321);
@@ -6903,9 +6903,9 @@ void test_state_checker_dir_readded_error(void **state) {
     ret = state_checker(input);
 
     assert_int_equal(ret, 0);
-    assert_int_equal(syscheck.directories[0]->dirs_status.object_type, WD_STATUS_DIR_TYPE);
-    assert_null(syscheck.directories[0]->dirs_status.status & WD_STATUS_EXISTS);
-    assert_null(syscheck.directories[0]->options & WHODATA_ACTIVE);
+    assert_int_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.object_type, WD_STATUS_DIR_TYPE);
+    assert_null(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.status & WD_STATUS_EXISTS);
+    assert_null(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->options & WHODATA_ACTIVE);
 }
 
 void test_state_checker_dir_readded_succesful(void **state) {
@@ -6918,8 +6918,8 @@ void test_state_checker_dir_readded_succesful(void **state) {
     SID_IDENTIFIER_AUTHORITY world_auth = {SECURITY_WORLD_SID_AUTHORITY};
     SYSTEMTIME st;
 
-    syscheck.directories[0]->dirs_status.status &= ~WD_STATUS_EXISTS;
-    syscheck.directories[0]->dirs_status.object_type = WD_STATUS_UNK_TYPE;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.status &= ~WD_STATUS_EXISTS;
+    ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.object_type = WD_STATUS_UNK_TYPE;
 
     memset(&st, 0, sizeof(SYSTEMTIME));
     st.wYear = 2020;
@@ -7051,10 +7051,10 @@ void test_state_checker_dir_readded_succesful(void **state) {
     ret = state_checker(input);
 
     assert_int_equal(ret, 0);
-    assert_memory_equal(&syscheck.directories[0]->dirs_status.last_check, &st, sizeof(SYSTEMTIME));
-    assert_int_equal(syscheck.directories[0]->dirs_status.object_type, WD_STATUS_DIR_TYPE);
-    assert_non_null(syscheck.directories[0]->dirs_status.status & WD_STATUS_EXISTS);
-    assert_non_null(syscheck.directories[0]->options & WHODATA_ACTIVE);
+    assert_memory_equal(&((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.last_check, &st, sizeof(SYSTEMTIME));
+    assert_int_equal(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.object_type, WD_STATUS_DIR_TYPE);
+    assert_non_null(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->dirs_status.status & WD_STATUS_EXISTS);
+    assert_non_null(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->options & WHODATA_ACTIVE);
 }
 
 void test_state_checker_dirs_cleanup_no_nodes(void ** state) {

--- a/src/unit_tests/wrappers/wazuh/config/syscheck_config_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/config/syscheck_config_wrappers.c
@@ -1,0 +1,20 @@
+/* Copyright (C) 2015-2021, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include <stddef.h>
+#include <stdarg.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "syscheck_config_wrappers.h"
+
+char **__wrap_expand_wildcards(const char *path) {
+    check_expected(path);
+
+    return mock_type(char **);
+}

--- a/src/unit_tests/wrappers/wazuh/config/syscheck_config_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/config/syscheck_config_wrappers.h
@@ -1,0 +1,16 @@
+/* Copyright (C) 2015-2021, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+
+#ifndef SYSCHECK_CONFIG_WRAPPERS
+#define SYSCHECK_CONFIG_WRAPPERS
+
+char **__wrap_expand_wildcards(const char *path);
+
+#endif // SYSCHECK_CONFIG_WRAPPERS

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
@@ -194,6 +194,19 @@ int __wrap_fim_db_process_missing_entry(fdb_t *fim_sql,
     return mock();
 }
 
+int __wrap_fim_db_remove_wildcard_entry(fdb_t *fim_sql,
+                                 fim_tmp_file *file,
+                                 __attribute__((unused)) pthread_mutex_t *mutex,
+                                 int storage,
+                                 __attribute__((unused)) event_data_t *evt_data,
+                                 __attribute__((unused)) directory_t *configuration) {
+    check_expected_ptr(fim_sql);
+    check_expected_ptr(file);
+    check_expected_ptr(storage);
+
+    return mock();
+}
+
 int __wrap_fim_db_remove_path(fdb_t *fim_sql, char *path) {
     check_expected_ptr(fim_sql);
     check_expected(path);

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
@@ -84,6 +84,13 @@ int __wrap_fim_db_process_missing_entry(fdb_t *fim_sql,
                                         int storage,
                                         event_data_t *evt_data);
 
+int __wrap_fim_db_remove_wildcard_entry(fdb_t *fim_sql,
+                                        fim_tmp_file *file,
+                                        pthread_mutex_t *mutex,
+                                        int storage,
+                                        event_data_t *evt_data,
+                                        directory_t *configuration);
+
 int __wrap_fim_db_remove_path(fdb_t *fim_sql, char *path);
 
 int __wrap_fim_db_set_all_unscanned(fdb_t *fim_sql);

--- a/src/unit_tests/wrappers/wazuh/syscheckd/run_realtime_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/run_realtime_wrappers.c
@@ -29,3 +29,10 @@ void expect_realtime_adddir_call(const char *path, int ret) {
     expect_string(__wrap_realtime_adddir, dir, path);
     will_return(__wrap_realtime_adddir, ret);
 }
+
+int __wrap_fim_add_inotify_watch(const char *dir,
+                                 __attribute__((unused)) const directory_t *configuration) {
+    check_expected(dir);
+
+    return mock();
+}

--- a/src/unit_tests/wrappers/wazuh/syscheckd/run_realtime_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/run_realtime_wrappers.c
@@ -14,8 +14,7 @@
 #include <cmocka.h>
 
 int __wrap_realtime_adddir(const char *dir,
-                           __attribute__((unused)) directory_t *configuration,
-                           __attribute__((unused)) int followsl) {
+                           __attribute__((unused)) directory_t *configuration) {
     check_expected(dir);
 
     return mock();

--- a/src/unit_tests/wrappers/wazuh/syscheckd/run_realtime_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/run_realtime_wrappers.h
@@ -20,4 +20,8 @@ int __wrap_realtime_start();
  * @brief This function loads the expect and will_return calls for the wrapper of realtime_adddir
  */
 void expect_realtime_adddir_call(const char *path, int ret);
+
+int __wrap_fim_add_inotify_watch(const char *dir,
+                                 const directory_t *configuration);
+
 #endif

--- a/src/unit_tests/wrappers/wazuh/syscheckd/run_realtime_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/run_realtime_wrappers.h
@@ -12,8 +12,7 @@
 #include "config/syscheck-config.h"
 
 int __wrap_realtime_adddir(const char *dir,
-                           directory_t *configuration,
-                           int followsl);
+                           directory_t *configuration);
 
 int __wrap_realtime_start();
 

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -16,6 +16,7 @@
 #include "wazuh_modules/wmodules.h"
 #include "sysInfo.h"
 #include "sym_load.h"
+#include "../os_net/os_net.h"
 
 HANDLE hMutex;
 int win_debug_level;


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/8259|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR solves the enhancement of update wildcards configuration at runtime. 
I've changed much of the way we used to store configured directories, which was in an array of directory_t *. Now an OSList is generated for the directories, and another one for the wildcards, which will be expanded and updated on each FIM scan.

## Configuration options

Using wildcards:
`<directories check_all="yes" whodata="yes">/dir?</directories>`

Directories that comply with these wildcards do not need to be created when starting Wazuh. So when they are created or destroyed we will be able to see the events that occur in them.
## Logs/Alerts example
```
DEBUG: (6361): Starting configuration wildcards update.
DEBUG: (6359): No matches found for the glob pattern: '/dir?'
DEBUG: (6363): Configuration wildcards update finalize.
```


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] ThreadSanitizer
- Memory tests for Windows
  - [x] Scan-build report


<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] Configuration on demand reports new parameters
- [x] Added unit tests (for new features)
