### PR TITLE
Wazuh-logtest: verbose mode

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -2015,7 +2015,7 @@ void * w_process_event_thread(__attribute__((unused)) void * id){
 
             /* Check each rule */
             else if (t_currently_rule = OS_CheckIfRuleMatch(lf, os_analysisd_last_events, &os_analysisd_cdblists,
-                     rulenode_pt, &rule_match, &os_analysisd_fts_list, &os_analysisd_fts_store, true), !t_currently_rule) {
+                     rulenode_pt, &rule_match, &os_analysisd_fts_list, &os_analysisd_fts_store, true, NULL), !t_currently_rule) {
 
                 continue;
             }

--- a/src/analysisd/logtest.h
+++ b/src/analysisd/logtest.h
@@ -50,6 +50,10 @@
 #define W_LOGTEST_JSON_MESSAGES              "messages"   ///< Message format field name of json output
 #define W_LOGTEST_JSON_CODE                   "codemsg"   ///< Code of message field name of json output (number)
 #define W_LOGTEST_JSON_OUTPUT                  "output"   ///< Output field name of json output
+#define W_LOGTEST_JSON_RULE_DEBUG          "rule_debug"   ///< Output field name of json rule_debug (string)
+#define W_LOGTEST_JSON_OPT                    "options"   ///< Requests options
+#define W_LOGTEST_JSON_OPT_RULE_DEBUG      "rule_debug"   ///< Enables rules debug option
+
 
 /* Commands allowed */
 #define W_LOGTEST_COMMAND_REMOVE_SESSION   "remove_session"    ///< Command used to remove a session
@@ -144,11 +148,13 @@ void *w_logtest_clients_handler();
  * @brief Process client's request
  * @param request client input
  * @param session client session
+ * @param debug_rules_str returns debugging rules message in *debug_rules_str if debug_rules_str is non-null
  * @param alert_generated returns true if the alert should be generated
  * @param list_msg list of error/warn/info messages
  * @return NULL on failure, otherwise the alert generated
  */
-cJSON *w_logtest_process_log(cJSON * request, w_logtest_session_t * session, bool * alert_generated, OSList * list_msg);
+cJSON *w_logtest_process_log(cJSON * request, w_logtest_session_t * session, bool * alert_generated,
+                             char ** debug_rules_str, OSList * list_msg);
 
 /**
  * @brief Preprocessing phase
@@ -178,13 +184,15 @@ void w_logtest_decoding_phase(Eventinfo * lf, w_logtest_session_t * session);
  *
  * @param lf struct to save the event processed
  * @param session client session
+ * @param debug_rules_str returns debugging rules message in *debug_rules_str if debug_rules_str is non-null
  * @param list_msg list of error/warn/info messages
  * @retval -1 on error
  * @retval  0 on success
  * @retval  1 on success and the event lf is added to the event list
 
  */
