### PR TITLE
Increase API limit param to 100000 items

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -3923,13 +3923,13 @@ components:
     limit:
       in: query
       name: limit
-      description: "Maximum number of elements to return"
+      description: "Maximum number of elements to return. Although up to 100.000 can be specified, it is recommended not to exceed 500 elements. Responses may be slower the more this number is exceeded. "
       schema:
         type: integer
         format: int32
         default: 500
         minimum: 1
-        maximum: 500
+        maximum: 100000
     list_filename_path:
       in: path
       name: filename

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -3930,6 +3930,16 @@ components:
         default: 500
         minimum: 1
         maximum: 100000
+    log_lines:
+      in: query
+      name: limit
+      description: "Maximum number of lines to return."
+      schema:
+        type: integer
+        format: int32
+        default: 500
+        minimum: 1
+        maximum: 500
     list_filename_path:
       in: path
       name: filename
@@ -8782,7 +8792,7 @@ paths:
         - $ref: '#/components/parameters/wait_for_complete'
         - $ref: '#/components/parameters/node_id'
         - $ref: '#/components/parameters/offset'
-        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/log_lines'
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/tag'
@@ -10203,7 +10213,7 @@ paths:
         - $ref: '#/components/parameters/pretty'
         - $ref: '#/components/parameters/wait_for_complete'
         - $ref: '#/components/parameters/offset'
-        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/log_lines'
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/tag'

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -152,12 +152,12 @@ stages:
       json:
         <<: *error_spec
 
-  - name: Try to show agents with limit 9999
+  - name: Try to show agents with limit 999999
     request:
       verify: False
       <<: *get_agents
       params:
-        limit: 9999
+        limit: 999999
     response:
       status_code: 400
 
@@ -2168,12 +2168,12 @@ stages:
       json:
         <<: *error_spec
 
-  - name: Try show groups with limit 9999
+  - name: Try show groups with limit 999999
     request:
       verify: False
       <<: *get_agents_groups
       params:
-        limit: 9999
+        limit: 999999
     response:
       status_code: 400
 
@@ -2407,12 +2407,12 @@ stages:
       json:
         <<: *error_spec
 
-  - name: Try show agents with limit 9999
+  - name: Try show agents with limit 999999
     request:
       verify: False
       <<: *groups_id_request
       params:
-        limit: 9999
+        limit: 999999
     response:
       status_code: 400
 
@@ -2855,12 +2855,12 @@ stages:
       json:
         <<: *error_spec
 
-  - name: Try show agents with limit 9999
+  - name: Try show agents with limit 999999
     request:
       verify: False
       <<: *groups_id_config_request
       params:
-        limit: 9999
+        limit: 999999
     response:
       status_code: 400
 
@@ -2976,12 +2976,12 @@ stages:
       json:
         <<: *error_spec
 
-  - name: Try get the files of a group with limit 9999
+  - name: Try get the files of a group with limit 999999
     request:
       verify: False
       <<: *groups_id_files_request
       params:
-        limit: 9999
+        limit: 999999
     response:
       status_code: 400
 
@@ -3399,12 +3399,12 @@ stages:
       json:
         <<: *error_spec
 
-  - name: Try show agents with limit 9999
+  - name: Try show agents with limit 999999
     request:
       verify: False
       <<: *no_group_request
       params:
-        limit: 9999
+        limit: 999999
     response:
       status_code: 400
 
@@ -3649,12 +3649,12 @@ stages:
       json:
         <<: *error_spec
 
-  - name: Try show agents with limit 9999
+  - name: Try show agents with limit 999999
     request:
       verify: False
       <<: *agents_outdated_request
       params:
-        limit: 9999
+        limit: 999999
     response:
       status_code: 400
 
@@ -3926,12 +3926,12 @@ stages:
       json:
         <<: *error_spec
 
-  - name: Try show agents with limit 9999
+  - name: Try show agents with limit 999999
     request:
       verify: False
       <<: *distinct_request
       params:
-        limit: 9999
+        limit: 999999
     response:
       status_code: 400
 

--- a/api/test/integration/test_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_sca_endpoints.tavern.yaml
@@ -117,7 +117,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Parameters -> limit=2500
+  - name: Parameters -> limit=999999
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/sca/001"
@@ -125,7 +125,7 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
-        limit: 2500
+        limit: 999999
     response:
       status_code: 400
 
