### PR TITLE
Correct handling of SQLITE_DONE code return in FIM db synchronization

### DIFF
--- a/src/syscheckd/db/fim_db.c
+++ b/src/syscheckd/db/fim_db.c
@@ -813,6 +813,7 @@ int fim_db_get_checksum_range(fdb_t *fim_sql,
     char **decoded_row = NULL;
     int m = n / 2;
     int i;
+    int result;
 
     if (str_pathlh == NULL || str_pathuh == NULL || ctx_left == NULL || ctx_right == NULL) {
         return FIMDB_ERR;
@@ -825,9 +826,17 @@ int fim_db_get_checksum_range(fdb_t *fim_sql,
     // Calculate checksum of the first half
     for (i = 0; i < m; i++) {
         char *path, *checksum;
-        if (sqlite3_step(fim_sql->stmt[RANGE_QUERY[type]]) != SQLITE_ROW) {
-            merror("Step error getting path range, first half 'start %s' 'top %s' (i:%d): %s (%d)", start, top, i,
-                   sqlite3_errmsg(fim_sql->db), sqlite3_extended_errcode(fim_sql->db));
+
+        result = sqlite3_step(fim_sql->stmt[RANGE_QUERY[type]]);
+
+        if (result != SQLITE_ROW) {
+            if (result == SQLITE_DONE) {
+                mdebug2("Received a synchronization message with empty range, first half 'start %s' 'top %s' (i:%d)", start, top, i);
+            } else {
+                merror("Step error getting path range, first half 'start %s' 'top %s' (i:%d): %s", start, top, i,
+                       sqlite3_errmsg(fim_sql->db));
+            }
+
             return FIMDB_ERR;
         }
 
@@ -852,13 +861,22 @@ int fim_db_get_checksum_range(fdb_t *fim_sql,
     //Calculate checksum of the second half
     for (i = m; i < n; i++) {
         char *path, *checksum;
-        if (sqlite3_step(fim_sql->stmt[RANGE_QUERY[type]]) != SQLITE_ROW) {
-            merror("Step error getting path range, second half 'start %s' 'top %s' (i:%d): %s (%d)", start, top, i,
-                   sqlite3_errmsg(fim_sql->db), sqlite3_extended_errcode(fim_sql->db));
+
+        result = sqlite3_step(fim_sql->stmt[RANGE_QUERY[type]]);
+
+        if (result != SQLITE_ROW) {
+            if (result == SQLITE_DONE) {
+                mdebug2("Received a synchronization message with empty range, first half 'start %s' 'top %s' (i:%d)", start, top, i);
+            } else {
+                merror("Step error getting path range, second half 'start %s' 'top %s' (i:%d): %s", start, top, i,
+                       sqlite3_errmsg(fim_sql->db));
+            }
+
             os_free(*str_pathlh);
             os_free(*str_pathuh);
             return FIMDB_ERR;
         }
+
         decoded_row = fim_db_decode_string_array(fim_sql->stmt[RANGE_QUERY[type]]);
         if (decoded_row == NULL || decoded_row[0] == NULL || decoded_row[1] == NULL) {
             free_strarray(decoded_row);

--- a/src/unit_tests/syscheckd/db/test_fim_db.c
+++ b/src/unit_tests/syscheckd/db/test_fim_db.c
@@ -1150,7 +1150,7 @@ static void fim_db_get_checksum_empty_range_fail_step_on_second_half(void **stat
     will_return(__wrap_sqlite3_step, SQLITE_DONE);
 
     expect_string(__wrap__mdebug2, formatted_msg,
-                  "Received a synchronization message with empty range, first half 'start start' 'top top' (i:1)");
+                  "Received a synchronization message with empty range, second half 'start start' 'top top' (i:1)");
 
     retval = fim_db_get_checksum_range(&fim_sql, FIM_TYPE_FILE, start, top, 2, ctx_left, ctx_right, &lower_half_path,
                                        &higher_half_path);

--- a/src/unit_tests/syscheckd/db/test_fim_db.c
+++ b/src/unit_tests/syscheckd/db/test_fim_db.c
@@ -1046,6 +1046,28 @@ static void fim_db_get_checksum_range_fail_step_on_first_half(void **state) {
     assert_int_equal(retval, FIMDB_ERR);
 }
 
+static void fim_db_get_checksum_empty_range_fail_step_on_first_half(void **state) {
+    fdb_t fim_sql;
+    const char *start = "start";
+    const char *top = "top";
+    EVP_MD_CTX *ctx_left = (EVP_MD_CTX *)123456, *ctx_right = (EVP_MD_CTX *)234567;
+    char *lower_half_path = NULL, *higher_half_path = NULL;
+    int retval;
+
+    expect_fim_db_clean_stmt();
+    expect_fim_db_bind_range(start, top, 0);
+
+    will_return(__wrap_sqlite3_step, 0);
+    will_return(__wrap_sqlite3_step, SQLITE_DONE);
+
+    expect_string(__wrap__mdebug2, formatted_msg,
+                  "Received a synchronization message with empty range, first half 'start start' 'top top' (i:0)");
+
+    retval = fim_db_get_checksum_range(&fim_sql, FIM_TYPE_FILE, start, top, 2, ctx_left, ctx_right, &lower_half_path,
+                                       &higher_half_path);
+    assert_int_equal(retval, FIMDB_ERR);
+}
+
 static void fim_db_get_checksum_range_fail_to_decode_string_array_on_first_half(void **state) {
     fdb_t fim_sql;
     const char *start = "start";
@@ -1097,6 +1119,38 @@ static void fim_db_get_checksum_range_fail_step_on_second_half(void **state) {
     will_return(__wrap_sqlite3_extended_errcode, 111);
     expect_string(__wrap__merror, formatted_msg,
                   "Step error getting path range, second half 'start start' 'top top' (i:1): ERROR MESSAGE (111)");
+
+    retval = fim_db_get_checksum_range(&fim_sql, FIM_TYPE_FILE, start, top, 2, ctx_left, ctx_right, &lower_half_path,
+                                       &higher_half_path);
+    assert_int_equal(retval, FIMDB_ERR);
+}
+
+static void fim_db_get_checksum_empty_range_fail_step_on_second_half(void **state) {
+    fdb_t fim_sql;
+    const char *start = "start";
+    const char *top = "top";
+    EVP_MD_CTX *ctx_left = (EVP_MD_CTX *)123456, *ctx_right = (EVP_MD_CTX *)234567;
+    char *lower_half_path = NULL, *higher_half_path = NULL;
+    const char *array[] = { "/some/path", "0123456789ABCDEF0123456789ABCDEF01234567", NULL };
+    int retval;
+
+    expect_fim_db_clean_stmt();
+    expect_fim_db_bind_range(start, top, 0);
+
+    will_return(__wrap_sqlite3_step, 0);
+    will_return(__wrap_sqlite3_step, SQLITE_ROW);
+
+    expect_fim_db_decode_string_array(2, array);
+
+    expect_string(__wrap_EVP_DigestUpdate, data, "0123456789ABCDEF0123456789ABCDEF01234567");
+    expect_value(__wrap_EVP_DigestUpdate, count, 40);
+    will_return(__wrap_EVP_DigestUpdate, 0);
+
+    will_return(__wrap_sqlite3_step, 0);
+    will_return(__wrap_sqlite3_step, SQLITE_DONE);
+
+    expect_string(__wrap__mdebug2, formatted_msg,
+                  "Received a synchronization message with empty range, first half 'start start' 'top top' (i:1)");
 
     retval = fim_db_get_checksum_range(&fim_sql, FIM_TYPE_FILE, start, top, 2, ctx_left, ctx_right, &lower_half_path,
                                        &higher_half_path);
@@ -2384,6 +2438,8 @@ int main(void) {
         cmocka_unit_test(fim_db_get_checksum_range_fail_to_decode_string_array_on_first_half),
         cmocka_unit_test(fim_db_get_checksum_range_fail_step_on_second_half),
         cmocka_unit_test(fim_db_get_checksum_range_fail_to_decode_string_array_on_second_half),
+        cmocka_unit_test(fim_db_get_checksum_empty_range_fail_step_on_first_half),
+        cmocka_unit_test(fim_db_get_checksum_empty_range_fail_step_on_second_half),
         cmocka_unit_test_teardown(fim_db_get_checksum_range_success, teardown_string_array),
         // fim_db_get_count_range
         cmocka_unit_test_setup_teardown(test_fim_db_get_count_range_error_stepping, test_fim_db_setup,


### PR DESCRIPTION
|Related issue|
|---|
|#8909|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Two if statements were redone to check for SQLITE_DONE code return and prevent it to show as an error message in fim_db_get_checksum_range function.

Valgrind report: [valgrind_syscheck.txt](https://github.com/wazuh/wazuh/files/6631229/valgrind_syscheck.txt)



## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
