### PR TITLE
[8822] Fix exception handling on windows getVersion issue (8/8.1 win versions only)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -742,7 +742,7 @@ ifeq (${MAKECMDGOALS},winagent)
 $(error Do not use 'winagent' directly, use 'TARGET=winagent')
 endif
 .PHONY: winagent
-winagent: external win32/libwinpthread-1.dll
+winagent: external win32/libwinpthread-1.dll win32/libgcc_s_sjlj-1.dll
 	${MAKE} ${WINDOWS_BINS} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32"
 	${MAKE} ${WINDOWS_ACTIVE_RESPONSES} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32"
 	cd win32/ && ./unix2dos.pl ossec.conf > default-ossec.conf
@@ -775,6 +775,9 @@ win32/syscollector: win32/shared_modules win32/sysinfo
 	cd ${SYSCOLLECTOR} && mkdir -p build && cd build && cmake ${CMAKE_OPTS} ${SYSCOLLECTOR_TEST} ${SYSCOLLECTOR_RELEASE_TYPE} .. && ${MAKE}
 
 win32/libwinpthread-1.dll: ${WIN_PTHREAD_LIB}
+	cp $< $@
+
+win32/libgcc_s_sjlj-1.dll: $(wildcard /usr/lib/gcc/i686-w64-mingw32/*-posix/libgcc_s_sjlj-1.dll)
 	cp $< $@
 
 ####################

--- a/src/data_provider/CMakeLists.txt
+++ b/src/data_provider/CMakeLists.txt
@@ -104,7 +104,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   set_target_properties(sysinfo PROPERTIES
       PREFIX ""
       SUFFIX ".dll"
-      LINK_FLAGS "-Wl,--add-stdcall-alias -static-libgcc -static-libstdc++"
+      LINK_FLAGS "-Wl,--add-stdcall-alias -static-libstdc++"
       POSITION_INDEPENDENT_CODE 0 # this is to avoid MinGW warning;
       # MinGW generates position-independent-code for DLL by default
   )

--- a/src/data_provider/src/osinfo/sysOsInfoWin.cpp
+++ b/src/data_provider/src/osinfo/sysOsInfoWin.cpp
@@ -18,28 +18,18 @@
 #include "registryHelper.h"
 #include "sharedDefs.h"
 
-// for retro compatibility compilation this macro is defined.
-// https://github.com/mirror/mingw-w64/blob/d2374f898457b0f4ea8bd4084a94f2dafc87a99a/mingw-w64-headers/include/sdkddkver.h#L25
-#ifndef _WIN32_WINNT_WINTHRESHOLD
-#define _WIN32_WINNT_WINTHRESHOLD 0x0A00
-static VERSIONHELPERAPI IsWindows10OrGreater()
-{
-    return IsWindowsVersionOrGreater(HIBYTE(_WIN32_WINNT_WINTHRESHOLD), LOBYTE(_WIN32_WINNT_WINTHRESHOLD), 0);
-}
-#endif
-
 static std::string getVersion(const bool isMinor = false)
 {
     std::string version;
     if(IsWindowsVistaOrGreater())
     {
         Utils::Registry currentVersion{HKEY_LOCAL_MACHINE, R"(SOFTWARE\Microsoft\Windows NT\CurrentVersion)"};
-        if (IsWindows10OrGreater())
+        try
         {
             const auto versionNumber{currentVersion.dword(isMinor ? "CurrentMinorVersionNumber" : "CurrentMajorVersionNumber")};
             version = std::to_string(versionNumber);
         }
-        else
+        catch (...)
         {
             enum OS_VERSION
             {

--- a/src/data_provider/src/osinfo/sysOsInfoWin.cpp
+++ b/src/data_provider/src/osinfo/sysOsInfoWin.cpp
@@ -23,13 +23,14 @@ static std::string getVersion(const bool isMinor = false)
     std::string version;
     if(IsWindowsVistaOrGreater())
     {
+        DWORD versionNumber {};
         Utils::Registry currentVersion{HKEY_LOCAL_MACHINE, R"(SOFTWARE\Microsoft\Windows NT\CurrentVersion)"};
-        try
+        if (IsWindows8OrGreater()
+            && currentVersion.dword(isMinor ? "CurrentMinorVersionNumber" : "CurrentMajorVersionNumber", versionNumber))
         {
-            const auto versionNumber{currentVersion.dword(isMinor ? "CurrentMinorVersionNumber" : "CurrentMajorVersionNumber")};
             version = std::to_string(versionNumber);
         }
-        catch (...)
+        else
         {
             enum OS_VERSION
             {

--- a/src/data_provider/src/osinfo/sysOsInfoWin.cpp
+++ b/src/data_provider/src/osinfo/sysOsInfoWin.cpp
@@ -18,10 +18,15 @@
 #include "registryHelper.h"
 #include "sharedDefs.h"
 
-static VERSIONHELPERAPI IsWindowsTenOrGreater()
+// for retro compatibility compilation this macro is defined.
+// https://github.com/mirror/mingw-w64/blob/d2374f898457b0f4ea8bd4084a94f2dafc87a99a/mingw-w64-headers/include/sdkddkver.h#L25
+#ifndef _WIN32_WINNT_WINTHRESHOLD
+#define _WIN32_WINNT_WINTHRESHOLD 0x0A00
+static VERSIONHELPERAPI IsWindows10OrGreater()
 {
     return IsWindowsVersionOrGreater(HIBYTE(_WIN32_WINNT_WINTHRESHOLD), LOBYTE(_WIN32_WINNT_WINTHRESHOLD), 0);
 }
+#endif
 
 static std::string getVersion(const bool isMinor = false)
 {
@@ -29,7 +34,7 @@ static std::string getVersion(const bool isMinor = false)
     if(IsWindowsVistaOrGreater())
     {
         Utils::Registry currentVersion{HKEY_LOCAL_MACHINE, R"(SOFTWARE\Microsoft\Windows NT\CurrentVersion)"};
-        if (IsWindowsTenOrGreater())
+        if (IsWindows10OrGreater())
         {
             const auto versionNumber{currentVersion.dword(isMinor ? "CurrentMinorVersionNumber" : "CurrentMajorVersionNumber")};
             version = std::to_string(versionNumber);

--- a/src/data_provider/src/osinfo/sysOsInfoWin.cpp
+++ b/src/data_provider/src/osinfo/sysOsInfoWin.cpp
@@ -24,7 +24,7 @@ static std::string getVersion(const bool isMinor = false)
     if(IsWindowsVistaOrGreater())
     {
         Utils::Registry currentVersion{HKEY_LOCAL_MACHINE, R"(SOFTWARE\Microsoft\Windows NT\CurrentVersion)"};
-        if (IsWindows8OrGreater())
+        if (IsWindows10OrGreater())
         {
             const auto versionNumber{currentVersion.dword(isMinor ? "CurrentMinorVersionNumber" : "CurrentMajorVersionNumber")};
             version = std::to_string(versionNumber);

--- a/src/data_provider/src/osinfo/sysOsInfoWin.cpp
+++ b/src/data_provider/src/osinfo/sysOsInfoWin.cpp
@@ -18,13 +18,18 @@
 #include "registryHelper.h"
 #include "sharedDefs.h"
 
+static VERSIONHELPERAPI IsWindowsTenOrGreater()
+{
+    return IsWindowsVersionOrGreater(HIBYTE(_WIN32_WINNT_WINTHRESHOLD), LOBYTE(_WIN32_WINNT_WINTHRESHOLD), 0);
+}
+
 static std::string getVersion(const bool isMinor = false)
 {
     std::string version;
     if(IsWindowsVistaOrGreater())
     {
         Utils::Registry currentVersion{HKEY_LOCAL_MACHINE, R"(SOFTWARE\Microsoft\Windows NT\CurrentVersion)"};
-        if (IsWindows10OrGreater())
+        if (IsWindowsTenOrGreater())
         {
             const auto versionNumber{currentVersion.dword(isMinor ? "CurrentMinorVersionNumber" : "CurrentMajorVersionNumber")};
             version = std::to_string(versionNumber);

--- a/src/data_provider/testtool/CMakeLists.txt
+++ b/src/data_provider/testtool/CMakeLists.txt
@@ -33,7 +33,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         psapi
         iphlpapi
         ws2_32
-        -static-libgcc -static-libstdc++
+        -static-libstdc++
     )
 elseif (CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
     target_link_libraries(sysinfo_test_tool

--- a/src/shared_modules/dbsync/CMakeLists.txt
+++ b/src/shared_modules/dbsync/CMakeLists.txt
@@ -60,7 +60,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   set_target_properties(dbsync PROPERTIES
         PREFIX ""
         SUFFIX ".dll"
-        LINK_FLAGS "-Wl,--add-stdcall-alias -static-libgcc -static-libstdc++"
+        LINK_FLAGS "-Wl,--add-stdcall-alias -static-libstdc++"
         POSITION_INDEPENDENT_CODE 0 # this is to avoid MinGW warning;
         # MinGW generates position-independent-code for DLL by default
   )

--- a/src/shared_modules/dbsync/testtool/CMakeLists.txt
+++ b/src/shared_modules/dbsync/testtool/CMakeLists.txt
@@ -23,7 +23,7 @@ add_executable(dbsync_test_tool
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 	target_link_libraries(dbsync_test_tool
 	    dbsync
-	    -static-libgcc -static-libstdc++
+	    -static-libstdc++
 	)
 elseif (CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
 	target_link_libraries(dbsync_test_tool

--- a/src/shared_modules/rsync/CMakeLists.txt
+++ b/src/shared_modules/rsync/CMakeLists.txt
@@ -62,7 +62,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   set_target_properties(rsync PROPERTIES
         PREFIX ""
         SUFFIX ".dll"
-        LINK_FLAGS "-Wl,--add-stdcall-alias -static-libgcc -static-libstdc++"
+        LINK_FLAGS "-Wl,--add-stdcall-alias -static-libstdc++"
         POSITION_INDEPENDENT_CODE 0 # this is to avoid MinGW warning;
         # MinGW generates position-independent-code for DLL by default
   )

--- a/src/shared_modules/rsync/testtool/CMakeLists.txt
+++ b/src/shared_modules/rsync/testtool/CMakeLists.txt
@@ -28,7 +28,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 	target_link_libraries(rsync_test_tool
 	    rsync
 	    dbsync
-	    -static-libgcc -static-libstdc++
+	    -static-libstdc++
 	)
 elseif (CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
 	target_link_libraries(rsync_test_tool

--- a/src/shared_modules/utils/registryHelper.h
+++ b/src/shared_modules/utils/registryHelper.h
@@ -59,16 +59,12 @@ namespace Utils
 
         bool dword(const std::string& valueName, DWORD& value) const
         {
-            bool ret{true};
-            try
+            DWORD size{sizeof(DWORD)};
+            const auto result
             {
-                value = this->dword(valueName);
-            }
-            catch(...)
-            {
-                ret = false;
-            }
-            return ret;
+                RegQueryValueEx(m_registryKey, valueName.c_str(), nullptr, nullptr, reinterpret_cast<LPBYTE>(&value), &size)
+            };
+            return result == ERROR_SUCCESS;
         }
 
         std::vector<std::string> enumerate() const

--- a/src/wazuh_modules/syscollector/CMakeLists.txt
+++ b/src/wazuh_modules/syscollector/CMakeLists.txt
@@ -80,7 +80,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   set_target_properties(syscollector PROPERTIES
         PREFIX ""
         SUFFIX ".dll"
-        LINK_FLAGS "-Wl,--add-stdcall-alias -static-libgcc -static-libstdc++"
+        LINK_FLAGS "-Wl,--add-stdcall-alias -static-libstdc++"
         POSITION_INDEPENDENT_CODE 0 # this is to avoid MinGW warning;
         # MinGW generates position-independent-code for DLL by default
   )

--- a/src/wazuh_modules/syscollector/testtool/CMakeLists.txt
+++ b/src/wazuh_modules/syscollector/testtool/CMakeLists.txt
@@ -47,7 +47,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         ssl
         ws2_32
         crypt32
-        -static-libgcc -static-libstdc++
+        -static-libstdc++
     )
 elseif (CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
     target_link_libraries(syscollector_test_tool

--- a/src/win32/wazuh-installer.nsi
+++ b/src/win32/wazuh-installer.nsi
@@ -210,6 +210,7 @@ Section "Wazuh Agent (required)" MainSec
     File /oname=active-response\bin\restart-wazuh.exe restart-wazuh.exe
     File /oname=active-response\bin\netsh.exe netsh.exe
     File /oname=libwinpthread-1.dll libwinpthread-1.dll
+    File /oname=libgcc_s_sjlj-1.dll libgcc_s_sjlj-1.dll
     File agent-auth.exe
     File /oname=wpk_root.pem ..\..\etc\wpk_root.pem
     File /oname=libwazuhext.dll ..\libwazuhext.dll
@@ -497,14 +498,8 @@ Section "Uninstall"
     Delete "$INSTDIR\tmp\*"
     Delete "$INSTDIR\incoming\*"
     Delete "$INSTDIR\wodles\*"
-    Delete "$INSTDIR\libwazuhext.dll"
-    Delete "$INSTDIR\libwazuhshared.dll"
-    Delete "$INSTDIR\dbsync.dll"
-    Delete "$INSTDIR\rsync.dll"
-    Delete "$INSTDIR\sysinfo.dll"
-    Delete "$INSTDIR\syscollector.dll"
-    Delete "$INSTDIR\queue\syscollector\db\local.db"
-    Delete "$INSTDIR\queue\syscollector\norm_config.json"
+    Delete "$INSTDIR\queue\syscollector\db\*"
+    Delete "$INSTDIR\queue\syscollector\*"
     Delete "$INSTDIR\ruleset\sca\*"
     Delete "$INSTDIR\ruleset\*"
 
@@ -527,6 +522,7 @@ Section "Uninstall"
     RMDir /r "$INSTDIR\queue\logcollector"
     RMDir "$INSTDIR\incoming"
     RMDir /r "$INSTDIR\upgrade"
+    RMDir /r "$INSTDIR\queue\syscollector"
 	RMDir "$INSTDIR\queue"
     RMDir "$INSTDIR\wodles"
     RMDir "$INSTDIR\ruleset\sca"

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -324,6 +324,9 @@
                     <Component Id="LIBWINPTHREAD_1.DLL" DiskId="1" Guid="C15C5883-00FB-41D7-B9E6-53C8BC30761F">
                         <File Id="LIBWINPTHREAD_1.DLL" Name="libwinpthread-1.dll" Source="libwinpthread-1.dll" />
                     </Component>
+                    <Component Id="LIBGCC_S_SJLJ_1.DLL" DiskId="1" Guid="27BDCB9A-F89F-4009-A789-1F779EB05697">
+                        <File Id="LIBGCC_S_SJLJ_1.DLL" Name="libgcc_s_sjlj-1.dll" Source="libgcc_s_sjlj-1.dll" />
+                    </Component>
                     <Component Id="MANAGE_AGENTS.EXE" DiskId="1" Guid="C15C5883-00FB-41D7-B7E6-53C8BC30761F">
                         <File Id="MANAGE_AGENTS.EXE" Name="manage_agents.exe" Source="manage_agents.exe" />
                     </Component>
@@ -367,6 +370,7 @@
                         <RemoveFile Id="NSIS_WIN32UI_EXE" Name="win32ui.exe" On="install" />
                         <RemoveFile Id="NSIS_AGENT_AUTH_EXE" Name="agent-auth.exe" On="install" />
                         <RemoveFile Id="NSIS_LIBWINPTHREAD_1_DLL" Name="libwinpthread-1.dll" On="install" />
+                        <RemoveFile Id="NSIS_LIBGCC_S_SJLJ_1.DLL" Name="libgcc_s_sjlj-1.dll" On="install" />
                         <RemoveFile Id="NSIS_MANAGE_AGENTS_EXE" Name="manage_agents.exe" On="install" />
                         <RemoveFile Id="NSIS_OSSEC_AGENT_EXE" Name="ossec-agent.exe" On="install" />
                         <RemoveFile Id="NSIS_OSSEC_AGENT_STATE" Name="ossec-agent.state" On="install" />
@@ -620,6 +624,7 @@
             <ComponentRef Id="INTERNAL_OPTIONS.CONF" />
             <ComponentRef Id="LICENSE.TXT" />
             <ComponentRef Id="LIBWINPTHREAD_1.DLL" />
+            <ComponentRef Id="LIBGCC_S_SJLJ_1.DLL" />
             <ComponentRef Id="MANAGE_AGENTS.EXE" />
             <ComponentRef Id="WAZUH_AGENT_EVENTCHANNEL.EXE" />
             <ComponentRef Id="WAZUH_AGENT.EXE" />


### PR DESCRIPTION
|Related issue|
|---|
|Closes #8822 |

## Description

The WazuhSvc stops after installing the 4.2 agent version because of an exception generated by the sysinfo.dll. The service runs just a moment and then it stops the execution because of this error.

![image](https://user-images.githubusercontent.com/22640902/119778468-f422db00-be9d-11eb-8685-1a80cea0fb9d.png)


The issue was reproduced in both Windows 8 x64 and Windows 8.1 x64 clean installations. It was also verified that the issue does not happen in Windows 10 x64. Attached you can find the logs of the agent installed on Windows 8.1.

## Tests
Plaftorms being tested:
- Windows XP
- Windows 7
- Windows 8/8.1
- Windows 10

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [X] Windows
  - [ ] MAC OS X
- [X] Source installation
- [X] Package installation
- [X] Source upgrade
- [X] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
