### PR TITLE
Add new option to configure the maximum response time of the API

### DIFF
--- a/api/api/configuration.py
+++ b/api/api/configuration.py
@@ -34,7 +34,7 @@ default_api_configuration = {
     "drop_privileges": True,
     "experimental_features": False,
     "intervals": {
-        "request_timeout": 20
+        "request_timeout": 10
     },
     "https": {
         "enabled": True,

--- a/api/api/configuration.py
+++ b/api/api/configuration.py
@@ -16,6 +16,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
 from jsonschema import validate, ValidationError
 
+import api.constants as api_constants
 from api.api_exception import APIError
 from api.constants import CONFIG_FILE_PATH, SECURITY_CONFIG_PATH
 from api.validator import api_config_schema, security_config_schema
@@ -32,6 +33,9 @@ default_api_configuration = {
     "use_only_authd": False,
     "drop_privileges": True,
     "experimental_features": False,
+    "intervals": {
+        "request_timeout": 20
+    },
     "https": {
         "enabled": True,
         "key": "api/configuration/ssl/server.key",
@@ -214,6 +218,7 @@ def read_yaml_config(config_file=CONFIG_FILE_PATH, default_conf=None) -> Dict:
 
     :return: API configuration
     """
+
     def replace_bools(conf):
         """Replace 'yes' and 'no' strings in configuration for actual booleans.
 
@@ -256,6 +261,10 @@ def read_yaml_config(config_file=CONFIG_FILE_PATH, default_conf=None) -> Dict:
 
     # Append wazuh_path to all paths in configuration
     append_wazuh_path(configuration, [('logs', 'path'), ('https', 'key'), ('https', 'cert'), ('https', 'ca')])
+
+    # Assign API request timeout
+    if config_file == api_constants.CONFIG_FILE_PATH:
+        api_constants.API_REQUEST_TIMEOUT = configuration['intervals']['request_timeout']
 
     return configuration
 

--- a/api/api/configuration.py
+++ b/api/api/configuration.py
@@ -16,7 +16,6 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
 from jsonschema import validate, ValidationError
 
-import api.constants as api_constants
 from api.api_exception import APIError
 from api.constants import CONFIG_FILE_PATH, SECURITY_CONFIG_PATH
 from api.validator import api_config_schema, security_config_schema
@@ -261,10 +260,6 @@ def read_yaml_config(config_file=CONFIG_FILE_PATH, default_conf=None) -> Dict:
 
     # Append wazuh_path to all paths in configuration
     append_wazuh_path(configuration, [('logs', 'path'), ('https', 'key'), ('https', 'cert'), ('https', 'ca')])
-
-    # Assign API request timeout
-    if config_file == api_constants.CONFIG_FILE_PATH:
-        api_constants.API_REQUEST_TIMEOUT = configuration['intervals']['request_timeout']
 
     return configuration
 

--- a/api/api/configuration/api.yaml
+++ b/api/api/configuration/api.yaml
@@ -48,6 +48,10 @@
 # Enable features under development
 # experimental_features: no
 
+# Modify API's intervals (time in seconds)
+# intervals:
+#   request_timeout: 20
+
 # Enable remote commands
 # remote_commands:
 #   localfile:

--- a/api/api/configuration/api.yaml
+++ b/api/api/configuration/api.yaml
@@ -14,6 +14,10 @@
 #  ssl_protocol: "TLSv1.2"
 #  ssl_ciphers: ""
 
+# Modify API's intervals (time in seconds)
+# intervals:
+#   request_timeout: 10
+
 # Logging configuration
 # Values for API log level: disabled, info, warning, error, debug, debug2 (each level includes the previous level).
 # logs:
@@ -47,10 +51,6 @@
 
 # Enable features under development
 # experimental_features: no
-
-# Modify API's intervals (time in seconds)
-# intervals:
-#   request_timeout: 20
 
 # Enable remote commands
 # remote_commands:

--- a/api/api/constants.py
+++ b/api/api/constants.py
@@ -14,3 +14,4 @@ SECURITY_PATH = os.path.join(CONFIG_PATH, 'security')
 SECURITY_CONFIG_PATH = os.path.join(SECURITY_PATH, 'security.yaml')
 RELATIVE_SECURITY_PATH = os.path.relpath(SECURITY_PATH, common.wazuh_path)
 API_LOG_FILE_PATH = os.path.join(common.wazuh_path, 'logs', 'api.log')
+API_REQUEST_TIMEOUT = None

--- a/api/api/constants.py
+++ b/api/api/constants.py
@@ -14,4 +14,3 @@ SECURITY_PATH = os.path.join(CONFIG_PATH, 'security')
 SECURITY_CONFIG_PATH = os.path.join(SECURITY_PATH, 'security.yaml')
 RELATIVE_SECURITY_PATH = os.path.relpath(SECURITY_PATH, common.wazuh_path)
 API_LOG_FILE_PATH = os.path.join(common.wazuh_path, 'logs', 'api.log')
-API_REQUEST_TIMEOUT = None

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -67,7 +67,7 @@ api_config_schema = {
             "type": "object",
             "additionalProperties": False,
             "properties": {
-                "request_timeout": {"type": "number"}
+                "request_timeout": {"type": "number", "minimum": 0}
             },
         },
         "https": {

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -63,6 +63,13 @@ api_config_schema = {
         "use_only_authd": {"type": "boolean"},
         "drop_privileges": {"type": "boolean"},
         "experimental_features": {"type": "boolean"},
+        "intervals": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "request_timeout": {"type": "number"}
+            },
+        },
         "https": {
             "type": "object",
             "additionalProperties": False,

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -20,7 +20,7 @@ from platform import platform
 from shutil import rmtree
 from time import time
 
-import api.constants as api_constants
+import api.configuration as aconf
 from wazuh.core import common, configuration, stats
 from wazuh.core.InputValidator import InputValidator
 from wazuh.core.cluster.utils import get_manager_status
@@ -375,7 +375,7 @@ class Agent:
 
     @staticmethod
     def _acquire_client_keys_lock(timeout=None):
-        timeout = api_constants.API_REQUEST_TIMEOUT - 1 if not timeout else timeout
+        timeout = aconf.api_conf['intervals']['request_timeout'] - 1 if not timeout else timeout
         if mutex.acquire(timeout=timeout):
             global lock_file
             lock_file = open("{}/var/run/.api_lock".format(common.wazuh_path), 'a+')

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -20,9 +20,10 @@ from platform import platform
 from shutil import rmtree
 from time import time
 
+import api.constants as api_constants
 from wazuh.core import common, configuration, stats
 from wazuh.core.InputValidator import InputValidator
-from wazuh.core.cluster.utils import get_manager_status, get_cluster_items
+from wazuh.core.cluster.utils import get_manager_status
 from wazuh.core.common import AGENT_COMPONENT_STATS_REQUIRED_VERSION
 from wazuh.core.exception import WazuhException, WazuhError, WazuhInternalError, WazuhResourceNotFound
 from wazuh.core.utils import chmod_r, WazuhVersion, plain_dict_to_nested_dict, get_fields_to_nest, WazuhDBQuery, \
@@ -373,7 +374,8 @@ class Agent:
         return dictionary
 
     @staticmethod
-    def _acquire_client_keys_lock(timeout=get_cluster_items()['intervals']['communication']['timeout_api_exe'] - 1):
+    def _acquire_client_keys_lock(timeout=None):
+        timeout = api_constants.API_REQUEST_TIMEOUT - 1 if not timeout else timeout
         if mutex.acquire(timeout=timeout):
             global lock_file
             lock_file = open("{}/var/run/.api_lock".format(common.wazuh_path), 'a+')

--- a/framework/wazuh/core/cluster/cluster.json
+++ b/framework/wazuh/core/cluster/cluster.json
@@ -108,8 +108,7 @@
 
         "communication":{
             "timeout_cluster_request": 20,
-            "timeout_api_request": 200,
-            "timeout_api_exe": 10,
+            "timeout_dapi_request": 200,
             "timeout_receiving_file": 120
         }
     },

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -18,7 +18,7 @@ from typing import Callable, Dict, Tuple, List
 
 from sqlalchemy.exc import OperationalError
 
-import api.constants as api_constants
+import api.configuration as aconf
 import wazuh.core.cluster.cluster
 import wazuh.core.cluster.utils
 import wazuh.core.manager
@@ -103,8 +103,7 @@ class DistributedAPI:
 
         self.local_clients = []
         self.local_client_arg = local_client_arg
-        if api_timeout:
-            api_constants.API_REQUEST_TIMEOUT = api_timeout
+        self.api_request_timeout = api_timeout if api_timeout else aconf.api_conf['intervals']['request_timeout']
 
     def debug_log(self, message):
         """Use debug or debug2 depending on the log type.
@@ -239,7 +238,7 @@ class DistributedAPI:
             before = time.time()
             self.check_wazuh_status()
 
-            timeout = api_constants.API_REQUEST_TIMEOUT if not self.wait_for_complete else None
+            timeout = self.api_request_timeout if not self.wait_for_complete else None
 
             # LocalClient only for control functions
             if self.local_client_arg is not None:
@@ -306,7 +305,7 @@ class DistributedAPI:
                 "current_user": self.current_user,
                 "broadcasting": self.broadcasting,
                 "nodes": self.nodes,
-                "api_timeout": api_constants.API_REQUEST_TIMEOUT
+                "api_timeout": self.api_request_timeout
                 }
 
     def get_error_info(self, e) -> Dict:

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -18,6 +18,7 @@ from typing import Callable, Dict, Tuple, List
 
 from sqlalchemy.exc import OperationalError
 
+import api.constants as api_constants
 import wazuh.core.cluster.cluster
 import wazuh.core.cluster.utils
 import wazuh.core.manager
@@ -40,7 +41,7 @@ class DistributedAPI:
                  debug: bool = False, request_type: str = 'local_master', current_user: str = '',
                  wait_for_complete: bool = False, from_cluster: bool = False, is_async: bool = False,
                  broadcasting: bool = False, basic_services: tuple = None, local_client_arg: str = None,
-                 rbac_permissions: Dict = None, nodes: list = None):
+                 rbac_permissions: Dict = None, nodes: list = None, api_timeout: int = None):
         """Class constructor.
 
         Parameters
@@ -75,6 +76,8 @@ class DistributedAPI:
             Default `None`, list of system nodes
         current_user : str
             User who started the request
+        api_timeout : int
+            Timeout set in source API for the request
         """
         self.logger = logger
         self.f = f
@@ -100,6 +103,8 @@ class DistributedAPI:
 
         self.local_clients = []
         self.local_client_arg = local_client_arg
+        if api_timeout:
+            api_constants.API_REQUEST_TIMEOUT = api_timeout
 
     def debug_log(self, message):
         """Use debug or debug2 depending on the log type.
@@ -234,9 +239,6 @@ class DistributedAPI:
             before = time.time()
             self.check_wazuh_status()
 
-            timeout = None if self.wait_for_complete \
-                else self.cluster_items['intervals']['communication']['timeout_api_exe']
-
             # LocalClient only for control functions
             if self.local_client_arg is not None:
                 lc = local_client.LocalClient()
@@ -248,7 +250,7 @@ class DistributedAPI:
                 loop = asyncio.get_running_loop()
                 task = loop.run_in_executor(threadpool, run_local)
             try:
-                data = await asyncio.wait_for(task, timeout=timeout)
+                data = await asyncio.wait_for(task, timeout=api_constants.API_REQUEST_TIMEOUT)
             except asyncio.TimeoutError:
                 raise exception.WazuhInternalError(3021)
             except OperationalError:
@@ -301,7 +303,8 @@ class DistributedAPI:
                 "rbac_permissions": self.rbac_permissions,
                 "current_user": self.current_user,
                 "broadcasting": self.broadcasting,
-                "nodes": self.nodes
+                "nodes": self.nodes,
+                "api_timeout": api_constants.API_REQUEST_TIMEOUT
                 }
 
     def get_error_info(self, e) -> Dict:

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -239,6 +239,8 @@ class DistributedAPI:
             before = time.time()
             self.check_wazuh_status()
 
+            timeout = api_constants.API_REQUEST_TIMEOUT if not self.wait_for_complete else None
+
             # LocalClient only for control functions
             if self.local_client_arg is not None:
                 lc = local_client.LocalClient()
@@ -250,7 +252,7 @@ class DistributedAPI:
                 loop = asyncio.get_running_loop()
                 task = loop.run_in_executor(threadpool, run_local)
             try:
-                data = await asyncio.wait_for(task, timeout=api_constants.API_REQUEST_TIMEOUT)
+                data = await asyncio.wait_for(task, timeout=timeout)
             except asyncio.TimeoutError:
                 raise exception.WazuhInternalError(3021)
             except OperationalError:

--- a/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
+++ b/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
@@ -6,6 +6,7 @@ import logging
 import os
 import sys
 from asyncio import TimeoutError
+from typing import Iterator
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -57,6 +58,12 @@ def raise_if_exc_routine(dapi_kwargs, expected_error=None):
             assert e.ext['code'] == expected_error
         else:
             assert False, f'Unexpected exception: {e.ext}'
+
+
+@pytest.fixture(scope="session", autouse=True)
+def default_session_fixture() -> Iterator[None]:
+    with patch('api.configuration.api_conf', {'intervals': {'request_timeout': 10}}):
+        yield
 
 
 @pytest.mark.parametrize('kwargs', [

--- a/framework/wazuh/core/cluster/local_client.py
+++ b/framework/wazuh/core/cluster/local_client.py
@@ -179,7 +179,7 @@ class LocalClient(client.AbstractClientManager):
                     or result == 'Sent request to master node':
                 try:
                     timeout = None if wait_for_complete \
-                        else self.cluster_items['intervals']['communication']['timeout_api_request']
+                        else self.cluster_items['intervals']['communication']['timeout_dapi_request']
                     await asyncio.wait_for(self.protocol.response_available.wait(), timeout=timeout)
                     request_result = self.protocol.response.decode()
                 except asyncio.TimeoutError:

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -275,7 +275,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         if command == b'dapi' or command == b'dapi_fwd':
             try:
                 timeout = None if wait_for_complete \
-                               else self.cluster_items['intervals']['communication']['timeout_api_request']
+                               else self.cluster_items['intervals']['communication']['timeout_dapi_request']
                 await asyncio.wait_for(self.server.pending_api_requests[request_id]['Event'].wait(), timeout=timeout)
                 request_result = self.server.pending_api_requests[request_id]['Response']
             except asyncio.TimeoutError:

--- a/framework/wazuh/core/cluster/tests/test_utils.py
+++ b/framework/wazuh/core/cluster/tests/test_utils.py
@@ -154,7 +154,7 @@ def test_get_cluster_items():
                                    'master': {'recalculate_integrity': 8, 'check_worker_lastkeepalive': 60,
                                               'max_allowed_time_without_keepalive': 120},
                                    'communication': {'timeout_cluster_request': 20, 'timeout_api_request': 200,
-                                                     'timeout_api_exe': 10, 'timeout_receiving_file': 120}},
+                                                     'request_timeout': 10, 'timeout_receiving_file': 120}},
                      'sync_options': {'get_agentinfo_newer_than': 1800}, 'distributed_api': {'enabled': True}}
 
 

--- a/framework/wazuh/core/cluster/tests/test_utils.py
+++ b/framework/wazuh/core/cluster/tests/test_utils.py
@@ -153,8 +153,8 @@ def test_get_cluster_items():
                                               'max_failed_keepalive_attempts': 2},
                                    'master': {'recalculate_integrity': 8, 'check_worker_lastkeepalive': 60,
                                               'max_allowed_time_without_keepalive': 120},
