### PR TITLE
Generate OS and kernel packages for SUSE

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -2520,6 +2520,102 @@ void test_wm_vuldet_generate_os_and_kernel_package_amazon_linux(void **state)
     assert_int_equal(ret, 0);
 }
 
+void test_wm_vuldet_generate_os_and_kernel_package_suse(void **state)
+{
+    agent_software *agent = *state;
+    sqlite3 *db = (sqlite3 *)1;
+
+    agent->dist = FEED_SUSE;
+    agent->dist_ver = FEED_SLES15;
+    agent->os_release = strdup("15");
+    agent->kernel_release = strdup("5.3.18-22-default");
+    agent->arch = strdup("x86_64");
+
+    will_return_count(__wrap_sqlite3_prepare_v2, SQLITE_OK, 4);
+    will_return_always(__wrap_sqlite3_bind_text, 0);
+    will_return_always(__wrap_sqlite3_bind_int, 0);
+    expect_sqlite3_step_call(SQLITE_DONE);
+    expect_sqlite3_step_call(SQLITE_DONE);
+    expect_sqlite3_step_call(SQLITE_DONE);
+    expect_sqlite3_step_call(SQLITE_DONE);
+
+    // OS package[0]
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "000");
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_value(__wrap_sqlite3_bind_text, pos, 3);
+    expect_value(__wrap_sqlite3_bind_int, index, 4);
+    expect_value(__wrap_sqlite3_bind_int, value, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 5);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "suse");
+    expect_value(__wrap_sqlite3_bind_text, pos, 6);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "linux_enterprise");
+    expect_value(__wrap_sqlite3_bind_text, pos, 7);
+    expect_value(__wrap_sqlite3_bind_text, pos, 8);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "15");
+    expect_value(__wrap_sqlite3_bind_text, pos, 9);
+    expect_value(__wrap_sqlite3_bind_text, pos, 10);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "x86_64");
+
+    // OS package[1]
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "000");
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_value(__wrap_sqlite3_bind_text, pos, 3);
+    expect_value(__wrap_sqlite3_bind_int, index, 4);
+    expect_value(__wrap_sqlite3_bind_int, value, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 5);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "suse");
+    expect_value(__wrap_sqlite3_bind_text, pos, 6);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "linux_enterprise_server");
+    expect_value(__wrap_sqlite3_bind_text, pos, 7);
+    expect_value(__wrap_sqlite3_bind_text, pos, 8);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "15");
+    expect_value(__wrap_sqlite3_bind_text, pos, 9);
+    expect_value(__wrap_sqlite3_bind_text, pos, 10);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "x86_64");
+
+    // OS package[2]
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "000");
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_value(__wrap_sqlite3_bind_text, pos, 3);
+    expect_value(__wrap_sqlite3_bind_int, index, 4);
+    expect_value(__wrap_sqlite3_bind_int, value, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 5);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "suse");
+    expect_value(__wrap_sqlite3_bind_text, pos, 6);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "suse_linux_enterprise_server");
+    expect_value(__wrap_sqlite3_bind_text, pos, 7);
+    expect_value(__wrap_sqlite3_bind_text, pos, 8);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "15");
+    expect_value(__wrap_sqlite3_bind_text, pos, 9);
+    expect_value(__wrap_sqlite3_bind_text, pos, 10);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "x86_64");
+
+    // Kernel package
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "000");
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_value(__wrap_sqlite3_bind_text, pos, 3);
+    expect_value(__wrap_sqlite3_bind_int, index, 4);
+    expect_value(__wrap_sqlite3_bind_int, value, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 5);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "linux");
+    expect_value(__wrap_sqlite3_bind_text, pos, 6);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "linux_kernel");
+    expect_value(__wrap_sqlite3_bind_text, pos, 7);
+    expect_value(__wrap_sqlite3_bind_text, pos, 8);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "5.3.18");
+    expect_value(__wrap_sqlite3_bind_text, pos, 9);
+    expect_value(__wrap_sqlite3_bind_text, pos, 10);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "x86_64");
+
+    int ret = wm_vuldet_generate_os_and_kernel_package(db, agent);
+
+    assert_int_equal(ret, 0);
+}
+
 void test_wm_vuldet_generate_os_and_kernel_package_null_db(void **state)
 {
     (void) state;
@@ -19208,6 +19304,7 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_generate_os_and_kernel_package_debian, setup_agent_software, teardown_agent_software),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_generate_os_and_kernel_package_redhat, setup_agent_software, teardown_agent_software),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_generate_os_and_kernel_package_amazon_linux, setup_agent_software, teardown_agent_software),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_generate_os_and_kernel_package_suse, setup_agent_software, teardown_agent_software),
         cmocka_unit_test(test_wm_vuldet_generate_os_and_kernel_package_null_db),
         cmocka_unit_test(test_wm_vuldet_generate_os_and_kernel_package_null_agent),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_generate_os_and_kernel_package_invalid_agent, setup_agent_software, teardown_agent_software),

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -1189,6 +1189,52 @@ void test_wm_vuldet_get_os_unix_info_mac (void **state)
     __real_cJSON_Delete(parsed_json);
 }
 
