### PR TITLE
Parse SUSE OVAL feeds for Vulnerability Detector

### DIFF
--- a/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
+++ b/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
@@ -43,12 +43,12 @@
     <!-- SUSE OS vulnerabilities -->
     <provider name="suse">
       <enabled>no</enabled>
-      <os>15-server</os>
-      <os>15-desktop</os>
-      <os>12-server</os>
-      <os>12-desktop</os>
       <os>11-server</os>
       <os>11-desktop</os>
+      <os>12-server</os>
+      <os>12-desktop</os>
+      <os>15-server</os>
+      <os>15-desktop</os>
       <update_interval>1h</update_interval>
     </provider>
 

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -10159,7 +10159,7 @@ void test_wm_vuldet_fetch_redhat_multi_url_no_valid_response(void **state)
     if(!update)
         return;
 
-    update->update_state = VU_TRUE;
+    update->update_state = VU_PACKG;
     update->update_it = 1;
     os_strdup("http://local_repo/rh-feed/redhat-feed[-].json", update->multi_url);
     update->timeout = 300;
@@ -10223,7 +10223,7 @@ void test_wm_vuldet_fetch_redhat_single_url_no_valid_response(void **state)
     if(!update)
         return;
 
-    update->update_state = VU_TRUE;
+    update->update_state = VU_PACKG;
     update->update_it = 1;
     update->update_from_year = 2010;
     update->timeout = 300;
@@ -10277,7 +10277,7 @@ void test_wm_vuldet_fetch_redhat_single_url_file_open_error(void **state)
     if(!update)
         return;
 
-    update->update_state = VU_TRUE;
+    update->update_state = VU_PACKG;
     update->update_it = 1;
     update->update_from_year = 2010;
     update->timeout = 300;
@@ -10320,7 +10320,7 @@ void test_wm_vuldet_fetch_redhat_single_url_file_read_remove_error(void **state)
     if(!update)
         return;
 
-    update->update_state = VU_TRUE;
+    update->update_state = VU_PACKG;
     update->update_it = 1;
     update->update_from_year = 2010;
     update->timeout = 300;
@@ -10373,7 +10373,7 @@ void test_wm_vuldet_fetch_redhat_single_url_file_read_ok(void **state)
     if(!update)
         return;
 
-    update->update_state = VU_TRUE;
+    update->update_state = VU_PACKG;
     update->update_it = 1;
     update->update_from_year = 2010;
     update->timeout = 300;

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -11299,6 +11299,55 @@ void test_wm_vuldet_oval_xml_preparser_debian(void **state)
     os_free(path);
 }
 
+void test_wm_vuldet_oval_xml_preparser_suse(void **state)
+{
+    char *path = NULL;
+
+    // open path
+    os_strdup("test_path", path);
+    expect_string(__wrap_fopen, path, path);
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 1);
+
+    // open tmp_path
+    expect_string(__wrap_fopen, path, VU_FIT_TEMP_FILE);
+    expect_string(__wrap_fopen, mode, "w");
+    will_return(__wrap_fopen, 2);
+
+    // Parsing XML
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "start?>");
+
+    // find oval definitions start
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "<oval_definitions>");
+
+    will_return(__wrap_fwrite, 1);
+
+    // find oval definitions end
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "</oval_definitions>");
+
+    will_return(__wrap_fwrite, 1);
+
+    // end loop
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, NULL);
+
+    // close opened files
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+    expect_value(__wrap_fclose, _File, 2);
+    will_return(__wrap_fclose, 1);
+
+    char *ret = wm_vuldet_oval_xml_preparser(path, FEED_SUSE);
+    assert_string_equal(ret, VU_FIT_TEMP_FILE);
+
+    os_free(ret);
+    os_free(path);
+}
+
 void test_wm_vuldet_oval_xml_preparser_redhat(void **state)
 {
     char *path = NULL;
@@ -12701,6 +12750,8 @@ void test_wm_vuldet_oval_xml_parser_other_invalid_element()
     os_free(update);
 }
 
+// wm_vuldet_oval_xml_parser (Ubuntu)
+
 void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_read_attribute()
 {
     XML_NODE node = NULL;
@@ -13241,6 +13292,47 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_valid_definition()
     os_free(update);
 }
 
+void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_valid_definition_patch()
+{
+    XML_NODE node = NULL;
+    XML_NODE child_node = NULL;
+    update_node *update = NULL;
+    wm_vuldet_db *parsed_oval = NULL;
+
+    os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
+
+    //create xml node
+    os_calloc(2, sizeof(xml_node *), node);
+    os_calloc(1, sizeof(xml_node), *node);
+    os_calloc(2, sizeof(char *), node[0]->attributes);
+    os_calloc(2, sizeof(char *), node[0]->values);
+    os_strdup("class", node[0]->attributes[0]);
+    os_strdup("patch", node[0]->values[0]);
+    os_strdup("definition", node[0]->element);
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_ref = FEED_UBUNTU;
+
+    // Create a fake xml child node so that the function can end with an error
+    os_calloc(2, sizeof(xml_node *), child_node);
+    os_calloc(1, sizeof(xml_node), *child_node);
+    will_return(__wrap_OS_GetElementsbyNode, child_node);
+
+    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mterror, formatted_msg, "(1231): Invalid NULL element in the configuration.");
+
+    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    assert_int_equal(ret, OS_INVALID);
+    assert_ptr_not_equal(parsed_oval->vulnerabilities, NULL);
+    assert_ptr_not_equal(parsed_oval->info_cves, NULL);
+
+    os_free(parsed_oval->vulnerabilities);
+    os_free(parsed_oval->info_cves);
+    os_free(parsed_oval);
+    OS_ClearNode(node);
+    os_free(update);
+}
+
 void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_reference_url()
 {
     XML_NODE node = NULL;
@@ -13423,76 +13515,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_invalid_criteria()
     os_free(update);
 }
 
