### PR TITLE
New configuration option to switch on and off the Authd TLS port

### DIFF
--- a/src/config/authd-config.c
+++ b/src/config/authd-config.c
@@ -33,6 +33,7 @@ int Read_Authd(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
     static const char *xml_ssl_manager_cert = "ssl_manager_cert";
     static const char *xml_ssl_manager_key = "ssl_manager_key";
     static const char *xml_ssl_auto_negotiate = "ssl_auto_negotiate";
+    static const char *xml_remote_enrollment = "remote_enrollment";
 
     authd_config_t *config = (authd_config_t *)d1;
     int i;
@@ -129,6 +130,15 @@ int Read_Authd(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
             }
 
             config->flags.use_password = b;
+        } else if (!strcmp(node[i]->element, xml_remote_enrollment)) {
+            short b = eval_bool(node[i]->content);
+
+            if (b < 0) {
+                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                return OS_INVALID;
+            }
+
+            config->flags.remote_enrollment = b;
         } else if (!strcmp(node[i]->element, xml_limit_maxagents)) {
             mdebug1("The <%s> tag is deprecated since version 4.1.0.", xml_limit_maxagents);
         } else if (!strcmp(node[i]->element, xml_ciphers)) {

--- a/src/config/authd-config.c
+++ b/src/config/authd-config.c
@@ -59,6 +59,7 @@ int Read_Authd(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
     config->manager_cert = strdup(manager_cert);
     config->manager_key = strdup(manager_key);
     config->flags.auto_negotiate = 0;
+    config->flags.remote_enrollment = 1;
 
     if (!node)
         return 0;

--- a/src/config/authd-config.h
+++ b/src/config/authd-config.h
@@ -20,6 +20,7 @@ typedef struct authd_flags_t {
     unsigned short use_password:1;
     unsigned short verify_host:1;
     unsigned short auto_negotiate:1;
+    unsigned short remote_enrollment:1;
 } authd_flags_t;
 
 typedef struct authd_config_t {

--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -160,13 +160,13 @@ w_err_t w_auth_parse_data(const char* buf, char *response,const char *authpass, 
                 snprintf(response, 2048, "ERROR: Invalid IP: %s", client_source_ip);
                 return OS_INVALID;
             }
-            snprintf(ip, IPSIZE + 1, "%s", client_source_ip);
+            snprintf(ip, IPSIZE, "%s", client_source_ip);
         }
 
     }
     else if(!config.flags.use_source_ip) {
         // use_source-ip = 0 and no -I argument in agent
-        snprintf(ip, IPSIZE + 1, "any");
+        snprintf(ip, IPSIZE, "any");
     }
     // else -> agent IP is already on ip
 

--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -160,13 +160,13 @@ w_err_t w_auth_parse_data(const char* buf, char *response,const char *authpass, 
                 snprintf(response, 2048, "ERROR: Invalid IP: %s", client_source_ip);
                 return OS_INVALID;
             }
-            snprintf(ip, IPSIZE, "%s", client_source_ip);
+            snprintf(ip, IPSIZE + 1, "%s", client_source_ip);
         }
 
     }
     else if(!config.flags.use_source_ip) {
         // use_source-ip = 0 and no -I argument in agent
-        snprintf(ip, IPSIZE, "any");
+        snprintf(ip, IPSIZE + 1, "any");
     }
     // else -> agent IP is already on ip
 

