### PR TITLE
Fixing duplicated variable name an possible memory leak in Vulnerability Detector

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5024,13 +5024,13 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
         j_agent_info = wdb_get_agent_info(id, &sock);
         if (!j_agent_info) {
             mdebug1("Failed to get agent '%d' information from Wazuh DB.", id);
-            goto end;
+            goto next;
         }
 
         j_field = cJSON_GetObjectItem(j_agent_info->child, "node_name");
         if(cJSON_IsString(j_field) && j_field->valuestring != NULL) {
             if (0 != strcmp(j_field->valuestring, vuldet->node_name)) {
-                goto end;
+                goto next;
             }
         }
 
@@ -5074,13 +5074,13 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
             if (agti_name) {
                 mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AG_NEVER_CON, agti_name);
             }
-            goto end;
+            goto next;
         } else if (!agti_os_major) {
             mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UNS_OS_VERSION, id, agti_name?agti_name:"");
-            goto end;
+            goto next;
         } else if (!agti_os_platform) {
             mtdebug1(WM_VULNDETECTOR_LOGTAG, "Failed to read platform from agent '%.3d'", id);
-            goto end;
+            goto next;
         }
 
         if (strcasestr(agti_os_name, vu_feed_ext[FEED_UBUNTU])) {
@@ -5178,7 +5178,7 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
                 } else {
                     mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UNS_OS_VERSION, id, vu_feed_ext[dist_error]);
                 }
-                goto end;
+                goto next;
             }
         }
 
@@ -5190,7 +5190,7 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
 
         if (!agti_register_ip) {
             mterror(WM_VULNDETECTOR_LOGTAG, VU_NULL_AGENT_IP, id);
-            goto end;
+            goto next;
         }
 
         j_field = cJSON_GetObjectItem(j_agent_info->child, "os_arch");
@@ -5201,7 +5201,7 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
 
         // Getting sys_osinfo data from agent database
         if (j_osinfo = wdb_get_agent_sys_osinfo(id, &sock), !j_osinfo) {
-            goto end;
+            goto next;
         }
 
         j_field = cJSON_GetObjectItem(j_osinfo->child, "triaged");
@@ -5278,7 +5278,7 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
             wm_vuldet_build_unix_os_release(agents, osinfo_major, osinfo_minor, osinfo_patch);
         }
 
-end:
+next:
         if (j_agent_info) cJSON_Delete(j_agent_info);
         if (j_osinfo) cJSON_Delete(j_osinfo);
     }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -4992,27 +4992,8 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
     scan_agent *agents = NULL;
     scan_agent *f_agent = NULL;
     int set_manager = 1;
-    int dist_error = -1;
-    bool is_centos = FALSE;
-    char str_id[OS_SIZE_128] = "";
-    char *name = NULL;
-    char *register_ip = NULL;
-    char *os_name = NULL;
-    char *os_major = NULL;
-    char *arch = NULL;
-    int build = 0;
-    int id = 0;
     int i = 0;
-    char *agent_version = NULL;
-    char *os_platform = NULL;
-    char *agent_major = NULL;
-    char *agent_minor = NULL;
-    vu_feed agent_dist_ver = -1;
-    vu_feed agent_dist = -1;
     int *id_array = NULL;
