### PR TITLE
Let upgrade from sources remove old service files

### DIFF
--- a/src/init/init.sh
+++ b/src/init/init.sh
@@ -30,14 +30,17 @@ runInit()
             type=agent
         fi
         # RHEL 8 services must to be installed in /usr/lib/systemd/system/
-        if [ "${DIST_NAME}" = "rhel" -a "${DIST_VER}" = "8" ] || [ "${DIST_NAME}" = "centos" -a "${DIST_VER}" = "8" ]; then
+        if [ "${DIST_NAME}" = "rhel" -a "${DIST_VER}" -ge "7" ] || [ "${DIST_NAME}" = "centos" -a "${DIST_VER}" -ge "7" ]; then
             SERVICE_UNIT_PATH=/usr/lib/systemd/system/wazuh-$type.service
+            rm -f /etc/systemd/system/wazuh-$type.service
         else
             SERVICE_UNIT_PATH=/etc/systemd/system/wazuh-$type.service
         fi
         GenerateService wazuh-$type.service > ${SERVICE_UNIT_PATH}
         chown root:ossec ${SERVICE_UNIT_PATH}
         systemctl daemon-reload
+
+        rm -f /etc/rc.d/init.d/${service}
 
         if [ "X${update_only}" = "X" ]
         then


### PR DESCRIPTION
|Related issue|
|---|
|Closes #9081|

The upgrade installation from sources and WPK (which uses the same installer) may leave the following files in an old version:

- /etc/systemd/system/wazuh-*.service
- /etc/rc.d/init.d/wazuh-*

This PR applies two changes:

1. Select `/usr/lib/systemd/system` as the service folder on RHEL and CentOS 7 and newer.
2. Remove old service files (mentioned above).

## Tests

- [x] Install 4.1.5 from packages and upgrade from sources on CentOS 7.
- [x] Check `systemctl start/stop/status`.
- [x] Check `service status`.