### PR TITLE
Move MITRE reference with `external_id` to the exterior level of the response for all MITRE endpoints

### DIFF
--- a/api/test/integration/test_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_mitre_endpoints.tavern.yaml
@@ -161,6 +161,20 @@ stages:
             reverse: True
       status_code: 200
 
+  - name: Sort mitigations by external_id
+    request:
+      verify: False
+      <<: *general_mitigations_request
+      params:
+        sort: -external_id
+    response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "external_id"
+            reverse: True
+      status_code: 200
+
   - name: Show mitigations using valid select
     request:
       verify: False
@@ -737,6 +751,20 @@ stages:
             reverse: True
       status_code: 200
 
+  - name: Sort tactics by external_id
+    request:
+      verify: False
+      <<: *general_tactics_request
+      params:
+        sort: -external_id
+    response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "external_id"
+            reverse: True
+      status_code: 200
+
   - name: Try to show tactics using valid select
     request:
       verify: False
@@ -1034,6 +1062,20 @@ stages:
             reverse: True
       status_code: 200
 
+  - name: Sort techniques by external_id
+    request:
+      verify: False
+      <<: *general_techniques_request
+      params:
+        sort: -external_id
+    response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "external_id"
+            reverse: True
+      status_code: 200
+
   - name: Try to show techniques using valid select
     request:
       verify: False
@@ -1322,6 +1364,20 @@ stages:
             reverse: True
       status_code: 200
 
+  - name: Sort groups by external_id
+    request:
+      verify: False
+      <<: *general_groups_request
+      params:
+        sort: -external_id
+    response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "external_id"
+            reverse: True
+      status_code: 200
+
   - name: Show groups using valid select
     request:
       verify: False
@@ -1607,6 +1663,20 @@ stages:
         - function: tavern_utils:test_sort_response
           extra_kwargs:
             key: "groups"
+            reverse: True
+      status_code: 200
+
+  - name: Sort softwares by external_id
+    request:
+      verify: False
+      <<: *general_software_request
+      params:
+        sort: -external_id
+    response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "external_id"
             reverse: True
       status_code: 200
 

--- a/framework/wazuh/core/mitre.py
+++ b/framework/wazuh/core/mitre.py
@@ -457,7 +457,7 @@ class WazuhDBQueryMitreGroups(WazuhDBQueryMitre):
             if 'description' in reference_external_id:
                 reference_external_id.pop('description')
             # Delete the reference from references and update the object
-            if reference_external_id in group['references']:
+            if reference_external_id:
                 group['references'].remove(reference_external_id)
             group.update(reference_external_id)
 

--- a/framework/wazuh/core/mitre.py
+++ b/framework/wazuh/core/mitre.py
@@ -197,7 +197,7 @@ class WazuhDBQueryMitreMitigations(WazuhDBQueryMitre):
             if 'description' in reference_external_id:
                 reference_external_id.pop('description')
             # Delete the reference from references and update the object
-            if reference_external_id in mitigation['references']:
+            if reference_external_id:
                 mitigation['references'].remove(reference_external_id)
             mitigation.update(reference_external_id)
 

--- a/framework/wazuh/core/mitre.py
+++ b/framework/wazuh/core/mitre.py
@@ -380,7 +380,7 @@ class WazuhDBQueryMitreTechniques(WazuhDBQueryMitre):
             if 'description' in reference_external_id:
                 reference_external_id.pop('description')
             # Delete the reference from references and update the object
-            if reference_external_id in technique['references']:
+            if reference_external_id:
                 technique['references'].remove(reference_external_id)
             technique.update(reference_external_id)
 

--- a/framework/wazuh/core/mitre.py
+++ b/framework/wazuh/core/mitre.py
@@ -511,6 +511,7 @@ class WazuhDBQueryMitreSoftware(WazuhDBQueryMitre):
                                       row['id'] == software['id']]
             self._move_external_id_mitre_resource(software)
 