-void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_invalid_operator_OR()
-{
-    XML_NODE node = NULL;
-    XML_NODE child_node = NULL;
-    update_node *update = NULL;
-    wm_vuldet_db *parsed_oval = NULL;
-
-    os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
-
-    //create xml node
-    os_calloc(2, sizeof(xml_node *), node);
-    os_calloc(1, sizeof(xml_node), *node);
-    os_calloc(2, sizeof(char *), node[0]->attributes);
-    os_calloc(2, sizeof(char *), node[0]->values);
-    os_strdup("operator", node[0]->attributes[0]);
-    os_strdup("OR", node[0]->values[0]);
-    os_strdup("criteria", node[0]->element);
-
-    os_calloc(1, sizeof(update_node), update);
-    update->dist_ref = FEED_UBUNTU;
-
-    // Fake child so that the function can end with an error
-    will_return(__wrap_OS_GetElementsbyNode, NULL);
-
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
-    assert_int_equal(ret, 0);
-
-    os_free(parsed_oval);
-    OS_ClearNode(node);
-    os_free(update);
-}
-
-void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_invalid_child_operator_OR()
-{
-    XML_NODE node = NULL;
-    XML_NODE child_node = NULL;
-    update_node *update = NULL;
-    wm_vuldet_db *parsed_oval = NULL;
-
-    os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
-
-    //create xml node
-    os_calloc(2, sizeof(xml_node *), node);
-    os_calloc(1, sizeof(xml_node), *node);
-    os_calloc(2, sizeof(char *), node[0]->attributes);
-    os_calloc(2, sizeof(char *), node[0]->values);
-    os_strdup("operator", node[0]->attributes[0]);
-    os_strdup("OR", node[0]->values[0]);
-    os_strdup("criteria", node[0]->element);
-
-    os_calloc(1, sizeof(update_node), update);
-    update->dist_ref = FEED_UBUNTU;
-
-    // Fake child so that the function can end with an error
-    os_calloc(2, sizeof(xml_node *), child_node);
-    os_calloc(1, sizeof(xml_node), *child_node);
-    will_return(__wrap_OS_GetElementsbyNode, child_node);
-
-    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mterror, formatted_msg, "(1231): Invalid NULL element in the configuration.");
-
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
-    assert_int_equal(ret, OS_INVALID);
-
-    os_free(parsed_oval);
-    OS_ClearNode(node);
-    os_free(update);
-}
-
-void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_invalid_operator_AND()
+void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_invalid_child()
 {
     XML_NODE node = NULL;
     XML_NODE child_node = NULL;
@@ -13508,173 +13531,6 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_invalid_operator_AND()
     os_calloc(2, sizeof(char *), node[0]->values);
     os_strdup("operator", node[0]->attributes[0]);
     os_strdup("AND", node[0]->values[0]);
-    os_strdup("criteria", node[0]->element);
-
-    os_calloc(1, sizeof(update_node), update);
-    update->dist_ref = FEED_UBUNTU;
-
-    // Fake child so that the function can end with an error
-    will_return(__wrap_OS_GetElementsbyNode, NULL);
-
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
-    assert_int_equal(ret, 0);
-
-    os_free(parsed_oval);
-    OS_ClearNode(node);
-    os_free(update);
-}
-
-void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_invalid_child_operator_AND()
-{
-    XML_NODE node = NULL;
-    XML_NODE child_node = NULL;
-    update_node *update = NULL;
-    wm_vuldet_db *parsed_oval = NULL;
-
-    os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
-
-    //create xml node
-    os_calloc(2, sizeof(xml_node *), node);
-    os_calloc(1, sizeof(xml_node), *node);
-    os_calloc(2, sizeof(char *), node[0]->attributes);
-    os_calloc(2, sizeof(char *), node[0]->values);
-    os_strdup("operator", node[0]->attributes[0]);
-    os_strdup("AND", node[0]->values[0]);
-    os_strdup("criteria", node[0]->element);
-
-    os_calloc(1, sizeof(update_node), update);
-    update->dist_ref = FEED_UBUNTU;
-
-    // Fake child so that the function can end with an error
-    os_calloc(2, sizeof(xml_node *), child_node);
-    os_calloc(1, sizeof(xml_node), *child_node);
-    will_return(__wrap_OS_GetElementsbyNode, child_node);
-
-    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mterror, formatted_msg, "(1231): Invalid NULL element in the configuration.");
-
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
-    assert_int_equal(ret, OS_INVALID);
-
-    os_free(parsed_oval);
-    OS_ClearNode(node);
-    os_free(update);
-}
-
-void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_invalid_operator()
-{
-    XML_NODE node = NULL;
-    XML_NODE child_node = NULL;
-    update_node *update = NULL;
-    wm_vuldet_db *parsed_oval = NULL;
-
-    os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
-
-    //create xml node
-    os_calloc(2, sizeof(xml_node *), node);
-    os_calloc(1, sizeof(xml_node), *node);
-    os_calloc(2, sizeof(char *), node[0]->attributes);
-    os_calloc(2, sizeof(char *), node[0]->values);
-    os_strdup("operator", node[0]->attributes[0]);
-    os_strdup("NOR", node[0]->values[0]);
-    os_strdup("criteria", node[0]->element);
-
-    os_calloc(1, sizeof(update_node), update);
-    update->dist_ref = FEED_UBUNTU;
-
-    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mterror, formatted_msg, "(5511): Invalid operator 'NOR'");
-
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
-    assert_int_equal(ret, OS_INVALID);
-
-    os_free(parsed_oval);
-    OS_ClearNode(node);
-    os_free(update);
-}
-
-void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_valid_operator_OR()
-{
-    XML_NODE node = NULL;
-    XML_NODE child_node = NULL;
-    update_node *update = NULL;
-    wm_vuldet_db *parsed_oval = NULL;
-
-    os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
-
-    //create xml node
-    os_calloc(2, sizeof(xml_node *), node);
-    os_calloc(1, sizeof(xml_node), *node);
-    os_calloc(2, sizeof(char *), node[0]->attributes);
-    os_calloc(2, sizeof(char *), node[0]->values);
-    os_strdup("operator", node[0]->attributes[0]);
-    os_strdup("OR", node[0]->values[0]);
-    os_strdup("criteria", node[0]->element);
-
-    os_calloc(1, sizeof(update_node), update);
-    update->dist_ref = FEED_UBUNTU;
-
-    // Fake child so that the function can end with an error
-    os_calloc(2, sizeof(xml_node *), child_node);
-    os_calloc(1, sizeof(xml_node), *child_node);
-    os_strdup("random_junk", child_node[0]->element);
-    will_return(__wrap_OS_GetElementsbyNode, child_node);
-
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
-    assert_int_equal(ret, 0);
-
-    os_free(parsed_oval);
-    OS_ClearNode(node);
-    os_free(update);
-}
-
-void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_criteria_comment_invalid()
-{
-    XML_NODE node = NULL;
-    XML_NODE child_node = NULL;
-    update_node *update = NULL;
-    wm_vuldet_db *parsed_oval = NULL;
-
-    os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
-
-    //create xml node
-    os_calloc(2, sizeof(xml_node *), node);
-    os_calloc(1, sizeof(xml_node), *node);
-    os_calloc(2, sizeof(char *), node[0]->attributes);
-    os_calloc(2, sizeof(char *), node[0]->values);
-    os_strdup("comment", node[0]->attributes[0]);
-    os_strdup("file version", node[0]->values[0]);
-    os_strdup("criteria", node[0]->element);
-
-    os_calloc(1, sizeof(update_node), update);
-    update->dist_ref = FEED_UBUNTU;
-
-    will_return(__wrap_OS_GetElementsbyNode, NULL);
-
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
-    assert_int_equal(ret, 0);
-
-    os_free(parsed_oval);
-    OS_ClearNode(node);
-    os_free(update);
-}
-
-void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_criteria_comment_invalid_child()
-{
-    XML_NODE node = NULL;
-    XML_NODE child_node = NULL;
-    update_node *update = NULL;
-    wm_vuldet_db *parsed_oval = NULL;
-
-    os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
-
-    //create xml node
-    os_calloc(2, sizeof(xml_node *), node);
-    os_calloc(1, sizeof(xml_node), *node);
-    os_calloc(2, sizeof(char *), node[0]->attributes);
-    os_calloc(2, sizeof(char *), node[0]->values);
-    os_strdup("comment", node[0]->attributes[0]);
-    os_strdup("file version", node[0]->values[0]);
     os_strdup("criteria", node[0]->element);
 
     os_calloc(1, sizeof(update_node), update);
@@ -13735,7 +13591,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_criterion_test_ref()
     os_free(update);
 }
 
-void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_criterion_comment1()
+void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_criterion_ignore()
 {
     XML_NODE node = NULL;
     XML_NODE child_node = NULL;
@@ -13748,12 +13604,13 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_criterion_comment1()
     //create xml node
     os_calloc(2, sizeof(xml_node *), node);
     os_calloc(1, sizeof(xml_node), *node);
-    os_calloc(2, sizeof(char *), node[0]->attributes);
-    os_calloc(2, sizeof(char *), node[0]->values);
-    os_strdup("comment", node[0]->attributes[0]);
+    os_calloc(3, sizeof(char *), node[0]->attributes);
+    os_calloc(3, sizeof(char *), node[0]->values);
     os_strdup("criterion", node[0]->element);
+    os_strdup("comment", node[0]->attributes[0]);
     os_strdup("while related to the CVE in some way, a decision has been made to ignore this issue", node[0]->values[0]);
-    parsed_oval->vulnerabilities->state_id = "CVE-id";
+    os_strdup("test_ref", node[0]->attributes[1]);
+    os_strdup("test_value", node[0]->values[1]);
 
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_UBUNTU;
@@ -13762,39 +13619,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_criterion_comment1()
     assert_int_equal(ret, 0);
     assert_int_equal(parsed_oval->vulnerabilities->ignore, 1);
 
-    os_free(parsed_oval->vulnerabilities);
-    os_free(parsed_oval);
-    OS_ClearNode(node);
-    os_free(update);
-}
-
-void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_criterion_comment0()
-{
-    XML_NODE node = NULL;
-    XML_NODE child_node = NULL;
-    update_node *update = NULL;
-    wm_vuldet_db *parsed_oval = NULL;
-
-    os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
-    os_calloc(1, sizeof(vulnerability), parsed_oval->vulnerabilities);
-
-    //create xml node
-    os_calloc(2, sizeof(xml_node *), node);
-    os_calloc(1, sizeof(xml_node), *node);
-    os_calloc(2, sizeof(char *), node[0]->attributes);
-    os_calloc(2, sizeof(char *), node[0]->values);
-    os_strdup("comment", node[0]->attributes[0]);
-    os_strdup("criterion", node[0]->element);
-    os_strdup("else random", node[0]->values[0]);
-    parsed_oval->vulnerabilities->state_id = "CVE-id";
-
-    os_calloc(1, sizeof(update_node), update);
-    update->dist_ref = FEED_UBUNTU;
-
-    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
-    assert_int_equal(ret, 0);
-    assert_int_equal(parsed_oval->vulnerabilities->ignore, 0);
-
+    os_free(parsed_oval->vulnerabilities->state_id);
     os_free(parsed_oval->vulnerabilities);
     os_free(parsed_oval);
     OS_ClearNode(node);
@@ -14185,6 +14010,8 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_other_invalid()
     os_free(update);
 }
 
