### PR TITLE
Fix SCA API integration tests

### DIFF
--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -12,7 +12,7 @@ from jsonschema import draft4_format_checker
 from wazuh.core import common
 
 _alphanumeric_param = re.compile(r'^[\w,\-\.\+\s\:]+$')
-_symbols_alphanumeric_param = re.compile(r'^[a-zA-Z0-9_,<>!\-.+\s:/()\'"|=~]+$')
+_symbols_alphanumeric_param = re.compile(r'^[a-zA-Z0-9_,<>!\-.+\s:/()\[\]\'\"|=~#]+$')
 _array_numbers = re.compile(r'^\d+(,\d+)*$')
 _array_names = re.compile(r'^[\w\-\.%]+(,[\w\-\.%]+)*$')
 _base64 = re.compile(r'^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$')
@@ -358,3 +358,5 @@ def format_group_names(value):
 @draft4_format_checker.checks("group_names_or_all")
 def format_group_names_or_all(value):
     return check_exp(value, _group_names_or_all)
+
+

--- a/api/test/integration/test_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_sca_endpoints.tavern.yaml
@@ -406,10 +406,10 @@ stages:
       status_code: 200
 
 ---
-test_name: GET /sca/001/checks/cis_debian9 (001 is an agent with version >=4.2.0)
+test_name: GET /sca/001/checks/{policy}
 
 stages:
-  - name: Parameters -> limit=1
+  - name: Parameter policy
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/sca/001"
@@ -422,30 +422,18 @@ stages:
       status_code: 200
       save:
         json:
-          expected_policy_id: data.affected_items[0].policy_id
+          sca_policy_id: data.affected_items[0].policy_id
 
-  - name: Request
+  - name: Obtain parameter values 1/2 (parameters are obtained in two steps as there is not any response with all the parameters at once)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data: !anything
-
-  - name: Parameters -> limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
         limit: 1
+        q: "file~a;status~a;remediation~a"  # Assert that the response will have all the fields
     response:
       status_code: 200
       json:
@@ -469,12 +457,42 @@ stages:
       save:
         json:
           expected_check_id: data.affected_items[0].id
+          expected_result: data.affected_items[0].result
+          expected_title: data.affected_items[0].title
+          expected_description: data.affected_items[0].description
+          expected_rationale: data.affected_items[0].rationale
+          expected_status: data.affected_items[0].status
+          expected_reason: data.affected_items[0].reason
+          expected_file: data.affected_items[0].file
+          expected_remediation: data.affected_items[0].remediation
+
+  - name: Obtain parameter values 2/2 (parameters are obtained in two steps as there is not any response with all the parameters at once)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 1
+        q: "command~a"  # Assert that the response will have all the fields
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items: !anything
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+      save:
+        json:
           expected_command: data.affected_items[0].command
 
   - name: Parameters -> limit=4
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -497,7 +515,7 @@ stages:
   - name: Parameters -> sort=-id,limit=2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -512,10 +530,10 @@ stages:
             reverse: True
       status_code: 200
 
-  - name: Parameters -> search=passwd,limit=1
+  - name: Parameters -> search,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -536,7 +554,7 @@ stages:
   - name: Parameters -> q=id
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -554,16 +572,16 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Parameters -> result=failed,limit=1
+  - name: Parameters -> result,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
         limit: 1
-        result: failed
+        result: "{expected_result:s}"
     response:
       status_code: 200
       json:
@@ -571,21 +589,21 @@ stages:
         data:
           affected_items:
             - <<: *sca_check_result_001
-              result: failed
+              result: "{expected_result:s}"
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Parameters -> file=/etc/shadow,limit=1
+  - name: Parameters -> file,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
         limit: 1
-        file: /etc/shadow
+        file: "{expected_file:s}"
     response:
       status_code: 200
       json:
@@ -593,7 +611,7 @@ stages:
         data:
           affected_items:
             - <<: *sca_check_result_001
-              file: /etc/shadow
+              file: "{expected_file:s}"
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
@@ -601,7 +619,7 @@ stages:
   - name: Parameters -> limit=999999
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -610,16 +628,16 @@ stages:
     response:
       status_code: 400
 
-  - name: Parameters -> title="Ensure shadow group is empty",limit=1
+  - name: Parameters -> title,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
         limit: 1
-        title: Ensure shadow group is empty
+        title: "{expected_title:s}"
     response:
       status_code: 200
       json:
@@ -627,36 +645,15 @@ stages:
         data:
           affected_items:
             - <<: *sca_check_result_001
-              title: Ensure shadow group is empty
+              title: "{expected_title:s}"
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: 0
-
-  - name: Parameters -> title="Ensure address space layout randomization (ASLR) is enabled",limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        title: Ensure address space layout randomization (ASLR) is enabled
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - title: Ensure address space layout randomization (ASLR) is enabled
-          failed_items: []
           total_failed_items: 0
 
   - name: Parameters -> title="non-existent"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -673,16 +670,16 @@ stages:
           failed_items: []
           total_failed_items: 0
 
