### PR TITLE
Change format for permissions on Windows from string to cJSON

### DIFF
--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -1674,6 +1674,7 @@ int fim_fetch_attributes_state(cJSON *attr, Eventinfo *lf, char new_state) {
     char buf_ptr[26];
 
     assert(lf != NULL);
+    assert(lf->fields != NULL);
 
     cJSON_ArrayForEach(attr_it, attr) {
         if (!attr_it->string) {
@@ -1753,7 +1754,6 @@ char *decode_ace_json(const cJSON *const perm_array, const char *const account_n
     cJSON *it;
     char *output = NULL;
     char *perms = NULL;
-    int perm_array_size;
     int length;
 
     if (perm_array == NULL) {
@@ -1770,26 +1770,22 @@ char *decode_ace_json(const cJSON *const perm_array, const char *const account_n
 
     snprintf(output, length + 1, "%s (%s): ", account_name, ace_type);
 
-    perm_array_size = cJSON_GetArraySize(perm_array);
-    if (perm_array_size == 0) {
-        wm_strcat(&output, ", ", '\0');
-        return output;
-    }
-
     cJSON_ArrayForEach(it, perm_array) {
         wm_strcat(&perms, cJSON_GetStringValue(it), '|');
     }
 
-    str_uppercase(perms);
-    wm_strcat(&output, perms, '\0');
-    free(perms);
+    if (perms) {
+        str_uppercase(perms);
+        wm_strcat(&output, perms, '\0');
+        free(perms);
+    }
 
     wm_strcat(&output, ", ", '\0');
 
     return output;
 }
 
-char *perm_json_to_old_format(cJSON *perm_json){
+char *perm_json_to_old_format(cJSON *perm_json) {
     char *account_name;
     char *output = NULL;
     int length;
@@ -1815,6 +1811,10 @@ char *perm_json_to_old_format(cJSON *perm_json){
             wm_strcat(&output, ace, '\0');
             free(ace);
         }
+    }
+
+    if (output == NULL) {
+        return NULL;
     }
 
     length = strlen(output);

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -278,6 +278,9 @@ typedef struct registry_ignore_regex {
 typedef struct fim_file_data {
     // Checksum attributes
     unsigned int size;
+#ifdef WIN32
+    cJSON * perm_json;
+#endif
     char * perm;
     char * attributes;
     char * uid;

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -305,6 +305,7 @@ typedef struct fim_file_data {
 typedef struct fim_registry_key {
     unsigned int id;
     char * path;
+    cJSON * perm_json;
     char * perm;
     char * uid;
     char * gid;

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -61,6 +61,8 @@
 #define FIM_AUDIT_DISABLED                      "(6946): Audit is disabled."
 #define FIM_WARN_FORMAT_PATH                    "(6947): Error formatting path: '%s'"
 #define FIM_DATABASE_NODES_COUNT_FAIL           "(6948): Unable to get the number of entries in database."
+#define FIM_CJSON_ERROR_CREATE_ITEM             "(6949): Cannot create a cJSON item"
+
 
 /* Monitord warning messages */
 #define ROTATE_LOG_LONG_PATH                    "(7500): The path of the rotated log is too long."

--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -360,11 +360,10 @@ unsigned int w_get_file_attrs(const char *file_path);
  * @brief Retrieves the permissions of a specific file (Windows)
  *
  * @param [in] file_path The path of the file from which to check permissions
- * @param [out] permissions Buffer in which to write the permissions
- * @param [in] perm_size The size of the permissions buffer
+ * @param [out] acl_json cJSON in which to write the acl
  * @return 0 on success, the error code on failure, -2 if ACE could not be obtained
  */
-int w_get_file_permissions(const char *file_path, char *permissions, int perm_size);
+int w_get_file_permissions(const char *file_path, cJSON *acl_json);
 
 /**
  * @brief Retrieves the group name from a group ID in windows
@@ -440,6 +439,13 @@ void decode_win_attributes(char *str, unsigned int attrs);
  * @return A string in human readable format with the Windows permission
  */
 char *decode_win_permissions(char *raw_perm);
+
+/**
+ * @brief Decodes a permission string and converts it to a human readable format
+ *
+ * @param [out] acl_json A cJSON with the permissions to decode
+ */
+void decode_win_acl_json(cJSON *acl_json);
 
 /**
  * @brief Transforms a bit mask of attributes into a human readable cJSON

--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -360,10 +360,12 @@ unsigned int w_get_file_attrs(const char *file_path);
  * @brief Retrieves the permissions of a specific file (Windows)
  *
  * @param [in] file_path The path of the file from which to check permissions
- * @param [out] acl_json cJSON in which to write the acl
- * @return 0 on success, the error code on failure, -2 if ACE could not be obtained
+ * @param [out] output_acl A cJSON pointer to an object holding the ACL of the file.
+ * @retval 0 on success.
+ * @retval -1 if the cJSON object could not be initialized.
+ * @retval An error code retrieved from `GetLastError` otherwise.
  */
-int w_get_file_permissions(const char *file_path, cJSON *acl_json);
+int w_get_file_permissions(const char *file_path, cJSON **output_acl);
 
 /**
  * @brief Retrieves the group name from a group ID in windows
@@ -386,12 +388,13 @@ char *get_registry_group(char **sid, HANDLE hndl);
 /**
  * @brief Retrieves the permissions of a registry key.
  *
- * @param hndl Handle for the registry key to check the permissions of.
- * @param perm_key Permissions associated to the registry key.
- *
- * @return Permissions in perm_key. ERROR_SUCCESS on success, different otherwise
+ * @param [in] hndl Handle for the registry key to check the permissions of.
+ * @param [out] output_acl A cJSON pointer to an object holding the ACL of the file.
+ * @retval 0 on success.
+ * @retval -1 if the cJSON object could not be initialized.
+ * @retval An error code retrieved from `GetLastError` otherwise.
 */
-DWORD get_registry_permissions(HKEY hndl, cJSON *perm_key);
+DWORD get_registry_permissions(HKEY hndl, cJSON **output_acl);
 
 /**
  * @brief Get last modification time from registry key.
@@ -401,16 +404,6 @@ DWORD get_registry_permissions(HKEY hndl, cJSON *perm_key);
  * @return Last modification time of registry key in POSIX format.
 */
 unsigned int get_registry_mtime(HKEY hndl);
-
-/**
- * @brief Copy ACE information into buffer
- *
- * @param [in] ace ACE structure
- * @param [out] perm Buffer in which to write the ACE information
- * @param [in] perm_size The size of the buffer
- * @return 0 on failure, the number of bytes written into perm on success
- */
-int copy_ace_info(void *ace, char *perm, int perm_size);
 
 /**
  * @brief Retrieves the account information (name and domain) from SID

--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -391,7 +391,7 @@ char *get_registry_group(char **sid, HANDLE hndl);
  *
  * @return Permissions in perm_key. ERROR_SUCCESS on success, different otherwise
 */
-DWORD get_registry_permissions(HKEY hndl, char *perm_key);
+DWORD get_registry_permissions(HKEY hndl, cJSON *perm_key);
 
 /**
  * @brief Get last modification time from registry key.

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -38,6 +38,7 @@ extern void mock_assert(const int result, const char* const expression,
 #endif
 #endif
 
+#ifdef WIN32
 /**
  * @brief Retrieves the permissions of a specific file (Windows)
  *
@@ -66,7 +67,7 @@ static void add_ace_to_json(cJSON *acl_json, char *sid, char *account_name, cons
  * @param [in] ace_type string "allowed" or "denied" depends on ace type
  */
 static void make_mask_readable (cJSON *ace_json, int mask, char *ace_type);
-
+#endif
 
 char *escape_syscheck_field(char *field) {
     char *esc_it;
@@ -1265,25 +1266,6 @@ void decode_win_attributes(char *str, unsigned int attrs) {
     }
 }
 
-void decode_win_acl_json (cJSON *acl_json) {
-    cJSON *json_object = NULL;
-    cJSON *allowed_item = NULL;
-    cJSON *denied_item = NULL;
-
-    assert(acl_json != NULL);
-
-    cJSON_ArrayForEach(json_object, acl_json) {
-        allowed_item = cJSON_GetObjectItem(json_object, "allowed");
-        if (allowed_item) {
-            make_mask_readable(json_object, allowed_item->valueint, "allowed");
-        }
-        denied_item = cJSON_GetObjectItem(json_object, "denied");
-        if (denied_item) {
-            make_mask_readable(json_object, denied_item->valueint, "denied");
-        }
-    }
-}
-
 void make_mask_readable (cJSON *ace_json, int mask, char *ace_type) {
     int i;
     int perm_bits[] = {
@@ -1341,6 +1323,25 @@ void make_mask_readable (cJSON *ace_json, int mask, char *ace_type) {
 	}
 
     cJSON_ReplaceItemInObject(ace_json, ace_type, perm_array);
+}
+
+void decode_win_acl_json (cJSON *acl_json) {
+    cJSON *json_object = NULL;
+    cJSON *allowed_item = NULL;
+    cJSON *denied_item = NULL;
+
+    assert(acl_json != NULL);
+
+    cJSON_ArrayForEach(json_object, acl_json) {
+        allowed_item = cJSON_GetObjectItem(json_object, "allowed");
+        if (allowed_item) {
+            make_mask_readable(json_object, allowed_item->valueint, "allowed");
+        }
+        denied_item = cJSON_GetObjectItem(json_object, "denied");
+        if (denied_item) {
+            make_mask_readable(json_object, denied_item->valueint, "denied");
+        }
+    }
 }
 
 char *decode_win_permissions(char *raw_perm) {

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -1154,13 +1154,7 @@ fim_file_data *fim_get_data(const char *file, const directory_t *configuration, 
 #ifdef WIN32
         int error;
 
-        data->perm_json = cJSON_CreateObject();
-        if (data->perm_json == NULL) {
-            mwarn(FIM_CJSON_ERROR_CREATE_ITEM);
-            return NULL;
-        }
-
-        error = w_get_file_permissions(file, data->perm_json);
+        error = w_get_file_permissions(file, &(data->perm_json));
         if (error) {
             mdebug1(FIM_EXTRACT_PERM_FAIL, file, error);
             free_file_data(data);

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -1168,7 +1168,6 @@ fim_file_data *fim_get_data(const char *file, const directory_t *configuration, 
         }
 
         decode_win_acl_json(data->perm_json);
-
         data->perm = cJSON_PrintUnformatted(data->perm_json);
 #else
         data->perm = agent_file_perm(statbuf->st_mode);

--- a/src/syscheckd/db/fim_db_files.c
+++ b/src/syscheckd/db/fim_db_files.c
@@ -180,6 +180,9 @@ fim_entry *fim_db_decode_full_row(sqlite3_stmt *stmt) {
     entry->file_entry.data->inode = (unsigned long int)sqlite3_column_int64(stmt, 8);
     entry->file_entry.data->size = (unsigned int)sqlite3_column_int(stmt, 9);
     sqlite_strdup((char *)sqlite3_column_text(stmt, 10), entry->file_entry.data->perm);
+#ifdef WIN32
+    entry->file_entry.data->perm_json = cJSON_Parse((char *)sqlite3_column_text(stmt, 10));
+#endif
     sqlite_strdup((char *)sqlite3_column_text(stmt, 11), entry->file_entry.data->attributes);
     sqlite_strdup((char *)sqlite3_column_text(stmt, 12), entry->file_entry.data->uid);
     sqlite_strdup((char *)sqlite3_column_text(stmt, 13), entry->file_entry.data->gid);

--- a/src/syscheckd/db/fim_db_files.c
+++ b/src/syscheckd/db/fim_db_files.c
@@ -181,7 +181,7 @@ fim_entry *fim_db_decode_full_row(sqlite3_stmt *stmt) {
     entry->file_entry.data->size = (unsigned int)sqlite3_column_int(stmt, 9);
     sqlite_strdup((char *)sqlite3_column_text(stmt, 10), entry->file_entry.data->perm);
 #ifdef WIN32
-    entry->file_entry.data->perm_json = cJSON_Parse((char *)sqlite3_column_text(stmt, 10));
+    entry->file_entry.data->perm_json = cJSON_Parse(entry->file_entry.data->perm);
 #endif
     sqlite_strdup((char *)sqlite3_column_text(stmt, 11), entry->file_entry.data->attributes);
     sqlite_strdup((char *)sqlite3_column_text(stmt, 12), entry->file_entry.data->uid);

--- a/src/syscheckd/db/fim_db_registries.c
+++ b/src/syscheckd/db/fim_db_registries.c
@@ -186,6 +186,7 @@ fim_registry_key *fim_db_decode_registry_key(sqlite3_stmt *stmt) {
     entry->id = (unsigned int)sqlite3_column_int(stmt, 0);
     sqlite_strdup((char *)sqlite3_column_text(stmt, 1), entry->path);
     sqlite_strdup((char *)sqlite3_column_text(stmt, 2), entry->perm);
+    entry->perm_json = cJSON_Parse(entry->perm);
     sqlite_strdup((char *)sqlite3_column_text(stmt, 3), entry->uid);
     sqlite_strdup((char *)sqlite3_column_text(stmt, 4), entry->gid);
     sqlite_strdup((char *)sqlite3_column_text(stmt, 5), entry->user_name);

--- a/src/syscheckd/registry/events.c
+++ b/src/syscheckd/registry/events.c
@@ -179,7 +179,7 @@ cJSON *fim_registry_key_attributes_json(const fim_registry_key *data, const regi
     cJSON_AddStringToObject(attributes, "type", "registry_key");
 
     if (configuration->opts & CHECK_PERM) {
-        cJSON_AddStringToObject(attributes, "perm", data->perm);
+        cJSON_AddItemToObject(attributes, "perm", cJSON_Duplicate(data->perm_json, 1));
     }
 
     if (configuration->opts & CHECK_OWNER) {

--- a/src/syscheckd/registry/registry.c
+++ b/src/syscheckd/registry/registry.c
@@ -464,6 +464,7 @@ fim_registry_key *fim_registry_get_key_data(HKEY key_handle, const char *path, c
         key->perm_json = cJSON_CreateObject();
         if (key->perm_json == NULL) {
             mwarn(FIM_CJSON_ERROR_CREATE_ITEM);
+            fim_registry_free_key(key);
             return NULL;
         }
 

--- a/src/syscheckd/registry/registry.c
+++ b/src/syscheckd/registry/registry.c
@@ -467,7 +467,7 @@ fim_registry_key *fim_registry_get_key_data(HKEY key_handle, const char *path, c
             return NULL;
         }
 
-        error = get_registry_permissions(key_handle, key->perm_json);
+        error = get_registry_permissions(key_handle, &(key->perm_json));
         if (error) {
             mdebug1(FIM_EXTRACT_PERM_FAIL, path, error);
             fim_registry_free_key(key);

--- a/src/unit_tests/analysisd/test_analysisd_syscheck.c
+++ b/src/unit_tests/analysisd/test_analysisd_syscheck.c
@@ -3498,6 +3498,21 @@ static void test_perm_json_to_old_format_both_aces(void **state) {
     free(decoded);
 }
 
+static void test_perm_json_to_old_format_empty_acl(void **state) {
+    cJSON *acl = cJSON_CreateObject();
+    char *decoded;
+
+    if (acl == NULL) {
+        fail_msg("Failed to create cJSON object");
+    }
+
+    *state = acl;
+
+    decoded = perm_json_to_old_format(acl);
+
+    assert_null(decoded);
+}
+
 static void test_perm_json_to_old_format_empty_aces(void **state) {
     cJSON *acl = cJSON_CreateObject();
     cJSON *ace = cJSON_CreateObject();
@@ -3764,6 +3779,7 @@ int main(void) {
         cmocka_unit_test_teardown(test_perm_json_to_old_format_allowed_ace_only, teardown_cjson),
         cmocka_unit_test_teardown(test_perm_json_to_old_format_denied_ace_only, teardown_cjson),
         cmocka_unit_test_teardown(test_perm_json_to_old_format_both_aces, teardown_cjson),
+        cmocka_unit_test_teardown(test_perm_json_to_old_format_empty_acl, teardown_cjson),
         cmocka_unit_test_teardown(test_perm_json_to_old_format_empty_aces, teardown_cjson),
         cmocka_unit_test_teardown(test_perm_json_to_old_format_multiple_aces, teardown_cjson),
 

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -133,7 +133,7 @@ set(CREATE_DB_BASE_FLAGS "-Wl,--wrap,_minfo -Wl,--wrap,_merror -Wl,--wrap,_mwarn
 target_link_libraries(test_create_db SYSCHECK_O ${TEST_DEPS} fim_shared)
 if(${TARGET} STREQUAL "winagent")
     target_link_libraries(test_create_db "${CREATE_DB_BASE_FLAGS} -Wl,--wrap=w_get_file_permissions -Wl,--wrap,getpid \
-                                          -Wl,--wrap=decode_win_permissions,--wrap=w_get_file_attrs,--wrap=os_winreg_check \
+                                          -Wl,--wrap=decode_win_acl_json,--wrap=w_get_file_attrs,--wrap=os_winreg_check \
                                           -Wl,--wrap,get_file_user -Wl,--wrap,fim_registry_scan \
                                           -Wl,--wrap,get_UTC_modification_time")
 else()

--- a/src/unit_tests/syscheckd/registry/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/registry/CMakeLists.txt
@@ -5,7 +5,7 @@ add_executable(test_registry test_registry.c)
 
 target_compile_options(test_registry PRIVATE "-Wall")
 
-target_link_libraries(test_registry SYSCHECK_O ${TEST_DEPS})
+target_link_libraries(test_registry SYSCHECK_O ${TEST_DEPS} fim_shared)
 target_link_libraries(test_registry "-Wl,--wrap=_mdebug2,--wrap=_mdebug1,--wrap=_merror,--wrap=_mwarn
                                      -Wl,--wrap=send_syscheck_msg,--wrap=os_random -Wl,--wrap,getpid
                                      -Wl,--wrap=fim_db_set_all_registry_data_unscanned
@@ -18,7 +18,7 @@ target_link_libraries(test_registry "-Wl,--wrap=_mdebug2,--wrap=_mdebug1,--wrap=
                                      -Wl,--wrap=fim_db_get_registry_keys_not_scanned,--wrap=fim_db_get_registry_data_not_scanned
                                      -Wl,--wrap=fim_db_set_registry_data_scanned,--wrap=fim_registry_value_diff
                                      -Wl,--wrap=fim_db_process_read_file,--wrap=get_registry_permissions
-                                     -Wl,--wrap=decode_win_permissions,--wrap=pthread_mutex_lock,--wrap=pthread_mutex_unlock")
+                                     -Wl,--wrap=decode_win_acl_json,--wrap=pthread_mutex_lock,--wrap=pthread_mutex_unlock")
 
 add_test(NAME test_registry COMMAND test_registry)
 
@@ -27,7 +27,7 @@ add_executable(test_events test_events.c)
 
 target_compile_options(test_events PRIVATE "-Wall")
 
-target_link_libraries(test_events SYSCHECK_O ${TEST_DEPS})
-target_link_libraries(test_events "-Wl,--wrap=_mdebug2,--wrap=_mdebug1,--wrap=_merror,--wrap=_mwarn")
+target_link_libraries(test_events SYSCHECK_O ${TEST_DEPS} fim_shared)
+target_link_libraries(test_events "-Wl,--wrap=_mdebug2,--wrap=_mdebug1,--wrap=_merror,--wrap=_mwarn,--wrap=_merror_exit,--wrap=_mterror_exit")
 
 add_test(NAME test_events COMMAND test_events)

--- a/src/unit_tests/syscheckd/test_fim.h
+++ b/src/unit_tests/syscheckd/test_fim.h
@@ -15,6 +15,8 @@ void expect_send_syscheck_msg(const char *msg);
 
 void expect_fim_diff_delete_compress_folder(struct dirent *dir);
 
+cJSON *create_win_permissions_object();
+
 /**********************************************************************************************************************\
  * Setups/Teardowns
 \**********************************************************************************************************************/

--- a/src/unit_tests/syscheckd/utils.c
+++ b/src/unit_tests/syscheckd/utils.c
@@ -48,3 +48,39 @@ int teardown_rb_tree(void **state) {
 
     return 0;
 }
+
+#define BASE_WIN_ALLOWED_ACE "[" \
+    "\"delete\"," \
+    "\"read_control\"," \
+    "\"write_dac\"," \
+    "\"write_owner\"," \
+    "\"synchronize\"," \
+    "\"read_data\"," \
+    "\"write_data\"," \
+    "\"append_data\"," \
+    "\"read_ea\"," \
+    "\"write_ea\"," \
+    "\"execute\"," \
+    "\"read_attributes\"," \
+    "\"write_attributes\"" \
+"]"
+
+#define BASE_WIN_DENIED_ACE "[" \
+    "\"read_control\"," \
+    "\"synchronize\"," \
+    "\"read_data\"," \
+    "\"read_ea\"," \
+    "\"execute\"," \
+    "\"read_attributes\"" \
+"]"
+
+#define BASE_WIN_ACE "{" \
+    "\"name\": \"Users\"," \
+    "\"allowed\": " BASE_WIN_ALLOWED_ACE "," \
+    "\"denied\": " BASE_WIN_DENIED_ACE \
+"}"
+
+cJSON *create_win_permissions_object() {
+    static const char * const BASE_WIN_PERMS = "{\"S-1-5-32-636\": " BASE_WIN_ACE "}";
+    return cJSON_Parse(BASE_WIN_PERMS);
+}

--- a/src/unit_tests/wrappers/wazuh/shared/syscheck_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/syscheck_op_wrappers.c
@@ -20,6 +20,11 @@ char *__wrap_decode_win_permissions(char *raw_perm) {
     return mock_type(char*);
 }
 
+void __wrap_decode_win_acl_json(cJSON *perms) {
+    check_expected(perms);
+    return;
+}
+
 int __wrap_delete_target_file(const char *path) {
     check_expected(path);
     return mock();
@@ -63,9 +68,13 @@ unsigned int __wrap_w_get_file_attrs(const char *file_path) {
     return mock();
 }
 
-int __wrap_w_get_file_permissions(const char *file_path, char *permissions, int perm_size) {
+int __wrap_w_get_file_permissions(const char *file_path, cJSON **output_acl) {
     check_expected(file_path);
-    snprintf(permissions, perm_size, "%s", mock_type(char*));
+
+    assert_non_null(output_acl);
+
+    *output_acl = mock_type(cJSON *);
+
     return mock();
 }
 
@@ -92,19 +101,21 @@ void expect_get_file_user(const char *path, char *sid, char *user) {
     will_return(__wrap_get_file_user, user);
 }
 
-void expect_w_get_file_permissions(const char *file_path, char *perms, int ret) {
+void expect_w_get_file_permissions(const char *file_path, cJSON *perms, int ret) {
     expect_string(__wrap_w_get_file_permissions, file_path, file_path);
     will_return(__wrap_w_get_file_permissions, perms);
     will_return(__wrap_w_get_file_permissions, ret);
 }
 
-DWORD __wrap_get_registry_permissions(__attribute__((unused)) HKEY hndl, char *perm_key) {
-    snprintf(perm_key, OS_SIZE_6144, "%s", mock_type(const char *));
+DWORD __wrap_get_registry_permissions(__attribute__((unused)) HKEY hndl, cJSON **output_acl) {
+    assert_non_null(output_acl);
+
+    *output_acl = mock_type(cJSON *);
 
     return mock();
 }
 
-void expect_get_registry_permissions(const char *permissions, DWORD retval) {
+void expect_get_registry_permissions(cJSON *permissions, DWORD retval) {
     will_return(__wrap_get_registry_permissions, permissions);
     will_return(__wrap_get_registry_permissions, retval);
 }

--- a/src/unit_tests/wrappers/wazuh/shared/syscheck_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/syscheck_op_wrappers.h
@@ -16,7 +16,11 @@
 #include <windows.h>
 #endif // WIN32
 
+#include <cJSON.h>
+
 char *__wrap_decode_win_permissions(char *raw_perm);
+
+void __wrap_decode_win_acl_json(cJSON *perms);
 
 int __wrap_delete_target_file(const char *path);
 
@@ -34,7 +38,7 @@ unsigned int __wrap_w_directory_exists(const char *path);
 
 unsigned int __wrap_w_get_file_attrs(const char *file_path);
 
-int __wrap_w_get_file_permissions(const char *file_path, char *permissions, int perm_size);
+int __wrap_w_get_file_permissions(const char *file_path, cJSON **output_acl);
 
 int __wrap_remove_empty_folders(const char *folder);
 
@@ -52,17 +56,17 @@ void expect_get_file_user(const char *path, char *sid, char *user);
 /**
  * @brief This function loads the expect and will return of the function w_get_file_permissions
  */
-void expect_w_get_file_permissions(const char *file_path, char *perms, int ret);
+void expect_w_get_file_permissions(const char *file_path, cJSON *perms, int ret);
 
 /**
  * @brief Mock calls to get_registry_permissions
  */
-DWORD __wrap_get_registry_permissions(HKEY hndl,  char *perm_key);
+DWORD __wrap_get_registry_permissions(__attribute__((unused)) HKEY hndl, cJSON **output_acl);
 
 /**
  * @brief This function loads the expect and will return of the function get_registry_permissions
  */
-void expect_get_registry_permissions(const char *permissions, DWORD retval);
+void expect_get_registry_permissions(cJSON *permissions, DWORD retval);
 
 #else
 /**


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/8585|


## Description

This PR aims to change the way Windows file permissions will be processed, changing them from string format to a cJSON format.

## Logs/Alerts example



## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
- Memory tests for Windows
  - [x] Scan-build report
  - [x] DrMemory

