### PR TITLE
Added Fortiweb Decoder and Ruleset

### DIFF
--- a/ruleset/decoders/0530-fortiweb_decoders.xml
+++ b/ruleset/decoders/0530-fortiweb_decoders.xml
@@ -1,0 +1,27 @@
+<decoder name="fortiweb-custom">
+	<prematch>^date=(\d\d\d\d-\d\d-\d\d) time=(\d\d:\d\d:\d\d)</prematch>
+</decoder>
+<decoder name="fortiweb-custom1">
+	<parent>fortiweb-custom</parent>
+	<regex>main_type="(\.*)" sub_type="(\.*)" </regex>
+	<order>type, sub_type</order>
+</decoder>
+<decoder name="fortiweb-custom1">
+	<parent>fortiweb-custom</parent>
+	<regex offset="after_regex">src=(\S+) src_port=\S+ dst=(\S+) dst_port=\S+ </regex>
+	<order>source, destination</order>
+</decoder>
+<decoder name="fortiweb-custom1">
+	<parent>fortiweb-custom</parent>
+	<regex offset="after_regex">http_url="(\S+)" http_host="(\S+)"</regex>
+	<order>url, host</order>
+</decoder>
+<decoder name="fortiweb-custom1">
+	<parent>fortiweb-custom</parent>
+	<regex offset="after_regex">matched_pattern="(\S+)"</regex>
+	<order>pattern</order>
+</decoder><decoder name="fortiweb-custom1">
+	<parent>fortiweb-custom</parent>
+	<regex>action=(\S+)</regex>
+	<order>action</order>
+</decoder>

--- a/ruleset/rules/0915-foriweb_rules.xml
+++ b/ruleset/rules/0915-foriweb_rules.xml
@@ -1,0 +1,11 @@
+<group name="fortiweb">
+<rule id="915000" level="3">
+  <decoded_as>fortiweb-custom</decoded_as>
+  <description>Fortiweb messages grouped.</description>
+</rule>
+<rule id="915001" level="7">
+   <if_sid>915000</if_sid>
+   <match>type=attack</match>
+  <description>Fortiweb: | $(sub_type)  | $(source) </description>
+</rule>
+</group>


### PR DESCRIPTION
|Added Fortiweb Decoder and Ruleset|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Fortiweb Decoder and Ruleset is added to the wazuh
It Creates an Alert for Each attack in the format Fortiweb: | $(sub_type)  | $(source)
<!--
Fortiweb Decoder and Ruleset is added to the wazuh
-->

## Configuration options
No new Configurations added
<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->
Alert Example 
Fortiweb: | $(sub_type)  | $(source)

## Tests
Tested with latest wazuh version using ossec-logtest 
