### PR TITLE
Modify XML parser to correlate SUSE packages with their dependencies

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -100,6 +100,7 @@ int wm_vuldet_insert_ALAS(sqlite3 *db, vu_alas_vuln *vul_it, const char *target)
 vu_alas_pkg *wm_vuldet_packages_parser(char *pkg);
 int wm_vuldet_json_alas_parser(cJSON *json_feed, wm_vuldet_db *parsed_vulnerabilities);
 void wm_vuldet_free_alas_pkg(vu_alas_pkg **alas_pkg);
+void wm_vuldet_update_dependency_list_suse(const xml_node *dependency_node, wm_vuldet_db *parsed_oval);
 
 /* setup/teardown */
 
@@ -11738,6 +11739,118 @@ void test_wm_vuldet_json_fread_not_compressed_ok(void **state)
     assert_ptr_equal(res, content);
 }
 
+// Tests wm_vuldet_update_dependency_list_suse
+
+void test_wm_vuldet_update_dependency_list_suse_NULL_attribute(void **state)
+{
+    xml_node        criterion_dep;
+    wm_vuldet_db    parsed_oval;
+
+    os_calloc(1, sizeof(xml_node *), criterion_dep.attributes);
+    os_calloc(1, sizeof(vulnerability), parsed_oval.vulnerabilities);
+    parsed_oval.suse_deps = NULL;
+
+    wm_vuldet_update_dependency_list_suse(&criterion_dep, &parsed_oval);
+
+    assert_string_equal("", parsed_oval.suse_deps->test_ref[0]);
+    assert_string_equal("", parsed_oval.vulnerabilities->deps->test_ref[0]);
+    assert_int_equal(1, parsed_oval.suse_deps->elements);
+    assert_int_equal(1, parsed_oval.vulnerabilities->deps->elements);
+
+    os_free(parsed_oval.suse_deps->test_ref[0]);
+    os_free(parsed_oval.suse_deps->test_ref);
+    os_free(parsed_oval.suse_deps);
+    os_free(parsed_oval.vulnerabilities->deps->test_ref);
+    os_free(parsed_oval.vulnerabilities->deps);
+    os_free(criterion_dep.attributes);
+    os_free(parsed_oval.vulnerabilities);
+}
+
+void test_wm_vuldet_update_dependency_list_suse_valid_criterion(void **state)
+{
+    xml_node        criterion_dep;
+    wm_vuldet_db    parsed_oval;
+
+    os_calloc(1, sizeof(xml_node *), criterion_dep.attributes);
+    os_calloc(1, sizeof(xml_node *), criterion_dep.values);
+    os_strdup("test_ref", criterion_dep.attributes[0]);
+    os_strdup("oval:org.opensuse.security:tst:2009117401", criterion_dep.values[0]);
+    os_calloc(1, sizeof(vulnerability), parsed_oval.vulnerabilities);
+    parsed_oval.suse_deps = NULL;
+
+    wm_vuldet_update_dependency_list_suse(&criterion_dep, &parsed_oval);
+
+    assert_string_equal("oval:org.opensuse.security:tst:2009117401", parsed_oval.suse_deps->test_ref[0]);
+    assert_string_equal("oval:org.opensuse.security:tst:2009117401", parsed_oval.vulnerabilities->deps->test_ref[0]);
+    assert_int_equal(1, parsed_oval.suse_deps->elements);
+    assert_int_equal(1, parsed_oval.vulnerabilities->deps->elements);
+
+    os_free(parsed_oval.suse_deps->test_ref[0]);
+    os_free(parsed_oval.suse_deps->test_ref);
+    os_free(parsed_oval.suse_deps);
+    os_free(parsed_oval.vulnerabilities->deps->test_ref);
+    os_free(parsed_oval.vulnerabilities->deps);
+    os_free(criterion_dep.attributes[0]);
+    os_free(criterion_dep.attributes);
+    os_free(criterion_dep.values[0]);
+    os_free(criterion_dep.values);
+    os_free(parsed_oval.vulnerabilities);
+}
+
+void test_wm_vuldet_update_dependency_list_suse_several_items(void **state)
+{
+    xml_node        criterion_dep;
+    wm_vuldet_db    parsed_oval;
+
+    os_calloc(1, sizeof(xml_node *), criterion_dep.attributes);
+    os_calloc(1, sizeof(xml_node *), criterion_dep.values);
+    os_strdup("test_ref", criterion_dep.attributes[0]);
+    os_strdup("oval:org.opensuse.security:tst:2009117401", criterion_dep.values[0]);
+    os_calloc(1, sizeof(vulnerability), parsed_oval.vulnerabilities);
+    parsed_oval.suse_deps = NULL;
+
+    wm_vuldet_update_dependency_list_suse(&criterion_dep, &parsed_oval);
+
+    assert_string_equal("oval:org.opensuse.security:tst:2009117401", parsed_oval.suse_deps->test_ref[0]);
+    assert_string_equal("oval:org.opensuse.security:tst:2009117401", parsed_oval.vulnerabilities->deps->test_ref[0]);
+    assert_int_equal(1, parsed_oval.suse_deps->elements);
+    assert_int_equal(1, parsed_oval.vulnerabilities->deps->elements);
+
+    wm_vuldet_update_dependency_list_suse(&criterion_dep, &parsed_oval);
+
+    assert_int_equal(1, parsed_oval.suse_deps->elements);
+    assert_int_equal(2, parsed_oval.vulnerabilities->deps->elements);
+    assert_string_equal("oval:org.opensuse.security:tst:2009117401", parsed_oval.vulnerabilities->deps->test_ref[1]);
+
+    os_free(criterion_dep.values[0]);
+    os_strdup("oval:org.opensuse.security:tst:2009117400", criterion_dep.values[0]);
+
+    wm_vuldet_update_dependency_list_suse(&criterion_dep, &parsed_oval);
+
+    assert_string_equal("oval:org.opensuse.security:tst:2009117400", parsed_oval.suse_deps->test_ref[1]);
+    assert_string_equal("oval:org.opensuse.security:tst:2009117400", parsed_oval.vulnerabilities->deps->test_ref[2]);
+    assert_int_equal(2, parsed_oval.suse_deps->elements);
+    assert_int_equal(3, parsed_oval.vulnerabilities->deps->elements);
+
+    wm_vuldet_update_dependency_list_suse(&criterion_dep, &parsed_oval);
+
+    assert_int_equal(2, parsed_oval.suse_deps->elements);
+    assert_int_equal(4, parsed_oval.vulnerabilities->deps->elements);
+    assert_string_equal("oval:org.opensuse.security:tst:2009117400", parsed_oval.vulnerabilities->deps->test_ref[3]);
+
+    os_free(parsed_oval.suse_deps->test_ref[0]);
+    os_free(parsed_oval.suse_deps->test_ref[1]);
+    os_free(parsed_oval.suse_deps->test_ref);
+    os_free(parsed_oval.suse_deps);
+    os_free(parsed_oval.vulnerabilities->deps->test_ref);
+    os_free(parsed_oval.vulnerabilities->deps);
+    os_free(criterion_dep.attributes[0]);
+    os_free(criterion_dep.attributes);
+    os_free(criterion_dep.values[0]);
+    os_free(criterion_dep.values);
+    os_free(parsed_oval.vulnerabilities);
+}
+
 // Tests wm_vuldet_oval_xml_preparser
 
 void test_wm_vuldet_oval_xml_preparser_invalid_open(void **state)