+// wm_vuldet_oval_xml_parser (Redhat)
+
 void test_wm_vuldet_oval_xml_parser_redhat_state()
 {
     XML_NODE node = NULL;
@@ -14438,6 +14265,442 @@ void test_wm_vuldet_oval_xml_parser_rhel_architecture_noarch()
     os_free(parsed_oval->info_states->arch[0]);
     os_free(parsed_oval->info_states->arch);
     os_free(parsed_oval->info_states);
+    os_free(parsed_oval);
+    OS_ClearNode(node);
+    os_free(update);
+}
+
+// wm_vuldet_oval_xml_parser (SUSE)
+
+void test_wm_vuldet_oval_xml_parser_suse_state() {
+    XML_NODE node = NULL;
+    update_node *update = NULL;
+
+    os_calloc(1, sizeof(xml_node *), node);
+    os_calloc(1, sizeof(xml_node), *node);
+    node[0]->element = "rpminfo_state";
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_ref = FEED_SUSE;
+
+    will_return(__wrap_OS_GetElementsbyNode, NULL);
+
+    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mterror, formatted_msg, "(1230): Invalid element in the configuration: 'rpminfo_state'.");
+
+    int ret = wm_vuldet_oval_xml_parser(NULL, node, NULL, update, 0);
+
+    assert_int_equal(ret, OS_INVALID);
+
+    os_free(node[0]);
+    os_free(node);
+    os_free(update);
+}
+
+void test_wm_vuldet_oval_xml_parser_suse_test() {
+    XML_NODE node = NULL;
+    update_node *update = NULL;
+
+    os_calloc(1, sizeof(xml_node *), node);
+    os_calloc(1, sizeof(xml_node), *node);
+    node[0]->element = "rpminfo_test";
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_ref = FEED_SUSE;
+
+    will_return(__wrap_OS_GetElementsbyNode, NULL);
+
+    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mterror, formatted_msg, "(1230): Invalid element in the configuration: 'rpminfo_test'.");
+
+    int ret = wm_vuldet_oval_xml_parser(NULL, node, NULL, update, 0);
+
+    assert_int_equal(ret, OS_INVALID);
+
+    os_free(node[0]);
+    os_free(node);
+    os_free(update);
+}
+
+void test_wm_vuldet_oval_xml_parser_suse_object() {
+    XML_NODE node = NULL;
+    update_node *update = NULL;
+
+    os_calloc(1, sizeof(xml_node *), node);
+    os_calloc(1, sizeof(xml_node), *node);
+    node[0]->element = "rpminfo_object";
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_ref = FEED_SUSE;
+
+    will_return(__wrap_OS_GetElementsbyNode, NULL);
+
+    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mterror, formatted_msg, "(1230): Invalid element in the configuration: 'rpminfo_object'.");
+
+    int ret = wm_vuldet_oval_xml_parser(NULL, node, NULL, update, 0);
+
+    assert_int_equal(ret, OS_INVALID);
+
+    os_free(node[0]);
+    os_free(node);
+    os_free(update);
+}
+
+void test_wm_vuldet_oval_xml_parser_suse_object_valid_content() {
+    XML_NODE node = NULL;
+    XML_NODE child_node = NULL;
+    update_node *update = NULL;
+    wm_vuldet_db *parsed_oval = NULL;
+
+    os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
+    os_calloc(1, sizeof(info_obj), parsed_oval->info_objs);
+
+    //create xml node
+    os_calloc(2, sizeof(xml_node *), node);
+    os_calloc(1, sizeof(xml_node), *node);
+    os_strdup("name", node[0]->element);
+    os_strdup("id_content", node[0]->content);
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_ref = FEED_SUSE;
+
+    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, VU_OBJ);
+    assert_int_equal(ret, 0);
+    assert_string_equal(parsed_oval->info_objs->obj, node[0]->content);
+
+    os_free(parsed_oval->info_objs->obj);
+    os_free(parsed_oval->info_objs);
+    os_free(parsed_oval);
+    OS_ClearNode(node);
+    os_free(update);
+}
+
+void test_wm_vuldet_oval_xml_parser_suse_evr() {
+    XML_NODE node = NULL;
+    XML_NODE child_node = NULL;
+    update_node *update = NULL;
+    wm_vuldet_db *parsed_oval = NULL;
+
+    os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
+    os_calloc(1, sizeof(info_state), parsed_oval->info_states);
+    parsed_oval->info_states->id = NULL;
+    parsed_oval->info_states->prev = NULL;
+
+    //create xml node
+    os_calloc(2, sizeof(xml_node *), node);
+    os_calloc(1, sizeof(xml_node), *node);
+    os_calloc(2, sizeof(char *), node[0]->attributes);
+    os_calloc(2, sizeof(char *), node[0]->values);
+    os_strdup("evr", node[0]->element);
+    os_strdup("0:23.1", node[0]->content);
+    os_strdup("operation", node[0]->attributes[0]);
+    os_strdup("less than", node[0]->values[0]);
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_ref = FEED_SUSE;
+
+    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    assert_int_equal(ret, 0);
+
+    os_free(parsed_oval->info_states->operation_value);
+    os_free(parsed_oval->info_states->operation);
+    os_free(parsed_oval->info_states);
+    os_free(parsed_oval);
+    OS_ClearNode(node);
+    os_free(update);
+}
+
+void test_wm_vuldet_oval_xml_parser_suse_evr_version() {
+    XML_NODE node = NULL;
+    XML_NODE child_node = NULL;
+    update_node *update = NULL;
+    wm_vuldet_db *parsed_oval = NULL;
+
+    os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
+    os_calloc(1, sizeof(info_state), parsed_oval->info_states);
+    parsed_oval->info_states->id = NULL;
+    parsed_oval->info_states->prev = NULL;
+
+    //create xml node
+    os_calloc(2, sizeof(xml_node *), node);
+    os_calloc(1, sizeof(xml_node), *node);
+    os_calloc(2, sizeof(char *), node[0]->attributes);
+    os_calloc(2, sizeof(char *), node[0]->values);
+    os_strdup("version", node[0]->element);
+    os_strdup("0:23.1", node[0]->content);
+    os_strdup("operation", node[0]->attributes[0]);
+    os_strdup("equals", node[0]->values[0]);
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_ref = FEED_SUSE;
+
+    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    assert_int_equal(ret, 0);
+
+    os_free(parsed_oval->info_states->operation_value);
+    os_free(parsed_oval->info_states->operation);
+    os_free(parsed_oval->info_states);
+    os_free(parsed_oval);
+    OS_ClearNode(node);
+    os_free(update);
+}
+
+void test_wm_vuldet_oval_xml_parser_suse_arch() {
+    XML_NODE node = NULL;
+    XML_NODE child_node = NULL;
+    update_node *update = NULL;
+    wm_vuldet_db *parsed_oval = NULL;
+
+    os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
+    os_calloc(1, sizeof(info_state), parsed_oval->info_states);
+    parsed_oval->info_states->id = NULL;
+    parsed_oval->info_states->prev = NULL;
+
+    //create xml node
+    os_calloc(2, sizeof(xml_node *), node);
+    os_calloc(1, sizeof(xml_node), *node);
+    os_calloc(2, sizeof(char *), node[0]->attributes);
+    os_calloc(2, sizeof(char *), node[0]->values);
+    os_strdup("arch", node[0]->element);
+    os_strdup("(x86_64|i386|aarch64)", node[0]->content);
+    os_strdup("operation", node[0]->attributes[0]);
+    os_strdup("pattern match", node[0]->values[0]);
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_ref = FEED_SUSE;
+
+    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    assert_int_equal(ret, 0);
+    assert_string_equal(parsed_oval->info_states->arch[0], "x86_64");
+    assert_string_equal(parsed_oval->info_states->arch[1], "i386");
+    assert_string_equal(parsed_oval->info_states->arch[2], "aarch64");
+
+    for (int i = 0; parsed_oval->info_states->arch[i]; i++) {
+        os_free(parsed_oval->info_states->arch[i]);
+    }
+    os_free(parsed_oval->info_states->arch);
+    os_free(parsed_oval->info_states);
+    os_free(parsed_oval);
+    OS_ClearNode(node);
+    os_free(update);
+}
+
+void test_wm_vuldet_oval_xml_parser_suse_state_ref() {
+    XML_NODE node = NULL;
+    XML_NODE child_node = NULL;
+    update_node *update = NULL;
+    wm_vuldet_db *parsed_oval = NULL;
+
+    os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
+    os_calloc(1, sizeof(info_test), parsed_oval->info_tests);
+
+    //create xml node
+    os_calloc(2, sizeof(xml_node *), node);
+    os_calloc(1, sizeof(xml_node), *node);
+    os_calloc(2, sizeof(char *), node[0]->attributes);
+    os_calloc(2, sizeof(char *), node[0]->values);
+    os_strdup("value_data", node[0]->values[0]);
+    os_strdup("state_ref", node[0]->attributes[0]);
+    os_strdup("state", node[0]->element);
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_ref = FEED_SUSE;
+
+    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, VU_PACKG);
+    assert_int_equal(ret, 0);
+    assert_string_equal(parsed_oval->info_tests->state, node[0]->values[0]);
+
+    os_free(parsed_oval->info_tests->state);
+    os_free(parsed_oval->info_tests);
+    os_free(parsed_oval);
+    OS_ClearNode(node);
+    os_free(update);
+}
+
+void test_wm_vuldet_oval_xml_parser_suse_object_ref() {
+    XML_NODE node = NULL;
+    XML_NODE child_node = NULL;
+    update_node *update = NULL;
+    wm_vuldet_db *parsed_oval = NULL;
+
+    os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
+    os_calloc(1, sizeof(info_test), parsed_oval->info_tests);
+
+    //create xml node
+    os_calloc(2, sizeof(xml_node *), node);
+    os_calloc(1, sizeof(xml_node), *node);
+    os_calloc(2, sizeof(char *), node[0]->attributes);
+    os_calloc(2, sizeof(char *), node[0]->values);
+    os_strdup("value_data", node[0]->values[0]);
+    os_strdup("object_ref", node[0]->attributes[0]);
+    os_strdup("object", node[0]->element);
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_ref = FEED_SUSE;
+
+    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, VU_PACKG);
+    assert_int_equal(ret, 0);
+    assert_string_equal(parsed_oval->info_tests->obj, node[0]->values[0]);
+
+    os_free(parsed_oval->info_tests->obj);
+    os_free(parsed_oval->info_tests);
+    os_free(parsed_oval);
+    OS_ClearNode(node);
+    os_free(update);
+}
+
+void test_wm_vuldet_oval_xml_parser_suse_criterion_not_affected() {
+    XML_NODE node = NULL;
+    XML_NODE child_node = NULL;
+    update_node *update = NULL;
+    wm_vuldet_db *parsed_oval = NULL;
+
+    os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
+    os_calloc(1, sizeof(vulnerability), parsed_oval->vulnerabilities);
+
+    //create xml node
+    os_calloc(2, sizeof(xml_node *), node);
+    os_calloc(1, sizeof(xml_node), *node);
+    os_calloc(3, sizeof(char *), node[0]->attributes);
+    os_calloc(3, sizeof(char *), node[0]->values);
+    os_strdup("criterion", node[0]->element);
+    os_strdup("comment", node[0]->attributes[0]);
+    os_strdup("this package is not affected", node[0]->values[0]);
+    os_strdup("test_ref", node[0]->attributes[1]);
+    os_strdup("test_value", node[0]->values[1]);
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_ref = FEED_SUSE;
+
+    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    assert_int_equal(ret, 0);
+    assert_int_equal(parsed_oval->vulnerabilities->ignore, 1);
+
+    os_free(parsed_oval->vulnerabilities->state_id);
+    os_free(parsed_oval->vulnerabilities);
+    os_free(parsed_oval);
+    OS_ClearNode(node);
+    os_free(update);
+}
+
+void test_wm_vuldet_oval_xml_parser_suse_criterion_skip() {
+    XML_NODE node = NULL;
+    XML_NODE child_node = NULL;
+    update_node *update = NULL;
+    wm_vuldet_db *parsed_oval = NULL;
+
+    os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
+    os_calloc(1, sizeof(vulnerability), parsed_oval->vulnerabilities);
+
+    //create xml node
+    os_calloc(2, sizeof(xml_node *), node);
+    os_calloc(1, sizeof(xml_node), *node);
+    os_calloc(2, sizeof(char *), node[0]->attributes);
+    os_calloc(2, sizeof(char *), node[0]->values);
+    os_strdup("criterion", node[0]->element);
+    os_strdup("comment", node[0]->attributes[0]);
+    os_strdup("SUSE Linux Enterprise Module 1", node[0]->values[0]);
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_ref = FEED_SUSE;
+
+    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    assert_int_equal(ret, 0);
+
+    os_free(parsed_oval->vulnerabilities);
+    os_free(parsed_oval);
+    OS_ClearNode(node);
+    os_free(update);
+}
+
+void test_wm_vuldet_oval_xml_parser_suse_cve() {
+    XML_NODE node = NULL;
+    XML_NODE child_node = NULL;
+    update_node *update = NULL;
+    wm_vuldet_db *parsed_oval = NULL;
+
+    os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
+    os_calloc(1, sizeof(info_cve), parsed_oval->info_cves);
+    os_calloc(1, sizeof(vulnerability), parsed_oval->vulnerabilities);
+
+    //create xml node
+    os_calloc(2, sizeof(xml_node *), node);
+    os_calloc(1, sizeof(xml_node), *node);
+    os_strdup("CVE-1234-1234", node[0]->content);
+    os_strdup("cve", node[0]->element);
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_ref = FEED_SUSE;
+
+    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    assert_int_equal(ret, 0);
+    assert_string_equal(parsed_oval->info_cves->cveid, node[0]->content);
+    assert_string_equal(parsed_oval->vulnerabilities->cve_id, node[0]->content);
+
+    os_free(parsed_oval->info_cves->cveid);
+    os_free(parsed_oval->info_cves);
+    os_free(parsed_oval->vulnerabilities->cve_id);
+    os_free(parsed_oval->vulnerabilities);
+    os_free(parsed_oval);
+    OS_ClearNode(node);
+    os_free(update);
+}
+
+void test_wm_vuldet_oval_xml_parser_suse_description() {
+    XML_NODE node = NULL;
+    update_node *update = NULL;
+    wm_vuldet_db *parsed_oval = NULL;
+
+    os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
+    os_calloc(1, sizeof(info_cve), parsed_oval->info_cves);
+
+    //create xml node
+    os_calloc(2, sizeof(xml_node *), node);
+    os_calloc(1, sizeof(xml_node), *node);
+    os_strdup("description", node[0]->element);
+    os_strdup("\n  This is the description.   \n", node[0]->content);
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_ref = FEED_SUSE;
+
+    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    assert_int_equal(ret, 0);
+    assert_string_equal(parsed_oval->info_cves->description, "This is the description.");
+
+    os_free(parsed_oval->info_cves->description);
+    os_free(parsed_oval->info_cves);
+    os_free(parsed_oval);
+    OS_ClearNode(node);
+    os_free(update);
+}
+
+void test_wm_vuldet_oval_xml_parser_suse_issued() {
+    XML_NODE node = NULL;
+    update_node *update = NULL;
+    wm_vuldet_db *parsed_oval = NULL;
+
+    os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
+    os_calloc(1, sizeof(info_cve), parsed_oval->info_cves);
+
+    //create xml node
+    os_calloc(2, sizeof(xml_node *), node);
+    os_calloc(1, sizeof(xml_node), *node);
+    os_calloc(2, sizeof(char *), node[0]->attributes);
+    os_calloc(2, sizeof(char *), node[0]->values);
+    os_strdup("issued", node[0]->element);
+    os_strdup("date", node[0]->attributes[0]);
+    os_strdup("value_data", node[0]->values[0]);
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_ref = FEED_SUSE;
+
+    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    assert_int_equal(ret, 0);
+    assert_string_equal(parsed_oval->info_cves->published, node[0]->values[0]);
+
+    os_free(parsed_oval->info_cves->published);
+    os_free(parsed_oval->info_cves);
     os_free(parsed_oval);
     OS_ClearNode(node);
     os_free(update);
@@ -19425,6 +19688,7 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_oval_xml_preparser_invalid_tmp_open, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_oval_xml_preparser_ubuntu, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_oval_xml_preparser_debian, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_oval_xml_preparser_suse, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_oval_xml_preparser_redhat, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_oval_xml_preparser_invalid_feed, setup_group, teardown_group),
         // Tests wm_vuldet_json_arch_parser
