### PR TITLE
Make `request_slice` dynamic in framework

### DIFF
--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -89,7 +89,7 @@ class InitAgent:
 test_data = InitAgent()
 
 
-def send_msg_to_wdb(msg, raw=False):
+def send_msg_to_wdb(msg, raw=False, *args, **kwargs):
     query = ' '.join(msg.split(' ')[2:])
     result = test_data.cur.execute(query).fetchall()
     return list(map(remove_nones_to_dict, map(dict, result)))
@@ -867,7 +867,7 @@ def test_agent_add_manual(socket_mock, mock_get_manager_name, mock_lockf, mock_s
 def test_get_manager_name(mock_connect, mock_send):
     get_manager_name()
     calls = [call('global sql select count(*) from agent where (id = 0)'),
-             call('global sql select name from agent where (id = 0) limit 1 offset 0')]
+             call('global sql select name from agent where (id = 0) limit 1 offset 0', update_slice=True)]
 
     mock_send.assert_has_calls(calls)
 

--- a/framework/wazuh/core/tests/test_rootcheck.py
+++ b/framework/wazuh/core/tests/test_rootcheck.py
@@ -50,7 +50,7 @@ def remove_db(data_path):
 test_data = InitRootcheck()
 
 
-def send_msg_to_wdb(msg, raw=False):
+def send_msg_to_wdb(msg, raw=False, *args, **kwargs):
     query = ' '.join(msg.split(' ')[3:])
     result = test_data.cur.execute(query).fetchall()
     return list(map(remove_nones_to_dict, map(dict, result)))