-  - name: Parameters -> description="The /etc/ssh/sshd_config file contains configuration specifications for sshd. The command below sets the owner and group of the file to root.",limit=1
+  - name: Parameters -> description,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
         limit: 1
-        description: The /etc/ssh/sshd_config file contains configuration specifications for sshd. The command below sets the owner and group of the file to root.
+        description: "{expected_description:s}"
     response:
       status_code: 200
       json:
@@ -690,21 +687,21 @@ stages:
         data:
           total_affected_items: !anyint
           affected_items:
-            - description: The /etc/ssh/sshd_config file contains configuration specifications for sshd. The command below sets the owner and group of the file to root.
+            - description: "{expected_description:s}"
           failed_items: []
           total_failed_items: 0
         message: !anystr
 
-  - name: Parameters -> remediation=Remove any legacy + entries from /etc/group if they exist.,limit=1
+  - name: Parameters -> remediation,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
         limit: 1
-        remediation: Remove any legacy + entries from /etc/group if they exist.
+        remediation: "{expected_remediation:s}"
     response:
       status_code: 200
       json:
@@ -712,21 +709,20 @@ stages:
         data:
           total_affected_items: !anyint
           affected_items:
-            - <<: *sca_check_result_001
-              remediation: Remove any legacy + entries from /etc/group if they exist.
+            - remediation: "{expected_remediation:s}"
           failed_items: []
           total_failed_items: 0
 
-  - name: Parameters -> rationale with apostrophe and parenthesis"
+  - name: Parameters -> rationale,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
         limit: 1
-        rationale: Having no timeout value associated with a connection could allow an unauthorized user access to another user's ssh session (e.g. user walks away from their computer and doesn't lock the screen). Setting a timeout value at least reduces the risk of this happening. While the recommended setting is 300 seconds (5 minutes), set this timeout value based on site policy. The recommended setting for ClientAliveCountMax is 0. In this case, the client session will be terminated after 5 minutes of idle time and no keepalive messages will be sent.
+        rationale: "{expected_rationale:s}"
     response:
       status_code: 200
       json:
@@ -734,63 +730,14 @@ stages:
         data:
           total_affected_items: !anyint
           affected_items:
-            - rationale: Having no timeout value associated with a connection could allow an unauthorized user access to another user's ssh session (e.g. user walks away from their computer and doesn't lock the screen). Setting a timeout value at least reduces the risk of this happening. While the recommended setting is 300 seconds (5 minutes), set this timeout value based on site policy. The recommended setting for ClientAliveCountMax is 0. In this case, the client session will be terminated after 5 minutes of idle time and no keepalive messages will be sent.
+            - rationale: "{expected_rationale:s}"
           failed_items: []
           total_failed_items: 0
 
-  - name: Parameters -> rationale with word "count"
+  - name: Parameters -> command,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        rationale: >-
-          Any users assigned to the shadow group would be granted read access to the /etc/shadow file.
-          If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking
-          program against the hashed passwords to break them. Other security information that is stored in
-          the /etc/shadow file (such as expiration) could also be useful to subvert additional user accounts.
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - rationale: >-
-                Any users assigned to the shadow group would be granted read access to the /etc/shadow file.
-                If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking
-                program against the hashed passwords to break them. Other security information that is stored in
-                the /etc/shadow file (such as expiration) could also be useful to subvert additional user accounts.
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> rationale with word "offset"
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        rationale: offset
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: 0
-          affected_items: []
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> command
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -808,16 +755,16 @@ stages:
           failed_items: []
           total_failed_items: 0
 
-  - name: Parameters -> status="Not applicable"
+  - name: Parameters -> status,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
         limit: 1
-        status: Not applicable
+        status: "{expected_status:s}"
     response:
       status_code: 200
       json:
@@ -825,20 +772,20 @@ stages:
         data:
           total_affected_items: !anyint
           affected_items:
-            - status: Not applicable
+            - status: "{expected_status:s}"
           failed_items: []
           total_failed_items: 0
 
-  - name: Parameters -> reason="Invalid path or wrong permissions to run command 'ip6tables -L'"
+  - name: Parameters -> reason,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
         limit: 1
-        reason: Invalid path or wrong permissions to run command 'ip6tables -L'
+        reason: "{expected_reason:s}"
     response:
       status_code: 200
       json:
@@ -846,434 +793,6 @@ stages:
         data:
           total_affected_items: !anyint
           affected_items:
