### PR TITLE
GeoIP for office365

### DIFF
--- a/extensions/filebeat/7.x/wazuh-module/alerts/ingest/pipeline.json
+++ b/extensions/filebeat/7.x/wazuh-module/alerts/ingest/pipeline.json
@@ -39,6 +39,15 @@
       }
     },
     {
+      "geoip": {
+        "field": "data.office365.ClientIP",
+        "target_field": "GeoLocation",
+        "properties": ["city_name", "country_name", "region_name", "location"],
+        "ignore_missing": true,
+        "ignore_failure": true
+      }
+    },
+    {
       "date": {
         "field": "timestamp",
         "target_field": "@timestamp",

--- a/extensions/filebeat/7.x/wazuh-module/archives/ingest/pipeline.json
+++ b/extensions/filebeat/7.x/wazuh-module/archives/ingest/pipeline.json
@@ -39,6 +39,15 @@
       }
     },
     {
+      "geoip": {
+        "field": "data.office365.ClientIP",
+        "target_field": "GeoLocation",
+        "properties": ["city_name", "country_name", "region_name", "location"],
+        "ignore_missing": true,
+        "ignore_failure": true
+      }
+    },
+    {
       "date": {
         "field": "timestamp",
         "target_field": "@timestamp",


### PR DESCRIPTION
Edited the ingest pipeline so office365 events use geolocalization by IP

|Related issue|
|---|
|https://github.com/wazuh/wazuh-kibana-app/issues/3400|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
In order to display geolocation information for office365 events, we need to find it through the client IP and add it to the index.
This PR adds a new element to the `geoip` ingest pipeline for filebeat that accomplishes this.