+
 @lru_cache(maxsize=None)
 def get_mitre_items(mitre_class: callable):
     """This function loads the MITRE data in order to speed up the use of the Framework function.

--- a/framework/wazuh/core/mitre.py
+++ b/framework/wazuh/core/mitre.py
@@ -22,6 +22,9 @@ RELATIONAL_REQUEST_SLICE = 256
 # Select used for each item's references
 SELECT_FIELDS_REFERENCES = ['url', 'description', 'source', 'external_id']
 
+# Extra fields from references
+EXTRA_FIELDS = {'url', 'source', 'external_id'}
+
 
 class WazuhDBQueryMitre(WazuhDBQuery):
 
@@ -158,6 +161,7 @@ class WazuhDBQueryMitreMitigations(WazuhDBQueryMitre):
                                    request_slice=MITIGATIONS_REQUEST_SLICE)
 
         self.relation_fields = {'techniques', 'references'}
+        self.extra_fields = EXTRA_FIELDS
 
     def _filter_status(self, status_filter):
         pass
@@ -185,6 +189,10 @@ class WazuhDBQueryMitreMitigations(WazuhDBQueryMitre):
             mitigation['references'] = [row_no_id for row, row_no_id in
                                         zip(references['items'], references_no_id['items']) if
                                         row['id'] == mitigation['id']]
+            reference_external_id = next(
+                (row_no_id for row_no_id in mitigation['references'] if 'external_id' in row_no_id), None)
+            mitigation.update(reference_external_id)
+            mitigation['references'].remove(reference_external_id)
 
 
 class WazuhDBQueryMitreReferences(WazuhDBQueryMitre):
@@ -243,6 +251,7 @@ class WazuhDBQueryMitreTactics(WazuhDBQueryMitre):
                                    select=list(set(self.fields.values()).intersection(set(select))))
 
         self.relation_fields = {'techniques', 'references'}
+        self.extra_fields = EXTRA_FIELDS
 
     def _filter_status(self, status_filter):
         pass
@@ -269,6 +278,10 @@ class WazuhDBQueryMitreTactics(WazuhDBQueryMitre):
             tactic['references'] = [row_no_id for row, row_no_id in
                                     zip(references['items'], references_no_id['items']) if
                                     row['id'] == tactic['id']]
+            reference_external_id = next(
+                (row_no_id for row_no_id in tactic['references'] if 'external_id' in row_no_id), None)
+            tactic.update(reference_external_id)
+            tactic['references'].remove(reference_external_id)
 
 
 class WazuhDBQueryMitreTechniques(WazuhDBQueryMitre):
@@ -300,8 +313,8 @@ class WazuhDBQueryMitreTechniques(WazuhDBQueryMitre):
                                    select=list(set(self.fields.values()).intersection(set(select))),
                                    request_slice=TECHNIQUES_REQUEST_SLICE)
 
-        self.relation_fields = {'tactics', 'mitigations', 'software', 'groups',
-                                'references'}
+        self.relation_fields = {'tactics', 'mitigations', 'software', 'groups', 'references'}
+        self.extra_fields = EXTRA_FIELDS
 
     def _filter_status(self, status_filter):
         pass
@@ -345,6 +358,10 @@ class WazuhDBQueryMitreTechniques(WazuhDBQueryMitre):
             technique['references'] = [row_no_id for row, row_no_id in
                                        zip(references['items'], references_no_id['items']) if
                                        row['id'] == technique['id']]
+            reference_external_id = next(
+                (row_no_id for row_no_id in technique['references'] if 'external_id' in row_no_id), None)
+            technique.update(reference_external_id)
+            technique['references'].remove(reference_external_id)
 
 
 class WazuhDBQueryMitreGroups(WazuhDBQueryMitre):
@@ -375,6 +392,7 @@ class WazuhDBQueryMitreGroups(WazuhDBQueryMitre):
                                    request_slice=GROUPS_REQUEST_SLICE)
 
         self.relation_fields = {'software', 'techniques', 'references'}
+        self.extra_fields = EXTRA_FIELDS
 
     def _filter_status(self, status_filter):
         pass
@@ -410,6 +428,10 @@ class WazuhDBQueryMitreGroups(WazuhDBQueryMitre):
             group['references'] = [row_no_id for row, row_no_id in
                                    zip(references['items'], references_no_id['items']) if
                                    row['id'] == group['id']]
+            reference_external_id = next(
+                (row_no_id for row_no_id in group['references'] if 'external_id' in row_no_id), None)
+            group.update(reference_external_id)
+            group['references'].remove(reference_external_id)
 
 
 class WazuhDBQueryMitreSoftware(WazuhDBQueryMitre):
@@ -440,6 +462,7 @@ class WazuhDBQueryMitreSoftware(WazuhDBQueryMitre):
                                    request_slice=SOFTWARE_REQUEST_SLICE)
 
         self.relation_fields = {'groups', 'techniques', 'references'}
+        self.extra_fields = EXTRA_FIELDS
 
     def _filter_status(self, status_filter):
         pass
@@ -477,6 +500,10 @@ class WazuhDBQueryMitreSoftware(WazuhDBQueryMitre):
             software['references'] = [row_no_id for row, row_no_id in
                                       zip(references['items'], references_no_id['items']) if
                                       row['id'] == software['id']]
+            reference_external_id = next(
+                (row_no_id for row_no_id in software['references'] if 'external_id' in row_no_id), None)
+            software.update(reference_external_id)
+            software['references'].remove(reference_external_id)
 
 
 @lru_cache(maxsize=None)
@@ -497,15 +524,17 @@ def get_mitre_items(mitre_class: callable):
     """
     info = {'min_select_fields': None, 'allowed_fields': None}
     db_query = mitre_class(limit=None)
