### PR TITLE
Addition of architecture and version for the Windows OS vulnerabilities in the CVEs inventory of the agents and vulnerabilities alerts

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1448,7 +1448,7 @@ int wm_vuldet_process_agent_vulnerabilities(sqlite3 *db, OSHash *cve_table, scan
                     atoi(report->agent_id),
                     report->cve,
                     report->condition ? report->condition : "Hotfix is not installed.");
-            } 
+            }
             else if (report->software && report->version && report->agent_id && report->cve) {
                 mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_PACK_VER_VULN, report->software,
                     report->version, atoi(report->agent_id), report->cve,
@@ -2360,7 +2360,7 @@ int wm_vuldet_find_obsolete_vulnerabilities(scan_ctx_t* scan_ctx) {
     }
     cJSON_ArrayForEach(j_vuln, j_obsolete_vulns) {
         char* package_name = cJSON_GetStringValue(cJSON_GetObjectItem(j_vuln, "name"));
-        char* cve_id = cJSON_GetStringValue(cJSON_GetObjectItem(j_vuln, "cve")); 
+        char* cve_id = cJSON_GetStringValue(cJSON_GetObjectItem(j_vuln, "cve"));
         mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_REMOVED_VULN, cve_id, package_name);
         if (wm_vuldet_send_removed_cve_report(j_vuln, scan_ctx) ) {
             mdebug1("Error trying to send removed CVEs report of agent: %d", scan_ctx->agent_id);
@@ -5277,6 +5277,11 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
         if (cJSON_IsString(j_field))
             osinfo_reference = j_field->valuestring;
 
+        j_field = cJSON_GetObjectItem(j_osinfo->child, "os_version");
+        char *osinfo_version = NULL;
+        if (cJSON_IsString(j_field))
+            osinfo_version = j_field->valuestring;
+
         j_field = cJSON_GetObjectItem(j_osinfo->child, "os_major");
         char *osinfo_major = NULL;
         if (cJSON_IsString(j_field))
@@ -5302,6 +5307,11 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
         if (cJSON_IsString(j_field))
             osinfo_release = j_field->valuestring;
 
+        j_field = cJSON_GetObjectItem(j_osinfo->child, "architecture");
+        char *osinfo_arch = NULL;
+        if (cJSON_IsString(j_field))
+            osinfo_arch = j_field->valuestring;
+
         // Writting results
         if (!agents) {
             os_calloc(1, sizeof(scan_agent), agents);
@@ -5323,15 +5333,21 @@ int wm_vuldet_collect_agents_to_scan(wm_vuldet_t *vuldet) {
         if (agti_name) {
             os_strdup(agti_name, agents->agent_name);
         }
-        if (agti_arch) {
+
+        if (osinfo_arch) {
+            os_strdup(osinfo_arch, agents->arch);
+        }
+        else if (agti_arch) {
             os_strdup(agti_arch, agents->arch);
         }
+
         agents->dist = agent_dist;
         agents->dist_ver = agent_dist_ver;
         agents->flags.centos = is_centos;
         agents->os_triaged = osinfo_triaged;
         agents->pending_attempts = WM_VULNDETECTOR_MAX_AGENT_SCAN_ATTEMPS;
         w_strdup(osinfo_reference, agents->os_reference);
+        w_strdup(osinfo_version, agents->os_version);
         w_strdup(agti_os_name, agents->os_name);
         if (agent_dist == FEED_WIN) {
             w_strdup(osinfo_os_release, agents->os_release);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -366,6 +366,7 @@ typedef struct scan_agent {
     scan_agent_flags flags;
     int os_triaged;
     char *os_reference;
+    char *os_version;
     char *os_release;
     char *os_name;
     char *kernel_release;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2274,15 +2274,23 @@ int wm_vuldet_process_agent_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd
             cpe_data = wm_vuldet_decode_cpe(report_node->generated_cpe);
         }
 
-        os_strdup(report_node->raw_product ? report_node->raw_product :
-                  (cpe_data && cpe_data->product) ? cpe_data->product : "" , report->software);
-        os_strdup(report_node->raw_version ? report_node->raw_version :
-                  (cpe_data && cpe_data->version) ? cpe_data->version : "", report->version);
-        os_strdup(report_node->raw_arch ? report_node->raw_arch :
-                  (cpe_data && cpe_data->target_hw) ? cpe_data->target_hw : "*", report->arch);
-
         os_strdup(report_node->raw_reference, report->reference);
         os_strdup(report_node->raw_type, report->type);
+        os_strdup(report_node->raw_product ? report_node->raw_product :
+                  (cpe_data && cpe_data->product) ? cpe_data->product : "" , report->software);
+
+        if (strcmp(report_node->raw_type, VULN_CVES_TYPE_OS)) {
+            os_strdup(report_node->raw_version ? report_node->raw_version :
+                  (cpe_data && cpe_data->version) ? cpe_data->version : "", report->version);
+            os_strdup(report_node->raw_arch ? report_node->raw_arch :
+                  (cpe_data && cpe_data->target_hw) ? cpe_data->target_hw : "*", report->arch);
+        }
+        else {
+            os_strdup(agent->os_version ? agent->os_version :
+                  (cpe_data && cpe_data->version) ? cpe_data->version : "", report->version);
+            os_strdup(agent->arch ? agent->arch :
+                  (cpe_data && cpe_data->target_hw) ? cpe_data->target_hw : "*", report->arch);
+        }
 
         report->pending = report_node->pending;
         wm_vuldet_build_nvd_condition(report_node, &report->condition, &report->is_hotfix);
@@ -2321,7 +2329,7 @@ int wm_vuldet_process_agent_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd
                 atoi(report->agent_id),
                 report->cve,
                 report->condition ? report->condition : "Hotfix is not installed.");
-        } 
+        }
         else if (report->software && report->version && report->agent_id && report->cve) {
             mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_PACK_VER_VULN, report->software,
                 report->version, atoi(report->agent_id), report->cve,

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2286,6 +2286,8 @@ int wm_vuldet_process_agent_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd
                   (cpe_data && cpe_data->target_hw) ? cpe_data->target_hw : "*", report->arch);
         }
         else {
+            // When the CVE affects the operating system, the NVD usually does not report the
+            // version and the architecture so, we take the information from the agent database.
             os_strdup(agent->os_version ? agent->os_version :
                   (cpe_data && cpe_data->version) ? cpe_data->version : "", report->version);
             os_strdup(agent->arch ? agent->arch :


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/9040 |

## Description

This pull request includes all the necessary changes to also add the architecture and version for the vulnerabilities reported for the Windows OS. These new fields are now included in the CVEs inventory and well as in the vulnerability alerts.

Here is an example of an alert JSON (check the `package` object):

```json
{
    "timestamp": "2021-06-16T15:57:10.394-0300",
    "rule": {
        "level": 10,
        "description": "CVE-2021-31194 affects Windows 8.1",
        "id": "23505",
        "firedtimes": 1,
        "mail": false,
        "groups": [
            "vulnerability-detector"
        ],
        "gdpr": [
            "IV_35.7.d"
        ],
        "pci_dss": [
            "11.2.1",
            "11.2.3"
        ],
        "tsc": [
            "CC7.1",
            "CC7.2"
        ]
    },
    "agent": {
        "id": "002",
        "name": "W81X64",
        "ip": "192.168.0.173"
    },
    "manager": {
        "name": "localhost.localdomain"
    },
    "id": "1623869830.2271601",
    "decoder": {
        "name": "json"
    },
    "data": {
        "vulnerability": {
            "package": {
                "name": "Windows 8.1",
                "version": "6.3.9600",
                "generated_cpe": "o:microsoft:windows_8.1:-::::::x86_64:",
                "architecture": "x86_64",
                "condition": "KB5003209 patch is not installed"
            },
            "cvss": {
                "cvss2": {
                    "vector": {
                        "attack_vector": "network",
                        "access_complexity": "low",
                        "authentication": "single",
                        "confidentiality_impact": "partial",
                        "integrity_impact": "partial",
                        "availability": "partial"
                    },
                    "base_score": "6.500000"
                },
                "cvss3": {
                    "vector": {
                        "attack_vector": "network",
                        "access_complexity": "low",
                        "privileges_required": "low",
                        "user_interaction": "none",
                        "scope": "unchanged",
                        "confidentiality_impact": "high",
                        "integrity_impact": "high",
                        "availability": "high"
                    },
                    "base_score": "8.800000"
                }
            },
            "cve": "CVE-2021-31194",
            "title": "CVE-2021-31194 affects Windows 8.1",
            "rationale": "OLE Automation Remote Code Execution Vulnerability",
            "severity": "High",
            "published": "2021-05-11",
            "updated": "2021-05-17",
            "cwe_reference": "NVD-CWE-noinfo",
            "references": [
                "https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-31194",
                "https://nvd.nist.gov/vuln/detail/CVE-2021-31194"
            ],
            "assigner": "secure@microsoft.com",
            "cve_version": "4.0"
        }
    },
    "location": "vulnerability-detector"
}
```

And this is an example of the vulnerabilities in the CVEs inventory.

![image](https://user-images.githubusercontent.com/5703274/122296659-0908f200-ced1-11eb-989b-333534eda9e0.png)

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

- Memory tests for Linux
  - [x] Scan-build report
![image](https://user-images.githubusercontent.com/5703274/122298261-e8da3280-ced2-11eb-8c15-0a410dc201ad.png)
