### PR TITLE
Applied test_sort_response function to all integration tests that use the sort parameter

### DIFF
--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -142,7 +142,7 @@ def test_sort_response(response, key=None, reverse=False):
         except KeyError:
             return ''
 
-        if isinstance(dictionary, str):
+        if isinstance(dictionary, str) and not dictionary.startswith('/') and not dictionary.startswith('\\'):
             return dictionary.lower()
 
         return dictionary

--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -141,6 +141,10 @@ def test_sort_response(response, key=None, reverse=False):
                 dictionary = dictionary[key]
         except KeyError:
             return ''
+
+        if isinstance(dictionary, str):
+            return dictionary.lower()
+
         return dictionary
 
     affected_items = response.json()['data']['affected_items']

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -49,12 +49,6 @@ stages:
             key: "id"
             reverse: true
       status_code: 200
-      json: &basic_response_inverse
-        error: 0
-        data:
-          failed_items: [ ]
-          total_affected_items: !anyint
-          total_failed_items: 0
 
   - name: Get all agents sorted by multiple fields
     request:
@@ -66,14 +60,8 @@ stages:
       verify_response_with:
         - function: tavern_utils:test_sort_response
           extra_kwargs:
-            key: "os.name,os.major,os.minor"
+            key: "os.name,os.major"
       status_code: 200
-      json:
-        error: 0
-        data:
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
 
   - name: Get all agents sorted by status
     request:
@@ -87,12 +75,6 @@ stages:
           extra_kwargs:
             key: "status"
       status_code: 200
-      json:
-        error: 0
-        data:
-          failed_items: [ ]
-          total_affected_items: 13
-          total_failed_items: 0
 
   - name: Pagination with offset 0 and limit 2
     request:
@@ -189,27 +171,6 @@ stages:
         limit: 999999
     response:
       status_code: 400
-
-  - name: Sort
-    request:
-      verify: False
-      <<: *get_agents
-      params:
-        sort: -id
-        limit: 2
-    response:
-      verify_response_with:
-        - function: tavern_utils:test_sort_response
-          extra_kwargs:
-            key: "id"
-            reverse: true
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          failed_items: []
-          total_affected_items: 13
-          total_failed_items: 0
 
   - name: Try to show agents using wrong sort
     request:
@@ -2241,12 +2202,6 @@ stages:
             key: "name"
             reverse: true
       status_code: 200
-      json:
-        error: !anyint
-        data:
-          failed_items: []
-          total_affected_items: 4
-          total_failed_items: 0
 
   - name: Try to show groups with wrong sort
     request:
@@ -2501,12 +2456,6 @@ stages:
             key: "id"
             reverse: true
       status_code: 200
-      json:
-        error: !anyint
-        data:
-          failed_items: []
-          total_affected_items: 4
-          total_failed_items: 0
 
   - name: Try show agents with wrong sort
     request:
@@ -2790,12 +2739,6 @@ stages:
           extra_kwargs:
             key: "{field}"
       status_code: 200
-      json:
-        error: !anyint
-        data:
-          failed_items: []
-          total_affected_items: 4
-          total_failed_items: 0
 
 ---
 test_name: GET /groups/{group_id}/configuration
@@ -3097,12 +3040,6 @@ stages:
             key: "hash"
             reverse: true
       status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
-          total_failed_items: 0
-          failed_items: []
 
   - name: Try get the files of a group with wrong sort
     request:
@@ -3497,12 +3434,6 @@ stages:
             key: "id"
             reverse: true
       status_code: 200
-      json:
-        error: !anyint
-        data:
-          failed_items: []
-          total_affected_items: 2
-          total_failed_items: 0
 
   - name: Try show agents with wrong sort
     request:
@@ -3610,8 +3541,6 @@ stages:
           extra_kwargs:
             key: "{field}"
       status_code: 200
-      json:
-        <<: *no_group_response
 
   - name: Select
     request:
@@ -3653,12 +3582,6 @@ stages:
             key: "id"
             reverse: true
       status_code: 200
-      json:
-        error: !anyint
-        data: &outdated_agents_response
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
 
   - name: Pagination
     request:
@@ -3669,16 +3592,13 @@ stages:
         limit: 1
         sort: -id
     response:
-      verify_response_with:
-        - function: tavern_utils:test_sort_response
-          extra_kwargs:
-            key: "id"
-            reverse: true
       status_code: 200
       json:
         error: !anyint
         data:
-          failed_items: []
+          affected_items:
+            - id: '009'
+          failed_items: [ ]
           total_affected_items: !anyint
           total_failed_items: 0
 