-            - reason: Invalid path or wrong permissions to run command 'ip6tables -L'
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> command="systemctl is-enabled autofs"
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{expected_policy_id:s}"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        command: systemctl is-enabled autofs
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - command: systemctl is-enabled autofs
-          failed_items: [ ]
-          total_failed_items: 0
-
-
----
-test_name: GET /sca/006/checks/cis_debian9_L1 (006 is an agent with version <4.2.0)
-
-stages:
-
-  - name: Request
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data: !anything
-
-  - name: Parameters -> limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - &sca_check_result_006
-              remediation: !anystr
-              rationale: !anystr
-              title: !anystr
-              policy_id: !anystr
-              description: !anystr
-              id: !anyint
-              result: !anystr
-              compliance: !anything
-              rules: !anything
-              condition: !anything
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> limit=4
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 4
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_check_result_006
-            - <<: *sca_check_result_006
-            - <<: *sca_check_result_006
-            - <<: *sca_check_result_006
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> sort=-id,limit=2
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 2
-        sort: -id
-    response:
-      verify_response_with:
-        - function: tavern_utils:test_sort_response
-          extra_kwargs:
-            key: "id"
-            reverse: true
-      status_code: 200
-
-  - name: Parameters -> search=passwd,limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        search: passwd
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_check_result_006
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> q=id=3098
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        q: id=3098
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_check_result_006
-              id: 3098
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> result=failed,limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        result: failed
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_check_result_006
-              result: failed
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> file=/etc/shadow,limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        file: /etc/shadow
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_check_result_006
-              file: /etc/shadow
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> limit=999999
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 999999
-    response:
-      status_code: 400
-
-  - name: Parameters -> title="Ensure shadow group is empty,limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        title: Ensure shadow group is empty
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_check_result_006
-              title: Ensure shadow group is empty
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> remediation=Remove any legacy + entries from /etc/group if they exist.,limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        remediation: Remove any legacy + entries from /etc/group if they exist.
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_check_result_006
-              remediation: Remove any legacy + entries from /etc/group if they exist.
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> rationale with apostrophe"
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        rationale: With automounting enabled anyone with physical access could attach a USB drive or disc and have it's contents available in system even if they lacked permissions to mount it themselves.
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - rationale: With automounting enabled anyone with physical access could attach a USB drive or disc and have it's contents available in system even if they lacked permissions to mount it themselves.
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> command="systemctl is-enabled autofs"
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        command: systemctl is-enabled autofs
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - command: systemctl is-enabled autofs
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> status="Not applicable"
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        status: Not applicable
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - status: Not applicable
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> reason="Invalid path or wrong permissions to run command '/sbin/modprobe -n -v freevxfs'"
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        reason: Invalid path or wrong permissions to run command '/sbin/modprobe -n -v freevxfs'
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - reason: Invalid path or wrong permissions to run command '/sbin/modprobe -n -v freevxfs'
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> rationale with word "count"
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        rationale: >-
-          Any users assigned to the shadow group would be granted read access to the /etc/shadow file.
-          If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking
-          program against the hashed passwords to break them. Other security information that is stored in
-          the /etc/shadow file (such as expiration) could also be useful to subvert additional user accounts.
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - rationale: >-
-                Any users assigned to the shadow group would be granted read access to the /etc/shadow file.
-                If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking
-                program against the hashed passwords to break them. Other security information that is stored in
-                the /etc/shadow file (such as expiration) could also be useful to subvert additional user accounts.
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> rationale with word "offset"
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        rationale: offset
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: 0
-          affected_items: []
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> command="dpkg -s libpam-pwquality"
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        command: dpkg -s libpam-pwquality
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - command: dpkg -s libpam-pwquality
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> reason="Invalid path or wrong permissions to run command 'ip6tables -L'"
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        reason: Invalid path or wrong permissions to run command 'ip6tables -L'
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - reason: Invalid path or wrong permissions to run command 'ip6tables -L'
+            - reason: "{expected_reason:s}"
           failed_items: []
           total_failed_items: 0


### PR DESCRIPTION
|Related issue|
|---|
| closes #9224 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hello team,
Some SCA API integration tests were failing because we had some responses hardcoded and they did not match anymore in the latest version. With this PR we have made these tests dynamic, avoiding this kind of errors.

In addition, one of the format validation regex was updated to allow the characters `#`, `[` and `]`.

## Tests performed
### Unit tests
```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.9.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: cov-2.12.0, asyncio-0.15.1
collected 238 items                                                                                                                                                                         

models/test/test_model.py ............                                                                                                                                                [  5%]
test/test_alogging.py ..........                                                                                                                                                      [  9%]
test/test_authentication.py ..........                                                                                                                                                [ 13%]
test/test_configuration.py ..........................................                                                                                                                 [ 31%]
test/test_util.py ...................................                                                                                                                                 [ 45%]
test/test_validator.py .................................................................................................................................                              [100%]

============================================================================= 238 passed, 13 warnings in 1.25s ==============================================================================
```

### Integration tests
```Collected tests [1]:
test_sca_endpoints.tavern.yaml


test_sca_endpoints.tavern.yaml 
	 2 passed, 4 warnings


```

Regards,
Víctor