### PR TITLE
Office365 module: Third iteration

### DIFF
--- a/src/unit_tests/wazuh_modules/github/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/github/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 # Tests list and flags
 list(APPEND tests_names "test_wm_github")
-list(APPEND tests_flags "-Wl,--wrap,_mwarn -Wl,--wrap,_merror -Wl,--wrap,_mtinfo -Wl,--wrap,_mterror\
+list(APPEND tests_flags "-Wl,--wrap,_mwarn -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mtinfo -Wl,--wrap,_mterror\
                         -Wl,--wrap,_mtwarn -Wl,--wrap,_mtdebug1 -Wl,--wrap,_mtdebug2 -Wl,--wrap,StartMQ -Wl,--wrap,sleep \
                         -Wl,--wrap,OS_IsValidIP -Wl,--wrap,OSMatch_Execute -Wl,--wrap,wm_sendmsg -Wl,--wrap,OSRegex_Compile \
                         -Wl,--wrap,wm_state_io -Wl,--wrap,OSRegex_Execute -Wl,--wrap,OSRegex_Execute_ex -Wl,--wrap,OSMatch_Compile \

--- a/src/unit_tests/wazuh_modules/github/test_wm_github.c
+++ b/src/unit_tests/wazuh_modules/github/test_wm_github.c
@@ -293,9 +293,6 @@ void test_github_scan_failure_action_org_null(void **state) {
     int queue_fd = 1;
     wm_max_eps = 1;
 
-    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
-    expect_string(__wrap__mtdebug1, formatted_msg, "No record for this organization: 'test_org'");
-
     wm_github_scan_failure_action(&data->github_config->fails, org_name, error_msg, queue_fd);
 
     assert_string_equal(data->github_config->fails->org_name, "test_org");
@@ -382,9 +379,6 @@ void test_github_execute_scan_no_initial_scan(void **state) {
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
     expect_any(__wrap__mtdebug1, formatted_msg);
 
-    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
-    expect_string(__wrap__mtdebug1, formatted_msg, "No record for this organization: 'test_org'");
-
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
     expect_any(__wrap_wurl_http_request, url);
@@ -437,9 +431,6 @@ void test_github_execute_scan_status_code_200(void **state) {
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
     expect_string(__wrap__mtdebug1, formatted_msg, "Error parsing response body.");
-
-    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
-    expect_string(__wrap__mtdebug1, formatted_msg, "No record for this organization: 'test_org'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -496,9 +487,6 @@ void test_github_execute_scan_status_code_200_null(void **state) {
     expect_any(__wrap_wurl_http_request, header);
     expect_any(__wrap_wurl_http_request, url);
     will_return(__wrap_wurl_http_request, data->response);
-
-    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
-    expect_string(__wrap__mtdebug1, formatted_msg, "No record for this organization: 'test_org'");
 
     expect_value(__wrap_wm_sendmsg, usec, 1000000);
     expect_value(__wrap_wm_sendmsg, queue, 0);

--- a/src/unit_tests/wazuh_modules/github/test_wm_github.c
+++ b/src/unit_tests/wazuh_modules/github/test_wm_github.c
@@ -116,15 +116,14 @@ void test_github_main_enable(void **state) {
 }
 
 void test_github_get_next_page_warn(void **state) {
-    char *header;
+    char *header = "test";
 
     expect_string(__wrap_OSRegex_Compile, pattern,"<(\\S+)>;\\s*rel=\"next\"");
     will_return(__wrap_OSRegex_Compile, 0);
 
-    expect_string(__wrap__mtwarn, tag, "wazuh-modulesd:github");
-    expect_string(__wrap__mtwarn, formatted_msg, "Cannot compile regex");
+    expect_string(__wrap__mwarn, formatted_msg, "Cannot compile regex.");
 
-    assert_null(wm_github_get_next_page(header));
+    assert_null(wm_read_http_header_element(header, GITHUB_NEXT_PAGE_REGEX));
 }
 
 void test_github_get_next_page_execute(void **state) {
@@ -138,10 +137,9 @@ void test_github_get_next_page_execute(void **state) {
 
     expect_any(__wrap_OSRegex_FreePattern, reg);
 
-    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
-    expect_string(__wrap__mtdebug1, formatted_msg, "No match regex.");
+    expect_string(__wrap__mdebug1, formatted_msg, "No match regex.");
 
-    assert_null(wm_github_get_next_page(header));
+    assert_null(wm_read_http_header_element(header, GITHUB_NEXT_PAGE_REGEX));
 }
 
 void test_github_get_next_page_sub_string(void **state) {
@@ -155,10 +153,9 @@ void test_github_get_next_page_sub_string(void **state) {
 
     expect_any(__wrap_OSRegex_FreePattern, reg);
 
-    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
-    expect_string(__wrap__mtdebug1, formatted_msg, "No next page was captured.");
+    expect_string(__wrap__mdebug1, formatted_msg, "No element was captured.");
 
-    assert_null(wm_github_get_next_page(header));
+    assert_null(wm_read_http_header_element(header, GITHUB_NEXT_PAGE_REGEX));
 }
 
 void test_github_get_next_page_complete(void **state) {
@@ -174,7 +171,7 @@ void test_github_get_next_page_complete(void **state) {
 
     expect_any(__wrap_OSRegex_FreePattern, reg);
 
-    next_page = wm_github_get_next_page(header);
+    next_page = wm_read_http_header_element(header, GITHUB_NEXT_PAGE_REGEX);
 
     assert_string_equal(next_page, "https://api.com/");
     os_free(next_page);

--- a/src/wazuh_modules/wm_github.c
+++ b/src/wazuh_modules/wm_github.c
@@ -26,7 +26,6 @@ STATIC void wm_github_auth_destroy(wm_github_auth* github_auth);
 STATIC void wm_github_fail_destroy(wm_github_fail* github_fails);
 STATIC wm_github_fail* wm_github_get_fail_by_org(wm_github_fail *fails, char *org_name);
 STATIC void wm_github_execute_scan(wm_github *github_config, int initial_scan);
-STATIC char* wm_github_get_next_page(char *header);
 STATIC void wm_github_scan_failure_action(wm_github_fail **current_fails, char *org_name, char *error_msg, int queue_fd);
 
 cJSON *wm_github_dump(const wm_github* github_config);
@@ -265,7 +264,7 @@ STATIC void wm_github_execute_scan(wm_github *github_config, int initial_scan) {
                         }
 
                         if (response_lenght == ITEM_PER_PAGE) {
-                            next_page = wm_github_get_next_page(response->header);
+                            next_page = wm_read_http_header_element(response->header, GITHUB_NEXT_PAGE_REGEX);
                             if (next_page == NULL) {
                                 scan_finished = 1;
                             } else {
@@ -336,33 +335,6 @@ STATIC wm_github_fail* wm_github_get_fail_by_org(wm_github_fail *fails, char *or
     }
 
     return current;
-}
-
-STATIC char* wm_github_get_next_page(char *header) {
-    char *next_page = NULL;
-    OSRegex regex;
-
-    if (!OSRegex_Compile("<(\\S+)>;\\s*rel=\"next\"", &regex, OS_RETURN_SUBSTRING)) {
-        mtwarn(WM_GITHUB_LOGTAG, "Cannot compile regex");
-        return NULL;
-    }
-
-    if (!OSRegex_Execute(header, &regex)) {
-        mtdebug1(WM_GITHUB_LOGTAG, "No match regex.");
-        OSRegex_FreePattern(&regex);
-        return NULL;
-    }
-
-    if (!regex.d_sub_strings[0]) {
-        mtdebug1(WM_GITHUB_LOGTAG, "No next page was captured.");
-        OSRegex_FreePattern(&regex);
-        return NULL;
-    }
-
-    os_strdup(regex.d_sub_strings[0], next_page);
-
-    OSRegex_FreePattern(&regex);
-    return next_page;
 }
 
 STATIC void wm_github_scan_failure_action(wm_github_fail **current_fails, char *org_name, char *error_msg, int queue_fd) {

--- a/src/wazuh_modules/wm_github.c
+++ b/src/wazuh_modules/wm_github.c
@@ -322,7 +322,6 @@ STATIC wm_github_fail* wm_github_get_fail_by_org(wm_github_fail *fails, char *or
     while (!target_org)
     {
         if (current == NULL) {
-            mtdebug1(WM_GITHUB_LOGTAG, "No record for this organization: '%s'", org_name);
             target_org = 1;
             continue;
         }
@@ -344,7 +343,6 @@ STATIC void wm_github_scan_failure_action(wm_github_fail **current_fails, char *
     org_fail = wm_github_get_fail_by_org(*current_fails, org_name);
 
     if (org_fail == NULL) {
-
         os_calloc(1, sizeof(wm_github_fail), org_fail);
 
         if (*current_fails) {
@@ -357,7 +355,6 @@ STATIC void wm_github_scan_failure_action(wm_github_fail **current_fails, char *
         } else {
             // First wm_github_fail
             *current_fails = org_fail;
-
         }
 
         os_strdup(org_name, org_fail->org_name);
@@ -387,6 +384,7 @@ STATIC void wm_github_scan_failure_action(wm_github_fail **current_fails, char *
             cJSON_AddItemToObject(fail_github, "github", fail_object);
 
             payload = cJSON_PrintUnformatted(fail_github);
+
             mtdebug2(WM_GITHUB_LOGTAG, "Sending GitHub internal message: '%s'", payload);
 
             if (wm_sendmsg(WM_GITHUB_MSG_DELAY, queue_fd, payload, WM_GITHUB_CONTEXT.name, LOCALFILE_MQ) < 0) {

--- a/src/wazuh_modules/wm_github.h
+++ b/src/wazuh_modules/wm_github.h
@@ -22,6 +22,7 @@
 
 #define ITEM_PER_PAGE 100
 #define RETRIES_TO_SEND_ERROR 3
+#define GITHUB_NEXT_PAGE_REGEX "<(\\S+)>;\\s*rel=\"next\""
 
 #define GITHUB_API_URL "https://api.github.com/orgs/%s/audit-log?phrase=created:%s..%s&include=%s&order=asc&per_page=%d"
 

--- a/src/wazuh_modules/wm_office365.h
+++ b/src/wazuh_modules/wm_office365.h
@@ -48,12 +48,20 @@ typedef struct wm_office365_state {
     time_t last_log_time;
 } wm_office365_state;
 
+typedef struct wm_office365_fail {
+    int fails;
+    char *tenant_id;
+    char *subscription_name;
+    struct wm_office365_fail *next;
+} wm_office365_fail;
+
 typedef struct wm_office365 {
     int enabled;
     int only_future_events;
     time_t interval;                        // Interval betweeen events in seconds
     wm_office365_auth *auth;
     wm_office365_subscription *subscription;
+    wm_office365_fail *fails;
     int queue_fd;
 } wm_office365;
 

--- a/src/wazuh_modules/wm_office365.h
+++ b/src/wazuh_modules/wm_office365.h
@@ -20,6 +20,7 @@
 
 #define WM_OFFICE365_MSG_DELAY 1000000 / wm_max_eps
 #define WM_OFFICE365_RETRIES_TO_SEND_ERROR 3
+#define WM_OFFICE365_NEXT_PAGE_REGEX "NextPageUrl:\\s*(\\S+)"
 
 #define WM_OFFICE365_API_ACCESS_TOKEN_URL "https://login.microsoftonline.com/%s/oauth2/v2.0/token"
 #define WM_OFFICE365_API_SUBSCRIPTION_URL "https://manage.office.com/api/v1.0/%s/activity/feed/subscriptions/%s?contentType=%s"

--- a/src/wazuh_modules/wm_office365.h
+++ b/src/wazuh_modules/wm_office365.h
@@ -20,7 +20,7 @@
 
 #define WM_OFFICE365_MSG_DELAY 1000000 / wm_max_eps
 #define WM_OFFICE365_RETRIES_TO_SEND_ERROR 3
-#define WM_OFFICE365_NEXT_PAGE_REGEX "NextPageUrl:\\s*(\\S+)"
+#define WM_OFFICE365_NEXT_PAGE_REGEX "NextPageUri:\\s*(\\S+)"
 
 #define WM_OFFICE365_API_ACCESS_TOKEN_URL "https://login.microsoftonline.com/%s/oauth2/v2.0/token"
 #define WM_OFFICE365_API_SUBSCRIPTION_URL "https://manage.office.com/api/v1.0/%s/activity/feed/subscriptions/%s?contentType=%s"

--- a/src/wazuh_modules/wmodules.c
+++ b/src/wazuh_modules/wmodules.c
@@ -216,6 +216,38 @@ long int wm_read_http_size(char *header) {
     return size;
 }
 
+char* wm_read_http_header_element(char *header, char *regex) {
+    char *element = NULL;
+    OSRegex os_regex;
+
+    if (!header || !regex) {
+        merror("Missing parameters.");
+        return NULL;
+    }
+
+    if (!OSRegex_Compile(regex, &os_regex, OS_RETURN_SUBSTRING)) {
+        mwarn("Cannot compile regex.");
+        return NULL;
+    }
+
+    if (!OSRegex_Execute(header, &os_regex)) {
+        mdebug1("No match regex.");
+        OSRegex_FreePattern(&os_regex);
+        return NULL;
+    }
+
+    if (!os_regex.d_sub_strings[0]) {
+        mdebug1("No element was captured.");
+        OSRegex_FreePattern(&os_regex);
+        return NULL;
+    }
+
+    os_strdup(os_regex.d_sub_strings[0], element);
+
+    OSRegex_FreePattern(&os_regex);
+    return element;
+}
+
 void wm_free(wmodule * config) {
     wmodule *cur_module;
     wmodule *next_module;

--- a/src/wazuh_modules/wmodules.h
+++ b/src/wazuh_modules/wmodules.h
@@ -141,6 +141,9 @@ void wm_kill_children();
 // Reads an HTTP header and extracts the size of the response
 long int wm_read_http_size(char *header);
 
+// Reads an HTTP header and extracts an element from a regex
+char* wm_read_http_header_element(char *header, char *regex);
+
 /* Load or save the running state
  * op: WM_IO_READ | WM_IO_WRITE
  * Returns 0 if success, or 1 if fail.


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/8680|

## Description

New features in office365 module:

- Retrieve content blobs.
- Retrieve next page from headers response.
- Split requests in periods of 24 hours when necessary.
- Retrieve logs from blobs.
- Send error message alert only after 3 retries.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
