### PR TITLE
Improve `DELETE /groups` endpoint

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1414,13 +1414,13 @@ components:
     AgentGroupDeleted:
       type: object
       required:
-      - affected_agents
+      - affected_items
       properties:
-        affected_agents:
+        affected_items:
           type: array
-          description: "List of agents which belonged to the group and might have been reassigned to group default"
+          description: "List of removed groups with the agents which belonged to the it and might have been reassigned to group default"
           items:
-            $ref: '#/components/schemas/AgentID'
+            $ref: '#/components/schemas/GroupDelete'
 
     AgentIdKey:
       type: object
@@ -1522,6 +1522,12 @@ components:
       minLength: 1
       description: "Group name|all"
       format: group_names_or_all
+
+    GroupDelete:
+      type: object
+      description: "Deleted group with a list of agents that were assigned to it"
+      additionalProperties:
+        type: array
 
     AgentConfiguration:
       type: object
@@ -6492,20 +6498,18 @@ paths:
                   properties:
                     data:
                       allOf:
-                      - $ref: '#/components/schemas/AllItemsResponseGroupIDs'
                       - $ref: '#/components/schemas/AgentGroupDeleted'
               example:
                 data:
                   affected_items:
-                    - 'webserver'
-                    - 'dataserver'
+                    - webserver:
+                        - '002'
+                        - '003'
+                    - dataserver:
+                        - '005'
                   total_affected_items: 2
                   total_failed_items: 0
                   failed_items: []
-                  affected_agents:
-                    - '002'
-                    - '003'
-                    - '005'
                   message: "All selected groups were deleted"
                   error: 0
         '400':

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1418,7 +1418,7 @@ components:
       properties:
         affected_items:
           type: array
-          description: "List of removed groups with the agents which belonged to the it and might have been reassigned to group default"
+          description: "List of removed groups with the agents which belonged to it and might have been reassigned to group default"
           items:
             $ref: '#/components/schemas/GroupDelete'
 

--- a/api/test/integration/test_agent_DELETE_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_DELETE_endpoints.tavern.yaml
@@ -372,7 +372,6 @@ stages:
       json:
         error: 1
         data:
-          affected_agents: []
           affected_items: []
           failed_items:
             - error:
@@ -397,7 +396,6 @@ stages:
       json:
         error: 1
         data:
-          affected_agents: []
           affected_items: []
           failed_items:
             - error:
@@ -422,12 +420,11 @@ stages:
       json:
         error: 0
         data:
-          affected_agents:
-            - '003'
-            - '006'
-            - '007'
           affected_items:
-            - 'group3'
+            - group3:
+                - '003'
+                - '006'
+                - '007'
           total_affected_items: 1
     delay_after: !float "{global_db_delay}"
 
@@ -488,7 +485,6 @@ stages:
       json:
         error: 1
         data:
-          affected_agents: []
           affected_items: []
           failed_items:
             - error:
@@ -514,11 +510,10 @@ stages:
       json:
         error: 2
         data:
-          affected_agents:
-            - '007'
-            - '009'
           affected_items:
-            - 'group1'
+            - group1:
+                - '007'
+                - '009'
           failed_items:
             - error:
                 code: 1712
@@ -543,9 +538,8 @@ stages:
       json:
         error: 0
         data:
-          affected_agents: []
           affected_items:
-            - 'group2'
+            - group2: []
           total_affected_items: 1
 
 ---

--- a/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
@@ -908,7 +908,6 @@ stages:
       json:
         error: 1
         data:
-          affected_agents: []
           affected_items: []
           failed_items:
             - error:
@@ -932,7 +931,6 @@ stages:
       json:
         error: 1
         data:
-          affected_agents: []
           affected_items: []
           failed_items:
             - error:
@@ -961,7 +959,6 @@ stages:
       json:
         error: 1
         data:
-          affected_agents: []
           affected_items: []
           failed_items:
             - error:
@@ -985,7 +982,6 @@ stages:
       json:
         error: 1
         data:
-          affected_agents: []
           affected_items: []
           failed_items:
             - error:

--- a/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
@@ -980,7 +980,6 @@ stages:
       json:
         error: 1
         data:
-          affected_agents: []
           affected_items: []
           failed_items:
             - error:
@@ -1004,10 +1003,9 @@ stages:
       json:
         error: 0
         data:
-          affected_agents:
-            - '003'
           affected_items:
-            - 'group3'
+            - group3:
+                - '003'
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
@@ -1032,7 +1030,6 @@ stages:
       json:
         error: 1
         data:
-          affected_agents: []
           affected_items: []
           failed_items:
             - error:
@@ -1056,7 +1053,6 @@ stages:
       json:
         error: 1
         data:
-          affected_agents: []
           affected_items: []
           failed_items:
             - error:

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -312,7 +312,9 @@ def get_agents_in_group(group_list, offset=0, limit=common.database_limit, sort=
     :param q: Defines query to filter in DB.
     :return: AffectedItemsWazuhResult.
     """
-    if group_list[0] not in get_groups():
+    system_groups = get_groups()
+    
+    if group_list[0] not in system_groups:
         raise WazuhResourceNotFound(1710)
 
     q = 'group=' + group_list[0] + (';' + q if q else '')
@@ -746,15 +748,18 @@ def remove_agents_from_group(agent_list=None, group_list=None):
                                       some_msg=f'Some agents were not removed from group {group_id}',
                                       none_msg=f'No agent was removed from group {group_id}'
                                       )
+
+    system_groups = get_groups()
+    system_agents = get_agents_info()
     # Check if group exists
-    if group_id not in get_groups():
+    if group_id not in system_groups:
         raise WazuhResourceNotFound(1710)
 
     for agent_id in agent_list:
         try:
             if agent_id == '000':
                 raise WazuhError(1703)
-            if agent_id not in get_agents_info():
+            elif agent_id not in system_agents:
                 raise WazuhResourceNotFound(1701)
             Agent.unset_single_group_agent(agent_id=agent_id, group_id=group_id, force=True)
             result.affected_items.append(agent_id)

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -603,8 +603,7 @@ def delete_groups(group_list=None):
                 raise WazuhResourceNotFound(1710)
             elif group_id == 'default':
                 raise WazuhError(1712)
-            agent_list = list(map(operator.itemgetter('id'),
-                                  WazuhDBQueryMultigroups(group_id=group_id, limit=None).run()['items']))
+            agent_list = [agent['id'] for agent in WazuhDBQueryMultigroups(group_id=group_id, limit=None).run()['items']]
             try:
                 affected_agents_result = remove_agents_from_group(agent_list=agent_list, group_list=[group_id])
                 if affected_agents_result.total_failed_items != 0:

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -636,7 +636,7 @@ def test_create_group_exceptions(group_id, exception, exception_code):
     ['random-1', 'random-2'],
 ])
 @patch('wazuh.agent.get_groups')
-@patch('wazuh.agent.remove_agents_from_group', return_value=AffectedItemsWazuhResult())
+@patch('wazuh.agent.remove_agents_from_group', return_value=AffectedItemsWazuhResult(affected_items=['000']))
 @patch('wazuh.agent.Agent.delete_single_group')
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
@@ -659,7 +659,14 @@ def test_agent_delete_groups(socket_mock, send_mock, mock_delete, mock_remove_ag
     assert isinstance(result.affected_items, list)
     # Check affected items
     assert result.total_affected_items == len(result.affected_items)
-    assert set(result.affected_items).difference(set(group_list)) == set()
+    group_set = set(group_list)
+    for affected_item in result.affected_items:
+        key = next(iter(affected_item))
+        group_set -= {key}
+        assert affected_item[key] == ['000']
+
+    assert group_set == set()
+
     # Check failed items
     assert result.total_failed_items == 0
 


### PR DESCRIPTION
|Related issue|
|---|
| closes #9014 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
Hello team,

As it was summed up in an [issue comment](https://github.com/wazuh/wazuh/issues/9014#issuecomment-862999914), the main reason why this endpoint did not scale at all with a high number of agents was because of the cache management. After a few improvements, this is the result:

![image](https://user-images.githubusercontent.com/37274979/122352692-a3a81600-cf4f-11eb-9fb5-4160e3862b32.png)

In addition, the response format has changed to be more consistent with the rest of endpoints:

```json
{
  "data": {
    "affected_items": [
      {
        "deleted_group": [
          "001",
          "002",
          "003",
          "004",
          "005"
        ]
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected groups were deleted",
  "error": 0
}
```

## Tests performed
### Unit tests
```
============================= test session starts ==============================
platform linux -- Python 3.9.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: cov-2.12.0, asyncio-0.15.1
collected 1587 items                                                           

wazuh/core/cluster/dapi/tests/test_dapi.py .......................       [  1%]
wazuh/core/cluster/tests/test_cluster.py ...................             [  2%]
wazuh/core/cluster/tests/test_common.py .......                          [  3%]
wazuh/core/cluster/tests/test_control.py .....                           [  3%]
wazuh/core/cluster/tests/test_local_client.py .                          [  3%]
wazuh/core/cluster/tests/test_utils.py .......                           [  3%]
wazuh/core/cluster/tests/test_worker.py .................                [  4%]
wazuh/core/tests/test_active_response.py ..............                  [  5%]
wazuh/core/tests/test_agent.py ......................................... [  8%]
........................................................................ [ 12%]
.........................................................                [ 16%]
wazuh/core/tests/test_cdb_list.py ...................................... [ 18%]
                                                                         [ 18%]
wazuh/core/tests/test_common.py .......                                  [ 19%]
wazuh/core/tests/test_configuration.py ................................. [ 21%]
...                                                                      [ 21%]
wazuh/core/tests/test_decoder.py ................                        [ 22%]
wazuh/core/tests/test_input_validator.py ...                             [ 22%]
wazuh/core/tests/test_logtest.py ..                                      [ 22%]
wazuh/core/tests/test_manager.py ...............                         [ 23%]
wazuh/core/tests/test_mitre.py .............                             [ 24%]
wazuh/core/tests/test_pyDaemonModule.py ......                           [ 25%]
wazuh/core/tests/test_results.py ....................................... [ 27%]
.                                                                        [ 27%]
wazuh/core/tests/test_rootcheck.py ..........                            [ 28%]
wazuh/core/tests/test_rule.py ......................                     [ 29%]
wazuh/core/tests/test_stats.py ....                                      [ 29%]
wazuh/core/tests/test_syscollector.py ...                                [ 30%]
wazuh/core/tests/test_utils.py ......................................... [ 32%]
........................................................................ [ 37%]
........................................................................ [ 41%]
......................................                                   [ 44%]
wazuh/core/tests/test_vulnerability.py .                                 [ 44%]
wazuh/core/tests/test_wazuh_queue.py ..................                  [ 45%]
wazuh/core/tests/test_wazuh_socket.py ....................               [ 46%]
wazuh/core/tests/test_wdb.py ......................                      [ 48%]
wazuh/rbac/tests/test_auth_context.py ..                                 [ 48%]
wazuh/rbac/tests/test_decorators.py .................................... [ 50%]
.....................................................................    [ 54%]
wazuh/rbac/tests/test_default_configuration.py ......................... [ 56%]
..............................                                           [ 58%]
wazuh/rbac/tests/test_orm.py ........................................... [ 60%]
...........                                                              [ 61%]
wazuh/rbac/tests/test_preprocessor.py ...........                        [ 62%]
wazuh/tests/test_active_response.py ............                         [ 63%]
wazuh/tests/test_agent.py .............................................. [ 65%]
...............................................................          [ 69%]
wazuh/tests/test_cdb_list.py ........................................... [ 72%]
..........                                                               [ 73%]
wazuh/tests/test_ciscat.py .................................             [ 75%]
wazuh/tests/test_cluster.py .......                                      [ 75%]
wazuh/tests/test_decoder.py ...................................          [ 78%]
wazuh/tests/test_group.py ........                                       [ 78%]
wazuh/tests/test_logtest.py ......                                       [ 78%]
wazuh/tests/test_manager.py ..................................           [ 81%]
wazuh/tests/test_mitre.py .......                                        [ 81%]
wazuh/tests/test_rootcheck.py .......................................... [ 84%]
.......                                                                  [ 84%]
wazuh/tests/test_rule.py ............................................... [ 87%]
.........                                                                [ 88%]
wazuh/tests/test_sca.py .......                                          [ 88%]
wazuh/tests/test_security.py ........................................... [ 91%]
.................................                                        [ 93%]
wazuh/tests/test_stats.py ................                               [ 94%]
wazuh/tests/test_syscheck.py ........................                    [ 95%]
wazuh/tests/test_syscollector.py ............                            [ 96%]
wazuh/tests/test_task.py ............................                    [ 98%]
wazuh/tests/test_vulnerability.py ..........................             [100%]

================ 1587 passed, 14 warnings in 249.25s (0:04:09) =================

```

Regards,
Víctor