### PR TITLE
Fix for missing registry field value_type in alerts

### DIFF
--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -1273,8 +1273,6 @@ static int fim_process_alert(_sdb * sdb, Eventinfo *lf, cJSON * event) {
                 os_strdup(object->valuestring, lf->fields[FIM_REGISTRY_ARCH].value);
             } else if (strcmp(object->string, "value_name") == 0) {
                 os_strdup(object->valuestring, lf->fields[FIM_REGISTRY_VALUE_NAME].value);
-            } else if (strcmp(object->string, "value_type") == 0) {
-                os_strdup(object->valuestring, lf->fields[FIM_REGISTRY_VALUE_TYPE].value);
             }
 
             break;
@@ -1719,6 +1717,8 @@ int fim_fetch_attributes_state(cJSON *attr, Eventinfo *lf, char new_state) {
                 dst_data = new_state ? &lf->fields[FIM_ATTRS].value : &lf->fields[FIM_ATTRS_BEFORE].value; //LCOV_EXCL_LINE
             } else if (new_state && strcmp(attr_it->string, "symlink_path") == 0) {
                 dst_data = &lf->fields[FIM_SYM_PATH].value;
+            } else if (strcmp(attr_it->string, "value_type") == 0) {
+                dst_data = &lf->fields[FIM_REGISTRY_VALUE_TYPE].value;
             }
 
             if (dst_data) {


### PR DESCRIPTION
|Related issue|
|---|
|#9172|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The lecture of the missing registry field value_type has been moved from fim_process_alert to fetch_attributes_state

valgrind: 
[valgrind_analysisd.txt](https://github.com/wazuh/wazuh/files/6769535/valgrind_analysisd.txt)


## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)


