### PR TITLE
Add context variable to indicate origin module in socket messages

### DIFF
--- a/framework/wazuh/core/active_response.py
+++ b/framework/wazuh/core/active_response.py
@@ -8,8 +8,8 @@ from wazuh.core.agent import Agent
 from wazuh.core.cluster.cluster import get_node
 from wazuh.core.cluster.utils import read_cluster_config
 from wazuh.core.exception import WazuhError
-from wazuh.core.wazuh_queue import WazuhQueue
 from wazuh.core.utils import WazuhVersion
+from wazuh.core.wazuh_queue import WazuhQueue
 from wazuh.core.wazuh_socket import create_wazuh_socket_message
 
 
@@ -81,7 +81,8 @@ def create_json_message(command: str = '', arguments: list = None, alert: dict =
     node_name = get_node().get('node') if cluster_enabled else None
 
     msg_queue = json.dumps(
-        create_wazuh_socket_message(origin={'name': node_name, 'module': 'api/framework'}, command=command,
+        create_wazuh_socket_message(origin={'name': node_name, 'module': common.origin_module.get()},
+                                    command=command,
                                     parameters={'extra_args': arguments if arguments else [],
                                                 'alert': alert if alert else {}}))
 

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -41,7 +41,8 @@ class DistributedAPI:
                  debug: bool = False, request_type: str = 'local_master', current_user: str = '',
                  wait_for_complete: bool = False, from_cluster: bool = False, is_async: bool = False,
                  broadcasting: bool = False, basic_services: tuple = None, local_client_arg: str = None,
-                 rbac_permissions: Dict = None, nodes: list = None, api_timeout: int = None):
+                 rbac_permissions: Dict = None, nodes: list = None, api_timeout: int = None,
+                 origin_module: str = 'api'):
         """Class constructor.
 
         Parameters
@@ -78,6 +79,8 @@ class DistributedAPI:
             User who started the request
         api_timeout : int
             Timeout set in source API for the request
+        origin_module : str
+            Origin module that created the DistributedAPI object. This value can be api or framework. Default `api`
         """
         self.logger = logger
         self.f = f
@@ -93,6 +96,7 @@ class DistributedAPI:
         self.broadcasting = broadcasting
         self.rbac_permissions = rbac_permissions if rbac_permissions is not None else {'rbac_mode': 'black'}
         self.current_user = current_user
+        self.origin_module = origin_module
         self.nodes = nodes if nodes is not None else list()
         if not basic_services:
             self.basic_services = ('wazuh-modulesd', 'wazuh-analysisd', 'wazuh-execd', 'wazuh-db')
@@ -229,6 +233,7 @@ class DistributedAPI:
             common.broadcast.set(self.broadcasting)
             common.cluster_nodes.set(self.nodes)
             common.current_user.set(self.current_user)
+            common.origin_module.set(self.origin_module)
             data = self.f(**self.f_kwargs)
             common.reset_context_cache()
             self.debug_log("Finished executing request locally")

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -41,8 +41,7 @@ class DistributedAPI:
                  debug: bool = False, request_type: str = 'local_master', current_user: str = '',
                  wait_for_complete: bool = False, from_cluster: bool = False, is_async: bool = False,
                  broadcasting: bool = False, basic_services: tuple = None, local_client_arg: str = None,
-                 rbac_permissions: Dict = None, nodes: list = None, api_timeout: int = None,
-                 origin_module: str = 'api'):
+                 rbac_permissions: Dict = None, nodes: list = None, api_timeout: int = None):
         """Class constructor.
 
         Parameters
@@ -79,8 +78,6 @@ class DistributedAPI:
             User who started the request
         api_timeout : int
             Timeout set in source API for the request
-        origin_module : str
-            Origin module that created the DistributedAPI object. This value can be api or framework. Default `api`
         """
         self.logger = logger
         self.f = f
@@ -96,7 +93,7 @@ class DistributedAPI:
         self.broadcasting = broadcasting
         self.rbac_permissions = rbac_permissions if rbac_permissions is not None else {'rbac_mode': 'black'}
         self.current_user = current_user
-        self.origin_module = origin_module
+        self.origin_module = 'API'
         self.nodes = nodes if nodes is not None else list()
         if not basic_services:
             self.basic_services = ('wazuh-modulesd', 'wazuh-analysisd', 'wazuh-execd', 'wazuh-db')

--- a/framework/wazuh/core/cluster/utils.py
+++ b/framework/wazuh/core/cluster/utils.py
@@ -18,9 +18,9 @@ from wazuh.core import common
 from wazuh.core.configuration import get_ossec_conf
 from wazuh.core.exception import WazuhException, WazuhError, WazuhInternalError
 from wazuh.core.results import WazuhResult
+from wazuh.core.utils import temporary_cache
 from wazuh.core.wazuh_socket import create_wazuh_socket_message
 from wazuh.core.wlogging import WazuhLogger
-from wazuh.core.utils import temporary_cache
 
 logger = logging.getLogger('wazuh')
 execq_lockfile = join(common.wazuh_path, "var/run/.api_execq_lock")