+void test_wm_vuldet_get_os_unix_info_suse(void **state)
+{
+    agent_software *agent = *state;
+
+    const char *query = "agent 000 sql SELECT OS_MAJOR, OS_MINOR, OS_PATCH, RELEASE FROM SYS_OSINFO;";
+    size_t query_size = strlen(query) + 1;
+
+    char *response = "ok [{\"os_major\":\"15\",\"release\":\"5.3.18-22-default\"}]";
+    size_t response_size = strlen(response) + 1;
+
+    expect_value(__wrap_OS_SendSecureTCP, sock, 11111);
+    expect_value(__wrap_OS_SendSecureTCP, size, query_size);
+    expect_string(__wrap_OS_SendSecureTCP, msg, query);
+    will_return(__wrap_OS_SendSecureTCP, 0);
+
+    expect_value(__wrap_OS_RecvSecureTCP, sock, 11111);
+    expect_value(__wrap_OS_RecvSecureTCP, size, OS_SIZE_128);
+    will_return(__wrap_OS_RecvSecureTCP, response);
+    will_return(__wrap_OS_RecvSecureTCP, response_size);
+
+    cJSON* parsed_json = __real_cJSON_CreateArray();
+    cJSON* object = __real_cJSON_CreateObject();
+    __real_cJSON_AddItemToArray(parsed_json, object);
+    cJSON* os_major = __real_cJSON_CreateString("15");
+    cJSON* release = __real_cJSON_CreateString("5.3.18-22-default");
+    __real_cJSON_AddItemToObject(object, "os_major", os_major);
+    __real_cJSON_AddItemToObject(object, "release", release);
+
+    will_return(__wrap_cJSON_Parse, parsed_json);
+    will_return(__wrap_cJSON_GetObjectItem, os_major);
+    will_return(__wrap_cJSON_GetObjectItem, NULL);
+    will_return(__wrap_cJSON_GetObjectItem, NULL);
+    will_return(__wrap_cJSON_GetObjectItem, release);
+
+    expect_function_call(__wrap_cJSON_Delete);
+
+    agent->dist = FEED_SUSE;
+    int ret = wm_vuldet_get_os_unix_info(agent);
+
+    assert_int_equal(ret, 0);
+    assert_string_equal(agent->os_release, "15");
+    assert_string_equal(agent->kernel_release, "5.3.18-22-default");
+
+    __real_cJSON_Delete(parsed_json);
+}
+
 /* wm_vuldet_linux_rm_nvd_not_affected_packages */
 
 void test_wm_vuldet_linux_rm_nvd_not_affected_packages_oval()
@@ -19253,6 +19299,7 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_get_os_unix_info_request_empty, setup_agent_software, teardown_agent_software),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_get_os_unix_info_request_parse_error, setup_agent_software, teardown_agent_software),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_get_os_unix_info_mac, setup_agent_software, teardown_agent_software),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_get_os_unix_info_suse, setup_agent_software, teardown_agent_software),
         // Tests wm_vuldet_discard_kernel_package
         cmocka_unit_test_setup_teardown(test_wm_vuldet_discard_kernel_package_null_kernel, setup_agent_software, teardown_agent_software),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_discard_kernel_package_redhat_no_kernel, setup_agent_software, teardown_agent_software),

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -6954,7 +6954,11 @@ int wm_vuldet_get_os_unix_info(agent_software *agent) {
         }
 
         os_calloc(ver_length + 1, sizeof(char), version);