@@ -3771,12 +3691,6 @@ stages:
             key: "id"
             reverse: true
       status_code: 200
-      json:
-        error: !anyint
-        data:
-          failed_items: [ ]
-          total_affected_items: 2
-          total_failed_items: 0
 
   - name: Filter agents by query
     request:
@@ -4016,9 +3930,12 @@ stages:
       params:
         sort: -id
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "id"
+            reverse: true
       status_code: 200
-      json:
-        <<: *basic_response_inverse
 
   - name: Try to show agents with wrong sort
     request:

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -43,26 +43,17 @@ stages:
       params:
         sort: -id
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "id"
+            reverse: true
       status_code: 200
       json: &basic_response_inverse
-        error: !anyint
+        error: 0
         data:
-          affected_items:
-            - id: '012'
-            - id: '011'
-            - id: '010'
-            - id: '009'
-            - id: '008'
-            - id: '007'
-            - id: '006'
-            - id: '005'
-            - id: '004'
-            - id: '003'
-            - id: '002'
-            - id: '001'
-            - id: '000'
-          failed_items: []
-          total_affected_items: 13
+          failed_items: [ ]
+          total_affected_items: !anyint
           total_failed_items: 0
 
   - name: Get all agents sorted by multiple fields
@@ -207,13 +198,15 @@ stages:
         sort: -id
         limit: 2
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "id"
+            reverse: true
       status_code: 200
       json:
         error: !anyint
         data:
-          affected_items:
-            - id: '012'
-            - id: '011'
           failed_items: []
           total_affected_items: 13
           total_failed_items: 0
@@ -2242,19 +2235,15 @@ stages:
       params:
         sort: -name
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "name"
+            reverse: true
       status_code: 200
       json:
         error: !anyint
         data:
-          affected_items:
-            - name: 'group3'
-              count: 4
-            - name: 'group2'
-              count: 5
-            - name: 'group1'
-              count: 5
-            - name: 'default'
-              count: 10
           failed_items: []
           total_affected_items: 4
           total_failed_items: 0
@@ -2506,14 +2495,15 @@ stages:
         sort: -id
         limit: 3
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "id"
+            reverse: true
       status_code: 200
       json:
         error: !anyint
         data:
-          affected_items:
-            - id: '008'
-            - id: '007'
-            - id: '006'
           failed_items: []
           total_affected_items: 4
           total_failed_items: 0
@@ -2795,15 +2785,14 @@ stages:
       params:
         sort: "{field}"
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "{field}"
       status_code: 200
       json:
         error: !anyint
         data:
-          affected_items:
-            - id: !anystr
-            - id: !anystr
-            - id: !anystr
-            - id: !anystr
           failed_items: []
           total_affected_items: 4
           total_failed_items: 0
@@ -3102,11 +3091,15 @@ stages:
       params:
         sort: -hash
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "hash"
+            reverse: true
       status_code: 200
       json:
         error: !anyint
         data:
-          affected_items: !anything
           total_affected_items: !anyint
           total_failed_items: 0
           failed_items: []
@@ -3498,13 +3491,15 @@ stages:
       params:
         sort: -id
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "id"
+            reverse: true
       status_code: 200
       json:
         error: !anyint
         data:
-          affected_items:
-            - id: '012'
-            - id: '011'
           failed_items: []
           total_affected_items: 2
           total_failed_items: 0
@@ -3610,6 +3605,10 @@ stages:
       params:
         sort: "{field}"
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "{field}"
       status_code: 200
       json:
         <<: *no_group_response
@@ -3648,17 +3647,15 @@ stages:
       params:
         sort: -id
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "id"
+            reverse: true
       status_code: 200
       json:
         error: !anyint
         data: &outdated_agents_response
-          affected_items:
-            - id: '010'
-            - id: '009'
-            - id: '008'
-            - id: '007'
-            - id: '006'
-            - id: '005'
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
@@ -3672,12 +3669,15 @@ stages:
         limit: 1
         sort: -id
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "id"
+            reverse: true
       status_code: 200
       json:
         error: !anyint
         data:
-          affected_items:
-            - id: '009'
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
@@ -3765,13 +3765,15 @@ stages:
         q: group=default;lastKeepAlive>1d
         sort: -id
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "id"
+            reverse: true
       status_code: 200
       json:
         error: !anyint
         data:
-          affected_items:
-            - id: '010'
-            - id: '009'
           failed_items: [ ]
           total_affected_items: 2
           total_failed_items: 0

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -234,23 +234,11 @@ stages:
       params:
         sort: name
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "name"
       status_code: 200