-    info['allowed_fields'] = set(db_query.fields.keys()).union(set(db_query.relation_fields))
+    info['allowed_fields'] = \
+        set(db_query.fields.keys()).union(set(db_query.relation_fields)).union(db_query.extra_fields)
     info['min_select_fields'] = set(db_query.min_select_fields)
     data = db_query.run()
 
     return info, data
 
 
-def get_results_with_select(mitre_class, filters, select, offset, limit, sort_by, sort_ascending, search_text,
-                            complementary_search, search_in_fields, q):
+def get_results_with_select(mitre_class: callable, filters: str, select: list, offset: int, limit: int, sort_by: dict,
+                            sort_ascending: bool, search_text: str, complementary_search: bool, search_in_fields: list,
+                            q: str) -> list:
     """Sanitize the select parameter and processes the list of MITRE resources.
 
     Parameters
@@ -517,20 +546,19 @@ def get_results_with_select(mitre_class, filters, select, offset, limit, sort_by
     select : list
         Select which fields to return (separated by comma).
     offset : int
-        First item to return
+        First item to return.
     limit : int
-        Maximum number of items to return
-
+        Maximum number of items to return.
     sort_by : dict
         Fields to sort the items by. Format: {"fields":["field1","field2"],"order":"asc|desc"}
     sort_ascending : bool
-        Sort in ascending (true) or descending (false) order
+        Sort in ascending (true) or descending (false) order.
     search_text : str
-        Text to search
+        Text to search.
     complementary_search : bool
-        Find items without the text to search
+        Find items without the text to search.
     search_in_fields : list
-        Fields to search in
+        Fields to search in.
     q : str
         Query for filtering a list of results.
 

--- a/framework/wazuh/core/mitre.py
+++ b/framework/wazuh/core/mitre.py
@@ -536,7 +536,7 @@ class WazuhDBQueryMitreSoftware(WazuhDBQueryMitre):
             if 'description' in reference_external_id:
                 reference_external_id.pop('description')
             # Delete the reference from references and update the object
-            if reference_external_id in software['references']:
+            if reference_external_id:
                 software['references'].remove(reference_external_id)
             software.update(reference_external_id)
 

--- a/framework/wazuh/core/mitre.py
+++ b/framework/wazuh/core/mitre.py
@@ -293,7 +293,7 @@ class WazuhDBQueryMitreTactics(WazuhDBQueryMitre):
             if 'description' in reference_external_id:
                 reference_external_id.pop('description')
             # Delete the reference from references and update the object
-            if reference_external_id in tactic['references']:
+            if reference_external_id:
                 tactic['references'].remove(reference_external_id)
             tactic.update(reference_external_id)
 

--- a/framework/wazuh/core/mitre.py
+++ b/framework/wazuh/core/mitre.py
@@ -189,10 +189,17 @@ class WazuhDBQueryMitreMitigations(WazuhDBQueryMitre):
             mitigation['references'] = [row_no_id for row, row_no_id in
                                         zip(references['items'], references_no_id['items']) if
                                         row['id'] == mitigation['id']]
+
+            # Take reference with external_id checking it is not None
             reference_external_id = next(
-                (row_no_id for row_no_id in mitigation['references'] if 'external_id' in row_no_id), None)
+                (row_no_id for row_no_id in mitigation['references'] if
+                 'external_id' in row_no_id and row_no_id['external_id']), {})
+            if 'description' in reference_external_id:
+                reference_external_id.pop('description')
+            # Delete the reference from references and update the object
+            if reference_external_id in mitigation['references']:
+                mitigation['references'].remove(reference_external_id)
             mitigation.update(reference_external_id)
-            mitigation['references'].remove(reference_external_id)
 
 
 class WazuhDBQueryMitreReferences(WazuhDBQueryMitre):
@@ -278,10 +285,17 @@ class WazuhDBQueryMitreTactics(WazuhDBQueryMitre):
             tactic['references'] = [row_no_id for row, row_no_id in
                                     zip(references['items'], references_no_id['items']) if
                                     row['id'] == tactic['id']]
+
+            # Take reference with external_id checking it is not None
             reference_external_id = next(
-                (row_no_id for row_no_id in tactic['references'] if 'external_id' in row_no_id), None)
+                (row_no_id for row_no_id in tactic['references'] if
+                 'external_id' in row_no_id and row_no_id['external_id']), {})
+            if 'description' in reference_external_id:
+                reference_external_id.pop('description')
+            # Delete the reference from references and update the object
+            if reference_external_id in tactic['references']:
+                tactic['references'].remove(reference_external_id)
             tactic.update(reference_external_id)
-            tactic['references'].remove(reference_external_id)
 
 
 class WazuhDBQueryMitreTechniques(WazuhDBQueryMitre):
@@ -358,10 +372,17 @@ class WazuhDBQueryMitreTechniques(WazuhDBQueryMitre):
             technique['references'] = [row_no_id for row, row_no_id in
                                        zip(references['items'], references_no_id['items']) if
                                        row['id'] == technique['id']]
+
+            # Take reference with external_id checking it is not None
             reference_external_id = next(
-                (row_no_id for row_no_id in technique['references'] if 'external_id' in row_no_id), None)
+                (row_no_id for row_no_id in technique['references'] if
+                 'external_id' in row_no_id and row_no_id['external_id']), {})
+            if 'description' in reference_external_id:
+                reference_external_id.pop('description')
+            # Delete the reference from references and update the object
+            if reference_external_id in technique['references']:
+                technique['references'].remove(reference_external_id)
             technique.update(reference_external_id)
-            technique['references'].remove(reference_external_id)
 
 
 class WazuhDBQueryMitreGroups(WazuhDBQueryMitre):
@@ -428,10 +449,17 @@ class WazuhDBQueryMitreGroups(WazuhDBQueryMitre):
             group['references'] = [row_no_id for row, row_no_id in
                                    zip(references['items'], references_no_id['items']) if
                                    row['id'] == group['id']]
+
+            # Take reference with external_id checking it is not None
             reference_external_id = next(
-                (row_no_id for row_no_id in group['references'] if 'external_id' in row_no_id), None)
+                (row_no_id for row_no_id in group['references'] if
+                 'external_id' in row_no_id and row_no_id['external_id']), {})
+            if 'description' in reference_external_id:
+                reference_external_id.pop('description')
+            # Delete the reference from references and update the object
+            if reference_external_id in group['references']:
+                group['references'].remove(reference_external_id)
             group.update(reference_external_id)
-            group['references'].remove(reference_external_id)
 
 
 class WazuhDBQueryMitreSoftware(WazuhDBQueryMitre):
@@ -500,10 +528,17 @@ class WazuhDBQueryMitreSoftware(WazuhDBQueryMitre):
             software['references'] = [row_no_id for row, row_no_id in
                                       zip(references['items'], references_no_id['items']) if
                                       row['id'] == software['id']]
+
+            # Take reference with external_id checking it is not None
             reference_external_id = next(
-                (row_no_id for row_no_id in software['references'] if 'external_id' in row_no_id), None)
+                (row_no_id for row_no_id in software['references'] if
+                 'external_id' in row_no_id and row_no_id['external_id']), {})
+            if 'description' in reference_external_id:
+                reference_external_id.pop('description')
+            # Delete the reference from references and update the object
+            if reference_external_id in software['references']:
+                software['references'].remove(reference_external_id)
             software.update(reference_external_id)
-            software['references'].remove(reference_external_id)
 
 
 @lru_cache(maxsize=None)

--- a/framework/wazuh/core/mitre.py
+++ b/framework/wazuh/core/mitre.py
@@ -48,6 +48,27 @@ class WazuhDBQueryMitre(WazuhDBQuery):
     def _filter_status(self, status_filter):
         pass
 
+    def _move_external_id_mitre_resource(self, mitre_resource: dict):
+        """Extract the dictionary with external id, source and url from references and move it to the external level of
+        the MITRE resource.
+
+        Parameters
+        ----------
+        mitre_resource : dict
+            MITRE resource we want to update the reference from.
+        """
+        # Take the reference with external_id checking it is not None
+        reference_external_id = next(
+            (row_no_id for row_no_id in mitre_resource['references'] if
+             'external_id' in row_no_id and row_no_id['external_id']), {})
+        if 'description' in reference_external_id:
+            reference_external_id.pop('description')
+
+        # Delete the reference from references and update the MITRE object
+        if reference_external_id:
+            mitre_resource['references'].remove(reference_external_id)
+        mitre_resource.update(reference_external_id)
+
 
 class WazuhDBQueryMitreMetadata(WazuhDBQueryMitre):
 
@@ -189,17 +210,7 @@ class WazuhDBQueryMitreMitigations(WazuhDBQueryMitre):
             mitigation['references'] = [row_no_id for row, row_no_id in
                                         zip(references['items'], references_no_id['items']) if
                                         row['id'] == mitigation['id']]
-
-            # Take reference with external_id checking it is not None
-            reference_external_id = next(
-                (row_no_id for row_no_id in mitigation['references'] if
-                 'external_id' in row_no_id and row_no_id['external_id']), {})
-            if 'description' in reference_external_id:
-                reference_external_id.pop('description')
-            # Delete the reference from references and update the object
-            if reference_external_id:
-                mitigation['references'].remove(reference_external_id)
-            mitigation.update(reference_external_id)
+            self._move_external_id_mitre_resource(mitigation)
 
 
 class WazuhDBQueryMitreReferences(WazuhDBQueryMitre):
@@ -285,17 +296,7 @@ class WazuhDBQueryMitreTactics(WazuhDBQueryMitre):
             tactic['references'] = [row_no_id for row, row_no_id in
                                     zip(references['items'], references_no_id['items']) if
                                     row['id'] == tactic['id']]
-
-            # Take reference with external_id checking it is not None
-            reference_external_id = next(
-                (row_no_id for row_no_id in tactic['references'] if
-                 'external_id' in row_no_id and row_no_id['external_id']), {})
-            if 'description' in reference_external_id:
-                reference_external_id.pop('description')
-            # Delete the reference from references and update the object
-            if reference_external_id:
-                tactic['references'].remove(reference_external_id)
-            tactic.update(reference_external_id)
+            self._move_external_id_mitre_resource(tactic)
 
 
 class WazuhDBQueryMitreTechniques(WazuhDBQueryMitre):
@@ -372,17 +373,7 @@ class WazuhDBQueryMitreTechniques(WazuhDBQueryMitre):
             technique['references'] = [row_no_id for row, row_no_id in
                                        zip(references['items'], references_no_id['items']) if
                                        row['id'] == technique['id']]
-
-            # Take reference with external_id checking it is not None
-            reference_external_id = next(
-                (row_no_id for row_no_id in technique['references'] if
-                 'external_id' in row_no_id and row_no_id['external_id']), {})
-            if 'description' in reference_external_id:
-                reference_external_id.pop('description')
-            # Delete the reference from references and update the object
-            if reference_external_id:
-                technique['references'].remove(reference_external_id)
-            technique.update(reference_external_id)
+            self._move_external_id_mitre_resource(technique)
 
 
 class WazuhDBQueryMitreGroups(WazuhDBQueryMitre):
@@ -449,17 +440,7 @@ class WazuhDBQueryMitreGroups(WazuhDBQueryMitre):
             group['references'] = [row_no_id for row, row_no_id in
                                    zip(references['items'], references_no_id['items']) if
                                    row['id'] == group['id']]
-
-            # Take reference with external_id checking it is not None
-            reference_external_id = next(
-                (row_no_id for row_no_id in group['references'] if
-                 'external_id' in row_no_id and row_no_id['external_id']), {})
-            if 'description' in reference_external_id:
-                reference_external_id.pop('description')
-            # Delete the reference from references and update the object
-            if reference_external_id:
-                group['references'].remove(reference_external_id)
-            group.update(reference_external_id)
+            self._move_external_id_mitre_resource(group)
 
 
 class WazuhDBQueryMitreSoftware(WazuhDBQueryMitre):
@@ -528,18 +509,7 @@ class WazuhDBQueryMitreSoftware(WazuhDBQueryMitre):
             software['references'] = [row_no_id for row, row_no_id in
                                       zip(references['items'], references_no_id['items']) if
                                       row['id'] == software['id']]
-
-            # Take reference with external_id checking it is not None
-            reference_external_id = next(
-                (row_no_id for row_no_id in software['references'] if
-                 'external_id' in row_no_id and row_no_id['external_id']), {})
-            if 'description' in reference_external_id:
-                reference_external_id.pop('description')
-            # Delete the reference from references and update the object
-            if reference_external_id:
-                software['references'].remove(reference_external_id)
-            software.update(reference_external_id)
-
+            self._move_external_id_mitre_resource(software)
 
 @lru_cache(maxsize=None)
 def get_mitre_items(mitre_class: callable):

--- a/framework/wazuh/core/tests/test_mitre.py
+++ b/framework/wazuh/core/tests/test_mitre.py
@@ -65,6 +65,7 @@ def test_get_mitre_items(mock_wdb, mitre_wdb_query_class):
     db_query_to_compare = mitre_wdb_query_class()
 
     assert isinstance(info['allowed_fields'], set) and info['allowed_fields'] == set(
-        db_query_to_compare.fields.keys()).union(db_query_to_compare.relation_fields)
+        db_query_to_compare.fields.keys()).union(
+        db_query_to_compare.relation_fields).union(db_query_to_compare.extra_fields)
     assert isinstance(info['min_select_fields'], set) and info[
         'min_select_fields'] == db_query_to_compare.min_select_fields

--- a/framework/wazuh/mitre.py
+++ b/framework/wazuh/mitre.py
@@ -2,20 +2,18 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-from typing import Dict
-
 from wazuh.core import common, mitre
 from wazuh.core.results import AffectedItemsWazuhResult
 from wazuh.rbac.decorators import expose_resources
 
 
 @expose_resources(actions=["mitre:read"], resources=["*:*:*"])
-def mitre_metadata() -> Dict:
-    """Return the metadata of the MITRE's database
+def mitre_metadata() -> AffectedItemsWazuhResult:
+    """Return the metadata of the MITRE's database.
 
     Returns
     -------
-    Metadata of MITRE's db
+    Metadata of MITRE's db.
     """
     result = AffectedItemsWazuhResult(none_msg='No MITRE metadata information was returned',
                                       all_msg='MITRE Metadata information was returned')
