### PR TITLE
Let FIM add realtime directories if the limit is no longer reached

### DIFF
--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -161,10 +161,11 @@ typedef struct whodata_dir_status whodata_dir_status;
 #endif
 
 typedef struct _rtfim {
-    int fd;
     unsigned int queue_overflow:1;
     OSHash *dirtb;
-#ifdef WIN32
+#ifndef WIN32
+    int fd;
+#else
     HANDLE evt;
 #endif
 } rtfim;
@@ -402,7 +403,7 @@ typedef struct _config {
     registry_ignore *value_ignore;                     /* List of registry values to ignore*/
     registry_ignore_regex *value_ignore_regex;         /* Regex of registry values to ignore */
     registry *registry;                                /* array of registry entries to be scanned */
-    int max_fd_win_rt;                                 /* Maximum number of descriptors in realtime */
+    unsigned int max_fd_win_rt;                        /* Maximum number of descriptors in realtime */
     whodata wdata;
     registry *registry_nodiff;                         /* list of values/registries to never output diff */
     registry_ignore_regex *registry_nodiff_regex;      /* regex of values/registries to never output diff */

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -397,7 +397,7 @@ typedef struct _config {
 
     /* Windows only registry checking */
 #ifdef WIN32
-    char realtime_change;                              /* Variable to activate the change to realtime from a whodata monitoring*/
+    unsigned int realtime_change:1;                    /* Variable to activate the change to realtime from a whodata monitoring*/
     registry_ignore *key_ignore;                       /* List of registry keys to ignore */
     registry_ignore_regex *key_ignore_regex;           /* Regex of registry keys to ignore */
     registry_ignore *value_ignore;                     /* List of registry values to ignore*/

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -160,15 +160,31 @@ typedef enum fdb_stmt {
 typedef struct whodata_dir_status whodata_dir_status;
 #endif
 
+#ifndef WIN32
 typedef struct _rtfim {
     unsigned int queue_overflow:1;
     OSHash *dirtb;
-#ifndef WIN32
     int fd;
-#else
-    HANDLE evt;
-#endif
 } rtfim;
+
+#else
+
+typedef struct _rtfim {
+    unsigned int queue_overflow:1;
+    OSHash *dirtb;
+    HANDLE evt;
+} rtfim;
+
+typedef struct _win32rtfim {
+    HANDLE h;
+    OVERLAPPED overlap;
+
+    char *dir;
+    TCHAR buffer[65536];
+    unsigned int watch_status;
+} win32rtfim;
+
+#endif
 
 typedef enum fim_type {FIM_TYPE_FILE, FIM_TYPE_REGISTRY} fim_type;
 
@@ -362,6 +378,7 @@ typedef struct _config {
     unsigned int enable_whodata:1;  /* At least one directory configured with whodata */
     unsigned int enable_synchronization:1;    /* Enable database synchronization */
     unsigned int enable_registry_synchronization:1; /* Enable registry database synchronization */
+    unsigned int realtime_change:1;                    /* Variable to activate the change to realtime from a whodata monitoring*/
 
     OSList *directories;            /* List of directories to be monitored */
     OSList *wildcards;              /* List of wildcards to be monitored */
@@ -397,7 +414,6 @@ typedef struct _config {
 
     /* Windows only registry checking */
 #ifdef WIN32
-    unsigned int realtime_change:1;                    /* Variable to activate the change to realtime from a whodata monitoring*/
     registry_ignore *key_ignore;                       /* List of registry keys to ignore */
     registry_ignore_regex *key_ignore_regex;           /* Regex of registry keys to ignore */
     registry_ignore *value_ignore;                     /* List of registry values to ignore*/

--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -260,6 +260,8 @@
 #define FIM_WILDCARDS_UPDATE_START          "(6361): Starting configuration wildcards update."
 #define FIM_WILDCARDS_REMOVE_DIRECTORY      "(6362): Removing entry '%s' due to it has not been expanded by the wildcards"
 #define FIM_WILDCARDS_UPDATE_FINALIZE       "(6363): Configuration wildcards update finalize."
+#define FIM_REALTIME_MAXNUM_WATCHES         "(6364): Unable to add directory to real time monitoring: '%s' - Maximum size permitted."
+
 
 /* Modules messages */
 #define WM_UPGRADE_RESULT_AGENT_INFO         "(8151): Agent Information obtained: '%s'"

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -426,7 +426,7 @@
 #define FIM_ERROR_REALTIME_WINDOWS_CALLBACK         "(6613): Real time Windows callback process: '%s' (%lx)."
 #define FIM_ERROR_REALTIME_WINDOWS_CALLBACK_EMPTY   "(6614): Real time call back called, but hash is empty."
 #define FIM_ERROR_UPDATE_ENTRY                      "(6615): Can't update entry invalid file '%s'."
-#define FIM_ERROR_REALTIME_MAXNUM_WATCHES           "(6616): Unable to add directory to real time monitoring: '%s' - Maximum size permitted."
+
 #define FIM_ERROR_AUDIT_MODE                        "(6617): Unable to get audit mode: %s (%d)."
 #define FIM_ERROR_REALTIME_INITIALIZE               "(6618): Unable to initialize real time file monitoring."
 #define FIM_ERROR_WHODATA_ADD_DIRECTORY             "(6619): Unable to add directory to whodata real time monitoring: '%s'. It will be monitored in Realtime"

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -149,7 +149,7 @@ int Read_Syscheck_Config(const char *cfgfile)
     if ((OSList_GetFirstNode(syscheck.directories) == NULL) && (syscheck.registry[0].entry == NULL && syscheck.wildcards == NULL)) {
         return (1);
     }
-    syscheck.max_fd_win_rt = getDefine_Int("syscheck", "max_fd_win_rt", 1, 1024);
+    syscheck.max_fd_win_rt = (unsigned int) getDefine_Int("syscheck", "max_fd_win_rt", 1, 1024);
 #endif
 
     return (0);

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -268,7 +268,7 @@ time_t fim_scan() {
                 realtime_sanitize_watch_map();
                 syscheck.realtime->queue_overflow = false;
             }
-            mdebug2(FIM_NUM_WATCHES, syscheck.realtime->dirtb->elements);
+            mdebug2(FIM_NUM_WATCHES, OSHash_Get_Elem_ex(syscheck.realtime->dirtb));
         }
         w_mutex_unlock(&syscheck.fim_realtime_mutex);
     }

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -392,7 +392,7 @@ void * fim_run_realtime(__attribute__((unused)) void * args) {
                     realtime_sanitize_watch_map();
                     syscheck.realtime->queue_overflow = false;
                 }
-                mdebug2(FIM_NUM_WATCHES, syscheck.realtime->dirtb->elements);
+                mdebug2(FIM_NUM_WATCHES, OSHash_Get_Elem_ex(syscheck.realtime->dirtb));
             }
         }
         w_mutex_unlock(&syscheck.fim_realtime_mutex);

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -350,28 +350,15 @@ void start_daemon()
 }
 // LCOV_EXCL_STOP
 
-
-// LCOV_EXCL_START
 // Starting Real-time thread
