### PR TITLE
Fix unhandled error when sending string in cluster

### DIFF
--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -770,7 +770,7 @@ class Handler(asyncio.Protocol):
         self.in_str[name].receive_data(str_data)
         return b"ok", b"Chunk received"
 
-    def process_error_str(self, expected_len):
+    def process_error_str(self, expected_len: bytes) -> Tuple[bytes, bytes]:
         """Search and delete item inside self.in_str.
 
         If null byetearray is created inside self.in_str and its len is the same as 'expected_len', it can be
@@ -788,14 +788,15 @@ class Handler(asyncio.Protocol):
         bytes
             Task_id of deleted item, if found.
         """
+        # Regex to find any character different to '\x00' (null) inside a string.
         regex = re.compile(b'[^\x00]')
         expected_len = int(expected_len.decode())
 
         for item in list(self.in_str):
-            if self.in_str.get(item, None):
-                if self.in_str.get(item).total == expected_len and not regex.match(self.in_str.get(item).payload):
-                    del self.in_str[item]
-                    return b'ok', item
+            if self.in_str.get(item, None) and self.in_str.get(item).total == expected_len and not \
+                    regex.match(self.in_str.get(item).payload):
+                self.in_str.pop(item, None)
+                return b'ok', item
 
         return b'ok', b'None'
 

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -182,6 +182,10 @@ class SyncWazuhdb:
             # Send list of chunks as a JSON string
             data = json.dumps({"set_data_command": self.set_data_command, "chunks": chunks}).encode()
             task_id = await self.worker.send_string(data)
+            if task_id.startswith(b'Error'):
+                raise WazuhClusterError(3016, extra_message=f'agent-info string could not be sent to the master '
+                                                            f'node: {task_id}')
+
             # Specify under which task_id the JSON can be found in the master.
             await self.worker.send_request(command=self.cmd, data=task_id)
             self.logger.debug(f"All chunks sent.")


### PR DESCRIPTION
|Related issue|
|---|
| Closes #8935 |

## Description

Hi team,

As it was explained in https://github.com/wazuh/wazuh/issues/8935#issuecomment-857801722, it could be the case that a worker asks to the master to reserve space to receive a string with agent information (agent-info). This information can take up a lot of space so it is necessary to delete it after each synchronization. 

The problem is that, in cases where the cluster has a large workload, if the master is not able to respond to the worker after the request to reserve space, it would be unable to correctly finish the task and the space would never be freed (until its process is restarted). 

This can cause a steady growth in RAM consumption by the `wazuh-clusterd` process. For example, in an environment with 1 worker and 30,000 agents where communication is forced to always fail (due to a `TmeoutError`), this would be the result: 
![not_fixed](https://user-images.githubusercontent.com/23361101/121505364-0b57e180-c9e3-11eb-89d7-13217fdb66b7.png)

It can be seen how in 2 minutes the RAM occupied by the process has been multiplied. 

To avoid this unwanted behavior, a new command (`err_str`) has been added. This command will be sent from one node to another in case of not having received a correct `task_id`. The node that receives the command is in charge of looking for a bytearray with the expected length and whose content is all null (`\x00`). If it is found, it deletes it and the space is freed. This avoids the memory leak that could be seen in the graph above:
![fixed](https://user-images.githubusercontent.com/23361101/121506098-b799c800-c9e3-11eb-84f6-a76cb10128a4.png)

(In both graphs there is a growth at the beginning. The master process occupies ~50MiB in memory when no worker is connected, and increases to ~70MiB when the connection is made)

Errors like the following would be displayed if a timeout during the agent-info sync process is obtained:
```
2021/06/10 10:12:20 INFO: [Worker worker1] [Agent-info sync] Starting.
2021/06/10 10:12:30 ERROR: [Worker worker1] [Main] There was an error while trying to send a string: b'Error sending request: timeout expired.'
2021/06/10 10:12:31 ERROR: [Worker worker1] [Agent-info sync] Error synchronizing agent info: Error 3016 - Received an error response: agent-info string could not be sent to the master node: b'Error sending request: timeout expired.'
```

Regards,
Selu.