### PR TITLE
Delete synchro conditionals, to clean rows if the configuration is changed

### DIFF
--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -1022,36 +1022,15 @@ Syscollector::Syscollector()
 std::string Syscollector::getCreateStatement() const
 {
     std::string ret;
-    if (m_os)
-    {
-        ret += OS_SQL_STATEMENT;
-    }
-    if (m_hardware)
-    {
-        ret += HW_SQL_STATEMENT;
-    }
-    if (m_packages)
-    {
-        ret += PACKAGES_SQL_STATEMENT;
-        if (m_hotfixes)
-        {
-            ret += HOTFIXES_SQL_STATEMENT;
-        }
-    }
-    if (m_processes)
-    {
-        ret += PROCESSES_SQL_STATEMENT;
-    }
-    if (m_ports)
-    {
-        ret += PORTS_SQL_STATEMENT;
-    }
-    if (m_network)
-    {
-        ret += NETIFACE_SQL_STATEMENT;
-        ret += NETPROTO_SQL_STATEMENT;
-        ret += NETADDR_SQL_STATEMENT;
-    }
+    ret += OS_SQL_STATEMENT;
+    ret += HW_SQL_STATEMENT;
+    ret += PACKAGES_SQL_STATEMENT;
+    ret += HOTFIXES_SQL_STATEMENT;
+    ret += PROCESSES_SQL_STATEMENT;
+    ret += PORTS_SQL_STATEMENT;
+    ret += NETIFACE_SQL_STATEMENT;
+    ret += NETPROTO_SQL_STATEMENT;
+    ret += NETADDR_SQL_STATEMENT;
     return ret;
 }
 
@@ -1227,10 +1206,7 @@ void Syscollector::scanHardware()
 
 void Syscollector::syncHardware()
 {
-    if (m_hardware)
-    {
-        m_spRsync->startSync(m_spDBSync->handle(), nlohmann::json::parse(HW_START_CONFIG_STATEMENT), m_reportSyncFunction);
-    }
+    m_spRsync->startSync(m_spDBSync->handle(), nlohmann::json::parse(HW_START_CONFIG_STATEMENT), m_reportSyncFunction);
 }
 
 nlohmann::json Syscollector::getOSData()
@@ -1254,10 +1230,7 @@ void Syscollector::scanOs()
 
 void Syscollector::syncOs()
 {
-    if (m_os)
-    {
-        m_spRsync->startSync(m_spDBSync->handle(), nlohmann::json::parse(OS_START_CONFIG_STATEMENT), m_reportSyncFunction);
-    }
+    m_spRsync->startSync(m_spDBSync->handle(), nlohmann::json::parse(OS_START_CONFIG_STATEMENT), m_reportSyncFunction);
 }
 
 nlohmann::json Syscollector::getNetworkData()
@@ -1376,12 +1349,9 @@ void Syscollector::scanNetwork()
 
 void Syscollector::syncNetwork()
 {
-    if (m_network)
-    {
-        m_spRsync->startSync(m_spDBSync->handle(), nlohmann::json::parse(NETIFACE_START_CONFIG_STATEMENT), m_reportSyncFunction);
-        m_spRsync->startSync(m_spDBSync->handle(), nlohmann::json::parse(NETPROTO_START_CONFIG_STATEMENT), m_reportSyncFunction);
-        m_spRsync->startSync(m_spDBSync->handle(), nlohmann::json::parse(NETADDRESS_START_CONFIG_STATEMENT), m_reportSyncFunction);
-    }
+    m_spRsync->startSync(m_spDBSync->handle(), nlohmann::json::parse(NETIFACE_START_CONFIG_STATEMENT), m_reportSyncFunction);
+    m_spRsync->startSync(m_spDBSync->handle(), nlohmann::json::parse(NETPROTO_START_CONFIG_STATEMENT), m_reportSyncFunction);
+    m_spRsync->startSync(m_spDBSync->handle(), nlohmann::json::parse(NETADDRESS_START_CONFIG_STATEMENT), m_reportSyncFunction);
 }
 
 nlohmann::json Syscollector::getPackagesData()
@@ -1448,14 +1418,8 @@ void Syscollector::scanPackages()
 
 void Syscollector::syncPackages()
 {
-    if (m_packages)
-    {
-        m_spRsync->startSync(m_spDBSync->handle(), nlohmann::json::parse(PACKAGES_START_CONFIG_STATEMENT), m_reportSyncFunction);
-        if (m_hotfixes)
-        {
-            m_spRsync->startSync(m_spDBSync->handle(), nlohmann::json::parse(HOTFIXES_START_CONFIG_STATEMENT), m_reportSyncFunction);
-        }
-    }
+    m_spRsync->startSync(m_spDBSync->handle(), nlohmann::json::parse(PACKAGES_START_CONFIG_STATEMENT), m_reportSyncFunction);
+    m_spRsync->startSync(m_spDBSync->handle(), nlohmann::json::parse(HOTFIXES_START_CONFIG_STATEMENT), m_reportSyncFunction);
 }
 
 nlohmann::json Syscollector::getPortsData()
@@ -1536,10 +1500,7 @@ void Syscollector::scanPorts()
 
 void Syscollector::syncPorts()
 {
-    if (m_ports)
-    {
-        m_spRsync->startSync(m_spDBSync->handle(), nlohmann::json::parse(PORTS_START_CONFIG_STATEMENT), m_reportSyncFunction);
-    }
+    m_spRsync->startSync(m_spDBSync->handle(), nlohmann::json::parse(PORTS_START_CONFIG_STATEMENT), m_reportSyncFunction);
 }
 
 nlohmann::json Syscollector::getProcessesData()
@@ -1570,10 +1531,7 @@ void Syscollector::scanProcesses()
 
 void Syscollector::syncProcesses()
 {
-    if (m_processes)
-    {
-        m_spRsync->startSync(m_spDBSync->handle(), nlohmann::json::parse(PROCESSES_START_CONFIG_STATEMENT), m_reportSyncFunction);
-    }
+    m_spRsync->startSync(m_spDBSync->handle(), nlohmann::json::parse(PROCESSES_START_CONFIG_STATEMENT), m_reportSyncFunction);
 }
 
 void Syscollector::scan()


### PR DESCRIPTION
|Related issue|
|---|
|Closes #9132 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This issue happens since the last scan is not being deleted, after it was disabled and a scan was made again.

Actual result: It always shows the scan time of the first scan.
Expected result: do not show data after a scan and that the feature is disabled.

Reproduce steps:
- Install Wazuh agent RC9
- Wait to the first one scan.
- Disable process or packages from agent configuration
- Restart agent
- Wait to the first one scan after agent restart
- Check 

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [x] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