-      json:
-        error: !anyint
-        data:
-          affected_items:
-            - <<: *cluster_nodes_response
-              type: master
-              name: master-node
-            - <<: *cluster_nodes_response
-              type: worker
-              name: worker1
-            - <<: *cluster_nodes_response
-              type: worker
-              name: worker2
-          failed_items: []
-          total_affected_items: 3
-          total_failed_items: 0
 
   - name: Sort nodes by name in descending order
     request:
@@ -259,23 +247,12 @@ stages:
       params:
         sort: -name
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "name"
+            reverse: true
       status_code: 200
-      json:
-        error: !anyint
-        data:
-          affected_items:
-            - <<: *cluster_nodes_response
-              type: worker
-              name: worker2
-            - <<: *cluster_nodes_response
-              type: worker
-              name: worker1
-            - <<: *cluster_nodes_response
-              type: master
-              name: master-node
-          failed_items: []
-          total_affected_items: 3
-          total_failed_items: 0
 
   - name: Search master
     request:
@@ -1491,16 +1468,11 @@ stages:
         limit: 2
         sort: tag
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "tag"
       status_code: 200
-      json:
-        error: !anyint
-        data:
-          affected_items:
-            - <<: *cluster_log
-            - <<: *cluster_log
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
 
   - name: Read logs with filters -> limit=1, sort=-level {node_id}
     request:
@@ -1510,15 +1482,12 @@ stages:
         limit: 1
         sort: -level
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "level"
+            reverse: true
       status_code: 200
-      json:
-        error: !anyint
-        data:
-          affected_items:
-            - <<: *cluster_log
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
 
   - name: Read logs with filters -> offset=2, limit=3 {node_id}
     request:

--- a/api/test/integration/test_decoder_endpoints.tavern.yaml
+++ b/api/test/integration/test_decoder_endpoints.tavern.yaml
@@ -343,14 +343,11 @@ stages:
         limit: 1
         sort: "{field}"
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "{field}"
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: *full_items_array
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: !anyint
 
     # GET /decoders?limit=1&sort=-{field}
   - name: Try to get decoders using an descendent sorted field answer
@@ -361,14 +358,12 @@ stages:
         limit: 1
         sort: "-{field}"
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "{field}"
+            reverse: true
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: *full_items_array
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: !anyint
 
 ---
 test_name: GET /decoders/{decoder_name}
@@ -520,17 +515,11 @@ stages:
       params:
         sort: "{field}"
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "{field}"
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: !anything
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: !anyint
-      save:
-        json:
-          total_items: data.total_affected_items
 
     # GET /decoders/auditd-selinux_macstatus?sort=-{field}
   - name: Try to get all decoders with specified decoder_name using an descendent sorted field answer
@@ -540,14 +529,12 @@ stages:
       params:
         sort: "-{field}"
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "{field}"
+            reverse: true
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: !anything
-          failed_items: []
-          total_affected_items: !int "{total_items}"
-          total_failed_items: !anyint
 
 ---
 test_name: GET /decoders/files
@@ -768,14 +755,12 @@ stages:
         limit: 1
         sort: "{field}"
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "{field}"
+            reverse: true
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: *full_items_array_files
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: !anyint
 
     # GET /decoders/files?limit=1&sort=-{field}
   - name: Try to get information about all decoders files using a descendent sorted field answer
@@ -786,14 +771,12 @@ stages:
         limit: 1
         sort: "-{field}"
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "{field}"
+            reverse: true
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: *full_items_array_files
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: !anyint
 
 ---
 test_name: GET /decoders/parents
@@ -951,12 +934,11 @@ stages:
         limit: 1
         sort: "{field}"
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "{field}"
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: *full_items_array_parents
-          total_affected_items: !anyint
 
   # GET /decoders/parents?limit=1&sort=-{field}
   - name: Try to get information about all decoders parents using a descendent sorted field answer
@@ -967,12 +949,12 @@ stages:
         limit: 1
         sort: "-{field}"
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "{field}"
+            reverse: true
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: *full_items_array_parents
-          total_affected_items: !anyint
 
 ---
 test_name: GET /decoders/files/{file}

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -541,16 +541,12 @@ stages:
         limit: 2
         sort: -level
     response:
-        status_code: 200
-        json:
-          error: !anyint
-          data:
-            affected_items:
-              - <<: *manager_log
-              - <<: *manager_log
-            failed_items: []
-            total_affected_items: !anyint
-            total_failed_items: 0
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "level"
+            reverse: true
+      status_code: 200
 
   # GET /manager/logs
   - name: Filters -> offset=3, limit=3

