### PR TITLE
Improve log message of the Vulnerability Detector scan result

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -5148,6 +5148,9 @@ void test_wm_vuldet_process_agent_vulnerabilities_vuln_cves_insert_error(void **
     will_return(__wrap_OSHash_Next, NULL);
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5468): The 'libhogweed4' package (5.3.4) from agent '000' is vulnerable to 'CVE-2016-6489'. Condition: 'Package less than 4.3-2'");
+    
+    expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5482): A total of '0' vulnerabilities have been reported for agent '000' thanks to the 'NVD' feed.");
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
@@ -5325,6 +5328,9 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_error(void **s
     expect_value(__wrap_OSHash_Next, self, cve_table);
     will_return(__wrap_OSHash_Next, NULL);
 
+    expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5468): The 'libhogweed4' package (5.3.4) from agent '000' is vulnerable to 'CVE-2016-6489'. Condition: 'Package less than 4.3-2'");
+    
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5482): A total of '0' vulnerabilities have been reported for agent '000' thanks to the 'NVD' feed.");
 
@@ -5508,6 +5514,9 @@ void test_wm_vuldet_process_agent_vulnerabilities_send_cve_report_negative_versi
     expect_value(__wrap_OSHash_Next, self, cve_table);
     will_return(__wrap_OSHash_Next, NULL);
 
+    expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5468): The 'libhogweed4' package () from agent '000' is vulnerable to 'CVE-2016-6489'. Condition: 'Package less than 4.3-2'");
+    
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5482): A total of '0' vulnerabilities have been reported for agent '000' thanks to the 'NVD' feed.");
 
@@ -7807,10 +7816,7 @@ void test_wm_vuldet_send_cve_report_without_title(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, name, "cve_version");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->cve_version);
     will_return(__wrap_cJSON_PrintUnformatted, json_text);
-
-    expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5467): Agent '001' is vulnerable to 'CVE-2016-6489'. Condition: 'Package less than 4.3-2'");
-
+    
     will_return(__wrap_wm_sendmsg, 0);
     expect_value(__wrap_wm_sendmsg, usec, 1000000 / wm_max_eps);
     expect_value(__wrap_wm_sendmsg, queue, 1);
@@ -7997,10 +8003,7 @@ void test_wm_vuldet_send_cve_report_without_condition(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, name, "cve_version");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->cve_version);
     will_return(__wrap_cJSON_PrintUnformatted, json_text);
-
-    expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5467): Agent '001' is vulnerable to 'CVE-2016-6489'. Condition: 'Package CVE-2016-6489 reports as vulnerable all the versions of this package 4.3-2'");
-
+   
     will_return(__wrap_wm_sendmsg, 0);
     expect_value(__wrap_wm_sendmsg, usec, 1000000 / wm_max_eps);
     expect_value(__wrap_wm_sendmsg, queue, 1);
@@ -8188,10 +8191,7 @@ void test_wm_vuldet_send_cve_report_without_ip(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, name, "cve_version");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->cve_version);
     will_return(__wrap_cJSON_PrintUnformatted, json_text);
-
-    expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5467): Agent '001' is vulnerable to 'CVE-2016-6489'. Condition: 'Package less than 4.3-2'");
-
+    
     will_return(__wrap_wm_sendmsg, 0);
     expect_value(__wrap_wm_sendmsg, usec, 1000000 / wm_max_eps);
     expect_value(__wrap_wm_sendmsg, queue, 1);
@@ -8378,10 +8378,7 @@ void test_wm_vuldet_send_cve_report_without_hotfix(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, name, "cve_version");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->cve_version);
     will_return(__wrap_cJSON_PrintUnformatted, json_text);
-
-    expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5468): The 'libhogweed4' package (3.4-1) from agent '001' is vulnerable to 'CVE-2016-6489'. Condition: 'Package less than 4.3-2'");
-
+    
     will_return(__wrap_wm_sendmsg, 0);
     expect_value(__wrap_wm_sendmsg, usec, 1000000 / wm_max_eps);
     expect_value(__wrap_wm_sendmsg, queue, 1);
@@ -8568,10 +8565,7 @@ void test_wm_vuldet_send_cve_report_sendmsg_error(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, name, "cve_version");
     expect_string(__wrap_cJSON_AddStringToObject, string, report->cve_version);
     will_return(__wrap_cJSON_PrintUnformatted, json_text);
-
-    expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5468): The 'libhogweed4' package (3.4-1) from agent '001' is vulnerable to 'CVE-2016-6489'. Condition: 'Package less than 4.3-2'");
-
+   
     will_return(__wrap_wm_sendmsg, OS_INVALID);
     expect_value(__wrap_wm_sendmsg, usec, 1000000 / wm_max_eps);
     expect_value(__wrap_wm_sendmsg, queue, 1);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1383,12 +1383,6 @@ int wm_vuldet_process_agent_vulnerabilities(sqlite3 *db, OSHash *cve_table, scan
                         scan_ctx->agent_id);
             }
 