@@ -32,7 +30,7 @@ def mitre_metadata() -> Dict:
 @expose_resources(actions=["mitre:read"], resources=["*:*:*"])
 def mitre_mitigations(filters: dict = None, offset=0, limit=common.database_limit, select=None, sort_by=None,
                       sort_ascending=True, search_text=None, complementary_search=False,
-                      search_in_fields=None, q='') -> Dict:
+                      search_in_fields=None, q='') -> AffectedItemsWazuhResult:
     """Get information of specified MITRE's mitigations and its relations.
 
     Parameters
@@ -40,28 +38,28 @@ def mitre_mitigations(filters: dict = None, offset=0, limit=common.database_limi
     filters : str
         Define field filters required by the user. Format: {"field1":"value1", "field2":["value2","value3"]}
     offset : int
-        First item to return
+        First item to return.
     limit : int
-        Maximum number of items to return
+        Maximum number of items to return.
     select : list
         Select which fields to return (separated by comma).
     sort_by : dict
         Fields to sort the items by. Format: {"fields":["field1","field2"],"order":"asc|desc"}
     sort_ascending : bool
-        Sort in ascending (true) or descending (false) order
+        Sort in ascending (true) or descending (false) order.
     search_text : str
-        Text to search
+        Text to search.
     complementary_search : bool
-        Find items without the text to search
+        Find items without the text to search.
     search_in_fields : list
-        Fields to search in
+        Fields to search in.
     q : str
         Query for filtering a list of results.
 
     Returns
     -------
-    dict
-        Dictionary with the information of the specified mitigations and their relationships
+    AffectedItemsWazuhResult
+        Dictionary with the information of the specified mitigations and their relationships.
     """
     data = mitre.get_results_with_select(mitre.WazuhDBQueryMitreMitigations, **locals())
 