--- a/api/test/integration/test_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_mitre_endpoints.tavern.yaml
@@ -160,13 +160,6 @@ stages:
             key: "techniques"
             reverse: True
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: !anything
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
 
   - name: Show mitigations using valid select
     request:
@@ -441,22 +434,14 @@ stages:
       verify: False
       <<: *general_references_request
       params:
-        sort: -source
+        sort: source
         limit: 3
     response:
       verify_response_with:
         - function: tavern_utils:test_sort_response
           extra_kwargs:
             key: "source"
-            reverse: True
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: !anything
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
 
   - name: Show references using valid select
     request:
@@ -751,13 +736,6 @@ stages:
             key: "techniques"
             reverse: True
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: !anything
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
 
   - name: Try to show tactics using valid select
     request:
@@ -1055,13 +1033,6 @@ stages:
             key: "mitigations"
             reverse: True
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: !anything
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
 
   - name: Try to show techniques using valid select
     request:
@@ -1350,13 +1321,6 @@ stages:
             key: "software"
             reverse: True
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: !anything
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
 
   - name: Show groups using valid select
     request:
@@ -1645,13 +1609,6 @@ stages:
             key: "groups"
             reverse: True
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: !anything
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
 
   - name: Show softwares using valid select
     request:

--- a/api/test/integration/test_rootcheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rootcheck_endpoints.tavern.yaml
@@ -419,14 +419,11 @@ stages:
       params:
         sort: +log
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "log"
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: !anything
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
 
   # GET /rootcheck/001?sort=-log
   - name: Sort response (descending)
@@ -441,7 +438,6 @@ stages:
           extra_kwargs:
             key: "log"
             reverse: True
-
 
 ---
 test_name: GET /rootcheck/001/last_scan

--- a/api/test/integration/test_rule_endpoints.tavern.yaml
+++ b/api/test/integration/test_rule_endpoints.tavern.yaml
@@ -140,13 +140,6 @@ stages:
             key: "filename"
             reverse: True
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: !anything
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
 
   - name: Sort rules by multiple fields
     request:
@@ -160,13 +153,6 @@ stages:
           extra_kwargs:
             key: "level,filename"
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: !anything
-          failed_items: [ ]
-          total_affected_items: !anyint
-          total_failed_items: 0
 
   - name: Show rules of the system using valid select
     request:
@@ -831,7 +817,7 @@ stages:
     response:
       status_code: 400
 
-  - name: Filter sort
+  - name: Test limit
     request:
       verify: False
       <<: *pci_dss_rules_request
@@ -860,13 +846,6 @@ stages:
             reverse: True
             # No `key` parameter needed as we are sorting a list of strings
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: !anything
-          failed_items: [ ]
-          total_affected_items: !anyint
-          total_failed_items: 0
 
   - name: Filter search
     request:
@@ -976,13 +955,6 @@ stages:
             reverse: True
             # No `key` parameter needed as we are sorting a list of strings
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: !anything
-          failed_items: [ ]
-          total_affected_items: !anyint
-          total_failed_items: 0
 
   - name: Filter search
     request:
@@ -1091,21 +1063,12 @@ stages:
       verify: False
       <<: *gpg13_rules_request
       params:
-        sort: "-"
+        sort: "+"
     response:
       verify_response_with:
         - function: tavern_utils:test_sort_response
-          extra_kwargs:
-            reverse: True
-            # No `key` parameter needed as we are sorting a list of strings
+          # No `key` parameter needed as we are sorting a list of strings
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: !anything
-          failed_items: [ ]
-          total_affected_items: !anyint
-          total_failed_items: 0
 
   - name: Filter search
     request:
@@ -1193,13 +1156,6 @@ stages:
             reverse: True
             # No `key` parameter needed as we are sorting a list of strings
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: !anything
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
 
   - name: Filter search
     request:
@@ -1287,13 +1243,6 @@ stages:
             reverse: True
             # No `key` parameter needed as we are sorting a list of strings
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: !anything
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
 
   - name: Filter search
     request:
@@ -1373,21 +1322,12 @@ stages:
       verify: False
       <<: *tsc_rules_request
       params:
-        sort: "-"
+        sort: "+"
     response:
       verify_response_with:
         - function: tavern_utils:test_sort_response
-          extra_kwargs:
-            reverse: True
-            # No `key` parameter needed as we are sorting a list of strings
+          # No `key` parameter needed as we are sorting a list of strings
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: !anything
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
 
   - name: Filter search
     request:
@@ -1475,13 +1415,6 @@ stages:
             reverse: True
             # No `key` parameter needed as we are sorting a list of strings
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: !anything
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
 
   - name: Filter search
     request:
@@ -1561,21 +1494,12 @@ stages:
       verify: False
       <<: *groups_rules_request
       params:
-        sort: "-"
+        sort: "+"
     response:
       verify_response_with:
         - function: tavern_utils:test_sort_response
-          extra_kwargs:
-            reverse: True
-            # No `key` parameter needed as we are sorting a list of strings
+          # No `key` parameter needed as we are sorting a list of strings
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: !anything
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
 
   - name: Filter search
     request:
@@ -1663,13 +1587,6 @@ stages:
             key: "filename"
             reverse: True
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: !anything
-          failed_items: [ ]
-          total_affected_items: !anyint
-          total_failed_items: 0
 
   - name: Invalid filter
     request:
@@ -2059,23 +1976,14 @@ stages:
       verify: False
       <<: *id_rules_request
       params:
-        sort: -filename
+        sort: filename
         rule_ids: 1
     response:
       verify_response_with:
         - function: tavern_utils:test_sort_response
           extra_kwargs:
             key: "filename"
-            reverse: True
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - <<: *rules_response
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
 
   - name: Filter search error
     request:

--- a/api/test/integration/test_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_sca_endpoints.tavern.yaml
@@ -195,7 +195,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Parameters -> sort=-score,limit=1
+  - name: Parameters -> sort=-score,limit=10
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/sca/001"
@@ -203,48 +203,15 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
-        limit: 1
+        limit: 10
         sort: -score
     response:
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - <<: *sca_agent_result_001
-          failed_items: []
-          total_affected_items: 1
-          total_failed_items: 0
       verify_response_with:
         - function: tavern_utils:test_sort_response
           extra_kwargs:
             key: "score"
             reverse: True
-
-  - name: Parameters -> sort=+score,limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        sort: +score
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - <<: *sca_agent_result_001
-          failed_items: []
-          total_affected_items: 1
-          total_failed_items: 0
-      verify_response_with:
-        - function: tavern_utils:test_sort_response
-          extra_kwargs:
-            key: "score"
 
   # Testing GET /sca/006
   - name: Parameters -> limit=2
@@ -414,21 +381,12 @@ stages:
         limit: 2
         sort: -score
     response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - <<: *sca_agent_result_006
-            - <<: *sca_agent_result_006
-          failed_items: [ ]
-          total_affected_items: 2
-          total_failed_items: 0
       verify_response_with:
         - function: tavern_utils:test_sort_response
           extra_kwargs:
             key: "score"
             reverse: True
+      status_code: 200
 
   - name: Parameters -> sort=+score,limit=2
     request:
@@ -441,20 +399,11 @@ stages:
         limit: 2
         sort: +score
     response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - <<: *sca_agent_result_006
-            - <<: *sca_agent_result_006
-          failed_items: [ ]
-          total_affected_items: 2
-          total_failed_items: 0
       verify_response_with:
         - function: tavern_utils:test_sort_response
           extra_kwargs:
             key: "score"
+      status_code: 200
 
 ---
 test_name: GET /sca/001/checks/cis_debian9 (001 is an agent with version >=4.2.0)
@@ -556,21 +505,12 @@ stages:
         limit: 2
         sort: -id
     response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - <<: *sca_check_result_001
-            - <<: *sca_check_result_001
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
       verify_response_with:
         - function: tavern_utils:test_sort_response
           extra_kwargs:
             key: "id"
             reverse: True
+      status_code: 200
 
   - name: Parameters -> search=passwd,limit=1
     request:
@@ -1014,16 +954,12 @@ stages:
         limit: 2
         sort: -id
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "id"
+            reverse: true
       status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_check_result_006
-            - <<: *sca_check_result_006
-          failed_items: []
-          total_failed_items: 0
 
   - name: Parameters -> search=passwd,limit=1
     request:

--- a/api/test/integration/test_security_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_GET_endpoints.tavern.yaml
@@ -98,52 +98,26 @@ stages:
       <<: *all_roles_request
       params:
         sort: name
-        limit: 2
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "name"
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - <<: *roles
-            - <<: *roles
-          total_affected_items: !anyint
-      save:
-        json:
-          second_role_id: data.affected_items[1].id
-          second_role_name: data.affected_items[1].name
 
   # GET /security/roles
-  - name: Sort the roles, limit=2, offset=1
-    request:
-      <<: *all_roles_request
-      params:
-        sort: name
-        limit: 2
-        offset: 1
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-          - id: !int "{second_role_id}"
-            name: "{second_role_name}"
-          - <<: *roles
-          total_affected_items: !anyint
-
-  # GET /security/roles
-  - name: Sort without limit
+  - name: Sort without limit (reverse)
     request:
       <<: *all_roles_request
       params:
         sort: -name
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "name"
+            reverse: true
       status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: !anyint
 
   # GET /security/roles
   - name: Select role name
