### PR TITLE
Improve `PUT /agents/group` endpoint

### DIFF
--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -977,7 +977,6 @@ class Agent:
         :return: Agent ID.
         """
         agent = Agent(agent_id)
-        agent_info = False
         if replace_list is None:
             replace_list = []
         if not force:
@@ -988,9 +987,6 @@ class Agent:
             if not Agent.group_exists(group_id):
                 raise WazuhResourceNotFound(1710)
 
-            agent.load_info_from_db()
-            agent_info = True
-
         # Get agent's group
         group_path = path.join(common.groups_path, agent_id)
         try:
@@ -998,7 +994,7 @@ class Agent:
                 multigroup_name = f.read().strip()
         except Exception as e:
             # Check if agent is never_connected.
-            not agent_info and agent.load_info_from_db()
+            agent.load_info_from_db()
             if agent.status == 'never_connected':
                 raise WazuhError(1753)
             raise WazuhInternalError(1005, extra_message=str(e))

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -1375,27 +1375,6 @@ def test_agent_set_agent_group_file_ko():
         Agent.set_agent_group_file('002', 'test_group')
 
 
-@pytest.mark.parametrize('groups, expected_result', [
-    ('default0,default1,default2,default3', True),
-    ('default0,default1', False),
-    ('', False)
-])
-@patch('wazuh.core.common.max_groups_per_multigroup', new=3)
-def test_agent_check_multigroup_limit(groups, expected_result):
-    """Test if check_multigroup_limit() returns True when limit of groups is reached
-
-    Parameters
-    ----------
-    groups : str
-        Groups to which the agent belongs.
-    expected_result : bool
-        Expected result.
-    """
-    with patch('wazuh.core.agent.Agent.get_agents_group_file', return_value=groups):
-        result = Agent.check_multigroup_limit('002')
-        assert result == expected_result, f'check_multigroup_limit returns {result} but should return {expected_result}'
-
-
 @pytest.mark.parametrize('agent_id, group_id, force, previous_groups, set_default', [
     ('002', 'test_group', False, 'default,test_group,another_test', False),
     ('002', 'test_group', True, 'default,test_group,another_test', False),


### PR DESCRIPTION
|Related issue|
|---|
| closes #6749 |

## Description

Hello team,

As it was reported in the issue, this endpoint did not scale properly with a high number of agents. Some small improvements have been done in order to slightly improve its performance, allowing at least 100k agents (for a single group) in a time within the timeout threshold. A complete rework could be done in the future with the new major version.


## Tests performed
### Unit tests

```shellsession
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.9.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: cov-2.12.0, asyncio-0.15.1
collected 1585 items                                                                                                                                                                                              

wazuh/core/cluster/dapi/tests/test_dapi.py .......................                                                                                                                                          [  1%]
wazuh/core/cluster/tests/test_cluster.py ...................                                                                                                                                                [  2%]
wazuh/core/cluster/tests/test_common.py .......                                                                                                                                                             [  3%]
wazuh/core/cluster/tests/test_control.py .....                                                                                                                                                              [  3%]
wazuh/core/cluster/tests/test_local_client.py .                                                                                                                                                             [  3%]
wazuh/core/cluster/tests/test_utils.py .......                                                                                                                                                              [  3%]
wazuh/core/cluster/tests/test_worker.py .................                                                                                                                                                   [  4%]
wazuh/core/tests/test_active_response.py ..............                                                                                                                                                     [  5%]
wazuh/core/tests/test_agent.py ........................................................................................................................................................................     [ 16%]
wazuh/core/tests/test_cdb_list.py ......................................                                                                                                                                    [ 18%]
wazuh/core/tests/test_common.py .......                                                                                                                                                                     [ 19%]
wazuh/core/tests/test_configuration.py ....................................                                                                                                                                 [ 21%]
wazuh/core/tests/test_decoder.py ................                                                                                                                                                           [ 22%]
wazuh/core/tests/test_input_validator.py ...                                                                                                                                                                [ 22%]
wazuh/core/tests/test_logtest.py ..                                                                                                                                                                         [ 22%]
wazuh/core/tests/test_manager.py ...............                                                                                                                                                            [ 23%]
wazuh/core/tests/test_mitre.py .............                                                                                                                                                                [ 24%]
wazuh/core/tests/test_pyDaemonModule.py ......                                                                                                                                                              [ 25%]
wazuh/core/tests/test_results.py ........................................                                                                                                                                   [ 27%]
wazuh/core/tests/test_rootcheck.py ..........                                                                                                                                                               [ 28%]
wazuh/core/tests/test_rule.py ......................                                                                                                                                                        [ 29%]
wazuh/core/tests/test_stats.py ....                                                                                                                                                                         [ 29%]
wazuh/core/tests/test_syscollector.py ...                                                                                                                                                                   [ 30%]
wazuh/core/tests/test_utils.py ............................................................................................................................................................................ [ 40%]
...................................................                                                                                                                                                         [ 44%]
wazuh/core/tests/test_vulnerability.py .                                                                                                                                                                    [ 44%]
wazuh/core/tests/test_wazuh_queue.py ..................                                                                                                                                                     [ 45%]
wazuh/core/tests/test_wazuh_socket.py ....................                                                                                                                                                  [ 46%]
wazuh/core/tests/test_wdb.py ......................                                                                                                                                                         [ 47%]
wazuh/rbac/tests/test_auth_context.py ..                                                                                                                                                                    [ 48%]
wazuh/rbac/tests/test_decorators.py .........................................................................................................                                                               [ 54%]
wazuh/rbac/tests/test_default_configuration.py .......................................................                                                                                                      [ 58%]
wazuh/rbac/tests/test_orm.py ......................................................                                                                                                                         [ 61%]
wazuh/rbac/tests/test_preprocessor.py ...........                                                                                                                                                           [ 62%]
wazuh/tests/test_active_response.py ............                                                                                                                                                            [ 63%]
wazuh/tests/test_agent.py .............................................................................................................                                                                     [ 69%]
wazuh/tests/test_cdb_list.py .....................................................                                                                                                                          [ 73%]
wazuh/tests/test_ciscat.py .................................                                                                                                                                                [ 75%]
wazuh/tests/test_cluster.py .......                                                                                                                                                                         [ 75%]
wazuh/tests/test_decoder.py ...................................                                                                                                                                             [ 77%]
wazuh/tests/test_group.py ........                                                                                                                                                                          [ 78%]
wazuh/tests/test_logtest.py ......                                                                                                                                                                          [ 78%]
wazuh/tests/test_manager.py ..................................                                                                                                                                              [ 81%]
wazuh/tests/test_mitre.py .......                                                                                                                                                                           [ 81%]
wazuh/tests/test_rootcheck.py .................................................                                                                                                                             [ 84%]
wazuh/tests/test_rule.py ........................................................                                                                                                                           [ 88%]
wazuh/tests/test_sca.py .......                                                                                                                                                                             [ 88%]
wazuh/tests/test_security.py ............................................................................                                                                                                   [ 93%]
wazuh/tests/test_stats.py ................                                                                                                                                                                  [ 94%]
wazuh/tests/test_syscheck.py ........................                                                                                                                                                       [ 95%]
wazuh/tests/test_syscollector.py ............                                                                                                                                                               [ 96%]
wazuh/tests/test_task.py ............................                                                                                                                                                       [ 98%]
wazuh/tests/test_vulnerability.py ..........................                                                                                                                                                [100%]

================================================================================== 1585 passed, 15 warnings in 256.66s (0:04:16) ==================================================================================

```

Regards,
Víctor