### PR TITLE
Fixing Windows installer to start WazuhSvc after upgrading from OssecSvc

### DIFF
--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -223,3 +223,11 @@ Private Function GetVersion()
 		GetVersion = Split(objItem.Version,".")(0)
 	Next
 End Function
+
+Public Function CheckSvcRunning()
+	Set wmi = GetObject("winmgmts://./root/cimv2")
+	state = wmi.Get("Win32_Service.Name='OssecSvc'").State
+	Session.Property("OSSECRUNNING") = state
+
+	CheckSvcRunning = 0
+End Function

--- a/src/win32/RemoveAllScript.vbs
+++ b/src/win32/RemoveAllScript.vbs
@@ -20,14 +20,14 @@
 
 ' This function is called only when uninstalling the product.
 ' Remove everything, but a few specified items.
-' 
+'
 public function removeAll()
 
    ' Retrieve the parameters
    strArgs = Session.Property("CustomActionData")
    args = Split(strArgs, ",")
    home_dir = Replace(args(0), Chr(34), "") 'APPLICATIONFOLDER
- 
+
    Set objSFO = CreateObject("Scripting.FileSystemObject")
 
    If objSFO.fileExists(home_dir & "ossec.conf.save") AND objSFO.fileExists(home_dir & "ossec.conf") Then
@@ -56,12 +56,12 @@ public function removeAll()
 
    If objSFO.folderExists(home_dir) Then
       Set folder = objSFO.GetFolder(home_dir)
- 
+
       ' Everything in the application's root folder will be deleted.
       ' *BUT*, the files specified here *will not* be deleted
        Dim filesToKeep: filesToKeep = Array("ossec.conf.save", "client.keys.save", _
                                             "local_internal_options.conf.save")
- 
+
       ' Construct a simple dictionary to check out later whether a file is in
       ' the list or not
       Dim dicFiles: Set dicFiles = CreateObject("Scripting.Dictionary")
@@ -69,8 +69,8 @@ public function removeAll()
       For Each x in filesToKeep
          dicFiles.add x, x
       Next
- 
- 
+
+
       ' Delete the files in the root folder
       For Each f In folder.Files
          name = f.name
@@ -80,18 +80,16 @@ public function removeAll()
             f.Delete True
          End If
       Next
- 
+
       ' And delete all the subfolders, empty or not
       For Each f In folder.SubFolders
          On Error Resume Next
          f.Delete True
       Next
 
- 
+
    End If   'objSFO.fileExists
- 
+
    removeAll = 0
 
 End Function   'removeAll
-
-

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -87,6 +87,8 @@
         <CustomAction Id="SetRemoveAllDataValue" Return="check" Property="CustomAction_RemoveAllScript" Value="&quot;[APPLICATIONFOLDER]&quot;" />
         <CustomAction Id="CustomAction_RemoveAllScript" BinaryKey="RemoveAllScript" VBScriptCall="removeAll" Return="check" Execute="commit" Impersonate="no" />
 
+        <CustomAction Id="CheckSvcRunning_OssecSvc" BinaryKey="InstallerScripts" VBScriptCall="CheckSvcRunning" Return="check" Execute="immediate" Impersonate="no" />
+
         <CustomAction Id="SetCustomActionDataValue" Return="check" Property="CustomAction_InstallerScripts" Value="&quot;[APPLICATIONFOLDER]&quot;,&quot;[ADDRESS]&quot;,&quot;[SERVER_PORT]&quot;,&quot;[PROTOCOL]&quot;,&quot;[NOTIFY_TIME]&quot;,&quot;[TIME_RECONNECT]&quot;,&quot;[WAZUH_MANAGER]&quot;,&quot;[WAZUH_MANAGER_PORT]&quot;,&quot;[WAZUH_PROTOCOL]&quot;,&quot;[WAZUH_KEEP_ALIVE_INTERVAL]&quot;,&quot;[WAZUH_TIME_RECONNECT]&quot;" />
         <CustomAction Id="CustomAction_InstallerScripts" BinaryKey="InstallerScripts" VBScriptCall="config" Return="check" Execute="commit" Impersonate="no" />
 
@@ -185,6 +187,7 @@
         </UI>
         <InstallExecuteSequence>
             <!-- Delete OSSEC service if it exist -->
+            <Custom Action="CheckSvcRunning_OssecSvc" After="AppSearch">OSSECINSTALLED</Custom>
             <Custom Action="StopOssecService" After="InstallInitialize">OSSECINSTALLED</Custom>
             <Custom Action="DeleteOssecService" After="StopOssecService">OSSECINSTALLED</Custom>
 
