### PR TITLE
Fix data provider issues in WSL ubuntu

### DIFF
--- a/src/data_provider/src/network/networkLinuxWrapper.h
+++ b/src/data_provider/src/network/networkLinuxWrapper.h
@@ -408,14 +408,13 @@ public:
 
     uint32_t mtu() const override
     {
-        std::string retVal;
-        const auto name { this->name() };
-        if (!name.empty())
+        uint32_t retVal { 0 };
+        const auto mtuFileContent { Utils::getFileContent(std::string(WM_SYS_IFDATA_DIR) + this->name() + "/mtu") };
+        if (!mtuFileContent.empty())
         {
-            const auto mtuFileContent { Utils::getFileContent(std::string(WM_SYS_IFDATA_DIR) + name + "/mtu") };
-            retVal = Utils::splitIndex(mtuFileContent, '\n', 0);
+            retVal =  std::stol(Utils::splitIndex(mtuFileContent, '\n', 0));
         }
-        return std::stol(retVal);
+        return retVal;
     }
 
     LinkStats stats() const override
@@ -426,20 +425,36 @@ public:
     std::string type() const override
     {
         const auto networkTypeCode { Utils::getFileContent(std::string(WM_SYS_IFDATA_DIR) + this->name() + "/type") };
-        const auto type { Utils::NetworkHelper::getNetworkTypeStringCode(std::stoi(networkTypeCode), NETWORK_INTERFACE_TYPE) };
-        return type.empty() ? UNKNOWN_VALUE : type;
+        std::string type { UNKNOWN_VALUE };
+        if (!networkTypeCode.empty())
+        {
+            type = Utils::NetworkHelper::getNetworkTypeStringCode(std::stoi(networkTypeCode), NETWORK_INTERFACE_TYPE);
+        }
+        return type;
     }
 
     std::string state() const override
     {
-        const auto operationalState { Utils::getFileContent(std::string(WM_SYS_IFDATA_DIR) + this->name() + "/operstate") };
-        return Utils::splitIndex(operationalState, '\n', 0);
+        const std::string operationalState { Utils::getFileContent(std::string(WM_SYS_IFDATA_DIR) + this->name() + "/operstate") };
+
+        std::string state { UNKNOWN_VALUE };
+        if (!operationalState.empty())
+        {
+             state = Utils::splitIndex(operationalState, '\n', 0);
+        }
+        return state;
     }
 
     std::string MAC() const override
     {
-        const auto mac { Utils::getFileContent(std::string(WM_SYS_IFDATA_DIR) + this->name() + "/address")};
-        return Utils::splitIndex(mac, '\n', 0);
+        const std::string macContent { Utils::getFileContent(std::string(WM_SYS_IFDATA_DIR) + this->name() + "/address")};
+
+        std::string mac { UNKNOWN_VALUE };
+        if (!macContent.empty())
+        {
+            mac = Utils::splitIndex(macContent, '\n', 0);
+        }
+        return mac;
     }
 };
 

--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -187,19 +187,19 @@ void SysInfo::getMemory(nlohmann::json& info) const
     std::map<std::string, std::string> systemInfo;
     getSystemInfo(WM_SYS_MEM_DIR, ":", systemInfo);
 
-    auto memTotal{ 1 };
-    auto memFree{ 0 };
+    auto memTotal{ 1ull };
+    auto memFree{ 0ull };
 
     const auto& itTotal { systemInfo.find("MemTotal") };
     if (itTotal != systemInfo.end())
     {
-        memTotal = std::stoi(itTotal->second);
+        memTotal = std::stoull(itTotal->second);
     }
 
     const auto& itFree { systemInfo.find("MemFree") };
     if (itFree != systemInfo.end())
     {
-        memFree = std::stoi(itFree->second);
+        memFree = std::stoull(itFree->second);
     }
 
     const auto ramTotal { memTotal == 0 ? 1 : memTotal };


### PR DESCRIPTION
|Related issue|
|---|
|Closes #8837 |

## Description
![imagen](https://user-images.githubusercontent.com/14300208/119931680-327cd080-bf58-11eb-8950-e574d724ad94.png)


Requirement to reproduce: host machine almost unused and 32gb of ram.

Steps to reproduce: 
- Install ubuntu 20.04 in windows machine with WSL.
- Install manager 4.2.
- Start wazuh manager.


Expected: No Error during hwinfo save.
Actual: Error during hwinfo save.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