-    cJSON *j_agent_info = NULL;
-    cJSON *j_osinfo = NULL;
-    cJSON *j_field = NULL;
     int sock = wm_vuldet_get_wdb_socket();
 
     if (sock < 0) {
@@ -5023,19 +5004,14 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
     id_array = wdb_get_agents_by_connection_status(AGENT_CS_ACTIVE, &sock);
 
     while (set_manager || (id_array && id_array[i] != -1)) {
-        dist_error = -1;
-        is_centos = FALSE;
-        name = NULL;
-        register_ip = NULL;
-        os_name = NULL;
-        os_major = NULL;
-        arch = NULL;
-        build = 0;
-
-        agent_version = NULL;
-        os_platform = NULL;
-        agent_major = NULL;
-        agent_minor = NULL;
+        cJSON *j_agent_info = NULL;
+        cJSON *j_osinfo = NULL;
+        cJSON *j_field = NULL;
+        vu_feed agent_dist_ver = -1;
+        vu_feed agent_dist = -1;
+        bool is_centos = FALSE;
+        int dist_error = -1;
+        int id = 0;
 
         if (set_manager) {
             id = --set_manager;
@@ -5048,129 +5024,134 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
         j_agent_info = wdb_get_agent_info(id, &sock);
         if (!j_agent_info) {
             mdebug1("Failed to get agent '%d' information from Wazuh DB.", id);
-            continue;
+            goto end;
         }
 
         j_field = cJSON_GetObjectItem(j_agent_info->child, "node_name");
         if(cJSON_IsString(j_field) && j_field->valuestring != NULL) {
             if (0 != strcmp(j_field->valuestring, vuldet->node_name)) {
-                cJSON_Delete(j_agent_info);
-                continue;
+                goto end;
             }
         }
 
         j_field = cJSON_GetObjectItem(j_agent_info->child, "os_name");
+        char *agti_os_name = NULL;
         if(cJSON_IsString(j_field) && j_field->valuestring != NULL) {
-            os_name = j_field->valuestring;
+            agti_os_name = j_field->valuestring;
         }
 
         j_field = cJSON_GetObjectItem(j_agent_info->child, "os_major");
+        char *agti_os_major = NULL;
         if(cJSON_IsString(j_field) && j_field->valuestring != NULL) {
-            os_major = j_field->valuestring;
+            agti_os_major = j_field->valuestring;
         }
 
         j_field = cJSON_GetObjectItem(j_agent_info->child, "name");
+        char *agti_name = NULL;
         if(cJSON_IsString(j_field) && j_field->valuestring != NULL) {
-            name = j_field->valuestring;
+            agti_name = j_field->valuestring;
         }
 
         j_field = cJSON_GetObjectItem(j_agent_info->child, "os_build");
+        int agti_build = 0;
         if(cJSON_IsNumber(j_field)){
-            build = j_field->valueint;
+            agti_build = j_field->valueint;
         }
 
         j_field = cJSON_GetObjectItem(j_agent_info->child, "version");
+        char *agti_version = NULL;
         if (cJSON_IsString(j_field) && j_field->valuestring != NULL) {
-            agent_version = j_field->valuestring;
+            agti_version = j_field->valuestring;
         }
 
         j_field = cJSON_GetObjectItem(j_agent_info->child, "os_platform");
+        char *agti_os_platform = NULL;
         if (cJSON_IsString(j_field) && j_field->valuestring != NULL) {
-            os_platform = j_field->valuestring;
+            agti_os_platform = j_field->valuestring;
         }
 
-        if (!os_name) {
-            if (name) {
-                mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AG_NEVER_CON, name);
+        if (!agti_os_name) {
+            if (agti_name) {
+                mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AG_NEVER_CON, agti_name);
             }
-            continue;
-        } else if (!os_major) {
-            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UNS_OS_VERSION, id, name?name:"");
-            continue;
-        } else if (!os_platform) {
+            goto end;
+        } else if (!agti_os_major) {
+            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UNS_OS_VERSION, id, agti_name?agti_name:"");
+            goto end;
+        } else if (!agti_os_platform) {
             mtdebug1(WM_VULNDETECTOR_LOGTAG, "Failed to read platform from agent '%.3d'", id);
-            continue;
+            goto end;
         }
 
-        if (strcasestr(os_name, vu_feed_ext[FEED_UBUNTU])) {
-            if (strstr(os_major, "20")) {
+        if (strcasestr(agti_os_name, vu_feed_ext[FEED_UBUNTU])) {
+            if (strstr(agti_os_major, "20")) {
                 agent_dist_ver = FEED_FOCAL;
-            } else if (strstr(os_major, "18")) {
+            } else if (strstr(agti_os_major, "18")) {
                 agent_dist_ver = FEED_BIONIC;
-            } else if (strstr(os_major, "16")) {
+            } else if (strstr(agti_os_major, "16")) {
                 agent_dist_ver = FEED_XENIAL;
-            } else if (strstr(os_major, "14")) {
+            } else if (strstr(agti_os_major, "14")) {
                 agent_dist_ver = FEED_TRUSTY;
             } else {
                 dist_error = FEED_UBUNTU;
             }
             agent_dist = FEED_UBUNTU;
-        } else if (strcasestr(os_name, vu_feed_ext[FEED_DEBIAN])) {
-            if (strstr(os_major, "9")) {
+        } else if (strcasestr(agti_os_name, vu_feed_ext[FEED_DEBIAN])) {
+            if (strstr(agti_os_major, "9")) {
                 agent_dist_ver = FEED_STRETCH;
-            } else if (strstr(os_major, "10")) {
+            } else if (strstr(agti_os_major, "10")) {
                 agent_dist_ver = FEED_BUSTER;
             } else {
                 dist_error = FEED_DEBIAN;
             }
             agent_dist = FEED_DEBIAN;
-        }  else if (strcasestr(os_name, vu_feed_ext[FEED_REDHAT])) {
-            if (strstr(os_major, "8")) {
+        }  else if (strcasestr(agti_os_name, vu_feed_ext[FEED_REDHAT])) {
+            if (strstr(agti_os_major, "8")) {
                 agent_dist_ver = FEED_RHEL8;
-            } else if (strstr(os_major, "7")) {
+            } else if (strstr(agti_os_major, "7")) {
                 agent_dist_ver = FEED_RHEL7;
-            } else if (strstr(os_major, "6")) {
+            } else if (strstr(agti_os_major, "6")) {
                 agent_dist_ver = FEED_RHEL6;
-            } else if (strstr(os_major, "5")) {
+            } else if (strstr(agti_os_major, "5")) {
                 agent_dist_ver = FEED_RHEL5;
             } else {
                 dist_error = FEED_REDHAT;
             }
             agent_dist = FEED_REDHAT;
-        } else if (strcasestr(os_name, vu_feed_ext[FEED_CENTOS])) {
-            if (strstr(os_major, "8")) {
+        } else if (strcasestr(agti_os_name, vu_feed_ext[FEED_CENTOS])) {
+            if (strstr(agti_os_major, "8")) {
                 agent_dist_ver = FEED_RHEL8;
-            } else if (strstr(os_major, "7")) {
+            } else if (strstr(agti_os_major, "7")) {
                 agent_dist_ver = FEED_RHEL7;
-            } else if (strstr(os_major, "6")) {
+            } else if (strstr(agti_os_major, "6")) {
                 agent_dist_ver = FEED_RHEL6;
-            } else if (strstr(os_major, "5")) {
+            } else if (strstr(agti_os_major, "5")) {
                 agent_dist_ver = FEED_RHEL5;
             } else {
                 dist_error = FEED_CENTOS;
             }
             agent_dist = FEED_REDHAT;
             is_centos = TRUE;
-        } else if (strcasestr(os_name, vu_feed_ext[FEED_ARCH])) {
+        } else if (strcasestr(agti_os_name, vu_feed_ext[FEED_ARCH])) {
             agent_dist_ver = FEED_ARCH;
             agent_dist= FEED_ARCH;
-        } else if (strcasestr(os_name, vu_feed_ext[FEED_WIN])) {
-            agent_dist_ver = wm_vuldet_decode_win_os(os_name);
+        } else if (strcasestr(agti_os_name, vu_feed_ext[FEED_WIN])) {
+            agent_dist_ver = wm_vuldet_decode_win_os(agti_os_name);
             agent_dist = FEED_WIN;
-        } else if (strcasestr(os_platform, vu_feed_ext[FEED_MAC])) {
+        } else if (strcasestr(agti_os_platform, vu_feed_ext[FEED_MAC])) {
             char *version = NULL;
             char *save_ptr = NULL;
-            w_strdup(agent_version, version);
+            w_strdup(agti_version, version);
 
-            if (agent_version) {
-                strtok_r(agent_version, "v", &save_ptr);
-                agent_major = strtok_r(NULL, ".", &save_ptr);
-                agent_minor = strtok_r(NULL, ".", &save_ptr);
-                if (!agent_major || !agent_minor) {
+            if (agti_version) {
+                strtok_r(agti_version, "v", &save_ptr);
+                char *tmp_major = strtok_r(NULL, ".", &save_ptr);
+                char *tmp_minor = strtok_r(NULL, ".", &save_ptr);
+                if (!tmp_major || !tmp_minor) {
                     dist_error = -2;
                     mterror(WM_VULNDETECTOR_LOGTAG, VU_VER_INVALID_FORMAT, id);
                 } else {
-                    if (atoi(agent_major) > 4 || (atoi(agent_major) == 4 && atoi(agent_minor) > 0)) {
+                    if (atoi(tmp_major) > 4 || (atoi(tmp_major) == 4 && atoi(tmp_minor) > 0)) {
                         agent_dist_ver = FEED_MAC;
                         agent_dist = FEED_MAC;
                     } else {
@@ -5191,71 +5172,72 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
 
         if (dist_error != -1) {
             // Check if the agent OS can be matched with a OVAL
-            if (agent_dist_ver = wm_vuldet_set_allowed_feed(os_name, os_major, vuldet->updates, &agent_dist), agent_dist_ver == FEED_UNKNOWN) {
+            if (agent_dist_ver = wm_vuldet_set_allowed_feed(agti_os_name, agti_os_major, vuldet->updates, &agent_dist), agent_dist_ver == FEED_UNKNOWN) {
                 if (dist_error == -2) {
-                    mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UNS_OS, id, os_name);
-                    continue;
+                    mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UNS_OS, id, agti_os_name);
                 } else {
                     mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UNS_OS_VERSION, id, vu_feed_ext[dist_error]);
-                    continue;
                 }
+                goto end;
             }
         }
 
         j_field = cJSON_GetObjectItem(j_agent_info->child, "register_ip");
+        char *agti_register_ip = NULL;
         if(cJSON_IsString(j_field) && j_field->valuestring != NULL){
-            register_ip = j_field->valuestring;
+            agti_register_ip = j_field->valuestring;
         }
 
-        if (!register_ip) {
+        if (!agti_register_ip) {
             mterror(WM_VULNDETECTOR_LOGTAG, VU_NULL_AGENT_IP, id);
-            continue;
+            goto end;
         }
 
         j_field = cJSON_GetObjectItem(j_agent_info->child, "os_arch");
+        char *agti_arch = NULL;
         if(cJSON_IsString(j_field) && j_field->valuestring != NULL){
-            arch = j_field->valuestring;
+            agti_arch = j_field->valuestring;
         }
 
         // Getting sys_osinfo data from agent database
         if (j_osinfo = wdb_get_agent_sys_osinfo(id, &sock), !j_osinfo) {
-            continue;
+            goto end;
         }
 
         j_field = cJSON_GetObjectItem(j_osinfo->child, "triaged");
-        int triaged = 0;
+        int osinfo_triaged = 0;
         if (cJSON_IsNumber(j_field))
-            triaged = j_field->valueint;
+            osinfo_triaged = j_field->valueint;
 
         j_field = cJSON_GetObjectItem(j_osinfo->child, "reference");
-        char *reference = NULL;
+        char *osinfo_reference = NULL;
         if (cJSON_IsString(j_field))
-            reference = j_field->valuestring;
+            osinfo_reference = j_field->valuestring;
 
         j_field = cJSON_GetObjectItem(j_osinfo->child, "os_major");
-        char *os_major = NULL;
+        char *osinfo_major = NULL;
         if (cJSON_IsString(j_field))
-            os_major = j_field->valuestring;
+            osinfo_major = j_field->valuestring;
 
         j_field = cJSON_GetObjectItem(j_osinfo->child, "os_minor");
-        char *os_minor = NULL;
+        char *osinfo_minor = NULL;
         if (cJSON_IsString(j_field))
-            os_minor = j_field->valuestring;
+            osinfo_minor = j_field->valuestring;
 
         j_field = cJSON_GetObjectItem(j_osinfo->child, "os_patch");
-        char *os_patch = NULL;
+        char *osinfo_patch = NULL;
         if (cJSON_IsString(j_field))
-            os_patch = j_field->valuestring;
+            osinfo_patch = j_field->valuestring;
 
         j_field = cJSON_GetObjectItem(j_osinfo->child, "os_release");
-        char *os_release = NULL;
+        char *osinfo_os_release = NULL;
         if (cJSON_IsString(j_field))
-            os_release = j_field->valuestring;
+            osinfo_os_release = j_field->valuestring;
 
         j_field = cJSON_GetObjectItem(j_osinfo->child, "release");
-        char *release = NULL;
+        char *osinfo_release = NULL;
         if (cJSON_IsString(j_field))
-            release = j_field->valuestring;
+            osinfo_release = j_field->valuestring;
 
         // Writting results
         if (!agents) {
@@ -5267,36 +5249,38 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
         }
 
         agents->next = NULL;
-        os_strdup(register_ip, agents->agent_ip);
+        os_strdup(agti_register_ip, agents->agent_ip);
 
-        agents->build = build;
+        agents->build = agti_build;
 
+        char str_id[OS_SIZE_128] = "";
         snprintf(str_id, sizeof(str_id), "%d", id);
         os_strdup(str_id, agents->agent_id);
 
-        if (name) {
-            os_strdup(name, agents->agent_name);
+        if (agti_name) {
+            os_strdup(agti_name, agents->agent_name);
         }
-        if (arch) {
-            os_strdup(arch, agents->arch);
+        if (agti_arch) {
+            os_strdup(agti_arch, agents->arch);
         }
         agents->dist = agent_dist;
         agents->dist_ver = agent_dist_ver;
         agents->flags.centos = is_centos;
-        agents->os_triaged = triaged;
+        agents->os_triaged = osinfo_triaged;
         agents->pending_attempts = WM_VULNDETECTOR_MAX_AGENT_SCAN_ATTEMPS;
-        w_strdup(reference, agents->os_reference);
-        w_strdup(os_name, agents->os_name);
+        w_strdup(osinfo_reference, agents->os_reference);
+        w_strdup(agti_os_name, agents->os_name);
         if (agent_dist == FEED_WIN) {
-            w_strdup(os_release, agents->os_release);
+            w_strdup(osinfo_os_release, agents->os_release);
         }
         else {
-            w_strdup(release, agents->kernel_release);
-            wm_vuldet_build_unix_os_release(agents, os_major, os_minor, os_patch);
+            w_strdup(osinfo_release, agents->kernel_release);
+            wm_vuldet_build_unix_os_release(agents, osinfo_major, osinfo_minor, osinfo_patch);
         }
 
-        cJSON_Delete(j_agent_info);
-        cJSON_Delete(j_osinfo);
+end:
+        if (j_agent_info) cJSON_Delete(j_agent_info);
+        if (j_osinfo) cJSON_Delete(j_osinfo);
     }
 
     vuldet->scan_agents = f_agent;


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/8953 |

## Description

This pull request implements all the necessary changes to fix the next items in the function that request the information of the agents that are going to be scanned in Vulnerability Detector:

- The `os_major` variable was duplicated making the code less readable.
- There was a potential memory leak when an agent was discarded by executing the `continue` statement. This resulted in the `cJSON *j_agent_info` not being released.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

- Memory tests for Linux
  - [x] Scan-build report

![image](https://user-images.githubusercontent.com/5703274/121582401-597ddc80-ca05-11eb-91f6-ac750ff19605.png)
