### PR TITLE
Removes unmonitored file information in logcollector

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -492,6 +492,7 @@ void LogCollectorStart()
                             minfo(FORGET_FILE, current->file);
                             os_file_status_t * old_file_status = OSHash_Delete_ex(files_status, current->file);
                             os_free(old_file_status);
+                            w_logcollector_state_delete_file(current->file);
                             current->exists = 0;
                             current->ign++;
 
@@ -569,6 +570,7 @@ void LogCollectorStart()
                                 minfo(FORGET_FILE, current->file);
                                 os_file_status_t * old_file_status = OSHash_Delete_ex(files_status, current->file);
                                 os_free(old_file_status);
+                                w_logcollector_state_delete_file(current->file);
                                 current->exists = 0;
                             }
                             current->ign++;
@@ -626,6 +628,7 @@ void LogCollectorStart()
                             minfo(FORGET_FILE, current->file);
                             os_file_status_t * old_file_status = OSHash_Delete_ex(files_status, current->file);
                             os_free(old_file_status);
+                            w_logcollector_state_delete_file(current->file);
                             current->exists = 0;
                         }
                         current->ign++;
@@ -668,9 +671,8 @@ void LogCollectorStart()
                                current->file);
 
                         os_file_status_t * old_file_status = OSHash_Delete_ex(files_status, current->file);
-                        if (old_file_status != NULL) {
-                            os_free(old_file_status);
-                        }
+                        os_free(old_file_status);
+                        w_logcollector_state_delete_file(current->file);
 
                         fclose(current->fp);
 
@@ -704,9 +706,8 @@ void LogCollectorStart()
 
                         /* Get new file */
                         os_file_status_t * old_file_status = OSHash_Delete_ex(files_status, current->file);
-                        if (old_file_status != NULL) {
-                            os_free(old_file_status);
-                        }
+                        os_free(old_file_status);
+                        w_logcollector_state_delete_file(current->file);
 
                         fclose(current->fp);
 