-int w_logtest_rulesmatching_phase(Eventinfo * lf, w_logtest_session_t * session, OSList * list_msg);
+int w_logtest_rulesmatching_phase(Eventinfo * lf, w_logtest_session_t * session,
+                                  char ** debug_rules_str, OSList * list_msg);
 
 /**
  * @brief Create resources necessary to service client

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -2592,7 +2592,8 @@ STATIC int doesRuleExist(int sid, RuleNode *r_node)
 RuleInfo *OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events,
                               ListNode **cdblists, RuleNode *curr_node,
                               regex_matching *rule_match, OSList **fts_list,
-                              OSHash **fts_store, const bool save_fts_value) {
+                              OSHash **fts_store, const bool save_fts_value,
+                              char ** debug_rules_str) {
 
     /* We check for:
      * decoded_as,
@@ -2627,6 +2628,13 @@ RuleInfo *OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events,
                   rule->comment);
     }
 #endif
+    if (debug_rules_str != NULL) {
+        char rule_str[50] = {0};
+        snprintf(rule_str, 50, "    Trying rule: %d - ", rule->sigid);
+        wm_strcat(debug_rules_str, rule_str, 0);
+        wm_strcat(debug_rules_str, rule->comment, 0);
+        wm_strcat(debug_rules_str, "\n", 0);
+    }
 
     /* Check if any decoder pre-matched here for syscheck event */
     if(lf->decoder_syscheck_id != 0 && (rule->decoded_as &&
@@ -3105,6 +3113,11 @@ RuleInfo *OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events,
         print_out("       *Rule %d matched.", rule->sigid);
     }
 #endif
+    if (debug_rules_str != NULL) {
+        char rule_str[50] = {0};
+        snprintf(rule_str, 50, "       *Rule %d matched.\n", rule->sigid);
+        wm_strcat(debug_rules_str, rule_str, 0);
+    }
 
     /* Search for dependent rules */
     if (curr_node->child) {
@@ -3115,9 +3128,13 @@ RuleInfo *OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events,
             print_out("       *Trying child rules.");
         }
 #endif
+        if (debug_rules_str != NULL) {
+            wm_strcat(debug_rules_str, "       *Trying child rules.\n", 0);
+        }
+
         while (child_node) {
             child_rule = OS_CheckIfRuleMatch(lf, last_events, cdblists, child_node, rule_match,
-                                             fts_list, fts_store, save_fts_value);
+                                             fts_list, fts_store, save_fts_value, debug_rules_str);
             if (child_rule != NULL) {
                 if (!child_rule->prev_rule) {
                     child_rule->prev_rule = rule;

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -266,12 +266,14 @@ RuleInfo *zerorulemember(int id, int level, int maxsize, int frequency,
  * @param curr_node rule to compare with the event "lf"
  * @param rule_match stores the regex of the rule
  * @param save_fts_value determine if fts value can be saved in fts-queue file
+ * @param debug_rules_str returns debugging rules message in *debug_rules_str if debug_rules_str is non-null
  * @return the rule information if it matches, otherwise null
  */
 RuleInfo *OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events,
                               ListNode **cdblists, RuleNode *curr_node,
                               regex_matching *rule_match, OSList **fts_list,
-                              OSHash **fts_store, const bool save_fts_value);
+                              OSHash **fts_store, const bool save_fts_value,
+                              char ** debug_rules_str);
 
 /**
  * @brief Set os_analysisd_rulelist to null

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -649,7 +649,7 @@ void OS_ReadMSG(char *ut_str)
 
                 /* Check each rule */
                 else if (currently_rule = OS_CheckIfRuleMatch(lf, os_analysisd_last_events, &os_analysisd_cdblists,
-                         rulenode_pt, &rule_match, &os_analysisd_fts_list, &os_analysisd_fts_store, false), !currently_rule) {
+                         rulenode_pt, &rule_match, &os_analysisd_fts_list, &os_analysisd_fts_store, false, NULL), !currently_rule) {
                     continue;
                 }
 

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -74,6 +74,8 @@
 #define LOGTEST_INV_NUM_TIMEOUT                 "(7002): Number of maximum user timeouts in logtest too high. Only allows %ds maximum timeouts"
 #define LOGTEST_WARN_TOKEN_EXPIRED              "(7003): '%s' token expires"
 #define LOGTEST_WARN_SESSION_NOT_FOUND          "(7004): No session found for token '%s'"
+#define LOGTEST_WARN_IGNORE_JSON_OPTION_OFIELD  "(7005): '%s' field must be a JSON object. The parameter will be ignored"
+
 
 /* Ruleset reading warnings */
 #define ANALYSISD_INV_VALUE_RULE                "(7600): Invalid value '%s' for attribute '%s' in rule %d"


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/7779|

## Description
This PR is for implementing verbose mode in `wazuh-logtest`. When this modifier is used, the output of ossec-logtest specifies every rule that is tested by the analysis engine.

Previously, this option was used in the `wazuh-logtest-legacy` tool. For example:
```
# echo "Oct 15 21:06:59 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928" | /var/ossec/bin/wazuh-logtest-legacy -v
2021/07/06 12:44:14 wazuh-testrule: INFO: Started (pid: 23554).

Since Wazuh v4.1.0 this binary is deprecated. Use wazuh-logtest instead

wazuh-testrule: Type one log per line.



**Phase 1: Completed pre-decoding.
       full event: 'Oct 15 21:06:59 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928'
       timestamp: 'Oct 15 21:06:59'
       hostname: 'linux-agent'
       program_name: 'sshd'
       log: 'Invalid user blimey from 18.18.18.18 port 48928'

**Phase 2: Completed decoding.
       decoder: 'sshd'
       srcuser: 'blimey'
       srcip: '18.18.18.18'
       srcport: '48928'

**Rule debugging:
    Trying rule: 1 - Generic template for all syslog rules.
       *Rule 1 matched.
       *Trying child rules.
    Trying rule: 600 - Active Response Messages Grouped
    Trying rule: 650 - Active Response JSON Messages Grouped
    Trying rule: 200 - Grouping of wazuh rules.
    Trying rule: 2100 - NFS rules grouped.
    Trying rule: 2507 - OpenLDAP group.
    Trying rule: 2550 - rshd messages grouped.
    Trying rule: 2701 - Ignoring procmail messages.
    Trying rule: 2800 - Pre-match rule for smartd.
    Trying rule: 5100 - Pre-match rule for kernel messages.
    Trying rule: 5200 - Ignoring hpiod for producing useless logs.
    Trying rule: 2830 - Crontab rule group.
    Trying rule: 5300 - Initial grouping for su messages.
    Trying rule: 5905 - useradd failed.
    Trying rule: 5400 - Initial group for sudo messages.
    Trying rule: 9100 - PPTPD messages grouped.
    Trying rule: 9200 - Squid syslog messages grouped.
    Trying rule: 2900 - Dpkg (Debian Package) log.
    Trying rule: 2930 - Yum logs.
    Trying rule: 2931 - Yum logs.
    Trying rule: 2940 - NetworkManager grouping.
    Trying rule: 2943 - nouveau driver grouping.
    Trying rule: 2962 - Perdition custom app group.
    Trying rule: 3100 - Grouping of the sendmail rules.
    Trying rule: 3190 - Grouping of the smf-sav sendmail milter rules.
    Trying rule: 3300 - Grouping of the postfix reject rules.
    Trying rule: 3320 - Grouping of the postfix rules.
    Trying rule: 3390 - Grouping of the clamsmtpd rules.
    Trying rule: 3395 - Grouping of the postfix warning rules.
    Trying rule: 3500 - Grouping for the spamd rules
    Trying rule: 3600 - Grouping of the imapd rules.
    Trying rule: 3700 - Grouping of mailscanner rules.
    Trying rule: 3800 - Grouping of Exchange rules.
    Trying rule: 3900 - Grouping for the courier rules.
    Trying rule: 4500 - Grouping for the Netscreen Firewall rules
    Trying rule: 4700 - Grouping of Cisco IOS rules
    Trying rule: 4800 - SonicWall messages grouped.
    Trying rule: 5500 - Grouping of the pam_unix rules.
    Trying rule: 5556 - unix_chkpwd grouping.
    Trying rule: 5600 - Grouping for the telnetd rules
    Trying rule: 5700 - SSHD messages grouped.
       *Rule 5700 matched.
       *Trying child rules.
    Trying rule: 5709 - sshd: Useless SSHD message without an user/ip and context.
    Trying rule: 5711 - sshd: Useless/Duplicated SSHD message without a user/ip.
    Trying rule: 5721 - sshd: System disconnected from sshd.
    Trying rule: 5722 - sshd: ssh connection closed.
    Trying rule: 5723 - sshd: key error.
    Trying rule: 5724 - sshd: key error.
    Trying rule: 5725 - sshd: Host ungracefully disconnected.
    Trying rule: 5727 - sshd: Attempt to start sshd when something already bound to the port.
    Trying rule: 5729 - sshd: Debug message.
    Trying rule: 5732 - sshd: Possible port forwarding failure.
    Trying rule: 5733 - sshd: User entered incorrect password.
    Trying rule: 5734 - sshd: sshd could not load one or more host keys.
    Trying rule: 5735 - sshd: Failed write due to one host disappearing.
    Trying rule: 5736 - sshd: Connection reset or aborted.
    Trying rule: 5750 - sshd: could not negotiate with client.
    Trying rule: 5756 - sshd: subsystem request failed.
    Trying rule: 5707 - sshd: OpenSSH challenge-response exploit.
    Trying rule: 5701 - sshd: Possible attack on the ssh server (or version gathering).
    Trying rule: 5706 - sshd: insecure connection attempt (scan).
    Trying rule: 5713 - sshd: Corrupted bytes on SSHD.
    Trying rule: 5731 - sshd: SSH Scanning.
    Trying rule: 5747 - sshd: bad client public DH value
    Trying rule: 5748 - sshd: corrupted MAC on input
    Trying rule: 5702 - sshd: Reverse lookup error (bad ISP or attack).
    Trying rule: 5710 - sshd: Attempt to login using a non-existent user
       *Rule 5710 matched.
       *Trying child rules.
    Trying rule: 5712 - sshd: brute force trying to get access to the system.
    Trying rule: 40111 - Multiple authentication failures.
    Trying rule: 60204 - Multiple Windows Logon Failures

**Phase 3: Completed filtering (rules).
       Rule id: '5710'
       Level: '5'
       Description: 'sshd: Attempt to login using a non-existent user'
**Alert to be generated.
```

## Json request
The following structure will be used for this new mode:
```
{
      "version": 1,
      "origin": {
          "name": "Integration Test",
          "module": "api"
      },
      "command": "log_processing",
      "parameters": {
          "event": "Oct 15 21:06:59 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928",
          "location": "master->/var/log/syslog",
          "log_format": "syslog",
          "options" : {
            "rule_debug": true
          }
      }
  }
  ```

## Logs/Alerts example
We can see a similar output to the previous binary when we launch `/var/ossec/bin/wazuh-logtest -v`:
```
a# echo "Oct 15 21:06:59 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928" | /var/ossec/bin/wazuh-logtest -v

Starting wazuh-logtest v4.3.0
Type one log per line

**Phase 1: Completed pre-decoding.
	full event: 'Oct 15 21:06:59 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928'
	timestamp: 'Oct 15 21:06:59'
	hostname: 'linux-agent'
	program_name: 'sshd'

**Phase 2: Completed decoding.
	name: 'sshd'
	parent: 'sshd'
	srcip: '18.18.18.18'
	srcport: '48928'
	srcuser: 'blimey'

**Rule debugging:
    Trying rule: 1 - Generic template for all syslog rules.
       *Rule 1 matched.
       *Trying child rules.
    Trying rule: 600 - Active Response Messages Grouped
    Trying rule: 650 - Active Response JSON Messages Grouped
    Trying rule: 200 - Grouping of wazuh rules.
    Trying rule: 2100 - NFS rules grouped.
    Trying rule: 2507 - OpenLDAP group.
    Trying rule: 2550 - rshd messages grouped.
    Trying rule: 2701 - Ignoring procmail messages.
    Trying rule: 2800 - Pre-match rule for smartd.
    Trying rule: 5100 - Pre-match rule for kernel messages.
    Trying rule: 5200 - Ignoring hpiod for producing useless logs.
    Trying rule: 2830 - Crontab rule group.
    Trying rule: 5300 - Initial grouping for su messages.
    Trying rule: 5905 - useradd failed.
    Trying rule: 5400 - Initial group for sudo messages.
    Trying rule: 9100 - PPTPD messages grouped.
    Trying rule: 9200 - Squid syslog messages grouped.
    Trying rule: 2900 - Dpkg (Debian Package) log.
    Trying rule: 2930 - Yum logs.
    Trying rule: 2931 - Yum logs.
    Trying rule: 2940 - NetworkManager grouping.
    Trying rule: 2943 - nouveau driver grouping.
    Trying rule: 2962 - Perdition custom app group.
    Trying rule: 3100 - Grouping of the sendmail rules.
    Trying rule: 3190 - Grouping of the smf-sav sendmail milter rules.
    Trying rule: 3300 - Grouping of the postfix reject rules.
    Trying rule: 3320 - Grouping of the postfix rules.
    Trying rule: 3390 - Grouping of the clamsmtpd rules.
    Trying rule: 3395 - Grouping of the postfix warning rules.
    Trying rule: 3500 - Grouping for the spamd rules
    Trying rule: 3600 - Grouping of the imapd rules.
    Trying rule: 3700 - Grouping of mailscanner rules.
    Trying rule: 3800 - Grouping of Exchange rules.
    Trying rule: 3900 - Grouping for the courier rules.
    Trying rule: 4500 - Grouping for the Netscreen Firewall rules
    Trying rule: 4700 - Grouping of Cisco IOS rules
    Trying rule: 4800 - SonicWall messages grouped.
    Trying rule: 5500 - Grouping of the pam_unix rules.
    Trying rule: 5556 - unix_chkpwd grouping.
    Trying rule: 5600 - Grouping for the telnetd rules
    Trying rule: 5700 - SSHD messages grouped.
       *Rule 5700 matched.
       *Trying child rules.
    Trying rule: 5709 - sshd: Useless SSHD message without an user/ip and context.
    Trying rule: 5711 - sshd: Useless/Duplicated SSHD message without a user/ip.
    Trying rule: 5721 - sshd: System disconnected from sshd.
    Trying rule: 5722 - sshd: ssh connection closed.
    Trying rule: 5723 - sshd: key error.
    Trying rule: 5724 - sshd: key error.
    Trying rule: 5725 - sshd: Host ungracefully disconnected.
    Trying rule: 5727 - sshd: Attempt to start sshd when something already bound to the port.
    Trying rule: 5729 - sshd: Debug message.
    Trying rule: 5732 - sshd: Possible port forwarding failure.
    Trying rule: 5733 - sshd: User entered incorrect password.
    Trying rule: 5734 - sshd: sshd could not load one or more host keys.
    Trying rule: 5735 - sshd: Failed write due to one host disappearing.
    Trying rule: 5736 - sshd: Connection reset or aborted.
    Trying rule: 5750 - sshd: could not negotiate with client.
    Trying rule: 5756 - sshd: subsystem request failed.
    Trying rule: 5707 - sshd: OpenSSH challenge-response exploit.
    Trying rule: 5701 - sshd: Possible attack on the ssh server (or version gathering).
    Trying rule: 5706 - sshd: insecure connection attempt (scan).
    Trying rule: 5713 - sshd: Corrupted bytes on SSHD.
    Trying rule: 5731 - sshd: SSH Scanning.
    Trying rule: 5747 - sshd: bad client public DH value
    Trying rule: 5748 - sshd: corrupted MAC on input
    Trying rule: 5702 - sshd: Reverse lookup error (bad ISP or attack).
    Trying rule: 5710 - sshd: Attempt to login using a non-existent user
       *Rule 5710 matched.
       *Trying child rules.
    Trying rule: 5712 - sshd: brute force trying to get access to the system.
    Trying rule: 40111 - Multiple authentication failures.
    Trying rule: 60204 - Multiple Windows Logon Failures


**Phase 3: Completed filtering (rules).
	id: '5710'
	level: '5'
	description: 'sshd: Attempt to login using a non-existent user'
	groups: '['syslog', 'sshd', 'invalid_login', 'authentication_failed']'
	firedtimes: '1'
	gdpr: '['IV_35.7.d', 'IV_32.2']'
	gpg13: '['7.1']'
	hipaa: '['164.312.b']'
	mail: 'False'
	mitre.id: '['T1110']'
	mitre.tactic: '['Credential Access']'
	mitre.technique: '['Brute Force']'
	nist_800_53: '['AU.14', 'AC.7', 'AU.6']'
	pci_dss: '['10.2.4', '10.2.5', '10.6.1']'
	tsc: '['CC6.1', 'CC6.8', 'CC7.2', 'CC7.3']'
**Alert to be generated.
```

## Tests
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
