### PR TITLE
Change RSync to async dispatch

### DIFF
--- a/src/shared_modules/utils/msgDispatcher.h
+++ b/src/shared_modules/utils/msgDispatcher.h
@@ -26,7 +26,7 @@ namespace Utils
     typename Value,
     typename RawValue,
     typename RawValueDecoder,
-    template <class, class> class ThreadDispatcher = SyncDispatcher
+    template <class, class> class ThreadDispatcher = AsyncDispatcher
     >
     class MsgDispatcher final : public ThreadDispatcher<RawValue, std::function<void(const RawValue&)>>
                               , public RawValueDecoder


### PR DESCRIPTION
|Related issue|
|---|
|Closes #9122 |

## Description
This issue aims to solve an interlock problem detected in syscollector functional tests.

This was detected by the operations team on a test deployment. @fhielpos 

The effect of this was that the agent was left with no response when synchronizing the processes.

**Expected**: no interlock
**Actual**: wmodules / agentd interlock

**Steps to reproduce**:
- Install Wazuh
- yum install stress
- Launch 20k processes. -> stress -m 20000 --vm-bytes 10 --vm-hang 5
- Wait Syscollector scan
- Check agent activity and cpu usage after syscollector scan.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [x] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