@@ -15250,7 +15363,12 @@ void test_wm_vuldet_oval_xml_parser_suse_criterion_skip() {
     int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
     assert_int_equal(ret, 0);
 
+    os_free(parsed_oval->vulnerabilities->deps->test_ref[0]);
+    os_free(parsed_oval->vulnerabilities->deps->test_ref);
+    os_free(parsed_oval->vulnerabilities->deps);
     os_free(parsed_oval->vulnerabilities);
+    os_free(parsed_oval->suse_deps->test_ref);
+    os_free(parsed_oval->suse_deps);
     os_free(parsed_oval);
     OS_ClearNode(node);
     os_free(update);
@@ -20346,6 +20464,10 @@ int main(void)
         cmocka_unit_test(test_wm_vuldet_json_fread_uncompress_fail),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_json_fread_compressed_removing_error, setup_group, teardown_group),
         cmocka_unit_test(test_wm_vuldet_json_fread_not_compressed_ok),
+        // Tests wm_vuldet_update_dependency_list
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_update_dependency_list_suse_NULL_attribute, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_update_dependency_list_suse_several_items, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_update_dependency_list_suse_valid_criterion, setup_group, teardown_group),
         // Tests wm_vuldet_oval_xml_preparser
         cmocka_unit_test_setup_teardown(test_wm_vuldet_oval_xml_preparser_invalid_open, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_oval_xml_preparser_invalid_tmp_open, setup_group, teardown_group),

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -15027,6 +15027,100 @@ void test_wm_vuldet_oval_xml_parser_rhel_architecture_noarch()
 
 // wm_vuldet_oval_xml_parser (SUSE)
 