@@ -168,7 +168,7 @@ def manager_restart() -> WazuhResult:
         # execq socket path
         socket_path = common.EXECQ
         # json msg for restarting Wazuh manager
-        msg = json.dumps(create_wazuh_socket_message(origin={'module': 'api/framework'},
+        msg = json.dumps(create_wazuh_socket_message(origin={'module': common.origin_module.get()},
                                                      command=common.RESTART_WAZUH_COMMAND,
                                                      parameters={'extra_args': [], 'alert': {}}))
         # initialize socket

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -215,6 +215,7 @@ current_user: ContextVar[str] = ContextVar('current_user', default='')
 broadcast: ContextVar[bool] = ContextVar('broadcast', default=False)
 cluster_nodes: ContextVar[list] = ContextVar('cluster_nodes', default=list())
 cluster_integrity_mtime: ContextVar[Dict] = ContextVar('cluster_integrity_mtime', default={})
+origin_module: ContextVar[str] = ContextVar('origin_module', default='framework')
 
 _context_cache = dict()
 

--- a/framework/wazuh/core/logtest.py
+++ b/framework/wazuh/core/logtest.py
@@ -2,7 +2,7 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-from wazuh.core.common import LOGTEST_SOCKET
+from wazuh.core.common import LOGTEST_SOCKET, origin_module
 from wazuh.core.wazuh_socket import WazuhSocketJSON, create_wazuh_socket_message
 
 
@@ -21,7 +21,7 @@ def send_logtest_msg(command: str = None, parameters: dict = None):
     dict
         Response from the logtest socket.
     """
-    full_message = create_wazuh_socket_message(origin={'name': 'Logtest', 'module': 'api/framework'},
+    full_message = create_wazuh_socket_message(origin={'name': 'Logtest', 'module': origin_module.get()},
                                                command=command,
                                                parameters=parameters)
     logtest_socket = WazuhSocketJSON(LOGTEST_SOCKET)

--- a/framework/wazuh/core/tests/test_logtest.py
+++ b/framework/wazuh/core/tests/test_logtest.py
@@ -32,6 +32,6 @@ def test_send_logtest_msg(create_message_mock, close_mock, send_mock, init_mock,
     with patch('wazuh.core.logtest.WazuhSocketJSON.receive', return_value=expected_response):
         response = send_logtest_msg(**params)
         init_mock.assert_called_with(LOGTEST_SOCKET)
-        create_message_mock.assert_called_with(origin={'name': 'Logtest', 'module': 'api/framework'}, **params)
+        create_message_mock.assert_called_with(origin={'name': 'Logtest', 'module': 'framework'}, **params)
         assert response == expected_response
 

--- a/framework/wazuh/core/wazuh_queue.py
+++ b/framework/wazuh/core/wazuh_queue.py
@@ -5,6 +5,7 @@
 import json
 import socket
 
+from wazuh.core.common import origin_module
 from wazuh.core.exception import WazuhInternalError, WazuhError
 from wazuh.core.wazuh_socket import create_wazuh_socket_message
 
@@ -42,7 +43,7 @@ class WazuhQueue:
     HC_SK_RESTART = "syscheck restart"  # syscheck restart
     HC_FORCE_RECONNECT = "force_reconnect"  # force reconnect command
     RESTART_AGENTS = "restart-ossec0"  # Agents, not manager (000)
-    RESTART_AGENTS_JSON = json.dumps(create_wazuh_socket_message(origin={'module': 'api/framework'},
+    RESTART_AGENTS_JSON = json.dumps(create_wazuh_socket_message(origin={'module': origin_module.get()},
                                                                  command="restart-wazuh0",
                                                                  parameters={"extra_args": [],
                                                                              "alert": {}}))  # Agents, not manager (000)


### PR DESCRIPTION
|Related issue|
|---|
| #7368 |

Hi team,

This PR closes #7368.

In this Pull request I have added a new context variable to `wazuh/core/common.py` to indicate if the wazuh socket messages created come from the **API** or from the **framework** module. 

This is used to delete the hardcoded variables when creating this messages.


For instance, when we try to restart agents, the following message is created and sent to its correspondant socket:

```
msg_queue = json.dumps(
        create_wazuh_socket_message(origin={'name': node_name, 'module': common.origin_module.get()},
                                    command=command,
                                    parameters={'extra_args': arguments if arguments else [],
                                                'alert': alert if alert else {}}))
```
                                                
If this request is called from the Wazuh API, the message will be the following:

`{"version": 1, "origin": {"name": "master-node", "module": "API"}, "command": "restart-ossec0", "parameters": {"extra_args": [], "alert": {}}}`

If the request is called from the framework itself (using the embedded python interpreter), the following message is created:

`{"version": 1, "origin": {"name": "master-node", "module": "framework"}, "command": "restart-ossec0", "parameters": {"extra_args": [], "alert": {}}}`


I have also reviewed unit tests and API integration tests:

```
framework/wazuh/core/tests/
============= 678 passed, 9 warnings in 4.07s =============

framework/wazuh/tests/
============= 598 passed, 13 warnings in 57.93s =============
```

Regards,
Manuel.
