### PR TITLE
Let Analysisd create the PID file and the input socket before parsing the ruleset

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -503,6 +503,23 @@ int main_analysisd(int argc, char **argv)
         merror_exit(SETUID_ERROR, user, errno, strerror(errno));
     }
 
+    /* Verbose message */
+    mdebug1(PRIVSEP_MSG, home_path, user);
+    os_free(home_path);
+
+    /* Signal manipulation */
+    StartSIG(ARGV0);
+
+    /* Create the PID file */
+    if (CreatePID(ARGV0, getpid()) < 0) {
+        merror_exit(PID_ERROR);
+    }
+
+    /* Set the queue */
+    if ((m_queue = StartMQ(DEFAULTQUEUE, READ, 0)) < 0) {
+        merror_exit(QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
+    }
+
     Config.decoder_order_size = (size_t)getDefine_Int("analysisd", "decoder_order_size", MIN_ORDER_SIZE, MAX_DECODER_ORDER_SIZE);
 
     if (!os_analysisd_last_events) {
@@ -744,23 +761,6 @@ int main_analysisd(int argc, char **argv)
 
     if (Config.queue_size != 0) {
         minfo("The option <queue_size> is deprecated and won't apply. Set up each queue size in the internal_options file.");
-    }
-
-    /* Verbose message */
-    mdebug1(PRIVSEP_MSG, home_path, user);
-    os_free(home_path);
-
-    /* Signal manipulation */
-    StartSIG(ARGV0);
-
-    /* Create the PID file */
-    if (CreatePID(ARGV0, getpid()) < 0) {
-        merror_exit(PID_ERROR);
-    }
-
-    /* Set the queue */
-    if ((m_queue = StartMQ(DEFAULTQUEUE, READ, 0)) < 0) {
-        merror_exit(QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
     }
 
     /* Whitelist */


### PR DESCRIPTION
|Related issue|
|---|
|Closes #8719|

This PR aims to change the startup procedure of Analysisd. Particularly, we propose to move these steps:

- Set up signal handling (to exit cleanly).
- Create the PID file that `wazuh-control` uses to check whether the daemon is running.
- Listen to the input queue (create the `queue` socket) to let other modules connect quickly.

Those steps should happen after jailing the process (`chroot`) and dropping privileges, but before parsing the ruleset.

## Tests

- [X] Introduce a 10-second delay in the ruleset parsing and start the service.