@@ -347,7 +347,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Parameters -> limit=2500
+  - name: Parameters -> limit=999999
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/sca/006"
@@ -355,7 +355,7 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
-        limit: 2500
+        limit: 999999
     response:
       status_code: 400
 
@@ -657,7 +657,7 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Parameters -> limit=2500
+  - name: Parameters -> limit=999999
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
@@ -665,7 +665,7 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
-        limit: 2500
+        limit: 999999
     response:
       status_code: 400
 
@@ -1110,7 +1110,7 @@ stages:
           failed_items: []
           total_failed_items: 0
 
-  - name: Parameters -> limit=2500
+  - name: Parameters -> limit=999999
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
@@ -1118,7 +1118,7 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
-        limit: 2500
+        limit: 999999
     response:
       status_code: 400
 

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -179,7 +179,7 @@ agent_info_sleep = 2  # Seconds between retries
 
 # Common variables
 database_limit = 500
-maximum_database_limit = 1000
+maximum_database_limit = 100000
 limit_seconds = 1800  # 600*3
 
 _ossec_uid = None

--- a/framework/wazuh/core/sca.py
+++ b/framework/wazuh/core/sca.py
@@ -6,7 +6,7 @@ import re
 from datetime import datetime
 
 from wazuh.core.agent import Agent
-from wazuh.core.common import database_limit
+from wazuh.core.common import maximum_database_limit
 from wazuh.core.exception import WazuhError
 from wazuh.core.utils import WazuhDBQuery, WazuhDBBackend
 
@@ -115,7 +115,7 @@ class WazuhDBQuerySCACheck(WazuhDBQuerySCA):
 
     def _add_limit_to_query(self):
         if self.limit:
-            if self.limit > database_limit:
+            if self.limit > maximum_database_limit:
                 raise WazuhError(1405, str(self.limit))
 
             # We add offset and limit only to the inner SELECT (subquery)

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -65,7 +65,7 @@ def ossec_log(level=None, tag=None, offset=0, limit=common.database_limit, sort_
                                       none_msg=f"Could not read logs"
                                                f"{' in specified node' if node_id != 'manager' else ''}"
                                       )
-    logs = get_ossec_logs(limit=limit)
+    logs = get_ossec_logs()
 
     query = []
     level and query.append(f'level={level}')

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -65,7 +65,7 @@ def ossec_log(level=None, tag=None, offset=0, limit=common.database_limit, sort_
                                       none_msg=f"Could not read logs"
                                                f"{' in specified node' if node_id != 'manager' else ''}"
                                       )
-    logs = get_ossec_logs()
+    logs = get_ossec_logs(limit=limit)
 
     query = []
     level and query.append(f'level={level}')

--- a/framework/wazuh/mitre.py
+++ b/framework/wazuh/mitre.py
@@ -7,7 +7,7 @@ from typing import Dict
 
 import more_itertools
 
-from wazuh.core.common import database_limit
+from wazuh.core.common import maximum_database_limit
 from wazuh.core.exception import WazuhError
 from wazuh.core.results import AffectedItemsWazuhResult
 from wazuh.core.utils import WazuhDBBackend, WazuhDBQuery, sort_array
@@ -58,7 +58,7 @@ class WazuhDBQueryMitre(WazuhDBQuery):
 
     def _add_limit_to_query(self):
         if self.limit:
-            if self.limit > database_limit:
+            if self.limit > maximum_database_limit:
                 raise WazuhError(1405, str(self.limit))
 
             # We add offset and limit only to the inner SELECT (subquery)

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -1242,6 +1242,9 @@ def test_agent_get_full_overview(socket_mock, send_mock, get_mock, summary_mock,
 def insert_agents_db(n_agents=100000):
     """Insert n_agents in the global.db test database.
 
+    All the tests using this fixture should be run in the last place, since
+    agent's database is modified.
+
     Parameters
     ----------
     n_agents : int
@@ -1266,10 +1269,7 @@ def insert_agents_db(n_agents=100000):
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
 def test_get_agents_big_env(mock_conn, mock_send, mock_get_agents, insert_agents_db, agent_list, params, expected_ids):
-    """Check that expected number of items is returned when limit is bigger than 500.
-
-    Tests that use 'insert_agents_db' should be run in the last place, since
-    agent's database is modified.
+    """Check that the expected number of items is returned when limit is greater than 500.
 
     Parameters
     ----------


### PR DESCRIPTION
|Related issue|
|---|
| Closes #8798 |

## Description

Hello team,

This PR increases the maximum number that can be specified inside the `limit` API param. Although the recommendation is still to use `limit=500` since it is the value that is most tested, it is now possible to obtain up to 100k items in a single request. This can help reduce waiting times in certain cases. 

For example, to obtain 40k agents, until now it was necessary to make 80 requests of 500 items and join all the results. For each of these requests, it is necessary to recalculate the RBAC permissions, redo the queries to DB, etc. All this overhead is avoided with a single request. Although the waiting time can be long for this single request, it is less than the sum of the previous 80 requests. 

## Results
We have created an environment with 100,000 active agents like the following: 
```JSON
{
    "os": {
        "arch": "test",
        "build": "7601",
        "codename": "test",
        "major": "6",
        "minor": "1",
        "name": "Microsoft Windows 7 Ultimate Edition Professional Service Pack 1",
        "platform": "windows",
        "uname": "Microsoft Windows 7 Ultimate Edition Professional Service Pack 1",
        "version": "6.1.7601"
    },
    "group": [
        "default",
        "test_group0",
        "test_group1",
        "test_group2",
        "test_group3"
    ],
    "dateAdd": "2021-05-25T06:4A9:45Z",
    "lastKeepAlive": "2021-05-25T09:38:21Z",
    "version": "Wazuh v4.0.2",
    "name": "new_agent_3",
    "node_name": "master-node",
    "manager": "wazuh-master",
    "ip": "any",
    "id": "003",
    "configSum": "bc0a416e9d7d4afdc71e0c5f27fb11c",
    "mergedSum": "b1999567779f39f3336a9baf730c0f5b",
    "status": "disconnected",
    "registerIP": "any"
}
```

This amounts to a total of 68.93 MB when fetching all the agents. However, if we compare the response times when obtaining them in 1 request with `limit=100000` or in 200 requests with `limit=500`, we see that there is a 66.19% decrease in the response time. 

| Limit | N requests | Total time (s) | Average | Median | Max | Min | 
|--|--|--|--|--|--|--|
| **100000** | **1** | 44.531 | 44.5 | 44.5 | 44.5 | 44.5 | 
| **500** | **200** | 131.725 | 0.659 | 0.663 | 0.992 | 0.464 |

However, and as explained in https://github.com/wazuh/wazuh/issues/8766#issuecomment-848559682, in cases where a higher speed is required to obtain the data and it is possible to use the parameters `q` and `sort`, the queries can be divided into smaller portions that use the filter `q=id>last_received_id`.  

This is the most efficient way to get information from SQLite, and waiting time could decrease 43.71% if compared with the previous improvement (44.531s), and a decrease of 80.97% if compared with the current Wazuh limit (500)
 
| Limit | N requests | Using filter q? | Total time (s) | Average | Median | Max | Min | 
|--|--|--|--|--|--|--|--|
| **100000** | **1** | No | 44.531 | 44.5 | 44.5 | 44.5 | 44.5 | 
| **25000** | **4** | No | 48.078 | 12.0 | 12.0 | 17.7 | 6.33 |
| **25000** | **4** | Yes | 25.067 | 6.27 | 6.29 | 6.33 | 6.16 |

![25000_limit](https://user-images.githubusercontent.com/23361101/119971562-6afcc880-bfb1-11eb-83f4-28bfe5d2f29b.png)

Here is a script that can be used to get up to 100.000 agents using the `q` parameter, as an example: [paginate_api.zip](https://github.com/wazuh/wazuh/files/6560299/paginate_api.zip)

## Things to consider

Since API can now retrieve much more data in a single request, longer response times can be achieved, leading to API timeout erros. Please take a look at this https://github.com/wazuh/wazuh/issues/8798#issuecomment-850385530 to know what to watch out for and how to fix these problems. 

## Discarded

Although #8798 talks about reducing the `request_slice` in certain cases to obtain better response times, this solution will be placed in a new issue in the future since it has some disadvantages that must be carefully studied. 

For instance, if the agent information is smaller than expected (for example when using the `select` or `q` fields), the information could be obtained much faster if `request_slice` has its original size of 500 items or even more. Therefore, it will be proposed to modify it so that it dynamically adapts its size to the information obtained from the DB. 

Regards,
Selu.