+void test_wm_vuldet_oval_xml_parser_suse_criterion_assign_dependencies()
+{
+    XML_NODE node = NULL;
+    XML_NODE child_node = NULL;
+    update_node *update = NULL;
+    wm_vuldet_db *parsed_oval = NULL;
+    dependencies deps;
+
+    os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
+    os_calloc(1, sizeof(vulnerability), parsed_oval->vulnerabilities);
+    os_calloc(1, sizeof(char *), deps.test_ref);
+
+    deps.elements = 1;
+    os_strdup("test", deps.test_ref[0]);
+    parsed_oval->vulnerabilities->deps = &deps;
+
+    //create xml node
+    os_calloc(2, sizeof(xml_node *), node);
+    os_calloc(1, sizeof(xml_node), *node);
+    os_calloc(3, sizeof(char *), node[0]->attributes);
+    os_calloc(3, sizeof(char *), node[0]->values);
+    os_strdup("test_ref", node[0]->attributes[0]);
+    os_strdup("test_ref", node[0]->attributes[1]);
+    os_strdup("value_ref", node[0]->values[0]);
+    os_strdup("value_ref1", node[0]->values[1]);
+    os_strdup("criterion", node[0]->element);
+    parsed_oval->vulnerabilities->cve_id = "CVE-id";
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_ref = FEED_SUSE;
+
+    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    assert_int_equal(ret, 0);
+    assert_string_equal("test", parsed_oval->vulnerabilities->deps->test_ref[0]);
+    assert_int_equal(1, parsed_oval->vulnerabilities->deps->elements);
+    assert_string_equal("test", parsed_oval->vulnerabilities->prev->deps->test_ref[0]);
+    assert_int_equal(1, parsed_oval->vulnerabilities->prev->deps->elements);
+    assert_string_equal(node[0]->values[1], parsed_oval->vulnerabilities->state_id);
+
+    os_free(parsed_oval->vulnerabilities->prev->state_id);
+    os_free(parsed_oval->vulnerabilities->state_id);
+    os_free(parsed_oval->vulnerabilities->cve_id);
+    os_free(parsed_oval->vulnerabilities->prev->deps->test_ref);
+    os_free(parsed_oval->vulnerabilities->prev);
+    os_free(parsed_oval->vulnerabilities->deps->test_ref[0]);
+    os_free(parsed_oval->vulnerabilities->deps->test_ref);
+    os_free(parsed_oval->vulnerabilities->deps);
+    os_free(parsed_oval->vulnerabilities);
+    os_free(parsed_oval);
+    OS_ClearNode(node);
+    os_free(update);
+}
+
+void test_wm_vuldet_oval_xml_parser_suse_criterion_test_ref_null_dependencies()
+{
+    XML_NODE node = NULL;
+    XML_NODE child_node = NULL;
+    update_node *update = NULL;
+    wm_vuldet_db *parsed_oval = NULL;
+
+    os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
+    os_calloc(1, sizeof(vulnerability), parsed_oval->vulnerabilities);
+
+    //create xml node
+    os_calloc(2, sizeof(xml_node *), node);
+    os_calloc(1, sizeof(xml_node), *node);
+    os_calloc(3, sizeof(char *), node[0]->attributes);
+    os_calloc(3, sizeof(char *), node[0]->values);
+    os_strdup("test_ref", node[0]->attributes[0]);
+    os_strdup("test_ref", node[0]->attributes[1]);
+    os_strdup("value_ref", node[0]->values[0]);
+    os_strdup("value_ref1", node[0]->values[1]);
+    os_strdup("criterion", node[0]->element);
+    parsed_oval->vulnerabilities->cve_id = "CVE-id";
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_ref = FEED_SUSE;
+
+    int ret = wm_vuldet_oval_xml_parser(NULL, node, parsed_oval, update, 0);
+    assert_int_equal(ret, 0);
+    assert_string_equal(node[0]->values[1], parsed_oval->vulnerabilities->state_id);
+    assert_null(parsed_oval->vulnerabilities->deps);
+    assert_null(parsed_oval->vulnerabilities->prev->deps);
+
+    os_free(parsed_oval->vulnerabilities->prev->state_id);
+    os_free(parsed_oval->vulnerabilities->state_id);
+    os_free(parsed_oval->vulnerabilities->cve_id);
+    os_free(parsed_oval->vulnerabilities->prev);
+    os_free(parsed_oval->vulnerabilities);
+    os_free(parsed_oval);
+    OS_ClearNode(node);
+    os_free(update);
+}
+
 void test_wm_vuldet_oval_xml_parser_suse_state() {
     XML_NODE node = NULL;
     update_node *update = NULL;
@@ -20552,6 +20646,8 @@ int main(void)
         cmocka_unit_test(test_wm_vuldet_oval_xml_parser_rhel_architecture_equals),
         cmocka_unit_test(test_wm_vuldet_oval_xml_parser_rhel_architecture_pattern),
         cmocka_unit_test(test_wm_vuldet_oval_xml_parser_rhel_architecture_noarch),
+        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_suse_criterion_assign_dependencies),
+        cmocka_unit_test(test_wm_vuldet_oval_xml_parser_suse_criterion_test_ref_null_dependencies),
         cmocka_unit_test(test_wm_vuldet_oval_xml_parser_suse_state),
         cmocka_unit_test(test_wm_vuldet_oval_xml_parser_suse_test),
         cmocka_unit_test(test_wm_vuldet_oval_xml_parser_suse_object),

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -64,12 +64,12 @@ STATIC void wm_vuldet_oval_append_rhsa(vulnerability *vul_it, char *cve);
 STATIC void wm_vuldet_oval_copy_rhsa(vulnerability *old, vulnerability *new);
 
 /**
- * @brief Update the list of dependencies needed to scan SUSE vulnerabilities
- * @param dep_id ID of the dependency
+ * @brief Update the list of dependencies needed to properly detect SUSE vulnerabilities.
+ * @param dependency_node XML node containing the SUSE dependency.
  * @param parsed_oval Parsed oval data strucure.
  *
  */
