### PR TITLE
logcollector: possible buffer overflow fixed

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -23,7 +23,7 @@
 
 #define MAX_ASCII_LINES 10
 #define MAX_UTF8_CHARS 1400
-#define OFFSET_SIZE 20
+#define OFFSET_SIZE     21  ///< Maximum 64-bit integer is 20-char long, plus 1 because of the '\0'
 
 /* Prototypes */
 static int update_fname(int i, int j);
@@ -2750,7 +2750,7 @@ STATIC char * w_save_files_status_to_cJSON() {
         char * path = hash_node->key;
         char offset[OFFSET_SIZE] = {0};
 
-        sprintf(offset, "%" PRIi64, data->offset);
+        snprintf(offset, OFFSET_SIZE, "%" PRIi64, data->offset);
 
         cJSON * item = cJSON_CreateObject();
 


### PR DESCRIPTION
|Related issue|
|---|
| closes #8932 |

## Description

Hi team,

We have fixed the bug mentioned on issue #8932 by modifying the `offset` buffer length and replacing `sprintf` with its secure method `snprintf`

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [x] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

Best Regards,

Mariano Koremblum