### PR TITLE
Added Haproxy decoders and Sample logs

### DIFF
--- a/ruleset/decoders/0535-haproxy_decoders.xml
+++ b/ruleset/decoders/0535-haproxy_decoders.xml
@@ -1,0 +1,25 @@
+<!--
+  -  haproxy http log decoder
+  -  Author: George Kissandrakis <gkissand@gmail.com>, Jose Cruz
+  -  Copyright (C) 2015-2021, Wazuh Inc.
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+
+<!--
+Sample logs:  (Disclaimer: the slashes - - - - - - was separated to avoid problems with XLM comments. When running tests, put the last 4 together)
+Dec 12 15:44:01 servername haproxy[29883]: 192.168.1.20:60292 [12/Dec/2019:15:44:01.504] fe~ be/lo4 0/0/0/1/1 200 175 - - - - - - 235/235/9/0/0 0/0 {www.localhost.com|10|9|0|0} "GET /index.html HTTP/1.1"
+Dec 12 15:44:02 servername haproxy[29883]: 192.168.1.20:60292 [12/Dec/2019:15:44:02.504] fe~ be/lo4 0/0/0/1/1 404 175 - - - - - - 235/235/9/0/0 0/0 {www.localhost.com|10|9|0|0} "POST /api/test/input.php HTTP/1.1"
+Dec 12 15:44:03 servername haproxy[29883]: 192.168.1.20:60292 [12/Dec/2019:15:44:03.504] fe~ be/lo4 0/0/0/1/1 500 175 - - - - - - 235/235/9/0/0 0/0 {www.localhost.com|10|9|0|0} "GET /cgi-bin/index.cgi HTTP/1.1"
+-->
+
+
+<decoder name="haproxy">
+  <program_name>^haproxy</program_name>
+</decoder>
+<decoder name="haproxy-httplog">
+  <parent>haproxy</parent>
+  <type>web-log</type>
+  <prematch>^\S+:\S+ [\S+] \S+ \S+ \S+ \S+ </prematch>
+  <regex>^(\d+.\d+.\d+.\d+):\S+ \S+ \S+ \S+ \S+ (\d+) \.* {(\S+)\|\.* "(\S+) (\S+)</regex>
+  <order>srcip, id, dstip, protocol, url</order>
+</decoder>


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-ruleset/pull/739|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR adds new decoders, new rules and new sample logs that was made in this old PR for wazuh/ruleset: https://github.com/wazuh/wazuh-ruleset/pull/739

Couldn't add the changes from the original PR as the branch was very outdated and belong to the user,

## Tests
Tests were made in a 4.3 manager by adding the rules and decoders and running the `wazuh-logtest` test, having the following results:

```
Dec 12 15:44:01 servername haproxy[29883]: 192.168.1.20:60292 [12/Dec/2019:15:44:01.504] fe~ be/lo4 0/0/0/1/1 200 175 - - ---- 235/235/9/0/0 0/0 {www.localhost.com|10|9|0|0} "GET /index.html HTTP/1.1"

**Phase 1: Completed pre-decoding.
	full event: 'Dec 12 15:44:01 servername haproxy[29883]: 192.168.1.20:60292 [12/Dec/2019:15:44:01.504] fe~ be/lo4 0/0/0/1/1 200 175 - - ---- 235/235/9/0/0 0/0 {www.localhost.com|10|9|0|0} "GET /index.html HTTP/1.1"'
	timestamp: 'Dec 12 15:44:01'
	hostname: 'servername'
	program_name: 'haproxy'

**Phase 2: Completed decoding.
	name: 'haproxy'
	parent: 'haproxy'
	dstip: 'www.localhost.com'
	id: '200'
	protocol: 'GET'
	srcip: '192.168.1.20'
	url: '/index.html'

**Phase 3: Completed filtering (rules).
	id: '31108'
	level: '0'
	description: 'Ignored URLs (simple queries).'
	groups: '['web', 'accesslog']'
	firedtimes: '1'
	mail: 'False'

Dec 12 15:44:02 servername haproxy[29883]: 192.168.1.20:60292 [12/Dec/2019:15:44:02.504] fe~ be/lo4 0/0/0/1/1 404 175 - - ---- 235/235/9/0/0 0/0 {www.localhost.com|10|9|0|0} "POST /api/test/input.php HTTP/1.1"

**Phase 1: Completed pre-decoding.
	full event: 'Dec 12 15:44:02 servername haproxy[29883]: 192.168.1.20:60292 [12/Dec/2019:15:44:02.504] fe~ be/lo4 0/0/0/1/1 404 175 - - ---- 235/235/9/0/0 0/0 {www.localhost.com|10|9|0|0} "POST /api/test/input.php HTTP/1.1"'
	timestamp: 'Dec 12 15:44:02'
	hostname: 'servername'
	program_name: 'haproxy'

**Phase 2: Completed decoding.
	name: 'haproxy'
	parent: 'haproxy'
	dstip: 'www.localhost.com'
	id: '404'
	protocol: 'POST'
	srcip: '192.168.1.20'
	url: '/api/test/input.php'

**Phase 3: Completed filtering (rules).
	id: '31101'
	level: '5'
	description: 'Web server 400 error code.'
	groups: '['web', 'accesslog', 'attack']'
	firedtimes: '1'
	gdpr: '['IV_35.7.d']'
	mail: 'False'
	nist_800_53: '['SA.11', 'SI.4']'
	pci_dss: '['6.5', '11.4']'
	tsc: '['CC6.6', 'CC7.1', 'CC8.1', 'CC6.1', 'CC6.8', 'CC7.2', 'CC7.3']'
**Alert to be generated.

Dec 12 15:44:03 servername haproxy[29883]: 192.168.1.20:60292 [12/Dec/2019:15:44:03.504] fe~ be/lo4 0/0/0/1/1 500 175 - - ---- 235/235/9/0/0 0/0 {www.localhost.com|10|9|0|0} "GET /cgi-bin/index.cgi HTTP/1.1"

**Phase 1: Completed pre-decoding.
	full event: 'Dec 12 15:44:03 servername haproxy[29883]: 192.168.1.20:60292 [12/Dec/2019:15:44:03.504] fe~ be/lo4 0/0/0/1/1 500 175 - - ---- 235/235/9/0/0 0/0 {www.localhost.com|10|9|0|0} "GET /cgi-bin/index.cgi HTTP/1.1"'
	timestamp: 'Dec 12 15:44:03'
	hostname: 'servername'
	program_name: 'haproxy'

**Phase 2: Completed decoding.
	name: 'haproxy'
	parent: 'haproxy'
	dstip: 'www.localhost.com'
	id: '500'
	protocol: 'GET'
	srcip: '192.168.1.20'
	url: '/cgi-bin/index.cgi'

**Phase 3: Completed filtering (rules).
	id: '31122'
	level: '5'
	description: 'Web server 500 error code (Internal Error).'
	groups: '['web', 'accesslog', 'system_error']'
	firedtimes: '1'
	mail: 'False'
**Alert to be generated.


```