@@ -471,30 +445,25 @@ stages:
     request:
       <<: *all_policies_request
       params:
-        sort: -name
-        limit: 2
+        sort: name
     response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - <<: *policies
-            - <<: *policies
-          total_affected_items: !anyint
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "name"
 
   # GET /security/policies
-  - name: Sort without limit
+  - name: Sort the policies (reverse)
     request:
       <<: *all_policies_request
       params:
         sort: -name
     response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: !anyint
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "name"
+            reverse: true
 
   # GET /security/policies
   - name: Select policy id
@@ -771,52 +740,26 @@ stages:
       <<: *all_rules_request
       params:
         sort: name
-        limit: 2
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "name"
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - <<: *rules
-            - <<: *rules
-          total_affected_items: !anyint
-      save:
-        json:
-          second_rule_id: data.affected_items[1].id
-          second_rule_name: data.affected_items[1].name
 
   # GET /security/rules
-  - name: Sort the rules, limit=2, offset=1
-    request:
-      <<: *all_rules_request
-      params:
-        sort: name
-        limit: 2
-        offset: 1
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-          - id: !int "{second_rule_id}"
-            name: "{second_rule_name}"
-          - <<: *rules
-          total_affected_items: !anyint
-
-  # GET /security/rules
-  - name: Sort without limit
+  - name: Sort the rules (reverse)
     request:
       <<: *all_rules_request
       params:
         sort: -name
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "name"
+            reverse: true
       status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: !anyint
 
   # GET /security/rules
   - name: Search in rules
@@ -1138,19 +1081,14 @@ stages:
     response:
       verify_response_with:
         # Check response item keys are the selected keys
-        function: tavern_utils:test_select_key_affected_items
-        extra_kwargs:
-          select_key: 'id' # required_fields={'id'}
+        - function: tavern_utils:test_select_key_affected_items
+          extra_kwargs:
+            select_key: 'id' # required_fields={'id'}
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "id"
+            reverse: true
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - id: 105
-            - id: 104
-          total_affected_items: !anyint
-          total_failed_items: 0
-          failed_items: [ ]
 
   - name: Get users in the system using search and select filters
     request:
@@ -1407,129 +1345,12 @@ stages:
       params:
         sort: "-username"
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "username"
+            reverse: true
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - id: 2
-              username: wazuh-wui
-              allow_run_as: true
-              roles:
-                - 1
-            - id: 1
-              username: wazuh
-              allow_run_as: true
-              roles:
-                - 1
-            - id: 99
-              username: testing
-              allow_run_as: false
-              roles:
-                - 1
-            - id: 104
-              username: rbac
-              allow_run_as: false
-              roles:
-                - 104
-                - 102
-                - 103
-            - id: 103
-              username: python
-              allow_run_as: false
-              roles:
-                - 101
-            - id: 102
-              username: ossec
-              allow_run_as: false
-              roles:
-                - 101
-                - 104
-            - id: 101
-              username: normal
-              allow_run_as: false
-              roles:
-                - 104
-                - 105
-                - 103
-            - id: 105
-              username: guest
-              allow_run_as: false
-              roles: []
-            - id: 100
-              username: administrator
-              allow_run_as: false
-              roles:
-                - 100
-                - 101
-          total_affected_items: 9
-          total_failed_items: 0
-          failed_items: []
-
-  - name: Testing sort
-    request:
-      <<: *all_users_request
-      params:
-        sort: "username"
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - id: 100
-              username: administrator
-              allow_run_as: false
-              roles:
-                - 100
-                - 101
-            - id: 105
-              username: guest
-              allow_run_as: false
-              roles: []
-            - id: 101
-              username: normal
-              allow_run_as: false
-              roles:
-                - 104
-                - 105
-                - 103
-            - id: 102
-              username: ossec
-              allow_run_as: false
-              roles:
-                - 101
-                - 104
-            - id: 103
-              username: python
-              allow_run_as: false
-              roles:
-                - 101
-            - id: 104
-              username: rbac
-              allow_run_as: false
-              roles:
-                - 104
-                - 102
-                - 103
-            - id: 99
-              username: testing
-              allow_run_as: false
-              roles:
-                - 1
-            - id: 1
-              username: wazuh
-              allow_run_as: true
-              roles:
-                - 1
-            - id: 2
-              username: wazuh-wui
-              allow_run_as: true
-              roles:
-                - 1
-          total_affected_items: 9
-          total_failed_items: 0
-          failed_items: []
 
   - name: Testing offset
     request:

--- a/api/test/integration/test_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_syscheck_endpoints.tavern.yaml
@@ -343,18 +343,14 @@ stages:
       verify: False
       <<: *get_syscheck_agent
       params:
-        limit: 1
+        limit: 20
         sort: file,date
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "file,date"
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - <<: *full_items_array
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
 
     # GET /syscheck/000?limit=1&sort=wrongparam
   - name: Try to get syscheck scan results for agent 000 using an invalid sort parameter
@@ -437,17 +433,14 @@ stages:
       verify: False
       <<: *get_syscheck_agent
       params:
-        limit: 1
+        limit: 10
         sort: "{field}"
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "{field}"
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: *full_items_array
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
 
     # GET /syscheck/000?limit=1&select={field}
   - name: Try to get syscheck scan results for agent 000 with a selected field answer
@@ -870,19 +863,14 @@ stages:
       verify: False
       <<: *get_syscheck_agent_002
       params:
-        limit: 2
+        limit: 5
         sort: file,date
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "file,date"
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - <<: *full_items_array_002
-            - <<: *full_items_array_002
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
 
     # GET /syscheck/002?limit=1&sort=wrongparam
   - name: Try to get syscheck scan results for agent 002 using an invalid sort parameter
@@ -941,17 +929,14 @@ stages:
       verify: False
       <<: *get_syscheck_agent_002
       params:
-        limit: 1
+        limit: 5
         sort: "{field}"
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "{field}"
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: *full_items_array_002
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
 
     # GET /syscheck/002?limit=1&select={field}
   - name: Try to get syscheck scan results for agent 002 with a selected field answer

--- a/api/test/integration/test_syscollector_endpoints.tavern.yaml
+++ b/api/test/integration/test_syscollector_endpoints.tavern.yaml
@@ -350,15 +350,13 @@ stages:
       <<: *packages_request_003
       params:
         sort: -name
-        limit: 2
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "name"
+            reverse: true
       status_code: 200
-      json:
-        error: !anyint
-        data:
-          affected_items:
-            - <<: *packages_response
-            - <<: *packages_response
 
   - name: Filter sort 2
     request:
@@ -366,15 +364,12 @@ stages:
       <<: *packages_request_003
       params:
         sort: +name
-        limit: 2
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "name"
       status_code: 200
-      json:
-        error: !anyint
-        data:
-          affected_items:
-            - <<: *packages_response
-            - <<: *packages_response
 
   - name: Wrong sort
     request:
@@ -1040,11 +1035,11 @@ stages:
       params:
         sort: "{field}"
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "{field}"
       status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
 
   - name: Processes of an agent, select
     request:
@@ -1312,13 +1307,12 @@ stages:
       <<: *port_request_005
       params:
         sort: "{field}"
-        limit: 1
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "{field}"
       status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
 
 ---
 test_name: GET /syscollector/{agent_id}/netaddr
@@ -1630,14 +1624,12 @@ stages:
       <<: *netaddr_request_002
       params:
         sort: +proto
-        limit: 1
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "proto"
       status_code: 200
-      json:
-        error: !anyint
-        data:
-          affected_items:
-            - <<: *netaddr_response
 
   - name: Invalid sort
     request:
@@ -1704,13 +1696,12 @@ stages:
       <<: *netaddr_request_002
       params:
         sort: "{field}"
-        limit: 1
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "{field}"
       status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
 
 ---
 test_name: GET /syscollector/{agent_id}/netproto
@@ -1976,14 +1967,12 @@ stages:
       <<: *netproto_request_003
       params:
         sort: +dhcp
-        limit: 1
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "dhcp"
       status_code: 200
-      json:
-        error: !anyint
-        data:
-          affected_items:
-            - <<: *netproto_response_003
 
   - name: Invalid sort
     request:
@@ -2035,13 +2024,12 @@ stages:
       <<: *netproto_request_003
       params:
         sort: "{field}"
-        limit: 1
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "{field}"
       status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
 
 ---
 test_name: GET /syscollector/{agent_id}/netiface
@@ -2215,14 +2203,12 @@ stages:
       <<: *netiface_request_008
       params:
         sort: +type
-        limit: 1
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "type"
       status_code: 200
-      json:
-        error: !anyint
-        data:
-          affected_items:
-            - <<: *netiface_response_008
 
   - name: Invalid sort
     request:
@@ -2703,13 +2689,12 @@ stages:
       <<: *netiface_request_008
       params:
         sort: "{field}"
