### PR TITLE
Adding vulnerability severity, score and detection time in insert/update function

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -53,7 +53,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_init_stmt_in_cache -Wl,--wrap,sqlite
                              -Wl,--wrap,wdb_exec_stmt -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,cJSON_Delete \
                              -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_CreateArray -Wl,--wrap,cJSON_CreateString -Wl,--wrap,cJSON_AddItemToObject \
                              -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_GetObjectItem -Wl,--wrap,wdb_exec_stmt_sized \
-                             -Wl,--wrap,wdb_exec_stmt_send -Wl,--wrap,wdbi_check_sync_status")
+                             -Wl,--wrap,wdb_exec_stmt_send -Wl,--wrap,wdbi_check_sync_status -Wl,--wrap,sqlite3_bind_double")
 
 
 list(APPEND wdb_tests_names "test_wdb_global_helpers")

--- a/src/unit_tests/wazuh_db/test_wdb_agents.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents.c
@@ -267,10 +267,13 @@ void test_wdb_agents_insert_vuln_cves_error_json(void **state) {
     const char* type = "PACKAGE";
     const char* status = "VALID";
     bool check_pkg_existence = true;
+    const char* severity = "Unknown";
+    double cvss2_score = 0.0;
+    double cvss3_score = 0.0;
 
     will_return(__wrap_cJSON_CreateObject, NULL);
 
-    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve, reference, type, status, check_pkg_existence);
+    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve, reference, type, status, check_pkg_existence, severity, cvss2_score, cvss3_score);
 
     assert_null(ret);
 }
@@ -286,6 +289,9 @@ void test_wdb_agents_insert_vuln_cves_success_pkg_not_found(void **state) {
     const char* type = "PACKAGE";
     const char* status = "VALID";
     bool check_pkg_existence = true;
+    const char* severity = "Unknown";
+    double cvss2_score = 0.0;
+    double cvss3_score = 0.0;
 
     will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
 
@@ -316,7 +322,7 @@ void test_wdb_agents_insert_vuln_cves_success_pkg_not_found(void **state) {
     expect_string(__wrap_cJSON_AddStringToObject, string, "PKG_NOT_FOUND");
     will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
 
-    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve, reference, type, status, check_pkg_existence);
+    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve, reference, type, status, check_pkg_existence, severity, cvss2_score, cvss3_score);
 
     assert_ptr_equal(1, ret);
 }
@@ -332,6 +338,9 @@ void test_wdb_agents_insert_vuln_cves_success_statement_init_fail(void **state) 
     const char* type = "PACKAGE";
     const char* status = "VALID";
     bool check_pkg_existence = true;
+    const char* severity = "Unknown";
+    double cvss2_score = 0.0;
+    double cvss3_score = 0.0;
 
     will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
 
@@ -365,7 +374,7 @@ void test_wdb_agents_insert_vuln_cves_success_statement_init_fail(void **state) 
     expect_string(__wrap_cJSON_AddStringToObject, string, "ERROR");
     will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
 
-    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve, reference, type, status, check_pkg_existence);
+    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve, reference, type, status, check_pkg_existence, severity, cvss2_score, cvss3_score);
 
     assert_ptr_equal(1, ret);
 }
@@ -381,6 +390,9 @@ void test_wdb_agents_insert_vuln_cves_success_statement_exec_fail(void **state) 
     const char* type = "PACKAGE";
     const char* status = "VALID";
     bool check_pkg_existence = true;
+    const char* severity = "Unknown";
+    double cvss2_score = 0.0;
+    double cvss3_score = 0.0;
 
     will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
 
@@ -424,6 +436,13 @@ void test_wdb_agents_insert_vuln_cves_success_statement_exec_fail(void **state) 
     expect_string(__wrap_sqlite3_bind_text, buffer, type);
     expect_value(__wrap_sqlite3_bind_text, pos, 7);
     expect_string(__wrap_sqlite3_bind_text, buffer, status);
