### PR TITLE
Change darwin netstat to use lsof

### DIFF
--- a/etc/templates/config/darwin/localfile-commands.template
+++ b/etc/templates/config/darwin/localfile-commands.template
@@ -1,6 +1,6 @@
   <localfile>
     <log_format>full_command</log_format>
-    <command>netstat -an | grep -e "tcp" -e "udp" | sed -E 's/([[:alnum:]]*)\ *[[:digit:]]*\ *[[:digit:]]*\ *(.*)\.([0-9\*]*)\ +([0-9\.\*]+).+/\1 \2 == \3 == \4/' | sort -k 4 -g | sed 's/ == \(.*\) ==/.\1/'| uniq</command>
+    <command>/usr/sbin/lsof -i -P -n +c 20 | /usr/bin/grep -e 'UDP' -e 'LISTEN' | /usr/bin/grep -ve '->' | /usr/bin/awk '{printf "%-20s %-20s %s %s %s\n", $1, $3, $5, $8, $9}' | /usr/bin/sed -E 's/(.+) +([][*[:digit:]abcdef\.:]+):([[:digit:]*]+)$/\1 \2 \3/' | /usr/bin/sort -k 6 -g | /usr/bin/uniq</command>
     <alias>netstat listening ports</alias>
     <frequency>360</frequency>
   </localfile>


### PR DESCRIPTION
No related issues 

## Description

I realised that some (maybe all) UDP sockets weren't being picked up in the netstat output on macOS. Whenever I've needed to list open ports before, most people seem to recommend using lsof instead. I've updated this to use lsof, and used full paths to the binaries for sed, awk, etc. because I (and therefore likely others) have installed the GNU versions of those using brew and they take precedence in the PATH. This way, you know you're using the macOS versions.

Notably, in the example below, my netcat instance on port 10000 wasn't showing in the netstat logs.

## Configuration options
N/A

## Logs/Alerts example

Example output (truncated):

```
racoon               root                 IPv6 UDP [fe80:6::14ef:9592:1a39:39d2] 4500
racoon               root                 IPv6 UDP [fe80:f::f7fb:7062:381d:82e] 4500
mDNSResponder        _mdnsresponder       IPv4 UDP 224.0.0.1 5350
mDNSResponder        _mdnsresponder       IPv4 UDP * 5353
mDNSResponder        _mdnsresponder       IPv6 UDP * 5353
figma-node           alastair             IPv4 TCP 127.0.0.1 7335
nc                   alastair             IPv4 UDP * 10000
Adobe\x20Desktop\x20 alastair             IPv4 TCP 127.0.0.1 15292
```

## Tests

I haven't done any work here as I'm assuming the file just gets packaged up? Happy to do further checks if required.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
