### PR TITLE
Improve framework syscheck code to make PUT /syscheck faster

### DIFF
--- a/api/api/controllers/syscheck_controller.py
+++ b/api/api/controllers/syscheck_controller.py
@@ -14,12 +14,13 @@ from wazuh.syscheck import run, clear, files, last_scan
 logger = logging.getLogger('wazuh-api')
 
 
-async def put_syscheck(request, agents_list='*', pretty=False, wait_for_complete=False):
+async def put_syscheck(request, agents_list: str = '*', pretty: bool = False,
+                       wait_for_complete: bool = False) -> web.Response:
     """Run a syscheck scan in the specified agents.
 
     Parameters
     ----------
-    list_agents : str
+    agents_list : str
         List of agent ids.
     pretty : bool
         Show results in human-readable format.

--- a/framework/wazuh/syscheck.py
+++ b/framework/wazuh/syscheck.py
@@ -39,7 +39,7 @@ def run(agent_list: Union[str, None] = None) -> AffectedItemsWazuhResult:
         try:
             agent = Agent(agent_id)
             agent.load_info_from_db()
-            agent_status = agent.status
+            agent_status = agent.status if agent.status else 'N/A'
             if agent_status.lower() == 'active':
                 wq.send_msg_to_agent(WazuhQueue.HC_SK_RESTART, agent_id)
                 result.affected_items.append(agent_id)

--- a/framework/wazuh/syscheck.py
+++ b/framework/wazuh/syscheck.py
@@ -37,7 +37,9 @@ def run(agent_list: Union[str, None] = None) -> AffectedItemsWazuhResult:
     wq = WazuhQueue(common.ARQUEUE)
     for agent_id in agent_list:
         try:
-            agent_status = Agent(agent_id).get_basic_information().get('status', 'N/A')
+            agent = Agent(agent_id)
+            agent.load_info_from_db()
+            agent_status = agent.status
             if agent_status.lower() == 'active':
                 wq.send_msg_to_agent(WazuhQueue.HC_SK_RESTART, agent_id)
                 result.affected_items.append(agent_id)

--- a/framework/wazuh/syscheck.py
+++ b/framework/wazuh/syscheck.py
@@ -5,7 +5,7 @@ from glob import glob
 from typing import Union
 
 from wazuh.core import common
-from wazuh.core.agent import Agent, get_agents_info
+from wazuh.core.agent import Agent, get_agents_info, get_rbac_filters, WazuhDBQueryAgents
 from wazuh.core.database import Connection
 from wazuh.core.exception import WazuhInternalError, WazuhError, WazuhResourceNotFound
 from wazuh.core.results import AffectedItemsWazuhResult
@@ -22,7 +22,7 @@ def run(agent_list: Union[str, None] = None) -> AffectedItemsWazuhResult:
 
     Parameters
     ----------
-    agent_list : str
+    agent_list : Union[str, None]
         List of the agents IDs to run the scan for.
 
     Returns
@@ -34,18 +34,27 @@ def run(agent_list: Union[str, None] = None) -> AffectedItemsWazuhResult:
                                       some_msg='Syscheck scan was not restarted on some agents',
                                       none_msg='No syscheck scan was restarted')
 
+    system_agents = get_agents_info()
+    rbac_filters = get_rbac_filters(system_resources=system_agents, permitted_resources=agent_list)
+    agent_list = set(agent_list)
+    not_found_agents = agent_list - system_agents
+
+    # Add non existent agents to failed_items
+    [result.add_failed_item(id_=agent, error=WazuhResourceNotFound(1701)) for agent in not_found_agents]
+
+    # Add non eligible agents to failed_items
+    non_eligible_agents = WazuhDBQueryAgents(limit=None, select=["id", "status"], query='status!=active',
+                                             **rbac_filters).run()['items']
+    [result.add_failed_item(
+        id_=agent['id'],
+        error=WazuhError(1601, extra_message=f'Status - {agent["status"]}')) for agent in non_eligible_agents]
+
     wq = WazuhQueue(common.ARQUEUE)
-    for agent_id in agent_list:
+    eligible_agents = agent_list - not_found_agents - {d['id'] for d in non_eligible_agents}
+    for agent_id in eligible_agents:
         try:
-            agent = Agent(agent_id)
-            agent.load_info_from_db()
-            agent_status = agent.status if agent.status else 'N/A'
-            if agent_status.lower() == 'active':
-                wq.send_msg_to_agent(WazuhQueue.HC_SK_RESTART, agent_id)
-                result.affected_items.append(agent_id)
-            else:
-                result.add_failed_item(
-                    id_=agent_id, error=WazuhError(1601, extra_message='Status - {}'.format(agent_status)))
+            wq.send_msg_to_agent(WazuhQueue.HC_SK_RESTART, agent_id)
+            result.affected_items.append(agent_id)
         except WazuhError as e:
             result.add_failed_item(id_=agent_id, error=e)
     wq.close()


### PR DESCRIPTION
|Related issue|
|---|
| #8867  |

Hi team,

This pull request closes #8867.

In this PR I have improved the `PUT /syscheck` endpoint by changing its framework code. Now we only create a `WazuhQueue` object when iterating over the agent list, as it has been done in the `PUT /rootcheck` improvement in the PR https://github.com/wazuh/wazuh/pull/8959.

As Adri said in this issue comment https://github.com/wazuh/wazuh/issues/8865#issuecomment-859368837, the difference of performance obtained is not high, but we see an improvement. To see bigger improvements, we would need the possibility to send a list of agents to the socket.


Regards,
Manuel.