### PR TITLE
Remove tmp variables from `GET /cluster/healthcheck` response

### DIFF
--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -180,7 +180,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                                                     not key.startswith('tmp')},
                            'last_sync_integrity': {key: value for key, value in self.integrity_sync_status.items() if
                                                    not key.startswith('tmp')},
-                           'last_sync_agentinfo': self.integrity_check_status,
+                           'last_sync_agentinfo': self.sync_agent_info_status,
                            'last_keep_alive': self.last_keepalive}
                 }
 

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -176,9 +176,11 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         return {'info': {'name': self.name, 'type': self.node_type, 'version': self.version, 'ip': self.ip},
                 'status': {'sync_integrity_free': self.sync_integrity_free,
                            'sync_extravalid_free': self.sync_extra_valid_free,
-                           'last_check_integrity': self.integrity_check_status,
-                           'last_sync_integrity': self.integrity_sync_status,
-                           'last_sync_agentinfo': self.sync_agent_info_status,
+                           'last_check_integrity': {key: value for key, value in self.integrity_check_status.items() if
+                                                    not key.startswith('tmp')},
+                           'last_sync_integrity': {key: value for key, value in self.integrity_sync_status.items() if
+                                                   not key.startswith('tmp')},
+                           'last_sync_agentinfo': self.integrity_check_status,
                            'last_keep_alive': self.last_keepalive}
                 }
 
@@ -261,7 +263,8 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             client, request = data.split(b' ', 1)
             client = client.decode()
             if client in self.server.clients:
-                result = (await self.server.clients[client].send_request(b'dapi', request_id.encode() + b' ' + request)).decode()
+                result = (await self.server.clients[client].send_request(b'dapi',
+                                                                         request_id.encode() + b' ' + request)).decode()
             else:
                 raise exception.WazuhClusterError(3022, extra_message=client)
         # Add request to local API requests queue.
@@ -275,7 +278,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         if command == b'dapi' or command == b'dapi_fwd':
             try:
                 timeout = None if wait_for_complete \
-                               else self.cluster_items['intervals']['communication']['timeout_dapi_request']
+                    else self.cluster_items['intervals']['communication']['timeout_dapi_request']
                 await asyncio.wait_for(self.server.pending_api_requests[request_id]['Event'].wait(), timeout=timeout)
                 request_result = self.server.pending_api_requests[request_id]['Response']
             except asyncio.TimeoutError:
@@ -526,7 +529,8 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         except KeyError as e:
             await self.send_request(command=b'syn_m_a_err',
                                     data=f"error while trying to access string under task_id {str(e)}.".encode())
-            raise exception.WazuhClusterError(3035, extra_message=f"it should be under task_id {str(e)}, but it's empty.")
+            raise exception.WazuhClusterError(3035,
+                                              extra_message=f"it should be under task_id {str(e)}, but it's empty.")
         except ValueError as e:
             await self.send_request(command=b'syn_m_a_err', data=f"error while trying to load JSON: {str(e)}".encode())
             raise exception.WazuhClusterError(3036, extra_message=str(e))
@@ -535,7 +539,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         before = time()
         for i, chunk in enumerate(data['chunks']):
             try:
-                logger.debug2(f"Sending chunk {i+1}/{len(data['chunks'])} to wazuh-db: {chunk}")
+                logger.debug2(f"Sending chunk {i + 1}/{len(data['chunks'])} to wazuh-db: {chunk}")
                 response = wdb_conn.send(f"{data['set_data_command']} {chunk}", raw=True)
                 if response[0] != 'ok':
                     result['error_messages'].append(response)
@@ -673,7 +677,8 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                                                'total_extra_valid': 0})
             logger.info("Files to create in worker: {} | Files to update in worker: {} | Files to delete in worker: {} "
                         "| Files to receive: {}".format(len(worker_files_ko['missing']), len(worker_files_ko['shared']),
-                                                        len(worker_files_ko['extra']), len(worker_files_ko['extra_valid']))
+                                                        len(worker_files_ko['extra']),
+                                                        len(worker_files_ko['extra_valid']))
                         )
 
             # Compress data: master files (only KO shared and missing).
