### PR TITLE
Fixing double-free in development branch `dev-cves-alerts-inventory` caused because of an already freed pointer returned by a function

### DIFF
--- a/src/wazuh_db/helpers/wdb_agents_helpers.c
+++ b/src/wazuh_db/helpers/wdb_agents_helpers.c
@@ -36,6 +36,7 @@ cJSON* wdb_get_agent_sys_osinfo(int id,
     if (!result || !result->child) {
         merror("Agents DB (%d) Error querying Wazuh DB to get OS information", id);
         cJSON_Delete(result);
+        result = NULL;
     }
 
     os_free(wdbquery);
@@ -389,6 +390,7 @@ cJSON* wdb_remove_vuln_cves_by_status(int id,
 
     if (WDBC_ERROR == wdb_res) {
         cJSON_Delete(data_out);
+        data_out = NULL;
     }
 
     if (!sock) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -778,6 +778,10 @@ struct vu_msu_vul_entry {
     struct vu_msu_vul_entry *prev;
 };
 
+/**
+ * @brief Structure that contains contextual information related
+ * to the current scan being performed over a particular agent.
+ */
 typedef struct scan_ctx_t {
     int             agent_id;
     char*           agent_name;


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/8860 |

## Description

This pull request includes all the necessary changes in order to fix a double-free in `wazuh-modulesd`. The issue was caused because of a pointer already freed being returned by the function `wdb_get_agent_sys_osinfo`. This function, in case of failing to obtain the OS information, released the `cJSON *` but didn't set the pointer to `NULL`. Then, it returned a pointer as if it were a valid pointer.

The fix implements a mechanism to set the `cJSON *` to `NULL` in case of calling `cJSON_Delete` before the return.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade

- Memory tests for Linux
  - [x] Scan-build report
![image](https://user-images.githubusercontent.com/5703274/120235753-1f585200-c231-11eb-87a2-617692ab5feb.png)
