### PR TITLE
Erroneous length of an IPv6 char array on auth.c fix

### DIFF
--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -144,27 +144,26 @@ w_err_t w_auth_parse_data(const char* buf, char *response,const char *authpass, 
 
     /* Check for IP when client uses -i option */
 
-    char client_source_ip[IPSIZE + 1] = {0};
-    char client_source_ip_token[3] = "IP:";
+    char client_source_ip[IPSIZE] = {0};
 
-    if(strncmp(++buf,client_source_ip_token,3)==0) {
+    if (strncmp(++buf, "IP:", 3) == 0) {
+
         char format[15];
         sprintf(format, " IP:\'%%%d[^\']\"", IPSIZE);
-        sscanf(buf, format ,client_source_ip);
+        sscanf(buf, format, client_source_ip);
 
         /* If IP: != 'src' overwrite the provided ip */
-        if(strncmp(client_source_ip,"src",3) != 0)
-        {
-            if (!OS_IsValidIP(client_source_ip, NULL)) {
+        if (strncmp(client_source_ip, "src", 3) != 0) {
+
+            if (OS_IsValidIP(client_source_ip, NULL) == 0) {
+
                 merror("Invalid IP: '%s'", client_source_ip);
                 snprintf(response, 2048, "ERROR: Invalid IP: %s", client_source_ip);
                 return OS_INVALID;
             }
             snprintf(ip, IPSIZE, "%s", client_source_ip);
         }
-
-    }
-    else if(!config.flags.use_source_ip) {
+    } else if(!config.flags.use_source_ip) {
         // use_source-ip = 0 and no -I argument in agent
         snprintf(ip, IPSIZE, "any");
     }


### PR DESCRIPTION
|Related issue|
|---|
| close #9215 |

## Description

Hi team!

This PR offers a solution to the issue #9215. On it, we've adjusted the length of the array that contains the IPv6; removed an unnecessary variable and adjusted the code block as the Wazuh coding style recommends.

## Logs/Alerts example

Previously, when compiling Wazuh from the source (using GCC 9.3 in debug mode), it raised the following warning:

```
os_auth/auth.c: In function ‘w_auth_parse_data’:
os_auth/auth.c:163:37: warning: ‘snprintf’ output may be truncated before the last format character [-Wformat-truncation=]
  163 |             snprintf(ip, IPSIZE, "%s", client_source_ip);
      |                                     ^
os_auth/auth.c:163:13: note: ‘snprintf’ output between 1 and 47 bytes into a destination of size 46
  163 |             snprintf(ip, IPSIZE, "%s", client_source_ip);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Now, this warning was cleared away.

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

Best Regards,

Mariano Koremblum