### PR TITLE
Update Makefile's "clean" rule to remove pacman-related object files

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2270,8 +2270,9 @@ ifneq ($(wildcard external/libarchive/Makefile),)
 	cd ${EXTERNAL_LIBARCHIVE} && ${MAKE} clean
 endif
 
-ifneq ($(wildcard external/pacman/lib/libalpm/libalpm.a),)
-	rm $(EXTERNAL_PACMAN)lib/libalpm/libalpm.a
+ifneq ($(wildcard external/pacman/lib/libalpm/*),)
+	rm -f $(EXTERNAL_PACMAN)lib/libalpm/libalpm.a
+	rm -f $(EXTERNAL_PACMAN)lib/libalpm/*.o
 endif
 endif
 


### PR DESCRIPTION
## Description

Hi team,

This _Pull Request_ aims to modify the `clean` rule in Wazuh's main **Makefile**, so it deletes all the `.o` files related to the **pacman** external library.

Before this change was introduced, only the `libalpm.a` library was deleted when cleaning **pacman**-related dependencies, leaving all the `.o` files inside their correspondent repository. However, this behavior contrasted with the one expected when cleaning the remaining external libraries.

Best regards,
Álvaro Romero

## Logs/Alerts example

```sh
$ make clean
...
rm -f external/pacman/lib/libalpm/libalpm.a
rm -f external/pacman/lib/libalpm/*.o
...
````

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux

