### PR TITLE
Added Cylance decoders, rules and .ini testfile

### DIFF
--- a/ruleset/decoders/0545-cylance_decoders.xml
+++ b/ruleset/decoders/0545-cylance_decoders.xml
@@ -1,0 +1,244 @@
+<!--
+-  Cylance decoders
+-  Author: Jose Lopez Rio, Jose Cruz
+-  Copyright (C) 2015-2021, Wazuh Inc.
+-  Copyright (C) 2009 Trend Micro Inc.
+-  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+<!--
+Event Type:Device
+Sep 17 15:57:27 ec2-52-72-144-44 1 2019-09-17T15:07:38.5460000Z sysloghost CylancePROTECT - - - Event Type: Device, Event Name: SystemSecurity, Device Name: xxxx, Agent Version: 0.0.0.0, IP Address: (0.0.0.0), MAC Address: (xxxxx), Logged On Users: (xxxxx), OS: Microsoft Windows Server 0000 Datacenter x64 0.0.0, Zone Names: (aws)
+Event Type:ExploitAttempt
+Sep 18 13:12:00 x-00-0-0-0 1 2019-09-18T13:06:18.3420000Z sysloghost CylancePROTECT - - - Event Type: ExploitAttempt, EventName: none, Device Name: xxx-xx-xx, IP Address: (0.0.0.0), Action: None, Process ID: 20288, Process Name:C:\WINDOWS\system32\xxxx.exe, User Name: SYSTEM, Violation Type: Remote Unmap of Memory, Zone Names: (User), Device Id: xx23xx-xx23xx-xx23xx-xx23xx-xx23xx, Policy Name: xxxxxx_+xxx+xxx
+Event Type:AuditLog
+Sep 17 14:38:29 x-00-0-0-0 1 2019-09-17T14:26:13.6670000Z sysloghost CylancePROTECT - - - Event Type: AuditLog, Event Name:LoginSuccess, Message: Provider: CylancePROTECT, Source IP: 0.0.0.0, User: xxxx xxx (xxxx@xxxx.com) Sep 14 19:28:48 xx-xx-xx-xx-00 1 2019-09-14T19:28:48.2330000Z sysloghost CylancePROTECT - - - Event Type: AuditLog, Event Name:LoginSuccess, Message: Provider: CylancePROTECT, Source IP: 0.0.0.0, User: xxxx (xxxx@xxxx.com)
+Event Type:ScriptControl
+Sep 16 05:02:49 x-00-0-0-0 1 2019-09-16T05:02:48.4470000Z sysloghost CylancePROTECT - - - Event Type: ScriptControl, Event Name: Blocked, Device Name: xxx-xxx-xxxx, File Path: c:\windows\temp\xxxx\xxxx\xxxx.vbs, Interpreter: ActiveScript, Interpreter Version: 0.0.0.0, Zone Names:(User), User Name: SYSTEM, Device Id: xx23-xx23-xx23-xx23-xx23, Policy Name: P4_AQT+MP_Block+SC_Block - PS Console Allow
+Event Type: AppControl
+Sep 14 02:43:41 x-00-0-0-0 1 2019-09-14T02:43:41.8100000Z sysloghost CylancePROTECT - - - Event Type: AppControl, Event Name: executionfromexternaldrives, Device Name: xxx-xxx23, IP Address: (0.0.0.0), Action: PEFileChange, Action Type: Allow, File Path: \\shared1\xxxx.exe, SHA256: xxxxxxxxxxxxxxxxxxxxxxxx12345xxxxxxxxx
+Event Type: Threat
+Sep 14 05:05:35 x-00-0-0-0 1 2019-09-14T02:48:13.1440000Z sysloghost CylancePROTECT - - - Event Type: Threat, Event Name: threat_changed, Device Name: xxxx-xxxx-xxxx, IP Address: (0.0.0.0), File Name: xxxx.tmp, Path: D:\xxx\xxxx\xxxx\xxxx\xxxx\, Drive Type: Internal Hard Drive, SHA256: xxxxxxxxxxxxxxxxxxxxxxxxx12345xxxxx,MD5: xxxxxxxxxxxxxxxxxxxx12345xxxxxx, Status: Quarantined, Cylance Score: 99, Found Date: 9/14/2019 2:48:13 AM, File Type: Executable, Is Running: False, Auto Run: False, Detected By: BackgroundThreatDetection, Zone Names: (User), Is Malware: False,Is Unique To Cylance: False, Threat Classification: UNCLASSIFIED,Device Id: xxx213-xxx123-xxx123-xxx123-xxxx123, Policy Name: P4_AQT+MP_Block+SC_Block - PS Console Allow
+Event Type: ThreatClassification
+Sep 14 02:43:41 x-00-0-0-0 1 2019-09-14T02:43:41.8100000Z sysloghost CylancePROTECT - - - Event Type: ThreatClassification,Event Name: ResearchSaved, Threat Class: Malware, Threat Subclass: Worm, SHA256: xxxxxxxxxxxxxxxxxxxxxxx12345 xxx12345
+-->
+
+#### BASIC FIELD TYPES #####
+
+<decoder name="CylancePROTECT_2.0">
+    <prematch>CylancePROTECT\s\w\s\w\s\w\s</prematch>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_parent">Event Type: (\w+)</regex>
+    <order>CylancePROTECT.Event.Type</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">Event Name: (\w+)</regex>
+    <order>CylancePROTECT.Event.Name</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">Device Name: (\.+),</regex>
+    <order>CylancePROTECT.Device.Name</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">IP Address: \p(\d+.\d+.\d+.\d+)\p</regex>
+    <order>CylancePROTECT.IP.Address</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">Zone Names: \((\w*)\)</regex>
+    <order>CylancePROTECT.Zone.Names</order>
+</decoder>
+<!--
+#### EVENT TYPE: Device ####
+-->
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_parent">Agent Version: (\d.\d.\d+.\d)</regex>
+    <order>CylancePROTECT.Agent.Version</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">MAC Address: \p(\w+)\p</regex>
+    <order>CylancePROTECT.MAC.Address</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">Logged On Users: \((\.+)\),</regex>
+    <order>CylancePROTECT.Username</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">OS: (\.+),</regex>
+    <order>CylancePROTECT.OS</order>
+</decoder>
+##### EVENT TYPE: ExploitAttempt
+<decoder name="CylancePROTECT_2.0-fields">
+<parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_parent">Action: (\w+)</regex>
+    <order>CylancePROTECT.Action</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">Process ID: (\d+)</regex>
+    <order>CylancePROTECT.Process.ID</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">Process Name: (\S+),</regex>
+    <order>CylancePROTECT.Process.Name</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">User Name: (\.+),</regex>
+    <order>CylancePROTECT.Username</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">Device ID: (\.+),</regex>
+    <order>CylancePROTECT.Device.ID</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">Policy Name: (\.+)</regex>
+    <order>CylancePROTECT.Policy.Name</order>
+</decoder>
+##### EVENT TYPE: AuditLog #####
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_parent">Message: (\.+),</regex>
+    <order>CylancePROTECT.Message</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">Source IP: (\d+.\d+.\d+.\d+)</regex>
+    <order>CylancePROTECT.Source.IP</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">User: (\.+)</regex>
+    <order>CylancePROTECT.Username</order>
+</decoder>
+####### EVENT TYPE: ScriptControl
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_parent">File Path: (\.+),</regex>
+    <order>CylancePROTECT.File.Path</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">Interpreter: (\w+)</regex>
+    <order>CylancePROTECT.Interpreter</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">Interpreter Version: (\S+)</regex>
+    <order>CylancePROTECT.Interpreter.Version</order>
+</decoder>
+###### EVENT TYPE: AppControl  ######
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_parent">Action Type: (\w+)</regex>
+    <order>CylancePROTECT.Action.Type</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">SHA256: (\.+)</regex>
+    <order>CylancePROTECT.SHA265</order>
+</decoder>
+###### EVENT TYPE: Memory Protection ######
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_parent">Violation Type: (\w*\s*\w*\s*\w*\s*\w*\s*\w*\s*\w*\s*\w*\s*\w*\s*\w*\s*\w*)</regex>
+    <order>CylancePROTECT.Violation.Type</order>
+</decoder>
+###### EVENT TYPE: Threat ######
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_parent">File Name: (\.+),</regex>
+    <order>CylancePROTECT.File.Name</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">Path: (\.+),</regex>
+    <order>CylancePROTECT.File.Path</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">Drive Type: (\w+\s\w+\s\w+),</regex>
+    <order>CylancePROTECT.Drive.Type</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">SHA256: (\.+),</regex>
+    <order>CylancePROTECT.SHA265</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">MD5: (\S+),</regex>
+    <order>CylancePROTECT.MD5</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">Status: (\w+)</regex>
+    <order>CylancePROTECT.Status</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">Cylance Score: (\d+)</regex>
+    <order>CylancePROTECT.Cylance.Score</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">Found Date: (\.+),</regex>
+    <order>CylancePROTECT.Found.Date</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">File Type: (\w+)</regex>
+    <order>CylancePROTECT.File.Type</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">Is Running: (\w+)</regex>
+    <order>CylancePROTECT.Is.Running</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">Auto Run: (\w+)</regex>
+    <order>CylancePROTECT.Auto.Run</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">Detected By: (\w+)</regex>
+    <order>CylancePROTECT.Detected.By</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">Is Malware: (\w+)</regex>
+    <order>CylancePROTECT.Is.Malware</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">Is Unique To Cylance: (\w+)</regex>
+    <order>CylancePROTECT.Is.Unique.To.Cylance</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_regex">Threat Classification: (\w+)</regex>
+    <order>CylancePROTECT.Threat.Classification</order>
+</decoder>
+######### EVENT TYPE: Threat Classificationi ########
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_parent">Threat Class: (\w+)</regex>
+    <order>CylancePROTECT.Threat.Class</order>
+</decoder>
+<decoder name="CylancePROTECT_2.0-fields">
+    <parent>CylancePROTECT_2.0</parent>
+    <regex offset="after_parent">Threat Subclass: (\w*\s*\w*\s*\w*)</regex>
+    <order>CylancePROTECT.Threat.Subclass</order>
+</decoder>

