### PR TITLE
Added Darwin's SCA and updated other template folder

### DIFF
--- a/etc/templates/config/centos/8/rootcheck.agent.template
+++ b/etc/templates/config/centos/8/rootcheck.agent.template
@@ -1,0 +1,19 @@
+  <!-- Policy monitoring -->
+  <rootcheck>
+    <disabled>no</disabled>
+    <check_files>yes</check_files>
+    <check_trojans>yes</check_trojans>
+    <check_dev>yes</check_dev>
+    <check_sys>yes</check_sys>
+    <check_pids>yes</check_pids>
+    <check_ports>yes</check_ports>
+    <check_if>yes</check_if>
+
+    <!-- Frequency that rootcheck is executed - every 12 hours -->
+    <frequency>43200</frequency>
+
+    <rootkit_files>etc/shared/rootkit_files.txt</rootkit_files>
+    <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
+
+    <skip_nfs>yes</skip_nfs>
+  </rootcheck>

--- a/etc/templates/config/centos/8/rootcheck.manager.template
+++ b/etc/templates/config/centos/8/rootcheck.manager.template
@@ -1,0 +1,19 @@
+  <!-- Policy monitoring -->
+  <rootcheck>
+    <disabled>no</disabled>
+    <check_files>yes</check_files>
+    <check_trojans>yes</check_trojans>
+    <check_dev>yes</check_dev>
+    <check_sys>yes</check_sys>
+    <check_pids>yes</check_pids>
+    <check_ports>yes</check_ports>
+    <check_if>yes</check_if>
+
+    <!-- Frequency that rootcheck is executed - every 12 hours -->
+    <frequency>43200</frequency>
+
+    <rootkit_files>etc/rootcheck/rootkit_files.txt</rootkit_files>
+    <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
+
+    <skip_nfs>yes</skip_nfs>
+  </rootcheck>

--- a/etc/templates/config/centos/8/sca.files
+++ b/etc/templates/config/centos/8/sca.files
@@ -1,0 +1,1 @@
+centos/8/cis_centos8_linux.yml

--- a/etc/templates/config/darwin/sca.files
+++ b/etc/templates/config/darwin/sca.files
@@ -1,0 +1,1 @@
+darwin/20/cis_apple_macOS_11.1.yml

--- a/etc/templates/config/debian/10/rootcheck.agent.template
+++ b/etc/templates/config/debian/10/rootcheck.agent.template
@@ -1,0 +1,19 @@
+  <!-- Policy monitoring -->
+  <rootcheck>
+    <disabled>no</disabled>
+    <check_files>yes</check_files>
+    <check_trojans>yes</check_trojans>
+    <check_dev>yes</check_dev>
+    <check_sys>yes</check_sys>
+    <check_pids>yes</check_pids>
+    <check_ports>yes</check_ports>
+    <check_if>yes</check_if>
+
+    <!-- Frequency that rootcheck is executed - every 12 hours -->
+    <frequency>43200</frequency>
+
+    <rootkit_files>etc/shared/rootkit_files.txt</rootkit_files>
+    <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
+
+    <skip_nfs>yes</skip_nfs>
+  </rootcheck>

--- a/etc/templates/config/debian/10/rootcheck.manager.template
+++ b/etc/templates/config/debian/10/rootcheck.manager.template
@@ -1,0 +1,19 @@
+  <!-- Policy monitoring -->
+  <rootcheck>
+    <disabled>no</disabled>
+    <check_files>yes</check_files>
+    <check_trojans>yes</check_trojans>
+    <check_dev>yes</check_dev>
+    <check_sys>yes</check_sys>
+    <check_pids>yes</check_pids>
+    <check_ports>yes</check_ports>
+    <check_if>yes</check_if>
+
+    <!-- Frequency that rootcheck is executed - every 12 hours -->
+    <frequency>43200</frequency>
+
+    <rootkit_files>etc/rootcheck/rootkit_files.txt</rootkit_files>
+    <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
+
+    <skip_nfs>yes</skip_nfs>
+  </rootcheck>

--- a/etc/templates/config/debian/10/sca.files
+++ b/etc/templates/config/debian/10/sca.files
@@ -1,0 +1,1 @@
+debian/cis_debian10.yml

--- a/etc/templates/config/generic/sca.manager.files
+++ b/etc/templates/config/generic/sca.manager.files
@@ -13,6 +13,9 @@ centos/8/cis_centos8_linux.yml
 darwin/15/cis_apple_macOS_10.11.yml
 darwin/16/cis_apple_macOS_10.12.yml
 darwin/17/cis_apple_macOS_10.13.yml
+darwin/18/cis_apple_macOS_10.14.yml
+darwin/19/cis_apple_macOS_10.15.yml
+darwin/20/cis_apple_macOS_11.1.yml
 debian/cis_debian7.yml
 debian/cis_debian8.yml
 debian/cis_debian9.yml

--- a/etc/templates/config/rhel/8/rootcheck.agent.template
+++ b/etc/templates/config/rhel/8/rootcheck.agent.template
@@ -1,0 +1,19 @@
+  <!-- Policy monitoring -->
+  <rootcheck>
+    <disabled>no</disabled>
+    <check_files>yes</check_files>
+    <check_trojans>yes</check_trojans>
+    <check_dev>yes</check_dev>
+    <check_sys>yes</check_sys>
+    <check_pids>yes</check_pids>
+    <check_ports>yes</check_ports>
+    <check_if>yes</check_if>
+
+    <!-- Frequency that rootcheck is executed - every 12 hours -->
+    <frequency>43200</frequency>
+
+    <rootkit_files>etc/shared/rootkit_files.txt</rootkit_files>
+    <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
+
+    <skip_nfs>yes</skip_nfs>
+  </rootcheck>

--- a/etc/templates/config/rhel/8/rootcheck.manager.template
+++ b/etc/templates/config/rhel/8/rootcheck.manager.template
@@ -1,0 +1,19 @@
+  <!-- Policy monitoring -->
+  <rootcheck>
+    <disabled>no</disabled>
+    <check_files>yes</check_files>
+    <check_trojans>yes</check_trojans>
+    <check_dev>yes</check_dev>
+    <check_sys>yes</check_sys>
+    <check_pids>yes</check_pids>
+    <check_ports>yes</check_ports>
+    <check_if>yes</check_if>
+
+    <!-- Frequency that rootcheck is executed - every 12 hours -->
+    <frequency>43200</frequency>
+
+    <rootkit_files>etc/rootcheck/rootkit_files.txt</rootkit_files>
+    <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
+
+    <skip_nfs>yes</skip_nfs>
+  </rootcheck>

--- a/etc/templates/config/rhel/8/sca.files
+++ b/etc/templates/config/rhel/8/sca.files
@@ -1,0 +1,1 @@
+rhel/8/cis_rhel8_linux.yml

--- a/etc/templates/config/sles/12/sca.files
+++ b/etc/templates/config/sles/12/sca.files
@@ -1,0 +1,1 @@
+sles/12/cis_sles12_linux.yml


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR updates and adds some templates to the existing SCA.

It adds the Centos 8 folder template for SCA.
Sets the default Darwin SCA to Darwin 20.
Adds the Debian 10 folder.
Adds to the `sca.manager.files` the versions of Darwin from 18 to 20.
Adds the Rhel 8 folder.
Sets as default Sels, the 12 version.