+    expect_value(__wrap_sqlite3_bind_text, pos, 8);
+    expect_string(__wrap_sqlite3_bind_text, buffer, severity);
+    will_return_count(__wrap_sqlite3_bind_double, OS_SUCCESS, -1);
+    expect_value(__wrap_sqlite3_bind_double, index, 9);
+    expect_value(__wrap_sqlite3_bind_double, value, 0.0);
+    expect_value(__wrap_sqlite3_bind_double, index, 10);
+    expect_value(__wrap_sqlite3_bind_double, value, 0.0);
 
     will_return(__wrap_wdb_exec_stmt_silent, OS_INVALID);
 
@@ -434,7 +453,7 @@ void test_wdb_agents_insert_vuln_cves_success_statement_exec_fail(void **state) 
     expect_string(__wrap_cJSON_AddStringToObject, string, "ERROR");
     will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
 
-    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve, reference, type, status, check_pkg_existence);
+    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve, reference, type, status, check_pkg_existence, severity, cvss2_score, cvss3_score);
 
     assert_ptr_equal(1, ret);
 }
@@ -451,6 +470,9 @@ void test_wdb_agents_insert_vuln_cves_success_pkg_found(void **state) {
     const char* type = "PACKAGE";
     const char* status = "VALID";
     bool check_pkg_existence = true;
+    const char* severity = "Unknown";
+    double cvss2_score = 0.0;
+    double cvss3_score = 0.0;
 
     will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
 
@@ -494,6 +516,13 @@ void test_wdb_agents_insert_vuln_cves_success_pkg_found(void **state) {
     expect_string(__wrap_sqlite3_bind_text, buffer, type);
     expect_value(__wrap_sqlite3_bind_text, pos, 7);
     expect_string(__wrap_sqlite3_bind_text, buffer, status);
+    expect_value(__wrap_sqlite3_bind_text, pos, 8);
+    expect_string(__wrap_sqlite3_bind_text, buffer, severity);
+    will_return_count(__wrap_sqlite3_bind_double, OS_SUCCESS, -1);
+    expect_value(__wrap_sqlite3_bind_double, index, 9);
+    expect_value(__wrap_sqlite3_bind_double, value, 0.0);
+    expect_value(__wrap_sqlite3_bind_double, index, 10);
+    expect_value(__wrap_sqlite3_bind_double, value, 0.0);
 
     will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
 
@@ -501,7 +530,7 @@ void test_wdb_agents_insert_vuln_cves_success_pkg_found(void **state) {
     expect_string(__wrap_cJSON_AddStringToObject, string, "SUCCESS");
     will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
 
-    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve, reference, type, status, check_pkg_existence);
+    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve, reference, type, status, check_pkg_existence, severity, cvss2_score, cvss3_score);
 
     assert_ptr_equal(1, ret);
 }

