### PR TITLE
Migrate sys_programs table to add pacman format

### DIFF
--- a/src/wazuh_db/schema_agents.sql
+++ b/src/wazuh_db/schema_agents.sql
@@ -352,7 +352,7 @@ CREATE INDEX IF NOT EXISTS cves_id ON vuln_cves (cve);
 
 BEGIN;
 
-INSERT INTO metadata (key, value) VALUES ('db_version', '7');
+INSERT INTO metadata (key, value) VALUES ('db_version', '8');
 INSERT INTO scan_info (module) VALUES ('fim');
 INSERT INTO scan_info (module) VALUES ('syscollector');
 INSERT INTO sync_info (component) VALUES ('fim');

--- a/src/wazuh_db/schema_upgrade_v8.sql
+++ b/src/wazuh_db/schema_upgrade_v8.sql
@@ -35,5 +35,6 @@ CREATE TABLE IF NOT EXISTS _sys_programs (
 INSERT INTO _sys_programs SELECT * FROM sys_programs;
 DROP TABLE IF EXISTS sys_programs;
 ALTER TABLE _sys_programs RENAME TO sys_programs;
+CREATE INDEX IF NOT EXISTS programs_id ON sys_programs (scan_id);
 
 INSERT OR REPLACE INTO metadata (key, value) VALUES ('db_version', 8);

--- a/src/wazuh_db/schema_upgrade_v8.sql
+++ b/src/wazuh_db/schema_upgrade_v8.sql
@@ -1,0 +1,39 @@
+/*
+ * SQL Schema for upgrading databases
+ * Copyright (C) 2015-2021, Wazuh Inc.
+ *
+ * May 21, 2021
+ *
+ * This program is a free software, you can redistribute it
+ * and/or modify it under the terms of GPLv2.
+*/
+
+CREATE TABLE IF NOT EXISTS _sys_programs (
+    scan_id INTEGER,
+    scan_time TEXT,
+    format TEXT NOT NULL CHECK (format IN ('pacman', 'deb', 'rpm', 'win', 'pkg')),
+    name TEXT,
+    priority TEXT,
+    section TEXT,
+    size INTEGER CHECK (size >= 0),
+    vendor TEXT,
+    install_time TEXT,
+    version TEXT,
+    architecture TEXT,
+    multiarch TEXT,
+    source TEXT,
+    description TEXT,
+    location TEXT,
+    triaged INTEGER(1),
+    cpe TEXT,
+    msu_name TEXT,
+    checksum TEXT NOT NULL CHECK (checksum <> ''),
+    item_id TEXT,
+    PRIMARY KEY (scan_id, name, version, architecture)
+);
+
+INSERT INTO _sys_programs SELECT * FROM sys_programs;
+DROP TABLE IF EXISTS sys_programs;
+ALTER TABLE _sys_programs RENAME TO sys_programs;
+
+INSERT OR REPLACE INTO metadata (key, value) VALUES ('db_version', 8);

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -284,6 +284,7 @@ extern char *schema_upgrade_v4_sql;
 extern char *schema_upgrade_v5_sql;
 extern char *schema_upgrade_v6_sql;
 extern char *schema_upgrade_v7_sql;
+extern char *schema_upgrade_v8_sql;
 extern char *schema_global_upgrade_v1_sql;
 extern char *schema_global_upgrade_v2_sql;
 

--- a/src/wazuh_db/wdb_upgrade.c
+++ b/src/wazuh_db/wdb_upgrade.c
@@ -37,7 +37,8 @@ wdb_t * wdb_upgrade(wdb_t *wdb) {
         schema_upgrade_v4_sql,
         schema_upgrade_v5_sql,
         schema_upgrade_v6_sql,
-        schema_upgrade_v7_sql
+        schema_upgrade_v7_sql,
+        schema_upgrade_v8_sql
     };
 
     char db_version[OS_SIZE_256 + 2];


### PR DESCRIPTION
|Related issue|
|---|
| #8763 |

## Description

This pull request adds the upgrade process for the `sys_programs` table of agents, so `pacman` packages are accepted as a valid format in managers upgrade from versions lower than 4.3.0.

The current database version has been bumped to 8.

## Logs/Alerts example

Once the manager is updated, the database gets this status:

*Schema is updated as expected*
```
sqlite> .schema sys_programs
CREATE TABLE IF NOT EXISTS "sys_programs" (    scan_id INTEGER,    scan_time TEXT,    format TEXT NOT NULL CHECK (format IN ('pacman', 'deb', 'rpm', 'win', 'pkg')),    name TEXT,    priority TEXT,    section TEXT,    size INTEGER CHECK (size >= 0),    vendor TEXT,    install_time TEXT,    version TEXT,    architecture TEXT,    multiarch TEXT,    source TEXT,    description TEXT,    location TEXT,    triaged INTEGER(1),    cpe TEXT,    msu_name TEXT,    checksum TEXT NOT NULL CHECK (checksum <> ''),    item_id TEXT,    PRIMARY KEY (scan_id, name, version, architecture));
```

*Packages are migrated*
```
sqlite> select count(*) from sys_programs;
1904
```

*Database version is updated to 8*
```
sqlite> select * from metadata;
db_version|8
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
