### PR TITLE
Fix error in filter q when using dates. Standardization of dates in API outputs.

### DIFF
--- a/api/api/controllers/default_controller.py
+++ b/api/api/controllers/default_controller.py
@@ -4,9 +4,10 @@
 
 import logging
 import socket
-import time
+from datetime import datetime
 
 from aiohttp import web
+
 from api.encoder import dumps, prettify
 from api.models.basic_info_model import BasicInfo
 from wazuh.core.results import WazuhResult
@@ -23,7 +24,6 @@ async def default_info(pretty=False):
     Returns various basic information about the API
     """
     info_data = load_spec()
-    timestamp = time.strftime("%Y-%m-%dT%H:%M:%S%z", time.gmtime())
     data = {
         'title': info_data['info']['title'],
         'api_version': info_data['info']['version'],
@@ -31,7 +31,7 @@ async def default_info(pretty=False):
         'license_name': info_data['info']['license']['name'],
         'license_url': info_data['info']['license']['url'],
         'hostname': socket.gethostname(),
-        'timestamp': timestamp
+        'timestamp': datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
     }
     response = WazuhResult({'data': BasicInfo.from_dict(data)})
 

--- a/api/api/controllers/default_controller.py
+++ b/api/api/controllers/default_controller.py
@@ -10,6 +10,7 @@ from aiohttp import web
 
 from api.encoder import dumps, prettify
 from api.models.basic_info_model import BasicInfo
+from wazuh.core.common import date_format
 from wazuh.core.results import WazuhResult
 from wazuh.core.security import load_spec
 
@@ -31,7 +32,7 @@ async def default_info(pretty=False):
         'license_name': info_data['info']['license']['name'],
         'license_url': info_data['info']['license']['url'],
         'hostname': socket.gethostname(),
-        'timestamp': datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+        'timestamp': datetime.utcnow().strftime(date_format)
     }
     response = WazuhResult({'data': BasicInfo.from_dict(data)})
 

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -9159,15 +9159,15 @@ paths:
               example:
                 data:
                   affected_items:
-                    - timestamp: '2021-05-27T12:18:08+00:00'
+                    - timestamp: '2021-05-27T12:18:08Z'
                       tag: wazuh-remoted
                       level: debug
                       description: " TCP socket 20 already in keystore. Updating..."
-                    - timestamp: '2021-05-27T12:18:08+00:00'
+                    - timestamp: '2021-05-27T12:18:08Z'
                       tag: wazuh-remoted
                       level: debug
                       description: " Agent '003' group is 'default'"
-                    - timestamp: '2021-05-27T12:18:08+00:00'
+                    - timestamp: '2021-05-27T12:18:08Z'
                       tag: wazuh-remoted
                       level: debug
                       description: " Agent '003' with group 'default' file 'merged.mg' MD5
@@ -10558,15 +10558,15 @@ paths:
               example:
                 data:
                   affected_items:
-                    - timestamp: '2020-04-15T14:47:54+00:00'
+                    - timestamp: '2020-04-15T14:47:54Z'
                       tag: wazuh-modulesd:syscollector
                       level: info
                       description: "Start syscheck scan"
-                    - timestamp: '2020-04-15T14:47:51+00:00'
+                    - timestamp: '2020-04-15T14:47:51Z'
                       tag: wazuh-modulesd:syscollector
                       level: info
                       description: "Starting evaluation"
-                    - timestamp: '2020-04-15T13:50:24+00:00'
+                    - timestamp: '2020-04-15T13:50:24Z'
                       tag: wazuh-maild
                       level: error
                       description: " (1223): Error Sending email to 69.172.200.109 (smtp server)"
@@ -10902,8 +10902,8 @@ paths:
                         North Korean group definitions are known to have significant overlap, and the name [Lazarus Group](https://attack.mitre.org/groups/G0032) is known to encompass a broad range of activity. Some organizations use the name Lazarus Group to refer to any activity attributed to North Korea.(Citation: US-CERT HIDDEN COBRA June 2017) Some organizations track North Korean clusters or groups such as Bluenoroff,(Citation: Kaspersky Lazarus Under The Hood Blog 2017) [APT37](https://attack.mitre.org/groups/G0067), and [APT38](https://attack.mitre.org/groups/G0082) separately, while other organizations may track some activity associated with those group names by the name Lazarus Group
                       name: APT38
                       id: intrusion-set--00f67a77-86a4-4adf-be26-1a54fc713340
-                      modified_time: '2020-03-30 18:50:43.737000'
-                      created_time: '2019-01-29 21:27:24.793000'
+                      modified_time: '2020-03-30T18:50:43.737000Z'
+                      created_time: '2019-01-29T21:27:24.793000Z'
                       software:
                         - tool--03342581-f790-4f03-ba41-e82e67392e23
                         - tool--afc079f3-c0ea-4096-b75d-3f05338b7f60
@@ -11043,8 +11043,8 @@ paths:
                       description: "Prevent files from having a trailing space after the extension."
                       name: "Space after Filename Mitigation"
                       id: "course-of-action--02f0f92a-0a51-4c94-9bda-6437b9a93f22"
-                      modified_time: '2019-07-25 11:46:32.010000'
-                      created_time: '2018-10-17 00:14:20.652000'
+                      modified_time: '2019-07-25T11:46:32.010000Z'
+                      created_time: '2018-10-17T00:14:20.652000Z'
                       techniques:
                         - "attack-pattern--e2907cea-4b43-4ed7-a570-0fdf0fbeea00"
                       references:
@@ -11163,8 +11163,8 @@ paths:
                         group. (Citation: Baumgartner Naikon 2015)"
                       name: HDoor
                       id: malware--007b44b6-e4c5-480b-b5b9-56f2081b1b7b
-                      modified_time: '2019-04-25 02:33:53.419000'
-                      created_time: '2017-05-31 21:32:40.801000'
+                      modified_time: '2019-04-25T02:33:53.419000Z'
+                      created_time: '2017-05-31T21:32:40.801000Z'
                       groups:
                         - intrusion-set--2a158b0a-7ef8-43cb-9985-bf34d1e12050
                       techniques:
@@ -11230,8 +11230,8 @@ paths:
                     - description: "The adversary is trying to move through your environment.\n\nLateral Movement consists of techniques that adversaries use to enter and control remote systems on a network. Following through on their primary objective often requires exploring the network to find their target and subsequently gaining access to it. Reaching their objective often involves pivoting through multiple systems and accounts to gain. Adversaries might install their own remote access tools to accomplish Lateral Movement or use legitimate credentials with native network and operating system tools, which may be stealthier. "
                       name: "Lateral Movement"
                       id: "x-mitre-tactic--7141578b-e50b-4dcc-bfa4-08a8dd689e9e"
-                      modified_time: "2019-07-19 17:44:36.953000"
-                      created_time: "2018-10-17 00:14:20.652000"
+                      modified_time: "2019-07-19T17:44:36.953000Z"
+                      created_time: "2018-10-17T00:14:20.652000Z"
                       short_name: "lateral-movement"
                       techniques:
                         - "attack-pattern--01327cde-66c4-4123-bf34-5f258d59457b"
@@ -11319,9 +11319,9 @@ paths:
 
                         Detection efforts may be focused on related stages of the adversary lifecycle, such as during Initial Access.
                       id: attack-pattern--9d48cab2-7929-4812-ad22-f536665f0109
-                      modified_time: '2020-10-25 22:58:23.086000'
+                      modified_time: '2020-10-25T22:58:23.086000Z'
                       deprecated: 0
-                      created_time: '2020-10-02 15:45:17.628000'
+                      created_time: '2020-10-02T15:45:17.628000Z'
                       name: Gather Victim Network Information
                       description: |-
                         Before compromising a victim, adversaries may gather information about the victim's networks that can be used during targeting. Information about networks may include a variety of details, including administrative data (ex: IP ranges, domain names, etc.) as well as specifics regarding its topology and operations.
@@ -11543,8 +11543,8 @@ paths:
               example:
                 data:
                   affected_items:
-                    - start: "2021-05-28 11:49:50"
-                      end: "2021-05-28 11:49:59"
+                    - start: "2021-05-28T11:49:50Z"
+                      end: "2021-05-28T11:49:59Z"
                   total_affected_items: 1
                   total_failed_items: 0
                   failed_items: []

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -5425,7 +5425,7 @@ paths:
                 license_name: "GPL 2.0"
                 license_url: "https://github.com/wazuh/wazuh/blob/4.3/LICENSE"
                 hostname: "wazuh"
-                timestamp: "2019-04-02T08:08:11+0000"
+                timestamp: "2019-04-02T08:08:11Z"
 
   /active-response:
     put:
@@ -6096,8 +6096,8 @@ paths:
                 data:
                   affected_items:
                     - global:
-                        start: '2021-05-27 08:01:38'
-                        end: '2021-05-27 08:08:13'
+                        start: '2021-05-27T08:01:38Z'
+                        end: '2021-05-27T08:08:13Z'
                         files:
                           - location: df -P
                             events: 20
@@ -6124,8 +6124,8 @@ paths:
                               - name: agent
                                 drops: 0
                       interval:
-                        start: '2021-05-27 08:08:08'
-                        end: '2021-05-27 08:08:08'
+                        start: '2021-05-27T08:08:08Z'
+                        end: '2021-05-27T08:08:08Z'
                         files:
                           - location: df -P
                             events: 0
@@ -6289,8 +6289,8 @@ paths:
                       module: "upgrade_module"
                       command: "upgrade"
                       status: "Legacy upgrade: check the result manually since the agent cannot report the result of the task"
-                      create_time: "2020/11/03 15:59:32"
-                      update_time: "2020/11/03 16:01:55"
+                      create_time: "2020-11-03T15:59:32Z"
+                      update_time: "2020-11-03T16:01:55Z"
                   total_affected_items: 1
                   total_failed_items: 0
                   failed_items: []
@@ -7829,12 +7829,12 @@ paths:
                         sync_integrity_free: true
                         sync_extravalid_free: true
                         last_check_integrity:
-                          date_start_master: 2021-05-27 10:50:51.325656
-                          date_end_master: 2021-05-27 10:50:51.342140
+                          date_start_master: 2021-05-27T10:50:51.325656Z
+                          date_end_master: 2021-05-27T10:50:51.342140Z
                         last_sync_integrity:
-                          date_start_master: 2021-05-27 10:48:54.086973
-                          tmp_date_start_master: 2021-05-27 10:48:54.086973
-                          date_end_master: 2021-05-27 10:48:54.093328
+                          date_start_master: 2021-05-27T10:48:54.086973Z
+                          tmp_date_start_master: 2021-05-27T10:48:54.086973Z
+                          date_end_master: 2021-05-27T10:48:54.093328Z
                           total_extra_valid: 0
                           total_files:
                             missing: 2
@@ -7842,10 +7842,10 @@ paths:
                             extra_valid: 0
                             shared: 0
                         last_sync_agentinfo:
-                          date_start_master: 2021-05-27 10:50:49.174463
-                          date_end_master: 2021-05-27 10:50:49.175921
+                          date_start_master: 2021-05-27T10:50:49.174463Z
+                          date_end_master: 2021-05-27T10:50:49.175921Z
                           n_synced_chunks: 1
-                        last_keep_alive: 2021-05-27 10:50:08.985208
+                        last_keep_alive: 2021-05-27T10:50:08.985208Z
                     - info:
                         name: worker2
                         type: worker
@@ -7856,12 +7856,12 @@ paths:
                         sync_integrity_free: true
                         sync_extravalid_free: true
                         last_check_integrity:
-                          date_start_master: 2021-05-27 10:50:51.939323
-                          date_end_master: 2021-05-27 10:50:51.955007
+                          date_start_master: 2021-05-27T10:50:51.939323Z
+                          date_end_master: 2021-05-27T10:50:51.955007Z
                         last_sync_integrity:
-                          date_start_master: 2021-05-27 10:48:54.706395
-                          tmp_date_start_master: 2021-05-27 10:48:54.706395
-                          date_end_master: 2021-05-27 10:48:54.726944
+                          date_start_master: 2021-05-27T10:48:54.706395Z
+                          tmp_date_start_master: 2021-05-27T10:48:54.706395Z
+                          date_end_master: 2021-05-27T10:48:54.726944Z
                           total_extra_valid: 0
                           total_files:
                             missing: 2
@@ -7869,10 +7869,10 @@ paths:
                             extra_valid: 0
                             shared: 0
                         last_sync_agentinfo:
-                          date_start_master: 2021-05-27 10:50:48.832800
-                          date_end_master: 2021-05-27 10:50:48.833854
+                          date_start_master: 2021-05-27T10:50:48.832800Z
+                          date_end_master: 2021-05-27T10:50:48.833854Z
                           n_synced_chunks: 1
-                        last_keep_alive: 2021-05-27 10:50:18.650204
+                        last_keep_alive: 2021-05-27T10:50:18.650204Z
                   total_affected_items: 3
                   total_failed_items: 0
                   failed_items: []
@@ -9704,7 +9704,7 @@ paths:
                     - "INFO: (7202): Session initialized with token '8cd2d6d1'"
                   token: 8cd2d6d1
                   output:
-                    timestamp: 2021-05-27T12:46:03.391+0000
+                    timestamp: 2021-05-27T12:46:03.391000Z
                     rule:
                       level: 2
                       description: "Unknown problem somewhere in the system."
@@ -11448,13 +11448,13 @@ paths:
               example:
                 data:
                   affected_items:
-                    - date_first: "2020-10-23 10:34:09"
+                    - date_first: "2020-10-23T10:34:09Z"
                       log: "Ending CIS-CAT scan. File: /var/ossec/wodles/ciscat/benchmarks/CIS_Ubuntu_Linux_16.04_LTS_Benchmark_v1.0.0-xccdf.xml."
-                      date_last: "2020-10-23 10:34:09"
+                      date_last: "2020-10-23T10:34:09Z"
                       status: "outstanding"
-                    - date_first: "2020-10-23 10:33:43"
+                    - date_first: "2020-10-23T10:33:43Z"
                       log: "Starting CIS-CAT scan. File: /var/ossec/wodles/ciscat/benchmarks/CIS_Ubuntu_Linux_16.04_LTS_Benchmark_v1.0.0-xccdf.xml."
-                      date_last: "2020-10-23 10:33:49"
+                      date_last: "2020-10-23T10:33:49Z"
                       status: "outstanding"
                   total_affected_items: 2
                   total_failed_items: 0
@@ -16653,8 +16653,8 @@ paths:
                       module: upgrade_module
                       command: upgrade
                       status: In progress
-                      create_time: 2020/11/10 11:55:33
-                      update_time: 2020/11/10 11:55:36
+                      create_time: 2020-11-10T11:55:33Z
+                      update_time: 2020-11-10T11:55:36Z
                   total_affected_items: 1
                   total_failed_items: 0
                   failed_items: []

--- a/api/test/integration/env/configurations/base/manager/configuration_files/master_only/agent_info.yaml
+++ b/api/test/integration/env/configurations/base/manager/configuration_files/master_only/agent_info.yaml
@@ -15,6 +15,7 @@
     node_name: master-node
     manager_host: wazuh-master
     connection_status: disconnected
+    date_add: 1625356800  # Sun, 04 Jul 2021 00:00:00 GMT
   labels:
     '#"_agent_ip"': 172.28.0.14
     '#"_manager_hostname"': wazuh-master
@@ -40,6 +41,7 @@
     node_name: master-node
     manager_host: wazuh-master
     connection_status: disconnected
+    date_add: 1625529600  # Tue, 06 Jul 2021 00:00:00 GMT
   labels:
     '#"_agent_ip"': 172.28.0.15
     '#"_manager_hostname"': wazuh-master

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -769,6 +769,32 @@ stages:
           total_affected_items: 4
           total_failed_items: 0
 
+  - name: Filter agents by query (datetime)
+    request:
+      verify: False
+      <<: *get_agents
+      params:
+        q: dateAdd<2021-07-01 00:00:00;lastKeepAlive>2021-07-01
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - id: '001'
+            - id: '002'
+            - id: '003'
+            - id: '004'
+            - id: '005'
+            - id: '006'
+            - id: '007'
+            - id: '008'
+            - id: '009'
+            - id: '010'
+          failed_items: [ ]
+          total_affected_items: 10
+          total_failed_items: 0
+
   - name: Filter agents by complex query
     request:
       verify: False

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -774,25 +774,51 @@ stages:
       verify: False
       <<: *get_agents
       params:
-        q: dateAdd<2021-07-01 00:00:00;lastKeepAlive>2021-07-01
+        q: dateAdd>2021-07-03 00:00:00;lastKeepAlive>2021-07-02
     response:
       status_code: 200
       json:
         error: !anyint
         data:
           affected_items:
-            - id: '001'
-            - id: '002'
-            - id: '003'
-            - id: '004'
-            - id: '005'
-            - id: '006'
-            - id: '007'
-            - id: '008'
             - id: '009'
             - id: '010'
           failed_items: [ ]
-          total_affected_items: 10
+          total_affected_items: 2
+          total_failed_items: 0
+
+  - name: Filter agents by query (datetime)
+    request:
+      verify: False
+      <<: *get_agents
+      params:
+        q: dateAdd>2021-07-03 00:00:00;dateAdd<2021-07-05 00:00:00
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - id: '009'
+          failed_items: [ ]
+          total_affected_items: 1
+          total_failed_items: 0
+
+  - name: Filter agents by query (datetime)
+    request:
+      verify: False
+      <<: *get_agents
+      params:
+        q: dateAdd>2021-07-07 00:00:00,dateAdd>2021-07-04 00:00:00
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - id: '010'
+          failed_items: [ ]
+          total_affected_items: 1
           total_failed_items: 0
 
   - name: Filter agents by complex query

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -663,6 +663,25 @@ stages:
             key: "level"
             expected_values: "info"
 
+  - name: Filters by query (timestamp<2021-07-01)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        q: timestamp<2021-07-01
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items: []
+          failed_items: []
+          total_affected_items: 0
+          total_failed_items: 0
+
 ---
 test_name: GET /manager/logs/summary
 

--- a/api/test/integration/test_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_mitre_endpoints.tavern.yaml
@@ -317,7 +317,25 @@ stages:
       verify: False
       <<: *general_mitigations_request
       params:
-        q: "created_time<2020-10-19 14:57:59;created_time>2020-10-19 14:57:57"
+        q: "created_time=2020-10-19T14:57:58.771000Z"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *mitigations_response
+              created_time: "2020-10-19T14:57:58.771000Z"
+          failed_items: [ ]
+          total_affected_items: 1
+          total_failed_items: 0
+
+  - name: Filter mitigations using q parameter (complex query)
+    request:
+      verify: False
+      <<: *general_mitigations_request
+      params:
+        q: "created_time<2020-10-19T14:57:59;created_time>2020-10-18"
     response:
       status_code: 200
       json:

--- a/api/test/integration/test_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_mitre_endpoints.tavern.yaml
@@ -325,7 +325,7 @@ stages:
         data:
           affected_items:
             - <<: *mitigations_response
-              created_time: "2020-10-19 14:57:58.771000"
+              created_time: "2020-10-19T14:57:58.771000Z"
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
@@ -915,7 +915,7 @@ stages:
         data:
           affected_items:
             - <<: *tactics_response
-              created_time: "2019-03-14 18:44:44.639000"
+              created_time: "2019-03-14T18:44:44.639000Z"
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
@@ -1226,7 +1226,7 @@ stages:
         data:
           affected_items:
             - <<: *techniques_response
-              created_time: "2020-02-11 18:42:07.281000"
+              created_time: "2020-02-11T18:42:07.281000Z"
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
@@ -1528,7 +1528,7 @@ stages:
         data:
           affected_items:
             - <<: *groups_response
-              created_time: "2019-01-29 21:27:24.793000"
+              created_time: "2019-01-29T21:27:24.793000Z"
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
@@ -1830,7 +1830,7 @@ stages:
         data:
           affected_items:
             - <<: *software_response
-              created_time: "2017-05-31 21:32:40.801000"
+              created_time: "2017-05-31T21:32:40.801000Z"
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0

--- a/api/test/integration/test_overview_endpoints.tavern.yaml
+++ b/api/test/integration/test_overview_endpoints.tavern.yaml
@@ -88,6 +88,6 @@ stages:
                uname: !anystr
                version: !anystr
              registerIP: any
-             status: active
+             status: disconnected
              version: !anystr
          nodes: !anything

--- a/api/test/integration/test_rbac_black_overview_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_overview_endpoints.tavern.yaml
@@ -84,6 +84,6 @@ stages:
                uname: !anystr
                version: !anystr
              registerIP: any
-             status: active
+             status: disconnected
              version: !anystr
          nodes: !anything

--- a/api/test/integration/test_rbac_white_overview_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_overview_endpoints.tavern.yaml
@@ -72,6 +72,6 @@ stages:
                uname: !anystr
                version: !anystr
              registerIP: any
-             status: active
+             status: disconnected
              version: !anystr
          nodes: !anything

--- a/api/test/integration/test_rbac_white_task_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_task_endpoints.tavern.yaml
@@ -48,10 +48,10 @@ stages:
         data:
           affected_items:
             - agent_id: "001"
-              create_time: !anyint
+              create_time: !anystr
               node: !anystr
               status: !anystr
-              last_update_time: !anyint
+              last_update_time: !anystr
               command: "upgrade"
               module: "upgrade_module"
               task_id: 1

--- a/api/test/integration/test_task_endpoints.tavern.yaml
+++ b/api/test/integration/test_task_endpoints.tavern.yaml
@@ -89,10 +89,10 @@ stages:
         data:
           affected_items: &task
             - agent_id: !anystr
-              create_time: !anyint
+              create_time: !anystr
               node: !anystr
               status: !anystr
-              last_update_time: !anyint
+              last_update_time: !anystr
               command: "upgrade"
               module: "upgrade_module"
               task_id: 2
@@ -113,10 +113,10 @@ stages:
         data:
           affected_items:
             - agent_id: !anystr
-              create_time: !anyint
+              create_time: !anystr
               node: !anystr
               status: !anystr
-              last_update_time: !anyint
+              last_update_time: !anystr
               command: "upgrade"
               module: "upgrade_module"
               task_id: 1
@@ -281,12 +281,12 @@ stages:
           affected_items:
             - <<: *task
               status: !anystr
-              last_update_time: !anyint
+              last_update_time: !anystr
               agent_id: !anystr
               task_id: 3
             - <<: *task
               status: !anystr
-              last_update_time: !anyint
+              last_update_time: !anystr
               agent_id: !anystr
               task_id: 4
           failed_items: []
@@ -310,7 +310,7 @@ stages:
           affected_items:
             - <<: *task
               status: !anystr
-              last_update_time: !anyint
+              last_update_time: !anystr
               agent_id: "003"
               task_id: !anyint
           failed_items: []
@@ -353,23 +353,23 @@ stages:
           affected_items:
             - <<: *task
               status: !anystr
-              last_update_time: !anyint
+              last_update_time: !anystr
               task_id: 1
             - <<: *task
               status: !anystr
-              last_update_time: !anyint
+              last_update_time: !anystr
               task_id: 2
             - <<: *task
               status: !anystr
-              last_update_time: !anyint
+              last_update_time: !anystr
               task_id: 3
             - <<: *task
               status: !anystr
-              last_update_time: !anyint
+              last_update_time: !anystr
               task_id: 4
             - <<: *task
               status: !anystr
-              last_update_time: !anyint
+              last_update_time: !anystr
               task_id: 5
           failed_items: []
           total_affected_items: 5

--- a/api/test/integration/test_task_endpoints.tavern.yaml
+++ b/api/test/integration/test_task_endpoints.tavern.yaml
@@ -203,6 +203,21 @@ stages:
       verify: False
       <<: *get_tasks
       params:
+        q: "create_time>2021-07-01"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          failed_items: [ ]
+          total_affected_items: 5
+          total_failed_items: 0
+
+  - name: Verify that query parameter works as expected
+    request:
+      verify: False
+      <<: *get_tasks
+      params:
         q: "agent_id>004;agent_id<006"
     response:
       status_code: 200

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -1373,5 +1373,11 @@ def core_upgrade_agents(agents_chunk, command='upgrade_result', wpk_repo=None, v
     s.send(dumps(msg).encode())
     data = loads(s.receive().decode())
     s.close()
+    for agent_info in data['data']:
+        if agent_info['message'] == 'Success':
+            agent_info['create_time'] = datetime.strptime(agent_info['create_time'],
+                                                          "%Y/%m/%d %H:%M:%S").strftime("%Y-%m-%dT%H:%M:%SZ")
+            agent_info['update_time'] = datetime.strptime(agent_info['update_time'],
+                                                          "%Y/%m/%d %H:%M:%S").strftime("%Y-%m-%dT%H:%M:%SZ")
 
     return data

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -1373,11 +1373,8 @@ def core_upgrade_agents(agents_chunk, command='upgrade_result', wpk_repo=None, v
     s.send(dumps(msg).encode())
     data = loads(s.receive().decode())
     s.close()
-    for agent_info in data['data']:
-        if agent_info['message'] == 'Success':
-            agent_info['create_time'] = datetime.strptime(agent_info['create_time'],
-                                                          "%Y/%m/%d %H:%M:%S").strftime("%Y-%m-%dT%H:%M:%SZ")
-            agent_info['update_time'] = datetime.strptime(agent_info['update_time'],
-                                                          "%Y/%m/%d %H:%M:%S").strftime("%Y-%m-%dT%H:%M:%SZ")
+    [agent_info.update((k, datetime.strptime(v, "%Y/%m/%d %H:%M:%S").strftime("%Y-%m-%dT%H:%M:%SZ"))
+                       for k, v in agent_info.items() if k in {'create_time', 'update_time'})
+     for agent_info in data['data']]
 
     return data

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -61,7 +61,7 @@ class WazuhDBQueryAgents(WazuhDBQuery):
 
     def _filter_date(self, date_filter, filter_db_name):
         WazuhDBQuery._filter_date(self, date_filter, filter_db_name)
-        self.query = self.query[:-1] + ' AND id != 0'
+        self.query += ' AND id != 0'
 
     def _sort_query(self, field):
         if field == 'os.version':

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -23,7 +23,7 @@ import api.configuration as aconf
 from wazuh.core import common, configuration, stats
 from wazuh.core.InputValidator import InputValidator
 from wazuh.core.cluster.utils import get_manager_status
-from wazuh.core.common import AGENT_COMPONENT_STATS_REQUIRED_VERSION
+from wazuh.core.common import AGENT_COMPONENT_STATS_REQUIRED_VERSION, date_format
 from wazuh.core.exception import WazuhException, WazuhError, WazuhInternalError, WazuhResourceNotFound
 from wazuh.core.utils import chmod_r, WazuhVersion, plain_dict_to_nested_dict, get_fields_to_nest, WazuhDBQuery, \
     WazuhDBQueryDistinct, WazuhDBQueryGroupBy, WazuhDBBackend, safe_move
@@ -1373,7 +1373,7 @@ def core_upgrade_agents(agents_chunk, command='upgrade_result', wpk_repo=None, v
     s.send(dumps(msg).encode())
     data = loads(s.receive().decode())
     s.close()
-    [agent_info.update((k, datetime.strptime(v, "%Y/%m/%d %H:%M:%S").strftime("%Y-%m-%dT%H:%M:%SZ"))
+    [agent_info.update((k, datetime.strptime(v, "%Y/%m/%d %H:%M:%S").strftime(date_format))
                        for k, v in agent_info.items() if k in {'create_time', 'update_time'})
      for agent_info in data['data']]
 

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -181,6 +181,8 @@ agent_info_sleep = 2  # Seconds between retries
 database_limit = 500
 maximum_database_limit = 100000
 limit_seconds = 1800  # 600*3
+date_format = "%Y-%m-%dT%H:%M:%SZ"
+decimals_date_format = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 _wazuh_uid = None
 _wazuh_gid = None

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -166,7 +166,7 @@ class WazuhException(Exception):
         1409: 'Invalid query operator.',
         1410: 'Selecting more than one field in distinct mode',
         1411: 'TimeFrame is not valid',
-        1412: 'Date filter not valid. Valid formats are timeframe, YYYY-MM-DD HH:mm:ss, YYYY-MM-DDTHH:mm:ssZ or YYYY-MM-DD',
+        1412: 'Date filter not valid. Valid formats are YYYY-MM-DD HH:mm:ss, YYYY-MM-DDTHH:mm:ssZ or YYYY-MM-DD',
         1413: {'message': 'Error reading rules file'},
         1414: {'message': 'Error reading rules file',
                'remediation': 'Please, make sure you have read permissions over the file'

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -166,7 +166,7 @@ class WazuhException(Exception):
         1409: 'Invalid query operator.',
         1410: 'Selecting more than one field in distinct mode',
         1411: 'TimeFrame is not valid',
-        1412: 'Date filter not valid. Valid formats are timeframe or YYYY-MM-DD HH:mm:ss',
+        1412: 'Date filter not valid. Valid formats are timeframe, YYYY-MM-DD HH:mm:ss, YYYY-MM-DDTHH:mm:ssZ or YYYY-MM-DD',
         1413: {'message': 'Error reading rules file'},
         1414: {'message': 'Error reading rules file',
                'remediation': 'Please, make sure you have read permissions over the file'

--- a/framework/wazuh/core/logtest.py
+++ b/framework/wazuh/core/logtest.py
@@ -29,7 +29,10 @@ def send_logtest_msg(command: str = None, parameters: dict = None):
     logtest_socket.send(full_message)
     response = logtest_socket.receive(raw=True)
     logtest_socket.close()
-    response['data']['output']['timestamp'] = datetime.strptime(
-        response['data']['output']['timestamp'], "%Y-%m-%dT%H:%M:%S.%f+0000").strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    try:
+        response['data']['output']['timestamp'] = datetime.strptime(
+            response['data']['output']['timestamp'], "%Y-%m-%dT%H:%M:%S.%f+0000").strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    except KeyError:
+        pass
 
     return response

--- a/framework/wazuh/core/logtest.py
+++ b/framework/wazuh/core/logtest.py
@@ -2,6 +2,7 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
+from datetime import datetime
 from wazuh.core.common import LOGTEST_SOCKET, origin_module
 from wazuh.core.wazuh_socket import WazuhSocketJSON, create_wazuh_socket_message
 
@@ -28,5 +29,7 @@ def send_logtest_msg(command: str = None, parameters: dict = None):
     logtest_socket.send(full_message)
     response = logtest_socket.receive(raw=True)
     logtest_socket.close()
+    response['data']['output']['timestamp'] = datetime.strptime(
+        response['data']['output']['timestamp'], "%Y-%m-%dT%H:%M:%S.%f+0000").strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
     return response

--- a/framework/wazuh/core/logtest.py
+++ b/framework/wazuh/core/logtest.py
@@ -3,7 +3,7 @@
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from datetime import datetime
-from wazuh.core.common import LOGTEST_SOCKET, origin_module
+from wazuh.core.common import LOGTEST_SOCKET, decimals_date_format, origin_module
 from wazuh.core.wazuh_socket import WazuhSocketJSON, create_wazuh_socket_message
 
 
@@ -31,7 +31,7 @@ def send_logtest_msg(command: str = None, parameters: dict = None):
     logtest_socket.close()
     try:
         response['data']['output']['timestamp'] = datetime.strptime(
-            response['data']['output']['timestamp'], "%Y-%m-%dT%H:%M:%S.%f+0000").strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+            response['data']['output']['timestamp'], "%Y-%m-%dT%H:%M:%S.%f+0000").strftime(decimals_date_format)
     except KeyError:
         pass
 

--- a/framework/wazuh/core/manager.py
+++ b/framework/wazuh/core/manager.py
@@ -67,8 +67,8 @@ def get_ossec_logs(limit=2000):
             date, tag, level, description = log_fields
 
             # We transform local time (ossec.log) to UTC with ISO8601 maintaining time integrity
-            log_line = {'timestamp': date.astimezone(timezone.utc),
-                        'tag': tag, 'level': level, 'description': description}
+            log_line = {'timestamp': date.strftime('%Y-%m-%dT%H:%M:%SZ'), 'tag': tag,
+                        'level': level, 'description': description}
             logs.append(log_line)
 
     return logs

--- a/framework/wazuh/core/manager.py
+++ b/framework/wazuh/core/manager.py
@@ -9,7 +9,6 @@ import re
 import socket
 from collections import OrderedDict
 from datetime import datetime
-from datetime import timezone
 from os.path import exists, join
 from typing import Dict
 
@@ -18,7 +17,7 @@ from wazuh import WazuhInternalError, WazuhError, WazuhException
 from wazuh.core import common
 from wazuh.core.cluster.utils import get_manager_status
 from wazuh.core.utils import tail
-from wazuh.core.wazuh_socket import create_wazuh_socket_message, WazuhSocket
+from wazuh.core.wazuh_socket import WazuhSocket
 
 _re_logtest = re.compile(r"^.*(?:ERROR: |CRITICAL: )(?:\[.*\] )?(.*)$")
 wcom_lockfile = join(common.wazuh_path, "var", "run", ".api_wcom_lock")
@@ -67,7 +66,7 @@ def get_ossec_logs(limit=2000):
             date, tag, level, description = log_fields
 
             # We transform local time (ossec.log) to UTC with ISO8601 maintaining time integrity
-            log_line = {'timestamp': date.strftime('%Y-%m-%dT%H:%M:%SZ'), 'tag': tag,
+            log_line = {'timestamp': date.strftime(common.date_format), 'tag': tag,
                         'level': level, 'description': description}
             logs.append(log_line)
 

--- a/framework/wazuh/core/mitre.py
+++ b/framework/wazuh/core/mitre.py
@@ -73,7 +73,7 @@ class WazuhDBQueryMitre(WazuhDBQuery):
 
     def _format_data_into_dictionary(self):
         """Standardization of dates to the ISO 8601 format."""
-        [t.update((k, datetime.strptime(v, '%Y-%m-%d %H:%M:%S.%f').strftime("%Y-%m-%dT%H:%M:%SZ"))
+        [t.update((k, datetime.strptime(v, '%Y-%m-%d %H:%M:%S.%f').strftime("%Y-%m-%dT%H:%M:%S.%fZ"))
                   for k, v in t.items() if k in self.date_fields) for t in self._data]
 
         return {'items': self._data, 'totalItems': self.total_items}

--- a/framework/wazuh/core/mitre.py
+++ b/framework/wazuh/core/mitre.py
@@ -72,6 +72,7 @@ class WazuhDBQueryMitre(WazuhDBQuery):
         mitre_resource.update(reference_external_id)
 
     def _format_data_into_dictionary(self):
+        """Standardization of dates to the ISO 8601 format."""
         for t in self._data:
             if t.keys() >= {'created_time', 'modified_time'}:
                 t['created_time'] = datetime.strptime(t['created_time'],

--- a/framework/wazuh/core/mitre.py
+++ b/framework/wazuh/core/mitre.py
@@ -73,12 +73,8 @@ class WazuhDBQueryMitre(WazuhDBQuery):
 
     def _format_data_into_dictionary(self):
         """Standardization of dates to the ISO 8601 format."""
-        for t in self._data:
-            if t.keys() >= {'created_time', 'modified_time'}:
-                t['created_time'] = datetime.strptime(t['created_time'],
-                                                      '%Y-%m-%d %H:%M:%S.%f').strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-                t['modified_time'] = datetime.strptime(t['modified_time'],
-                                                       '%Y-%m-%d %H:%M:%S.%f').strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        [t.update((k, datetime.strptime(v, '%Y-%m-%d %H:%M:%S.%f').strftime("%Y-%m-%dT%H:%M:%SZ"))
+                  for k, v in t.items() if k in self.date_fields) for t in self._data]
 
         return {'items': self._data, 'totalItems': self.total_items}
 

--- a/framework/wazuh/core/mitre.py
+++ b/framework/wazuh/core/mitre.py
@@ -73,7 +73,7 @@ class WazuhDBQueryMitre(WazuhDBQuery):
 
     def _format_data_into_dictionary(self):
         """Standardization of dates to the ISO 8601 format."""
-        [t.update((k, datetime.strptime(v, '%Y-%m-%d %H:%M:%S.%f').strftime("%Y-%m-%dT%H:%M:%S.%fZ"))
+        [t.update((k, datetime.strptime(v, '%Y-%m-%d %H:%M:%S.%f').strftime(common.decimals_date_format))
                   for k, v in t.items() if k in self.date_fields) for t in self._data]
 
         return {'items': self._data, 'totalItems': self.total_items}

--- a/framework/wazuh/core/mitre.py
+++ b/framework/wazuh/core/mitre.py
@@ -3,6 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GP
 
 import copy
+from datetime import datetime
 from functools import lru_cache
 from typing import Union
 
@@ -41,6 +42,7 @@ class WazuhDBQueryMitre(WazuhDBQuery):
                               fields=fields, default_sort_field=default_sort_field,
                               default_sort_order=default_sort_order, filters=filters, query=query, count=count,
                               get_data=True, min_select_fields=min_select_fields,
+                              date_fields={'created_time', 'modified_time'},
                               backend=WazuhDBBackend(query_format='mitre', request_slice=request_slice))
 
         self.relation_fields = set()  # This variable contains valid fields not included in the database (relations)
@@ -68,6 +70,16 @@ class WazuhDBQueryMitre(WazuhDBQuery):
         if reference_external_id:
             mitre_resource['references'].remove(reference_external_id)
         mitre_resource.update(reference_external_id)
+
+    def _format_data_into_dictionary(self):
+        for t in self._data:
+            if t.keys() >= {'created_time', 'modified_time'}:
+                t['created_time'] = datetime.strptime(t['created_time'],
+                                                      '%Y-%m-%d %H:%M:%S.%f').strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                t['modified_time'] = datetime.strptime(t['modified_time'],
+                                                       '%Y-%m-%d %H:%M:%S.%f').strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+        return {'items': self._data, 'totalItems': self.total_items}
 
 
 class WazuhDBQueryMitreMetadata(WazuhDBQueryMitre):

--- a/framework/wazuh/core/rootcheck.py
+++ b/framework/wazuh/core/rootcheck.py
@@ -67,7 +67,7 @@ class WazuhDBQueryRootcheck(WazuhDBQuery):
     def _format_data_into_dictionary(self):
         def format_fields(field_name, value):
             if field_name in ['date_first', 'date_last']:
-                return datetime.utcfromtimestamp(value).strftime("%Y-%m-%d %H:%M:%S")
+                return datetime.utcfromtimestamp(value).strftime("%Y-%m-%dT%H:%M:%SZ")
             else:
                 return value
 
@@ -99,12 +99,12 @@ def last_scan(agent_id):
     result = wdb_conn.execute(f"agent {agent_id} sql SELECT max(date_last) FROM pm_event WHERE "
                               "log = 'Ending rootcheck scan.'")
     time = list(result[0].values())[0] if result else None
-    end = datetime.utcfromtimestamp(time).strftime("%Y-%m-%d %H:%M:%S") if time is not None else None
+    end = datetime.utcfromtimestamp(time).strftime("%Y-%m-%dT%H:%M:%SZ") if time is not None else None
 
     # start time
     result = wdb_conn.execute(f"agent {agent_id} sql SELECT max(date_last) FROM pm_event "
                               "WHERE log = 'Starting rootcheck scan.'")
     time = list(result[0].values())[0] if result else None
-    start = datetime.utcfromtimestamp(time).strftime("%Y-%m-%d %H:%M:%S") if time is not None else None
+    start = datetime.utcfromtimestamp(time).strftime("%Y-%m-%dT%H:%M:%SZ") if time is not None else None
 
     return {'start': start, 'end': None if start is None else None if end is None or end < start else end}

--- a/framework/wazuh/core/rootcheck.py
+++ b/framework/wazuh/core/rootcheck.py
@@ -5,6 +5,7 @@
 from datetime import datetime
 
 from wazuh.core.agent import Agent
+from wazuh.core.common import date_format
 from wazuh.core.exception import WazuhException
 from wazuh.core.utils import WazuhDBQuery, WazuhDBBackend
 from wazuh.core.wdb import WazuhDBConnection
@@ -66,10 +67,8 @@ class WazuhDBQueryRootcheck(WazuhDBQuery):
 
     def _format_data_into_dictionary(self):
         def format_fields(field_name, value):
-            if field_name in ['date_first', 'date_last']:
-                return datetime.utcfromtimestamp(value).strftime("%Y-%m-%dT%H:%M:%SZ")
-            else:
-                return value
+            return datetime.utcfromtimestamp(value).strftime(date_format) \
+                if field_name in ['date_first', 'date_last'] else value
 
         return {'items': [{field: format_fields(field, db_tuple[field]) for field in self.select |
                            self.min_select_fields if field in db_tuple and db_tuple[field] is not None}
@@ -99,12 +98,12 @@ def last_scan(agent_id):
     result = wdb_conn.execute(f"agent {agent_id} sql SELECT max(date_last) FROM pm_event WHERE "
                               "log = 'Ending rootcheck scan.'")
     time = list(result[0].values())[0] if result else None
-    end = datetime.utcfromtimestamp(time).strftime("%Y-%m-%dT%H:%M:%SZ") if time is not None else None
+    end = datetime.utcfromtimestamp(time).strftime(date_format) if time is not None else None
 
     # start time
     result = wdb_conn.execute(f"agent {agent_id} sql SELECT max(date_last) FROM pm_event "
                               "WHERE log = 'Starting rootcheck scan.'")
     time = list(result[0].values())[0] if result else None
-    start = datetime.utcfromtimestamp(time).strftime("%Y-%m-%dT%H:%M:%SZ") if time is not None else None
+    start = datetime.utcfromtimestamp(time).strftime(date_format) if time is not None else None
 
     return {'start': start, 'end': None if start is None else None if end is None or end < start else end}

--- a/framework/wazuh/core/sca.py
+++ b/framework/wazuh/core/sca.py
@@ -71,25 +71,6 @@ class WazuhDBQuerySCA(WazuhDBQuery):
     def _default_count_query(self):
         return f"SELECT COUNT(DISTINCT {self.count_field})" + " FROM ({0})"
 
-    def _process_filter(self, field_name, field_filter, q_filter):
-        if field_name in self.date_fields and not isinstance(q_filter['value'], (int, float)):
-            # Filter a date, but only if it is in string (YYYY-MM-DD hh:mm:ss) format.
-            # If it matches the same format as DB (timestamp integer), filter directly by value (next if cond).
-            self._filter_date(q_filter, field_name)
-        else:
-            if q_filter['value'] is not None:
-                self.request[field_filter] = q_filter['value'] if field_name != "version" else re.sub(
-                    r'([a-zA-Z])([v])', r'\1 \2', q_filter['value'])
-                if q_filter['operator'] == 'LIKE' and q_filter['field'] not in self.wildcard_equal_fields:
-                    self.request[field_filter] = "%{}%".format(self.request[field_filter])
-                self.query += '{} {} :{}'.format(self.fields[field_name].split(' as ')[0], q_filter['operator'],
-                                                 field_filter)
-                if not field_filter.isdigit():
-                    # filtering without being uppercase/lowercase sensitive
-                    self.query += ' COLLATE NOCASE'
-            else:
-                self.query += '{} IS null'.format(self.fields[field_name])
-
     def _format_data_into_dictionary(self):
         def format_fields(field_name, value):
             if field_name in ['end_scan', 'start_scan']:

--- a/framework/wazuh/core/stats.py
+++ b/framework/wazuh/core/stats.py
@@ -4,6 +4,7 @@
 
 import json
 import os
+from datetime import datetime
 
 from wazuh.core import common
 from wazuh.core.exception import WazuhInternalError, WazuhError
@@ -59,7 +60,10 @@ def get_daemons_stats_from_socket(agent_id, daemon):
 
     # Format response
     try:
-        return json.loads(rec_msg)['data']
+        data = json.loads(rec_msg)['data']
+        [d.update((k, datetime.strptime(v, "%Y/%m/%d %H:%M:%S").strftime("%Y-%m-%dT%H:%M:%SZ"))
+                  for k, v in d.items() if k in {'last_keepalive', 'last_ack'}) for d in data['data']]
+        return data
     except Exception:
         rec_msg = rec_msg.split(" ", 1)[1]
         raise WazuhError(1117, extra_message=rec_msg)

--- a/framework/wazuh/core/stats.py
+++ b/framework/wazuh/core/stats.py
@@ -61,8 +61,8 @@ def get_daemons_stats_from_socket(agent_id, daemon):
     # Format response
     try:
         data = json.loads(rec_msg)['data']
-        [d.update((k, datetime.strptime(v, "%Y/%m/%d %H:%M:%S").strftime("%Y-%m-%dT%H:%M:%SZ"))
-                  for k, v in d.items() if k in {'last_keepalive', 'last_ack'}) for d in data['data']]
+        data.update((k, datetime.strptime(data[k], "%Y-%m-%d %H:%M:%S").strftime("%Y-%m-%dT%H:%M:%SZ"))
+                    for k, v in data.items() if k in {'last_keepalive', 'last_ack'})
         return data
     except Exception:
         rec_msg = rec_msg.split(" ", 1)[1]

--- a/framework/wazuh/core/stats.py
+++ b/framework/wazuh/core/stats.py
@@ -61,7 +61,7 @@ def get_daemons_stats_from_socket(agent_id, daemon):
     # Format response
     try:
         data = json.loads(rec_msg)['data']
-        data.update((k, datetime.strptime(data[k], "%Y-%m-%d %H:%M:%S").strftime("%Y-%m-%dT%H:%M:%SZ"))
+        data.update((k, datetime.strptime(data[k], "%Y-%m-%d %H:%M:%S").strftime(common.date_format))
                     for k, v in data.items() if k in {'last_keepalive', 'last_ack'})
         return data
     except Exception:

--- a/framework/wazuh/core/syscheck.py
+++ b/framework/wazuh/core/syscheck.py
@@ -19,16 +19,6 @@ class WazuhDBQuerySyscheck(WazuhDBQuery):
                          *args, **kwargs)
         self.nested = nested
 
-    def _filter_date(self, date_filter, filter_db_name):
-        # dates are stored as timestamps
-        try:
-            date_filter['value'] = int(datetime.timestamp(datetime.strptime(date_filter['value'], "%Y-%m-%d %H:%M:%S")))
-        except ValueError:
-            date_filter['value'] = int(datetime.timestamp(datetime.strptime(date_filter['value'], "%Y-%m-%d")))
-        self.query += "{0} IS NOT NULL AND {0} {1} :{2}".format(self.fields[filter_db_name], date_filter['operator'],
-                                                                date_filter['field'])
-        self.request[date_filter['field']] = date_filter['value']
-
     def _format_data_into_dictionary(self):
         def format_fields(field_name, value):
             if field_name == 'mtime' or field_name == 'date':

--- a/framework/wazuh/core/syscollector.py
+++ b/framework/wazuh/core/syscollector.py
@@ -99,6 +99,7 @@ class WazuhDBQuerySyscollector(WazuhDBQuery):
                          *args, **kwargs)
         self.array = array
         self.nested = nested
+        self.date_fields = {'scan.time', 'install_time'}
 
     def _format_data_into_dictionary(self):
         if self.nested:

--- a/framework/wazuh/core/task.py
+++ b/framework/wazuh/core/task.py
@@ -53,6 +53,7 @@ class WazuhDBQueryTask(WazuhDBQuery):
             super()._process_filter(field_name, field_filter, q_filter)
 
     def _format_data_into_dictionary(self):
+        """Standardization of dates to the ISO 8601 format."""
         for t in self._data:
             if t.keys() >= {'create_time', 'last_update_time'}:
                 t['create_time'] = datetime.utcfromtimestamp(t['create_time']).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/framework/wazuh/core/task.py
+++ b/framework/wazuh/core/task.py
@@ -2,6 +2,7 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GP
 
+from datetime import datetime
 from json import dumps, loads
 
 from wazuh.core import common
@@ -32,6 +33,7 @@ class WazuhDBQueryTask(WazuhDBQuery):
         WazuhDBQuery.__init__(self, offset=offset, limit=limit, table=table, sort=sort, search=search, select=select,
                               fields=fields, default_sort_field=default_sort_field, default_sort_order='ASC',
                               filters=filters, query=query, count=count, get_data=get_data,
+                              date_fields={'create_time', 'last_update_time'},
                               min_select_fields=min_select_fields, backend=WazuhDBBackend(query_format='task'))
 
     def _final_query(self):
@@ -49,6 +51,14 @@ class WazuhDBQueryTask(WazuhDBQuery):
             self.request[field_filter] = q_filter['value']
         else:
             super()._process_filter(field_name, field_filter, q_filter)
+
+    def _format_data_into_dictionary(self):
+        for t in self._data:
+            if t.keys() >= {'create_time', 'last_update_time'}:
+                t['create_time'] = datetime.utcfromtimestamp(t['create_time']).strftime("%Y-%m-%dT%H:%M:%SZ")
+                t['last_update_time'] = datetime.utcfromtimestamp(t['last_update_time']).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        return {'items': self._data, 'totalItems': self.total_items}
 
 
 def send_to_tasks_socket(command):

--- a/framework/wazuh/core/task.py
+++ b/framework/wazuh/core/task.py
@@ -54,10 +54,8 @@ class WazuhDBQueryTask(WazuhDBQuery):
 
     def _format_data_into_dictionary(self):
         """Standardization of dates to the ISO 8601 format."""
-        for t in self._data:
-            if t.keys() >= {'create_time', 'last_update_time'}:
-                t['create_time'] = datetime.utcfromtimestamp(t['create_time']).strftime("%Y-%m-%dT%H:%M:%SZ")
-                t['last_update_time'] = datetime.utcfromtimestamp(t['last_update_time']).strftime("%Y-%m-%dT%H:%M:%SZ")
+        [t.update((k, datetime.utcfromtimestamp(v).strftime("%Y-%m-%dT%H:%M:%SZ"))
+                  for k, v in t.items() if k in self.date_fields) for t in self._data]
 
         return {'items': self._data, 'totalItems': self.total_items}
 

--- a/framework/wazuh/core/task.py
+++ b/framework/wazuh/core/task.py
@@ -54,7 +54,7 @@ class WazuhDBQueryTask(WazuhDBQuery):
 
     def _format_data_into_dictionary(self):
         """Standardization of dates to the ISO 8601 format."""
-        [t.update((k, datetime.utcfromtimestamp(v).strftime("%Y-%m-%dT%H:%M:%SZ"))
+        [t.update((k, datetime.utcfromtimestamp(v).strftime(common.date_format))
                   for k, v in t.items() if k in self.date_fields) for t in self._data]
 
         return {'items': self._data, 'totalItems': self.total_items}

--- a/framework/wazuh/core/tests/test_logtest.py
+++ b/framework/wazuh/core/tests/test_logtest.py
@@ -25,10 +25,10 @@ def test_send_logtest_msg(create_message_mock, close_mock, send_mock, init_mock,
 
     Parameters
     ----------
-    message : dict
-        Message that will be sent to the logtest socket.
+    params : dict
+        Params that will be sent to the logtest socket.
     """