@@ -19473,22 +19737,15 @@ int main(void)
         cmocka_unit_test(test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_state),
         cmocka_unit_test(test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_ref),
         cmocka_unit_test(test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_valid_definition),
+        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_valid_definition_patch),
         cmocka_unit_test(test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_reference_url),
         cmocka_unit_test(test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_reference_id),
         cmocka_unit_test(test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_reference_id_cve_exists),
         cmocka_unit_test(test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_title),
         cmocka_unit_test(test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_invalid_criteria),
-        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_invalid_operator_OR),
-        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_invalid_child_operator_OR),
-        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_invalid_operator_AND),
-        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_invalid_child_operator_AND),
-        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_invalid_operator),
-        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_valid_operator_OR),
-        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_criteria_comment_invalid),
-        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_criteria_comment_invalid_child),
+        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_invalid_child),
         cmocka_unit_test(test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_criterion_test_ref),
-        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_criterion_comment1),
-        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_criterion_comment0),
+        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_criterion_ignore),
         cmocka_unit_test(test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_description),
         cmocka_unit_test(test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_product_version),
         cmocka_unit_test(test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_product_name),
@@ -19510,6 +19767,20 @@ int main(void)
         cmocka_unit_test(test_wm_vuldet_oval_xml_parser_rhel_architecture_equals),
         cmocka_unit_test(test_wm_vuldet_oval_xml_parser_rhel_architecture_pattern),
         cmocka_unit_test(test_wm_vuldet_oval_xml_parser_rhel_architecture_noarch),
