### PR TITLE
Fix double file handle closing in Logcollector

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1016,7 +1016,7 @@ int handle_file(int i, int j, __attribute__((unused)) int do_fseek, int do_log)
     lf->fp = _fdopen(fd, "r");
     if (!lf->fp) {
         merror(FOPEN_ERROR, lf->file, errno, strerror(errno));
-        CloseHandle(lf->h);
+        _close(fd);
         goto error;
     }
 
@@ -1105,7 +1105,7 @@ int reload_file(logreader * lf) {
     lf->fp = _fdopen(fd, "r");
 
     if (!lf->fp) {
-        CloseHandle(lf->h);
+        _close(fd);
         return (-1);
     }
 #endif

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -568,9 +568,6 @@ void LogCollectorStart()
                     if (update_fname(i, j)) {
                         if (current->fp) {
                             fclose(current->fp);
-#ifdef WIN32
-                            CloseHandle(current->h);
-#endif
                         }
                         current->fp = NULL;
                         current->exists = 1;
@@ -644,12 +641,10 @@ void LogCollectorStart()
                                     NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
                     if (h1 == INVALID_HANDLE_VALUE) {
                         fclose(current->fp);
-                        CloseHandle(current->h);
                         current->fp = NULL;
                         minfo(LOGCOLLECTOR_INVALID_HANDLE_VALUE, current->file);
                     } else if (GetFileInformationByHandle(h1, &lpFileInformation) == 0) {
                         fclose(current->fp);
-                        CloseHandle(current->h);
                         CloseHandle(h1);
                         current->fp = NULL;
                         minfo(LOGCOLLECTOR_INVALID_HANDLE_VALUE, current->file);
@@ -709,7 +704,6 @@ void LogCollectorStart()
                         fclose(current->fp);
 
 #ifdef WIN32
-                        CloseHandle(current->h);
                         CloseHandle(h1);
 #endif
 
@@ -744,7 +738,6 @@ void LogCollectorStart()
                         fclose(current->fp);
 
 #ifdef WIN32
-                        CloseHandle(current->h);
                         CloseHandle(h1);
 #endif
                         current->fp = NULL;
@@ -771,16 +764,10 @@ void LogCollectorStart()
                                         FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
                                         NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
                         if (h1 == INVALID_HANDLE_VALUE) {
-                            if (current->h) {
-                                CloseHandle(current->h);
-                            }
                             mdebug1(LOGCOLLECTOR_INVALID_HANDLE_VALUE, current->file);
                             file_exists = 0;
                             w_logcollector_state_delete_file(current->file);
                         } else if (GetFileInformationByHandle(h1, &lpFileInformation) == 0) {
-                            if (current->h) {
-                                CloseHandle(current->h);
-                            }
                             mdebug1(LOGCOLLECTOR_INVALID_HANDLE_VALUE, current->file);
                             file_exists = 0;
                             w_logcollector_state_delete_file(current->file);
@@ -827,9 +814,6 @@ void LogCollectorStart()
 
                     if (current->fp) {
                         fclose(current->fp);
-#ifdef WIN32
-                        CloseHandle(current->h);
-#endif
                     }
 
                     current->fp = NULL;
@@ -1043,7 +1027,6 @@ int handle_file(int i, int j, __attribute__((unused)) int do_fseek, int do_log)
     if (GetFileInformationByHandle(lf->h, &lpFileInformation) == 0) {
         merror("Unable to get file information by handle.");
         fclose(lf->fp);
-        CloseHandle(lf->h);
         lf->fp = NULL;
         goto error;
     }
@@ -1143,7 +1126,6 @@ void close_file(logreader * lf) {
     lf->fp = NULL;
 
 #ifdef WIN32
-    CloseHandle(lf->h);
     lf->h = NULL;
 #endif
 }
@@ -2241,7 +2223,6 @@ void * w_input_thread(__attribute__((unused)) void * t_id){
                     if((c_currenttime - current->age) >= file_currenttime) {
                         mdebug1("Ignoring file '%s' due to modification time",current->file);
                         fclose(current->fp);
-                        CloseHandle(current->h);
                         current->fp = NULL;
                         current->h = NULL;
                         w_mutex_unlock(&current->mutex);
@@ -2331,9 +2312,6 @@ void * w_input_thread(__attribute__((unused)) void * t_id){
 
                         /* Close the file */
                         fclose(current->fp);
-    #ifdef WIN32
-                        CloseHandle(current->h);
-    #endif
                         current->fp = NULL;
 
                         /* Try to open it again */
@@ -2797,7 +2775,7 @@ STATIC void w_load_files_status(cJSON * global_json) {
         }
     }
 #if defined(Darwin) || (defined(__linux__) && defined(WAZUH_UNIT_TESTING))
-   
+
    w_macos_set_status_from_JSON(global_json);
 
 #endif
@@ -3009,7 +2987,7 @@ void w_macos_release_log_stream(void) {
 }
 
 void w_macos_release_log_execution(void) {
-    
+
     w_macos_release_log_show();
     w_macos_release_log_stream();
 }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #9066|

This PR aims to remove every call to `CloseHandle()` on files closed by `fclose()` in Logcollector on Windows agents, as the underlying file handle is implicitly closed, as explained at #9066.

## Tests

- [X] Build agent on Windows.
- [ ] Stress test on the Windows agent.
- [ ] Check that this change won't cause handle leaks.
- [x] Run a Coverity scan on this branch.