### PR TITLE
Fetch SUSE feeds for Vulnerability Detector

### DIFF
--- a/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
+++ b/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
@@ -40,6 +40,18 @@
       <update_interval>1h</update_interval>
     </provider>
 
+    <!-- SUSE OS vulnerabilities -->
+    <provider name="suse">
+      <enabled>no</enabled>
+      <os>15-server</os>
+      <os>15-desktop</os>
+      <os>12-server</os>
+      <os>12-desktop</os>
+      <os>11-server</os>
+      <os>11-desktop</os>
+      <update_interval>1h</update_interval>
+    </provider>
+
     <!-- Arch OS vulnerabilities -->
     <provider name="arch">
       <enabled>no</enabled>

--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -165,6 +165,7 @@ int wm_vuldet_set_feed_version(char *feed, char *version, update_node **upd_list
             goto end;
         }
         upd->dist_ref = FEED_UBUNTU;
+
     } else if (strcasestr(feed, vu_feed_tag[FEED_DEBIAN]) && version) {
         if (!strcmp(version, "10") || strcasestr(version, vu_feed_tag[FEED_BUSTER])) {
             os_index = CVE_BUSTER;
@@ -235,6 +236,7 @@ int wm_vuldet_set_feed_version(char *feed, char *version, update_node **upd_list
             goto end;
         }
         upd->dist_ref = FEED_REDHAT;
+
     } else if (strcasestr(feed, vu_feed_tag[FEED_ALAS])) {
         if (!version) {
             retval = OS_INVALID;
@@ -259,18 +261,69 @@ int wm_vuldet_set_feed_version(char *feed, char *version, update_node **upd_list
         }
         upd->dist_ref = FEED_ALAS;
         upd->json_format = 1;
+
+    } else if (strcasestr(feed, vu_feed_tag[FEED_SUSE])) {
+        if (!version) {
+            retval = OS_INVALID;
+            goto end;
+        }
+        // SLES 15
+        if (!strcmp(version, "15-server") || strcasestr(vu_feed_tag[FEED_SLES15], version)) {
+            os_index = CVE_SLES15;
+            os_strdup(vu_feed_tag[FEED_SLES15], upd->version);
+            upd->dist_tag_ref = FEED_SLES15;
+            upd->dist_ext = vu_feed_ext[FEED_SLES15];
+        // SLED 15
+        } else if (!strcmp(version, "15-desktop") || strcasestr(vu_feed_tag[FEED_SLED15], version)) {
+            os_index = CVE_SLED15;
+            os_strdup(vu_feed_tag[FEED_SLED15], upd->version);
+            upd->dist_tag_ref = FEED_SLED15;
+            upd->dist_ext = vu_feed_ext[FEED_SLED15];
+        // SLES 12
+        } else if (!strcmp(version, "12-server") || strcasestr(vu_feed_tag[FEED_SLES12], version)) {
+            os_index = CVE_SLES12;
+            os_strdup(vu_feed_tag[FEED_SLES12], upd->version);
+            upd->dist_tag_ref = FEED_SLES12;
+            upd->dist_ext = vu_feed_ext[FEED_SLES12];
+        // SLED 12
+        } else if (!strcmp(version, "12-desktop") || strcasestr(vu_feed_tag[FEED_SLED12], version)) {
+            os_index = CVE_SLED12;
+            os_strdup(vu_feed_tag[FEED_SLED12], upd->version);
+            upd->dist_tag_ref = FEED_SLED12;
+            upd->dist_ext = vu_feed_ext[FEED_SLED12];
+        // SLES 11
+        } else if (!strcmp(version, "11-server") || strcasestr(vu_feed_tag[FEED_SLES11], version)) {
+            os_index = CVE_SLES11;
+            os_strdup(vu_feed_tag[FEED_SLES11], upd->version);
+            upd->dist_tag_ref = FEED_SLES11;
+            upd->dist_ext = vu_feed_ext[FEED_SLES11];
+        // SLED 11
+        } else if (!strcmp(version, "11-desktop") || strcasestr(vu_feed_tag[FEED_SLED11], version)) {
+            os_index = CVE_SLED11;
+            os_strdup(vu_feed_tag[FEED_SLED11], upd->version);
+            upd->dist_tag_ref = FEED_SLED11;
+            upd->dist_ext = vu_feed_ext[FEED_SLED11];
+        } else {
+            merror("Invalid SUSE version '%s'", version);
+            retval = OS_INVALID;
+            goto end;
+        }
+        upd->dist_ref = FEED_SUSE;
+
     } else if (strcasestr(feed, vu_feed_tag[FEED_ARCH])) {
         os_index = CVE_ARCH;
         upd->dist_tag_ref = FEED_ARCH;
         upd->dist_ext = vu_feed_ext[FEED_ARCH];
         upd->dist_ref = FEED_ARCH;
         upd->json_format = 1;
+
     } else if (strcasestr(feed, vu_feed_tag[FEED_MSU])) {
         os_index = CVE_MSU;
         upd->dist_tag_ref = FEED_MSU;
         upd->dist_ext = vu_feed_ext[FEED_MSU];
         upd->dist_ref = FEED_MSU;
         upd->json_format = 1;
+
     } else if (strcasestr(feed, vu_feed_tag[FEED_NVD])) {
         os_index = CVE_NVD;
         upd->dist_tag_ref = FEED_NVD;
@@ -286,6 +339,7 @@ int wm_vuldet_set_feed_version(char *feed, char *version, update_node **upd_list
         upd_list[CPE_WDIC]->dist_ext = vu_feed_ext[FEED_CPEW];
         upd_list[CPE_WDIC]->dist_ref = FEED_CPEW;
         upd_list[CPE_WDIC]->json_format = 1;
+
     } else {
         merror("Invalid feed '%s' at module '%s'", feed, WM_VULNDETECTOR_CONTEXT.name);
         retval = OS_INVALID;
@@ -979,6 +1033,7 @@ char wm_vuldet_provider_type(char *pr_name) {
     if (strcasestr(pr_name, vu_feed_tag[FEED_CANONICAL]) ||
         strcasestr(pr_name, vu_feed_tag[FEED_DEBIAN]) ||
         strcasestr(pr_name, vu_feed_tag[FEED_ALAS]) ||
+        strcasestr(pr_name, vu_feed_tag[FEED_SUSE]) ||
         strcasestr(pr_name, vu_feed_tag[FEED_REDHAT])) {
         return 0;
     } else if (strcasestr(pr_name, vu_feed_tag[FEED_NVD]) ||

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -409,6 +409,7 @@
 #define VU_VER_READING_ERROR        "(5589): Couldn't read Wazuh version for agent '%.3d'"
 #define VU_OVAL_VULN_NOT_FOUND      "(5590): No vulnerabilities could be found in the OVAL for agent '%.3d'"
 #define VU_PKG_INVALID_VER          "(5591): Invalid version for package '%s' of the inventory: '%s'"
+#define VU_SUSE_VERSION_ERROR       "(5592): Invalid SUSE OS version."
 
 /* File integrity monitoring error messages*/
 #define FIM_ERROR_ADD_FILE                          "(6600): Unable to add file to db: '%s'"

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -16857,6 +16857,84 @@ void test_wm_vuldet_set_feed_update_url_redhat_greater_5(void **state)
     os_free(update);
 }
 
+void test_wm_vuldet_set_feed_update_url_alas(void **state)
+{
+    bool ret;
+    int ind_dist;
+    int dist_tag_ref[] = {FEED_ALAS1, FEED_ALAS2};
+
+    update_node *update = NULL;
+    char *url = NULL;
+
+    os_calloc(1, sizeof(update_node), update);
+    os_calloc(1, OS_SIZE_2048 + 1, url);
+    update->dist_ref = FEED_ALAS;
+
+    for (ind_dist = 0; ind_dist < sizeof(dist_tag_ref)/sizeof(int); ind_dist++) {
+        update->dist_tag_ref = dist_tag_ref[ind_dist];
+        ret = wm_vuldet_set_feed_update_url(update);
+        assert_true(ret);
+        snprintf(url, OS_SIZE_2048, ind_dist ? ALAS2_REPO : ALAS_REPO);
+        assert_string_equal(update->url, url);
+        os_free(update->url);
+    }
+
+    os_free(url);
+    os_free(update);
+}
+
+void test_wm_vuldet_set_feed_update_url_suse(void **state)
+{
+    bool ret;
+    int ind_dist;
+    int dist_tag_ref[] = {FEED_SLES15, FEED_SLED15, FEED_SLES12, FEED_SLED12, FEED_SLES11, FEED_SLED11};
+    char * repos[6][2] = {
+        {SLES_REPO, "15"},
+        {SLED_REPO, "15"},
+        {SLES_REPO, "12"},
+        {SLED_REPO, "12"},
+        {SLES_REPO, "11"},
+        {SLED_REPO, "11"}
+    };
+
+    update_node *update = NULL;
+    char *url = NULL;
+
+    os_calloc(1, sizeof(update_node), update);
+    os_calloc(1, OS_SIZE_2048 + 1, url);
+    update->dist_ref = FEED_SUSE;
+
+    for (ind_dist = 0; ind_dist < sizeof(dist_tag_ref)/sizeof(int); ind_dist++) {
+        update->dist_tag_ref = dist_tag_ref[ind_dist];
+        ret = wm_vuldet_set_feed_update_url(update);
+        assert_true(ret);
+        snprintf(url, OS_SIZE_2048, repos[ind_dist][0], repos[ind_dist][1]);
+        assert_string_equal(update->url, url);
+        os_free(update->url);
+    }
+
+    os_free(url);
+    os_free(update);
+}
+
+void test_wm_vuldet_set_feed_update_url_suse_invalid(void **state)
+{
+    bool ret;
+    update_node *update = NULL;
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_ref = FEED_SUSE;
+    update->dist_tag_ref = -1;
+
+    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mterror, formatted_msg, "(5592): Invalid SUSE OS version.");
+
+    ret = wm_vuldet_set_feed_update_url(update);
+    assert_false(ret);
+
+    os_free(update);
+}
+
 void test_wm_vuldet_set_feed_update_url_invalid(void **state)
 {
     bool ret;
@@ -19478,6 +19556,9 @@ int main(void)
         cmocka_unit_test(test_wm_vuldet_set_feed_update_url_debian),
         cmocka_unit_test(test_wm_vuldet_set_feed_update_url_redhat_5),
         cmocka_unit_test(test_wm_vuldet_set_feed_update_url_redhat_greater_5),
+        cmocka_unit_test(test_wm_vuldet_set_feed_update_url_alas),
+        cmocka_unit_test(test_wm_vuldet_set_feed_update_url_suse),
+        cmocka_unit_test(test_wm_vuldet_set_feed_update_url_suse_invalid),
         cmocka_unit_test(test_wm_vuldet_set_feed_update_url_invalid),
         // Tests wm_vuldet_oval_append_rhsa
         cmocka_unit_test(test_wm_vuldet_oval_append_rhsa_empty),

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -98,7 +98,7 @@ STATIC int wm_vuldet_remove_target_table(sqlite3 *db, char *TABLE, const char *t
 
 /**
  * @brief Set and validate the required URL for the feed.
- * Currently Debian, Ubuntu and RedHat are supported.
+ * Currently Debian, Ubuntu, Amazon and SUSE and RedHat are supported.
  * @param update Update structure of the feed being analyzed.
  * @return False if an unexpected feed is analyzed; True othewise.
  */
@@ -381,6 +381,7 @@ const char *vu_feed_tag[] = {
     "JREDHAT",
     "CENTOS",
     "ALAS",
+    "SUSE",
     "ARCH",
     "WIN",
     // Ubuntu versions
@@ -402,6 +403,13 @@ const char *vu_feed_tag[] = {
     // Amazon versions
     "Amazon-Linux",
     "Amazon-Linux-2",
+    // SUSE versions
+    "SLES15",
+    "SLED15",
+    "SLES12",
+    "SLED12",
+    "SLES11",
+    "SLED11",
     // WINDOWS
     "WS2003",
     "WS2003R2",
@@ -453,6 +461,13 @@ const char *vu_feed_ext[] = {
     // Amazon versions
     "Amazon Linux 1",
     "Amazon Linux 2",
+    // SUSE versions
+    "SUSE Linux Enterprise Server 15",
+    "SUSE Linux Enterprise Desktop 15",
+    "SUSE Linux Enterprise Server 12",
+    "SUSE Linux Enterprise Desktop 12",
+    "SUSE Linux Enterprise Server 11",
+    "SUSE Linux Enterprise Desktop 11",
     // WINDOWS
     "Windows Server 2003",
     "Windows Server 2003 R2",
@@ -3978,6 +3993,24 @@ bool wm_vuldet_set_feed_update_url(update_node *update) {
     } else if (update->dist_ref == FEED_ALAS) {
         snprintf(repo, OS_SIZE_2048, update->dist_tag_ref == FEED_ALAS1 ? ALAS_REPO : ALAS2_REPO);
 
+    } else if (update->dist_ref == FEED_SUSE) {
+        if (update->dist_tag_ref == FEED_SLES15) {
+            snprintf(repo, OS_SIZE_2048, SLES_REPO, "15");
+        } else if (update->dist_tag_ref == FEED_SLED15) {
+            snprintf(repo, OS_SIZE_2048, SLED_REPO, "15");
+        } else if (update->dist_tag_ref == FEED_SLES12) {
+            snprintf(repo, OS_SIZE_2048, SLES_REPO, "12");
+        } else if (update->dist_tag_ref == FEED_SLED12) {
+            snprintf(repo, OS_SIZE_2048, SLED_REPO, "12");
+        } else if (update->dist_tag_ref == FEED_SLES11) {
+            snprintf(repo, OS_SIZE_2048, SLES_REPO, "11");
+        } else if (update->dist_tag_ref == FEED_SLED11) {
+            snprintf(repo, OS_SIZE_2048, SLED_REPO, "11");
+        } else {
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_SUSE_VERSION_ERROR);
+            os_free(repo);
+            return false;
+        }
     } else if (update->dist_ref == FEED_REDHAT) {
         if (update->dist_tag_ref == FEED_RHEL5)
             snprintf(repo, OS_SIZE_2048, "%s", RED_HAT5_REPO);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -440,6 +440,7 @@ const char *vu_feed_ext[] = {
     "JSON Red Hat Enterprise Linux",
     "CentOS",
     "Amazon Linux",
+    "SUSE Linux Enterprise",
     "Arch Linux",
     "Microsoft Windows",
     // Ubuntu versions

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -45,6 +45,8 @@
 #define ALAS_REPO_META "https://feed.wazuh.com/vulnerability-detector/ALAS/1/alas.meta"
 #define ALAS2_REPO "https://feed.wazuh.com/vulnerability-detector/ALAS/2/alas2.json.gz"
 #define ALAS2_REPO_META "https://feed.wazuh.com/vulnerability-detector/ALAS/2/alas2.meta"
+#define SLES_REPO "https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.server.%s.xml"
+#define SLED_REPO "https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.desktop.%s.xml"
 #define RED_HAT_REPO_DEFAULT_MIN_YEAR 2010
 #define RED_HAT_REPO_MAX_REQ_ITS 100
 #define RED_HAT_REPO_MAX_FAIL_ITS 5
@@ -246,6 +248,7 @@ typedef enum vu_feed {
     FEED_JREDHAT, // JSON RedHat
     FEED_CENTOS,
     FEED_ALAS,
+    FEED_SUSE,
     FEED_ARCH,
     FEED_WIN,
     // Ubuntu versions
@@ -267,6 +270,13 @@ typedef enum vu_feed {
     // Amazon versions
     FEED_ALAS1,
     FEED_ALAS2,
+    // SUSE versions
+    FEED_SLES15,
+    FEED_SLED15,
+    FEED_SLES12,
+    FEED_SLED12,
+    FEED_SLES11,
+    FEED_SLED11,
     // WINDOWS
     FEED_WS2003,
     FEED_WS2003R2,
@@ -407,6 +417,12 @@ typedef enum cve_db {
     CVE_JREDHAT, // JSON RedHat
     CVE_ALAS1,
     CVE_ALAS2,
+    CVE_SLES15,
+    CVE_SLED15,
+    CVE_SLES12,
+    CVE_SLED12,
+    CVE_SLES11,
+    CVE_SLED11,
     CVE_ARCH,
     CVE_NVD,
     CPE_WDIC,


### PR DESCRIPTION
|Related issue|
|---|
| #8373 |

## Description

This pull request adds the configuration block for the new SUSE provider. In addition, it modifies functions needed to fetch the corresponding feeds.

Unit tests have been added to cover the added code.

## Configuration options

```xml
    <!-- SUSE OS vulnerabilities -->
    <provider name="suse">
      <enabled>no</enabled>
      <os>15-server</os>
      <os>15-desktop</os>
      <os>12-server</os>
      <os>12-desktop</os>
      <os>11-server</os>
      <os>11-desktop</os>
      <update_interval>1h</update_interval>
    </provider>
```

## Logs/Alerts example

**Config debug logs**
```
2021/06/08 13:20:34 wazuh-modulesd[38049] wmodules-vuln-detector.c:629 at wm_vuldet_read_provider(): DEBUG: Added suse (15-server) feed. Interval: 3600s | Path: 'none' | Url: 'none' | Timeout: 300s
2021/06/08 13:20:34 wazuh-modulesd[38049] wmodules-vuln-detector.c:629 at wm_vuldet_read_provider(): DEBUG: Added suse (15-desktop) feed. Interval: 3600s | Path: 'none' | Url: 'none' | Timeout: 300s
2021/06/08 13:20:34 wazuh-modulesd[38049] wmodules-vuln-detector.c:629 at wm_vuldet_read_provider(): DEBUG: Added suse (12-server) feed. Interval: 3600s | Path: 'none' | Url: 'none' | Timeout: 300s
2021/06/08 13:20:34 wazuh-modulesd[38049] wmodules-vuln-detector.c:629 at wm_vuldet_read_provider(): DEBUG: Added suse (12-desktop) feed. Interval: 3600s | Path: 'none' | Url: 'none' | Timeout: 300s
2021/06/08 13:20:34 wazuh-modulesd[38049] wmodules-vuln-detector.c:629 at wm_vuldet_read_provider(): DEBUG: Added suse (11-server) feed. Interval: 3600s | Path: 'none' | Url: 'none' | Timeout: 300s
2021/06/08 13:20:34 wazuh-modulesd[38049] wmodules-vuln-detector.c:629 at wm_vuldet_read_provider(): DEBUG: Added suse (11-desktop) feed. Interval: 3600s | Path: 'none' | Url: 'none' | Timeout: 300s
```

**Fetch logs**
```
2021/06/08 13:20:46 wazuh-modulesd:vulnerability-detector[38296] wm_vuln_detector.c:4209 at wm_vuldet_check_feed(): INFO: (5400): Starting 'SUSE Linux Enterprise Server 15' database update.
2021/06/08 13:20:46 wazuh-modulesd:download[38296] wm_download.c:229 at wm_download_dispatch(): DEBUG: Downloading 'https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.server.15.xml' to 'tmp/vuln-temp'
2021/06/08 13:20:57 wazuh-modulesd:download[38296] wm_download.c:249 at wm_download_dispatch(): DEBUG: Download of 'https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.server.15.xml' finished.
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
- [x] Added unit tests (for new features)
- [x] Stress test for affected components
