### PR TITLE
Added parameters description, fix issue when updating and related UTs

### DIFF
--- a/src/unit_tests/wazuh_db/test_wdb_agents.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents.c
@@ -278,7 +278,7 @@ void test_wdb_agents_insert_vuln_cves_error_json(void **state) {
     assert_null(ret);
 }
 
-void test_wdb_agents_insert_vuln_cves_success_pkg_not_found(void **state) {
+void test_wdb_agents_insert_vuln_cves_update_success(void **state) {
     cJSON *ret = NULL;
     test_struct_t *data  = (test_struct_t *)*state;
     const char* name = "package";
@@ -308,6 +308,46 @@ void test_wdb_agents_insert_vuln_cves_success_pkg_not_found(void **state) {
 
     expect_string(__wrap_cJSON_AddStringToObject, name, "action");
     expect_string(__wrap_cJSON_AddStringToObject, string, "UPDATE");
+    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "SUCCESS");
+    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
+
+    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve, reference, type, status, check_pkg_existence, severity, cvss2_score, cvss3_score);
+
+    assert_ptr_equal(1, ret);
+}
+
+void test_wdb_agents_insert_vuln_cves_pkg_not_found(void **state) {
+    cJSON *ret = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char* name = "package";
+    const char* version = "4.0";
+    const char* architecture = "x86";
+    const char* cve = "CVE-2021-1200";
+    const char* reference = "1c979289c63e6225fea818ff9ca83d9d0d25c46a";
+    const char* type = "PACKAGE";
+    const char* status = "VALID";
+    bool check_pkg_existence = true;
+    const char* severity = "Unknown";
+    double cvss2_score = 0.0;
+    double cvss3_score = 0.0;
+
+    will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_FIND_CVE);
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
+
+    will_return_count(__wrap_sqlite3_bind_text, OS_SUCCESS, -1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, cve);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, reference);
+
+    expect_sqlite3_step_call(SQLITE_DONE);
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "action");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "INSERT");
     will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
 
     expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_PROGRAM_FIND);
@@ -457,7 +497,6 @@ void test_wdb_agents_insert_vuln_cves_success_statement_exec_fail(void **state) 
 
     assert_ptr_equal(1, ret);
 }
-
 
 void test_wdb_agents_insert_vuln_cves_success_pkg_found(void **state) {
     cJSON *ret = NULL;
@@ -1234,7 +1273,8 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_agents_find_cve_error, test_setup, test_teardown),
         /* Tests wdb_agents_insert_vuln_cves */
         cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cves_error_json, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cves_success_pkg_not_found, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cves_update_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cves_pkg_not_found, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cves_success_statement_init_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cves_success_statement_exec_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cves_success_pkg_found, test_setup, test_teardown),

