### PR TITLE
Fix segfault for wazuh-logtest-legacy -a argument

### DIFF
--- a/src/analysisd/alerts/log.c
+++ b/src/analysisd/alerts/log.c
@@ -102,7 +102,7 @@ void OS_Store_Flush(){
     fflush(_eflog);
 }
 
-void OS_Log(Eventinfo *lf)
+void OS_Log(Eventinfo *lf, FILE * fp)
 {
     int i;
     char labels[OS_MAXSTR] = {0};
@@ -126,7 +126,7 @@ void OS_Log(Eventinfo *lf)
     }
 
     /* Writing to the alert log file */
-    fprintf(_aflog,
+    fprintf(fp,
             "** Alert %ld.%ld:%s - %s\n"
             "%d %s %02d %s %s%s%s\n%sRule: %d (level %d) -> '%s'"
             "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n",
@@ -185,100 +185,100 @@ void OS_Log(Eventinfo *lf)
     /* FIM events */
 
     if (lf->filename) {
-        fprintf(_aflog, "Attributes:\n");
+        fprintf(fp, "Attributes:\n");
 
         if (lf->fields[FIM_SIZE].value && *lf->fields[FIM_SIZE].value) {
-            fprintf(_aflog, " - Size: %s\n", lf->fields[FIM_SIZE].value);
+            fprintf(fp, " - Size: %s\n", lf->fields[FIM_SIZE].value);
         }
 
         if (lf->fields[FIM_PERM].value) {
-            fprintf(_aflog, " - Permissions: %s\n", lf->fields[FIM_PERM].value);
+            fprintf(fp, " - Permissions: %s\n", lf->fields[FIM_PERM].value);
         }
 
         if (lf->mtime_after) {
-            fprintf(_aflog, " - Date: %s", ctime_r(&lf->mtime_after, buf_ptr));
+            fprintf(fp, " - Date: %s", ctime_r(&lf->mtime_after, buf_ptr));
         }
         if (lf->inode_after) {
-            fprintf(_aflog, " - Inode: %ld\n", lf->inode_after);
+            fprintf(fp, " - Inode: %ld\n", lf->inode_after);
         }
         if (lf->fields[FIM_UID].value && lf->fields[FIM_UNAME].value) {
             if (*lf->fields[FIM_UNAME].value) {
-                fprintf(_aflog, " - User: %s (%s)\n", lf->fields[FIM_UNAME].value, lf->fields[FIM_UID].value);
+                fprintf(fp, " - User: %s (%s)\n", lf->fields[FIM_UNAME].value, lf->fields[FIM_UID].value);
             }
         }
         if (lf->fields[FIM_GID].value && lf->fields[FIM_GNAME].value) {
             if (*lf->fields[FIM_GNAME].value) {
-                fprintf(_aflog, " - Group: %s (%s)\n", lf->fields[FIM_GNAME].value, lf->fields[FIM_GID].value);
+                fprintf(fp, " - Group: %s (%s)\n", lf->fields[FIM_GNAME].value, lf->fields[FIM_GID].value);
             }
         }
         if (lf->fields[FIM_MD5].value) {
             if (strcmp(lf->fields[FIM_MD5].value, "xxx") && *lf->fields[FIM_MD5].value) {
-                fprintf(_aflog, " - MD5: %s\n", lf->fields[FIM_MD5].value);
+                fprintf(fp, " - MD5: %s\n", lf->fields[FIM_MD5].value);
             }
         }
 
         if (lf->fields[FIM_SHA1].value) {
             if (strcmp(lf->fields[FIM_SHA1].value, "xxx") && *lf->fields[FIM_SHA1].value) {
-                fprintf(_aflog, " - SHA1: %s\n", lf->fields[FIM_SHA1].value);
+                fprintf(fp, " - SHA1: %s\n", lf->fields[FIM_SHA1].value);
             }
         }
 
         if (lf->fields[FIM_SHA256].value) {
             if (strcmp(lf->fields[FIM_SHA256].value, "xxx") && *lf->fields[FIM_SHA256].value) {
-                fprintf(_aflog, " - SHA256: %s\n", lf->fields[FIM_SHA256].value);
+                fprintf(fp, " - SHA256: %s\n", lf->fields[FIM_SHA256].value);
             }
         }
 
         if (lf->fields[FIM_ATTRS].value) {
             if (lf->fields[FIM_ATTRS].value && *lf->fields[FIM_ATTRS].value) {
-                fprintf(_aflog, " - File attributes: %s\n", lf->fields[FIM_ATTRS].value);
+                fprintf(fp, " - File attributes: %s\n", lf->fields[FIM_ATTRS].value);
             }
         }
 
         if (lf->fields[FIM_USER_NAME].value && strcmp(lf->fields[FIM_USER_NAME].value, "") != 0) {
-            fprintf(_aflog, " - (Audit) %s: %s\n", "User name", lf->fields[FIM_USER_NAME].value);
+            fprintf(fp, " - (Audit) %s: %s\n", "User name", lf->fields[FIM_USER_NAME].value);
         }
         if (lf->fields[FIM_AUDIT_NAME].value && strcmp(lf->fields[FIM_AUDIT_NAME].value, "") != 0) {
-            fprintf(_aflog, " - (Audit) %s: %s\n", "Audit name", lf->fields[FIM_AUDIT_NAME].value);
+            fprintf(fp, " - (Audit) %s: %s\n", "Audit name", lf->fields[FIM_AUDIT_NAME].value);
         }
         if (lf->fields[FIM_EFFECTIVE_NAME].value && strcmp(lf->fields[FIM_EFFECTIVE_NAME].value, "") != 0) {
-            fprintf(_aflog, " - (Audit) %s: %s\n", "Effective name", lf->fields[FIM_EFFECTIVE_NAME].value);
+            fprintf(fp, " - (Audit) %s: %s\n", "Effective name", lf->fields[FIM_EFFECTIVE_NAME].value);
         }
         if (lf->fields[FIM_GROUP_NAME].value && strcmp(lf->fields[FIM_GROUP_NAME].value, "") != 0) {
-            fprintf(_aflog, " - (Audit) %s: %s\n", "Group name", lf->fields[FIM_GROUP_NAME].value);
+            fprintf(fp, " - (Audit) %s: %s\n", "Group name", lf->fields[FIM_GROUP_NAME].value);
         }
         if (lf->fields[FIM_PROC_ID].value && strcmp(lf->fields[FIM_PROC_ID].value, "") != 0) {
-            fprintf(_aflog, " - (Audit) %s: %s\n", "Process id", lf->fields[FIM_PROC_ID].value);
+            fprintf(fp, " - (Audit) %s: %s\n", "Process id", lf->fields[FIM_PROC_ID].value);
         }
         if (lf->fields[FIM_PROC_NAME].value && strcmp(lf->fields[FIM_PROC_NAME].value, "") != 0) {
-            fprintf(_aflog, " - (Audit) %s: %s\n", "Process name", lf->fields[FIM_PROC_NAME].value);
+            fprintf(fp, " - (Audit) %s: %s\n", "Process name", lf->fields[FIM_PROC_NAME].value);
         }
         if (lf->fields[FIM_AUDIT_CWD].value && strcmp(lf->fields[FIM_AUDIT_CWD].value, "") != 0) {
-            fprintf(_aflog, " - (Audit) %s: %s\n", "Process cwd", lf->fields[FIM_AUDIT_CWD].value);
+            fprintf(fp, " - (Audit) %s: %s\n", "Process cwd", lf->fields[FIM_AUDIT_CWD].value);
         }
         if (lf->fields[FIM_PROC_PNAME].value && strcmp(lf->fields[FIM_PROC_PNAME].value, "") != 0) {
-            fprintf(_aflog, " - (Audit) %s: %s\n", "Parent process name", lf->fields[FIM_PROC_PNAME].value);
+            fprintf(fp, " - (Audit) %s: %s\n", "Parent process name", lf->fields[FIM_PROC_PNAME].value);
         }
         if (lf->fields[FIM_PPID].value && strcmp(lf->fields[FIM_PPID].value, "") != 0) {
-            fprintf(_aflog, " - (Audit) %s: %s\n", "Parent process id", lf->fields[FIM_PPID].value);
+            fprintf(fp, " - (Audit) %s: %s\n", "Parent process id", lf->fields[FIM_PPID].value);
         }
         if (lf->fields[FIM_AUDIT_PCWD].value && strcmp(lf->fields[FIM_AUDIT_PCWD].value, "") != 0) {
-            fprintf(_aflog, " - (Audit) %s: %s\n", "Parent process cwd", lf->fields[FIM_AUDIT_PCWD].value);
+            fprintf(fp, " - (Audit) %s: %s\n", "Parent process cwd", lf->fields[FIM_AUDIT_PCWD].value);
         }
 
         if (lf->fields[FIM_DIFF].value) {
-            fprintf(_aflog, "\nWhat changed:\n%s\n", lf->fields[FIM_DIFF].value);
+            fprintf(fp, "\nWhat changed:\n%s\n", lf->fields[FIM_DIFF].value);
         }
 
         if (lf->sk_tag) {
             if (strcmp(lf->sk_tag, "") != 0) {
                 char * tags;
                 os_strdup(lf->sk_tag, tags);
-                fprintf(_aflog, "\nTags:\n");
+                fprintf(fp, "\nTags:\n");
                 char * tag;
                 tag = strtok_r(tags, ",", &saveptr);
                 while (tag != NULL) {
-                    fprintf(_aflog, " - %s\n", tag);
+                    fprintf(fp, " - %s\n", tag);
                     tag = strtok_r(NULL, ",", &saveptr);
                 }
                 free(tags);
@@ -290,7 +290,7 @@ void OS_Log(Eventinfo *lf)
     if (lf->fields && !lf->filename) {
         for (i = 0; i < lf->nfields; i++) {
             if (lf->fields[i].value != NULL && *lf->fields[i].value != '\0') {
-                fprintf(_aflog, "%s: %s\n", lf->fields[i].key, lf->fields[i].value);
+                fprintf(fp, "%s: %s\n", lf->fields[i].key, lf->fields[i].value);
             }
         }
     }
@@ -299,12 +299,12 @@ void OS_Log(Eventinfo *lf)
     if (lf->last_events) {
         char **lasts = lf->last_events;
         while (*lasts) {
-            fprintf(_aflog, "%s\n", *lasts);
+            fprintf(fp, "%s\n", *lasts);
             lasts++;
         }
     }
 
-    fprintf(_aflog, "\n");
+    fprintf(fp, "\n");
 
     return;
 }

--- a/src/analysisd/alerts/log.h
+++ b/src/analysisd/alerts/log.h
@@ -18,7 +18,7 @@
 #define FWDROP "drop"
 #define FWALLOW "accept"
 
-void OS_Log(Eventinfo *lf);
+void OS_Log(Eventinfo *lf, FILE * fp);
 void OS_CustomLog(const Eventinfo *lf, const char *format);
 void OS_Store(const Eventinfo *lf);
 void OS_Log_Flush();

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -1475,7 +1475,7 @@ void * w_writer_log_thread(__attribute__((unused)) void * args ){
                     OS_CustomLog(lf, Config.custom_alert_output_format);
                 } else if (Config.alerts_log) {
                     __crt_ftell = ftell(_aflog);
-                    OS_Log(lf);
+                    OS_Log(lf, _aflog);
                 } else if(Config.jsonout_output){
                     __crt_ftell = ftell(_jflog);
                 }
@@ -2254,7 +2254,7 @@ void * w_writer_log_statistical_thread(__attribute__((unused)) void * args ){
                 OS_CustomLog(lf, Config.custom_alert_output_format);
             } else if (Config.alerts_log) {
                 __crt_ftell = ftell(_aflog);
-                OS_Log(lf);
+                OS_Log(lf, _aflog);
             } else if (Config.jsonout_output) {
                 __crt_ftell = ftell(_jflog);
             }

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -706,7 +706,8 @@ void OS_ReadMSG(char *ut_str)
                 /* Log the alert if configured to */
                 if (currently_rule->alert_opts & DO_LOGALERT) {
                     if (alert_only) {
-                        OS_Log(lf);
+                        OS_Log(lf, stdout);
+                        fflush(stdout);
                         __crt_ftell++;
                     } else {
                         print_out("**Alert to be generated.\n\n");


### PR DESCRIPTION
|Related issue|
|---|
|Closes #8890|


Hi team!,

This PR solves the segfault when an alert is generated with the -a option.

PR Output:

```
╰─# /var/ossec/bin/wazuh-logtest-legacy -a      
2021/06/02 23:11:10 wazuh-testrule: INFO: Started (pid: 148714).
Since Wazuh v4.1.0 this binary is deprecated. Use wazuh-logtest instead
Oct 15 21:07:00 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928
** Alert 1622675471.1: - syslog,sshd,invalid_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_AU.6,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2021 Jun 02 23:11:11 linux-agent->stdin
Rule: 5710 (level 5) -> '(null)'
Src IP: 18.18.18.18
Src Port: 48928
Oct 15 21:07:00 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928
^C#                                                                                                                                                     
╭─root@30-u20-manager ~/repos/wazuh ‹4.2*› 
╰─# /var/ossec/bin/wazuh-logtest-legacy -V 
Wazuh v4.2.0 - Wazuh Inc.
This program is free software; you can redistribute it and/or modify
it under the terms of the GNU General Public License (version 2) as 
published by the Free Software Foundation. For more details, go to 
https://www.gnu.org/licenses/gpl.html
```



## Logs/Alerts example

input log:
```
Oct 15 21:07:00 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928
```

PR Output
```
** Alert 1622675471.1: - syslog,sshd,invalid_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_AU.6,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2021 Jun 02 23:11:11 linux-agent->stdin
Rule: 5710 (level 5) -> '(null)'
Src IP: 18.18.18.18
Src Port: 48928
Oct 15 21:07:00 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928
```


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [X] ~Windows~
  - [X] ~MAC OS X~
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [X] ~Dr. Memory~
  - [X] ~AddressSanitizer~
- Memory tests for Windows
  - [X] ~Scan-build report~
  - [X] ~Coverity~
  - [X] ~Dr. Memory~
- Memory tests for macOS
  - [X] ~Scan-build report~
  - [X] ~Leaks~
  - [X] ~AddressSanitizer~

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