-        snprintf(version, ver_length, "%s.%s", major, minor);
+        if(agent->dist == FEED_SUSE){
+            snprintf(version, ver_length, "%s", major);
+        } else {
+            snprintf(version, ver_length, "%s.%s", major, minor);
+        }
 
         if (agent->dist == FEED_MAC && patch) {
             snprintf(version + strlen(version), strlen(patch) + 2, ".%s", patch);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -331,7 +331,8 @@ const char *vu_vendor_list[] = {
     "redhat",
     "archlinux",
     "linux",
-    "amazon"
+    "amazon",
+    "suse"
 };
 
 const char *vu_os_product_name_list[] = {
@@ -342,7 +343,12 @@ const char *vu_os_product_name_list[] = {
     "linux_kernel",
     "linux",
     "linux_1",
-    "linux_2"
+    "linux_2",
+    "linux_enterprise",
+    "linux_enterprise_desktop",
+    "suse_linux_enterprise_desktop",
+    "linux_enterprise_server",
+    "suse_linux_enterprise_server"
 };
 
 const char *vu_vendor_list_ubuntu_debian[] = {
@@ -5713,6 +5719,22 @@ int wm_vuldet_generate_os_and_kernel_package(sqlite3 *db, agent_software *agent)
             vendor = vu_vendor_list[V_AMAZON];
             os_free(agent->os_release);
             os_strdup("*", agent->os_release);
+        break;
+        case FEED_SLED11:
+        case FEED_SLED12:
+        case FEED_SLED15:
+            product_name[0] = vu_os_product_name_list[PR_SUSE];
+            product_name[1] = vu_os_product_name_list[PR_SLED1];
+            product_name[2] = vu_os_product_name_list[PR_SLED2];
+            vendor = vu_vendor_list[V_SUSE];
+        break;
+        case FEED_SLES11:
+        case FEED_SLES12:
+        case FEED_SLES15:
+            product_name[0] = vu_os_product_name_list[PR_SUSE];
+            product_name[1] = vu_os_product_name_list[PR_SLES1];
+            product_name[2] = vu_os_product_name_list[PR_SLES2];
+            vendor = vu_vendor_list[V_SUSE];
         break;
         default:
             return 1;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -184,7 +184,8 @@ typedef enum vu_vendor {
     V_REDHAT,
     V_ARCH,
     V_KERNEL,
-    V_AMAZON
+    V_AMAZON,
+    V_SUSE
 } vu_vendor;
 
 typedef enum vu_package_dist_id {
@@ -203,6 +204,11 @@ typedef enum vu_product_name {
     PR_AMAZON,
     PR_AMAZON1,
     PR_AMAZON2,
+    PR_SUSE,
+    PR_SLED1,
+    PR_SLED2,
+    PR_SLES1,
+    PR_SLES2,
     PR_NOSYSTEM
 } vu_product_name;
 


### PR DESCRIPTION
|Related issue|
|---|
|#8375|

## Description

This PR aims to generate the OS and kernel packages for SUSE, so that they match with the NVD.

In the case of the generation of the OS package, we have analyzed most of the cases that affect both SUSE server and desktop for versions 11, 12 and 15, obtaining the conclusions of this https://github.com/wazuh/wazuh/issues/8375#issuecomment-856933588.

So to address all possible cases that could be added in the future within the NVD, we have added the following formats:
- SUSE Linux Enterprise Desktop (`SLED`):
```
cpe:2.3:o:suse:linux_enterprise:os_major:*:*:*:*:*:*:*
cpe:2.3:o:suse:linux_enterprise_desktop:os_major:*:*:*:*:*:*:*
cpe:2.3:o:suse:suse_linux_enterprise_desktop:os_major:*:*:*:*:*:*:*
```
- SUSE Linux Enterprise Server (`SLES`):
```
cpe:2.3:o:suse:linux_enterprise:os_major:*:*:*:*:*:*:*
cpe:2.3:o:suse:linux_enterprise_server:os_major:*:*:*:*:*:*:*
cpe:2.3:o:suse:suse_linux_enterprise_server:os_major:*:*:*:*:*:*:*
```
And to obtain that `os_major` value, the `os_release` value had to be readjusted for SUSE, so in the event that the version does not contain `os_minor` (as are the cases of SUSE), only the `os_major` is obtained so that it matches correctly.

## Example

If we have the following CPEs:
- `cpe:2.3:o:suse:suse_linux_enterprise_desktop:11.0:sp3:*:*:*:*:*:*`
- `cpe:2.3:o:suse:suse_linux_enterprise_desktop:11:sp3:*:*:*:*:*:*`

By creating the following CPE, both CPEs would be found in our database:
- `cpe:2.3:o:suse:suse_linux_enterprise_desktop:11:*:*:*:*:*:*:*`

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] Added unit tests (for new features)