@@ -76,7 +74,7 @@ def mitre_mitigations(filters: dict = None, offset=0, limit=common.database_limi
 @expose_resources(actions=["mitre:read"], resources=["*:*:*"])
 def mitre_references(filters: dict = None, offset=0, limit=common.database_limit, select=None, sort_by=None,
                      sort_ascending=True, search_text=None, complementary_search=False,
-                     search_in_fields=None, q='') -> Dict:
+                     search_in_fields=None, q='') -> AffectedItemsWazuhResult:
     """Get information of specified MITRE's references.
 
     Parameters
@@ -84,27 +82,27 @@ def mitre_references(filters: dict = None, offset=0, limit=common.database_limit
     filters : str
         Define field filters required by the user. Format: {"field1":"value1", "field2":["value2","value3"]}
     offset : int
-        First item to return
+        First item to return.
     limit : int
-        Maximum number of items to return
+        Maximum number of items to return.
     select : list
         Select which fields to return (separated by comma).
     sort_by : dict
         Fields to sort the items by. Format: {"fields":["field1","field2"],"order":"asc|desc"}
     sort_ascending : bool
-        Sort in ascending (true) or descending (false) order
+        Sort in ascending (true) or descending (false) order.
     search_text : str
-        Text to search
+        Text to search.
     complementary_search : bool
-        Find items without the text to search
+        Find items without the text to search.
     search_in_fields : list
-        Fields to search in
+        Fields to search in.
     q : str
         Query for filtering a list of results.
 
     Returns
     -------
-    dict
+    AffectedItemsWazuhResult
         Dictionary with the information of the specified references.
     """
     data = mitre.get_results_with_select(mitre.WazuhDBQueryMitreReferences, **locals())
