### PR TITLE
Let wazuh-db remove agent files on cluster enviornments

### DIFF
--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -171,7 +171,7 @@ int OS_RemoveAgent(const char *u_id) {
     // Remove DB from wazuh-db
     int sock = -1;
     int error;
-    snprintf(wdbquery, OS_SIZE_128, "agent %s remove", u_id);
+    snprintf(wdbquery, OS_SIZE_128, "wazuhdb remove %s", u_id);
     os_calloc(OS_SIZE_6144, sizeof(char), wdboutput);
     if (error = wdbc_query_ex(&sock, wdbquery, wdboutput, OS_SIZE_6144), !error) {
         mdebug1("DB from agent %s was deleted '%s'", u_id, wdboutput);

--- a/src/analysisd/decoders/dbsync.c
+++ b/src/analysisd/decoders/dbsync.c
@@ -144,7 +144,9 @@ static void dispatch_check(dbsync_context_t * ctx, const char * command) {
     case WDBC_OK:
         break;
     case WDBC_ERROR:
-        merror("dbsync: Bad response from database: %s", arg);
+        if (strcmp(arg, "Agent not found") != 0) {
+            merror("dbsync: Bad response from database: %s", arg);
+        }
         // Fallthrough
     default:
         goto end;
@@ -192,7 +194,9 @@ static void dispatch_state(dbsync_context_t * ctx) {
     case WDBC_OK:
         break;
     case WDBC_ERROR:
-        merror("dbsync: Bad response from database: %s", arg);
+        if (strcmp(arg, "Agent not found") != 0) {
+            merror("dbsync: Bad response from database: %s", arg);
+        }
         // Fallthrough
     default:
         goto end;
@@ -236,7 +240,9 @@ static void dispatch_clear(dbsync_context_t * ctx) {
     case WDBC_OK:
         break;
     case WDBC_ERROR:
-        merror("dbsync: Bad response from database: %s", arg);
+        if (strcmp(arg, "Agent not found") != 0) {
+            merror("dbsync: Bad response from database: %s", arg);
+        }
         // Fallthrough
     default:
         goto end;

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -348,6 +348,10 @@ int fim_db_search(char *f_name, char *c_sum, char *w_sum, Eventinfo *lf, _sdb *s
     }
     *(check_sum++) = '\0';
 
+    if (strcmp(response, "ok") != 0) {
+        goto exit_fail;
+    }
+
     //extract changes and date_alert fields only available from wazuh_db
     sk_decode_extradata(&oldsum, check_sum);
 
@@ -1424,7 +1428,9 @@ void fim_send_db_query(int * sock, const char * query) {
     case WDBC_OK:
         break;
     case WDBC_ERROR:
-        merror("FIM decoder: Bad response from database: %s", arg);
+        if (strcmp(arg, "Agent not found") != 0) {
+            merror("FIM decoder: Bad response from database: %s", arg);
+        }
         // Fallthrough
     default:
         goto end;

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -842,7 +842,7 @@ void* run_writer(__attribute__((unused)) void *arg) {
                 mdebug1("Could not remove the information stored in Wazuh DB of the agent %s.", cur->id);
             }
 
-            snprintf(wdbquery, OS_SIZE_128, "agent %s remove", cur->id);
+            snprintf(wdbquery, OS_SIZE_128, "wazuhdb remove %s", cur->id);
             wdbc_query_ex(&wdb_sock, wdbquery, wdboutput, sizeof(wdboutput));
 
             free(cur->id);

--- a/src/shared/auth_client.c
+++ b/src/shared/auth_client.c
@@ -72,7 +72,7 @@ int auth_remove_agent(int sock, const char *id, int json_format) {
             int wdb_sock = -1;
             int error;
 
-            snprintf(wdbquery, OS_SIZE_128, "agent %s remove", id);
+            snprintf(wdbquery, OS_SIZE_128, "wazuhdb remove %s", id);
             os_calloc(OS_SIZE_6144, sizeof(char), wdboutput);
             if (error = wdbc_query_ex(&wdb_sock, wdbquery, wdboutput, OS_SIZE_6144), error) {
                 merror("Could not remove the agent %s. Error: %d.", id, error);

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -19,7 +19,8 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                         -Wl,--wrap,wdbi_query_checksum -Wl,--wrap,wdbi_query_clear -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,wdb_step \
                         -Wl,--wrap,sqlite3_changes -Wl,--wrap,sqlite3_bind_int -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,sqlite3_last_insert_rowid \
                         -Wl,--wrap,sqlite3_step -Wl,--wrap,wdb_open_agent2 -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_agents_insert_vuln_cve \
-                        -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_agents_clear_vuln_cve")
+                        -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_agents_clear_vuln_cve -Wl,--wrap,wdb_open_global \
+                        -Wl,--wrap,wdb_global_agent_exists")
 
 list(APPEND wdb_tests_names "test_wdb_global_parser")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \

--- a/src/unit_tests/wazuh_db/test_wdb.c
+++ b/src/unit_tests/wazuh_db/test_wdb.c
@@ -478,7 +478,7 @@ void test_wdb_init_stmt_in_cache_invalid_statement(void **state) {
     will_return(__wrap_sqlite3_finalize, SQLITE_OK);
 
     // wdb_stmt_cache
-    expect_string(__wrap__merror, formatted_msg, "DB(000) SQL statement index (171) out of bounds");
+    expect_string(__wrap__merror, formatted_msg, "DB(000) SQL statement index (172) out of bounds");
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
     sqlite3_stmt* result = wdb_init_stmt_in_cache(data->wdb,WDB_STMT_SIZE);

--- a/src/unit_tests/wazuh_db/test_wdb_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_parser.c
@@ -14,6 +14,7 @@
 
 typedef struct test_struct {
     wdb_t *wdb;
+    wdb_t *wdb_global;
     char *output;
 } test_struct_t;
 
@@ -22,6 +23,7 @@ static int test_setup(void **state) {
 
     init_data = malloc(sizeof(test_struct_t));
     init_data->wdb = malloc(sizeof(wdb_t));
+    init_data->wdb_global = malloc(sizeof(wdb_t));
     init_data->wdb->id = strdup("000");
     init_data->output = malloc(256*sizeof(char));
 
@@ -36,6 +38,7 @@ static int test_teardown(void **state){
     free(data->output);
     free(data->wdb->id);
     free(data->wdb);
+    free(data->wdb_global);
     free(data);
 
     return 0;
@@ -750,6 +753,12 @@ void test_vuln_cve_syntax_error(void **state) {
 
     os_strdup("agent 000 vuln_cve", query);
 
+    will_return(__wrap_wdb_open_global, data->wdb_global);
+
+    expect_value(__wrap_wdb_global_agent_exists, wdb, data->wdb_global);
+    expect_value(__wrap_wdb_global_agent_exists, agent_id, 0);
+    will_return(__wrap_wdb_global_agent_exists, 1);
+
     expect_value(__wrap_wdb_open_agent2, agent_id, atoi(data->wdb->id));
     will_return(__wrap_wdb_open_agent2, (wdb_t*)1); // Returning any value
     expect_string(__wrap__mdebug2, formatted_msg, "Agent 000 query: vuln_cve");
@@ -771,6 +780,12 @@ void test_vuln_cve_invalid_action(void **state) {
     char *query = NULL;
 
     os_strdup("agent 000 vuln_cve invalid", query);
+    will_return(__wrap_wdb_open_global, data->wdb_global);
+
+    expect_value(__wrap_wdb_global_agent_exists, wdb, data->wdb_global);
+    expect_value(__wrap_wdb_global_agent_exists, agent_id, 0);
+    will_return(__wrap_wdb_global_agent_exists, 1);
+
     expect_value(__wrap_wdb_open_agent2, agent_id, atoi(data->wdb->id));
     will_return(__wrap_wdb_open_agent2, (wdb_t*)1); // Returning any value
     expect_string(__wrap__mdebug2, formatted_msg, "Agent 000 query: vuln_cve invalid");

--- a/src/unit_tests/wazuh_db/test_wdb_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_parser.c
@@ -753,12 +753,6 @@ void test_vuln_cve_syntax_error(void **state) {
 
     os_strdup("agent 000 vuln_cve", query);
 
-    will_return(__wrap_wdb_open_global, data->wdb_global);
-
-    expect_value(__wrap_wdb_global_agent_exists, wdb, data->wdb_global);
-    expect_value(__wrap_wdb_global_agent_exists, agent_id, 0);
-    will_return(__wrap_wdb_global_agent_exists, 1);
-
     expect_value(__wrap_wdb_open_agent2, agent_id, atoi(data->wdb->id));
     will_return(__wrap_wdb_open_agent2, (wdb_t*)1); // Returning any value
     expect_string(__wrap__mdebug2, formatted_msg, "Agent 000 query: vuln_cve");
@@ -780,11 +774,6 @@ void test_vuln_cve_invalid_action(void **state) {
     char *query = NULL;
 
     os_strdup("agent 000 vuln_cve invalid", query);
-    will_return(__wrap_wdb_open_global, data->wdb_global);
-
-    expect_value(__wrap_wdb_global_agent_exists, wdb, data->wdb_global);
-    expect_value(__wrap_wdb_global_agent_exists, agent_id, 0);
-    will_return(__wrap_wdb_global_agent_exists, 1);
 
     expect_value(__wrap_wdb_open_agent2, agent_id, atoi(data->wdb->id));
     will_return(__wrap_wdb_open_agent2, (wdb_t*)1); // Returning any value

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -262,3 +262,9 @@ cJSON* __wrap_wdb_global_get_agents_to_disconnect(__attribute__((unused)) wdb_t 
     *status = mock();
     return mock_ptr_type(cJSON*);
 }
+
+int __wrap_wdb_global_agent_exists(wdb_t *wdb, int agent_id) {
+    check_expected_ptr(wdb);
+    check_expected(agent_id);
+    return mock();
+}

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -87,4 +87,5 @@ cJSON* __wrap_wdb_global_get_agents_by_connection_status (wdb_t *wdb, int last_a
 
 cJSON* __wrap_wdb_global_get_agents_to_disconnect(wdb_t *wdb, int last_agent_id, int keep_alive, const char *sync_status, wdbc_result* status);
 
+int __wrap_wdb_global_agent_exists(wdb_t *wdb, int agent_id);
 #endif

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -159,6 +159,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_GET_AGENT_INFO] = "SELECT * FROM agent WHERE id = ?;",
     [WDB_STMT_GLOBAL_RESET_CONNECTION_STATUS] = "UPDATE agent SET connection_status = 'disconnected', sync_status = ? where connection_status != 'disconnected' AND connection_status != 'never_connected' AND id != 0;",
     [WDB_STMT_GLOBAL_GET_AGENTS_TO_DISCONNECT] = "SELECT id FROM agent WHERE id > ? AND connection_status = 'active' AND last_keepalive < ?;",
+    [WDB_STMT_GLOBAL_AGENT_EXISTS] = "SELECT EXISTS(SELECT 1 FROM agent WHERE id=?);",
     [WDB_STMT_TASK_INSERT_TASK] = "INSERT INTO TASKS VALUES(NULL,?,?,?,?,?,?,?,?);",
     [WDB_STMT_TASK_GET_LAST_AGENT_TASK] = "SELECT *, MAX(CREATE_TIME) FROM TASKS WHERE AGENT_ID = ?;",
     [WDB_STMT_TASK_GET_LAST_AGENT_UPGRADE_TASK] = "SELECT *, MAX(CREATE_TIME) FROM TASKS WHERE AGENT_ID = ? AND (COMMAND = 'upgrade' OR COMMAND = 'upgrade_custom');",

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -176,6 +176,7 @@ typedef enum wdb_stmt {
     WDB_STMT_GLOBAL_GET_AGENT_INFO,
     WDB_STMT_GLOBAL_GET_AGENTS_TO_DISCONNECT,
     WDB_STMT_GLOBAL_RESET_CONNECTION_STATUS,
+    WDB_STMT_GLOBAL_AGENT_EXISTS,
     WDB_STMT_TASK_INSERT_TASK,
     WDB_STMT_TASK_GET_LAST_AGENT_TASK,
     WDB_STMT_TASK_GET_LAST_AGENT_UPGRADE_TASK,
@@ -1536,6 +1537,17 @@ cJSON* wdb_global_get_agent_info(wdb_t *wdb, int id);
  * @retval NULL on error.
  */
 cJSON* wdb_global_get_all_agents(wdb_t *wdb, int last_agent_id, wdbc_result* status);
+
+/**
+ * @brief Checks the given ID is in the agent table.
+ *
+ * @param [in] wdb The Global struct database.
+ * @param [in] agent_id ID to check.
+ * @retval 0 if the ID was not found.
+ * @retval 1 if the ID was found.
+ * @retval -1 on error.
+ */
+int wdb_global_agent_exists(wdb_t *wdb, int agent_id);
 
 /**
  * @brief Function to reset connection_status column of every agent (excluding the manager).

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -245,21 +245,25 @@ int wdb_parse(char * input, char * output) {
 
         mdebug2("Agent %s query: %s", sagent_id, query);
 
-        if (wdb_global = wdb_open_global(), !wdb_global) {
-            mdebug2("Couldn't open DB global: %s/%s.db", WDB2_DIR, WDB_GLOB_NAME);
-            snprintf(output, OS_MAXSTR + 1, "err Couldn't open DB global");
-            wdb_leave(wdb_global);
+        // Don't perform this check if it's a manager.
+        if (agent_id != 0) {
+            if (wdb_global = wdb_open_global(), !wdb_global) {
+                mdebug2("Couldn't open DB global: %s/%s.db", WDB2_DIR, WDB_GLOB_NAME);
+                snprintf(output, OS_MAXSTR + 1, "err Couldn't open DB global");
+                wdb_leave(wdb_global);
 
-            return -1;
-        }
+                return -1;
+            }
 
-        if (wdb_global_agent_exists(wdb_global, agent_id) <= 0) {
-            mdebug2("No agent with id %s found.", sagent_id);
-            snprintf(output, OS_MAXSTR + 1, "err Agent not found");
+            if (wdb_global_agent_exists(wdb_global, agent_id) <= 0) {
+                mdebug2("No agent with id %s found.", sagent_id);
+                snprintf(output, OS_MAXSTR + 1, "err Agent not found");
+                wdb_leave(wdb_global);
+
+                return -1;
+            }
             wdb_leave(wdb_global);
-            return -1;
         }
-        wdb_leave(wdb_global);
 
         if (wdb = wdb_open_agent2(agent_id), !wdb) {
             merror("Couldn't open DB for agent '%s'", sagent_id);

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -304,7 +304,6 @@ void wm_sync_agents() {
             snprintf(id, 9, "%03d", agents[i]);
 
             if (OS_IsAllowedID(&keys, id) == -1) {
-                char full_name[FILE_SIZE + 1];
                 char *name = wdb_get_agent_name(agents[i], &wdb_wmdb_sock);
 
                 if (wdb_remove_agent(agents[i], &wdb_wmdb_sock) < 0) {
@@ -317,7 +316,7 @@ void wm_sync_agents() {
                     os_malloc(WDBOUTPUT_SIZE, wdboutput);
                 }
 
-                snprintf(wdbquery, OS_SIZE_128, "agent %s remove", id);
+                snprintf(wdbquery, OS_SIZE_128, "wazuhdb remove %s", id);
                 error = wdbc_query_ex(&wdb_wmdb_sock, wdbquery, wdboutput, WDBOUTPUT_SIZE);
 
                 if (error == 0) {
@@ -331,7 +330,8 @@ void wm_sync_agents() {
                 OS_RemoveAgentTimestamp(id);
                 OS_RemoveAgentGroup(id);
 
-                if (name == NULL) {
+                if (name == NULL || *name == '\0') {
+                    os_free(name);
                     continue;
                 }
 


### PR DESCRIPTION
|Related issue|
|---|
|8605|

## Description
This PR aims to add the necessary modifications to wazuh-db in order to remove the agent files on cluster environments.

Closes #8605 


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [X] Source installation
- [X] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
