### PR TITLE
Rework API integration tests to use tavern_utils functions for select parameter

### DIFF
--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -369,16 +369,13 @@ stages:
         select: name,version
     response:
       status_code: 200
+      verify_response_with:
+        - function: tavern_utils:test_select_key_affected_items
+          extra_kwargs:
+            select_key: "name,version"
       json:
         error: !anyint
         data:
-          affected_items:
-            - name: !anystr
-              version: !anystr
-            - name: !anystr
-              version: !anystr
-            - name: !anystr
-              version: !anystr
           failed_items: []
           total_affected_items: 3
           total_failed_items: 0
@@ -391,13 +388,13 @@ stages:
         select: type
     response:
       status_code: 200
+      verify_response_with:
+        - function: tavern_utils:test_select_key_affected_items
+          extra_kwargs:
+            select_key: "type"
       json:
         error: !anyint
         data:
-          affected_items:
-            - type: !anystr
-            - type: !anystr
-            - type: !anystr
           failed_items: []
           total_affected_items: 3
           total_failed_items: 0

--- a/api/test/integration/test_rootcheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rootcheck_endpoints.tavern.yaml
@@ -402,11 +402,13 @@ stages:
         distinct: true
     response:
       status_code: 200
+      verify_response_with:
+        - function: tavern_utils:test_select_key_affected_items
+          extra_kwargs:
+            select_key: "status"
       json:
         error: 0
         data:
-          affected_items:
-            - status: "outstanding"
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0


### PR DESCRIPTION
|Related issue|
|---|
| closes #8900 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Hello team,

There were a few API integration tests that were not using the specific tavern custom function to test the `select` parameter. These have been updated to use it.

## Tests performed
### Integration tests
```
test_cluster_endpoints
	 44 passed, 1 xpassed, 58 warnings

test_rootcheck_endpoints
	 4 passed, 6 warnings

```

Regards,
Víctor