### PR TITLE
Improve log message of the Vulnerability Detector scan result on removed vulnerabilities

### DIFF
--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -95,6 +95,7 @@
 #define VU_ERROR_CMP_VER      "(5487): Unknown relation '%s' between versions '%s' and '%s' for package '%s'"
 #define VU_DISCARD_CVE_ENTRY  "(5488): Package '%s' not affected by '%s' with misleading condition (%s '%s')."
 #define VU_AG_BASELINE_SCAN   "(5489): A baseline scan will be run on agent '%.3d'"
+#define VU_REMOVED_VULN       "(5490): The vulnerability '%s' affecting '%s' was eliminated"
 
 /* File integrity monitoring debug messages */
 #define FIM_DIFF_SKIPPED                    "(6200): Diff execution skipped for containing insecure characters."

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -18774,9 +18774,24 @@ void test_wm_vuldet_find_obsolete_vulnerabilities_report_fail() {
     will_return(__wrap_wdb_remove_vuln_cves_by_status, j_obsolete_vulns);
     expect_string(__wrap__mdebug1, formatted_msg, "Error trying to send removed CVEs report of agent: 1");
 
+    // Vulnerability removed log    
+    will_return(__wrap_cJSON_GetStringValue, "PACKAGE");
+    will_return(__wrap_cJSON_GetStringValue, "CVE");
+    expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5490): The vulnerability 'CVE' affecting 'PACKAGE' was eliminated");
     // wm_vuldet_send_removed_cve_report
-    will_return_count(__wrap_cJSON_GetObjectItem, NULL, -1);
-    will_return_count(__wrap_cJSON_GetStringValue, NULL, -1);
+    will_return_count(__wrap_cJSON_GetStringValue, NULL, 6);
+
+    // Vulnerability removed log (nvd)
+    will_return(__wrap_cJSON_GetStringValue, "PACKAGE_nvd");
+    will_return(__wrap_cJSON_GetStringValue, "CVE_nvd");
+    expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5490): The vulnerability 'CVE_nvd' affecting 'PACKAGE_nvd' was eliminated");
+    // wm_vuldet_send_removed_cve_report (nvd)
+    will_return_count(__wrap_cJSON_GetStringValue, NULL, 6);
+
+    // wm_vuldet_send_removed_cve_report
+    will_return_count(__wrap_cJSON_GetObjectItem, NULL, -1);    
     will_return_count(__wrap_cJSON_CreateObject, NULL, 3);
     expect_function_calls(__wrap_cJSON_AddItemToObject, 2);
     will_return_count(__wrap_cJSON_AddItemToObject, 0, -1);
@@ -18787,7 +18802,7 @@ void test_wm_vuldet_find_obsolete_vulnerabilities_report_fail() {
     expect_string(__wrap_wdb_remove_vuln_cves_by_status, status, VULN_CVES_STATUS_OBSOLETE);
     will_return(__wrap_wdb_remove_vuln_cves_by_status, j_obsolete_vulns);
     expect_string(__wrap__mdebug1, formatted_msg, "Error trying to send removed CVEs report of agent: 1");
-
+    
     // wm_vuldet_send_removed_cve_report
     will_return_count(__wrap_cJSON_CreateObject, NULL, 3);
     expect_function_calls(__wrap_cJSON_AddItemToObject, 2);
@@ -18801,7 +18816,7 @@ void test_wm_vuldet_find_obsolete_vulnerabilities_report_fail() {
     __real_cJSON_Delete(j_obsolete_vulns);
 }
 
-/*Tests wm_vuldet_find_obsolete_vulnerabilities */
+/*Tests wm_vuldet_send_removed_cve */
 
 void test_wm_vuldet_send_removed_cve_report_fail() {
     int retval;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2359,6 +2359,9 @@ int wm_vuldet_find_obsolete_vulnerabilities(scan_ctx_t* scan_ctx) {
         return OS_INVALID;
     }
     cJSON_ArrayForEach(j_vuln, j_obsolete_vulns) {
+        char* package_name = cJSON_GetStringValue(cJSON_GetObjectItem(j_vuln, "name"));
+        char* cve_id = cJSON_GetStringValue(cJSON_GetObjectItem(j_vuln, "cve")); 
+        mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_REMOVED_VULN, cve_id, package_name);
         if (wm_vuldet_send_removed_cve_report(j_vuln, scan_ctx) ) {
             mdebug1("Error trying to send removed CVEs report of agent: %d", scan_ctx->agent_id);
             retval = OS_INVALID;
@@ -2371,6 +2374,9 @@ int wm_vuldet_find_obsolete_vulnerabilities(scan_ctx_t* scan_ctx) {
         return OS_INVALID;
     }
     cJSON_ArrayForEach(j_vuln, j_obsolete_vulns) {
+        char* package_name = cJSON_GetStringValue(cJSON_GetObjectItem(j_vuln, "name"));
+        char* cve_id = cJSON_GetStringValue(cJSON_GetObjectItem(j_vuln, "cve"));
+        mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_REMOVED_VULN, cve_id, package_name);
         if (wm_vuldet_send_removed_cve_report(j_vuln, scan_ctx) ) {
             mdebug1("Error trying to send removed CVEs report of agent: %d", scan_ctx->agent_id);
             retval = OS_INVALID;


### PR DESCRIPTION
|Related issue|
|---|
|#8970|

## Description
This PR includes improvements to the log messages after the Vulnerability Detector scan.
- It creates a message `The vulnerability 'CVE-000' affecting 'wazuhintegrationpackage-0' was eliminated` when the vulnerability is removed from the inventory.

## Logs/Alerts example
![image](https://user-images.githubusercontent.com/11434230/121969412-8bb37500-cd4a-11eb-8bfc-14cf1de66cc2.png)

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Package installation
- [X] Source upgrade
- [X] Package upgrade

