### PR TITLE
Fixed MS Logs rule 83200 bug

### DIFF
--- a/ruleset/rules/0435-ms_logs_rules.xml
+++ b/ruleset/rules/0435-ms_logs_rules.xml
@@ -14,7 +14,8 @@
     -->
     <rule id="83200" level="5">
         <if_sid>18101</if_sid>
-        <id>1102</id>
+        <id>^1102$</id>
+        <field name="type">Security</field>
         <description>The audit log was cleared</description>
         <mitre>
             <id>T1070</id>
@@ -55,4 +56,3 @@
     </rule>
 
 </group>
-


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-ruleset/issues/244|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Closes https://github.com/wazuh/wazuh-ruleset/issues/244

This PR adds a fix to an old error in rule `83200`

<!--
Add a clear description of how the problem has been solved.
-->
The problem is solved by adding an additional type field:
```
 <id>^1102$</id>
 <field name="type">Security</field>
```


## Configuration options
I tested these changes in a wazuh manager with 4.3 version
<!--
When proceed, this section should include new configuration parameters.
-->

## Tests

After testing the `wazuh logtest` with this sample log:

```
2017 Mar 28 10:08:59 WinEvtLog: Security: INFORMATION(1102): Microsoft-Windows-Eventlog: (no user): no domain: WIN-P57C9KN929H: The audit log was cleared.  Subject:   Security ID: S-1-5-21-2895701376-138392475-4243184240-1000   Account Name: Alberto   Domain Name: WIN-P57C9KN929H   Logon ID: 0x18709
```
The following result was generated:

```
root@ubuntu20LTS:/home/vagrant# /var/ossec/bin/wazuh-logtest
Starting wazuh-logtest v4.3.0
Type one log per line

2017 Mar 28 10:08:59 WinEvtLog: Security: INFORMATION(1102): Microsoft-Windows-Eventlog: (no user): no domain: WIN-P57C9KN929H: The audit log was cleared.  Subject:   Security ID: S-1-5-21-2895701376-138392475-4243184240-1000   Account Name: Alberto   Domain Name: WIN-P57C9KN929H   Logon ID: 0x18709
    -->
**Phase 1: Completed pre-decoding.
	full event: '2017 Mar 28 10:08:59 WinEvtLog: Security: INFORMATION(1102): Microsoft-Windows-Eventlog: (no user): no domain: WIN-P57C9KN929H: The audit log was cleared.  Subject:   Security ID: S-1-5-21-2895701376-138392475-4243184240-1000   Account Name: Alberto   Domain Name: WIN-P57C9KN929H   Logon ID: 0x18709'
	timestamp: '2017 Mar 28 10:08:59'
	program_name: 'WinEvtLog'

**Phase 2: Completed decoding.
	name: 'windows'
	parent: 'windows'
	account_name: 'Alberto'
	dstuser: '(no user)'
	extra_data: 'Microsoft-Windows-Eventlog'
	id: '1102'
	security_id: 'S-1-5-21-2895701376-138392475-4243184240-1000'
	status: 'INFORMATION'
	system_name: 'WIN-P57C9KN929H'
	type: 'Security'

**Phase 3: Completed filtering (rules).
	id: '83200'
	level: '5'
	description: 'The audit log was cleared'
	groups: '['windows', 'windows_logs', 'log_clearing_auditlog']'
	firedtimes: '1'
	gdpr: '['II_5.1.f', 'IV_30.1.g']'
	gpg13: '['10.1']'
	mail: 'False'
	mitre.id: '['T1070']'
	mitre.tactic: '['Defense Evasion']'
	mitre.technique: '['Indicator Removal on Host']'
**Alert to be generated.

```

After this test `ossec.log` was clear from warnings or errors.