-STATIC void wm_vuldet_update_dependency_list_suse(const char *dep_id, wm_vuldet_db *parsed_oval);
+STATIC void wm_vuldet_update_dependency_list_suse(const xml_node *dependency_node, wm_vuldet_db *parsed_oval);
 
 STATIC int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_oval, update_node *update, vu_logic condition);
 STATIC int wm_vuldet_json_parser(char *json_path, wm_vuldet_db *uparsed_vulnerabilities, update_node *update);
@@ -2802,7 +2802,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
         free(vul_aux->package_name);
         os_free(vul_aux->package_version);
         if (vul_aux->deps) {
-            os_free(vul_aux->deps->values);
+            os_free(vul_aux->deps->test_ref);
             os_free(vul_aux->deps);
         }
         free(vul_aux);
@@ -3334,27 +3334,39 @@ void wm_vuldet_oval_append_rhsa(vulnerability *vul_it, char *cve) {
     index++;
 }
 
-void wm_vuldet_update_dependency_list_suse(const char *dep_id, wm_vuldet_db *parsed_oval) {
+void wm_vuldet_update_dependency_list_suse(const xml_node *criterion_dep, wm_vuldet_db *parsed_oval) {
+    const char *dependency_id = "";
     int i = 0;
 
+    for (int j = 0; criterion_dep->attributes[j]; j++) {
+        if (!strcmp(criterion_dep->attributes[j], "test_ref")) {
+            dependency_id = criterion_dep->attributes[j];
+            break;
+        }
+    }
+    /*
+    * Though still empty, we use the current vulnerability structure as a placeholder for all the
+    * dependencies affecting the current <criteria operator="AND"> node.
+    * This structure will later be assigned to each one of the affected vulnerabilities inside this node.
+    */
     if (!parsed_oval->vulnerabilities->deps) {
-        os_calloc(1, sizeof(references), parsed_oval->vulnerabilities->deps);
-        os_calloc(1, sizeof(char *), parsed_oval->vulnerabilities->deps->values);
+        os_calloc(1, sizeof(dependencies), parsed_oval->vulnerabilities->deps);
+        os_calloc(1, sizeof(char *), parsed_oval->vulnerabilities->deps->test_ref);
         parsed_oval->vulnerabilities->deps->elements = 1;
     } else {
         parsed_oval->vulnerabilities->deps->elements++;
-        os_realloc(parsed_oval->vulnerabilities->deps->values, parsed_oval->vulnerabilities->deps->elements *
-        sizeof(char *), parsed_oval->vulnerabilities->deps->values);
+        os_realloc(parsed_oval->vulnerabilities->deps->test_ref, parsed_oval->vulnerabilities->deps->elements *
+        sizeof(char *), parsed_oval->vulnerabilities->deps->test_ref);
     }
 
     if (!parsed_oval->suse_deps) {
-        os_calloc(1, sizeof(references), parsed_oval->suse_deps);
+        os_calloc(1, sizeof(dependencies), parsed_oval->suse_deps);
         parsed_oval->suse_deps->elements = 0;
-        parsed_oval->suse_deps->values = NULL;
+        parsed_oval->suse_deps->test_ref = NULL;
     } else {
         // Scroll through the array of dependencies to check if the ID is already inside
         for (; i < parsed_oval->suse_deps->elements; i++) {
-            if (!(strcmp(dep_id, parsed_oval->suse_deps->values[i]))) {
+            if (!(strcmp(dependency_id, parsed_oval->suse_deps->test_ref[i]))) {
                 break;
             }
         }
@@ -3363,12 +3375,12 @@ void wm_vuldet_update_dependency_list_suse(const char *dep_id, wm_vuldet_db *par
     // Check if the loop has scrolled through the whole array
     if (i == parsed_oval->suse_deps->elements) {
         parsed_oval->suse_deps->elements++,
-        os_realloc(parsed_oval->suse_deps->values, sizeof(char *) * parsed_oval->suse_deps->elements, parsed_oval->suse_deps->values);
-        os_strdup(dep_id, parsed_oval->suse_deps->values[i]);
+        os_realloc(parsed_oval->suse_deps->test_ref, sizeof(char *) * parsed_oval->suse_deps->elements, parsed_oval->suse_deps->test_ref);
+        os_strdup(dependency_id, parsed_oval->suse_deps->test_ref[i]);
     }
 
-    // Assign the current dependency to the array of dependencies of the current package
-    parsed_oval->vulnerabilities->deps->values[parsed_oval->vulnerabilities->deps->elements - 1] = parsed_oval->suse_deps->values[i];
+    // Assign this dependency to the dependency array of the current vulnerability structure
+    parsed_oval->vulnerabilities->deps->test_ref[parsed_oval->vulnerabilities->deps->elements - 1] = parsed_oval->suse_deps->test_ref[i];
 }
 
 int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_oval, update_node *update, vu_logic condition) {
@@ -3763,7 +3775,7 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
                          * as dependencies for each vulnerability
                         */
                         if (!strncmp(node[i]->values[j], "SUSE Linux Enterprise", 21)) {
-                            wm_vuldet_update_dependency_list_suse(node[i]->values[j - 1], parsed_oval);
+                            wm_vuldet_update_dependency_list_suse(node[i], parsed_oval);
                             skip_package = true;
                             break;
                         }
@@ -3795,14 +3807,15 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
                     if (dist == FEED_SUSE && !parsed_oval->vulnerabilities->deps && parsed_oval->vulnerabilities->prev 
                         && parsed_oval->vulnerabilities->prev->deps) {
                         /*
-                        * The dependencies list for SUSE vulnerabilities is only filled for the first package of each 'AND' operator
-                        * so it has to be copied for subsequent vulnerabilities
+                        * The dependency list for SUSE vulnerabilities is only filled for the first package
+                        * of each <criteria operator="AND"> node.
+                        * This structure is then copied for subsequent vulnerabilities.
                         */
                         int elements = parsed_oval->vulnerabilities->prev->deps->elements;
-                        os_calloc(1, sizeof(references), parsed_oval->vulnerabilities->deps);
-                        os_calloc(elements, sizeof(char *), parsed_oval->vulnerabilities->deps->values);
+                        os_calloc(1, sizeof(dependencies), parsed_oval->vulnerabilities->deps);
+                        os_calloc(elements, sizeof(char *), parsed_oval->vulnerabilities->deps->test_ref);
                         for (int i = 0; i < elements; i++) {
-                            parsed_oval->vulnerabilities->deps->values[i] = parsed_oval->vulnerabilities->prev->deps->values[i];
+                            parsed_oval->vulnerabilities->deps->test_ref[i] = parsed_oval->vulnerabilities->prev->deps->test_ref[i];
                         }
                         parsed_oval->vulnerabilities->deps->elements = elements;
                     }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2801,10 +2801,6 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
         free(vul_aux->state_id);
         free(vul_aux->package_name);
         os_free(vul_aux->package_version);
-        if (vul_aux->deps) {
-            os_free(vul_aux->deps->test_ref);
-            os_free(vul_aux->deps);
-        }
         free(vul_aux);
     }
 
@@ -3338,16 +3334,16 @@ void wm_vuldet_update_dependency_list_suse(const xml_node *criterion_dep, wm_vul
     const char *dependency_id = "";
     int i = 0;
 
-    for (int j = 0; criterion_dep->attributes[j]; j++) {
-        if (!strcmp(criterion_dep->attributes[j], "test_ref")) {
-            dependency_id = criterion_dep->values[j];
+    for (; criterion_dep->attributes[i]; i++) {
+        if (!strcmp(criterion_dep->attributes[i], "test_ref")) {
+            dependency_id = criterion_dep->values[i];
             break;
         }
     }
     /*
     * Though still empty, we use the current vulnerability structure as a placeholder for all the
     * dependencies affecting the current <criteria operator="AND"> node.
-    * This structure will later be assigned to each one of the affected vulnerabilities inside this node.
+    * This structure will later be assigned to each one of the affected packages inside this node.
     */
     if (!parsed_oval->vulnerabilities->deps) {
         os_calloc(1, sizeof(dependencies), parsed_oval->vulnerabilities->deps);
@@ -3359,6 +3355,7 @@ void wm_vuldet_update_dependency_list_suse(const xml_node *criterion_dep, wm_vul
         sizeof(char *), parsed_oval->vulnerabilities->deps->test_ref);
     }
 
+    i = 0;
     if (!parsed_oval->suse_deps) {
         os_calloc(1, sizeof(dependencies), parsed_oval->suse_deps);
         parsed_oval->suse_deps->elements = 0;
@@ -3772,7 +3769,7 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
                     if (dist == FEED_SUSE) {
                         /*
                          * In SUSE feeds we have to consider SUSE Linux Enterprise packages
-                         * as dependencies for each vulnerability
+                         * as dependencies for each affected package.
                         */
                         if (!strncmp(node[i]->values[j], "SUSE Linux Enterprise", 21)) {
                             wm_vuldet_update_dependency_list_suse(node[i], parsed_oval);
@@ -3809,13 +3806,13 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
                         /*
                         * The dependency list for SUSE vulnerabilities is only filled for the first package
                         * of each <criteria operator="AND"> node.
-                        * This structure is then copied for subsequent vulnerabilities.
+                        * This structure is then copied for subsequent packages with the same dependencies.
                         */
                         int elements = parsed_oval->vulnerabilities->prev->deps->elements;
                         os_calloc(1, sizeof(dependencies), parsed_oval->vulnerabilities->deps);
                         os_calloc(elements, sizeof(char *), parsed_oval->vulnerabilities->deps->test_ref);
-                        for (int i = 0; i < elements; i++) {
-                            parsed_oval->vulnerabilities->deps->test_ref[i] = parsed_oval->vulnerabilities->prev->deps->test_ref[i];
+                        for (int k = 0; k < elements; k++) {
+                            parsed_oval->vulnerabilities->deps->test_ref[k] = parsed_oval->vulnerabilities->prev->deps->test_ref[k];
                         }
                         parsed_oval->vulnerabilities->deps->elements = elements;
                     }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -3340,7 +3340,7 @@ void wm_vuldet_update_dependency_list_suse(const xml_node *criterion_dep, wm_vul
 
     for (int j = 0; criterion_dep->attributes[j]; j++) {
         if (!strcmp(criterion_dep->attributes[j], "test_ref")) {
-            dependency_id = criterion_dep->attributes[j];
+            dependency_id = criterion_dep->values[j];
             break;
         }
     }
@@ -3374,7 +3374,7 @@ void wm_vuldet_update_dependency_list_suse(const xml_node *criterion_dep, wm_vul
 
     // Check if the loop has scrolled through the whole array
     if (i == parsed_oval->suse_deps->elements) {
-        parsed_oval->suse_deps->elements++,
+        parsed_oval->suse_deps->elements++;
         os_realloc(parsed_oval->suse_deps->test_ref, sizeof(char *) * parsed_oval->suse_deps->elements, parsed_oval->suse_deps->test_ref);
         os_strdup(dependency_id, parsed_oval->suse_deps->test_ref[i]);
     }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2624,6 +2624,14 @@ int wm_vuldet_insert_cve_info(wm_vuldet_db *parsed_oval, sqlite3 *db, sqlite3_st
     return 0;
 }
 
+void wm_vuldet_clean_suse_dependencies_info(wm_vuldet_db *ctrl_block) {
+    references *aux_list = ctrl_block->suse_deps;
+
+    while (aux_list) {
+    
+    }
+}
+
 int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
     sqlite3 *db;
     sqlite3_stmt *stmt = NULL;
@@ -3322,6 +3330,43 @@ void wm_vuldet_oval_append_rhsa(vulnerability *vul_it, char *cve) {
     index++;
 }
 
+void wm_vuldet_update_dependency_list_suse(const char *dep_id, wm_vuldet_db *parsed_oval) {
+    int i = 0;
+
+    if (!parsed_oval->vulnerabilities->deps) {
+        os_calloc(1, sizeof(references), parsed_oval->vulnerabilities->deps);
+        os_calloc(1, sizeof(char *), parsed_oval->vulnerabilities->deps->values);
+        parsed_oval->vulnerabilities->deps->elements = 1;
+    } else {
+        parsed_oval->vulnerabilities->deps->elements++;
+        os_realloc(parsed_oval->vulnerabilities->deps->values, parsed_oval->vulnerabilities->deps->elements *
+        sizeof(char *), parsed_oval->vulnerabilities->deps->values);
+    }
+
+    if (!parsed_oval->suse_deps) {
+        os_calloc(1, sizeof(references), parsed_oval->suse_deps);
+        parsed_oval->suse_deps->elements = 0;
+        parsed_oval->suse_deps->values = NULL;
+    } else {
+        // Scroll through the array of dependencies to check if the ID is already inside
+        for (; i < parsed_oval->suse_deps->elements; i++) {
+            if (!(strcmp(dep_id, parsed_oval->suse_deps->values[i]))) {
+                break;
+            }
+        }
+    }
+
+    // Check if the loop has scrolled trhough the whole array
+    if (i == parsed_oval->suse_deps->elements) {
+        parsed_oval->suse_deps->elements++,
+        os_realloc(parsed_oval->suse_deps->values, sizeof(char *) * parsed_oval->suse_deps->elements, parsed_oval->suse_deps->values);
+        os_strdup(dep_id, parsed_oval->suse_deps->values[i]);
+    }
+
+    // Assign the current dependency to the array of dependencies of the current package
+    parsed_oval->vulnerabilities->deps->values[parsed_oval->vulnerabilities->deps->elements - 1] = parsed_oval->suse_deps->values[i];
+}
+
 int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_oval, update_node *update, vu_logic condition) {
     int i, j;
     int retval = 0;
@@ -3710,10 +3755,11 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
                     char * not_vulnerable = NULL;
                     if (dist == FEED_SUSE) {
                         /*
-                         * In SUSE feeds we have to discard SUSE Linux Enterprise packages
-                         * which are not using for the matching criteria
+                         * In SUSE feeds we have to consider SUSE Linux Enterprise packages
+                         * as dependencies for each vulnerability
                         */
                         if (!strncmp(node[i]->values[j], "SUSE Linux Enterprise", 21)) {
+                            wm_vuldet_update_dependency_list_suse(node[i]->values[j - 1], parsed_oval);
                             skip_package = true;
                             break;
                         }
@@ -3742,6 +3788,20 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
                     }
                     parsed_oval->vulnerabilities->ignore = ignore;
                     os_strdup(node[i]->values[j], parsed_oval->vulnerabilities->state_id);
+                    if (dist == FEED_SUSE && !parsed_oval->vulnerabilities->deps && parsed_oval->vulnerabilities->prev 
+                        && parsed_oval->vulnerabilities->prev->deps) {
+                        /*
+                        * In SUSE feeds we have to consider SUSE Linux Enterprise packages
+                        * as dependencies for each vulnerability
+                        */
+                        int elements = parsed_oval->vulnerabilities->prev->deps->elements;
+                        os_calloc(1, sizeof(references), parsed_oval->vulnerabilities->deps);
+                        os_calloc(elements, sizeof(char *), parsed_oval->vulnerabilities->deps->values);
+                        for (int i = 0; i < elements; i++) {
+                            parsed_oval->vulnerabilities->deps->values[i] = parsed_oval->vulnerabilities->prev->deps->values[i];
+                        }
+                        parsed_oval->vulnerabilities->deps->elements = elements;
+                    }
                 }
             }
         }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -63,6 +63,14 @@ STATIC void wm_vuldet_oval_append_rhsa(vulnerability *vul_it, char *cve);
  */
 STATIC void wm_vuldet_oval_copy_rhsa(vulnerability *old, vulnerability *new);
 
+/**
+ * @brief Update the list of dependencies needed to scan SUSE vulnerabilities
+ * @param dep_id ID of the dependency
+ * @param parsed_oval Parsed oval data strucure.
+ *
+ */
+STATIC void wm_vuldet_update_dependency_list_suse(const char *dep_id, wm_vuldet_db *parsed_oval);
+
 STATIC int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_oval, update_node *update, vu_logic condition);
 STATIC int wm_vuldet_json_parser(char *json_path, wm_vuldet_db *uparsed_vulnerabilities, update_node *update);
 
@@ -2624,14 +2632,6 @@ int wm_vuldet_insert_cve_info(wm_vuldet_db *parsed_oval, sqlite3 *db, sqlite3_st
     return 0;
 }
 
-void wm_vuldet_clean_suse_dependencies_info(wm_vuldet_db *ctrl_block) {
-    references *aux_list = ctrl_block->suse_deps;
-
-    while (aux_list) {
-    
-    }
-}
-
 int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
     sqlite3 *db;
     sqlite3_stmt *stmt = NULL;
@@ -2801,6 +2801,10 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
         free(vul_aux->state_id);
         free(vul_aux->package_name);
         os_free(vul_aux->package_version);
+        if (vul_aux->deps) {
+            os_free(vul_aux->deps->values);
+            os_free(vul_aux->deps);
+        }
         free(vul_aux);
     }
 
@@ -3356,7 +3360,7 @@ void wm_vuldet_update_dependency_list_suse(const char *dep_id, wm_vuldet_db *par
         }
     }
 
-    // Check if the loop has scrolled trhough the whole array
+    // Check if the loop has scrolled through the whole array
     if (i == parsed_oval->suse_deps->elements) {
         parsed_oval->suse_deps->elements++,
         os_realloc(parsed_oval->suse_deps->values, sizeof(char *) * parsed_oval->suse_deps->elements, parsed_oval->suse_deps->values);
@@ -3791,8 +3795,8 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
                     if (dist == FEED_SUSE && !parsed_oval->vulnerabilities->deps && parsed_oval->vulnerabilities->prev 
                         && parsed_oval->vulnerabilities->prev->deps) {
                         /*
-                        * In SUSE feeds we have to consider SUSE Linux Enterprise packages
-                        * as dependencies for each vulnerability
+                        * The dependencies list for SUSE vulnerabilities is only filled for the first package of each 'AND' operator
+                        * so it has to be copied for subsequent vulnerabilities
                         */
                         int elements = parsed_oval->vulnerabilities->prev->deps->elements;
                         os_calloc(1, sizeof(references), parsed_oval->vulnerabilities->deps);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -590,7 +590,6 @@ typedef struct vulnerability {
     char **rhsa_list; // For CVEs which share a common RHSA - RedHat
     struct references *deps;
     struct vulnerability *prev;
-    
 } vulnerability;
 
 typedef struct rh_vulnerability {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -564,7 +564,7 @@ typedef struct references {
 
 typedef struct dependencies {
     int elements;
-    const char **test_ref;
+    char **test_ref;
 } dependencies;
 
 typedef struct info_cve {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -588,7 +588,9 @@ typedef struct vulnerability {
     char *package_version;
     int ignore;
     char **rhsa_list; // For CVEs which share a common RHSA - RedHat
+    struct references *deps;
     struct vulnerability *prev;
+    
 } vulnerability;
 
 typedef struct rh_vulnerability {
@@ -637,6 +639,7 @@ typedef struct wm_vuldet_db {
     cpe_list *nvd_cpes;
     oval_metadata metadata;
     vu_alas_vuln *alas_vuln;
+    references *suse_deps;
     const char *OS;
 } wm_vuldet_db;
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -562,6 +562,11 @@ typedef struct references {
     char **values;
 } references;
 
+typedef struct dependencies {
+    int elements;
+    const char **test_ref;
+} dependencies;
+
 typedef struct info_cve {
     char *cveid;
     char *title; // Not available in Red Hat feed
@@ -588,7 +593,7 @@ typedef struct vulnerability {
     char *package_version;
     int ignore;
     char **rhsa_list; // For CVEs which share a common RHSA - RedHat
-    struct references *deps;
+    struct dependencies *deps;
     struct vulnerability *prev;
 } vulnerability;
 
@@ -638,7 +643,7 @@ typedef struct wm_vuldet_db {
     cpe_list *nvd_cpes;
     oval_metadata metadata;
     vu_alas_vuln *alas_vuln;
-    references *suse_deps;
+    dependencies *suse_deps;
     const char *OS;
 } wm_vuldet_db;
 


### PR DESCRIPTION
|Related issue|
|---|
|#9154|

## Description

Hi team,

The **OVAL** feeds for **SUSE** establish a relationship between packages and dependencies that is currently ignored by our **XML** parser. However, this relationship is mandatory to correctly detect or discard vulnerabilities. 

As described in #9154, this _Pull Request_ aims to modify said **XML** parser to correlate each vulnerability with its group of dependencies, as given by **SUSE** feeds:

```xml
<criteria operator="AND">
    <criteria operator="OR">
        <criterion test_ref="oval:org.opensuse.security:tst:2009223735" comment="SUSE Linux Enterprise Module for Basesystem 15 is installed"/>
        <criterion test_ref="oval:org.opensuse.security:tst:2009254629" comment="SUSE Linux Enterprise Module for Basesystem 15 SP1 is installed"/>
        <criterion test_ref="oval:org.opensuse.security:tst:2009228624" comment="SUSE Linux Enterprise Module for Development Tools 15 is installed"/>
        <criterion test_ref="oval:org.opensuse.security:tst:2009255446" comment="SUSE Linux Enterprise Module for Development Tools 15 SP1 is installed"/>
    </criteria>
    <criteria operator="OR">
        <criterion test_ref="oval:org.opensuse.security:tst:2009334017" comment="kernel-default is not affected"/>
        <criterion test_ref="oval:org.opensuse.security:tst:2009333928" comment="kernel-source is not affected"/>
    </criteria>
</criteria>
````

Best regards,
Álvaro Romero.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
- [ ] Source installation
- [ ] Source upgrade


- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
