### PR TITLE
Limit files scanned per second while solving inode collisions

### DIFF
--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -318,8 +318,6 @@ void fim_checker(const char *path, fim_element *item, whodata_evt *w_evt, int re
             return;
         }
 
-        check_max_fps();
-
         fim_file(path, item, w_evt, report);
         break;
 
@@ -474,6 +472,8 @@ static fim_sanitize_state_t fim_process_file_from_db(const char *path, OSList *s
     if (fim_db_append_paths_from_inode(syscheck.database, item.statbuf.st_ino, item.statbuf.st_dev, stack, tree) == 0) {
         // We have somehow reached a point an infinite loop could happen, we will need to update the current file
         // forcefully which will generate a false positive alert
+        check_max_fps();
+
         item.mode = FIM_SCHEDULED;
         item.index = fim_configuration_directory(entry->file_entry.path);
         if (item.index == -1) {
@@ -494,6 +494,8 @@ static fim_sanitize_state_t fim_process_file_from_db(const char *path, OSList *s
 end:
     // Once here, either the used row was cleared and is available or this file is a hardlink to other file
     // either way the only thing left to do is to process the file
+    check_max_fps();
+
     item.mode = FIM_SCHEDULED;
     item.index = fim_configuration_directory(entry->file_entry.path);
     if (item.index == -1) {
@@ -689,6 +691,8 @@ static cJSON *_fim_file(const char *path, fim_element *item, whodata_evt *w_evt)
                 break;
         }
     }
+
+    check_max_fps();
 
     //Get file attributes
     new = fim_get_data(path, item);


### PR DESCRIPTION
|Related issue|
|---|
|#8781|

## Description
This PR closes #8781.

Added a call to check the number of files processed per second while solving inode collisions in FIM. It also changes the original check so that files that have already been scanned and won't be processed are not taken into account.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] AddressSanitizer + UBSanitizer
  - [x] ThreadSanitizer
- Memory tests for Windows
  - [x] Scan-build report
