### PR TITLE
Validate audisp configuration on whodata startup

### DIFF
--- a/src/unit_tests/syscheckd/whodata/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/whodata/CMakeLists.txt
@@ -53,7 +53,8 @@ if(NOT ${TARGET} STREQUAL "winagent")
                               -Wl,--wrap,getpid -Wl,--wrap,sleep -Wl,--wrap,unlink -Wl,--wrap,audit_delete_rule \
                               -Wl,--wrap,select -Wl,--wrap,audit_parse -Wl,--wrap,symlink -Wl,--wrap,SendMSG \
                               -Wl,--wrap,audit_get_rule_list -Wl,--wrap,fim_audit_reload_rules \
-                              -Wl,--wrap,search_audit_rule -Wl,--wrap,abspath")
+                              -Wl,--wrap,search_audit_rule -Wl,--wrap,abspath -Wl,--wrap,OS_SHA1_Str \
+                              -Wl,--wrap,OS_SHA1_File")
 
     target_link_libraries(test_syscheck_audit SYSCHECK_O ${TEST_DEPS})
 

--- a/src/unit_tests/syscheckd/whodata/test_syscheck_audit.c
+++ b/src/unit_tests/syscheckd/whodata/test_syscheck_audit.c
@@ -25,6 +25,7 @@
 #include "wrappers/wazuh/shared/file_op_wrappers.h"
 #include "wrappers/wazuh/shared/mq_op_wrappers.h"
 #include "wrappers/wazuh/os_net/os_net_wrappers.h"
+#include "wrappers/wazuh/os_crypto/sha1_op_wrappers.h"
 #include "wrappers/wazuh/syscheckd/audit_parse_wrappers.h"
 #include "wrappers/wazuh/syscheckd/audit_rule_handling_wrappers.h"
 
