### PR TITLE
Update unit tests for wm_gcp module

### DIFF
--- a/src/config/wmodules-gcp.c
+++ b/src/config/wmodules-gcp.c
@@ -33,6 +33,24 @@ static short eval_bool(const char *str) {
     return !str ? OS_INVALID : !strcmp(str, "yes") ? 1 : !strcmp(str, "no") ? 0 : OS_INVALID;
 }
 
+static void clean_bucket(wm_gcp_bucket *cur_bucket, wm_gcp_bucket_base *gcp) {
+    if (cur_bucket->bucket) os_free(cur_bucket->bucket);
+    if (cur_bucket->type) os_free(cur_bucket->type);
+    if (cur_bucket->credentials_file) os_free(cur_bucket->credentials_file);
+    if (cur_bucket->prefix) os_free(cur_bucket->prefix);
+    if (cur_bucket->only_logs_after) os_free(cur_bucket->only_logs_after);
+
+    if (gcp->buckets) {
+        if (gcp->buckets->next) {
+            wm_gcp_bucket *buck = gcp->buckets->next;
+            while(buck != NULL)
+                buck = buck->next;
+        } else {
+            os_free(gcp->buckets);
+        }
+    }
+}
+
 /* Read XML configuration */
 
 int wm_gcp_pubsub_read(xml_node **nodes, wmodule *module) {
@@ -285,23 +303,28 @@ int wm_gcp_bucket_read(const OS_XML *xml, xml_node **nodes, wmodule *module) {
             }
 
             // Expand bucket Child Nodes
-
             if (!(children = OS_GetElementsbyNode(xml, nodes[i]))) {
                 continue;
             }
 
             // type is an attribute of the bucket tag
-            if (!strcmp(*nodes[i]->attributes, XML_BUCKET_TYPE)) {
-                if (!strcmp(*nodes[i]->values, ACCESS_LOGS_BUCKET_TYPE)) {
-                    os_strdup(*nodes[i]->values, cur_bucket->type);
+            if (nodes[i]->attributes){
+                if (!strcmp(*nodes[i]->attributes, XML_BUCKET_TYPE)) {
+                    if (!strcmp(*nodes[i]->values, ACCESS_LOGS_BUCKET_TYPE)) {
+                        os_strdup(*nodes[i]->values, cur_bucket->type);
+                    } else {
+                        merror("Invalid bucket type '%s'. The valid one is '%s'", *nodes[i]->values, ACCESS_LOGS_BUCKET_TYPE);
+                        OS_ClearNode(children);
+                        return OS_INVALID;
+                    }
                 } else {
-                    mterror(WM_GCP_BUCKET_LOGTAG, "Invalid bucket type '%s'. Valid one is '%s'",
-                        *nodes[i]->values, ACCESS_LOGS_BUCKET_TYPE);
+                    merror("Attribute name '%s' is not valid. The valid one is '%s'.", *nodes[i]->attributes,
+                    XML_BUCKET_TYPE, WM_GCP_BUCKET_LOGTAG);
                     OS_ClearNode(children);
                     return OS_INVALID;
                 }
             } else {
-                mterror(WM_GCP_BUCKET_LOGTAG, "Attribute name '%s' is not valid. The valid one is '%s'.", *nodes[i]->attributes, XML_BUCKET_TYPE);
+                merror("No bucket type was specified. The valid one is '%s'.", ACCESS_LOGS_BUCKET_TYPE);
                 OS_ClearNode(children);
                 return OS_INVALID;
             }
@@ -340,18 +363,28 @@ int wm_gcp_bucket_read(const OS_XML *xml, xml_node **nodes, wmodule *module) {
                     if (strlen(children[j]->content) != 0) {
                         free(cur_bucket->prefix);
                         os_strdup(children[j]->content, cur_bucket->prefix);
+                    } else if (strlen(children[j]->content) == 0) {
+                        merror("Empty content for tag '%s' at module '%s'", XML_PREFIX, WM_GCP_BUCKET_CONTEXT.name);
+                        OS_ClearNode(children);
+                        return OS_INVALID;
                     }
                 } else if (!strcmp(children[j]->element, XML_ONLY_LOGS_AFTER)) {
                     if (strlen(children[j]->content) != 0) {
                         free(cur_bucket->only_logs_after);
                         os_strdup(children[j]->content, cur_bucket->only_logs_after);
+                    } else if (strlen(children[j]->content) == 0) {
+                        merror("Empty content for tag '%s' at module '%s'", XML_ONLY_LOGS_AFTER, WM_GCP_BUCKET_CONTEXT.name);
+                        OS_ClearNode(children);
+                        return OS_INVALID;
                     }
                 } else if (!strcmp(children[j]->element, XML_CREDENTIALS_FILE)) {
                     if(strlen(children[j]->content) >= PATH_MAX) {
                         merror("File path is too long. Max path length is %d.", PATH_MAX);
+                        OS_ClearNode(children);
                         return OS_INVALID;
                     } else if (strlen(children[j]->content) == 0) {
                         merror("Empty content for tag '%s' at module '%s'", XML_CREDENTIALS_FILE, WM_GCP_BUCKET_CONTEXT.name);
+                        OS_ClearNode(children);
                         return OS_INVALID;
                     }
 
@@ -363,6 +396,7 @@ int wm_gcp_bucket_read(const OS_XML *xml, xml_node **nodes, wmodule *module) {
                         const char * const realpath_buffer_ref = realpath(children[j]->content, realpath_buffer);
                         if (!realpath_buffer_ref) {
                             mwarn("File '%s' from tag '%s' not found.", realpath_buffer, XML_CREDENTIALS_FILE);
+                            OS_ClearNode(children);
                             return OS_INVALID;
                         }
                     }
@@ -370,6 +404,7 @@ int wm_gcp_bucket_read(const OS_XML *xml, xml_node **nodes, wmodule *module) {
                     // Beware of IsFile inverted, twisted logic.
                     if (IsFile(realpath_buffer)) {
                         mwarn("File '%s' not found. Check your configuration.", realpath_buffer);
+                        OS_ClearNode(children);
                         return OS_INVALID;
                     }
 
@@ -381,6 +416,22 @@ int wm_gcp_bucket_read(const OS_XML *xml, xml_node **nodes, wmodule *module) {
                 }
             }
             OS_ClearNode(children);
+
+            if (!cur_bucket->bucket) {
+                merror("No value defined for tag '%s' in module '%s'.", XML_BUCKET_NAME, WM_GCP_BUCKET_CONTEXT.name);
+                clean_bucket(cur_bucket, gcp);
+                return OS_INVALID;
+            }
+            else if (!cur_bucket->type) {
+                merror("No value defined for tag '%s' in module '%s'.", XML_BUCKET_TYPE, WM_GCP_BUCKET_CONTEXT.name);
+                clean_bucket(cur_bucket, gcp);
+                return OS_INVALID;
+            }
+            else if (!cur_bucket->credentials_file) {
+                merror("No value defined for tag '%s' in module '%s'.", XML_CREDENTIALS_FILE, WM_GCP_BUCKET_CONTEXT.name);
+                clean_bucket(cur_bucket, gcp);
+                return OS_INVALID;
+            }
         } else if (is_sched_tag(nodes[i]->element)) {
             // Do nothing
         } else {
@@ -392,6 +443,11 @@ int wm_gcp_bucket_read(const OS_XML *xml, xml_node **nodes, wmodule *module) {
 
     const int sched_read = sched_scan_read(&(gcp->scan_config), nodes, module->context->name);
     if ( sched_read != 0 ) {
+        return OS_INVALID;
+    }
+
+    if (!gcp->buckets) {
+        mwarn("No buckets or services definitions found at module '%s'.", WM_GCP_BUCKET_CONTEXT.name);
         return OS_INVALID;
     }
 

--- a/src/unit_tests/wazuh_modules/gcp/test_wmodules_gcp.c
+++ b/src/unit_tests/wazuh_modules/gcp/test_wmodules_gcp.c
@@ -31,6 +31,16 @@ static const char *XML_MAX_MESSAGES = "max_messages";
 static const char *XML_PULL_ON_START = "pull_on_start";
 static const char *XML_LOGGING = "logging";
 
+static const char *XML_RUN_ON_START = "run_on_start";
+static const char *XML_BUCKET = "bucket";
+static const char *XML_BUCKET_TYPE = "type";
+static const char *XML_BUCKET_NAME = "name";
+static const char *XML_PREFIX = "path";
+static const char *XML_ONLY_LOGS_AFTER = "only_logs_after";
+static const char *XML_REMOVE_FROM_BUCKET = "remove_from_bucket";
+
+static const char *ACCESS_LOGS_BUCKET_TYPE = "access_logs";
+
 typedef struct __group_data_s {
     OS_XML *xml;
     xml_node **nodes;
@@ -47,7 +57,7 @@ int replace_configuration_value(XML_NODE nodes, const char *tag, const char *new
     // find the required tag and change it to the new value
     for(i = 0; nodes[i]; i++) {
         if(!strcmp(nodes[i]->element, tag)) {
-            free(nodes[i]->content);
+            os_free(nodes[i]->content);
             if(new_value != NULL){
                 nodes[i]->content = strdup(new_value);
 
@@ -63,17 +73,78 @@ int replace_configuration_value(XML_NODE nodes, const char *tag, const char *new
     return -2;
 }
 
+int replace_bucket_configuration_value(group_data_t *data, const char *tag, const char *new_value) {
+    int i;
+    int j;
+    OS_XML *xml = data->xml;
+    XML_NODE nodes = data->nodes;
+    xml_node **children = NULL;
+
+    if(xml == NULL || tag == NULL || nodes == NULL || *nodes == NULL)
+        return -1;
+
+    // find the required tag and change it to the new value
+    for(i = 0; nodes[i]; i++) {
+        if(!strcmp(nodes[i]->element, "bucket")) {
+            if (!(children = OS_GetElementsbyNode(xml, nodes[i])))
+                continue;
+
+            for (j = 0; children[j]; j++) {
+                if (!strcmp(children[j]->element, tag)) {
+                    OS_ClearNode(children);
+                    OS_ClearNode(data->nodes);
+                    os_free(xml->ct[i+j+2])
+                    os_strdup(new_value, xml->ct[i+j+2]);
+                    if(data->nodes = OS_GetElementsbyNode(data->xml, NULL), data->nodes == NULL)
+                        return -1;
+                    return 0;
+                }
+            }
+            OS_ClearNode(children);
+        }
+    }
+    // If we got here, the given tag was not found
+    return -2;
+}
+
+int replace_bucket_configuration_attribute(group_data_t *data, const char *tag, const char *new_value) {
+    int i;
+    int j;
+    OS_XML *xml = data->xml;
+    XML_NODE nodes = data->nodes;
+
+    if(xml == NULL || tag == NULL || nodes == NULL || *nodes == NULL)
+        return -1;
+
+    // find the required tag and change it to the new value
+    for(i = 0; nodes[i]; i++) {
+        if(!strcmp(nodes[i]->element, "bucket")) {
+            if (strcmp(*nodes[i]->attributes, tag) == 0){
+                os_free(xml->ct[i+1])
+                os_strdup(new_value, xml->ct[i+1]);
+                OS_ClearNode(data->nodes);
+                if(data->nodes = OS_GetElementsbyNode(data->xml, NULL), data->nodes == NULL)
+                    return -1;
+                return 0;
+            }
+        }
+    }
+    // If we got here, the given tag was not found
+    return -2;
+}
+
 /* setup/teardown */
 static int setup_group(void **state) {
-    group_data_t *data = calloc(1, sizeof(group_data_t));
+    group_data_t *data;
+    os_calloc(1, sizeof(group_data_t), data);
 
     if(data == NULL)
         return -1;
 
-    if(data->module = calloc(1, sizeof(wmodule)), data->module == NULL)
+    if(os_calloc(1, sizeof(wmodule), data->module), data->module == NULL)
         return -1;
 
-    if(data->xml = calloc(1, sizeof(OS_XML)), data->xml == NULL)
+    if(os_calloc(1, sizeof(OS_XML), data->xml), data->xml == NULL)
         return -1;
 
     *state = data;
@@ -84,15 +155,15 @@ static int setup_group(void **state) {
 static int teardown_group(void **state) {
     group_data_t *data = *state;
 
-    free(data->xml);
-    free(data->module);
+    os_free(data->xml);
+    os_free(data->module);
 
-    free(data);
+    os_free(data);
 
     return 0;
 }
 
-static int setup_test(void **state) {
+static int setup_test_pubsub(void **state) {
     group_data_t *data = *state;
     char *base_config = "<enabled>yes</enabled>"
                         "<pull_on_start>no</pull_on_start>"
@@ -114,7 +185,7 @@ static int setup_test(void **state) {
     return 0;
 }
 
-static int setup_test_no_project_id(void **state) {
+static int setup_test_pubsub_no_project_id(void **state) {
     group_data_t *data = *state;
     char *base_config = "<enabled>yes</enabled>"
                         "<pull_on_start>no</pull_on_start>"
@@ -135,7 +206,7 @@ static int setup_test_no_project_id(void **state) {
     return 0;
 }
 
-static int setup_test_no_subscription_name(void **state) {
+static int setup_test_pubsub_no_subscription_name(void **state) {
     group_data_t *data = *state;
     char *base_config = "<enabled>yes</enabled>"
                         "<pull_on_start>no</pull_on_start>"
@@ -156,7 +227,7 @@ static int setup_test_no_subscription_name(void **state) {
     return 0;
 }
 
-static int setup_test_no_credentials_file(void **state) {
+static int setup_test_pubsub_no_credentials_file(void **state) {
     group_data_t *data = *state;
     char *base_config = "<enabled>yes</enabled>"
                         "<pull_on_start>no</pull_on_start>"
@@ -177,17 +248,205 @@ static int setup_test_no_credentials_file(void **state) {
     return 0;
 }
 
-static int teardown_test(void **state) {
+static int teardown_test_pubsub(void **state) {
     group_data_t *data = *state;
     wm_gcp_pubsub *gcp = data->module->data;
 
-    free(data->module->tag);
+    os_free(data->module->tag);
 
-    if(gcp->project_id) free(gcp->project_id);
-    if(gcp->subscription_name) free(gcp->subscription_name);
-    if(gcp->credentials_file) free(gcp->credentials_file);
+    if(gcp->project_id) os_free(gcp->project_id);
+    if(gcp->subscription_name) os_free(gcp->subscription_name);
+    if(gcp->credentials_file) os_free(gcp->credentials_file);
 
-    free(gcp);
+    os_free(gcp);
+
+    data->module->data = NULL;
+
+    OS_ClearXML(data->xml);
+    OS_ClearNode(data->nodes);
+
+    return 0;
+}
+
+static int setup_test_bucket(void **state) {
+    group_data_t *data = *state;
+    char *base_config = "<enabled>yes</enabled>"
+                        "<run_on_start>no</run_on_start>"
+                        "<logging>disabled</logging>"
+                        "<bucket type='access_logs'>"
+                          "<name>wazuh-gcp-bucket-tests</name>"
+                          "<credentials_file>credentials.json</credentials_file>"
+                          "<only_logs_after>2021-JUN-01</only_logs_after>"
+                          "<path>access_logs/</path>"
+                          "<remove_from_bucket>no</remove_from_bucket>"
+                        "</bucket>";
+
+    if(OS_ReadXMLString(base_config, data->xml) != 0){
+        return -1;
+    }
+
+    if(data->nodes = OS_GetElementsbyNode(data->xml, NULL), data->nodes == NULL)
+        return -1;
+
+    return 0;
+}
+
+static int setup_test_bucket_no_bucket(void **state) {
+    group_data_t *data = *state;
+    char *base_config = "<enabled>yes</enabled>"
+                        "<run_on_start>no</run_on_start>"
+                        "<logging>disabled</logging>"
+                        "<bucket type='access_logs'>"
+                          "<credentials_file>credentials.json</credentials_file>"
+                          "<only_logs_after>2021-JUN-01</only_logs_after>"
+                          "<path>access_logs/</path>"
+                          "<remove_from_bucket>no</remove_from_bucket>"
+                        "</bucket>";
+
+
+    if(OS_ReadXMLString(base_config, data->xml) != 0){
+        return -1;
+    }
+
+    if(data->nodes = OS_GetElementsbyNode(data->xml, NULL), data->nodes == NULL)
+        return -1;
+
+    return 0;
+}
+
+static int setup_test_bucket_no_bucket_type(void **state) {
+    group_data_t *data = *state;
+    char *base_config = "<enabled>yes</enabled>"
+                        "<run_on_start>no</run_on_start>"
+                        "<logging>disabled</logging>"
+                        "<bucket>"
+                          "<name>wazuh-gcp-bucket-tests</name>"
+                          "<credentials_file>credentials.json</credentials_file>"
+                          "<only_logs_after>2021-JUN-01</only_logs_after>"
+                          "<path>access_logs/</path>"
+                          "<remove_from_bucket>no</remove_from_bucket>"
+                        "</bucket>";
+
+
+    if(OS_ReadXMLString(base_config, data->xml) != 0){
+        return -1;
+    }
+
+    if(data->nodes = OS_GetElementsbyNode(data->xml, NULL), data->nodes == NULL)
+        return -1;
+
+    return 0;
+}
+
+
+static int setup_test_bucket_no_only_logs_after(void **state) {
+    group_data_t *data = *state;
+    char *base_config = "<enabled>yes</enabled>"
+                        "<run_on_start>no</run_on_start>"
+                        "<logging>disabled</logging>"
+                        "<bucket type='access_logs'>"
+                          "<name>wazuh-gcp-bucket-tests</name>"
+                          "<credentials_file>credentials.json</credentials_file>"
+                          "<path>access_logs/</path>"
+                          "<remove_from_bucket>no</remove_from_bucket>"
+                        "</bucket>";
+
+
+    if(OS_ReadXMLString(base_config, data->xml) != 0){
+        return -1;
+    }
+
+    if(data->nodes = OS_GetElementsbyNode(data->xml, NULL), data->nodes == NULL)
+        return -1;
+
+    return 0;
+}
+
+static int setup_test_bucket_no_credentials_file(void **state) {
+    group_data_t *data = *state;
+    char *base_config = "<enabled>yes</enabled>"
+                        "<run_on_start>no</run_on_start>"
+                        "<logging>disabled</logging>"
+                        "<bucket type='access_logs'>"
+                          "<name>wazuh-gcp-bucket-tests</name>"
+                          "<only_logs_after>2021-JUN-01</only_logs_after>"
+                          "<path>access_logs/</path>"
+                          "<remove_from_bucket>no</remove_from_bucket>"
+                        "</bucket>";
+
+
+    if(OS_ReadXMLString(base_config, data->xml) != 0){
+        return -1;
+    }
+
+    if(data->nodes = OS_GetElementsbyNode(data->xml, NULL), data->nodes == NULL)
+        return -1;
+
+    return 0;
+}
+
+static int setup_test_bucket_no_path(void **state) {
+    group_data_t *data = *state;
+    char *base_config = "<enabled>yes</enabled>"
+                        "<run_on_start>no</run_on_start>"
+                        "<logging>disabled</logging>"
+                        "<bucket type='access_logs'>"
+                          "<name>wazuh-gcp-bucket-tests</name>"
+                          "<credentials_file>credentials.json</credentials_file>"
+                          "<only_logs_after>2021-JUN-01</only_logs_after>"
+                          "<remove_from_bucket>no</remove_from_bucket>"
+                        "</bucket>";
+
+
+    if(OS_ReadXMLString(base_config, data->xml) != 0){
+        return -1;
+    }
+
+    if(data->nodes = OS_GetElementsbyNode(data->xml, NULL), data->nodes == NULL)
+        return -1;
+
+    return 0;
+}
+
+static int setup_test_bucket_no_remove(void **state) {
+    group_data_t *data = *state;
+    char *base_config = "<enabled>yes</enabled>"
+                        "<run_on_start>no</run_on_start>"
+                        "<logging>disabled</logging>"
+                        "<bucket type='access_logs'>"
+                          "<name>wazuh-gcp-bucket-tests</name>"
+                          "<credentials_file>credentials.json</credentials_file>"
+                          "<only_logs_after>2021-JUN-01</only_logs_after>"
+                          "<path>access_logs/</path>"
+                        "</bucket>";
+
+
+    if(OS_ReadXMLString(base_config, data->xml) != 0){
+        return -1;
+    }
+
+    if(data->nodes = OS_GetElementsbyNode(data->xml, NULL), data->nodes == NULL)
+        return -1;
+
+    return 0;
+}
+
+static int teardown_test_bucket(void **state) {
+    group_data_t *data = *state;
+    wm_gcp_bucket_base *gcp_config = data->module->data;;
+    wm_gcp_bucket *gcp_bucket = gcp_config->buckets;
+
+    os_free(data->module->tag);
+
+    if (gcp_bucket) {
+        if (gcp_bucket->bucket) os_free(gcp_bucket->bucket);
+        if (gcp_bucket->type) os_free(gcp_bucket->type);
+        if (gcp_bucket->credentials_file) os_free(gcp_bucket->credentials_file);
+        if (gcp_bucket->prefix) os_free(gcp_bucket->prefix);
+        if (gcp_bucket->only_logs_after) os_free(gcp_bucket->only_logs_after);
+        os_free(gcp_bucket);
+    }
+    os_free(gcp_config);
 
     data->module->data = NULL;
 
@@ -695,7 +954,7 @@ static void test_wm_gcp_pubsub_read_invalid_tag(void **state) {
     int ret;
 
     // Make an invalid XML tag element
-    free(data->nodes[0]->element);
+    os_free(data->nodes[0]->element);
 
     if(data->nodes[0]->element = strdup("invalid"), data->nodes[0]->element == NULL)
         fail();
@@ -712,7 +971,7 @@ static void test_wm_gcp_pubsub_read_invalid_element(void **state) {
     int ret;
 
     // Make an invalid XML tag element
-    free(data->nodes[0]->element);
+    os_free(data->nodes[0]->element);
     data->nodes[0]->element = NULL;
 
     expect_string(__wrap__merror, formatted_msg, "(1231): Invalid NULL element in the configuration.");
@@ -722,33 +981,546 @@ static void test_wm_gcp_pubsub_read_invalid_element(void **state) {
     assert_int_equal(ret, -1);
 }
 
+/* tests */
+/* wm_gcp_pubsub_read */
+static void test_wm_gcp_bucket_read_full_configuration(void **state) {
+    group_data_t *data = *state;
+    wm_gcp_bucket_base *gcp;
 
+    int ret;
+
+    expect_string(__wrap_realpath, path, "credentials.json");
+    will_return(__wrap_realpath, "credentials.json");
+
+    expect_string(__wrap_IsFile, file, "credentials.json");
+    will_return(__wrap_IsFile, 0);
+
+    expect_value(__wrap_sched_scan_read, nodes, data->nodes);
+    expect_string(__wrap_sched_scan_read, MODULE_NAME, GCP_BUCKET_WM_NAME);
+    will_return(__wrap_sched_scan_read, 0);
+
+
+    ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
+
+    assert_int_equal(ret, 0);
+
+    gcp = data->module->data;
+
+    assert_non_null(gcp);
+    assert_int_equal(gcp->enabled, 1);
+    assert_int_equal(gcp->run_on_start, 0);
+    assert_int_equal(gcp->logging, 0);
+    assert_string_equal(gcp->buckets->bucket, "wazuh-gcp-bucket-tests");
+    assert_string_equal(gcp->buckets->only_logs_after, "2021-JUN-01");
+    assert_string_equal(gcp->buckets->credentials_file, "credentials.json");
+    assert_string_equal(gcp->buckets->prefix, "access_logs/");
+    assert_int_equal(gcp->buckets->remove_from_bucket, 0);
+
+    assert_ptr_equal(data->module->context, &WM_GCP_BUCKET_CONTEXT);
+    assert_string_equal(data->module->tag, GCP_BUCKET_WM_NAME);
+}
+
+static void test_wm_gcp_bucket_read_enabled_tag_invalid(void **state) {
+    group_data_t *data = *state;
+    int ret;
+
+    if(replace_configuration_value(data->nodes, XML_ENABLED, "invalid") != 0)
+        fail();
+
+    expect_string(__wrap__merror, formatted_msg, "Invalid content for tag 'enabled'");
+
+    ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+static void test_wm_gcp_bucket_read_no_bucket_type(void **state) {
+    group_data_t *data = *state;
+    int ret;
+
+    expect_string(__wrap__merror, formatted_msg, "No bucket type was specified. The valid one is 'access_logs'.");
+
+    ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+
+static void test_wm_gcp_bucket_read_bucket_type_invalid(void **state) {
+    group_data_t *data = *state;
+    int ret;
+
+    if(replace_bucket_configuration_attribute(data, XML_BUCKET_TYPE, "") != 0)
+        fail();
+
+    expect_string(__wrap__merror, formatted_msg, "Invalid bucket type ''. The valid one is 'access_logs'");
+
+    ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+static void test_wm_gcp_bucket_read_bucket_tag_invalid(void **state) {
+    group_data_t *data = *state;
+    int ret;
+
+    if(replace_bucket_configuration_value(data, XML_BUCKET_NAME, "") != 0)
+        fail();
+
+    expect_string(__wrap__merror, formatted_msg, "Empty content for tag 'name' at module 'gcp-bucket'.");
+
+    ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+static void test_wm_gcp_bucket_read_no_bucket_tag(void **state) {
+    group_data_t *data = *state;
+    int ret;
+
+    expect_string(__wrap_realpath, path, "credentials.json");
+    will_return(__wrap_realpath, "credentials.json");
+
+    expect_string(__wrap_IsFile, file, "credentials.json");
+    will_return(__wrap_IsFile, 0);
+
+    expect_string(__wrap__merror, formatted_msg, "No value defined for tag 'name' in module 'gcp-bucket'.");
+
+    ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+static void test_wm_gcp_bucket_read_only_logs_after_tag_invalid(void **state) {
+    group_data_t *data = *state;
+    int ret;
+
+    if(replace_bucket_configuration_value(data, XML_ONLY_LOGS_AFTER, "") != 0)
+        fail();
+
+    expect_string(__wrap_realpath, path, "credentials.json");
+    will_return(__wrap_realpath, "credentials.json");
+
+    expect_string(__wrap_IsFile, file, "credentials.json");
+    will_return(__wrap_IsFile, 0);
+
+    expect_string(__wrap__merror, formatted_msg, "Empty content for tag 'only_logs_after' at module 'gcp-bucket'");
+
+    ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+static void test_wm_gcp_bucket_read_credentials_file_full_path(void **state) {
+    group_data_t *data = *state;
+    wm_gcp_bucket_base *gcp;
+    int ret;
+
+    if(replace_bucket_configuration_value(data, XML_CREDENTIALS_FILE, "/some/path/credentials.json") != 0)
+        fail();
+
+    expect_string(__wrap_IsFile, file, "/some/path/credentials.json");
+    will_return(__wrap_IsFile, 0);
+
+    expect_value(__wrap_sched_scan_read, nodes, data->nodes);
+    expect_string(__wrap_sched_scan_read, MODULE_NAME, GCP_BUCKET_WM_NAME);
+    will_return(__wrap_sched_scan_read, 0);
+
+    ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
+
+    assert_int_equal(ret, 0);
+
+    gcp = data->module->data;
+
+    assert_non_null(gcp);
+    assert_int_equal(gcp->enabled, 1);
+    assert_int_equal(gcp->run_on_start, 0);
+    assert_int_equal(gcp->logging, 0);
+    assert_string_equal(gcp->buckets->bucket, "wazuh-gcp-bucket-tests");
+    assert_string_equal(gcp->buckets->only_logs_after, "2021-JUN-01");
+    assert_string_equal(gcp->buckets->credentials_file, "/some/path/credentials.json");
+    assert_string_equal(gcp->buckets->prefix, "access_logs/");
+    assert_int_equal(gcp->buckets->remove_from_bucket, 0);
+
+    assert_ptr_equal(data->module->context, &WM_GCP_BUCKET_CONTEXT);
+    assert_string_equal(data->module->tag, GCP_BUCKET_WM_NAME);
+}
+
+static void test_wm_gcp_bucket_read_credentials_file_tag_empty(void **state) {
+    group_data_t *data = *state;
+    int ret;
+
+    if(replace_bucket_configuration_value(data, XML_CREDENTIALS_FILE, "") != 0)
+        fail();
+
+    expect_string(__wrap__merror, formatted_msg, "Empty content for tag 'credentials_file' at module 'gcp-bucket'");
+
+    ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+static void test_wm_gcp_bucket_read_credentials_file_tag_too_long(void **state) {
+    group_data_t *data = *state;
+    char buffer[OS_MAXSTR];
+    int ret;
+
+    memset(buffer, 'a', OS_MAXSTR);
+    buffer[OS_MAXSTR] = '\0';
+
+    if(replace_bucket_configuration_value(data, XML_CREDENTIALS_FILE, buffer) != 0)
+        fail();
+
+    snprintf(buffer, OS_MAXSTR, "File path is too long. Max path length is %d.", PATH_MAX);
+    expect_string(__wrap__merror, formatted_msg, buffer);
+
+    ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+static void test_wm_gcp_bucket_read_credentials_file_tag_realpath_error(void **state) {
+    group_data_t *data = *state;
+    int ret;
+
+    expect_string(__wrap_realpath, path, "credentials.json");
+
+    will_return(__wrap_realpath, (char *) NULL);   //  realpath failed
+
+    expect_string(__wrap__mwarn, formatted_msg, "File '' from tag 'credentials_file' not found.");
+
+    ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+static void test_wm_gcp_bucket_read_credentials_file_tag_file_not_found(void **state) {
+    group_data_t *data = *state;
+    int ret;
+
+    expect_string(__wrap_realpath, path, "credentials.json");
+    will_return(__wrap_realpath, "credentials.json");
+
+    expect_string(__wrap_IsFile, file, "credentials.json");
+    will_return(__wrap_IsFile, 1);
+
+    expect_string(__wrap__mwarn, formatted_msg, "File 'credentials.json' not found. Check your configuration.");
+
+    ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+static void test_wm_gcp_bucket_read_no_credentials_file_tag(void **state) {
+    group_data_t *data = *state;
+    int ret;
+
+    expect_string(__wrap__merror, formatted_msg, "No value defined for tag 'credentials_file' in module 'gcp-bucket'.");
+
+    ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+static void test_wm_gcp_bucket_read_run_on_start_tag_invalid(void **state) {
+    group_data_t *data = *state;
+    int ret;
+
+    if(replace_configuration_value(data->nodes, XML_RUN_ON_START, "invalid") != 0)
+        fail();
+
+
+    expect_string(__wrap__merror, formatted_msg, "Invalid content for tag 'run_on_start'");
+
+    ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+static void test_wm_gcp_bucket_read_logging_tag_debug(void **state) {
+    group_data_t *data = *state;
+    wm_gcp_bucket_base *gcp;
+    int ret;
+
+    if(replace_configuration_value(data->nodes, XML_LOGGING, "debug") != 0)
+        fail();
+
+    expect_string(__wrap_realpath, path, "credentials.json");
+    will_return(__wrap_realpath, "credentials.json");
+
+    expect_string(__wrap_IsFile, file, "credentials.json");
+    will_return(__wrap_IsFile, 0);
+
+    expect_value(__wrap_sched_scan_read, nodes, data->nodes);
+    expect_string(__wrap_sched_scan_read, MODULE_NAME, GCP_BUCKET_WM_NAME);
+    will_return(__wrap_sched_scan_read, 0);
+
+    ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
+
+    assert_int_equal(ret, 0);
+
+    gcp = data->module->data;
+
+    assert_non_null(gcp);
+    assert_int_equal(gcp->enabled, 1);
+    assert_int_equal(gcp->run_on_start, 0);
+    assert_int_equal(gcp->logging, 1);
+    assert_string_equal(gcp->buckets->bucket, "wazuh-gcp-bucket-tests");
+    assert_string_equal(gcp->buckets->only_logs_after, "2021-JUN-01");
+    assert_string_equal(gcp->buckets->credentials_file, "credentials.json");
+    assert_string_equal(gcp->buckets->prefix, "access_logs/");
+    assert_int_equal(gcp->buckets->remove_from_bucket, 0);
+
+    assert_ptr_equal(data->module->context, &WM_GCP_BUCKET_CONTEXT);
+    assert_string_equal(data->module->tag, GCP_BUCKET_WM_NAME);
+}
+
+static void test_wm_gcp_bucket_read_logging_tag_info(void **state) {
+    group_data_t *data = *state;
+    wm_gcp_bucket_base *gcp;
+    int ret;
+
+    if(replace_configuration_value(data->nodes, XML_LOGGING, "info") != 0)
+        fail();
+
+    expect_string(__wrap_realpath, path, "credentials.json");
+    will_return(__wrap_realpath, "credentials.json");
+
+    expect_string(__wrap_IsFile, file, "credentials.json");
+    will_return(__wrap_IsFile, 0);
+
+    expect_value(__wrap_sched_scan_read, nodes, data->nodes);
+    expect_string(__wrap_sched_scan_read, MODULE_NAME, GCP_BUCKET_WM_NAME);
+    will_return(__wrap_sched_scan_read, 0);
+
+    ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
+
+    assert_int_equal(ret, 0);
+
+    gcp = data->module->data;
+
+    assert_non_null(gcp);
+    assert_int_equal(gcp->enabled, 1);
+    assert_int_equal(gcp->run_on_start, 0);
+    assert_int_equal(gcp->logging, 2);
+    assert_string_equal(gcp->buckets->bucket, "wazuh-gcp-bucket-tests");
+    assert_string_equal(gcp->buckets->only_logs_after, "2021-JUN-01");
+    assert_string_equal(gcp->buckets->credentials_file, "credentials.json");
+    assert_string_equal(gcp->buckets->prefix, "access_logs/");
+    assert_int_equal(gcp->buckets->remove_from_bucket, 0);
+
+    assert_ptr_equal(data->module->context, &WM_GCP_BUCKET_CONTEXT);
+    assert_string_equal(data->module->tag, GCP_BUCKET_WM_NAME);
+}
+
+static void test_wm_gcp_bucket_read_logging_tag_warning(void **state) {
+    group_data_t *data = *state;
+    wm_gcp_bucket_base *gcp;
+    int ret;
+
+    if(replace_configuration_value(data->nodes, XML_LOGGING, "warning") != 0)
+        fail();
+
+    expect_string(__wrap_realpath, path, "credentials.json");
+    will_return(__wrap_realpath, "credentials.json");
+
+    expect_string(__wrap_IsFile, file, "credentials.json");
+    will_return(__wrap_IsFile, 0);
+
+    expect_value(__wrap_sched_scan_read, nodes, data->nodes);
+    expect_string(__wrap_sched_scan_read, MODULE_NAME, GCP_BUCKET_WM_NAME);
+    will_return(__wrap_sched_scan_read, 0);
+
+    ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
+
+    assert_int_equal(ret, 0);
+
+    gcp = data->module->data;
+
+    assert_non_null(gcp);
+    assert_int_equal(gcp->enabled, 1);
+    assert_int_equal(gcp->run_on_start, 0);
+    assert_int_equal(gcp->logging, 3);
+    assert_string_equal(gcp->buckets->bucket, "wazuh-gcp-bucket-tests");
+    assert_string_equal(gcp->buckets->only_logs_after, "2021-JUN-01");
+    assert_string_equal(gcp->buckets->credentials_file, "credentials.json");
+    assert_string_equal(gcp->buckets->prefix, "access_logs/");
+    assert_int_equal(gcp->buckets->remove_from_bucket, 0);
+
+    assert_ptr_equal(data->module->context, &WM_GCP_BUCKET_CONTEXT);
+    assert_string_equal(data->module->tag, GCP_BUCKET_WM_NAME);
+}
+
+static void test_wm_gcp_bucket_read_logging_tag_error(void **state) {
+    group_data_t *data = *state;
+    wm_gcp_bucket_base *gcp;
+    int ret;
+
+    if(replace_configuration_value(data->nodes, XML_LOGGING, "error") != 0)
+        fail();
+
+    expect_string(__wrap_realpath, path, "credentials.json");
+    will_return(__wrap_realpath, "credentials.json");
+
+    expect_string(__wrap_IsFile, file, "credentials.json");
+    will_return(__wrap_IsFile, 0);
+
+    expect_value(__wrap_sched_scan_read, nodes, data->nodes);
+    expect_string(__wrap_sched_scan_read, MODULE_NAME, GCP_BUCKET_WM_NAME);
+    will_return(__wrap_sched_scan_read, 0);
+
+    ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
+
+    assert_int_equal(ret, 0);
+
+    gcp = data->module->data;
+
+    assert_non_null(gcp);
+    assert_int_equal(gcp->enabled, 1);
+    assert_int_equal(gcp->run_on_start, 0);
+    assert_int_equal(gcp->logging, 4);
+    assert_string_equal(gcp->buckets->bucket, "wazuh-gcp-bucket-tests");
+    assert_string_equal(gcp->buckets->only_logs_after, "2021-JUN-01");
+    assert_string_equal(gcp->buckets->credentials_file, "credentials.json");
+    assert_string_equal(gcp->buckets->prefix, "access_logs/");
+    assert_int_equal(gcp->buckets->remove_from_bucket, 0);
+
+    assert_ptr_equal(data->module->context, &WM_GCP_BUCKET_CONTEXT);
+    assert_string_equal(data->module->tag, GCP_BUCKET_WM_NAME);
+}
+
+static void test_wm_gcp_bucket_read_logging_tag_critical(void **state) {
+    group_data_t *data = *state;
+    wm_gcp_bucket_base *gcp;
+    int ret;
+
+    if(replace_configuration_value(data->nodes, XML_LOGGING, "critical") != 0)
+        fail();
+
+    expect_string(__wrap_realpath, path, "credentials.json");
+    will_return(__wrap_realpath, "credentials.json");
+
+    expect_string(__wrap_IsFile, file, "credentials.json");
+    will_return(__wrap_IsFile, 0);
+
+    expect_value(__wrap_sched_scan_read, nodes, data->nodes);
+    expect_string(__wrap_sched_scan_read, MODULE_NAME, GCP_BUCKET_WM_NAME);
+    will_return(__wrap_sched_scan_read, 0);
+
+    ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
+
+    assert_int_equal(ret, 0);
+
+    gcp = data->module->data;
+
+    assert_non_null(gcp);
+    assert_int_equal(gcp->enabled, 1);
+    assert_int_equal(gcp->run_on_start, 0);
+    assert_int_equal(gcp->logging, 5);
+    assert_string_equal(gcp->buckets->bucket, "wazuh-gcp-bucket-tests");
+    assert_string_equal(gcp->buckets->only_logs_after, "2021-JUN-01");
+    assert_string_equal(gcp->buckets->credentials_file, "credentials.json");
+    assert_string_equal(gcp->buckets->prefix, "access_logs/");
+    assert_int_equal(gcp->buckets->remove_from_bucket, 0);
+
+    assert_ptr_equal(data->module->context, &WM_GCP_BUCKET_CONTEXT);
+    assert_string_equal(data->module->tag, GCP_BUCKET_WM_NAME);
+}
+
+static void test_wm_gcp_bucket_read_logging_tag_invalid(void **state) {
+    group_data_t *data = *state;
+    int ret;
+
+    if(replace_configuration_value(data->nodes, XML_LOGGING, "invalid") != 0)
+        fail();
+
+    expect_string(__wrap__merror, formatted_msg, "Invalid content for tag 'logging'");
+
+    ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+static void test_wm_gcp_bucket_read_invalid_tag(void **state) {
+    group_data_t *data = *state;
+    int ret;
+
+    // Make an invalid XML tag element
+    os_free(data->nodes[0]->element);
+
+    if(data->nodes[0]->element = strdup("invalid"), data->nodes[0]->element == NULL)
+        fail();
+
+    expect_string(__wrap__merror, formatted_msg, "No such tag 'invalid' at module 'gcp-bucket'.");
+
+    ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
+
+    assert_int_equal(ret, -1);
+}
+
+static void test_wm_gcp_bucket_read_invalid_element(void **state) {
+    group_data_t *data = *state;
+    int ret;
+
+    // Make an invalid XML tag element
+    os_free(data->nodes[0]->element);
+    data->nodes[0]->element = NULL;
+
+    expect_string(__wrap__merror, formatted_msg, "(1231): Invalid NULL element in the configuration.");
+
+    ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
+
+    assert_int_equal(ret, -1);
+}
 
 int main(void) {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_full_configuration, setup_test, teardown_test),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_enabled_tag_invalid, setup_test, teardown_test),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_project_id_tag_invalid, setup_test, teardown_test),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_no_project_id_tag, setup_test_no_project_id, teardown_test),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_subscription_name_tag_invalid, setup_test, teardown_test),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_no_subscription_name_tag, setup_test_no_subscription_name, teardown_test),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_credentials_file_full_path, setup_test, teardown_test),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_credentials_file_tag_empty, setup_test, teardown_test),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_credentials_file_tag_too_long, setup_test, teardown_test),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_credentials_file_tag_realpath_error, setup_test, teardown_test),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_credentials_file_tag_file_not_found, setup_test, teardown_test),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_no_credentials_file_tag, setup_test_no_credentials_file, teardown_test),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_max_messages_tag_empty, setup_test, teardown_test),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_max_messages_tag_not_digit, setup_test, teardown_test),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_pull_on_start_tag_invalid, setup_test, teardown_test),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_logging_tag_debug, setup_test, teardown_test),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_logging_tag_info, setup_test, teardown_test),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_logging_tag_warning, setup_test, teardown_test),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_logging_tag_error, setup_test, teardown_test),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_logging_tag_critical, setup_test, teardown_test),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_logging_tag_invalid, setup_test, teardown_test),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_invalid_tag, setup_test, teardown_test),
-        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_invalid_element, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_full_configuration, setup_test_pubsub, teardown_test_pubsub),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_enabled_tag_invalid, setup_test_pubsub, teardown_test_pubsub),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_project_id_tag_invalid, setup_test_pubsub, teardown_test_pubsub),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_no_project_id_tag, setup_test_pubsub_no_project_id, teardown_test_pubsub),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_subscription_name_tag_invalid, setup_test_pubsub, teardown_test_pubsub),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_no_subscription_name_tag, setup_test_pubsub_no_subscription_name, teardown_test_pubsub),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_credentials_file_full_path, setup_test_pubsub, teardown_test_pubsub),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_credentials_file_tag_empty, setup_test_pubsub, teardown_test_pubsub),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_credentials_file_tag_too_long, setup_test_pubsub, teardown_test_pubsub),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_credentials_file_tag_realpath_error, setup_test_pubsub, teardown_test_pubsub),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_credentials_file_tag_file_not_found, setup_test_pubsub, teardown_test_pubsub),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_no_credentials_file_tag, setup_test_pubsub_no_credentials_file, teardown_test_pubsub),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_max_messages_tag_empty, setup_test_pubsub, teardown_test_pubsub),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_max_messages_tag_not_digit, setup_test_pubsub, teardown_test_pubsub),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_pull_on_start_tag_invalid, setup_test_pubsub, teardown_test_pubsub),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_logging_tag_debug, setup_test_pubsub, teardown_test_pubsub),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_logging_tag_info, setup_test_pubsub, teardown_test_pubsub),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_logging_tag_warning, setup_test_pubsub, teardown_test_pubsub),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_logging_tag_error, setup_test_pubsub, teardown_test_pubsub),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_logging_tag_critical, setup_test_pubsub, teardown_test_pubsub),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_logging_tag_invalid, setup_test_pubsub, teardown_test_pubsub),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_invalid_tag, setup_test_pubsub, teardown_test_pubsub),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_pubsub_read_invalid_element, setup_test_pubsub, teardown_test_pubsub),
+
+        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_full_configuration, setup_test_bucket, teardown_test_bucket),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_enabled_tag_invalid, setup_test_bucket, teardown_test_bucket),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_bucket_type_invalid, setup_test_bucket, teardown_test_bucket),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_no_bucket_type, setup_test_bucket_no_bucket_type, teardown_test_bucket),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_bucket_tag_invalid, setup_test_bucket, teardown_test_bucket),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_no_bucket_tag, setup_test_bucket_no_bucket, teardown_test_bucket),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_only_logs_after_tag_invalid, setup_test_bucket, teardown_test_bucket),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_credentials_file_full_path, setup_test_bucket, teardown_test_bucket),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_credentials_file_tag_empty, setup_test_bucket, teardown_test_bucket),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_credentials_file_tag_too_long, setup_test_bucket, teardown_test_bucket),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_credentials_file_tag_realpath_error, setup_test_bucket, teardown_test_bucket),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_credentials_file_tag_file_not_found, setup_test_bucket, teardown_test_bucket),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_no_credentials_file_tag, setup_test_bucket_no_credentials_file, teardown_test_bucket),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_run_on_start_tag_invalid, setup_test_bucket, teardown_test_bucket),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_logging_tag_debug, setup_test_bucket, teardown_test_bucket),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_logging_tag_info, setup_test_bucket, teardown_test_bucket),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_logging_tag_warning, setup_test_bucket, teardown_test_bucket),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_logging_tag_error, setup_test_bucket, teardown_test_bucket),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_logging_tag_critical, setup_test_bucket, teardown_test_bucket),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_logging_tag_invalid, setup_test_bucket, teardown_test_bucket),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_invalid_tag, setup_test_bucket, teardown_test_bucket),
+        cmocka_unit_test_setup_teardown(test_wm_gcp_bucket_read_invalid_element, setup_test_bucket, teardown_test_bucket),
     };
     return cmocka_run_group_tests(tests, setup_group, teardown_group);
 }


### PR DESCRIPTION
|Related issue|
|---|
|#9140|


## Description

This PR updates `test_wm_gcp.c` and `test_wmodules.c` unit tests. The existing tests for gcp-pubsub have been updated to match the changes made in #8716 while new unit tests have been introduced for the new `gcp-bucket` module. Several memory leaks have been removed from the pubsub tests.

This PR also fix some inconsistences in the gcp module related to the new `gcp-bucket`.
