### PR TITLE
Improve api and cluster processes behavior

### DIFF
--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -6,8 +6,9 @@
 
 import argparse
 import sys
+from atexit import register
 
-from wazuh.core import common
+from wazuh.core import common, utils
 
 
 def start(foreground, root, config_file):
@@ -130,11 +131,13 @@ def start(foreground, root, config_file):
         print(f"Starting API as root")
 
     # Foreground/Daemon
+    utils.check_pid('wazuh-apid')
     if not foreground:
         pyDaemonModule.pyDaemon()
-        pyDaemonModule.create_pid('wazuh-apid', os.getpid())
-    else:
-        print(f"Starting API in foreground")
+    pid = os.getpid()
+    pyDaemonModule.create_pid('wazuh-apid', pid) or register(pyDaemonModule.delete_pid, 'wazuh-apid', pid)
+    if foreground:
+        print(f"Starting API in foreground (pid: {pid})")
 
     # Load the SPEC file into memory to use as a reference for future calls
     wazuh.security.load_spec()

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -124,6 +124,7 @@ os_pidfile = os.path.join('var', 'run')
 analysisd_stats = os.path.join(wazuh_path, 'var', 'run', 'wazuh-analysisd.state')
 remoted_stats = os.path.join(wazuh_path, 'var', 'run', 'wazuh-remoted.state')
 ar_conf_path = os.path.join(wazuh_path, 'etc', 'shared', 'ar.conf')
+pidfiles_path = os.path.join(wazuh_path, 'var', 'run')
 
 # Ruleset
 # Ruleset paths

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -413,7 +413,6 @@ class WazuhException(Exception):
         3000: 'Cluster',
         3001: 'Error creating zip file',
         3002: {'message': 'Error creating PID file'},
-        3003: {'message': 'Error deleting PID file'},
         3004: {'message': 'Error in cluster configuration',
                'remediation': f'Please, visit the official documentation (https://documentation.wazuh.com/{WAZUH_VERSION}/user-manual/configuring-cluster/index.html)'
                               ' to get more information about how to configure a cluster'},

--- a/framework/wazuh/core/pyDaemonModule.py
+++ b/framework/wazuh/core/pyDaemonModule.py
@@ -54,7 +54,7 @@ def pyDaemon():
 
 
 def create_pid(name, pid):
-    filename = "{0}/{1}/{2}-{3}.pid".format(common.wazuh_path, common.os_pidfile, name, pid)
+    filename = f"{common.wazuh_path}/{common.os_pidfile}/{name}-{pid}.pid"
 
     with open(filename, 'a') as fp:
         try:
@@ -65,9 +65,9 @@ def create_pid(name, pid):
 
 
 def delete_pid(name, pid):
-    filename = "{0}/{1}/{2}-{3}.pid".format(common.wazuh_path, common.os_pidfile, name, pid)
+    filename = f"{common.wazuh_path}/{common.os_pidfile}/{name}-{pid}.pid"
     try:
         if os.path.exists(filename):
             os.unlink(filename)
-    except OSError as e:
-        raise WazuhInternalError(3003, str(e))
+    except OSError:
+        pass

--- a/framework/wazuh/core/tests/test_pyDaemonModule.py
+++ b/framework/wazuh/core/tests/test_pyDaemonModule.py
@@ -41,7 +41,7 @@ def test_create_pid():
     with TemporaryDirectory() as tmpdirname:
         tmpfile = NamedTemporaryFile(dir=tmpdirname, delete=False, suffix='-255.pid')
         with patch('wazuh.core.pyDaemonModule.common.os_pidfile', new=tmpdirname.split('/')[2]):
-            create_pid(tmpfile.name.split('/')[3].split('-')[0],'255')
+            create_pid(tmpfile.name.split('/')[3].split('-')[0], '255')
 
 
 @patch('wazuh.core.pyDaemonModule.common.wazuh_path', new='/tmp')
@@ -53,7 +53,7 @@ def test_create_pid_ko(mock_chmod):
         tmpfile = NamedTemporaryFile(dir=tmpdirname, delete=False, suffix='-255.pid')
         with patch('wazuh.core.pyDaemonModule.common.os_pidfile', new=tmpdirname.split('/')[2]):
             with pytest.raises(WazuhException, match=".* 3002 .*"):
-                create_pid(tmpfile.name.split('/')[3].split('-')[0],'255')
+                create_pid(tmpfile.name.split('/')[3].split('-')[0], '255')
 
 
 @patch('wazuh.core.pyDaemonModule.common.wazuh_path', new='/tmp')
@@ -63,16 +63,4 @@ def test_delete_pid():
     with TemporaryDirectory() as tmpdirname:
         tmpfile = NamedTemporaryFile(dir=tmpdirname, delete=False, suffix='-255.pid')
         with patch('wazuh.core.pyDaemonModule.common.os_pidfile', new=tmpdirname.split('/')[2]):
-            delete_pid(tmpfile.name.split('/')[3].split('-')[0],'255')
-
-
-@patch('wazuh.core.pyDaemonModule.common.wazuh_path', new='/tmp')
-@patch('wazuh.core.pyDaemonModule.os.path.exists', side_effect=OSError)
-def test_delete_pid_ko(mock_exists):
-    """Tests delete_pid function exception works"""
-
-    with TemporaryDirectory() as tmpdirname:
-        tmpfile = NamedTemporaryFile(dir=tmpdirname, delete=False, suffix='-255.pid')
-        with patch('wazuh.core.pyDaemonModule.common.os_pidfile', new=tmpdirname.split('/')[2]):
-            with pytest.raises(WazuhException, match=".* 3003 .*"):
-                delete_pid(tmpfile.name.split('/')[3].split('-')[0],'255')
+            delete_pid(tmpfile.name.split('/')[3].split('-')[0], '255')

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -50,7 +50,7 @@ def check_pid(daemon):
     Parameters
     ----------
     daemon : str
-        Daemon's name
+        Daemon's name.
     """
     regex = rf'{daemon}-(.*).pid'
     for pidfile in os.listdir(pidfiles_path):


### PR DESCRIPTION
|Related issue|
|---|
|#7190|

Hi team,

This PR closes #7190. In this PR we have added the PID of the cluster processes and the API when these processes are started in foreground mode. 

We have also improved the pidfile deletion, now both the API and the cluster will delete their pidfile when they receive a SIGTERM signal.

Finally, we have fixed a bug that was causing the API to not create any pidfile when started in foreground mode. This caused wazuh-control to not know its status.

Regards