@@ -2623,7 +2624,7 @@ STATIC void w_initialize_file_status() {
 
         fclose(fd);
     } else if (errno != ENOENT) {
-        merror_exit(FOPEN_ERROR, LOCALFILE_STATUS, errno, strerror(errno));
+        merror(FOPEN_ERROR, LOCALFILE_STATUS, errno, strerror(errno));
     }
 }
 

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -490,6 +490,8 @@ void LogCollectorStart()
                     if (current->file && current->exists) {
                         if (reload_file(current) == -1) {
                             minfo(FORGET_FILE, current->file);
+                            os_file_status_t * old_file_status = OSHash_Delete_ex(files_status, current->file);
+                            os_free(old_file_status);
                             current->exists = 0;
                             current->ign++;
 
@@ -565,6 +567,8 @@ void LogCollectorStart()
                         if (errno == ENOENT) {
                             if(current->exists==1){
                                 minfo(FORGET_FILE, current->file);
+                                os_file_status_t * old_file_status = OSHash_Delete_ex(files_status, current->file);
+                                os_free(old_file_status);
                                 current->exists = 0;
                             }
                             current->ign++;
@@ -620,6 +624,8 @@ void LogCollectorStart()
                     if (!current->fp) {
                         if(current->exists==1){
                             minfo(FORGET_FILE, current->file);
+                            os_file_status_t * old_file_status = OSHash_Delete_ex(files_status, current->file);
+                            os_free(old_file_status);
                             current->exists = 0;
                         }
                         current->ign++;

--- a/src/logcollector/main.c
+++ b/src/logcollector/main.c
@@ -186,8 +186,6 @@ int main(int argc, char **argv)
         merror_exit(PID_ERROR);
     }
 
-    minfo(STARTUP_MSG, (int)getpid());
-
     /* Start the queue */
     if ((logr_queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
         merror_exit(QUEUE_FATAL, DEFAULTQUEUE);

--- a/src/logcollector/state.c
+++ b/src/logcollector/state.c
@@ -64,6 +64,14 @@ STATIC void _w_logcollector_state_update_file(w_lc_state_storage_t * state, char
 STATIC void _w_logcollector_state_update_target(w_lc_state_storage_t * state, char * fpath, char * target, bool dropped);
 
 /**
+ * @brief Removes the `fpath` file from `state`
+ * 
+ * @param state state to be used
+ * @param fpath file path or locafile location value
+ */
+STATIC void _w_logcollector_state_delete_file(w_lc_state_storage_t * state, char * fpath);
+
+/**
  * @brief Dump state information to file
  *
  */
@@ -259,6 +267,7 @@ void _w_logcollector_state_update_target(w_lc_state_storage_t * state, char * fp
         if (OSHash_Add(state->states, fpath, data) != 2) {
             w_lc_state_target_t ** target = data->targets;
             while (*target != NULL) {
+                os_free((*target)->name);
                 os_free(*target);
                 target++;
             }
@@ -267,6 +276,44 @@ void _w_logcollector_state_update_target(w_lc_state_storage_t * state, char * fp
             merror(HUPDATE_ERROR, fpath, LOGCOLLECTOR_STATE_DESCRIPTION);
         }
     }
+}
+
+void w_logcollector_state_delete_file(char * fpath) {
+
+    if (fpath == NULL) {
+        return;
+    }
+
+    w_mutex_lock(&g_lc_raw_stats_mutex);
+
+    if (g_lc_state_type & LC_STATE_GLOBAL) {
+        _w_logcollector_state_delete_file(g_lc_states_global, fpath);
+    }
+    if (g_lc_state_type & LC_STATE_INTERVAL) {
+        _w_logcollector_state_delete_file(g_lc_states_interval, fpath);
+    }
+
+    w_mutex_unlock(&g_lc_raw_stats_mutex);
+}
+
+void _w_logcollector_state_delete_file(w_lc_state_storage_t * state, char * fpath) {
+
+    w_lc_state_file_t * data = NULL;
+
+    if (data = (w_lc_state_file_t *) OSHash_Delete(state->states, fpath), data == NULL) {
+        return;
+    }
+
+    w_lc_state_target_t ** target = data->targets;
+    while (*target != NULL) {
+        os_free((*target)->name);
+        os_free(*target);
+        target++;
+    }
+    os_free(data->targets);
+    os_free(data);
+
+    return;
 }
 
 void w_logcollector_state_generate() {

--- a/src/logcollector/state.h
+++ b/src/logcollector/state.h
@@ -18,8 +18,7 @@
 #define LOGCOLLECTOR_STATE      "var/run/wazuh-logcollector.state"
 #endif
 
-// Double of max value of logcollector.queue_size
-#define LOGCOLLECTOR_STATE_FILES_MAX   200200               ///< max amount of localfiles location for states
+#define LOGCOLLECTOR_STATE_FILES_MAX   40                   ///< Size of the statistics hash table
 #define LOGCOLLECTOR_STATE_DESCRIPTION "logcollector_state" ///< String identifier for errors
 
 // Macros to add files/targets node to states
@@ -98,6 +97,13 @@ void w_logcollector_state_update_target(char * fpath, char * target, bool droppe
  * @param bytes amount of bytes. If bigger than zero, event counter will increment.
  */
 void w_logcollector_state_update_file(char * fpath, uint64_t bytes);
+
+/**
+ * @brief Removes the `fpath` file from statistics
+ * 
+ * @param fpath file path or locafile location value
+ */
+void w_logcollector_state_delete_file(char * fpath);
 
 /**
  * @brief Get current state in JSON format

--- a/src/unit_tests/logcollector/CMakeLists.txt
+++ b/src/unit_tests/logcollector/CMakeLists.txt
@@ -27,7 +27,8 @@ list(APPEND logcollector_flags "-Wl,--wrap,OSHash_Add_ex -Wl,--wrap,OSHash_Add -
                                 -Wl,--wrap,cJSON_GetObjectItem -Wl,--wrap,cJSON_GetArraySize -Wl,--wrap,cJSON_GetArrayItem \
                                 -Wl,--wrap,cJSON_GetStringValue -Wl,--wrap,OS_SHA1_File_Nbytes -Wl,--wrap,fileno -Wl,--wrap,fstat \
                                 -Wl,--wrap,pthread_rwlock_rdlock -Wl,--wrap,pthread_rwlock_unlock \
-                                -Wl,--wrap,stat -Wl,--wrap=fgetc -Wl,--wrap=w_fseek -Wl,--wrap,w_ftell -Wl,--wrap,OS_SHA1_File_Nbytes_with_fp_check")
+                                -Wl,--wrap,stat -Wl,--wrap=fgetc -Wl,--wrap=w_fseek -Wl,--wrap,w_ftell -Wl,--wrap,OS_SHA1_File_Nbytes_with_fp_check \
+                                -Wl,--wrap,_mdebug1")
 
 list(APPEND logcollector_names "test_read_multiline_regex")
 list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets \
@@ -55,7 +56,7 @@ list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,ff
                                 -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,pthread_mutex_lock \
                                 -Wl,--wrap,cJSON_Delete -Wl,--wrap,cJSON_Print -Wl,--wrap,getDefine_Int \
                                 -Wl,--wrap,FOREVER -Wl,--wrap,sleep -Wl,--wrap,getpid -Wl,--wrap,cJSON_Duplicate \
-                                -Wl,--wrap,strftime")
+                                -Wl,--wrap,strftime -Wl,--wrap,OSHash_Delete")
 
 list(APPEND logcollector_names "test_lccom")
 list(APPEND logcollector_flags "-Wl,--wrap,w_logcollector_state_get -Wl,--wrap,cJSON_CreateObject \

--- a/src/unit_tests/logcollector/test_state.c
+++ b/src/unit_tests/logcollector/test_state.c
@@ -35,6 +35,9 @@ void w_logcollector_state_update_target(char * fpath, char * target, bool droppe
 void w_logcollector_state_generate();
 void w_logcollector_state_dump();
 void * w_logcollector_state_main(__attribute__((unused)) void * args);
+void _w_logcollector_state_delete_file(w_lc_state_storage_t * state, char * fpath);
+void w_logcollector_state_delete_file(char * fpath);
+
 extern cJSON * g_lc_json_stats;
 extern w_lc_state_storage_t * g_lc_states_global;
 extern w_lc_state_storage_t * g_lc_states_interval;
@@ -49,6 +52,22 @@ static int setup_group(void ** state) {
 
 static int teardown_group(void ** state) {
     test_mode = 0;
+    return 0;
+}
+
+static int setup_global(void ** state) {
+    char **array = calloc(10, sizeof(char*));
+
+    if(array == NULL)
+        return -1;
+
+    *state = array;
+
+    return 0;
+}
+
+static int teardown_global(void ** state) {
+
     return 0;
 }
 
@@ -1053,6 +1072,7 @@ void test__w_logcollector_state_delete_file_no_data(void ** state) {
     os_free(storage.states);
 
 }
+
 void test__w_logcollector_state_delete_file_ok(void ** state) {
 
     w_lc_state_storage_t storage = {0};
@@ -1072,6 +1092,102 @@ void test__w_logcollector_state_delete_file_ok(void ** state) {
 
     _w_logcollector_state_delete_file(&storage, "test_path");
     os_free(storage.states);
+}
+
+/* w_logcollector_state_delete_file */
+
+void test_w_logcollector_state_delete_file_fpath_NULL(void ** state) {
+
+    char * fpath = NULL;
+
+    w_logcollector_state_delete_file(fpath);
+
+}
+
+void test_w_logcollector_state_delete_file_global(void ** state) {
+
+    char * fpath = NULL;
+
+    os_strdup("test", fpath);
+
+    g_lc_state_type = 1;
+
+    os_calloc(1, sizeof(w_lc_state_storage_t), g_lc_states_global);
+    g_lc_states_global->states = (OSHash *) 2;
+
+    expect_value(__wrap_OSHash_Delete, self, g_lc_states_global->states);
+    expect_string(__wrap_OSHash_Delete, key, fpath);
+    will_return(__wrap_OSHash_Delete, NULL);
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    w_logcollector_state_delete_file(fpath);
+
+    os_free(fpath);
+    os_free(g_lc_states_global);
+
+}
+
+void test_w_logcollector_state_delete_file_interval(void ** state) {
+
+    char * fpath = NULL;
+
+    os_strdup("test", fpath);
+
+    g_lc_state_type = 2;
+
+    os_calloc(1, sizeof(w_lc_state_storage_t), g_lc_states_interval);
+    g_lc_states_interval->states = (OSHash *) 2;
+
+    expect_value(__wrap_OSHash_Delete, self, g_lc_states_interval->states);
+    expect_string(__wrap_OSHash_Delete, key, fpath);
+    will_return(__wrap_OSHash_Delete, NULL);
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    w_logcollector_state_delete_file(fpath);
+
+    os_free(fpath);
+    os_free(g_lc_states_interval);
+
+}
+
+void test_w_logcollector_state_delete_file_global_interval(void ** state) {
+
+    char * fpath = NULL;
+
+    os_strdup("test", fpath);
+
+    g_lc_state_type = 3;
+
+    os_calloc(1, sizeof(w_lc_state_storage_t), g_lc_states_global);
+    g_lc_states_global->states = (OSHash *) 2;
+
+    os_calloc(1, sizeof(w_lc_state_storage_t), g_lc_states_interval);
+    g_lc_states_interval->states = (OSHash *) 2;
+
+    expect_value(__wrap_OSHash_Delete, self, g_lc_states_global->states);
+    expect_string(__wrap_OSHash_Delete, key, fpath);
+    will_return(__wrap_OSHash_Delete, NULL);
+
+    expect_value(__wrap_OSHash_Delete, self, g_lc_states_interval->states);
+    expect_string(__wrap_OSHash_Delete, key, fpath);
+    will_return(__wrap_OSHash_Delete, NULL);
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    w_logcollector_state_delete_file(fpath);
+
+    os_free(fpath);
+    os_free(g_lc_states_global);
+    os_free(g_lc_states_interval);
+
 }
 
 int main(void) {
@@ -1129,6 +1245,13 @@ int main(void) {
         // Test _w_logcollector_state_delete_file
         cmocka_unit_test(test__w_logcollector_state_delete_file_no_data),
         cmocka_unit_test(test__w_logcollector_state_delete_file_ok),
+
+        // Test _w_logcollector_state_delete_file
+        cmocka_unit_test(test_w_logcollector_state_delete_file_fpath_NULL),
+        cmocka_unit_test(test_w_logcollector_state_delete_file_global),
+        cmocka_unit_test(test_w_logcollector_state_delete_file_interval),
+        cmocka_unit_test(test_w_logcollector_state_delete_file_global_interval),
+
     };
 
     return cmocka_run_group_tests(tests, setup_group, teardown_group);


### PR DESCRIPTION
|Related issue|
|---|
|Close #8796 |


## Description

Hi Team,

This PR is divided into 2 commits, which allow to perform the tests separately.

**Clears Only-Future-Event table of unmonitored files**:

Removes from the status table, used by only-future-event, files that were once monitored but no longer exist. This implies that no historical information about files that were monitored will be stored in the `/var/ossec/queue/logcollector/file_status.json` file.

**Clears state table of unmonitored files**:

Removes from the status table, used for the statistics feature, files that were once monitored but no longer exist. This implies that no historical information on the statistics of a file that is no longer monitored


Regards,
Julian

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer
- Memory tests for Windows
  - [x] Scan-build report
  - [x] Coverity

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)
- [x] Stress test for affected components
