### PR TITLE
Update API integration tests mapping JSON

### DIFF
--- a/api/test/integration/mapping/integration_test_api_endpoints.json
+++ b/api/test/integration/mapping/integration_test_api_endpoints.json
@@ -1357,6 +1357,22 @@
                     "test_security_POST_endpoints.tavern.yaml",
                     "test_security_PUT_endpoints.tavern.yaml"
                 ]
+            },
+            {
+                "name": "utils.py",
+                "tag": "utils",
+                "tests": [
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml"
+                ]
             }
         ]
     },


### PR DESCRIPTION
Hi team,

This PR updates the JSON used to map each API, cluster and framework file with the API integration tests that must be run when these files are modified.

Regards,
Manuel.