### PR TITLE
Fixes segfault when can not connect to wdb

### DIFF
--- a/src/analysisd/mitre.c
+++ b/src/analysisd/mitre.c
@@ -237,6 +237,11 @@ end:
 }
 
 technique_data* mitre_get_attack(const char *mitre_id) {
+
+    if (techniques_table == NULL) {
+        return NULL;
+    }
+
     return OSHash_Get(techniques_table, mitre_id);
 }
 

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -737,7 +737,7 @@ InstallCommon()
         fi
     elif [ -f libwazuhshared.so ]
     then
-        ${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} libwazuhshared.so ${INSTALLDIR}/lib
+        ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} libwazuhshared.so ${INSTALLDIR}/lib
 
         if ([ "X${DIST_NAME}" = "Xrhel" ] || [ "X${DIST_NAME}" = "Xcentos" ] || [ "X${DIST_NAME}" = "XCentOS" ]) && [ ${DIST_VER} -le 5 ]; then
             chcon -t textrel_shlib_t ${INSTALLDIR}/lib/libwazuhshared.so


### PR DESCRIPTION
|Related issue|
|---|
|Closes #8913 |

## Description

Hi team!,

When wazuh-analysisd fails to connect to the wdb and get the data from the Mitre ATT&CK, the technique map is not initialized.
This PR adds a check when getting the mitre technique from the map, avoiding the segfault.

### Master:
Valgrind report
```
==186723== Thread 3:
==186723== Invalid read of size 4
==186723==    at 0x2538A9: _os_genhash (hash_op.c:99)
==186723==    by 0x25424B: OSHash_Get (hash_op.c:381)
==186723==    by 0x122B1A: mitre_get_attack (mitre.c:240)
==186723==    by 0x14FAF1: Eventinfo_to_jsonstr (to_json.c:197)
==186723==    by 0x141B8C: w_logtest_process_log (logtest.c:217)
==186723==    by 0x14487D: w_logtest_process_request_log_processing (logtest.c:1068)
==186723==    by 0x14435F: w_logtest_process_request (logtest.c:993)
==186723==    by 0x141807: w_logtest_clients_handler (logtest.c:143)
==186723==    by 0x14136C: w_logtest_init (logtest.c:64)
==186723==    by 0x50C3608: start_thread (pthread_create.c:477)
==186723==    by 0x51FF292: clone (clone.S:95)
==186723==  Address 0x4 is not stack'd, malloc'd or (recently) free'd
```

[Valgrind master full report.log](https://github.com/wazuh/wazuh/files/6611419/Valgrind.master.log)

### PR: 
[scan build](https://github.com/wazuh/wazuh/files/6611403/scan.zip)
[Valgrind_Report.log](https://github.com/wazuh/wazuh/files/6611401/ValgrindPRs.log)

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] ~Windows~
  - [x] ~MAC OS X~
- [x] Source installation
- [x] ~Package installation~
- [x] Source upgrade
- [x] ~Package upgrade~
- [x] ~Review logs syntax and correct language~
- [x] ~QA templates contemplate the added capabilities~

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] ~Dr. Memory~
  - [x] ~AddressSanitizer~
- ~Memory tests for Windows~
- ~Memory tests for macOS~


<!-- Checks for huge PRs that affect the product more generally -->
- [x] ~Retrocompatibility with older Wazuh versions~
- [x] ~Working on cluster environments~
- [x] ~Configuration on demand reports new parameters~
- [x] ~The data flow works as expected (agent-manager-api-app)~
- [x] ~Added unit tests (for new features)~
- [x] ~Stress test for affected components~