--- a/framework/wazuh/core/tests/test_wdb.py
+++ b/framework/wazuh/core/tests/test_wdb.py
@@ -192,6 +192,6 @@ def test_failed_execute(send_mock, connect_mock, error_query, error_type, expect
             mywdb.execute(error_query, delete=delete, update=update)
     else:
         with patch("wazuh.core.wdb.WazuhDBConnection._send", return_value=[{'total': 5}]):
-            with patch("wazuh.core.wdb.range", side_effect=error_type):
+            with patch("wazuh.core.wdb.min", side_effect=error_type):
                 with pytest.raises(exception.WazuhException, match=f'.* {expected_exception} .*'):
                     mywdb.execute(error_query, delete=delete, update=update)

--- a/framework/wazuh/core/wdb.py
+++ b/framework/wazuh/core/wdb.py
@@ -27,6 +27,7 @@ class WazuhDBConnection:
         """
         self.socket_path = common.wdb_socket_path
         self.request_slice = request_slice
+        self.slice_changed = False
         self.max_size = max_size
         self.__conn = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         try:
@@ -80,7 +81,7 @@ class WazuhDBConnection:
             if not check:
                 raise WazuhError(2004, error_text)
 
-    def _send(self, msg, raw=False):
+    def _send(self, msg, raw=False, update_slice=False):
         """
         Send a message to the wdb socket
         """
@@ -97,7 +98,15 @@ class WazuhDBConnection:
 
         # Max size socket buffer is 64KB
         if data_size >= MAX_SOCKET_BUFFER_SIZE:
+            # self.slice_changed is used so 'request_slice' is not updated multiple times due to
+            # recursion in send_request_to_wdb()
+            if update_slice and self.request_slice > 1 and not self.slice_changed:
+                self.request_slice //= 2
+                self.slice_changed = True
             raise WazuhInternalError(2009)
+        elif update_slice and (data_size*2) < MAX_SOCKET_BUFFER_SIZE and not self.slice_changed:
+            self.request_slice *= 2
+            self.slice_changed = True
 
         if data[0] == "err":
             raise WazuhError(2003, data[1])
@@ -221,7 +230,7 @@ class WazuhDBConnection:
         def send_request_to_wdb(query_lower, step, off, response):
             try:
                 request = query_lower.replace(':limit', 'limit {}'.format(step)).replace(':offset', 'offset {}'.format(off))
-                response.extend(self._send(request))
+                response.extend(self._send(request, update_slice=True))
             except WazuhInternalError:
                 # if the step is already 1, it can't be divided
                 if step == 1:
@@ -244,7 +253,6 @@ class WazuhDBConnection:
 
         # only for update queries
         if update:
-            # regex = re.compile(r"\w+ \d+? sql update ([a-z0-9,*_ ]+) set value = '([a-z0-9,*_ ]+)' where key (=|like)?"
             regex = re.compile(r"\w+ \d+? sql update ([\w\d,*_ ]+) set value = '([\w\d,*_ ]+)' where key (=|like)?"
                                r" '([a-z0-9,*_%\- ]+)'")
             if regex.match(query_lower) is None:
@@ -287,15 +295,19 @@ class WazuhDBConnection:
             limit = lim if lim != 0 else total
 
             response = []
-            step = limit if limit < self.request_slice and limit > 0 else self.request_slice
             if ':limit' not in query_lower:
                 query_lower += ' :limit'
             if ':offset' not in query_lower:
                 query_lower += ' :offset'
 
             try:
-                for off in range(offset, limit + offset, step):
-                    send_request_to_wdb(query_lower, step, off, response)
+                off = offset
+                while off < limit + offset:
+                    step = limit if self.request_slice > limit > 0 else self.request_slice
+                    # Min() used to avoid fetching more items than the maximum specified in `limit`.
+                    send_request_to_wdb(query_lower, min(limit + offset - off, step), off, response)
+                    off += step
+                    self.slice_changed = False
             except ValueError as e:
                 raise WazuhError(2006, str(e))
             except (WazuhError, WazuhInternalError) as e:

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -47,7 +47,7 @@ full_agent_list = ['000', '001', '002', '003', '004', '005', '006', '007', '008'
 short_agent_list = ['000', '001', '002', '003', '004', '005']
 
 
-def send_msg_to_wdb(msg, raw=False):
+def send_msg_to_wdb(msg, raw=False, *args, **kwargs):
     query = ' '.join(msg.split(' ')[2:])
     result = test_data.cur.execute(query).fetchall()
     return list(map(remove_nones_to_dict, map(dict, result)))

--- a/framework/wazuh/tests/test_vulnerability.py
+++ b/framework/wazuh/tests/test_vulnerability.py
@@ -29,7 +29,7 @@ test_data = InitAgent(data_path=test_data_path)
 test_data_cve = InitAgent(data_path=test_data_path, db_name='schema_cve_test.sql')
 
 
-def send_msg_to_wdb(msg, raw=False):
+def send_msg_to_wdb(msg, raw=False, *args, **kwargs):
     # Tests for CVE endpoint use a different schema and query
     query = msg[msg.find('sql') + len('sql '):]
     result = test_data.cur.execute(query).fetchall() if msg.startswith('global') else test_data_cve.cur.execute(query).fetchall()


### PR DESCRIPTION
|Related issue|
|---|
| Closes #8877 |

## Description

Hi team,

This PR adds a new way to calculate (or recalculate) the size of `request_slice`, as proposed in #8877. The approach is very simple: 
- `request_slice` starts at 500.
- A query is sent to wazuh-db. If the size of the response is 65536, we understand that it does not fit in the socket. Therefore, before raising an exception (this was already done), we cut the `request_slice` size in half for future requests.
- If the response size takes up less than half the available space on the socket (65536 B), the `request_slice` is multiplied by two. 

With this, better times are achieved since the `request_slice` does not have to be calculated by trial and error for each query (as before), but its last value is used for the following requests. In addition, it will be adjusted to the amount of data required (more items will fit if the `select=id` parameter is used than if the complete information is obtained, for example). 

However, there is one thing to keep in mind. The `request_slice` value is only saved between different queries of the same API request. That is, if we try to get 100k agents with `limit=100000`, many small queries of 62 items (for example) will be sent to wazuh-db. 

On the contrary, if we perform 200 queries with `limit=500` to obtain the 100k agents, `request_slice` will be reinitialized for each of those 200 requests and no time improvement will be appreciated. 

## Results

Check out https://github.com/wazuh/wazuh/issues/8877#issuecomment-852884533 where results are better detailed.

Regards,
Selu.