### PR TITLE
Fix a descriptor leak in the agent when failed to connect to Authd

### DIFF
--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -228,7 +228,7 @@ static int w_enrollment_connect(w_enrollment_ctx *cfg, const char * server_addre
     ERR_clear_error();
     int ret = SSL_connect(cfg->ssl);
     if (ret <= 0) {
-        merror("SSL error (%d). Connection refused by the manager. Maybe the port specified is incorrect. Exiting.", SSL_get_error(cfg->ssl, ret));
+        merror("SSL error (%d). Connection refused by the manager. Maybe the port specified is incorrect.", SSL_get_error(cfg->ssl, ret));
         ERR_print_errors_fp(stderr);  // This function empties the error queue
         os_free(ip_address);
         SSL_CTX_free(ctx);

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -232,6 +232,7 @@ static int w_enrollment_connect(w_enrollment_ctx *cfg, const char * server_addre
         ERR_print_errors_fp(stderr);  // This function empties the error queue
         os_free(ip_address);
         SSL_CTX_free(ctx);
+        OS_CloseSocket(sock);
         return ENROLLMENT_CONNECTION_FAILURE;
     }
 

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -56,7 +56,7 @@ set(ENROLLMENT_OP_BASE_FLAGS "-Wl,--wrap=OS_IsValidIP,--wrap=_merror,--wrap=_mwa
                                 -Wl,--wrap=SSL_new,--wrap=SSL_connect,--wrap=SSL_get_error,--wrap=SSL_set_bio \
                                 -Wl,--wrap=SSL_write,--wrap=fopen,--wrap=fclose,--wrap=SSL_read \
                                 -Wl,--wrap=BIO_new_socket,--wrap=_merror_exit,--wrap=TempFile,--wrap=OS_MoveFile \
-                                -Wl,--wrap=fgets -Wl,--wrap,getpid")
+                                -Wl,--wrap=fgets -Wl,--wrap,getpid -Wl,--wrap,OS_CloseSocket")
 if(${TARGET} STREQUAL "winagent")
     list(APPEND shared_tests_flags "${ENROLLMENT_OP_BASE_FLAGS}")
 else()

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -470,6 +470,10 @@ void test_w_enrollment_connect_SSL_connect_error(void **state) {
     will_return(__wrap_SSL_get_error, 100);
     expect_string(__wrap__merror, formatted_msg, "SSL error (100). Connection refused by the manager. Maybe the port specified is incorrect.");
 
+    // Close socket
+    expect_value(__wrap_OS_CloseSocket, sock, 5);
+    will_return(__wrap_OS_CloseSocket, 0);
+
     int ret = w_enrollment_connect(cfg, cfg->target_cfg->manager_name);
     assert_int_equal(ret, ENROLLMENT_CONNECTION_FAILURE);
 }
@@ -847,6 +851,10 @@ void test_w_enrollment_request_key(void **state) {
     SSL_CTX *ctx = get_ssl_context(DEFAULT_CIPHERS, 0);
 
     expect_string(__wrap__minfo, formatted_msg, "Requesting a key from server: valid_hostname");
+
+    // Close socket
+    expect_value(__wrap_OS_CloseSocket, sock, 5);
+    will_return(__wrap_OS_CloseSocket, 0);
 
     // w_enrollment_connect
     {

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -468,7 +468,7 @@ void test_w_enrollment_connect_SSL_connect_error(void **state) {
 
     expect_value(__wrap_SSL_get_error, i, -1);
     will_return(__wrap_SSL_get_error, 100);
-    expect_string(__wrap__merror, formatted_msg, "SSL error (100). Connection refused by the manager. Maybe the port specified is incorrect. Exiting.");
+    expect_string(__wrap__merror, formatted_msg, "SSL error (100). Connection refused by the manager. Maybe the port specified is incorrect.");
 
     int ret = w_enrollment_connect(cfg, cfg->target_cfg->manager_name);
     assert_int_equal(ret, ENROLLMENT_CONNECTION_FAILURE);

--- a/src/unit_tests/wrappers/wazuh/os_net/os_net_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/os_net/os_net_wrappers.c
@@ -100,3 +100,8 @@ int __wrap_wnet_select(__attribute__((unused)) int sock,
                        __attribute__((unused)) int timeout) {
     return (int)mock();
 }
+
+int __wrap_OS_CloseSocket(int sock) {
+    check_expected(sock);
+    return mock();
+}


### PR DESCRIPTION
|Related issue|
|---|
|Closes #8786|

This PR aims to apply the following changes:

1. Fix a descriptor leak in the agent that happens when the enrollment port (1515) is available but cannot communicate via TLS.
2. Remove the word "Exiting" from the error log:
> SSL error (5). Connection refused by the manager. Maybe the port specified is incorrect. Exiting.
3. Add socket closure checking to the Enrollment library unit tests.

## Tests

- [X] Run the same condition as explained at #8786 on Valgrind.
- [X] Add unit tests for this case.

### New file descriptor report
<details>

```
==2456== FILE DESCRIPTORS: 9 open at exit.
==2456== Open AF_INET socket 7: 127.0.0.1:54328 <-> 127.0.0.1:1514
==2456==    at 0x506190B: socket (syscall-template.S:78)
==2456==    by 0x1A0DB3: OS_Connect (os_net.c:256)
==2456==    by 0x1A0FAC: OS_ConnectTCP (os_net.c:325)
==2456==    by 0x11B073: connect_server (start_agent.c:100)
==2456==    by 0x11B92E: agent_ping_to_server (start_agent.c:319)
==2456==    by 0x11B4C9: w_agentd_keys_init (start_agent.c:209)
==2456==    by 0x11B17B: start_agent (start_agent.c:133)
==2456==    by 0x1157FB: AgentdStart (agentd.c:154)
==2456==    by 0x11A5AF: main (main.c:185)
==2456==
==2456== Open AF_UNIX socket 8: <unknown>
==2456==    at 0x506190B: socket (syscall-template.S:78)
==2456==    by 0x1A0BCD: OS_ConnectUnixDomain (os_net.c:203)
==2456==    by 0x193F3A: StartMQ (mq_op.c:33)
==2456==    by 0x1157B5: AgentdStart (agentd.c:147)
==2456==    by 0x11A5AF: main (main.c:185)
==2456==
==2456== Open AF_UNIX socket 6: queue/sockets/queue
==2456==    at 0x506190B: socket (syscall-template.S:78)
==2456==    by 0x1A09B9: OS_BindUnixDomain (os_net.c:153)
==2456==    by 0x193E90: StartMQ (mq_op.c:24)
==2456==    by 0x115464: AgentdStart (agentd.c:84)
==2456==    by 0x11A5AF: main (main.c:185)
==2456==
==2456== Open file descriptor 5: /dev/urandom
==2456==    at 0x4F2FA5B: open (open64.c:48)
==2456==    by 0x19DC5C: randombytes (randombytes.c:62)
==2456==    by 0x19DD38: srandom_init (randombytes.c:82)
==2456==    by 0x11505E: AgentdStart (agentd.c:27)
==2456==    by 0x11A5AF: main (main.c:185)
==2456==
==2456== Open file descriptor 4: /proc/stat
==2456==    at 0x4F2FA5B: open (open64.c:48)
==2456==    by 0x4942F4F: init_libproc (in /var/ossec/lib/libwazuhext.so)
==2456==    by 0x4011B89: call_init.part.0 (dl-init.c:72)
==2456==    by 0x4011C90: call_init (dl-init.c:30)
==2456==    by 0x4011C90: _dl_init (dl-init.c:119)
==2456==    by 0x4001139: ??? (in /usr/lib/x86_64-linux-gnu/ld-2.31.so)
==2456==    by 0x1: ???
==2456==    by 0x1FFF0004D6: ???
==2456==    by 0x1FFF0004E3: ???
==2456==
==2456== Open file descriptor 3: /proc/uptime
==2456==    at 0x4F2FA5B: open (open64.c:48)
==2456==    by 0x4942EFB: init_libproc (in /var/ossec/lib/libwazuhext.so)
==2456==    by 0x4011B89: call_init.part.0 (dl-init.c:72)
==2456==    by 0x4011C90: call_init (dl-init.c:30)
==2456==    by 0x4011C90: _dl_init (dl-init.c:119)
==2456==    by 0x4001139: ??? (in /usr/lib/x86_64-linux-gnu/ld-2.31.so)
==2456==    by 0x1: ???
==2456==    by 0x1FFF0004D6: ???
==2456==    by 0x1FFF0004E3: ???
==2456==
==2456== Open file descriptor 2: /dev/pts/0
==2456==    <inherited from parent>
==2456==
==2456== Open file descriptor 1: /dev/pts/0
==2456==    <inherited from parent>
==2456==
==2456== Open file descriptor 0: /dev/pts/0
==2456==    <inherited from parent>
```

</details>

### Helper scripts

This script helps replicate the condition that would produce a descriptor leak:

<details>
<summary>listen.py</summary>

```py
#! /usr/bin/env python3

import socket
import sys
import struct

if __name__ == '__main__':
    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
    sock.bind(('0.0.0.0', int(sys.argv[1])))
    sock.listen(128)

    while True:
        peer = sock.accept()[0]
        print('Connected')
        data = peer.recv(4096)
        payload = data[4:].decode(errors='ignore')

        if  payload == '#ping':
            print('Ping-pong')
            peer.send(struct.pack('<I5s', 5, b'#pong'))
        else:
            print(payload)
        peer.close()
        print('Disconnected')
```

</details>

### How to test

1. Run this line in a shell:
```sh
./listen.py 1514 & ./listen.py 1515 &
```

2. Set the manager address to `localhost`:
```xml
<ossec_config>
  <client>
    <server>
      <address>localhost</address>
      <port>1514</port>
      <protocol>tcp</protocol>
    </server>
  </client>
</ossec_config>
```

3. Run the agent on foreground:
```sh
[ -n "`pidof wazuh-execd`" ] || /var/ossec/bin/wazuh-execd
valgrind --track-fds=yes --leak-check=full --num-callers=20 --track-origins=yes /var/ossec/bin/wazuh-agentd -fd
```