@@ -343,7 +346,7 @@
                         <File Id="WAZUH_AGENT_UPGRADE_OSSEC.EXE" Name="wazuh-agent.exe" Source="wazuh-agent.exe" />
                         <ServiceInstall Name="WazuhSvc" Type="ownProcess" Start="auto" ErrorControl="normal" Description="Wazuh Windows Agent" DisplayName="Wazuh" Id="svc_install_upgrade_ossec" />
                         <ServiceControl Id="ServiceControl_ossec_upgrade" Name="WazuhSvc" Remove="uninstall" Start="install" Stop="both" Wait="yes" />
-                        <Condition>OSSECINSTALLED AND (VersionNT &gt;= 600)</Condition>
+                        <Condition>OSSECINSTALLED AND (OSSECRUNNING = "Running") AND (VersionNT &gt;= 600)</Condition>
                     </Component>
                     <Component Id="VISTA_SEC.TXT" DiskId="1" Guid="20EF5801-369B-4EC2-87A2-59DCE56308D9">
                         <File Id="VISTA_SEC.TXT" Name="vista_sec.txt" Source="vista_sec.txt" />

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -334,15 +334,16 @@
                         <Condition>VersionNT &gt;= 600</Condition>
                     </Component>
                     <Component Id="WAZUH_AGENT.EXE" DiskId="1" Guid="5CCEA6DC-8434-4137-9486-55AE3949266B">
-
                         <File Id="WAZUH_AGENT.EXE" Name="wazuh-agent.exe" Source="wazuh-agent.exe" />
-
                         <ServiceInstall Name="WazuhSvc" Type="ownProcess" Start="auto" ErrorControl="normal" Description="Wazuh Windows Agent" DisplayName="Wazuh" Id="svc_install" />
-
-
                         <ServiceControl Id="ServiceControl" Name="WazuhSvc" Stop="both" Remove="uninstall" Wait="yes" />
-
-                        <Condition>VersionNT &lt; 600</Condition>
+                        <Condition>NOT(OSSECINSTALLED) AND (VersionNT &lt; 600)</Condition>
+                    </Component>
+                    <Component Id="WAZUH_AGENT_UPGRADE_OSSEC.EXE" DiskId="1" Guid="FB49A2F0-3433-47D4-A668-4139718AFDAC">
+                        <File Id="WAZUH_AGENT_UPGRADE_OSSEC.EXE" Name="wazuh-agent.exe" Source="wazuh-agent.exe" />
+                        <ServiceInstall Name="WazuhSvc" Type="ownProcess" Start="auto" ErrorControl="normal" Description="Wazuh Windows Agent" DisplayName="Wazuh" Id="svc_install_upgrade_ossec" />
+                        <ServiceControl Id="ServiceControl_ossec_upgrade" Name="WazuhSvc" Remove="uninstall" Start="install" Stop="both" Wait="yes" />
+                        <Condition>OSSECINSTALLED AND (VersionNT &gt;= 600)</Condition>
                     </Component>
                     <Component Id="VISTA_SEC.TXT" DiskId="1" Guid="20EF5801-369B-4EC2-87A2-59DCE56308D9">
                         <File Id="VISTA_SEC.TXT" Name="vista_sec.txt" Source="vista_sec.txt" />
@@ -623,6 +624,7 @@
             <ComponentRef Id="MANAGE_AGENTS.EXE" />
             <ComponentRef Id="WAZUH_AGENT_EVENTCHANNEL.EXE" />
             <ComponentRef Id="WAZUH_AGENT.EXE" />
+            <ComponentRef Id="WAZUH_AGENT_UPGRADE_OSSEC.EXE" />
             <ComponentRef Id="VISTA_SEC.TXT" />
             <ComponentRef Id="RESTART_WAZUH.EXE" />
             <ComponentRef Id="ROUTE_NULL.EXE" />


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/8687 |

## Description

This pull request includes all the necessary changes in the Windows installer in order to behave in the following way when upgrading from `OssecSvc`:

- If `OssecSvc` was running, the `WazuhSvc` is automatically started after the upgrade.
- If `OssecSvc` was not running, the `WazuhSvc` is not started after the upgrade.

## Tests

- Compilation without warnings in every supported platform
  - [x] Windows
- [x] Package installation
- [x] Package upgrade