### PR TITLE
Remove delay in the restart procedure at Execd

### DIFF
--- a/src/os_execd/wcom.c
+++ b/src/os_execd/wcom.c
@@ -210,7 +210,6 @@ size_t wcom_restart(char ** output) {
                 os_strdup("err Cannot fork", *output);
             break;
             case 0:
-                sleep(1);
                 if (execv(exec_cmd[0], exec_cmd) < 0) {
                     merror(EXEC_CMDERROR, *exec_cmd, strerror(errno));
                     _exit(1);


### PR DESCRIPTION
The child process is not tracked by the service control.

|Related issue|
|---|
|#8880|

This PR removes the 1-second delay between the call to restart the system by Execd (wcom socket) and the actual call to `ossec-control restart` (until 4.1) or `restart.sh` (as of 4.2).

This change should avoid point 2 (https://github.com/wazuh/wazuh/issues/8880#issuecomment-859544982).

## Tests

- [X] The issue is no longer reproducible after applying this patch.