-    expected_response = {'response': True}
+    expected_response = {'data': {'response': True, 'output': {'timestamp': '1970-01-01T00:00:00.000000+0000'}}}
     with patch('wazuh.core.logtest.WazuhSocketJSON.receive', return_value=expected_response):
         response = send_logtest_msg(**params)
         init_mock.assert_called_with(LOGTEST_SOCKET)

--- a/framework/wazuh/core/tests/test_rootcheck.py
+++ b/framework/wazuh/core/tests/test_rootcheck.py
@@ -161,8 +161,8 @@ def test_WazuhDBQueryRootcheck_format_data_into_dictionary(mock_info, mock_backe
     test._data = [{'log': 'Testing', 'date_first': 1603645251, 'status': 'solved', 'date_last': 1603648851,
          'cis': '2.3 Debian Linux', 'pci_dss': '4.1'}]
     result = test._format_data_into_dictionary()
-    assert result['items'][0]['date_first'] == datetime.utcfromtimestamp(1603645251).strftime("%Y-%m-%d %H:%M:%S") and\
-           result['items'][0]['date_last'] == datetime.utcfromtimestamp(1603648851).strftime("%Y-%m-%d %H:%M:%S")
+    assert result['items'][0]['date_first'] == datetime.utcfromtimestamp(1603645251).strftime("%Y-%m-%dT%H:%M:%SZ") and\
+           result['items'][0]['date_last'] == datetime.utcfromtimestamp(1603648851).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 @patch('wazuh.core.agent.Agent.get_basic_information')
@@ -171,7 +171,7 @@ def test_WazuhDBQueryRootcheck_format_data_into_dictionary(mock_info, mock_backe
 def test_last_scan(mock_connect, mock_send, mock_info):
     """Check if last_scan function returns expected datetime according to the database"""
     result = rootcheck.last_scan('001')
-    assert result == {'end': '2020-10-27 12:29:40', 'start': '2020-10-27 12:19:40'}
+    assert result == {'end': '2020-10-27T12:29:40Z', 'start': '2020-10-27T12:19:40Z'}
 
 
 remove_db(test_data_path)

--- a/framework/wazuh/core/tests/test_rootcheck.py
+++ b/framework/wazuh/core/tests/test_rootcheck.py
@@ -10,6 +10,7 @@ from unittest.mock import patch, ANY
 import pytest
 
 from api.util import remove_nones_to_dict
+from wazuh.core.common import date_format
 from wazuh.core.exception import WazuhException
 
 with patch('wazuh.core.common.wazuh_uid'):
@@ -161,8 +162,8 @@ def test_WazuhDBQueryRootcheck_format_data_into_dictionary(mock_info, mock_backe
     test._data = [{'log': 'Testing', 'date_first': 1603645251, 'status': 'solved', 'date_last': 1603648851,
          'cis': '2.3 Debian Linux', 'pci_dss': '4.1'}]
     result = test._format_data_into_dictionary()
-    assert result['items'][0]['date_first'] == datetime.utcfromtimestamp(1603645251).strftime("%Y-%m-%dT%H:%M:%SZ") and\
-           result['items'][0]['date_last'] == datetime.utcfromtimestamp(1603648851).strftime("%Y-%m-%dT%H:%M:%SZ")
+    assert result['items'][0]['date_first'] == datetime.utcfromtimestamp(1603645251).strftime(date_format) and\
+           result['items'][0]['date_last'] == datetime.utcfromtimestamp(1603648851).strftime(date_format)
 
 
 @patch('wazuh.core.agent.Agent.get_basic_information')

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -264,6 +264,40 @@ def test_process_array(array, filters, limit, search_text, sort_by, expected_ite
     assert result == {'items': expected_items, 'totalItems': len_expected_items}
 
 
+@pytest.mark.parametrize('array, q, expected_items', [
+    ([{'item': 'value_2', 'datetime': '2017-10-25T14:48:53.732000Z'}, {'item': 'value_1',
+                                                                       'datetime': '2018-05-15T12:34:12.544000Z'}],
+     'datetime=2017-10-25T14:48:53.732000Z', [{'item': 'value_2', 'datetime': '2017-10-25T14:48:53.732000Z'}]),
+    ([{'item': 'value_2', 'datetime': '2017-10-25T14:48:53.732000Z'}, {'item': 'value_1',
+                                                                       'datetime': '2018-05-15T12:34:12.544000Z'}],
+     'datetime<2017-10-26', [{'item': 'value_2', 'datetime': '2017-10-25T14:48:53.732000Z'}]),
+    ([{'item': 'value_2', 'datetime': '2017-10-25T14:48:53.732000Z'}, {'item': 'value_1',
+                                                                       'datetime': '2018-05-15T12:34:12.544000Z'}],
+     'datetime>2019-10-26,datetime<2017-10-26', [{'item': 'value_2', 'datetime': '2017-10-25T14:48:53.732000Z'}]),
+    ([{'item': 'value_2', 'datetime': '2017-10-25T14:48:53.732000Z'}, {'item': 'value_1',
+                                                                       'datetime': '2018-05-15T12:34:12.544000Z'}],
+     'datetime>2017-10-26;datetime<2018-05-15T12:34:12.644000Z', [{'item': 'value_1',
+                                                                   'datetime': '2018-05-15T12:34:12.544000Z'}]),
+    ([{'item': 'value_2', 'datetime': '2017-10-25T14:48:53Z'}, {'item': 'value_1', 'datetime': '2018-05-15T12:34:12Z'}],
+     'datetime>2017-10-26;datetime<2018-05-15T12:34:12.001000Z', [{'item': 'value_1',
+                                                                   'datetime': '2018-05-15T12:34:12Z'}]),
+])
+def test_process_array_q(array, q, expected_items):
+    """Check the proper functioning of the q parameter.
+
+    Parameters
+    ----------
+    array : list
+        List of values on which to apply the filter.
+    q : str
+    expected_items : list
+        List of items after applying the filter
+    """
+    result = process_array(array=array, q=q)
+
+    assert result == {'items': expected_items, 'totalItems': len(expected_items)}
+
+
 def test_sort_array_type():
     """Test sort_array function."""
     assert isinstance(sort_array(mock_array, mock_sort_by), list)

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -1402,15 +1402,8 @@ class WazuhDBQuery(object):
         raise NotImplementedError
 
     def _filter_date(self, date_filter, filter_db_name):
-        # date_filter['value'] can be either a timeframe or a date in format %Y-%m-%d %H:%M:%S
-        if date_filter['value'].isdigit() or re.match(r'\d+[dhms]', date_filter['value']):
-            query_operator = '>' if date_filter['operator'] == '<' or date_filter['operator'] == '=' else '<'
-            self.request[date_filter['field']] = get_timeframe_in_seconds(date_filter['value'])
-            self.query += "{0} IS NOT NULL AND {0} {1}" \
-                          " strftime('%s', 'now') - :{2} ".format(self.fields[filter_db_name],
-                                                                   query_operator,
-                                                                   date_filter['field'])
-        elif re.match(r'\d{4}-\d{2}-\d{2}([ T]\d{2}:\d{2}:\d{2}Z?)?', date_filter['value']):
+        # date_filter['value'] can be a date in format %Y-%m-%d, %Y-%m-%d %H:%M:%S or %Y-%m-%dT%H:%M:%SZ
+        if re.match(r'\d{4}-\d{2}-\d{2}([ T]\d{2}:\d{2}:\d{2}Z?)?', date_filter['value']):
             self.query += "{0} IS NOT NULL AND {0} {1} strftime('%s', :{2})".format(
                 self.fields[filter_db_name], date_filter['operator'], date_filter['field'])
             self.request[date_filter['field']] = date_filter['value']

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -1406,13 +1406,13 @@ class WazuhDBQuery(object):
         if date_filter['value'].isdigit() or re.match(r'\d+[dhms]', date_filter['value']):
             query_operator = '>' if date_filter['operator'] == '<' or date_filter['operator'] == '=' else '<'
             self.request[date_filter['field']] = get_timeframe_in_seconds(date_filter['value'])
-            self.query += "({0} IS NOT NULL AND {0} {1}" \
-                          " strftime('%s', 'now') - :{2}) ".format(self.fields[filter_db_name],
+            self.query += "{0} IS NOT NULL AND {0} {1}" \
+                          " strftime('%s', 'now') - :{2} ".format(self.fields[filter_db_name],
                                                                    query_operator,
                                                                    date_filter['field'])
-        elif re.match(r'\d{4}-\d{2}-\d{2}', date_filter['value']):
-            self.query += "{0} IS NOT NULL AND {0} {1} :{2}".format(self.fields[filter_db_name],
-                                                                    date_filter['operator'], date_filter['field'])
+        elif re.match(r'\d{4}-\d{2}-\d{2}([ T]\d{2}:\d{2}:\d{2}Z?)?', date_filter['value']):
+            self.query += "{0} IS NOT NULL AND {0} {1} strftime('%s', :{2})".format(
+                self.fields[filter_db_name], date_filter['operator'], date_filter['field'])
             self.request[date_filter['field']] = date_filter['value']
         else:
             raise WazuhError(1412, date_filter['value'])

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -928,6 +928,16 @@ def filter_array_by_query(q: str, input_array: typing.List) -> typing.List:
 
     :return: list with processed query
     """
+    def check_date_format(s_date):
+        date_patterns = ['%Y-%m-%dT%H:%M:%SZ', '%Y-%m-%d %H:%M:%S', '%Y-%m-%dT%H:%M:%S.%fZ']
+
+        for pattern in date_patterns:
+            try:
+                return datetime.strptime(s_date, pattern)
+            except ValueError:
+                pass
+
+        return s_date
 
     def check_clause(value1: typing.Union[str, int], op: str, value2: str) -> bool:
         """
@@ -953,11 +963,14 @@ def filter_array_by_query(q: str, input_array: typing.List) -> typing.List:
                     return True
             else:
                 # cast value2 to integer if value1 is integer
+                value2 = check_date_format(value2)
+                if type(value2) == datetime:
+                    val = check_date_format(val)
                 value2 = int(value2) if type(val) == int else value2
                 if operators[op](val, value2):
                     return True
-        else:
-            return False
+
+        return False
 
     def get_match_candidates(iterable, key_list: list, candidates: list):
         """Get the match candidates following a list of keys.

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -743,7 +743,7 @@ def plain_dict_to_nested_dict(data, nested=None, non_nested=None, force_fields=[
     non_nested_dict = {f: data[f] for f in data.keys() if f.split(split_character)[0]
                        not in nested_dict.keys()}
 
-    # append both dictonaries
+    # append both dictionaries
     nested_dict.update(non_nested_dict)
 
     return nested_dict

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -1410,7 +1410,7 @@ class WazuhDBQuery(object):
                           " strftime('%s', 'now') - :{2} ".format(self.fields[filter_db_name],
                                                                    query_operator,
                                                                    date_filter['field'])
-        elif re.match(r'\d{4}-\d{2}-\d{2}([ T]\d{2}:\d{2}:\d{2}Z?)?', date_filter['value']):
+        elif re.match(r'\d{4}-\d{2}-\d{2}([ T]\d{2}:\d{2}:\d{2}(.\d{1,6})?Z?)?', date_filter['value']):
             self.query += "{0} IS NOT NULL AND {0} {1} strftime('%s', :{2})".format(
                 self.fields[filter_db_name], date_filter['operator'], date_filter['field'])
             self.request[date_filter['field']] = date_filter['value']

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -941,7 +941,7 @@ def filter_array_by_query(q: str, input_array: typing.List) -> typing.List:
         -------
         In case of a date, return the element after its conversion. Otherwise it return the element.
         """
-        date_patterns = ['%Y-%m-%dT%H:%M:%SZ', '%Y-%m-%d %H:%M:%S', '%Y-%m-%dT%H:%M:%S.%fZ']
+        date_patterns = ['%Y-%m-%d', '%Y-%m-%dT%H:%M:%SZ', '%Y-%m-%d %H:%M:%S', '%Y-%m-%dT%H:%M:%S.%fZ']
 
         for pattern in date_patterns:
             try:

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -1369,7 +1369,7 @@ class WazuhDBQuery(object):
 
     def _process_filter(self, field_name, field_filter, q_filter):
         if field_name in self.date_fields and not isinstance(q_filter['value'], (int, float)):
-            # Filter a date, but only if it is in string (YYYY-MM-DD hh:mm:ss) format.
+            # Filter a date, only if it is a string and it can be derived into a date.
             # If it matches the same format as DB (timestamp integer), filter directly by value (next if cond).
             self._filter_date(q_filter, field_name)
         elif 'rbac' in field_name:

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -1402,8 +1402,15 @@ class WazuhDBQuery(object):
         raise NotImplementedError
 
     def _filter_date(self, date_filter, filter_db_name):
-        # date_filter['value'] can be a date in format %Y-%m-%d, %Y-%m-%d %H:%M:%S or %Y-%m-%dT%H:%M:%SZ
-        if re.match(r'\d{4}-\d{2}-\d{2}([ T]\d{2}:\d{2}:\d{2}Z?)?', date_filter['value']):
+        # date_filter['value'] can be either a timeframe or a date in formats %Y-%m-%d, %Y-%m-%d %H:%M:%S or %Y-%m-%dT%H:%M:%SZ
+        if date_filter['value'].isdigit() or re.match(r'\d+[dhms]', date_filter['value']):
+            query_operator = '>' if date_filter['operator'] == '<' or date_filter['operator'] == '=' else '<'
+            self.request[date_filter['field']] = get_timeframe_in_seconds(date_filter['value'])
+            self.query += "{0} IS NOT NULL AND {0} {1}" \
+                          " strftime('%s', 'now') - :{2} ".format(self.fields[filter_db_name],
+                                                                   query_operator,
+                                                                   date_filter['field'])
+        elif re.match(r'\d{4}-\d{2}-\d{2}([ T]\d{2}:\d{2}:\d{2}Z?)?', date_filter['value']):
             self.query += "{0} IS NOT NULL AND {0} {1} strftime('%s', :{2})".format(
                 self.fields[filter_db_name], date_filter['operator'], date_filter['field'])
             self.request[date_filter['field']] = date_filter['value']

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -928,16 +928,28 @@ def filter_array_by_query(q: str, input_array: typing.List) -> typing.List:
 
     :return: list with processed query
     """
-    def check_date_format(s_date):
+    def check_date_format(element):
+        """Check if a given field is a date. If so, transform the date to the standard API format (ISO 8601).
+        If not, return the field.
+
+        Parameters
+        ----------
+        element : str
+            Item to check.
+
+        Returns
+        -------
+        In case of a date, return the element after its conversion. Otherwise it return the element.
+        """
         date_patterns = ['%Y-%m-%dT%H:%M:%SZ', '%Y-%m-%d %H:%M:%S', '%Y-%m-%dT%H:%M:%S.%fZ']
 
         for pattern in date_patterns:
             try:
-                return datetime.strptime(s_date, pattern)
+                return datetime.strptime(element, pattern)
             except ValueError:
                 pass
 
-        return s_date
+        return element
 
     def check_clause(value1: typing.Union[str, int], op: str, value2: str) -> bool:
         """

--- a/framework/wazuh/tests/test_mitre.py
+++ b/framework/wazuh/tests/test_mitre.py
@@ -6,6 +6,7 @@
 
 import os
 import sys
+from datetime import datetime
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -58,6 +59,13 @@ def sort_entries(entries, sort_key='id'):
     return sorted(entries, key=lambda k: k[sort_key])
 
 
+def check_datetime(element, key):
+    if key in {'created_time', 'modified_time'}:
+        element[key] = datetime.strptime(element[key], '%Y-%m-%d %H:%M:%S.%f').strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+    return element[key]
+
+
 # Tests
 
 @patch('wazuh.core.utils.WazuhDBConnection', return_value=InitWDBSocketMock(sql_schema_file='schema_mitre_test.sql'))
@@ -76,8 +84,8 @@ def test_mitre_mitigations(mock_mitre_db, mitre_db):
     result = mitre.mitre_mitigations()
     rows = mitre_query(mitre_db, "SELECT * FROM mitigation")
 
-    assert all(item[key] == row[key] for item, row in zip(sort_entries(result.affected_items), sort_entries(rows))
-               for key in row)
+    assert all(item[key] == check_datetime(row, key) for item, row in zip(sort_entries(result.affected_items),
+                                                                          sort_entries(rows)) for key in row)
 
 
 @patch('wazuh.core.utils.WazuhDBConnection', return_value=InitWDBSocketMock(sql_schema_file='schema_mitre_test.sql'))
@@ -91,7 +99,7 @@ def test_mitre_references(mock_mitre_dbmitre, mitre_db):
     sorted_rows = sort_entries(sort_entries(sort_entries(rows, sort_key='id'), sort_key='source'), sort_key='url')
 
     assert result.affected_items
-    assert all(item[key] == row[key] for item, row in zip(sorted_result, sorted_rows) for key in row)
+    assert all(item[key] == check_datetime(row, key) for item, row in zip(sorted_result, sorted_rows) for key in row)
 
 
 @patch('wazuh.core.utils.WazuhDBConnection', return_value=InitWDBSocketMock(sql_schema_file='schema_mitre_test.sql'))
@@ -101,8 +109,8 @@ def test_mitre_tactics(mock_mitre_db, mitre_db):
     rows = mitre_query(mitre_db, "SELECT * FROM tactic")
 
     assert result.affected_items
-    assert all(item[key] == row[key] for item, row in zip(sort_entries(result.affected_items), sort_entries(rows))
-               for key in row)
+    assert all(item[key] == check_datetime(row, key) for item, row in zip(sort_entries(result.affected_items),
+                                                                          sort_entries(rows)) for key in row)
 
 
 @patch('wazuh.core.utils.WazuhDBConnection', return_value=InitWDBSocketMock(sql_schema_file='schema_mitre_test.sql'))
@@ -112,8 +120,8 @@ def test_mitre_techniques(mock_mitre_db, mitre_db):
     rows = mitre_query(mitre_db, "SELECT * FROM technique")
 
     assert result.affected_items
-    assert all(item[key] == row[key] for item, row in zip(sort_entries(result.affected_items), sort_entries(rows))
-               for key in row)
+    assert all(item[key] == check_datetime(row, key) for item, row in zip(sort_entries(result.affected_items),
+                                                                          sort_entries(rows)) for key in row)
 
 
 @patch('wazuh.core.utils.WazuhDBConnection', return_value=InitWDBSocketMock(sql_schema_file='schema_mitre_test.sql'))
@@ -123,8 +131,8 @@ def test_mitre_groups(mock_mitre_db, mitre_db):
     rows = mitre_query(mitre_db, "SELECT * FROM `group`")
 
     assert result.affected_items
-    assert all(item[key] == row[key] for item, row in zip(sort_entries(result.affected_items), sort_entries(rows))
-               for key in row)
+    assert all(item[key] == check_datetime(row, key) for item, row in zip(sort_entries(result.affected_items),
+                                                                          sort_entries(rows)) for key in row)
 
 
 @patch('wazuh.core.utils.WazuhDBConnection', return_value=InitWDBSocketMock(sql_schema_file='schema_mitre_test.sql'))
@@ -134,5 +142,5 @@ def test_mitre_software(mock_mitre_db, mitre_db):
     rows = mitre_query(mitre_db, "SELECT * FROM software")
 
     assert result.affected_items
-    assert all(item[key] == row[key] for item, row in zip(sort_entries(result.affected_items), sort_entries(rows))
-               for key in row)
+    assert all(item[key] == check_datetime(row, key) for item, row in zip(sort_entries(result.affected_items),
+                                                                          sort_entries(rows)) for key in row)

--- a/framework/wazuh/tests/test_mitre.py
+++ b/framework/wazuh/tests/test_mitre.py
@@ -21,6 +21,7 @@ with patch('wazuh.core.common.wazuh_uid'):
         wazuh.rbac.decorators.expose_resources = RBAC_bypasser
         from wazuh import mitre
         from wazuh.core import mitre as core_mitre
+        from wazuh.core.common import decimals_date_format
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 
@@ -61,7 +62,7 @@ def sort_entries(entries, sort_key='id'):
 
 def check_datetime(element, key):
     if key in {'created_time', 'modified_time'}:
-        element[key] = datetime.strptime(element[key], '%Y-%m-%d %H:%M:%S.%f').strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        element[key] = datetime.strptime(element[key], '%Y-%m-%d %H:%M:%S.%f').strftime(decimals_date_format)
 
     return element[key]
 

--- a/framework/wazuh/tests/test_rootcheck.py
+++ b/framework/wazuh/tests/test_rootcheck.py
@@ -133,7 +133,7 @@ def test_clear(mock_connect, mock_info, agent_list, expected_affected_items, exp
 def test_get_last_scan(mock_connect, mock_send, mock_info):
     """Check if get_last_scan() returned results have expected format and content"""
     result = rootcheck.get_last_scan(['001']).render()['data']['affected_items'][0]
-    assert result['start'] == '2020-10-27 12:19:40' and result['end'] == '2020-10-27 12:29:40'
+    assert result['start'] == '2020-10-27T12:19:40Z' and result['end'] == '2020-10-27T12:29:40Z'
 
 
 @pytest.mark.parametrize('limit', [


### PR DESCRIPTION
|Related issue|
|---|
|#9079|

Hi team,

This PR closes #9079. We have changed the format of all dates in the API outputs in this PR, so we have standardized within the Framework the ISO 8601 format.

In addition, we have fixed a bug that caused the 'q' filter to not work properly when dates were added to it.

More information here: https://github.com/wazuh/wazuh/issues/9079#issuecomment-875658462