### PR TITLE
Add fix to update scan time field on all scans.

### DIFF
--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -1237,7 +1237,7 @@ nlohmann::json Syscollector::getOSData()
 {
     nlohmann::json ret;
     ret[0] = m_spInfo->os();
-    ret[0]["checksum"] = getItemChecksum(ret[0]);
+    ret[0]["checksum"] = std::to_string(std::chrono::system_clock::now().time_since_epoch().count());
     return ret;
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #9131 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This issue happens since many times the osinfo table from which the scan time shown in the ui is obtained is not updated, therefore the scan time of the registry is not updated.


Actual result:  It always shows the scan time of the first scan.
Expected result: Show the time of the last scan of the agent regardless if I update any value.

Reproduce steps:
- Install Wazuh agent RC9
- Wait to the second one scan.
- Check scan time in kibana UI

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [x] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