+        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_suse_state),
+        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_suse_test),
+        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_suse_object),
+        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_suse_object_valid_content),
+        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_suse_evr),
+        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_suse_evr_version),
+        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_suse_arch),
+        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_suse_state_ref),
+        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_suse_object_ref),
+        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_suse_criterion_not_affected),
+        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_suse_criterion_skip),
+        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_suse_cve),
+        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_suse_description),
+        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_suse_issued),
         // Tests wm_vuldet_json_parser
         cmocka_unit_test(test_wm_vuldet_json_parser_file_content_NULL),
         cmocka_unit_test(test_wm_vuldet_json_parser_json_nvd_parser_NULL),

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2564,7 +2564,9 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
 
     switch (update->dist_ref) {
         case FEED_REDHAT:
+            // CVE_INFO_TABLE is filled from the JSON feed in RedHat
             if (wm_vuldet_remove_target_table(db, ARCHITECTURES_TABLE, parsed_oval->OS) ||
+                wm_vuldet_remove_target_table(db, METADATA_TABLE, parsed_oval->OS) ||
                 wm_vuldet_remove_target_table(db, CVE_TABLE, parsed_oval->OS)) {
                 return OS_INVALID;
             }
@@ -2590,9 +2592,18 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
             }
             break;
         case FEED_ALAS:
+            // METADATA is handled by the metadata file in ALAS (not OVAL)
             if (wm_vuldet_remove_target_table(db, CVE_TABLE, parsed_oval->OS) ||
                 wm_vuldet_remove_target_table(db, ARCHITECTURES_TABLE, parsed_oval->OS) ||
                 wm_vuldet_remove_target_table(db, CVE_REF_TABLE, parsed_oval->OS)) {
+                return OS_INVALID;
+            }
+        break;
+        case FEED_SUSE:
+            if (wm_vuldet_remove_target_table(db, CVE_TABLE, parsed_oval->OS)      ||
+                wm_vuldet_remove_target_table(db, METADATA_TABLE, parsed_oval->OS) ||
+                wm_vuldet_remove_target_table(db, CVE_INFO_TABLE, parsed_oval->OS) ||
+                wm_vuldet_remove_target_table(db, ARCHITECTURES_TABLE, parsed_oval->OS)) {
                 return OS_INVALID;
             }
         break;
@@ -3119,6 +3130,10 @@ char *wm_vuldet_oval_xml_preparser(char *path, vu_feed dist) {
                     continue;
                 }
             }