--- a/ruleset/rules/0730-cylance_rules.xml
+++ b/ruleset/rules/0730-cylance_rules.xml
@@ -1,0 +1,84 @@
+<!--
+-  Cylance rules
+-  Author: Jose Lopez Rio, Jose Cruz
+-  Copyright (C) 2015-2021, Wazuh Inc.
+-  Copyright (C) 2009 Trend Micro Inc.
+-  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+<group name="CylancePROTECT_2.0">
+    <rule id="65700" level="0">
+        <decoded_as>CylancePROTECT_2.0</decoded_as>
+        <description>Cylance events messages grouped.</description>
+    </rule>
+
+    <rule id="65701" level="6">
+        <if_sid>65700</if_sid>
+        <field name="CylancePROTECT.Event.Type">Threat</field>
+        <description>Cylance: $(CylancePROTECT.File.Name) at $(CylancePROTECT.File.Path) on $(CylancePROTECT.Device.Name) may be malicious | File Type: $(CylancePROTECT.File.Type) | Action Taken: $(CylancePROTECT.Status) | Threat Score: $(CylancePROTECT.Cylance.Score)</description>
+        <group>gdpr_IV_35.7.d,</group>
+    </rule>
+
+    <rule id="65702" level="6">
+        <if_sid>65700</if_sid>
+        <field name="CylancePROTECT.Event.Type">ExploitAttempt</field>
+        <description>Cylance: Exploit Attempt was discovered within the $(CylancePROTECT.Process.Name) process. | Violation Type: $(CylancePROTECT.Violation.Type) | User: $(CylancePROTECT.Username) | Device Name: $(CylancePROTECT.Device.Name)</description>
+        <group>gdpr_IV_35.7.d,</group>
+    </rule>
+
+<!-- Memory Protection Not tested due to lack of logs -->
+    <rule id="65703" level="6">
+        <if_sid>65700</if_sid>
+        <field name="CylancePROTECT.Event.Type">Memory_Protection</field>
+        <description>Cylance: Memory Protection triggered due to Process: $(CylancePROTECT.Process.Name) | Violation Type: $(CylancePROTECT.Violation.Type) | Action: $(CylancePROTECT.Action)|  User: $(CylancePROTECT.Username) | Device Name: $(CylancePROTECT.Device.Name)</description>
+        <group>gdpr_IV_35.7.d,</group>
+    </rule>
+
+    <rule id="65704" level="6">
+        <if_sid>65700</if_sid>
+        <field name="CylancePROTECT.Event.Type">ScriptControl</field>
+        <description>Cylance: $(CylancePROTECT.File.Path) was $(CylancePROTECT.Event.Name) on $(CylancePROTECT.Device.Name). | Interpreter: $(CylancePROTECT.Interpreter) | User: $(CylancePROTECT.Username)</description>
+        <group>gdpr_IV_35.7.d,</group>
+    </rule>
+
+    <rule id="65705" level="3">
+        <if_sid>65700</if_sid>
+        <field name="CylancePROTECT.Event.Type">AuditLog</field>
+        <description>Cylance: $(CylancePROTECT.Event.Name) by $(CylancePROTECT.Username) from $(CylancePROTECT.Source.IP).</description>
+        <group>gdpr_IV_35.7.d,</group>
+    </rule>
+
+    <rule id="65706" level="3">
+        <if_sid>65700</if_sid>
+        <field name="CylancePROTECT.Event.Type">AppControl</field>
+        <description>Cylance: Event: $(CylancePROTECT.Event.Name) | Action: $(CylancePROTECT.Action.Type) | File Path: $(CylancePROTECT.File.Path) | Device Name: $(CylancePROTECT.Device.Name).</description>
+        <group>gdpr_IV_35.7.d,</group>
+    </rule>
+
+    <rule id="65707" level="3">
+        <if_sid>65700</if_sid>
+        <field name="CylancePROTECT.Event.Type">Device</field>
+        <description>Cylance: Event: $(CylancePROTECT.Event.Name) | Device Name: $(CylancePROTECT.Device.Name) | User: $(CylancePROTECT.Username) | OS: $(CylancePROTECT.OS)</description>
+        <group>gdpr_IV_35.7.d,</group>
+    </rule>
+<!-- Add Device Control Rule and test Memory Protection Rule when we have logs for these-->
+
+<!-- Email/Frequency alert rules below here -->
+
+    <rule id="65708" level="12" frequency="5" timeframe="120">
+        <if_matched_sid>65701</if_matched_sid>
+        <same_field>CylancePROTECT.Device.Name</same_field>
+        <description>Cylance: Multiple malware events have been detected on $(CylancePROTECT.Device.Name)</description>
+    </rule>
+
+    <rule id="65709" level="12" frequency="5" timeframe="120">
+        <if_matched_sid>65702</if_matched_sid>
+        <same_field>CylancePROTECT.Device.Name</same_field>
+        <description>Cylance: Multiple exploitation attempts have been detected on $(CylancePROTECT.Device.Name)</description>
+    </rule>
+
+    <rule id="65710" level="14" frequency="10" timeframe="60">
+        <if_matched_sid>65702</if_matched_sid>
+        <description>Cylance: Multiple exploitation attempts have been detected.</description>
+    </rule>
+
+</group>