-                                   'communication': {'timeout_cluster_request': 20, 'timeout_api_request': 200,
-                                                     'request_timeout': 10, 'timeout_receiving_file': 120}},
+                                   'communication': {'timeout_cluster_request': 20, 'timeout_dapi_request': 200,
+                                                     'timeout_receiving_file': 120}},
                      'sync_options': {'get_agentinfo_newer_than': 1800}, 'distributed_api': {'enabled': True}}
 
 

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -697,7 +697,7 @@ def test_agent_remove_manual(socket_mock, run_wdb_mock, send_mock, grp_mock, pwd
                                   for row in test_data.global_db.execute(
             'select id, name, register_ip, internal_key from agent where id > 0')])
 
-    with patch('api.constants.API_REQUEST_TIMEOUT', 10):
+    with patch('api.configuration.api_conf', {'intervals': {'request_timeout': 10}}):
         with patch('wazuh.core.agent.open', mock_open(read_data=client_keys_text)) as m:
             if exists_backup_dir:
                 exists_mock.side_effect = [True, True, True] + [False] * 10
@@ -856,7 +856,7 @@ def test_agent_add_manual(socket_mock, mock_get_manager_name, mock_lockf, mock_s
           'MjBkODNjNTVjZDE5N2YyMzk3NzA0YWRhNjg1YzQz'
     client_keys_text = f'001 windows-agent any {key}\n \n002 #name '
 
-    with patch('api.constants.API_REQUEST_TIMEOUT', 10):
+    with patch('api.configuration.api_conf', {'intervals': {'request_timeout': 10}}):
         with patch('wazuh.core.agent.mmap.mmap', mock_open(read_data=client_keys_text.encode())):
             agent = Agent(1)
 
@@ -1681,7 +1681,7 @@ def test_agent_remove_manual_ko(socket_mock, send_mock, grp_mock, pwd_mock, chmo
     """
 
     def check_exception(client_keys):
-        with patch('api.constants.API_REQUEST_TIMEOUT', 10):
+        with patch('api.configuration.api_conf', {'intervals': {'request_timeout': 10}}):
             with patch(
                     'wazuh.core.agent.open',
                     mock_open(read_data=client_keys) if not isinstance(client_keys, Exception) else client_keys) as m:
@@ -1702,9 +1702,8 @@ def test_agent_remove_manual_ko(socket_mock, send_mock, grp_mock, pwd_mock, chmo
         check_exception(client_keys_text)
 
     if expected_exception == 1701:
-        with patch('api.constants.API_REQUEST_TIMEOUT', 10):
-            with patch('wazuh.core.wdb.WazuhDBConnection.run_wdb_command'):
-                check_exception(client_keys_text)
+        with patch('wazuh.core.wdb.WazuhDBConnection.run_wdb_command'):
+            check_exception(client_keys_text)
 
 
 @pytest.mark.parametrize('system_resources, permitted_resources, filters, expected_result', [

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -697,31 +697,32 @@ def test_agent_remove_manual(socket_mock, run_wdb_mock, send_mock, grp_mock, pwd
                                   for row in test_data.global_db.execute(
             'select id, name, register_ip, internal_key from agent where id > 0')])
 
-    with patch('wazuh.core.agent.open', mock_open(read_data=client_keys_text)) as m:
-        if exists_backup_dir:
-            exists_mock.side_effect = [True, True, True] + [False] * 10
-        else:
-            exists_mock.side_effect = lambda x: not (common.backup_path in x)
-        Agent('001')._remove_manual(backup=backup)
-
-        m.assert_any_call(common.client_keys)
-        stat_mock.assert_called_once_with(common.client_keys)
-        mock_delete_agents.assert_called_once_with(['001'])
-        run_wdb_mock.assert_called_once_with('global sql DELETE FROM belongs WHERE id_agent = 001')
-        remove_mock.assert_any_call(os.path.join(common.wazuh_path, 'queue/rids/001'))
-        mkstemp_mock.assert_called_once_with(prefix=common.client_keys, suffix=".tmp")
-
-        # make sure the mock is called with a string according to a non-backup path
-        exists_mock.assert_any_call('{0}/queue/agent-groups/001'.format(test_data_path))
-        safe_move_mock.assert_called_with('mock_tmp_file', common.client_keys,
-                                          permissions=stat_mock().st_mode)
-        if backup:
+    with patch('api.constants.API_REQUEST_TIMEOUT', 10):
+        with patch('wazuh.core.agent.open', mock_open(read_data=client_keys_text)) as m:
             if exists_backup_dir:
-                backup_path = os.path.join(common.backup_path, f'agents/1975/Jan/01/001-agent-1-any-002')
+                exists_mock.side_effect = [True, True, True] + [False] * 10
             else:
-                backup_path = os.path.join(common.backup_path, f'agents/1975/Jan/01/001-agent-1-any')
-            makedirs_mock.assert_called_once_with(backup_path)
-            chmod_r_mock.assert_called_once_with(backup_path, 0o750)
+                exists_mock.side_effect = lambda x: not (common.backup_path in x)
+            Agent('001')._remove_manual(backup=backup)
+
+            m.assert_any_call(common.client_keys)
+            stat_mock.assert_called_once_with(common.client_keys)
+            mock_delete_agents.assert_called_once_with(['001'])
+            run_wdb_mock.assert_called_once_with('global sql DELETE FROM belongs WHERE id_agent = 001')
+            remove_mock.assert_any_call(os.path.join(common.wazuh_path, 'queue/rids/001'))
+            mkstemp_mock.assert_called_once_with(prefix=common.client_keys, suffix=".tmp")
+
+            # make sure the mock is called with a string according to a non-backup path
+            exists_mock.assert_any_call('{0}/queue/agent-groups/001'.format(test_data_path))
+            safe_move_mock.assert_called_with('mock_tmp_file', common.client_keys,
+                                              permissions=stat_mock().st_mode)
+            if backup:
+                if exists_backup_dir:
+                    backup_path = os.path.join(common.backup_path, f'agents/1975/Jan/01/001-agent-1-any-002')
+                else:
+                    backup_path = os.path.join(common.backup_path, f'agents/1975/Jan/01/001-agent-1-any')
+                makedirs_mock.assert_called_once_with(backup_path)
+                chmod_r_mock.assert_called_once_with(backup_path, 0o750)
 
 
 @pytest.mark.parametrize("authd_status", [
@@ -855,17 +856,18 @@ def test_agent_add_manual(socket_mock, mock_get_manager_name, mock_lockf, mock_s
           'MjBkODNjNTVjZDE5N2YyMzk3NzA0YWRhNjg1YzQz'
     client_keys_text = f'001 windows-agent any {key}\n \n002 #name '
 
-    with patch('wazuh.core.agent.mmap.mmap', mock_open(read_data=client_keys_text.encode())):
-        agent = Agent(1)
+    with patch('api.constants.API_REQUEST_TIMEOUT', 10):
+        with patch('wazuh.core.agent.mmap.mmap', mock_open(read_data=client_keys_text.encode())):
+            agent = Agent(1)
 
-        agent._add_manual('test_agent', ip=ip, id=id, key=key, force=force)
+            agent._add_manual('test_agent', ip=ip, id=id, key=key, force=force)
 
-        assert agent.id == id if id is not None else agent.id == '002', 'ID should has been updated.'
+            assert agent.id == id if id is not None else agent.id == '002', 'ID should has been updated.'
 
-        mock_get_manager_name.assert_called_once()
-        mkstemp_mock.assert_called_once_with(prefix=common.client_keys, suffix=".tmp")
-        mock_safe_move.assert_called_once_with('mock_tmp_file', common.client_keys,
-                                               permissions=ANY)
+            mock_get_manager_name.assert_called_once()
+            mkstemp_mock.assert_called_once_with(prefix=common.client_keys, suffix=".tmp")
+            mock_safe_move.assert_called_once_with('mock_tmp_file', common.client_keys,
+                                                   permissions=ANY)
 
 
 @pytest.mark.parametrize('test_case', safe_load(open(os.path.join(os.path.dirname(__file__), 'data', 'test_agent',
@@ -1679,10 +1681,12 @@ def test_agent_remove_manual_ko(socket_mock, send_mock, grp_mock, pwd_mock, chmo
     """
 
     def check_exception(client_keys):
-        with patch('wazuh.core.agent.open',
-                   mock_open(read_data=client_keys) if not isinstance(client_keys, Exception) else client_keys) as m:
-            with pytest.raises(WazuhException, match=f".* {expected_exception} .*"):
-                Agent(agent_id)._remove_manual()
+        with patch('api.constants.API_REQUEST_TIMEOUT', 10):
+            with patch(
+                    'wazuh.core.agent.open',
+                    mock_open(read_data=client_keys) if not isinstance(client_keys, Exception) else client_keys) as m:
+                with pytest.raises(WazuhException, match=f".* {expected_exception} .*"):
+                    Agent(agent_id)._remove_manual()
 
     client_keys_text = '\n'.join([f'{str(row["id"]).zfill(3) if expected_exception != 1701 else "100"} '
                                   f'{row["name"]} '
@@ -1698,8 +1702,9 @@ def test_agent_remove_manual_ko(socket_mock, send_mock, grp_mock, pwd_mock, chmo
         check_exception(client_keys_text)
 
     if expected_exception == 1701:
-        with patch('wazuh.core.wdb.WazuhDBConnection.run_wdb_command'):
-            check_exception(client_keys_text)
+        with patch('api.constants.API_REQUEST_TIMEOUT', 10):
+            with patch('wazuh.core.wdb.WazuhDBConnection.run_wdb_command'):
+                check_exception(client_keys_text)
 
 
 @pytest.mark.parametrize('system_resources, permitted_resources, filters, expected_result', [


### PR DESCRIPTION
|Related issue|
|---|
|#8799|

## Description

Hi team,

This PR is part of issue #8799. In this PR we have added a new option to configure the API response time. In the case of distributed requests, the request time will be the one set in the source API.

Regards