### PR TITLE
Syscheck max depth read

### DIFF
--- a/src/config/wmodules_syscheck.c
+++ b/src/config/wmodules_syscheck.c
@@ -115,6 +115,14 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void* d1, int modules, const
     config->disk_quota_full_msg = true;
     config->audit_key = NULL;
 
+    config->rt_delay = getDefine_Int("syscheck", "rt_delay", 0, 1000);
+    config->max_depth = getDefine_Int("syscheck", "default_max_depth", 1, 320);
+    config->file_max_size = (size_t)getDefine_Int("syscheck", "file_max_size", 0, 4095) * 1024 * 1024;
+    config->sym_checker_interval = getDefine_Int("syscheck", "symlink_scan_interval", 1, 2592000);
+
+#ifndef WIN32
+    config->max_audit_entries = getDefine_Int("syscheck", "max_audit_entries", 1, 4096);
+#endif
 
     /* Read config */
     if (node && read_syscheck_config_xml(xml, node, config, modules) < 0) {

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -129,7 +129,7 @@ set(CREATE_DB_BASE_FLAGS "-Wl,--wrap,_mtinfo -Wl,--wrap,_mterror -Wl,--wrap,_mtw
                           -Wl,--wrap,pthread_rwlock_unlock -Wl,--wrap,pthread_rwlock_rdlock \
                           -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_mutex_unlock \
                           -Wl,--wrap,expand_wildcards -Wl,--wrap,fim_add_inotify_watch \
-                          -Wl,--wrap,fim_db_remove_wildcard_entry")
+                          -Wl,--wrap,fim_db_remove_wildcard_entry -Wl,--wrap,getDefine_Int")
 
 target_link_libraries(test_create_db SYSCHECK_O ${TEST_DEPS} fim_shared)
 if(${TARGET} STREQUAL "winagent")
@@ -174,7 +174,7 @@ set(RUN_REALTIME_BASE_FLAGS "-Wl,--wrap,inotify_init -Wl,--wrap,inotify_add_watc
                              -Wl,--wrap=OSHash_Begin -Wl,--wrap=OSHash_Next -Wl,--wrap=pthread_mutex_lock \
                              -Wl,--wrap=pthread_mutex_unlock -Wl,--wrap=getpid -Wl,--wrap=atexit -Wl,--wrap=os_random \
                              -Wl,--wrap,inotify_rm_watch -Wl,--wrap,pthread_rwlock_wrlock -Wl,--wrap,pthread_rwlock_unlock \
-                             -Wl,--wrap,pthread_rwlock_rdlock")
+                             -Wl,--wrap,pthread_rwlock_rdlock -Wl,--wrap,getDefine_Int")
 
 list(APPEND syscheckd_tests_names "test_run_realtime")
 if(${TARGET} STREQUAL "agent")
@@ -194,7 +194,7 @@ set(SYSCHECK_CONFIG_BASE_FLAGS "-Wl,--wrap,_mterror -Wl,--wrap,_mtdebug1 -Wl,--w
                                 -Wl,--wrap,_merror -Wl,--wrap,_mdebug1 -Wl,--wrap,_mwarn \
                                 -Wl,--wrap,pthread_rwlock_rdlock -Wl,--wrap,pthread_rwlock_unlock \
                                 -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_rwlock_wrlock \
-                                -Wl,--wrap,pthread_mutex_unlock")
+                                -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,getDefine_Int")
 
 list(APPEND syscheckd_tests_names "test_syscheck_config")
 if(${TARGET} STREQUAL "agent")
@@ -249,7 +249,7 @@ set(RUN_CHECK_BASE_FLAGS "-Wl,--wrap,_mtinfo -Wl,--wrap,_mterror -Wl,--wrap,_mtd
                           -Wl,--wrap,fim_db_get_path_range -Wl,--wrap,fim_db_delete_range -Wl,--wrap,lstat \
                           -Wl,--wrap,fim_configuration_directory -Wl,--wrap,inotify_rm_watch -Wl,--wrap,os_random \
                           -Wl,--wrap,stat -Wl,--wrap,getpid -Wl,--wrap,fim_db_get_path_from_pattern -Wl,--wrap,gettime \
-                          -Wl,--wrap,remove_audit_rule_syscheck")
+                          -Wl,--wrap,remove_audit_rule_syscheck -Wl,--wrap,getDefine_Int")
 
 list(APPEND syscheckd_tests_names "test_run_check")
 if(${TARGET} STREQUAL "agent")

--- a/src/unit_tests/syscheckd/db/expect_fim_db.c
+++ b/src/unit_tests/syscheckd/db/expect_fim_db.c
@@ -168,9 +168,7 @@ int setup_fim_db_group(void **state) {
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
-#ifndef TEST_SERVER
     will_return_always(__wrap_getDefine_Int, 0);
-#endif
 
     OS_XML xml;
     XML_NODE node;

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -188,6 +188,20 @@ static int setup_group(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
+    will_return(__wrap_getDefine_Int, 5);
+    will_return(__wrap_getDefine_Int, 256);
+    will_return(__wrap_getDefine_Int, 1024);
+    will_return(__wrap_getDefine_Int, 600);
+#ifndef TEST_WINAGENT
+    will_return(__wrap_getDefine_Int, 4096);
+#endif //TEST_WINAGENT
+#ifndef TEST_SERVER
+    will_return(__wrap_getDefine_Int, 0);
+#endif //TEST_SERVER
+#ifdef TEST_WINAGENT
+    will_return(__wrap_getDefine_Int, 1024);
+#endif //TEST_WINAGENT
+
     // Read and setup global values.
     OS_XML xml;
     XML_NODE node;
@@ -283,6 +297,19 @@ static int setup_root_group(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
+    will_return(__wrap_getDefine_Int, 5);
+    will_return(__wrap_getDefine_Int, 256);
+    will_return(__wrap_getDefine_Int, 1024);
+    will_return(__wrap_getDefine_Int, 600);
+#ifndef TEST_WINAGENT
+    will_return(__wrap_getDefine_Int, 4096);
+#endif //TEST_WINAGENT
+#ifndef TEST_SERVER
+    will_return(__wrap_getDefine_Int, 0);
+#endif //TEST_SERVER
+#ifdef TEST_WINAGENT
+    will_return(__wrap_getDefine_Int, 1024);
+#endif //TEST_WINAGENT
     // Read and setup global values.
     OS_XML xml;
     XML_NODE node;

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -94,6 +94,20 @@ static int setup_group(void ** state) {
     syscheck.database = fim_db_init(FIM_DB_DISK);
 #endif
 
+    will_return(__wrap_getDefine_Int, 5);
+    will_return(__wrap_getDefine_Int, 256);
+    will_return(__wrap_getDefine_Int, 1024);
+    will_return(__wrap_getDefine_Int, 600);
+#ifndef TEST_WINAGENT
+    will_return(__wrap_getDefine_Int, 4096);
+#endif //TEST_WINAGENT
+#ifndef TEST_SERVER
+    will_return(__wrap_getDefine_Int, 0);
+#endif //TEST_SERVER
+#ifdef TEST_WINAGENT
+    will_return(__wrap_getDefine_Int, 1024);
+#endif //TEST_WINAGENT
+
     will_return_always(__wrap_os_random, 12345);
     int ret = 0;
     OS_XML xml;

--- a/src/unit_tests/syscheckd/test_run_realtime.c
+++ b/src/unit_tests/syscheckd/test_run_realtime.c
@@ -65,6 +65,20 @@ static int setup_group(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
+    will_return(__wrap_getDefine_Int, 5);
+    will_return(__wrap_getDefine_Int, 256);
+    will_return(__wrap_getDefine_Int, 1024);
+    will_return(__wrap_getDefine_Int, 600);
+#ifndef TEST_WINAGENT
+    will_return(__wrap_getDefine_Int, 4096);
+#endif //TEST_WINAGENT
+#ifndef TEST_SERVER
+    will_return(__wrap_getDefine_Int, 0);
+#endif //TEST_SERVER
+#ifdef TEST_WINAGENT
+    will_return(__wrap_getDefine_Int, 1023);
+#endif //TEST_WINAGENT
+
     test_mode = 0;
     OS_XML xml;
     XML_NODE node;

--- a/src/unit_tests/syscheckd/test_syscheck_config.c
+++ b/src/unit_tests/syscheckd/test_syscheck_config.c
@@ -70,6 +70,19 @@ void test_Read_Syscheck_Config_success(void **state)
     expect_any_always(__wrap__mdebug1, formatted_msg);
     expect_any_always(__wrap__mwarn, formatted_msg);
 
+    will_return(__wrap_getDefine_Int, 5);
+    will_return(__wrap_getDefine_Int, 256);
+    will_return(__wrap_getDefine_Int, 1024);
+    will_return(__wrap_getDefine_Int, 600);
+#ifndef TEST_WINAGENT
+    will_return(__wrap_getDefine_Int, 4096);
+#endif //TEST_WINAGENT
+#ifndef TEST_SERVER
+    will_return(__wrap_getDefine_Int, 0);
+#endif //TEST_SERVER
+#ifdef TEST_WINAGENT
+    will_return(__wrap_getDefine_Int, 1024);
+#endif //TEST_WINAGENT
     OS_XML xml;
     XML_NODE node;
     XML_NODE chld_node;
@@ -133,6 +146,19 @@ void test_Read_Syscheck_Config_undefined(void **state)
     expect_function_call_any(__wrap_pthread_mutex_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
+    will_return(__wrap_getDefine_Int, 5);
+    will_return(__wrap_getDefine_Int, 256);
+    will_return(__wrap_getDefine_Int, 1024);
+    will_return(__wrap_getDefine_Int, 600);
+#ifndef TEST_WINAGENT
+    will_return(__wrap_getDefine_Int, 4096);
+#endif //TEST_WINAGENT
+#ifndef TEST_SERVER
+    will_return(__wrap_getDefine_Int, 0);
+#endif //TEST_SERVER
+#ifdef TEST_WINAGENT
+    will_return(__wrap_getDefine_Int, 1024);
+#endif //TEST_WINAGENT
     OS_XML xml;
     XML_NODE node;
     XML_NODE chld_node;
@@ -188,6 +214,16 @@ void test_Read_Syscheck_Config_unparsed(void **state)
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
 
+    will_return(__wrap_getDefine_Int, 5);
+    will_return(__wrap_getDefine_Int, 256);
+    will_return(__wrap_getDefine_Int, 1024);
+    will_return(__wrap_getDefine_Int, 600);
+#ifndef TEST_WINAGENT
+    will_return(__wrap_getDefine_Int, 4096);
+#endif //TEST_WINAGENT
+#ifndef TEST_SERVER
+    will_return(__wrap_getDefine_Int, 0);
+#endif //TEST_SERVER
     OS_XML xml;
     OS_ReadXML("test_empty_config.conf", &xml);
     assert_null(OS_GetElementsbyNode(&xml, NULL));
@@ -244,6 +280,19 @@ void test_getSyscheckConfig(void **state)
 
     expect_any_always(__wrap__mdebug1, formatted_msg);
 
+    will_return(__wrap_getDefine_Int, 5);
+    will_return(__wrap_getDefine_Int, 256);
+    will_return(__wrap_getDefine_Int, 1024);
+    will_return(__wrap_getDefine_Int, 600);
+#ifndef TEST_WINAGENT
+    will_return(__wrap_getDefine_Int, 4096);
+#endif //TEST_WINAGENT
+#ifndef TEST_SERVER
+    will_return(__wrap_getDefine_Int, 0);
+#endif //TEST_SERVER
+#ifdef TEST_WINAGENT
+    will_return(__wrap_getDefine_Int, 1024);
+#endif //TEST_WINAGENT
     OS_XML xml;
     XML_NODE node;
     XML_NODE chld_node;
@@ -392,6 +441,19 @@ void test_getSyscheckConfig_no_audit(void **state)
     expect_function_call_any(__wrap_pthread_mutex_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
+    will_return(__wrap_getDefine_Int, 5);
+    will_return(__wrap_getDefine_Int, 256);
+    will_return(__wrap_getDefine_Int, 1024);
+    will_return(__wrap_getDefine_Int, 600);
+#ifndef TEST_WINAGENT
+    will_return(__wrap_getDefine_Int, 4096);
+#endif //TEST_WINAGENT
+#ifndef TEST_SERVER
+    will_return(__wrap_getDefine_Int, 0);
+#endif //TEST_SERVER
+#ifdef TEST_WINAGENT
+    will_return(__wrap_getDefine_Int, 1024);
+#endif //TEST_WINAGENT
     OS_XML xml;
     XML_NODE node;
     XML_NODE chld_node;
@@ -515,6 +577,14 @@ void test_getSyscheckConfig_no_directories(void **state)
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
+    will_return(__wrap_getDefine_Int, 5);
+    will_return(__wrap_getDefine_Int, 256);
+    will_return(__wrap_getDefine_Int, 1024);
+    will_return(__wrap_getDefine_Int, 600);
+    will_return(__wrap_getDefine_Int, 4096);
+#ifndef TEST_SERVER
+    will_return(__wrap_getDefine_Int, 0);
+#endif //TEST_SERVER
     OS_XML xml;
     OS_ReadXML("test_empty_config.conf", &xml);
     assert_null(OS_GetElementsbyNode(&xml, NULL));
@@ -535,6 +605,11 @@ void test_getSyscheckConfig_no_directories(void **state)
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
+    will_return(__wrap_getDefine_Int, 5);
+    will_return(__wrap_getDefine_Int, 256);
+    will_return(__wrap_getDefine_Int, 1024);
+    will_return(__wrap_getDefine_Int, 600);
+    will_return(__wrap_getDefine_Int, 0);
     OS_XML xml;
     OS_ReadXML("test_empty_config.conf", &xml);
     assert_null(OS_GetElementsbyNode(&xml, NULL));
@@ -621,6 +696,19 @@ void test_SyscheckConf_DirectoriesWithCommas(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_unlock);
     expect_function_call_any(__wrap_pthread_rwlock_rdlock);
 
+    will_return(__wrap_getDefine_Int, 5);
+    will_return(__wrap_getDefine_Int, 256);
+    will_return(__wrap_getDefine_Int, 1024);
+    will_return(__wrap_getDefine_Int, 600);
+#ifndef TEST_WINAGENT
+    will_return(__wrap_getDefine_Int, 4096);
+#endif //TEST_WINAGENT
+#ifndef TEST_SERVER
+    will_return(__wrap_getDefine_Int, 0);
+#endif //TEST_SERVER
+#ifdef TEST_WINAGENT
+    will_return(__wrap_getDefine_Int, 1024);
+#endif //TEST_WINAGENT
     OS_XML xml;
     XML_NODE node;
     XML_NODE chld_node;
@@ -658,6 +746,19 @@ void test_getSyscheckInternalOptions(void **state)
 
     expect_any_always(__wrap__mdebug1, formatted_msg);
 
+    will_return(__wrap_getDefine_Int, 5);
+    will_return(__wrap_getDefine_Int, 256);
+    will_return(__wrap_getDefine_Int, 1024);
+    will_return(__wrap_getDefine_Int, 600);
+#ifndef TEST_WINAGENT
+    will_return(__wrap_getDefine_Int, 4096);
+#endif //TEST_WINAGENT
+#ifndef TEST_SERVER
+    will_return(__wrap_getDefine_Int, 0);
+#endif //TEST_SERVER
+#ifdef TEST_WINAGENT
+    will_return(__wrap_getDefine_Int, 1024);
+#endif //TEST_WINAGENT
     OS_XML xml;
     XML_NODE node;
     XML_NODE chld_node;

--- a/src/wazuh_modules/wm_syscheck.c
+++ b/src/wazuh_modules/wm_syscheck.c
@@ -185,7 +185,6 @@ static void wm_syscheck_log_config(const wm_syscheck_t *sys) {
 void* wm_syscheck_main(wm_syscheck_t *sys) {
     syscheck_config* config = (syscheck_config*)sys;
     syscheck = *config;
-    read_internal(0);
     mtdebug1(SYSCHECK_LOGTAG, "Starting syscheck.");
     if (syscheck.disabled == 1) {
         if (syscheck.directories == NULL || OSList_GetFirstNode(syscheck.directories) == NULL) {


### PR DESCRIPTION
|Related issue|
|---|
| Closes #8948 |

## Description
This PR aims to add the read of internal syscheck configuration in Read_Syscheck function.

## DoD
- [ ] code changes.
- [ ] unit test