### PR TITLE
Fix FIM problems with mutex and locks

### DIFF
--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -262,15 +262,11 @@ time_t fim_scan() {
     else {
         // In the first scan, the fim initialization is different between Linux and Windows.
         // Realtime watches are set after the first scan in Windows.
-        w_mutex_lock(&syscheck.fim_realtime_mutex);
-        if (syscheck.realtime != NULL) {
-            if (syscheck.realtime->queue_overflow) {
-                realtime_sanitize_watch_map();
-                syscheck.realtime->queue_overflow = false;
-            }
-            mdebug2(FIM_NUM_WATCHES, OSHash_Get_Elem_ex(syscheck.realtime->dirtb));
+        if (fim_realtime_get_queue_overflow()) {
+            fim_realtime_set_queue_overflow(false);
+            realtime_sanitize_watch_map();
         }
-        w_mutex_unlock(&syscheck.fim_realtime_mutex);
+        fim_realtime_print_watches();
     }
 
     minfo(FIM_FREQUENCY_ENDED);
@@ -767,7 +763,7 @@ _fim_file(const char *path, const directory_t *configuration, event_data_t *evt_
     }
 
     if (configuration->options & CHECK_SEECHANGES) {
-        diff = fim_file_diff(path);
+        diff = fim_file_diff(path, configuration);
     }
 
     json_event = fim_json_event(&new, saved ? saved->file_entry.data : NULL, configuration, evt_data, diff);
@@ -815,7 +811,7 @@ static cJSON *_fim_file_force_update(const fim_entry *saved,
     evt_data->type = FIM_MODIFICATION; // Checking for changes
 
     if (configuration->options & CHECK_SEECHANGES) {
-        diff = fim_file_diff(new.file_entry.path);
+        diff = fim_file_diff(new.file_entry.path, configuration);
     }
 
     json_event = fim_json_event(&new, saved->file_entry.data, configuration, evt_data, diff);
@@ -854,14 +850,10 @@ void fim_realtime_event(char *file) {
          */
         fim_rt_delay();
 
-        w_rwlock_rdlock(&syscheck.directories_lock);
         fim_checker(file, &evt_data, NULL);
-        w_rwlock_unlock(&syscheck.directories_lock);
     } else {
         // Otherwise, it could be a file deleted or a directory moved (or renamed).
-        w_rwlock_rdlock(&syscheck.directories_lock);
         fim_process_missing_entry(file, FIM_REALTIME, NULL);
-        w_rwlock_unlock(&syscheck.directories_lock);
     }
 }
 
@@ -1720,6 +1712,7 @@ void update_wildcards_config() {
     removed_entries = OSList_Create();
     if (removed_entries == NULL) {
         merror(MEM_ERROR, errno, strerror(errno));
+        w_rwlock_unlock(&syscheck.directories_lock);
         return;
     }
     OSList_SetFreeDataPointer(removed_entries, (void (*)(void *))free_directory);
@@ -1730,7 +1723,7 @@ void update_wildcards_config() {
         if (dir_it->is_wildcard && dir_it->is_expanded == 0) {
 #if INOTIFY_ENABLED
             if (FIM_MODE(dir_it->options) == FIM_REALTIME) {
-                fim_delete_realtime_watches(dir_it);
+                fim_realtime_delete_watches(dir_it);
             }
 #endif
 #if ENABLE_AUDIT

--- a/src/syscheckd/fim_diff_changes.c
+++ b/src/syscheckd/fim_diff_changes.c
@@ -66,10 +66,11 @@ int fim_diff_registry_tmp(const char *value_data,
  * @brief Initializes the structure with the data needed for diff
  *
  * @param filename Path of file monitored
+ * @param configuration Configuration associated with the file
  *
  * @return Structure with all the data necessary to compute differences
  */
-diff_data *initialize_file_diff_data(const char *filename);
+diff_data *initialize_file_diff_data(const char *filename, const directory_t *configuration);
 
 /**
  * @brief Free the structure with the data needed for diff
@@ -389,13 +390,13 @@ int fim_diff_registry_tmp(const char *value_data,
 
 #endif
 
-char *fim_file_diff(const char *filename) {
+char *fim_file_diff(const char *filename, const directory_t *configuration) {
 
     char *diff_changes = NULL;
     int limits_reached;
 
     // Generate diff structure
-    diff_data *diff = initialize_file_diff_data(filename);
+    diff_data *diff = initialize_file_diff_data(filename, configuration);
     if (!diff){
         return NULL;
     }
@@ -459,7 +460,7 @@ cleanup:
 }
 
 
-diff_data *initialize_file_diff_data(const char *filename){
+diff_data *initialize_file_diff_data(const char *filename, const directory_t *configuration){
     diff_data *diff;
     char buffer[PATH_MAX];
     char abs_diff_dir_path[PATH_MAX + 1];
@@ -470,10 +471,7 @@ diff_data *initialize_file_diff_data(const char *filename){
     diff->file_size = 0;
 
     if (syscheck.file_size_enabled) {
-        w_rwlock_rdlock(&syscheck.directories_lock);
-        const directory_t *configuration = fim_configuration_directory(filename);
         diff->size_limit = configuration->diff_size_limit;
-        w_rwlock_unlock(&syscheck.directories_lock);
     }
 
     // Get absolute path of filename:

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -359,7 +359,26 @@ int fim_add_inotify_watch(const char *dir, const directory_t *configuration);
  *
  * @param configuration Configuration associated with the file or directory
  */
-void fim_delete_realtime_watches(const directory_t *configuration);
+void fim_realtime_delete_watches(const directory_t *configuration);
+
+/**
+ * @brief Check whether the realtime event queue has overflown.
+ *
+ * @return 0 if the queue hasn't overflown, 1 otherwise.
+ */
+int fim_realtime_get_queue_overflow();
+
+/**
+ * @brief Set the value of the queue overflown flag.
+ *
+ * @param value The new value to set the queue overflow flag.
+ */
+void fim_realtime_set_queue_overflow(int value);
+
+/**
+ * @brief Log the number of realtime watches currently set.
+ */
+void fim_realtime_print_watches();
 
 /**
  * @brief Process events in the real time queue
@@ -636,10 +655,11 @@ char *fim_registry_value_diff(const char *key_name,
  * @brief Function that generates the diff file of a file monitored when the option report_changes is activated
  *
  * @param filename Path of file monitored
+ * @param configuration Configuration associated with the given path.
  * @return String with the diff to add to the alert
  */
 
-char * fim_file_diff(const char *filename);
+char *fim_file_diff(const char *filename, const directory_t *configuration);
 
 /**
  * @brief Deletes the filename diff folder and modify diff_folder_size if disk_quota enabled

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -173,7 +173,7 @@ set(RUN_REALTIME_BASE_FLAGS "-Wl,--wrap,inotify_init -Wl,--wrap,inotify_add_watc
                              -Wl,--wrap=OSHash_Begin -Wl,--wrap=OSHash_Next -Wl,--wrap=pthread_mutex_lock \
                              -Wl,--wrap=pthread_mutex_unlock -Wl,--wrap=getpid -Wl,--wrap=atexit -Wl,--wrap=os_random \
                              -Wl,--wrap,inotify_rm_watch -Wl,--wrap,pthread_rwlock_wrlock -Wl,--wrap,pthread_rwlock_unlock \
-                             -Wl,--wrap,pthread_rwlock_rdlock")
+                             -Wl,--wrap,pthread_rwlock_rdlock -Wl,--wrap,OSHash_Get_Elem_ex")
 
 list(APPEND syscheckd_tests_names "test_run_realtime")
 if(${TARGET} STREQUAL "agent")
@@ -184,8 +184,7 @@ elseif(${TARGET} STREQUAL "winagent")
   # Create event channel tests for run_realtime
   list(APPEND syscheckd_event_tests_names "test_run_realtime_event")
   list(APPEND syscheckd_event_tests_flags "${RUN_REALTIME_BASE_FLAGS} -Wl,--wrap=whodata_audit_start \
-                                           -Wl,--wrap=check_path_type,--wrap=set_winsacl,--wrap=w_directory_exists \
-                                           -Wl,--wrap=OSHash_Get_Elem_ex")
+                                           -Wl,--wrap=check_path_type,--wrap=set_winsacl,--wrap=w_directory_exists")
 else()
   list(APPEND syscheckd_tests_flags "${RUN_REALTIME_BASE_FLAGS}")
 endif()

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -4335,13 +4335,16 @@ static void test_fim_realtime_event_file_exists(void **state) {
     fim_data_t *fim_data = *state;
     struct stat buf = { .st_mode = 0 };
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+#ifndef TEST_WINAGENT
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
-#ifndef TEST_WINAGENT
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 #else
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
 #endif
@@ -4385,10 +4388,8 @@ static void test_fim_realtime_event_file_exists(void **state) {
 
 static void test_fim_realtime_event_file_missing(void **state) {
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
     struct stat stat_buf = { .st_mode = 0 };
 #ifdef TEST_WINAGENT

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -53,7 +53,7 @@ void fim_link_check_delete(directory_t *configuration);
 void fim_link_delete_range(const directory_t *configuration);
 void fim_link_silent_scan(char *path, directory_t *configuration);
 void fim_link_reload_broken_link(char *path, directory_t *configuration);
-void fim_delete_realtime_watches(const directory_t *configuration);
+void fim_realtime_delete_watches(const directory_t *configuration);
 #endif
 
 extern time_t last_time;
@@ -986,7 +986,7 @@ void test_fim_link_check_delete(void **state) {
 
     expect_string(__wrap_remove_audit_rule_syscheck, path, affected_config->symbolic_links);
 
-    expect_fim_configuration_directory_call(pointed_folder, NULL);
+    expect_fim_configuration_directory_call("data", NULL);
     fim_link_check_delete(affected_config);
 
     assert_string_equal(affected_config->path, link_path);
@@ -1048,12 +1048,11 @@ void test_fim_delete_realtime_watches(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
 
-    expect_fim_configuration_directory_call(pointed_folder, ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)));
-    expect_fim_configuration_directory_call("data", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0)));
+    expect_fim_configuration_directory_call("data", ((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1)));
 
     will_return(__wrap_inotify_rm_watch, 1);
 
-    fim_delete_realtime_watches(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1)));
+    fim_realtime_delete_watches(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1)));
 
     assert_null(OSHash_Begin(syscheck.realtime->dirtb, &pos));
 }

--- a/src/unit_tests/syscheckd/test_run_realtime.c
+++ b/src/unit_tests/syscheckd/test_run_realtime.c
@@ -610,7 +610,10 @@ void test_realtime_process_len(void **state) {
     paths = os_AddStrArray("/test", paths);
 
     will_return(__wrap_rbtree_keys, paths);
+
+    expect_function_call(__wrap_pthread_rwlock_rdlock);
     expect_string(__wrap_fim_realtime_event, file, "/test");
+    expect_function_call(__wrap_pthread_rwlock_unlock);
 
     test_mode = 1;
     realtime_process();
@@ -647,7 +650,10 @@ void test_realtime_process_len_zero(void **state) {
     paths = os_AddStrArray("/test", paths);
 
     will_return(__wrap_rbtree_keys, paths);
+
+    expect_function_call(__wrap_pthread_rwlock_rdlock);
     expect_string(__wrap_fim_realtime_event, file, "/test");
+    expect_function_call(__wrap_pthread_rwlock_unlock);
 
     test_mode = 1;
     realtime_process();
@@ -682,7 +688,10 @@ void test_realtime_process_len_path_separator(void **state) {
     paths = os_AddStrArray("/test", paths);
 
     will_return(__wrap_rbtree_keys, paths);
+
+    expect_function_call(__wrap_pthread_rwlock_rdlock);
     expect_string(__wrap_fim_realtime_event, file, "/test");
+    expect_function_call(__wrap_pthread_rwlock_unlock);
 
     test_mode = 1;
     realtime_process();
@@ -705,6 +714,8 @@ void test_realtime_process_overflow(void **state) {
     expect_function_call(__wrap_pthread_mutex_unlock);
 
     expect_string(__wrap__mwarn, formatted_msg, "Real-time inotify kernel queue is full. Some events may be lost. Next scheduled scan will recover lost data.");
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
     expect_string(__wrap_send_log_msg, msg, "ossec: Real-time inotify kernel queue is full. Some events may be lost. Next scheduled scan will recover lost data.");
     will_return(__wrap_send_log_msg, 1);
 
@@ -712,7 +723,10 @@ void test_realtime_process_overflow(void **state) {
     paths = os_AddStrArray("/test", paths);
 
     will_return(__wrap_rbtree_keys, paths);
+
+    expect_function_call(__wrap_pthread_rwlock_rdlock);
     expect_string(__wrap_fim_realtime_event, file, "/test");
+    expect_function_call(__wrap_pthread_rwlock_unlock);
 
     realtime_process();
 
@@ -754,7 +768,10 @@ void test_realtime_process_delete(void **state) {
     paths = os_AddStrArray("/test", paths);
 
     will_return(__wrap_rbtree_keys, paths);
+
+    expect_function_call(__wrap_pthread_rwlock_rdlock);
     expect_string(__wrap_fim_realtime_event, file, "/test");
+    expect_function_call(__wrap_pthread_rwlock_unlock);
 
     test_mode = 1;
     realtime_process();
@@ -816,7 +833,10 @@ void test_realtime_process_move_self(void **state) {
     paths = os_AddStrArray("/test", paths);
 
     will_return(__wrap_rbtree_keys, paths);
+
+    expect_function_call(__wrap_pthread_rwlock_rdlock);
     expect_string(__wrap_fim_realtime_event, file, "/test");
+    expect_function_call(__wrap_pthread_rwlock_unlock);
 
     test_mode = 1;
     realtime_process();
@@ -908,8 +928,14 @@ void test_delete_subdirectories_watches_deletes(void **state) {
 
 
 void test_realtime_sanitize_watch_map_empty_hash(void **state) {
+    expect_function_call(__wrap_pthread_rwlock_rdlock);
+    expect_function_call(__wrap_pthread_mutex_lock);
+
     expect_value(__wrap_OSHash_Begin, self, syscheck.realtime->dirtb);
     will_return(__wrap_OSHash_Begin, NULL);
+
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_pthread_rwlock_unlock);
 
     expect_any(__wrap__mdebug2, formatted_msg);
 
@@ -918,6 +944,10 @@ void test_realtime_sanitize_watch_map_empty_hash(void **state) {
 
 void test_realtime_sanitize_watch_map_inotify_not_connected(void **state) {
     OSHashNode node;
+
+    expect_function_call(__wrap_pthread_rwlock_rdlock);
+    expect_function_call(__wrap_pthread_mutex_lock);
+
     expect_value(__wrap_OSHash_Begin, self, syscheck.realtime->dirtb);
     will_return(__wrap_OSHash_Begin, &node);
 
@@ -925,6 +955,9 @@ void test_realtime_sanitize_watch_map_inotify_not_connected(void **state) {
 
     expect_value(__wrap_OSHash_Next, self, syscheck.realtime->dirtb);
     will_return(__wrap_OSHash_Next, NULL);
+
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_pthread_rwlock_unlock);
 
     expect_any(__wrap__mdebug2, formatted_msg);
 
@@ -1699,9 +1732,15 @@ void test_RTCallBack_error_on_callback(void **state) {
 void test_RTCallBack_empty_hash_table(void **state) {
     OVERLAPPED ov = {.hEvent = "C:\\a\\path"};
 
-    expect_value(__wrap_OSHash_Get, self, syscheck.realtime->dirtb);
-    expect_any(__wrap_OSHash_Get, key);
-    will_return(__wrap_OSHash_Get, NULL);
+    expect_function_call(__wrap_pthread_rwlock_rdlock);
+    expect_function_call(__wrap_pthread_mutex_lock);
+
+    expect_value(__wrap_OSHash_Get_ex, self, syscheck.realtime->dirtb);
+    expect_any(__wrap_OSHash_Get_ex, key);
+    will_return(__wrap_OSHash_Get_ex, NULL);
+
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_pthread_rwlock_unlock);
 
     expect_string(__wrap__merror, formatted_msg, FIM_ERROR_REALTIME_WINDOWS_CALLBACK_EMPTY);
 
@@ -1714,11 +1753,17 @@ void test_RTCallBack_no_bytes_returned(void **state) {
 
     rt->watch_status = 1;
 
-    expect_value(__wrap_OSHash_Get, self, syscheck.realtime->dirtb);
-    expect_any(__wrap_OSHash_Get, key);
-    will_return(__wrap_OSHash_Get, rt);
+    expect_function_call(__wrap_pthread_rwlock_rdlock);
+    expect_function_call(__wrap_pthread_mutex_lock);
+
+    expect_value(__wrap_OSHash_Get_ex, self, syscheck.realtime->dirtb);
+    expect_any(__wrap_OSHash_Get_ex, key);
+    will_return(__wrap_OSHash_Get_ex, rt);
 
     expect_string(__wrap__mwarn, formatted_msg, FIM_WARN_REALTIME_OVERFLOW);
+
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_pthread_rwlock_unlock);
 
     // Inside realtime_win32read
     will_return(wrap_ReadDirectoryChangesW, 1);
@@ -1731,8 +1776,8 @@ void test_RTCallBack_acquired_changes_null_dir(void **state) {
     OVERLAPPED ov;
     PFILE_NOTIFY_INFORMATION pinfo;
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
-    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call(__wrap_pthread_rwlock_rdlock);
+    expect_function_call(__wrap_pthread_mutex_lock);
 
     // Fill the win32rtfim struct with testing data
     pinfo = (PFILE_NOTIFY_INFORMATION) rt->buffer;
@@ -1748,9 +1793,9 @@ void test_RTCallBack_acquired_changes_null_dir(void **state) {
 
     // Begin calls to mock functions
 
-    expect_value(__wrap_OSHash_Get, self, syscheck.realtime->dirtb);
-    expect_string(__wrap_OSHash_Get, key, "C:\\a\\path");
-    will_return(__wrap_OSHash_Get, rt);
+    expect_value(__wrap_OSHash_Get_ex, self, syscheck.realtime->dirtb);
+    expect_string(__wrap_OSHash_Get_ex, key, "C:\\a\\path");
+    will_return(__wrap_OSHash_Get_ex, rt);
 
     expect_string(__wrap_fim_configuration_directory, path, "C:\\a\\path");
     will_return(__wrap_fim_configuration_directory, 0);
@@ -1761,6 +1806,9 @@ void test_RTCallBack_acquired_changes_null_dir(void **state) {
     // Inside realtime_win32read
     will_return(wrap_ReadDirectoryChangesW, 1);
 
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_pthread_rwlock_unlock);
+
     RTCallBack(ERROR_SUCCESS, 1, &ov);
 }
 
@@ -1769,8 +1817,9 @@ void test_RTCallBack_acquired_changes(void **state) {
     OVERLAPPED ov;
     PFILE_NOTIFY_INFORMATION pinfo;
 
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
-    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+
+    expect_function_call(__wrap_pthread_rwlock_rdlock);
+    expect_function_call(__wrap_pthread_mutex_lock);
 
     // Fill the win32rtfim struct with testing data
     pinfo = (PFILE_NOTIFY_INFORMATION) rt->buffer;
@@ -1786,9 +1835,9 @@ void test_RTCallBack_acquired_changes(void **state) {
 
     // Begin calls to mock functions
 
-    expect_value(__wrap_OSHash_Get, self, syscheck.realtime->dirtb);
-    expect_string(__wrap_OSHash_Get, key, "C:\\a\\path\\file.test");
-    will_return(__wrap_OSHash_Get, rt);
+    expect_value(__wrap_OSHash_Get_ex, self, syscheck.realtime->dirtb);
+    expect_string(__wrap_OSHash_Get_ex, key, "C:\\a\\path\\file.test");
+    will_return(__wrap_OSHash_Get_ex, rt);
 
     expect_string(__wrap_fim_configuration_directory, path, "C:\\a\\path\\file.test");
     will_return(__wrap_fim_configuration_directory, 0);
@@ -1801,9 +1850,75 @@ void test_RTCallBack_acquired_changes(void **state) {
     // Inside realtime_win32read
     will_return(wrap_ReadDirectoryChangesW, 1);
 
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_pthread_rwlock_unlock);
+
     RTCallBack(ERROR_SUCCESS, 1, &ov);
 }
 #endif
+
+static void test_fim_realtime_get_queue_overflow(void **state) {
+    rtfim realtime = { .queue_overflow = false };
+    int retval;
+
+    syscheck.realtime = &realtime;
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    retval = fim_realtime_get_queue_overflow();
+
+    assert_int_equal(retval, false);
+
+    realtime.queue_overflow = true;
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    retval = fim_realtime_get_queue_overflow();
+
+    assert_int_equal(retval, true);
+
+    syscheck.realtime = NULL;
+}
+
+static void test_fim_realtime_set_queue_overflow(void **state) {
+    rtfim realtime = { .queue_overflow = false };
+
+    syscheck.realtime = &realtime;
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    fim_realtime_set_queue_overflow(true);
+
+    assert_int_equal(realtime.queue_overflow, true);
+
+    syscheck.realtime = NULL;
+}
+
+static void test_fim_realtime_print_watches(void **state) {
+    rtfim realtime = { .queue_overflow = false };
+    char msg[OS_SIZE_256];
+
+    syscheck.realtime = &realtime;
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+
+    expect_any(__wrap_OSHash_Get_Elem_ex, self);
+    will_return(__wrap_OSHash_Get_Elem_ex, 257);
+
+    snprintf(msg, OS_SIZE_256, FIM_NUM_WATCHES, 257);
+    expect_string(__wrap__mdebug2, formatted_msg, msg);
+
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    fim_realtime_print_watches();
+
+    syscheck.realtime = NULL;
+
+}
+
 
 int main(void) {
 #ifndef WIN_WHODATA
@@ -1903,5 +2018,16 @@ int main(void) {
     };
 #endif
 
-    return cmocka_run_group_tests(tests, setup_group, teardown_group);
+    const struct CMUnitTest realtime_helper_tests[] = {
+        cmocka_unit_test(test_fim_realtime_get_queue_overflow),
+        cmocka_unit_test(test_fim_realtime_set_queue_overflow),
+        cmocka_unit_test(test_fim_realtime_print_watches),
+    };
+
+    int results = 0;
+
+    results += cmocka_run_group_tests(tests, setup_group, teardown_group);
+    results += cmocka_run_group_tests(realtime_helper_tests, NULL, NULL);
+
+    return results;
 }

--- a/src/unit_tests/syscheckd/test_syscheck.c
+++ b/src/unit_tests/syscheckd/test_syscheck.c
@@ -277,8 +277,9 @@ void test_Start_win32_Syscheck_dirs_and_registry(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
-    directory_t *directory0 = fim_create_directory("c:\\Dir1", 0, NULL, 512, NULL, 1024, 0);
+    directory_t *directory0 = fim_create_directory("c:\\dir1", 0, NULL, 512, NULL, 1024, 0);
     OSList_InsertData(syscheck.directories, NULL, directory0);
 
     syscheck.disabled = 0;
@@ -287,7 +288,7 @@ void test_Start_win32_Syscheck_dirs_and_registry(void **state) {
                                      { NULL, 0, 0, 0, 0, NULL, NULL, NULL } };
     syscheck.registry = syscheck_registry;
 
-    char *syscheck_ignore[] = {"Dir1", NULL};
+    char *syscheck_ignore[] = {"dir1", NULL};
     syscheck.ignore = syscheck_ignore;
 
     OSMatch regex;
@@ -315,13 +316,13 @@ void test_Start_win32_Syscheck_dirs_and_registry(void **state) {
 
     expect_string(__wrap__minfo, formatted_msg, "(6002): Monitoring registry entry: 'Entry1 [x64]', with options ''");
 
-    expect_string(__wrap__minfo, formatted_msg, "(6003): Monitoring path: 'Dir1', with options ''.");
+    expect_string(__wrap__minfo, formatted_msg, "(6003): Monitoring path: 'c:\\dir1', with options ''.");
 
     expect_string(__wrap__minfo, formatted_msg, FIM_FILE_SIZE_LIMIT_DISABLED);
 
     expect_string(__wrap__minfo, formatted_msg, FIM_DISK_QUOTA_LIMIT_DISABLED);
 
-    expect_string(__wrap__minfo, formatted_msg, "(6206): Ignore 'file' entry 'Dir1'");
+    expect_string(__wrap__minfo, formatted_msg, "(6206): Ignore 'file' entry 'dir1'");
 
     expect_string(__wrap__minfo, formatted_msg, "(6207): Ignore 'file' sregex '^regex$'");
 
@@ -342,6 +343,9 @@ void test_Start_win32_Syscheck_dirs_and_registry(void **state) {
     expect_function_call(__wrap_start_daemon);
 
     Start_win32_Syscheck();
+
+    free_directory(directory0);
+    OSList_DeleteThisNode(syscheck.directories, syscheck.directories->first_node);
 }
 
 void test_Start_win32_Syscheck_whodata_active(void **state) {
@@ -349,8 +353,9 @@ void test_Start_win32_Syscheck_whodata_active(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
-    directory_t *directory0 = fim_create_directory("Dir1", WHODATA_ACTIVE, NULL, 512, NULL, -1, 0);
+    directory_t *directory0 = fim_create_directory("c:\\dir1", WHODATA_ACTIVE, NULL, 512, NULL, -1, 0);
 
     registry syscheck_registry[] = { { NULL, 0, 0, 0, 0, NULL, NULL } };
 
@@ -379,7 +384,7 @@ void test_Start_win32_Syscheck_whodata_active(void **state) {
 
     expect_string(__wrap__minfo, formatted_msg, "(6015): Real-time Whodata mode is not compatible with this version of Windows.");
 
-    expect_string(__wrap__minfo, formatted_msg, "(6003): Monitoring path: 'Dir1', with options 'realtime'.");
+    expect_string(__wrap__minfo, formatted_msg, "(6003): Monitoring path: 'c:\\dir1', with options 'realtime'.");
 
     expect_value(__wrap_fim_db_init, memory, 0);
     will_return(__wrap_fim_db_init, NULL);
@@ -397,6 +402,9 @@ void test_Start_win32_Syscheck_whodata_active(void **state) {
     expect_function_call(__wrap_start_daemon);
 
     Start_win32_Syscheck();
+
+    free_directory(directory0);
+    OSList_DeleteThisNode(syscheck.directories, syscheck.directories->first_node);
 }
 
 #endif
@@ -415,14 +423,12 @@ int main(void) {
     const struct CMUnitTest tests_win[] = {
             cmocka_unit_test(test_Start_win32_Syscheck_no_config_file),
             cmocka_unit_test(test_Start_win32_Syscheck_corrupted_config_file),
-            cmocka_unit_test(test_Start_win32_Syscheck_syscheck_disabled_1),
-            cmocka_unit_test(test_Start_win32_Syscheck_syscheck_disabled_2),
             cmocka_unit_test(test_Start_win32_Syscheck_dirs_and_registry),
             cmocka_unit_test(test_Start_win32_Syscheck_whodata_active),
+            cmocka_unit_test(test_Start_win32_Syscheck_syscheck_disabled_1),
+            cmocka_unit_test(test_Start_win32_Syscheck_syscheck_disabled_2),
     };
 #endif
-
-    return cmocka_run_group_tests(tests, setup_group, teardown_group);
 
     ret = cmocka_run_group_tests(tests, setup_group, teardown_group);
 #ifdef TEST_WINAGENT


### PR DESCRIPTION
## Description

This PR fixes the following problems in FIM:
- Fix wildcards update returning without releasing the directories lock.
- Prevent fim_file_diff from recursively locking the directories for read operations which could cause a deadlock in Windows.
- Added several helper functions for accessing realtime fields that should always be protected by a mutex.

<!--
Add a clear description of how the problem has been solved.
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] AddressSanitizer + UBSanitizer
  - [x] ThreadSanitizer
- Memory tests for Windows
  - [x] Scan-build report
  - [x] Dr. Memory