@@ -257,20 +258,23 @@ void test_init_auditd_socket_failure(void **state) {
 
 
 void test_set_auditd_config_audit3_plugin_created(void **state) {
-    (void) state;
-
     // Audit 3
     expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
     will_return(__wrap_IsDir, 0);
 
+    expect_abspath(AUDIT_SOCKET, 0);
+
     // Plugin already created
     const char *audit3_socket = "/etc/audit/plugins.d/af_wazuh.conf";
 
-    expect_string(__wrap_IsLink, file, audit3_socket);
-    will_return(__wrap_IsLink, 0);
+    expect_any(__wrap_OS_SHA1_Str, str);
+    expect_any(__wrap_OS_SHA1_Str, length);
+    will_return(__wrap_OS_SHA1_Str, "6e3a100fc85241f04ed9686d37738e7d08086fb4");
 
-    expect_string(__wrap_IsFile, file, audit3_socket);
-    will_return(__wrap_IsFile, 0);
+    expect_string(__wrap_OS_SHA1_File, fname, audit3_socket);
+    expect_value(__wrap_OS_SHA1_File, mode, OS_TEXT);
+    will_return(__wrap_OS_SHA1_File, "6e3a100fc85241f04ed9686d37738e7d08086fb4");
+    will_return(__wrap_OS_SHA1_File, 0);
 
     expect_string(__wrap_IsSocket, sock, AUDIT_SOCKET);
     will_return(__wrap_IsSocket, 0);
@@ -300,8 +304,6 @@ void test_set_auditd_config_wrong_audit_version(void **state) {
 
 
 void test_set_auditd_config_audit2_plugin_created(void **state) {
-    (void) state;
-
     // Not Audit 3
     expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
     will_return(__wrap_IsDir, 1);
@@ -309,14 +311,19 @@ void test_set_auditd_config_audit2_plugin_created(void **state) {
     expect_string(__wrap_IsDir, file, "/etc/audisp/plugins.d");
     will_return(__wrap_IsDir, 0);
 
+    expect_abspath(AUDIT_SOCKET, 0);
+
     // Plugin already created
     const char *audit2_socket = "/etc/audisp/plugins.d/af_wazuh.conf";
 
-    expect_string(__wrap_IsLink, file, audit2_socket);
-    will_return(__wrap_IsLink, 0);
+    expect_any(__wrap_OS_SHA1_Str, str);
+    expect_any(__wrap_OS_SHA1_Str, length);
+    will_return(__wrap_OS_SHA1_Str, "6e3a100fc85241f04ed9686d37738e7d08086fb4");
 
-    expect_string(__wrap_IsFile, file, audit2_socket);
-    will_return(__wrap_IsFile, 0);
+    expect_string(__wrap_OS_SHA1_File, fname, audit2_socket);
+    expect_value(__wrap_OS_SHA1_File, mode, OS_TEXT);
+    will_return(__wrap_OS_SHA1_File, "6e3a100fc85241f04ed9686d37738e7d08086fb4");
+    will_return(__wrap_OS_SHA1_File, 0);
 
     expect_string(__wrap_IsSocket, sock, AUDIT_SOCKET);
     will_return(__wrap_IsSocket, 0);
@@ -329,7 +336,6 @@ void test_set_auditd_config_audit2_plugin_created(void **state) {
 
 
 void test_set_auditd_config_audit_socket_not_created(void **state) {
-    (void) state;
     char buffer[OS_SIZE_128] = {0};
     syscheck.restart_audit = 0;
 
@@ -337,14 +343,19 @@ void test_set_auditd_config_audit_socket_not_created(void **state) {
     expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
     will_return(__wrap_IsDir, 0);
 
+    expect_abspath(AUDIT_SOCKET, 0);
+
     // Plugin already created
     const char *audit3_socket = "/etc/audit/plugins.d/af_wazuh.conf";
 
-    expect_string(__wrap_IsLink, file, audit3_socket);
-    will_return(__wrap_IsLink, 0);
+    expect_any(__wrap_OS_SHA1_Str, str);
+    expect_any(__wrap_OS_SHA1_Str, length);
+    will_return(__wrap_OS_SHA1_Str, "6e3a100fc85241f04ed9686d37738e7d08086fb4");
 
-    expect_string(__wrap_IsFile, file, audit3_socket);
-    will_return(__wrap_IsFile, 0);
+    expect_string(__wrap_OS_SHA1_File, fname, audit3_socket);
+    expect_value(__wrap_OS_SHA1_File, mode, OS_TEXT);
+    will_return(__wrap_OS_SHA1_File, "6e3a100fc85241f04ed9686d37738e7d08086fb4");
+    will_return(__wrap_OS_SHA1_File, 0);
 
     snprintf(buffer, OS_SIZE_128, FIM_WARN_AUDIT_SOCKET_NOEXIST, AUDIT_SOCKET);
     expect_string(__wrap_IsSocket, sock, AUDIT_SOCKET);
@@ -361,7 +372,6 @@ void test_set_auditd_config_audit_socket_not_created(void **state) {
 
 
 void test_set_auditd_config_audit_socket_not_created_restart(void **state) {
-    (void) state;
     char buffer[OS_SIZE_128] = {0};
     syscheck.restart_audit = 1;
 
@@ -369,18 +379,22 @@ void test_set_auditd_config_audit_socket_not_created_restart(void **state) {
     expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
     will_return(__wrap_IsDir, 0);
 
+    expect_abspath(AUDIT_SOCKET, 0);
+
     // Plugin already created
     const char *audit3_socket = "/etc/audit/plugins.d/af_wazuh.conf";
 
-    expect_string(__wrap_IsLink, file, audit3_socket);
-    will_return(__wrap_IsLink, 0);
+    expect_any(__wrap_OS_SHA1_Str, str);
+    expect_any(__wrap_OS_SHA1_Str, length);
+    will_return(__wrap_OS_SHA1_Str, "6e3a100fc85241f04ed9686d37738e7d08086fb4");
 
-    expect_string(__wrap_IsFile, file, audit3_socket);
-    will_return(__wrap_IsFile, 0);
+    expect_string(__wrap_OS_SHA1_File, fname, audit3_socket);
+    expect_value(__wrap_OS_SHA1_File, mode, OS_TEXT);
+    will_return(__wrap_OS_SHA1_File, "6e3a100fc85241f04ed9686d37738e7d08086fb4");
+    will_return(__wrap_OS_SHA1_File, 0);
 
     snprintf(buffer, OS_SIZE_128, FIM_AUDIT_NOSOCKET, AUDIT_SOCKET);
     expect_string(__wrap__minfo, formatted_msg, buffer);
-
     expect_string(__wrap_IsSocket, sock, AUDIT_SOCKET);
     will_return(__wrap_IsSocket, 1);
 
@@ -393,9 +407,7 @@ void test_set_auditd_config_audit_socket_not_created_restart(void **state) {
 }
 
 
-void test_set_auditd_config_audit_plugin_not_created(void **state) {
-    (void) state;
-
+void test_set_auditd_config_audit_plugin_tampered_configuration(void **state) {
     // Audit 3
     expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
     will_return(__wrap_IsDir, 0);
@@ -405,20 +417,82 @@ void test_set_auditd_config_audit_plugin_not_created(void **state) {
 
     expect_string(__wrap__minfo, formatted_msg, "(6024): Generating Auditd socket configuration file: 'etc/af_wazuh.conf'");
 
-    expect_string(__wrap_IsLink, file, audit3_socket);
-    will_return(__wrap_IsLink, 1);
+    expect_any(__wrap_OS_SHA1_Str, str);
+    expect_any(__wrap_OS_SHA1_Str, length);
+    will_return(__wrap_OS_SHA1_Str, "6e3a100fc85241f04ed9686d37738e7d08086fb4");
 
-    expect_abspath(AUDIT_CONF_FILE, 1);
+    expect_string(__wrap_OS_SHA1_File, fname, audit3_socket);
+    expect_value(__wrap_OS_SHA1_File, mode, OS_TEXT);
+    will_return(__wrap_OS_SHA1_File, "0123456789abcdef0123456789abcdef01234567");
+    will_return(__wrap_OS_SHA1_File, 0);
+
     expect_abspath(AUDIT_SOCKET, 1);
+    expect_abspath(AUDIT_CONF_FILE, 1);
 
     expect_string(__wrap_fopen, path, "etc/af_wazuh.conf");
     expect_string(__wrap_fopen, mode, "w");
     will_return(__wrap_fopen, 1);
 
-    expect_any_always(__wrap_fprintf, __stream);
-    expect_any_always(__wrap_fprintf, formatted_msg);
-    will_return_always(__wrap_fprintf, 1);
-    will_return_always(__wrap_fwrite, 1);
+    will_return(__wrap_fwrite, 1);
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 0);
+
+    // Create plugin
+    expect_string(__wrap_symlink, path1, "etc/af_wazuh.conf");
+    expect_string(__wrap_symlink, path2, audit3_socket);
+    will_return(__wrap_symlink, -1);
+    errno = EEXIST;
+
+    expect_string(__wrap_unlink, file, "/etc/audit/plugins.d/af_wazuh.conf");
+    will_return(__wrap_unlink, 0);
+
+    // Delete and create
+    expect_string(__wrap_symlink, path1, "etc/af_wazuh.conf");
+    expect_string(__wrap_symlink, path2, audit3_socket);
+    will_return(__wrap_symlink, 0);
+
+    expect_string(__wrap__minfo, formatted_msg, "(6025): Audit plugin configuration (etc/af_wazuh.conf) was modified. Restarting Auditd service.");
+
+    // Restart
+    syscheck.restart_audit = 1;
+    will_return(__wrap_audit_restart, 99);
+
+    int ret;
+    ret = set_auditd_config();
+
+    errno = 0;
+    assert_int_equal(ret, 99);
+}
+
+
+void test_set_auditd_config_audit_plugin_not_created(void **state) {
+    // Audit 3
+    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
+    will_return(__wrap_IsDir, 0);
+
+    // Plugin not created
+    const char *audit3_socket = "/etc/audit/plugins.d/af_wazuh.conf";
+
+    expect_any(__wrap_OS_SHA1_Str, str);
+    expect_any(__wrap_OS_SHA1_Str, length);
+    will_return(__wrap_OS_SHA1_Str, "6e3a100fc85241f04ed9686d37738e7d08086fb4");
+
+    expect_string(__wrap_OS_SHA1_File, fname, audit3_socket);
+    expect_value(__wrap_OS_SHA1_File, mode, OS_TEXT);
+    will_return(__wrap_OS_SHA1_File, "6e3a100fc85241f04ed9686d37738e7d08086fb4");
+    will_return(__wrap_OS_SHA1_File, -1);
+
+    expect_string(__wrap__minfo, formatted_msg, "(6024): Generating Auditd socket configuration file: 'etc/af_wazuh.conf'");
+
+    expect_abspath(AUDIT_SOCKET, 1);
+    expect_abspath(AUDIT_CONF_FILE, 1);
+
+    expect_string(__wrap_fopen, path, "etc/af_wazuh.conf");
+    expect_string(__wrap_fopen, mode, "w");
+    will_return(__wrap_fopen, 1);
+
+    will_return(__wrap_fwrite, 1);
 
     expect_value(__wrap_fclose, _File, 1);
     will_return(__wrap_fclose, 0);
@@ -442,8 +516,6 @@ void test_set_auditd_config_audit_plugin_not_created(void **state) {
 
 
 void test_set_auditd_config_audit_plugin_not_created_fopen_error(void **state) {
-    (void) state;
-
     // Audit 3
     expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
     will_return(__wrap_IsDir, 0);
@@ -453,11 +525,17 @@ void test_set_auditd_config_audit_plugin_not_created_fopen_error(void **state) {
     // Plugin not created
     const char *audit3_socket = "/etc/audit/plugins.d/af_wazuh.conf";
 
-    expect_string(__wrap_IsLink, file, audit3_socket);
-    will_return(__wrap_IsLink, 1);
-
-    expect_abspath(AUDIT_CONF_FILE, 1);
     expect_abspath(AUDIT_SOCKET, 1);
+    expect_abspath(AUDIT_CONF_FILE, 1);
+
+    expect_any(__wrap_OS_SHA1_Str, str);
+    expect_any(__wrap_OS_SHA1_Str, length);
+    will_return(__wrap_OS_SHA1_Str, "6e3a100fc85241f04ed9686d37738e7d08086fb4");
+
+    expect_string(__wrap_OS_SHA1_File, fname, audit3_socket);
+    expect_value(__wrap_OS_SHA1_File, mode, OS_TEXT);
+    will_return(__wrap_OS_SHA1_File, "0123456789abcdef0123456789abcdef01234567");
+    will_return(__wrap_OS_SHA1_File, 0);
 
     expect_string(__wrap_fopen, path, "etc/af_wazuh.conf");
     expect_string(__wrap_fopen, mode, "w");
@@ -473,8 +551,6 @@ void test_set_auditd_config_audit_plugin_not_created_fopen_error(void **state) {
 
 
 void test_set_auditd_config_audit_plugin_not_created_fclose_error(void **state) {
-    (void) state;
-
     expect_string(__wrap__minfo, formatted_msg, "(6024): Generating Auditd socket configuration file: 'etc/af_wazuh.conf'");
 
     // Audit 3
@@ -484,20 +560,23 @@ void test_set_auditd_config_audit_plugin_not_created_fclose_error(void **state) 
     // Plugin not created
     const char *audit3_socket = "/etc/audit/plugins.d/af_wazuh.conf";
 
-    expect_string(__wrap_IsLink, file, audit3_socket);
-    will_return(__wrap_IsLink, 1);
-
-    expect_abspath(AUDIT_CONF_FILE, 1);
     expect_abspath(AUDIT_SOCKET, 1);
+    expect_abspath(AUDIT_CONF_FILE, 1);
+
+    expect_any(__wrap_OS_SHA1_Str, str);
+    expect_any(__wrap_OS_SHA1_Str, length);
+    will_return(__wrap_OS_SHA1_Str, "6e3a100fc85241f04ed9686d37738e7d08086fb4");
+
+    expect_string(__wrap_OS_SHA1_File, fname, audit3_socket);
+    expect_value(__wrap_OS_SHA1_File, mode, OS_TEXT);
+    will_return(__wrap_OS_SHA1_File, "0123456789abcdef0123456789abcdef01234567");
+    will_return(__wrap_OS_SHA1_File, 0);
 
     expect_string(__wrap_fopen, path, "etc/af_wazuh.conf");
     expect_string(__wrap_fopen, mode, "w");
     will_return(__wrap_fopen, 1);
 
-    expect_any_always(__wrap_fprintf, __stream);
-    expect_any_always(__wrap_fprintf, formatted_msg);
-    will_return_always(__wrap_fprintf, 1);
-    will_return_always(__wrap_fwrite, 1);
+    will_return(__wrap_fwrite, 1);
 
     expect_value(__wrap_fclose, _File, 1);
     will_return(__wrap_fclose, -1);
@@ -512,8 +591,6 @@ void test_set_auditd_config_audit_plugin_not_created_fclose_error(void **state) 
 
 
 void test_set_auditd_config_audit_plugin_not_created_recreate_symlink(void **state) {
-    (void) state;
-
     expect_string(__wrap__minfo, formatted_msg, "(6024): Generating Auditd socket configuration file: 'etc/af_wazuh.conf'");
 
     // Audit 3
@@ -523,20 +600,23 @@ void test_set_auditd_config_audit_plugin_not_created_recreate_symlink(void **sta
     // Plugin not created
     const char *audit3_socket = "/etc/audit/plugins.d/af_wazuh.conf";
 
-    expect_string(__wrap_IsLink, file, audit3_socket);
-    will_return(__wrap_IsLink, 1);
-
-    expect_abspath(AUDIT_CONF_FILE, 1);
     expect_abspath(AUDIT_SOCKET, 1);
+    expect_abspath(AUDIT_CONF_FILE, 1);
+
+    expect_any(__wrap_OS_SHA1_Str, str);
+    expect_any(__wrap_OS_SHA1_Str, length);
+    will_return(__wrap_OS_SHA1_Str, "6e3a100fc85241f04ed9686d37738e7d08086fb4");
+
+    expect_string(__wrap_OS_SHA1_File, fname, audit3_socket);
+    expect_value(__wrap_OS_SHA1_File, mode, OS_TEXT);
+    will_return(__wrap_OS_SHA1_File, "0123456789abcdef0123456789abcdef01234567");
+    will_return(__wrap_OS_SHA1_File, 0);
 
     expect_string(__wrap_fopen, path, "etc/af_wazuh.conf");
     expect_string(__wrap_fopen, mode, "w");
     will_return(__wrap_fopen, 1);
 
-    expect_any_always(__wrap_fprintf, __stream);
-    expect_any_always(__wrap_fprintf, formatted_msg);
-    will_return_always(__wrap_fprintf, 1);
-    will_return_always(__wrap_fwrite, 1);
+    will_return(__wrap_fwrite, 1);
 
     expect_value(__wrap_fclose, _File, 1);
     will_return(__wrap_fclose, 0);
@@ -568,8 +648,6 @@ void test_set_auditd_config_audit_plugin_not_created_recreate_symlink(void **sta
 
 
 void test_set_auditd_config_audit_plugin_not_created_recreate_symlink_restart(void **state) {
-    (void) state;
-
     // Audit 3
     expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
     will_return(__wrap_IsDir, 0);
@@ -579,20 +657,23 @@ void test_set_auditd_config_audit_plugin_not_created_recreate_symlink_restart(vo
 
     expect_string(__wrap__minfo, formatted_msg, "(6024): Generating Auditd socket configuration file: 'etc/af_wazuh.conf'");
 
-    expect_string(__wrap_IsLink, file, audit3_socket);
-    will_return(__wrap_IsLink, 1);
-
-    expect_abspath(AUDIT_CONF_FILE, 1);
     expect_abspath(AUDIT_SOCKET, 1);
+    expect_abspath(AUDIT_CONF_FILE, 1);
+
+    expect_any(__wrap_OS_SHA1_Str, str);
+    expect_any(__wrap_OS_SHA1_Str, length);
+    will_return(__wrap_OS_SHA1_Str, "6e3a100fc85241f04ed9686d37738e7d08086fb4");
+
+    expect_string(__wrap_OS_SHA1_File, fname, audit3_socket);
+    expect_value(__wrap_OS_SHA1_File, mode, OS_TEXT);
+    will_return(__wrap_OS_SHA1_File, "0123456789abcdef0123456789abcdef01234567");
+    will_return(__wrap_OS_SHA1_File, 0);
 
     expect_string(__wrap_fopen, path, "etc/af_wazuh.conf");
     expect_string(__wrap_fopen, mode, "w");
     will_return(__wrap_fopen, 1);
 
-    expect_any_always(__wrap_fprintf, __stream);
-    expect_any_always(__wrap_fprintf, formatted_msg);
-    will_return_always(__wrap_fprintf, 1);
-    will_return_always(__wrap_fwrite, 1);
+    will_return(__wrap_fwrite, 1);
 
     expect_value(__wrap_fclose, _File, 1);
     will_return(__wrap_fclose, 0);
@@ -625,8 +706,6 @@ void test_set_auditd_config_audit_plugin_not_created_recreate_symlink_restart(vo
 
 
 void test_set_auditd_config_audit_plugin_not_created_recreate_symlink_error(void **state) {
-    (void) state;
-
     // Audit 3
     expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
     will_return(__wrap_IsDir, 0);
@@ -636,20 +715,23 @@ void test_set_auditd_config_audit_plugin_not_created_recreate_symlink_error(void
     // Plugin not created
     const char *audit3_socket = "/etc/audit/plugins.d/af_wazuh.conf";
 
-    expect_string(__wrap_IsLink, file, audit3_socket);
-    will_return(__wrap_IsLink, 1);
-
-    expect_abspath(AUDIT_CONF_FILE, 1);
     expect_abspath(AUDIT_SOCKET, 1);
+    expect_abspath(AUDIT_CONF_FILE, 1);
+
+    expect_any(__wrap_OS_SHA1_Str, str);
+    expect_any(__wrap_OS_SHA1_Str, length);
+    will_return(__wrap_OS_SHA1_Str, "6e3a100fc85241f04ed9686d37738e7d08086fb4");
+
+    expect_string(__wrap_OS_SHA1_File, fname, audit3_socket);
+    expect_value(__wrap_OS_SHA1_File, mode, OS_TEXT);
+    will_return(__wrap_OS_SHA1_File, "0123456789abcdef0123456789abcdef01234567");
+    will_return(__wrap_OS_SHA1_File, 0);
 
     expect_string(__wrap_fopen, path, "etc/af_wazuh.conf");
     expect_string(__wrap_fopen, mode, "w");
     will_return(__wrap_fopen, 1);
 
-    expect_any_always(__wrap_fprintf, __stream);
-    expect_any_always(__wrap_fprintf, formatted_msg);
-    will_return_always(__wrap_fprintf, 1);
-    will_return_always(__wrap_fwrite, 1);
+    will_return(__wrap_fwrite, 1);
 
     expect_value(__wrap_fclose, _File, 1);
     will_return(__wrap_fclose, 0);
@@ -678,8 +760,6 @@ void test_set_auditd_config_audit_plugin_not_created_recreate_symlink_error(void
 
 
 void test_set_auditd_config_audit_plugin_not_created_recreate_symlink_unlink_error(void **state) {
-    (void) state;
-
     // Audit 3
     expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
     will_return(__wrap_IsDir, 0);
@@ -689,20 +769,23 @@ void test_set_auditd_config_audit_plugin_not_created_recreate_symlink_unlink_err
     // Plugin not created
     const char *audit3_socket = "/etc/audit/plugins.d/af_wazuh.conf";
 
-    expect_string(__wrap_IsLink, file, audit3_socket);
-    will_return(__wrap_IsLink, 1);
-
-    expect_abspath(AUDIT_CONF_FILE, 1);
     expect_abspath(AUDIT_SOCKET, 1);
+    expect_abspath(AUDIT_CONF_FILE, 1);
+
+    expect_any(__wrap_OS_SHA1_Str, str);
+    expect_any(__wrap_OS_SHA1_Str, length);
+    will_return(__wrap_OS_SHA1_Str, "6e3a100fc85241f04ed9686d37738e7d08086fb4");
+
+    expect_string(__wrap_OS_SHA1_File, fname, audit3_socket);
+    expect_value(__wrap_OS_SHA1_File, mode, OS_TEXT);
+    will_return(__wrap_OS_SHA1_File, "0123456789abcdef0123456789abcdef01234567");
+    will_return(__wrap_OS_SHA1_File, 0);
 
     expect_string(__wrap_fopen, path, "etc/af_wazuh.conf");
     expect_string(__wrap_fopen, mode, "w");
     will_return(__wrap_fopen, 1);
 
-    expect_any_always(__wrap_fprintf, __stream);
-    expect_any_always(__wrap_fprintf, formatted_msg);
-    will_return_always(__wrap_fprintf, 1);
-    will_return_always(__wrap_fwrite, 1);
+    will_return(__wrap_fwrite, 1);
 
     expect_value(__wrap_fclose, _File, 1);
     will_return(__wrap_fclose, 0);
@@ -1077,6 +1160,7 @@ int main(void) {
         cmocka_unit_test(test_set_auditd_config_audit3_plugin_created),
         cmocka_unit_test(test_set_auditd_config_audit_socket_not_created),
         cmocka_unit_test(test_set_auditd_config_audit_socket_not_created_restart),
+        cmocka_unit_test(test_set_auditd_config_audit_plugin_tampered_configuration),
         cmocka_unit_test(test_set_auditd_config_audit_plugin_not_created),
         cmocka_unit_test(test_set_auditd_config_audit_plugin_not_created_fopen_error),
         cmocka_unit_test(test_set_auditd_config_audit_plugin_not_created_fclose_error),

--- a/src/unit_tests/wrappers/wazuh/os_crypto/sha1_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/os_crypto/sha1_op_wrappers.c
@@ -64,3 +64,12 @@ int __wrap_OS_SHA1_File_Nbytes_with_fp_check(const char * fname, __attribute__((
     return mock();
 }
 #endif
+
+int __wrap_OS_SHA1_Str(const char *str, ssize_t length, os_sha1 output) {
+    check_expected(str);
+    check_expected(length);
+
+    snprintf(output, 41, "%s", mock_type(char *));
+
+    return 0;
+}

--- a/src/unit_tests/wrappers/wazuh/os_crypto/sha1_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/os_crypto/sha1_op_wrappers.h
@@ -28,4 +28,6 @@ int __wrap_OS_SHA1_File_Nbytes_with_fp_check(const char * fname, SHA_CTX * c, os
                                       DWORD fd_check);
 #endif
 
+int __wrap_OS_SHA1_Str(const char *str, ssize_t length, os_sha1 output);
+
 #endif


### PR DESCRIPTION
|Related issue|
|---|
|#8912|


## Description
This PR closes #8912. The root problem causing whodata to break on an upgrade was that the audit plugin configuration held a directory that no longer existed, we fix this by checking the SHA1 hash from the file against the configuration that would be created if the file didn't exist.

It could be argued that forcing this configuration file to have our intended content could cause users to not be able to change it afterwards, however, I can't really think of a case where a user would change this file that doesn't break whodata.

## Logs/Alerts example
If the plugin configuration file is tampered, upon a restart the following logs will be shown:
```
2021/06/08 10:40:02 wazuh-syscheckd: INFO: (6024): Generating Auditd socket configuration file: 'etc/af_wazuh.conf'
2021/06/08 10:40:02 wazuh-syscheckd: INFO: (6025): Audit plugin configuration (etc/af_wazuh.conf) was modified. Restarting Auditd service.
```

As long as the file is not tampered with and the audit socket exists, no restart of the auditd service will be issued.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] AddressSanitizer + UBSanitizer

- [x] Added unit tests (for new features)