--- a/src/os_auth/config.c
+++ b/src/os_auth/config.c
@@ -61,6 +61,7 @@ cJSON *getAuthdConfig(void) {
     else
         cJSON_AddNumberToObject(auth,"force_time",config.force_time);
     if (config.flags.disabled) cJSON_AddStringToObject(auth,"disabled","yes"); else cJSON_AddStringToObject(auth,"disabled","no");
+    if (config.flags.remote_enrollment) cJSON_AddStringToObject(auth,"remote_enrollment","yes"); else cJSON_AddStringToObject(auth,"remote_enrollment","no");
     if (config.flags.use_source_ip) cJSON_AddStringToObject(auth,"use_source_ip","yes"); else cJSON_AddStringToObject(auth,"use_source_ip","no");
     if (config.flags.force_insert) cJSON_AddStringToObject(auth,"force_insert","yes"); else cJSON_AddStringToObject(auth,"force_insert","no");
     if (config.flags.clear_removed) cJSON_AddStringToObject(auth,"purge","yes"); else cJSON_AddStringToObject(auth,"purge","no");

--- a/src/os_auth/local-server.c
+++ b/src/os_auth/local-server.c
@@ -170,7 +170,7 @@ void* run_local_server(__attribute__((unused)) void *arg) {
 
 // Dispatch local request
 char* local_dispatch(const char *input) {
-    cJSON *request;
+    cJSON *request = NULL;
     cJSON *function;
     cJSON *arguments;
     cJSON *response = NULL;

--- a/src/os_auth/local-server.c
+++ b/src/os_auth/local-server.c
@@ -28,7 +28,8 @@ typedef enum auth_local_err {
     ENOAGENT,
     EDUPID,
     EAGLIM,
-    EINVGROUP
+    EINVGROUP,
+    ENOMASTER
 } auth_local_err;
 
 
@@ -49,7 +50,8 @@ static const struct {
     { 9011, "Agent ID not found" },
     { 9012, "Duplicated ID" },
     { 9013, "Maximum number of agents reached" },
-    { 9014, "Invalid Group(s) Name(s)"}
+    { 9014, "Invalid Group(s) Name(s)" },
+    { 9015, "Cannot execute this request on a worker node" }
 };
 
 // Dispatch local request
@@ -105,9 +107,7 @@ void* run_local_server(__attribute__((unused)) void *arg) {
             if (errno != EINTR) {
                 merror_exit("at run_local_server(): select(): %s", strerror(errno));
             }
-
             continue;
-
         case 0:
             continue;
         }
@@ -116,7 +116,6 @@ void* run_local_server(__attribute__((unused)) void *arg) {
             if ((errno == EBADF && running) || (errno != EBADF && errno != EINTR)) {
                 merror("at run_local_server(): accept(): %s", strerror(errno));
             }
-
             continue;
         }
 
@@ -179,6 +178,11 @@ char* local_dispatch(const char *input) {
     int ierror;
 
     if (input[0] == '{') {
+        if (config.worker_node) {
+            ierror = ENOMASTER;
+            goto fail;
+        }
+
         const char *jsonErrPtr;
         if (request = cJSON_ParseWithOpts(input, &jsonErrPtr, 0), !request) {
             ierror = EJSON;
@@ -220,9 +224,9 @@ char* local_dispatch(const char *input) {
 
             ip = item->valuestring;
 
-            if(item = cJSON_GetObjectItem(arguments, "groups"), item) {
+            if (item = cJSON_GetObjectItem(arguments, "groups"), item) {
                 groups = wstr_delete_repeated_groups(item->valuestring);
-                if (!groups){
+                if (!groups) {
                     ierror = EINVGROUP;
                     goto fail;
                 }
@@ -230,7 +234,9 @@ char* local_dispatch(const char *input) {
 
             key = (item = cJSON_GetObjectItem(arguments, "key"), item) ? item->valuestring : NULL;
             force = (item = cJSON_GetObjectItem(arguments, "force"), item) ? item->valueint : -1;
+
             response = local_add(id, name, ip, groups, key, force);
+
             os_free(groups);
         } else if (!strcmp(function->valuestring, "remove")) {
             cJSON *item;
@@ -247,6 +253,7 @@ char* local_dispatch(const char *input) {
             }
 
             purge = cJSON_IsTrue(cJSON_GetObjectItem(arguments, "purge"));
+
             response = local_remove(item->valuestring, purge);
         } else if (!strcmp(function->valuestring, "get")) {
             cJSON *item;
@@ -304,8 +311,8 @@ cJSON* local_add(const char *id, const char *name, const char *ip, char *groups,
     w_mutex_lock(&mutex_keys);
 
     /* Check if groups are valid to be aggregated */
-    if (groups){
-        if (OS_SUCCESS != w_auth_validate_groups(groups, NULL)){
+    if (groups) {
+        if (OS_SUCCESS != w_auth_validate_groups(groups, NULL)) {
             ierror = EINVGROUP;
             goto fail;
         }
@@ -368,7 +375,7 @@ cJSON* local_add(const char *id, const char *name, const char *ip, char *groups,
     }
 
 
-    if(groups) {
+    if (groups) {
         char path[PATH_MAX];
         if (snprintf(path, PATH_MAX, GROUPS_DIR "/%s", keys.keyentries[index]->id) >= PATH_MAX) {
             ierror = EINVGROUP;

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -496,16 +496,16 @@ int main(int argc, char **argv)
     atexit(cleanup);
 
     /* Join threads */
-    w_mutex_lock(&mutex_keys);
-    w_cond_signal(&cond_pending);
-    w_mutex_unlock(&mutex_keys);
-
     pthread_join(thread_local_server, NULL);
     if (config.flags.remote_enrollment) {
         pthread_join(thread_dispatcher, NULL);
         pthread_join(thread_remote_server, NULL);
     }
     if (!config.worker_node) {
+        /* Send signal to writer thread */
+        w_mutex_lock(&mutex_keys);
+        w_cond_signal(&cond_pending);
+        w_mutex_unlock(&mutex_keys);
         pthread_join(thread_writer, NULL);
     }
 

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -37,11 +37,11 @@
 static void help_authd(char * home_path) __attribute((noreturn));
 static int ssl_error(const SSL *ssl, int ret);
 
-/* Thread for remote server */
-void run_remote_server(int client_sock);
-
 /* Thread for dispatching connection pool */
 static void* run_dispatcher(void *arg);
+
+/* Thread for remote server */
+static void* run_remote_server(void *arg);
 
 /* Thread for writing keystore onto disk */
 static void* run_writer(void *arg);
@@ -159,9 +159,10 @@ int main(int argc, char **argv)
     gid_t gid;
     const char *group = GROUPGLOBAL;
 
-    pthread_t thread_dispatcher = 0;
-    pthread_t thread_writer = 0;
     pthread_t thread_local_server = 0;
+    pthread_t thread_dispatcher = 0;
+    pthread_t thread_remote_server = 0;
+    pthread_t thread_writer = 0;
 
     /* Set the name */
     OS_SetName(ARGV0);
@@ -369,7 +370,7 @@ int main(int argc, char **argv)
 
     mdebug1(WAZUH_HOMEDIR, home_path);
 
-    switch(w_is_worker()){
+    switch(w_is_worker()) {
     case -1:
         merror("Invalid option at cluster configuration");
         exit(0);
@@ -408,13 +409,27 @@ int main(int argc, char **argv)
     /* Start up message */
     minfo(STARTUP_MSG, (int)getpid());
 
-    /* Getting SSL cert. */
+    /* Checking client keys file */
     fp = fopen(KEYS_FILE, "a");
     if (!fp) {
         merror("Unable to open %s (key file)", KEYS_FILE);
         exit(1);
     }
     fclose(fp);
+
+    if (config.flags.remote_enrollment) {
+        /* Start SSL */
+        if (ctx = os_ssl_keys(1, home_path, config.ciphers, config.manager_cert, config.manager_key, config.agent_ca, config.flags.auto_negotiate), !ctx) {
+            merror("SSL error. Exiting.");
+            exit(1);
+        }
+
+        /* Connect via TCP */
+        if (remote_sock = OS_Bindporttcp(config.port, NULL, 0), remote_sock <= 0) {
+            merror(BIND_ERROR, config.port, errno, strerror(errno));
+            exit(1);
+        }
+    }
 
     /* Before chroot */
     srandom_init();
@@ -426,159 +441,77 @@ int main(int argc, char **argv)
     }
 
     /* Chroot */
-    if (Privsep_Chroot(home_path) < 0)
+    if (Privsep_Chroot(home_path) < 0) {
         merror_exit(CHROOT_ERROR, home_path, errno, strerror(errno));
+    }
 
     nowChroot();
     os_free(home_path);
-
-    atexit(cleanup);
 
     /* Initialize queues */
     insert_tail = &queue_insert;
     remove_tail = &queue_remove;
 
+    /* Load client keys in master node */
     if (!config.worker_node) {
         OS_PassEmptyKeyfile();
         OS_ReadKeys(&keys, 0, !config.flags.clear_removed);
     }
 
-    /* If remote enrollment is not enabled on the worker node, it goes to sleep */
-    if (!config.flags.remote_enrollment && config.worker_node) {
-        minfo("Port %hu was set as disabled. The deamon goes to sleep.", config.port);
-        while (running) {
-            sleep(1);
-        }
-        exit(0);
-    }
-
     /* Start working threads */
-    if (!config.worker_node) {
-        if (status = pthread_create(&thread_writer, NULL, run_writer, NULL), status != 0) {
-            merror("Couldn't create thread: %s", strerror(status));
-            return EXIT_FAILURE;
-        }
-        if (config.flags.remote_enrollment) {
-            if (status = pthread_create(&thread_local_server, NULL, run_local_server, NULL), status != 0) {
-                merror("Couldn't create thread: %s", strerror(status));
-                return EXIT_FAILURE;
-            }
-        }
+
+    if (status = pthread_create(&thread_local_server, NULL, (void *)&run_local_server, NULL), status != 0) {
+        merror("Couldn't create thread: %s", strerror(status));
+        return EXIT_FAILURE;
     }
 
     if (config.flags.remote_enrollment) {
-        if (status = pthread_create(&thread_dispatcher, NULL, (void *)&run_dispatcher, home_path), status != 0) {
+        client_queue = queue_init(AUTH_POOL);
+
+        if (status = pthread_create(&thread_dispatcher, NULL, (void *)&run_dispatcher, NULL), status != 0) {
             merror("Couldn't create thread: %s", strerror(status));
             return EXIT_FAILURE;
         }
 
-        /* Create PID files */
-        if (CreatePID(ARGV0, getpid()) < 0) {
-            merror_exit(PID_ERROR);
+        if (status = pthread_create(&thread_remote_server, NULL, (void *)&run_remote_server, NULL), status != 0) {
+            merror("Couldn't create thread: %s", strerror(status));
+            return EXIT_FAILURE;
         }
-        run_remote_server(remote_sock);
-
     } else {
         minfo("Port %hu was set as disabled.", config.port);
-        /* Create PID files */
-        if (CreatePID(ARGV0, getpid()) < 0) {
-            merror_exit(PID_ERROR);
-        }
-        run_local_server(NULL);
     }
+
+    if (!config.worker_node) {
+        if (status = pthread_create(&thread_writer, NULL, (void *)&run_writer, NULL), status != 0) {
+            merror("Couldn't create thread: %s", strerror(status));
+            return EXIT_FAILURE;
+        }
+    }
+
+    /* Create PID files */
+    if (CreatePID(ARGV0, getpid()) < 0) {
+        merror_exit(PID_ERROR);
+    }
+
+    atexit(cleanup);
 
     /* Join threads */
     w_mutex_lock(&mutex_keys);
     w_cond_signal(&cond_pending);
     w_mutex_unlock(&mutex_keys);
 
+    pthread_join(thread_local_server, NULL);
+    if (config.flags.remote_enrollment) {
+        pthread_join(thread_dispatcher, NULL);
+        pthread_join(thread_remote_server, NULL);
+    }
     if (!config.worker_node) {
         pthread_join(thread_writer, NULL);
     }
-    if (config.flags.remote_enrollment) {
-        pthread_join(thread_dispatcher, NULL);
-        if (!config.worker_node) {
-            pthread_join(thread_local_server, NULL);
-        }
-    }
 
+    queue_free(client_queue);
     minfo("Exiting...");
     return (0);
-}
-
-/* Remote server */
-void run_remote_server(int client_sock) {
-    struct sockaddr_in _nc;
-    socklen_t _ncl;
-    fd_set fdset;
-    struct timeval timeout;
-
-    mdebug1("Remote server ready.");
-
-    /* Initialize queues */
-    client_queue = queue_init(AUTH_POOL);
-
-    if (config.timeout_sec || config.timeout_usec) {
-        minfo("Setting network timeout to %.6f sec.", config.timeout_sec + config.timeout_usec / 1000000.);
-    } else {
-        mdebug1("Network timeout is disabled.");
-    }
-
-    /* Connect via TCP */
-    remote_sock = OS_Bindporttcp(config.port, NULL, 0);
-    if (remote_sock <= 0) {
-        merror(BIND_ERROR, config.port, errno, strerror(errno));
-        exit(1);
-    }
-
-    while (running) {
-        memset(&_nc, 0, sizeof(_nc));
-        _ncl = sizeof(_nc);
-
-        // Wait for socket
-        FD_ZERO(&fdset);
-        FD_SET(remote_sock, &fdset);
-        timeout.tv_sec = 1;
-        timeout.tv_usec = 0;
-
-        switch (select(remote_sock + 1, &fdset, NULL, NULL, &timeout)) {
-        case -1:
-            if (errno != EINTR) {
-                merror_exit("at main(): select(): %s", strerror(errno));
-            }
-
-            continue;
-
-        case 0:
-            continue;
-        }
-
-        if ((client_sock = accept(remote_sock, (struct sockaddr *) &_nc, &_ncl)) > 0) {
-            if (config.timeout_sec || config.timeout_usec) {
-                if (OS_SetRecvTimeout(client_sock, config.timeout_sec, config.timeout_usec) < 0) {
-                    static int reported = 0;
-
-                    if (!reported) {
-                        int error = errno;
-                        merror("Could not set timeout to network socket: %s (%d)", strerror(error), error);
-                        reported = 1;
-                    }
-                }
-            }
-            struct client *new_client;
-            os_malloc(sizeof(struct client), new_client);
-            new_client->socket = client_sock;
-            new_client->addr = _nc.sin_addr;
-
-            if (queue_push_ex(client_queue, new_client) == -1) {
-                merror("Too many connections. Rejecting.");
-                close(client_sock);
-            }
-        } else if ((errno == EBADF && running) || (errno != EBADF && errno != EINTR))
-            merror("at main(): accept(): %s", strerror(errno));
-    }
-    queue_free(client_queue);
-    close(remote_sock);
 }
 
 /* Thread for dispatching connection pool */
@@ -592,14 +525,10 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
     char response[2048];
     response[2047] = '\0';
 
-    char * home_path = (char *)arg;
+    authd_sigblock();
 
-    /* Start SSL */
-    ctx = os_ssl_keys(1, home_path, config.ciphers, config.manager_cert, config.manager_key, config.agent_ca, config.flags.auto_negotiate);
-    if (!ctx) {
-        merror("SSL error. Exiting.");
-        exit(1);
-    }
+    /* Initialize some variables */
+    memset(ip, '\0', IPSIZE + 1);
 
     if (config.flags.use_password) {
         /* Checking if there is a custom password file */
@@ -620,9 +549,9 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
             fclose(fp);
         }
 
-        if (buf_p[0] != '\0')
+        if (buf_p[0] != '\0') {
             minfo("Accepting connections on port %hu. Using password specified on file: %s", config.port, AUTHD_PASS);
-        else {
+        } else {
             /* Getting temporary pass. */
             authpass = __generatetmppass();
             minfo("Accepting connections on port %hu. Random password chosen for agent authentication: %s", config.port, authpass);
@@ -631,20 +560,15 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
         minfo("Accepting connections on port %hu. No password required.", config.port);
     }
 
-    authd_sigblock();
-
-    /* Initialize some variables */
-    memset(ip, '\0', IPSIZE + 1);
-
     mdebug1("Dispatch thread ready.");
 
     while (running) {
         const struct timespec timeout = { .tv_sec = time(NULL) + 1 };
         struct client *client = queue_pop_ex_timedwait(client_queue, &timeout);
 
-
-        if (!client)
+        if (!client) {
             continue;
+        }
 
         strncpy(ip, inet_ntoa(client->addr), IPSIZE - 1);
         ssl = SSL_new(ctx);
@@ -698,17 +622,17 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
         char *centralized_group = NULL;
         char* new_id = NULL;
         char* new_key = NULL;
-        if(OS_SUCCESS == w_auth_parse_data(buf, response, authpass, ip, &agentname, &centralized_group)){
+        if (OS_SUCCESS == w_auth_parse_data(buf, response, authpass, ip, &agentname, &centralized_group)) {
             if (config.worker_node) {
                 minfo("Dispatching request to master node");
-                if( 0 == w_request_agent_add_clustered(response, agentname, ip, centralized_group, &new_id, &new_key, config.flags.force_insert?config.force_time:-1, NULL) ) {
+                if (0 == w_request_agent_add_clustered(response, agentname, ip, centralized_group, &new_id, &new_key, config.flags.force_insert?config.force_time:-1, NULL)) {
                     enrollment_ok = TRUE;
                 }
             }
             else {
                 w_mutex_lock(&mutex_keys);
-                if(OS_SUCCESS == w_auth_validate_data(response, ip, agentname, centralized_group)){
-                    if(OS_SUCCESS == w_auth_add_agent(response, ip, agentname, centralized_group, &new_id, &new_key)){
+                if (OS_SUCCESS == w_auth_validate_data(response, ip, agentname, centralized_group)) {
+                    if (OS_SUCCESS == w_auth_add_agent(response, ip, agentname, centralized_group, &new_id, &new_key)) {
                         enrollment_ok = TRUE;
                     }
                 }
@@ -716,7 +640,7 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
             }
         }
 
-        if(enrollment_ok)
+        if (enrollment_ok)
         {
             snprintf(response, 2048, "OSSEC K:'%s %s %s %s'", new_id, agentname, ip, new_key);
             minfo("Agent key generated for '%s' (requested by %s)", agentname, ip);
@@ -735,7 +659,7 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
                     }
                 }
             }
-            else{
+            else {
                 if (ret < 0) {
                     merror("SSL write error (%d)", ret);
                     merror("Agent key not saved for %s", agentname);
@@ -769,8 +693,78 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
         os_free(new_key);
     }
 
-    SSL_CTX_free(ctx);
     mdebug1("Dispatch thread finished");
+
+    SSL_CTX_free(ctx);
+    return NULL;
+}
+
+/* Thread for remote server */
+void* run_remote_server(__attribute__((unused)) void *arg) {
+    int client_sock = 0;
+    struct sockaddr_in _nc;
+    socklen_t _ncl;
+    fd_set fdset;
+    struct timeval timeout;
+
+    authd_sigblock();
+
+    if (config.timeout_sec || config.timeout_usec) {
+        minfo("Setting network timeout to %.6f sec.", config.timeout_sec + config.timeout_usec / 1000000.);
+    } else {
+        mdebug1("Network timeout is disabled.");
+    }
+
+    mdebug1("Remote server ready.");
+
+    while (running) {
+        memset(&_nc, 0, sizeof(_nc));
+        _ncl = sizeof(_nc);
+
+        // Wait for socket
+        FD_ZERO(&fdset);
+        FD_SET(remote_sock, &fdset);
+        timeout.tv_sec = 1;
+        timeout.tv_usec = 0;
+
+        switch (select(remote_sock + 1, &fdset, NULL, NULL, &timeout)) {
+        case -1:
+            if (errno != EINTR) {
+                merror_exit("at main(): select(): %s", strerror(errno));
+            }
+            continue;
+        case 0:
+            continue;
+        }
+
+        if ((client_sock = accept(remote_sock, (struct sockaddr *) &_nc, &_ncl)) > 0) {
+            if (config.timeout_sec || config.timeout_usec) {
+                if (OS_SetRecvTimeout(client_sock, config.timeout_sec, config.timeout_usec) < 0) {
+                    static int reported = 0;
+
+                    if (!reported) {
+                        int error = errno;
+                        merror("Could not set timeout to network socket: %s (%d)", strerror(error), error);
+                        reported = 1;
+                    }
+                }
+            }
+            struct client *new_client;
+            os_malloc(sizeof(struct client), new_client);
+            new_client->socket = client_sock;
+            new_client->addr = _nc.sin_addr;
+
+            if (queue_push_ex(client_queue, new_client) == -1) {
+                merror("Too many connections. Rejecting.");
+                close(client_sock);
+            }
+        } else if ((errno == EBADF && running) || (errno != EBADF && errno != EINTR))
+            merror("at main(): accept(): %s", strerror(errno));
+    }
+
+    mdebug1("Remote server thread finished");
+
+    close(remote_sock);
     return NULL;
 }
 
@@ -793,8 +787,9 @@ void* run_writer(__attribute__((unused)) void *arg) {
     while (running) {
         w_mutex_lock(&mutex_keys);
 
-        while (!write_pending && running)
+        while (!write_pending && running) {
             w_cond_wait(&cond_pending, &mutex_keys);
+        }
 
         copy_keys = OS_DupKeys(&keys);
         copy_insert = queue_insert;
@@ -806,8 +801,9 @@ void* run_writer(__attribute__((unused)) void *arg) {
         write_pending = 0;
         w_mutex_unlock(&mutex_keys);
 
-        if (OS_WriteKeys(copy_keys) < 0)
+        if (OS_WriteKeys(copy_keys) < 0) {
             merror("Couldn't write file client.keys");
+        }
 
         OS_FreeKeys(copy_keys);
         free(copy_keys);
@@ -817,8 +813,8 @@ void* run_writer(__attribute__((unused)) void *arg) {
             next = cur->next;
             OS_AddAgentTimestamp(cur->id, cur->name, cur->ip, cur_time);
 
-            if(cur->group){
-                if(set_agent_group(cur->id,cur->group) == -1){
+            if (cur->group) {
+                if (set_agent_group(cur->id,cur->group) == -1) {
                     merror("Unable to set agent centralized group: %s (internal error)", cur->group);
                 }
 

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -446,7 +446,7 @@ int main(int argc, char **argv)
     /* If remote enrollment is not enabled on the worker node, it goes to sleep */
     if (!config.flags.remote_enrollment && config.worker_node) {
         minfo("Port %hu was set as disabled. The deamon goes to sleep.", config.port);
-        while (FOREVER()) {
+        while (running) {
             sleep(1);
         }
         exit(0);


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/8616|

## Description

Added a new option that enables or disables the TLS port (1515 by default), but allows Authd to continue serving API and cluster requests.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Valgrind (memcheck and descriptor leaks check)
