### PR TITLE
8414 monitord logging with modulesd tag

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -424,9 +424,6 @@ authd.debug=0
 # Exec daemon debug (server, local or Unix agent)
 execd.debug=0
 
-# Monitor daemon debug (server, local or Unix agent)
-monitord.debug=0
-
 # Log collector (server, local or Unix agent)
 logcollector.debug=0
 

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -737,7 +737,7 @@ InstallCommon()
         fi
     elif [ -f libwazuhshared.so ]
     then
-        ${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} libwazuhshared.so ${INSTALLDIR}/lib
+        ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} libwazuhshared.so ${INSTALLDIR}/lib
 
         if ([ "X${DIST_NAME}" = "Xrhel" ] || [ "X${DIST_NAME}" = "Xcentos" ] || [ "X${DIST_NAME}" = "XCentOS" ]) && [ ${DIST_VER} -le 5 ]; then
             chcon -t textrel_shlib_t ${INSTALLDIR}/lib/libwazuhshared.so

--- a/src/monitord/compress_log.c
+++ b/src/monitord/compress_log.c
@@ -45,7 +45,7 @@ void OS_CompressLog(const char *logfile)
     zlog = gzopen(logfileGZ, "w");
     if (!zlog) {
         fclose(log);
-        merror(FOPEN_ERROR, logfileGZ, errno, strerror(errno));
+        mterror(WM_MONITOR_LOGTAG, FOPEN_ERROR, logfileGZ, errno, strerror(errno));
         return;
     }
 
@@ -55,7 +55,7 @@ void OS_CompressLog(const char *logfile)
             break;
         }
         if (gzwrite(zlog, buf, (unsigned)len) != len) {
-            merror("Compression error: %s", gzerror(zlog, &err));
+            mterror(WM_MONITOR_LOGTAG, "Compression error: %s", gzerror(zlog, &err));
         }
     }
 
@@ -64,7 +64,7 @@ void OS_CompressLog(const char *logfile)
 
     /* Remove uncompressed file */
     if ( unlink(logfile) == -1)
-        merror("Unable to delete '%s' due to '%s'", logfile, strerror(errno));
+        mterror(WM_MONITOR_LOGTAG, "Unable to delete '%s' due to '%s'", logfile, strerror(errno));
 
     return;
 }

