### PR TITLE
Fix only_future_events option in GitHub module

### DIFF
--- a/src/config/wmodules-github.c
+++ b/src/config/wmodules-github.c
@@ -11,7 +11,6 @@
 #include "wazuh_modules/wmodules.h"
 
 static const char *XML_ENABLED = "enabled";
-static const char *XML_RUN_ON_START = "run_on_start";
 static const char *XML_INTERVAL = "interval";
 static const char *XML_TIME_DELAY = "time_delay";
 static const char *XML_ONLY_FUTURE_EVENTS = "only_future_events";
@@ -70,7 +69,6 @@ int wm_github_read(const OS_XML *xml, xml_node **nodes, wmodule *module) {
         module->tag = strdup(module->context->name);
         os_calloc(1, sizeof(wm_github), github_config);
         github_config->enabled =            WM_GITHUB_DEFAULT_ENABLED;
-        github_config->run_on_start =       WM_GITHUB_DEFAULT_RUN_ON_START;
         github_config->only_future_events = WM_GITHUB_DEFAULT_ONLY_FUTURE_EVENTS;
         github_config->interval =           WM_GITHUB_DEFAULT_INTERVAL;
         github_config->time_delay =         WM_GITHUB_DEFAULT_DELAY;
@@ -95,15 +93,6 @@ int wm_github_read(const OS_XML *xml, xml_node **nodes, wmodule *module) {
                 github_config->enabled = 0;
             else {
                 merror("Invalid content for tag '%s' at module '%s'.", XML_ENABLED, WM_GITHUB_CONTEXT.name);
-                return OS_INVALID;
-            }
-        } else if (!strcmp(nodes[i]->element, XML_RUN_ON_START)) {
-            if (!strcmp(nodes[i]->content, "yes"))
-                github_config->run_on_start = 1;
-            else if (!strcmp(nodes[i]->content, "no"))
-                github_config->run_on_start = 0;
-            else {
-                merror("Invalid content for tag '%s' at module '%s'.", XML_RUN_ON_START, WM_GITHUB_CONTEXT.name);
                 return OS_INVALID;
             }
         } else if (!strcmp(nodes[i]->element, XML_INTERVAL)) {

--- a/src/unit_tests/wazuh_modules/github/test_wm_github.c
+++ b/src/unit_tests/wazuh_modules/github/test_wm_github.c
@@ -100,7 +100,6 @@ void test_github_main_fail_StartMQ(void **state) {
 void test_github_main_enable(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     data->github_config->enabled = 1;
-    data->github_config->run_on_start = 1;
     data->github_config->interval = 2;
 
     expect_string(__wrap_StartMQ, path, DEFAULTQUEUE);
@@ -183,7 +182,7 @@ void test_github_get_next_page_complete(void **state) {
 
 void test_github_dump_no_options(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
-    char *test = "{\"github\":{\"enabled\":\"no\",\"run_on_start\":\"no\",\"only_future_events\":\"no\"}}";
+    char *test = "{\"github\":{\"enabled\":\"no\",\"only_future_events\":\"no\"}}";
 
     cJSON *root = wm_github_dump(data->github_config);
     data->root_c = cJSON_PrintUnformatted(root);
@@ -195,7 +194,6 @@ void test_github_dump_no_options(void **state) {
 void test_github_dump_yes_options(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     data->github_config->enabled = 1;
-    data->github_config->run_on_start = 1;
     data->github_config->only_future_events = 1;
     data->github_config->interval = 10;
     data->github_config->time_delay = 1;
@@ -204,7 +202,7 @@ void test_github_dump_yes_options(void **state) {
     os_strdup("test_org", data->github_config->auth->org_name);
     os_strdup("all", data->github_config->event_type);
 
-    char *test = "{\"github\":{\"enabled\":\"yes\",\"run_on_start\":\"yes\",\"only_future_events\":\"yes\",\"interval\":10,\"time_delay\":1,\"api_auth\":[{\"org_name\":\"test_org\",\"api_token\":\"test_token\"}],\"event_type\":\"all\"}}";
+    char *test = "{\"github\":{\"enabled\":\"yes\",\"only_future_events\":\"yes\",\"interval\":10,\"time_delay\":1,\"api_auth\":[{\"org_name\":\"test_org\",\"api_token\":\"test_token\"}],\"event_type\":\"all\"}}";
 
     cJSON *root = wm_github_dump(data->github_config);
     data->root_c = cJSON_PrintUnformatted(root);
@@ -310,7 +308,6 @@ void test_github_scan_failure_action_org_null(void **state) {
 void test_github_execute_scan(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     data->github_config->enabled = 1;
-    data->github_config->run_on_start = 1;
     data->github_config->only_future_events = 1;
     data->github_config->interval = 10;
     data->github_config->time_delay = 1;
@@ -331,33 +328,11 @@ void test_github_execute_scan(void **state) {
     expect_any(__wrap_wm_state_io, size);
     will_return(__wrap_wm_state_io, 1);
 
-    will_return(__wrap_localtime_r, 1);
-
-    will_return(__wrap_strftime,"2021-05-07 12:24:56");
-    will_return(__wrap_strftime, 20);
-
-    will_return(__wrap_localtime_r, 1);
-
-    will_return(__wrap_strftime,"2021-05-07 12:34:56");
-    will_return(__wrap_strftime, 20);
-
     expect_string(__wrap_wm_state_io, tag, "github-test_org");
     expect_value(__wrap_wm_state_io, op, WM_IO_WRITE);
     expect_any(__wrap_wm_state_io, state);
     expect_any(__wrap_wm_state_io, size);
     will_return(__wrap_wm_state_io, 1);
-
-    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
-    expect_any(__wrap__mtdebug1, formatted_msg);
-
-    expect_string(__wrap_wm_state_io, tag, "github-test_org");
-    expect_value(__wrap_wm_state_io, op, WM_IO_WRITE);
-    expect_any(__wrap_wm_state_io, state);
-    expect_any(__wrap_wm_state_io, size);
-    will_return(__wrap_wm_state_io, 1);
-
-    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
-    expect_string(__wrap__mtdebug1, formatted_msg, "No record for this organization: 'test_org'");
 
     wm_github_execute_scan(data->github_config, initial_scan);
 }
@@ -374,7 +349,6 @@ void test_github_execute_scan_current_null(void **state) {
 void test_github_execute_scan_no_initial_scan(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     data->github_config->enabled = 1;
-    data->github_config->run_on_start = 1;
     data->github_config->only_future_events = 1;
     data->github_config->interval = 10;
     data->github_config->time_delay = 1;
@@ -427,7 +401,6 @@ void test_github_execute_scan_no_initial_scan(void **state) {
 void test_github_execute_scan_status_code_200(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     data->github_config->enabled = 1;
-    data->github_config->run_on_start = 1;
     data->github_config->only_future_events = 1;
     data->github_config->interval = 10;
     data->github_config->time_delay = 1;
@@ -483,7 +456,6 @@ void test_github_execute_scan_status_code_200(void **state) {
 void test_github_execute_scan_status_code_200_null(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     data->github_config->enabled = 1;
-    data->github_config->run_on_start = 1;
     data->github_config->only_future_events = 1;
     data->github_config->interval = 10;
     data->github_config->time_delay = 1;
@@ -588,7 +560,6 @@ static int teardown_test_read(void **state) {
 void test_read_configuration(void **state) {
     const char *string =
         "<enabled>no</enabled>\n"
-        "<run_on_start>yes</run_on_start>\n"
         "<interval>10m</interval>\n"
         "<time_delay>1s</time_delay>"
         "<only_future_events>no</only_future_events>"
@@ -605,7 +576,6 @@ void test_read_configuration(void **state) {
     assert_int_equal(wm_github_read(&(test->xml), test->nodes, test->module),0);
     wm_github *module_data = (wm_github*)test->module->data;
     assert_int_equal(module_data->enabled, 0);
-    assert_int_equal(module_data->run_on_start, 1);
     assert_int_equal(module_data->interval, 600);
     assert_int_equal(module_data->time_delay, 1);
     assert_int_equal(module_data->only_future_events, 0);
@@ -617,7 +587,6 @@ void test_read_configuration(void **state) {
 void test_read_configuration_1(void **state) {
     const char *string =
         "<enabled>no</enabled>\n"
-        "<run_on_start>yes</run_on_start>\n"
         "<interval>10m</interval>\n"
         "<time_delay>1s</time_delay>"
         "<only_future_events>no</only_future_events>"
@@ -638,7 +607,6 @@ void test_read_configuration_1(void **state) {
     assert_int_equal(wm_github_read(&(test->xml), test->nodes, test->module),0);
     wm_github *module_data = (wm_github*)test->module->data;
     assert_int_equal(module_data->enabled, 0);
-    assert_int_equal(module_data->run_on_start, 1);
     assert_int_equal(module_data->interval, 600);
     assert_int_equal(module_data->time_delay, 1);
     assert_int_equal(module_data->only_future_events, 0);
@@ -661,7 +629,6 @@ void test_read_default_configuration(void **state) {
     assert_int_equal(wm_github_read(&(test->xml), test->nodes, test->module),0);
     wm_github *module_data = (wm_github*)test->module->data;
     assert_int_equal(module_data->enabled, 1);
-    assert_int_equal(module_data->run_on_start, 1);
     assert_int_equal(module_data->interval, 600);
     assert_int_equal(module_data->time_delay, 1);
     assert_int_equal(module_data->only_future_events, 1);
@@ -673,7 +640,6 @@ void test_read_default_configuration(void **state) {
 void test_read_interval(void **state) {
     const char *string =
         "<enabled>yes</enabled>\n"
-        "<run_on_start>yes</run_on_start>\n"
         "<interval>10</interval>\n"
         "<time_delay>10</time_delay>"
         "<only_future_events>no</only_future_events>"
@@ -695,7 +661,6 @@ void test_read_interval(void **state) {
 void test_read_interval_s(void **state) {
     const char *string =
         "<enabled>no</enabled>\n"
-        "<run_on_start>yes</run_on_start>\n"
         "<interval>50s</interval>\n"
         "<time_delay>10</time_delay>"
         "<only_future_events>no</only_future_events>"
@@ -717,7 +682,6 @@ void test_read_interval_s(void **state) {
 void test_read_interval_m(void **state) {
     const char *string =
         "<enabled>no</enabled>\n"
-        "<run_on_start>yes</run_on_start>\n"
         "<interval>1m</interval>\n"
         "<time_delay>10</time_delay>"
         "<only_future_events>no</only_future_events>"
@@ -739,7 +703,6 @@ void test_read_interval_m(void **state) {
 void test_read_interval_h(void **state) {
     const char *string =
         "<enabled>no</enabled>\n"
-        "<run_on_start>yes</run_on_start>\n"
         "<interval>2h</interval>\n"
         "<time_delay>10</time_delay>"
         "<only_future_events>no</only_future_events>"
@@ -761,7 +724,6 @@ void test_read_interval_h(void **state) {
 void test_read_interval_d(void **state) {
     const char *string =
         "<enabled>no</enabled>\n"
-        "<run_on_start>yes</run_on_start>\n"
         "<interval>3d</interval>\n"
         "<time_delay>10</time_delay>"
         "<only_future_events>no</only_future_events>"
@@ -783,7 +745,6 @@ void test_read_interval_d(void **state) {
 void test_repeatd_tag(void **state) {
     const char *string =
         "<enabled>no</enabled>\n"
-        "<run_on_start>yes</run_on_start>\n"
         "<interval>10m</interval>\n"
         "<time_delay>1s</time_delay>"
         "<only_future_events>no</only_future_events>"
@@ -803,7 +764,6 @@ void test_repeatd_tag(void **state) {
     assert_int_equal(wm_github_read(&(test->xml), test->nodes, test->module),0);
     wm_github *module_data = (wm_github*)test->module->data;
     assert_int_equal(module_data->enabled, 0);
-    assert_int_equal(module_data->run_on_start, 1);
     assert_int_equal(module_data->interval, 600);
     assert_int_equal(module_data->time_delay, 1);
     assert_int_equal(module_data->only_future_events, 0);
@@ -815,7 +775,6 @@ void test_repeatd_tag(void **state) {
 void test_fake_tag(void **state) {
     const char *string =
         "<enabled>no</enabled>\n"
-        "<run_on_start>yes</run_on_start>\n"
         "<interval>10m</interval>\n"
         "<time_delay>1s</time_delay>"
         "<only_future_events>no</only_future_events>"
@@ -834,31 +793,9 @@ void test_fake_tag(void **state) {
     assert_int_equal(wm_github_read(&(test->xml), test->nodes, test->module),-1);
 }
 
-void test_invalid_content_1(void **state) {
-    const char *string =
-        "<enabled>no</enabled>\n"
-        "<run_on_start>invalid</run_on_start>\n"
-        "<interval>10m</interval>\n"
-        "<time_delay>1s</time_delay>"
-        "<only_future_events>no</only_future_events>"
-        "<api_auth>"
-            "<org_name>Wazuh</org_name>"
-            "<api_token>Wazuh_token</api_token>"
-        "</api_auth>"
-        "<api_parameters>"
-            "<event_type>all</event_type>"
-        "</api_parameters>"
-    ;
-    test_structure *test = *state;
-    expect_string(__wrap__merror, formatted_msg, "Invalid content for tag 'run_on_start' at module 'github'.");
-    test->nodes = string_to_xml_node(string, &(test->xml));
-    assert_int_equal(wm_github_read(&(test->xml), test->nodes, test->module),-1);
-}
-
 void test_invalid_content_2(void **state) {
     const char *string =
         "<enabled>no</enabled>\n"
-        "<run_on_start>no</run_on_start>\n"
         "<interval>10m</interval>\n"
         "<time_delay>1s</time_delay>"
         "<only_future_events>yes</only_future_events>"
@@ -879,7 +816,6 @@ void test_invalid_content_2(void **state) {
 void test_invalid_content_3(void **state) {
     const char *string =
         "<enabled>no</enabled>\n"
-        "<run_on_start>no</run_on_start>\n"
         "<interval>10m</interval>\n"
         "<time_delay>1s</time_delay>"
         "<only_future_events>invalid</only_future_events>"
@@ -900,7 +836,6 @@ void test_invalid_content_3(void **state) {
 void test_invalid_content_4(void **state) {
     const char *string =
         "<enabled>invalid</enabled>\n"
-        "<run_on_start>no</run_on_start>\n"
         "<interval>10m</interval>\n"
         "<time_delay>1s</time_delay>"
         "<only_future_events>yes</only_future_events>"
@@ -921,7 +856,6 @@ void test_invalid_content_4(void **state) {
 void test_invalid_content_5(void **state) {
     const char *string =
         "<enabled>no</enabled>\n"
-        "<run_on_start>no</run_on_start>\n"
         "<interval>invalid</interval>\n"
         "<time_delay>1s</time_delay>"
         "<only_future_events>yes</only_future_events>"
@@ -942,7 +876,6 @@ void test_invalid_content_5(void **state) {
 void test_invalid_time_delay_1(void **state) {
     const char *string =
         "<enabled>no</enabled>\n"
-        "<run_on_start>no</run_on_start>\n"
         "<interval>10m</interval>\n"
         "<time_delay>-1</time_delay>"
         "<only_future_events>no</only_future_events>"
@@ -963,7 +896,6 @@ void test_invalid_time_delay_1(void **state) {
 void test_invalid_time_delay_2(void **state) {
     const char *string =
         "<enabled>no</enabled>\n"
-        "<run_on_start>no</run_on_start>\n"
         "<interval>10m</interval>\n"
         "<time_delay>1y</time_delay>"
         "<only_future_events>no</only_future_events>"
@@ -984,7 +916,6 @@ void test_invalid_time_delay_2(void **state) {
 void test_error_api_auth(void **state) {
     const char *string =
         "<enabled>no</enabled>\n"
-        "<run_on_start>no</run_on_start>\n"
         "<interval>10m</interval>\n"
         "<time_delay>1</time_delay>"
         "<only_future_events>no</only_future_events>"
@@ -1001,7 +932,6 @@ void test_error_api_auth(void **state) {
 void test_error_api_auth_1(void **state) {
     const char *string =
         "<enabled>no</enabled>\n"
-        "<run_on_start>no</run_on_start>\n"
         "<interval>10m</interval>\n"
         "<time_delay>1</time_delay>"
         "<only_future_events>no</only_future_events>"
@@ -1022,7 +952,6 @@ void test_error_api_auth_1(void **state) {
 void test_error_org_name(void **state) {
     const char *string =
         "<enabled>no</enabled>\n"
-        "<run_on_start>no</run_on_start>\n"
         "<interval>10m</interval>\n"
         "<time_delay>1</time_delay>"
         "<only_future_events>no</only_future_events>"
@@ -1043,7 +972,6 @@ void test_error_org_name(void **state) {
 void test_error_org_name_1(void **state) {
     const char *string =
         "<enabled>no</enabled>\n"
-        "<run_on_start>no</run_on_start>\n"
         "<interval>10m</interval>\n"
         "<time_delay>1</time_delay>"
         "<only_future_events>no</only_future_events>"
@@ -1063,7 +991,6 @@ void test_error_org_name_1(void **state) {
 void test_error_api_token(void **state) {
     const char *string =
         "<enabled>no</enabled>\n"
-        "<run_on_start>no</run_on_start>\n"
         "<interval>10m</interval>\n"
         "<time_delay>1s</time_delay>"
         "<only_future_events>no</only_future_events>"
@@ -1084,7 +1011,6 @@ void test_error_api_token(void **state) {
 void test_error_api_token_1(void **state) {
     const char *string =
         "<enabled>no</enabled>\n"
-        "<run_on_start>no</run_on_start>\n"
         "<interval>10m</interval>\n"
         "<time_delay>1s</time_delay>"
         "<only_future_events>no</only_future_events>"
@@ -1104,7 +1030,6 @@ void test_error_api_token_1(void **state) {
 void test_error_event_type_1(void **state) {
     const char *string =
         "<enabled>no</enabled>\n"
-        "<run_on_start>no</run_on_start>\n"
         "<interval>10m</interval>\n"
         "<time_delay>1s</time_delay>"
         "<only_future_events>no</only_future_events>"
@@ -1155,7 +1080,6 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_read_interval_d, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_repeatd_tag, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_fake_tag, setup_test_read, teardown_test_read),
-        cmocka_unit_test_setup_teardown(test_invalid_content_1, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_invalid_content_2, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_invalid_content_3, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_invalid_content_4, setup_test_read, teardown_test_read),

--- a/src/wazuh_modules/wm_github.c
+++ b/src/wazuh_modules/wm_github.c
@@ -54,10 +54,8 @@ void * wm_github_main(wm_github* github_config) {
         }
 #endif
 
-        if (github_config->run_on_start) {
-            // Execute initial scan
-            wm_github_execute_scan(github_config, 1);
-        }
+        // Execute initial scan
+        wm_github_execute_scan(github_config, 1);
 
         while (1) {
             sleep(github_config->interval);
@@ -126,11 +124,6 @@ cJSON *wm_github_dump(const wm_github* github_config) {
     } else {
         cJSON_AddStringToObject(wm_info, "enabled", "no");
     }
-    if (github_config->run_on_start) {
-        cJSON_AddStringToObject(wm_info, "run_on_start", "yes");
-    } else {
-        cJSON_AddStringToObject(wm_info, "run_on_start", "no");
-    }
     if (github_config->only_future_events) {
         cJSON_AddStringToObject(wm_info, "only_future_events", "yes");
     } else {
@@ -196,34 +189,37 @@ STATIC int wm_github_execute_scan(wm_github *github_config, int initial_scan) {
         memset(org_state_name, '\0', OS_SIZE_1024);
         snprintf(org_state_name, OS_SIZE_1024 -1, "%s-%s", WM_GITHUB_CONTEXT.name, current->org_name);
 
+        memset(&org_state_struc, 0, sizeof(org_state_struc));
+
         // Load state for organization
         if (wm_state_io(org_state_name, WM_IO_READ, &org_state_struc, sizeof(org_state_struc)) < 0) {
             memset(&org_state_struc, 0, sizeof(org_state_struc));
-            org_state_struc.last_log_time = 0;
+        }
+
+        new_scan_time = time(0) - github_config->time_delay;
+
+        if (initial_scan && (!org_state_struc.last_log_time || github_config->only_future_events)) {
+            org_state_struc.last_log_time = new_scan_time;
+            if (wm_state_io(org_state_name, WM_IO_WRITE, &org_state_struc, sizeof(org_state_struc)) < 0) {
+                mterror(WM_GITHUB_LOGTAG, "Couldn't save running state.");
+            }
+            current = next;
+            continue;
         }
 
         last_scan_time = (time_t)org_state_struc.last_log_time + 1;
+
         char last_scan_time_str[80];
         memset(last_scan_time_str, '\0', 80);
         struct tm tm_last_scan = { .tm_sec = 0 };
         localtime_r(&last_scan_time, &tm_last_scan);
         strftime(last_scan_time_str, sizeof(last_scan_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_last_scan);
 
-        new_scan_time = time(0) - github_config->time_delay;
         char new_scan_time_str[80];
         memset(new_scan_time_str, '\0', 80);
         struct tm tm_new_scan = { .tm_sec = 0 };
         localtime_r(&new_scan_time, &tm_new_scan);
         strftime(new_scan_time_str, sizeof(new_scan_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_new_scan);
-
-        if (initial_scan && github_config->only_future_events) {
-            org_state_struc.last_log_time = new_scan_time;
-            if (wm_state_io(org_state_name, WM_IO_WRITE, &org_state_struc, sizeof(org_state_struc)) < 0) {
-                mterror(WM_GITHUB_LOGTAG, "Couldn't save running state.");
-            }
-            scan_finished = 1;
-            fail = 0;
-        }
 
         memset(url, '\0', OS_SIZE_8192);
         snprintf(url, OS_SIZE_8192 -1, GITHUB_API_URL, current->org_name, last_scan_time_str, new_scan_time_str, github_config->event_type, ITEM_PER_PAGE);

--- a/src/wazuh_modules/wm_github.h
+++ b/src/wazuh_modules/wm_github.h
@@ -15,7 +15,6 @@
 #define WM_GITHUB_LOGTAG ARGV0 ":" GITHUB_WM_NAME
 
 #define WM_GITHUB_DEFAULT_ENABLED 1
-#define WM_GITHUB_DEFAULT_RUN_ON_START 1
 #define WM_GITHUB_DEFAULT_ONLY_FUTURE_EVENTS 1
 #define WM_GITHUB_DEFAULT_INTERVAL 600
 #define WM_GITHUB_DEFAULT_DELAY 1
@@ -45,7 +44,6 @@ typedef struct wm_github_fail {
 
 typedef struct wm_github {
     int enabled;
-    int run_on_start;
     int only_future_events;
     time_t interval;                        // Interval betweeen events in seconds
     time_t time_delay;


### PR DESCRIPTION
## Description

This PR attempt to fix the way that `only_future_events` works in GitHub module.

- If Wazuh starts and there is no bookmark saved (first time), nothing is scanned (regardless of the value of `only_future_events`) and the bookmark is saved to now.
- If Wazuh starts and there is a bookmark saved:
  - If `only_future_events` is set to yes, nothing is scanned and the bookmark is updated to now.
  - If `only_future_events` is set to no, events are searched from the bookmark to now and the bookmark is updated to now.

Also, due to the behavior of `only_future_events`, the `run_on_start` option does not make sense so it was removed.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)