### PR TITLE
Prevent the agent from raising errors when the leaky bucket is full

### DIFF
--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -258,16 +258,11 @@ static int wm_sca_send_alert(wm_sca_t * data,cJSON *json_alert)
     if (wm_sendmsg(data->msg_delay, queue_fd, msg,WM_SCA_STAMP, SCA_MQ) < 0) {
         merror(QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
 
-        if(data->queue >= 0){
-            close(data->queue);
-        }
-
         if ((data->queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
             mwarn("Can't connect to queue.");
         } else {
             if(wm_sendmsg(data->msg_delay, data->queue, msg,WM_SCA_STAMP, SCA_MQ) < 0) {
                 merror(QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
-                close(data->queue);
             }
         }
     }

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -339,8 +339,9 @@ int SendMSG(__attribute__((unused)) int queue, const char *message, const char *
         if (send_msg(tmpstr, -1) >= 0) {
             retval = 0;
         }
-    } else if (buffer_append(tmpstr) == 0) {
-            retval = 0;
+    } else {
+        buffer_append(tmpstr);
+        retval = 0;
     }
 
     if (!ReleaseMutex(hMutex)) {


### PR DESCRIPTION
|Related issue|
|---|
|#9171|

We detected that most of the errors shown at #9171 were produced when the leaky bucket is full. When running on Windows, the agent confuses that condition with a connection error. In fact, the Windows implementation of function `OS_SendMSG` bypasses the socket's `send` operation and tries to enqueue the messages. So, `OS_SendMSG` may return an error code (`-1`):

- If `send` fails, on UNIX.
- If the buffer is full, on Windows.

In addition, `OS_SendMSG` closes the socket when it returns an error code, but SCA was closing the socket again. That is a double-close hazard.

So, this PR aims to apply two changes:
1. A full buffer condition shall not produce any error.
2. SCA shall not close the connection socket if `OS_SendMSG` fails.

## Tests

- [x] The agent on Windows no longer prints errors when the leaky bucket is full.
- [x] The tool `strace` on Linux no longer reports that `close() returns `EBADF`.