### PR TITLE
Remove calculate_status framework function and unittest test case

### DIFF
--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -84,6 +84,25 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
+  - name: Get all agents sorted by status
+    request:
+      verify: False
+      <<: *get_agents
+      params:
+        sort: status
+    response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "status"
+      status_code: 200
+      json:
+        error: 0
+        data:
+          failed_items: [ ]
+          total_affected_items: 13
+          total_failed_items: 0
+
   - name: Pagination with offset 0 and limit 2
     request:
       verify: False

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -252,9 +252,14 @@ stages:
         select: 'os.platform'
         limit: 2
     response:
+      verify_response_with:
+        # Check response item keys are the selected keys
+        function: tavern_utils:test_select_key_affected_items
+        extra_kwargs:
+          select_key: 'os.platform'
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '000'
@@ -276,9 +281,14 @@ stages:
         limit: 2
         offset: 1
     response:
+      verify_response_with:
+        # Check response item keys are the selected keys
+        function: tavern_utils:test_select_key_affected_items
+        extra_kwargs:
+          select_key: 'dateAdd,mergedSum'
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '001'
@@ -973,9 +983,14 @@ stages:
         select: 'os.platform'
         agents_list: '000'
     response:
+      verify_response_with:
+        # Check response item keys are the selected keys
+        function: tavern_utils:test_select_key_affected_items
+        extra_kwargs:
+          select_key: 'os.platform'
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '000'
@@ -994,9 +1009,14 @@ stages:
         select: 'dateAdd,status'
         agents_list: '000'
     response:
+      verify_response_with:
+        # Check response item keys are the selected keys
+        function: tavern_utils:test_select_key_affected_items
+        extra_kwargs:
+          select_key: 'dateAdd,status'
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '000'
@@ -2530,9 +2550,14 @@ stages:
       params:
         select: 'os.platform'
     response:
+      verify_response_with:
+        # Check response item keys are the selected keys
+        function: tavern_utils:test_select_key_affected_items
+        extra_kwargs:
+          select_key: 'os.platform'
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '003'
@@ -2560,9 +2585,14 @@ stages:
         limit: 1
         offset: 2
     response:
+      verify_response_with:
+        # Check response item keys are the selected keys
+        function: tavern_utils:test_select_key_affected_items
+        extra_kwargs:
+          select_key: 'dateAdd,mergedSum'
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '007'
@@ -2721,9 +2751,14 @@ stages:
       params:
         select: "{field}"
     response:
+      verify_response_with:
+        # Check response item keys are the selected keys
+        function: tavern_utils:test_select_key_affected_items
+        extra_kwargs:
+          select_key: "{field}"
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '003'
@@ -3283,9 +3318,14 @@ stages:
         select: name
         name: wazuh-agent1
     response:
+      verify_response_with:
+        # Check response item keys are the selected keys
+        function: tavern_utils:test_select_key_affected_items
+        extra_kwargs:
+          select_key: 'name'
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           <<: *get_agents_by_name_response
 
@@ -3297,9 +3337,14 @@ stages:
         select: name,id,status
         name: wazuh-agent1
     response:
+      verify_response_with:
+        # Check response item keys are the selected keys
+        function: tavern_utils:test_select_key_affected_items
+        extra_kwargs:
+          select_key: 'name,id,status'
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: '001'
@@ -3560,6 +3605,11 @@ stages:
       params:
         select: "{field}"
     response:
+      verify_response_with:
+        # Check response item keys are the selected keys
+        function: tavern_utils:test_select_key_affected_items
+        extra_kwargs:
+          select_key: "{field}"
       status_code: 200
       json:
         <<: *no_group_response

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -1216,17 +1216,6 @@ def format_fields(field_name, value):
         return value
 
 
