### PR TITLE
Office365 module: First iteration

### DIFF
--- a/src/config/wmodules-office365.c
+++ b/src/config/wmodules-office365.c
@@ -28,7 +28,7 @@ time_t time_convert_1d(const char *time_c) {
     char *endptr;
     time_t time_i = strtoul(time_c, &endptr, 0);
 
-    if (time_i <= 0 || time_i >= UINT_MAX) {
+    if (time_i <= 0 || time_i >= INT_MAX) {
         return OS_INVALID;
     }
 

--- a/src/config/wmodules-office365.c
+++ b/src/config/wmodules-office365.c
@@ -23,11 +23,6 @@ static const char *XML_CLIENT_SECRET        = "client_secret";
 
 static const char *XML_SUBSCRIPTIONS                = "subscriptions";
 static const char *XML_SUBSCRIPTION                 = "subscription";
-static const char *SUBSCRIPTIONS_TYPE_AZURE_AD      = "Audit.AzureActiveDirectory";
-static const char *SUBSCRIPTIONS_TYPE_EXCHANGE      = "Audit.Exchange";
-static const char *SUBSCRIPTIONS_TYPE_SHAREPOINT    = "Audit.SharePoint";
-static const char *SUBSCRIPTIONS_TYPE_GENERAL       = "Audit.General";
-static const char *SUBSCRIPTIONS_TYPE_ALL           = "DLP.All";
 
 time_t time_convert_1d(const char *time_c) {
     char *endptr;
@@ -77,6 +72,7 @@ int wm_office365_read(__attribute__((unused)) const OS_XML *xml, xml_node **node
     xml_node **children = NULL;
     wm_office365* office365_config = NULL;
     wm_office365_auth *office365_auth = NULL;
+    wm_office365_subscription *office365_subscription = NULL;
 
     if (!module->data) {
         // Default initialization
@@ -87,12 +83,6 @@ int wm_office365_read(__attribute__((unused)) const OS_XML *xml, xml_node **node
         office365_config->enabled =            WM_OFFICE365_DEFAULT_ENABLED;
         office365_config->only_future_events = WM_OFFICE365_DEFAULT_ONLY_FUTURE_EVENTS;
         office365_config->interval =           WM_OFFICE365_DEFAULT_INTERVAL;
-
-        office365_config->subscription.azure        = WM_OFFICE365_DEFAULT_AZURE;
-        office365_config->subscription.exchange     = WM_OFFICE365_DEFAULT_EXCHANGE;
-        office365_config->subscription.sharepoint   = WM_OFFICE365_DEFAULT_SHAREPOINT;
-        office365_config->subscription.general      = WM_OFFICE365_DEFAULT_GENERAL;
-        office365_config->subscription.dlp          = WM_OFFICE365_DEFAULT_DLP;
 
         module->data = office365_config;
     } else {
@@ -213,22 +203,21 @@ int wm_office365_read(__attribute__((unused)) const OS_XML *xml, xml_node **node
                 continue;
             }
             for (j = 0; children[j]; j++) {
+
                 if (!strcmp(children[j]->element, XML_SUBSCRIPTION)) {
-                    if (!strcmp(children[j]->content, SUBSCRIPTIONS_TYPE_AZURE_AD)) {
-                        office365_config->subscription.azure = 1;
-                    } else if (!strcmp(children[j]->content, SUBSCRIPTIONS_TYPE_EXCHANGE)) {
-                        office365_config->subscription.exchange = 1;
-                    } else if (!strcmp(children[j]->content, SUBSCRIPTIONS_TYPE_SHAREPOINT)) {
-                        office365_config->subscription.sharepoint = 1;
-                    } else if (!strcmp(children[j]->content, SUBSCRIPTIONS_TYPE_GENERAL)) {
-                        office365_config->subscription.general = 1;
-                    } else if (!strcmp(children[j]->content, SUBSCRIPTIONS_TYPE_ALL)) {
-                        office365_config->subscription.dlp = 1;
-                    } else {
-                        merror("Invalid content for tag '%s' at module '%s'.", children[j]->element, WM_OFFICE365_CONTEXT.name);
+                    if (strlen(children[j]->content) == 0) {
+                        merror("Empty content for tag '%s' at module '%s'.", XML_SUBSCRIPTION, WM_OFFICE365_CONTEXT.name);
                         OS_ClearNode(children);
                         return OS_INVALID;
                     }
+                    if (office365_subscription) {
+                        os_calloc(1, sizeof(wm_office365_subscription), office365_subscription->next);
+                        office365_subscription = office365_subscription->next;
+                    } else {
+                        os_calloc(1, sizeof(wm_office365_subscription), office365_subscription);
+                        office365_config->subscription = office365_subscription;
+                    }
+                    os_strdup(children[j]->content, office365_subscription->subscription_name);
                 } else {
                     merror("No such tag '%s' at module '%s'.", children[j]->element, WM_OFFICE365_CONTEXT.name);
                     OS_ClearNode(children);
@@ -247,18 +236,9 @@ int wm_office365_read(__attribute__((unused)) const OS_XML *xml, xml_node **node
         merror("Empty content for tag '%s' at module '%s'.", XML_API_AUTH, WM_OFFICE365_CONTEXT.name);
         return OS_INVALID;
     }
-    if (!office365_config->subscription.azure &&
-        !office365_config->subscription.exchange &&
-        !office365_config->subscription.general &&
-        !office365_config->subscription.sharepoint &&
-        !office365_config->subscription.dlp)
-    {
-        mwarn("At module '%s': No subscription was provided, everything will be monitored by default.", WM_OFFICE365_CONTEXT.name);
-        office365_config->subscription.azure = 1;
-        office365_config->subscription.exchange = 1;
-        office365_config->subscription.sharepoint = 1;
-        office365_config->subscription.general = 1;
-        office365_config->subscription.dlp = 1;
+    if (!office365_subscription) {
+        merror("Empty content for tag '%s' at module '%s'.", XML_SUBSCRIPTIONS, WM_OFFICE365_CONTEXT.name);
+        return OS_INVALID;
     }
 
     return OS_SUCCESS;

--- a/src/headers/url.h
+++ b/src/headers/url.h
@@ -30,7 +30,8 @@ int w_download_status(int status,const char *url,const char *dest);
 int wurl_request(const char * url, const char * dest, const char *header, const char *data, const long timeout);
 int wurl_request_gz(const char * url, const char * dest, const char * header, const char * data, const long timeout, char *sha256);
 char * wurl_http_get(const char * url);
-curl_response *wurl_http_get_with_header(const char *header, const char *url);
+curl_response *wurl_http_request(const char *header, const char *url, const char *payload);
+void wurl_free_response(curl_response* response);
 #ifndef CLIENT
 int wurl_request_bz2(const char * url, const char * dest, const char * header, const char * data, const long timeout, char *sha256);
 int wurl_request_uncompress_bz2_gz(const char * url, const char * dest, const char * header, const char * data, const long timeout, char *sha256);

--- a/src/unit_tests/wazuh_modules/github/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/github/CMakeLists.txt
@@ -11,7 +11,7 @@ list(APPEND tests_flags "-Wl,--wrap,_mwarn -Wl,--wrap,_merror -Wl,--wrap,_mtinfo
                         -Wl,--wrap,_mtwarn -Wl,--wrap,_mtdebug1 -Wl,--wrap,_mtdebug2 -Wl,--wrap,StartMQ -Wl,--wrap,sleep \
                         -Wl,--wrap,OS_IsValidIP -Wl,--wrap,OSMatch_Execute -Wl,--wrap,wm_sendmsg -Wl,--wrap,OSRegex_Compile \
                         -Wl,--wrap,wm_state_io -Wl,--wrap,OSRegex_Execute -Wl,--wrap,OSRegex_Execute_ex -Wl,--wrap,OSMatch_Compile \
-                        -Wl,--wrap,OSRegex_FreePattern -Wl,--wrap,wurl_http_get_with_header -Wl,--wrap,strftime -Wl,--wrap,localtime_r")
+                        -Wl,--wrap,OSRegex_FreePattern -Wl,--wrap,wurl_http_request -Wl,--wrap,strftime -Wl,--wrap,localtime_r")
 list(APPEND use_shared_libs 1)
 
 list(APPEND shared_libs "../scheduling/wmodules_scheduling_helpers.h")

--- a/src/unit_tests/wazuh_modules/github/test_wm_github.c
+++ b/src/unit_tests/wazuh_modules/github/test_wm_github.c
@@ -343,7 +343,7 @@ void test_github_execute_scan_current_null(void **state) {
 
     int initial_scan = 1;
 
-    assert_int_equal(wm_github_execute_scan(data->github_config, initial_scan), 0);
+    wm_github_execute_scan(data->github_config, initial_scan);
 }
 
 void test_github_execute_scan_no_initial_scan(void **state) {
@@ -388,9 +388,9 @@ void test_github_execute_scan_no_initial_scan(void **state) {
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
     expect_string(__wrap__mtdebug1, formatted_msg, "No record for this organization: 'test_org'");
 
-    expect_any(__wrap_wurl_http_get_with_header, header);
-    expect_any(__wrap_wurl_http_get_with_header, url);
-    will_return(__wrap_wurl_http_get_with_header, data->response);
+    expect_any(__wrap_wurl_http_request, header);
+    expect_any(__wrap_wurl_http_request, url);
+    will_return(__wrap_wurl_http_request, data->response);
 
     wm_github_execute_scan(data->github_config, initial_scan);
 
@@ -443,9 +443,9 @@ void test_github_execute_scan_status_code_200(void **state) {
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
     expect_string(__wrap__mtdebug1, formatted_msg, "No record for this organization: 'test_org'");
 
-    expect_any(__wrap_wurl_http_get_with_header, header);
-    expect_any(__wrap_wurl_http_get_with_header, url);
-    will_return(__wrap_wurl_http_get_with_header, data->response);
+    expect_any(__wrap_wurl_http_request, header);
+    expect_any(__wrap_wurl_http_request, url);
+    will_return(__wrap_wurl_http_request, data->response);
 
     wm_github_execute_scan(data->github_config, initial_scan);
 
@@ -493,9 +493,9 @@ void test_github_execute_scan_status_code_200_null(void **state) {
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
     expect_any(__wrap__mtdebug1, formatted_msg);
 
-    expect_any(__wrap_wurl_http_get_with_header, header);
-    expect_any(__wrap_wurl_http_get_with_header, url);
-    will_return(__wrap_wurl_http_get_with_header, data->response);
+    expect_any(__wrap_wurl_http_request, header);
+    expect_any(__wrap_wurl_http_request, url);
+    will_return(__wrap_wurl_http_request, data->response);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
     expect_string(__wrap__mtdebug1, formatted_msg, "No record for this organization: 'test_org'");

--- a/src/unit_tests/wrappers/wazuh/shared/url_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/url_wrappers.c
@@ -47,8 +47,11 @@ char* __wrap_wurl_http_get(const char * url) {
     return mock_type(char *);
 }
 
-curl_response* __wrap_wurl_http_get_with_header(const char *header, const char* url) {
+curl_response* __wrap_wurl_http_request(const char *header, const char* url, const char *payload) {
     check_expected(header);
     check_expected(url);
+    if (payload) {
+        check_expected(payload);
+    }
     return mock_type(curl_response*);
 }

--- a/src/unit_tests/wrappers/wazuh/shared/url_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/url_wrappers.h
@@ -17,6 +17,6 @@ int __wrap_wurl_request(const char * url, const char * dest, const char *header,
 
 char* __wrap_wurl_http_get(const char * url);
 
-curl_response* __wrap_wurl_http_get_with_header(const char *header, const char* url);
+curl_response* __wrap_wurl_http_request(const char *header, const char* url, const char *payload);
 
 #endif

--- a/src/wazuh_modules/wm_office365.c
+++ b/src/wazuh_modules/wm_office365.c
@@ -282,10 +282,8 @@ STATIC char* wm_office365_get_access_token(wm_office365_auth* office365_auth, ch
             } else {
                 os_strdup(response->body, *error_msg);
             }
-
             cJSON_Delete(response_json);
         }
-
         wurl_free_response(response);
     }
 
@@ -314,7 +312,7 @@ STATIC void wm_office365_scan_failure_action(char *tenant_id, char *error_msg, i
     }
 
     cJSON_AddStringToObject(fail_office365, "integration", WM_OFFICE365_CONTEXT.name);
-    cJSON_AddItemToObject(fail_office365, "office_365", fail_object);
+    cJSON_AddItemToObject(fail_office365, "office365", fail_object);
 
     payload = cJSON_PrintUnformatted(fail_office365);
     mtdebug2(WM_OFFICE365_LOGTAG, "Sending Office365 internal message: '%s'", payload);

--- a/src/wazuh_modules/wm_office365.c
+++ b/src/wazuh_modules/wm_office365.c
@@ -22,6 +22,7 @@
 STATIC void* wm_office365_main(wm_office365* office365_config);    // Module main function. It won't return
 STATIC void wm_office365_destroy(wm_office365* office365_config);
 STATIC void wm_office365_auth_destroy(wm_office365_auth* office365_auth);
+STATIC void wm_office365_subscription_destroy(wm_office365_subscription* office365_subscription);
 STATIC int wm_office365_execute_scan(wm_office365 *office365_config, int initial_scan);
 
 cJSON *wm_office365_dump(const wm_office365* office365_config);
@@ -69,6 +70,7 @@ void * wm_office365_main(wm_office365* office365_config) {
 void wm_office365_destroy(wm_office365* office365_config) {
     mtinfo(WM_OFFICE365_LOGTAG, "Module Office365 finished.");
     wm_office365_auth_destroy(office365_config->auth);
+    wm_office365_subscription_destroy(office365_config->subscription);
     os_free(office365_config);
 }
 
@@ -87,6 +89,20 @@ void wm_office365_auth_destroy(wm_office365_auth* office365_auth)
         current = next;
     }
     office365_auth = NULL;
+}
+
+void wm_office365_subscription_destroy(wm_office365_subscription* office365_subscription)
+{
+    wm_office365_subscription* current = office365_subscription;
+    wm_office365_subscription* next = NULL;
+    while (current != NULL)
+    {
+        next = current->next;
+        os_free(current->subscription_name);
+        os_free(current);
+        current = next;
+    }
+    office365_subscription = NULL;
 }
 
 cJSON *wm_office365_dump(const wm_office365* office365_config) {
@@ -131,47 +147,77 @@ cJSON *wm_office365_dump(const wm_office365* office365_config) {
             cJSON_free(arr_auth);
         }
     }
-    cJSON *arr_subscription = cJSON_CreateArray();
-
-    if (office365_config->subscription.azure) {
-        cJSON_AddItemToArray(arr_subscription, cJSON_CreateString("Audit.AzureActiveDirectory"));
-    }
-    if (office365_config->subscription.exchange) {
-        cJSON_AddItemToArray(arr_subscription, cJSON_CreateString("Audit.Exchange"));
-    }
-    if (office365_config->subscription.sharepoint) {
-        cJSON_AddItemToArray(arr_subscription, cJSON_CreateString("Audit.SharePoint"));
-    }
-    if (office365_config->subscription.general) {
-        cJSON_AddItemToArray(arr_subscription, cJSON_CreateString("Audit.General"));
-    }
-    if (office365_config->subscription.dlp) {
-        cJSON_AddItemToArray(arr_subscription, cJSON_CreateString("DLP.All"));
+    if (office365_config->subscription) {
+        wm_office365_subscription *iter;
+        cJSON *arr_subscription = cJSON_CreateArray();
+        for (iter = office365_config->subscription; iter; iter = iter->next) {
+            cJSON_AddItemToArray(arr_subscription, cJSON_CreateString(iter->subscription_name));
+        }
+        if (cJSON_GetArraySize(arr_subscription) > 0) {
+            cJSON_AddItemToObject(wm_info, "subscriptions", arr_subscription);
+        } else {
+            cJSON_free(arr_subscription);
+        }
     }
 
-    if (cJSON_GetArraySize(arr_subscription) > 0) {
-        cJSON_AddItemToObject(wm_info, "subscriptions", arr_subscription);
-    } else {
-        cJSON_free(arr_subscription);
-    }
     cJSON_AddItemToObject(root, "office365", wm_info);
 
     return root;
 }
 
 STATIC int wm_office365_execute_scan(wm_office365 *office365_config, int initial_scan) {
-    wm_office365_auth* next = NULL;
-    wm_office365_auth* current = office365_config->auth;
+    //char url[OS_SIZE_8192];
+    char tenant_state_name[OS_SIZE_1024];
+    //char auth_header[PATH_MAX];
+    //time_t last_scan_time;
+    time_t new_scan_time;
+    //curl_response *response;
+    wm_office365_state tenant_state_struc;
+    wm_office365_auth* next_auth = NULL;
+    wm_office365_auth* current_auth = office365_config->auth;
 
-    while (current != NULL)
+    while (current_auth != NULL)
     {
-        next = current->next;
+        next_auth = current_auth->next;
 
-        mtdebug1(WM_OFFICE365_LOGTAG, "Scanning tenant: '%s'", current->tenant_id);
+        mtdebug1(WM_OFFICE365_LOGTAG, "Scanning tenant: '%s'", current_auth->tenant_id);
 
-        // TODO
+        // TODO: Obtain access token
 
-        current = next;
+        wm_office365_subscription* next_subscription = NULL;
+        wm_office365_subscription* current_subscription = office365_config->subscription;
+
+        while (current_subscription != NULL)
+        {
+            next_subscription = current_subscription->next;
+
+            memset(tenant_state_name, '\0', OS_SIZE_1024);
+            snprintf(tenant_state_name, OS_SIZE_1024 -1, "%s-%s-%s", WM_OFFICE365_CONTEXT.name, current_auth->tenant_id, current_subscription->subscription_name);
+
+            memset(&tenant_state_struc, 0, sizeof(tenant_state_struc));
+
+            // Load state for tenant
+            if (wm_state_io(tenant_state_name, WM_IO_READ, &tenant_state_struc, sizeof(tenant_state_struc)) < 0) {
+                memset(&tenant_state_struc, 0, sizeof(tenant_state_struc));
+            }
+
+            new_scan_time = time(0);
+
+            if (initial_scan && (!tenant_state_struc.last_log_time || office365_config->only_future_events)) {
+                tenant_state_struc.last_log_time = new_scan_time;
+                if (wm_state_io(tenant_state_name, WM_IO_WRITE, &tenant_state_struc, sizeof(tenant_state_struc)) < 0) {
+                    mterror(WM_OFFICE365_LOGTAG, "Couldn't save running state.");
+                }
+                current_subscription = next_subscription;
+                continue;
+            }
+
+            // TODO: Start subscription and get logs
+
+            current_subscription = next_subscription;
+        }
+
+        current_auth = next_auth;
     }
 
     return 0;

--- a/src/wazuh_modules/wm_office365.h
+++ b/src/wazuh_modules/wm_office365.h
@@ -17,11 +17,13 @@
 #define WM_OFFICE365_DEFAULT_ENABLED 1
 #define WM_OFFICE365_DEFAULT_ONLY_FUTURE_EVENTS 1
 #define WM_OFFICE365_DEFAULT_INTERVAL 600
-#define WM_OFFICE365_DEFAULT_AZURE 0
-#define WM_OFFICE365_DEFAULT_EXCHANGE 0
-#define WM_OFFICE365_DEFAULT_SHAREPOINT 0
-#define WM_OFFICE365_DEFAULT_GENERAL 0
-#define WM_OFFICE365_DEFAULT_DLP 0
+
+#define WM_OFFICE365_MSG_DELAY 1000000 / wm_max_eps
+#define WM_OFFICE365_RETRIES_TO_SEND_ERROR 3
+
+#define WM_OFFICE365_API_ACCESS_TOKEN_URL "https://login.microsoftonline.com/%s/oauth2/v2.0/token"
+#define WM_OFFICE365_API_SUBSCRIPTION_URL "https://manage.office.com/api/v1.0/%s/activity/feed/subscriptions/start?contentType=%s"
+#define WM_OFFICE365_API_CONTENT_BLOB_URL "https://manage.office.com/api/v1.0/%s/activity/feed/subscriptions/content?contentType=%s&startTime=%s&endTime=%s"
 
 typedef struct wm_office365_auth {
     char *tenant_id;
@@ -31,20 +33,21 @@ typedef struct wm_office365_auth {
     struct wm_office365_auth *next;
 } wm_office365_auth;
 
-typedef struct subscription_flags_t {
-    unsigned short azure:1;
-    unsigned short exchange:1;
-    unsigned short sharepoint:1;
-    unsigned short general:1;
-    unsigned short dlp:1;
-} subscription_flags_t;
+typedef struct wm_office365_subscription {
+    char *subscription_name;
+    struct wm_office365_subscription *next;
+} wm_office365_subscription;
+
+typedef struct wm_office365_state {
+    time_t last_log_time;
+} wm_office365_state;
 
 typedef struct wm_office365 {
     int enabled;
     int only_future_events;
     time_t interval;                        // Interval betweeen events in seconds
     wm_office365_auth *auth;
-    subscription_flags_t subscription;
+    wm_office365_subscription *subscription;
     int queue_fd;
 } wm_office365;
 

--- a/src/wazuh_modules/wm_office365.h
+++ b/src/wazuh_modules/wm_office365.h
@@ -25,6 +25,8 @@
 #define WM_OFFICE365_API_SUBSCRIPTION_URL "https://manage.office.com/api/v1.0/%s/activity/feed/subscriptions/start?contentType=%s"
 #define WM_OFFICE365_API_CONTENT_BLOB_URL "https://manage.office.com/api/v1.0/%s/activity/feed/subscriptions/content?contentType=%s&startTime=%s&endTime=%s"
 
+#define WM_OFFICE365_API_ACCESS_TOKEN_PAYLOAD "client_id=%s&scope=https://manage.office.com/.default&grant_type=client_credentials&client_secret=%s"
+
 typedef struct wm_office365_auth {
     char *tenant_id;
     char *client_id;


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/8680|

## Description

New features in office365 module:

- Added subscriptions array, which allows to have a dynamic number of subscriptions.
- Get access token to office365 API, one request for each tenant. Send message to manager in case of failure.
- Add POST requests capability to `libcurl`.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