@@ -120,7 +118,7 @@ def mitre_references(filters: dict = None, offset=0, limit=common.database_limit
 @expose_resources(actions=["mitre:read"], resources=["*:*:*"])
 def mitre_techniques(filters: dict = None, offset=0, limit=common.database_limit, select=None, sort_by=None,
                      sort_ascending=True, search_text=None, complementary_search=False,
-                     search_in_fields=None, q='') -> Dict:
+                     search_in_fields=None, q='') -> AffectedItemsWazuhResult:
     """Get information of specified MITRE's techniques and its relations.
 
     Parameters
@@ -128,28 +126,28 @@ def mitre_techniques(filters: dict = None, offset=0, limit=common.database_limit
     filters : str
         Define field filters required by the user. Format: {"field1":"value1", "field2":["value2","value3"]}
     offset : int
-        First item to return
+        First item to return.
     limit : int
-        Maximum number of items to return
+        Maximum number of items to return.
     select : list
         Select which fields to return (separated by comma).
     sort_by : dict
         Fields to sort the items by. Format: {"fields":["field1","field2"],"order":"asc|desc"}
     sort_ascending : bool
-        Sort in ascending (true) or descending (false) order
+        Sort in ascending (true) or descending (false) order.
     search_text : str
-        Text to search
+        Text to search.
     complementary_search : bool
-        Find items without the text to search
+        Find items without the text to search.
     search_in_fields : list
-        Fields to search in
+        Fields to search in.
     q : str
         Query for filtering a list of results.
 
     Returns
     -------
-    dict
-        Dictionary with the information of the specified techniques and their relationships
+    AffectedItemsWazuhResult
+        Dictionary with the information of the specified techniques and their relationships.
     """
     data = mitre.get_results_with_select(mitre.WazuhDBQueryMitreTechniques, **locals())
 