-def calculate_status(last_keep_alive, pending, today=datetime.utcnow()):
-    """Calculates state based on last keep alive
-    """
-    if not last_keep_alive or last_keep_alive == 'unknown':
-        return "never_connected"
-    else:
-        last_date = datetime.utcfromtimestamp(last_keep_alive)
-        difference = (today - last_date).total_seconds()
-        return "disconnected" if difference > common.limit_seconds else ("pending" if pending else "active")
-
-
 def send_restart_command(agent_id: str = '', agent_version: str = '') -> str:
     """Send restart command to an agent.
 

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -264,8 +264,7 @@ class WazuhDBQueryGroupByAgents(WazuhDBQueryGroupBy, WazuhDBQueryAgents):
 
         WazuhDBQueryAgents.__init__(self, *args, **kwargs)
         WazuhDBQueryGroupBy.__init__(self, *args, table=self.table, fields=self.fields, filter_fields=filter_fields,
-                                     default_sort_field=self.default_sort_field,
-                                     min_select_fields=self.min_select_fields, backend=self.backend, **kwargs)
+                                     default_sort_field=self.default_sort_field, backend=self.backend, **kwargs)
         self.remove_extra_fields = True
 
     def _format_data_into_dictionary(self):

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -274,12 +274,7 @@ class WazuhDBQueryGroupByAgents(WazuhDBQueryGroupBy, WazuhDBQueryAgents):
                 if field not in result.keys():
                     result[field] = 'unknown'
 
-            # compute 'status' field, format id with zero padding and remove non-user-requested fields.
-            # Also remove, extra fields (internal key and registration IP)
-            selected_fields = self.select - self.extra_fields if self.remove_extra_fields else self.select
-            selected_fields |= self.min_select_fields
-            self._data = [{key: format_fields(key, value)
-                           for key, value in item.items() if key in selected_fields} for item in self._data]
+        fields_to_nest, non_nested = get_fields_to_nest(self.fields.keys(), ['os'], '.')
 
         # compute 'status' field, format id with zero padding and remove non-user-requested fields.
         # Also remove, extra fields (internal key and registration IP)

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -1531,27 +1531,6 @@ def test_agent_get_stats_ko(socket_mock, send_mock, mock_wazuh_socket):
         agent.get_stats('logcollector')
 
 
-@pytest.mark.parametrize('last_keep_alive, pending, expected_status', [
-    (10, False, 'active'),
-    (1900, False, 'disconnected'),
-    (10, True, 'pending'),
-])
-def test_calculate_status(last_keep_alive, pending, expected_status):
-    """Test calculate_status returns expected status according to last_keep_alive.
-
-    Parameters
-    ----------
-    last_keep_alive : int
-        Seconds since last connection.
-    pending : bool
-        Return pending if status is not disconnected.
-    expected_status : str
-        Expected status to be returned.
-    """
-    result = calculate_status(int(time()) - last_keep_alive, pending)
-    assert result == expected_status, 'Result message is not as expected.'
-
-
 @pytest.mark.parametrize('agents_list, versions_list', [
     (['001', '002', '003', '004'],
      [{'version': ver} for ver in ['Wazuh v4.2.0', 'Wazuh v4.0.0', 'Wazuh v4.2.1', 'Wazuh v3.13.2']])

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -159,8 +159,8 @@ def test_WazuhDBQueryAgents_filter_date(mock_socket_conn):
 
 
 @pytest.mark.parametrize('field, expected_query', [
-    ('status', 'last_keepAlive asc'),
     ('os.version', 'CAST(os_major AS INTEGER) asc, CAST(os_minor AS INTEGER) asc'),
+    ('status', 'status asc'),
     ('id', 'id asc'),
 ])
 @patch('socket.socket.connect')
@@ -198,7 +198,7 @@ def test_WazuhDBQueryAgents_format_data_into_dictionary(mock_socket_conn):
     query_agent = WazuhDBQueryAgents(offset=0, limit=1, sort=None,
                                      search=None, select={'id', 'status', 'group', 'dateAdd', 'manager'},
                                      default_sort_field=None, query=None, count=5,
-                                     get_data=None, min_select_fields='os.version')
+                                     get_data=None, min_select_fields={'os.version'})
 
     # Mock _data variable with our own data
     query_agent._data = data


### PR DESCRIPTION
|Related issue|
|---|
| #8802 |

Hi team,

This PR closes #8802,

In this pull request, I have removed the unused calculate_status framework function and its unit test.

### Unittests results:

```
framework/wazuh/core/tests/
===================== 662 passed, 1 xfailed, 2 xpassed, 10 warnings in 4.71s =====================


framework/wazuh/tests/
===================== 591 passed, 13 warnings in 67.11s (0:01:07) =====================

api/api/test/
===================== 225 passed, 16 warnings in 1.16s =====================

framework/wazuh/core/cluster/tests/
===================== 56 passed, 4 warnings in 0.44s =====================

framework/wazuh/core/cluster/dapi/tests/
===================== 23 passed, 9 warnings in 0.60s =====================

framework/wazuh/rbac/tests/
===================== 227 passed, 3 warnings in 178.93s (0:02:58) =====================
```


### API integration tests results:

```
test_agent_DELETE_endpoints.tavern.yaml 
	 6 passed, 8 warnings

test_agent_GET_endpoints.tavern.yaml 
	 91 passed, 93 warnings

test_security_DELETE_endpoints.tavern.yaml 
	 15 passed, 17 warnings

test_security_GET_endpoints.tavern.yaml 
	 11 passed, 13 warnings

test_security_POST_endpoints.tavern.yaml 
	 7 passed, 9 warnings

test_security_PUT_endpoints.tavern.yaml 
	 9 passed, 11 warnings
```

Regards,
Manuel.
