### PR TITLE
Fixed rules includidng stat command

### DIFF
--- a/ruleset/sca/centos/6/cis_centos6_linux.yml
+++ b/ruleset/sca/centos/6/cis_centos6_linux.yml
@@ -1,6 +1,6 @@
 # Security Configuration Assessment
 # CIS Checks for CentOS 6
-# Copyright (C) 2015-2021, Wazuh Inc.
+# Copyright (C) 2015-2020, Wazuh Inc.
 #
 # This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
@@ -529,7 +529,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /boot/grub/grub.conf -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /boot/grub/grub.conf -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 1.4.2 Set Boot Loader Password (Scored)
   - id: 5529
@@ -827,7 +827,7 @@ checks:
       - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
-      - 'c:stat /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 1.7.1.5 Configure /etc/issue permissions (Scored)
   - id: 5547
@@ -846,7 +846,7 @@ checks:
       - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
-      - 'c:stat /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 # 1.7.1.6 Configure /etc/issue.net permissions (Not Scored)
   - id: 5548
     title: "Ensure permissions on /etc/issue.net are configured"
@@ -864,7 +864,7 @@ checks:
       - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
-      - 'c:stat /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 1.7.2 Ensure GDM login banner is configured (Scored)
   - id: 5549
@@ -1836,7 +1836,7 @@ checks:
       - pci_dss: ["1.3.5"]
     condition: all
     rules:
-      - 'c:stat /etc/hosts.allow -> r:^Access: \(0644/-rw-r--r--\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)'
+      - 'c:stat -L /etc/hosts.allow -> r:^Access: \(0644/-rw-r--r--\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)'
 
 
 # 3.4.5 Ensure permissions on /etc/hosts.deny are configured (Scored)