--- a/src/monitord/generate_reports.c
+++ b/src/monitord/generate_reports.c
@@ -42,7 +42,7 @@ void generate_reports(int cday, int cmon, int cyear, const struct tm *p)
              */
             pid = fork();
             if (pid < 0) {
-                merror("Fork failed. cause: %d - %s", errno, strerror(errno));
+                mterror(WM_MONITOR_LOGTAG, "Fork failed. cause: %d - %s", errno, strerror(errno));
                 s++;
                 continue;
             } else if (pid == 0) {
@@ -52,10 +52,10 @@ void generate_reports(int cday, int cmon, int cyear, const struct tm *p)
                 aname[255] = '\0';
                 snprintf(fname, 255, "/logs/.report-%d.log", (int)getpid());
 
-                minfo("Starting daily reporting for '%s'", mond.reports[s]->title);
+                mtinfo(WM_MONITOR_LOGTAG, "Starting daily reporting for '%s'", mond.reports[s]->title);
                 mond.reports[s]->r_filter.fp = fopen(fname, "w+");
                 if (!mond.reports[s]->r_filter.fp) {
-                    merror("Unable to open temporary reports file.");
+                    mterror(WM_MONITOR_LOGTAG, "Unable to open temporary reports file.");
                     s++;
                     continue;
                 }
@@ -72,7 +72,7 @@ void generate_reports(int cday, int cmon, int cyear, const struct tm *p)
                     fflush(mond.reports[s]->r_filter.fp);
 
                     if (ftell(mond.reports[s]->r_filter.fp) < 10) {
-                        minfo("Report '%s' empty.", mond.reports[s]->title);
+                        mtinfo(WM_MONITOR_LOGTAG, "Report '%s' empty.", mond.reports[s]->title);
                     } else if (OS_SendCustomEmail(mond.reports[s]->emailto,
                                                   mond.reports[s]->title,
                                                   mond.smtpserver,
@@ -82,7 +82,7 @@ void generate_reports(int cday, int cmon, int cyear, const struct tm *p)
                                                   mond.reports[s]->r_filter.fp,
                                                   p)
                                != 0) {
-                        mwarn("Unable to send report email.");
+                        mtwarn(WM_MONITOR_LOGTAG, "Unable to send report email.");
                     }
 
                     fclose(mond.reports[s]->r_filter.fp);
@@ -107,17 +107,17 @@ void generate_reports(int cday, int cmon, int cyear, const struct tm *p)
             int wp;
             wp = waitpid((pid_t) - 1, NULL, WNOHANG);
             if (wp < 0) {
-                merror(WAITPID_ERROR, errno, strerror(errno));
+                mterror(WM_MONITOR_LOGTAG, WAITPID_ERROR, errno, strerror(errno));
             } else if (wp == 0) {
                 /* If there is still any report left, sleep 5 and try again */
                 sleep(5);
                 twait++;
 
                 if (twait > 2) {
-                    mwarn("Report taking too long to complete. Waiting for it to finish...");
+                    mtwarn(WM_MONITOR_LOGTAG, "Report taking too long to complete. Waiting for it to finish...");
                     sleep(10);
                     if (twait > 10) {
-                        mwarn("Report took too long. Moving on...");
+                        mtwarn(WM_MONITOR_LOGTAG, "Report took too long. Moving on...");
                         break;
                     }
                 }

--- a/src/monitord/monitor_actions.c
+++ b/src/monitord/monitor_actions.c
@@ -24,8 +24,8 @@ void monitor_send_deletion_msg(char *agent) {
 
     if (SendMSG(mond.a_queue, str, ARGV0, LOCALFILE_MQ) < 0) {
         mond.a_queue = -1;  // set an invalid fd so we can attempt to reconnect later on.
-        mdebug1("Could not generate removed agent alert for '%s'", agent);
-        merror(QUEUE_SEND);
+        mtdebug1(WM_MONITOR_LOGTAG, "Could not generate removed agent alert for '%s'", agent);
+        mterror(WM_MONITOR_LOGTAG, QUEUE_SEND);
     }
 }
 
@@ -41,7 +41,7 @@ void monitor_send_disconnection_msg(char *agent) {
             // Agent is no longer in the database
             monitor_send_deletion_msg(agent);
         } else {
-            mdebug1("Could not generate disconnected agent alert for '%s'", agent);
+            mtdebug1(WM_MONITOR_LOGTAG, "Could not generate disconnected agent alert for '%s'", agent);
         }
     }
 }
@@ -57,7 +57,7 @@ void monitor_agents_disconnection(){
         for (int i = 0; agents_array[i] != -1; i++) {
             snprintf(str_agent_id, 12, "%d", agents_array[i]);
             if (OSHash_Add(agents_to_alert_hash, str_agent_id, (void*)time(0)) == 0) {
-                mdebug1("Can't add agent ID '%d' to the alerts hash table", agents_array[i]);
+                mtdebug1(WM_MONITOR_LOGTAG, "Can't add agent ID '%d' to the alerts hash table", agents_array[i]);
             }
         }
     }
@@ -108,7 +108,7 @@ void monitor_agents_alert(){
                     }
                 }
         } else {
-            mdebug1("Unable to retrieve agent's '%s' data from Wazuh DB", agent_hash_node->key);
+            mtdebug1(WM_MONITOR_LOGTAG, "Unable to retrieve agent's '%s' data from Wazuh DB", agent_hash_node->key);
             OSHash_Delete(agents_to_alert_hash, agent_hash_node->key);
         }
         cJSON_Delete(j_agent_info);
@@ -151,7 +151,7 @@ void monitor_agents_deletion(){
                     cJSON_Delete(j_agent_info);
                 }
             } else {
-                mdebug1("Unable to retrieve agent's '%d' data from Wazuh DB", agents_array[i]);
+                mtdebug1(WM_MONITOR_LOGTAG, "Unable to retrieve agent's '%d' data from Wazuh DB", agents_array[i]);
                 snprintf(str_agent_id, 12, "%d", agents_array[i]);
                 OSHash_Delete(agents_to_alert_hash, str_agent_id);
             }