-        limit: 1
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "{field}"
       status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
 
 ---
 test_name: GET /syscollector/{agent_id}/os
@@ -3171,30 +3156,6 @@ stages:
     response:
       status_code: 400
 
-  - name: Sort
-    request:
-      verify: False
-      <<: *netaddr_request
-      params:
-        sort: +proto
-        limit: 1
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          affected_items:
-            - <<: *netaddr_response
-
-  - name: Invalid sort
-    request:
-      verify: False
-      <<: *netaddr_request
-      params:
-        sort: -wrong
-    response:
-      <<: *error_response_1403
-
 ---
 test_name: GET /syscollector/{agent_id}/netaddr?{sort,select}
 
@@ -3225,20 +3186,6 @@ stages:
         function: tavern_utils:test_select_key_affected_items
         extra_kwargs:
           select_key: "{field:s}"
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
-
-  - name: Netaddress of an agent, sort
-    request:
-      verify: False
-      <<: *netaddr_request
-      params:
-        sort: "{field}"
-        limit: 1
-    response:
-      status_code: 200
       json:
         error: !anyint
         data:
@@ -3523,14 +3470,12 @@ stages:
       <<: *netproto_request
       params:
         sort: +dhcp
-        limit: 1
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "dhcp"
       status_code: 200
-      json:
-        error: !anyint
-        data:
-          affected_items:
-            - <<: *netproto_response
 
   - name: Invalid sort
     request:
@@ -3581,13 +3526,12 @@ stages:
       <<: *netproto_request
       params:
         sort: "{field}"
-        limit: 1
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "{field}"
       status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
 
 ---
 test_name: GET /syscollector/{agent_id}/netiface
@@ -3760,14 +3704,13 @@ stages:
       <<: *netiface_request
       params:
         sort: -type
-        limit: 1
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "type"
+            reverse: true
       status_code: 200
-      json:
-        error: !anyint
-        data:
-          affected_items:
-            - <<: *netiface_response
 
   - name: Invalid sort
     request:
@@ -4233,13 +4176,13 @@ stages:
       <<: *netiface_request
       params:
         sort: "{field}"
-        limit: 1
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "{field}"
       status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
+
 ---
 test_name: GET /syscollector/{agent_id}/hotfixes
 

--- a/framework/wazuh/syscollector.py
+++ b/framework/wazuh/syscollector.py
@@ -54,6 +54,14 @@ def get_item_agent(agent_list, offset=0, limit=common.database_limit, select=Non
         except WazuhResourceNotFound as e:
             result.add_failed_item(id_=agent, error=e)
 
+    # Avoid that integer type fields are casted to string, this prevents sort parameter malfunctioning
+    if len(result.affected_items) and sort and len(sort['fields']) == 1:
+        fields = sort['fields'][0].split('.')
+        element = result.affected_items[0][fields.pop(0)]
+        for field in fields:
+            element = element[field]
+        result.sort_casting = [type(element).__name__]
+
     result.affected_items = merge(*[[res] for res in result.affected_items],
                                   criteria=result.sort_fields,
                                   ascending=result.sort_ascending,

--- a/framework/wazuh/syscollector.py
+++ b/framework/wazuh/syscollector.py
@@ -55,12 +55,16 @@ def get_item_agent(agent_list, offset=0, limit=common.database_limit, select=Non
             result.add_failed_item(id_=agent, error=e)
 
     # Avoid that integer type fields are casted to string, this prevents sort parameter malfunctioning
-    if len(result.affected_items) and sort and len(sort['fields']) == 1:
-        fields = sort['fields'][0].split('.')
-        element = result.affected_items[0][fields.pop(0)]
-        for field in fields:
-            element = element[field]
-        result.sort_casting = [type(element).__name__]
+    try:
+        if len(result.affected_items) and sort and len(sort['fields']) == 1:
+            fields = sort['fields'][0].split('.')
+            element = result.affected_items[0][fields.pop(0)]
+            for field in fields:
+                element = element[field]
+            element_type = type(element).__name__
+            result.sort_casting = [element_type] if element_type not in ['str', 'datetime'] else ['str']
+    except KeyError:
+        pass
 
     result.affected_items = merge(*[[res] for res in result.affected_items],
                                   criteria=result.sort_fields,


### PR DESCRIPTION
|Related issue|
|---|
|#8899|

Hi team,

This PR closes #8899. In this PR we have modified all the integration tests that make use of the sort parameter. These tests' responses will be checked with the function `test_sort_response`, created for this purpose.

In addition, we have detected and fixed a bug in the sort parameter of syscollector.

Regards