### PR TITLE
Improve sendsync error logs

### DIFF
--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -692,8 +692,7 @@ class SendSyncRequestQueue(WazuhRequestQueue):
                 result = await wazuh_sendsync(**request)
                 task_id = await node.send_string(result.encode())
             except Exception as e:
-                self.logger.error(f"Error in SendSync: {e}", exc_info=True)
-                task_id = b'Error in SendSync: ' + str(e).encode()
+                task_id = f'Error in SendSync (parameters {request}): {str(e)}'.encode()
 
             if task_id.startswith(b'Error'):
                 self.logger.error(task_id.decode())


### PR DESCRIPTION
|Related issue|
|---|
| Closes #8541 |

## Description

Hello team!

This PR improves the error messages in `sendsync`, as requested in #8541. Now, the message is not repeated and it contains the received request:
```
2021/05/05 12:44:50 INFO: [Master] [Local integrity] Starting.
2021/05/05 12:44:50 INFO: [Master] [Local integrity] Finished in 0.010s. Calculated metadata of 11 files.
2021/05/05 12:44:53 ERROR: [Master] [SendSync] Error in SendSync (parameters {'daemon_name': 'authd', 'message': {'arguments': {'name': '1e8429c147c7', 'ip': 'any', 'force': 0}, 'function': 'add'}}): Error 1013 - Unable to connect with socket: [Errno 111] Connection refused
2021/05/05 12:44:55 INFO: [Worker worker1] [Integrity check] Starting. Received metadata of 11 files.
```

To fix the problem of duplicated logs, we had to dispense with the traceback of the execution. Anyway and as seen here, it did not provide useful information in this case: 
```
Traceback (most recent call last):
  File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.2.0-py3.9.egg/wazuh/core/wazuh_socket.py", line 27, in _connect
    self.s.connect(self.path)
ConnectionRefusedError: [Errno 111] Connection refused

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.2.0-py3.9.egg/wazuh/core/cluster/dapi/dapi.py", line 694, in run
    result = await wazuh_sendsync(**request)
  File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.2.0-py3.9.egg/wazuh/core/wazuh_socket.py", line 278, in wazuh_sendsync
    raise e
  File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.2.0-py3.9.egg/wazuh/core/wazuh_socket.py", line 270, in wazuh_sendsync
    sock = WazuhSocket(daemons[daemon_name]['path'])
  File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.2.0-py3.9.egg/wazuh/core/wazuh_socket.py", line 22, in __init__
    self._connect()
  File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.2.0-py3.9.egg/wazuh/core/wazuh_socket.py", line 29, in _connect
    raise WazuhException(1013, str(e))
wazuh.core.exception.WazuhException: Error 1013 - Unable to connect with socket: [Errno 111] Connection refused
```

Regards,
Selu.