-#ifdef WIN32
+#if defined WIN32
 DWORD WINAPI fim_run_realtime(__attribute__((unused)) void * args) {
-#else
-void * fim_run_realtime(__attribute__((unused)) void * args) {
-#endif
-
-#if defined INOTIFY_ENABLED || defined WIN32
-    static int _base_line = 0;
-    int nfds = -1;
-
-#ifdef WIN32
     directory_t *dir_it;
     OSListNode *node_it;
 
+    int _base_line = 0;
     set_priority_windows_thread();
-#endif
-
-    while (1) {
-#ifdef WIN32
+    while (FOREVER()) {
         // Directories in Windows configured with real-time add recursive watches
         w_rwlock_wrlock(&syscheck.directories_lock);
         OSList_foreach(node_it, syscheck.directories) {
@@ -381,17 +368,11 @@ void * fim_run_realtime(__attribute__((unused)) void * args) {
             }
         }
         w_rwlock_unlock(&syscheck.directories_lock);
-#endif
 
         w_mutex_lock(&syscheck.fim_realtime_mutex);
         if (_base_line == 0) {
             _base_line = 1;
-
             if (syscheck.realtime != NULL) {
-                if (syscheck.realtime->queue_overflow) {
-                    realtime_sanitize_watch_map();
-                    syscheck.realtime->queue_overflow = false;
-                }
                 mdebug2(FIM_NUM_WATCHES, OSHash_Get_Elem_ex(syscheck.realtime->dirtb));
             }
         }
@@ -403,6 +384,34 @@ void * fim_run_realtime(__attribute__((unused)) void * args) {
         }
 #endif
         w_mutex_lock(&syscheck.fim_realtime_mutex);
+        if (syscheck.realtime && OSHash_Get_Elem_ex(syscheck.realtime->dirtb) > 0) {
+            log_realtime_status(1);
+
+            if (WaitForSingleObjectEx(syscheck.realtime->evt, SYSCHECK_WAIT * 1000, TRUE) == WAIT_FAILED) {
+                merror(FIM_ERROR_REALTIME_WAITSINGLE_OBJECT);
+            }
+        } else {
+            sleep(SYSCHECK_WAIT);
+        }
+        w_mutex_unlock(&syscheck.fim_realtime_mutex);
+
+    }
+}
+
+#elif defined INOTIFY_ENABLED
+void *fim_run_realtime(__attribute__((unused)) void * args) {
+    int _base_line = 0;
+    int nfds = -1;
+
+    while (FOREVER()) {
+        w_mutex_lock(&syscheck.fim_realtime_mutex);
+        if (_base_line == 0) {
+            _base_line = 1;
+            if (syscheck.realtime != NULL) {
+                mdebug2(FIM_NUM_WATCHES, OSHash_Get_Elem_ex(syscheck.realtime->dirtb));
+            }
+        }
+
         if (syscheck.realtime && (syscheck.realtime->fd >= 0)) {
             nfds = syscheck.realtime->fd;
         }
@@ -410,7 +419,6 @@ void * fim_run_realtime(__attribute__((unused)) void * args) {
 
         if (nfds >= 0) {
             log_realtime_status(1);
-#ifdef INOTIFY_ENABLED
             struct timeval selecttime;
             fd_set rfds;
             int run_now = 0;
@@ -436,17 +444,14 @@ void * fim_run_realtime(__attribute__((unused)) void * args) {
                 realtime_process();
             }
 
-#elif defined WIN32
-            if (WaitForSingleObjectEx(syscheck.realtime->evt, SYSCHECK_WAIT * 1000, TRUE) == WAIT_FAILED) {
-                merror(FIM_ERROR_REALTIME_WAITSINGLE_OBJECT);
-            }
-#endif
         } else {
             sleep(SYSCHECK_WAIT);
         }
     }
+}
 
 #else
+void * fim_run_realtime(__attribute__((unused)) void * args) {
     directory_t *dir_it;
     OSListNode *node_it;
     w_rwlock_rdlock(&syscheck.directories_lock);
@@ -460,11 +465,9 @@ void * fim_run_realtime(__attribute__((unused)) void * args) {
     w_rwlock_unlock(&syscheck.directories_lock);
 
     pthread_exit(NULL);
-#endif
-
 }
+#endif
 // LCOV_EXCL_STOP
-
 
 #ifdef WIN32
 void set_priority_windows_thread() {

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -402,6 +402,7 @@ DWORD WINAPI fim_run_realtime(__attribute__((unused)) void * args) {
         }
         w_rwlock_unlock(&syscheck.directories_lock);
     }
+    return 0;
 }
 
 #elif defined INOTIFY_ENABLED

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -367,11 +367,9 @@ DWORD WINAPI fim_run_realtime(__attribute__((unused)) void * args) {
     }
     w_rwlock_unlock(&syscheck.directories_lock);
 
-    w_mutex_lock(&syscheck.fim_realtime_mutex);
     if (syscheck.realtime != NULL) {
-        mdebug2(FIM_NUM_WATCHES, OSHash_Get_Elem_ex(syscheck.realtime->dirtb));
+        mdebug2(FIM_NUM_WATCHES, get_realtime_watches());
     }
-    w_mutex_unlock(&syscheck.fim_realtime_mutex);
 
     while (FOREVER()) {
 
@@ -380,8 +378,7 @@ DWORD WINAPI fim_run_realtime(__attribute__((unused)) void * args) {
             set_whodata_mode_changes();
         }
 #endif
-        w_mutex_lock(&syscheck.fim_realtime_mutex);
-        if (syscheck.realtime && OSHash_Get_Elem_ex(syscheck.realtime->dirtb) > 0) {
+        if (get_realtime_watches() > 0) {
             log_realtime_status(1);
 
             if (WaitForSingleObjectEx(syscheck.realtime->evt, SYSCHECK_WAIT * 1000, TRUE) == WAIT_FAILED) {
@@ -390,7 +387,6 @@ DWORD WINAPI fim_run_realtime(__attribute__((unused)) void * args) {
         } else {
             sleep(SYSCHECK_WAIT);
         }
-        w_mutex_unlock(&syscheck.fim_realtime_mutex);
 
         // Directories in Windows configured with real-time add recursive watches
         w_rwlock_wrlock(&syscheck.directories_lock);

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -355,6 +355,7 @@ void start_daemon()
 DWORD WINAPI fim_run_realtime(__attribute__((unused)) void * args) {
     directory_t *dir_it;
     OSListNode *node_it;
+    int watches;
 
     set_priority_windows_thread();
     // Directories in Windows configured with real-time add recursive watches
@@ -367,8 +368,9 @@ DWORD WINAPI fim_run_realtime(__attribute__((unused)) void * args) {
     }
     w_rwlock_unlock(&syscheck.directories_lock);
 
-    if (syscheck.realtime != NULL) {
-        mdebug2(FIM_NUM_WATCHES, get_realtime_watches());
+    watches = get_realtime_watches();
+    if (watches != 0) {
+        mdebug2(FIM_NUM_WATCHES, watches);
     }
 
     while (FOREVER()) {

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -422,6 +422,7 @@ void CALLBACK RTCallBack(DWORD dwerror, DWORD dwBytes, LPOVERLAPPED overlap)
     if(rtlocald->watch_status == FIM_RT_HANDLE_CLOSED) {
         w_mutex_lock(&syscheck.fim_realtime_mutex);
         rtlocald = OSHash_Delete_ex(syscheck.realtime->dirtb, wdchar);
+        syscheck.realtime->fd = OSHash_Get_Elem_ex(syscheck.realtime->dirtb);
         free_win32rtfim_data(rtlocald);
         mdebug1(FIM_REALTIME_CALLBACK, wdchar);
         w_mutex_unlock(&syscheck.fim_realtime_mutex);
@@ -503,7 +504,7 @@ int realtime_start() {
     }
     OSHash_SetFreeDataPointer(syscheck.realtime->dirtb, (void (*)(void *))free_win32rtfim_data);
 
-    syscheck.realtime->fd = -1;
+    syscheck.realtime->fd = 0;
     syscheck.realtime->evt = CreateEvent(NULL, TRUE, FALSE, NULL);
 
     return (0);
@@ -604,7 +605,6 @@ int realtime_adddir(const char *dir, directory_t *configuration) {
             w_mutex_unlock(&syscheck.fim_realtime_mutex);
             return (0);
         }
-        syscheck.realtime->fd++;
 
         /* Add final elements to the hash */
         os_strdup(dir, rtlocald->dir);
@@ -623,6 +623,7 @@ int realtime_adddir(const char *dir, directory_t *configuration) {
             merror_exit(FIM_CRITICAL_ERROR_OUT_MEM);
         }
 
+        syscheck.realtime->fd = OSHash_Get_Elem_ex(syscheck.realtime->dirtb);
         mdebug1(FIM_REALTIME_NEWDIRECTORY, dir);
     }
     w_mutex_unlock(&syscheck.fim_realtime_mutex);
@@ -643,6 +644,7 @@ int fim_check_realtime_directory(win32rtfim *rtlocald) {
             mdebug1(FIM_REALTIME_CALLBACK, rtlocald->dir);
             rtlocald = OSHash_Delete_ex(syscheck.realtime->dirtb, rtlocald->dir);
             free_win32rtfim_data(rtlocald);
+            syscheck.realtime->fd = OSHash_Get_Elem_ex(syscheck.realtime->dirtb);
             return 1;
         }
 

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -422,7 +422,6 @@ void CALLBACK RTCallBack(DWORD dwerror, DWORD dwBytes, LPOVERLAPPED overlap)
     if(rtlocald->watch_status == FIM_RT_HANDLE_CLOSED) {
         w_mutex_lock(&syscheck.fim_realtime_mutex);
         rtlocald = OSHash_Delete_ex(syscheck.realtime->dirtb, wdchar);
-        syscheck.realtime->fd = OSHash_Get_Elem_ex(syscheck.realtime->dirtb);
         free_win32rtfim_data(rtlocald);
         mdebug1(FIM_REALTIME_CALLBACK, wdchar);
         w_mutex_unlock(&syscheck.fim_realtime_mutex);
@@ -504,7 +503,6 @@ int realtime_start() {
     }
     OSHash_SetFreeDataPointer(syscheck.realtime->dirtb, (void (*)(void *))free_win32rtfim_data);
 
-    syscheck.realtime->fd = 0;
     syscheck.realtime->evt = CreateEvent(NULL, TRUE, FALSE, NULL);
 
     return (0);
@@ -573,7 +571,7 @@ int realtime_adddir(const char *dir, directory_t *configuration) {
     }
     /* Maximum limit for realtime on Windows */
     w_mutex_lock(&syscheck.fim_realtime_mutex);
-    if (syscheck.realtime->fd > syscheck.max_fd_win_rt) {
+    if (OSHash_Get_Elem_ex(syscheck.realtime->dirtb) > syscheck.max_fd_win_rt) {
         merror(FIM_ERROR_REALTIME_MAXNUM_WATCHES, dir);
         w_mutex_unlock(&syscheck.fim_realtime_mutex);
         return (0);
@@ -623,7 +621,6 @@ int realtime_adddir(const char *dir, directory_t *configuration) {
             merror_exit(FIM_CRITICAL_ERROR_OUT_MEM);
         }
 
-        syscheck.realtime->fd = OSHash_Get_Elem_ex(syscheck.realtime->dirtb);
         mdebug1(FIM_REALTIME_NEWDIRECTORY, dir);
     }
     w_mutex_unlock(&syscheck.fim_realtime_mutex);
@@ -644,7 +641,6 @@ int fim_check_realtime_directory(win32rtfim *rtlocald) {
             mdebug1(FIM_REALTIME_CALLBACK, rtlocald->dir);
             rtlocald = OSHash_Delete_ex(syscheck.realtime->dirtb, rtlocald->dir);
             free_win32rtfim_data(rtlocald);
-            syscheck.realtime->fd = OSHash_Get_Elem_ex(syscheck.realtime->dirtb);
             return 1;
         }
 

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -736,6 +736,14 @@ int w_update_sacl(const char *obj_path);
  */
 #ifdef WIN32
 DWORD WINAPI fim_run_integrity(void __attribute__((unused)) * args);
+
+/**
+ * @brief Get the number of realtime watches opened by FIM.
+ *
+ * @return Number of realtime watches.
+ */
+unsigned int get_realtime_watches();
+
 #else
 void *fim_run_integrity(void *args);
 #endif

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -246,19 +246,26 @@ set(RUN_CHECK_BASE_FLAGS "-Wl,--wrap,_minfo -Wl,--wrap,_merror -Wl,--wrap,_mdebu
                           -Wl,--wrap,fim_db_get_path_range -Wl,--wrap,fim_db_delete_range -Wl,--wrap,lstat \
                           -Wl,--wrap,fim_configuration_directory -Wl,--wrap,inotify_rm_watch -Wl,--wrap,os_random \
                           -Wl,--wrap,stat -Wl,--wrap,getpid -Wl,--wrap,fim_db_get_path_from_pattern -Wl,--wrap,gettime \
-                          -Wl,--wrap,remove_audit_rule_syscheck")
+                          -Wl,--wrap,remove_audit_rule_syscheck -Wl,--wrap,realtime_process -Wl,--wrap,FOREVER \
+                          -Wl,--wrap,select -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_mutex_unlock")
 
 list(APPEND syscheckd_tests_names "test_run_check")
 if(${TARGET} STREQUAL "agent")
   list(APPEND syscheckd_tests_flags "${RUN_CHECK_BASE_FLAGS} -Wl,--wrap=sleep -Wl,--wrap,time")
 elseif(${TARGET} STREQUAL "winagent")
-  list(APPEND syscheckd_tests_flags "${RUN_CHECK_BASE_FLAGS} -Wl,--wrap=realtime_start")
+  list(APPEND syscheckd_tests_flags "${RUN_CHECK_BASE_FLAGS} -Wl,--wrap=realtime_start \
+                                     -Wl,--wrap,WaitForSingleObjectEx -Wl,--wrap,pthread_rwlock_rdlock \
+                                     -Wl,--wrap,pthread_rwlock_unlock -Wl,--wrap,pthread_rwlock_wrlock")
 
   # Create event channel tests for run_check
   list(APPEND syscheckd_event_tests_names "test_run_check_event")
   list(APPEND syscheckd_event_tests_flags "${RUN_CHECK_BASE_FLAGS} -Wl,--wrap=realtime_start,--wrap=run_whodata_scan \
-                                                                    -Wl,--wrap=audit_restore -Wl,--wrap,pthread_rwlock_rdlock -Wl,--wrap,pthread_rwlock_unlock \
-                                                                    -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_rwlock_wrlock -Wl,--wrap,pthread_mutex_unlock")
+                                                                   -Wl,--wrap=audit_restore
+                                                                   -Wl,--wrap,pthread_rwlock_rdlock \
+                                                                   -Wl,--wrap,pthread_rwlock_unlock \
+                                                                   -Wl,--wrap,pthread_mutex_lock \
+                                                                   -Wl,--wrap,pthread_rwlock_wrlock \
+                                                                   -Wl,--wrap,pthread_mutex_unlock")
 else()
   list(APPEND syscheckd_tests_flags "${RUN_CHECK_BASE_FLAGS} -Wl,--wrap=sleep,--wrap,time")
 endif()

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -184,7 +184,8 @@ elseif(${TARGET} STREQUAL "winagent")
   # Create event channel tests for run_realtime
   list(APPEND syscheckd_event_tests_names "test_run_realtime_event")
   list(APPEND syscheckd_event_tests_flags "${RUN_REALTIME_BASE_FLAGS} -Wl,--wrap=whodata_audit_start \
-                                           -Wl,--wrap=check_path_type,--wrap=set_winsacl,--wrap=w_directory_exists")
+                                           -Wl,--wrap=check_path_type,--wrap=set_winsacl,--wrap=w_directory_exists \
+                                           -Wl,--wrap=OSHash_Get_Elem_ex")
 else()
   list(APPEND syscheckd_tests_flags "${RUN_REALTIME_BASE_FLAGS}")
 endif()

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -626,8 +626,6 @@ void test_fim_run_realtime_w_sleep(void **state) {
     }
     will_return(__wrap_FOREVER, 1);
 
-    snprintf(debug_msg, OS_SIZE_128, FIM_NUM_WATCHES, added_dirs);
-    expect_string(__wrap__mdebug2, formatted_msg, debug_msg);
     expect_value(wrap_Sleep, dwMilliseconds, SYSCHECK_WAIT * 1000);
 
     OSList_foreach(node_it, syscheck.directories) {

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -38,6 +38,11 @@ void set_whodata_mode_changes();
 
 /* External 'static' functions prototypes */
 void fim_send_msg(char mq, const char * location, const char * msg);
+#ifdef WIN32
+DWORD WINAPI fim_run_realtime(__attribute__((unused)) void * args);
+#else
+void * fim_run_realtime(__attribute__((unused)) void * args);
+#endif
 
 #ifndef TEST_WINAGENT
 void fim_link_update(const char *new_path, directory_t *configuration);
@@ -68,13 +73,12 @@ time_t __wrap_time(time_t *timer) {
 
 static int setup_group(void ** state) {
 #ifdef TEST_WINAGENT
-#ifdef WIN_WHODATA
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_rdlock);
-#endif
+
     expect_string(__wrap__mdebug1, formatted_msg, "(6287): Reading configuration file: 'test_syscheck.conf'");
     expect_string(__wrap__mdebug1, formatted_msg, "Found ignore regex node .log$|.htm$|.jpg$|.png$|.chm$|.pnf$|.evtx$|.swp$");
     expect_string(__wrap__mdebug1, formatted_msg, "Found ignore regex node .log$|.htm$|.jpg$|.png$|.chm$|.pnf$|.evtx$|.swp$ OK?");
@@ -85,7 +89,9 @@ static int setup_group(void ** state) {
     expect_string(__wrap__mdebug1, formatted_msg, "Found nodiff regex node test_$");
     expect_string(__wrap__mdebug1, formatted_msg, "Found nodiff regex node test_$ OK?");
     expect_string(__wrap__mdebug1, formatted_msg, "Found nodiff regex size 1");
-#else
+#else // !TEST_WINAGENT
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
     expect_string(__wrap__mdebug1, formatted_msg, "(6287): Reading configuration file: 'test_syscheck.conf'");
     expect_string(__wrap__mdebug1, formatted_msg, "Found ignore regex node .log$|.swp$");
     expect_string(__wrap__mdebug1, formatted_msg, "Found ignore regex node .log$|.swp$ OK?");
@@ -95,7 +101,7 @@ static int setup_group(void ** state) {
     expect_string(__wrap__mdebug1, formatted_msg, "Found nodiff regex size 0");
 
     syscheck.database = fim_db_init(FIM_DB_DISK);
-#endif
+#endif // TEST_WINAGENT
 
 #if defined(TEST_AGENT) || defined(TEST_WINAGENT)
     expect_string(__wrap__mdebug1, formatted_msg, "(6208): Reading Client Configuration [test_syscheck.conf]");
@@ -118,10 +124,11 @@ static int setup_group(void ** state) {
         return -1;
     }
 
-    OSHash_Add_ex(syscheck.realtime->dirtb, "key", strdup("data"));
 
 #ifdef TEST_WINAGENT
     time_mock_value = 1;
+#else
+    OSHash_Add_ex(syscheck.realtime->dirtb, "key", strdup("data"));
 #endif
     return 0;
 }
@@ -129,6 +136,9 @@ static int setup_group(void ** state) {
 #ifndef TEST_WINAGENT
 
 static int setup_symbolic_links(void **state) {
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+
     directory_t *config = (directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1);
 
     if (config->path != NULL) {
@@ -148,6 +158,9 @@ static int setup_symbolic_links(void **state) {
 }
 
 static int teardown_symbolic_links(void **state) {
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+
     directory_t *config = (directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1);
     if (config->path != NULL) {
         free(config->path);
@@ -197,13 +210,10 @@ static int teardown_tmp_file(void **state) {
 
 static int teardown_group(void **state) {
 #ifdef TEST_WINAGENT
-#ifdef WIN_WHODATA
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
-    expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
-#endif
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
     if (syscheck.realtime) {
         if (syscheck.realtime->dirtb) {
@@ -212,6 +222,9 @@ static int teardown_group(void **state) {
         free(syscheck.realtime);
         syscheck.realtime = NULL;
     }
+#else
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
 #endif
 
     fim_db_clean();
@@ -237,6 +250,60 @@ static int teardown_max_fps(void **state) {
     return 0;
 }
 
+#ifdef TEST_WINAGENT
+
+typedef struct _win32rtfim {
+    HANDLE h;
+    OVERLAPPED overlap;
+
+    char *dir;
+    TCHAR buffer[65536];
+    unsigned int watch_status;
+} win32rtfim;
+
+extern void free_win32rtfim_data(win32rtfim *data);
+
+static int setup_hash(void **state) {
+    directory_t *dir_it;
+    OSListNode *node_it;
+
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+
+    win32rtfim *rtlocald;
+    rtlocald = calloc(1, sizeof(win32rtfim));
+    OSList_foreach(node_it, syscheck.directories) {
+        dir_it = node_it->data;
+        if (dir_it->options & REALTIME_ACTIVE) {
+            OSHash_Add_ex(syscheck.realtime->dirtb, strdup(dir_it->path), rtlocald);
+        }
+    }
+    syscheck.realtime->evt = (HANDLE)234;
+    return 0;
+}
+
+static int teardown_hash(void **state) {
+    directory_t *dir_it;
+    OSListNode *node_it;
+
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+
+    OSList_foreach(node_it, syscheck.directories) {
+        dir_it = node_it->data;
+        if (dir_it->options & REALTIME_ACTIVE) {
+            free_win32rtfim_data(OSHash_Delete_ex(syscheck.realtime->dirtb, dir_it->path));
+        }
+    }
+    return 0;
+}
+#endif
 /* tests */
 
 void test_fim_whodata_initialize(void **state)
@@ -328,7 +395,222 @@ void test_fim_send_msg_retry_error(void **state) {
     fim_send_msg(SYSCHECK_MQ, SYSCHECK, "test");
 }
 
-#ifdef TEST_WINAGENT
+#ifndef TEST_WINAGENT
+
+void test_fim_run_realtime_first_error(void **state) {
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    syscheck.realtime->fd = 4;
+    char debug_msg[OS_SIZE_128] = {0};
+    snprintf(debug_msg, OS_SIZE_128, FIM_NUM_WATCHES, 1);
+    will_return(__wrap_FOREVER, 1);
+
+
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg);
+
+    will_return(__wrap_select, -1);
+    expect_string(__wrap__merror, formatted_msg, FIM_ERROR_SELECT);
+
+    will_return(__wrap_FOREVER, 0);
+
+    fim_run_realtime(NULL);
+}
+
+void test_fim_run_realtime_first_timeout(void **state) {
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    syscheck.realtime->fd = 4;
+    char debug_msg[OS_SIZE_128] = {0};
+
+    snprintf(debug_msg, OS_SIZE_128, FIM_NUM_WATCHES, 1);
+    will_return(__wrap_FOREVER, 1);
+
+
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg);
+
+    will_return(__wrap_select, 0);
+
+    will_return(__wrap_FOREVER, 0);
+
+    fim_run_realtime(NULL);
+}
+
+void test_fim_run_realtime_first_sleep(void **state) {
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    syscheck.realtime->fd = -1;
+    char debug_msg[OS_SIZE_128] = {0};
+    snprintf(debug_msg, OS_SIZE_128, FIM_NUM_WATCHES, 1);
+    will_return(__wrap_FOREVER, 1);
+
+
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg);
+    expect_value(__wrap_sleep, seconds, SYSCHECK_WAIT);
+
+    will_return(__wrap_FOREVER, 0);
+
+    fim_run_realtime(NULL);
+}
+
+void test_fim_run_realtime_first_process(void **state) {
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    syscheck.realtime->fd = 4;
+    char debug_msg[OS_SIZE_128] = {0};
+    snprintf(debug_msg, OS_SIZE_128, FIM_NUM_WATCHES, 1);
+
+    will_return(__wrap_FOREVER, 1);
+
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg);
+
+    will_return(__wrap_select, 4);
+    expect_function_call(__wrap_realtime_process);
+    will_return(__wrap_FOREVER, 0);
+
+    fim_run_realtime(NULL);
+}
+
+void test_fim_run_realtime_process_after_timeout(void **state) {
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    syscheck.realtime->fd = 4;
+    char debug_msg[OS_SIZE_128] = {0};
+    snprintf(debug_msg, OS_SIZE_128, FIM_NUM_WATCHES, 1);
+    will_return(__wrap_FOREVER, 1);
+
+
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg);
+    will_return(__wrap_select, 0);
+
+    will_return(__wrap_FOREVER, 1);
+
+    will_return(__wrap_select, 4);
+    expect_function_call(__wrap_realtime_process);
+    will_return(__wrap_FOREVER, 0);
+
+    fim_run_realtime(NULL);
+}
+#else
+
+void test_fim_run_realtime_w_first_timeout(void **state) {
+    char debug_msg[OS_SIZE_128] = {0};
+    directory_t *dir_it;
+    OSListNode *node_it;
+    int added_dirs = 0;
+
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+
+    // set_priority_windows_thread
+    expect_string(__wrap__mdebug1, formatted_msg, "(6320): Setting process priority to: '10'");
+    will_return(wrap_GetCurrentThread, (HANDLE)123456);
+    expect_SetThreadPriority_call((HANDLE)123456, THREAD_PRIORITY_LOWEST, true);
+
+    will_return(__wrap_FOREVER, 1);
+
+    OSList_foreach(node_it, syscheck.directories) {
+        dir_it = node_it->data;
+        if (dir_it->options & REALTIME_ACTIVE) {
+            expect_string(__wrap_realtime_adddir, dir, dir_it->path);
+            will_return(__wrap_realtime_adddir, 0);
+            added_dirs++;
+        }
+    }
+
+    snprintf(debug_msg, OS_SIZE_128, FIM_NUM_WATCHES, added_dirs);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg);
+
+    expect_value(wrap_WaitForSingleObjectEx, hHandle, (DWORD)234);
+    expect_value(wrap_WaitForSingleObjectEx, dwMilliseconds, SYSCHECK_WAIT * 1000);
+    expect_value(wrap_WaitForSingleObjectEx, bAlertable, TRUE);
+    will_return(wrap_WaitForSingleObjectEx, WAIT_FAILED);
+
+    expect_string(__wrap__merror, formatted_msg, FIM_ERROR_REALTIME_WAITSINGLE_OBJECT);
+
+    will_return(__wrap_FOREVER, 0);
+
+    fim_run_realtime(NULL);
+}
+
+void test_fim_run_realtime_w_wait_success(void **state) {
+    char debug_msg[OS_SIZE_128] = {0};
+    directory_t *dir_it;
+    OSListNode *node_it;
+    int added_dirs = 0;
+
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+
+    // set_priority_windows_thread
+    expect_string(__wrap__mdebug1, formatted_msg, "(6320): Setting process priority to: '10'");
+    will_return(wrap_GetCurrentThread, (HANDLE)123456);
+    expect_SetThreadPriority_call((HANDLE)123456, THREAD_PRIORITY_LOWEST, true);
+
+    will_return(__wrap_FOREVER, 1);
+
+    OSList_foreach(node_it, syscheck.directories) {
+        dir_it = node_it->data;
+        if (dir_it->options & REALTIME_ACTIVE) {
+            expect_string(__wrap_realtime_adddir, dir, dir_it->path);
+            will_return(__wrap_realtime_adddir, 0);
+            added_dirs++;
+        }
+    }
+
+    snprintf(debug_msg, OS_SIZE_128, FIM_NUM_WATCHES, added_dirs);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg);
+
+    expect_value(wrap_WaitForSingleObjectEx, hHandle, (DWORD)234);
+    expect_value(wrap_WaitForSingleObjectEx, dwMilliseconds, SYSCHECK_WAIT * 1000);
+    expect_value(wrap_WaitForSingleObjectEx, bAlertable, TRUE);
+    will_return(wrap_WaitForSingleObjectEx, WAIT_IO_COMPLETION);
+
+    will_return(__wrap_FOREVER, 0);
+
+    fim_run_realtime(NULL);
+}
+
+void test_fim_run_realtime_w_sleep(void **state) {
+    char debug_msg[OS_SIZE_128] = {0};
+    directory_t *dir_it;
+    OSListNode *node_it;
+    int added_dirs = 0;
+
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+
+    // set_priority_windows_thread
+    expect_string(__wrap__mdebug1, formatted_msg, "(6320): Setting process priority to: '10'");
+    will_return(wrap_GetCurrentThread, (HANDLE)123456);
+    expect_SetThreadPriority_call((HANDLE)123456, THREAD_PRIORITY_LOWEST, true);
+
+    will_return(__wrap_FOREVER, 1);
+
+    OSList_foreach(node_it, syscheck.directories) {
+        dir_it = node_it->data;
+        if (dir_it->options & REALTIME_ACTIVE) {
+            expect_string(__wrap_realtime_adddir, dir, dir_it->path);
+            will_return(__wrap_realtime_adddir, 0);
+        }
+    }
+
+    snprintf(debug_msg, OS_SIZE_128, FIM_NUM_WATCHES, added_dirs);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg);
+    expect_value(wrap_Sleep, dwMilliseconds, SYSCHECK_WAIT * 1000);
+
+    will_return(__wrap_FOREVER, 0);
+
+    fim_run_realtime(NULL);
+}
 
 void test_fim_whodata_initialize_fail_set_policies(void **state)
 {
@@ -568,6 +850,8 @@ void test_send_syscheck_msg_10_eps(void ** state) {
     }
 
     // We must not sleep the first 9 times
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
 
     for (int i = 1; i < syscheck.max_eps; i++) {
         expect_string(__wrap__mdebug2, formatted_msg, "(6321): Sending FIM event: {}");
@@ -618,6 +902,8 @@ void test_fim_send_scan_info(void **state) {
 #ifndef TEST_WINAGENT
 void test_fim_link_update(void **state) {
     char *new_path = "/new_path";
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
     directory_t *affected_config = (directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1);
 
     expect_fim_db_get_path_from_pattern(syscheck.database, "/folder/%", NULL, FIM_DB_DISK, FIMDB_OK);
@@ -634,6 +920,9 @@ void test_fim_link_update(void **state) {
 }
 
 void test_fim_link_update_already_added(void **state) {
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+
     char *link_path = "/home";
     char error_msg[OS_SIZE_128];
     directory_t *affected_config = (directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1);
@@ -654,6 +943,9 @@ void test_fim_link_update_already_added(void **state) {
 void test_fim_link_check_delete(void **state) {
     char *link_path = "/link";
     char *pointed_folder = "/folder";
+
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
     directory_t *affected_config = (directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1);
 
     expect_string(__wrap_lstat, filename, affected_config->symbolic_links);
@@ -675,6 +967,9 @@ void test_fim_link_check_delete_lstat_error(void **state) {
     char *link_path = "/link";
     char *pointed_folder = "/folder";
     char error_msg[OS_SIZE_128];
+
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
     directory_t *affected_config = (directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1);
 
     expect_string(__wrap_lstat, filename, pointed_folder);
@@ -695,6 +990,9 @@ void test_fim_link_check_delete_lstat_error(void **state) {
 void test_fim_link_check_delete_noentry_error(void **state) {
     char *link_path = "/link";
     char *pointed_folder = "/folder";
+
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
     directory_t *affected_config = (directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1);
 
     expect_string(__wrap_lstat, filename, pointed_folder);
@@ -717,6 +1015,9 @@ void test_fim_delete_realtime_watches(void **state) {
     char *link_path = "/link";
     char *pointed_folder = "/folder";
 
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+
     expect_fim_configuration_directory_call(pointed_folder, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)));
     expect_fim_configuration_directory_call("data", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)));
 
@@ -730,6 +1031,9 @@ void test_fim_delete_realtime_watches(void **state) {
 void test_fim_link_delete_range(void **state) {
     fim_tmp_file *tmp_file = *state;
 
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+
     expect_fim_db_get_path_from_pattern(syscheck.database, "/folder/%", tmp_file, FIM_DB_DISK, FIMDB_OK);
     expect_wrapper_fim_db_delete_range_call(syscheck.database, FIM_DB_DISK, tmp_file, FIMDB_OK);
     fim_link_delete_range(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1)));
@@ -738,6 +1042,9 @@ void test_fim_link_delete_range(void **state) {
 void test_fim_link_delete_range_error(void **state) {
     char error_msg[OS_SIZE_128];
     fim_tmp_file *tmp_file = *state;
+
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
 
     snprintf(error_msg, OS_SIZE_128, FIM_DB_ERROR_RM_PATTERN, "/folder/%");
     expect_fim_db_get_path_from_pattern(syscheck.database, "/folder/%", tmp_file, FIM_DB_DISK, FIMDB_OK);
@@ -750,6 +1057,10 @@ void test_fim_link_delete_range_error(void **state) {
 
 void test_fim_link_silent_scan(void **state) {
     char *link_path = "/link";
+
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+
     directory_t *affected_config = (directory_t *)OSList_GetDataFromIndex(syscheck.directories, 3);
 
     expect_realtime_adddir_call(link_path, 0);
@@ -762,6 +1073,10 @@ void test_fim_link_reload_broken_link_already_monitored(void **state) {
     char *link_path = "/link";
     char *pointed_folder = "/folder";
     char error_msg[OS_SIZE_128];
+
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+
     directory_t *affected_config = (directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1);
 
     snprintf(error_msg, OS_SIZE_128, FIM_LINK_ALREADY_ADDED, link_path);
@@ -777,6 +1092,10 @@ void test_fim_link_reload_broken_link_already_monitored(void **state) {
 void test_fim_link_reload_broken_link_reload_broken(void **state) {
     char *link_path = "/link";
     char *pointed_folder = "/new_path";
+
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+
     directory_t *affected_config = (directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1);
 
     expect_fim_checker_call(pointed_folder, affected_config);
@@ -794,11 +1113,16 @@ void test_fim_link_reload_broken_link_reload_broken(void **state) {
 #endif
 
 void test_check_max_fps_no_sleep(void **state) {
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
     will_return(__wrap_gettime, last_time + 1);
+
     check_max_fps();
 }
 
 void test_check_max_fps_sleep(void **state) {
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
     last_time = 10;
     files_read = syscheck.max_files_per_second;
 
@@ -832,6 +1156,11 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_check_max_fps_no_sleep, setup_max_fps, teardown_max_fps),
         cmocka_unit_test_setup_teardown(test_check_max_fps_sleep, setup_max_fps, teardown_max_fps),
 #ifndef TEST_WINAGENT
+        cmocka_unit_test(test_fim_run_realtime_first_error),
+        cmocka_unit_test(test_fim_run_realtime_first_timeout),
+        cmocka_unit_test(test_fim_run_realtime_first_sleep),
+        cmocka_unit_test(test_fim_run_realtime_first_process),
+        cmocka_unit_test(test_fim_run_realtime_process_after_timeout),
         cmocka_unit_test_setup_teardown(test_fim_link_update, setup_symbolic_links, teardown_symbolic_links),
         cmocka_unit_test_setup_teardown(test_fim_link_update_already_added, setup_symbolic_links, teardown_symbolic_links),
         cmocka_unit_test_setup_teardown(test_fim_link_check_delete, setup_symbolic_links, teardown_symbolic_links),
@@ -843,6 +1172,10 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_fim_link_silent_scan, setup_symbolic_links, teardown_symbolic_links),
         cmocka_unit_test_setup_teardown(test_fim_link_reload_broken_link_already_monitored, setup_symbolic_links, teardown_symbolic_links),
         cmocka_unit_test_setup_teardown(test_fim_link_reload_broken_link_reload_broken, setup_symbolic_links, teardown_symbolic_links),
+#else
+        cmocka_unit_test_setup_teardown(test_fim_run_realtime_w_first_timeout, setup_hash, teardown_hash),
+        cmocka_unit_test_setup_teardown(test_fim_run_realtime_w_wait_success, setup_hash, teardown_hash),
+        cmocka_unit_test(test_fim_run_realtime_w_sleep),
 #endif
     };
 

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -41,15 +41,6 @@ void fim_send_msg(char mq, const char * location, const char * msg);
 #ifdef WIN32
 DWORD WINAPI fim_run_realtime(__attribute__((unused)) void * args);
 
-typedef struct _win32rtfim {
-    HANDLE h;
-    OVERLAPPED overlap;
-
-    char *dir;
-    TCHAR buffer[65536];
-    unsigned int watch_status;
-} win32rtfim;
-
 extern void free_win32rtfim_data(win32rtfim *data);
 
 #else

--- a/src/unit_tests/syscheckd/test_run_realtime.c
+++ b/src/unit_tests/syscheckd/test_run_realtime.c
@@ -1496,6 +1496,7 @@ void test_realtime_adddir_whodata_dir_success(void **state) {
 
 void test_realtime_adddir_max_limit_reached(void **state) {
     int ret;
+    char msg[OS_SIZE_256] = { '\0' };
 
     expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
@@ -1509,8 +1510,8 @@ void test_realtime_adddir_max_limit_reached(void **state) {
     expect_value(__wrap_OSHash_Get_Elem_ex, self, syscheck.realtime->dirtb);
     will_return(__wrap_OSHash_Get_Elem_ex, 257);
 
-    expect_string(__wrap__merror, formatted_msg,
-        "(6616): Unable to add directory to real time monitoring: 'C:\\a\\path' - Maximum size permitted.");
+    snprintf(msg, OS_SIZE_256, FIM_REALTIME_MAXNUM_WATCHES, "C:\\a\\path");
+    expect_string(__wrap__mdebug1, formatted_msg, msg);
 
     ret = realtime_adddir("C:\\a\\path", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)));
 

--- a/src/unit_tests/syscheckd/test_run_realtime.c
+++ b/src/unit_tests/syscheckd/test_run_realtime.c
@@ -310,7 +310,7 @@ void test_realtime_start_success(void **state) {
 
     assert_int_equal(ret, 0);
 #ifdef TEST_WINAGENT
-    assert_int_equal(syscheck.realtime->fd, -1);
+    assert_int_equal(syscheck.realtime->fd, 0);
     assert_ptr_equal(syscheck.realtime->evt, 123456);
 #endif
 }
@@ -1598,6 +1598,9 @@ void test_realtime_adddir_duplicate_entry_non_existent_directory_closed_handle(v
     expect_string(__wrap_OSHash_Delete_ex, key, "C:\\a\\path");
     will_return(__wrap_OSHash_Delete_ex, rtlocald);
 
+    expect_value(__wrap_OSHash_Get_Elem_ex, self, syscheck.realtime->dirtb);
+    will_return(__wrap_OSHash_Get_Elem_ex, 127);
+
     snprintf(debug_msg, OS_SIZE_128, FIM_REALTIME_CALLBACK, "C:\\a\\path");
     expect_string(__wrap__mdebug1, formatted_msg, debug_msg);
 
@@ -1672,6 +1675,8 @@ void test_realtime_adddir_success(void **state) {
     will_return(wrap_CreateFile, (HANDLE)123456);
 
     will_return(wrap_ReadDirectoryChangesW, 1);
+    expect_value(__wrap_OSHash_Get_Elem_ex, self, syscheck.realtime->dirtb);
+    will_return(__wrap_OSHash_Get_Elem_ex, 127);
 
     expect_string(__wrap__mdebug1, formatted_msg,
                   "(6227): Directory added for real time monitoring: 'C:\\a\\path'");

--- a/src/unit_tests/syscheckd/test_run_realtime.c
+++ b/src/unit_tests/syscheckd/test_run_realtime.c
@@ -1510,8 +1510,12 @@ void test_realtime_adddir_max_limit_reached(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
+    expect_value(__wrap_OSHash_Get_ex, self, syscheck.realtime->dirtb);
+    expect_string(__wrap_OSHash_Get_ex, key, "C:\\a\\path");
+    will_return(__wrap_OSHash_Get_ex, NULL);
+
     expect_value(__wrap_OSHash_Get_Elem_ex, self, syscheck.realtime->dirtb);
-    will_return(__wrap_OSHash_Get_Elem_ex, 1024);
+    will_return(__wrap_OSHash_Get_Elem_ex, 257);
 
     expect_string(__wrap__merror, formatted_msg,
         "(6616): Unable to add directory to real time monitoring: 'C:\\a\\path' - Maximum size permitted.");
@@ -1529,9 +1533,6 @@ void test_realtime_adddir_duplicate_entry(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
-
-    expect_value(__wrap_OSHash_Get_Elem_ex, self, syscheck.realtime->dirtb);
-    will_return(__wrap_OSHash_Get_Elem_ex, 128);
 
     expect_value(__wrap_OSHash_Get_ex, self, syscheck.realtime->dirtb);
     expect_string(__wrap_OSHash_Get_ex, key, "C:\\a\\path");
@@ -1554,10 +1555,7 @@ void test_realtime_adddir_duplicate_entry_non_existent_directory_valid_handle(vo
     expect_function_call_any(__wrap_pthread_mutex_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
-    expect_value(__wrap_OSHash_Get_Elem_ex, self, syscheck.realtime->dirtb);
-    will_return(__wrap_OSHash_Get_Elem_ex, 128);
-
-    expect_value(__wrap_OSHash_Get_ex, self, syscheck.realtime->dirtb);
+        expect_value(__wrap_OSHash_Get_ex, self, syscheck.realtime->dirtb);
     expect_string(__wrap_OSHash_Get_ex, key, "C:\\a\\path");
     will_return(__wrap_OSHash_Get_ex, &rtlocald);
 
@@ -1609,9 +1607,6 @@ void test_realtime_adddir_duplicate_entry_non_existent_directory_closed_handle(v
     expect_string(__wrap_OSHash_Delete_ex, key, "C:\\a\\path");
     will_return(__wrap_OSHash_Delete_ex, rtlocald);
 
-    expect_value(__wrap_OSHash_Get_Elem_ex, self, syscheck.realtime->dirtb);
-    will_return(__wrap_OSHash_Get_Elem_ex, 127);
-
     snprintf(debug_msg, OS_SIZE_128, FIM_REALTIME_CALLBACK, "C:\\a\\path");
     expect_string(__wrap__mdebug1, formatted_msg, debug_msg);
 
@@ -1629,8 +1624,6 @@ void test_realtime_adddir_duplicate_entry_non_existent_directory_invalid_handle(
     expect_function_call_any(__wrap_pthread_mutex_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
-    expect_value(__wrap_OSHash_Get_Elem_ex, self, syscheck.realtime->dirtb);
-    will_return(__wrap_OSHash_Get_Elem_ex, 128);
 
     expect_value(__wrap_OSHash_Get_ex, self, syscheck.realtime->dirtb);
     expect_string(__wrap_OSHash_Get_ex, key, "C:\\a\\path");

--- a/src/unit_tests/syscheckd/test_run_realtime.c
+++ b/src/unit_tests/syscheckd/test_run_realtime.c
@@ -114,8 +114,18 @@ static int teardown_RTCallBack(void **state) {
 
     return 0;
 }
-#endif
-#endif
+#endif // WIN_WHODATA
+
+static int setup_realtime_adddir_realtime_start_error(void **state) {
+    *state = syscheck.realtime;
+    return 0;
+}
+
+static int teardown_realtime_adddir_realtime_start_error(void **state) {
+    return 0;
+}
+
+# else // TEST_WINAGENT
 
 static int setup_realtime_adddir_realtime_start_error(void **state) {
     *state = syscheck.realtime;
@@ -128,6 +138,7 @@ static int teardown_realtime_adddir_realtime_start_error(void **state) {
 
     return 0;
 }
+#endif
 
 static int setup_realtime_start(void **state) {
     OSHash *hash = calloc(1, sizeof(OSHash));
@@ -310,7 +321,6 @@ void test_realtime_start_success(void **state) {
 
     assert_int_equal(ret, 0);
 #ifdef TEST_WINAGENT
-    assert_int_equal(syscheck.realtime->fd, 0);
     assert_ptr_equal(syscheck.realtime->evt, 123456);
 #endif
 }
@@ -1500,7 +1510,8 @@ void test_realtime_adddir_max_limit_reached(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
-    syscheck.realtime->fd = 1024;
+    expect_value(__wrap_OSHash_Get_Elem_ex, self, syscheck.realtime->dirtb);
+    will_return(__wrap_OSHash_Get_Elem_ex, 1024);
 
     expect_string(__wrap__merror, formatted_msg,
         "(6616): Unable to add directory to real time monitoring: 'C:\\a\\path' - Maximum size permitted.");
@@ -1519,7 +1530,8 @@ void test_realtime_adddir_duplicate_entry(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
-    syscheck.realtime->fd = 128;
+    expect_value(__wrap_OSHash_Get_Elem_ex, self, syscheck.realtime->dirtb);
+    will_return(__wrap_OSHash_Get_Elem_ex, 128);
 
     expect_value(__wrap_OSHash_Get_ex, self, syscheck.realtime->dirtb);
     expect_string(__wrap_OSHash_Get_ex, key, "C:\\a\\path");
@@ -1542,7 +1554,8 @@ void test_realtime_adddir_duplicate_entry_non_existent_directory_valid_handle(vo
     expect_function_call_any(__wrap_pthread_mutex_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
-    syscheck.realtime->fd = 128;
+    expect_value(__wrap_OSHash_Get_Elem_ex, self, syscheck.realtime->dirtb);
+    will_return(__wrap_OSHash_Get_Elem_ex, 128);
 
     expect_value(__wrap_OSHash_Get_ex, self, syscheck.realtime->dirtb);
     expect_string(__wrap_OSHash_Get_ex, key, "C:\\a\\path");
@@ -1585,8 +1598,6 @@ void test_realtime_adddir_duplicate_entry_non_existent_directory_closed_handle(v
     rtlocald->watch_status = FIM_RT_HANDLE_CLOSED;
     rtlocald->h = (HANDLE)1234;
 
-    syscheck.realtime->fd = 128;
-
     expect_value(__wrap_OSHash_Get_ex, self, syscheck.realtime->dirtb);
     expect_string(__wrap_OSHash_Get_ex, key, "C:\\a\\path");
     will_return(__wrap_OSHash_Get_ex, rtlocald);
@@ -1618,7 +1629,8 @@ void test_realtime_adddir_duplicate_entry_non_existent_directory_invalid_handle(
     expect_function_call_any(__wrap_pthread_mutex_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
-    syscheck.realtime->fd = 128;
+    expect_value(__wrap_OSHash_Get_Elem_ex, self, syscheck.realtime->dirtb);
+    will_return(__wrap_OSHash_Get_Elem_ex, 128);
 
     expect_value(__wrap_OSHash_Get_ex, self, syscheck.realtime->dirtb);
     expect_string(__wrap_OSHash_Get_ex, key, "C:\\a\\path");
@@ -1640,7 +1652,8 @@ void test_realtime_adddir_handle_error(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
-    syscheck.realtime->fd = 128;
+    expect_value(__wrap_OSHash_Get_Elem_ex, self, syscheck.realtime->dirtb);
+    will_return(__wrap_OSHash_Get_Elem_ex, 128);
 
     expect_value(__wrap_OSHash_Get_ex, self, syscheck.realtime->dirtb);
     expect_string(__wrap_OSHash_Get_ex, key, "C:\\a\\path");

--- a/src/unit_tests/syscheckd/test_run_realtime.c
+++ b/src/unit_tests/syscheckd/test_run_realtime.c
@@ -37,14 +37,6 @@
 
 #ifdef TEST_WINAGENT
 // This struct should always reflect the one defined in run_realtime.c
-typedef struct _win32rtfim {
-    HANDLE h;
-    OVERLAPPED overlap;
-
-    char *dir;
-    TCHAR buffer[65536];
-    unsigned int watch_status;
-} win32rtfim;
 
 int realtime_win32read(win32rtfim *rtlocald);
 void free_win32rtfim_data(win32rtfim *data);

--- a/src/unit_tests/wrappers/wazuh/shared/hash_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/hash_op_wrappers.c
@@ -120,3 +120,8 @@ int __wrap_OSHash_Update(__attribute__((unused)) OSHash *self,
                             __attribute__((unused)) void *data) {
     return mock();
 }
+
+int __wrap_OSHash_Get_Elem_ex(OSHash *self) {
+    check_expected_ptr(self);
+    return mock();
+}

--- a/src/unit_tests/wrappers/wazuh/shared/hash_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/hash_op_wrappers.h
@@ -46,4 +46,6 @@ int __wrap_OSHash_Update(OSHash *self, const char *key, void *data);
 
 extern int OSHash_Add_ex_check_data;
 
+int __wrap_OSHash_Get_Elem_ex(OSHash *self);
+
 #endif

--- a/src/unit_tests/wrappers/wazuh/syscheckd/run_realtime_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/run_realtime_wrappers.c
@@ -24,6 +24,9 @@ int __wrap_realtime_adddir(const char *dir,
 int __wrap_realtime_start() {
     return 0;
 }
+void __wrap_realtime_process() {
+    function_called();
+}
 
 void expect_realtime_adddir_call(const char *path, int ret) {
     expect_string(__wrap_realtime_adddir, dir, path);

--- a/src/unit_tests/wrappers/wazuh/syscheckd/run_realtime_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/run_realtime_wrappers.h
@@ -24,4 +24,5 @@ void expect_realtime_adddir_call(const char *path, int ret);
 int __wrap_fim_add_inotify_watch(const char *dir,
                                  const directory_t *configuration);
 
+void __wrap_realtime_process();
 #endif

--- a/src/unit_tests/wrappers/windows/synchapi_wrappers.c
+++ b/src/unit_tests/wrappers/windows/synchapi_wrappers.c
@@ -27,3 +27,10 @@ HANDLE wrap_CreateEvent(LPSECURITY_ATTRIBUTES lpEventAttributes,
     check_expected(lpName);
     return mock_type(HANDLE);
 }
+
+DWORD wrap_WaitForSingleObjectEx(HANDLE hHandle, DWORD dwMilliseconds, BOOL bAlertable) {
+    check_expected(hHandle);
+    check_expected(dwMilliseconds);
+    check_expected(bAlertable);
+    return mock_type(DWORD);
+}

--- a/src/unit_tests/wrappers/windows/synchapi_wrappers.h
+++ b/src/unit_tests/wrappers/windows/synchapi_wrappers.h
@@ -16,6 +16,8 @@
 #define Sleep wrap_Sleep
 #undef CreateEvent
 #define CreateEvent wrap_CreateEvent
+#undef WaitForSingleObjectEx
+#define WaitForSingleObjectEx wrap_WaitForSingleObjectEx
 
 VOID wrap_Sleep(DWORD dwMilliseconds);
 
@@ -23,5 +25,7 @@ HANDLE wrap_CreateEvent(LPSECURITY_ATTRIBUTES lpEventAttributes,
                         WINBOOL bManualReset,
                         WINBOOL bInitialState,
                         LPCSTR lpName);
+
+DWORD wrap_WaitForSingleObjectEx(HANDLE hHandle, DWORD dwMilliseconds, BOOL bAlertable);
 
 #endif


### PR DESCRIPTION
|Related issue|
|---|
|#8487|


## Description
Hi team! 
As described in issue #8487, if FIM has reached the limit set in `max_fd_win_rt`, it won't add any directory when this limit is no longer reached. This PR aims to fix this.

Closes #8487 

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Windows
- [X] Source installation
- [X] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Windows
  - [x] Scan-build report
  - [ ] Coverity