@@ -164,7 +162,8 @@ def mitre_techniques(filters: dict = None, offset=0, limit=common.database_limit
 @expose_resources(actions=["mitre:read"], resources=["*:*:*"])
 def mitre_tactics(filters: dict = None, offset: int = 0, limit: int = common.database_limit, select: list = None,
                   sort_by: dict = None, sort_ascending: bool = True, search_text: str = None,
-                  complementary_search: bool = False, search_in_fields: list = None, q: str = '') -> dict:
+                  complementary_search: bool = False, search_in_fields: list = None,
+                  q: str = '') -> AffectedItemsWazuhResult:
     """Get information of specified MITRE's tactics and its relations.
 
     Parameters
@@ -192,7 +191,7 @@ def mitre_tactics(filters: dict = None, offset: int = 0, limit: int = common.dat
 
     Returns
     -------
-    dict
+    AffectedItemsWazuhResult
         Dictionary with the information of the specified tactics and their relationships.
     """
     data = mitre.get_results_with_select(mitre.WazuhDBQueryMitreTactics, **locals())
@@ -208,7 +207,8 @@ def mitre_tactics(filters: dict = None, offset: int = 0, limit: int = common.dat
 @expose_resources(actions=["mitre:read"], resources=["*:*:*"])
 def mitre_groups(filters: dict = None, offset: int = 0, limit: int = common.database_limit, select: list = None,
                  sort_by: dict = None, sort_ascending: bool = True, search_text: str = None,
-                 complementary_search: bool = False, search_in_fields: list = None, q: str = '') -> Dict:
+                 complementary_search: bool = False, search_in_fields: list = None,
+                 q: str = '') -> AffectedItemsWazuhResult:
     """Get information of specified MITRE's groups and its relations.
 
     Parameters
@@ -216,27 +216,27 @@ def mitre_groups(filters: dict = None, offset: int = 0, limit: int = common.data
     filters : str
         Define field filters required by the user. Format: {"field1":"value1", "field2":["value2","value3"]}
     offset : int
-        First item to return
+        First item to return.
     limit : int
-        Maximum number of items to return
+        Maximum number of items to return.
     select : list
         Select which fields to return (separated by comma).
     sort_by : dict
         Fields to sort the items by. Format: {"fields":["field1","field2"],"order":"asc|desc"}
     sort_ascending : bool
-        Sort in ascending (true) or descending (false) order
+        Sort in ascending (true) or descending (false) order.
     search_text : str
-        Text to search
+        Text to search.
     complementary_search : bool
-        Find items without the text to search
+        Find items without the text to search.
     search_in_fields : list
-        Fields to search in
+        Fields to search in.
     q : str
         Query for filtering a list of results.
 
     Returns
     -------
-    dict
+    AffectedItemsWazuhResult
         Dictionary with the information of the specified groups and their relationships.
     """
     data = mitre.get_results_with_select(mitre.WazuhDBQueryMitreGroups, **locals())
