### PR TITLE
Add new unit and integration tests for API models

### DIFF
--- a/api/api/models/base_model_.py
+++ b/api/api/models/base_model_.py
@@ -221,14 +221,14 @@ class Body(Model):
         return util.deserialize_model(dikt, cls)
 
     @classmethod
-    def decode_body(cls, dikt, unicode_error=None, attribute_error=None):
+    def decode_body(cls, body, unicode_error=None, attribute_error=None):
         try:
-            body = dikt.decode('utf-8')
+            decoded_body = body.decode('utf-8')
         except UnicodeDecodeError:
             raise_if_exc(WazuhError(unicode_error))
         except AttributeError:
             raise_if_exc(WazuhError(attribute_error))
-        return body
+        return decoded_body
 
     @classmethod
     def validate_content_type(cls, request, expected_content_type):

--- a/api/api/models/test/test_model.py
+++ b/api/api/models/test/test_model.py
@@ -51,6 +51,7 @@ class TestModel(bm.Body):
     def arg_2(self, arg_2):
         self._arg_2 = arg_2
 
+
 class RequestMock:
     """Class Request mock."""
     def __init__(self, content_type):
@@ -180,7 +181,7 @@ def test_body_decode_body_ko():
 
 def test_body_validate_content_type():
     """Test class Body `validate_content_type` method."""
-    content_type ='application/json'
+    content_type = 'application/json'
     request = RequestMock(content_type)
 
     TestModel.validate_content_type(request, content_type)

--- a/api/api/models/test/test_model.py
+++ b/api/api/models/test/test_model.py
@@ -1,0 +1,196 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+import sys
+from json import JSONDecodeError
+from unittest.mock import patch, MagicMock
+
+import pytest
+from connexion import ProblemException
+
+with patch('wazuh.core.common.wazuh_uid'):
+    with patch('wazuh.core.common.wazuh_gid'):
+        sys.modules['api.authentication'] = MagicMock()
+        from api.models import base_model_ as bm
+        from wazuh import WazuhError
+        from api.util import deserialize_model
+
+        del sys.modules['api.authentication']
+
+
+class TestModel(bm.Body):
+    """Test class for custom Model. Body inherits from Model and has all the attributes required for testing."""
+
+    def __init__(self, arg_1: str = None, arg_2: int = None):
+        self.swagger_types = {
+            'arg_1': str,
+            'arg_2': int
+        }
+
+        self.attribute_map = {
+            'arg_1': 'arg_1',
+            'arg_2': 'arg_2'
+        }
+
+        self._arg_1 = arg_1
+        self._arg_2 = arg_2
+
+    @property
+    def arg_1(self):
+        return self._arg_1
+
+    @arg_1.setter
+    def arg_1(self, arg_1):
+        self._arg_1 = arg_1
+
+    @property
+    def arg_2(self):
+        return self._arg_2
+
+    @arg_2.setter
+    def arg_2(self, arg_2):
+        self._arg_2 = arg_2
+
+class RequestMock:
+    """Class Request mock."""
+    def __init__(self, content_type):
+        self._content_type = content_type
+
+    @property
+    def content_type(self):
+        return self._content_type
+
+
+def test_model_from_dict():
+    """Test class Model `from_dict` method."""
+    exc = WazuhError(1000)
+    with pytest.raises(exc.__class__):
+        bm.Model.from_dict(exc)
+
+    dikt = {'test_key': 'test_value'}
+    assert bm.Model.from_dict(dikt) == deserialize_model(dikt, bm.Model)
+
+
+def test_model_to_dict():
+    """Test class Model `to_dict` method."""
+    test_model = TestModel('value1', 2)
+    dikt = test_model.to_dict()
+    assert isinstance(dikt, dict)
+    assert dikt == {'arg_1': 'value1', 'arg_2': 2}
+
+
+def test_model_to_str():
+    """Test class Model `to_str` method."""
+    test_model = TestModel('value1', 2)
+    dikt = test_model.to_dict()
+    str_dikt = test_model.to_str()
+    assert isinstance(str_dikt, str)
+    assert str_dikt == str(dikt)
+
+
+def test_model_operator_overloading():
+    """Test class Model multiple operator overloading."""
+    original_dict = {'arg_1': 'value1', 'arg_2': 2}
+    test_model = TestModel(*list(original_dict.values()))
+
+    # Operator __repr__ (for print)
+    # Assert that we can print a Model right away
+    print(test_model)
+
+    equal_model = TestModel(*list(original_dict.values()))
+    not_equal_model = TestModel()
+
+    # Operator == (__eq__)
+    assert test_model == equal_model
+    with pytest.raises(AssertionError):
+        assert test_model == not_equal_model
+
+    # Operator != (__ne__)
+    assert test_model != not_equal_model
+    with pytest.raises(AssertionError):
+        assert test_model != equal_model
+
+
+def test_model_properties():
+    """Test setters and getters (properties) from class Model."""
+    test_model = TestModel()
+    value = 'test'
+
+    assert test_model.arg_1 is None
+    test_model.arg_1 = value
+    assert test_model.arg_1 == value
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('additional_kwargs', [
+    {},
+    {'additional': 'test'}
+])
+async def test_body_get_kwargs(additional_kwargs):
+    """Test class Body `get_kwargs` class method."""
+    request = {'arg_1': 'value1'}  # Missing arg_2
+    test_model = TestModel(*list(request.values()))
+
+    kwargs = await TestModel.get_kwargs(request, additional_kwargs=additional_kwargs)
+    request.update(additional_kwargs)
+    try:
+        assert kwargs == test_model.to_dict()
+    except AssertionError:
+        # Check for additional_kwargs
+        assert set(kwargs) - set(test_model.to_dict()) == set(additional_kwargs)
+
+
+@pytest.mark.asyncio
+async def test_body_get_kwargs_ko():
+    """Test class Body `get_kwargs` class method exceptions."""
+    invalid_request = {'invalid': 'value1'}
+    with patch('api.models.base_model_.util.deserialize_model', side_effect=JSONDecodeError('msg', 'a', 1)):
+        with pytest.raises(ProblemException) as exc:
+            await TestModel.get_kwargs(invalid_request)
+
+        assert exc.value.ext['code'] == 1018
+
+    with pytest.raises(ProblemException) as exc:
+        await TestModel.get_kwargs(invalid_request)
+
+    # Custom exception. Very specific detail
+    assert 'Invalid field found' in exc.value.detail
+
+
+def test_body_decode_body():
+    """Test class Body `decode_body` class method."""
+    body = 'body'
+    assert TestModel.decode_body(body.encode()) == body
+
+
+def test_body_decode_body_ko():
+    """Test class Body `decode_body` class method exceptions."""
+    # UnicodeDecodeError
+    with pytest.raises(ProblemException) as exc:
+        TestModel.decode_body('test'.encode('utf-16'), unicode_error=1911)
+
+    assert exc.value.ext['code'] == 1911
+
+    # AttributeError
+    with pytest.raises(ProblemException) as exc:
+        TestModel.decode_body('test', attribute_error=1912)
+
+    assert exc.value.ext['code'] == 1912
+
+
+def test_body_validate_content_type():
+    """Test class Body `validate_content_type` method."""
+    content_type ='application/json'
+    request = RequestMock(content_type)
+
+    TestModel.validate_content_type(request, content_type)
+
+
+def test_body_validate_content_type_ko():
+    """Test class Body `validate_content_type` method exceptions."""
+    request = RequestMock('application/json')
+
+    with pytest.raises(ProblemException) as exc:
+        TestModel.validate_content_type(request, 'application/xml')
+
+    assert exc.value.ext['code'] == 6002