@@ -706,7 +711,8 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                 # Notify error to worker and delete its received file.
                 self.logger.error(f"Error sending files information: {e}")
                 result = await self.send_request(command=b'syn_m_c_r', data=task_id + b' ' +
-                                                 json.dumps(e, cls=c_common.WazuhJSONEncoder).encode())
+                                                                            json.dumps(e,
+                                                                                       cls=c_common.WazuhJSONEncoder).encode())
             except Exception as e:
                 # Notify error to worker and delete its received file.
                 self.logger.error(f"Error sending files information: {e}")
@@ -719,7 +725,8 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                 logger.debug("Finished sending files to worker.")
                 # Log 'Finished in' message only if there are no extra_valid files to sync.
                 if not worker_files_ko['extra_valid']:
-                    self.integrity_sync_status['date_start_master'] = self.integrity_sync_status['tmp_date_start_master']
+                    self.integrity_sync_status['date_start_master'] = self.integrity_sync_status[
+                        'tmp_date_start_master']
                     self.integrity_sync_status['date_end_master'] = datetime.now()
                     logger.info("Finished in {:.3f}s.".format((self.integrity_sync_status['date_end_master'] -
                                                                self.integrity_sync_status['date_start_master'])
@@ -770,7 +777,8 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                         # Destination path.
                         full_unmerged_name = os.path.join(common.wazuh_path, file_path)
                         # Path where to create the file before moving it to the destination path (with safe_move).
-                        tmp_unmerged_path = os.path.join(common.wazuh_path, 'queue', 'cluster', self.name, os.path.basename(file_path))
+                        tmp_unmerged_path = os.path.join(common.wazuh_path, 'queue', 'cluster', self.name,
+                                                         os.path.basename(file_path))
 
                         try:
                             agent_id = os.path.basename(file_path)
@@ -803,7 +811,8 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                             mtime_epoch = timegm(mtime.timetuple())
                             utils.safe_move(tmp_unmerged_path, full_unmerged_name,
                                             ownership=(common.wazuh_uid(), common.wazuh_gid()),
-                                            permissions=self.cluster_items['files'][data['cluster_item_key']]['permissions'],
+                                            permissions=self.cluster_items['files'][data['cluster_item_key']][
+                                                'permissions'],
                                             time=(mtime_epoch, mtime_epoch)
                                             )
                             self.integrity_sync_status['total_extra_valid'] += 1
@@ -931,7 +940,7 @@ class Master(server.AbstractServer):
             Healthcheck and basic information from master node.
         """
         return {'info': {'name': self.configuration['node_name'], 'type': self.configuration['node_type'],
-                'version': metadata.__version__, 'ip': self.configuration['nodes'][0]}}
+                         'version': metadata.__version__, 'ip': self.configuration['nodes'][0]}}
 
     async def file_status_update(self):
         """Asynchronous task that obtain files status periodically.
@@ -976,7 +985,8 @@ class Master(server.AbstractServer):
 
         # Get active agents by node and format last keep alive date format
         for node_name in workers_info.keys():
-            workers_info[node_name]["info"]["n_active_agents"] = Agent.get_agents_overview(filters={'status': 'active', 'node_name': node_name})['totalItems']
+            workers_info[node_name]["info"]["n_active_agents"] = \
+            Agent.get_agents_overview(filters={'status': 'active', 'node_name': node_name})['totalItems']
             if workers_info[node_name]['info']['type'] != 'master':
                 workers_info[node_name]['status']['last_keep_alive'] = str(
                     datetime.fromtimestamp(workers_info[node_name]['status']['last_keep_alive']))


### PR DESCRIPTION
|Related issue|
|---|
| closes #9021 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
 
Hello team,

This PR adds a change in the `.to_dict` method of the class `MasterHandler` to remove any temporal variables used for inner processing.

### `GET /cluster/healthcheck` response

```json
{
  "data": {
    "affected_items": [
      {
        "info": {
          "name": "master-node",
          "type": "master",
          "version": "4.3.0",
          "ip": "wazuh-master",
          "n_active_agents": 1
        }
      },
      {
        "info": {
          "name": "worker1",
          "type": "worker",
          "version": "4.3.0",
          "ip": "172.18.0.6",
          "n_active_agents": 0
        },
        "status": {
          "sync_integrity_free": true,
          "sync_extravalid_free": true,
          "last_check_integrity": {
            "date_start_master": "2021-06-29 11:33:58.053970",
            "date_end_master": "2021-06-29 11:33:58.072101"
          },
          "last_sync_integrity": {
            "date_start_master": "n/a",
            "date_end_master": "n/a",
            "total_extra_valid": 0,
            "total_files": {
              "missing": 0,
              "shared": 0,
              "extra": 0,
              "extra_valid": 0
            }
          },
          "last_sync_agentinfo": {
            "date_start_master": "2021-06-29 11:33:58.053970",
            "date_end_master": "2021-06-29 11:33:58.072101"
          },
          "last_keep_alive": "2021-06-29 11:33:45.862957"
        }
      },
      {
        "info": {
          "name": "worker2",
          "type": "worker",
          "version": "4.3.0",
          "ip": "172.18.0.2",
          "n_active_agents": 0
        },
        "status": {
          "sync_integrity_free": true,
          "sync_extravalid_free": true,
          "last_check_integrity": {
            "date_start_master": "2021-06-29 11:33:58.055449",
            "date_end_master": "2021-06-29 11:33:58.075284"
          },
          "last_sync_integrity": {
            "date_start_master": "n/a",
            "date_end_master": "n/a",
            "total_extra_valid": 0,
            "total_files": {
              "missing": 0,
              "shared": 0,
              "extra": 0,
              "extra_valid": 0
            }
          },
          "last_sync_agentinfo": {
            "date_start_master": "2021-06-29 11:33:58.055449",
            "date_end_master": "2021-06-29 11:33:58.075284"
          },
          "last_keep_alive": "2021-06-29 11:33:45.864200"
        }
      }
    ],
    "total_affected_items": 3,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected nodes healthcheck information was returned",
  "error": 0
}
```

No changes were needed for tests as the API integration tests only check that the keys within the response appear and have a specific value. 

## Tests performed
### Unit tests
```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.9.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: cov-2.12.0, asyncio-0.15.1
collected 1581 items                                                                                                                                                                        

wazuh/core/cluster/dapi/tests/test_dapi.py .......................                                                                                                                    [  1%]
wazuh/core/cluster/tests/test_cluster.py ...................                                                                                                                          [  2%]
wazuh/core/cluster/tests/test_common.py .......                                                                                                                                       [  3%]
wazuh/core/cluster/tests/test_control.py .....                                                                                                                                        [  3%]
wazuh/core/cluster/tests/test_local_client.py .                                                                                                                                       [  3%]
wazuh/core/cluster/tests/test_utils.py .......                                                                                                                                        [  3%]
wazuh/core/cluster/tests/test_worker.py .................                                                                                                                             [  4%]
wazuh/core/tests/test_active_response.py ..............                                                                                                                               [  5%]
wazuh/core/tests/test_agent.py ...................................................................................................................................................... [ 15%]
...............                                                                                                                                                                       [ 16%]
wazuh/core/tests/test_cdb_list.py ......................................                                                                                                              [ 18%]
wazuh/core/tests/test_common.py .......                                                                                                                                               [ 19%]
wazuh/core/tests/test_configuration.py ....................................                                                                                                           [ 21%]
wazuh/core/tests/test_decoder.py ................                                                                                                                                     [ 22%]
wazuh/core/tests/test_input_validator.py ...                                                                                                                                          [ 22%]
wazuh/core/tests/test_logtest.py ..                                                                                                                                                   [ 22%]
wazuh/core/tests/test_manager.py ...............                                                                                                                                      [ 23%]
wazuh/core/tests/test_mitre.py .............                                                                                                                                          [ 24%]
wazuh/core/tests/test_pyDaemonModule.py .....                                                                                                                                         [ 24%]
wazuh/core/tests/test_results.py ........................................                                                                                                             [ 27%]
wazuh/core/tests/test_rootcheck.py ..........                                                                                                                                         [ 28%]
wazuh/core/tests/test_rule.py ......................                                                                                                                                  [ 29%]
wazuh/core/tests/test_stats.py ....                                                                                                                                                   [ 29%]
wazuh/core/tests/test_syscollector.py ...                                                                                                                                             [ 29%]
wazuh/core/tests/test_utils.py ...................................................................................................................................................... [ 39%]
.........................................................................                                                                                                             [ 43%]
wazuh/core/tests/test_vulnerability.py .                                                                                                                                              [ 44%]
wazuh/core/tests/test_wazuh_queue.py ..................                                                                                                                               [ 45%]
wazuh/core/tests/test_wazuh_socket.py ....................                                                                                                                            [ 46%]
wazuh/core/tests/test_wdb.py ......................                                                                                                                                   [ 47%]
wazuh/rbac/tests/test_auth_context.py ..                                                                                                                                              [ 47%]
wazuh/rbac/tests/test_decorators.py .........................................................................................................                                         [ 54%]
wazuh/rbac/tests/test_default_configuration.py .......................................................                                                                                [ 58%]
wazuh/rbac/tests/test_orm.py ......................................................                                                                                                   [ 61%]
wazuh/rbac/tests/test_preprocessor.py ...........                                                                                                                                     [ 62%]
wazuh/tests/test_active_response.py ............                                                                                                                                      [ 62%]
wazuh/tests/test_agent.py .............................................................................................................                                               [ 69%]
wazuh/tests/test_cdb_list.py .....................................................                                                                                                    [ 73%]
wazuh/tests/test_ciscat.py .................................                                                                                                                          [ 75%]
wazuh/tests/test_cluster.py .......                                                                                                                                                   [ 75%]
wazuh/tests/test_decoder.py ...................................                                                                                                                       [ 77%]
wazuh/tests/test_group.py ........                                                                                                                                                    [ 78%]
wazuh/tests/test_logtest.py ......                                                                                                                                                    [ 78%]
wazuh/tests/test_manager.py ..................................                                                                                                                        [ 80%]
wazuh/tests/test_mitre.py .......                                                                                                                                                     [ 81%]
wazuh/tests/test_rootcheck.py ..................................................                                                                                                      [ 84%]
wazuh/tests/test_rule.py ........................................................                                                                                                     [ 88%]
wazuh/tests/test_sca.py .......                                                                                                                                                       [ 88%]
wazuh/tests/test_security.py ............................................................................                                                                             [ 93%]
wazuh/tests/test_stats.py ................                                                                                                                                            [ 94%]
wazuh/tests/test_syscheck.py .......................                                                                                                                                  [ 95%]
wazuh/tests/test_syscollector.py ............                                                                                                                                         [ 96%]
wazuh/tests/test_task.py ............................                                                                                                                                 [ 98%]
wazuh/tests/test_vulnerability.py ..........................                                                                                                                          [100%]

======================================================================= 1581 passed, 14 warnings in 261.50s (0:04:21) =======================================================================

```

### Integration tests
```
Collected tests [1]:
test_cluster_endpoints.tavern.yaml


test_cluster_endpoints.tavern.yaml 
	 44 passed, 1 xpassed, 58 warnings
```

Regards,
Víctor