+        } else if (dist == FEED_SUSE) {
+            if (strstr(buffer, "?>")) {
+                continue;
+            }
 
         } else if (dist != FEED_UBUNTU) {
             os_free(tmp_file);
@@ -3251,6 +3266,7 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
     static const char *XML_ADVISORY = "advisory";
     static const char *XML_SEVERITY = "severity";
     static const char *XML_PUBLIC_DATE = "public_date";
+    static const char *XML_ISSUED = "issued";
     static const char *XML_UPDATED = "updated";
     static const char *XML_BUG = "bug";
     static const char *XML_REF = "ref";
@@ -3267,9 +3283,12 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
     static const char *XML_TESTS = "tests";
     static const char *XML_RPM_LINUX_INFO_TEST = "red-def:rpminfo_test";
     static const char *XML_RPM_LINUX_INFO_OBJ = "red-def:rpminfo_object";
+    static const char *XML_RPM_SUSE_INFO_TEST = "rpminfo_test";
+    static const char *XML_RPM_SUSE_INFO_OBJ = "rpminfo_object";
     static const char *XML_DPKG_LINUX_INFO_TEST = "linux-def:dpkginfo_test";
     static const char *XML_LINUX_OBJ = "linux-def:object";
     static const char *XML_LINUX_RPM_OBJ = "red-def:object";
+    static const char *XML_LINUX_RPM_SUSE_OBJ = "object";
     static const char *XML_OBJECT_REF = "object_ref";
     static const char *XML_LINUX_STATE = "linux-def:state";
     static const char *XML_STATE_REF = "state_ref";
@@ -3278,17 +3297,22 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
     static const char *XML_DPKG_LINUX_INFO_OBJ = "linux-def:dpkginfo_object";
     static const char *XML_LINUX_NAME = "linux-def:name";
     static const char *XML_LINUX_RPM_STATE = "red-def:state";
+    static const char *XML_LINUX_RPM_SUSE_STATE = "state";
     static const char *XML_LINUX_RPM_NAME = "red-def:name";
+    static const char *XML_LINUX_RPM_SUSE_NAME = "name";
     static const char *XML_VAR_REF = "var_ref";
     static const char *XML_VAR_CHECK = "var_check";
     static const char *XML_STATES = "states";
     static const char *XML_RPM_LINUX_INFO_STATE = "red-def:rpminfo_state";
+    static const char *XML_RPM_SUSE_INFO_STATE = "rpminfo_state";
     static const char *XML_DPKG_LINUX_INFO_STATE = "linux-def:dpkginfo_state";
     static const char *XML_LINUX_DEF_EVR = "linux-def:evr";
     static const char *XML_LINUX_RPM_DEF_EVR = "red-def:evr";
+    static const char *XML_LINUX_RPM_SUSE_DEF_EVR = "evr";
     static const char *XML_OPERATION = "operation";
     static const char *XML_DATATYPE = "datatype";
     static const char *XML_RPM_ARCHITECTURE = "red-def:arch";
+    static const char *XML_RPM_SUSE_ARCHITECTURE = "arch";
     // Variables
     static const char *XML_VARIABLES = "variables";
     static const char *XML_CONST_VAR = "constant_variable";
@@ -3302,7 +3326,8 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
         }
 
         if ((dist == FEED_UBUNTU && !strcmp(node[i]->element, XML_DPKG_LINUX_INFO_STATE)) ||
-            (dist == FEED_REDHAT && !strcmp(node[i]->element, XML_RPM_LINUX_INFO_STATE))) {
+            (dist == FEED_REDHAT && !strcmp(node[i]->element, XML_RPM_LINUX_INFO_STATE)) ||
+            (dist == FEED_SUSE && !strcmp(node[i]->element, XML_RPM_SUSE_INFO_STATE))) {
             if (chld_node = OS_GetElementsbyNode(xml, node[i]), !chld_node) {
                 goto invalid_elem;
             }
@@ -3348,7 +3373,8 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
             }
         }
         else if ((dist == FEED_UBUNTU && !strcmp(node[i]->element, XML_DPKG_LINUX_INFO_TEST)) ||
-                (dist == FEED_REDHAT && !strcmp(node[i]->element, XML_RPM_LINUX_INFO_TEST))) {
+                 (dist == FEED_REDHAT && !strcmp(node[i]->element, XML_RPM_LINUX_INFO_TEST)) ||
+                 (dist == FEED_SUSE && !strcmp(node[i]->element, XML_RPM_SUSE_INFO_TEST))) {
             if (chld_node = OS_GetElementsbyNode(xml, node[i]), !chld_node) {
                 goto invalid_elem;
             }
@@ -3369,7 +3395,8 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
         }
 
         else if ((dist == FEED_UBUNTU && !strcmp(node[i]->element, XML_DPKG_LINUX_INFO_OBJ)) ||
-                 (dist == FEED_REDHAT && !strcmp(node[i]->element, XML_RPM_LINUX_INFO_OBJ))) {
+                 (dist == FEED_REDHAT && !strcmp(node[i]->element, XML_RPM_LINUX_INFO_OBJ)) ||
+                 (dist == FEED_SUSE && !strcmp(node[i]->element, XML_RPM_SUSE_INFO_OBJ))) {
             if (chld_node = OS_GetElementsbyNode(xml, node[i]), !chld_node) {
                 goto invalid_elem;
             }
@@ -3389,8 +3416,10 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
             if (wm_vuldet_oval_xml_parser(xml, chld_node, parsed_oval, update, VU_PACKG) == OS_INVALID) {
                 goto end;
             }
-        } else if (condition == VU_OBJ && ((dist == FEED_UBUNTU && !strcmp(node[i]->element, XML_LINUX_NAME)) ||
-                    (dist == FEED_REDHAT && !strcmp(node[i]->element, XML_LINUX_RPM_NAME)))) {
+        } else if (condition == VU_OBJ &&
+                    ((dist == FEED_UBUNTU && !strcmp(node[i]->element, XML_LINUX_NAME)) ||
+                    (dist == FEED_REDHAT && !strcmp(node[i]->element, XML_LINUX_RPM_NAME)) ||
+                    (dist == FEED_SUSE && !strcmp(node[i]->element, XML_LINUX_RPM_SUSE_NAME)))) {
             if (node[i]->content && *node[i]->content) {
                 w_strdup(node[i]->content, parsed_oval->info_objs->obj);
             } else {
@@ -3431,7 +3460,8 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
                 }
             }
         } else if ((dist == FEED_UBUNTU && !strcmp(node[i]->element, XML_LINUX_DEF_EVR)) ||
-                    (dist == FEED_REDHAT && !strcmp(node[i]->element, XML_LINUX_RPM_DEF_EVR))) {
+                   (dist == FEED_REDHAT && !strcmp(node[i]->element, XML_LINUX_RPM_DEF_EVR)) ||
+                   (dist == FEED_SUSE && !strcmp(node[i]->element, XML_LINUX_RPM_SUSE_DEF_EVR))) {
             if (node[i]->attributes && *node[i]->attributes && node[i]->content && *node[i]->content) {
                 if (dist_ref == FEED_RHEL5) {
                     // The RHEL5 OVAL contains vulnerable packages of others platforms
@@ -3459,7 +3489,8 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
                 }
 
             }
-        } else if (dist == FEED_REDHAT && !strcmp(node[i]->element, XML_RPM_ARCHITECTURE)) {
+        } else if ((dist == FEED_REDHAT && !strcmp(node[i]->element, XML_RPM_ARCHITECTURE)) ||
+                   (dist == FEED_SUSE && !strcmp(node[i]->element, XML_RPM_SUSE_ARCHITECTURE))) {
             if (node[i]->attributes && *node[i]->attributes && node[i]->content && *node[i]->content) {
                 os_calloc(1, sizeof(char *), parsed_oval->info_states->arch);
                 for (j = 0; node[i]->attributes[j]; j++) {
@@ -3472,6 +3503,15 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
                             char * saveptr = NULL;
                             int k = 0;
                             os_strdup(node[i]->content, archs);
+                            if (dist == FEED_SUSE) {
+                                /*
+                                * SUSE archs are contained in brackets
+                                * (aarch64|ppc64le|s390x|x86_64)
+                                */
+                                char * aux_archs = os_strip_char(archs, '(');
+                                os_free(archs);
+                                archs = os_strip_char(aux_archs, ')');
+                            }
                             arch_item = strtok_r(archs, "|", &saveptr);
                             while (arch_item) {
                                 k++;
@@ -3490,7 +3530,8 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
             }
         } else if ((condition == VU_PACKG) &&
                    ((dist == FEED_UBUNTU && !strcmp(node[i]->element, XML_LINUX_STATE)) ||
-                   (dist == FEED_REDHAT && !strcmp(node[i]->element, XML_LINUX_RPM_STATE)))) {
+                    (dist == FEED_REDHAT && !strcmp(node[i]->element, XML_LINUX_RPM_STATE)) ||
+                    (dist == FEED_SUSE && !strcmp(node[i]->element, XML_LINUX_RPM_SUSE_STATE)))) {
             for (j = 0; node[i]->attributes[j]; j++) {
                 if (!strcmp(node[i]->attributes[j], XML_STATE_REF)) {
                     if (!parsed_oval->info_tests->state) {
@@ -3500,7 +3541,8 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
             }
         } else if ((condition == VU_PACKG) &&
                    ((dist == FEED_UBUNTU && !strcmp(node[i]->element, XML_LINUX_OBJ)) ||
-                   (dist == FEED_REDHAT && !strcmp(node[i]->element, XML_LINUX_RPM_OBJ)))) {
+                    (dist == FEED_REDHAT && !strcmp(node[i]->element, XML_LINUX_RPM_OBJ)) ||
+                    (dist == FEED_SUSE && !strcmp(node[i]->element, XML_LINUX_RPM_SUSE_OBJ)))) {
             for (j = 0; node[i]->attributes[j]; j++) {
                 if (!strcmp(node[i]->attributes[j], XML_OBJECT_REF)) {
                     if (!parsed_oval->info_tests->obj) {
@@ -3558,7 +3600,7 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
         else if (!strcmp(node[i]->element, XML_TITLE)) {
             os_strdup(node[i]->content, parsed_oval->info_cves->title);
         }
-        else if ((dist == FEED_UBUNTU || dist == FEED_REDHAT) && !strcmp(node[i]->element, XML_CRITERIA)) {
+        else if ((dist == FEED_UBUNTU || dist == FEED_REDHAT || dist == FEED_SUSE) && !strcmp(node[i]->element, XML_CRITERIA)) {
             if (!node[i]->attributes) {
                 if (chld_node = OS_GetElementsbyNode(xml, node[i]), !chld_node) {
                     goto invalid_elem;
@@ -3610,11 +3652,16 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
                 }
             }
         }
-        else if ((dist == FEED_UBUNTU || dist == FEED_REDHAT) && !strcmp(node[i]->element, XML_CRITERION)) {
+        else if ((dist == FEED_UBUNTU || dist == FEED_REDHAT || dist == FEED_SUSE) && !strcmp(node[i]->element, XML_CRITERION)) {
             for (j = 0; node[i]->attributes[j]; j++) {
                 // Checks if the package isn't vulnerable
                 if (!strcmp(node[i]->attributes[j], XML_COMMENT)) {
-                    STATIC const char not_vulnerable[] = "while related to the CVE in some way, a decision has been made to ignore this issue";
+                    char * not_vulnerable = NULL;
+                    if (dist == FEED_SUSE) {
+                        not_vulnerable = "is not affected";
+                    } else {
+                        not_vulnerable = "while related to the CVE in some way, a decision has been made to ignore this issue";
+                    }
 
                     if (parsed_oval->vulnerabilities->state_id && strstr(node[i]->values[j], not_vulnerable)) {
                         parsed_oval->vulnerabilities->ignore = 1; // Out of support || Will not fix
@@ -3655,6 +3702,15 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
                 os_strdup(node[i]->content, parsed_oval->info_cves->severity);
             } else {
                 parsed_oval->info_cves->severity = NULL;
+            }
+        }
+        else if (dist == FEED_SUSE && !strcmp(node[i]->element, XML_ISSUED)) {
+            if (node[i]->attributes) {
+                for (j = 0; node[i]->attributes[j]; j++) {
+                    if (!strcmp(node[i]->attributes[j], XML_DATE)) {
+                        os_strdup(node[i]->values[j], parsed_oval->info_cves->published);
+                    }
+                }
             }
         }
         else if (!strcmp(node[i]->element, XML_UPDATED)) {
@@ -3849,7 +3905,8 @@ int wm_vuldet_index_feed(update_node *update) {
 
         if (update->dist_ref == FEED_UBUNTU ||
             update->dist_ref == FEED_DEBIAN ||
-            update->dist_ref == FEED_REDHAT) {
+            update->dist_ref == FEED_REDHAT ||
+            update->dist_ref == FEED_SUSE) {
 
             switch (w_uncompress_bz2_gz_file(path, VU_TEMP_FILE)) {
             case -1:

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5117,13 +5117,26 @@ int wm_vuldet_set_agents_info(const char *node_name, agent_software **agents_sof
                 dist_error = FEED_ALAS;
             }
             agent_dist = FEED_ALAS;
-        } else if (strcasestr(os_name, vu_feed_ext[FEED_SUSE])) {
+        // SUSE Linux Enterprise Server agents
+        } else if (strcasestr(os_name, "SLES")) {
             if (strstr(os_major, "11")) {
-                agent_dist_ver = (strcasestr(os_platform, "sles", 4) ? FEED_SLES11 : FEED_SLED11);
+                agent_dist_ver = FEED_SLES11;
             } else if (strstr(os_major, "12")) {
-                agent_dist_ver = (strcasestr(os_platform, "sles", 4) ? FEED_SLES12 : FEED_SLED12);
+                agent_dist_ver = FEED_SLES12;
             } else if (strstr(os_major, "15")) {
-                agent_dist_ver = (strcasestr(os_platform, "sles", 4) ? FEED_SLES15 : FEED_SLED15);
+                agent_dist_ver = FEED_SLES15;
+            } else {
+                dist_error = FEED_SUSE;
+            }
+            agent_dist = FEED_SUSE;
+        // SUSE Linux Enterprise Desktop agents
+        } else if (strcasestr(os_name, "SLED")) {
+            if (strstr(os_major, "11")) {
+                agent_dist_ver = FEED_SLED11;
+            } else if (strstr(os_major, "12")) {
+                agent_dist_ver = FEED_SLED12;
+            } else if (strstr(os_major, "15")) {
+                agent_dist_ver = FEED_SLED15;
             } else {
                 dist_error = FEED_SUSE;
             }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -3511,6 +3511,7 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
                                 char * aux_archs = os_strip_char(archs, '(');
                                 os_free(archs);
                                 archs = os_strip_char(aux_archs, ')');
+                                os_free(aux_archs);
                             }
                             arch_item = strtok_r(archs, "|", &saveptr);
                             while (arch_item) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2779,7 +2779,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
         if (state_it->operation_value != NULL) {
 
             // Get ID to insert architectures
-            if (update->dist_ref == FEED_REDHAT) {
+            if (update->dist_ref == FEED_REDHAT || update->dist_ref == FEED_SUSE) {
                 arch_id++;
             }
 
@@ -3257,6 +3257,7 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
     static const char *XML_VULNERABILITY = "vulnerability";
     static const char *XML_PATCH = "patch"; // rhel
     static const char *XML_ID = "id";
+    static const char *XML_CVE = "cve";
     static const char *XML_METADATA = "metadata";
     static const char *XML_TITLE = "title";
     static const char *XML_DESCRIPTION = "description";
@@ -3309,6 +3310,7 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
     static const char *XML_LINUX_DEF_EVR = "linux-def:evr";
     static const char *XML_LINUX_RPM_DEF_EVR = "red-def:evr";
     static const char *XML_LINUX_RPM_SUSE_DEF_EVR = "evr";
+    static const char *XML_LINUX_VERSION = "version";
     static const char *XML_OPERATION = "operation";
     static const char *XML_DATATYPE = "datatype";
     static const char *XML_RPM_ARCHITECTURE = "red-def:arch";
@@ -3461,7 +3463,7 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
             }
         } else if ((dist == FEED_UBUNTU && !strcmp(node[i]->element, XML_LINUX_DEF_EVR)) ||
                    (dist == FEED_REDHAT && !strcmp(node[i]->element, XML_LINUX_RPM_DEF_EVR)) ||
-                   (dist == FEED_SUSE && !strcmp(node[i]->element, XML_LINUX_RPM_SUSE_DEF_EVR))) {
+                   (dist == FEED_SUSE && (!strcmp(node[i]->element, XML_LINUX_RPM_SUSE_DEF_EVR) || !strcmp(node[i]->element, XML_LINUX_VERSION)))) {
             if (node[i]->attributes && *node[i]->attributes && node[i]->content && *node[i]->content) {
                 if (dist_ref == FEED_RHEL5) {
                     // The RHEL5 OVAL contains vulnerable packages of others platforms
@@ -3483,7 +3485,7 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
                         os_strdup(node[i]->content, parsed_oval->info_states->operation_value);
                     }
                 }
-                if (!parsed_oval->info_states->operation && !strcmp(*node[i]->attributes, XML_DATATYPE) && !strcmp(*node[i]->values, "version")) {
+                if (!parsed_oval->info_states->operation && !strcmp(*node[i]->attributes, XML_DATATYPE) && !strcmp(*node[i]->values, XML_LINUX_VERSION)) {
                     os_strdup(vu_package_comp[VU_COMP_EQ], parsed_oval->info_states->operation);
                     os_strdup(node[i]->content, parsed_oval->info_states->operation_value);
                 }
@@ -3571,7 +3573,8 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
         else if (!strcmp(node[i]->element, XML_REFERENCE)) {
             for (j = 0; node[i]->attributes[j]; j++) {
                 if (!strcmp(node[i]->attributes[j], XML_REF_ID) &&
-                    strstr(node[i]->values[j], "CVE")) {
+                    !strncmp(node[i]->values[j], "CVE-", 4) &&
+                    dist != FEED_SUSE) {
                     // Create new CVE structure when a new reference appears.
                     // Append the new CVE name to the already existing vulnerability.
                     if (parsed_oval->vulnerabilities->cve_id) {
@@ -3600,6 +3603,21 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
         else if (!strcmp(node[i]->element, XML_TITLE)) {
             os_strdup(node[i]->content, parsed_oval->info_cves->title);
         }
+        else if (dist == FEED_SUSE && !strcmp(node[i]->element, XML_CVE)) {
+            // Create new CVE structure when a new reference appears.
+            // Append the new CVE name to the already existing vulnerability.
+            if (parsed_oval->vulnerabilities->cve_id) {     // ~~~~ VER SI SE PUEDE QUITAR UNO DE ESTOS DOS ELSEIF
+                info_cve *new;
+                os_calloc(1, sizeof(info_cve), new);
+                new->prev = parsed_oval->info_cves->prev;
+                parsed_oval->info_cves->prev = new;
+                os_strdup(node[i]->content, new->cveid);
+                wm_vuldet_oval_append_rhsa(parsed_oval->vulnerabilities, node[i]->content);
+            } else {
+                os_strdup(node[i]->content, parsed_oval->vulnerabilities->cve_id);
+                os_strdup(node[i]->content, parsed_oval->info_cves->cveid);
+            }
+        }
         else if ((dist == FEED_UBUNTU || dist == FEED_REDHAT || dist == FEED_SUSE) && !strcmp(node[i]->element, XML_CRITERIA)) {
             if (!node[i]->attributes) {
                 if (chld_node = OS_GetElementsbyNode(xml, node[i]), !chld_node) {
@@ -3609,7 +3627,7 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
                     retval = OS_INVALID;
                     goto end;
                 }
-            } else {
+            } else {    // ~~~~ BORRAR ESTE ELSE (NO SE USA EL OPERATOR)
                 char operator_found = 0;
                 for (j = 0; node[i]->attributes[j]; j++) {
                     if (!strcmp(node[i]->attributes[j], XML_OPERATOR)) {
@@ -3658,6 +3676,13 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
                 if (!strcmp(node[i]->attributes[j], XML_COMMENT)) {
                     char * not_vulnerable = NULL;
                     if (dist == FEED_SUSE) {
+                        /*
+                         * In SUSE feeds we have to discard SUSE Linux Enterprise packages
+                         * which doesn't affect the matching criteria and insert useless entries in the DB
+                        */
+                        if (!strncmp(node[i]->values[j], "SUSE Linux Enterprise", 21)) {
+                            goto end;
+                        }
                         not_vulnerable = "is not affected";
                     } else {
                         not_vulnerable = "while related to the CVE in some way, a decision has been made to ignore this issue";
@@ -3667,8 +3692,10 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
                         parsed_oval->vulnerabilities->ignore = 1; // Out of support || Will not fix
                     }
                 }
-
-                else if (!strcmp(node[i]->attributes[j], XML_TEST_REF)) {
+            }
+            // Repeate the loop to read the "test_ref" attribute after the comment
+            for (j = 0; node[i]->attributes[j]; j++) {
+                if (!strcmp(node[i]->attributes[j], XML_TEST_REF)) {
                     if (parsed_oval->vulnerabilities->state_id &&
                         parsed_oval->vulnerabilities->cve_id) {
                         wm_vuldet_add_oval_vulnerability(parsed_oval);
@@ -3681,6 +3708,13 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
         }
         else if (!strcmp(node[i]->element, XML_DESCRIPTION)) {
             os_strdup(node[i]->content, parsed_oval->info_cves->description);
+            // SUSE feeds provide the description in newlines
+            if (dist == FEED_SUSE) {
+                os_free(parsed_oval->info_cves->description);
+                char * fixed_description = NULL;
+                fixed_description = os_strip_char(node[i]->content, '\n');
+                parsed_oval->info_cves->description = w_strtrim(fixed_description);
+            }
         }
         else if (!strcmp(node[i]->element, XML_OVAL_PRODUCT_VERSION)) {
             os_strdup(node[i]->content, parsed_oval->metadata.product_version);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5116,6 +5116,17 @@ int wm_vuldet_set_agents_info(const char *node_name, agent_software **agents_sof
                 dist_error = FEED_ALAS;
             }
             agent_dist = FEED_ALAS;
+        } else if (strcasestr(os_name, vu_feed_ext[FEED_SUSE])) {
+            if (strstr(os_major, "11")) {
+                agent_dist_ver = (strcasestr(os_platform, "sles", 4) ? FEED_SLES11 : FEED_SLED11);
+            } else if (strstr(os_major, "12")) {
+                agent_dist_ver = (strcasestr(os_platform, "sles", 4) ? FEED_SLES12 : FEED_SLED12);
+            } else if (strstr(os_major, "15")) {
+                agent_dist_ver = (strcasestr(os_platform, "sles", 4) ? FEED_SLES15 : FEED_SLED15);
+            } else {
+                dist_error = FEED_SUSE;
+            }
+            agent_dist = FEED_SUSE;
         } else if (strcasestr(os_name, vu_feed_ext[FEED_CENTOS])) {
             if (strstr(os_major, "8")) {
                 agent_dist_ver = FEED_RHEL8;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2779,7 +2779,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
         if (state_it->operation_value != NULL) {
 
             // Get ID to insert architectures
-            if (update->dist_ref == FEED_REDHAT || update->dist_ref == FEED_SUSE) {
+            if (state_it->arch && (update->dist_ref == FEED_REDHAT || update->dist_ref == FEED_SUSE)) {
                 arch_id++;
             }
 
@@ -2798,7 +2798,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
                 sqlite3_bind_text(stmt, 2, (state_it->operation_value + 2), -1, NULL);
             }
 
-            sqlite3_bind_int(stmt, 3, arch_id);
+            sqlite3_bind_int(stmt, 3, state_it->arch ? arch_id : 0);
             sqlite3_bind_text(stmt, 4, state_it->id, -1, NULL);
 
             if (result = wm_vuldet_step(stmt), result != SQLITE_DONE && result != SQLITE_CONSTRAINT) {
@@ -3195,6 +3195,7 @@ void wm_vuldet_adapt_title(char *title, char *cve) {
 
 void wm_vuldet_oval_copy_rhsa(vulnerability *old, vulnerability *new) {
     if (!old->rhsa_list) {
+        // If no Redhat feed do nothing
         return;
     }
 
@@ -3274,9 +3275,6 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
     static const char *XML_DEBIAN = "debian";
     static const char *XML_DATE = "date";
     static const char *XML_CRITERIA = "criteria";
-    static const char *XML_OPERATOR = "operator";
-    static const char *XML_OR = "OR";
-    static const char *XML_AND = "AND";
     static const char *XML_CRITERION = "criterion";
     static const char *XML_TEST_REF = "test_ref";
     static const char *XML_COMMENT = "comment";
@@ -3604,73 +3602,22 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
             os_strdup(node[i]->content, parsed_oval->info_cves->title);
         }
         else if (dist == FEED_SUSE && !strcmp(node[i]->element, XML_CVE)) {
-            // Create new CVE structure when a new reference appears.
-            // Append the new CVE name to the already existing vulnerability.
-            if (parsed_oval->vulnerabilities->cve_id) {     // ~~~~ VER SI SE PUEDE QUITAR UNO DE ESTOS DOS ELSEIF
-                info_cve *new;
-                os_calloc(1, sizeof(info_cve), new);
-                new->prev = parsed_oval->info_cves->prev;
-                parsed_oval->info_cves->prev = new;
-                os_strdup(node[i]->content, new->cveid);
-                wm_vuldet_oval_append_rhsa(parsed_oval->vulnerabilities, node[i]->content);
-            } else {
-                os_strdup(node[i]->content, parsed_oval->vulnerabilities->cve_id);
-                os_strdup(node[i]->content, parsed_oval->info_cves->cveid);
-            }
+            // For SUSE feeds read the CVE ID from the CVE tag instead of the references ID
+            os_strdup(node[i]->content, parsed_oval->vulnerabilities->cve_id);
+            os_strdup(node[i]->content, parsed_oval->info_cves->cveid);
         }
         else if ((dist == FEED_UBUNTU || dist == FEED_REDHAT || dist == FEED_SUSE) && !strcmp(node[i]->element, XML_CRITERIA)) {
-            if (!node[i]->attributes) {
-                if (chld_node = OS_GetElementsbyNode(xml, node[i]), !chld_node) {
-                    goto invalid_elem;
-                }
-                if (wm_vuldet_oval_xml_parser(xml, chld_node, parsed_oval, update, condition) == OS_INVALID) {
-                    retval = OS_INVALID;
-                    goto end;
-                }
-            } else {    // ~~~~ BORRAR ESTE ELSE (NO SE USA EL OPERATOR)
-                char operator_found = 0;
-                for (j = 0; node[i]->attributes[j]; j++) {
-                    if (!strcmp(node[i]->attributes[j], XML_OPERATOR)) {
-                        int result = VU_TRUE;
-                        operator_found = 1;
-                        if (!strcmp(node[i]->values[j], XML_OR)) {
-                            if (chld_node = OS_GetElementsbyNode(xml, node[i]), !chld_node) {
-                                continue;
-                            } else if (result = wm_vuldet_oval_xml_parser(xml, chld_node, parsed_oval, update, VU_OR), result == OS_INVALID) {
-                                retval = OS_INVALID;
-                                goto end;
-                            }
-
-                        } else if (!strcmp(node[i]->values[j], XML_AND)) {
-                            if (chld_node = OS_GetElementsbyNode(xml, node[i]), !chld_node) {
-                                continue;
-                            } else if (result = wm_vuldet_oval_xml_parser(xml, chld_node, parsed_oval, update, VU_AND), result == OS_INVALID) {
-                                retval = OS_INVALID;
-                                goto end;
-                            }
-
-                        } else {
-                            mterror(WM_VULNDETECTOR_LOGTAG, VU_INVALID_OPERATOR, node[i]->values[j]);
-                            retval = OS_INVALID;
-                            goto end;
-                        }
-                    }
-                }
-                // Checks for version comparasions without operators
-                if (!operator_found && node[i]->attributes && node[i]->values &&
-                    *node[i]->attributes && *node[i]->values &&
-                    !strcmp(*node[i]->attributes, XML_COMMENT) &&
-                    !strcmp(*node[i]->values, "file version")) {
-                    if (chld_node = OS_GetElementsbyNode(xml, node[i]), !chld_node) {
-                        continue;
-                    } else if (wm_vuldet_oval_xml_parser(xml, chld_node, parsed_oval, update, VU_AND) == OS_INVALID) {
-                        retval = OS_INVALID;
-                        goto end;
-                    }
-                }
+            if (chld_node = OS_GetElementsbyNode(xml, node[i]), !chld_node) {
+                goto invalid_elem;
+            }
+            if (wm_vuldet_oval_xml_parser(xml, chld_node, parsed_oval, update, condition) == OS_INVALID) {
+                retval = OS_INVALID;
+                goto end;
             }
         }
         else if ((dist == FEED_UBUNTU || dist == FEED_REDHAT || dist == FEED_SUSE) && !strcmp(node[i]->element, XML_CRITERION)) {
+            bool skip_package = false;
+            int ignore = 0;
             for (j = 0; node[i]->attributes[j]; j++) {
                 // Checks if the package isn't vulnerable
                 if (!strcmp(node[i]->attributes[j], XML_COMMENT)) {
@@ -3678,42 +3625,49 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
                     if (dist == FEED_SUSE) {
                         /*
                          * In SUSE feeds we have to discard SUSE Linux Enterprise packages
-                         * which doesn't affect the matching criteria and insert useless entries in the DB
+                         * which are not using for the matching criteria
                         */
                         if (!strncmp(node[i]->values[j], "SUSE Linux Enterprise", 21)) {
-                            goto end;
+                            skip_package = true;
+                            break;
                         }
                         not_vulnerable = "is not affected";
                     } else {
                         not_vulnerable = "while related to the CVE in some way, a decision has been made to ignore this issue";
                     }
 
-                    if (parsed_oval->vulnerabilities->state_id && strstr(node[i]->values[j], not_vulnerable)) {
-                        parsed_oval->vulnerabilities->ignore = 1; // Out of support || Will not fix
+                    if (strstr(node[i]->values[j], not_vulnerable)) {
+                        ignore = 1;     // Out of support || Will not fix || Not affected
                     }
                 }
             }
-            // Repeate the loop to read the "test_ref" attribute after the comment
+
+            if (skip_package) {
+                continue;
+            }
+            // Repeat the loop to read the "test_ref" attribute after the comment
             for (j = 0; node[i]->attributes[j]; j++) {
                 if (!strcmp(node[i]->attributes[j], XML_TEST_REF)) {
                     if (parsed_oval->vulnerabilities->state_id &&
-                        parsed_oval->vulnerabilities->cve_id) {
+                    parsed_oval->vulnerabilities->cve_id) {
                         wm_vuldet_add_oval_vulnerability(parsed_oval);
                         wm_vuldet_oval_copy_rhsa(parsed_oval->vulnerabilities->prev, parsed_oval->vulnerabilities);
                         os_strdup(parsed_oval->vulnerabilities->prev->cve_id, parsed_oval->vulnerabilities->cve_id);
                     }
+                    parsed_oval->vulnerabilities->ignore = ignore;
                     os_strdup(node[i]->values[j], parsed_oval->vulnerabilities->state_id);
                 }
             }
         }
         else if (!strcmp(node[i]->element, XML_DESCRIPTION)) {
-            os_strdup(node[i]->content, parsed_oval->info_cves->description);
             // SUSE feeds provide the description in newlines
             if (dist == FEED_SUSE) {
-                os_free(parsed_oval->info_cves->description);
                 char * fixed_description = NULL;
                 fixed_description = os_strip_char(node[i]->content, '\n');
-                parsed_oval->info_cves->description = w_strtrim(fixed_description);
+                os_strdup(w_strtrim(fixed_description), parsed_oval->info_cves->description);
+                os_free(fixed_description);
+            } else {
+                os_strdup(node[i]->content, parsed_oval->info_cves->description);
             }
         }
         else if (!strcmp(node[i]->element, XML_OVAL_PRODUCT_VERSION)) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -155,10 +155,6 @@ typedef enum vu_severity {
 } vu_severity;
 
 typedef enum vu_logic {
-    VU_TRUE,
-    VU_FALSE,
-    VU_OR,
-    VU_AND,
     VU_PACKG,
     VU_OBJ,
     VU_FILE_TEST,


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/8374 |

## Description

This pull request adds the following changes:

- Assign SUSE agents their corresponding OVAL feed when starting the Vulnerability scan.
- Parse the SUSE feeds and insert the vulnerabilities in the DB
- Change the OS order in the SUSE config template
- Fix the architectures IDs insertion in the DB. IDs were incremented unneeded when packages without architecture were inserted.
- Remove unused code from the OVAL parser.
- Add unit tests for the added changes. 100% coverage for modified functions:
    - [x] `wm_vuldet_oval_xml_preparser`
    - [x]  `wm_vuldet_oval_xml_parser`

## Logs/Alerts example

```
2021/06/16 10:49:10 wazuh-modulesd:vulnerability-detector: INFO: (5400): Starting 'SUSE Linux Enterprise Server 15' database update.
2021/06/16 10:49:45 wazuh-modulesd:vulnerability-detector: INFO: (5430): The update of the 'SUSE Linux Enterprise Server 15' feed finished successfully.
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)

