### PR TITLE
Add new vuln endpoint and new parameters

### DIFF
--- a/api/api/controllers/vulnerability_controller.py
+++ b/api/api/controllers/vulnerability_controller.py
@@ -16,7 +16,7 @@ logger = logging.getLogger('wazuh-api')
 
 async def get_vulnerability_agent(request, pretty=False, wait_for_complete=False, agent_id=None, offset=0, limit=None,
                                   sort=None, search=None, select=None, q='', distinct=None, architecture=None, cve=None,
-                                  name=None, version=None, type=None, status=None):
+                                  name=None, version=None, type=None, status=None, severity=None):
     """Get agents' vulnerabilities.
 
     Parameters
@@ -51,9 +51,12 @@ async def get_vulnerability_agent(request, pretty=False, wait_for_complete=False
     version : str
         Filter by version.
     type : str
-        Filter by CVE type
+        Filter by CVE type.
     status : str
-        Filter by CVE status
+        Filter by CVE status.
+    severity : str
+        Filter by CVE severity.
+
     Returns
     -------
     web.json_response
@@ -73,11 +76,43 @@ async def get_vulnerability_agent(request, pretty=False, wait_for_complete=False
             'name': name,
             'version': version,
             'status':  status,
-            'type': type
+            'type': type,
+            'severity': severity
         }
     }
 
     dapi = DistributedAPI(f=vulnerability.get_agent_cve,
+                          f_kwargs=remove_nones_to_dict(f_kwargs),
+                          request_type='distributed_master',
+                          is_async=False,
+                          wait_for_complete=wait_for_complete,
+                          logger=logger,
+                          rbac_permissions=request['token_info']['rbac_policies']
+                          )
+    data = raise_if_exc(await dapi.distribute_function())
+
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
+
+
+async def get_last_scan_agent(request, pretty=False, wait_for_complete=False, agent_id=None):
+    """Return when the last full and partial vulnerability scan of a specified agent end.
+
+    Parameters
+    ----------
+    pretty : bool
+        Show results in human-readable format.
+    wait_for_complete : bool
+        Disable timeout response.
+    agent_id : str
+        ID of the agent to retrieve scans info.
+
+    Returns
+    -------
+    web.json_response
+    """
+    f_kwargs = {'agent_list': [agent_id]}
+
+    dapi = DistributedAPI(f=vulnerability.last_scan,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
                           request_type='distributed_master',
                           is_async=False,

--- a/api/api/controllers/vulnerability_controller.py
+++ b/api/api/controllers/vulnerability_controller.py
@@ -95,7 +95,7 @@ async def get_vulnerability_agent(request, pretty=False, wait_for_complete=False
 
 
 async def get_last_scan_agent(request, pretty=False, wait_for_complete=False, agent_id=None):
-    """Return when the last full and partial vulnerability scan of a specified agent end.
+    """Return when the last full and partial vulnerability scan of a specified agent ended.
 
     Parameters
     ----------

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1157,7 +1157,7 @@ components:
               items:
                 $ref: '#/components/schemas/SyscheckDatabase'
 
-    AllItemsResponseSyscheckLastScan:
+    AllItemsResponseLastScan:
       allOf:
         - $ref: '#/components/schemas/AllItemsResponse'
         - type: object
@@ -4592,6 +4592,13 @@ components:
         enum:
           - os
           - package
+    cve_severity:
+      in: query
+      name: severity
+      description: "Filter by CVE severity"
+      schema:
+        type: string
+        format: names
     wait_for_complete:
       in: query
       name: wait_for_complete
@@ -12450,7 +12457,7 @@ paths:
                   - type: object
                     properties:
                       data:
-                        $ref: '#/components/schemas/AllItemsResponseSyscheckLastScan'
+                        $ref: '#/components/schemas/AllItemsResponseLastScan'
               example:
                 data:
                   affected_items:
@@ -16680,6 +16687,7 @@ paths:
         - $ref: '#/components/parameters/cve_version'
         - $ref: '#/components/parameters/cve_type'
         - $ref: '#/components/parameters/cve_status'
+        - $ref: '#/components/parameters/cve_severity'
       responses:
         '200':
           description: "Get agent vulnerabilities"
@@ -16690,18 +16698,76 @@ paths:
               example:
                 data:
                   affected_items:
-                    - cve: CVE-2020-27350
-                      architecture: amd64
-                      version: 1.2.32ubuntu0.1
-                      name: apt
-                    - cve: CVE-2019-18276
-                      architecture: amd64
-                      version: 4.3-14ubuntu1.4
-                      name: bash
+                    - architecture: amd64
+                      name: binutils
+                      version: 2.34-6ubuntu1.1
+                      type: PACKAGE
+                      severity: Medium
+                      cvss2_score: 7.1
+                      cve: CVE-2021-3487
+                      detection_time: '2021-06-14T07:45:51Z'
+                      cvss3_score: 6.5
+                      status: VALID
+                    - architecture: amd64
+                      name: binutils
+                      version: 2.34-6ubuntu1.1
+                      type: PACKAGE
+                      severity: High
+                      cvss2_score: 6.8
+                      cve: CVE-2021-20294
+                      detection_time: '2021-06-14T07:45:51Z'
+                      cvss3_score: 7.8
+                      status: VALID
                   total_affected_items: 2
                   total_failed_items: 0
                   failed_items: []
                 message: "All selected vulnerabilities were returned"
+                error: 0
+        '400':
+          $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDeniedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
+
+  /vulnerability/{agent_id}/last_scan:
+    get:
+      tags:
+      - Vulnerability
+      summary: "Get last scan datetime"
+      description: "Return when the last full and partial vulnerability scan of a specified agent ended."
+      operationId: api.controllers.vulnerability_controller.get_last_scan_agent
+      x-rbac-actions:
+        - $ref: '#/x-rbac-catalog/actions/vulnerability:read'
+      parameters:
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+        - $ref: '#/components/parameters/agent_id'
+      responses:
+        '200':
+          description: "Scan dates"
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/AllItemsResponseLastScan'
+              example:
+                data:
+                  affected_items:
+                    - last_full_scan: '2021-06-14T07:45:51Z'
+                      last_partial_scan: '2021-06-14T10:15:56Z'
+                  total_affected_items: 1
+                  total_failed_items: 0
+                  failed_items: [ ]
+                message: Last vulnerability scans of the agent were returned
                 error: 0
         '400':
           $ref: '#/components/responses/ResponseError'

--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -218,7 +218,7 @@ def test_expected_value(response, key, expected_values):
     expected_values = set(expected_values.split(',')) if not isinstance(expected_values, list) else set(expected_values)
 
     for item in response.json()['data']['affected_items']:
-        response_set = set(item[key]) if isinstance(item[key], list) else {item[key]}
+        response_set = set(map(str, item[key])) if isinstance(item[key], list) else {str(item[key])}
         assert bool(expected_values.intersection(response_set)), \
             f'Expected values {expected_values} not found in {item[key]}'
 

--- a/api/test/integration/test_rbac_black_vulnerability_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_vulnerability_endpoints.tavern.yaml
@@ -38,3 +38,37 @@ stages:
       status_code: 403
       json:
         error: 4000
+
+---
+test_name: GET /vulnerability/{agent_id}/last_scan
+
+stages:
+
+  - name: Get when the last full and partial scans for agent 001 ended
+    request:
+      verify: False
+      method: GET
+      url: "{protocol:s}://{host:s}:{port:d}/vulnerability/001/last_scan"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - last_full_scan: !anything
+              last_partial_scan: !anystr
+          failed_items: [ ]
+          total_affected_items: 1
+          total_failed_items: 0
+
+  - name: Try to get when the last full and partial scans for agent 002 ended
+    request:
+      verify: False
+      method: GET
+      url: "{protocol:s}://{host:s}:{port:d}/vulnerability/002/last_scan"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      <<: *permission_denied

--- a/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
@@ -156,6 +156,20 @@ stages:
       <<: *permission_denied
 
 ---
+test_name: GET /vulnerability/{agent_id}/last_scan
+
+stages:
+  - name: Try to get when the last full and partial scans for agent 001 ended
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/vulnerability/001"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      <<: *permission_denied
+
+---
 test_name: DELETE /agents/{agent_id}/group
 
 stages:

--- a/api/test/integration/test_rbac_white_vulnerability_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_vulnerability_endpoints.tavern.yaml
@@ -39,3 +39,37 @@ stages:
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
+
+---
+test_name: GET /vulnerability/{agent_id}/last_scan
+
+stages:
+
+  - name: Try to get when the last full and partial scans for agent 001 ended
+    request:
+      verify: False
+      method: GET
+      url: "{protocol:s}://{host:s}:{port:d}/vulnerability/001/last_scan"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      <<: *permission_denied
+
+  - name: Get when the last full and partial scans for agent 002 ended
+    request:
+      verify: False
+      method: GET
+      url: "{protocol:s}://{host:s}:{port:d}/vulnerability/002/last_scan"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - last_full_scan: !anything
+              last_partial_scan: !anystr
+          failed_items: [ ]
+          total_affected_items: 1
+          total_failed_items: 0

--- a/api/test/integration/test_vulnerability_endpoints.tavern.yaml
+++ b/api/test/integration/test_vulnerability_endpoints.tavern.yaml
@@ -29,6 +29,10 @@ stages:
               name: !anystr
               type: !anystr
               status: !anystr
+              cvss2_score: !anyfloat
+              cvss3_score: !anyfloat
+              detection_time: !anystr
+              severity: !anystr
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
@@ -40,6 +44,10 @@ stages:
           expected_name: data.affected_items[0].name
           expected_type: data.affected_items[0].type
           expected_status: data.affected_items[0].status
+          expected_cvss2_score: data.affected_items[0].cvss2_score
+          expected_cvss3_score: data.affected_items[0].cvss3_score
+          expected_detection_time: data.affected_items[0].detection_time
+          expected_severity: data.affected_items[0].severity
 
   - name: Get agent's vulnerabilities (filter by Type)
     request:
@@ -118,6 +126,60 @@ stages:
           extra_kwargs:
             key: "name"
             expected_values: "{expected_name}"
+
+  - name: Get agent's vulnerabilities (filter by severity)
+    request:
+      <<: *vulnerability_request_001
+      params:
+        severity: "{expected_severity}"
+    response:
+      status_code: 200
+      verify_response_with:
+        - function: tavern_utils:test_expected_value
+          extra_kwargs:
+            key: "severity"
+            expected_values: "{expected_severity}"
+
+  - name: Get agent's vulnerabilities (filter by CVSS2 score)
+    request:
+      <<: *vulnerability_request_001
+      params:
+        q: "cvss2_score={expected_cvss2_score}"
+    response:
+      status_code: 200
+      verify_response_with:
+        - function: tavern_utils:test_expected_value
+          extra_kwargs:
+            key: "cvss2_score"
+            expected_values: "{expected_cvss2_score}"
+
+  - name: Get agent's vulnerabilities (filter by CVSS3 score)
+    request:
+      <<: *vulnerability_request_001
+      params:
+        q: "cvss3_score={expected_cvss3_score}"
+    response:
+      status_code: 200
+      verify_response_with:
+        - function: tavern_utils:test_expected_value
+          extra_kwargs:
+            key: "cvss3_score"
+            expected_values: "{expected_cvss3_score}"
+
+  - name: Try to get agent's vulnerabilities (filter by an unexistent CVSS3 score)
+    request:
+      <<: *vulnerability_request_001
+      params:
+        q: "cvss3_score>100"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items: [ ]
+          failed_items: [ ]
+          total_affected_items: 0
+          total_failed_items: 0
 
   - name: Sort agent's vulnerabilities (version)
     request:
@@ -245,4 +307,29 @@ stages:
               name: !anystr
           failed_items: []
           total_affected_items: !anyint
+          total_failed_items: 0
+
+---
+test_name: GET /vulnerability/001/last_scan
+
+stages:
+
+  # GET /vulnerability/001/last_scan
+  - name: Get when the last full and partial scans for agent 001 ended
+    request:
+      verify: False
+      method: GET
+      url: "{protocol:s}://{host:s}:{port:d}/vulnerability/001/last_scan"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - last_full_scan: !anything
+              last_partial_scan: !anystr
+          failed_items: []
+          total_affected_items: 1
           total_failed_items: 0

--- a/framework/wazuh/core/tests/test_vulnerability.py
+++ b/framework/wazuh/core/tests/test_vulnerability.py
@@ -25,7 +25,9 @@ def test_WazuhDBQueryVulnerability__init__(mock_conn, mock_info, mock_send, mock
     mock_backend.assert_called_once_with('001')
     mock_wazuhDBQuery.assert_called_once_with(
         ANY, offset=500, limit=500, table='vuln_cves', sort=None, search=None, select=None,
-        fields={'name': 'name', 'version': 'version', 'architecture': 'architecture', 'cve': 'cve', 'status': 'status', 'type': 'type'},
+        fields={'name': 'name', 'version': 'version', 'architecture': 'architecture', 'cve': 'cve', 'status': 'status',
+                'type': 'type', 'detection_time': 'detection_time', 'severity': 'severity',
+                'cvss2_score': 'cvss2_score', 'cvss3_score': 'cvss3_score'},
         default_sort_field='name', default_sort_order='ASC', filters={}, query='version>3.9.81', backend=ANY,
         min_select_fields=set(), count=True, get_data=True, distinct=False
     )

--- a/framework/wazuh/core/tests/test_vulnerability.py
+++ b/framework/wazuh/core/tests/test_vulnerability.py
@@ -27,7 +27,7 @@ def test_WazuhDBQueryVulnerability__init__(mock_conn, mock_info, mock_send, mock
         ANY, offset=500, limit=500, table='vuln_cves', sort=None, search=None, select=None,
         fields={'name': 'name', 'version': 'version', 'architecture': 'architecture', 'cve': 'cve', 'status': 'status',
                 'type': 'type', 'detection_time': 'detection_time', 'severity': 'severity',
-                'cvss2_score': 'cvss2_score', 'cvss3_score': 'cvss3_score'},
-        default_sort_field='name', default_sort_order='ASC', filters={}, query='version>3.9.81', backend=ANY,
-        min_select_fields=set(), count=True, get_data=True, distinct=False
+                'cvss2_score': 'cvss2_score', 'cvss3_score': 'cvss3_score'}, filters={}, count=True, get_data=True,
+        date_fields={'detection_time', 'last_partial_scan', 'last_full_scan'}, min_select_fields=set(),  distinct=False,
+        default_sort_field='name', default_sort_order='ASC',  query='version>3.9.81', backend=ANY
     )

--- a/framework/wazuh/core/vulnerability.py
+++ b/framework/wazuh/core/vulnerability.py
@@ -5,23 +5,40 @@
 from wazuh.core import common
 from wazuh.core.agent import Agent
 from wazuh.core.utils import WazuhDBQuery, WazuhDBBackend
+from datetime import datetime
 
 
 class WazuhDBQueryVulnerability(WazuhDBQuery):
     """"""
     fields = {
         'name': 'name', 'version': 'version', 'architecture': 'architecture', 'cve': 'cve', 'status': 'status',
-        'type': 'type'
+        'type': 'type', 'detection_time': 'detection_time', 'severity': 'severity', 'cvss2_score': 'cvss2_score',
+        'cvss3_score': 'cvss3_score'
     }
 
     def __init__(self, agent_id, offset=0, limit=common.database_limit, sort=None, search=None, select=None, query='',
-                 count=True, get_data=True, distinct=False, default_sort_field='name', filters=None, fields=fields):
+                 count=True, get_data=True, distinct=False, default_sort_field='name', filters=None, fields=fields,
+                 table='vuln_cves'):
         if filters is None:
             filters = {}
         # Check if the agent exists
         Agent(agent_id).get_basic_information()
         backend = WazuhDBBackend(agent_id)
-        WazuhDBQuery.__init__(self, offset=offset, limit=limit, table='vuln_cves', sort=sort, search=search,
+        WazuhDBQuery.__init__(self, offset=offset, limit=limit, table=table, sort=sort, search=search,
                               select=select, fields=fields, default_sort_field=default_sort_field,
                               default_sort_order='ASC', filters=filters, query=query, backend=backend,
                               min_select_fields=set(), count=count, get_data=get_data, distinct=distinct)
+
+    def _format_data_into_dictionary(self):
+        def format_fields(field_name, value):
+            if field_name in ['detection_time', 'last_partial_scan', 'last_full_scan']:
+                try:
+                    return datetime.utcfromtimestamp(int(value))
+                except (ValueError, TypeError):
+                    return value
+            else:
+                return value
+
+        self._data = [{key: format_fields(key, value) for key, value in item.items()} for item in self._data]
+
+        return super()._format_data_into_dictionary()

--- a/framework/wazuh/core/vulnerability.py
+++ b/framework/wazuh/core/vulnerability.py
@@ -35,9 +35,9 @@ class WazuhDBQueryVulnerability(WazuhDBQuery):
                 try:
                     return datetime.utcfromtimestamp(int(value))
                 except (ValueError, TypeError):
-                    return value
-            else:
-                return value
+                    pass
+            
+            return value
 
         self._data = [{key: format_fields(key, value) for key, value in item.items()} for item in self._data]
 

--- a/framework/wazuh/core/vulnerability.py
+++ b/framework/wazuh/core/vulnerability.py
@@ -2,10 +2,11 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GP
 
+from datetime import datetime
+
 from wazuh.core import common
 from wazuh.core.agent import Agent
 from wazuh.core.utils import WazuhDBQuery, WazuhDBBackend
-from datetime import datetime
 
 
 class WazuhDBQueryVulnerability(WazuhDBQuery):

--- a/framework/wazuh/core/vulnerability.py
+++ b/framework/wazuh/core/vulnerability.py
@@ -28,11 +28,12 @@ class WazuhDBQueryVulnerability(WazuhDBQuery):
         WazuhDBQuery.__init__(self, offset=offset, limit=limit, table=table, sort=sort, search=search,
                               select=select, fields=fields, default_sort_field=default_sort_field,
                               default_sort_order='ASC', filters=filters, query=query, backend=backend,
-                              min_select_fields=set(), count=count, get_data=get_data, distinct=distinct)
+                              min_select_fields=set(), count=count, get_data=get_data, distinct=distinct,
+                              date_fields={'detection_time', 'last_partial_scan', 'last_full_scan'})
 
     def _format_data_into_dictionary(self):
         def format_fields(field_name, value):
-            if field_name in ['detection_time', 'last_partial_scan', 'last_full_scan']:
+            if field_name in self.date_fields:
                 try:
                     return datetime.utcfromtimestamp(int(value))
                 except (ValueError, TypeError):

--- a/framework/wazuh/tests/data/schema_cve_test.sql
+++ b/framework/wazuh/tests/data/schema_cve_test.sql
@@ -11,27 +11,41 @@ CREATE TABLE IF NOT EXISTS vuln_cves (
     version TEXT,
     architecture TEXT,
     cve TEXT,
-    type TEXT,
-    status TEXT,
-    PRIMARY KEY (name, version, architecture, cve)
+    detection_time TEXT DEFAULT '',
+    severity TEXT DEFAULT '-' CHECK (severity IN ('Critical', 'High', 'Medium', 'Low', 'None', '-')),
+    cvss2_score REAL DEFAULT 0,
+    cvss3_score REAL DEFAULT 0,
+    reference TEXT DEFAULT '' NOT NULL,
+    type TEXT DEFAULT '' NOT NULL CHECK (type IN ('OS', 'PACKAGE')),
+    status TEXT DEFAULT 'PENDING' NOT NULL CHECK (status IN ('VALID', 'PENDING', 'OBSOLETE')),
+    PRIMARY KEY (reference, cve)
 );
 CREATE INDEX IF NOT EXISTS packages_id ON vuln_cves (name);
 CREATE INDEX IF NOT EXISTS cves_id ON vuln_cves (cve);
+CREATE INDEX IF NOT EXISTS cve_type ON vuln_cves (type);
+CREATE INDEX IF NOT EXISTS cve_status ON vuln_cves (status);
+
+CREATE TABLE IF NOT EXISTS vuln_metadata (
+    LAST_PARTIAL_SCAN INTEGER,
+    LAST_FULL_SCAN INTEGER
+);
 
 BEGIN;
 
 -- Data from https://www.cvedetails.com/vulnerability-list/
-INSERT INTO vuln_cves (name,version,architecture,cve,type,status)
-VALUES ('Invenio-previewer', '0.1.0', 'ARM', 'CVE-2019-1020019','OS','VALID');
+INSERT INTO vuln_cves (name,version,architecture,cve,type,status,detection_time,severity,cvss2_score,cvss3_score,reference)
+VALUES ('Invenio-previewer', '0.1.0', 'ARM', 'CVE-2019-1020019', 'OS', 'VALID', '1623656751', 'Medium', 4.3, 6.1, '0198aaaadb185181ad323433735248fbf41362b5');
 
-INSERT INTO vuln_cves (name,version,architecture,cve,type,status)
-VALUES ('Discourse', '0.8.0', 'PowerPC', 'CVE-2019-1020018','OS','VALID');
+INSERT INTO vuln_cves (name,version,architecture,cve,type,status,detection_time,severity,cvss2_score,cvss3_score,reference)
+VALUES ('Discourse', '0.8.0', 'PowerPC', 'CVE-2019-1020018', 'OS', 'VALID', '1623656751', 'High', 7.5, 7.3, '24cbb88312a71cc2fee7b9fb545cfd404ea7c9a8');
 
-INSERT INTO vuln_cves (name,version,architecture,cve,type,status)
-VALUES ('Ash-aio', '2.0.0.0', 'x86', 'CVE-2019-1020016','OS','OBSOLETE');
+INSERT INTO vuln_cves (name,version,architecture,cve,type,status,detection_time,severity,cvss2_score,cvss3_score,reference)
+VALUES ('Ash-aio', '2.0.0.0', 'x86', 'CVE-2019-1020016', 'OS', 'OBSOLETE', '1623656751', 'Low', 1.9, 2.5, 'fe22d729473dc47625a583dd97e1d3a779105b19');
 
-INSERT INTO vuln_cves (name,version,architecture,cve,type,status)
-VALUES ('Credential Helpers', '0.1.0', 'x86', 'CVE-2019-1020014','PACKAGE','OBSOLETE');
+INSERT INTO vuln_cves (name,version,architecture,cve,type,status,detection_time,severity,cvss2_score,cvss3_score,reference)
+VALUES ('Credential Helpers', '0.1.0', 'x86', 'CVE-2019-1020014', 'PACKAGE', 'OBSOLETE', '1623656949', 'Critical', 7.5, 9.8, '2783fabf4b0d5b5f3217703fb24bb75ec58a8ce3');
 
-INSERT INTO vuln_cves (name,version,architecture,cve,type,status)
-VALUES ('Smokedetector', '-', 'x86', 'CVE-2019-1020011','PACKAGE','PENDING');
+INSERT INTO vuln_cves (name,version,architecture,cve,type,status,detection_time,severity,cvss2_score,cvss3_score,reference)
+VALUES ('Smokedetector', '-', 'x86', 'CVE-2019-1020011', 'PACKAGE', 'PENDING', '1623656949', 'High', 6.8, 8.1, 'e0680fb636baccbb7484f7b3daf5b4c0ce485960');
+
+INSERT INTO vuln_metadata (LAST_PARTIAL_SCAN, LAST_FULL_SCAN) VALUES (1623656949, 1623656751);

--- a/framework/wazuh/tests/data/security/rbac_catalog.yml
+++ b/framework/wazuh/tests/data/security/rbac_catalog.yml
@@ -846,6 +846,7 @@ get_rbac_actions:
           effect: allow
         related_endpoints:
           - GET /vulnerability/{agent_id}
+          - GET /vulnerability/{agent_id}/last_scan
 
 
 get_rbac_resources:

--- a/framework/wazuh/vulnerability.py
+++ b/framework/wazuh/vulnerability.py
@@ -9,8 +9,6 @@ from wazuh.core.vulnerability import WazuhDBQueryVulnerability
 from wazuh.core.results import AffectedItemsWazuhResult
 from wazuh.rbac.decorators import expose_resources
 
-logger = logging.getLogger('wazuh')
-
 
 @expose_resources(actions=["vulnerability:read"], resources=["agent:id:{agent_list}"], post_proc_func=None)
 def get_agent_cve(agent_list=None, offset=0, limit=common.database_limit, sort=None, search=None, select=None, q='',
@@ -52,6 +50,35 @@ def get_agent_cve(agent_list=None, offset=0, limit=common.database_limit, sort=N
     db_query = WazuhDBQueryVulnerability(agent_id=agent_list[0], offset=offset, limit=limit, sort=sort, search=search,
                                          select=select, query=q, filters=filters, count=True, get_data=True,
                                          distinct=distinct)
+    data = db_query.run()
+    result.affected_items.extend(data['items'])
+    result.total_affected_items = data['totalItems']
+
+    return result
+
+
+@expose_resources(actions=["vulnerability:read"], resources=["agent:id:{agent_list}"], post_proc_func=None)
+def last_scan(agent_list):
+    """Return when the last full and partial vulnerability scan of a specified agent end.
+
+    Parameters
+    ----------
+    agent_list : list
+        List of agents ID's.
+
+    Returns
+    -------
+    result : AffectedItemsWazuhResult
+        Confirmation/Error message and scan dates.
+    """
+    result = AffectedItemsWazuhResult(all_msg='Last vulnerability scans of the agent were returned',
+                                      none_msg='No last scan information was returned'
+                                      )
+
+    db_query = WazuhDBQueryVulnerability(agent_id=agent_list[0], table='vuln_metadata',
+                                         default_sort_field='last_full_scan',
+                                         fields={'last_partial_scan': 'LAST_PARTIAL_SCAN',
+                                                 'last_full_scan': 'LAST_FULL_SCAN'})
     data = db_query.run()
     result.affected_items.extend(data['items'])
     result.total_affected_items = data['totalItems']

--- a/framework/wazuh/vulnerability.py
+++ b/framework/wazuh/vulnerability.py
@@ -57,7 +57,7 @@ def get_agent_cve(agent_list=None, offset=0, limit=common.database_limit, sort=N
 
 @expose_resources(actions=["vulnerability:read"], resources=["agent:id:{agent_list}"], post_proc_func=None)
 def last_scan(agent_list):
-    """Return when the last full and partial vulnerability scan of a specified agent end.
+    """Return when the last full and partial vulnerability scan of a specified agent ended.
 
     Parameters
     ----------

--- a/framework/wazuh/vulnerability.py
+++ b/framework/wazuh/vulnerability.py
@@ -2,11 +2,9 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-import logging
-
 from wazuh.core import common
-from wazuh.core.vulnerability import WazuhDBQueryVulnerability
 from wazuh.core.results import AffectedItemsWazuhResult
+from wazuh.core.vulnerability import WazuhDBQueryVulnerability
 from wazuh.rbac.decorators import expose_resources
 
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes #8863 |

## Description

Hello team!

This PR adds the following new fields in the API response to `GET /vulnerability/{agent_id}` endpoint:
- cvss2_score
- cvss3_score
- detection_time
- severity

However, only severity has been added as a filter on the endpoint. The rest of the new fields, as they are numeric, make more sense to be used to obtain ranges that can be specified within the q parameter, such as: 

> `GET /vulnerability/001?q=cvss3_score>9&severity=critical`
```JSON
{
  "data": {
    "affected_items": [
      {
        "architecture": "amd64",
        "severity": "Critical",
        "version": "3.8.5-1~20.04",
        "name": "python3.8-minimal",
        "cvss2_score": 7.5,
        "cve": "CVE-2021-3177",
        "cvss3_score": 9.8,
        "type": "PACKAGE",
        "detection_time": "2021-06-14T11:25:46Z",
        "status": "VALID"
      }
    ],
    "total_affected_items": 67,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected vulnerabilities were returned",
  "error": 0
}
```

Regards,
Selu.