### PR TITLE
Office365 module: Second iteration

### DIFF
--- a/src/headers/url.h
+++ b/src/headers/url.h
@@ -18,6 +18,9 @@
 #define WURL_DOWNLOAD_FILE_ERROR "Cannot download file '%s' from URL: '%s'"
 #define WURL_TIMEOUT_ERROR  "Timeout reached when downloading file '%s' from URL: '%s'"
 
+#define WURL_GET_METHOD "GET"
+#define WURL_POST_METHOD "POST"
+
 typedef struct curl_response {
     char *header;               /* Response header */
     char *body;                 /* Response body */
@@ -30,7 +33,7 @@ int w_download_status(int status,const char *url,const char *dest);
 int wurl_request(const char * url, const char * dest, const char *header, const char *data, const long timeout);
 int wurl_request_gz(const char * url, const char * dest, const char * header, const char * data, const long timeout, char *sha256);
 char * wurl_http_get(const char * url);
-curl_response *wurl_http_request(const char *header, const char *url, const char *payload);
+curl_response *wurl_http_request(char *method, char **headers, const char *url, const char *payload);
 void wurl_free_response(curl_response* response);
 #ifndef CLIENT
 int wurl_request_bz2(const char * url, const char * dest, const char * header, const char * data, const long timeout, char *sha256);

--- a/src/unit_tests/wazuh_modules/github/test_wm_github.c
+++ b/src/unit_tests/wazuh_modules/github/test_wm_github.c
@@ -388,6 +388,7 @@ void test_github_execute_scan_no_initial_scan(void **state) {
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
     expect_string(__wrap__mtdebug1, formatted_msg, "No record for this organization: 'test_org'");
 
+    expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
     expect_any(__wrap_wurl_http_request, url);
     will_return(__wrap_wurl_http_request, data->response);
@@ -443,6 +444,7 @@ void test_github_execute_scan_status_code_200(void **state) {
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
     expect_string(__wrap__mtdebug1, formatted_msg, "No record for this organization: 'test_org'");
 
+    expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
     expect_any(__wrap_wurl_http_request, url);
     will_return(__wrap_wurl_http_request, data->response);
@@ -493,6 +495,7 @@ void test_github_execute_scan_status_code_200_null(void **state) {
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
     expect_any(__wrap__mtdebug1, formatted_msg);
 
+    expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
     expect_any(__wrap_wurl_http_request, url);
     will_return(__wrap_wurl_http_request, data->response);

--- a/src/unit_tests/wrappers/wazuh/shared/url_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/url_wrappers.c
@@ -47,11 +47,19 @@ char* __wrap_wurl_http_get(const char * url) {
     return mock_type(char *);
 }
 
-curl_response* __wrap_wurl_http_request(const char *header, const char* url, const char *payload) {
-    check_expected(header);
+curl_response* __wrap_wurl_http_request(char *method, char **headers, const char* url, const char *payload) {
+    check_expected(method);
+
+    char** ptr = headers;
+    for (char* header = *ptr; header; header=*++ptr) {
+        check_expected(header);
+    }
+
     check_expected(url);
+
     if (payload) {
         check_expected(payload);
     }
+
     return mock_type(curl_response*);
 }

--- a/src/unit_tests/wrappers/wazuh/shared/url_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/url_wrappers.h
@@ -17,6 +17,6 @@ int __wrap_wurl_request(const char * url, const char * dest, const char *header,
 
 char* __wrap_wurl_http_get(const char * url);
 
-curl_response* __wrap_wurl_http_request(const char *header, const char* url, const char *payload);
+curl_response* __wrap_wurl_http_request(char *method, char **headers, const char* url, const char *payload);
 
 #endif

--- a/src/wazuh_modules/wm_office365.h
+++ b/src/wazuh_modules/wm_office365.h
@@ -22,10 +22,13 @@
 #define WM_OFFICE365_RETRIES_TO_SEND_ERROR 3
 
 #define WM_OFFICE365_API_ACCESS_TOKEN_URL "https://login.microsoftonline.com/%s/oauth2/v2.0/token"
-#define WM_OFFICE365_API_SUBSCRIPTION_URL "https://manage.office.com/api/v1.0/%s/activity/feed/subscriptions/start?contentType=%s"
+#define WM_OFFICE365_API_SUBSCRIPTION_URL "https://manage.office.com/api/v1.0/%s/activity/feed/subscriptions/%s?contentType=%s"
 #define WM_OFFICE365_API_CONTENT_BLOB_URL "https://manage.office.com/api/v1.0/%s/activity/feed/subscriptions/content?contentType=%s&startTime=%s&endTime=%s"
 
 #define WM_OFFICE365_API_ACCESS_TOKEN_PAYLOAD "client_id=%s&scope=https://manage.office.com/.default&grant_type=client_credentials&client_secret=%s"
+
+#define WM_OFFICE365_API_SUBSCRIPTION_START "start"
+#define WM_OFFICE365_API_SUBSCRIPTION_STOP "stop"
 
 typedef struct wm_office365_auth {
     char *tenant_id;


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/8680|

## Description

New features in office365 module:

- Added subscriptions start request.
- Set method to `libcurl` request.
- Set multiple headers to `libcurl` request.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