--- a/src/wazuh_db/helpers/wdb_agents_helpers.h
+++ b/src/wazuh_db/helpers/wdb_agents_helpers.h
@@ -32,7 +32,7 @@ typedef enum agents_db_access {
  *                 The cJSON object must be freed by the caller.
  */
 cJSON* wdb_get_agent_sys_osinfo(int id,
-                          int *sock);
+                                int *sock);
 
 /**
  * @brief Sets the triaged status in the sys_osinfo table of the specified agent's database.
@@ -42,7 +42,7 @@ cJSON* wdb_get_agent_sys_osinfo(int id,
  * @return Returns 0 on success or -1 on error.
  */
 int wdb_set_agent_sys_osinfo_triaged(int id,
-                               int *sock);
+                                     int *sock);
 
 /**
  * @brief Insert or update a vulnerability to the vuln_cves table in the agents database.
@@ -52,6 +52,9 @@ int wdb_set_agent_sys_osinfo_triaged(int id,
  * @param[in] version The affected package version.
  * @param[in] architecture The affected package architecture.
  * @param[in] cve The vulnerability ID.
+ * @param [in] severity A string representing the severity of the vulnerability.
+ * @param [in] cvss2_score The vulnerability score according to CVSS v2.
+ * @param [in] cvss3_score The vulnerability score according to CVSS v3.
  * @param[in] reference The package reference.
  * @param[in] type The package type.
  * @param[in] status The vulnerability status.

--- a/src/wazuh_db/wdb_agents.c
+++ b/src/wazuh_db/wdb_agents.c
@@ -93,7 +93,6 @@ cJSON* wdb_agents_insert_vuln_cves(wdb_t *wdb,
                                    double cvss2_score,
                                    double cvss3_score) {
 
-    bool insert = FALSE;
     cJSON* result = cJSON_CreateObject();
     if (!result) {
         return NULL;
@@ -101,43 +100,42 @@ cJSON* wdb_agents_insert_vuln_cves(wdb_t *wdb,
 
     if (wdb_agents_find_cve(wdb, cve, reference)) {
         cJSON_AddStringToObject(result, "action", "UPDATE");
+        cJSON_AddStringToObject(result, "status", "SUCCESS");
     }
     else {
         cJSON_AddStringToObject(result, "action", "INSERT");
-        insert = TRUE;
-    }
 
-    if (check_pkg_existence && !wdb_agents_find_package(wdb, reference)) {
-        cJSON_AddStringToObject(result, "status", "PKG_NOT_FOUND");
-    }
-    else if (insert){
-        sqlite3_stmt* stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_VULN_CVES_INSERT);
+        if (check_pkg_existence && !wdb_agents_find_package(wdb, reference)) {
+            cJSON_AddStringToObject(result, "status", "PKG_NOT_FOUND");
+        }
+        else {
+            sqlite3_stmt* stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_VULN_CVES_INSERT);
 
-        if (stmt) {
-            sqlite3_bind_text(stmt, 1, name, -1, NULL);
-            sqlite3_bind_text(stmt, 2, version, -1, NULL);
-            sqlite3_bind_text(stmt, 3, architecture, -1, NULL);
-            sqlite3_bind_text(stmt, 4, cve, -1, NULL);
-            sqlite3_bind_text(stmt, 5, reference, -1, NULL);
-            sqlite3_bind_text(stmt, 6, type, -1, NULL);
-            sqlite3_bind_text(stmt, 7, status, -1, NULL);
-            sqlite3_bind_text(stmt, 8, severity, -1, NULL);
-            sqlite3_bind_double(stmt, 9, cvss2_score);
-            sqlite3_bind_double(stmt, 10, cvss3_score);
+            if (stmt) {
+                sqlite3_bind_text(stmt, 1, name, -1, NULL);
+                sqlite3_bind_text(stmt, 2, version, -1, NULL);
+                sqlite3_bind_text(stmt, 3, architecture, -1, NULL);
+                sqlite3_bind_text(stmt, 4, cve, -1, NULL);
+                sqlite3_bind_text(stmt, 5, reference, -1, NULL);
+                sqlite3_bind_text(stmt, 6, type, -1, NULL);
+                sqlite3_bind_text(stmt, 7, status, -1, NULL);
+                sqlite3_bind_text(stmt, 8, severity, -1, NULL);
+                sqlite3_bind_double(stmt, 9, cvss2_score);
+                sqlite3_bind_double(stmt, 10, cvss3_score);
 
-            if (OS_SUCCESS == wdb_exec_stmt_silent(stmt)) {
-                cJSON_AddStringToObject(result, "status", "SUCCESS");
+                if (OS_SUCCESS == wdb_exec_stmt_silent(stmt)) {
+                    cJSON_AddStringToObject(result, "status", "SUCCESS");
+                }
+                else {
+                    mdebug1("Exec statement error %s", sqlite3_errmsg(wdb->db));
+                    cJSON_AddStringToObject(result, "status", "ERROR");
+                }
             }
             else {
-                mdebug1("Exec statement error %s", sqlite3_errmsg(wdb->db));
                 cJSON_AddStringToObject(result, "status", "ERROR");
             }
         }
-        else {
-            cJSON_AddStringToObject(result, "status", "ERROR");
-        }
     }
-
     return result;
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|#8882|

## Description

This PR includes: 
- Adds some additional information for the new parameters severity, cvss2_score, cvss3_score that were missing in the previous development. 
- Fixes an issue when a package is updated in `vuln_cves`. Status was not returned in the JSON response.
- Fixes UTs related to the previous changes.
## Dod
### Status is returned when a package is updated.

![2021-06-02_14-08](https://user-images.githubusercontent.com/13010397/120537843-2790c880-c3bc-11eb-880c-6056a8a7d02f.png)

### Valgrind

[valgrind.txt](https://github.com/wazuh/wazuh/files/6586857/valgrind.txt)

### Coverage 

![2021-06-02_14-52](https://user-images.githubusercontent.com/13010397/120537966-47c08780-c3bc-11eb-8941-0a6738891add.png)

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [X] Added unit tests (for new features)