### PR TITLE
Remove inode collision algorithm

### DIFF
--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -42,8 +42,6 @@ typedef enum fdb_stmt {
     FIMDB_STMT_GET_COUNT_DATA,
     FIMDB_STMT_GET_INODE,
     FIMDB_STMT_GET_PATH_FROM_PATTERN,
-    FIMDB_STMT_DATA_ROW_EXISTS,
-    FIMDB_STMT_PATH_IS_SCANNED,
     // Registries
 #ifdef WIN32
     FIMDB_STMT_REPLACE_REG_DATA,
@@ -337,12 +335,12 @@ typedef struct fdb_transaction_t
     time_t interval;
 } fdb_transaction_t;
 
-typedef struct fdb_t
-{
+typedef struct fdb_t {
     sqlite3 *db;
     sqlite3_stmt *stmt[FIMDB_STMT_SIZE];
     fdb_transaction_t transaction;
     volatile bool full;
+    pthread_mutex_t mutex;
 } fdb_t;
 
 typedef struct _config {

--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -261,6 +261,7 @@
 #define FIM_WILDCARDS_REMOVE_DIRECTORY      "(6362): Removing entry '%s' due to it has not been expanded by the wildcards"
 #define FIM_WILDCARDS_UPDATE_FINALIZE       "(6363): Configuration wildcards update finalize."
 
+
 /* Modules messages */
 #define WM_UPGRADE_RESULT_AGENT_INFO         "(8151): Agent Information obtained: '%s'"
 #define WM_UPGRADE_MODULE_DISABLED           "(8152): Module Agent Upgrade disabled. Exiting..."

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -53,21 +53,6 @@ static const char *FIM_EVENT_MODE[] = {
  */
 void update_wildcards_config();
 
-/**
- * @brief Process a path coming from a wildcard that has been deleted
- *
- * @param configuration Configuration associated with the file
- */
-void fim_process_wildcard_removed(directory_t *configuration);
-
-static cJSON *
-_fim_file(const char *path, const directory_t *configuration, event_data_t *evt_data);
-
-#ifndef WIN32
-static cJSON *_fim_file_force_update(const fim_entry *saved,
-                                     const directory_t *configuration,
-                                     event_data_t *evt_data);
-#endif
 
 void fim_generate_delete_event(fdb_t *fim_sql,
                                fim_entry *entry,
@@ -166,9 +151,7 @@ time_t fim_scan() {
 
     update_wildcards_config();
 
-    w_mutex_lock(&syscheck.fim_entry_mutex);
     fim_db_set_all_unscanned(syscheck.database);
-    w_mutex_unlock(&syscheck.fim_entry_mutex);
 
     w_rwlock_rdlock(&syscheck.directories_lock);
     OSList_foreach(node_it, syscheck.directories) {
@@ -196,9 +179,7 @@ time_t fim_scan() {
     fim_registry_scan();
 #endif
     if (syscheck.file_limit_enabled) {
-        w_mutex_lock(&syscheck.fim_entry_mutex);
         nodes_count = fim_db_get_count_entries(syscheck.database);
-        w_mutex_unlock(&syscheck.fim_entry_mutex);
     }
 
     check_deleted_files();
@@ -212,13 +193,9 @@ time_t fim_scan() {
             char *path;
             event_data_t evt_data = { .mode = FIM_SCHEDULED, .report_event = true, .w_evt = NULL };
 
-            w_mutex_lock(&syscheck.fim_entry_mutex);
-            if (syscheck.database->full) {
-                w_mutex_unlock(&syscheck.fim_entry_mutex);
-
+            if (fim_db_is_full(syscheck.database)) {
                 break;
             }
-            w_mutex_unlock(&syscheck.fim_entry_mutex);
 
             path = fim_get_real_path(dir_it);
 
@@ -239,7 +216,7 @@ time_t fim_scan() {
         w_mutex_unlock(&syscheck.fim_scan_mutex);
 
 #ifdef WIN32
-        if (!syscheck.database->full) {
+        if (fim_db_is_full(syscheck.database) != 0) {
             fim_registry_scan();
         }
 #endif
@@ -330,9 +307,7 @@ void fim_checker(const char *path, event_data_t *evt_data, const directory_t *pa
             return;
         }
 
-        w_mutex_lock(&syscheck.fim_entry_mutex);
         saved_entry = fim_db_get_path(syscheck.database, path);
-        w_mutex_unlock(&syscheck.fim_entry_mutex);
 
         if (saved_entry) {
             evt_data->type = FIM_DELETE;
@@ -443,276 +418,6 @@ int fim_directory(const char *dir, event_data_t *evt_data, const directory_t *co
     return 0;
 }
 
-#ifndef WIN32
-/**
- * @brief Processes a file by extracting its information from the DB.
- *
- * @param path The path to the file being processed.
- * @param stack A list used as a stack to store paths to stored inodes that have a conflict with the analysed file.
- * @param tree A tree that helps prevent duplicate entries from being added to the stack.
- * @param event In case the processed file generates and event, it's returned here.
- * @return A fim_sanitize_state_t value representing how the operation ended.
- * @retval FIM_FILE_UPDATED The file has been updated correctly in the DB.
- * @retval FIM_FILE_DELETED The file has been deleted from the DB.
- * @retval FIM_FILE_ADDED_PATHS A collision was detected with provided inode, the paths gotten from the conflicting inode are added to `stack`.
- * @retval FIM_FILE_ERROR An error occured while processing the file.
- */
-static fim_sanitize_state_t fim_process_file_from_db(const char *path, OSList *stack, rb_tree *tree, cJSON **event) {
-    event_data_t evt_data = { .mode = FIM_SCHEDULED, .w_evt = NULL, .report_event = true };
-    fim_entry *entry;
-    directory_t *configuration = NULL;
-
-    assert(path != NULL);
-    assert(stack != NULL);
-    assert(tree != NULL);
-    assert(event != NULL);
-
-    entry = fim_db_get_path(syscheck.database, path);
-    if (entry == NULL) {
-        // We didn't get an entry
-        return FIM_FILE_ERROR;
-    }
-
-    if (w_stat(entry->file_entry.path, &(evt_data.statbuf)) == -1) {
-        if (errno != ENOENT) {
-            mdebug1(FIM_STAT_FAILED, entry->file_entry.path, errno, strerror(errno));
-            free_entry(entry);
-            return FIM_FILE_ERROR;
-        }
-
-        configuration = fim_configuration_directory(path);
-        if (configuration == NULL) {
-            // This should not happen
-            free_entry(entry);
-            return FIM_FILE_ERROR;
-        }
-
-        if (configuration->options & CHECK_SEECHANGES) {
-            fim_diff_process_delete_file(entry->file_entry.path); // LCOV_EXCL_LINE
-        }
-
-        if (fim_db_remove_path(syscheck.database, entry->file_entry.path) == FIMDB_ERR) {
-            free_entry(entry);
-            return FIM_FILE_ERROR;
-        }
-
-        evt_data.type = FIM_DELETE;
-
-        *event = fim_json_event(entry, NULL, configuration, &evt_data, NULL);
-        free_entry(entry);
-
-        return FIM_FILE_DELETED;
-    }
-
-    if (entry->file_entry.data->dev == evt_data.statbuf.st_dev &&
-        entry->file_entry.data->inode == evt_data.statbuf.st_ino) {
-        goto end;
-    }
-
-    // We need to check if the new inode is being used in the DB
-    switch (fim_db_data_exists(syscheck.database, evt_data.statbuf.st_ino, evt_data.statbuf.st_dev)) {
-    case FIMDB_ERR:
-        free_entry(entry);
-        return FIM_FILE_ERROR;
-    case 0:
-        goto end;
-    default:
-    case 1:
-        break;
-    }
-
-    // The inode is currently being used, scan those files first
-    if (fim_db_append_paths_from_inode(syscheck.database, evt_data.statbuf.st_ino, evt_data.statbuf.st_dev, stack,
-                                       tree) == 0) {
-        // We have somehow reached a point an infinite loop could happen, we will need to update the current file
-        // forcefully which will generate a false positive alert
-        check_max_fps();
-        configuration = fim_configuration_directory(path);
-        if (configuration == NULL) {
-            // This should not happen
-            free_entry(entry);     // LCOV_EXCL_LINE
-            return FIM_FILE_ERROR; // LCOV_EXCL_LINE
-        }
-
-        *event = _fim_file_force_update(entry, configuration, &evt_data);
-        free_entry(entry);
-
-        return FIM_FILE_UPDATED;
-    }
-
-    free_entry(entry);
-    return FIM_FILE_ADDED_PATHS;
-
-end:
-    // Once here, either the used row was cleared and is available or this file is a hardlink to other file
-    // either way the only thing left to do is to process the file
-    check_max_fps();
-
-    configuration = fim_configuration_directory(path);
-    if (configuration == NULL) {
-        // This should not happen
-        free_entry(entry);     // LCOV_EXCL_LINE
-        return FIM_FILE_ERROR; // LCOV_EXCL_LINE
-    }
-
-    *event = _fim_file(path, configuration, &evt_data);
-    free_entry(entry);
-
-    return FIM_FILE_UPDATED;
-}
-
-/**
- * @brief Resolves a conflict on the given inode.
- *
- * @param inode The inode that caused a collision with an existing DB entry.
- * @param dev The device that caused a collision with an existing DB entry.
- * @return 0 if the collision was solved correctly, -1 if an error occurred.
- */
-static int fim_resolve_db_collision(unsigned long inode, unsigned long dev) {
-    rb_tree *tree;
-    OSList *stack;
-
-    tree = rbtree_init();
-    if (tree == NULL) {
-        return -1; // LCOV_EXCL_LINE
-    }
-
-    stack = OSList_Create();
-    if (stack == NULL) {
-        rbtree_destroy(tree); // LCOV_EXCL_LINE
-        return -1;            // LCOV_EXCL_LINE
-    }
-
-    fim_db_append_paths_from_inode(syscheck.database, inode, dev, stack, tree);
-    w_mutex_unlock(&syscheck.fim_entry_mutex);
-
-    while (stack->currently_size != 0) {
-        char *current_path;
-        cJSON *event = NULL;
-        OSListNode *last = OSList_GetLastNode(stack);
-
-        if (last == NULL) {
-            mdebug2("Failed getting the next node to scan"); // LCOV_EXCL_LINE
-            break;                                           // LCOV_EXCL_LINE
-        }
-
-        current_path = (char *)last->data;
-
-        w_mutex_lock(&syscheck.fim_entry_mutex);
-
-        switch (fim_process_file_from_db(current_path, stack, tree, &event)) {
-        case FIM_FILE_UPDATED:
-        case FIM_FILE_DELETED:
-            OSList_DeleteCurrentlyNode(stack);
-            break;
-        case FIM_FILE_ADDED_PATHS:
-            // Nothing to do here, we will move to the new last path and retry there
-            break;
-        case FIM_FILE_ERROR:
-        default:
-            OSList_Destroy(stack);
-            rbtree_destroy(tree);
-            return -1;
-        }
-
-        w_mutex_unlock(&syscheck.fim_entry_mutex);
-
-        if (event) {
-            send_syscheck_msg(event); // LCOV_EXCL_LINE
-        }
-
-        cJSON_Delete(event);
-        event = NULL;
-    }
-
-    OSList_Destroy(stack);
-    rbtree_destroy(tree);
-
-    w_mutex_lock(&syscheck.fim_entry_mutex);
-
-    return 0;
-}
-#endif
-
-/**
- * @brief Makes any necessary queries to get the entry updated in the DB.
- *
- * @param path The path to the file being processed.
- * @param data The information linked to the path to be updated
- * @param saved If the file had information stored in the DB, that data is returned in this parameter.
- * @param event_mode The mode that triggered the event being processed.
- * @return The result of the update operation.
- * @retval FIMDB_ERR if an error occurs in the DB.
- * @retval -1 if an error occurs.
- * @retval 0 if the operation ends correctly.
- */
-static int fim_update_db_data(const char *path,
-                              const fim_file_data *data,
-                              fim_entry **saved,
-                              __attribute__((unused)) fim_event_mode event_mode) {
-    assert(saved != NULL);
-
-    *saved = fim_db_get_path(syscheck.database, path);
-
-#ifndef WIN32
-    // We will rely on realtime and whodata modes not losing deletion and creation events.
-    // This will potentially trigger false positives in very particular cases and environments but
-    // there is no easy way to implement the DB correction algorithm in those modes.
-    if (event_mode != FIM_SCHEDULED) {
-        return fim_db_insert(syscheck.database, path, data, *saved != NULL ? (*saved)->file_entry.data : NULL);
-    }
-#endif
-
-    if (*saved == NULL) {
-#ifndef WIN32
-        switch (fim_db_data_exists(syscheck.database, data->inode, data->dev)) {
-        case FIMDB_ERR:
-            return -1;
-        case 1:
-            if (fim_resolve_db_collision(data->inode, data->dev) != 0) {
-                mwarn("Failed to resolve an inode collision for file '%s'", path);
-                return -1;
-            }
-            // Fallthrough
-        case 0:
-        default:
-            return fim_db_insert(syscheck.database, path, data, NULL);
-        }
-#else // WIN32
-        return fim_db_insert(syscheck.database, path, data, NULL);
-#endif
-    }
-
-    if (strcmp(data->checksum, (*saved)->file_entry.data->checksum) == 0) {
-        // Entry up to date
-        fim_db_set_scanned(syscheck.database, path);
-        return 0;
-    }
-
-#ifndef WIN32
-    if (data->dev == (*saved)->file_entry.data->dev && data->inode == (*saved)->file_entry.data->inode) {
-        return fim_db_insert(syscheck.database, path, data, (*saved)->file_entry.data);
-    }
-
-    switch (fim_db_data_exists(syscheck.database, data->inode, data->dev)) {
-    case FIMDB_ERR:
-        return -1;
-    case 0:
-        return fim_db_insert(syscheck.database, path, data, (*saved)->file_entry.data);
-    case 1:
-    default:
-        break;
-    }
-
-    if (fim_resolve_db_collision(data->inode, data->dev) != 0) {
-        mwarn("Failed to resolve an inode collision for file '%s'", path); // LCOV_EXCL_LINE
-        return -1;                                                         // LCOV_EXCL_LINE
-    }
-#endif
-
-    // At this point, we should be safe to store the new data
-    return fim_db_insert(syscheck.database, path, data, (*saved)->file_entry.data);
-}
 
 /**
  * @brief Processes a file, update the DB entry and return an event. No mutex is used inside this function.
@@ -732,21 +437,6 @@ _fim_file(const char *path, const directory_t *configuration, event_data_t *evt_
     assert(configuration != NULL);
     assert(evt_data != NULL);
 
-    if (evt_data->mode == FIM_SCHEDULED) {
-        // Prevent analysis of the same file twice during the same scan
-        switch (fim_db_file_is_scanned(syscheck.database, path)) {
-            case FIMDB_ERR:
-                mdebug2("Failed to query status of file '%s'", path);
-                // Fallthrough
-            case 1:
-                return NULL;
-            case 0:
-            default:
-                break;
-        }
-    }
-
-    check_max_fps();
     new.file_entry.path = (char *)path;
     new.file_entry.data = fim_get_data(path, configuration, &(evt_data->statbuf));
     if (new.file_entry.data == NULL) {
@@ -754,7 +444,7 @@ _fim_file(const char *path, const directory_t *configuration, event_data_t *evt_
         return NULL;
     }
 
-    if (fim_update_db_data(path, new.file_entry.data, &saved, evt_data->mode) != 0) {
+    if (fim_db_file_update(syscheck.database, path, new.file_entry.data, &saved) != FIMDB_OK) {
         free_file_data(new.file_entry.data);
         free_entry(saved);
         return NULL;
@@ -779,56 +469,10 @@ _fim_file(const char *path, const directory_t *configuration, event_data_t *evt_
     return json_event;
 }
 
-#ifndef WIN32
-/**
- * @brief Virtually identical to `_fim_file`, except this function updates the DB with no further validations
- *
- * @param saved Information extracted from FIM DB about the file being processed.
- * @param configuration The configuration associated with the file being processed.
- * @param evt_data Information on how the event was triggered.
- * @return A JSON event, NULL if no event is triggered.
- */
-static cJSON *_fim_file_force_update(const fim_entry *saved,
-                                     const directory_t *configuration,
-                                     event_data_t *evt_data) {
-    fim_entry new;
-    cJSON *json_event = NULL;
-    char *diff = NULL;
-
-    assert(saved != NULL);
-    assert(configuration != NULL);
-    assert(evt_data != NULL);
-
-    // Get file attributes
-    new.file_entry.path = (char *)saved->file_entry.path;
-    new.file_entry.data = fim_get_data(new.file_entry.path, configuration, &(evt_data->statbuf));
-    if (new.file_entry.data == NULL) {
-        mdebug1(FIM_GET_ATTRIBUTES, new.file_entry.path);
-        return NULL;
-    }
-
-    if (fim_db_insert(syscheck.database, new.file_entry.path, new.file_entry.data, saved->file_entry.data) != 0) {
-        free_file_data(new.file_entry.data);
-        return NULL;
-    }
-
-    evt_data->type = FIM_MODIFICATION; // Checking for changes
-
-    if (configuration->options & CHECK_SEECHANGES) {
-        diff = fim_file_diff(new.file_entry.path);
-    }
-
-    json_event = fim_json_event(&new, saved->file_entry.data, configuration, evt_data, diff);
-
-    os_free(diff);
-    free_file_data(new.file_entry.data);
-
-    return json_event;
-}
-#endif
-
 void fim_file(const char *path, const directory_t *configuration, event_data_t *evt_data) {
     cJSON *json_event = NULL;
+
+    check_max_fps();
 
     w_mutex_lock(&syscheck.fim_entry_mutex);
     json_event = _fim_file(path, configuration, evt_data);
@@ -888,9 +532,7 @@ void fim_whodata_event(whodata_evt * w_evt) {
         const unsigned long int inode = strtoul(w_evt->inode, NULL, 10);
         const unsigned long int dev = strtoul(w_evt->dev, NULL, 10);
 
-        w_mutex_lock(&syscheck.fim_entry_mutex);
         paths = fim_db_get_paths_from_inode(syscheck.database, inode, dev);
-        w_mutex_unlock(&syscheck.fim_entry_mutex);
 
         if(paths) {
             for(int i = 0; paths[i]; i++) {
@@ -909,9 +551,7 @@ void fim_process_wildcard_removed(directory_t *configuration) {
     fim_tmp_file *files = NULL;
     event_data_t evt_data = { .mode = FIM_SCHEDULED, .w_evt = NULL, .report_event = true, .type = FIM_DELETE };
 
-    w_mutex_lock(&syscheck.fim_entry_mutex);
     fim_entry *entry = fim_db_get_path(syscheck.database, configuration->path);
-    w_mutex_unlock(&syscheck.fim_entry_mutex);
 
     if (entry != NULL) {
         fim_generate_delete_event(syscheck.database, entry, &syscheck.fim_entry_mutex, &evt_data, configuration, NULL);
@@ -925,9 +565,7 @@ void fim_process_wildcard_removed(directory_t *configuration) {
     // Create the sqlite LIKE pattern -> "pathname/%"
     snprintf(pattern, PATH_MAX, "%s%c%%", configuration->path, PATH_SEP);
 
-    w_mutex_lock(&syscheck.fim_entry_mutex);
     fim_db_get_path_from_pattern(syscheck.database, pattern, &files, syscheck.database_store);
-    w_mutex_unlock(&syscheck.fim_entry_mutex);
 
     if (files && files->elements) {
         if (fim_db_remove_wildcard_entry(syscheck.database, files, &syscheck.fim_entry_mutex, syscheck.database_store,
@@ -942,9 +580,7 @@ void fim_process_missing_entry(char * pathname, fim_event_mode mode, whodata_evt
     fim_tmp_file *files = NULL;
 
     // Search path in DB.
-    w_mutex_lock(&syscheck.fim_entry_mutex);
     saved_data = fim_db_get_path(syscheck.database, pathname);
-    w_mutex_unlock(&syscheck.fim_entry_mutex);
 
     // Exists, create event.
     if (saved_data) {
@@ -960,9 +596,7 @@ void fim_process_missing_entry(char * pathname, fim_event_mode mode, whodata_evt
     // Create the sqlite LIKE pattern -> "pathname/%"
     snprintf(pattern, PATH_MAX, "%s%c%%", pathname, PATH_SEP);
 
-    w_mutex_lock(&syscheck.fim_entry_mutex);
     fim_db_get_path_from_pattern(syscheck.database, pattern, &files, syscheck.database_store);
-    w_mutex_unlock(&syscheck.fim_entry_mutex);
 
     if (files && files->elements) {
         event_data_t evt_data = { .mode = mode, .w_evt = w_evt, .report_event = true, .type = FIM_DELETE };
@@ -980,9 +614,7 @@ void fim_check_db_state() {
     char *json_plain = NULL;
     char alert_msg[OS_SIZE_256] = {'\0'};
 
-    w_mutex_lock(&syscheck.fim_entry_mutex);
     nodes_count = fim_db_get_count_entries(syscheck.database);
-    w_mutex_unlock(&syscheck.fim_entry_mutex);
 
     if (nodes_count < 0) {
         mwarn(FIM_DATABASE_NODES_COUNT_FAIL);
@@ -1309,13 +941,10 @@ void fim_get_checksum (fim_file_data * data) {
 
 void check_deleted_files() {
     fim_tmp_file *file = NULL;
-    w_mutex_lock(&syscheck.fim_entry_mutex);
 
     if (fim_db_get_not_scanned(syscheck.database, &file, syscheck.database_store) != FIMDB_OK) {
         merror(FIM_DB_ERROR_RM_NOT_SCANNED);
     }
-
-    w_mutex_unlock(&syscheck.fim_entry_mutex);
 
     if (file && file->elements) {
         w_rwlock_rdlock(&syscheck.directories_lock);

--- a/src/syscheckd/db/fim_db.c
+++ b/src/syscheckd/db/fim_db.c
@@ -15,6 +15,14 @@
 #include "unit_tests/wrappers/windows/libc/stdio_wrappers.h"
 #endif
 #define static
+
+/* Replace assert with mock_assert */
+extern void mock_assert(const int result, const char* const expression,
+                        const char * const file, const int line);
+
+#undef assert
+#define assert(expression) \
+    mock_assert((int)(expression), #expression, __FILE__, __LINE__);
 #endif
 
 const char *SQL_STMT[] = {
@@ -50,8 +58,6 @@ const char *SQL_STMT[] = {
     [FIMDB_STMT_GET_COUNT_DATA] = "SELECT count(*) FROM file_data",
     [FIMDB_STMT_GET_INODE] = "SELECT inode FROM file_data where rowid=(SELECT inode_id FROM file_entry WHERE path = ?)",
     [FIMDB_STMT_GET_PATH_FROM_PATTERN] = "SELECT path FROM file_entry INNER JOIN file_data ON file_data.rowid=file_entry.inode_id WHERE path LIKE ?",
-    [FIMDB_STMT_DATA_ROW_EXISTS] = "SELECT EXISTS(SELECT 1 FROM file_data WHERE inode=? AND dev=?);",
-    [FIMDB_STMT_PATH_IS_SCANNED] = "SELECT scanned FROM file_entry WHERE path = ?;",
     // Registries
 #ifdef WIN32
     [FIMDB_STMT_REPLACE_REG_DATA] = "INSERT OR REPLACE INTO registry_data (key_id, name, type, size, hash_md5, hash_sha1, hash_sha256, scanned, last_event, checksum) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
@@ -103,6 +109,8 @@ fdb_t *fim_db_init(int storage) {
 
     os_calloc(1, sizeof(fdb_t), fim);
     fim->transaction.interval = COMMIT_INTERVAL;
+
+    w_mutex_init(&fim->mutex, NULL);
 
     if (storage == FIM_DB_DISK) {
         fim_db_clean();
@@ -367,13 +375,16 @@ fim_entry *fim_db_get_entry_from_sync_msg(fdb_t *fim_sql, fim_type type, const c
 
     *finder = '\0';
 
+    w_mutex_lock(&fim_sql->mutex);
+
     value_name = filter_special_chars(finder + 1);
     key_path = filter_special_chars(full_path);
     os_calloc(1, sizeof(fim_entry), entry);
     entry->type = FIM_TYPE_REGISTRY;
-    entry->registry_entry.key = fim_db_get_registry_key(fim_sql, key_path, arch);
+    entry->registry_entry.key = _fim_db_get_registry_key(fim_sql, key_path, arch);
 
     if (entry->registry_entry.key == NULL) {
+        w_mutex_unlock(&fim_sql->mutex);
         free(key_path);
         free(full_path);
         os_free(value_name);
@@ -382,6 +393,7 @@ fim_entry *fim_db_get_entry_from_sync_msg(fdb_t *fim_sql, fim_type type, const c
     }
 
     if (value_name == NULL || *value_name == '\0') {
+        w_mutex_unlock(&fim_sql->mutex);
         free(key_path);
         free(full_path);
         os_free(value_name);
@@ -391,14 +403,16 @@ fim_entry *fim_db_get_entry_from_sync_msg(fdb_t *fim_sql, fim_type type, const c
     free(key_path);
     free(full_path);
 
-    entry->registry_entry.value = fim_db_get_registry_data(fim_sql, entry->registry_entry.key->id, value_name);
+    entry->registry_entry.value = _fim_db_get_registry_data(fim_sql, entry->registry_entry.key->id, value_name);
 
     free(value_name);
 
     if (entry->registry_entry.value == NULL) {
+        w_mutex_unlock(&fim_sql->mutex);
         fim_registry_free_entry(entry);
         return NULL;
     }
+    w_mutex_unlock(&fim_sql->mutex);
     return entry;
 }
 #endif
@@ -423,9 +437,12 @@ end:
 void fim_db_check_transaction(fdb_t *fim_sql) {
     time_t now = time(NULL);
 
+    w_mutex_lock(&fim_sql->mutex);
+
     if (fim_sql->transaction.last_commit + fim_sql->transaction.interval <= now) {
         if (!fim_sql->transaction.last_commit) {
             fim_sql->transaction.last_commit = now;
+            w_mutex_unlock(&fim_sql->mutex);
             return;
         }
 
@@ -436,6 +453,8 @@ void fim_db_check_transaction(fdb_t *fim_sql) {
             while (fim_db_exec_simple_wquery(fim_sql, "BEGIN;") == FIMDB_ERR);
         }
     }
+
+    w_mutex_unlock(&fim_sql->mutex);
 }
 
 void fim_db_force_commit(fdb_t *fim_sql) {
@@ -467,6 +486,8 @@ int fim_db_process_get_query(fdb_t *fim_sql,
     int result;
     int i;
 
+    w_mutex_lock(&fim_sql->mutex);
+
     for (i = 0; result = sqlite3_step(fim_sql->stmt[index]), result == SQLITE_ROW; i++) {
 #ifndef WIN32
         fim_entry *entry = fim_db_decode_full_row(fim_sql->stmt[index]);
@@ -478,7 +499,7 @@ int fim_db_process_get_query(fdb_t *fim_sql,
         free_entry(entry);
     }
 
-    fim_db_check_transaction(fim_sql);
+    w_mutex_unlock(&fim_sql->mutex);
 
     return result != SQLITE_DONE ? FIMDB_ERR : FIMDB_OK;
 }
@@ -500,8 +521,6 @@ int fim_db_multiple_row_query(fdb_t *fim_sql, int index, void *(*decode)(sqlite3
             free_row(decoded_row);
         }
     }
-
-    fim_db_check_transaction(fim_sql);
 
     return result != SQLITE_DONE ? FIMDB_ERR : FIMDB_OK;
 }
@@ -597,24 +616,25 @@ void fim_db_callback_calculate_checksum(__attribute__((unused)) fdb_t *fim_sql, 
 }
 
 int fim_db_get_count(fdb_t *fim_sql, int index) {
-
+    int retval = FIMDB_ERR;
 #ifndef WIN32
-    if (index == FIMDB_STMT_GET_COUNT_PATH || index == FIMDB_STMT_GET_COUNT_DATA ||
-        index == FIMDB_STMT_COUNT_DB_ENTRIES) {
+    assert(index == FIMDB_STMT_GET_COUNT_PATH || index == FIMDB_STMT_GET_COUNT_DATA ||
+           index == FIMDB_STMT_COUNT_DB_ENTRIES);
 #else
-    if (index == FIMDB_STMT_GET_COUNT_REG_KEY || index == FIMDB_STMT_GET_COUNT_REG_DATA ||
-        index == FIMDB_STMT_GET_COUNT_PATH || index == FIMDB_STMT_GET_COUNT_DATA ||
-        index == FIMDB_STMT_COUNT_DB_ENTRIES) {
+    assert(index == FIMDB_STMT_GET_COUNT_REG_KEY || index == FIMDB_STMT_GET_COUNT_REG_DATA ||
+           index == FIMDB_STMT_GET_COUNT_PATH || index == FIMDB_STMT_GET_COUNT_DATA ||
+           index == FIMDB_STMT_COUNT_DB_ENTRIES);
 #endif
-        fim_db_clean_stmt(fim_sql, index);
 
-        if (sqlite3_step(fim_sql->stmt[index]) == SQLITE_ROW) {
-            return sqlite3_column_int(fim_sql->stmt[index], 0);
-        } else {
-            return FIMDB_ERR;
-        }
+    w_mutex_lock(&fim_sql->mutex);
+    fim_db_clean_stmt(fim_sql, index);
+
+    if (sqlite3_step(fim_sql->stmt[index]) == SQLITE_ROW) {
+        retval = sqlite3_column_int(fim_sql->stmt[index], 0);
     }
-    return FIMDB_ERR;
+    w_mutex_unlock(&fim_sql->mutex);
+
+    return retval;
 }
 
 int fim_db_process_read_file(fdb_t *fim_sql,
@@ -638,7 +658,6 @@ int fim_db_process_read_file(fdb_t *fim_sql,
             return FIMDB_ERR;
         }
 
-        w_mutex_lock(mutex);
         fim_entry *entry = NULL;
 
 #ifndef WIN32
@@ -663,8 +682,6 @@ int fim_db_process_read_file(fdb_t *fim_sql,
         }
 #endif
 
-        w_mutex_unlock(mutex);
-
         if (entry != NULL) {
             callback(fim_sql, entry, mutex, alert, mode, w_evt);
             free_entry(entry);
@@ -683,13 +700,11 @@ int fim_db_process_read_file(fdb_t *fim_sql,
 // General use functions
 
 void fim_db_bind_range(fdb_t *fim_sql, int index, const char *start, const char *top) {
-    if (index == FIMDB_STMT_GET_PATH_RANGE ||
-        index == FIMDB_STMT_GET_REG_PATH_RANGE ||
-        index == FIMDB_STMT_GET_COUNT_RANGE ||
-        index == FIMDB_STMT_GET_REG_COUNT_RANGE ) {
-        sqlite3_bind_text(fim_sql->stmt[index], 1, start, -1, NULL);
-        sqlite3_bind_text(fim_sql->stmt[index], 2, top, -1, NULL);
-    }
+    assert(index == FIMDB_STMT_GET_PATH_RANGE || index == FIMDB_STMT_GET_REG_PATH_RANGE ||
+           index == FIMDB_STMT_GET_COUNT_RANGE || index == FIMDB_STMT_GET_REG_COUNT_RANGE);
+
+    sqlite3_bind_text(fim_sql->stmt[index], 1, start, -1, NULL);
+    sqlite3_bind_text(fim_sql->stmt[index], 2, top, -1, NULL);
 }
 
 char *fim_db_decode_string(sqlite3_stmt *stmt) {
@@ -724,10 +739,14 @@ char **fim_db_decode_string_array(sqlite3_stmt *stmt) {
 int fim_db_get_string(fdb_t *fim_sql, int index, char **str) {
     int result;
 
+    w_mutex_lock(&fim_sql->mutex);
     fim_db_clean_stmt(fim_sql, index);
 
-    if (result = sqlite3_step(fim_sql->stmt[index]), result != SQLITE_ROW && result != SQLITE_DONE) {
+    result = sqlite3_step(fim_sql->stmt[index]);
+
+    if (result != SQLITE_ROW && result != SQLITE_DONE) {
         merror("Step error getting row string: %s", sqlite3_errmsg(fim_sql->db));
+        w_mutex_unlock(&fim_sql->mutex);
         return FIMDB_ERR;
     }
 
@@ -735,6 +754,8 @@ int fim_db_get_string(fdb_t *fim_sql, int index, char **str) {
         char *text = (char *)sqlite3_column_text(fim_sql->stmt[index], 0);
         sqlite_strdup(text, *str);
     }
+
+    w_mutex_unlock(&fim_sql->mutex);
 
     return FIMDB_OK;
 }
@@ -764,10 +785,19 @@ int fim_db_get_data_checksum(fdb_t *fim_sql, fim_type type, void *arg) {
         [FIM_TYPE_FILE] = FIMDB_STMT_GET_ALL_CHECKSUMS,
         [FIM_TYPE_REGISTRY] = FIMDB_STMT_GET_REG_ALL_CHECKSUMS,
     };
+    int retval;
+
+    w_mutex_lock(&fim_sql->mutex);
 
     fim_db_clean_stmt(fim_sql, CHECKSUM_QUERY[type]);
-    return fim_db_multiple_row_query(fim_sql, CHECKSUM_QUERY[type], FIM_DB_DECODE_TYPE(fim_db_decode_string), free,
+    retval = fim_db_multiple_row_query(fim_sql, CHECKSUM_QUERY[type], FIM_DB_DECODE_TYPE(fim_db_decode_string), free,
                                      FIM_DB_CALLBACK_TYPE(fim_db_callback_calculate_checksum), 0, arg);
+
+    w_mutex_unlock(&fim_sql->mutex);
+
+    fim_db_check_transaction(fim_sql);
+
+    return retval;
 }
 
 int fim_db_get_count_range(fdb_t *fim_sql, fim_type type, const char *start, const char *top, int *count) {
@@ -776,16 +806,21 @@ int fim_db_get_count_range(fdb_t *fim_sql, fim_type type, const char *start, con
         [FIM_TYPE_REGISTRY] = FIMDB_STMT_GET_REG_COUNT_RANGE,
     };
 
+    w_mutex_lock(&fim_sql->mutex);
+
     // Clean and bind statements
     fim_db_clean_stmt(fim_sql, RANGE_QUERY[type]);
     fim_db_bind_range(fim_sql, RANGE_QUERY[type], start, top);
 
     if (sqlite3_step(fim_sql->stmt[RANGE_QUERY[type]]) != SQLITE_ROW) {
         merror("Step error getting count range 'start %s' 'top %s': %s", start, top, sqlite3_errmsg(fim_sql->db));
+        w_mutex_unlock(&fim_sql->mutex);
         return FIMDB_ERR;
     }
 
     *count = sqlite3_column_int(fim_sql->stmt[RANGE_QUERY[type]], 0);
+
+    w_mutex_unlock(&fim_sql->mutex);
 
     return FIMDB_OK;
 }
@@ -811,6 +846,8 @@ int fim_db_get_checksum_range(fdb_t *fim_sql,
         return FIMDB_ERR;
     }
 
+    w_mutex_lock(&fim_sql->mutex);
+
     // Clean statements
     fim_db_clean_stmt(fim_sql, RANGE_QUERY[type]);
     fim_db_bind_range(fim_sql, RANGE_QUERY[type], start, top);
@@ -821,6 +858,7 @@ int fim_db_get_checksum_range(fdb_t *fim_sql,
         if (sqlite3_step(fim_sql->stmt[RANGE_QUERY[type]]) != SQLITE_ROW) {
             merror("Step error getting path range, first half 'start %s' 'top %s' (i:%d): %s", start, top, i,
                    sqlite3_errmsg(fim_sql->db));
+            w_mutex_unlock(&fim_sql->mutex);
             return FIMDB_ERR;
         }
 
@@ -828,6 +866,7 @@ int fim_db_get_checksum_range(fdb_t *fim_sql,
         if (decoded_row == NULL || decoded_row[0] == NULL || decoded_row[1] == NULL) {
             free_strarray(decoded_row);
             merror("Failed to decode checksum range query");
+            w_mutex_unlock(&fim_sql->mutex);
             return FIMDB_ERR;
         }
 
@@ -850,6 +889,7 @@ int fim_db_get_checksum_range(fdb_t *fim_sql,
                    sqlite3_errmsg(fim_sql->db));
             os_free(*str_pathlh);
             os_free(*str_pathuh);
+            w_mutex_unlock(&fim_sql->mutex);
             return FIMDB_ERR;
         }
         decoded_row = fim_db_decode_string_array(fim_sql->stmt[RANGE_QUERY[type]]);
@@ -858,6 +898,7 @@ int fim_db_get_checksum_range(fdb_t *fim_sql,
             os_free(*str_pathlh);
             os_free(*str_pathuh);
             merror("Failed to decode checksum range query");
+            w_mutex_unlock(&fim_sql->mutex);
             return FIMDB_ERR;
         }
 
@@ -877,8 +918,10 @@ int fim_db_get_checksum_range(fdb_t *fim_sql,
         merror("Failed to obtain required paths in order to form message");
         os_free(*str_pathlh);
         os_free(*str_pathuh);
+        w_mutex_unlock(&fim_sql->mutex);
         return FIMDB_ERR;
     }
+    w_mutex_unlock(&fim_sql->mutex);
 
     return FIMDB_OK;
 }
@@ -897,6 +940,8 @@ int fim_db_get_path_range(fdb_t *fim_sql,
         return FIMDB_ERR;
     }
 
+    w_mutex_lock(&fim_sql->mutex);
+
     fim_db_clean_stmt(fim_sql, RANGE_QUERY[type]);
     fim_db_bind_range(fim_sql, RANGE_QUERY[type], start, top);
 
@@ -904,6 +949,9 @@ int fim_db_get_path_range(fdb_t *fim_sql,
                                         free, FIM_DB_CALLBACK_TYPE(fim_db_callback_save_string), storage,
                                         (void *)*file);
 
+    w_mutex_unlock(&fim_sql->mutex);
+
+    fim_db_check_transaction(fim_sql);
 
     if (*file && (*file)->elements == 0) {
         fim_db_clean_file(file, storage);
@@ -966,12 +1014,12 @@ int fim_db_read_line_from_file(fim_tmp_file *file, int storage, int it, char **b
 
 #ifndef WIN32
 // LCOV_EXCL_START
-inline int fim_db_get_count_entries(fdb_t * fim_sql) {
+inline int fim_db_get_count_entries(fdb_t *fim_sql) {
     return fim_db_get_count_file_entry(fim_sql);
 }
 // LCOV_EXCL_STOP
 #else
-int fim_db_get_count_entries(fdb_t * fim_sql) {
+int fim_db_get_count_entries(fdb_t *fim_sql) {
     int res = fim_db_get_count(fim_sql, FIMDB_STMT_COUNT_DB_ENTRIES);
 
     if(res == FIMDB_ERR) {
@@ -980,3 +1028,13 @@ int fim_db_get_count_entries(fdb_t * fim_sql) {
     return res;
 }
 #endif
+
+int fim_db_is_full(fdb_t *fim_sql) {
+    int retval;
+
+    w_mutex_lock(&fim_sql->mutex);
+    retval = fim_sql->full;
+    w_mutex_unlock(&fim_sql->mutex);
+
+    return retval;
+}

--- a/src/syscheckd/db/fim_db.h
+++ b/src/syscheckd/db/fim_db.h
@@ -143,18 +143,6 @@ void fim_db_clean_file(fim_tmp_file **file, int storage);
 fim_entry *fim_db_get_entry_from_sync_msg(fdb_t *fim_sql, fim_type type, const char *path);
 
 /**
- * @brief Get a registry key using its path.
- *
- * @param fim_sql FIM database struct.
- * @param arch An integer specifying the bit count of the register element, must be ARCH_32BIT or ARCH_64BIT.
- * @param path Path to registry key.
- * @param arch Architecture of the registry
- *
- * @return FIM registry key struct on success, NULL on error.
-*/
-fim_registry_key *fim_db_get_registry_key(fdb_t *fim_sql, const char *path, unsigned int arch);
-
-/**
  * @brief Read paths and registry paths which are stored in a temporal storage.
  *
  * @param fim_sql FIM database structure.
@@ -420,5 +408,14 @@ int fim_db_read_line_from_file(fim_tmp_file *file, int storage, int it, char **b
  * @return Number of entries in the FIM DB.
  */
 int fim_db_get_count_entries(fdb_t * fim_sql);
+
+/**
+ * @brief Check if the FIM DB is full.
+ *
+ * @param fim_sql FIM database struct.
+ * @retval 0 if the DB is not full.
+ * @retval 1 if the DB is full.
+ */
+int fim_db_is_full(fdb_t *fim_sql);
 
 #endif /* FIM_DB_COMMON_H */

--- a/src/syscheckd/db/fim_db_files.h
+++ b/src/syscheckd/db/fim_db_files.h
@@ -44,23 +44,6 @@ fim_entry *fim_db_get_path(fdb_t *fim_sql, const char *file_path);
 char **fim_db_get_paths_from_inode(fdb_t *fim_sql, unsigned long int inode, unsigned long int dev);
 
 /**
- * @brief Get all the paths asociated to an inode
- *
- * @param fim_sql FIM databse struct.
- * @param inode Inode.
- * @param dev Device.
- * @param list A list to which the paths retrieved from the DB will be added to.
- * @param tree A tree which helps avoid the operation from appending paths that already exist in the list.
- *
- * @return The number of paths retrieved from the DB
- */
-int fim_db_append_paths_from_inode(fdb_t *fim_sql,
-                                   unsigned long int inode,
-                                   unsigned long int dev,
-                                   OSList *list,
-                                   rb_tree *tree);
-
-/**
  * @brief Insert or update entry data.
  *
  * @param fim_sql FIM database struct.
@@ -243,29 +226,15 @@ int fim_db_get_count_file_entry(fdb_t * fim_sql);
 int fim_db_get_path_from_pattern(fdb_t *fim_sql, const char *pattern, fim_tmp_file **file, int storage);
 
 /**
- * @brief Verifies if the data row identified by a given device and inode exists in file_data.
+ * @brief Makes any necessary queries to get the entry updated in the DB.
  *
  * @param fim_sql FIM database struct.
- * @param inode The inode to look for.
- * @param dev The device that must be associated with the desired inode.
- *
- * @return An integer signaling wheter the row exists or not.
- * @retval 1 if the row exists.
- * @retval 0 if the row does not exist.
- * @retval FIMDB_ERR if an error occurs when executing the query.
+ * @param path The path to the file being processed.
+ * @param data The information linked to the path to be updated
+ * @param saved If the file had information stored in the DB, that data is returned in this parameter.
+ * @return The result of the update operation.
+ * @retval Returns any of the values returned by fim_db_set_scanned and fim_db_insert.
  */
-int fim_db_data_exists(fdb_t *fim_sql, unsigned long int inode, unsigned long int dev);
-
-/**
- * @brief Checks the DB to see if a given file has already been scanned.
- *
- * @param fim_sql FIM database struct.
- * @param path Path to the file we want to verify.
- * @return An integer signaling if the files was scanned or not.
- * @retval 1 if the files was scanned already.
- * @retval 0 if tha file has not been scanned or no entry was found on the DB.
- * @retval FIMDB_ERR if an error happened during the query.
- */
-int fim_db_file_is_scanned(fdb_t *fim_sql, const char *path);
+int fim_db_file_update(fdb_t *fim_sql, const char *path, const fim_file_data *data, fim_entry **saved);
 
 #endif /* FIM_DB_FILES_H */

--- a/src/syscheckd/db/fim_db_registries.h
+++ b/src/syscheckd/db/fim_db_registries.h
@@ -77,6 +77,18 @@ int fim_db_get_registry_data_checksum(fdb_t *fim_sql, void * arg);
 int fim_db_get_registry_key_rowid(fdb_t *fim_sql, const char *path, unsigned int arch, unsigned int *rowid);
 
 /**
+ * @brief Get registry data using its key_id and name. This function must not be called from outside fim_db,
+ * use `fim_db_get_registry_data` instead.
+ *
+ * @param fim_sql FIM database struct.
+ * @param key_id ID of the registry.
+ * @param name Name of the registry value.
+ *
+ * @return FIM registry data struct on success, NULL on error.
+ */
+fim_registry_value_data *_fim_db_get_registry_data(fdb_t *fim_sql, unsigned int key_id, const char *name);
+
+/**
  * @brief Get registry data using its key_id and name.
  *
  * @param fim_sql FIM database struct.
@@ -86,6 +98,32 @@ int fim_db_get_registry_key_rowid(fdb_t *fim_sql, const char *path, unsigned int
  * @return FIM registry data struct on success, NULL on error.
  */
 fim_registry_value_data *fim_db_get_registry_data(fdb_t *fim_sql, unsigned int key_id, const char *name);
+
+/**
+ * @brief Get a registry key using its path. This function must not be called from outside fim_db,
+ * use `fim_db_get_registry_key` instead.
+ *
+ * @param fim_sql FIM database struct.
+ * @param arch An integer specifying the bit count of the register element, must be ARCH_32BIT or ARCH_64BIT.
+ * @param path Path to registry key.
+ * @param arch Architecture of the registry
+ *
+ * @return FIM registry key struct on success, NULL on error.
+*/
+fim_registry_key *_fim_db_get_registry_key(fdb_t *fim_sql, const char *path, unsigned int arch);
+
+/**
+ * @brief Get a registry key using its path.
+ *
+ * @param fim_sql FIM database struct.
+ * @param arch An integer specifying the bit count of the register element, must be ARCH_32BIT or ARCH_64BIT.
+ * @param path Path to registry key.
+ * @param arch Architecture of the registry
+ *
+ * @return FIM registry key struct on success, NULL on error.
+*/
+fim_registry_key *fim_db_get_registry_key(fdb_t *fim_sql, const char *path, unsigned int arch);
+
 
 /**
  * @brief Get all the key paths

--- a/src/syscheckd/fim_sync.c
+++ b/src/syscheckd/fim_sync.c
@@ -233,21 +233,17 @@ void fim_sync_checksum_split(const char * start, const char * top, long id) {
         component = FIM_COMPONENT_FILE;
     }
 
-    w_mutex_lock(&syscheck.fim_entry_mutex);
     if (fim_db_get_count_range(syscheck.database, type, start, top, &range_size) != FIMDB_OK) {
         merror(FIM_DB_ERROR_COUNT_RANGE, start, top);
         range_size = 0;
     }
-    w_mutex_unlock(&syscheck.fim_entry_mutex)
 
     switch (range_size) {
     case 0:
         return;
 
     case 1:
-        w_mutex_lock(&syscheck.fim_entry_mutex);
         entry = fim_db_get_entry_from_sync_msg(syscheck.database, type, start);
-        w_mutex_unlock(&syscheck.fim_entry_mutex);
 
         if (entry == NULL) {
             merror(FIM_DB_ERROR_GET_PATH, start);
@@ -268,10 +264,8 @@ void fim_sync_checksum_split(const char * start, const char * top, long id) {
         EVP_DigestInit(ctx_left, EVP_sha1());
         EVP_DigestInit(ctx_right, EVP_sha1());
 
-        w_mutex_lock(&syscheck.fim_entry_mutex);
         result = fim_db_get_checksum_range(syscheck.database, type, start, top, range_size, ctx_left, ctx_right,
                                             &str_pathlh, &str_pathuh);
-        w_mutex_unlock(&syscheck.fim_entry_mutex)
 
         if (result == FIMDB_OK) {
             unsigned char digest[EVP_MAX_MD_SIZE] = {0};
@@ -321,16 +315,13 @@ void fim_sync_send_list(const char *start, const char *top) {
         component = FIM_COMPONENT_FILE;
     }
 
-    w_mutex_lock(&syscheck.fim_entry_mutex);
     if (fim_db_get_path_range(syscheck.database, type, start, top, &file, syscheck.database_store) != FIMDB_OK) {
         merror(FIM_DB_ERROR_SYNC_DB);
         if (file != NULL) {
             fim_db_clean_file(&file, syscheck.database_store);
         }
-        w_mutex_unlock(&syscheck.fim_entry_mutex);
         return;
     }
-    w_mutex_unlock(&syscheck.fim_entry_mutex);
 
     if (file == NULL) {
         return;
@@ -346,9 +337,7 @@ void fim_sync_send_list(const char *start, const char *top) {
         cJSON *file_data;
         char *plain;
 
-        w_mutex_lock(&syscheck.fim_entry_mutex);
         entry = fim_db_get_entry_from_sync_msg(syscheck.database, type, line);
-        w_mutex_unlock(&syscheck.fim_entry_mutex);
 
         if (entry == NULL) {
             merror(FIM_DB_ERROR_GET_PATH, line);

--- a/src/syscheckd/registry/registry.c
+++ b/src/syscheckd/registry/registry.c
@@ -580,18 +580,14 @@ void fim_registry_process_key_delete_event(fdb_t *fim_sql,
         }
     }
 
-    w_mutex_lock(mutex);
     result = fim_db_get_values_from_registry_key(fim_sql, &file, syscheck.database_store, data->registry_entry.key->id);
-    w_mutex_unlock(mutex);
 
     if (result == FIMDB_OK && file && file->elements) {
         fim_db_process_read_registry_data_file(fim_sql, file, mutex, fim_registry_process_value_delete_event,
                                                syscheck.database_store, _alert, _ev_mode, _w_evt);
     }
 
-    w_mutex_lock(mutex);
     fim_db_remove_registry_key(fim_sql, data);
-    w_mutex_unlock(mutex);
 
     if (configuration->opts & CHECK_SEECHANGES) {
         fim_diff_process_delete_registry(data->registry_entry.key->path, data->registry_entry.key->arch);
@@ -606,9 +602,7 @@ void fim_registry_process_unscanned_entries() {
     fim_event_mode event_mode = FIM_SCHEDULED;
     int result;
 
-    w_mutex_lock(&syscheck.fim_entry_mutex);
     result = fim_db_get_registry_keys_not_scanned(syscheck.database, &file, syscheck.database_store);
-    w_mutex_unlock(&syscheck.fim_entry_mutex);
 
     if (result != FIMDB_OK) {
         mwarn(FIM_REGISTRY_UNSCANNED_KEYS_FAIL);
@@ -618,9 +612,7 @@ void fim_registry_process_unscanned_entries() {
                                  &event_mode, NULL);
     }
 
-    w_mutex_lock(&syscheck.fim_entry_mutex);
     result = fim_db_get_registry_data_not_scanned(syscheck.database, &file, syscheck.database_store);
-    w_mutex_unlock(&syscheck.fim_entry_mutex);
 
     if (result != FIMDB_OK) {
         mwarn(FIM_REGISTRY_UNSCANNED_VALUE_FAIL);

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -821,13 +821,9 @@ STATIC void fim_link_delete_range(directory_t *configuration) {
     // Create the sqlite LIKE pattern.
     snprintf(pattern, PATH_MAX, "%s%c%%", configuration->symbolic_links, PATH_SEP);
 
-    w_mutex_lock(&syscheck.fim_entry_mutex);
-
     if (fim_db_get_path_from_pattern(syscheck.database, pattern, &file, syscheck.database_store) != FIMDB_OK) {
         merror(FIM_DB_ERROR_RM_PATTERN, pattern);
     }
-
-    w_mutex_unlock(&syscheck.fim_entry_mutex);
 
     if (file && file->elements) {
         if (fim_db_delete_range(syscheck.database, file, &syscheck.fim_entry_mutex, syscheck.database_store,

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -52,13 +52,6 @@ typedef enum fim_scan_event {
     FIM_SCAN_END
 } fim_scan_event;
 
-typedef enum {
-    FIM_FILE_UPDATED,
-    FIM_FILE_DELETED,
-    FIM_FILE_ADDED_PATHS,
-    FIM_FILE_ERROR
-} fim_sanitize_state_t;
-
 typedef enum fim_state_db {
     FIM_STATE_DB_EMPTY,
     FIM_STATE_DB_NORMAL,

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -123,12 +123,11 @@ set(CREATE_DB_BASE_FLAGS "-Wl,--wrap,_minfo -Wl,--wrap,_merror -Wl,--wrap,_mwarn
                           -Wl,--wrap,DirSize -Wl,--wrap,seechanges_get_diff_path -Wl,--wrap,stat \
                           -Wl,--wrap,fim_file_diff -Wl,--wrap,fim_diff_process_delete_file \
                           -Wl,--wrap,fim_db_get_count_entries -Wl,--wrap,fim_db_get_path_from_pattern \
-                          -Wl,--wrap,fim_db_file_is_scanned -Wl,--wrap,fim_db_data_exists \
-                          -Wl,--wrap,fim_db_append_paths_from_inode -Wl,--wrap,pthread_rwlock_wrlock \
-                          -Wl,--wrap,pthread_rwlock_unlock -Wl,--wrap,pthread_rwlock_rdlock \
-                          -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_mutex_unlock \
-                          -Wl,--wrap,expand_wildcards -Wl,--wrap,fim_add_inotify_watch \
-                          -Wl,--wrap,fim_db_remove_wildcard_entry")
+                          -Wl,--wrap,pthread_rwlock_wrlock -Wl,--wrap,pthread_rwlock_unlock \
+                          -Wl,--wrap,pthread_rwlock_rdlock -Wl,--wrap,pthread_mutex_lock \
+                          -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,expand_wildcards -Wl,--wrap,fim_add_inotify_watch \
+                          -Wl,--wrap,fim_db_remove_wildcard_entry -Wl,--wrap,fim_db_file_update \
+                          -Wl,--wrap,fim_db_is_full")
 
 target_link_libraries(test_create_db SYSCHECK_O ${TEST_DEPS} fim_shared)
 if(${TARGET} STREQUAL "winagent")

--- a/src/unit_tests/syscheckd/db/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/db/CMakeLists.txt
@@ -18,7 +18,7 @@ set(FIM_DB_BASE_FLAGS "-Wl,--wrap=w_is_file,--wrap=remove,--wrap=sqlite3_open_v2
                        -Wl,--wrap=fprintf,--wrap=fgets,--wrap=stat,--wrap=wstr_split,--wrap=os_random \
                        -Wl,--wrap=DirSize,--wrap=IsDir,--wrap=sqlite3_column_count,--wrap=getDefine_Int,--wrap=wfopen \
                        -Wl,--wrap=fgetpos,--wrap=fgetc,--wrap=pthread_rwlock_rdlock,--wrap=pthread_rwlock_unlock \
-                       -Wl,--wrap=pthread_rwlock_wrlock")
+                       -Wl,--wrap=pthread_rwlock_wrlock,--wrap=pthread_mutex_lock,--wrap=pthread_mutex_unlock")
 
 target_link_libraries(test_fim_db SYSCHECK_O ${TEST_DEPS} fim_shared)
 if(${TARGET} STREQUAL "winagent")

--- a/src/unit_tests/syscheckd/db/expect_fim_db.c
+++ b/src/unit_tests/syscheckd/db/expect_fim_db.c
@@ -80,9 +80,11 @@ const fim_registry_value_data DEFAULT_REGISTRY_VALUE = {
  * Successfully wrappes a fim_db_check_transaction() call
  * */
 void expect_fim_db_check_transaction() {
+    expect_function_call(__wrap_pthread_mutex_lock);
     expect_fim_db_exec_simple_wquery("END;");
     expect_string(__wrap__mdebug1, formatted_msg, "Database transaction completed.");
     expect_fim_db_exec_simple_wquery("BEGIN;");
+    expect_function_call(__wrap_pthread_mutex_unlock);
 }
 
 /**
@@ -103,6 +105,8 @@ void expect_fim_db_clean_stmt() {
 }
 
 void expect_fim_db_get_count_entries(int retval) {
+    expect_function_call(__wrap_pthread_mutex_lock);
+
     expect_fim_db_clean_stmt();
 
     will_return(__wrap_sqlite3_step, 0);
@@ -110,6 +114,8 @@ void expect_fim_db_get_count_entries(int retval) {
 
     expect_value(__wrap_sqlite3_column_int, iCol, 0);
     will_return(__wrap_sqlite3_column_int, retval);
+
+    expect_function_call(__wrap_pthread_mutex_unlock);
 }
 
 void expect_fim_db_force_commit() {
@@ -145,11 +151,15 @@ void expect_fim_db_read_line_from_file_disk_success(int index, FILE *fd, const c
 }
 
 void expect_fim_db_get_path_success(const char *path, const fim_entry *entry) {
+    expect_function_call(__wrap_pthread_mutex_lock);
+
     expect_fim_db_clean_stmt();
     expect_fim_db_bind_path(path);
 
     will_return(__wrap_sqlite3_step, 0);
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
+
+    expect_function_call(__wrap_pthread_mutex_unlock);
 
     expect_fim_db_decode_full_row_from_entry(entry);
 }
@@ -163,6 +173,8 @@ int setup_fim_db_group(void **state) {
     expect_any_always(__wrap__mdebug1, formatted_msg);
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
 #ifndef TEST_SERVER
@@ -183,6 +195,8 @@ int setup_fim_db_group(void **state) {
 
 int teardown_fim_db_group(void **state) {
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
     Free_Syscheck(&syscheck);

--- a/src/unit_tests/syscheckd/db/expect_fim_db_files.c
+++ b/src/unit_tests/syscheckd/db/expect_fim_db_files.c
@@ -70,15 +70,21 @@ void expect_fim_db_bind_get_inode() {
 }
 
 void expect_fim_db_insert_path_success() {
+    expect_function_call(__wrap_pthread_mutex_lock);
+
     expect_fim_db_clean_stmt();
 
     expect_fim_db_bind_replace_path(2);
 
     will_return(__wrap_sqlite3_step, 0);
     will_return(__wrap_sqlite3_step, SQLITE_DONE);
+
+    expect_function_call(__wrap_pthread_mutex_unlock);
 }
 
 void expect_fim_db_insert_data_success(int row_id) {
+    expect_function_call(__wrap_pthread_mutex_lock);
+
     expect_fim_db_clean_stmt();
 
     if (row_id == 0) {
@@ -93,6 +99,8 @@ void expect_fim_db_insert_data_success(int row_id) {
     if (row_id == 0) {
         will_return(__wrap_sqlite3_last_insert_rowid, 1);
     }
+
+    expect_function_call(__wrap_pthread_mutex_unlock);
 }
 
 void expect_fim_db_bind_path(const char *path) {
@@ -161,6 +169,10 @@ void expect_fim_db_decode_full_row() {
 }
 
 void expect_fim_db_decode_full_row_from_entry(const fim_entry *entry) {
+    if (entry == NULL) {
+        return;
+    }
+
     expect_value(__wrap_sqlite3_column_text, iCol, 0);
     will_return(__wrap_sqlite3_column_text, entry->file_entry.path);
 

--- a/src/unit_tests/syscheckd/db/expect_fim_db_registries.c
+++ b/src/unit_tests/syscheckd/db/expect_fim_db_registries.c
@@ -97,6 +97,8 @@ void expect_fim_db_bind_registry_path(const char *path, unsigned int arch) {
 }
 
 void expect_fim_db_get_registry_key(const fim_registry_key *key) {
+    expect_function_call(__wrap_pthread_mutex_lock);
+
     expect_fim_db_clean_stmt();
     expect_fim_db_bind_registry_path(key->path, key->arch);
 
@@ -104,14 +106,18 @@ void expect_fim_db_get_registry_key(const fim_registry_key *key) {
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
     expect_fim_db_decode_registry_key(key);
+
+    expect_function_call(__wrap_pthread_mutex_unlock);
 }
 
 void expect_fim_db_get_registry_key_fail(const fim_registry_key *key) {
+    expect_function_call(__wrap_pthread_mutex_lock);
     expect_fim_db_clean_stmt();
     expect_fim_db_bind_registry_path(key->path, key->arch);
 
     will_return(__wrap_sqlite3_step, 0);
     will_return(__wrap_sqlite3_step, SQLITE_ERROR);
+    expect_function_call(__wrap_pthread_mutex_unlock);
 }
 
 void expect_fim_db_bind_registry_data_name_key_id(const char *name, int key_id) {

--- a/src/unit_tests/syscheckd/registry/test_registry.c
+++ b/src/unit_tests/syscheckd/registry/test_registry.c
@@ -793,17 +793,13 @@ static void test_fim_registry_scan_no_entries_configured(void **state) {
     expect_string(__wrap__mdebug1, formatted_msg, FIM_WINREGISTRY_START);
     expect_string(__wrap__mdebug1, formatted_msg, FIM_WINREGISTRY_ENDED);
 
-    expect_function_call(__wrap_pthread_mutex_lock);
     will_return(__wrap_fim_db_get_registry_keys_not_scanned, NULL);
     will_return(__wrap_fim_db_get_registry_keys_not_scanned, FIMDB_ERR);
-    expect_function_call(__wrap_pthread_mutex_unlock);
 
     expect_string(__wrap__mwarn, formatted_msg, FIM_REGISTRY_UNSCANNED_KEYS_FAIL);
 
-    expect_function_call(__wrap_pthread_mutex_lock);
     will_return(__wrap_fim_db_get_registry_data_not_scanned, NULL);
     will_return(__wrap_fim_db_get_registry_data_not_scanned, FIMDB_ERR);
-    expect_function_call(__wrap_pthread_mutex_unlock);
 
     expect_string(__wrap__mwarn, formatted_msg, FIM_REGISTRY_UNSCANNED_VALUE_FAIL);
 
@@ -875,15 +871,11 @@ static void test_fim_registry_scan_base_line_generation(void **state) {
 
     expect_function_call(__wrap_pthread_mutex_unlock);
 
-    expect_function_call(__wrap_pthread_mutex_lock);
     will_return(__wrap_fim_db_get_registry_keys_not_scanned, NULL);
     will_return(__wrap_fim_db_get_registry_keys_not_scanned, FIMDB_OK);
-    expect_function_call(__wrap_pthread_mutex_unlock);
 
-    expect_function_call(__wrap_pthread_mutex_lock);
     will_return(__wrap_fim_db_get_registry_data_not_scanned, NULL);
     will_return(__wrap_fim_db_get_registry_data_not_scanned, FIMDB_OK);
-    expect_function_call(__wrap_pthread_mutex_unlock);
 
     expect_string(__wrap__mdebug1, formatted_msg, FIM_WINREGISTRY_ENDED);
 
@@ -989,15 +981,11 @@ static void test_fim_registry_scan_regular_scan(void **state) {
 
     expect_function_call(__wrap_pthread_mutex_unlock);
 
-    expect_function_call(__wrap_pthread_mutex_lock);
     will_return(__wrap_fim_db_get_registry_keys_not_scanned, NULL);
     will_return(__wrap_fim_db_get_registry_keys_not_scanned, FIMDB_OK);
-    expect_function_call(__wrap_pthread_mutex_unlock);
 
-    expect_function_call(__wrap_pthread_mutex_lock);
     will_return(__wrap_fim_db_get_registry_data_not_scanned, NULL);
     will_return(__wrap_fim_db_get_registry_data_not_scanned, FIMDB_OK);
-    expect_function_call(__wrap_pthread_mutex_unlock);
 
     expect_string(__wrap__mdebug1, formatted_msg, FIM_WINREGISTRY_ENDED);
 
@@ -1018,17 +1006,13 @@ static void test_fim_registry_scan_RegOpenKeyEx_fail(void **state) {
     expect_RegOpenKeyEx_call(HKEY_LOCAL_MACHINE, "Software\\Classes\\batfile", 0,
                              KEY_READ | KEY_WOW64_64KEY, NULL, -1);
 
-    expect_function_call(__wrap_pthread_mutex_lock);
     will_return(__wrap_fim_db_get_registry_keys_not_scanned, NULL);
     will_return(__wrap_fim_db_get_registry_keys_not_scanned, FIMDB_ERR);
-    expect_function_call(__wrap_pthread_mutex_unlock);
 
     expect_string(__wrap__mwarn, formatted_msg, FIM_REGISTRY_UNSCANNED_KEYS_FAIL);
 
-    expect_function_call(__wrap_pthread_mutex_lock);
     will_return(__wrap_fim_db_get_registry_data_not_scanned, NULL);
     will_return(__wrap_fim_db_get_registry_data_not_scanned, FIMDB_ERR);
-    expect_function_call(__wrap_pthread_mutex_unlock);
 
     expect_string(__wrap__mwarn, formatted_msg, FIM_REGISTRY_UNSCANNED_VALUE_FAIL);
 
@@ -1052,17 +1036,13 @@ static void test_fim_registry_scan_RegQueryInfoKey_fail(void **state) {
                              KEY_READ | KEY_WOW64_64KEY, NULL, ERROR_SUCCESS);
     expect_RegQueryInfoKey_call(1, 0, &last_write_time, -1);
 
-    expect_function_call(__wrap_pthread_mutex_lock);
     will_return(__wrap_fim_db_get_registry_keys_not_scanned, &file);
     will_return(__wrap_fim_db_get_registry_keys_not_scanned, FIMDB_OK);
-    expect_function_call(__wrap_pthread_mutex_unlock);
 
     will_return(__wrap_fim_db_process_read_file, 0);
 
-    expect_function_call(__wrap_pthread_mutex_lock);
     will_return(__wrap_fim_db_get_registry_data_not_scanned, &file);
     will_return(__wrap_fim_db_get_registry_data_not_scanned, FIMDB_OK);
-    expect_function_call(__wrap_pthread_mutex_unlock);
 
     will_return(__wrap_fim_db_process_read_registry_data_file, 0);
 
@@ -1125,14 +1105,11 @@ static void test_fim_registry_process_key_delete_event_success(void **state) {
     fim_event_mode event_mode = FIM_SCHEDULED;
     void *w_event = NULL;
 
-    expect_function_call(__wrap_pthread_mutex_lock);
     expect_fim_db_get_values_from_registry_key_call(syscheck.database, data->file, FIM_DB_DISK, FIMDB_OK);
-    expect_function_call(__wrap_pthread_mutex_unlock);
 
     will_return(__wrap_fim_db_process_read_registry_data_file, FIMDB_OK);
-    expect_function_call(__wrap_pthread_mutex_lock);
+
     expect_fim_db_remove_registry_key_call(syscheck.database, data->entry, FIMDB_OK);
-    expect_function_call(__wrap_pthread_mutex_unlock);
 
     fim_registry_process_key_delete_event(syscheck.database, data->entry, &mutex, &alert, &event_mode, w_event);
 

--- a/src/unit_tests/syscheckd/test_fim.h
+++ b/src/unit_tests/syscheckd/test_fim.h
@@ -4,6 +4,7 @@
 #include "syscheck.h"
 #include "syscheck-config.h"
 
+#include "wrappers/posix/pthread_wrappers.h"
 #include "wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "wrappers/wazuh/shared/mq_op_wrappers.h"
 

--- a/src/unit_tests/syscheckd/test_fim_sync.c
+++ b/src/unit_tests/syscheckd/test_fim_sync.c
@@ -294,8 +294,6 @@ static void expect_fim_db_get_data_checksum_error(const fdb_t *db) {
 }
 
 static void expect_fim_db_get_count_range_n(char *start, char *stop, int n) {
-    expect_function_call(__wrap_pthread_mutex_lock);
-
     expect_value(__wrap_fim_db_get_count_range, fim_sql, syscheck.database);
     expect_value(__wrap_fim_db_get_count_range, type, FIM_TYPE_FILE);
     expect_string(__wrap_fim_db_get_count_range, start, start);
@@ -303,8 +301,6 @@ static void expect_fim_db_get_count_range_n(char *start, char *stop, int n) {
 
     will_return(__wrap_fim_db_get_count_range, n);
     will_return(__wrap_fim_db_get_count_range, FIMDB_OK);
-
-    expect_function_call(__wrap_pthread_mutex_unlock);
 }
 
 static void expect_fim_db_get_data_checksum_success(const fdb_t *db, char **first, char **last) {
@@ -321,16 +317,12 @@ static void expect_fim_db_get_data_checksum_success(const fdb_t *db, char **firs
 }
 
 static void expect_fim_db_get_entry_from_sync_msg(char *path, int type, fim_entry *mock_entry) {
-    expect_function_call(__wrap_pthread_mutex_lock);
-
     expect_value(__wrap_fim_db_get_entry_from_sync_msg, fim_sql, syscheck.database);
 #ifdef TEST_WINAGENT
     expect_value(__wrap_fim_db_get_entry_from_sync_msg, type, type);
 #endif
     expect_value(__wrap_fim_db_get_entry_from_sync_msg, path, path);
     will_return(__wrap_fim_db_get_entry_from_sync_msg, mock_entry);
-
-    expect_function_call(__wrap_pthread_mutex_unlock);
 }
 
 static void expect_fim_db_get_path_range(fdb_t *db,
@@ -340,9 +332,6 @@ static void expect_fim_db_get_path_range(fdb_t *db,
                                         int storage,
                                         fim_tmp_file *file,
                                         int ret) {
-
-    expect_function_call(__wrap_pthread_mutex_lock);
-
     expect_value(__wrap_fim_db_get_path_range, fim_sql, db);
     expect_value(__wrap_fim_db_get_path_range, type, type);
     expect_string(__wrap_fim_db_get_path_range, start, start);
@@ -350,8 +339,6 @@ static void expect_fim_db_get_path_range(fdb_t *db,
     expect_value(__wrap_fim_db_get_path_range, storage, storage);
     will_return(__wrap_fim_db_get_path_range, file);
     will_return(__wrap_fim_db_get_path_range, ret);
-
-    expect_function_call(__wrap_pthread_mutex_unlock);
 }
 
 static void expect_fim_db_read_line_from_file(fim_tmp_file *file, int storage, int it, char *buffer, int ret) {
@@ -477,14 +464,12 @@ static void test_fim_sync_checksum_split_get_count_range_error(void **state) {
     char buffer[256];
 
     snprintf(buffer, 256, FIM_DB_ERROR_COUNT_RANGE, first, last);
-    expect_function_call(__wrap_pthread_mutex_lock);
     expect_value(__wrap_fim_db_get_count_range, fim_sql, syscheck.database);
     expect_value(__wrap_fim_db_get_count_range, type, FIM_TYPE_FILE);
     expect_string(__wrap_fim_db_get_count_range, start, first);
     expect_string(__wrap_fim_db_get_count_range, top, last);
     will_return(__wrap_fim_db_get_count_range, 0);
     will_return(__wrap_fim_db_get_count_range, FIMDB_ERR);
-    expect_function_call(__wrap_pthread_mutex_unlock);
 
     expect_string(__wrap__merror, formatted_msg, buffer);
 
@@ -533,8 +518,6 @@ static void test_fim_sync_checksum_split_range_size_1_get_path_error(void **stat
 static void test_fim_sync_checksum_split_range_size_default(void **state) {
     expect_fim_db_get_count_range_n("start", "top", 2);
 
-    expect_function_call(__wrap_pthread_mutex_lock);
-
     expect_value(__wrap_fim_db_get_checksum_range, fim_sql, syscheck.database);
     expect_string(__wrap_fim_db_get_checksum_range, start, "start");
     expect_string(__wrap_fim_db_get_checksum_range, top, "top");
@@ -544,7 +527,6 @@ static void test_fim_sync_checksum_split_range_size_default(void **state) {
     will_return(__wrap_fim_db_get_checksum_range, strdup("path2"));
     will_return(__wrap_fim_db_get_checksum_range, FIMDB_OK);
 
-    expect_function_call(__wrap_pthread_mutex_unlock);
     expect_dbsync_check_msg_call("fim_file", INTEGRITY_CHECK_LEFT, 1234, "start", "path1", "path2",
                                  strdup("plain_text"));
 

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
@@ -343,40 +343,34 @@ void expect_fim_db_remove_path(fdb_t *fim_sql, char *path, int ret_val) {
     will_return(__wrap_fim_db_remove_path, ret_val);
 }
 
-int __wrap_fim_db_file_is_scanned(__attribute__((unused)) fdb_t *fim_sql, const char *path) {
+void expect_fim_db_insert(fdb_t *db, const char *file_path, int ret) {
+    expect_value(__wrap_fim_db_insert, fim_sql, db);
+    expect_string(__wrap_fim_db_insert, file_path, file_path);
+    will_return(__wrap_fim_db_insert, ret);
+}
+
+void expect_fim_db_set_scanned(fdb_t *db, const char *file_path, int ret) {
+    expect_value(__wrap_fim_db_set_scanned, fim_sql, db);
+    expect_string(__wrap_fim_db_set_scanned, path, file_path);
+    will_return(__wrap_fim_db_set_scanned, ret);
+}
+
+int __wrap_fim_db_file_update(fdb_t *fim_sql,
+                              const char *path,
+                              const __attribute__((unused)) fim_file_data *data,
+                              fim_entry **saved) {
+    check_expected_ptr(fim_sql);
     check_expected(path);
+
+    if (saved != NULL) {
+        *saved = mock_type(fim_entry *);
+    }
+
     return mock();
 }
 
-int __wrap_fim_db_data_exists(__attribute__((unused)) fdb_t *fim_sql, unsigned long int inode, unsigned long int dev) {
-    check_expected(inode);
-    check_expected(dev);
+int __wrap_fim_db_is_full(fdb_t *fim_sql) {
+    check_expected_ptr(fim_sql);
+
     return mock();
-}
-
-int __wrap_fim_db_append_paths_from_inode(__attribute__((unused)) fdb_t *fim_sql,
-                                          unsigned long int inode,
-                                          unsigned long int dev,
-                                          OSList *list,
-                                          rb_tree *tree) {
-    char **paths;
-    int i;
-
-    check_expected(inode);
-    check_expected(dev);
-    assert_non_null(list);
-    assert_non_null(tree);
-
-    paths = mock_type(char **);
-    if (paths == NULL) {
-        return 0;
-    }
-
-    for (i = 0; paths[i]; i++) {
-        rb_node *leaf = rbtree_insert(tree, paths[i], NULL);
-
-        OSList_AddData(list, leaf->key);
-    }
-
-    return i;
 }

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
@@ -177,4 +177,11 @@ int __wrap_fim_db_append_paths_from_inode(fdb_t *fim_sql,
                                           OSList *list,
                                           rb_tree *tree);
 
+int __wrap_fim_db_file_update(fdb_t *fim_sql,
+                              const char *path,
+                              const __attribute__((unused)) fim_file_data *data,
+                              fim_entry **saved);
+
+int __wrap_fim_db_is_full(fdb_t *fim_sql);
+
 #endif


### PR DESCRIPTION
|Related issue|
|---|
|#8856|

## Description

This PR closes #8856, by deleting most of the code added by #7990. Some functions were kept since they allowed for cleaner and more maintainable code.

We also added a mutex to the `fdb_t` struct in order to move responsibility of keeping access to the DB thread safe into files linked to the DB themselves. If the outside code needs to make multiple accesses to the DB or needs some other operation to be atomic `fim_entry_mutex` must be used, otherwise, accesses to the DB that set/get a value can now be made by directly calling the appropriate DB function.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] AddressSanitizer + UBSanitizer
  - [x] ThreadSanitizer
- Memory tests for Windows
  - [x] Scan-build report

- [x] Added unit tests (for new features)