@@ -1853,7 +1853,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/hosts.deny -> r:^Access: \(0644/-rw-r--r--\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/hosts.deny -> r:^Access: \(0644/-rw-r--r--\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
 ###############################################
@@ -2526,7 +2526,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/crontab -> r:^Access: \(0\d00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/crontab -> r:^Access: \(0\d00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.3 Ensure permissions on /etc/cron.hourly are configured (Scored)
   - id: 5638
@@ -2542,7 +2542,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.hourly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.hourly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.4 Ensure permissions on /etc/cron.daily are configured (Scored)
   - id: 5639
@@ -2558,7 +2558,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.daily -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.daily -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.5 Ensure permissions on /etc/cron.weekly are configured (Scored)
   - id: 5640
@@ -2574,7 +2574,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.weekly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.weekly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
 # 5.1.6 Ensure permissions on /etc/cron.monthly are configured (Scored)
@@ -2591,7 +2591,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.monthly -> r:^Access: \(0\w00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.monthly -> r:^Access: \(0\w00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.7 Ensure permissions on /etc/cron.d are configured (Scored)
   - id: 5642
@@ -2607,7 +2607,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.d -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.d -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.8 Ensure at/cron is restricted to authorized users (Scored)
   - id: 5643
@@ -2623,10 +2623,10 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.deny -> r:No such file or directory$'
-      - 'c:stat /etc/at.deny -> r:No such file or directory$'
-      - 'c:stat /etc/cron.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      - 'c:stat /etc/at.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.deny -> r:No such file or directory$'
+      - 'c:stat -L /etc/at.deny -> r:No such file or directory$'
+      - 'c:stat -L /etc/cron.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/at.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 ###############################################
 # 5.2 Configure SSH
@@ -2645,7 +2645,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/ssh/sshd_config -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/sshd_config -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.2.2 Set SSH Protocol to 2 (Scored)
   - id: 5645
@@ -3057,7 +3057,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/passwd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/passwd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 
 # 6.1.3 Configure /etc/shadow permissions (Scored)
@@ -3074,7 +3074,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/shadow -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/shadow -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.4 Configure /etc/group permissions (Scored)
   - id: 5670
@@ -3090,7 +3090,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/group -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/group -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.5 Configure /etc/gshadow permissions (Scored)
   - id: 5671
@@ -3106,7 +3106,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/gshadow -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/gshadow -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.6 Configure /etc/passwd- permissions (Scored)
   - id: 5672
@@ -3122,7 +3122,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/passwd- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/passwd- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.7 Configure /etc/shadow- permissions (Scored)
   - id: 5673
@@ -3138,7 +3138,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/shadow- -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/shadow- -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.8 Configure /etc/group- permissions (Scored)
   - id: 5674
@@ -3154,7 +3154,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/group- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/group- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.9 Configure /etc/gshadow- permissions (Scored)
   - id: 5675
@@ -3170,7 +3170,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/gshadow- -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/gshadow- -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 ###############################################
 # 6.2 Review User and Group Settings

--- a/ruleset/sca/centos/7/cis_centos7_linux.yml
+++ b/ruleset/sca/centos/7/cis_centos7_linux.yml
@@ -1,6 +1,6 @@
 # Security Configuration Assessment
 # CIS Checks for CentOS 7
-# Copyright (C) 2015-2021, Wazuh Inc.
+# Copyright (C) 2015-2020, Wazuh Inc.
 #
 # This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
@@ -600,8 +600,8 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /boot/grub2/grub.cfg -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
-      - 'c:stat /boot/grub2/user.cfg -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)|cannot stat'
+      - 'c:stat -L /boot/grub2/grub.cfg -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /boot/grub2/user.cfg -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)|cannot stat'
 
 # 1.5.3 Single user authentication
   - id: 6031
@@ -885,7 +885,7 @@ checks:
       - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
-      - 'c:stat /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 1.8.1.5 Configure /etc/issue permissions (Scored)
   - id: 6047
@@ -904,7 +904,7 @@ checks:
       - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
-      - 'c:stat /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 # 1.8.1.6 Configure /etc/issue.net permissions (Not Scored)
   - id: 6048
     title: "Ensure permissions on /etc/issue.net are configured"
@@ -922,7 +922,7 @@ checks:
       - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
-      - 'c:stat /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 
 # 1.9 Ensure updates, patches, and additional security software are installed
@@ -2722,7 +2722,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/crontab -> r:^Access: \(0\w00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/crontab -> r:^Access: \(0\w00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
 # 5.1.3 Ensure permissions on /etc/cron.hourly are configured (Automated)
@@ -2739,7 +2739,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.hourly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.hourly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.4 Ensure permissions on /etc/cron.daily are configured (Automated)
   - id: 6145
@@ -2755,7 +2755,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.daily -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.daily -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.5 Ensure permissions on /etc/cron.weekly are configured (Automated)
   - id: 6146
@@ -2771,7 +2771,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.weekly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.weekly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
 # 5.1.6 Ensure permissions on /etc/cron.monthly are configured (Automated)
@@ -2788,7 +2788,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.monthly -> r:^Access: \(0\w00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.monthly -> r:^Access: \(0\w00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.7 Ensure permissions on /etc/cron.d are configured (Automated)
   - id: 6148
@@ -2804,7 +2804,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.d -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.d -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.8 Ensure cron is restricted to authorized users (Scored)
   - id: 6149
@@ -2820,9 +2820,9 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.deny -> r:No such file or directory$'
-      - 'c:stat /etc/cron.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      - 'c:stat /etc/at.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.deny -> r:No such file or directory$'
+      - 'c:stat -L /etc/cron.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/at.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.9 Ensure at is restricted to authorized users (Automated)
   - id: 6150
@@ -2838,8 +2838,8 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/at.deny -> r:No such file or directory$'
-      - 'c:stat /etc/at.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/at.deny -> r:No such file or directory$'
+      - 'c:stat -L /etc/at.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
 
@@ -2860,7 +2860,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/ssh/sshd_config -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/sshd_config -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
 
@@ -2878,9 +2878,9 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_rsa_key" -exec stat {} \; -> r:^Access: \(0\d40/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_ecdsa_key" -exec stat {} \; -> r:^Access: \(0\d40/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_ed25519_key" -exec stat {} \; -> r:^Access: \(0\d400/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_rsa_key" -exec stat -L {} \; -> r:^Access: \(0\d40/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_ecdsa_key" -exec stat -L {} \; -> r:^Access: \(0\d40/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_ed25519_key" -exec stat -L {} \; -> r:^Access: \(0\d400/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
 # 5.2.3 Ensure permissions on SSH public host key files are configured  (Automated)
@@ -2897,9 +2897,9 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_rsa_key.pub" -exec stat {} \; -> r:^Access: \(0\d444/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_ecdsa_key.pub" -exec stat {} \; -> r:^Access: \(0\d44/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_ed25519_key.pub" -exec stat {} \; -> r:^Access: \(0\d44/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_rsa_key.pub" -exec stat -L {} \; -> r:^Access: \(0\d444/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_ecdsa_key.pub" -exec stat -L {} \; -> r:^Access: \(0\d44/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_ed25519_key.pub" -exec stat -L {} \; -> r:^Access: \(0\d44/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
 # 5.2.4 Ensure SSH access is limited (Scored)
@@ -3444,7 +3444,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/passwd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/passwd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.3 Ensure permissions on /etc/shadow are configured (Automated)
   - id: 6185
@@ -3459,7 +3459,7 @@ checks:
       - nist_800_53: ["CM.1"]
     condition: all
     rules:
-      - 'c:stat /etc/shadow -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/shadow -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.4 Ensure permissions on /etc/group are configured (Automated)
   - id: 6186
@@ -3475,7 +3475,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/group -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/group -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.5 Ensure permissions on /etc/gshadow are configured (Automated)
   - id: 6187
@@ -3491,7 +3491,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/gshadow -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/gshadow -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.6 Ensure permissions on /etc/passwd-are configured (Automated)
   - id: 6188
@@ -3507,7 +3507,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/passwd- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/passwd- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.7 Ensure permissions on /etc/shadow-are configured (Automated)
   - id: 6189
@@ -3523,7 +3523,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/shadow- -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/shadow- -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.8 Ensure permissions on /etc/group-are configured (Automated)
   - id: 6190
@@ -3539,7 +3539,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/group- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/group- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.9 Ensure permissions on /etc/gshadow-are configured (Automated)
   - id: 6191
@@ -3555,7 +3555,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/gshadow- -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/gshadow- -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 
 

--- a/ruleset/sca/centos/8/cis_centos8_linux.yml
+++ b/ruleset/sca/centos/8/cis_centos8_linux.yml
@@ -1,6 +1,6 @@
 # Security Configuration Assessment
 # CIS Checks for CentOS 8
-# Copyright (C) 2015-2021, Wazuh Inc.
+# Copyright (C) 2015-2020, Wazuh Inc.
 #
 # This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
@@ -551,8 +551,8 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /boot/grub2/grub.cfg -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
-      - 'c:stat /boot/grub2/grubenv -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /boot/grub2/grub.cfg -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /boot/grub2/grubenv -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 1.5.2 Set Boot Loader Password (Scored)
   - id: 6529 
@@ -832,7 +832,7 @@ checks:
       - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
-      - 'c:stat /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 1.8.1.5 Configure /etc/issue permissions (Scored)
   - id: 6545 
@@ -851,7 +851,7 @@ checks:
       - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
-      - 'c:stat /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 1.8.1.6 Configure /etc/issue.net permissions (Scored)
   - id: 6546 
@@ -870,7 +870,7 @@ checks:
       - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
-      - 'c:stat /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 1.8.2 Ensure GDM login banner is configured (Scored)
   - id: 6547 
@@ -2526,7 +2526,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/crontab -> r:^Access: \(0\d00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/crontab -> r:^Access: \(0\d00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
 # 5.1.3 Ensure permissions on /etc/cron.hourly are configured (Scored)
@@ -2543,7 +2543,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.hourly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.hourly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.4 Ensure permissions on /etc/cron.daily are configured (Scored)
   - id: 6635 
@@ -2559,7 +2559,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.daily -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.daily -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.5 Ensure permissions on /etc/cron.weekly are configured (Scored)
   - id: 6636 
@@ -2575,7 +2575,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.weekly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.weekly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
 # 5.1.6 Ensure permissions on /etc/cron.monthly are configured (Scored)
@@ -2592,7 +2592,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.monthly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.monthly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.7 Ensure permissions on /etc/cron.d are configured (Scored)
   - id: 6638 
@@ -2608,7 +2608,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.d -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.d -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.8 Ensure at/cron is restricted to authorized users (Scored)
   - id: 6639 
@@ -2624,10 +2624,10 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.deny -> r:No such file or directory$'
-      - 'c:stat /etc/at.deny -> r:No such file or directory$'
-      - 'c:stat /etc/cron.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      - 'c:stat /etc/at.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.deny -> r:No such file or directory$'
+      - 'c:stat -L /etc/at.deny -> r:No such file or directory$'
+      - 'c:stat -L /etc/cron.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/at.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 ###############################################
 # 5.2 Configure SSH
@@ -2646,7 +2646,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/ssh/sshd_config -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/sshd_config -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.2.2 Ensure SSH access is limited (Scored)
   - id: 6641 
@@ -2680,9 +2680,9 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/ssh/ssh_host_rsa_key -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      - 'c:stat /etc/ssh/ssh_host_ecdsa_key -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      - 'c:stat /etc/ssh/ssh_host_ed25519_key -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/ssh_host_rsa_key -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/ssh_host_ecdsa_key -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/ssh_host_ed25519_key -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.2.4 Ensure permissions on SSH public host key files are configured (Scored)
   - id: 6643 
@@ -2698,9 +2698,9 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/ssh/ssh_host_rsa_key.pub -> r:^Access: \(0\d\d\d/\w\w\w\w\w\w-\w\w-\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      - 'c:stat /etc/ssh/ssh_host_ecdsa_key.pub -> r:^Access: \(0\d\d\d/\w\w\w\w\w\w-\w\w-\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      - 'c:stat /etc/ssh/ssh_host_ed25519_key.pub -> r:^Access: \(0\d\d\d/\w\w\w\w\w\w-\w\w-\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/ssh_host_rsa_key.pub -> r:^Access: \(0\d\d\d/\w\w\w\w\w\w-\w\w-\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/ssh_host_ecdsa_key.pub -> r:^Access: \(0\d\d\d/\w\w\w\w\w\w-\w\w-\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/ssh_host_ed25519_key.pub -> r:^Access: \(0\d\d\d/\w\w\w\w\w\w-\w\w-\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.2.5 Ensure SSH LogLevel is appropriate (Scored)
   - id: 6644 
@@ -3215,7 +3215,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/passwd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/passwd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.3 Configure /etc/shadow permissions (Scored)
   - id: 6674 
@@ -3231,7 +3231,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/shadow -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)|Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\w*/\s*\t*shadow\)'
+      - 'c:stat -L /etc/shadow -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)|Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\w*/\s*\t*shadow\)'
 
 # 6.1.4 Configure /etc/group permissions (Scored)
   - id: 6675 
@@ -3247,7 +3247,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/group -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/group -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.5 Configure /etc/gshadow permissions (Scored)
   - id: 6676 
@@ -3263,7 +3263,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/gshadow -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)|Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\w*/\s*\t*shadow\)'
+      - 'c:stat -L /etc/gshadow -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)|Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\w*/\s*\t*shadow\)'
 
 # 6.1.6 Configure /etc/passwd- permissions (Scored)
   - id: 6677 
@@ -3279,7 +3279,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/passwd- -> r:Access:\s*\(0\d00/-\w\w-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/passwd- -> r:Access:\s*\(0\d00/-\w\w-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.7 Configure /etc/shadow- permissions (Scored)
   - id: 6678 
@@ -3295,7 +3295,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/shadow- -> r:Access:\s*\(0\d00/-\w\w-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)|Access:\s*\(0\d00/-\w\w-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\w*/\s*\t*shadow\)'
+      - 'c:stat -L /etc/shadow- -> r:Access:\s*\(0\d00/-\w\w-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)|Access:\s*\(0\d00/-\w\w-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\w*/\s*\t*shadow\)'
 
 # 6.1.8 Configure /etc/group- permissions (Scored)
   - id: 6679 
@@ -3311,7 +3311,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/group- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/group- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.9 Configure /etc/gshadow- permissions (Scored)
   - id: 6680 
@@ -3327,7 +3327,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/gshadow- -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)|Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\w*/\s*\t*shadow\)'
+      - 'c:stat -L /etc/gshadow- -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)|Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\w*/\s*\t*shadow\)'
 
 
 

--- a/ruleset/sca/debian/cis_debian10.yml
+++ b/ruleset/sca/debian/cis_debian10.yml
@@ -1,6 +1,6 @@
 # Security Configuration Assessment
 # CIS Checks for Debian Linux 10
-# Copyright (C) 2015-2021, Wazuh Inc.
+# Copyright (C) 2015-2020, Wazuh Inc.
 #
 # This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
@@ -534,7 +534,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /boot/grub/grub.cfg -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /boot/grub/grub.cfg -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
   - id: 2531
     title: "Ensure bootloader password is set"
@@ -760,7 +760,7 @@ checks:
       - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
-      - 'c:stat /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
   - id: 2545
     title: "Ensure permissions on /etc/issue are configured"
@@ -778,7 +778,7 @@ checks:
       - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
-      - 'c:stat /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
   - id: 2546
     title: "Ensure permissions on /etc/issue.net are configured"
@@ -796,7 +796,7 @@ checks:
       - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
-      - 'c:stat /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
   - id: 2547
     title: "Ensure GDM login banner is configured"
@@ -2463,7 +2463,7 @@ checks:
       - gdpr_IV: ["35.7","32.2"]
     condition: all
     rules:
-      - 'c:stat /etc/crontab -> r:^Access: \(0\d00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/crontab -> r:^Access: \(0\d00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
 # 5.1.3 Ensure permissions on /etc/cron.hourly are configured (Scored)
@@ -2480,7 +2480,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.hourly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.hourly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.4 Ensure permissions on /etc/cron.daily are configured (Scored)
   - id: 2638
@@ -2496,7 +2496,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.daily -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.daily -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.5 Ensure permissions on /etc/cron.weekly are configured (Scored)
   - id: 2639
@@ -2512,7 +2512,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.weekly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.weekly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
 # 5.1.6 Ensure permissions on /etc/cron.monthly are configured (Scored)
@@ -2529,7 +2529,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.monthly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.monthly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.7 Ensure permissions on /etc/cron.d are configured (Scored)
   - id: 2641
@@ -2545,7 +2545,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.d -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.d -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.8 Ensure at/cron is restricted to authorized users (Scored)
   - id: 2642
@@ -2565,8 +2565,8 @@ checks:
       - 'f:/etc/at.allow'
       - 'not f:/etc/cron.deny'
       - 'not f:/etc/at.deny'
-      - 'c:stat /etc/cron.allow -> r:^Access: \(0\d\d0/\w\w\w\w\w-----\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      - 'c:stat /etc/at.allow -> r:^Access: \(0\d\d0/\w\w\w\w\w-----\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.allow -> r:^Access: \(0\d\d0/\w\w\w\w\w-----\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/at.allow -> r:^Access: \(0\d\d0/\w\w\w\w\w-----\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 ######################################################
 # 5.2 SSH Server Configuration
@@ -2585,7 +2585,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/ssh/sshd_config -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/sshd_config -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.2.2 Ensure permissions on SSH private host key files are configured (Scored)
   - id: 2644
@@ -2601,9 +2601,9 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/ssh/ssh_host_rsa_key -> r:^Access: \(0\d00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      - 'c:stat /etc/ssh/ssh_host_ecdsa_key -> r:^Access: \(0\d00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      - 'c:stat /etc/ssh/ssh_host_ed25519_key -> r:^Access: \(0\d00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/ssh_host_rsa_key -> r:^Access: \(0\d00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/ssh_host_ecdsa_key -> r:^Access: \(0\d00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/ssh_host_ed25519_key -> r:^Access: \(0\d00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.2.3 Ensure permissions on SSH public host key files are configured (Scored)
   - id: 2645
@@ -2619,9 +2619,9 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/ssh/ssh_host_rsa_key.pub -> r:^Access: \(0\d\d\d/-\w\w\w\w--\w--\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      - 'c:stat /etc/ssh/ssh_host_ecdsa_key.pub -> r:^Access: \(0\d\d\d/-\w\w\w\w--\w--\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      - 'c:stat /etc/ssh/ssh_host_ed25519_key.pub -> r:^Access: \(0\d\d\d/-\w\w\w\w--\w--\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/ssh_host_rsa_key.pub -> r:^Access: \(0\d\d\d/-\w\w\w\w--\w--\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/ssh_host_ecdsa_key.pub -> r:^Access: \(0\d\d\d/-\w\w\w\w--\w--\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/ssh_host_ed25519_key.pub -> r:^Access: \(0\d\d\d/-\w\w\w\w--\w--\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.2.4 Ensure SSH Protocol is not set to 1 (Scored)
   - id: 2646
@@ -3198,7 +3198,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/passwd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/passwd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.3 Ensure permissions on /etc/gshadow- are configured (Scored)
   - id: 2679
@@ -3214,7 +3214,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/gshadow- -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)|Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/gshadow- -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)|Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.4 Ensure permissions on /etc/shadow are configured (Scored)
   - id: 2680
@@ -3230,7 +3230,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/shadow -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)'
+      - 'c:stat -L /etc/shadow -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)'
 
 # 6.1.5 Ensure permissions on /etc/group are configured (Scored)
   - id: 2681
@@ -3246,7 +3246,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/group -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/group -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.6 Ensure permissions on /etc/passwd- are configured (Scored)
   - id: 2682
@@ -3262,7 +3262,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/passwd- -> r:Access:\s*\(0\d00/-\w\w-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/passwd- -> r:Access:\s*\(0\d00/-\w\w-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.7 Ensure permissions on /etc/shadow- are configured (Scored)
   - id: 2683
@@ -3278,7 +3278,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/shadow- -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)|Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/shadow- -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)|Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.8 Ensure permissions on /etc/group- are configured (Scored)
   - id: 2684
@@ -3294,7 +3294,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/group- -> r:Access:\s*\(0\d00/-\w\w-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/group- -> r:Access:\s*\(0\d00/-\w\w-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.9 Ensure permissions on /etc/gshadow are configured (Scored)
   - id: 2685
@@ -3310,7 +3310,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/gshadow -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)'
+      - 'c:stat -L /etc/gshadow -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)'
 
 ####################################################
 # 6.2 User and Group Settings

--- a/ruleset/sca/debian/cis_debian7.yml
+++ b/ruleset/sca/debian/cis_debian7.yml
@@ -1,6 +1,6 @@
 # Security Configuration Assessment
 # CIS Checks for Debian Linux 7
-# Copyright (C) 2015-2021, Wazuh Inc.
+# Copyright (C) 2015-2020, Wazuh Inc.
 #
 # This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
@@ -346,7 +346,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /boot/grub/grub.cfg -> r:Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /boot/grub/grub.cfg -> r:Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
   - id: 1022
     title: "Set Permissions on bootloader config"
@@ -360,7 +360,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /boot/grub/grub.cfg -> r:^Access: \(0\d00/-\w\w\w------\)'
+      - 'c:stat -L /boot/grub/grub.cfg -> r:^Access: \(0\d00/-\w\w\w------\)'
 
   - id: 1023
     title: "Set Boot Loader Password"
@@ -1933,7 +1933,7 @@ checks:
       - gdpr_IV: ["35.7","32.2"]
     condition: all
     rules:
-      - 'c:stat /etc/crontab -> r:^Access: \(0\d00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/crontab -> r:^Access: \(0\d00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 9.1.3 Set User/Group Owner and Permission on /etc/cron.hourly (Scored)
   - id: 1110
@@ -1948,7 +1948,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.hourly -> r:^Access: \(0\d00/d\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.hourly -> r:^Access: \(0\d00/d\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 9.1.4 Set User/Group Owner and Permission on /etc/cron.daily (Scored)
   - id: 1111
@@ -1963,7 +1963,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.daily -> r:^Access: \(0\d00/d\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.daily -> r:^Access: \(0\d00/d\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 9.1.5 Set User/Group Owner and Permission on /etc/cron.weekly (Scored)
   - id: 1112
@@ -1978,7 +1978,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.weekly -> r:^Access: \(0\d00/d\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.weekly -> r:^Access: \(0\d00/d\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
 # 9.1.6 Set User/Group Owner and Permission on /etc/cron.monthly (Scored)
@@ -1994,7 +1994,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.monthly -> r:^Access: \(0\d00/d\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.monthly -> r:^Access: \(0\d00/d\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 9.1.7 Set User/Group Owner and Permission on /etc/cron.d (Scored)
   - id: 1114
@@ -2009,7 +2009,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.d -> r:^Access: \(0\d00/d\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.d -> r:^Access: \(0\d00/d\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 9.1.8 Restrict at/cron to Authorized Users (Scored)
   - id: 1115
@@ -2028,8 +2028,8 @@ checks:
       - 'f:/etc/at.allow'
       - 'not f:/etc/cron.deny'
       - 'not f:/etc/at.deny'
-      - 'c:stat -c%u-%g-%a /etc/cron.allow -> r:^0-0-600'
-      - 'c:stat -c%u-%g-%a /etc/at.allow -> r:^0-0-600'
+      - 'c:stat -L -c%u-%g-%a /etc/cron.allow -> r:^0-0-600'
+      - 'c:stat -L -c%u-%g-%a /etc/at.allow -> r:^0-0-600'
 
 ###########################################
 # 9.2 Configure PAM
@@ -2121,7 +2121,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/ssh/sshd_config -> r:^Access: \(0\d00/-\w\w-------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/sshd_config -> r:^Access: \(0\d00/-\w\w-------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 9.3.4 Disable SSH X11 Forwarding (Scored)
   - id: 1122
@@ -2412,9 +2412,9 @@ checks:
       - 'f:/etc/motd'
       - 'f:/etc/issue'
       - 'f:/etc/issue.net'
-      - 'c:stat -c%u-%g-%a /etc/motd -> 0-0-644'
-      - 'c:stat -c%u-%g-%a /etc/issue -> 0-0-644'
-      - 'c:stat -c%u-%g-%a /etc/issue.net -> 0-0-644'
+      - 'c:stat -L -c%u-%g-%a /etc/motd -> 0-0-644'
+      - 'c:stat -L -c%u-%g-%a /etc/issue -> 0-0-644'
+      - 'c:stat -L -c%u-%g-%a /etc/issue.net -> 0-0-644'
 
 # 11.2 Remove OS Information from Login Warning Banners (Scored)
   - id: 1141

--- a/ruleset/sca/debian/cis_debian8.yml
+++ b/ruleset/sca/debian/cis_debian8.yml
@@ -1,6 +1,6 @@
 # Security Configuration Assessment
 # CIS Checks for Debian Linux 8
-# Copyright (C) 2015-2021, Wazuh Inc.
+# Copyright (C) 2015-2020, Wazuh Inc.
 #
 # This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
@@ -435,7 +435,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /boot/grub/grub.cfg -> r:Access:\s*\(0\w00/-\w\w-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /boot/grub/grub.cfg -> r:Access:\s*\(0\w00/-\w\w-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
   - id: 1526
     title: "Ensure bootloader password is set"
@@ -705,7 +705,7 @@ checks:
       - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
-      - 'c:stat /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
   - id: 1543
     title: "Ensure permissions on /etc/issue are configured"
@@ -723,7 +723,7 @@ checks:
       - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
-      - 'c:stat /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
   - id: 1544
     title: "Ensure permissions on /etc/issue.net are configured"
@@ -741,7 +741,7 @@ checks:
       - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
-      - 'c:stat /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
   - id: 1545
     title: "Ensure GDM login banner is configured"
@@ -1466,7 +1466,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/hosts.allow -> r:^Access: \(0644/-rw-r--r--\)\s*\t*Uid:\s*\t*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\t*\(\s*\t*0/\s*\t*root\)$'
+      - 'c:stat -L /etc/hosts.allow -> r:^Access: \(0644/-rw-r--r--\)\s*\t*Uid:\s*\t*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\t*\(\s*\t*0/\s*\t*root\)$'
 
   - id: 1588
     title: "Verify permissions on /etc/hosts.deny"
@@ -1480,7 +1480,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/hosts.deny -> r:^Access: \(0644/-rw-r--r--\)\s*\t*Uid:\s*\t*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\t*\(\s*\t*0/\s*\t*root\)$'
+      - 'c:stat -L /etc/hosts.deny -> r:^Access: \(0644/-rw-r--r--\)\s*\t*Uid:\s*\t*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\t*\(\s*\t*0/\s*\t*root\)$'
 
 # 3.4 Uncommon Network Protocols
 
@@ -2204,7 +2204,7 @@ checks:
       - gdpr_IV: ["35.7","32.2"]
     condition: all
     rules:
-      - 'c:stat /etc/crontab -> r:^Access: \(0\d00/\w\w\w-------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/crontab -> r:^Access: \(0\d00/\w\w\w-------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
 # 5.1.3 Ensure permissions on /etc/cron.hourly are configured (Scored)
@@ -2222,7 +2222,7 @@ checks:
 
     condition: all
     rules:
-      - 'c:stat /etc/cron.hourly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.hourly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.4 Ensure permissions on /etc/cron.daily are configured (Scored)
   - id: 1629
@@ -2238,7 +2238,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.daily -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.daily -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.5 Ensure permissions on /etc/cron.weekly are configured (Scored)
   - id: 1630
@@ -2254,7 +2254,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.weekly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.weekly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
 # 5.1.6 Ensure permissions on /etc/cron.monthly are configured (Scored)
@@ -2271,7 +2271,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.monthly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.monthly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.7 Ensure permissions on /etc/cron.d are configured (Scored)
   - id: 1632
@@ -2287,7 +2287,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.d -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.d -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
   - id: 1633
@@ -2307,8 +2307,8 @@ checks:
       - 'f:/etc/at.allow'
       - 'not f:/etc/cron.deny'
       - 'not f:/etc/at.deny'
-      - 'c:stat -c%u-%g-%a /etc/cron.allow -> r:^0-0-\d00'
-      - 'c:stat -c%u-%g-%a /etc/at.allow -> r:^0-0-\d00'
+      - 'c:stat -L -c%u-%g-%a /etc/cron.allow -> r:^0-0-\d00'
+      - 'c:stat -L -c%u-%g-%a /etc/at.allow -> r:^0-0-\d00'
 
 # 5.2 SSH Server Configuration
 
@@ -2325,7 +2325,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat -c%u-%g-%a /etc/ssh/sshd_config -> r:^0-0-\d00'
+      - 'c:stat -L -c%u-%g-%a /etc/ssh/sshd_config -> r:^0-0-\d00'
 
   - id: 1635
     title: "Ensure SSH Protocol is set to 2"
@@ -2798,7 +2798,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/passwd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/passwd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.3 Ensure permissions on /etc/shadow are configured (Scored)
   - id: 1664
@@ -2814,7 +2814,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/shadow -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)'
+      - 'c:stat -L /etc/shadow -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)'
 
 # 6.1.4 Configure /etc/group permissions (Scored)
   - id: 1665
@@ -2830,7 +2830,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/group -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/group -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.5 Ensure permissions on /etc/gshadow are configured (Scored)
   - id: 1666
@@ -2846,7 +2846,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/gshadow -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)'
+      - 'c:stat -L /etc/gshadow -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)'
 
 # 6.1.6 Ensure permissions on /etc/passwd- are configured (Scored)
   - id: 1667
@@ -2862,7 +2862,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/passwd- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/passwd- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.7 Ensure permissions on /etc/shadow- are configured (Scored)
   - id: 1668
@@ -2878,7 +2878,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/shadow- -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\) && r:Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)|Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/shadow- -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\) && r:Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)|Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.8 Configure /etc/group- permissions (Scored)
   - id: 1669
@@ -2894,7 +2894,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/group- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/group- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.9 Ensure permissions on /etc/gshadow- are configured (Scored)
   - id: 1670
@@ -2910,7 +2910,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/gshadow- -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\) && r:Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)|Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/gshadow- -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\) && r:Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)|Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.2 User and Group Settings
 

--- a/ruleset/sca/debian/cis_debian9.yml
+++ b/ruleset/sca/debian/cis_debian9.yml
@@ -1,6 +1,6 @@
 # Security Configuration Assessment
 # CIS Checks for Debian Linux 9
-# Copyright (C) 2015-2021, Wazuh Inc.
+# Copyright (C) 2015-2020, Wazuh Inc.
 #
 # This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
@@ -423,7 +423,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /boot/grub/grub.cfg -> r:Access:\s*\(0\d00/-\w\w-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /boot/grub/grub.cfg -> r:Access:\s*\(0\d00/-\w\w-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
   - id: 2025
     title: "Ensure bootloader password is set"
@@ -696,7 +696,7 @@ checks:
       - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
-      - 'c:stat /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
   - id: 2042
     title: "Ensure permissions on /etc/issue are configured"
@@ -714,7 +714,7 @@ checks:
       - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
-      - 'c:stat /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
   - id: 2043
     title: "Ensure permissions on /etc/issue.net are configured"
@@ -732,7 +732,7 @@ checks:
       - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
-      - 'c:stat /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
   - id: 2044
     title: "Ensure GDM login banner is configured"
@@ -1455,7 +1455,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/hosts.allow -> r:^Access: \(0644/-rw-r--r--\)\s*\t*Uid:\s*\t*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\t*\(\s*\t*0/\s*\t*root\)$'
+      - 'c:stat -L /etc/hosts.allow -> r:^Access: \(0644/-rw-r--r--\)\s*\t*Uid:\s*\t*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\t*\(\s*\t*0/\s*\t*root\)$'
 
   - id: 2087
     title: "Verify permissions on /etc/hosts.deny"
@@ -1469,7 +1469,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/hosts.deny -> r:^Access: \(0644/-rw-r--r--\)\s*\t*Uid:\s*\t*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\t*\(\s*\t*0/\s*\t*root\)$'
+      - 'c:stat -L /etc/hosts.deny -> r:^Access: \(0644/-rw-r--r--\)\s*\t*Uid:\s*\t*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\t*\(\s*\t*0/\s*\t*root\)$'
 
   - id: 2088
     title: "Ensure DCCP is disabled"
@@ -2173,7 +2173,7 @@ checks:
       - gdpr_IV: ["35.7","32.2"]
     condition: all
     rules:
-      - 'c:stat /etc/crontab -> r:^Access: \(0\d00/\w\w\w-------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/crontab -> r:^Access: \(0\d00/\w\w\w-------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
 # 5.1.3 Ensure permissions on /etc/cron.hourly are configured (Scored)
@@ -2191,7 +2191,7 @@ checks:
 
     condition: all
     rules:
-      - 'c:stat /etc/cron.hourly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.hourly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.4 Ensure permissions on /etc/cron.daily are configured (Scored)
   - id: 2127
@@ -2207,7 +2207,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.daily -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.daily -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.5 Ensure permissions on /etc/cron.weekly are configured (Scored)
   - id: 2128
@@ -2223,7 +2223,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.weekly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.weekly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
 # 5.1.6 Ensure permissions on /etc/cron.monthly are configured (Scored)
@@ -2240,7 +2240,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.monthly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.monthly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.7 Ensure permissions on /etc/cron.d are configured (Scored)
   - id: 2130
@@ -2256,7 +2256,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.d -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.d -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
   - id: 2131
     title: "Ensure at/cron is restricted to authorized users"
@@ -2275,8 +2275,8 @@ checks:
       - 'f:/etc/at.allow'
       - 'not f:/etc/cron.deny'
       - 'not f:/etc/at.deny'
-      - 'c:stat /etc/cron.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      - 'c:stat /etc/at.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/at.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.2 SSH Server Configuration
 
@@ -2293,7 +2293,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/ssh/sshd_config -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/sshd_config -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
   - id: 2133
     title: "Ensure SSH Protocol is set to 2"
@@ -2760,7 +2760,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/gshadow -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)'
+      - 'c:stat -L /etc/gshadow -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)'
 
   - id: 2162
     title: "Ensure permissions on /etc/shadow- are configured"
@@ -2775,7 +2775,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/shadow- -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)'
+      - 'c:stat -L /etc/shadow- -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)'
 
   - id: 2163
     title: "Ensure permissions on /etc/gshadow- are configured"
@@ -2790,7 +2790,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/gshadow- -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)'
+      - 'c:stat -L /etc/gshadow- -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)'
 
   - id: 2164
     title: "Ensure permissions on /etc/passwd are configured"
@@ -2805,7 +2805,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/passwd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/passwd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
   - id: 2165
     title: "Ensure permissions on /etc/shadow are configured"
@@ -2820,7 +2820,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/shadow -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)'
+      - 'c:stat -L /etc/shadow -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)'
 
   - id: 2166
     title: "Ensure permissions on /etc/group are configured"
@@ -2835,7 +2835,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/group -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/group -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
   - id: 2167
     title: "Ensure permissions on /etc/passwd- are configured"
@@ -2850,7 +2850,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/passwd- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/passwd- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 
   - id: 2168
@@ -2866,7 +2866,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/group- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/group- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 
 # 6.2 User and Group Settings

--- a/ruleset/sca/rhel/6/cis_rhel6_linux.yml
+++ b/ruleset/sca/rhel/6/cis_rhel6_linux.yml
@@ -1,6 +1,6 @@
 # Security Configuration Assessment
 # CIS Checks for RHEL 6
-# Copyright (C) 2015-2021, Wazuh Inc.
+# Copyright (C) 2015-2020, Wazuh Inc.
 #
 # This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
@@ -545,7 +545,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /boot/grub/grub.conf -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /boot/grub/grub.conf -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 1.4.2 Set Boot Loader Password (Scored)
   - id: 4030
@@ -841,7 +841,7 @@ checks:
       - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
-      - 'c:stat /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 1.7.1.5 Configure /etc/issue permissions (Scored)
   - id: 4048
@@ -860,7 +860,7 @@ checks:
       - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
-      - 'c:stat /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 # 1.7.1.6 Configure /etc/issue.net permissions (Not Scored)
   - id: 4049
     title: "Ensure permissions on /etc/issue.net are configured"
@@ -878,7 +878,7 @@ checks:
       - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
-      - 'c:stat /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 1.7.2 Ensure GDM login banner is configured (Scored)
   - id: 4050
@@ -1850,7 +1850,7 @@ checks:
       - pci_dss: ["1.3.5"]
     condition: all
     rules:
-      - 'c:stat /etc/hosts.allow -> r:^Access: \(0644/-rw-r--r--\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)'
+      - 'c:stat -L /etc/hosts.allow -> r:^Access: \(0644/-rw-r--r--\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)'
 
 
 # 3.4.5 Ensure permissions on /etc/hosts.deny are configured (Scored)
@@ -1867,7 +1867,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/hosts.deny -> r:^Access: \(0644/-rw-r--r--\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/hosts.deny -> r:^Access: \(0644/-rw-r--r--\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
 ###############################################
@@ -2534,7 +2534,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/crontab -> r:^Access: \(0\d00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/crontab -> r:^Access: \(0\d00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.3 Ensure permissions on /etc/cron.hourly are configured (Scored)
   - id: 4139
@@ -2550,7 +2550,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.hourly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.hourly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.4 Ensure permissions on /etc/cron.daily are configured (Scored)
   - id: 4140
@@ -2566,7 +2566,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.daily -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.daily -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.5 Ensure permissions on /etc/cron.weekly are configured (Scored)
   - id: 4141
@@ -2582,7 +2582,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.weekly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.weekly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
 # 5.1.6 Ensure permissions on /etc/cron.monthly are configured (Scored)
@@ -2599,7 +2599,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.monthly -> r:^Access: \(0\w00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.monthly -> r:^Access: \(0\w00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.7 Ensure permissions on /etc/cron.d are configured (Scored)
   - id: 4143
@@ -2615,7 +2615,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.d -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.d -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.8 Ensure at/cron is restricted to authorized users (Scored)
   - id: 4144
@@ -2631,10 +2631,10 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.deny -> r:No such file or directory$'
-      - 'c:stat /etc/at.deny -> r:No such file or directory$'
-      - 'c:stat /etc/cron.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      - 'c:stat /etc/at.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.deny -> r:No such file or directory$'
+      - 'c:stat -L /etc/at.deny -> r:No such file or directory$'
+      - 'c:stat -L /etc/cron.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/at.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 ###############################################
 # 5.2 Configure SSH
@@ -2653,7 +2653,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/ssh/sshd_config -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/sshd_config -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.2.2 Set SSH Protocol to 2 (Scored)
   - id: 4146
@@ -3062,7 +3062,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/passwd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/passwd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 
 # 6.1.3 Configure /etc/shadow permissions (Scored)
@@ -3079,7 +3079,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/shadow -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/shadow -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.4 Configure /etc/group permissions (Scored)
   - id: 4171
@@ -3095,7 +3095,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/group -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/group -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.5 Configure /etc/gshadow permissions (Scored)
   - id: 4172
@@ -3111,7 +3111,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/gshadow -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/gshadow -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.6 Configure /etc/passwd- permissions (Scored)
   - id: 4173
@@ -3127,7 +3127,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/passwd- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/passwd- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.7 Configure /etc/shadow- permissions (Scored)
   - id: 4174
@@ -3143,7 +3143,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/shadow- -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/shadow- -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.8 Configure /etc/group- permissions (Scored)
   - id: 4175
@@ -3159,7 +3159,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/group- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/group- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.9 Configure /etc/gshadow- permissions (Scored)
   - id: 4176
@@ -3175,7 +3175,7 @@ the potential attack surface."
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/gshadow- -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/gshadow- -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 ###############################################
 # 6.2 Review User and Group Settings

--- a/ruleset/sca/rhel/7/cis_rhel7_linux.yml
+++ b/ruleset/sca/rhel/7/cis_rhel7_linux.yml
@@ -1,6 +1,6 @@
 # Security Configuration Assessment
 # CIS Checks for RHEL 7
-# Copyright (C) 2015-2021, Wazuh Inc.
+# Copyright (C) 2015-2020, Wazuh Inc.
 #
 # This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
@@ -620,8 +620,8 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /boot/grub2/grub.cfg -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
-      - 'c:stat /boot/grub2/user.cfg -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)|cannot stat'
+      - 'c:stat -L /boot/grub2/grub.cfg -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /boot/grub2/user.cfg -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)|cannot stat'
 
 # 1.5.3 Single user authentication
   - id: 4532
@@ -904,7 +904,7 @@ checks:
       - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
-      - 'c:stat /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 1.8.1.5 Configure /etc/issue permissions (Scored)
   - id: 4548
@@ -923,7 +923,7 @@ checks:
       - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
-      - 'c:stat /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 # 1.8.1.6 Configure /etc/issue.net permissions (Not Scored)
   - id: 4549
     title: "Ensure permissions on /etc/issue.net are configured"
@@ -941,7 +941,7 @@ checks:
       - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
-      - 'c:stat /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 
 # 1.9 Ensure updates, patches, and additional security software are installed
@@ -2742,7 +2742,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/crontab -> r:^Access: \(0\w00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/crontab -> r:^Access: \(0\w00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
 # 5.1.3 Ensure permissions on /etc/cron.hourly are configured (Automated)
@@ -2759,7 +2759,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.hourly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.hourly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.4 Ensure permissions on /etc/cron.daily are configured (Automated)
   - id: 4646
@@ -2775,7 +2775,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.daily -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.daily -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.5 Ensure permissions on /etc/cron.weekly are configured (Automated)
   - id: 4647
@@ -2791,7 +2791,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.weekly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.weekly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
 # 5.1.6 Ensure permissions on /etc/cron.monthly are configured (Automated)
@@ -2808,7 +2808,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.monthly -> r:^Access: \(0\w00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.monthly -> r:^Access: \(0\w00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.7 Ensure permissions on /etc/cron.d are configured (Automated)
   - id: 4649
@@ -2824,7 +2824,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.d -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.d -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.8 Ensure cron is restricted to authorized users (Scored)
   - id: 4650
@@ -2840,9 +2840,9 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.deny -> r:No such file or directory$'
-      - 'c:stat /etc/cron.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      - 'c:stat /etc/at.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.deny -> r:No such file or directory$'
+      - 'c:stat -L /etc/cron.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/at.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.9 Ensure at is restricted to authorized users (Automated)
   - id: 4651
@@ -2858,8 +2858,8 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/at.deny -> r:No such file or directory$'
-      - 'c:stat /etc/at.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/at.deny -> r:No such file or directory$'
+      - 'c:stat -L /etc/at.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
 
@@ -2880,7 +2880,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/ssh/sshd_config -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/sshd_config -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
 
@@ -2898,9 +2898,9 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_rsa_key" -exec stat {} \; -> r:^Access: \(0\d40/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_ecdsa_key" -exec stat {} \; -> r:^Access: \(0\d40/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_ed25519_key" -exec stat {} \; -> r:^Access: \(0\d400/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_rsa_key" -exec stat -L {} \; -> r:^Access: \(0\d40/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_ecdsa_key" -exec stat -L {} \; -> r:^Access: \(0\d40/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_ed25519_key" -exec stat -L {} \; -> r:^Access: \(0\d400/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
 # 5.2.3 Ensure permissions on SSH public host key files are configured  (Automated)
@@ -2917,9 +2917,9 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_rsa_key.pub" -exec stat {} \; -> r:^Access: \(0\d444/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_ecdsa_key.pub" -exec stat {} \; -> r:^Access: \(0\d44/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_ed25519_key.pub" -exec stat {} \; -> r:^Access: \(0\d44/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_rsa_key.pub" -exec stat -L {} \; -> r:^Access: \(0\d444/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_ecdsa_key.pub" -exec stat -L {} \; -> r:^Access: \(0\d44/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_ed25519_key.pub" -exec stat -L {} \; -> r:^Access: \(0\d44/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
 # 5.2.4 Ensure SSH access is limited (Scored)
@@ -3468,7 +3468,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/passwd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/passwd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.3 Ensure permissions on /etc/shadow are configured (Automated)
   - id: 4686
@@ -3483,7 +3483,7 @@ checks:
       - nist_800_53: ["CM.1"]
     condition: all
     rules:
-      - 'c:stat /etc/shadow -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/shadow -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.4 Ensure permissions on /etc/group are configured (Automated)
   - id: 4687
@@ -3499,7 +3499,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/group -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/group -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.5 Ensure permissions on /etc/gshadow are configured (Automated)
   - id: 4688
@@ -3515,7 +3515,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/gshadow -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/gshadow -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.6 Ensure permissions on /etc/passwd-are configured (Automated)
   - id: 4689
@@ -3531,7 +3531,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/passwd- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/passwd- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.7 Ensure permissions on /etc/shadow-are configured (Automated)
   - id: 4690
@@ -3547,7 +3547,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/shadow- -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/shadow- -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.8 Ensure permissions on /etc/group-are configured (Automated)
   - id: 4691
@@ -3563,7 +3563,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/group- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/group- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.9 Ensure permissions on /etc/gshadow-are configured (Automated)
   - id: 4692
@@ -3579,7 +3579,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/gshadow- -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/gshadow- -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 
 

--- a/ruleset/sca/rhel/8/cis_rhel8_linux.yml
+++ b/ruleset/sca/rhel/8/cis_rhel8_linux.yml
@@ -1,6 +1,6 @@
 # Security Configuration Assessment
 # CIS Checks for RHEL 8
-# Copyright (C) 2015-2021, Wazuh Inc.
+# Copyright (C) 2015-2020, Wazuh Inc.
 #
 # This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
@@ -565,8 +565,8 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /boot/grub2/grub.cfg -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
-      - 'c:stat /boot/grub2/grubenv -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /boot/grub2/grub.cfg -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /boot/grub2/grubenv -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 1.5.2 Set Boot Loader Password (Scored)
   - id: 5030 
@@ -827,7 +827,7 @@ checks:
       - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
-      - 'c:stat /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 1.8.1.5 Configure /etc/issue permissions (Scored)
   - id: 5045 
@@ -846,7 +846,7 @@ checks:
       - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
-      - 'c:stat /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 1.8.1.6 Configure /etc/issue.net permissions (Scored)
   - id: 5046 
@@ -865,7 +865,7 @@ checks:
       - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
-      - 'c:stat /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 1.8.2 Ensure GDM login banner is configured (Scored)
   - id: 5047 
@@ -2537,7 +2537,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/crontab -> r:^Access: \(0\d00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/crontab -> r:^Access: \(0\d00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
 # 5.1.3 Ensure permissions on /etc/cron.hourly are configured (Scored)
@@ -2554,7 +2554,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.hourly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.hourly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.4 Ensure permissions on /etc/cron.daily are configured (Scored)
   - id: 5136 
@@ -2570,7 +2570,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.daily -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.daily -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.5 Ensure permissions on /etc/cron.weekly are configured (Scored)
   - id: 5137 
@@ -2586,7 +2586,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.weekly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.weekly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
 # 5.1.6 Ensure permissions on /etc/cron.monthly are configured (Scored)
@@ -2603,7 +2603,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.monthly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.monthly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.7 Ensure permissions on /etc/cron.d are configured (Scored)
   - id: 5139 
@@ -2619,7 +2619,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.d -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.d -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.8 Ensure at/cron is restricted to authorized users (Scored)
   - id: 5140 
@@ -2635,10 +2635,10 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/cron.deny -> r:No such file or directory$'
-      - 'c:stat /etc/at.deny -> r:No such file or directory$'
-      - 'c:stat /etc/cron.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      - 'c:stat /etc/at.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/cron.deny -> r:No such file or directory$'
+      - 'c:stat -L /etc/at.deny -> r:No such file or directory$'
+      - 'c:stat -L /etc/cron.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/at.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 ###############################################
 # 5.2 Configure SSH
@@ -2657,7 +2657,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/ssh/sshd_config -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/sshd_config -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.2.2 Ensure SSH access is limited (Scored)
   - id: 5142 
@@ -2691,9 +2691,9 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/ssh/ssh_host_rsa_key -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      - 'c:stat /etc/ssh/ssh_host_ecdsa_key -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      - 'c:stat /etc/ssh/ssh_host_ed25519_key -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/ssh_host_rsa_key -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/ssh_host_ecdsa_key -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/ssh_host_ed25519_key -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.2.4 Ensure permissions on SSH public host key files are configured (Scored)
   - id: 5144 
@@ -2709,9 +2709,9 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/ssh/ssh_host_rsa_key.pub -> r:^Access: \(0\d\d\d/\w\w\w\w\w\w-\w\w-\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      - 'c:stat /etc/ssh/ssh_host_ecdsa_key.pub -> r:^Access: \(0\d\d\d/\w\w\w\w\w\w-\w\w-\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      - 'c:stat /etc/ssh/ssh_host_ed25519_key.pub -> r:^Access: \(0\d\d\d/\w\w\w\w\w\w-\w\w-\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/ssh_host_rsa_key.pub -> r:^Access: \(0\d\d\d/\w\w\w\w\w\w-\w\w-\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/ssh_host_ecdsa_key.pub -> r:^Access: \(0\d\d\d/\w\w\w\w\w\w-\w\w-\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat -L /etc/ssh/ssh_host_ed25519_key.pub -> r:^Access: \(0\d\d\d/\w\w\w\w\w\w-\w\w-\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
 # 5.2.5 Ensure SSH LogLevel is appropriate (Scored)
@@ -3228,7 +3228,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/passwd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/passwd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.3 Configure /etc/shadow permissions (Scored)
   - id: 5175 
@@ -3244,7 +3244,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/shadow -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)|Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\w*/\s*\t*shadow\)'
+      - 'c:stat -L /etc/shadow -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)|Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\w*/\s*\t*shadow\)'
 
 # 6.1.4 Configure /etc/group permissions (Scored)
   - id: 5176 
@@ -3260,7 +3260,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/group -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/group -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.5 Configure /etc/gshadow permissions (Scored)
   - id: 5177 
@@ -3276,7 +3276,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/gshadow -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)|Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\w*/\s*\t*shadow\)'
+      - 'c:stat -L /etc/gshadow -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)|Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\w*/\s*\t*shadow\)'
 
 # 6.1.6 Configure /etc/passwd- permissions (Scored)
   - id: 5178 
@@ -3292,7 +3292,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/passwd- -> r:Access:\s*\(0\d00/-\w\w-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/passwd- -> r:Access:\s*\(0\d00/-\w\w-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.7 Configure /etc/shadow- permissions (Scored)
   - id: 5179 
@@ -3308,7 +3308,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/shadow- -> r:Access:\s*\(0\d00/-\w\w-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)|Access:\s*\(0\d00/-\w\w-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\w*/\s*\t*shadow\)'
+      - 'c:stat -L /etc/shadow- -> r:Access:\s*\(0\d00/-\w\w-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)|Access:\s*\(0\d00/-\w\w-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\w*/\s*\t*shadow\)'
 
 # 6.1.8 Configure /etc/group- permissions (Scored)
   - id: 5180 
@@ -3324,7 +3324,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/group- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /etc/group- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.9 Configure /etc/gshadow- permissions (Scored)
   - id: 5181 
@@ -3340,7 +3340,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:stat /etc/gshadow- -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)|Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\w*/\s*\t*shadow\)'
+      - 'c:stat -L /etc/gshadow- -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)|Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\w*/\s*\t*shadow\)'
 
 
 

--- a/ruleset/sca/sles/12/cis_sles12_linux.yml
+++ b/ruleset/sca/sles/12/cis_sles12_linux.yml
@@ -1,6 +1,6 @@
 # Security Configuration Assessment
 # CIS Checks for SUSE SLES 12
-# Copyright (C) 2015-2021, Wazuh Inc.
+# Copyright (C) 2015-2020, Wazuh Inc.
 #
 # This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
@@ -925,3 +925,2415 @@ checks:
     condition: none
     rules:
       - 'f:/etc/shadow -> r:^\w+::'
+
+  - id: 7558
+    title: Ensure mounting of cramfs filesystems is disabled
+    description: >
+      The cramfs filesystem type is a compressed read-only Linux filesystem embedded in small
+      footprint systems. A cramfs image can be used without having to first decompress the
+      image.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      server. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
+      install cramfs /bin/true
+      
+      Run the following command to unload the cramfs module:
+      # rmmod cramfs
+    compliance:
+      - cis: ["1.1.1.1"]
+      - cis_csc: ["13"]
+    condition: any
+    rules:
+      - 'c:modprobe -n -v cramfs -> r:install'
+      - 'c:modprobe -n -v cramfs -> r:cramfs'
+
+  - id: 7559
+    title: Ensure mounting of freevxfs filesystems is disabled
+    description: >
+      The freevxfs filesystem type is a free version of the Veritas type filesystem. This is the
+      primary filesystem type for HP-UX operating systems.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
+      install freevxfs /bin/true
+      
+      Run the following command to unload the freevxfs module:
+      # rmmod freevxfs
+    compliance:
+      - cis: ["1.1.1.2"]
+      - cis_csc: ["13"]
+    condition: any
+    rules:
+      - 'c:modprobe -n -v freevxfs -> r:install'
+      - 'c:modprobe -n -v freevxfs -> r:freevxfs'
+
+  - id: 7560
+    title: Ensure mounting of jffs2 filesystems is disabled
+    description: >
+      The jffs2 (journaling flash filesystem 2) filesystem type is a log-structured filesystem used
+      in flash memory devices.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
+      install jffs2 /bin/true
+      
+      Run the following command to unload the jffs2 module:
+      # rmmod jffs2
+    compliance:
+      - cis: ["1.1.1.3"]
+      - cis_csc: ["13"]
+    condition: any
+    rules:
+      - 'c:modprobe -n -v jffs2 -> r:install'
+      - 'c:modprobe -n -v jffs2 -> r:jffs2'
+
+  - id: 7561
+    title: Ensure mounting of hfs filesystems is disabled
+    description: >
+      The hfs filesystem type is a hierarchical filesystem that allows you to mount Mac OS
+      filesystems.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
+      install hfs /bin/true
+      
+      Run the following command to unload the hfs module:
+      # rmmod hfs
+    compliance:
+      - cis: ["1.1.1.4"]
+      - cis_csc: ["13"]
+    condition: any
+    rules:
+      - 'c:modprobe -n -v hfs -> r:install'
+      - 'c:modprobe -n -v hfs -> r:hfs'
+
+  - id: 7562
+    title: Ensure mounting of hfsplus filesystems is disabled
+    description: >
+      The hfsplus filesystem type is a hierarchical filesystem designed to replace hfs that allows
+      you to mount Mac OS filesystems.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
+      install hfsplus /bin/true
+      
+      Run the following command to unload the hfsplus module:
+      # rmmod hfsplus
+    compliance:
+      - cis: ["1.1.1.5"]
+      - cis_csc: ["13"]
+    condition: any
+    rules:
+      - 'c:modprobe -n -v hfsplus -> r:install'
+      - 'c:modprobe -n -v hfsplus -> r:hfsplus'
+
+  - id: 7563
+    title: Ensure mounting of squashfs filesystems is disabled
+    description: >
+      The squashfs filesystem type is a compressed read-only Linux filesystem embedded in
+      small footprint systems (similar to cramfs ). A squashfs image can be used without having
+      to first decompress the image.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
+      install squashfs /bin/true
+      
+      Run the following command to unload the squashfs module:
+      # rmmod squashfs
+    compliance:
+      - cis: ["1.1.1.6"]
+      - cis_csc: ["13"]
+    condition: any
+    rules:
+      - 'c:modprobe -n -v squashfs -> r:install'
+      - 'c:modprobe -n -v squashfs -> r:squashfs'
+
+  - id: 7564
+    title: Ensure mounting of udf filesystems is disabled
+    description: >
+      The udf filesystem type is the universal disk format used to implement ISO/IEC 13346 and
+      ECMA-167 specifications. This is an open vendor filesystem type for data storage on a
+      broad range of media. This filesystem type is necessary to support writing DVDs and newer
+      optical disc formats.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
+      install udf /bin/true
+      
+      Run the following command to unload the udf module:
+      # rmmod udf
+    compliance:
+      - cis: ["1.1.1.7"]
+      - cis_csc: ["13"]
+    condition: any
+    rules:
+      - 'c:modprobe -n -v udf -> r:install'
+      - 'c:modprobe -n -v udf -> r:udf'
+
+  - id: 7565
+    title: Ensure mounting of FAT filesystems is disabled
+    description: >
+      The FAT filesystem format is primarily used on older windows systems and portable USB
+      drives or flash modules. It comes in three types FAT12 , FAT16 , and FAT32 all of which are
+      supported by the vfat kernel module.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
+      install vfat /bin/true
+      
+      Run the following command to unload the vfat module:
+      # rmmod vfat
+    compliance:
+      - cis: ["1.1.1.8"]
+      - cis_csc: ["13"]
+    condition: any
+    rules:
+      - 'c:modprobe -n -v vfat -> r:install'
+      - 'c:modprobe -n -v vfat -> r:vfat'
+
+  - id: 7566
+    title: Ensure separate partition exists for /var/tmp
+    description: >
+      The /var/tmp directory is a world-writable directory used for temporary storage by all
+      users and some applications.
+    rationale: >
+      Since the /var/tmp directory is intended to be world-writable, there is a risk of resource
+      exhaustion if it is not bound to a separate partition. In addition, making /var/tmp its own
+      file system allows an administrator to set the noexec option on the mount, making
+      /var/tmp useless for an attacker to install executable code. It would also prevent an
+      attacker from establishing a hardlink to a system setuid program and wait for it to be
+      updated. Once the program was updated, the hardlink would be broken and the attacker
+      would have his own copy of the program. If the program happened to have a security
+      vulnerability, the attacker could continue to exploit the known flaw.
+    remediation: >
+      For new installations, during installation create a custom partition setup and specify a
+      separate partition for /var/tmp .
+      For systems that were previously installed, create a new partition and configure
+      /etc/fstab as appropriate.
+    compliance:
+      - cis: ["1.1.7"]
+    condition: all
+    rules:
+      - 'c:mount -> r:\s/var/tmp\s'
+
+  - id: 7567
+    title: Ensure nodev option set on /var/tmp partition
+    description: The nodev mount option specifies that the filesystem cannot contain special devices.
+    rationale: >
+      Since the /var/tmp filesystem is not intended to support devices, set this option to ensure
+      that users cannot attempt to create block or character special devices in /var/tmp .
+    remediation: >
+      Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the
+      /var/tmp partition. See the fstab(5) manual page for more information.
+      
+      Run the following command to remount /var/tmp :
+      # mount -o remount,nodev /var/tmp
+    compliance:
+      - cis: ["1.1.8"]
+    condition: all
+    rules:
+      - 'c:mount -> r:\s+/var/tmp\s+ && r:nodev'
+
+  - id: 7568
+    title: Ensure nosuid option set on /var/tmp partition
+    description: The nosuid mount option specifies that the filesystem cannot contain setuid files.
+    rationale: >
+      Since the /var/tmp filesystem is only intended for temporary file storage, set this option to
+      ensure that users cannot create setuid files in /var/tmp .
+    remediation: >
+      Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the
+      /var/tmp partition. See the fstab(5) manual page for more information.
+      
+      Run the following command to remount /var/tmp :
+      # mount -o remount,nosuid /var/tmp
+    compliance:
+      - cis: ["1.1.9"]
+    condition: all
+    rules:
+      - 'c:mount -> r:\s+/var/tmp\s+ && r:nosuid'
+
+  - id: 7569
+    title: Ensure noexec option set on /var/tmp partition
+    description: The noexec mount option specifies that the filesystem cannot contain executable binaries.
+    rationale: >
+      Since the /var/tmp filesystem is only intended for temporary file storage, set this option to
+      ensure that users cannot run executable binaries from /var/tmp .
+    remediation: >
+      Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the
+      /var/tmp partition. See the fstab(5) manual page for more information.
+      
+      Run the following command to remount /var/tmp :
+      # mount -o remount,noexec /var/tmp
+    compliance:
+      - cis: ["1.1.10"]
+      - cis_csc: ["2"]
+    condition: all
+    rules:
+      - 'c:mount -> r:\s/var/tmp\s && r:noexec'
+
+  - id: 7570
+    title: Ensure AIDE is installed
+    description: >
+      AIDE takes a snapshot of filesystem state including modification times, permissions, and
+      file hashes which can then be used to compare against the current state of the filesystem to
+      detect modifications to the system.
+    rationale: >
+      By monitoring the filesystem state compromised files can be detected to prevent or limit
+      the exposure of accidental or malicious misconfigurations or modified binaries.
+    remediation: >
+      Run the following command to install aide :
+      # zypper install aide
+      
+      Configure AIDE as appropriate for your environment. Consult the AIDE documentation for
+      options.
+      
+      Initialize AIDE:
+        # aide --init
+      # mv /var/lib/aide/aide.db.new /var/lib/aide/aide.db
+      The name of the aide.db.new database may be different on your system.
+    compliance:
+      - cis: ["1.3.1"]
+      - cis_csc: ["3.5"]
+    references:
+      - AIDE stable manual http://aide.sourceforge.net/stable/manual.html
+    condition: none
+    rules:
+      - 'c:rpm -q aide -> r:not installed'
+
+  - id: 7571
+    title: Ensure TCP Wrappers is installed
+    description: >
+      TCP Wrappers provides a simple access list and standardized logging method for services
+      capable of supporting it. In the past, services that were called from inetd and xinetd
+      supported the use of tcp wrappers. As inetd and xinetd have been falling in disuse, any
+      service that can support tcp wrappers will have the libwrap.so library attached to it.
+    rationale: >
+      TCP Wrappers provide a good simple access list mechanism to services that may not have
+      that support built in. It is recommended that all services that can support TCP Wrappers,
+      use it.
+    remediation: >
+      Run the following command to install tcpd :
+      # zypper install tcpd
+      
+      Notes:
+      To verify if a service supports TCP Wrappers, run the following command:
+      
+        # ldd <path-to-daemon> | grep libwrap.so
+      If there is any output, then the service supports TCP Wrappers.
+    compliance:
+      - cis: ["3.4.1"]
+      - cis_csc: ["9.2"]
+    condition: none
+    rules:
+      - 'c:rpm -q tcpd -> r:not installed'
+
+  - id: 7572
+    title: Ensure iptables is installed
+    description: >
+      iptables allows configuration of the IPv4 tables in the linux kernel and the rules stored
+      within them. Most firewall configuration utilities operate as a front end to iptables.
+    rationale: >
+      iptables is required for firewall management and configuration.
+    remediation: >
+      Run the following command to install iptables :
+      # zypper install iptables
+    compliance:
+      - cis: ["3.6.1"]
+      - cis_csc: ["9.2"]
+    condition: none
+    rules:
+      - 'c:rpm -q iptables -> r:not installed'
+
+  - id: 7573
+    title: Ensure rsyslog or syslog-ng is installed
+    description: >
+      The rsyslog and syslog-ng software are recommended replacements to the original
+      syslogd daemon which provide improvements over syslogd , such as connection-oriented
+      (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of
+      log data en route to a central logging server.
+    rationale: >
+      The security enhancements of rsyslog and syslog-ng such as connection-oriented (i.e.
+      TCP) transmission of logs, the option to log to database formats, and the encryption of log
+      data en route to a central logging server) justify installing and configuring the package.
+    remediation: >
+      Install rsyslog or syslog-ng using one of the following commands:
+      # zypper install rsyslog
+      # zypper install syslog-ng
+    compliance:
+      - cis: ["4.2.3"]
+      - cis_csc: ["6.2"]
+    condition: any
+    rules:
+      - 'not c:rpm -q rsyslog -> r:not installed'
+      - 'not c:rpm -q syslog-ng -> r:not installed'
+
+  - id: 7574
+    title: Ensure SETroubleshoot is not installed
+    description: >
+      The SETroubleshoot service notifies desktop users of SELinux denials through a userfriendly interface. The service provides important information around configuration errors,
+      unauthorized intrusions, and other potential errors.
+    rationale: >
+      The SETroubleshoot service is an unnecessary daemon to have running on a server,
+      especially if X Windows is disabled.
+    remediation: >
+      Run the following command to uninstall s etroubleshoot :
+      # zypper remove setroubleshoot
+    compliance:
+      - cis: ["1.6.1.4"]
+    condition: all
+    rules:
+      - 'c:rpm -q setroubleshoot -> r:not installed'
+
+  - id: 7575
+    title: Ensure the MCS Translation Service (mcstrans) is not installed
+    description: >
+      The mcstransd daemon provides category label information to client processes requesting
+      information. The label translations are defined in /etc/selinux/targeted/setrans.conf
+    rationale: >
+      Since this service is not used very often, remove it to reduce the amount of potentially
+      vulnerable code running on the system.
+    remediation: >
+      Run the following command to uninstall mcstrans:
+      # zypper remove mcstrans
+    compliance:
+      - cis: ["1.6.1.5"]
+    condition: all
+    rules:
+      - 'c:rpm -q mcstrans -> r:not installed'
+
+  - id: 7576
+    title: Ensure rsh client is not installed
+    description: The rsh package contains the client commands for the rsh services.
+    rationale: >
+      These legacy clients contain numerous security exposures and have been replaced with the
+      more secure SSH package. Even if the server is removed, it is best to ensure the clients are
+      also removed to prevent users from inadvertently attempting to use these commands and
+      therefore exposing their credentials. Note that removing the rsh package removes the
+      clients for rsh , rcp and rlogin .
+    remediation: >
+      Run the following command to uninstall rsh :
+      # zypper remove rsh
+    compliance:
+      - cis: ["2.3.2"]
+      - cis_csc: ["3.4"]
+    condition: all
+    rules:
+      - 'c:rpm -q rsh -> r:not installed'
+
+  - id: 7577
+    title: Ensure talk client is not installed
+    description: >
+      The talk software makes it possible for users to send and receive messages across systems
+      through a terminal session. The talk client, which allows initialization of talk sessions, is
+      installed by default.
+    rationale: The software presents a security risk as it uses unencrypted protocols for communication.
+    remediation: >
+      Run the following command to uninstall talk :
+      # zypper remove talk
+    compliance:
+      - cis: ["2.3.3"]
+      - cis_csc: ["2"]
+    condition: all
+    rules:
+      - 'c:rpm -q talk -> r:not installed'
+
+
+  - id: 7578
+    title: Ensure telnet client is not installed
+    description: >
+      The telnet package contains the telnet client, which allows users to start connections to
+      other systems via the telnet protocol.
+    rationale: >
+      The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission
+      medium could allow an unauthorized user to steal credentials. The ssh package provides
+      an encrypted session and stronger security and is included in most Linux distributions.
+    remediation: >
+      Run the following command to uninstall telnet :
+      # zypper remove telnet
+    compliance:
+      - cis: ["2.3.4"]
+      - cis_csc: ["3.4"]
+    condition: all
+    rules:
+      - 'c:rpm -q telnet -> r:not installed'
+
+  - id: 7579
+    title: Ensure LDAP client is not installed
+    description: >
+      The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for
+      NIS/YP. It is a service that provides a method for looking up information from a central
+      database.
+    rationale: >
+      If the system will not need to act as an LDAP client, it is recommended that the software be
+      removed to reduce the potential attack surface.
+    remediation: >
+      Run the following command to uninstall openldap2-client :
+      # zypper remove openldap2-client
+    compliance:
+      - cis: ["2.3.5"]
+      - cis_csc: ["2"]
+    condition: all
+    rules:
+      - 'c:rpm -q openldap2-client -> r:not installed'
+
+  - id: 7580
+    title: Ensure prelink is disabled
+    description: >
+      prelinkis a program that modifies ELF shared libraries and ELF dynamically linked
+      binaries in such a way that the time needed for the dynamic linker to perform relocations
+      at startup significantly decreases.
+    rationale: >
+      The prelinking feature can interfere with the operation of AIDE, because it changes
+      binaries. Prelinking can also increase the vulnerability of the system if a malicious user is
+      able to compromise a common library such as libc.
+    remediation: >
+      Run the following commands to restore binaries to normal and uninstall prelink :
+      # prelink -ua
+      # zypper remove prelink
+    compliance:
+      - cis: ["1.5.4"]
+      - cis_csc: ["3.5"]
+    condition: all
+    rules:
+      - 'c:rpm -q prelink -> r:not installed'
+
+  - id: 7581
+    title: Ensure DCCP is disabled
+    description: >
+      The Datagram Congestion Control Protocol (DCCP) is a transport layer protocol that
+      supports streaming media and telephony. DCCP provides a way to gain access to
+      congestion control, without having to do it at the application layer, but does not provide insequence delivery.
+    rationale: >
+      If the protocol is not required, it is recommended that the drivers not be installed to reduce
+      the potential attack surface.
+    remediation: >
+      Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
+      install dccp /bin/true
+    compliance:
+      - cis: ["3.5.1"]
+      - cis_csc: ["9.1"]
+    condition: any
+    rules:
+      - 'c:modprobe -n -v dccp -> r:install'
+      - 'c:modprobe -n -v dccp -> r:dccp'
+
+  - id: 7582
+    title: Ensure SCTP is disabled
+    description: >
+      The Stream Control Transmission Protocol (SCTP) is a transport layer protocol used to
+      support message oriented communication, with several streams of messages in one
+      connection. It serves a similar function as TCP and UDP, incorporating features of both. It is
+      message-oriented like UDP, and ensures reliable in-sequence transport of messages with
+      congestion control like TCP.
+    rationale: >
+      If the protocol is not being used, it is recommended that kernel module not be loaded,
+      disabling the service to reduce the potential attack surface.
+    remediation: >
+      Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
+      install sctp /bin/true
+    compliance:
+      - cis: ["3.5.2"]
+      - cis_csc: ["9.1"]
+    condition: any
+    rules:
+      - 'c:modprobe -n -v sctp -> r:install'
+      - 'c:modprobe -n -v sctp -> r:sctp'
+
+  - id: 7583
+    title: Ensure RDS is disabled
+    description: >
+      The Reliable Datagram Sockets (RDS) protocol is a transport layer protocol designed to
+      provide low-latency, high-bandwidth communications between cluster nodes. It was
+      developed by the Oracle Corporation.
+    rationale: >
+      If the protocol is not being used, it is recommended that kernel module not be loaded,
+      disabling the service to reduce the potential attack surface.
+    remediation: >
+      Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
+      install rds /bin/true
+    compliance:
+      - cis: ["3.5.3"]
+      - cis_csc: ["9.1"]
+    condition: any
+    rules:
+      - 'c:modprobe -n -v rds -> r:install'
+      - 'c:modprobe -n -v rds -> r:rds'
+
+  - id: 7584
+    title: Ensure TIPC is disabled
+    description: >
+      The Transparent Inter-Process Communication (TIPC) protocol is designed to provide
+      communication between cluster nodes.
+    rationale: >
+      If the protocol is not being used, it is recommended that kernel module not be loaded,
+      disabling the service to reduce the potential attack surface.
+    remediation: >
+      Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
+      install tipc /bin/true
+    compliance:
+      - cis: ["3.5.4"]
+      - cis_csc: ["9.1"]
+    condition: any
+    rules:
+      - 'c:modprobe -n -v tipc -> r:install'
+      - 'c:modprobe -n -v tipc -> r:tipc'
+
+  - id: 7585
+    title: Ensure SSH X11 forwarding is disabled
+    description: >
+      The X11Forwarding parameter provides the ability to tunnel X11 traffic through the
+      connection to enable remote graphic connections.
+    rationale: >
+      Disable X11 forwarding unless there is an operational requirement to use X11 applications
+      directly. There is a small risk that the remote X11 servers of users who are logged in via
+      SSH with X11 forwarding could be compromised by other users on the X11 server. Note
+      that even if X11 forwarding is disabled, users can always install their own forwarders.
+    remediation: >
+      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+      X11Forwarding no
+    compliance:
+      - cis: ["5.2.4"]
+    condition: all
+    rules:
+      - 'f:/etc/ssh/sshd_config -> r:^\s*X11Forwarding\s+no'
+
+  - id: 7586
+    title: Ensure SSH PermitUserEnvironment is disabled
+    description: >
+      The PermitUserEnvironment option allows users to present environment options to the
+      ssh daemon.
+    rationale: >
+      Permitting users the ability to set environment variables through the SSH daemon could
+      potentially allow users to bypass security controls (e.g. setting an execution path that has
+      ssh executing trojan'd programs)
+    remediation: >
+      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+      PermitUserEnvironment no
+    compliance:
+      - cis: ["5.2.10"]
+      - cis_csc: ["16"]
+    condition: all
+    rules:
+      - 'f:/etc/ssh/sshd_config -> r:^\s*PermitUserEnvironment\s+no'
+
+  - id: 7587
+    title: Ensure permissions on bootloader config are configured
+    description: >
+      The grub configuration file contains information on boot settings and passwords for
+      unlocking boot options. The grub configuration is usually located at
+      /boot/grub2/grub.cfg.
+    rationale: >
+      Setting the permissions to read and write for root only prevents non-root users from
+      seeing the boot parameters or changing them. Non-root users who read the boot
+      parameters may be able to identify weaknesses in security upon boot and be able to exploit
+      them.
+    remediation: >
+      Run the following commands to set permissions on your grub configuration:
+      # chown root:root /boot/grub2/grub.cfg
+      # chmod og-rwx /boot/grub2/grub.cfg
+    compliance:
+      - cis: ["1.4.1"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:stat -L /boot/grub2/grub.cfg -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7588
+    title: Ensure permissions on /etc/motd are configured
+    description: >
+      The contents of the /etc/motd file are displayed to users after login and function as a
+      message of the day for authenticated users.
+    rationale: >
+      If the /etc/motd file does not have the correct ownership it could be modified by
+      unauthorized users with incorrect or misleading information.
+    remediation: >
+      Run the following commands to set permissions on /etc/motd :
+      # chown root:root /etc/motd
+      # chmod 644 /etc/motd
+    compliance:
+      - cis: ["1.7.1.4"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/motd -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7589
+    title: Ensure permissions on /etc/issue are configured
+    description: The contents of the /etc/issue file are displayed to users prior to login for local terminals.
+    rationale: >
+      If the /etc/issue file does not have the correct ownership it could be modified by
+      unauthorized users with incorrect or misleading information.
+    remediation: >
+      Run the following commands to set permissions on /etc/issue :
+      # chown root:root /etc/issue
+      # chmod 644 /etc/issue
+    compliance:
+      - cis: ["1.7.1.5"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/issue -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7590
+    title: Ensure permissions on /etc/issue.net are configured
+    description: >
+      The contents of the /etc/issue.net file are displayed to users prior to login for remote
+      connections from configured services.
+    rationale: >
+      If the /etc/issue.net file does not have the correct ownership it could be modified by
+      unauthorized users with incorrect or misleading information.
+    remediation: >
+      Run the following commands to set permissions on /etc/issue.net :
+      # chown root:root /etc/issue.net
+      # chmod 644 /etc/issue.net
+    compliance:
+      - cis: ["1.7.1.6"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/issue.net -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7591
+    title: Ensure permissions on /etc/hosts.allow are configured
+    description: >
+      The /etc/hosts.allow file contains networking information that is used by many
+      applications and therefore must be readable for these applications to operate.
+    rationale: >
+      It is critical to ensure that the /etc/hosts.allow file is protected from unauthorized write
+      access. Although it is protected by default, the file permissions could be changed either
+      inadvertently or through malicious actions.
+    remediation: >
+      Run the following commands to set permissions on /etc/hosts.allow :
+      # chown root:root /etc/hosts.allow
+      # chmod 644 /etc/hosts.allow
+    compliance:
+      - cis: ["3.4.4"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/hosts.allow -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7592
+    title: Ensure permissions on /etc/hosts.deny are configured
+    description: >
+      The /etc/hosts.deny file contains network information that is used by many system
+      applications and therefore must be readable for these applications to operate.
+    rationale: >
+      It is critical to ensure that the /etc/hosts.deny file is protected from unauthorized write
+      access. Although it is protected by default, the file permissions could be changed either
+      inadvertently or through malicious actions.
+    remediation: >
+      Run the following commands to set permissions on /etc/hosts.deny :
+      # chown root:root /etc/hosts.deny
+      # chmod 644 /etc/hosts.deny
+    compliance:
+      - cis: ["3.4.5"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/hosts.deny -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7593
+    title: Ensure permissions on /etc/crontab are configured
+    description: >
+      The /etc/crontab file is used by cron to control its own jobs. The commands in this item
+      make sure that root is the user and group owner of the file and that only the owner can
+      access the file.
+    rationale: >
+      This file contains information on what system jobs are run by cron. Write access to these
+      files could provide unprivileged users with the ability to elevate their privileges. Read
+      access to these files could provide users with the ability to gain insight on system jobs that
+      run on the system and could provide them a way to gain unauthorized privileged access.
+    remediation: >
+      Run the following commands to set ownership and permissions on /etc/crontab :
+      # chown root:root /etc/crontab
+      # chmod og-rwx /etc/crontab
+    compliance:
+      - cis: ["5.1.2"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/crontab -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7594
+    title: Ensure permissions on /etc/cron.hourly are configured
+    description: >
+      This directory contains system cron jobs that need to run on an hourly basis. The files in
+      this directory cannot be manipulated by the crontab command, but are instead edited by
+      system administrators using a text editor. The commands below restrict read/write and
+      search access to user and group root, preventing regular users from accessing this
+      directory.
+    rationale: >
+      Granting write access to this directory for non-privileged users could provide them the
+      means for gaining unauthorized elevated privileges. Granting read access to this directory
+      could give an unprivileged user insight in how to gain elevated privileges or circumvent
+      auditing controls.
+    remediation: >
+      Run the following commands to set ownership and permissions on /etc/cron.hourly :
+      # chown root:root /etc/cron.hourly
+      # chmod og-rwx /etc/cron.hourly
+    compliance:
+      - cis: ["5.1.3"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/cron.hourly -> r:^Access:\s*\(0700/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7595
+    title: Ensure permissions on /etc/cron.daily are configured
+    description: >
+      The /etc/cron.daily directory contains system cron jobs that need to run on a daily basis.
+      The files in this directory cannot be manipulated by the crontab command, but are instead
+      edited by system administrators using a text editor. The commands below restrict
+      read/write and search access to user and group root, preventing regular users from
+      accessing this directory.
+    rationale: >
+      Granting write access to this directory for non-privileged users could provide them the
+      means for gaining unauthorized elevated privileges. Granting read access to this directory
+      could give an unprivileged user insight in how to gain elevated privileges or circumvent
+      auditing controls.
+    remediation: >
+      Run the following commands to set ownership and permissions on /etc/cron.daily :
+      # chown root:root /etc/cron.daily
+      # chmod og-rwx /etc/cron.daily
+    compliance:
+      - cis: ["5.1.4"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/cron.daily -> r:^Access:\s*\(0700/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7596
+    title: Ensure permissions on /etc/cron.weekly are configured
+    description: >
+      The /etc/cron.weekly directory contains system cron jobs that need to run on a weekly
+      basis. The files in this directory cannot be manipulated by the crontab command, but are
+      instead edited by system administrators using a text editor. The commands below restrict
+      read/write and search access to user and group root, preventing regular users from
+      accessing this directory.
+    rationale: >
+      Granting write access to this directory for non-privileged users could provide them the
+      means for gaining unauthorized elevated privileges. Granting read access to this directory
+      could give an unprivileged user insight in how to gain elevated privileges or circumvent
+      auditing controls.
+    remediation: >
+      Run the following commands to set ownership and permissions on /etc/cron.weekly :
+      # chown root:root /etc/cron.weekly
+      # chmod og-rwx /etc/cron.weekly
+    compliance:
+      - cis: ["5.1.5"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/cron.weekly -> r:^Access:\s*\(0700/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7597
+    title: Ensure permissions on /etc/cron.monthly are configured
+    description: >
+      The /etc/cron.monthly directory contains system cron jobs that need to run on a monthly
+      basis. The files in this directory cannot be manipulated by the crontab command, but are
+      instead edited by system administrators using a text editor. The commands below restrict
+      read/write and search access to user and group root, preventing regular users from
+      accessing this directory.
+    rationale: >
+      Granting write access to this directory for non-privileged users could provide them the
+      means for gaining unauthorized elevated privileges. Granting read access to this directory
+      could give an unprivileged user insight in how to gain elevated privileges or circumvent
+      auditing controls.
+    remediation: >
+      Run the following commands to set ownership and permissions on /etc/cron.monthly :
+      # chown root:root /etc/cron.monthly
+      # chmod og-rwx /etc/cron.monthly
+    compliance:
+      - cis: ["5.1.6"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/cron.monthly -> r:^Access:\s*\(0700/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7598
+    title: Ensure permissions on /etc/cron.d are configured
+    description: >
+      The /etc/cron.d directory contains system cron jobs that need to run in a similar manner
+      to the hourly, daily weekly and monthly jobs from /etc/crontab , but require more
+      granular control as to when they run. The files in this directory cannot be manipulated by
+      the crontab command, but are instead edited by system administrators using a text editor.
+      The commands below restrict read/write and search access to user and group root,
+      preventing regular users from accessing this directory.
+    rationale: >
+      Granting write access to this directory for non-privileged users could provide them the
+      means for gaining unauthorized elevated privileges. Granting read access to this directory
+      could give an unprivileged user insight in how to gain elevated privileges or circumvent
+      auditing controls.
+    remediation: >
+      Run the following commands to set ownership and permissions on /etc/cron.d :
+      # chown root:root /etc/cron.d
+      # chmod og-rwx /etc/cron.d
+    compliance:
+      - cis: ["5.1.7"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/cron.d -> r:^Access:\s*\(0700/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7599
+    title: Ensure permissions on /etc/ssh/sshd_config are configured
+    description: >
+      The /etc/ssh/sshd_config file contains configuration specifications for sshd. The
+      command below sets the owner and group of the file to root.
+    rationale: >
+      The /etc/ssh/sshd_config file needs to be protected from unauthorized changes by nonprivileged users.
+    remediation: >
+      Run the following commands to set ownership and permissions on /etc/ssh/sshd_config:
+      # chown root:root /etc/ssh/sshd_config
+      # chmod og-rwx /etc/ssh/sshd_config
+    compliance:
+      - cis: ["5.2.1"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/ssh/sshd_config -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7600
+    title: Ensure permissions on /etc/passwd are configured
+    description: >
+      The /etc/passwd file contains user account information that is used by many system
+      utilities and therefore must be readable for these utilities to operate.
+    rationale: >
+      It is critical to ensure that the /etc/passwd file is protected from unauthorized write
+      access. Although it is protected by default, the file permissions could be changed either
+      inadvertently or through malicious actions.
+    remediation: >
+      Run the following command to set permissions on /etc/passwd :
+      # chown root:root /etc/passwd
+      # chmod 644 /etc/passwd
+    compliance:
+      - cis: ["6.1.2"]
+      - cis_csc: ["16.14"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/passwd -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7601
+    title: Ensure permissions on /etc/shadow are configured
+    description: >
+      The /etc/shadow file is used to store the information about user accounts that is critical to
+      the security of those accounts, such as the hashed password and other security
+      information.
+    rationale: >
+      If attackers can gain read access to the /etc/shadow file, they can easily run a password
+      cracking program against the hashed password to break it. Other security information that
+      is stored in the /etc/shadow file (such as expiration) could also be useful to subvert the
+      user accounts.
+    remediation: >
+      Run the following commands to set permissions on /etc/shadow:
+      # chown root:shadow /etc/shadow
+      # chmod o-rwx,g-wx /etc/shadow
+    compliance:
+      - cis: ["6.1.3"]
+      - cis_csc: ["16.14"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/shadow -> r:^Access:\s*\(0640/-rw-r-----\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*15/\s*shadow\)'
+
+  - id: 7602
+    title: Ensure permissions on /etc/group are configured
+    description: >
+      The /etc/group file contains a list of all the valid groups defined in the system. The
+      command below allows read/write access for root and read access for everyone else.
+    rationale: >
+      The /etc/group file needs to be protected from unauthorized changes by non-privileged
+      users, but needs to be readable as this information is used with many non-privileged
+      programs.
+    remediation: >
+      Run the following command to set permissions on /etc/group :
+      # chown root:root /etc/group
+      # chmod 644 /etc/group
+    compliance:
+      - cis: ["6.1.4"]
+      - cis_csc: ["16.14"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/group -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7603
+    title: Ensure permissions on /etc/gshadow are configured
+    description: >
+      The /etc/gshadow file is used to store the information about groups that is critical to the
+      security of those accounts, such as the hashed password and other security information.
+    rationale: >
+      If attackers can gain read access to the /etc/gshadow file, they can easily run a password
+      cracking program against the hashed password to break it. Other security information that
+      is stored in the /etc/gshadow file (such as group administrators) could also be useful to
+      subvert the group.
+    remediation: >
+      Run the one of the following chown commands as appropriate and the chmod to set
+      permissions on /etc/gshadow:
+      
+      # chown root:root /etc/gshadow
+      # chown root:shadow /etc/gshadow
+      # chmod o-rwx,g-rw /etc/gshadow
+    compliance:
+      - cis: ["6.1.5"]
+      - cis_csc: ["16.14"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/gshadow -> r:^Access:\s*\(0640/-rw-r-----\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7604
+    title: Ensure permissions on /etc/passwd- are configured
+    description: The /etc/passwd- file contains backup user account information.
+    rationale: >
+      It is critical to ensure that the /etc/passwd- file is protected from unauthorized access.
+      Although it is protected by default, the file permissions could be changed either
+      inadvertently or through malicious actions.
+    remediation: >
+      Run the following command to set permissions on /etc/passwd- :
+      
+      # chown root:root /etc/passwd-
+      # chmod u-x,go-wx /etc/passwd-
+    compliance:
+      - cis: ["6.1.6"]
+      - cis_csc: ["16.14"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/passwd- -> r:^Access:\s*\(0644/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7605
+    title: Ensure permissions on /etc/shadow- are configured
+    description: >
+      The /etc/shadow- file is used to store backup information about user accounts that is
+      critical to the security of those accounts, such as the hashed password and other security
+      information.
+    rationale: >
+      It is critical to ensure that the /etc/shadow- file is protected from unauthorized access.
+      Although it is protected by default, the file permissions could be changed either
+      inadvertently or through malicious actions.
+    remediation: >
+      Run the one of the following chown commands as appropriate and the chmod to set
+      permissions on /etc/shadow- :
+      
+      # chown root:root /etc/shadow-
+      # chown root:shadow /etc/shadow-
+      # chmod o-rwx,g-rw /etc/shadow-
+    compliance:
+      - cis: ["6.1.7"]
+      - cis_csc: ["16.14"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/shadow- -> r:^Access:\s*\(0640/-rw-r-----\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*15/\s*shadow\)'
+
+  - id: 7606
+    title: Ensure permissions on /etc/group- are configured
+    description: The /etc/group- file contains a backup list of all the valid groups defined in the system.
+    rationale: >
+      It is critical to ensure that the /etc/group- file is protected from unauthorized access.
+      Although it is protected by default, the file permissions could be changed either
+      inadvertently or through malicious actions.
+    remediation: >
+      Run the following command to set permissions on /etc/group- :
+      
+      # chown root:root /etc/group-   
+      # chmod u-x,go-wx /etc/group-   
+    compliance:
+      - cis: ["6.1.8"]
+      - cis_csc: ["16.14"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/group -> r:^Access:\s*\(0644/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7607
+    title: Ensure permissions on /etc/gshadow- are configured
+    description: >
+      The /etc/gshadow- file is used to store backup information about groups that is critical to
+      the security of those accounts, such as the hashed password and other security
+      information.
+    rationale: >
+      It is critical to ensure that the /etc/gshadow- file is protected from unauthorized access.
+      Although it is protected by default, the file permissions could be changed either
+      inadvertently or through malicious actions.
+    remediation: >
+      Run the one of the following chown commands as appropriate and the chmod to set
+      permissions on /etc/gshadow- :
+      
+      # chown root:root /etc/gshadow-
+      # chown root:shadow /etc/gshadow-
+      # chmod o-rwx,g-rw /etc/gshadow-
+    compliance:
+      - cis: ["6.1.9"]
+      - cis_csc: ["16.14"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/gshadow- -> r:^Access:\s*\(0640/-rw-r-----\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7608
+    title: Ensure no legacy "+" entries exist in /etc/passwd
+    description: >
+      The character + in various files used to be markers for systems to insert data from NIS
+      maps at a certain point in a system configuration file. These entries are no longer required
+      on most systems, but may exist in files that have been imported from other platforms.
+    rationale: These entries may provide an avenue for attackers to gain privileged access on the system.
+    remediation: Remove any legacy '+' entries from /etc/passwd if they exist.
+    compliance:
+      - cis: ["6.2.2"]
+      - cis_csc: ["16.9"]
+    condition: none
+    rules:
+      - 'f:/etc/passwd -> r:^+:'
+
+  - id: 7609
+    title: Ensure no legacy "+" entries exist in /etc/shadow
+    description: >
+      The character + in various files used to be markers for systems to insert data from NIS
+      maps at a certain point in a system configuration file. These entries are no longer required
+      on most systems, but may exist in files that have been imported from other platforms.
+    rationale: These entries may provide an avenue for attackers to gain privileged access on the system.
+    remediation: Remove any legacy '+' entries from /etc/shadow if they exist.
+    compliance:
+      - cis: ["6.2.3"]
+      - cis_csc: ["16.9"]
+    condition: none
+    rules:
+      - 'f:/etc/shadow -> r:^+:'
+
+  - id: 7610
+    title: Ensure no legacy "+" entries exist in /etc/group
+    description: >
+      The character + in various files used to be markers for systems to insert data from NIS
+      maps at a certain point in a system configuration file. These entries are no longer required
+      on most systems, but may exist in files that have been imported from other platforms.
+    rationale: These entries may provide an avenue for attackers to gain privileged access on the system.
+    remediation: Remove any legacy '+' entries from /etc/group if they exist.
+    compliance:
+      - cis: ["6.2.4"]
+      - cis_csc: ["16.9"]
+    condition: none
+    rules:
+      - 'f:/etc/group -> r:^+:'
+
+  - id: 7611
+    title: Disable Automounting
+    description: autofs allows automatic mounting of devices, typically including CD/DVDs and USB drives.
+    rationale: >
+      With automounting enabled anyone with physical access could attach a USB drive or disc
+      and have its contents available in system even if they lacked permissions to mount it
+      themselves.
+    remediation: >
+      Run the following command to disable autofs:
+      # systemctl disable autofs
+    compliance:
+      - cis: ["1.1.22"]
+      - cis_csc: ["8.3"]
+    condition: none
+    rules:
+      - 'c:systemctl is-enabled autofs -> r:enabled'
+
+  - id: 7612
+    title: Ensure bootloader password is set
+    description: >
+      Setting the boot loader password will require that anyone rebooting the system must enter
+      a password before being able to set command line boot parameters
+    rationale: >
+      Requiring a boot password upon execution of the boot loader will prevent an unauthorized
+      user from entering boot parameters or changing the boot partition. This prevents users
+      from weakening security (e.g. turning off SELinux at boot time).
+    remediation: >
+      Create an encrypted password with grub-mkpasswd-pbkdf2:
+      # grub2-mkpasswd-pbkdf2
+      Enter password: <password>
+      Reenter password: <password>
+      Your PBKDF2 is <encrypted-password>
+      
+      Add the following into /etc/grub.d/01_users or a custom /etc/grub.d configuration file:
+      cat <<EOF
+      set superusers="<username>"
+      password_pbkdf2 <username> <encrypted-password>
+      EOF
+      
+      Run the following command to update the grub2 configuration:
+      # grub2-mkconfig > /boot/grub2/grub.cfg
+    compliance:
+      - cis: ["1.4.2"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'f:/boot/grub2/grub.cfg -> r:^\s*set superusers'
+      - 'f:/boot/grub2/grub.cfg -> r:^\s*password_pbkdf2\s+\S+\s+\S+'
+
+  - id: 7613
+    title: Ensure authentication required for single user mode
+    description: >
+      Single user mode (rescue mode) is used for recovery when the system detects an issue
+      during boot or by manual selection from the bootloader.
+    rationale: >
+      Requiring authentication in single user mode (rescue mode) prevents an unauthorized user
+      from rebooting the system into single user to gain root privileges without credentials.
+    remediation: >
+      Edit /usr/lib/systemd/system/rescue.service and
+      /usr/lib/systemd/system/emergency.service and set ExecStart to use
+      '/usr/sbin/sulogin':
+      ExecStart=-/bin/sh -c "/usr/sbin/sulogin; /usr/bin/systemctl --job-mode=fail
+      --no-block default"
+      
+      Notes:
+      The systemctl option --fail is synonymous with --job-mode=fail. Using either is
+      acceptable.
+    compliance:
+      - cis: ["1.4.3"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'f:/usr/lib/systemd/system/rescue.service -> r:^ExecStart=-/bin/sh -c "/usr/sbin/sulogin; /usr/bin/systemctl --job-mode=fail --no-block default"'
+      - 'f:/usr/lib/systemd/system/emergency.service -> r:^ExecStart=-/bin/sh -c "/usr/sbin/sulogin; /usr/bin/systemctl --job-mode=fail --no-block default"'
+
+  - id: 7614
+    title: Ensure XD/NX support is enabled
+    description: >
+      Recent processors in the x86 family support the ability to prevent code execution on a per
+      memory page basis. Generically and on AMD processors, this ability is called No Execute
+      (NX), while on Intel processors it is called Execute Disable (XD). This ability can help
+      prevent exploitation of buffer overflow vulnerabilities and should be activated whenever
+      possible. Extra steps must be taken to ensure that this protection is enabled, particularly on
+      32-bit x86 systems. Other processors, such as Itanium and POWER, have included such
+      support since inception and the standard kernel for those platforms supports the feature.
+    rationale: >
+      Enabling any feature that can protect against buffer overflow attacks enhances the security
+      of the system.
+    remediation: >
+      On 32 bit systems install a kernel with PAE support, no installation is required on 64 bit
+      systems:
+      If necessary configure your bootloader to load the new kernel and reboot the system.
+      You may need to enable NX or XD support in your bios.
+      
+      Notes:
+      Ensure your system supports the XD or NX bit and has PAE support before implementing
+      this recommendation as this may prevent it from booting if these are not supported by
+      your hardware.
+    compliance:
+      - cis: ["1.5.2"]
+      - cis_csc: ["8.4"]
+    condition: all
+    rules:
+      - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
+
+  - id: 7615
+    title: Ensure AppArmor is not disabled in bootloader configuration
+    description: >
+      Configure AppArmor to be enabled at boot time and verify that it has not been overwritten
+      by the bootloader boot parameters.
+    rationale: >
+      AppArmor must be enabled at boot time in your bootloader configuration to ensure that
+      the controls it provides are not overridden.
+    remediation: >
+      Edit /etc/default/grub and remove all instances of apparmor =0 from all CMDLINE_LINUX
+      parameters:
+      GRUB_CMDLINE_LINUX_DEFAULT="quiet"
+      GRUB_CMDLINE_LINUX=""
+      
+      Run the following command to update the grub2 configuration:
+      # grub2-mkconfig > /boot/grub2/grub.cfg
+    compliance:
+      - cis: ["1.6.2.1"]
+      - cis_csc: ["14.4"]
+    condition: none
+    rules:
+      - 'f:/boot/grub2/grub.cfg -> r:^\s*linux && r:apparmor=0'
+
+  - id: 7616
+    title: Ensure message of the day is configured properly
+    description: >
+      The contents of the /etc/motd file are displayed to users after login and function as a
+      message of the day for authenticated users.
+      
+      Unix-based systems have typically displayed information about the OS release and patch
+      level upon logging in to the system. This information can be useful to developers who are
+      developing software for a particular OS platform. If mingetty(8) supports the following
+      options, they display operating system information: \m - machine architecture \r -
+      operating system release \s - operating system name \v - operating system version
+    rationale: >
+      Warning messages inform users who are attempting to login to the system of their legal
+      status regarding the system and must include the name of the organization that owns the
+      system and any monitoring policies that are in place. Displaying OS and patch level
+      information in login banners also has the side effect of providing detailed system
+      information to attackers attempting to target specific exploits of a system. Authorized users
+      can easily get this information by running the " uname -a " command once they have logged
+      in.
+    remediation: >
+      Edit the /etc/motd file with the appropriate contents according to your site policy, remove
+      any instances of \m , \r , \s , or \v.
+    compliance:
+      - cis: ["1.7.1.1"]
+    condition: none
+    rules:
+      - 'f:/etc/motd -> r:\\m'
+      - 'f:/etc/motd -> r:\\r'
+      - 'f:/etc/motd -> r:\\s'
+      - 'f:/etc/motd -> r:\\v'
+
+  - id: 7617
+    title: Ensure local login warning banner is configured properly
+    description: >
+      The contents of the /etc/issue file are displayed to users prior to login for local terminals.
+      
+      Unix-based systems have typically displayed information about the OS release and patch
+      level upon logging in to the system. This information can be useful to developers who are
+      developing software for a particular OS platform. If mingetty(8) supports the following
+      options, they display operating system information: \m - machine architecture \r -
+      operating system release \s - operating system name \v - operating system version
+    rationale: >
+      Warning messages inform users who are attempting to login to the system of their legal
+      status regarding the system and must include the name of the organization that owns the
+      system and any monitoring policies that are in place. Displaying OS and patch level
+      information in login banners also has the side effect of providing detailed system
+      information to attackers attempting to target specific exploits of a system. Authorized users
+      can easily get this information by running the " uname -a " command once they have logged
+      in.
+    remediation: >
+      Edit the /etc/issue file with the appropriate contents according to your site policy,
+      remove any instances of \m , \r , \s , or \v :
+
+      # echo "Authorized uses only. All activity may be monitored and reported." >
+      /etc/issue
+    compliance:
+      - cis: ["1.7.1.2"]
+    condition: none
+    rules:
+      - 'f:/etc/issue -> r:\\m'
+      - 'f:/etc/issue -> r:\\r'
+      - 'f:/etc/issue -> r:\\s'
+      - 'f:/etc/issue -> r:\\v'
+
+  - id: 7618
+    title: Ensure remote login warning banner is configured properly
+    description: >
+      The contents of the /etc/issue.net file are displayed to users prior to login for remote
+      connections from configured services.
+      
+      Unix-based systems have typically displayed information about the OS release and patch
+      level upon logging in to the system. This information can be useful to developers who are
+      developing software for a particular OS platform. If mingetty(8) supports the following
+      options, they display operating system information: \m - machine architecture \r -
+      operating system release \s - operating system name \v - operating system version
+    rationale: >
+      Warning messages inform users who are attempting to login to the system of their legal
+      status regarding the system and must include the name of the organization that owns the
+      system and any monitoring policies that are in place. Displaying OS and patch level
+      information in login banners also has the side effect of providing detailed system
+      information to attackers attempting to target specific exploits of a system. Authorized users
+      can easily get this information by running the " uname -a " command once they have logged
+      in.
+    remediation: >
+      Edit the /etc/issue.net file with the appropriate contents according to your site policy,
+      remove any instances of \m , \r , \s , or \v :
+      
+      # echo "Authorized uses only. All activity may be monitored and reported." >
+      /etc/issue.net
+    compliance:
+      - cis: ["1.7.1.3"]
+    condition: none
+    rules:
+      - 'f:/etc/issue.net -> r:\\m'
+      - 'f:/etc/issue.net -> r:\\r'
+      - 'f:/etc/issue.net -> r:\\s'
+      - 'f:/etc/issue.net -> r:\\v'
+
+  - id: 7619
+    title: Ensure updates, patches, and additional security software are installed
+    description: >
+      Periodically patches are released for included software either due to security flaws or to
+      include additional functionality.
+    rationale: >
+      Newer patches may contain security enhancements that would not be available through the
+      latest full update. As a result, it is recommended that the latest software patches be used to
+      take advantage of the latest functionality. As with any software installation, organizations
+      need to determine if a given update meets their requirements and verify the compatibility
+      and supportability of any additional software against the update revision that is selected.
+    remediation: >
+      Use your package manager to update all packages on the system according to site policy.
+      The following command will install all available updates:
+      # zypper update
+      
+      Notes:
+      Site policy may mandate a testing period before install onto production systems for
+      available updates.
+    compliance:
+      - cis: ["1.8"]
+      - cis_csc: ["4.5"]
+    condition: all
+    rules:
+      - 'c:zypper list-updates -> r:^No updates found'
+
+  - id: 7620
+    title: Ensure time synchronization is in use
+    description: >
+      System time should be synchronized between all systems in an environment. This is
+      typically done by establishing an authoritative time server or set of servers and having all
+      systems synchronize their clocks to them.
+      
+      Notes:
+        - On systems where host based time synchronization is not available, verify that chrony
+          is installed or systemd-timesyncd is enabled.
+        - On systems where host based time synchronization is available consult your
+          documentation and verify that host based synchronization is in use.
+        - If another method for time synchronization is being used, this section may be skipped.
+    rationale: >
+        Time synchronization is important to support time sensitive security mechanisms like
+        Kerberos and also ensures log files have consistent time records across the enterprise,
+        which aids in forensic investigations.
+    remediation: >
+        On systems where host based time synchronization is not available, install chrony OR
+        enable systemd-timesyncd:
+        
+          Run the following command to install chrony:
+        # zypper install chrony
+        
+        OR
+        
+        Run the following command to enable systemd-timesyncd
+        # systemctl enable systemd-timesyncd
+        
+        Note: On systems where host based time synchronization is available consult your
+        virtualization software documentation and setup host based synchronization.
+    compliance:
+      - cis: ["2.2.1.1"]
+      - cis_csc: ["6.1"]
+    condition: any
+    rules:
+      - 'c:rpm -q chrony -> r:^chrony-\S+'
+      - 'c:rpm -q ntp -> r:^ntp-\S+'
+
+  - id: 7621
+    title: Ensure chrony is configured
+    description: >
+      chrony is a daemon which implements the Network Time Protocol (NTP) is designed to
+      synchronize system clocks across a variety of systems and use a source that is highly
+      accurate. More information on chrony can be found at http://chrony.tuxfamily.org/. chrony
+      can be configured to be a client and/or a server.
+    rationale: >
+      If chrony is in use on the system proper configuration is vital to ensuring time
+      synchronization is working properly.
+      
+      This recommendation only applies if chrony is in use on the system.
+    remediation: >
+      Add or edit server or pool lines to /etc/chrony.conf as appropriate:
+      server <remote-server>
+      
+      Add or edit the OPTIONS in /etc/sysconfig/chronyd to include '-u chrony':
+      OPTIONS="-u chrony"
+    compliance:
+      - cis: ["2.2.1.3"]
+      - cis_csc: ["6.1"]
+    condition: all
+    rules:
+      - 'f:/etc/chrony.conf -> r:^\s*server\s+\.+'
+      - 'f:/etc/sysconfig/chronyd -> r:^\s*OPTIONS\s*=\s*"-u\s*chrony"'
+
+  - id: 7622
+    title: Ensure CUPS is not enabled
+    description: >
+      The Common Unix Print System (CUPS) provides the ability to print to both local and
+      network printers. A system running CUPS can also accept print jobs from remote systems
+      and print them to local printers. It also provides a web based remote administration
+      capability.
+    rationale: >
+      If the system does not need to print jobs or accept print jobs from other systems, it is
+      recommended that CUPS be disabled to reduce the potential attack surface.
+    remediation: >
+      Run the following command to disable cups :
+      # systemctl disable cups
+    compliance:
+      - cis: ["2.2.4"]
+      - cis_csc: ["9.1"]
+    references:
+      - http://www.cups.org
+    condition: none
+    rules:
+      - 'c:systemctl is-enabled cups -> r:^enabled'
+
+  - id: 7623
+    title: Ensure LDAP server is not enabled
+    description: >
+      The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for
+      NIS/YP. It is a service that provides a method for looking up information from a central
+      database.
+    rationale: >
+      If the system will not need to act as an LDAP server, it is recommended that the software be
+      disabled to reduce the potential attack surface.
+    remediation: >
+      Run the following command to disable slapd :
+      # systemctl disable slapd
+    compliance:
+      - cis: ["2.2.6"]
+      - cis_csc: ["9.1"]
+    references:
+      - http://www.openldap.org
+    condition: none
+    rules:
+      - 'c:systemctl is-enabled slapd -> r:^enabled'
+
+  - id: 7624
+    title: Ensure default deny firewall policy
+    description: >
+      A default deny all policy on connections ensures that any unconfigured network usage will
+      be rejected.
+    rationale: >
+      With a default accept policy the firewall will accept any packet that is not configured to be
+      denied. It is easier to white list acceptable usage than to black list unacceptable usage.
+    remediation: >
+      Run the following commands to implement a default DROP policy:
+      # iptables -P INPUT DROP
+      # iptables -P OUTPUT DROP
+      # iptables -P FORWARD DROP
+
+      Notes:
+      Changing firewall settings while connected over network can result in being locked out of
+      the system.
+     
+      Remediation will only affect the active system firewall, be sure to configure the default
+      policy in your firewall management to apply on boot as well.
+    compliance:
+      - cis: ["3.6.2"]
+      - cis_csc: ["9.2"]
+    condition: all
+    rules:
+      - 'c:iptables -L -> r:^Chain\s+INPUT\s+\(policy\s+DROP\)'
+      - 'c:iptables -L -> r:^Chain\s+FORWARD\s+\(policy\s+DROP\)'
+      - 'c:iptables -L -> r:^Chain\s+OUTPUT\s+\(policy\s+DROP\)'
+
+  - id: 7625
+    title: Ensure loopback traffic is configured
+    description: >
+      Configure the loopback interface to accept traffic. Configure all other interfaces to deny
+      traffic to the loopback network (127.0.0.0/8).
+    rationale: >
+      Loopback traffic is generated between processes on machine and is typically critical to
+      operation of the system. The loopback interface is the only place that loopback network
+      (127.0.0.0/8) traffic should be seen, all other interfaces should ignore traffic on this
+      network as an anti-spoofing measure.
+    remediation: >
+      Run the following commands to implement the loopback rules:
+      # iptables -A INPUT -i lo -j ACCEPT
+      # iptables -A OUTPUT -o lo -j ACCEPT
+      # iptables -A INPUT -s 127.0.0.0/8 -j DROP195 | P a g e
+      
+      Notes:
+      Changing firewall settings while connected over network can result in being locked out of
+      the system.
+      
+      Remediation will only affect the active system firewall, be sure to configure the default
+      policy in your firewall management to apply on boot as well.
+    compliance:
+      - cis: ["3.6.3"]
+      - cis_csc: ["9.2"]
+    condition: all
+    rules:
+      - 'c:iptables -L INPUT -v -n -> r:^\s*\d+\s+\d+\s+ACCEPT\s+all\s+--\s+lo\s+*\s+0.0.0.0/0\s+0.0.0.0/0'
+      - 'c:iptables -L INPUT -v -n -> r:^\s*\d+\s+\d+\s+DROP\s+all\s+--\s+*\s+*\s+127.0.0.0/8\s+0.0.0.0/0'
+      - 'c:iptables -L OUTPUT -v -n -> r:^\s*\d+\s+\d+\s+ACCEPT\s+all\s+--\s+*\s+lo\s+0.0.0.0/0\s+0.0.0.0/0'
+
+  - id: 7626
+    title: Ensure audit log storage size is configured
+    description: >
+      Configure the maximum size of the audit log file. Once the log reaches the maximum size, it
+      will be rotated and a new log file will be started.
+    rationale: >
+      It is important that an appropriate size is determined for log files so that they do not impact
+      the system and audit data is not lost.
+    remediation: >
+      Set the following parameter in /etc/audit/auditd.conf in accordance with site policy:
+      max_log_file = <MB>
+      
+      Notes:
+      The max_log_file parameter is measured in megabytes.
+    compliance:
+      - cis: ["4.1.1.1"]
+      - cis_csc: ["6.3"]
+    condition: all
+    rules:
+      - 'f:/etc/audit/auditd.conf -> r:^\s*max_log_file\s*=\s*\d+'
+
+  - id: 7627
+    title: Ensure system is disabled when audit logs are full
+    description: >
+      The auditd daemon can be configured to halt the system when the audit logs are full.
+    rationale: >
+      In high security contexts, the risk of detecting unauthorized access or nonrepudiation
+      exceeds the benefit of the system's availability.
+    remediation: >
+      Set the following parameters in /etc/audit/auditd.conf:
+      space_left_action = email
+      action_mail_acct = root
+      admin_space_left_action = halt
+    compliance:
+      - cis: ["4.1.1.2"]
+      - cis_csc: ["6.3"]
+    condition: all
+    rules:
+      - 'f:/etc/audit/auditd.conf -> r:^\s*space_left_action\s*=\s*email'
+      - 'f:/etc/audit/auditd.conf -> r:^\s*action_mail_acct\s*=\s*root'
+      - 'f:/etc/audit/auditd.conf -> r:^\s*admin_space_left_action\s*=\s*halt'
+
+  - id: 7628
+    title: Ensure audit logs are not automatically deleted
+    description: >
+      The max_log_file_action setting determines how to handle the audit log file reaching the
+      max file size. A value of keep_logs will rotate the logs but never delete old logs.
+    rationale: >
+      In high security contexts, the benefits of maintaining a long audit history exceed the cost of
+      storing the audit history.
+    remediation: >
+      Set the following parameter in /etc/audit/auditd.conf:
+      max_log_file_action = keep_logs
+    compliance:
+      - cis: ["4.1.1.3"]
+      - cis_csc: ["6.3"]
+    condition: all
+    rules:
+      - 'f:/etc/audit/auditd.conf -> r:^\s*max_log_file_action\s*=\s*keep_logs'
+
+  - id: 7629
+    title: Ensure auditd service is enabled
+    description: Turn on the auditd daemon to record system events.
+    rationale: >
+      The capturing of system events provides system administrators with information to allow
+      them to determine if unauthorized access to their system is occurring.
+    remediation: >
+      Run the following command to enable auditd :
+      # systemctl enable auditd
+    compliance:
+      - cis: ["4.1.2"]
+      - cis_csc: ["6.2"]
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled auditd -> r:^enabled'
+
+  - id: 7630
+    title: Ensure events that modify user/group information are collected
+    description: >
+      Record events affecting the group , passwd (user IDs), shadow and gshadow (passwords) or
+      /etc/security/opasswd (old passwords, based on remember parameter in the PAM
+      configuration) files. The parameters in this section will watch the files to see if they have
+      been opened for write or have had attribute changes (e.g. permissions) and tag them with
+      the identifier "identity" in the audit log file.
+    rationale: >
+      Unexpected changes to these files could be an indication that the system has been
+      compromised and that an unauthorized user is attempting to hide their activities or
+      compromise additional accounts.
+    remediation: >
+      Add the following lines to the /etc/audit/audit.rules file:
+      -w /etc/group -p wa -k identity
+      -w /etc/passwd -p wa -k identity
+      -w /etc/gshadow -p wa -k identity
+      -w /etc/shadow -p wa -k identity
+      -w /etc/security/opasswd -p wa -k identity
+      
+      Notes:
+      Reloading the auditd config to set active settings may require a system reboot.
+    compliance:
+      - cis: ["4.1.5"]
+      - cis_csc: ["5.4"]
+    condition: all
+    rules:
+      - 'c:grep identity /etc/audit/audit.rules -> r:^\s*-w\s+/etc/group\s+-p\s+wa\s+-k\s+identity'
+      - 'c:grep identity /etc/audit/audit.rules -> r:^\s*-w\s+/etc/passwd\s+-p\s+wa\s+-k\s+identity'
+      - 'c:grep identity /etc/audit/audit.rules -> r:^\s*-w\s+/etc/gshadow\s+-p\s+wa\s+-k\s+identity'
+      - 'c:grep identity /etc/audit/audit.rules -> r:^\s*-w\s+/etc/shadow\s+-p\s+wa\s+-k\s+identity'
+      - 'c:grep identity /etc/audit/audit.rules -> r:^\s*-w\s+/etc/security/opasswd\s+-p\s+wa\s+-k\s+identity'
+      - 'c:auditctl -l | grep identity -> r:^\s*-w\s+/etc/group\s+-p\s+wa\s+-k\s+identity'
+      - 'c:auditctl -l | grep identity -> r:^\s*-w\s+/etc/passwd\s+-p\s+wa\s+-k\s+identity'
+      - 'c:auditctl -l | grep identity -> r:^\s*-w\s+/etc/gshadow\s+-p\s+wa\s+-k\s+identity'
+      - 'c:auditctl -l | grep identity -> r:^\s*-w\s+/etc/shadow\s+-p\s+wa\s+-k\s+identity'
+      - 'c:auditctl -l | grep identity -> r:^\s*-w\s+/etc/security/opasswd\s+-p\s+wa\s+-k\s+identity'
+
+  - id: 7631
+    title: Ensure events that modify the system's Mandatory Access Controls are collected
+    description: >
+      Monitor SELinux/AppArmor mandatory access controls. The parameters below monitor
+      any write access (potential additional, deletion or modification of files in the directory) or
+      attribute changes to the /etc/selinux or /etc/apparmor and /etc/apparmor.d directories.
+    rationale: >
+      Changes to files in these directories could indicate that an unauthorized user is attempting
+      to modify access controls and change security contexts, leading to a compromise of the
+      system.
+    remediation: >
+      On systems using SELinux add the following line to the /etc/audit/audit.rules file:
+      -w /etc/selinux/ -p wa -k MAC-policy
+      -w /usr/share/selinux/ -p wa -k MAC-policy
+      
+      On systems using AppArmor add the following line to the /etc/audit/audit.rules file:
+      -w /etc/apparmor/ -p wa -k MAC-policy
+      -w /etc/apparmor.d/ -p wa -k MAC-policy
+      
+      Notes:
+      Reloading the auditd config to set active settings may require a system reboot.
+    compliance:
+      - cis: ["4.1.7"]
+      - cis_csc: ["3.6"]
+    condition: all
+    rules:
+      - 'c:grep MAC-policy /etc/audit/audit.rules -> r:^\s*-w\s+/etc/selinux/\s+-p\s+wa\s+-k\s+MAC-policy'
+      - 'c:grep MAC-policy /etc/audit/audit.rules -> r:^\s*-w\s+/usr/share/selinux/\s+-p\s+wa\s+-k\s+MAC-policy'
+      - 'c:auditctl -l | grep MAC-policy -> r:^\s*-w\s+/etc/selinux/\s+-p\s+wa\s+-k\s+MAC-policy'
+      - 'c:auditctl -l | grep MAC-policy -> r:^\s*-w\s+/usr/share/selinux/\s+-p\s+wa\s+-k\s+MAC-policy'
+
+  - id: 7632
+    title: Ensure login and logout events are collected
+    description: >
+      Monitor login and logout events. The parameters below track changes to files associated
+      with login/logout events. The file /var/log/faillog tracks failed events from login. The
+      file /var/log/lastlog maintain records of the last time a user successfully logged in. The
+      file /var/log/tallylog maintains records of failures via the pam_tally2 module
+    rationale: >
+      Monitoring login/logout events could provide a system administrator with information
+      associated with brute force attacks against user logins.
+    remediation: >
+      Add the following lines to the /etc/audit/audit.rules file:
+      -w /var/log/faillog -p wa -k logins
+      -w /var/log/lastlog -p wa -k logins
+      -w /var/log/tallylog -p wa -k logins
+      
+      Notes:
+      Reloading the auditd config to set active settings may require a system reboot.
+    compliance:
+      - cis: ["4.1.8"]
+      - cis_csc: ["5.5","16.10","16.4"]
+    condition: all
+    rules:
+      - 'c:grep logins /etc/audit/audit.rules -> r:^\s*-w\s+/var/log/faillog\s+-p\s+wa\s+-k\s+logins'
+      - 'c:grep logins /etc/audit/audit.rules -> r:^\s*-w\s+/var/log/lastlog\s+-p\s+wa\s+-k\s+logins'
+      - 'c:grep logins /etc/audit/audit.rules -> r:^\s*-w\s+/var/log/tallylog\s+-p\s+wa\s+-k\s+logins'
+      - 'c:auditctl -l | grep logins -> r:^\s*-w\s+/var/log/faillog\s+-p\s+wa\s+-k\s+logins'
+      - 'c:auditctl -l | grep logins -> r:^\s*-w\s+/var/log/lastlog\s+-p\s+wa\s+-k\s+logins'
+      - 'c:auditctl -l | grep logins -> r:^\s*-w\s+/var/log/tallylog\s+-p\s+wa\s+-k\s+logins'
+
+  - id: 7633
+    title: Ensure session initiation information is collected
+    description: >
+      Monitor session initiation events. The parameters in this section track changes to the files
+      associated with session events. The file /var/run/utmp file tracks all currently logged in
+      users. All audit records will be tagged with the identifier "session." The /var/log/wtmp file
+      tracks logins, logouts, shutdown, and reboot events. The file /var/log/btmp keeps track of
+      failed login attempts and can be read by entering the command /usr/bin/last -f
+      /var/log/btmp . All audit records will be tagged with the identifier "logins."
+    rationale: >
+      Monitoring these files for changes could alert a system administrator to logins occurring at
+      unusual hours, which could indicate intruder activity (i.e. a user logging in at a time when
+      they do not normally log in).
+    remediation: >
+      Add the following lines to the /etc/audit/audit.rules file:
+      -w /var/run/utmp -p wa -k session
+      -w /var/log/wtmp -p wa -k logins
+      -w /var/log/btmp -p wa -k logins
+      
+      Notes:
+      The last command can be used to read /var/log/wtmp (last with no parameters) and
+      /var/run/utmp (last -f /var/run/utmp)
+      Reloading the auditd config to set active settings may require a system reboot.
+    compliance:
+      - cis: ["4.1.9"]
+      - cis_csc: ["5.5","16.10","16.4"]
+    condition: all
+    rules:
+      - 'c:grep -E "(session|logins)" /etc/audit/audit.rules -> r:^\s*-w\s+/var/run/utmp\s+-p\s+wa\s+-k\s+session'
+      - 'c:grep -E "(session|logins)" /etc/audit/audit.rules -> r:^\s*-w\s+/var/log/wtmp\s+-p\s+wa\s+-k\s+logins'
+      - 'c:grep -E "(session|logins)" /etc/audit/audit.rules -> r:^\s*-w\s+/var/log/btmp\s+-p\s+wa\s+-k\s+logins'
+      - 'c:auditctl -l | grep -E "(session|logins)" -> r:^\s*-w\s+/var/run/utmp\s+-p\s+wa\s+-k\s+session'
+      - 'c:auditctl -l | grep -E "(session|logins)" -> r:^\s*-w\s+/var/log/wtmp\s+-p\s+wa\s+-k\s+logins'
+      - 'c:auditctl -l | grep -E "(session|logins)" -> r:^\s*-w\s+/var/log/btmp\s+-p\s+wa\s+-k\s+logins'
+
+  - id: 7634
+    title: Ensure changes to system administration scope (sudoers) is collected
+    description: >
+      Monitor scope changes for system administrations. If the system has been properly
+      configured to force system administrators to log in as themselves first and then use the
+      sudo command to execute privileged commands, it is possible to monitor changes in scope.
+      The file /etc/sudoers will be written to when the file or its attributes have changed. The
+      audit records will be tagged with the identifier "scope."
+    rationale: >
+      Changes in the /etc/sudoers file can indicate that an unauthorized change has been made
+      to scope of system administrator activity.
+    remediation: >
+      Add the following line to the /etc/audit/audit.rules file:
+      -w /etc/sudoers -p wa -k scope
+      -w /etc/sudoers.d/ -p wa -k scope
+      
+      Notes:
+      Reloading the auditd config to set active settings may require a system reboot.
+    compliance:
+      - cis: ["4.1.15"]
+      - cis_csc: ["5.4"]
+    condition: all
+    rules:
+      - 'c:grep scope /etc/audit/audit.rules -> r:^\s*-w\s+/etc/sudoers\s+-p\s+wa\s+-k\s+scope'
+      - 'c:grep scope /etc/audit/audit.rules -> r:^\s*-w\s+/etc/sudoers.d/\s+-p\s+wa\s+-k\s+scope'
+      - 'c:auditctl -l | grep scope -> r:^\s*-w\s+/etc/sudoers\s+-p\s+wa\s+-k\s+scope'
+      - 'c:auditctl -l | grep scope -> r:^\s*-w\s+/etc/sudoers.d/\s+-p\s+wa\s+-k\s+scope'
+
+  - id: 7635
+    title: Ensure system administrator actions (sudolog) are collected
+    description: >
+      Monitor the sudo log file. If the system has been properly configured to disable the use of
+      the su command and force all administrators to have to log in first and then use sudo to
+      execute privileged commands, then all administrator commands will be logged to
+      /var/log/sudo.log . Any time a command is executed, an audit event will be triggered as
+      the /var/log/sudo.log file will be opened for write and the executed administration
+      command will be written to the log.
+    rationale: >
+      Changes in /var/log/sudo.log indicate that an administrator has executed a command or
+      the log file itself has been tampered with. Administrators will want to correlate the events
+      written to the audit trail with the records written to /var/log/sudo.log to verify if
+      unauthorized commands have been executed.
+    remediation: >
+      Add the following lines to the /etc/audit/audit.rules file:
+      -w /var/log/sudo.log -p wa -k actions
+    compliance:
+      - cis: ["4.1.16"]
+      - cis_csc: ["5.1","5.5"]
+    condition: all
+    rules:
+      - 'c:grep actions /etc/audit/audit.rules -> r:^\s*-w\s+/var/log/sudo.log\s+-p\s+wa\s+-k\s+actions'
+      - 'c:auditctl -l | grep actions -> r:^\s*-w\s+/var/log/sudo.log\s+-p\s+wa\s+-k\s+actions'
+
+  - id: 7636
+    title: Ensure the audit configuration is immutable
+    description: >
+      Set system audit so that audit rules cannot be modified with auditctl . Setting the flag "-e
+      2" forces audit to be put in immutable mode. Audit changes can only be made on system
+      reboot.
+    rationale: >
+      In immutable mode, unauthorized users cannot execute changes to the audit system to
+      potentially hide malicious activity and then put the audit rules back. Users would most
+      likely notice a system reboot and that could alert administrators of an attempt to make
+      unauthorized audit changes.
+    remediation: >
+      Add the following line to the end of the /etc/audit/audit.rules file.
+      -e 2
+      
+      Notes:
+      This setting will ensure reloading the auditd config to set active settings requires a system
+      reboot.
+    compliance:
+      - cis: ["4.1.18"]
+      - cis_csc: ["3","6"]
+    condition: all
+    rules:
+      - 'c:grep "^\s*[^#]" /etc/audit/audit.rules | tail -1 -> r:^\s*-e\s+2\s*$'
+
+  - id: 7637
+    title: Ensure tftp server is not enabled
+    description: >
+      Trivial File Transfer Protocol (TFTP) is a simple file transfer protocol, typically used to
+      automatically transfer configuration or boot machines from a boot server. The package
+      atftp is used to define and support a TFTP server.
+    rationale: >
+      TFTP does not support authentication nor does it ensure the confidentiality or integrity of
+      data. It is recommended that TFTP be removed, unless there is a specific need for TFTP. In
+      that case, extreme caution must be used when configuring the services.
+    remediation: >
+      Run the following command to disable tftp:
+      # systemctl disable atftpd
+    compliance:
+      - cis: ["2.2.17"]
+    condition: none
+    rules:
+      - 'c:systemctl is-enabled atftpd -> r:enabled'
+
+  - id: 7638
+    title: Ensure rsync service is not enabled
+    description: The rsyncd service can be used to synchronize files between systems over network links.
+    rationale: >
+      The rsyncd service presents a security risk as it uses unencrypted protocols for
+      communication.
+    remediation: >
+      Run the following command to disable rsyncd:
+      # systemctl disable rsyncd
+    compliance:
+      - cis: ["2.2.18"]
+    condition: none
+    rules:
+      - 'c:systemctl is-enabled rsyncd -> r:enabled'
+
+  - id: 7639
+    title: Ensure IPv6 router advertisements are not accepted
+    description: This setting disables the system's ability to accept IPv6 router advertisements.
+    rationale: >
+      It is recommended that systems not accept router advertisements as they could be tricked
+      into routing traffic to compromised machines. Setting hard routes within the system
+      (usually a single default route to a trusted router) protects the system from bad routes.
+    remediation: >
+      Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file:
+      net.ipv6.conf.all.accept_ra = 0
+      net.ipv6.conf.default.accept_ra = 0
+      
+      Run the following commands to set the active kernel parameters:
+      # sysctl -w net.ipv6.conf.all.accept_ra=0
+      # sysctl -w net.ipv6.conf.default.accept_ra=0
+      # sysctl -w net.ipv6.route.flush=1
+    compliance:
+      - cis: ["3.3.1"]
+      - cis_csc: ["3","11"]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv6.conf.all.accept_ra -> r:\s*0$'
+      - 'c:sysctl net.ipv6.conf.default.accept_ra -> r:\s*0$'
+      - 'c:grep -Rh "net\.ipv6\.conf\.all\.accept_ra" /etc/sysctl.conf /etc/sysctl.d -> r:^\s*net.ipv6.conf.all.accept_ra\s*=\s*0'
+      - 'c:grep -Rh "net\.ipv6\.conf\.default\.accept_ra" /etc/sysctl.conf /etc/sysctl.d -> r:^\s*net.ipv6.conf.default.accept_ra\s*=\s*0'
+
+  - id: 7640
+    title: Ensure IPv6 redirects are not accepted
+    description: >
+      This setting prevents the system from accepting ICMP redirects. ICMP redirects tell the
+      system about alternate routes for sending traffic.
+    rationale: >
+      It is recommended that systems not accept ICMP redirects as they could be tricked into
+      routing traffic to compromised machines. Setting hard routes within the system (usually a
+      single default route to a trusted router) protects the system from bad routes.
+    remediation: >
+      Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file:
+      net.ipv6.conf.all.accept_redirects = 0
+      net.ipv6.conf.default.accept_redirects = 0
+      
+      Run the following commands to set the active kernel parameters:
+      # sysctl -w net.ipv6.conf.all.accept_redirects=0
+      # sysctl -w net.ipv6.conf.default.accept_redirects=0
+      # sysctl -w net.ipv6.route.flush=1
+    compliance:
+      - cis: ["3.3.2"]
+      - cis_csc: ["3","11"]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv6.conf.all.accept_redirects -> r:\s*0$'
+      - 'c:sysctl net.ipv6.conf.default.accept_redirects -> r:\s*0$'
+      - 'c:grep -Rh "net\.ipv6\.conf\.all\.accept_redirect" /etc/sysctl.conf /etc/sysctl.d -> r:^\s*net.ipv6.conf.all.accept_redirect\s*=\s*0'
+      - 'c:grep -Rh "net\.ipv6\.conf\.default\.accept_redirect" /etc/sysctl.conf /etc/sysctl.d -> r:^\s*net.ipv6.conf.default.accept_redirect\s*=\s*0'
+
+  - id: 7641
+    title: Ensure /etc/hosts.allow is configured
+    description: >
+      The /etc/hosts.allow file specifies which IP addresses are permitted to connect to the
+      host. It is intended to be used in conjunction with the /etc/hosts.deny file.
+    rationale: >
+      The /etc/hosts.allow file supports access control by IP and helps ensure that only
+      authorized systems can connect to the system.
+    remediation: >
+      Run the following command to create /etc/hosts.allow :
+      # echo "ALL: <net>/<mask>, <net>/<mask>, ..." >/etc/hosts.allow
+      
+      where each <net>/<mask> combination (for example, "192.168.1.0/255.255.255.0")
+      represents one network block in use by your organization that requires access to this
+      system.
+      
+      Notes:
+      Contents of the /etc/hosts.allow file will vary depending on your network configuration.
+    compliance:
+      - cis: ["3.4.2"]
+      - cis_csc: ["9.2"]
+    condition: all
+    rules:
+      - 'f:/etc/hosts.allow -> r:^\s*ALL:\s+\S+'
+
+  - id: 7642
+    title: Ensure /etc/hosts.deny is configured
+    description: >
+      The /etc/hosts.deny file specifies which IP addresses are not permitted to connect to the
+      host. It is intended to be used in conjunction with the /etc/hosts.allow file.
+    rationale: >
+      The /etc/hosts.deny file serves as a failsafe so that any host not specified in
+      /etc/hosts.allow is denied access to the system.
+    remediation: >
+      Run the following command to create /etc/hosts.deny :
+      # echo "ALL: ALL" >> /etc/hosts.deny
+      
+      Notes:
+      Contents of the /etc/hosts.deny file may include additional options depending on your
+      network configuration.
+    compliance:
+      - cis: ["3.4.3"]
+      - cis_csc: ["9.2"]
+    condition: all
+    rules:
+      - 'f:/etc/hosts.deny -> r:^\s*ALL:\s+ALL'
+
+  - id: 7643
+    title: Ensure rsyslog Service is enabled
+    description: Once the rsyslog package is installed it needs to be activated.
+    rationale: >
+      If the rsyslog service is not activated the system may default to the syslogd service or lack
+      logging instead.
+    remediation: >
+      Run the following command to enable rsyslog :
+      # systemctl enable rsyslog
+    compliance:
+      - cis: ["4.2.1.1"]
+      - cis_csc: ["6.2"]
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled rsyslog -> r:enabled'
+
+  - id: 7644
+    title: Ensure syslog-ng service is enabled
+    description: >
+      Once the syslog-ng package is installed it needs to be activated.
+    rationale: >
+      If the syslog-ng service is not activated the system may default to the syslogd service or
+      lack logging instead.
+    remediation: >
+      Run the following command to enable syslog-ng :
+      # systemctl enable syslog-ng
+    compliance:
+      - cis: ["4.2.2.1"]
+      - cis_csc: ["6.2"]
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled syslog-ng -> r:enabled'
+
+  - id: 7645
+    title: Ensure cron daemon is enabled
+    description: The cron daemon is used to execute batch jobs on the system.
+    rationale: >
+      While there may not be user jobs that need to be run on the system, the system does have
+      maintenance jobs that may include security monitoring that have to run, and cron is used
+      to execute them.
+    remediation: >
+      Run the following command to enable cron :
+      # systemctl enable cron
+    compliance:
+      - cis: ["5.1.1"]
+      - cis_csc: ["6"]
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled cron -> r:enabled'
+
+  - id: 7646
+    title: Ensure at/cron is restricted to authorized users
+    description: >
+      Configure /etc/cron.allow and /etc/at.allow to allow specific users to use these
+      services. If /etc/cron.allow or /etc/at.allow do not exist, then /etc/at.deny and
+      /etc/cron.deny are checked. Any user not specifically defined in those files is allowed to
+      use at and cron. By removing the files, only users in /etc/cron.allow and /etc/at.allow
+      are allowed to use at and cron. Note that even though a given user is not listed in
+      cron.allow , cron jobs can still be run as that user. The cron.allow file only controls
+      administrative access to the crontab command for scheduling and modifying cron jobs.
+    rationale: >
+      On many systems, only the system administrator is authorized to schedule cron jobs. Using
+      the cron.allow file to control who can run cron jobs enforces this policy. It is easier to
+      manage an allow list than a deny list. In a deny list, you could potentially add a user ID to
+      the system and forget to add it to the deny files.
+    remediation: >
+      Run the following commands to remove /etc/cron.deny and /etc/at.deny and create and
+      set permissions and ownership for /etc/cron.allow and /etc/at.allow :
+      
+      # rm /etc/cron.deny
+      # rm /etc/at.deny
+      # touch /etc/cron.allow
+      # touch /etc/at.allow
+      # chmod og-rwx /etc/cron.allow
+      # chmod og-rwx /etc/at.allow
+      # chown root:root /etc/cron.allow
+      # chown root:root /etc/at.allow
+    compliance:
+      - cis: ["5.1.8"]
+      - cis_csc: ["16"]
+    condition: all
+    rules:
+      - 'not f:/etc/cron.deny'
+      - 'not f:/etc/at.deny'
+      - 'c:stat -L /etc/cron.allow -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+      - 'c:stat -L /etc/at.allow -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7647
+    title: Ensure only approved MAC algorithms are used
+    description: This variable limits the types of MAC algorithms that SSH can use during communication.
+    rationale: >
+      MD5 and 96-bit MAC algorithms are considered weak and have been shown to increase
+      exploitability in SSH downgrade attacks. Weak algorithms continue to have a great deal of
+      attention as a weak spot that can be exploited with expanded computing power. An
+      attacker that breaks the algorithm could take advantage of a MiTM position to decrypt the
+      SSH tunnel and capture credentials and information
+    remediation: >
+      Edit the /etc/ssh/sshd_config file to set the parameter in accordance with site policy. The
+      following includes all supported and accepted MACs:
+      
+      MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-
+      etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com
+    compliance:
+      - cis: ["5.2.11"]
+      - cis_csc: ["3.4"]
+    references:
+      - http://www.mitls.org/pages/attacks/SLOTH
+    condition: none
+    rules:
+      - 'c:sshd -T -> r:^macs\s+ && r:hmac-md5\s*'
+      - 'c:sshd -T -> r:^macs\s+ && r:hmac-md5-96\s*'
+      - 'c:sshd -T -> r:^macs\s+ && r:hmac-ripemd160\s*'
+      - 'c:sshd -T -> r:^macs\s+ && r:hmac-sha1\s*'
+      - 'c:sshd -T -> r:^macs\s+ && r:hmac-sha1-96\s*'
+      - 'c:sshd -T -> r:^macs\s+ && r:umac-64@openssh.com\s*'
+      - 'c:sshd -T -> r:^macs\s+ && r:hmac-md5-etm@openssh.com\s*'
+      - 'c:sshd -T -> r:^macs\s+ && r:hmac-md5-96-etm@openssh.com\s*'
+      - 'c:sshd -T -> r:^macs\s+ && r:hmac-ripemd160-etm@openssh.com\s*'
+      - 'c:sshd -T -> r:^macs\s+ && r:hmac-sha1-etm@openssh.com\s*'
+      - 'c:sshd -T -> r:^macs\s+ && r:hmac-sha1-96-etm@openssh.com\s*'
+      - 'c:sshd -T -> r:^macs\s+ && r:umac-64-etm@openssh.com\s*'
+
+  - id: 7648
+    title: Ensure SSH Idle Timeout Interval is configured
+    description: >
+      The two options ClientAliveInterval and ClientAliveCountMax control the timeout of
+      ssh sessions. When the ClientAliveInterval variable is set, ssh sessions that have no
+      activity for the specified length of time are terminated. When the ClientAliveCountMax
+      variable is set, sshd will send client alive messages at every ClientAliveInterval interval.
+      When the number of consecutive client alive messages are sent with no response from the
+      client, the ssh session is terminated. For example, if the ClientAliveInterval is set to 15
+      seconds and the ClientAliveCountMax is set to 3, the client ssh session will be terminated
+      after 45 seconds of idle time.
+    rationale: >
+      Having no timeout value associated with a connection could allow an unauthorized user
+      access to another user's ssh session (e.g. user walks away from their computer and doesn't
+      lock the screen). Setting a timeout value at least reduces the risk of this happening..
+      
+      While the recommended setting is 300 seconds (5 minutes), set this timeout value based on
+      site policy. The recommended setting for ClientAliveCountMax is 0. In this case, the client
+      session will be terminated after 5 minutes of idle time and no keepalive messages will be
+      sent.
+    remediation: >
+      Edit the /etc/ssh/sshd_config file to set the parameters according to site policy:
+      ClientAliveInterval 300
+      ClientAliveCountMax 0
+    compliance:
+      - cis: ["5.2.12"]
+      - cis_csc: ["16.4"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> n:^clientaliveinterval\s+(\d+) compare >= 1'
+      - 'c:sshd -T -> n:^clientaliveinterval\s+(\d+) compare <= 300'
+      - 'c:sshd -T -> n:^ClientAliveCountMax\s+(\d+) compare == 0'
+
+  - id: 7649
+    title: Ensure SSH LoginGraceTime is set to one minute or less
+    description: >
+      The LoginGraceTime parameter specifies the time allowed for successful authentication to
+      the SSH server. The longer the Grace period is the more open unauthenticated connections
+      can exist. Like other session controls in this session the Grace Period should be limited to
+      appropriate organizational limits to ensure the service is available for needed access.
+    rationale: >
+      Setting the LoginGraceTime parameter to a low number will minimize the risk of successful
+      brute force attacks to the SSH server. It will also limit the number of concurrent
+      unauthenticated connections While the recommended setting is 60 seconds (1 Minute), set
+      the number based on site policy.
+    remediation: >
+      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+      LoginGraceTime 60
+    compliance:
+      - cis: ["5.2.13"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> n:^logingracetime\s+(\d+) compare >= 1'
+      - 'c:sshd -T -> n:^logingracetime\s+(\d+) compare <= 60'
+
+  - id: 7650
+    title: Ensure SSH access is limited
+    description: >
+      There are several options available to limit which users and group can access the system
+      via SSH. It is recommended that at least one of the following options be leveraged:
+      AllowUsers
+      
+      The AllowUsers variable gives the system administrator the option of allowing specific
+      users to ssh into the system. The list consists of space separated user names. Numeric user
+      IDs are not recognized with this variable. If a system administrator wants to restrict user
+      access further by only allowing the allowed users to log in from a particular host, the entry
+      can be specified in the form of user@host. AllowGroups
+      
+      The AllowGroups variable gives the system administrator the option of allowing specific
+      groups of users to ssh into the system. The list consists of space separated group names.
+      Numeric group IDs are not recognized with this variable. DenyUsers
+      
+      The DenyUsers variable gives the system administrator the option of denying specific users
+      to ssh into the system. The list consists of space separated user names. Numeric user IDs
+      are not recognized with this variable. If a system administrator wants to restrict user
+      access further by specifically denying a user's access from a particular host, the entry can
+      be specified in the form of user@host. DenyGroups
+      
+      The DenyGroups variable gives the system administrator the option of denying specific
+      groups of users to ssh into the system. The list consists of space separated group names.
+      Numeric group IDs are not recognized with this variable.
+    rationale: >
+      Restricting which users can remotely access the system via SSH will help ensure that only
+      authorized users access the system.
+    remediation: >
+      Edit the /etc/ssh/sshd_config file to set one or more of the parameter as follows:
+      
+      AllowUsers <userlist>
+      AllowGroups <grouplist>
+      DenyUsers <userlist>
+      DenyGroups <grouplist>
+    compliance:
+      - cis: ["5.2.14"]
+      - cis_csc: ["5.1","5.8"]
+    condition: any
+    rules:
+      - 'c:sshd -T -> r:^\s*allowusers\s+\S+'
+      - 'c:sshd -T -> r:^\s*allowgroups\s+\S+'
+      - 'c:sshd -T -> r:^\s*denyusers\s+\S+'
+      - 'c:sshd -T -> r:^\s*denygroups\s+\S+'
+
+  - id: 7651
+    title: Ensure SSH warning banner is configured
+    description: >
+      The Banner parameter specifies a file whose contents must be sent to the remote user
+      before authentication is permitted. By default, no banner is displayed.
+    rationale: >
+      Banners are used to warn connecting users of the particular site's policy regarding
+      connection. Presenting a warning message prior to the normal user login may assist the
+      prosecution of trespassers on the computer system.
+    remediation: >
+      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+      
+      Banner /etc/issue.net
+    compliance:
+      - cis: ["5.2.15"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^banner\s+/etc/issue.net'
+
+  - id: 7652
+    title: Ensure lockout for failed password attempts is configured
+    description: >
+      Lock out users after n unsuccessful consecutive login attempts. The first sets of changes are
+      made to the PAM configuration files. The second set of changes are applied to the program
+      specific PAM configuration file. The second set of changes must be applied to each program
+      that will lock out users. Check the documentation for each secondary program for
+      instructions on how to configure them to work with PAM.
+      
+      Set the lockout number to the policy in effect at your site.
+    rationale: >
+      Locking out user IDs after n unsuccessful consecutive login attempts mitigates brute force
+      password attacks against your systems.
+    remediation: >
+      Edit the /etc/pam.d/common-auth file and add the following pam_tally2.so line:
+      auth required pam_tally2.so onerr=fail audit silent deny=5 unlock_time=900
+      
+      Edit the /etc/pam.d/common-account file and add the following pam_tally2.so line:
+      account required pam_tally2.so
+      
+      Notes:
+      Additional module options may be set, recommendation only covers those listed here.
+      
+      If a user has been locked out because they have reached the maximum consecutive failure
+      count defined by deny= in the pam_tally2.so module, the user can be unlocked by issuing
+      the command pam_tally2 -u --reset. This command sets the failed count to 0, effectively
+      unlocking the user.
+      
+      Use of the "audit" keyword may log credentials in the case of user error during
+      authentication. This risk should be evaluated in the context of the site policies of your
+      organization.
+    compliance:
+      - cis: ["5.3.2"]
+      - cis_csc: ["16.7"]
+    condition: all
+    rules:
+      - 'c:grep pam_tally2\.so /etc/pam.d/common-auth -> r:^\t*auth\t*required\t*pam_tally2.so\t*\.*'
+      - 'c:grep pam_tally2\.so /etc/pam.d/common-account -> r:^\t*account\t*required\t*pam_tally2.so'
+
+  - id: 7653
+    title: Ensure password reuse is limited
+    description: >
+      The /etc/security/opasswd file stores the users' old passwords and can be checked to
+      ensure that users are not recycling recent passwords.
+    rationale: >
+      Forcing users not to reuse their past 5 passwords make it less likely that an attacker will be
+      able to guess the password.
+      Note that these change only apply to accounts configured on the local system.
+    remediation: >
+      Edit the /etc/pam.d/common-password file to include the remember option and conform to
+      site policy as shown:
+      password required pam_pwhistory.so remember=5
+      
+      Notes:
+      Additional module options may be set, recommendation only covers those listed here.
+    compliance:
+      - cis: ["5.3.3"]
+      - cis_csc: ["16"]
+    condition: all
+    rules:
+      - 'f:/etc/pam.d/common-password -> n:^\s*password\t+required\t+pam_pwhistory\.so\t+remember\s*=\s*(\d+) compare >= 5'
+
+  - id: 7654
+    title: Ensure password hashing algorithm is SHA-512
+    description: >
+      The commands below change password encryption from md5 to sha512 (a much stronger
+      hashing algorithm). All existing accounts will need to perform a password change to
+      upgrade the stored hashes to the new algorithm.
+    rationale: >
+      The SHA-512 algorithm provides much stronger hashing than MD5, thus providing
+      additional protection to the system by increasing the level of effort for an attacker to
+      successfully determine passwords.
+      
+      Note that these change only apply to accounts configured on the local system.
+    remediation: >
+      Edit the /etc/pam.d/common-password file to include the sha512 option for pam_unix.so as
+      shown:
+      password required pam_unix.so sha512
+    compliance:
+      - cis: ["5.3.4"]
+      - cis_csc: ["16.14"]
+    condition: all
+    rules:
+      - 'f:/etc/pam.d/common-password -> r:^\s*password\t+required\t+pam_unix.so\t+sha512'
+
+  - id: 7655
+    title: Ensure default group for the root account is GID 0
+    description: >
+      The usermod command can be used to specify which group the root user belongs to. This
+      affects permissions of files that are created by the root user.
+    rationale: >
+      Using GID 0 for the _root_ account helps prevent _root_ -owned files from accidentally
+      becoming accessible to non-privileged users.
+    remediation: >
+      Run the following command to set the root user default group to GID 0 :
+      # usermod -g 0 root
+    compliance:
+      - cis: ["5.4.3"]
+      - cis_csc: ["5"]
+    condition: all
+    rules:
+      - 'f:/etc/passwd -> r:^root:\S+:\S+:0:'
+
+  - id: 7656
+    title: Ensure default user shell timeout is 900 seconds or less 
+    description: >
+      The default TMOUT determines the shell timeout for users. The TMOUT value is measured in
+      seconds.
+    rationale: >
+      Having no timeout value associated with a shell could allow an unauthorized user access to
+      another user's shell session (e.g. user walks away from their computer and doesn't lock the
+      screen). Setting a timeout value at least reduces the risk of this happening.
+    remediation: >
+      Edit the /etc/bashrc and /etc/profile files (and the appropriate files for any other shell
+      supported on your system) and add or edit any umask parameters as follows:
+      TMOUT=600
+      
+      Notes:
+      The audit and remediation in this recommendation apply to bash and shell. If other shells
+      are supported on the system, it is recommended that their configuration files also are
+      checked. Other methods of setting a timeout exist for other shells not covered here.
+    compliance:
+      - cis: ["5.4.5"]
+      - cis_csc: ["13"]
+    condition: all
+    rules:
+      - 'f:/etc/bashrc -> r:^TMOUT'
+      - 'f:/etc/profile -> r:^TMOUT'
+      - 'not f:/etc/bashrc -> n:^TMOUT=(\d+) compare > 900'
+      - 'not f:/etc/profile -> n:^TMOUT=(\d+) compare > 900'
+
+  - id: 7657
+    title: Ensure the SELinux state is enforcing
+    description: Set SELinux to enable when the system is booted.
+    rationale: >
+      SELinux must be enabled at boot time in to ensure that the controls it provides are in effect
+      at all times.
+    remediation: >
+      Edit the /etc/selinux/config file to set the SELINUX parameter:
+      SELINUX=enforcing
+    compliance:
+      - cis: ["1.6.1.2"]
+      - cis_csc: ["14.4"]
+    condition: all
+    rules:
+      - 'f:/etc/selinux/config -> r:^\s*SELINUX=enforcing'
+      - 'c:sestatus -> r:^\s*SELinux status:\t*enabled'
+      - 'c:sestatus -> r:^\s*Current mode:\t*enforcing'
+      - 'c:sestatus -> r:^\s*Mode from config file:\t*enforcing'
+
+  - id: 7658
+    title: Ensure SELinux policy is configured
+    description: >
+      Configure SELinux to meet or exceed the default targeted policy, which constrains daemons
+      and system software only.
+    rationale: >
+      Security configuration requirements vary from site to site. Some sites may mandate a
+      policy that is stricter than the default policy, which is perfectly acceptable. This item is
+      intended to ensure that at least the default recommendations are met.
+    remediation: >
+      Edit the /etc/selinux/config file to set the SELINUXTYPE parameter:
+      SELINUXTYPE=targeted
+      
+      Notes:
+      If your organization requires stricter policies, ensure that they are set in the
+      /etc/selinux/configfile.
+    compliance:
+      - cis: ["1.6.1.3"]
+    condition: all
+    rules:
+      - 'f:/etc/selinux/config -> r:^\s*SELINUXTYPE=targeted'
+      - 'not c:sestatus -> r:^\s*Loaded policy name:\t*minimum'
+
+  - id: 7659
+    title: Ensure GDM login banner is configured
+    description: >
+      GDM is the GNOME Display Manager which handles graphical login for GNOME based
+      systems.
+    rationale: >
+      Warning messages inform users who are attempting to login to the system of their legal
+      status regarding the system and must include the name of the organization that owns the
+      system and any monitoring policies that are in place.
+    remediation: >
+      Create the /etc/dconf/profile/gdm file with the following contents:
+      user-db:user
+      system-db:gdm
+      file-db:/usr/share/gdm/greeter-dconf-defaults
+      
+      Create or edit the banner-message-enable and banner-message-text options in
+      /etc/dconf/db/gdm.d/01-banner-message:
+      [org/gnome/login-screen]
+      banner-message-enable=true
+      banner-message-text='Authorized uses only. All activity may be monitored and
+      reported.'
+      
+      Run the following command to update the system databases:
+      # dconf update
+      
+      Notes:
+      Additional options and sections may appear in the /etc/dconf/db/gdm.d/01-bannermessage file.
+      If a different GUI login service is in use, consult your documentation and apply an
+      equivalent banner.
+    compliance:
+      - cis: ["1.7.2"]
+    condition: all
+    rules:
+      - 'f:/etc/dconf/profile/gdm -> r:^\s*user-db:user'
+      - 'f:/etc/dconf/profile/gdm -> r:^\s*system-db:gdm'
+      - 'f:/etc/dconf/profile/gdm -> r:^\s*file-db:/usr/share/gdm/greeter-dconf-defaults'
+      - 'c:grep -Rh "banner-message-enable=true" /etc/dconf/db/gdm.d -> r:^\s*banner-message-enable=true'
+      - 'c:grep -Rh "banner-message-text=" /etc/dconf/db/gdm.d -> r:^\s*banner-message-text=\S+'
+
+#  - id: 
+#    title: 
+#    description: 
+#    rationale: 
+#    remediation: 
+#    compliance:
+#      - cis: [""]
+#      - cis_csc: [""]
+#    references:
+#      - 
+#    condition: 
+#    rules:
+#      - ''

--- a/ruleset/sca/sles/15/cis_sles15_linux.yml
+++ b/ruleset/sca/sles/15/cis_sles15_linux.yml
@@ -1,0 +1,3710 @@
+# Security Configuration Assessment
+# CIS Checks for SUSE SLES 15
+# Copyright (C) 2015-2021, Wazuh Inc.
+#
+# This program is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation
+#
+# Based on:
+# CIS Benchmark for SUSE Linux Enterprise 15 v1.0.0 - 06-30-2020
+
+policy:
+  id: "cis_sles15_linux"
+  file: "cis_sles15_linux.yml"
+  name: "CIS SUSE Linux Enterprise 15 Benchmark"
+  description: "This document provides prescriptive guidance for establishing a secure configuration posture for SUSE Linux Enterprise 12 systems running on x86 and x64 platforms. This document was tested against SUSE Linux Enterprise Server 15 SP1."
+  references:
+    - https://www.cisecurity.org/cis-benchmarks/
+
+requirements:
+  title: "Check SUSE 15 version"
+  description: "Requirements for running the SCA scan against SUSE Linux Enterprise Server 15"
+  condition: all
+  rules:
+    - 'f:/etc/os-release -> r:SUSE Linux Enterprise Server 15'
+
+variables:
+  $sshd_file: /etc/ssh/sshd_config
+
+checks:
+
+# Section 1.1 - Filesystem Configuration
+
+  - id: 7500
+    title: Ensure nodev option set on /tmp partition
+    description: The nodev mount option specifies that the filesystem cannot contain special devices.
+    rationale: >
+      Since the /tmp filesystem is not intended to support devices, set this option to ensure that
+      users cannot attempt to create block or character special devices in /tmp .
+    remediation: >
+      Edit the /etc/fstab file OR the /etc/systemd/system/localfs.target.wants/tmp.mount file:
+      IF /etc/fstab is used to mount /tmp:
+      Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /tmp
+      partition. See the fstab(5) manual page for more information.
+      Run the following command to remount /tmp :
+
+      # mount -o remount,nodev /tmp
+
+      OR
+      IF systemd is used to mount /tmp:
+      Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to add nodev to the /tmp
+      mount options:
+      [Mount]
+      Options=mode=1777,strictatime,noexec,nodev,nosuid
+
+      Run the following command to restart the systemd daemon:
+      # systemctl daemon-reload
+      
+      Run the following command to restart tmp.mount
+      # systemctl restart tmp.mount
+    compliance:
+      - cis: ["1.1.4"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:mount -> r:\s/tmp\s && r:nodev'
+
+  - id: 7501
+    title: Ensure nosuid option set on /tmp partition
+    description: The nosuid mount option specifies that the filesystem cannot contain setuid files.
+    rationale: >
+      Since the /tmp filesystem is only intended for temporary file storage, set this option to
+      ensure that users cannot create setuid files in /tmp.
+    remediation: >
+      IF /etc/fstab is used to mount /tmp
+      Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /tmp
+      partition. See the fstab(5) manual page for more information.
+      Run the following command to remount /tmp :
+      # mount -o remount,nosuid /tmp
+    
+      OR
+      IF systemd is used to mount /tmp:
+      Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to add nosuid to the /tmp
+      mount options:
+      [Mount]
+      Options=mode=1777,strictatime,noexec,nodev,nosuid
+    
+      Run the following command to restart the systemd daemon:
+      # systemctl daemon-reload
+    
+      Run the following command to restart tmp.mount:
+      # systemctl restart tmp.mount
+    compliance:
+      - cis: ["1.1.5"]
+      - cis_csc: ["5.1","13"]
+    condition: all
+    rules:
+      - 'c:mount -> r:\s/tmp\s && r:nosuid'
+
+  - id: 7502
+    title: Ensure noexec option set on /tmp partition
+    description: The noexec mount option specifies that the filesystem cannot contain executable binaries.
+    rationale: >
+      Since the /tmp filesystem is only intended for temporary file storage, set this option to
+      ensure that users cannot run executable binaries from /tmp .
+    remediation: >
+      Edit the /etc/fstab file OR the /etc/systemd/system/localfs.target.wants/tmp.mount file:
+      
+      IF /etc/fstab is used to mount /tmp
+      Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /tmp
+      partition. See the fstab(5) manual page for more information.
+      Run the following command to remount /tmp :
+      
+      # mount -o remount,noexec /tmp
+      
+      OR
+      IF systemd is used to mount /tmp:
+      Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to add noexec to the /tmp
+      mount options:
+      
+      [Mount]
+      Options=mode=1777,strictatime,noexec,nodev,nosuid
+      
+      Run the following command to restart the systemd daemon:
+      # systemctl daemon-reload
+      
+      Run the following command to restart tmp.mount
+      # systemctl restart tmp.mount
+
+    compliance:
+      - cis: ["1.1.3"]
+      - cis_csc: ["2.6"]
+    condition: all
+    rules:
+      - 'c:mount -> r:\s/tmp\s && r:noexec'
+
+  - id: 7503
+    title: Ensure separate partition exists for /var
+    description: >
+      The /var directory is used by daemons and other system services to temporarily store
+      dynamic data. Some directories created by these processes may be world-writable.
+      
+      Note: When modifying /var it is advisable to bring the system to emergency mode (so auditd
+      is not running), rename the existing directory, mount the new file system, and migrate the
+      data over before returning to multiuser mode.
+    rationale: >
+      Since the /var directory may contain world-writable files and directories, there is a risk of
+      resource exhaustion if it is not bound to a separate partition.
+    remediation: >
+      For new installations, during installation create a custom partition setup and specify a
+      separate partition for /var .
+      For systems that were previously installed, create a new partition and configure
+      /etc/fstab as appropriate.
+    compliance:
+      - cis: ["1.1.10"]
+      - cis_csc: ["5.1"]
+    references:
+      - AJ Lewis, "LVM HOWTO", http://tldp.org/HOWTO/LVM-HOWTO/
+    condition: all
+    rules:
+      - 'c:mount -> r:\s/var\s'
+
+  - id: 7504
+    title: Ensure separate partition exists for /var/log
+    description: The /var/log directory is used by system services to store log data.
+    rationale: >
+      There are two important reasons to ensure that system logs are stored on a separate
+      partition: protection against resource exhaustion (since logs can grow quite large) and
+      protection of audit data.
+      
+      Note: When modifying /var/log it is advisable to bring the system to emergency mode (so
+      auditd is not running), rename the existing directory, mount the new file system, and migrate
+      the data over before returning to multiuser mode.
+    remediation: >
+      For new installations, during installation create a custom partition setup and specify a
+      separate partition for /var/log .
+      For systems that were previously installed, create a new partition and configure
+      /etc/fstab as appropriate.
+    compliance:
+      - cis: ["1.1.15"]
+      - cis_csc: ["6.4"]
+    references:
+      - AJ Lewis, "LVM HOWTO", http://tldp.org/HOWTO/LVM-HOWTO/
+    condition: all
+    rules:
+      - 'c:mount -> r:\s/var/log\s'
+
+  - id: 7505
+    title: Ensure separate partition exists for /var/log/audit
+    description: >
+      The auditing daemon, auditd , stores log data in the /var/log/audit directory.
+      
+      Note: When modifying /var/log/audit it is advisable to bring the system to emergency mode
+      (so auditd is not running), rename the existing directory, mount the new file system, and
+      migrate the data over before returning to multiuser mode.
+    rationale: >
+      There are two important reasons to ensure that data gathered by auditd is stored on a
+      separate partition: protection against resource exhaustion (since the audit.log file can
+      grow quite large) and protection of audit data. The audit daemon calculates how much free
+      space is left and performs actions based on the results. If other processes (such as syslog )
+      consume space in the same partition as auditd , it may not perform as desired.
+    remediation: >
+      For new installations, during installation create a custom partition setup and specify a
+      separate partition for /var/log/audit .
+      For systems that were previously installed, create a new partition and configure
+      /etc/fstab as appropriate.
+    compliance:
+      - cis: ["1.1.16"]
+      - cis_csc: ["6.4"]
+    references:
+      - AJ Lewis, "LVM HOWTO", http://tldp.org/HOWTO/LVM-HOWTO/
+    condition: all
+    rules:
+      - 'c:mount -> r:\s/var/log/audit\s'
+
+  - id: 7506
+    title: Ensure separate partition exists for /home
+    description: The /home directory is used to support disk storage needs of local users.
+    rationale: >
+      If the system is intended to support local users, create a separate partition for the /home
+      directory to protect against resource exhaustion and restrict the type of files that can be
+      stored under /home .
+    remediation: >
+      For new installations, during installation create a custom partition setup and specify a
+      separate partition for /home .
+      For systems that were previously installed, create a new partition and configure
+      /etc/fstab as appropriate.
+    compliance:
+      - cis: ["1.1.17"]
+      - cis_csc: ["5.1","13"]
+    references:
+      - AJ Lewis, "LVM HOWTO", http://tldp.org/HOWTO/LVM-HOWTO/
+    condition: all
+    rules:
+      - 'c:mount -> r:\s/home\s'
+
+  - id: 7507
+    title: Ensure nodev option set on /home partition
+    description: >
+      The nodev mount option specifies that the filesystem cannot contain special devices.
+
+      Note: The actions in this recommendation refer to the /home partition, which is the default
+      user partition. If you have created other user partitions, it is recommended that the
+      Remediation and Audit steps be applied to these partitions as well.
+    rationale: >
+      Since the user partitions are not intended to support devices, set this option to ensure that
+      users cannot attempt to create block or character special devices.
+    remediation: >
+      Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /home
+      partition. See the fstab(5) manual page for more information.
+      
+      Run the following command to remount /home/ with the nodev mount option:
+      # mount -o remount,nodev /home
+    compliance:
+      - cis: ["1.1.18"]
+      - cis_csc: ["5.1","13"]
+    condition: all
+    rules:
+      - 'c:mount -> r:\s/home\s && r:nodev'
+
+  - id: 7508
+    title: Ensure nosuid option set on /dev/shm partition
+    description: >
+      The nosuid mount option specifies that the filesystem cannot contain setuid files.
+      Note: /dev/shm is mounted automatically by systemd. /dev/shm needs to be added to
+      /etc/fstab to add mount options even though it is already being mounted on boot.
+    rationale: >
+      Setting this option on a file system prevents users from introducing privileged programs
+      onto the system and allowing non-root users to execute them.
+    remediation: >
+      Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the
+      /dev/shm partition. See the fstab(5) manual page for more information.
+      
+      Run the following command to remount /dev/shm:
+      # mount -o remount,noexec,nodev,nosuid /dev/shm
+    compliance:
+      - cis: ["1.1.9"]
+      - cis_csc: ["5.1","13"]
+    condition: all
+    rules:
+      - 'c:mount -> r:\s/dev/shm\s && r:nosuid'
+
+  - id: 7509
+    title: Ensure noexec option set on /dev/shm partition
+    description: >
+      The noexec mount option specifies that the filesystem cannot contain executable binaries.
+
+      Note: /dev/shm is mounted automatically by systemd. /dev/shm needs to be added to
+      /etc/fstab to add mount options even though it is already being mounted on boot.
+    rationale: >
+      Setting this option on a file system prevents users from executing programs from shared
+      memory. This deters users from introducing potentially malicious software on the system.
+    remediation: >
+      Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the
+      /dev/shm partition. See the fstab(5) manual page for more information.
+      
+      Run the following command to remount /dev/shm:
+      # mount -o remount,noexec,nodev,nosuid /dev/shm
+    compliance:
+      - cis: ["1.1.7"]
+      - cis_csc: ["2.6","13"]
+    condition: all
+    rules:
+      - 'c:mount -> r:\s/dev/shm\s && r:noexec'
+
+  - id: 7510
+    title: Ensure core dumps are restricted
+    description: >
+      A core dump is the memory of an executable program. It is generally used to determine
+      why a program aborted. It can also be used to glean confidential information from a core
+      file. The system provides the ability to set a soft limit for core dumps, but this can be
+      overridden by the user.
+    rationale: >
+      Setting a hard limit on core dumps prevents users from overriding the soft variable. If core
+      dumps are required, consider setting limits for user groups (see limits.conf(5) ). In
+      addition, setting the fs.suid_dumpable variable to 0 will prevent setuid programs from
+      dumping core.
+    remediation: >
+      Add the following line to /etc/security/limits.conf or a /etc/security/limits.d/*
+      file:
+      * hard core 0
+      
+      Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file:
+      fs.suid_dumpable = 0
+      
+      Run the following command to set the active kernel parameter:
+      # sysctl -w fs.suid_dumpable=0
+      
+      If systemd-coredump is installed:
+      edit /etc/systemd/coredump.conf and add/modify the following lines:
+      Storage=none
+      ProcessSizeMax=0
+      
+      Run the command:
+      systemctl daemon-reload
+    compliance:
+      - cis: ["1.6.1"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:grep -Rh ^*[[:space:]]*hard[[:space:]][[:space:]]*core[[:space:]][[:space:]]* /etc/security/limits.conf /etc/security/limits.d -> r:\s*\t*0$'
+      - 'c:sysctl fs.suid_dumpable -> r:\s0$'
+      - 'c:grep -Rh fs\.suid_dumpable /etc/sysctl.conf /etc/sysctl.d -> r:^\s*fs.suid_dumpable\s*=\s*0\s*$'
+
+  - id: 7511
+    title: Ensure address space layout randomization (ASLR) is enabled
+    description: >
+      Address space layout randomization (ASLR) is an exploit mitigation technique which
+      randomly arranges the address space of key data areas of a process.
+    rationale: >
+      Randomly placing virtual memory regions will make it difficult to write memory page
+      exploits as the memory placement will be consistently shifting.
+    remediation: >
+      Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file:
+      kernel.randomize_va_space = 2
+      
+      Run the following command to set the active kernel parameter:
+      # sysctl -w kernel.randomize_va_space=2
+    compliance:
+      - cis: ["1.6.3"]
+      - cis_csc: ["8.3"]
+    condition: all
+    rules:
+      - 'c:grep -Rh ^kernel\.randomize_va_space /etc/sysctl.conf /etc/sysctl.d -> r:^\s*kernel.randomize_va_space\s*=\s*2$'
+      - 'c:sysctl kernel.randomize_va_space -> r:\s2$|\t2$'
+
+  - id: 7512
+    title: Ensure rsh client is not installed
+    description: The rsh package contains the client commands for the rsh services.
+    rationale: >
+      These legacy clients contain numerous security exposures and have been replaced with the
+      more secure SSH package. Even if the server is removed, it is best to ensure the clients are
+      also removed to prevent users from inadvertently attempting to use these commands and
+      therefore exposing their credentials. Note that removing the rsh package removes the
+      clients for rsh , rcp and rlogin.
+    remediation: >
+      Run the following command to remove the rsh package:
+      # zypper remove rsh
+    compliance:
+      - cis: ["2.3.2"]
+      - cis_csc: ["2.6"]
+    condition: all
+    rules:
+      - 'c:rpm -q rsh -> r:not installed'
+
+  - id: 7513
+    title: Ensure talk client is not installed
+    description: >
+      The talk software makes it possible for users to send and receive messages across systems
+      through a terminal session. The talk client, which allows initialization of talk sessions, is
+      installed by default.
+    rationale: >
+      The software presents a security risk as it uses unencrypted protocols for communication.
+    remediation: >
+      Run the following command to remove the talk package:
+      # zypper remove talk
+    compliance:
+      - cis: ["2.3.3"]
+      - cis_csc: ["2.6"]
+    condition: all
+    rules:
+      - 'c:rpm -q talk -> r:not installed'
+
+  - id: 7514
+    title: Ensure telnet-server is not installed
+    description: >
+      The telnet package contains the telnet daemon, which accepts connections from users
+      from other systems via the telnet protocol.
+    rationale: >
+      The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission
+      medium could allow a user with access to sniff network traffic the ability to steal
+      credentials. The ssh package provides an encrypted session and stronger security.
+    remediation: >
+      Run the following command to remove the telnet-server package:
+      # zypper remove telnet
+    compliance:
+      - cis: ["2.2.19"]
+      - cis_csc: ["2.6","9.2"]
+    condition: all
+    rules:
+      - 'c:rpm -q telnet -> r:not installed'
+
+  - id: 7515
+    title: Ensure FTP Server is not installed
+    description: >
+      FTP (File Transfer Protocol) is a traditional and widely used standard tool for transferring
+      files between a server and clients over a network, especially where no authentication is
+      necessary (permits anonymous users to connect to a server).
+    rationale: >
+      FTP does not protect the confidentiality of data or authentication credentials. It is
+      recommended SFTP be used if file transfer is required. Unless there is a need to run the
+      system as a FTP server (for example, to allow anonymous downloads), it is recommended
+      that the package be removed to reduce the potential attack surface.
+      
+      Note: Additional FTP servers also exist and should be removed if not required.
+    remediation: >
+      Run the following command to remove vsftpd:
+      # zypper remove vsftpd
+    compliance:
+      - cis: ["2.2.10"]
+      - cis_csc: ["9.2"]
+    condition: all
+    rules:
+      - 'c:rpm -q vsftpd -> r:not installed'
+
+  - id: 7516
+    title: Ensure rsync is not installed or the rsyncd service is masked
+    description: The rsyncd service can be used to synchronize files between systems over network links.
+    rationale: >
+      Unless required, the rsync package should be removed to reduce the attack surface area of
+      the system.
+      
+      The rsyncd service presents a security risk as it uses unencrypted protocols for
+      communication.
+      
+      Note: If a required dependency exists for the rsync package, but the rsyncd service is not
+      required, the service should be masked.
+    remediation: >
+      Run the following command to remove the rsync package:
+      # zypper remove rsync
+      
+      OR
+      
+      Run the following command to mask the rsyncd service:
+      # systemctl --now mask rsyncd
+    compliance:
+      - cis: ["2.2.17"]
+      - cis_csc: ["9.2"]
+    condition: any
+    rules:
+      - 'c:rpm -q rsync -> r:not installed'
+      - 'c:systemctl is-enabled rsyncd -> r:^masked'
+
+  - id: 7517
+    title: Ensure xinetd is not installed
+    description: >
+      The eXtended InterNET Daemon ( xinetd ) is an open source super daemon that replaced
+      the original inetd daemon. The xinetd daemon listens for well known services and
+      dispatches the appropriate daemon to properly respond to service requests.
+    rationale: >
+      If there are no xinetd services required, it is recommended that the package be removed to
+      reduce the attack surface are of the system.
+      
+      Note: If an xinetd service or services are required, ensure that any xinetd service not required
+      is stopped and disabled
+    remediation: >
+      Run the following command to remove xinetd:
+      # zypper remove xinetd
+    compliance:
+      - cis: ["2.1.1"]
+      - cis_csc: ["2.6","9.2"]
+    condition: all
+    rules:
+      - 'c:rpm -q xinetd -> r:not installed'
+
+  - id: 7518
+    title: Ensure X11 Server components are not installed
+    description: >
+      The X Window System provides a Graphical User Interface (GUI) where users can have
+      multiple windows in which to run programs and various add on. The X Windows system is
+      typically used on workstations where users login, but not on servers where users typically
+      do not login.
+    rationale: >
+      Unless your organization specifically requires graphical login access via X Windows,
+      remove it to reduce the potential attack surface.
+    remediation: >
+      Run the following command to remove the X Windows Server packages:
+      # zypper remove xorg-x11-server*
+    compliance:
+      - cis: ["2.2.2"]
+      - cis_csc: ["2.6"]
+    condition: none
+    rules:
+      - 'c:rpm -qa -> r:^xorg-x11'
+
+  - id: 7519
+    title: Ensure Avahi Server is not installed
+    description: >
+      Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD
+      service discovery. Avahi allows programs to publish and discover services and hosts
+      running on a local network with no specific configuration. For example, a user can plug a
+      computer into a network and Avahi automatically finds printers to print to, files to look at
+      and people to talk to, as well as network services running on the machine.
+    rationale: >
+      Automatic discovery of network services is not normally required for system functionality.
+      It is recommended to remove this package to reduce the potential attack surface.
+    remediation: >
+      Run the following commands to stop, mask and remove avahi-autoipd and avahi:
+      # systemctl stop avahi-daemon.socket avahi-daemon.service
+      # zypper remove avahi-autoipd avahi
+    compliance:
+      - cis: ["2.2.3"]
+      - cis_csc: ["9.2"]
+    condition: none
+    rules:
+      - 'c:rpm -qa -> r:^avahi'
+
+  - id: 7520
+    title: Ensure DHCP Server is not installed
+    description: >
+      The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be
+      dynamically assigned IP addresses.
+    rationale: >
+      Unless a system is specifically set up to act as a DHCP server, it is recommended that the
+      dhcp package be removed to reduce the potential attack surface.
+    remediation: >
+      Run the following command to remove dhcp:
+      # zypper remove dhcp
+    compliance:
+      - cis: ["2.2.5"]
+      - cis_csc: ["9.2"]
+    references:
+      - dhcpd(8)
+    condition: all
+    rules:
+      - 'c:rpm -q dhcp -> r:not installed'
+
+  - id: 7522
+    title: Ensure DNS Server is not installed
+    description: >
+      The Domain Name System (DNS) is a hierarchical naming system that maps names to IP
+      addresses for computers, services and other resources connected to a network.
+    rationale: >
+      Unless a system is specifically designated to act as a DNS server, it is recommended that the
+      package be removed to reduce the potential attack surface.
+    remediation: >
+      Run the following command to remove bind:
+      # zypper remove bind
+    compliance:
+      - cis: ["2.2.9"]
+      - cis_csc: ["9.2"]
+    condition: all
+    rules:
+      - 'c:rpm -q bind -> r:not installed'
+
+  - id: 7523
+    title: Ensure FTP Server is not installed
+    description: >
+      FTP (File Transfer Protocol) is a traditional and widely used standard tool for transferring
+      files between a server and clients over a network, especially where no authentication is
+      necessary (permits anonymous users to connect to a server).
+    rationale: >
+      FTP does not protect the confidentiality of data or authentication credentials. It is
+      recommended SFTP be used if file transfer is required. Unless there is a need to run the
+      system as a FTP server (for example, to allow anonymous downloads), it is recommended
+      that the package be removed to reduce the potential attack surface.
+      
+      Note: Additional FTP servers also exist and should be removed if not required.
+    remediation: >
+      Run the following command to remove vsftpd:
+      # zypper remove vsftpd
+    compliance:
+      - cis: ["2.2.10"]
+      - cis_csc: ["9.2"]
+    condition: all
+    rules:
+      - 'c:rpm -q vsftpd -> r:not installed'
+
+  - id: 7524
+    title: Ensure HTTP server is not installed
+    description: HTTP or web servers provide the ability to host web site content.
+    rationale: >
+      Unless there is a need to run the system as a web server, it is recommended that the
+      package be removed to reduce the potential attack surface.
+      
+      Notes:
+        - Several http servers exist. apache, apache2, lighttpd, and nginx are example
+          packages that provide an HTTP server
+        - These and other packages should also be audited, and removed if not required
+    remediation: >
+      Run the following command to remove apache2:
+      # zypper remove apache2
+    compliance:
+      - cis: ["2.2.11"]
+      - cis_csc: ["9.2"]
+    condition: all
+    rules:
+      - 'c:rpm -q apache2 -> r:not installed'
+
+  - id: 7525
+    title: Ensure IMAP and POP3 server is not installed
+    description: dovecot is an open source IMAP and POP3 server for Linux based systems.
+    rationale: >
+      Unless POP3 and/or IMAP servers are to be provided by this system, it is recommended
+      that the package be removed to reduce the potential attack surface.
+      
+      Notes:
+        - Several IMAP/POP3 servers exist and can use other service names. courier-imap and
+          cyrus-imap are example services that provide a mail server.
+        - These and other services should also be audited and the packages removed if not
+          required.
+    remediation: >
+      Run the following command to remove dovecot:
+      # zypper remove dovecot
+    compliance:
+      - cis: ["2.2.12"]
+      - cis_csc: ["9.2"]
+    condition: all
+    rules:
+      - 'c:rpm -q dovecot -> r:not installed'
+
+  - id: 7526
+    title: Ensure Samba is not installed
+    description: >
+      The Samba daemon allows system administrators to configure their Linux systems to share
+      file systems and directories with Windows desktops. Samba will advertise the file systems
+      and directories via the Server Message Block (SMB) protocol. Windows desktop users will
+      be able to mount these directories and file systems as letter drives on their systems.
+    rationale: >
+      If there is no need to mount directories and file systems to Windows systems, then this
+      package can be removed to reduce the potential attack surface.
+    remediation: >
+      Run the following command to remove samba:
+      # zypper remove samba
+    compliance:
+      - cis: ["2.2.13"]
+      - cis_csc: ["9.2"]
+    condition: all
+    rules:
+      - 'c:rpm -q samba -> r:not installed'
+
+  - id: 7527
+    title: Ensure HTTP Proxy Server is not installed
+    description: Squid is a standard proxy server used in many distributions and environments.
+    rationale: >
+      Unless a system is specifically set up to act as a proxy server, it is recommended that the
+      squid package be removed to reduce the potential attack surface.
+      
+      Note: Several HTTP proxy servers exist. These should be checked and removed unless required.
+    remediation: >
+      Run the following command to remove the squid package:
+      # zypper remove squid
+    compliance:
+      - cis: ["2.2.14"]
+      - cis_csc: ["9.2"]
+    condition: all
+    rules:
+      - 'c:rpm -q squid -> r:not installed'
+
+  - id: 7528
+    title: Ensure net-snmp is not installed
+    description: >
+      Simple Network Management Protocol (SNMP) is a widely used protocol for monitoring the
+      health and welfare of network equipment, computer equipment and devices like UPSs.
+
+        - Net-SNMP is a suite of applications used to implement SNMPv1 (RFC 1157),
+          SNMPv2 (RFCs 1901-1908), and SNMPv3 (RFCs 3411-3418) using both IPv4 and
+          IPv6.
+        - Support for SNMPv2 classic (a.k.a. "SNMPv2 historic" - RFCs 1441-1452) was
+          dropped with the 4.0 release of the UCD-snmp package.
+        - The Simple Network Management Protocol (SNMP) server is used to listen for SNMP
+          commands from an SNMP management system, execute the commands or collect the
+          information and then send results back to the requesting system.
+    rationale: >
+      The SNMP server can communicate using SNMPv1, which transmits data in the clear and
+      does not require authentication to execute commands. SNMPv3 replaces the simple/clear
+      text password sharing used in SNMPv2 with more securely encoded parameters. If the the
+      SNMP service is not required, the net-snmp package should be removed to reduce the
+      attack surface of the system.
+      
+      Note: If SNMP is required:
+        - The server should be configured for SNMP v3 only. User Authentication and Message
+          Encryption should be configured.
+        - If SNMP v2 is absolutely necessary, modify the community strings' values.
+    remediation: >
+      Run the following command to remove net-snmpd:
+      # zypper remove net-snmp
+    compliance:
+      - cis: ["2.2.15"]
+      - cis_csc: ["2.6","9.2"]
+    condition: all
+    rules:
+      - 'c:rpm -q net-snmp -> r:not installed'
+
+  - id: 7529
+    title: Ensure NIS server is not installed
+    description: >
+      The ypserv package provides the Network Information Service (NIS). This service, formally
+      known as Yellow Pages, is a client-server directory service protocol for distributing system
+      configuration files. The NIS server is a collection of programs that allow for the distribution
+      of configuration files.
+    rationale: >
+      The NIS service is inherently an insecure system that has been vulnerable to DOS attacks,
+      buffer overflows and has poor authentication for querying NIS maps. NIS generally has
+      been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is
+      recommended that the ypserv package be removed, and if required a more secure services
+      be used.
+    remediation: >
+      Run the following command to remove ypserv:
+      # zypper remove ypserv
+    compliance:
+      - cis: ["2.2.18"]
+      - cis_csc: ["2.6","9.2"]
+    condition: all
+    rules:
+      - 'c:rpm -q ypserv -> r:not installed'
+
+  - id: 7530
+    title: Ensure NIS Client is not installed
+    description: >
+      The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server
+      directory service protocol used to distribute system configuration files. The NIS client (
+      ypbind ) was used to bind a machine to an NIS server and receive the distributed
+      configuration files.
+    rationale: >
+      The NIS service is inherently an insecure system that has been vulnerable to DOS attacks,
+      buffer overflows and has poor authentication for querying NIS maps. NIS generally has
+      been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is
+      recommended that the service be removed.
+    remediation: >
+      Run the following command to remove the ypbind package:
+      # zypper remove ypbind
+    compliance:
+      - cis: ["2.3.1"]
+      - cis_csc: ["2.6"]
+    condition: all
+    rules:
+      - 'c:rpm -q ypbind -> r:not installed'
+
+  - id: 7532
+    title: Ensure packet redirect sending is disabled
+    description: >
+      ICMP Redirects are used to send routing information to other hosts. As a host itself does
+      not act as a router (in a host only configuration), there is no need to send redirects.
+    rationale: >
+      An attacker could use a compromised host to send invalid ICMP redirects to other router
+      devices in an attempt to corrupt routing and have users access a system set up by the
+      attacker as opposed to a valid system.
+    remediation: >
+      Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file:
+      net.ipv4.conf.all.send_redirects = 0
+      net.ipv4.conf.default.send_redirects = 0
+      
+      Run the following commands to set the active kernel parameters:
+      # sysctl -w net.ipv4.conf.all.send_redirects=0
+      # sysctl -w net.ipv4.conf.default.send_redirects=0
+      # sysctl -w net.ipv4.route.flush=1
+    compliance:
+      - cis: ["3.2.2"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv4.conf.all.send_redirects -> r:^net.ipv4.conf.all.send_redirects\s*=\s*0$'
+      - 'c:sysctl net.ipv4.conf.default.send_redirects -> r:^net.ipv4.conf.default.send_redirects\s*=\s*0$'
+      - 'c:grep -Rh net\.ipv4\.conf\.all\.send_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.send_redirects\s*=\s*0$'
+      - 'c:grep -Rh net\.ipv4\.conf\.default\.send_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.send_redirects\s*=\s*0$'
+
+  - id: 7534
+    title: Ensure secure ICMP redirects are not accepted
+    description: >
+      Secure ICMP redirects are the same as ICMP redirects, except they come from gateways
+      listed on the default gateway list. It is assumed that these gateways are known to your
+      system, and that they are likely to be secure.
+    rationale: >
+      It is still possible for even known gateways to be compromised. Setting
+      net.ipv4.conf.all.secure_redirects to 0 protects the system from routing table
+      updates by possibly compromised known gateways.
+    remediation: >
+      Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file:
+      net.ipv4.conf.all.secure_redirects = 0
+      net.ipv4.conf.default.secure_redirects = 0
+      
+      Run the following commands to set the active kernel parameters:
+      # sysctl -w net.ipv4.conf.all.secure_redirects=0
+      # sysctl -w net.ipv4.conf.default.secure_redirects=0
+      # sysctl -w net.ipv4.route.flush=1
+    compliance:
+      - cis: ["3.3.3"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv4.conf.all.secure_redirects -> r:^net.ipv4.conf.all.secure_redirects\s*=\s*0$'
+      - 'c:sysctl net.ipv4.conf.default.secure_redirects -> r:^net.ipv4.conf.default.secure_redirects\s*=\s*0$'
+      - 'c:grep -Rh net\.ipv4\.conf\.all\.secure_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.secure_redirects\s*=\s*0$'
+      - 'c:grep -Rh net\.ipv4\.conf\.default\.secure_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.secure_redirects\s*=\s*0$'
+
+  - id: 7535
+    title: Ensure suspicious packets are logged
+    description: >
+      When enabled, this feature logs packets with un-routable source addresses to the kernel
+      log.
+    rationale: >
+      Enabling this feature and logging these packets allows an administrator to investigate the
+      possibility that an attacker is sending spoofed packets to their system.
+    remediation: >
+      Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file:
+      net.ipv4.conf.all.log_martians = 1
+      net.ipv4.conf.default.log_martians = 1
+      
+      Run the following commands to set the active kernel parameters:
+      # sysctl -w net.ipv4.conf.all.log_martians=1
+      # sysctl -w net.ipv4.conf.default.log_martians=1
+      # sysctl -w net.ipv4.route.flush=1
+    compliance:
+      - cis: ["3.3.4"]
+      - cis_csc: ["6.2","6.3"]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv4.conf.all.log_martians -> r:^net.ipv4.conf.all.log_martians\s*=\s*1$'
+      - 'c:sysctl net.ipv4.conf.default.log_martians -> r:^net.ipv4.conf.default.log_martians\s*=\s*1$'
+      - 'c:grep -Rh net\.ipv4\.conf\.all\.log_martians /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.log_martians\s*=\s*1$'
+      - 'c:grep -Rh net\.ipv4\.conf\.default\.log_martians /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.log_martians\s*=\s*1$'
+
+  - id: 7536
+    title: Ensure broadcast ICMP requests are ignored
+    description: >
+      Setting net.ipv4.icmp_echo_ignore_broadcasts to 1 will cause the system to ignore all
+      ICMP echo and timestamp requests to broadcast and multicast addresses.
+    rationale: >
+      Accepting ICMP echo and timestamp requests with broadcast or multicast destinations for
+      your network could be used to trick your host into starting (or participating) in a Smurf
+      attack. A Smurf attack relies on an attacker sending large amounts of ICMP broadcast
+      messages with a spoofed source address. All hosts receiving this message and responding
+      would send echo-reply messages back to the spoofed address, which is probably not
+      routable. If many hosts respond to the packets, the amount of traffic on the network could
+      be significantly multiplied.
+    remediation: >
+      Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file:
+      net.ipv4.icmp_echo_ignore_broadcasts = 1
+      
+      Run the following commands to set the active kernel parameters:
+      # sysctl -w net.ipv4.icmp_echo_ignore_broadcasts=1
+      # sysctl -w net.ipv4.route.flush=1
+    compliance:
+      - cis: ["3.3.5"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv4.icmp_echo_ignore_broadcasts -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
+      - 'c:grep -Rh net\.ipv4\.icmp_echo_ignore_broadcasts /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
+
+  - id: 7537
+    title: Ensure bogus ICMP responses are ignored
+    description: >
+      Setting icmp_ignore_bogus_error_responses to 1 prevents the kernel from logging bogus
+      responses (RFC-1122 non-compliant) from broadcast reframes, keeping file systems from
+      filling up with useless log messages.
+    rationale: >
+      Some routers (and some attackers) will send responses that violate RFC-1122 and attempt
+      to fill up a log file system with many useless error messages.
+    remediation: >
+      Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file:
+      net.ipv4.icmp_ignore_bogus_error_responses = 1
+      
+      Run the following commands to set the active kernel parameters:
+      # sysctl -w net.ipv4.icmp_ignore_bogus_error_responses=1
+      # sysctl -w net.ipv4.route.flush=1
+    compliance:
+      - cis: ["3.3.6"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv4.icmp_ignore_bogus_error_responses -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
+      - 'c:grep -Rh net\.ipv4\.icmp_ignore_bogus_error_responses /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
+
+  - id: 7538
+    title: Ensure Reverse Path Filtering is enabled
+    description: >
+      Setting net.ipv4.conf.all.rp_filter and net.ipv4.conf.default.rp_filter to 1 forces
+      the Linux kernel to utilize reverse path filtering on a received packet to determine if the
+      packet was valid. Essentially, with reverse path filtering, if the return packet does not go
+      out the same interface that the corresponding source packet came from, the packet is
+      dropped (and logged if log_martians is set).
+    rationale: >
+      Setting these flags is a good way to deter attackers from sending your system bogus
+      packets that cannot be responded to. One instance where this feature breaks down is if
+      asymmetrical routing is employed. This would occur when using dynamic routing protocols
+      (bgp, ospf, etc) on your system. If you are using asymmetrical routing on your system, you
+      will not be able to enable this feature without breaking the routing.
+    remediation: >
+      Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file:
+      net.ipv4.conf.all.rp_filter = 1
+      net.ipv4.conf.default.rp_filter = 1
+      
+      Run the following commands to set the active kernel parameters:
+      # sysctl -w net.ipv4.conf.all.rp_filter=1
+      # sysctl -w net.ipv4.conf.default.rp_filter=1
+      # sysctl -w net.ipv4.route.flush=1
+    compliance:
+      - cis: ["3.3.7"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv4.conf.all.rp_filter -> r:^net.ipv4.conf.all.rp_filter\s*=\s*1$'
+      - 'c:sysctl net.ipv4.conf.default.rp_filter -> r:^net.ipv4.conf.default.rp_filter\s*=\s*1$'
+      - 'c:grep -Rh net\.ipv4\.conf\.all\.rp_filter /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.rp_filter\s*=\s*1$'
+      - 'c:grep -Rh net\.ipv4\.conf\.default\.rp_filter /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.rp_filter\s*=\s*1$'
+
+  - id: 7539
+    title: Ensure TCP SYN Cookies is enabled
+    description: >
+      When tcp_syncookies is set, the kernel will handle TCP SYN packets normally until the
+      half-open connection queue is full, at which time, the SYN cookie functionality kicks in. SYN
+      cookies work by not using the SYN queue at all. Instead, the kernel simply replies to the
+      SYN with a SYN|ACK, but will include a specially crafted TCP sequence number that
+      encodes the source and destination IP address and port number and the time the packet
+      was sent. A legitimate connection would send the ACK packet of the three way handshake
+      with the specially crafted sequence number. This allows the system to verify that it has
+      received a valid response to a SYN cookie and allow the connection, even though there is no
+      corresponding SYN in the queue.
+    rationale: >
+      Attackers use SYN flood attacks to perform a denial of service attacked on a system by
+      sending many SYN packets without completing the three way handshake. This will quickly
+      use up slots in the kernel's half-open connection queue and prevent legitimate connections
+      from succeeding. SYN cookies allow the system to keep accepting valid connections, even if
+      under a denial of service attack.
+    remediation: >
+      Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file:
+      net.ipv4.tcp_syncookies = 1
+      
+      Run the following commands to set the active kernel parameters:
+      # sysctl -w net.ipv4.tcp_syncookies=1
+      # sysctl -w net.ipv4.route.flush=1
+    compliance:
+      - cis: ["3.3.8"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:grep -Rh net\.ipv4\.tcp_syncookies /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.tcp_syncookies\s*=\s*1$'
+      - 'c:/sbin/sysctl net.ipv4.tcp_syncookies -> r:^net.ipv4.tcp_syncookies\s*=\s*1$'
+
+  - id: 7540
+    title: Ensure SSH MaxAuthTries is set to 4 or less
+    description: >
+      The MaxAuthTries parameter specifies the maximum number of authentication attempts
+      permitted per connection. When the login failure count reaches half the number, error
+      messages will be written to the syslog file detailing the login failure.
+    rationale: >
+      Setting the MaxAuthTries parameter to a low number will minimize the risk of successful
+      brute force attacks to the SSH server. While the recommended setting is 4, set the number
+      based on site policy.
+    remediation: >
+      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+      MaxAuthTries 4
+    compliance:
+      - cis: ["5.2.7"]
+      - cis_csc: ["16.13"]
+    condition: all
+    rules:
+      - 'f:$sshd_file -> !r:^\s*\t*# && n:^MaxAuthTries\s*\t*(\d+) compare <= 4'
+
+  - id: 7541
+    title: Ensure SSH IgnoreRhosts is enabled
+    description: >
+      The IgnoreRhosts parameter specifies that .rhosts and .shosts files will not be used in
+      RhostsRSAAuthentication or HostbasedAuthentication.
+    rationale: Setting this parameter forces users to enter a password when authenticating with ssh.
+    remediation: >
+      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+      IgnoreRhosts yes
+    compliance:
+      - cis: ["5.2.8"]
+      - cis_csc: ["9.2"]
+    condition: all
+    rules:
+      - 'f:$sshd_file -> !r:^\s*\t*# && r:IgnoreRhosts\s*\t*yes'
+
+  - id: 7542
+    title: Ensure SSH HostbasedAuthentication is disabled
+    description: >
+      The HostbasedAuthentication parameter specifies if authentication is allowed through
+      trusted hosts via the user of .rhosts, or /etc/hosts.equiv, along with successful public
+      key client host authentication. This option only applies to SSH Protocol Version 2.
+    rationale: >
+      Even though the .rhosts files are ineffective if support is disabled in /etc/pam.conf,
+      disabling the ability to use .rhosts files in SSH provides an additional layer of protection.
+    remediation: >
+      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+      HostbasedAuthentication no
+    compliance:
+      - cis: ["5.2.9"]
+      - cis_csc: ["16.3"]
+    condition: all
+    rules:
+      - 'f:$sshd_file -> !r:^\s*\t*# && r:HostbasedAuthentication\s*\t*no'
+
+  - id: 7543
+    title: Ensure SSH root login is disabled
+    description: >
+      The PermitRootLogin parameter specifies if the root user can log in using ssh. The default
+      is no.
+    rationale: >
+      Disallowing root logins over SSH requires system admins to authenticate using their own
+      individual account, then escalating to root via sudo or su. This in turn limits opportunity for
+      non-repudiation and provides a clear audit trail in the event of a security incident.
+    remediation: >
+      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+      PermitRootLogin no
+    compliance:
+      - cis: ["5.2.10"]
+      - cis_csc: ["4.3"]
+    condition: all
+    rules:
+      - 'f:$sshd_file -> !r:^\s*\t*# && r:PermitRootLogin\s*\t*no'
+
+  - id: 7544
+    title: Ensure SSH PermitEmptyPasswords is disabled
+    description: >
+      The PermitEmptyPasswords parameter specifies if the SSH server allows login to accounts
+      with empty password strings.
+    rationale: >
+      Disallowing remote shell access to accounts that have an empty password reduces the
+      probability of unauthorized access to the system
+    remediation: >
+      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+      PermitEmptyPasswords no
+    compliance:
+      - cis: ["5.2.11"]
+      - cis_csc: ["16.3"]
+    condition: all
+    rules:
+      - 'f:$sshd_file -> !r:^\s*\t*# && r:PermitEmptyPasswords\s*\t*no'
+
+  - id: 7545
+    title: Ensure SSH LogLevel is appropriate
+    description: >
+      INFO level is the basic level that only records login activity of SSH users. In many situations,
+      such as Incident Response, it is important to determine when a particular user was active
+      on a system. The logout record can eliminate those users who disconnected, which helps
+      narrow the field.
+      
+      VERBOSE level specifies that login and logout activity as well as the key fingerprint for any
+      SSH key used for login will be logged. This information is important for SSH key
+      management, especially in legacy environments.
+    rationale: >
+      SSH provides several logging levels with varying amounts of verbosity. DEBUG is specifically
+      not recommended other than strictly for debugging SSH communications since it provides
+      so much data that it is difficult to identify important security information.
+    remediation: >
+      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+      LogLevel VERBOSE
+      OR
+      LogLevel INFO
+    compliance:
+      - cis: ["5.2.5"]
+      - cis_csc: ["6.2","6.3"]
+    references:
+      - https://www.ssh.com/ssh/sshd_config/
+    condition: any
+    rules:
+      - 'f:$sshd_file -> !r:^\s*\t*# && r:LogLevel\s*\t*VERBOSE'
+      - 'f:$sshd_file -> !r:^\s*\t*# && r:LogLevel\s*\t*INFO'      
+
+  - id: 7546
+    title: Ensure root is the only UID 0 account
+    description: Any account with UID 0 has superuser privileges on the system.
+    rationale: >
+      This access must be limited to only the default root account and only from the system
+      console. Administrative access must be through an unprivileged account using an approved
+      mechanism as noted in Item 5.6 Ensure access to the su command is restricted.
+    remediation: >
+      Remove any users other than root with UID 0 or assign them a new UID if appropriate.
+    compliance:
+      - cis: ["6.2.3"]
+      - cis_csc: ["5.1"]
+    condition: none
+    rules:
+      - 'f:/etc/passwd -> !r:^\s*\t*# && !r:^\s*\t*root: && r:^\w+:\w+:0:'
+
+  - id: 7547
+    title: Ensure mounting of squashfs filesystems is disabled
+    description: >
+      The squashfs filesystem type is a compressed read-only Linux filesystem embedded in
+      small footprint systems (similar to cramfs ). A squashfs image can be used without having
+      to first decompress the image.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
+      Example: vi /etc/modprobe.d/squashfs.conf
+      and add the following line:
+      install squashfs /bin/true
+      
+      Run the following command to unload the squashfs module:
+      # modprobe -r squashfs
+    compliance:
+      - cis: ["1.1.1.1"]
+      - cis_csc: ["5.1"]
+    condition: any
+    rules:
+      - 'c:modprobe -n -v squashfs -> r:install'
+      - 'c:modprobe -n -v squashfs -> r:squashfs'
+
+  - id: 7548
+    title: Ensure mounting of udf filesystems is disabled
+    description: >
+      The udf filesystem type is the universal disk format used to implement ISO/IEC 13346 and
+      ECMA-167 specifications. This is an open vendor filesystem type for data storage on a
+      broad range of media. This filesystem type is necessary to support writing DVDs and newer
+      optical disc formats.
+    rationale: >
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
+    remediation: >
+      Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
+      Example: vi /etc/modprobe.d/udf.conf
+      and add the following line:
+      install udf /bin/true
+      
+      Run the following command to unload the udf module:
+      # modprobe -r udf
+    compliance:
+      - cis: ["1.1.1.2"]
+      - cis_csc: ["5.1"]
+    condition: any
+    rules:
+      - 'c:modprobe -n -v udf -> r:install'
+      - 'c:modprobe -n -v udf -> r:udf'
+
+  - id: 7549
+    title: Ensure /dev/shm is configured
+    description: >
+      /dev/shm is a traditional shared memory concept. One program will create a memory
+      portion, which other processes (if permitted) can access. If /dev/shm is not configured,
+      tmpfs will be mounted to /dev/shm by systemd.
+      
+      Notes:
+        - An entry for /dev/shm in /etc/fstab will take precedence.
+        - tmpfs can be resized using the size={size} parameter in /etc/fstab. If we don't specify
+          the size, it will be half the RAM.
+      
+      Resize tmpfs example:
+      tmpfs /dev/shm tmpfs defaults,noexec,nodev,nosuid,size=2G 0 0
+    rationale: >
+      Any user can upload and execute files inside the /dev/shm similar to the /tmp partition.
+      Configuring /dev/shm allows an administrator to set the noexec option on the mount,
+      making /dev/shm useless for an attacker to install executable code. It would also prevent an
+      attacker from establishing a hardlink to a system setuid program and wait for it to be
+      updated. Once the program was updated, the hardlink would be broken and the attacker
+      would have his own copy of the program. If the program happened to have a security
+      vulnerability, the attacker could continue to exploit the known flaw.
+    remediation: >
+      Edit /etc/fstab and add or edit the following line:
+      tmpfs /dev/shm tmpfs defaults,noexec,nodev,nosuid 0 0
+      
+      Run the following command to remount /dev/shm:
+      # mount -o remount,noexec,nodev,nosuid /dev/shm
+    compliance:
+      - cis: ["1.1.6"]
+      - cis_csc: ["5.1","13"]
+    condition: all
+    rules:
+      - 'c:mount -> r:\.+\s+/dev/shm\s+'
+      - 'f:/etc/fstab -> r:\.+\s+/dev/shm\s+'
+
+  - id: 7550
+    title: Ensure separate partition exists for /var/tmp
+    description: >
+      The /var/tmp directory is a world-writable directory used for temporary storage by all
+      users and some applications and is intended for temporary files that are preserved across
+      reboots.
+      
+      Note: tmpfs should not be used for /var/tmp/. tmpfs is a temporary filesystem that resides in
+      memory and/or swap partition(s). Files in tmpfs are automatically cleared at each bootup.
+    rationale: >
+      Since the /var/tmp directory is intended to be world-writable, there is a risk of resource
+      exhaustion if it is not bound to a separate partition. In addition, making /var/tmp its own
+      file system allows an administrator to set the noexec option on the mount, making
+      /var/tmp useless for an attacker to install executable code. It would also prevent an
+      attacker from establishing a hardlink to a system setuid program and wait for it to be
+      updated. Once the program was updated, the hardlink would be broken and the attacker
+      would have his own copy of the program. If the program happened to have a security
+      vulnerability, the attacker could continue to exploit the known flaw.
+    remediation: >
+      For new installations, during installation create a custom partition setup and specify a
+      separate partition for /var/tmp .
+      For systems that were previously installed, create a new partition and configure
+      /etc/fstab as appropriate.
+    compliance:
+      - cis: ["1.1.11"]
+      - cis_csc: ["5.1","13"]
+    condition: all
+    rules:
+      - 'c:mount -> r:\s/var/tmp\s'
+
+  - id: 7551
+    title: Ensure noexec option set on /var/tmp partition
+    description: The noexec mount option specifies that the filesystem cannot contain executable binaries.
+    rationale: >
+      Since the /var/tmp filesystem is only intended for temporary file storage, set this option to
+      ensure that users cannot run executable binaries from /var/tmp .
+    remediation: >
+      Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the
+      /var/tmp partition. See the fstab(5) manual page for more information.
+      
+      Run the following command to remount /var/tmp :
+      # mount -o remount,noexec /var/tmp
+    compliance:
+      - cis: ["1.1.12"]
+      - cis_csc: ["2.6"]
+    condition: all
+    rules:
+      - 'c:mount -> r:\s/var/tmp\s && r:noexec'
+
+  - id: 7552
+    title: Ensure nodev option set on /var/tmp partition
+    description: The nodev mount option specifies that the filesystem cannot contain special devices.
+    rationale: >
+      Since the /var/tmp filesystem is not intended to support devices, set this option to ensure
+      that users cannot attempt to create block or character special devices in /var/tmp .
+    remediation: >
+      Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the
+      /var/tmp partition. See the fstab(5) manual page for more information.
+      
+      Run the following command to remount /var/tmp :
+      # mount -o remount,nodev /var/tmp
+    compliance:
+      - cis: ["1.1.13"]
+      - cis_csc: ["5.1","13"]
+    condition: all
+    rules:
+      - 'c:mount -> r:\s+/var/tmp\s+ && r:nodev'
+
+  - id: 7553
+    title: Ensure nosuid option set on /var/tmp partition
+    description: The nosuid mount option specifies that the filesystem cannot contain setuid files.
+    rationale: >
+      Since the /var/tmp filesystem is only intended for temporary file storage, set this option to
+      ensure that users cannot create setuid files in /var/tmp
+    remediation: >
+      Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the
+      /var/tmp partition. See the fstab(5) manual page for more information.
+      
+      Run the following command to remount /var/tmp :
+      # mount -o remount,nosuid /var/tmp
+    compliance:
+      - cis: ["1.1.14"]
+      - cis_csc: ["5.1","13"]
+    condition: all
+    rules:
+      - 'c:mount -> r:\s+/var/tmp\s+ && r:nosuid'
+
+  - id: 7554
+    title: Disable Automounting
+    description: >
+      autofs allows automatic mounting of devices, typically including CD/DVDs and USB drives.
+      Notes:
+        - Additional methods of disabling a service exist. Consult your distribution
+          documentation for appropriate methods.
+        - This control should align with the tolerance of the use of portable drives and optical
+          media in the organization.
+          - On a server requiring an admin to manually mount media can be part of
+            defense-in-depth to reduce the risk of unapproved software or information
+            being introduced or proprietary software or information being exfiltrated.
+          - If admins commonly use flash drives and Server access has sufficient physical
+            controls, requiring manual mounting may not increase security.
+    rationale: >
+      With automounting enabled anyone with physical access could attach a USB drive or disc
+      and have its contents available in system even if they lacked permissions to mount it
+      themselves.
+    remediation: >
+      Run the following command to mask autofs:
+      # systemctl --now mask autofs
+    compliance:
+      - cis: ["1.1.23"]
+      - cis_csc: ["8.4","8.5"]
+    condition: none
+    rules:
+      - 'c:systemctl is-enabled autofs -> r:enabled'
+
+  - id: 7556
+    title: Ensure sudo is installed
+    description: >
+      sudo allows a permitted user to execute a command as the superuser or another user, as
+      specified by the security policy. The invoking user's real (not effective) user ID is used to
+      determine the user name with which to query the security policy.
+    rationale: >
+      sudo supports a plugin architecture for security policies and input/output logging. Third
+      parties can develop and distribute their own policy and I/O logging plugins to work
+      seamlessly with the sudo front end. The default security policy is sudoers, which is
+      configured via the file /etc/sudoers.
+      
+      The security policy determines what privileges, if any, a user has to run sudo. The policy
+      may require that users authenticate themselves with a password or another authentication
+      mechanism. If authentication is required, sudo will exit if the user's password is not
+      entered within a configurable time limit. This limit is policy-specific.
+    remediation: >
+      Run the following command to install sudo.
+      # zypper install sudo
+    compliance:
+      - cis: ["1.3.1"]
+      - cis_csc: ["4"]
+    references:
+      - SUDO(8)
+    condition: none
+    rules:
+      - 'c:rpm -q sudo -> r:not installed'
+
+  - id: 7557
+    title: Ensure sudo commands use pty
+    description: >
+      sudo can be configured to run only from a pseudo-pty
+      
+      Note: visudo edits the sudoers file in a safe fashion, analogous to vipw(8). visudo locks the
+      sudoers file against multiple simultaneous edits, provides basic sanity checks, and checks for
+      parse errors. If the sudoers file is currently being edited you will receive a message to try
+      again later. The -f option allows you to tell visudo which file to edit.
+    rationale: >
+      Attackers can run a malicious program using sudo, which would again fork a background
+      process that remains even when the main program has finished executing.
+      This can be mitigated by configuring sudo to run other commands only from a pseudo-pty,
+      whether I/O logging is turned on or not.
+    remediation: >
+      Edit the file /etc/sudoers or a file in /etc/sudoers.d/ with visudo or visudo -f <PATH
+      TO FILE> and add the following line:
+      
+      Defaults use_pty
+    compliance:
+      - cis: ["1.3.2"]
+      - cis_csc: ["4"]
+    references:
+      - SUDO(8)
+    condition: all
+    rules:
+      - 'c:grep -REsih "^Defaults" /etc/sudoers /etc/sudoers.d -> r:^\wefaults\s+use_pty'
+
+  - id: 7558
+    title: Ensure sudo log file exists
+    description: >
+      sudo can use a custom log file
+      
+      Note: visudo edits the sudoers file in a safe fashion, analogous to vipw(8). visudo locks the
+      sudoers file against multiple simultaneous edits, provides basic sanity checks, and checks
+      for parse errors. If the sudoers file is currently being edited you will receive a message to
+      try again later. The -f option allows you to tell visudo which file to edit.
+    rationale: A sudo log file simplifies auditing of sudo commands
+    remediation: >
+      edit the file /etc/sudoers or a file in /etc/sudoers.d/ with visudo or visudo -f <PATH
+      TO FILE> and add the following line:
+      Defaults logfile="<PATH TO CUSTOM LOG FILE>"
+      
+      Example
+      Defaults logfile="/var/log/sudo.log"
+    compliance:
+      - cis: ["1.3.3"]
+      - cis_csc: ["6.3"]
+    references:
+      - SUDO(8)
+      - VISUDO(8)
+    condition: all
+    rules:
+      - 'c:grep -REsih "^Defaults" /etc/sudoers /etc/sudoers.d -> r:^\wefaults\s+logfile="\.+"'
+
+  - id: 7559
+    title: Ensure AIDE is installed
+    description: >
+      AIDE takes a snapshot of filesystem state including modification times, permissions, and
+      file hashes which can then be used to compare against the current state of the filesystem to
+      detect modifications to the system.
+      
+      Note: The prelinking feature can interfere with AIDE because it alters binaries to speed up
+      their start up times. Run prelink -ua to restore the binaries to their prelinked state, thus
+      avoiding false positives from AIDE.
+    rationale: >
+      By monitoring the filesystem state compromised files can be detected to prevent or limit
+      the exposure of accidental or malicious misconfigurations or modified binaries.
+    remediation: >
+      Configure AIDE as appropriate for your environment. Consult the AIDE documentation for
+      options.
+      Run the following command to install AIDE:
+      # zypper install aide
+      
+      Run the following commands to initialize AIDE:
+      # aide --init
+      # mv /var/lib/aide/aide.db.new /var/lib/aide/aide.db
+    compliance:
+      - cis: ["1.4.1"]
+      - cis_csc: ["14.9"]
+    references:
+      - AIDE stable manual: http://aide.sourceforge.net/stable/manual.html
+    condition: none
+    rules:
+      - 'c:rpm -q aide -> r:not installed'
+
+  - id: 7560
+    title: Ensure bootloader password is set
+    description: >
+      Setting the boot loader password will require that anyone rebooting the system must enter
+      a password before being able to set command line boot parameters
+      
+      Notes:
+        - This recommendation is designed around the grub2 bootloader, if LILO or another
+          bootloader is in use in your environment enact equivalent settings. Replace
+          `/boot/grub2/grub.cfg with the appropriate grub configuration file for your
+          environment
+        - The information can be placed in any /etc/grub.d file as long as that file is
+          incorporated into grub.cfg
+          - The superuser/user information and password should not be contained in the
+            /etc/grub.d/00_header file.
+          - A custom file, such as /etc/grub.d/40_custom should be used so it is not
+            overwritten should the Grub package be updated.
+    rationale: >
+      Requiring a boot password upon execution of the boot loader will prevent an unauthorized
+      user from entering boot parameters or changing the boot partition. This prevents users
+      from weakening security (e.g. turning off SELinux at boot time).
+    remediation: >
+      Create an encrypted password with grub2-mkpasswd-pbkdf2:
+        # grub2-mkpasswd-pbkdf2
+        Enter password: <password>
+        Reenter password: <password>
+        Your PBKDF2 is <encrypted-password>
+      
+      Add the following into /etc/grub.d/40_custom
+        set superusers="<username>"
+        password_pbkdf2 <username> <encrypted-password>
+      
+      Run the following command to update the grub2 configuration:
+        # grub2-mkconfig -o /boot/grub2/grub.cfg
+    compliance:
+      - cis: ["1.5.1"]
+      - cis_csc: ["5.1"]
+    references:
+      - https://documentation.suse.com/sles/15-SP1/html/SLES-all/cha-grub2.html
+    condition: all
+    rules:
+      - 'f:/boot/grub2/grub.cfg -> r:^\s*set superusers'
+      - 'f:/boot/grub2/grub.cfg -> r:^\s*password'
+
+  - id: 7561
+    title: Ensure permissions on bootloader config are configured
+    description: >
+      The grub configuration file contains information on boot settings and passwords for
+      unlocking boot options. The grub2 configuration is usually grub.cfg stored in
+      /boot/grub2/.
+      
+      Notes:
+        - This recommendation is designed around the grub2 bootloader.
+        - If LILO or another bootloader is in use in your environment:
+          - Enact equivalent settings
+          - Replace /boot/grub2/grub.cfg and /boot/grub2/user.cfg with the
+            appropriate boot configuration files for your environment
+    rationale: >
+      Setting the permissions to read and write for root only prevents non-root users from
+      seeing the boot parameters or changing them. Non-root users who read the boot
+      parameters may be able to identify weaknesses in security upon boot and be able to exploit
+      them.
+    remediation: >
+      Run the following commands to set ownership and permissions on your grub
+      configuration:
+      # chown root:root /boot/grub2/grub.cfg
+      # chmod og-rwx /boot/grub2/grub.cfg
+    compliance:
+      - cis: ["1.5.2"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:stat -L /boot/grub2/grub.cfg -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7562
+    title: Ensure authentication required for single user mode
+    description: >
+      Single user mode (rescue mode) is used for recovery when the system detects an issue
+      during boot or by manual selection from the bootloader.
+    rationale: >
+      Requiring authentication in single user mode (rescue mode) prevents an unauthorized user
+      from rebooting the system into single user to gain root privileges without credentials.
+    remediation: >
+      Edit /usr/lib/systemd/system/rescue.service and add/modify the following line:
+      ExecStart=-/usr/lib/systemd/systemd-sulogin-shell rescue
+      
+      Edit /usr/lib/systemd/system/emergency.service and add/modify the following line:
+      ExecStart=-/usr/lib/systemd/systemd-sulogin-shell emergency
+    compliance:
+      - cis: ["1.5.3"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'f:/usr/lib/systemd/system/rescue.service -> r:^ExecStart=\.*/systemd/systemd-sulogin-shell\s+rescue'
+      - 'f:/usr/lib/systemd/system/emergency.service -> r:^ExecStart=\.*/systemd/systemd-sulogin-shell\s+emergency'
+
+  - id: 7563
+    title: Ensure XD/NX support is enabled
+    description: >
+      Recent processors in the x86 family support the ability to prevent code execution on a per
+      memory page basis. Generically and on AMD processors, this ability is called No Execute
+      (NX), while on Intel processors it is called Execute Disable (XD). This ability can help
+      prevent exploitation of buffer overflow vulnerabilities and should be activated whenever
+      possible. Extra steps must be taken to ensure that this protection is enabled, particularly on
+      32-bit x86 systems. Other processors, such as Itanium and POWER, have included such
+      support since inception and the standard kernel for those platforms supports the feature.
+    rationale: >
+      Enabling any feature that can protect against buffer overflow attacks enhances the security
+      of the system.
+      
+      Note: Ensure your system supports the XD or NX bit and has PAE support before implementing
+      this recommendation as this may prevent it from booting if these are not supported by your
+      hardware.
+    remediation: >
+      On 32 bit systems install a kernel with PAE support, no installation is required on 64 bit
+      systems:
+      If necessary configure your bootloader to load the new kernel and reboot the system.
+      You may need to enable NX or XD support in your bios.
+    compliance:
+      - cis: ["1.6.2"]
+      - cis_csc: ["8.3"]
+    condition: all
+    rules:
+      - 'c:journalctl -> r:\.*kernel: NX \(Execute Disable\) protection:\s*active'
+
+  - id: 7564
+    title: Ensure prelink is disabled
+    description: >
+      prelinkis a program that modifies ELF shared libraries and ELF dynamically linked
+      binaries in such a way that the time needed for the dynamic linker to perform relocations
+      at startup significantly decreases.
+    rationale: >
+      The prelinking feature can interfere with the operation of AIDE, because it changes
+      binaries. Prelinking can also increase the vulnerability of the system if a malicious user is
+      able to compromise a common library such as libc.
+    remediation: >
+      Run the following command to restore binaries to normal:
+      # prelink -ua
+      
+      Run the following command to uninstall prelink:
+      # zypper remove prelink
+    compliance:
+      - cis: ["1.6.4"]
+      - cis_csc: ["14.9"]
+    condition: all
+    rules:
+      - 'c:rpm -q prelink -> r:not installed'
+
+  - id: 7565
+    title: Ensure AppArmor is installed
+    description: AppArmor provides Mandatory Access Controls.
+    rationale: >
+      Without a Mandatory Access Control system installed only the default Discretionary Access
+      Control system will be available.
+    remediation: >
+      Run the following command to install AppArmor:
+      # zypper install -t pattern apparmor
+    compliance:
+      - cis: ["1.7.1.1"]
+      - cis_csc: ["14.6"]
+    condition: none
+    rules:
+      - 'c:rpm -q apparmor-docs -> r:not installed'
+      - 'c:rpm -q apparmor-parser -> r:not installed'
+      - 'c:rpm -q apparmor-profiles -> r:not installed'
+      - 'c:rpm -q apparmor-utils -> r:not installed'
+      - 'c:rpm -q libapparmor1 -> r:not installed'      
+
+  - id: 7567
+    title: Ensure message of the day is configured properly
+    description: >
+      The contents of the /etc/motd file are displayed to users after login and function as a
+      message of the day for authenticated users.
+      
+      Unix-based systems have typically displayed information about the OS release and patch
+      level upon logging in to the system. This information can be useful to developers who are
+      developing software for a particular OS platform. If mingetty(8) supports the following
+      options, they display operating system information: \m - machine architecture \r -
+      operating system release \s - operating system name \v - operating system version
+    rationale: >
+      Warning messages inform users who are attempting to login to the system of their legal
+      status regarding the system and must include the name of the organization that owns the
+      system and any monitoring policies that are in place. Displaying OS and patch level
+      information in login banners also has the side effect of providing detailed system
+      information to attackers attempting to target specific exploits of a system. Authorized users
+      can easily get this information by running the " uname -a " command once they have logged
+      in.
+    remediation: >
+      Edit the /etc/motd file with the appropriate contents according to your site policy, remove
+      any instances of \m , \r , \s , \v or references to the OS platform
+      
+      OR
+      
+      If the motd is not used, this file can be removed.
+      Run the following command to remove the motd file:
+      # rm /etc/motd
+    compliance:
+      - cis: ["1.8.1.1"]
+      - cis_csc: ["5.1"]
+    condition: none
+    rules:
+      - 'f:/etc/motd -> r:\\m'
+      - 'f:/etc/motd -> r:\\r'
+      - 'f:/etc/motd -> r:\\s'
+      - 'f:/etc/motd -> r:\\v'
+
+  - id: 7568
+    title: Ensure local login warning banner is configured properly
+    description: >
+      The contents of the /etc/issue file are displayed to users prior to login for local terminals.
+      Unix-based systems have typically displayed information about the OS release and patch
+      level upon logging in to the system. This information can be useful to developers who are
+      developing software for a particular OS platform. If mingetty(8) supports the following
+      options, they display operating system information: \m - machine architecture \r -
+      operating system release \s - operating system name \v - operating system version - or the
+      operating system's name
+    rationale: >
+      Warning messages inform users who are attempting to login to the system of their legal
+      status regarding the system and must include the name of the organization that owns the
+      system and any monitoring policies that are in place. Displaying OS and patch level
+      information in login banners also has the side effect of providing detailed system
+      information to attackers attempting to target specific exploits of a system. Authorized users
+      can easily get this information by running the " uname -a " command once they have logged
+      in.
+    remediation: >
+      Edit the /etc/issue file with the appropriate contents according to your site policy,
+      remove any instances of \m , \r , \s , \v or references to the OS platform
+      # echo "Authorized uses only. All activity may be monitored and reported." >
+      /etc/issue
+    compliance:
+      - cis: ["1.8.1.2"]
+      - cis_csc: ["5.1"]
+    condition: none
+    rules:
+      - 'f:/etc/issue -> r:\\m'
+      - 'f:/etc/issue -> r:\\r'
+      - 'f:/etc/issue -> r:\\s'
+      - 'f:/etc/issue -> r:\\v'
+
+  - id: 7569
+    title: Ensure remote login warning banner is configured properly
+    description: >
+      The contents of the /etc/issue.net file are displayed to users prior to login for remote
+      connections from configured services.
+      Unix-based systems have typically displayed information about the OS release and patch
+      level upon logging in to the system. This information can be useful to developers who are
+      developing software for a particular OS platform. If mingetty(8) supports the following
+      options, they display operating system information: \m - machine architecture \r -
+      operating system release \s - operating system name \v - operating system version
+    rationale: >
+      Warning messages inform users who are attempting to login to the system of their legal
+      status regarding the system and must include the name of the organization that owns the
+      system and any monitoring policies that are in place. Displaying OS and patch level
+      information in login banners also has the side effect of providing detailed system
+      information to attackers attempting to target specific exploits of a system. Authorized users
+      can easily get this information by running the " uname -a " command once they have logged
+      in.
+    remediation: >
+      Edit the /etc/issue.net file with the appropriate contents according to your site policy,
+      remove any instances of \m , \r , \s , \v or references to the OS platform
+      # echo "Authorized uses only. All activity may be monitored and reported." >
+      /etc/issue.net
+    compliance:
+      - cis: ["1.8.1.3"]
+      - cis_csc: ["5.1"]
+    condition: none
+    rules:
+      - 'f:/etc/issue.net -> r:\\m'
+      - 'f:/etc/issue.net -> r:\\r'
+      - 'f:/etc/issue.net -> r:\\s'
+      - 'f:/etc/issue.net -> r:\\v'
+
+  - id: 7570
+    title: Ensure permissions on /etc/motd are configured
+    description: >
+      The contents of the /etc/motd file are displayed to users after login and function as a
+      message of the day for authenticated users.
+    rationale: >
+      If the /etc/motd file does not have the correct ownership it could be modified by
+      unauthorized users with incorrect or misleading information.
+    remediation: >
+      Run the following commands to set permissions on /etc/motd :
+      # chown root:root /etc/motd
+      # chmod u-x,go-wx /etc/motd
+    compliance:
+      - cis: ["1.8.1.4"]
+      - cis_csc: ["14.6"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/motd -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7571
+    title: Ensure permissions on /etc/issue are configured
+    description: >
+      The contents of the /etc/issue file are displayed to users prior to login for local terminals.
+    rationale: >
+      If the /etc/issue file does not have the correct ownership it could be modified by
+      unauthorized users with incorrect or misleading information.
+    remediation: >
+      Run the following commands to set permissions on /etc/issue:
+      # chown root:root /etc/issue
+      # chmod u-x,go-wx /etc/issue
+    compliance:
+      - cis: ["1.8.1.5"]
+      - cis_csc: ["14.6"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/issue -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7572
+    title: Ensure permissions on /etc/issue.net are configured
+    description: >
+      The contents of the /etc/issue.net file are displayed to users prior to login for remote
+      connections from configured services.
+    rationale: >
+      If the /etc/issue.net file does not have the correct ownership it could be modified by
+      unauthorized users with incorrect or misleading information.
+    remediation: >
+      Run the following commands to set permissions on /etc/issue.net:
+      # chown root:root /etc/issue.net
+      # chmod u-x,go-wx /etc/issue.net
+    compliance:
+      - cis: ["1.8.1.6"]
+      - cis_csc: ["14.6"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/issue.net -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7573
+    title: Ensure chrony is configured
+    description: >
+      chrony is a daemon which implements the Network Time Protocol (NTP) and is designed to
+      synchronize system clocks across a variety of systems and use a source that is highly
+      accurate. More information on chrony can be found at: http://chrony.tuxfamily.org/.
+      chrony can be configured to be a client and/or a server.
+    rationale: >
+      If chrony is in use on the system proper configuration is vital to ensuring time
+      synchronization is working properly.
+      
+      Note: This recommendation only applies if chrony is in use on the system. If another method of
+      time synchronization is in use on the system, this recommendation can be skipped.
+    remediation: >
+      Add or edit server or pool lines to /etc/chrony.conf as appropriate:
+      server <remote-server>
+      
+      Add or edit the OPTIONS in /etc/sysconfig/chronyd to include '-u chrony':
+      OPTIONS="-u chrony"
+    compliance:
+      - cis: ["2.2.1.3"]
+      - cis_csc: ["6.1"]
+    condition: all
+    rules:
+      - 'f:/etc/chrony.conf -> r:^\s*server\s+\.+'
+      - 'f:/etc/sysconfig/chronyd -> r:^\s*OPTIONS\s*=\s*"-u\s*chrony"'
+
+  - id: 7574
+    title: Ensure CUPS is not installed
+    description: >
+      The Common Unix Print System (CUPS) provides the ability to print to both local and
+      network printers. A system running CUPS can also accept print jobs from remote systems
+      and print them to local printers. It also provides a web based remote administration
+      capability.
+    rationale: >
+      If the system does not need to print jobs or accept print jobs from other systems, it is
+      recommended that CUPS be removed to reduce the potential attack surface.
+      
+      Note: Removing CUPS will prevent printing from the system
+    remediation: >
+      Run the following command to remove cups:
+      # zypper remove cups
+    compliance:
+      - cis: ["2.2.4"]
+      - cis_csc: ["9.2"]
+    references:
+      - http://www.cups.org
+    condition: all
+    rules:
+      - 'c:rpm -q cups -> r:not installed'
+
+  - id: 7575
+    title: Ensure LDAP server is not installed
+    description: >
+      The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for
+      NIS/YP. It is a service that provides a method for looking up information from a central
+      database.
+    rationale: >
+      If the system will not need to act as an LDAP server, it is recommended that the software be
+      removed to reduce the potential attack surface.
+    remediation: >
+      Run the following command to remove openldap-servers:
+      # zypper remove openldap2
+    compliance:
+      - cis: ["2.2.6"]
+      - cis_csc: ["9.2"]
+    references:
+      - http://www.openldap.org
+    condition: all
+    rules:
+      - 'c:rpm -q openldap2 -> r:not installed'
+
+  - id: 7576
+    title: Ensure mail transfer agent is configured for local-only mode
+    description: >
+      Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming
+      mail and transfer the messages to the appropriate user or mail server. If the system is not
+      intended to be a mail server, it is recommended that the MTA be configured to only process
+      local mail.
+    rationale: >
+      The software for all Mail Transfer Agents is complex and most have a long history of
+      security issues. While it is important to ensure that the system can process local mail
+      messages, it is not necessary to have the MTA's daemon listening on a port unless the
+      server is intended to be a mail server that receives and processes mail from other systems.
+      Notes:
+        - This recommendation is designed around the postfix mail server.
+        - Depending on your environment you may have an alternative MTA installed such as
+          sendmail. If this is the case consult the documentation for your installed MTA to
+          configure the recommended state.
+    remediation: >
+      Edit /etc/postfix/main.cf and add the following line to the RECEIVING MAIL section. If
+      the line already exists, change it to look like the line below:
+      inet_interfaces = loopback-only
+      
+      Run the folloing command to restart postfix:
+      # systemctl restart postfix
+    compliance:
+      - cis: ["2.2.16"]
+      - cis_csc: ["9.2"]
+    condition: all
+    rules:
+      - 'f:/etc/postfix/main.cf -> r:^\s*inet_interfaces\s*=\s*loopback-only'
+
+  - id: 7577
+    title: Ensure telnet client is not installed
+    description: >
+      The telnet package contains the telnet client, which allows users to start connections to
+      other systems via the telnet protocol.
+    rationale: >
+      The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission
+      medium could allow an unauthorized user to steal credentials. The ssh package provides
+      an encrypted session and stronger security and is included in most Linux distributions.
+    remediation: >
+      Run the following command to remove the telnet package:
+      # zypper remove telnet
+    compliance:
+      - cis: ["2.3.4"]
+      - cis_csc: ["2.6"]
+    condition: all
+    rules:
+      - 'c:rpm -q telnet -> r:not installed'
+
+  - id: 7578
+    title: Ensure LDAP client is not installed
+    description: >
+      The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for
+      NIS/YP. It is a service that provides a method for looking up information from a central
+      database.
+    rationale: >
+      If the system will not need to act as an LDAP client, it is recommended that the software be
+      removed to reduce the potential attack surface.
+    remediation: >
+      Run the following command to remove the openldap-clients package:
+      # zypper remove openldap2-clients
+    compliance:
+      - cis: ["2.3.5"]
+      - cis_csc: ["2.6"]
+    condition: all
+    rules:
+      - 'c:rpm -q openldap2-clients -> r:not installed'
+
+  - id: 7579
+    title: Ensure IPv6 router advertisements are not accepted
+    description: This setting disables the system's ability to accept IPv6 router advertisements.
+    rationale: >
+      It is recommended that systems do not accept router advertisements as they could be
+      tricked into routing traffic to compromised machines. Setting hard routes within the
+      system (usually a single default route to a trusted router) protects the system from bad
+      routes.
+    remediation: >
+      IF IPv6 is enabled:
+      
+      Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file:
+      net.ipv6.conf.all.accept_ra = 0
+      net.ipv6.conf.default.accept_ra = 0
+      
+      Run the following commands to set the active kernel parameters:
+      # sysctl -w net.ipv6.conf.all.accept_ra=0
+      # sysctl -w net.ipv6.conf.default.accept_ra=0
+      # sysctl -w net.ipv6.route.flush=1
+    compliance:
+      - cis: ["3.3.9"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv6.conf.all.accept_ra -> r:\s*0$'
+      - 'c:sysctl net.ipv6.conf.default.accept_ra -> r:\s*0$'
+      - 'c:grep -Rh "net\.ipv6\.conf\.all\.accept_ra" /etc/sysctl.conf /etc/sysctl.d -> r:^\s*net.ipv6.conf.all.accept_ra\s*=\s*0'
+      - 'c:grep -Rh "net\.ipv6\.conf\.default\.accept_ra" /etc/sysctl.conf /etc/sysctl.d -> r:^\s*net.ipv6.conf.default.accept_ra\s*=\s*0'
+
+  - id: 7580
+    title: Ensure DCCP is disabled
+    description: >
+      The Datagram Congestion Control Protocol (DCCP) is a transport layer protocol that
+      supports streaming media and telephony. DCCP provides a way to gain access to
+      congestion control, without having to do it at the application layer, but does not provide 
+      insequence delivery.
+    rationale: >
+      If the protocol is not required, it is recommended that the drivers not be installed to reduce
+      the potential attack surface.
+    remediation: >
+      Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
+      Example: vim /etc/modprobe.d/dccp.conf
+      and add the following line:
+      
+      install dccp /bin/true
+    compliance:
+      - cis: ["3.4.1"]
+      - cis_csc: ["9.2"]
+    condition: all
+    rules:
+      - 'c:grep -R dccp /etc/modprobe.d -> r:^/etc/modprobe.d/\.+.conf:\s*install\s+dccp\s+/bin/true'
+
+  - id: 7581
+    title: Ensure SCTP is disabled
+    description: >
+      The Stream Control Transmission Protocol (SCTP) is a transport layer protocol used to
+      support message oriented communication, with several streams of messages in one
+      connection. It serves a similar function as TCP and UDP, incorporating features of both. It is
+      message-oriented like UDP, and ensures reliable in-sequence transport of messages with
+      congestion control like TCP.
+    rationale: >
+      If the protocol is not being used, it is recommended that kernel module not be loaded,
+      disabling the service to reduce the potential attack surface.
+    remediation: >
+      Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
+      Example: vim /etc/modprobe.d/sctp.conf
+      and add the following line:
+      
+      install sctp /bin/true
+    compliance:
+      - cis: ["3.4.2"]
+      - cis_csc: ["9.2"]
+    condition: all
+    rules:
+      - 'c:grep -R sctp /etc/modprobe.d -> r:^/etc/modprobe.d/\.+.conf:\s*install\s+sctp\s+/bin/true'
+
+  - id: 7582
+    title: Ensure FirewallD is installed
+    description: >
+      firewalld is a firewall management tool for Linux operating systems. It provides firewall
+      features by acting as a front-end for the Linux kernel's netfilter framework via the iptables
+      backend or provides firewall features by acting as a front-end for the Linux kernel's
+      netfilter framework via the nftables utility.
+      
+      FirewallD replaces iptables as the default firewall management tool. Use the firewalld
+      utility to configure a firewall for less complex firewalls. The utility is easy to use and covers
+      the typical use cases scenario. FirewallD supports both IPv4 and IPv6 networks and can
+      administer separate firewall zones with varying degrees of trust as defined in zone profiles.
+      
+      Note: Starting in v0.6.0, FirewallD added support for acting as a front-end for the Linux
+      kernel's netfilter framework via the nftables userspace utility, acting as an alternative to the
+      nft command line program.
+    rationale: >
+      A firewall utility is required to configure the Linux kernel's netfilter framework via the
+      iptables or nftables back-end.
+      
+      The Linux kernel's netfilter framework host-based firewall can protect against threats
+      originating from within a corporate network to include malicious mobile code and poorly
+      configured software on a host.
+      
+      Note: Only one firewall utility should be installed and configured. FirewallD is dependent on
+      the iptables package.
+    remediation: >
+      Run the following command to install FirewallD and iptables:
+      # zypper install firewalld iptables
+    compliance:
+      - cis: ["3.5.1.1"]
+      - cis_csc: ["9.4"]
+    condition: none
+    rules:
+      - 'c:rpm -q firewalld -> r:not installed'
+      - 'c:rpm -q iptables -> r:not installed'
+
+  - id: 7583
+    title: Ensure firewalld service is enabled and running
+    description: >
+      firewalld.service enables the enforcement of firewall rules configured through
+      firewalld
+    rationale: >
+      Ensure that the firewalld.service is enabled and running to enforce firewall rules
+      configured through firewalld
+    remediation: >
+      Run the following command to unmask firewalld
+      # systemctl unmask firewalld
+      
+      Run the following command to enable and start firewalld
+      # systemctl --now enable firewalld
+    compliance:
+      - cis: ["3.5.1.3"]
+      - cis_csc: ["9.4"]
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled firewalld -> r:^enabled'
+      - 'c:firewall-cmd --state -> r:^running'
+
+  - id: 7584
+    title: Ensure nftables is installed
+    description: >
+      nftables provides a new in-kernel packet classification framework that is based on a
+      network-specific Virtual Machine (VM) and a new nft userspace command line tool.
+      nftables reuses the existing Netfilter subsystems such as the existing hook infrastructure,
+      the connection tracking system, NAT, userspace queuing and logging subsystem.
+        Notes:
+          - nftables is available in Linux kernel 3.13 and newer.
+          - Only one firewall utility should be installed and configured.
+    rationale: >
+      nftables is a subsystem of the Linux kernel that can protect against threats originating from
+      within a corporate network to include malicious mobile code and poorly configured
+      software on a host.
+    remediation: >
+      Run the following command to install nftables
+      # zypper install nftables
+    compliance:
+      - cis: ["3.5.2.1"]
+      - cis_csc: ["9.4"]
+    condition: none
+    rules:
+      - 'c:rpm -q nftables -> r:not installed'
+
+  - id: 7585
+    title: Ensure a table exists
+    description: >
+      Tables hold chains. Each table only has one address family and only applies to packets of
+      this family. Tables can have one of five families.
+    rationale: >
+      nftables doesn't have any default tables. Without a table being build, nftables will not filter
+      network traffic.
+    remediation: >
+      Run the following command to create a table in nftables
+      # nft create table inet <table name>
+    compliance:
+      - cis: ["3.5.2.4"]
+      - cis_csc: ["9.4"]
+    condition: all
+    rules:
+      - 'c:nft list tables -> r:^table inet\s+\.+'
+
+  - id: 7586
+    title: Ensure base chains exist
+    description: >
+      Chains are containers for rules. They exist in two kinds, base chains and regular chains. A
+      base chain is an entry point for packets from the networking stack, a regular chain may be
+      used as jump target and is used for better rule organization.
+    rationale: >
+      If a base chain doesn't exist with a hook for input, forward, and delete, packets that would
+      flow through those chains will not be touched by nftables.
+    remediation: >
+      Run the following command to create the base chains:
+      # nft create chain inet <table name> <base chain name> { type filter hook
+      <(input|forward|output)> priority 0 \; }
+    compliance:
+      - cis: ["3.5.2.5"]
+      - cis_csc: ["9.4"]
+    condition: all
+    rules:
+      - 'c:nft list ruleset -> !r:^# && r:type hook input\s+\.+'
+      - 'c:nft list ruleset -> !r:^# && r:type hook forward\s+\.+'
+      - 'c:nft list ruleset -> !r:^# && r:type hook output\s+\.+'
+
+  - id: 7587
+    title: Ensure default deny firewall policy
+    description: >
+      Base chain policy is the default verdict that will be applied to packets reaching the end of
+      the chain.
+    rationale: >
+      There are two policies: accept (Default) and drop. If the policy is set to accept, the firewall
+      will accept any packet that is not configured to be denied and the packet will continue
+      transversing the network stack.
+      It is easier to white list acceptable usage than to black list unacceptable usage.
+      
+      Note: Changing firewall settings while connected over network can result in being locked
+      out of the system.
+    remediation: >
+      Run the following command for the base chains with the input, forward, and output hooks
+      to implement a default DROP policy:
+      # nft chain <table family> <table name> <chain name> { policy drop \; }
+      
+      Example:
+      # nft chain inet filter input { policy drop \; }
+      # nft chain inet filter forward { policy drop \; }
+      # nft chain inet filter output { policy drop \; }
+    compliance:
+      - cis: ["3.5.2.8"]
+      - cis_csc: ["9.4"]
+    references:
+      - Manual Page nft
+    condition: all
+    rules:
+      - 'c:nft list ruleset -> !r:^# && r:type hook input\s+\.+policy\s+drop'
+      - 'c:nft list ruleset -> !r:^# && r:type hook forward\s+\.+policy\s+drop'
+      - 'c:nft list ruleset -> !r:^# && r:type hook output\s+\.+policy\s+drop'
+
+  - id: 7588
+    title: Ensure nftables service is enabled
+    description: >
+      The nftables service allows for the loading of nftables rulesets during boot, or starting on
+      the nftables service
+    rationale: >
+      The nftables service restores the nftables rules from the rules files referenced in the
+      /etc/sysconfig/nftables.conf file during boot or the starting of the nftables service
+    remediation: >
+      Run the following command to enable the nftables service:
+      # systemctl enable nftables
+    compliance:
+      - cis: ["3.5.2.9"]
+      - cis_csc: ["9.4"]
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled nftables -> r:^enabled'
+
+  - id: 7589
+    title: Ensure iptables package is installed
+    description: >
+      iptables is a utility program that allows a system administrator to configure the tables
+      provided by the Linux kernel firewall, implemented as different Netfilter modules, and the
+      chains and rules it stores. Different kernel modules and programs are used for different
+      protocols; iptables applies to IPv4, ip6tables to IPv6, arptables to ARP, and ebtables to
+      Ethernet frames.
+    rationale: >
+      A method of configuring and maintaining firewall rules is necessary to configure a Host
+      Based Firewall.
+    remediation: >
+      Run the following command to install iptables
+      # zypper install iptables
+    compliance:
+      - cis: ["3.5.1.1"]
+      - cis_csc: ["9.4"]
+    condition: none
+    rules:
+      - 'c:rpm -q iptables -> r:not installed'
+
+  - id: 7590
+    title: Ensure nftables is not installed
+    description: >
+      nftables is a subsystem of the Linux kernel providing filtering and classification of network
+      packets/datagrams/frames and is the successor to iptables.
+    rationale: >
+      Running both iptables and nftables may lead to conflict.
+    remediation: >
+      Run the following command to remove nftables:
+      # zypper remove nftables
+    compliance:
+      - cis: ["3.5.3.1.2"]
+      - cis_csc: ["9.4"]
+    condition: all
+    rules:
+      - 'c:rpm -q nftables -> r:not installed'
+
+  - id: 7591
+    title: Ensure default deny firewall policy
+    description: >
+      A default deny all policy on connections ensures that any unconfigured network usage will
+      be rejected.
+    rationale: >
+      With a default accept policy the firewall will accept any packet that is not configured to be
+      denied. It is easier to white list acceptable usage than to black list unacceptable usage.
+      
+      Note: Changing firewall settings while connected over network can result in being locked
+      out of the system.
+    remediation: >
+      Run the following commands to implement a default DROP policy:
+      # iptables -P INPUT DROP
+      # iptables -P OUTPUT DROP
+      # iptables -P FORWARD DROP
+    compliance:
+      - cis: ["3.5.3.2.1"]
+      - cis_csc: ["9.4"]
+    condition: all
+    rules:
+      - 'c:iptables -L -> r:^Chain INPUT \(policy DROP\)'
+      - 'c:iptables -L -> r:^Chain FORWARD \(policy DROP\)'
+      - 'c:iptables -L -> r:^Chain OUTPUT \(policy DROP\)'
+
+  - id: 7592
+    title: Ensure loopback traffic is configured
+    description: >
+      Configure the loopback interface to accept traffic. Configure all other interfaces to deny
+      traffic to the loopback network (127.0.0.0/8).
+    rationale: >
+      Loopback traffic is generated between processes on machine and is typically critical to
+      operation of the system. The loopback interface is the only place that loopback network
+      (127.0.0.0/8) traffic should be seen, all other interfaces should ignore traffic on this
+      network as an anti-spoofing measure.
+      
+      Note: Changing firewall settings while connected over network can result in being locked
+      out of the system.
+    remediation: >
+      Run the following commands to implement the loopback rules:
+      # iptables -A INPUT -i lo -j ACCEPT
+      # iptables -A OUTPUT -o lo -j ACCEPT
+      # iptables -A INPUT -s 127.0.0.0/8 -j DROP
+    compliance:
+      - cis: ["3.5.3.2.2"]
+      - cis_csc: ["9.4"]
+    condition: all
+    rules:
+      - 'c:iptables -L INPUT -v -n -> r:^\s*\d+\s+\d+\s+ACCEPT\s+all\s+--\s+lo\s+*\s+0.0.0.0/0\s+0.0.0.0/0'
+      - 'c:iptables -L INPUT -v -n -> r:^\s*\d+\s+\d+\s+DROP\s+all\s+--\s+*\s+*\s+127.0.0.0/8\s+0.0.0.0/0'
+      - 'c:iptables -L OUTPUT -v -n -> r:^\s*\d+\s+\d+\s+ACCEPT\s+all\s+--\s+*\s+lo\s+0.0.0.0/0\s+0.0.0.0/0'
+
+  - id: 7593
+    title: Ensure auditd is installed
+    description: >
+      auditd is the userspace component to the Linux Auditing System. It's responsible for
+      writing audit records to the disk
+    rationale: >
+      The capturing of system events provides system administrators with information to allow
+      them to determine if unauthorized access to their system is occurring.
+    remediation: >
+      Run the following command to Install auditd
+      # zypper install audit
+    compliance:
+      - cis: ["4.1.1.1"]
+      - cis_csc: ["6.2","6.3"]
+    condition: none
+    rules:
+      - 'c:rpm -q audit -> r:not installed'
+
+  - id: 7594
+    title: Ensure auditd service is enabled and running
+    description: Turn on the auditd daemon to record system events.
+    rationale: >
+      The capturing of system events provides system administrators with information to allow
+      them to determine if unauthorized access to their system is occurring.
+    remediation: >
+      Run the following command to enable and start auditd:
+      # systemctl --now enable auditd
+    compliance:
+      - cis: ["4.1.1.2"]
+      - cis_csc: ["6.2","6.3"]
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled auditd -> r:^enabled'
+      - 'c:systemctl status auditd -> r:^\s*Active: active \(running\) since \.+'
+
+  - id: 7596
+    title: Ensure audit log storage size is configured
+    description: >
+      Configure the maximum size of the audit log file. Once the log reaches the maximum size, it
+      will be rotated and a new log file will be started.
+      
+      Notes:
+        - The max_log_file parameter is measured in megabytes.
+        - Other methods of log rotation may be appropriate based on site policy. One example is
+          time-based rotation strategies which don't have native support in auditd
+          configurations. Manual audit of custom configurations should be evaluated for
+          effectiveness and completeness.
+    rationale: >
+      It is important that an appropriate size is determined for log files so that they do not impact
+      the system and audit data is not lost.
+    remediation: >
+      Set the following parameter in /etc/audit/auditd.conf in accordance with site policy:
+      max_log_file = <MB>
+    compliance:
+      - cis: ["4.1.2.1"]
+      - cis_csc: ["6.4"]
+    condition: all
+    rules:
+      - 'f:/etc/audit/auditd.conf -> r:^\s*max_log_file\s*=\s*\d+'
+
+  - id: 7597
+    title: Ensure audit logs are not automatically deleted
+    description: >
+      The max_log_file_action setting determines how to handle the audit log file reaching the
+      max file size. A value of keep_logs will rotate the logs but never delete old logs.
+    rationale: >
+      In high security contexts, the benefits of maintaining a long audit history exceed the cost of
+      storing the audit history.
+    remediation: >
+      Set the following parameter in /etc/audit/auditd.conf:
+      max_log_file_action = keep_logs
+    compliance:
+      - cis: ["4.1.2.2"]
+      - cis_csc: ["6.2","6.4"]
+    condition: all
+    rules:
+      - 'f:/etc/audit/auditd.conf -> r:^\s*max_log_file_action\s*=\s*keep_logs'
+
+  - id: 7598
+    title: Ensure system is disabled when audit logs are full 
+    description: The auditd daemon can be configured to halt the system when the audit logs are full.
+    rationale: >
+      In high security contexts, the risk of detecting unauthorized access or nonrepudiation
+      exceeds the benefit of the system's availability.
+    remediation: >
+      Set the following parameters in /etc/audit/auditd.conf:
+      space_left_action = email
+      action_mail_acct = root
+      admin_space_left_action = halt
+    compliance:
+      - cis: ["4.1.2.3"]
+      - cis_csc: ["6.2","6.4"]
+    condition: all
+    rules:
+      - 'f:/etc/audit/auditd.conf -> r:^\s*space_left_action\s*=\s*email'
+      - 'f:/etc/audit/auditd.conf -> r:^\s*action_mail_acct\s*=\s*root'
+      - 'f:/etc/audit/auditd.conf -> r:^\s*admin_space_left_action\s*=\s*halt'
+
+  - id: 7599
+    title: Ensure events that modify user/group information are collected
+    description: >
+      Record events affecting the group , passwd (user IDs), shadow and gshadow (passwords) or
+      /etc/security/opasswd (old passwords, based on remember parameter in the PAM
+      configuration) files. The parameters in this section will watch the files to see if they have
+      been opened for write or have had attribute changes (e.g. permissions) and tag them with
+      the identifier "identity" in the audit log file.
+      
+      Note: Reloading the auditd config to set active settings may require a system reboot.
+    rationale: >
+      Unexpected changes to these files could be an indication that the system has been
+      compromised and that an unauthorized user is attempting to hide their activities or
+      compromise additional accounts.
+    remediation: >
+      Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+      Example: vi /etc/audit/rules.d/identity.rules
+      and add the following lines:
+      
+      -w /etc/group -p wa -k identity
+      -w /etc/passwd -p wa -k identity
+      -w /etc/gshadow -p wa -k identity
+      -w /etc/shadow -p wa -k identity
+      -w /etc/security/opasswd -p wa -k identity
+    compliance:
+      - cis: ["4.1.4"]
+      - cis_csc: ["4.8"]
+    condition: all
+    rules:
+      - 'c:grep -R identity /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/etc/group\s+-p\s+wa\s+-k\s+identity'
+      - 'c:grep -R identity /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/etc/passwd\s+-p\s+wa\s+-k\s+identity'
+      - 'c:grep -R identity /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/etc/gshadow\s+-p\s+wa\s+-k\s+identity'
+      - 'c:grep -R identity /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/etc/shadow\s+-p\s+wa\s+-k\s+identity'
+      - 'c:grep -R identity /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/etc/security/opasswd\s+-p\s+wa\s+-k\s+identity'
+      - 'c:auditctl -l | grep identity -> r:^\s*-w\s+/etc/group\s+-p\s+wa\s+-k\s+identity'
+      - 'c:auditctl -l | grep identity -> r:^\s*-w\s+/etc/passwd\s+-p\s+wa\s+-k\s+identity'
+      - 'c:auditctl -l | grep identity -> r:^\s*-w\s+/etc/gshadow\s+-p\s+wa\s+-k\s+identity'
+      - 'c:auditctl -l | grep identity -> r:^\s*-w\s+/etc/shadow\s+-p\s+wa\s+-k\s+identity'
+      - 'c:auditctl -l | grep identity -> r:^\s*-w\s+/etc/security/opasswd\s+-p\s+wa\s+-k\s+identity'
+
+  - id: 7600
+    title: Ensure events that modify the system's Mandatory Access Controls are collected
+    description: >
+      Monitor SELinux mandatory access controls. The parameters below monitor any write
+      access (potential additional, deletion or modification of files in the directory) or attribute
+      changes to the /etc/selinux/ and /usr/share/selinux/ directories.
+      
+      Notes:
+        - If a different Mandatory Access Control method is used, changes to the corresponding
+          directories should be audited.
+        - Reloading the auditd config to set active settings requires the auditd service to be
+          restarted, and may require a system reboot.
+    rationale: >
+      Changes to files in the /etc/selinux/ and /usr/share/selinux/ directories could indicate
+      that an unauthorized user is attempting to modify access controls and change security
+      contexts, leading to a compromise of the system.
+    remediation: >
+      Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+      Example: vi /etc/audit/rules.d/MAC_policy.rules
+      and add the following lines:
+      
+      -w /etc/selinux/ -p wa -k MAC-policy
+      -w /usr/share/selinux/ -p wa -k MAC-policy
+    compliance:
+      - cis: ["4.1.6"]
+      - cis_csc: ["5.5"]
+    condition: all
+    rules:
+      - 'c:grep -R MAC-policy /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/etc/selinux/\s+-p\s+wa\s+-k\s+MAC-policy'
+      - 'c:grep -R MAC-policy /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/usr/share/selinux/\s+-p\s+wa\s+-k\s+MAC-policy'
+      - 'c:auditctl -l | grep MAC-policy -> r:^\s*-w\s+/etc/selinux/\s+-p\s+wa\s+-k\s+MAC-policy'
+      - 'c:auditctl -l | grep MAC-policy -> r:^\s*-w\s+/usr/share/selinux/\s+-p\s+wa\s+-k\s+MAC-policy'
+
+  - id: 7601
+    title: Ensure login and logout events are collected
+    description: >
+      Monitor login and logout events. The parameters below track changes to files associated
+      with login/logout events.
+        - The file /var/log/faillog tracks failed events from login.
+        - The file /var/log/lastlog maintain records of the last time a user successfully
+          logged in.
+        - The file /var/log/tallylog maintains records of failures via the pam_tally2
+          module
+      Note: Reloading the auditd config to set active settings requires the auditd service to be
+      restarted, and may require a system reboot.
+    rationale: >
+      Monitoring login/logout events could provide a system administrator with information
+      associated with brute force attacks against user logins.
+    remediation: >
+      Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+      Example: vi /etc/audit/rules.d/logins.rules
+      and add the following lines:
+      
+      -w /var/log/faillog -p wa -k logins
+      -w /var/log/lastlog -p wa -k logins
+      -w /var/log/tallylog -p wa -k logins
+    compliance:
+      - cis: ["4.1.7"]
+      - cis_csc: ["4.9","16.11","16.13"]
+    condition: all
+    rules:
+      - 'c:grep -R logins /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/var/log/faillog\s+-p\s+wa\s+-k\s+logins'
+      - 'c:grep -R logins /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/var/log/lastlog\s+-p\s+wa\s+-k\s+logins'
+      - 'c:grep -R logins /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/var/log/tallylog\s+-p\s+wa\s+-k\s+logins'
+      - 'c:auditctl -l | grep logins -> r:^\s*-w\s+/var/log/faillog\s+-p\s+wa\s+-k\s+logins'
+      - 'c:auditctl -l | grep logins -> r:^\s*-w\s+/var/log/lastlog\s+-p\s+wa\s+-k\s+logins'
+      - 'c:auditctl -l | grep logins -> r:^\s*-w\s+/var/log/tallylog\s+-p\s+wa\s+-k\s+logins'
+
+  - id: 7602
+    title: Ensure session initiation information is collected
+    description: >
+      Monitor session initiation events. The parameters in this section track changes to the files
+      associated with session events. The file /var/run/utmp tracks all currently logged in users.
+      All audit records will be tagged with the identifier "session." The /var/log/wtmp file tracks
+      logins, logouts, shutdown, and reboot events. The file /var/log/btmp keeps track of failed
+      login attempts and can be read by entering the command /usr/bin/last -f
+      /var/log/btmp . All audit records will be tagged with the identifier "logins."
+      
+      Notes:
+        - The last command can be used to read /var/log/wtmp (last with no parameters)
+          and /var/run/utmp (last -f /var/run/utmp)
+        - Reloading the auditd config to set active settings requires the auditd service to be
+          restarted, and may require a system reboot.
+    rationale: >
+      Monitoring these files for changes could alert a system administrator to logins occurring at
+      unusual hours, which could indicate intruder activity (i.e. a user logging in at a time when
+      they do not normally log in).
+    remediation: >
+      Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+      Example: vi /etc/audit/rules.d/session.rules
+      and add the following lines:
+      
+      -w /var/run/utmp -p wa -k session
+      -w /var/log/wtmp -p wa -k logins
+      -w /var/log/btmp -p wa -k logins
+    compliance:
+      - cis: ["4.1.8"]
+      - cis_csc: ["4.9","16.11","16.13"]
+    condition: all
+    rules:
+      - 'c:grep -RE "(session|logins)" /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/var/run/utmp\s+-p\s+wa\s+-k\s+session'
+      - 'c:grep -RE "(session|logins)" /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/var/log/wtmp\s+-p\s+wa\s+-k\s+logins'
+      - 'c:grep -RE "(session|logins)" /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/var/log/btmp\s+-p\s+wa\s+-k\s+logins'
+      - 'c:auditctl -l | grep -E "(session|logins)" -> r:^\s*-w\s+/var/run/utmp\s+-p\s+wa\s+-k\s+session'
+      - 'c:auditctl -l | grep -E "(session|logins)" -> r:^\s*-w\s+/var/log/wtmp\s+-p\s+wa\s+-k\s+logins'
+      - 'c:auditctl -l | grep -E "(session|logins)" -> r:^\s*-w\s+/var/log/btmp\s+-p\s+wa\s+-k\s+logins'
+
+  - id: 7603
+    title: Ensure changes to system administration scope (sudoers) is collected
+    description: >
+      Monitor scope changes for system administrators. If the system has been properly
+      configured to force system administrators to log in as themselves first and then use the
+      sudo command to execute privileged commands, it is possible to monitor changes in scope.
+      The file /etc/sudoers or a file in the /etc/sudoers.d directory will be written to when the
+      file or its attributes have changed.
+      
+      Notes: Reloading the auditd config to set active settings may require a system reboot.
+    rationale: >
+      Changes in the /etc/sudoers file, or a file in the /etc/sudoers.d/ directory can indicate
+      that an unauthorized change has been made to scope of system administrator activity.
+    remediation: >
+      Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+      Example: vi /etc/audit/rules.d/scope.rules
+      and add the following lines:
+      
+      -w /etc/sudoers -p wa -k scope
+      -w /etc/sudoers.d/ -p wa -k scope
+    compliance:
+      - cis: ["4.1.14"]
+      - cis_csc: ["4.8"]
+    condition: all
+    rules:
+      - 'c:grep -R scope /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/etc/sudoers\s+-p\s+wa\s+-k\s+scope'
+      - 'c:grep -R scope /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/etc/sudoers.d/\s+-p\s+wa\s+-k\s+scope'
+      - 'c:auditctl -l | grep scope -> r:^\s*-w\s+/etc/sudoers\s+-p\s+wa\s+-k\s+scope'
+      - 'c:auditctl -l | grep scope -> r:^\s*-w\s+/etc/sudoers.d/\s+-p\s+wa\s+-k\s+scope'
+
+  - id: 7604
+    title: Ensure the audit configuration is immutable
+    description: >
+      Set system audit so that audit rules cannot be modified with auditctl . Setting the flag "-e
+      2" forces audit to be put in immutable mode. Audit changes can only be made on system
+      reboot.
+      
+      Note: This setting will require the system to be rebooted to update the active auditd
+      configuration settings.
+    rationale: >
+      In immutable mode, unauthorized users cannot execute changes to the audit system to
+      potentially hide malicious activity and then put the audit rules back. Users would most
+      likely notice a system reboot and that could alert administrators of an attempt to make
+      unauthorized audit changes.
+    remediation: >
+      Edit or create the file /etc/audit/rules.d/99-finalize.rules and add the following line
+      at the end of the file:
+      
+      -e 2
+    compliance:
+      - cis: ["4.1.17"]
+      - cis_csc: ["6.2","6.3"]
+    condition: all
+    rules:
+      - 'c:grep -R "^\s*[^#]" /etc/audit/rules.d/ | tail -1 -> r:^/etc/audit/rules.d/\.+.rules:\s*-e\s+2\s*$'
+
+  - id: 7605
+    title: Ensure rsyslog is installed
+    description: >
+      The rsyslog software is a recommended replacement to the original syslogd daemon.
+      rsyslog provides improvements over syslogd, including:
+        - connection-oriented (i.e. TCP) transmission of logs
+        - The option to log to database formats
+        - Encryption of log data en route to a central logging server
+    rationale: >
+      The security enhancements of rsyslog such as connection-oriented (i.e. TCP) transmission
+      of logs, the option to log to database formats, and the encryption of log data en route to a
+      central logging server) justify installing and configuring the package.
+    remediation: >
+      Run the following command to install rsyslog:
+      # zypper install rsyslog
+    compliance:
+      - cis: ["4.2.1.1"]
+      - cis_csc: ["6.2","6.3"]
+    condition: none
+    rules:
+      - 'c:rpm -q rsyslog -> r:not installed'
+
+  - id: 7606
+    title: Ensure rsyslog Service is enabled and running
+    description: rsyslog needs to be enabled and running to perform logging
+    rationale: >
+      If the rsyslog service is not activated the system may default to the syslogd service or lack
+      logging instead.
+    remediation: >
+      Run the following command to enable and start rsyslog:
+      # systemctl --now enable rsyslog
+    compliance:
+      - cis: ["4.2.1.2"]
+      - cis_csc: ["6.2","6.3"]
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled rsyslog -> r:^enabled'
+      - 'c:systemctl status rsyslog -> r:^\s*Active: active \(running\) since \.+'
+
+  - id: 7607
+    title: Ensure rsyslog default file permissions configured
+    description: >
+      rsyslog will create logfiles that do not already exist on the system. This setting controls
+      what permissions will be applied to these newly created files.
+      The $FileCreateMode parameter specifies the file creation mode with which rsyslogd
+      creates new files. If not specified, the value 0644 is used.
+      Notes:
+        - The value given must always be a 4-digit octal number, with the initial digit being
+          zero.
+        - This setting can be overridden by a less restrictive setting in any file ending in .conf in
+          the /etc/rsyslog.d/ directory
+    rationale: >
+      It is important to ensure that log files have the correct permissions to ensure that sensitive
+      data is archived and protected.
+    remediation: >
+      Edit the /etc/rsyslog.conf and /etc/rsyslog.d/*.conf files and set $FileCreateMode to
+      0640 or more restrictive:
+      
+      $FileCreateMode 0640
+    compliance:
+      - cis: ["4.2.1.3"]
+      - cis_csc: ["5.1"]
+    references:
+      - See the rsyslog.conf(5) man page for more information.
+    condition: all
+    rules:
+      - 'c:grep -Rh ^\$FileCreateMode /etc/rsyslog.conf /etc/rsyslog.d/ -> r:^\$FileCreateMode\s+0640'
+
+  - id: 7608
+    title: Ensure journald is configured to send logs to rsyslog
+    description: >
+      Data from journald may be stored in volatile memory or persisted locally on the server.
+      Utilities exist to accept remote export of journald logs, however, use of the rsyslog service
+      provides a consistent means of log collection and export.
+      
+      Notes:
+        - This recommendation assumes that recommendation 4.2.1.5, "Ensure rsyslog is
+          configured to send logs to a remote log host" has been implemented.
+        - The main configuration file /etc/systemd/journald.conf is read before any of the
+          custom *.conf files. If there are custom configs present, they override the main
+          configuration parameters
+        - As noted in the journald man pages: journald logs may be exported to rsyslog either
+          through the process mentioned here, or through a facility like systemdjournald.service. There are trade-offs involved in each implementation, where
+          ForwardToSyslog will immediately capture all events (and forward to an external log
+          server, if properly configured), but may not capture all boot-up activities. Mechanisms
+          such as systemd-journald.service, on the other hand, will record bootup events, but
+          may delay sending the information to rsyslog, leading to the potential for log
+          manipulation prior to export. Be aware of the limitations of all tools employed to
+          secure a system.
+    rationale: >
+      Storing log data on a remote host protects log integrity from local attacks. If an attacker
+      gains root access on the local system, they could tamper with or remove log data that is
+      stored on the local system.
+    remediation: >
+      Edit the /etc/systemd/journald.conf file and add the following line:
+      ForwardToSyslog=yes
+    compliance:
+      - cis: ["4.2.2.1"]
+      - cis_csc: ["6.5"]
+    references:
+      - https://github.com/konstruktoid/hardening/blob/master/systemd.adoc#etcsystemdjournaldconf
+    condition: all
+    rules:
+      - 'f:/etc/systemd/journald.conf -> r:^ForwardToSyslog=yes'
+
+  - id: 7609
+    title: Ensure journald is configured to compress large log files
+    description: >
+      The journald system includes the capability of compressing overly large files to avoid filling
+      up the system with logs or making the log's size unmanageable.
+      
+      Note: The main configuration file /etc/systemd/journald.conf is read before any of the
+      custom *.conf files. If there are custom configs present, they override the main configuration
+      parameters
+    rationale: >
+      Uncompressed large files may unexpectedly fill a filesystem leading to resource
+      unavailability. Compressing logs prior to write can prevent sudden, unexpected filesystem
+      impacts.
+    remediation: >
+      Edit the /etc/systemd/journald.conf file and add the following line:
+      Compress=yes
+    compliance:
+      - cis: ["4.2.2.2"]
+      - cis_csc: ["6.4"]
+    references:
+      - https://github.com/konstruktoid/hardening/blob/master/systemd.adoc#etcsystemdjournaldconf
+    condition: all
+    rules:
+      - 'f:/etc/systemd/journald.conf -> r:^Compress=yes'
+
+  - id: 7610
+    title: Ensure journald is configured to write logfiles to persistent disk
+    description: >
+      Data from journald may be stored in volatile memory or persisted locally on the server.
+      Logs in memory will be lost upon a system reboot. By persisting logs to local disk on the
+      server they are protected from loss.
+      
+      Note: The main configuration file /etc/systemd/journald.conf is read before any of the
+      custom *.conf files. If there are custom configs present, they override the main configuration
+      parameters
+    rationale: >
+      Writing log data to disk will provide the ability to forensically reconstruct events which
+      may have impacted the operations or security of a system even after a system crash or
+      reboot.
+    remediation: >
+      Edit the /etc/systemd/journald.conf file and add the following line:
+      Storage=persistent
+    compliance:
+      - cis: ["4.2.2.3"]
+      - cis_csc: ["6.2","6.3"]
+    references:
+      - https://github.com/konstruktoid/hardening/blob/master/systemd.adoc#etcsystemdjournaldconf
+    condition: all
+    rules:
+      - 'f:/etc/systemd/journald.conf -> r:^Storage=persistent'
+
+  - id: 7611
+    title: Ensure cron daemon is enabled and running
+    description: The cron daemon is used to execute batch jobs on the system.
+    rationale: >
+      While there may not be user jobs that need to be run on the system, the system does have
+      maintenance jobs that may include security monitoring that have to run. If another method
+      for scheduling tasks is not being used, cron is used to execute them, and needs to be
+      enabled and running.
+    remediation: >
+      Run the following command to enable and start cron:
+      # systemctl --now enable cron
+      
+      OR
+      
+      Run the following command to remove cron:
+      # zypper remove cronie
+    compliance:
+      - cis: ["5.1.1"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled cron -> r:^enabled'
+      - 'c:systemctl status cron -> r:^\s*Active: active \(running\) since \.+'
+
+  - id: 7612
+    title: Ensure permissions on /etc/crontab are configured
+    description: >
+      The /etc/crontab file is used by cron to control its own jobs. The commands in this item
+      make sure that root is the user and group owner of the file and that only the owner can
+      access the file.
+    rationale: >
+      This file contains information on what system jobs are run by cron. Write access to these
+      files could provide unprivileged users with the ability to elevate their privileges. Read
+      access to these files could provide users with the ability to gain insight on system jobs that
+      run on the system and could provide them a way to gain unauthorized privileged access.
+    remediation: >
+      Run the following commands to set ownership and permissions on /etc/crontab:
+      # chown root:root /etc/crontab
+      # chmod u-x,og-rwx /etc/crontab
+      
+      OR
+      
+      Run the following command to remove cron:
+      # zypper remove cronie
+    compliance:
+      - cis: ["5.1.2"]
+      - cis_csc: ["14.6"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/crontab -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7613
+    title: Ensure permissions on /etc/cron.hourly are configured
+    description: >
+      This directory contains system cron jobs that need to run on an hourly basis. The files in
+      this directory cannot be manipulated by the crontab command, but are instead edited by
+      system administrators using a text editor. The commands below restrict read/write and
+      search access to user and group root, preventing regular users from accessing this
+      directory.
+    rationale: >
+      Granting write access to this directory for non-privileged users could provide them the
+      means for gaining unauthorized elevated privileges. Granting read access to this directory
+      could give an unprivileged user insight in how to gain elevated privileges or circumvent
+      auditing controls.
+    remediation: >
+      Run the following commands to set ownership and permissions on the /etc/cron.hourly/
+      directory:
+      # chown root:root /etc/cron.hourly/
+      # chmod og-rwx /etc/cron.hourly/
+      
+      OR
+      
+      Run the following command to remove cron
+      # zypper remove cronie
+    compliance:
+      - cis: ["5.1.3"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/cron.hourly/ -> r:^Access:\s*\(0700/drwx------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7614
+    title: Ensure permissions on /etc/cron.daily are configured
+    description: >
+      The /etc/cron.daily directory contains system cron jobs that need to run on a daily basis.
+      The files in this directory cannot be manipulated by the crontab command, but are instead
+      edited by system administrators using a text editor. The commands below restrict
+      read/write and search access to user and group root, preventing regular users from
+      accessing this directory.
+    rationale: >
+      Granting write access to this directory for non-privileged users could provide them the
+      means for gaining unauthorized elevated privileges. Granting read access to this directory
+      could give an unprivileged user insight in how to gain elevated privileges or circumvent
+      auditing controls.
+    remediation: >
+      Run the following commands to set ownership and permissions on /etc/cron.daily
+      directory:
+      # chown root:root /etc/cron.daily
+      # chmod og-rwx /etc/cron.daily
+      
+      OR
+      
+      Run the following command to remove cron:
+      # zypper remove cronie
+    compliance:
+      - cis: ["5.1.4"]
+      - cis_csc: ["14.6"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/cron.daily/ -> r:^Access:\s*\(0700/drwx------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7615
+    title: Ensure permissions on /etc/cron.weekly are configured
+    description: >
+      The /etc/cron.weekly directory contains system cron jobs that need to run on a weekly
+      basis. The files in this directory cannot be manipulated by the crontab command, but are
+      instead edited by system administrators using a text editor. The commands below restrict
+      read/write and search access to user and group root, preventing regular users from
+      accessing this directory.
+    rationale: >
+      Granting write access to this directory for non-privileged users could provide them the
+      means for gaining unauthorized elevated privileges. Granting read access to this directory
+      could give an unprivileged user insight in how to gain elevated privileges or circumvent
+      auditing controls.
+    remediation: >
+      Granting write access to this directory for non-privileged users could provide them the
+      means for gaining unauthorized elevated privileges. Granting read access to this directory
+      could give an unprivileged user insight in how to gain elevated privileges or circumvent
+      auditing controls.
+    compliance:
+      - cis: ["5.1.5"]
+      - cis_csc: ["14.6"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/cron.weekly -> r:^Access:\s*\(0700/drwx------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7616
+    title: Ensure permissions on /etc/cron.monthly are configured
+    description: >
+      The /etc/cron.monthly directory contains system cron jobs that need to run on a monthly
+      basis. The files in this directory cannot be manipulated by the crontab command, but are
+      instead edited by system administrators using a text editor. The commands below restrict
+      read/write and search access to user and group root, preventing regular users from
+      accessing this directory.
+    rationale: >
+      Granting write access to this directory for non-privileged users could provide them the
+      means for gaining unauthorized elevated privileges. Granting read access to this directory
+      could give an unprivileged user insight in how to gain elevated privileges or circumvent
+      auditing controls.
+    remediation: >
+      Run the following commands to set ownership and permissions on /etc/cron.monthly
+      directory:
+      # chown root:root /etc/cron.monthly
+      # chmod og-rwx /etc/cron.monthly
+      
+      OR
+      
+      Run the following command to remove cron:
+      # zypper remove cronie
+    compliance:
+      - cis: ["5.1.6"]
+      - cis_csc: ["14.6"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/cron.monthly/ -> r:^Access:\s*\(0700/drwx------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7617
+    title: Ensure permissions on /etc/cron.d are configured
+    description: >
+      The /etc/cron.d/ directory contains system cron jobs that need to run in a similar manner
+      to the hourly, daily weekly and monthly jobs from /etc/crontab , but require more
+      granular control as to when they run. The files in this directory cannot be manipulated by
+      the crontab command, but are instead edited by system administrators using a text editor.
+      The commands below restrict read/write and search access to user and group root,
+      preventing regular users from accessing this directory.
+    rationale: >
+      Granting write access to this directory for non-privileged users could provide them the
+      means for gaining unauthorized elevated privileges. Granting read access to this directory
+      could give an unprivileged user insight in how to gain elevated privileges or circumvent
+      auditing controls.
+    remediation: >
+      Run the following commands to set ownership and permissions on /etc/cron.d directory:
+      # chown root:root /etc/cron.d
+      # chmod og-rwx /etc/cron.d
+      
+      OR
+      
+      Run the following command to remove cron:
+      # zypper remove cronie
+    compliance:
+      - cis: ["5.1.7"]
+      - cis_csc: ["14.6"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/cron.d -> r:^Access:\s*\(0700/drwx------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7618
+    title: Ensure cron is restricted to authorized users 
+    description: >
+      If cron is installed in the system, configure /etc/cron.allow to allow specific users to use
+      these services. If /etc/cron.allow does not exist, then /etc/cron.deny is checked. Any
+      user not specifically defined in those files is allowed to use cron. By removing the file, only
+      users in /etc/cron.allow are allowed to use cron.
+      
+      Note: Even though a given user is not listed in cron.allow, cron jobs can still be run as that
+      user. The cron.allow file only controls administrative access to the crontab command for
+      scheduling and modifying cron jobs.
+    rationale: >
+      On many systems, only the system administrator is authorized to schedule cron jobs. Using
+      the cron.allow file to control who can run cron jobs enforces this policy. It is easier to
+      manage an allow list than a deny list. In a deny list, you could potentially add a user ID to
+      the system and forget to add it to the deny files.
+    remediation: >
+      Run the following command to remove /etc/cron.deny:
+      # rm /etc/cron.deny
+      
+      Run the following command to create /etc/cron.allow
+      # touch /etc/cron.allow
+      
+      Run the following commands to set the owner and permissions on /etc/cron.allow:
+      # chown root:root /etc/cron.allow
+      # chmod u-x,og-rwx /etc/cron.allow
+      
+      OR
+      
+      Run the following command to remove cron
+      # zypper remove cronie
+    compliance:
+      - cis: ["5.1.8"]
+      - cis_csc: ["16"]
+    condition: all
+    rules:
+      - 'not f:/etc/cron.deny'
+      - 'c:stat -L /etc/cron.allow -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7619
+    title: Ensure at is restricted to authorized users
+    description: >
+      If at is installed in the system, configure /etc/at.allow to allow specific users to use these
+      services. If /etc/at.allow does not exist, then /etc/at.deny is checked. Any user not
+      specifically defined in those files is allowed to use at. By removing the file, only users in
+      /etc/at.allow are allowed to use at.
+      
+      Note: Even though a given user is not listed in at.allow, at jobs can still be run as that user.
+      The at.allow file only controls administrative access to the at command for scheduling and
+      modifying at jobs.
+    rationale: >
+      On many systems, only the system administrator is authorized to schedule at jobs. Using
+      the at.allow file to control who can run at jobs enforces this policy. It is easier to manage
+      an allow list than a deny list. In a deny list, you could potentially add a user ID to the system
+      and forget to add it to the deny files.
+    remediation: >
+      Run the following command to remove /etc/at.deny:
+      # rm /etc/at.deny
+      
+      Run the following command to create /etc/at.allow
+      # touch /etc/at.allow
+      
+      Run the following commands to set the owner and permissions on /etc/at.allow:
+      # chown root:root /etc/at.allow
+      # chmod u-x,og-rwx /etc/at.allow
+      
+      OR
+      
+      Run the following command to remove at:
+      # zypper remove at
+    compliance:
+      - cis: ["5.1.9"]
+      - cis_csc: ["16"]
+    condition: all
+    rules:
+      - 'not f:/etc/at.deny'
+      - 'c:stat -L /etc/at.allow -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7620
+    title: Ensure permissions on /etc/ssh/sshd_config are configured
+    description: >
+      The /etc/ssh/sshd_config file contains configuration specifications for sshd. The
+      command below sets the owner and group of the file to root.
+    rationale: >
+      The /etc/ssh/sshd_config file needs to be protected from unauthorized changes by nonprivileged users.
+    remediation: >
+      Run the following commands to set ownership and permissions on /etc/ssh/sshd_config:
+      
+      # chown root:root /etc/ssh/sshd_config
+      # chmod og-rwx /etc/ssh/sshd_config
+    compliance:
+      - cis: ["5.2.1"]
+      - cis_csc: ["14.6"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/ssh/sshd_config -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7621
+    title: Ensure SSH access is limited
+    description: >
+      There are several options available to limit which users and group can access the system
+      via SSH. It is recommended that at least one of the following options be leveraged:
+        - AllowUsers:
+          - The AllowUsers variable gives the system administrator the option of
+            allowing specific users to ssh into the system. The list consists of space
+            separated user names. Numeric user IDs are not recognized with this
+            variable. If a system administrator wants to restrict user access further by
+            only allowing the allowed users to log in from a particular host, the entry can
+            be specified in the form of user@host.
+        - AllowGroups:
+          - The AllowGroups variable gives the system administrator the option of
+            allowing specific groups of users to ssh into the system. The list consists of
+            space separated group names. Numeric group IDs are not recognized with
+            this variable.
+        - DenyUsers:
+          - The DenyUsers variable gives the system administrator the option of denying
+            specific users to ssh into the system. The list consists of space separated user
+            names. Numeric user IDs are not recognized with this variable. If a system
+            administrator wants to restrict user access further by specifically denying a
+            user's access from a particular host, the entry can be specified in the form of
+            user@host.
+        - DenyGroups:
+          - The DenyGroups variable gives the system administrator the option of
+            denying specific groups of users to ssh into the system. The list consists of
+            space separated group names. Numeric group IDs are not recognized with
+            this variable.
+    rationale: >
+      Restricting which users can remotely access the system via SSH will help ensure that only
+      authorized users access the system.
+    remediation: >
+      Edit the /etc/ssh/sshd_config file to set one or more of the parameter as follows:
+      AllowUsers <userlist>
+      
+      OR
+      AllowGroups <grouplist>
+      
+      OR
+      DenyUsers <userlist>
+      
+      OR
+      DenyGroups <grouplist>
+    compliance:
+      - cis: ["5.2.4"]
+      - cis_csc: ["4.3"]
+    condition: any
+    rules:
+      - 'c:sshd -T -> r:^\s*allowusers\s+\S+'
+      - 'c:sshd -T -> r:^\s*allowgroups\s+\S+'
+      - 'c:sshd -T -> r:^\s*denyusers\s+\S+'
+      - 'c:sshd -T -> r:^\s*denygroups\s+\S+'
+
+  - id: 7622
+    title: Ensure SSH X11 forwarding is disabled
+    description: >
+      The X11Forwarding parameter provides the ability to tunnel X11 traffic through the
+      connection to enable remote graphic connections.
+    rationale: >
+      Disable X11 forwarding unless there is an operational requirement to use X11 applications
+      directly. There is a small risk that the remote X11 servers of users who are logged in via
+      SSH with X11 forwarding could be compromised by other users on the X11 server. Note
+      that even if X11 forwarding is disabled, users can always install their own forwarders.
+    remediation: >
+      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+      X11Forwarding no
+    compliance:
+      - cis: ["5.2.6"]
+      - cis_csc: ["9.2"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*x11forwarding\s+no'
+
+  - id: 7623
+    title: Ensure SSH PermitUserEnvironment is disabled
+    description: >
+      The PermitUserEnvironment option allows users to present environment options to the
+      ssh daemon.
+    rationale: >
+      Permitting users the ability to set environment variables through the SSH daemon could
+      potentially allow users to bypass security controls (e.g. setting an execution path that has
+      ssh executing a Trojan’s programs)
+    remediation: >
+      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+      PermitUserEnvironment no
+    compliance:
+      - cis: ["5.2.12"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^\s*permituserenvironment\s+no'
+
+  - id: 7624
+    title: Ensure only strong Ciphers are used
+    description: >
+      This variable limits the ciphers that SSH can use during communication.
+      Notes:
+        - Some organizations may have stricter requirements for approved ciphers. Ensure that
+          ciphers used are in compliance with site policy
+        - The only "strong" ciphers currently FIPS 140-2 compliant are: aes256-ctr,aes192-
+          ctr,aes128-ctr
+        - CVE-2013-4548 referenced bellow applies to OpenSSH versions 6.2 and 6.3. If running
+          these versions of Open SSH, Please upgrade to version 6.4 or later to fix the
+          vulnerability, or disable AES-GCM in the server configuration
+      
+      The Following are the supported ciphers in openSSH 7.9:
+      3des-cbc
+      aes128-cbc
+      aes192-cbc
+      aes256-cbc
+      aes128-ctr
+      aes192-ctr
+      aes256-ctr
+      aes128-gcm@openssh.com
+      aes256-gcm@openssh.com
+      chacha20-poly1305@openssh.com
+    rationale: >
+      Weak ciphers that are used for authentication to the cryptographic module cannot be relied
+      upon to provide confidentiality or integrity, and system data may be compromised.
+        - The DES, Triple DES, and Blowfish ciphers, as used in SSH, have a birthday bound of
+          approximately four billion blocks, which makes it easier for remote attackers to
+          obtain cleartext data via a birthday attack against a long-duration encrypted session,
+          aka a "Sweet32" attack
+        - The RC4 algorithm, as used in the TLS protocol and SSL protocol, does not properly
+          combine state data with key data during the initialization phase, which makes it
+          easier for remote attackers to conduct plaintext-recovery attacks against the initial
+          bytes of a stream by sniffing network traffic that occasionally relies on keys affected
+          by the Invariance Weakness, and then using a brute-force approach involving LSB
+          values, aka the "Bar Mitzvah" issue
+        - The passwords used during an SSH session encrypted with RC4 can be recovered by
+          an attacker who is able to capture and replay the session
+        - Error handling in the SSH protocol; Client and Server, when using a block cipher
+          algorithm in Cipher Block Chaining (CBC) mode, makes it easier for remote
+          attackers to recover certain plaintext data from an arbitrary block of ciphertext in
+          an SSH session via unknown vectors
+        - The mm_newkeys_from_blob function in monitor_wrap.c, when an AES-GCM cipher
+          is used, does not properly initialize memory for a MAC context data structure, which
+          allows remote authenticated users to bypass intended ForceCommand and loginshell restrictions via packet data that provides a crafted callback address
+    remediation: >
+      Edit the /etc/ssh/sshd_config file add/modify the Ciphers line to contain a comma
+      separated list of the site approved ciphers
+      
+      Example:
+      Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-
+      gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+    compliance:
+      - cis: ["5.2.13"]
+      - cis_csc: ["14.4"]
+    references:
+      - https://nvd.nist.gov/vuln/detail/CVE-2016-2183
+      - https://nvd.nist.gov/vuln/detail/CVE-2015-2808
+      - https://www.kb.cert.org/vuls/id/565052
+      - https://www.openssh.com/txt/cbc.adv
+      - https://nvd.nist.gov/vuln/detail/CVE-2008-5161
+      - https://nvd.nist.gov/vuln/detail/CVE-2013-4548
+      - https://www.kb.cert.org/vuls/id/565052
+      - https://www.openssh.com/txt/cbc.adv
+      - SSHD_CONFIG(5)
+    condition: none
+    rules:
+      - 'c:sshd -T -> r:^ciphers\s+ && r:3des-cbc'
+      - 'c:sshd -T -> r:^ciphers\s+ && r:aes128-cbc'
+      - 'c:sshd -T -> r:^ciphers\s+ && r:aes192-cbc'
+      - 'c:sshd -T -> r:^ciphers\s+ && r:aes256-cbc'
+
+  - id: 7625
+    title: Ensure only strong MAC algorithms are used
+    description: >
+      This variable limits the types of MAC algorithms that SSH can use during communication.
+      Notes:
+        - Some organizations may have stricter requirements for approved MACs. Ensure that
+          MACs used are in compliance with site policy
+        - The only "strong" MACs currently FIPS 140-2 approved are hmac-sha2-256 and hmacsha2-512
+      
+      The Supported MACs are:
+      hmac-md5
+      hmac-md5-96
+      hmac-sha1
+      hmac-sha1-96
+      hmac-sha2-256
+      hmac-sha2-512
+      umac-64@openssh.com
+      umac-128@openssh.com
+      hmac-md5-etm@openssh.com
+      hmac-md5-96-etm@openssh.com
+      hmac-sha1-etm@openssh.com
+      hmac-sha1-96-etm@openssh.com
+      hmac-sha2-256-etm@openssh.com
+      hmac-sha2-512-etm@openssh.com
+      umac-64-etm@openssh.com
+      umac-128-etm@openssh.com
+    rationale: >
+      MD5 and 96-bit MAC algorithms are considered weak and have been shown to increase
+      exploitability in SSH downgrade attacks. Weak algorithms continue to have a great deal of
+      attention as a weak spot that can be exploited with expanded computing power. An
+      attacker that breaks the algorithm could take advantage of a MiTM position to decrypt the
+      SSH tunnel and capture credentials and information
+    remediation: >
+      Edit the /etc/ssh/sshd_config file and add/modify the MACs line to contain a comma
+      separated list of the site approved MACs
+      
+      Example:
+      MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-
+      512,hmac-sha2-256
+    compliance:
+      - cis: ["5.2.14"]
+      - cis_csc: ["14.4","16.5"]
+    references:
+      - http://www.mitls.org/pages/attacks/SLOTH
+      - SSHD_CONFIG(5)
+    condition: none
+    rules:
+      - 'c:sshd -T -> r:^macs\s+ && r:hmac-md5'
+      - 'c:sshd -T -> r:^macs\s+ && r:hmac-md5-96'
+      - 'c:sshd -T -> r:^macs\s+ && r:hmac-ripemd160'
+      - 'c:sshd -T -> r:^macs\s+ && r:hmac-sha1'
+      - 'c:sshd -T -> r:^macs\s+ && r:hmac-sha1-96'
+      - 'c:sshd -T -> r:^macs\s+ && r:umac-64@openssh.com'
+      - 'c:sshd -T -> r:^macs\s+ && r:umac-128@openssh.com'
+      - 'c:sshd -T -> r:^macs\s+ && r:hmac-md5-etm@openssh.com'
+      - 'c:sshd -T -> r:^macs\s+ && r:hmac-md5-96-etm@openssh.com'
+      - 'c:sshd -T -> r:^macs\s+ && r:hmac-ripemd160-etm@openssh.com'
+      - 'c:sshd -T -> r:^macs\s+ && r:hmac-sha1-etm@openssh.com'
+      - 'c:sshd -T -> r:^macs\s+ && r:hmac-sha1-96-etm@openssh.com'
+      - 'c:sshd -T -> r:^macs\s+ && r:umac-64-etm@openssh.com'
+      - 'c:sshd -T -> r:^macs\s+ && r:umac-128-etm@openssh.com'
+
+  - id: 7626
+    title: Ensure only strong Key Exchange algorithms are used
+    description: >
+      Key exchange is any method in cryptography by which cryptographic keys are exchanged
+      between two parties, allowing use of a cryptographic algorithm. If the sender and receiver
+      wish to exchange encrypted messages, each must be equipped to encrypt messages to be
+      sent and decrypt messages received
+      
+      Notes:
+      Kex algorithms have a higher preference the earlier they appear in the list
+        - Some organizations may have stricter requirements for approved Key exchange
+          algorithms. Ensure that Key exchange algorithms used are in compliance with site
+          policy.
+        - The only Key Exchange Algorithms currently FIPS 140-2 approved are: ecdh-sha2-
+          nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchangesha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffiehellman-group14-sha256
+      
+      The Key Exchange algorithms supported by OpenSSH 7.9 are:
+      curve25519-sha256
+      curve25519-sha256@libssh.org
+      diffie-hellman-group1-sha1
+      diffie-hellman-group14-sha1
+      diffie-hellman-group14-sha256
+      diffie-hellman-group16-sha512
+      diffie-hellman-group18-sha512
+      diffie-hellman-group-exchange-sha1
+      diffie-hellman-group-exchange-sha256
+      ecdh-sha2-nistp256
+      ecdh-sha2-nistp384
+      ecdh-sha2-nistp521
+    rationale: >
+      Key exchange methods that are considered weak should be removed. A key exchange
+      method may be weak because too few bits are used, or the hashing algorithm is considered
+      too weak. Using weak algorithms could expose connections to man-in-the-middle attacks
+    remediation: >
+      Edit the /etc/ssh/sshd_config file add/modify the KexAlgorithms line to contain a comma
+      separated list of the site approved key exchange algorithms
+      
+      Example
+      KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellmangroup14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-
+      sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffiehellman-group-exchange-sha256
+    compliance:
+      - cis: ["5.2.15"]
+      - cis_csc: ["14.4"]
+    condition: none
+    rules:
+      - 'c:sshd -T -> r:^kexalgorithms\s+ && r:diffie-hellman-group1-sha1'
+      - 'c:sshd -T -> r:^kexalgorithms\s+ && r:diffie-hellman-group14-sha1'
+      - 'c:sshd -T -> r:^kexalgorithms\s+ && r:diffie-hellman-group-exchange-sha1'
+
+  - id: 7627
+    title: Ensure SSH Idle Timeout Interval is configured
+    description: >
+      The two options ClientAliveInterval and ClientAliveCountMax control the timeout of
+      ssh sessions.
+
+        - ClientAliveInterval sets a timeout interval in seconds after which if no data has
+          been received from the client, sshd will send a message through the encrypted
+          channel to request a response from the client. The default is 0, indicating that these
+          messages will not be sent to the client.
+        - ClientAliveCountMax sets the number of client alive messages which may be sent
+          without sshd receiving any messages back from the client. If this threshold is
+          reached while client alive messages are being sent, sshd will disconnect the client,
+          terminating the session. The default value is 3.
+            - The client alive messages are sent through the encrypted channel
+            - Setting ClientAliveCountMax to 0 disables connection termination
+      
+      Example: If the ClientAliveInterval is set to 15 seconds and the ClientAliveCountMax is
+      set to 3, the client ssh session will be terminated after 45 seconds of idle time.
+    rationale: >
+      Having no timeout value associated with a connection could allow an unauthorized user
+      access to another user's ssh session (e.g. user walks away from their computer and doesn't
+      lock the screen). Setting a timeout value reduces this risk.
+       The recommended ClientAliveInterval setting is 300 seconds (5 minutes)
+       The recommended ClientAliveCountMax setting is 3
+       The ssh session would send three keep alive messages at 5 minute intervals. If no
+      response is received after the third keep alive message, the ssh session would be
+      terminated after 15 minutes.
+    remediation: >
+      Having no timeout value associated with a connection could allow an unauthorized user
+      access to another user's ssh session (e.g. user walks away from their computer and doesn't
+      lock the screen). Setting a timeout value reduces this risk.
+        - The recommended ClientAliveInterval setting is 300 seconds (5 minutes)
+        - The recommended ClientAliveCountMax setting is 3
+        - The ssh session would send three keep alive messages at 5 minute intervals. If no
+          response is received after the third keep alive message, the ssh session would be
+          terminated after 15 minutes.
+    compliance:
+      - cis: ["5.2.16"]
+      - cis_csc: ["16.11"]
+    references:
+      - https://man.openbsd.org/sshd_config
+    condition: all
+    rules:
+      - 'c:sshd -T -> n:^clientaliveinterval\s+(\d+) compare >= 1'
+      - 'c:sshd -T -> n:^clientaliveinterval\s+(\d+) compare <= 300'
+      - 'c:sshd -T -> n:^ClientAliveCountMax\s+(\d+) compare <= 3'
+
+  - id: 7628
+    title: Ensure SSH LoginGraceTime is set to one minute or less
+    description: >
+      The LoginGraceTime parameter specifies the time allowed for successful authentication to
+      the SSH server. The longer the Grace period is the more open unauthenticated connections
+      can exist. Like other session controls in this session the Grace Period should be limited to
+      appropriate organizational limits to ensure the service is available for needed access.
+    rationale: >
+      Setting the LoginGraceTime parameter to a low number will minimize the risk of successful
+      brute force attacks to the SSH server. It will also limit the number of concurrent
+      unauthenticated connections While the recommended setting is 60 seconds (1 Minute), set
+      the number based on site policy.
+    remediation: >
+      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+      LoginGraceTime 60
+    compliance:
+      - cis: ["5.2.17"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> n:^logingracetime\s+(\d+) compare >= 1'
+      - 'c:sshd -T -> n:^logingracetime\s+(\d+) compare <= 60'
+
+  - id: 7629
+    title: Ensure SSH warning banner is configured
+    description: >
+      The Banner parameter specifies a file whose contents must be sent to the remote user
+      before authentication is permitted. By default, no banner is displayed.
+    rationale: >
+      Banners are used to warn connecting users of the particular site's policy regarding
+      connection. Presenting a warning message prior to the normal user login may assist the
+      prosecution of trespassers on the computer system.
+    remediation: >
+      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+      
+      Banner /etc/issue.net
+    compliance:
+      - cis: ["5.2.18"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^banner\s+/etc/issue.net'
+
+  - id: 7630
+    title: Ensure SSH PAM is enabled
+    description: >
+      UsePAM Enables the Pluggable Authentication Module interface. If set to “yes” this will
+      enable PAM authentication using ChallengeResponseAuthentication and
+      PasswordAuthentication in addition to PAM account and session module processing for all
+      authentication types
+    rationale: >
+      When usePAM is set to yes, PAM runs through account and session types properly. This is
+      important if you want to restrict access to services based off of IP, time or other factors of
+      the account. Additionally, you can make sure users inherit certain environment variables
+      on login or disallow access to the server
+    remediation: >
+      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+      
+      UsePAM yes
+    compliance:
+      - cis: ["5.2.19"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^usepam\s+yes'
+
+  - id: 7631
+    title: Ensure SSH AllowTcpForwarding is disabled
+    description: >
+      SSH port forwarding is a mechanism in SSH for tunneling application ports from the client
+      to the server, or servers to clients. It can be used for adding encryption to legacy
+      applications, going through firewalls, and some system administrators and IT professionals
+      use it for opening backdoors into the internal network from their home machines
+    rationale: >
+      Leaving port forwarding enabled can expose the organization to security risks and backdoors.
+      
+      SSH connections are protected with strong encryption. This makes their contents invisible
+      to most deployed network monitoring and traffic filtering solutions. This invisibility carries
+      considerable risk potential if it is used for malicious purposes such as data exfiltration.
+      Cybercriminals or malware could exploit SSH to hide their unauthorized communications,
+      or to exfiltrate stolen data from the target network
+    remediation: >
+      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+      
+      AllowTcpForwarding no
+    compliance:
+      - cis: ["5.2.20"]
+      - cis_csc: ["9.2"]
+    references:
+      - https://www.ssh.com/ssh/tunneling/example
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^allowtcpforwarding\s+no'
+
+  - id: 7632
+    title: Ensure SSH MaxStartups is configured
+    description: >
+      The MaxStartups parameter specifies the maximum number of concurrent unauthenticated
+      connections to the SSH daemon.
+    rationale: >
+      To protect a system from denial of service due to a large number of pending authentication
+      connection attempts, use the rate limiting function of MaxStartups to protect availability of
+      sshd logins and prevent overwhelming the daemon.
+    remediation: >
+      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+      
+      maxstartups 10:30:60
+    compliance:
+      - cis: ["5.2.21"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> r:^maxstartups\s+10:30:60\s*$'
+
+  - id: 7633
+    title: Ensure SSH MaxSessions is limited 
+    description: >
+      The MaxSessions parameter specifies the maximum number of open sessions permitted
+      from a given connection.
+    rationale: >
+      To protect a system from denial of service due to a large number of concurrent sessions,
+      use the rate limiting function of MaxSessions to protect availability of sshd logins and
+      prevent overwhelming the daemon.
+    remediation: >
+      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+      
+      MaxSessions 10
+    compliance:
+      - cis: ["5.2.22"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:sshd -T -> n:^maxsessions\s+(\d+) compare <= 10'
+
+  - id: 7634
+    title: Ensure password reuse is limited
+    description: >
+      The /etc/security/opasswd file stores the users' old passwords and can be checked to
+      ensure that users are not recycling recent passwords.
+      
+      Notes:
+      - Additional module options may be set, recommendation only covers those listed here.
+      - This setting only applies to local accounts.
+      - This option is configured with the remember=n module option in /etc/pam.d/commonpassword
+    rationale: >
+      Forcing users not to reuse their past passwords make it less likely that an attacker will be
+      able to guess the password.
+    remediation: >
+      Run the following command:
+      # pam-config -a --pwhistory --pwhistory-remember=5
+      
+      OR
+      
+      Edit the file /etc/pam.d/common-password to include the remember= option and conform to
+      site policy as shown:
+      password required pam_pwhistory.so remember=5
+    compliance:
+      - cis: ["5.3.3"]
+      - cis_csc: ["16"]
+    condition: any
+    rules:
+      - 'f:/etc/pam.d/common-password -> n:^\s*password\t+requisite\t+pam_pwhistory\.so\t+remember\s*=\s*(\d+) compare >= 5'
+      - 'f:/etc/pam.d/common-password -> n:^\s*password\t+required\t+pam_pwhistory\.so\t+remember\s*=\s*(\d+) compare >= 5'
+
+  - id: 7635
+    title: Ensure password hashing algorithm is SHA-512
+    description: >
+      Login passwords are hashed and stored in the /etc/shadow file.
+      
+      Note: These changes only apply to accounts configured on the local system.
+    rationale: >
+      The SHA-512 algorithm provides much stronger hashing than MD5, thus providing
+      additional protection to the system by increasing the level of effort for an attacker to
+      successfully determine passwords.
+    remediation: >
+      Edit the /etc/login.defs file and modify ENCRYPT_METHOD to SHA512:
+      ENCRYPT_METHOD sha512
+      
+      Notes:
+        - Any system accounts that need to be expired should be carefully done separately by the
+          system administrator to prevent any potential problems
+        - If it is determined that the password algorithm being used is not SHA-512, once it is
+          changed, it is recommended that all user ID's be immediately expired and forced to
+          change their passwords on next login, In accordance with local site policies
+        - To accomplish this, the following command can be used
+          # awk -F: '( $3<'"$(awk '/^\s*UID_MIN/{print $2}' /etc/login.defs)"' &&
+          $1 != "nfsnobody" ) { print $1 }' /etc/passwd | xargs -n 1 chage -d 0
+    compliance:
+      - cis: ["5.4.1.1"]
+      - cis_csc: ["16.4"]
+    condition: all
+    rules:
+      - 'f:/etc/login.defs -> r:^\s*ENCRYPT_METHOD\s+SHA512'
+
+  - id: 7636
+    title: Ensure default group for the root account is GID 0
+    description: >
+      The usermod command can be used to specify which group the root user belongs to. This
+      affects permissions of files that are created by the root user.
+    rationale: >
+      Using GID 0 for the root account helps prevent root -owned files from accidentally
+      becoming accessible to non-privileged users.
+    remediation: >
+      Run the following command to set the root user default group to GID 0 :
+      # usermod -g 0 root
+    compliance:
+      - cis: ["5.4.3"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'f:/etc/passwd -> r:^root:\S+:\S+:0:'
+
+  - id: 7637
+    title: Ensure permissions on /etc/passwd are configured
+    description: >
+      The /etc/passwd file contains user account information that is used by many system
+      utilities and therefore must be readable for these utilities to operate.
+    rationale: >
+      It is critical to ensure that the /etc/passwd file is protected from unauthorized write
+      access. Although it is protected by default, the file permissions could be changed either
+      inadvertently or through malicious actions.
+    remediation: >
+      Run the following commands to set owner, group, and permissions on /etc/passwd:
+      
+      # chown root:root /etc/passwd
+      # chmod u-x,g-wx,o-wx /etc/passwd
+    compliance:
+      - cis: ["6.1.2"]
+      - cis_csc: ["14.6"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/passwd -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7638
+    title: Ensure permissions on /etc/shadow are configured
+    description: >
+      The /etc/shadow file is used to store the information about user accounts that is critical to
+      the security of those accounts, such as the hashed password and other security
+      information.
+    rationale: >
+      If attackers can gain read access to the /etc/shadow file, they can easily run a password
+      cracking program against the hashed password to break it. Other security information that
+      is stored in the /etc/shadow file (such as expiration) could also be useful to subvert the
+      user accounts.
+    remediation: >
+      Run the following commands to set owner, group, and permissions on /etc/shadow:
+      
+      # chown root:root /etc/shadow
+      # chmod u-x,g-wx,o-rwx /etc/shadow
+    compliance:
+      - cis: ["6.1.3"]
+      - cis_csc: ["14.6"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/shadow -> r:^Access:\s*\(0640/-rw-r-----\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*15/\s*shadow\)'
+
+  - id: 7639
+    title: Ensure permissions on /etc/group are configured
+    description: >
+      The /etc/group file contains a list of all the valid groups defined in the system. The
+      command below allows read/write access for root and read access for everyone else.
+    rationale: >
+      The /etc/group file needs to be protected from unauthorized changes by non-privileged
+      users, but needs to be readable as this information is used with many non-privileged
+      programs.
+    remediation: >
+      Run the following commands to set owner, group, and permissions on /etc/group :
+      
+      # chown root:root /etc/group
+      # chmod u-x,g-wx,o-wx /etc/group
+    compliance:
+      - cis: ["6.1.4"]
+      - cis_csc: ["14.6"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/group -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7640
+    title: Ensure permissions on /etc/passwd- are configured
+    description: The /etc/passwd- file contains backup user account information.
+    rationale: >
+      It is critical to ensure that the /etc/passwd- file is protected from unauthorized access.
+      Although it is protected by default, the file permissions could be changed either
+      inadvertently or through malicious actions.
+    remediation: >
+      Run the following commands to set owner, group, and permissions on /etc/passwd- :
+      
+      # chown root:root /etc/passwd-
+      # chmod u-x,go-wx /etc/passwd
+    compliance:
+      - cis: ["6.1.5"]
+      - cis_csc: ["14.6"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/passwd -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7641
+    title: Ensure permissions on /etc/shadow- are configured
+    description: >
+      The /etc/shadow- file is used to store backup information about user accounts that is
+      critical to the security of those accounts, such as the hashed password and other security
+      information.
+    rationale: >
+      It is critical to ensure that the /etc/shadow- file is protected from unauthorized access.
+      Although it is protected by default, the file permissions could be changed either
+      inadvertently or through malicious actions.
+    remediation: >
+      Run the following commands to set owner, group, and permissions on /etc/shadow-:
+      
+      # chown root:shadow /etc/shadow-
+      # chmod u-x,g-wx,o-rwx /etc/shadow
+    compliance:
+      - cis: ["6.1.6"]
+      - cis_csc: ["14.6"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/shadow- -> r:^Access:\s*\(0640/-rw-r-----\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*15/\s*shadow\)'
+
+  - id: 7642
+    title: Ensure permissions on /etc/group- are configured
+    description: The /etc/group- file contains a backup list of all the valid groups defined in the system.
+    rationale: >
+      It is critical to ensure that the /etc/group- file is protected from unauthorized access.
+      Although it is protected by default, the file permissions could be changed either
+      inadvertently or through malicious actions.
+    remediation: >
+      Run the following commands to set owner, group, and permissions on /etc/group-:
+      
+      # chown root:root /etc/group-
+      # chmod u-x,go-wx /etc/group-
+    compliance:
+      - cis: ["6.1.7"]
+      - cis_csc: ["14.6"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/group- -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+  - id: 7643
+    title: Ensure accounts in /etc/passwd use shadowed passwords
+    description: >
+      Local accounts can uses shadowed passwords. With shadowed passwords, The passwords
+      are saved in shadow password file, /etc/shadow, encrypted by a salted one-way hash.
+      Accounts with a shadowed password have an x in the second field in /etc/passwd.
+    rationale: >
+      The /etc/passwd file also contains information like user ID's and group ID's that are used
+      by many system programs. Therefore, the /etc/passwd file must remain world readable. In
+      spite of encoding the password with a randomly-generated one-way hash function, an
+      attacker could still break the system if they got access to the /etc/passwd file. This can be
+      mitigated by using shadowed passwords, thus moving the passwords in the /etc/passwd
+      file to /etc/shadow. The /etc/shadow file is set so only root will be able to read and write.
+      This helps mitigate the risk of an attacker gaining access to the encoded passwords with
+      which to perform a dictionary attack.
+      
+      Notes:
+        - All accounts must have passwords or be locked to prevent the account from being used
+          by an unauthorized user.
+        - A user account with an empty second field in /etc/passwd allows the account to be
+          logged into by providing only the username.
+    remediation: >
+      If any accounts in the /etc/passwd file do not have a single x in the password field, run the
+      following command to set these accounts to use shadowed passwords:
+      
+      # sed -e 's/^\([a-zA-Z0-9_]*\):[^:]*:/\1:x:/' -i /etc/passwd
+      
+      Investigate to determine if the account is logged in and what it is being used for, to
+      determine if it needs to be forced off.
+    compliance:
+      - cis: ["6.2.1"]
+      - cis_csc: ["4.4"]
+    condition: none
+    rules:
+      - 'f:/etc/passwd -> !r:^\.+:x:'
+
+  - id: 7644
+    title: Ensure /etc/shadow password fields are not empty
+    description: >
+      An account with an empty password field means that anybody may log in as that user
+      without providing a password.
+    rationale: >
+      All accounts must have passwords or be locked to prevent the account from being used by
+      an unauthorized user.
+    remediation: >
+      If any accounts in the /etc/shadow file do not have a password, run the following command
+      to lock the account until it can be determined why it does not have a password:
+      
+      # passwd -l <username>
+      
+      Also, check to see if the account is logged in and investigate what it is being used for to
+      determine if it needs to be forced off.
+    compliance:
+      - cis: ["6.2.2"]
+      - cis_csc: ["4.4"]
+    condition: none
+    rules:
+      - 'c:grep -E ^[^:]+:: /etc/shadow -> r:::'
+
+#  - id: 
+#    title: 
+#    description: 
+#    rationale: 
+#    remediation: 
+#    compliance:
+#      - cis: [""]
+#      - cis_csc: [""]
+#    references:
+#      - 
+#    condition: 
+#    rules:
+#      - ''
+

--- a/ruleset/sca/sunos/cis_solaris11.yml
+++ b/ruleset/sca/sunos/cis_solaris11.yml
@@ -1,6 +1,6 @@
 # Security Configuration Assessment
 # CIS Checks for Oracle Solaris 11
-# Copyright (C) 2015-2021, Wazuh Inc.
+# Copyright (C) 2015-2020, Wazuh Inc.
 #
 # This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
@@ -192,7 +192,7 @@ checks:
       - 'c:coreadm'
       - 'c:coreadm -> r:per-process core dumps: disabled'
       - 'c:coreadm -> r:per-process setid core dumps: disabled'
-      - 'c:stat -c%u-%g-%a /var/cores -> r:^\d-\d-700'
+      - 'c:stat -L -c%u-%g-%a /var/cores -> r:^\d-\d-700'
 
   - id: 8014 
     title: "Enable Stack Protection"
@@ -565,7 +565,7 @@ checks:
     rules:
       - 'f:/etc/issue -> r:Authorized users only. All activity may be monitored and reported'
       - 'f:/etc/motd -> r:Authorized users only. All activity may be monitored and reported'
-      - 'c:stat -c%u-%g-%a /etc/issue -> r:^0-0-644'
+      - 'c:stat -L -c%u-%g-%a /etc/issue -> r:^0-0-644'
 
   - id: 8042 
     title: "Enable a Warning Banner for the SSH Service"


### PR DESCRIPTION
|Related issue|
|---|
|#7624|

All the stat commands called in SCA rules should include the -L flag to follow symbolic links.
Solution: Replace "stat" command for "stat -L" on rules within these files:

cis_centos6_linux.yml
cis_centos7_linux.yml
cis_centos8_linux.yml
cis_debian7.yml
cis_debian8.yml
cis_debian9.yml
cis_debian10.yml
cis_nginx_1.yml
cis_rhel6_linux.yml
cis_rhel7_linux.yml
cis_rhel8_linux.yml
cis_sles12_linux.yml
cis_sles15_linux.yml
cis_solaris11.yml