### PR TITLE
Add new `max_upload_size` API option

### DIFF
--- a/api/api/configuration.py
+++ b/api/api/configuration.py
@@ -32,6 +32,7 @@ default_api_configuration = {
     "use_only_authd": False,
     "drop_privileges": True,
     "experimental_features": False,
+    "max_upload_size": 1048576,
     "intervals": {
         "request_timeout": 10
     },

--- a/api/api/configuration.py
+++ b/api/api/configuration.py
@@ -32,7 +32,7 @@ default_api_configuration = {
     "use_only_authd": False,
     "drop_privileges": True,
     "experimental_features": False,
-    "max_upload_size": 1048576,
+    "max_upload_size": 10485760,
     "intervals": {
         "request_timeout": 10
     },

--- a/api/api/configuration/api.yaml
+++ b/api/api/configuration/api.yaml
@@ -52,6 +52,9 @@
 # Enable features under development
 # experimental_features: no
 
+# Maximum body size that the API can accept, in bytes (0 -> limitless)
+# max_upload_size: 1048576
+
 # Enable remote commands
 # remote_commands:
 #   localfile:

--- a/api/api/configuration/api.yaml
+++ b/api/api/configuration/api.yaml
@@ -53,7 +53,7 @@
 # experimental_features: no
 
 # Maximum body size that the API can accept, in bytes (0 -> limitless)
-# max_upload_size: 1048576
+# max_upload_size: 10485760
 
 # Enable remote commands
 # remote_commands:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -8058,6 +8058,7 @@ paths:
                         use_only_authd: false
                         drop_privileges: true
                         experimental_features: false
+                        max_upload_size: 1048576
                         https:
                           enabled: true
                           key: "/var/ossec/api/configuration/ssl/server.key"
@@ -8096,6 +8097,7 @@ paths:
                         use_only_authd: false
                         drop_privileges: true
                         experimental_features: false
+                        max_upload_size: 1048576
                         https:
                           enabled: true
                           key: "/var/ossec/api/configuration/ssl/server.key"
@@ -8133,6 +8135,7 @@ paths:
                         use_only_authd: false
                         drop_privileges: true
                         experimental_features: false
+                        max_upload_size: 1048576
                         https:
                           enabled: true
                           key: "/var/ossec/api/configuration/ssl/server.key"
@@ -8584,6 +8587,8 @@ paths:
           $ref: '#/components/responses/InvalidHTTPMethodResponse'
         '406':
           $ref: '#/components/responses/WrongContentTypeResponse'
+        '413':
+          $ref: '#/components/responses/RequestTooLargeResponse'
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
 
@@ -9562,6 +9567,8 @@ paths:
           $ref: '#/components/responses/PermissionDeniedResponse'
         '405':
           $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '413':
+          $ref: '#/components/responses/RequestTooLargeResponse'
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
     delete:
@@ -10009,6 +10016,8 @@ paths:
           $ref: '#/components/responses/InvalidHTTPMethodResponse'
         '406':
           $ref: '#/components/responses/WrongContentTypeResponse'
+        '413':
+          $ref: '#/components/responses/RequestTooLargeResponse'
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
 
@@ -10693,6 +10702,7 @@ paths:
                         use_only_authd: false
                         drop_privileges: true
                         experimental_features: false
+                        max_upload_size: 1048576
                   total_affected_items: 1
                   total_failed_items: 0
                   failed_items: []
@@ -12015,6 +12025,8 @@ paths:
           $ref: '#/components/responses/InvalidHTTPMethodResponse'
         '406':
           $ref: '#/components/responses/WrongContentTypeResponse'
+        '413':
+          $ref: '#/components/responses/RequestTooLargeResponse'
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
     delete:
@@ -12791,6 +12803,8 @@ paths:
           $ref: '#/components/responses/InvalidHTTPMethodResponse'
         '406':
           $ref: '#/components/responses/WrongContentTypeResponse'
+        '413':
+          $ref: '#/components/responses/RequestTooLargeResponse'
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
     delete:
@@ -14757,6 +14771,8 @@ paths:
           $ref: '#/components/responses/PermissionDeniedResponse'
         '405':
           $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '413':
+          $ref: '#/components/responses/RequestTooLargeResponse'
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
 
@@ -15212,6 +15228,8 @@ paths:
           $ref: '#/components/responses/InvalidHTTPMethodResponse'
         '406':
           $ref: '#/components/responses/WrongContentTypeResponse'
+        '413':
+          $ref: '#/components/responses/RequestTooLargeResponse'
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
 
@@ -15834,6 +15852,8 @@ paths:
           $ref: '#/components/responses/InvalidHTTPMethodResponse'
         '406':
           $ref: '#/components/responses/WrongContentTypeResponse'
+        '413':
+          $ref: '#/components/responses/RequestTooLargeResponse'
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
 
@@ -16557,6 +16577,8 @@ paths:
           $ref: '#/components/responses/InvalidHTTPMethodResponse'
         '406':
           $ref: '#/components/responses/WrongContentTypeResponse'
+        '413':
+          $ref: '#/components/responses/RequestTooLargeResponse'
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
 

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -8058,7 +8058,7 @@ paths:
                         use_only_authd: false
                         drop_privileges: true
                         experimental_features: false
-                        max_upload_size: 1048576
+                        max_upload_size: 10485760
                         https:
                           enabled: true
                           key: "/var/ossec/api/configuration/ssl/server.key"
@@ -8097,7 +8097,7 @@ paths:
                         use_only_authd: false
                         drop_privileges: true
                         experimental_features: false
-                        max_upload_size: 1048576
+                        max_upload_size: 10485760
                         https:
                           enabled: true
                           key: "/var/ossec/api/configuration/ssl/server.key"
@@ -8135,7 +8135,7 @@ paths:
                         use_only_authd: false
                         drop_privileges: true
                         experimental_features: false
-                        max_upload_size: 1048576
+                        max_upload_size: 10485760
                         https:
                           enabled: true
                           key: "/var/ossec/api/configuration/ssl/server.key"
@@ -10702,7 +10702,7 @@ paths:
                         use_only_authd: false
                         drop_privileges: true
                         experimental_features: false
-                        max_upload_size: 1048576
+                        max_upload_size: 10485760
                   total_affected_items: 1
                   total_failed_items: 0
                   failed_items: []

--- a/api/api/test/test_configuration.py
+++ b/api/api/test/test_configuration.py
@@ -16,6 +16,7 @@ custom_api_configuration = {
     "use_only_authd": False,
     "drop_privileges": True,
     "experimental_features": False,
+    "max_upload_size": 1048576,
     "https": {
         "enabled": True,
         "key": "api/configuration/ssl/server.key",
@@ -104,6 +105,7 @@ def test_read_configuration(mock_open, mock_exists, read_config):
     {'use_only_authd': 'invalid_type'},
     {'drop_privileges': 'invalid_type'},
     {'experimental_features': 'invalid_type'},
+    {'max_upload_size': 'invalid_type'},
     {'https': {'enabled': 'invalid_type'}},
     {'https': {'key': 12345}},
     {'https': {'cert': 12345}},

--- a/api/api/test/test_configuration.py
+++ b/api/api/test/test_configuration.py
@@ -16,7 +16,7 @@ custom_api_configuration = {
     "use_only_authd": False,
     "drop_privileges": True,
     "experimental_features": False,
-    "max_upload_size": 1048576,
+    "max_upload_size": 10485760,
     "https": {
         "enabled": True,
         "key": "api/configuration/ssl/server.key",

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -63,6 +63,7 @@ api_config_schema = {
         "use_only_authd": {"type": "boolean"},
         "drop_privileges": {"type": "boolean"},
         "experimental_features": {"type": "boolean"},
+        "max_upload_size": {"type": "integer", "minimum": 0},
         "intervals": {
             "type": "object",
             "additionalProperties": False,

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -162,6 +162,9 @@ def start(foreground, root, config_file):
                 options={"middlewares": [response_postprocessing, set_user_name, security_middleware, request_logging,
                                          set_secure_headers]})
 
+    # Maximum body size that the API can accept (bytes)
+    app.app._client_max_size = configuration.api_conf['max_upload_size']
+
     # Enable CORS
     if api_conf['cors']['enabled']:
         import aiohttp_cors


### PR DESCRIPTION
|Related issue|
|---|
| Closes #9054 |

## Description

Hello team,

As requested in #9054, this PR adds a new API config option called `max_upload_size`. It lets the user choose how big can the body be in the API requests. If the limit is exceeded, a 413 code (Request Entity Too Large) is returned:
```JSON
{
  "title": "Request Entity Too Large",
  "detail": "Maximum request body size 10 exceeded, actual body size 41"
}
```

The following can be specified so there is no limit on the body size:
```YAML
# Maximum body size that the API can accept, in bytes (0 -> limitless)
max_upload_size: 0
```

Regards,
Selu.