--- a/ruleset/testing/tests/cylance.ini
+++ b/ruleset/testing/tests/cylance.ini
@@ -1,0 +1,35 @@
+[Cylance_Device]
+log 1 pass = Sep 17 15:57:27 x-00-0-0-0 1 2019-09-17T15:07:38.5460000Z sysloghost CylancePROTECT - - - Event Type: Device, Event Name: SystemSecurity, Device Name: xxxx, Agent Version: 0.0.0.0, IP Address: (0.0.0.0), MAC Address: (xxxxx), Logged On Users: (xxxxx), OS: Microsoft Windows Server 0000 Datacenter x64 0.0.0, Zone Names: (aws)
+rule = 65707
+alert = 3
+decoder = CylancePROTECT_2.0
+[Cylance_ExploitAttempt]
+log 1 pass = Sep 18 13:12:00 x-00-0-0-0 1 2019-09-18T13:06:18.3420000Z sysloghost CylancePROTECT - - - Event Type: ExploitAttempt, EventName: none, Device Name: xxx-xx-xx, IP Address: (0.0.0.0), Action: None, Process ID: 20288, Process Name:C:\WINDOWS\system32\xxxx.exe, User Name: SYSTEM, Violation Type: Remote Unmap of Memory, Zone Names: (User), Device Id: xx23xx-xx23xx-xx23xx-xx23xx-xx23xx, Policy Name: P4_AQT+MP_Block+SC_Block
+rule = 65702
+alert = 6
+decoder = CylancePROTECT_2.0
+[Cylance_AuditLog]
+log 1 pass = Sep 17 14:38:29 x-00-0-0-0 1 2019-09-17T14:26:13.6670000Z sysloghost CylancePROTECT - - - Event Type: AuditLog, Event Name:LoginSuccess, Message: Provider: CylancePROTECT, Source IP: 0.0.0.0, User: xxxx xxx (xxxx@xxxx.com) Sep 14 19:28:48 xx-xx-xx-xx-00 1 2019-09-14T19:28:48.2330000Z sysloghost CylancePROTECT - - - Event Type: AuditLog, Event Name:LoginSuccess, Message: Provider: CylancePROTECT, Source IP: 0.0.0.0, User: xxxx (xxxx@xxxx.com)
+rule = 65705
+alert = 3
+decoder = CylancePROTECT_2.0
+[Cylance_ScriptControl]
+log 1 pass = Sep 16 05:02:49 x-00-0-0-0 1 2019-09-16T05:02:48.4470000Z sysloghost CylancePROTECT - - - Event Type: ScriptControl, Event Name: Blocked, Device Name: xxx-xxx-xxxx, File Path: c:\windows\temp\xxxx\xxxx\xxxx.vbs, Interpreter: ActiveScript, Interpreter Version: 0.0.0.0, Zone Names:(User), User Name: SYSTEM, Device Id: xx23-xx23-xx23-xx23-xx23, Policy Name: P4_AQT+MP_Block+SC_Block - PS Console Allow
+rule = 65704
+alert = 6
+decoder = CylancePROTECT_2.0
+[Cylance_AppControl]
+log 1 pass = Sep 14 02:43:41 x-00-0-0-0 1 2019-09-14T02:43:41.8100000Z sysloghost CylancePROTECT - - - Event Type: AppControl, Event Name: executionfromexternaldrives, Device Name: xxx-xxx23, IP Address: (0.0.0.0), Action: PEFileChange, Action Type: Allow, File Path: \\shared1\xxxx.exe, SHA256: xxxxxxxxxxxxxxxxxxxxxxxx12345xxxxxxxxx
+rule = 65706
+alert = 3
+decoder = CylancePROTECT_2.0
+[Cylance_Threat]
+log 1 pass = Sep 14 05:05:35 x-00-0-0-0 1 2019-09-14T02:48:13.1440000Z sysloghost CylancePROTECT - - - Event Type: Threat, Event Name: threat_changed, Device Name: xxxx-xxxx-xxxx, IP Address: (0.0.0.0), File Name: xxxx.tmp, Path: D:\xxx\xxxx\xxxx\xxxx\xxxx\, Drive Type: Internal Hard Drive, SHA256: xxxxxxxxxxxxxxxxxxxxxxxxx12345xxxxx,MD5: xxxxxxxxxxxxxxxxxxxx12345xxxxxx, Status: Quarantined, Cylance Score: 99, Found Date: 9/14/2019 2:48:13 AM, File Type: Executable, Is Running: False, Auto Run: False, Detected By: BackgroundThreatDetection, Zone Names: (User), Is Malware: False,Is Unique To Cylance: False, Threat Classification: UNCLASSIFIED,Device Id: xxx213-xxx123-xxx123-xxx123-xxxx123, Policy Name: P4_AQT+MP_Block+SC_Block - PS Console Allow
+rule = 65701
+alert = 6
+decoder = CylancePROTECT_2.0
+[Cylance_ThreatClassification]
+log 1 pass = Sep 14 02:43:41 x-00-0-0-0 1 2019-09-14T02:43:41.8100000Z sysloghost CylancePROTECT - - - Event Type: ThreatClassification,Event Name: ResearchSaved, Threat Class: Malware, Threat Subclass: Worm, SHA256: xxxxxxxxxxxxxxxxxxxxxxx12345 xxx12345
+rule = 65701
+alert = 6
+decoder = CylancePROTECT_2.0


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-ruleset/pull/495|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR adds new decoders, new rules and new sample logs, also a `.ini` test file that was made in this old PR for wazuh/ruleset: https://github.com/wazuh/wazuh-ruleset/pull/495

## Tests
Tests were made in a 4.3 manager by adding the rules and decoders and running the `runtest.py` test, having the following results:

```
root@ubuntu20LTS:/home/vagrant/wazuh/ruleset/testing# ./runtests.py -t tests/cylance.ini 
- [ File = ./tests/cylance.ini ] ---------
.......

```