### PR TITLE
Fix run_realtime.c message according to wazuh renaming

### DIFF
--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -175,7 +175,7 @@ void realtime_process() {
         if (event->wd == -1 && event->mask == IN_Q_OVERFLOW) {
             mwarn("Real-time inotify kernel queue is full. Some events may be lost. Next scheduled scan will recover lost data.");
             syscheck.realtime->queue_overflow = true;
-            send_log_msg("ossec: Real-time inotify kernel queue is full. Some events may be lost. Next scheduled scan will recover lost data.");
+            send_log_msg("wazuh: Real-time inotify kernel queue is full. Some events may be lost. Next scheduled scan will recover lost data.");
             continue;
         }
 


### PR DESCRIPTION
## Description

This PR adds some changes that have been lost on the 5.0-dev branch for file `run_realtime.c`. This changes are part of #6867 (changes [here](https://github.com/wazuh/wazuh/pull/6867/files#diff-c74ca6ce38dfd1eb1051dcbacafb750b3840894a28a6405dde90b78aee1add44))

https://github.com/wazuh/wazuh/blob/b298ff8add782db078a845b79a47e02cb6e33565/src/syscheckd/run_realtime.c#L156




Regards,
Nico