### PR TITLE
Changed win-powershell_rules ID to avoid duplication

### DIFF
--- a/ruleset/rules/0915-win-powershell_rules.xml
+++ b/ruleset/rules/0915-win-powershell_rules.xml
@@ -9,7 +9,7 @@
 <group name="windows, powershell,">
 
 <!-- Powershell Operational grouping -->
-    <rule id="91601" level="0">
+    <rule id="91801" level="0">
         <if_sid>60000</if_sid>
         <field name="win.system.channel">^Microsoft-Windows-PowerShell/Operational$</field>
         <options>no_full_log</options>
@@ -18,7 +18,7 @@
 
     <!-- Powershell Script Block rules -->
 
-    <rule id="91602" level="0">
+    <rule id="91802" level="0">
         <if_sid>91601</if_sid>
         <field name="win.eventdata.ScriptBlockId" type="pcre2">.+</field>
         <options>no_full_log</options>
@@ -26,7 +26,7 @@
     </rule>
 
     <!-- Sample log: {"win":{"eventdata":{"path":"C:\\\\Users\\\\AtomicRed\\\\AppData\\\\Roaming\\\\TransbaseOdbcDriver\\\\screenshot__.ps1","messageNumber":"1","messageTotal":"1","scriptBlockText":"function screenshot([Drawing.Rectangle]$bounds, $path){      $bmp = New-Object System.Drawing.Bitmap($bounds.width, $bounds.height)     $graphics = [Drawing.Graphics]::FromImage($bmp)     $graphics.CopyFromScreen($bounds.Location, [Drawing.Point]::Empty, $bounds.size)     $bmp.Save($path)     $graphics.Dispose()     $bmp.Dispose() }","scriptBlockId":"1b79ef82-0efe-4734-b092-3a4b9f17e080"},"system":{"eventID":"4104","keywords":"0x0","providerGuid":"{a0c1853b-5c40-4b15-8766-3cf1c58f985a}","level":"5","channel":"Microsoft-Windows-PowerShell/Operational","opcode":"15","message":"\"Creating Scriptblock text (1 of 1):\r\nfunction screenshot([Drawing.Rectangle]$bounds, $path){ \n    $bmp = New-Object System.Drawing.Bitmap($bounds.width, $bounds.height)\n    $graphics = [Drawing.Graphics]::FromImage($bmp)\n    $graphics.CopyFromScreen($bounds.Location, [Drawing.Point]::Empty, $bounds.size)\n    $bmp.Save($path)\n    $graphics.Dispose()\n    $bmp.Dispose()\n}\r\n\r\nScriptBlock ID: 1b79ef82-0efe-4734-b092-3a4b9f17e080\r\nPath: C:\\Users\\AtomicRed\\AppData\\Roaming\\TransbaseOdbcDriver\\screenshot__.ps1\"","version":"1","systemTime":"2021-06-17T19:42:48.3171903Z","eventRecordID":"95916","threadID":"5292","computer":"hrmanager.ExchangeTest.com","task":"2","processID":"1756","severityValue":"VERBOSE","providerName":"Microsoft-Windows-PowerShell"}}} -->
-    <rule id="91603" level="14">
+    <rule id="91803" level="14">
         <if_sid>91602</if_sid>
         <field name="win.system.message" type="pcre2">CopyFromScreen</field>
         <options>no_full_log</options>


### PR DESCRIPTION
|Related issue|
|---|
| #9145 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Closes #9145  and solve the rule's ID duplication problem.

<!--
Add a clear description of how the problem has been solved.
-->
Changed the rule's ID to `91801` and beyond.
We should study to add a solution to solve this for future scenarios.


