### PR TITLE
Remove libwazuhshared.so in clean-internals

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2317,6 +2317,7 @@ clean-internals: clean-unit-tests
 	rm -f ${wdb_o}
 	rm -f ${SELINUX_MODULE}
 	rm -f ${SELINUX_POLICY}
+	rm -f $(WAZUH_LIB)
 	rm -rf $(DBSYNC)build
 	rm -rf $(RSYNC)build
 	rm -rf $(SHARED_UTILS_TEST)build


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Hi team!
I noticed that `libwazuhshared.so` is not removed when cleaning the internals dependencies. This PR aims to fix this behavior

## Windows
```
root@ubuntuagent:/home/vagrant/wazuh/src# ls
active-response  ci             error_messages   libwazuhshared.dll  os_crypto      os_maild  Readme.md  selinux         util
addagent         client-agent   external         logcollector        os_csyslogd    os_net    remoted    shared          VERSION
agentlessd       config         headers          Makefile            os_dbd         os_regex  reportd    shared_modules  wazuh_db
analysisd        data_provider  init             monitord            os_execd       os_xml    REVISION   syscheckd       wazuh_modules
build.py         Doxyfile       libwazuhext.dll  os_auth             os_integrator  os_zlib   rootcheck  unit_tests      win32
root@ubuntuagent:/home/vagrant/wazuh/src# make clean-internals TARGET=winagent
..............................................
...........................................
rm -rf wazuh_modules/syscollector/build
rm -rf data_provider/build
rm -rf libwazuhext
root@ubuntuagent:/home/vagrant/wazuh/src# ls
active-response  build.py      data_provider   headers       monitord     os_dbd         os_net    Readme.md  rootcheck       syscheckd   wazuh_db
addagent         ci            Doxyfile        init          os_auth      os_execd       os_regex  remoted    selinux         unit_tests  wazuh_modules
agentlessd       client-agent  error_messages  logcollector  os_crypto    os_integrator  os_xml    reportd    shared          util        win32
analysisd        config        external        Makefile      os_csyslogd  os_maild       os_zlib   REVISION   shared_modules  VERSION
```

## Linux
```
root@ubuntuagent:/home/vagrant/wazuh/src# ls
active-response  config                 headers         libwazuhshared.so  os_csyslogd    os_zlib        rootcheck.a     VERSION             wazuh-syscheckd
addagent         data_provider          host-deny       logcollector       os_dbd         pf             route-null      wazuh-agentd        win32
agent-auth       default-firewall-drop  init            Makefile           os_execd       Readme.md      selinux         wazuh_db
agentlessd       disable-account        ip-customblock  manage_agents      os_integrator  remoted        shared          wazuh-execd
analysisd        Doxyfile               ipfw            monitord           os_maild       reportd        shared_modules  wazuh-logcollector
build.py         error_messages         kaspersky       npf                os_net         restart-wazuh  syscheckd       wazuh_modules
ci               external               libwazuh.a      os_auth            os_regex       REVISION       unit_tests      wazuh-modulesd
client-agent     firewalld-drop         libwazuhext.so  os_crypto          os_xml         rootcheck      util            wazuh-slack
root@ubuntuagent:/home/vagrant/wazuh/src# make clean-internals
.......
.......
rm -rf libwazuhext
root@ubuntuagent:/home/vagrant/wazuh/src# ls
active-response  build.py      data_provider   headers       monitord     os_dbd         os_net    Readme.md  rootcheck       syscheckd   wazuh_db
addagent         ci            Doxyfile        init          os_auth      os_execd       os_regex  remoted    selinux         unit_tests  wazuh_modules
agentlessd       client-agent  error_messages  logcollector  os_crypto    os_integrator  os_xml    reportd    shared          util        win32
analysisd        config        external        Makefile      os_csyslogd  os_maild       os_zlib   REVISION   shared_modules  VERSION
``` 

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
  - [ ] MAC OS X