@@ -252,7 +252,8 @@ def mitre_groups(filters: dict = None, offset: int = 0, limit: int = common.data
 @expose_resources(actions=["mitre:read"], resources=["*:*:*"])
 def mitre_software(filters: dict = None, offset: int = 0, limit: int = common.database_limit, select: list = None,
                    sort_by: dict = None, sort_ascending: bool = True, search_text: str = None,
-                   complementary_search: bool = False, search_in_fields: list = None, q: str = '') -> Dict:
+                   complementary_search: bool = False, search_in_fields: list = None,
+                   q: str = '') -> AffectedItemsWazuhResult:
     """Get information of specified MITRE's software and its relations.
 
     Parameters
@@ -260,27 +261,27 @@ def mitre_software(filters: dict = None, offset: int = 0, limit: int = common.da
     filters : str
         Define field filters required by the user. Format: {"field1":"value1", "field2":["value2","value3"]}
     offset : int
-        First item to return
+        First item to return.
     limit : int
-        Maximum number of items to return
+        Maximum number of items to return.
     select : list
         Select which fields to return (separated by comma).
     sort_by : dict
         Fields to sort the items by. Format: {"fields":["field1","field2"],"order":"asc|desc"}
     sort_ascending : bool
-        Sort in ascending (true) or descending (false) order
+        Sort in ascending (true) or descending (false) order.
     search_text : str
-        Text to search
+        Text to search.
     complementary_search : bool
-        Find items without the text to search
+        Find items without the text to search.
     search_in_fields : list
-        Fields to search in
+        Fields to search in.
     q : str
         Query for filtering a list of results.
 
     Returns
     -------
-    dict
+    AffectedItemsWazuhResult
         Dictionary with the information of the specified software and their relationships.
     """
     data = mitre.get_results_with_select(mitre.WazuhDBQueryMitreSoftware, **locals())


### PR DESCRIPTION
|Related issue|
|---|
| #8879 |

Hi team

This PR closes #8879.

In this pull request, I have included the reference with `external_id` out of the references list of each MITRE item.

I have updated unittest and API integration tests to include this change.

`GET /mitre/mitigations?wait_for_complete=true&limit=1`

<details>

<summary>Response</summary>

```
{
  "data": {
    "affected_items": [
      {
        "deprecated": 1,
        "created_time": "2018-10-17 00:14:20.652000",
        "name": "Password Filter DLL Mitigation",
        "mitre_version": "1.0",
        "id": "course-of-action--00d7d21b-69d6-4797-88a2-c86f3fc97651",
        "description": "Ensure only valid password filters are registered. Filter DLLs must be present in Windows installation directory (<code>C:\\Windows\\System32\\</code> by default) of a domain controller and/or local computer with a corresponding entry in <code>HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Lsa\\Notification Packages</code>. (Citation: Microsoft Install Password Filter n.d)",
        "modified_time": "2019-07-25 11:22:19.139000",
        "techniques": [
          "attack-pattern--b8c5c9dd-a662-479d-9428-ae745872537c"
        ],
        "references": [
          {
            "source": "Microsoft Install Password Filter n.d",
            "url": "https://msdn.microsoft.com/library/windows/desktop/ms721766.aspx",
            "description": "Microsoft. (n.d.). Installing and Registering a Password Filter DLL. Retrieved November 21, 2017."
          }
        ],
        "source": "mitre-attack",
        "external_id": "T1174",
        "url": "https://attack.mitre.org/mitigations/T1174"
      }
    ],
    "total_affected_items": 266,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "MITRE mitigations information was returned",
  "error": 0
}
```

</details>

With these changes, we can now sort by external_id, source and url:

`GET /mitre/mitigations?wait_for_complete=true&limit=3&sort=-external_id&select=external_id,name
`

<details>

<summary>Response</summary>

```
{
  "data": {
    "affected_items": [
      {
        "external_id": "T1501",
        "name": "Systemd Service Mitigation",
        "id": "course-of-action--83130e62-bca6-4a81-bd4b-8e233bd49db6"
      },
      {
        "external_id": "T1500",
        "name": "Compile After Delivery Mitigation",
        "id": "course-of-action--ae56a49d-5281-45c5-ab95-70a1439c338e"
      },
      {
        "external_id": "T1499",
        "name": "Endpoint Denial of Service Mitigation",
        "id": "course-of-action--82c21600-ccb6-4232-8c04-ef3792b56628"
      }
    ],
    "total_affected_items": 266,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "MITRE mitigations information was returned",
  "error": 0
}
```

</details>


### Test results:

```
pytest framework/wazuh/core/tests/test_mitre.py 
=================== 13 passed, 2 warnings in 0.17s ===================

pytest framework/wazuh/tests/test_mitre.py 
=================== 7 passed, 2 warnings in 0.19s ===================
```

```
test_mitre_endpoints.tavern.yaml 
	 7 passed, 13 warnings

test_rbac_black_mitre_endpoints.tavern.yaml 
	 7 passed, 13 warnings

test_rbac_white_mitre_endpoints.tavern.yaml 
	 7 passed, 13 warnings
```

Regards,
Manuel.