@@ -199,7 +199,7 @@ int delete_old_agent(const char *agent) {
     char *agent_id = get_agent_id_from_name(agent_name);
     if(agent_id) {
         if (sock = auth_connect(), sock < 0) {
-            mdebug1("Monitord could not connect to to Authd socket. Is Authd running?");
+            mtdebug1(WM_MONITOR_LOGTAG, "Monitord could not connect to to Authd socket. Is Authd running?");
             val = -1;
             free(agent_id);
             return val;
@@ -243,7 +243,7 @@ int mon_send_agent_msg(char *agent, char *msg) {
         snprintf(header, OS_SIZE_256, "[%03d] (%s) %s", ag_id, ag_name, ag_ip);
         if (SendMSG(mond.a_queue, msg, header, SECURE_MQ) < 0) {
             mond.a_queue = -1;  // set an invalid fd so we can attempt to reconnect later on.
-            merror(QUEUE_SEND);
+            mterror(WM_MONITOR_LOGTAG, QUEUE_SEND);
             return 1;
         }
         return 0;

--- a/src/monitord/monitord.c
+++ b/src/monitord/monitord.c
@@ -113,6 +113,7 @@ cJSON *getMonitorInternalOptions(void) {
     cJSON_AddNumberToObject(monconf,"size_rotate",mond.size_rotate);
     cJSON_AddNumberToObject(monconf,"daily_rotations",mond.daily_rotations);
     cJSON_AddNumberToObject(monconf,"delete_old_agents",mond.delete_old_agents);
+    cJSON_AddNumberToObject(monconf, "debug", wm_debug_level);
 
     return monconf;
 }

--- a/src/monitord/monitord.c
+++ b/src/monitord/monitord.c
@@ -49,7 +49,7 @@ void Monitord()
     /* Connect to the message queue or exit */
     monitor_queue_connect();
     if (mond.a_queue < 0) {
-        merror_exit(QUEUE_FATAL, DEFAULTQUEUE);
+        mterror_exit(WM_MONITOR_LOGTAG, QUEUE_FATAL, DEFAULTQUEUE);
     }
 
     // Start com request thread
@@ -58,7 +58,7 @@ void Monitord()
     /* Creating agents disconnected alert table */
     agents_to_alert_hash = OSHash_Create();
     if(!agents_to_alert_hash) {
-        merror(MEM_ERROR, errno, strerror(errno));
+        mterror(WM_MONITOR_LOGTAG, MEM_ERROR, errno, strerror(errno));
     }
 
     /* Get current time and initiate counters */
@@ -185,7 +185,7 @@ int MonitordConfig(const char *cfg, monitor_config *mond, int no_agents, short d
 
     if (ReadConfig(modules, cfg, mond, NULL) < 0 ||
         ReadConfig(CGLOBAL, cfg, &mond->global, NULL) < 0) {
-        merror_exit(CONFIG_ERROR, cfg);
+        mterror_exit(WM_MONITOR_LOGTAG, CONFIG_ERROR, cfg);
     }
 
     return OS_SUCCESS;
@@ -196,7 +196,7 @@ void monitor_queue_connect() {
         /* Send startup message */
         if (SendMSG(mond.a_queue, OS_AD_STARTED, ARGV0, LOCALFILE_MQ) < 0) {
             mond.a_queue = -1;  // We keep trying to reconnect next time.
-            merror(QUEUE_SEND);
+            mterror(WM_MONITOR_LOGTAG, QUEUE_SEND);
         }
     }
 }

--- a/src/monitord/monitord.h
+++ b/src/monitord/monitord.h
@@ -16,6 +16,8 @@
 #define ARGV0 "wazuh-modules"
 #endif
 
+#define WM_MONITOR_LOGTAG ARGV0 ":monitor"  // Tag for log messages
+
 #include "../headers/store_op.h"
 #include "config/reports-config.h"
 #include "config/global-config.h"

--- a/src/monitord/monitord.h
+++ b/src/monitord/monitord.h
@@ -173,6 +173,7 @@ extern monitor_config mond;
 extern bool worker_node;
 extern OSHash* agents_to_alert_hash;
 extern monitor_time_control mond_time_control;
+extern int wm_debug_level;
 
 
 #endif /* MONITORD_H */

--- a/src/monitord/rotate_log.c
+++ b/src/monitord/rotate_log.c
@@ -51,12 +51,12 @@ void w_rotate_log(int compress, int keep_log_days, int new_day, int rotate_json,
     int counter = 0;
 
     if (new_day)
-        minfo("Running daily rotation of log files.");
+        mtinfo(WM_MONITOR_LOGTAG, "Running daily rotation of log files.");
     else {
         if (rotate_json)
-            minfo("Rotating '%s' file: Maximum size reached.", LOGJSONFILE);
+            mtinfo(WM_MONITOR_LOGTAG, "Rotating '%s' file: Maximum size reached.", LOGJSONFILE);
         else
-            minfo("Rotating '%s' file: Maximum size reached.", LOGFILE);
+            mtinfo(WM_MONITOR_LOGTAG, "Rotating '%s' file: Maximum size reached.", LOGFILE);
     }
 
     if (new_day)
@@ -91,11 +91,11 @@ void w_rotate_log(int compress, int keep_log_days, int new_day, int rotate_json,
     // Create folders
 
     if (IsDir(year_dir) < 0 && mkdir(year_dir, 0770) < 0) {
-        merror_exit(MKDIR_ERROR, year_dir, errno, strerror(errno));
+        mterror_exit(WM_MONITOR_LOGTAG, MKDIR_ERROR, year_dir, errno, strerror(errno));
     }
 
     if (IsDir(month_dir) < 0 && mkdir(month_dir, 0770) < 0) {
-        merror_exit(MKDIR_ERROR, month_dir, errno, strerror(errno));
+        mterror_exit(WM_MONITOR_LOGTAG, MKDIR_ERROR, month_dir, errno, strerror(errno));
     }
 
     if (new_day || (!new_day && !rotate_json)) {
@@ -117,7 +117,7 @@ void w_rotate_log(int compress, int keep_log_days, int new_day, int rotate_json,
                 counter = 1;
                 while (counter < daily_rotations) {
                     if (rename_ex(old_rename_path, rename_path) != 0) {
-                        merror("Couldn't rename compressed log '%s' to '%s': '%s'", old_rename_path, rename_path, strerror(errno));
+                        mterror(WM_MONITOR_LOGTAG, "Couldn't rename compressed log '%s' to '%s': '%s'", old_rename_path, rename_path, strerror(errno));
                         return;
                     }
                     counter++;
@@ -134,7 +134,7 @@ void w_rotate_log(int compress, int keep_log_days, int new_day, int rotate_json,
                     OS_CompressLog(new_path);
                 }
             } else {
-                merror("Couldn't rename '%s' to '%s': %s", old_path, new_path, strerror(errno));
+                mterror(WM_MONITOR_LOGTAG, "Couldn't rename '%s' to '%s': %s", old_path, new_path, strerror(errno));
             }
         }
 
@@ -161,7 +161,7 @@ void w_rotate_log(int compress, int keep_log_days, int new_day, int rotate_json,
                 counter = 1;
                 while (counter < daily_rotations) {
                     if (rename_ex(old_rename_path, rename_path) != 0) {
-                        merror("Couldn't rename compressed log '%s' to '%s': '%s'", old_rename_path, rename_path, strerror(errno));
+                        mterror(WM_MONITOR_LOGTAG, "Couldn't rename compressed log '%s' to '%s': '%s'", old_rename_path, rename_path, strerror(errno));
                         return;
                     }
                     counter++;
@@ -178,12 +178,12 @@ void w_rotate_log(int compress, int keep_log_days, int new_day, int rotate_json,
                     OS_CompressLog(new_path_json);
                 }
             } else {
-                merror("Couldn't rename '%s' to '%s': %s", old_path_json, new_path_json, strerror(errno));
+                mterror(WM_MONITOR_LOGTAG, "Couldn't rename '%s' to '%s': %s", old_path_json, new_path_json, strerror(errno));
             }
         }
     }
 
-    minfo("Starting new log after rotation.");
+    mtinfo(WM_MONITOR_LOGTAG, "Starting new log after rotation.");
 
     // Remove old compressed files
     remove_old_logs(base_dir, keep_log_days);
@@ -197,7 +197,7 @@ void remove_old_logs(const char *base_dir, int keep_log_days) {
     struct dirent *dirent = NULL;
 
     if (dir = opendir(base_dir), !dir) {
-        merror("Couldn't open directory '%s' to delete old logs: %s", base_dir, strerror(errno));
+        mterror(WM_MONITOR_LOGTAG, "Couldn't open directory '%s' to delete old logs: %s", base_dir, strerror(errno));
         return;
     }
 
@@ -223,7 +223,7 @@ void remove_old_logs_y(const char * base_dir, int year, time_t threshold) {
     struct dirent *dirent = NULL;
 
     if (dir = opendir(base_dir), !dir) {
-        merror("Couldn't open directory '%s' to delete old logs: %s", base_dir, strerror(errno));
+        mterror(WM_MONITOR_LOGTAG, "Couldn't open directory '%s' to delete old logs: %s", base_dir, strerror(errno));
         return;
     }
 
@@ -246,7 +246,7 @@ void remove_old_logs_y(const char * base_dir, int year, time_t threshold) {
         if (month < 12) {
             remove_old_logs_m(path, year, month, threshold);
         } else {
-            mwarn("Unexpected folder '%s'", path);
+            mtwarn(WM_MONITOR_LOGTAG, "Unexpected folder '%s'", path);
         }
     }
 
@@ -271,7 +271,7 @@ void remove_old_logs_m(const char * base_dir, int year, int month, time_t thresh
     tm.tm_sec = 0;
 
     if (dir = opendir(base_dir), !dir) {
-        merror("Couldn't open directory '%s' to delete old logs: %s", base_dir, strerror(errno));
+        mterror(WM_MONITOR_LOGTAG, "Couldn't open directory '%s' to delete old logs: %s", base_dir, strerror(errno));
         return;
     }
 
@@ -286,7 +286,7 @@ void remove_old_logs_m(const char * base_dir, int year, int month, time_t thresh
 
             if (mktime(&tm) <= threshold) {
                 snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
-                mdebug2("Removing old log '%s'", path);
+                mtdebug2(WM_MONITOR_LOGTAG, "Removing old log '%s'", path);
                 unlink(path);
             }
         }
@@ -296,7 +296,7 @@ void remove_old_logs_m(const char * base_dir, int year, int month, time_t thresh
 
             if (mktime(&tm) <= threshold) {
                 snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
-                mdebug2("Removing old log '%s'", path);
+                mtdebug2(WM_MONITOR_LOGTAG, "Removing old log '%s'", path);
                 unlink(path);
             }
         }
@@ -306,7 +306,7 @@ void remove_old_logs_m(const char * base_dir, int year, int month, time_t thresh
 
             if (mktime(&tm) <= threshold) {
                 snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
-                mdebug2("Removing old log '%s'", path);
+                mtdebug2(WM_MONITOR_LOGTAG, "Removing old log '%s'", path);
                 unlink(path);
             }
         }
@@ -316,7 +316,7 @@ void remove_old_logs_m(const char * base_dir, int year, int month, time_t thresh
 
             if (mktime(&tm) <= threshold) {
                 snprintf(path, PATH_MAX, "%s/%s", base_dir, dirent->d_name);
-                mdebug2("Removing old log '%s'", path);
+                mtdebug2(WM_MONITOR_LOGTAG, "Removing old log '%s'", path);
                 unlink(path);
             }
         }

--- a/src/monitord/sign_log.c
+++ b/src/monitord/sign_log.c
@@ -64,21 +64,21 @@ void OS_SignLog(const char *logfile, const char *logfile_old, const char * ext)
 
     /* Generate MD5 of the old file */
     if (OS_MD5_File(logfilesum_old, mf_sum_old, OS_TEXT) < 0) {
-        minfo("No previous md5 checksum found: '%s'. "
+        mtinfo(WM_MONITOR_LOGTAG, "No previous md5 checksum found: '%s'. "
                "Starting over.", logfilesum_old);
         strncpy(mf_sum_old, "none", 6);
     }
 
     /* Generate SHA-1 of the old file  */
     if (OS_SHA1_File(logfilesum_old, sf_sum_old, OS_TEXT) < 0) {
-        minfo("No previous sha1 checksum found: '%s'. "
+        mtinfo(WM_MONITOR_LOGTAG, "No previous sha1 checksum found: '%s'. "
                "Starting over.", logfilesum_old);
         strncpy(sf_sum_old, "none", 6);
     }
 
     /* Generate SHA-256 of the old file  */
     if (OS_SHA256_File(logfilesum_old, sf256_sum_old, OS_TEXT) < 0) {
-        minfo("No previous sha256 checksum found: '%s'. "
+        mtinfo(WM_MONITOR_LOGTAG, "No previous sha256 checksum found: '%s'. "
                "Starting over.", logfilesum_old);
         strncpy(sf256_sum_old, "none", 6);
     }
@@ -106,7 +106,7 @@ void OS_SignLog(const char *logfile, const char *logfile_old, const char * ext)
 
                 fclose(fp);
             } else {
-                merror(FOPEN_ERROR, logfile_r, errno, strerror(errno));
+                mterror(WM_MONITOR_LOGTAG, FOPEN_ERROR, logfile_r, errno, strerror(errno));
                 break;
             }
         }
@@ -140,7 +140,7 @@ void OS_SignLog(const char *logfile, const char *logfile_old, const char * ext)
 
     fp = fopen(logfilesum, "w");
     if (!fp) {
-        merror(FOPEN_ERROR, logfilesum, errno, strerror(errno));
+        mterror(WM_MONITOR_LOGTAG, FOPEN_ERROR, logfilesum, errno, strerror(errno));
         return;
     }
 

--- a/src/unit_tests/monitord/CMakeLists.txt
+++ b/src/unit_tests/monitord/CMakeLists.txt
@@ -39,12 +39,12 @@ target_link_libraries(MONITOR_O ${WAZUHLIB} ${WAZUHEXT} -lpthread)
 target_link_libraries(MAILD_O ${WAZUHLIB} ${WAZUHEXT} -lpthread)
 
 list(APPEND monitord_tests_names "test_monitord")
-list(APPEND monitord_tests_flags "-Wl,--wrap,_mdebug1 -Wl,--wrap,_mdebug2 -Wl,--wrap,_merror -Wl,--wrap,time\
+list(APPEND monitord_tests_flags "-Wl,--wrap,_mtdebug1 -Wl,--wrap,_mtdebug2 -Wl,--wrap,_mterror -Wl,--wrap,time\
                                   -Wl,--wrap,StartMQ -Wl,--wrap,SendMSG -Wl,--wrap,getDefine_Int -Wl,--wrap,ReadConfig\
-                                  -Wl,--wrap,_merror_exit")
+                                  -Wl,--wrap,_mterror_exit")
 
 list(APPEND monitord_tests_names "test_monitor_actions")
-list(APPEND monitord_tests_flags "-Wl,--wrap,_mdebug1 -Wl,--wrap,_mdebug2 -Wl,--wrap,_merror -Wl,--wrap,SendMSG -Wl,--wrap,wdb_find_agent\
+list(APPEND monitord_tests_flags "-Wl,--wrap,_mtdebug1 -Wl,--wrap,_mtdebug2 -Wl,--wrap,_mterror -Wl,--wrap,SendMSG -Wl,--wrap,wdb_find_agent\
                                   -Wl,--wrap,wdb_disconnect_agents -Wl,--wrap,time -Wl,--wrap,OSHash_Add -Wl,--wrap,OSHash_Add_ex\
                                   -Wl,--wrap,OSHash_Create -Wl,--wrap,OSHash_Delete_ex -Wl,--wrap,OSHash_Get -Wl,--wrap,wdb_get_agent_info\
                                   -Wl,--wrap,OSHash_Next -Wl,--wrap,OSHash_Begin -Wl,--wrap,OSHash_Delete -Wl,--wrap,auth_connect\

--- a/src/unit_tests/monitord/test_monitor_actions.c
+++ b/src/unit_tests/monitord/test_monitor_actions.c
@@ -116,8 +116,10 @@ void test_monitor_send_deletion_msg_fail(void **state) {
     expect_value(__wrap_SendMSG, loc, LOCALFILE_MQ);
     will_return(__wrap_SendMSG, -1);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "Could not generate removed agent alert for 'Agent1-any'");
-    expect_string(__wrap__merror, formatted_msg, QUEUE_SEND);
+    expect_string(__wrap__mtdebug1, tag, WM_MONITOR_LOGTAG);
+    expect_string(__wrap__mtdebug1, formatted_msg, "Could not generate removed agent alert for 'Agent1-any'");
+    expect_string(__wrap__mterror, tag, WM_MONITOR_LOGTAG);
+    expect_string(__wrap__mterror, formatted_msg, QUEUE_SEND);
 
     monitor_send_deletion_msg(agent);
 
@@ -166,8 +168,10 @@ void test_monitor_send_disconnection_msg_send_msg_fail(void **state) {
     expect_value(__wrap_SendMSG, loc, SECURE_MQ);
     will_return(__wrap_SendMSG, -1);
     mond.a_queue = 1;
-    expect_string(__wrap__merror, formatted_msg, QUEUE_SEND);
-    expect_string(__wrap__mdebug1, formatted_msg, "Could not generate disconnected agent alert for 'Agent1-any'");
+    expect_string(__wrap__mterror, tag, WM_MONITOR_LOGTAG);
+    expect_string(__wrap__mterror, formatted_msg, QUEUE_SEND);
+    expect_string(__wrap__mtdebug1, tag, WM_MONITOR_LOGTAG);
+    expect_string(__wrap__mtdebug1, formatted_msg, "Could not generate disconnected agent alert for 'Agent1-any'");
 
     monitor_send_disconnection_msg(agent);
 
@@ -202,7 +206,8 @@ void test_monitor_send_disconnection_msg_fail(void **state) {
     expect_string(__wrap_wdb_find_agent, ip, "any");
     will_return(__wrap_wdb_find_agent, 0);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "Could not generate disconnected agent alert for 'Agent1-any'");
+    expect_string(__wrap__mtdebug1, tag, WM_MONITOR_LOGTAG);
+    expect_string(__wrap__mtdebug1, formatted_msg, "Could not generate disconnected agent alert for 'Agent1-any'");
     mond.a_queue = 1;
 
     monitor_send_disconnection_msg(agent);
@@ -236,7 +241,8 @@ void test_monitor_agents_disconnection(void **state) {
     expect_string(__wrap_OSHash_Add, key, "13");
     expect_string(__wrap_OSHash_Add, key, "5");
 
-    expect_string(__wrap__mdebug1, formatted_msg, "Can't add agent ID '5' to the alerts hash table");
+    expect_string(__wrap__mtdebug1, tag, WM_MONITOR_LOGTAG);
+    expect_string(__wrap__mtdebug1, formatted_msg, "Can't add agent ID '5' to the alerts hash table");
 
     monitor_agents_disconnection();
 }
@@ -244,7 +250,8 @@ void test_monitor_agents_disconnection(void **state) {
 void test_monitor_send_disconnection_ip_fail(void **state) {
     char *agent = "Agent1";
 
-    expect_string(__wrap__mdebug1, formatted_msg, "Could not generate disconnected agent alert for 'Agent1'");
+    expect_string(__wrap__mtdebug1, tag, WM_MONITOR_LOGTAG);
+    expect_string(__wrap__mtdebug1, formatted_msg, "Could not generate disconnected agent alert for 'Agent1'");
 
     monitor_send_disconnection_msg(agent);
 }
@@ -259,7 +266,8 @@ void test_monitor_send_disconnection_name_size_fail(void **state) {
     wm_strcat(&agent, "any", '-');
 
     snprintf(debug_message, OS_SIZE_512, "Could not generate disconnected agent alert for '%s'", agent);
-    expect_string(__wrap__mdebug1, formatted_msg, debug_message);
+    expect_string(__wrap__mtdebug1, tag, WM_MONITOR_LOGTAG);
+    expect_string(__wrap__mtdebug1, formatted_msg, debug_message);
 
     monitor_send_disconnection_msg(agent);
 
@@ -312,7 +320,8 @@ void test_monitor_agents_alert_agent_info_fail() {
     expect_value(__wrap_wdb_get_agent_info, id, 1);
     will_return(__wrap_wdb_get_agent_info, j_agent_info);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "Unable to retrieve agent's '1' data from Wazuh DB");
+    expect_string(__wrap__mtdebug1, tag, WM_MONITOR_LOGTAG);
+    expect_string(__wrap__mtdebug1, formatted_msg, "Unable to retrieve agent's '1' data from Wazuh DB");
     expect_value(__wrap_OSHash_Delete, self, agents_to_alert_hash);
     expect_value(__wrap_OSHash_Delete, key, "1");
     will_return(__wrap_OSHash_Delete, 2);
@@ -422,7 +431,8 @@ void test_monitor_agents_deletion_agent_info_fail() {
     expect_value(__wrap_wdb_get_agent_info, id, 13);
     will_return(__wrap_wdb_get_agent_info, NULL);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "Unable to retrieve agent's '13' data from Wazuh DB");
+    expect_string(__wrap__mtdebug1, tag, WM_MONITOR_LOGTAG);
+    expect_string(__wrap__mtdebug1, formatted_msg, "Unable to retrieve agent's '13' data from Wazuh DB");
     expect_value(__wrap_OSHash_Delete, self, agents_to_alert_hash);
     expect_string(__wrap_OSHash_Delete, key, "13");
     will_return(__wrap_OSHash_Delete, 2);
@@ -455,7 +465,8 @@ void test_monitor_agents_deletion_auth_fail() {
     os_strdup("13", agent_id_str);
     will_return(__wrap_get_agent_id_from_name, agent_id_str);
     will_return(__wrap_auth_connect, -1);
-    expect_string(__wrap__mdebug1, formatted_msg, "Monitord could not connect to to Authd socket. Is Authd running?");
+    expect_string(__wrap__mtdebug1, tag, WM_MONITOR_LOGTAG);
+    expect_string(__wrap__mtdebug1, formatted_msg, "Monitord could not connect to to Authd socket. Is Authd running?");
 
     monitor_agents_deletion();
 }

--- a/src/unit_tests/monitord/test_monitord.c
+++ b/src/unit_tests/monitord/test_monitord.c
@@ -339,7 +339,8 @@ void test_monitor_queue_connect_msg_fail(void **state) {
     expect_string(__wrap_SendMSG, locmsg, ARGV0);
     expect_value(__wrap_SendMSG, loc, LOCALFILE_MQ);
     will_return(__wrap_SendMSG, -1);
-    expect_string(__wrap__merror, formatted_msg, QUEUE_SEND);
+    expect_string(__wrap__mterror, tag, WM_MONITOR_LOGTAG);
+    expect_string(__wrap__mterror, formatted_msg, QUEUE_SEND);
 
     monitor_queue_connect();
 
@@ -503,7 +504,8 @@ void test_MonitordConfig_fail(void **state) {
     expect_string(__wrap_ReadConfig, cfgfile, cfg);
     will_return(__wrap_ReadConfig, -1);
 
-    expect_string(__wrap__merror_exit, formatted_msg, "(1202): Configuration error at '/config_path'.");
+    expect_string(__wrap__mterror_exit, tag, WM_MONITOR_LOGTAG);
+    expect_string(__wrap__mterror_exit, formatted_msg, "(1202): Configuration error at '/config_path'.");
 
     MonitordConfig(cfg, &mond, no_agents, day_wait);
 }

--- a/src/wazuh_modules/wm_monitor.c
+++ b/src/wazuh_modules/wm_monitor.c
@@ -13,6 +13,7 @@
 #include "wm_monitor.h"
 #include "wmodules.h"
 #include "defs.h"
+#include "os_net/os_net.h"
 
 #define DEFAULT_NO_AGENT 0
 #define DEFAULT_DAY_WAIT -1
@@ -29,6 +30,7 @@ const wm_context WM_MONITOR_CONTEXT = {
     (wm_routine)wm_monitor_main,
     (wm_routine)(void *)wm_monitor_destroy,
     (cJSON * (*)(const void *))wm_monitor_dump,
+    NULL,
     NULL,
 };
 

--- a/src/wazuh_modules/wm_monitor.h
+++ b/src/wazuh_modules/wm_monitor.h
@@ -18,8 +18,6 @@
 
 extern const wm_context WM_MONITOR_CONTEXT; // Context
 
-#define WM_MONITOR_LOGTAG ARGV0 ":monitor"  // Tag for log messages
-
 typedef struct wm_monitor_t {
     monitor_config *mond;
     bool *worker_node;


### PR DESCRIPTION
|Related issue|
|---|
|Closes #8414|

## Description

Hi team!

This PR aims to change every `monitor` log function to their tagged version, and use `wazuh-modulesd:monitor` as tag. Also, removing `monitord.debug` from internal options, reporting `wazuh-modules.debug` when active configuration is requested.

## DoD
- [X] Fix and update logs so that the logging looks like: `wazuh-modulesd:monitor`
- [X] Remove from internal_configuration monitord.debug key-value.
- [x] Check compatibility with framework for monitord.debug key-value.
- [x] Functional tests (Linux)
- [x] PR CI Pass (Only Build and unit-tests)