--- a/src/unit_tests/wazuh_db/test_wdb_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_parser.c
@@ -1335,7 +1335,9 @@ void test_vuln_cves_insert_command_error(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     char *query = NULL;
 
-    os_strdup("insert {\"name\":\"package\",\"version\":\"2.2\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1500\",\"reference\":\"8549fd9faf9b124635298e9311ccf672c2ad05d1\",\"type\":\"PACKAGE\",\"status\":\"VALID\",\"check_pkg_existence\":true}", query);
+    os_strdup("insert {\"name\":\"package\",\"version\":\"2.2\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1500\","
+              "\"reference\":\"8549fd9faf9b124635298e9311ccf672c2ad05d1\",\"type\":\"PACKAGE\",\"status\":\"VALID\","
+              "\"check_pkg_existence\":true,\"severity\":null,\"cvss2_score\":0,\"cvss3_score\":0}", query);
 
     // wdb_parse_agents_insert_vuln_cves
     expect_string(__wrap_wdb_agents_insert_vuln_cves, name, "package");
@@ -1346,6 +1348,10 @@ void test_vuln_cves_insert_command_error(void **state) {
     expect_string(__wrap_wdb_agents_insert_vuln_cves, type, "PACKAGE");
     expect_string(__wrap_wdb_agents_insert_vuln_cves, status, "VALID");
     expect_value(__wrap_wdb_agents_insert_vuln_cves, check_pkg_existence, true);
+    expect_value(__wrap_wdb_agents_insert_vuln_cves, severity, NULL);
+    expect_value(__wrap_wdb_agents_insert_vuln_cves, cvss2_score, 0);
+    expect_value(__wrap_wdb_agents_insert_vuln_cves, cvss3_score, 0);
+
     will_return(__wrap_wdb_agents_insert_vuln_cves, NULL);
 
     expect_string(__wrap__mdebug1, formatted_msg, "Error inserting vulnerability in vuln_cves.");
@@ -1362,9 +1368,11 @@ void test_vuln_cves_insert_command_success(void **state) {
     int ret = OS_INVALID;
     test_struct_t *data  = (test_struct_t *)*state;
     char *query = NULL;
-    os_strdup("insert {\"name\":\"package\",\"version\":\"2.2\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1500\",\"reference\":\"8549fd9faf9b124635298e9311ccf672c2ad05d1\",\"type\":\"PACKAGE\",\"status\":\"VALID\",\"check_pkg_existence\":true}", query);
     char *result = NULL;
     os_strdup("[{\"test\":\"TEST\"}]", result);
+    os_strdup("insert {\"name\":\"package\",\"version\":\"2.2\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1500\","
+              "\"reference\":\"8549fd9faf9b124635298e9311ccf672c2ad05d1\",\"type\":\"PACKAGE\",\"status\":\"VALID\","
+              "\"check_pkg_existence\":true,\"severity\":\"MEDIUM\",\"cvss2_score\":5.2,\"cvss3_score\":6}", query);
 
     cJSON *test =  cJSON_CreateObject();
 
@@ -1377,6 +1385,9 @@ void test_vuln_cves_insert_command_success(void **state) {
     expect_string(__wrap_wdb_agents_insert_vuln_cves, type, "PACKAGE");
     expect_string(__wrap_wdb_agents_insert_vuln_cves, status, "VALID");
     expect_value(__wrap_wdb_agents_insert_vuln_cves, check_pkg_existence, true);
+    expect_string(__wrap_wdb_agents_insert_vuln_cves, severity, "MEDIUM");
+    expect_value(__wrap_wdb_agents_insert_vuln_cves, cvss2_score, 5.2);
+    expect_value(__wrap_wdb_agents_insert_vuln_cves, cvss3_score, 6);
     will_return(__wrap_wdb_agents_insert_vuln_cves, test);
     will_return(__wrap_cJSON_PrintUnformatted, result);
 

--- a/src/unit_tests/wrappers/externals/sqlite/sqlite3_wrappers.c
+++ b/src/unit_tests/wrappers/externals/sqlite/sqlite3_wrappers.c
@@ -73,6 +73,14 @@ int __wrap_sqlite3_bind_parameter_index(__attribute__((unused)) sqlite3_stmt * s
     return mock();
 }
 
+int __wrap_sqlite3_bind_double(__attribute__((unused)) sqlite3_stmt* stmt,
+                        int index,
+                        double value) {
+    check_expected(index);
+    check_expected(value);
+
+    return mock();
+}
 
 int __wrap_sqlite3_clear_bindings(__attribute__((unused)) sqlite3_stmt* pStmt) {
     return mock();

--- a/src/unit_tests/wrappers/externals/sqlite/sqlite3_wrappers.c
+++ b/src/unit_tests/wrappers/externals/sqlite/sqlite3_wrappers.c
@@ -74,8 +74,8 @@ int __wrap_sqlite3_bind_parameter_index(__attribute__((unused)) sqlite3_stmt * s
 }
 
 int __wrap_sqlite3_bind_double(__attribute__((unused)) sqlite3_stmt* stmt,
-                        int index,
-                        double value) {
+                               int index,
+                               double value) {
     check_expected(index);
     check_expected(value);
 

--- a/src/unit_tests/wrappers/externals/sqlite/sqlite3_wrappers.h
+++ b/src/unit_tests/wrappers/externals/sqlite/sqlite3_wrappers.h
@@ -36,6 +36,10 @@ void expect_sqlite3_bind_text_call(int position, const char *buf, int ret);
 int __wrap_sqlite3_bind_parameter_index(__attribute__((unused)) sqlite3_stmt * stmt,
                                         const char *zName);
 
+int __wrap_sqlite3_bind_double(__attribute__((unused)) sqlite3_stmt* stmt,
+                        int index,
+                        double value);
+
 int __wrap_sqlite3_clear_bindings(sqlite3_stmt* pStmt);
 
 int __wrap_sqlite3_close_v2();

--- a/src/unit_tests/wrappers/externals/sqlite/sqlite3_wrappers.h
+++ b/src/unit_tests/wrappers/externals/sqlite/sqlite3_wrappers.h
@@ -37,8 +37,8 @@ int __wrap_sqlite3_bind_parameter_index(__attribute__((unused)) sqlite3_stmt * s
                                         const char *zName);
 
 int __wrap_sqlite3_bind_double(__attribute__((unused)) sqlite3_stmt* stmt,
-                        int index,
-                        double value);
+                               int index,
+                               double value);
 
 int __wrap_sqlite3_clear_bindings(sqlite3_stmt* pStmt);
 

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.c
@@ -29,7 +29,10 @@ cJSON* __wrap_wdb_agents_insert_vuln_cves(__attribute__((unused)) wdb_t *wdb,
                                           const char* reference,
                                           const char* type,
                                           const char* status,
-                                          bool check_pkg_existence) {
+                                          bool check_pkg_existence,
+                                          const char* severity,
+                                          double cvss2_score,
+                                          double cvss3_score) {
     check_expected(name);
     check_expected(version);
     check_expected(architecture);
@@ -38,6 +41,10 @@ cJSON* __wrap_wdb_agents_insert_vuln_cves(__attribute__((unused)) wdb_t *wdb,
     check_expected(type);
     check_expected(status);
     check_expected(check_pkg_existence);
+    check_expected(severity);
+    check_expected(cvss2_score);
+    check_expected(cvss3_score);
+
     return mock_ptr_type(cJSON*);
 }
 

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.h
@@ -23,7 +23,10 @@ cJSON* __wrap_wdb_agents_insert_vuln_cves(wdb_t *wdb,
                                           const char* reference,
                                           const char* type,
                                           const char* status,
-                                          bool check_pkg_existence);
+                                          bool check_pkg_existence,
+                                          const char* severity,
+                                          double cvss2_score,
+                                          double cvss3_score);
 int __wrap_wdb_agents_update_vuln_cves_status(wdb_t *wdb, const char* old_status, const char* new_status, const char* type);
 int __wrap_wdb_agents_remove_vuln_cves(wdb_t *wdb, const char* cve, const char* reference);
 wdbc_result __wrap_wdb_agents_remove_vuln_cves_by_status(wdb_t *wdb, const char* status, char **output);

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -222,7 +222,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_SYSCOLLECTOR_OSINFO_DELETE_AROUND] = "DELETE FROM sys_osinfo WHERE os_name < ? OR os_name > ? OR checksum = 'legacy' OR checksum = '';",
     [WDB_STMT_SYSCOLLECTOR_OSINFO_DELETE_RANGE] = "DELETE FROM sys_osinfo WHERE os_name > ? AND os_name < ?;",
     [WDB_STMT_SYSCOLLECTOR_OSINFO_CLEAR] = "DELETE FROM sys_osinfo;",
-    [WDB_STMT_VULN_CVES_INSERT] = "INSERT OR REPLACE INTO vuln_cves (name, version, architecture, cve, reference, type, status) VALUES (?,?,?,?,?,?,?);",
+    [WDB_STMT_VULN_CVES_INSERT] = "INSERT OR REPLACE INTO vuln_cves (name, version, architecture, cve, reference, type, status, severity, cvss2_score, cvss3_score, first_detection) VALUES (?,?,?,?,?,?,?,?,?,?,strftime('%s', 'now'));",
     [WDB_STMT_VULN_CVES_CLEAR] = "DELETE FROM vuln_cves;",
     [WDB_STMT_VULN_CVES_UPDATE] = "UPDATE vuln_cves SET status = ? WHERE status = ?;",
     [WDB_STMT_VULN_CVES_UPDATE_BY_TYPE] = "UPDATE vuln_cves SET status = ? WHERE type = ?;",

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -222,7 +222,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_SYSCOLLECTOR_OSINFO_DELETE_AROUND] = "DELETE FROM sys_osinfo WHERE os_name < ? OR os_name > ? OR checksum = 'legacy' OR checksum = '';",
     [WDB_STMT_SYSCOLLECTOR_OSINFO_DELETE_RANGE] = "DELETE FROM sys_osinfo WHERE os_name > ? AND os_name < ?;",
     [WDB_STMT_SYSCOLLECTOR_OSINFO_CLEAR] = "DELETE FROM sys_osinfo;",
-    [WDB_STMT_VULN_CVES_INSERT] = "INSERT OR REPLACE INTO vuln_cves (name, version, architecture, cve, reference, type, status, severity, cvss2_score, cvss3_score, detection_time) VALUES (?,?,?,?,?,?,?,?,?,?,strftime('%s', 'now'));",
+    [WDB_STMT_VULN_CVES_INSERT] = "INSERT INTO vuln_cves (name, version, architecture, cve, reference, type, status, severity, cvss2_score, cvss3_score, detection_time) VALUES (?,?,?,?,?,?,?,?,?,?,strftime('%s', 'now'));",
     [WDB_STMT_VULN_CVES_CLEAR] = "DELETE FROM vuln_cves;",
     [WDB_STMT_VULN_CVES_UPDATE] = "UPDATE vuln_cves SET status = ? WHERE status = ?;",
     [WDB_STMT_VULN_CVES_UPDATE_BY_TYPE] = "UPDATE vuln_cves SET status = ? WHERE type = ?;",

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -222,7 +222,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_SYSCOLLECTOR_OSINFO_DELETE_AROUND] = "DELETE FROM sys_osinfo WHERE os_name < ? OR os_name > ? OR checksum = 'legacy' OR checksum = '';",
     [WDB_STMT_SYSCOLLECTOR_OSINFO_DELETE_RANGE] = "DELETE FROM sys_osinfo WHERE os_name > ? AND os_name < ?;",
     [WDB_STMT_SYSCOLLECTOR_OSINFO_CLEAR] = "DELETE FROM sys_osinfo;",
-    [WDB_STMT_VULN_CVES_INSERT] = "INSERT OR REPLACE INTO vuln_cves (name, version, architecture, cve, reference, type, status, severity, cvss2_score, cvss3_score, first_detection) VALUES (?,?,?,?,?,?,?,?,?,?,strftime('%s', 'now'));",
+    [WDB_STMT_VULN_CVES_INSERT] = "INSERT OR REPLACE INTO vuln_cves (name, version, architecture, cve, reference, type, status, severity, cvss2_score, cvss3_score, detection_time) VALUES (?,?,?,?,?,?,?,?,?,?,strftime('%s', 'now'));",
     [WDB_STMT_VULN_CVES_CLEAR] = "DELETE FROM vuln_cves;",
     [WDB_STMT_VULN_CVES_UPDATE] = "UPDATE vuln_cves SET status = ? WHERE status = ?;",
     [WDB_STMT_VULN_CVES_UPDATE_BY_TYPE] = "UPDATE vuln_cves SET status = ? WHERE type = ?;",

--- a/src/wazuh_db/wdb_agents.c
+++ b/src/wazuh_db/wdb_agents.c
@@ -101,7 +101,6 @@ cJSON* wdb_agents_insert_vuln_cves(wdb_t *wdb,
 
     if (wdb_agents_find_cve(wdb, cve, reference)) {
         cJSON_AddStringToObject(result, "action", "UPDATE");
-        insert = FALSE;
     }
     else {
         cJSON_AddStringToObject(result, "action", "INSERT");

--- a/src/wazuh_db/wdb_agents.c
+++ b/src/wazuh_db/wdb_agents.c
@@ -88,8 +88,12 @@ cJSON* wdb_agents_insert_vuln_cves(wdb_t *wdb,
                                    const char* reference,
                                    const char* type,
                                    const char* status,
-                                   bool check_pkg_existence) {
+                                   bool check_pkg_existence,
+                                   const char* severity,
+                                   double cvss2_score,
+                                   double cvss3_score) {
 
+    bool insert = FALSE;
     cJSON* result = cJSON_CreateObject();
     if (!result) {
         return NULL;
@@ -97,15 +101,17 @@ cJSON* wdb_agents_insert_vuln_cves(wdb_t *wdb,
 
     if (wdb_agents_find_cve(wdb, cve, reference)) {
         cJSON_AddStringToObject(result, "action", "UPDATE");
+        insert = FALSE;
     }
     else {
         cJSON_AddStringToObject(result, "action", "INSERT");
+        insert = TRUE;
     }
 
     if (check_pkg_existence && !wdb_agents_find_package(wdb, reference)) {
         cJSON_AddStringToObject(result, "status", "PKG_NOT_FOUND");
     }
-    else {
+    else if (insert){
         sqlite3_stmt* stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_VULN_CVES_INSERT);
 
         if (stmt) {
@@ -116,6 +122,9 @@ cJSON* wdb_agents_insert_vuln_cves(wdb_t *wdb,
             sqlite3_bind_text(stmt, 5, reference, -1, NULL);
             sqlite3_bind_text(stmt, 6, type, -1, NULL);
             sqlite3_bind_text(stmt, 7, status, -1, NULL);
+            sqlite3_bind_text(stmt, 8, severity, -1, NULL);
+            sqlite3_bind_double(stmt, 9, cvss2_score);
+            sqlite3_bind_double(stmt, 10, cvss3_score);
 
             if (OS_SUCCESS == wdb_exec_stmt_silent(stmt)) {
                 cJSON_AddStringToObject(result, "status", "SUCCESS");

--- a/src/wazuh_db/wdb_agents.h
+++ b/src/wazuh_db/wdb_agents.h
@@ -62,6 +62,9 @@ bool wdb_agents_find_cve(wdb_t *wdb, const char* cve, const char* reference);
  * @param [in] type The package type.
  * @param [in] status The vulnerability status.
  * @param [in] check_pkg_existence If TRUE, it enables a package existence verification in sys_programs table.
+ * @param [in] severity A string representing the severity of the vulnerability.
+ * @param [in] cvss2_score The vulnerability score according to CVSS v2.
+ * @param [in] cvss3_score The vulnerability score according to CVSS v3.
  * @return Returns cJSON object with 'action': 'INSERT' | 'UPDATE'.
  *                               and 'status': 'SUCCESS' | 'ERROR' | 'PKG_NOT_FOUND'
  *         The cJSON object must be freed by the caller.
@@ -74,7 +77,10 @@ cJSON* wdb_agents_insert_vuln_cves(wdb_t *wdb,
                                    const char* reference,
                                    const char* type,
                                    const char* status,
-                                   bool check_pkg_existence);
+                                   bool check_pkg_existence,
+                                   const char* severity,
+                                   double cvss2_score,
+                                   double cvss3_score);
 
 /**
  * @brief Function to update the status field in agent database vuln_cves table.

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5963,6 +5963,9 @@ int wdb_parse_agents_insert_vuln_cves(wdb_t* wdb, char* input, char* output) {
         cJSON* j_type = cJSON_GetObjectItem(data, "type");
         cJSON* j_status = cJSON_GetObjectItem(data, "status");
         cJSON* j_check_pkg_existence = cJSON_GetObjectItem(data, "check_pkg_existence");
+        cJSON* j_severity = cJSON_GetObjectItem(data, "severity");
+        cJSON* j_cvss2_score = cJSON_GetObjectItem(data, "cvss2_score");
+        cJSON* j_cvss3_score = cJSON_GetObjectItem(data, "cvss3_score");
         // Required fields
         if (!cJSON_IsString(j_name) || !cJSON_IsString(j_version) || !cJSON_IsString(j_architecture) ||!cJSON_IsString(j_cve) ||
             !cJSON_IsString(j_reference) || !cJSON_IsString(j_type) || !cJSON_IsString(j_status) ||!cJSON_IsBool(j_check_pkg_existence)) {
@@ -5971,7 +5974,9 @@ int wdb_parse_agents_insert_vuln_cves(wdb_t* wdb, char* input, char* output) {
         }
         else {
             cJSON* result = wdb_agents_insert_vuln_cves(wdb, j_name->valuestring, j_version->valuestring, j_architecture->valuestring, j_cve->valuestring,
-                                            j_reference->valuestring, j_type->valuestring, j_status->valuestring, (bool)j_check_pkg_existence->valueint);
+                                            j_reference->valuestring, j_type->valuestring, j_status->valuestring, (bool)j_check_pkg_existence->valueint,
+                                            cJSON_GetStringValue(j_severity), cJSON_IsNumber(j_cvss2_score) ? j_cvss2_score->valuedouble : 0,
+                                            cJSON_IsNumber(j_cvss3_score) ? j_cvss3_score->valuedouble : 0);
 
             if (result) {
                 char *out = cJSON_PrintUnformatted(result);

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5973,10 +5973,10 @@ int wdb_parse_agents_insert_vuln_cves(wdb_t* wdb, char* input, char* output) {
             snprintf(output, OS_MAXSTR + 1, "err Invalid JSON data, missing required fields");
         }
         else {
-            cJSON* result = wdb_agents_insert_vuln_cves(wdb, j_name->valuestring, j_version->valuestring, j_architecture->valuestring, j_cve->valuestring,
-                                            j_reference->valuestring, j_type->valuestring, j_status->valuestring, (bool)j_check_pkg_existence->valueint,
-                                            cJSON_GetStringValue(j_severity), cJSON_IsNumber(j_cvss2_score) ? j_cvss2_score->valuedouble : 0,
-                                            cJSON_IsNumber(j_cvss3_score) ? j_cvss3_score->valuedouble : 0);
+            cJSON* result = wdb_agents_insert_vuln_cves(wdb, cJSON_GetStringValue(j_name), cJSON_GetStringValue(j_version), cJSON_GetStringValue(j_architecture), cJSON_GetStringValue(j_cve),
+                                                        cJSON_GetStringValue(j_reference), cJSON_GetStringValue(j_type), cJSON_GetStringValue(j_status), (bool)j_check_pkg_existence->valueint,
+                                                        cJSON_GetStringValue(j_severity), cJSON_IsNumber(j_cvss2_score) ? j_cvss2_score->valuedouble : 0,
+                                                        cJSON_IsNumber(j_cvss3_score) ? j_cvss3_score->valuedouble : 0);
 
             if (result) {
                 char *out = cJSON_PrintUnformatted(result);


### PR DESCRIPTION
|Related issue|
|---|
|#8772|

## Description

This PR updates `wdb_agents_insert_vuln_cves` method with new parameters:
- **severity**
- **cvss2_score**
- **cvss3_score**

Also, the query inserts a timestamp for every detected vulnerability.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)