-            if (scan_ctx->scan_type == VU_BASELINE_SCAN || update) {
-                // No report should be generated for baseline scans or already reported vulnerabilities
-                pkg = next;
-                continue;
-            }
-
             os_calloc(1, sizeof(vu_report), report);
 
             // Adding agent information
@@ -1436,18 +1430,34 @@ int wm_vuldet_process_agent_vulnerabilities(sqlite3 *db, OSHash *cve_table, scan
                 }
             }
 
-            // Sending CVE report
-            if (wm_vuldet_send_cve_report(report)) {
-                mterror(WM_VULNDETECTOR_LOGTAG, VU_SEND_AGENT_REPORT_ERROR, report->cve, report->software, scan_ctx->agent_id);
-            } else {
-                if (pkg->feed & VU_SRC_NVD) {
-                    vuln_reported_nvd++;
-                }
-                if (pkg->feed & VU_SRC_OVAL) {
-                    vuln_reported_vendor++;
-                }
-                vuln_reported++;
+            if (report->is_hotfix) {
+                mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_HOTFIX_VUL,
+                    atoi(report->agent_id),
+                    report->cve,
+                    report->condition ? report->condition : "Hotfix is not installed.");
+            } 
+            else if (report->software && report->version && report->agent_id && report->cve) {
+                mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_PACK_VER_VULN, report->software,
+                    report->version, atoi(report->agent_id), report->cve,
+                    report->condition && *report->condition != '\0' ? report->condition :
+                    "exists");
             }
+
+            if (scan_ctx->scan_type != VU_BASELINE_SCAN && !update) {
+                // Sending CVE report
+                if (wm_vuldet_send_cve_report(report)) {
+                    mterror(WM_VULNDETECTOR_LOGTAG, VU_SEND_AGENT_REPORT_ERROR, report->cve, report->software, scan_ctx->agent_id);
+                } else {
+                    if (pkg->feed & VU_SRC_NVD) {
+                        vuln_reported_nvd++;
+                    }
+                    if (pkg->feed & VU_SRC_OVAL) {
+                        vuln_reported_vendor++;
+                    }
+                    vuln_reported++;
+                }
+            }
+
             wm_vuldet_free_report(report);
 
             pkg = next;
@@ -1617,20 +1627,6 @@ int wm_vuldet_send_cve_report(vu_report *report) {
         snprintf(header, OS_SIZE_256, "%s", VU_WM_NAME);
         snprintf(alert_msg, OS_MAXSTR, "%s", str_json);
         send_queue = LOCALFILE_MQ;
-    }
-
-    if (report->is_hotfix) {
-        mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_HOTFIX_VUL,
-            atoi(report->agent_id),
-            report->cve,
-            report->condition ? report->condition : "Hotfix is not installed.");
-    } else {
-        if (report->software && report->version && report->agent_id && report->cve) {
-        mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_PACK_VER_VULN, report->software,
-            report->version, atoi(report->agent_id), report->cve,
-            report->condition && *report->condition != '\0' ? report->condition :
-            "exists");
-        }
     }
 
     if (wm_sendmsg(usec, *vu_queue, alert_msg, header, send_queue) < 0) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2316,6 +2316,19 @@ int wm_vuldet_process_agent_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd
                 agent->agent_id ? agent->agent_id : "null");
         }
 
+        if (report->is_hotfix) {
+            mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_HOTFIX_VUL,
+                atoi(report->agent_id),
+                report->cve,
+                report->condition ? report->condition : "Hotfix is not installed.");
+        } 
+        else if (report->software && report->version && report->agent_id && report->cve) {
+            mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_PACK_VER_VULN, report->software,
+                report->version, atoi(report->agent_id), report->cve,
+                report->condition && *report->condition != '\0' ? report->condition :
+                "exists");
+        }
+
         if (scan_ctx->scan_type != VU_BASELINE_SCAN && !update) {
             // No report should be generated for baseline scans or already reported vulnerabilities
             // Sending CVE report


### PR DESCRIPTION
|Related issue|
|---|
|#8970|

## Description
This PR includes improvements to the log messages after the Vulnerability Detector scan.
- It makes the message `The 'wazuhintegrationpackage-0' package (0.9) from agent '001' is vulnerable to 'CVE-000'. Condition: 'Package less than 2.0.0'` get logged even if the alert of this vulnerability is bypassed, because of a baseline scan or because the vulnerability was already reported.


## Logs/Alerts example
![image](https://user-images.githubusercontent.com/11434230/121713552-5d683800-cab3-11eb-911f-7cf04015aa21.png)

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Package installation
- [X] Source upgrade
- [X] Package upgrade