--- a/api/test/integration/mapping/integration_test_api_endpoints.json
+++ b/api/test/integration/mapping/integration_test_api_endpoints.json
@@ -1271,6 +1271,27 @@
         ]
     },
     {
+        "path": "framework/wazuh/core/tests/data/test_agent/add_manual",
+        "files": [
+            {
+                "name": "add_manual_use_cases.yaml",
+                "tag": "add",
+                "tests": [
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
         "path": "framework/wazuh/core/tests/data/test_rootcheck",
         "files": [
             {

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -1241,6 +1241,21 @@ stages:
           total_affected_items: 0
           total_failed_items: 1
 
+  # PUT /manager/configuration
+  - name: Try to upload an invalid configuration with an invalid content-type
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      method: PUT
+      data: "{invalid_ossec_conf:s}"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/json
+    response:
+      status_code: 406
+      json:
+        error: 6002
+
   # GET /manager/configuration/
   - name: Ensure the config didn't change
     request:


### PR DESCRIPTION
|Related issue|
|---|
| closes #8928 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hello team,

This PR adds a new unit test module for the API modules. In addition, one integration test case was added to the manager AIT to test the `content-type` validation.

## Tests performed
### Unit tests
```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.9.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: cov-2.12.0, asyncio-0.15.1
collected 237 items                                                                                                                                                                         

api/models/test/test_model.py ............                                                                                                                                            [  5%]
api/test/test_alogging.py ..........                                                                                                                                                  [  9%]
api/test/test_authentication.py ..........                                                                                                                                            [ 13%]
api/test/test_configuration.py .........................................                                                                                                              [ 30%]
api/test/test_util.py ...................................                                                                                                                             [ 45%]
api/test/test_validator.py .................................................................................................................................                          [100%]

============================================================================= 237 passed, 13 warnings in 1.03s ==============================================================================
```
> **NOTE**: the new tests are in `api/models/test/test_model.py`

### Integration tests
```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.9.5, pytest-5.4.3, py-1.10.0, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: tavern-1.0.0, metadata-1.11.0, html-3.1.1
collected 31 items                                                                                                                                                                          

test_manager_endpoints.tavern.yaml ...............................                                                                                                                    [100%]

======================================================================== 31 passed, 34 warnings in 67.29s (0:01:07) =========================================================================
```

Regards,
Víctor