### PR TITLE
Add FIM db to RTR checks

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -11,7 +11,9 @@ import argparse
 from ci import utils
 
 module_list = ['wazuh_modules/syscollector', 'shared_modules/dbsync', 'shared_modules/rsync', 'shared_modules/utils',
-               'data_provider']
+               'data_provider', 'syscheckd/db']
+
+module_list_str = '|'.join(module_list)
 
 
 class CommandLineParser:
@@ -31,16 +33,26 @@ class CommandLineParser:
         """
         action = False
         parser = argparse.ArgumentParser()
-        parser.add_argument("-r", "--readytoreview", help="Run all the quality checks needed to create a PR. Example: python3 build.py -r <data_provider|shared_modules/dbsync|shared_modules/rsync|shared_modules/utils|wazuh_modules/syscollector>")
-        parser.add_argument("-m", "--make", help="Compile the lib. Example: python3 build.py -m <data_provider|shared_modules/dbsync|shared_modules/rsync|shared_modules/utils|wazuh_modules/syscollector>")
-        parser.add_argument("-t", "--tests", help="Run tests (should be configured with TEST=on). Example: python3 build.py -t <data_provider|shared_modules/dbsync|shared_modules/rsync|shared_modules/utils|wazuh_modules/syscollector>")
-        parser.add_argument("-c", "--coverage", help="Collect tests coverage and generates report. Example: python3 build.py -c <data_provider|shared_modules/dbsync|shared_modules/rsync|shared_modules/utils|wazuh_modules/syscollector>")
-        parser.add_argument("-v", "--valgrind", help="Run valgrind on tests. Example: python3 build.py -v <data_provider|shared_modules/dbsync|shared_modules/rsync|shared_modules/utils|wazuh_modules/syscollector>")
-        parser.add_argument("--clean", help="Clean the lib. Example: python3 build.py --clean <data_provider|shared_modules/dbsync|shared_modules/rsync|shared_modules/utils|wazuh_modules/syscollector>")
-        parser.add_argument("--cppcheck", help="Run cppcheck on the code. Example: python3 build.py --cppcheck <data_provider|shared_modules/dbsync|shared_modules/rsync|shared_modules/utils|wazuh_modules/syscollector>")
-        parser.add_argument("--asan", help="Run ASAN on the code. Example: python3 build.py --asan <data_provider|shared_modules/dbsync|shared_modules/rsync|shared_modules/utils|wazuh_modules/syscollector>")
-        parser.add_argument("--scheck", help="Run AStyle on the code for checking purposes. Example: python3 build.py --scheck <data_provider|shared_modules/dbsync|shared_modules/rsync|shared_modules/utils|wazuh_modules/syscollector>")
-        parser.add_argument("--sformat", help="Run AStyle on the code formatting the needed files. Example: python3 build.py --sformat <data_provider|shared_modules/dbsync|shared_modules/rsync|shared_modules/utils|wazuh_modules/syscollector>")
+        parser.add_argument("-r", "--readytoreview",
+                            help=f'Run all the quality checks needed to create a PR. Example: python3 build.py -r <{module_list_str}>')
+        parser.add_argument(
+            "-m", "--make", help=f'Compile the lib. Example: python3 build.py -m <{module_list_str}>')
+        parser.add_argument(
+            "-t", "--tests", help=f'Run tests (should be configured with TEST=on). Example: python3 build.py -t <{module_list_str}>')
+        parser.add_argument(
+            "-c", "--coverage", help=f'Collect tests coverage and generates report. Example: python3 build.py -c <{module_list_str}>')
+        parser.add_argument(
+            "-v", "--valgrind", help=f'Run valgrind on tests. Example: python3 build.py -v <{module_list_str}>')
+        parser.add_argument(
+            "--clean", help=f'Clean the lib. Example: python3 build.py --clean <{module_list_str}>')
+        parser.add_argument(
+            "--cppcheck", help=f'Run cppcheck on the code. Example: python3 build.py --cppcheck <{module_list_str}>')
+        parser.add_argument(
+            "--asan", help=f'Run ASAN on the code. Example: python3 build.py --asan <{module_list_str}>')
+        parser.add_argument(
+            "--scheck", help=f'Run AStyle on the code for checking purposes. Example: python3 build.py --scheck <{module_list_str}>')
+        parser.add_argument(
+            "--sformat", help=f'Run AStyle on the code formatting the needed files. Example: python3 build.py --sformat <{module_list_str}>')
 
         args = parser.parse_args()
         if self._argIsValid(args.readytoreview):

--- a/src/ci/input/rtr_input.json
+++ b/src/ci/input/rtr_input.json
@@ -19,6 +19,10 @@
         {
             "name":"wazuh_modules/syscollector",
             "flags":"-r"
+        },
+        {
+            "name":"syscheckd/db",
+            "flags":"--scheck"
         }
     ]
 }

--- a/src/ci/utils.py
+++ b/src/ci/utils.py
@@ -111,6 +111,7 @@ deleteFolderDic = {
     'shared_modules/rsync':         ['build', 'smokeTests/output'],
     'data_provider':                ['build', 'smokeTests/output'],
     'shared_modules/utils':         ['build'],
+    'syscheckd/db':                 ['build']
 }
 
 currentBuildDir = Path(__file__).parent
@@ -459,6 +460,8 @@ def _getFoldersToAStyle(moduleName):
     foldersToScan = ""
     if str(moduleName) == 'shared_modules/utils':
         foldersToScan = f'{moduleName}/../*.h {moduleName}/*.cpp'
+    elif str(moduleName) == 'syscheckd/db':
+        foldersToScan = f'{moduleName}/*.hpp {moduleName}/*.cpp'
     else:
         foldersToScan = f'{moduleName}/*.h {moduleName}/*.cpp'
     return foldersToScan

--- a/src/syscheckd/db/include/db.hpp
+++ b/src/syscheckd/db/include/db.hpp
@@ -60,7 +60,7 @@ extern "C" {
 #define FIM_DB_FREE_TYPE(_func) (void (*)(void *))(_func)
 #define FIM_DB_CALLBACK_TYPE(_func) (void (*)(fdb_t *, void *, int,  void *))(_func)
 
-extern const char *schema_fim_sql;
+extern const char* schema_fim_sql;
 
 /**
  * @brief Executes a simple query in a given database.
@@ -70,7 +70,7 @@ extern const char *schema_fim_sql;
  *
  * @return int 0 on success, -1 on error.
  */
-int fim_db_exec_simple_wquery(fdb_t *fim_sql, const char *query);
+int fim_db_exec_simple_wquery(fdb_t* fim_sql, const char* query);
 
 
 /**
@@ -86,8 +86,8 @@ int fim_db_exec_simple_wquery(fdb_t *fim_sql, const char *query);
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_process_get_query(fdb_t *fim_sql, int type, int index, void (*callback)(fdb_t *, fim_entry *, int, void *),
-                             int storage, void * arg);
+int fim_db_process_get_query(fdb_t* fim_sql, int type, int index, void (*callback)(fdb_t*, fim_entry*, int, void*),
+                             int storage, void* arg);
 
 /**
  * @brief
@@ -102,8 +102,8 @@ int fim_db_process_get_query(fdb_t *fim_sql, int type, int index, void (*callbac
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_multiple_row_query(fdb_t *fim_sql, int index, void *(*decode)(sqlite3_stmt *), void (*free_row)(void *),
-                              void (*callback)(fdb_t *, void *, int, void *), int storage, void *arg);
+int fim_db_multiple_row_query(fdb_t* fim_sql, int index, void* (*decode)(sqlite3_stmt*), void (*free_row)(void*),
+                              void (*callback)(fdb_t*, void*, int, void*), int storage, void* arg);
 
 /**
  * @brief Create a new database.
@@ -115,7 +115,7 @@ int fim_db_multiple_row_query(fdb_t *fim_sql, int index, void *(*decode)(sqlite3
  *
  * @return 0 on success, -1 otherwise
  */
-int fim_db_create_file(const char *path, const char *source, int storage, sqlite3 **fim_db);
+int fim_db_create_file(const char* path, const char* source, int storage, sqlite3** fim_db);
 
 /**
  * @brief Create a new temporal storage to save all the files' paths.
@@ -124,7 +124,7 @@ int fim_db_create_file(const char *path, const char *source, int storage, sqlite
  *
  * @return New file structure.
  */
-fim_tmp_file *fim_db_create_temp_file(int storage);
+fim_tmp_file* fim_db_create_temp_file(int storage);
 
 
 /**
@@ -133,7 +133,7 @@ fim_tmp_file *fim_db_create_temp_file(int storage);
  * @param file Storage structure.
  * @param storage Type of storage (memory or disk).
  */
-void fim_db_clean_file(fim_tmp_file **file, int storage);
+void fim_db_clean_file(fim_tmp_file** file, int storage);
 
 /**
  * @brief Get a fim entry from a path received in a failed synchronization.
@@ -145,7 +145,7 @@ void fim_db_clean_file(fim_tmp_file **file, int storage);
  *
  * @return FIM entry struct on success, NULL on error.
  */
-fim_entry *fim_db_get_entry_from_sync_msg(fdb_t *fim_sql, fim_type type, const char *path);
+fim_entry* fim_db_get_entry_from_sync_msg(fdb_t* fim_sql, fim_type type, const char* path);
 
 /**
  * @brief Read paths and registry paths which are stored in a temporal storage.
@@ -160,9 +160,9 @@ fim_entry *fim_db_get_entry_from_sync_msg(fdb_t *fim_sql, fim_type type, const c
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
- int fim_db_process_read_file(fdb_t *fim_sql, fim_tmp_file *file, int type, pthread_mutex_t *mutex,
-                              void (*callback)(fdb_t *, fim_entry *, pthread_mutex_t *, void *, void *, void *),
-                              int storage, void * alert, void * mode, void * w_evt);
+int fim_db_process_read_file(fdb_t* fim_sql, fim_tmp_file* file, int type, pthread_mutex_t* mutex,
+                             void (*callback)(fdb_t*, fim_entry*, pthread_mutex_t*, void*, void*, void*),
+                             int storage, void* alert, void* mode, void* w_evt);
 
 /**
  * @brief Calculate checksum of data entries between @start and @top.
@@ -182,15 +182,15 @@ fim_entry *fim_db_get_entry_from_sync_msg(fdb_t *fim_sql, fim_type type, const c
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_get_checksum_range(fdb_t *fim_sql,
+int fim_db_get_checksum_range(fdb_t* fim_sql,
                               fim_type type,
-                              const char *start,
-                              const char *top,
+                              const char* start,
+                              const char* top,
                               int n,
-                              EVP_MD_CTX *ctx_left,
-                              EVP_MD_CTX *ctx_right,
-                              char **str_pathlh,
-                              char **str_pathuh);
+                              EVP_MD_CTX* ctx_left,
+                              EVP_MD_CTX* ctx_right,
+                              char** str_pathlh,
+                              char** str_pathuh);
 
 /**
  * @brief Get path list between @start and @top. (stored in @file).
@@ -204,7 +204,7 @@ int fim_db_get_checksum_range(fdb_t *fim_sql,
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_get_path_range(fdb_t *fim_sql, fim_type type, const char *start, const char *top, fim_tmp_file **file, int storage);
+int fim_db_get_path_range(fdb_t* fim_sql, fim_type type, const char* start, const char* top, fim_tmp_file** file, int storage);
 
 /**
  * @brief Initialize FIM databases.
@@ -216,7 +216,7 @@ int fim_db_get_path_range(fdb_t *fim_sql, fim_type type, const char *start, cons
  *
  * @return FIM database struct.
  */
-fdb_t *fim_db_init(int storage);
+fdb_t* fim_db_init(int storage);
 
 /**
  * @brief Finalize stmt and close DB.
@@ -225,7 +225,7 @@ fdb_t *fim_db_init(int storage);
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-void fim_db_close(fdb_t *fim_sql);
+void fim_db_close(fdb_t* fim_sql);
 
 /**
  * @brief Clean the FIM databases.
@@ -240,7 +240,7 @@ void fim_db_clean(void);
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_cache(fdb_t *fim_sql);
+int fim_db_cache(fdb_t* fim_sql);
 
 /**
  * @brief Finalize all statements.
@@ -249,21 +249,21 @@ int fim_db_cache(fdb_t *fim_sql);
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_finalize_stmt(fdb_t *fim_sql);
+int fim_db_finalize_stmt(fdb_t* fim_sql);
 
 /**
  * @brief End transaction and commit.
  *
  * @param fim_sql FIM database struct.
  */
-void fim_db_check_transaction(fdb_t *fim_sql);
+void fim_db_check_transaction(fdb_t* fim_sql);
 
 /**
  * @brief Force the commit in the database.
  *
  * @param fim_sql FIM database struct.
  */
-void fim_db_force_commit(fdb_t *fim_sql);
+void fim_db_force_commit(fdb_t* fim_sql);
 
 /**
  * @brief Reset statement and clean bindings parameters.
@@ -273,7 +273,7 @@ void fim_db_force_commit(fdb_t *fim_sql);
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_clean_stmt(fdb_t *fim_sql, int index);
+int fim_db_clean_stmt(fdb_t* fim_sql, int index);
 
 /**
  * @brief Get count of all entries in the database. This function must not be called from outside fim_db,
@@ -286,7 +286,7 @@ int fim_db_clean_stmt(fdb_t *fim_sql, int index);
  *
  * @return Number of entries in selected database.
 */
-int _fim_db_get_count(fdb_t *fim_sql, int index);
+int _fim_db_get_count(fdb_t* fim_sql, int index);
 
 /**
  * @brief Get count of all entries in the database.
@@ -298,7 +298,7 @@ int _fim_db_get_count(fdb_t *fim_sql, int index);
  *
  * @return Number of entries in selected database.
 */
-int fim_db_get_count(fdb_t *fim_sql, int index);
+int fim_db_get_count(fdb_t* fim_sql, int index);
 
 /**
  * @brief Count the number of entries between range @start and @top.
@@ -311,7 +311,7 @@ int fim_db_get_count(fdb_t *fim_sql, int index);
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_get_count_range(fdb_t *fim_sql, fim_type type, const char *start, const char *top, int *counter);
+int fim_db_get_count_range(fdb_t* fim_sql, fim_type type, const char* start, const char* top, int* counter);
 
 
 // Callbacks
@@ -326,7 +326,7 @@ int fim_db_get_count_range(fdb_t *fim_sql, fim_type type, const char *start, con
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-void fim_db_callback_save_path(fdb_t *fim_sql, fim_entry *entry, int storage, void *arg);
+void fim_db_callback_save_path(fdb_t* fim_sql, fim_entry* entry, int storage, void* arg);
 
 /**
  * @brief Write a string into the storage pointed by @arg.
@@ -338,7 +338,7 @@ void fim_db_callback_save_path(fdb_t *fim_sql, fim_entry *entry, int storage, vo
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-void fim_db_callback_save_string(fdb_t * fim_sql, const char *str, int storage, void *arg);
+void fim_db_callback_save_string(fdb_t* fim_sql, const char* str, int storage, void* arg);
 
 /**
  * @brief Callback function: Entry checksum calculation.
@@ -348,7 +348,7 @@ void fim_db_callback_save_string(fdb_t * fim_sql, const char *str, int storage, 
  * @param storage 1 Store database in memory, disk otherwise.
  * @param arg
  */
-void fim_db_callback_calculate_checksum(fdb_t *fim_sql, char *checksum, int storage, void *arg);
+void fim_db_callback_calculate_checksum(fdb_t* fim_sql, char* checksum, int storage, void* arg);
 
 /**
  * @brief Binds data into a range data statement.
@@ -358,7 +358,7 @@ void fim_db_callback_calculate_checksum(fdb_t *fim_sql, char *checksum, int stor
  * @param start First entry of the range.
  * @param top Last entry of the range.
  */
-void fim_db_bind_range(fdb_t *fim_sql, int index, const char *start, const char *top);
+void fim_db_bind_range(fdb_t* fim_sql, int index, const char* start, const char* top);
 
 /**
  * @brief Decode a single string from the executed sqlite3 statement.
@@ -366,7 +366,7 @@ void fim_db_bind_range(fdb_t *fim_sql, int index, const char *start, const char 
  * @param stmt A sqlite3_stmt that has just been stepped.
  * @return A string with the query result, the caller is responsible of deallocating it using free. NULL on error.
  */
-char *fim_db_decode_string(sqlite3_stmt *stmt);
+char* fim_db_decode_string(sqlite3_stmt* stmt);
 
 /**
  * @brief Get the last/first row from file_entry.
@@ -377,7 +377,7 @@ char *fim_db_decode_string(sqlite3_stmt *stmt);
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_get_last_path(fdb_t * fim_sql, int type, char **path);
+int fim_db_get_last_path(fdb_t* fim_sql, int type, char** path);
 
 /**
  * @brief Get the last/first row from file_entry.
@@ -388,7 +388,7 @@ int fim_db_get_last_path(fdb_t * fim_sql, int type, char **path);
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_get_first_path(fdb_t * fim_sql, int type, char **path);
+int fim_db_get_first_path(fdb_t* fim_sql, int type, char** path);
 
 /**
  * @brief Get checksum of all file_entry.
@@ -399,7 +399,7 @@ int fim_db_get_first_path(fdb_t * fim_sql, int type, char **path);
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_get_data_checksum(fdb_t *fim_sql, fim_type type, void *arg);
+int fim_db_get_data_checksum(fdb_t* fim_sql, fim_type type, void* arg);
 
 /**
  * @brief Read a single line from a fim_tmp_file.
@@ -416,7 +416,7 @@ int fim_db_get_data_checksum(fdb_t *fim_sql, fim_type type, void *arg);
  * @retval -1
  * Fail at fseek
  */
-int fim_db_read_line_from_file(fim_tmp_file *file, int storage, int it, char **buffer);
+int fim_db_read_line_from_file(fim_tmp_file* file, int storage, int it, char** buffer);
 
 /**
  * @brief Get count of all entries in the FIM DB.
@@ -425,7 +425,7 @@ int fim_db_read_line_from_file(fim_tmp_file *file, int storage, int it, char **b
  *
  * @return Number of entries in the FIM DB.
  */
-int fim_db_get_count_entries(fdb_t * fim_sql);
+int fim_db_get_count_entries(fdb_t* fim_sql);
 
 /**
  * @brief Check if the FIM DB is full.
@@ -434,14 +434,14 @@ int fim_db_get_count_entries(fdb_t * fim_sql);
  * @retval 0 if the DB is not full.
  * @retval 1 if the DB is full.
  */
-int fim_db_is_full(fdb_t *fim_sql);
+int fim_db_is_full(fdb_t* fim_sql);
 
 /**
  * @brief Check if database if full
  *
  * @param fim_sql FIM database structure.
  */
-int fim_db_check_limit(fdb_t *fim_sql);
+int fim_db_check_limit(fdb_t* fim_sql);
 
 
 /**
@@ -453,7 +453,7 @@ int fim_db_check_limit(fdb_t *fim_sql);
  *
  * @return FIM entry struct on success, NULL on error.
  */
-int fim_db_get_multiple_path(fdb_t *fim_sql, int index, FILE *fd);
+int fim_db_get_multiple_path(fdb_t* fim_sql, int index, FILE* fd);
 
 /**
  * @brief Get entry data using path.
@@ -463,7 +463,7 @@ int fim_db_get_multiple_path(fdb_t *fim_sql, int index, FILE *fd);
  *
  * @return FIM entry struct on success, NULL on error.
  */
-fim_entry *fim_db_get_path(fdb_t *fim_sql, const char *file_path);
+fim_entry* fim_db_get_path(fdb_t* fim_sql, const char* file_path);
 
 /**
  * @brief Get all the paths asociated to an inode
@@ -474,7 +474,7 @@ fim_entry *fim_db_get_path(fdb_t *fim_sql, const char *file_path);
  *
  * @return char** An array of the paths asociated to the inode.
  */
-char **fim_db_get_paths_from_inode(fdb_t *fim_sql, unsigned long int inode, unsigned long int dev);
+char** fim_db_get_paths_from_inode(fdb_t* fim_sql, unsigned long int inode, unsigned long int dev);
 
 /**
  * @brief Delete entry from the DB using file path.
@@ -484,7 +484,7 @@ char **fim_db_get_paths_from_inode(fdb_t *fim_sql, unsigned long int inode, unsi
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_remove_path(fdb_t *fim_sql, const char *path);
+int fim_db_remove_path(fdb_t* fim_sql, const char* path);
 
 /**
  * @brief Set all entries from database to unscanned.
@@ -493,7 +493,7 @@ int fim_db_remove_path(fdb_t *fim_sql, const char *path);
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_set_all_unscanned(fdb_t *fim_sql);
+int fim_db_set_all_unscanned(fdb_t* fim_sql);
 
 /**
  * @brief Get all the unscanned files by saving them in a temporal storage.
@@ -504,7 +504,7 @@ int fim_db_set_all_unscanned(fdb_t *fim_sql);
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_get_not_scanned(fdb_t * fim_sql, fim_tmp_file **file, int storage);
+int fim_db_get_not_scanned(fdb_t* fim_sql, fim_tmp_file** file, int storage);
 
 /**
  * @brief Delete not scanned entries from database.
@@ -516,7 +516,7 @@ int fim_db_get_not_scanned(fdb_t * fim_sql, fim_tmp_file **file, int storage);
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_delete_not_scanned(fdb_t *fim_sql, fim_tmp_file *file, pthread_mutex_t *mutex, int storage);
+int fim_db_delete_not_scanned(fdb_t* fim_sql, fim_tmp_file* file, pthread_mutex_t* mutex, int storage);
 
 /**
  * @brief Removes a range of paths from the database.
@@ -533,12 +533,12 @@ int fim_db_delete_not_scanned(fdb_t *fim_sql, fim_tmp_file *file, pthread_mutex_
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_delete_range(fdb_t *fim_sql,
-                        fim_tmp_file *file,
-                        pthread_mutex_t *mutex,
+int fim_db_delete_range(fdb_t* fim_sql,
+                        fim_tmp_file* file,
+                        pthread_mutex_t* mutex,
                         int storage,
-                        event_data_t *evt_data,
-                        directory_t *configuration);
+                        event_data_t* evt_data,
+                        directory_t* configuration);
 
 /**
  * @brief Remove a range of paths from database if they have a specific monitoring mode.
@@ -551,11 +551,11 @@ int fim_db_delete_range(fdb_t *fim_sql,
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_process_missing_entry(fdb_t *fim_sql,
-                                 fim_tmp_file *file,
-                                 pthread_mutex_t *mutex,
+int fim_db_process_missing_entry(fdb_t* fim_sql,
+                                 fim_tmp_file* file,
+                                 pthread_mutex_t* mutex,
                                  int storage,
-                                 event_data_t *evt_data);
+                                 event_data_t* evt_data);
 
 /**
  * @brief Remove a wildcard directory that were not expanded from the configuration
@@ -569,12 +569,12 @@ int fim_db_process_missing_entry(fdb_t *fim_sql,
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_remove_wildcard_entry(fdb_t *fim_sql,
-                                 fim_tmp_file *file,
-                                 pthread_mutex_t *mutex,
+int fim_db_remove_wildcard_entry(fdb_t* fim_sql,
+                                 fim_tmp_file* file,
+                                 pthread_mutex_t* mutex,
                                  int storage,
-                                 event_data_t *evt_data,
-                                 directory_t *configuration);
+                                 event_data_t* evt_data,
+                                 directory_t* configuration);
 
 /**
  * @brief Decodes a row from the database to be saved in a fim_entry structure.
@@ -583,7 +583,7 @@ int fim_db_remove_wildcard_entry(fdb_t *fim_sql,
  *
  * @return fim_entry* The filled structure.
  */
-fim_entry *fim_db_decode_full_row(sqlite3_stmt *stmt);
+fim_entry* fim_db_decode_full_row(sqlite3_stmt* stmt);
 
 /**
  * @brief Get count of all inodes in file_entry table.
@@ -592,7 +592,7 @@ fim_entry *fim_db_decode_full_row(sqlite3_stmt *stmt);
  *
  * @return Number of inodes in file_entry table.
  */
-int fim_db_get_count_file_inode(fdb_t * fim_sql);
+int fim_db_get_count_file_inode(fdb_t* fim_sql);
 
 /**
  * @brief Get count of all entries in file_entry table.
@@ -601,7 +601,7 @@ int fim_db_get_count_file_inode(fdb_t * fim_sql);
  *
  * @return Number of entries in file_entry table.
  */
-int fim_db_get_count_file_entry(fdb_t * fim_sql);
+int fim_db_get_count_file_entry(fdb_t* fim_sql);
 
 /**
  * @brief Get path list using the sqlite LIKE operator using @pattern. (stored in @file).
@@ -611,7 +611,7 @@ int fim_db_get_count_file_entry(fdb_t * fim_sql);
  * @param storage 1 Store database in memory, disk otherwise.
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_get_path_from_pattern(fdb_t *fim_sql, const char *pattern, fim_tmp_file **file, int storage);
+int fim_db_get_path_from_pattern(fdb_t* fim_sql, const char* pattern, fim_tmp_file** file, int storage);
 
 /**
  * @brief Makes any necessary queries to get the entry updated in the DB.
@@ -623,7 +623,7 @@ int fim_db_get_path_from_pattern(fdb_t *fim_sql, const char *pattern, fim_tmp_fi
  * @return The result of the update operation.
  * @retval Returns any of the values returned by fim_db_set_scanned and fim_db_insert_entry.
  */
-int fim_db_file_update(fdb_t *fim_sql, const char *path, const fim_file_data *data, fim_entry **saved);
+int fim_db_file_update(fdb_t* fim_sql, const char* path, const fim_file_data* data, fim_entry** saved);
 
 #ifdef WIN32
 
@@ -640,9 +640,9 @@ int fim_db_file_update(fdb_t *fim_sql, const char *path, const fim_file_data *da
  * @param w_evt Whodata information for callback function.
  *
  */
-int fim_db_process_read_registry_data_file(fdb_t *fim_sql, fim_tmp_file *file, pthread_mutex_t *mutex,
-                                           void (*callback)(fdb_t *, fim_entry *, pthread_mutex_t *, void *, void *, void *),
-                                           int storage, void * alert, void * mode, void * w_evt);
+int fim_db_process_read_registry_data_file(fdb_t* fim_sql, fim_tmp_file* file, pthread_mutex_t* mutex,
+                                           void (*callback)(fdb_t*, fim_entry*, pthread_mutex_t*, void*, void*, void*),
+                                           int storage, void* alert, void* mode, void* w_evt);
 
 // Registry callbacks
 
@@ -656,7 +656,7 @@ int fim_db_process_read_registry_data_file(fdb_t *fim_sql, fim_tmp_file *file, p
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-void fim_db_callback_save_reg_data_name(fdb_t *fim_sql, fim_entry *entry, int storage, void *arg);
+void fim_db_callback_save_reg_data_name(fdb_t* fim_sql, fim_entry* entry, int storage, void* arg);
 
 // Registry functions.
 
@@ -668,7 +668,7 @@ void fim_db_callback_save_reg_data_name(fdb_t *fim_sql, fim_entry *entry, int st
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_get_registry_key_checksum(fdb_t *fim_sql, void * arg);
+int fim_db_get_registry_key_checksum(fdb_t* fim_sql, void* arg);
 
 /**
  * @brief Get checksum of all registry data.
@@ -678,7 +678,7 @@ int fim_db_get_registry_key_checksum(fdb_t *fim_sql, void * arg);
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_get_registry_data_checksum(fdb_t *fim_sql, void * arg);
+int fim_db_get_registry_data_checksum(fdb_t* fim_sql, void* arg);
 
 /**
  * @brief Get the rowid of a key path.
@@ -688,7 +688,7 @@ int fim_db_get_registry_data_checksum(fdb_t *fim_sql, void * arg);
  * @param arch Architecture of the registry
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_get_registry_key_rowid(fdb_t *fim_sql, const char *path, unsigned int arch, unsigned int *rowid);
+int fim_db_get_registry_key_rowid(fdb_t* fim_sql, const char* path, unsigned int arch, unsigned int* rowid);
 
 /**
  * @brief Get registry data using its key_id and name. This function must not be called from outside fim_db,
@@ -700,7 +700,7 @@ int fim_db_get_registry_key_rowid(fdb_t *fim_sql, const char *path, unsigned int
  *
  * @return FIM registry data struct on success, NULL on error.
  */
-fim_registry_value_data *_fim_db_get_registry_data(fdb_t *fim_sql, unsigned int key_id, const char *name);
+fim_registry_value_data* _fim_db_get_registry_data(fdb_t* fim_sql, unsigned int key_id, const char* name);
 
 /**
  * @brief Get registry data using its key_id and name.
@@ -711,7 +711,7 @@ fim_registry_value_data *_fim_db_get_registry_data(fdb_t *fim_sql, unsigned int 
  *
  * @return FIM registry data struct on success, NULL on error.
  */
-fim_registry_value_data *fim_db_get_registry_data(fdb_t *fim_sql, unsigned int key_id, const char *name);
+fim_registry_value_data* fim_db_get_registry_data(fdb_t* fim_sql, unsigned int key_id, const char* name);
 
 /**
  * @brief Get a registry key using its path. This function must not be called from outside fim_db,
@@ -724,7 +724,7 @@ fim_registry_value_data *fim_db_get_registry_data(fdb_t *fim_sql, unsigned int k
  *
  * @return FIM registry key struct on success, NULL on error.
 */
-fim_registry_key *_fim_db_get_registry_key(fdb_t *fim_sql, const char *path, unsigned int arch);
+fim_registry_key* _fim_db_get_registry_key(fdb_t* fim_sql, const char* path, unsigned int arch);
 
 /**
  * @brief Get a registry key using its path.
@@ -736,7 +736,7 @@ fim_registry_key *_fim_db_get_registry_key(fdb_t *fim_sql, const char *path, uns
  *
  * @return FIM registry key struct on success, NULL on error.
 */
-fim_registry_key *fim_db_get_registry_key(fdb_t *fim_sql, const char *path, unsigned int arch);
+fim_registry_key* fim_db_get_registry_key(fdb_t* fim_sql, const char* path, unsigned int arch);
 
 
 /**
@@ -747,7 +747,7 @@ fim_registry_key *fim_db_get_registry_key(fdb_t *fim_sql, const char *path, unsi
  *
  * @return char** An array of the paths asociated to the key_id.
  */
-char **fim_db_get_all_registry_key(fdb_t *fim_sql, unsigned long int key_id);
+char** fim_db_get_all_registry_key(fdb_t* fim_sql, unsigned long int key_id);
 
 /**
  * @brief Insert or update registry data.
@@ -759,8 +759,8 @@ char **fim_db_get_all_registry_key(fdb_t *fim_sql, unsigned long int key_id);
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_insert_registry_data(fdb_t *fim_sql,
-                                fim_registry_value_data *data,
+int fim_db_insert_registry_data(fdb_t* fim_sql,
+                                fim_registry_value_data* data,
                                 unsigned int key_id,
                                 unsigned int replace_entry);
 
@@ -773,7 +773,7 @@ int fim_db_insert_registry_data(fdb_t *fim_sql,
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_insert_registry_key(fdb_t *fim_sql, fim_registry_key *entry, unsigned int rowid);
+int fim_db_insert_registry_key(fdb_t* fim_sql, fim_registry_key* entry, unsigned int rowid);
 
 /**
  * @brief Calculate checksum of registry keys between @start and @top.
@@ -790,8 +790,8 @@ int fim_db_insert_registry_key(fdb_t *fim_sql, fim_registry_key *entry, unsigned
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_registry_key_checksum_range(fdb_t *fim_sql, const char *start, const char *top,
-                                       long id, int n, pthread_mutex_t *mutex);
+int fim_db_registry_key_checksum_range(fdb_t* fim_sql, const char* start, const char* top,
+                                       long id, int n, pthread_mutex_t* mutex);
 
 /**
  * @brief Count the number of entries between range @start and @top.
@@ -803,7 +803,7 @@ int fim_db_registry_key_checksum_range(fdb_t *fim_sql, const char *start, const 
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_get_registry_key_count_range(fdb_t *fim_sql, char *start, char *top, int *counter);
+int fim_db_get_registry_key_count_range(fdb_t* fim_sql, char* start, char* top, int* counter);
 
 /**
  * @brief Count the number of registry data entries between range @start and @top.
@@ -816,7 +816,7 @@ int fim_db_get_registry_key_count_range(fdb_t *fim_sql, char *start, char *top, 
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
 
-int fim_db_get_registry_data_count_range(fdb_t *fim_sql, const char *start, const char *top, int *counter);
+int fim_db_get_registry_data_count_range(fdb_t* fim_sql, const char* start, const char* top, int* counter);
 
 /**
  * @brief Get the last/first row from registry_key table.
@@ -827,7 +827,7 @@ int fim_db_get_registry_data_count_range(fdb_t *fim_sql, const char *start, cons
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_get_row_registry_key(fdb_t *fim_sql, int mode, char **path);
+int fim_db_get_row_registry_key(fdb_t* fim_sql, int mode, char** path);
 
 /**
  * @brief Get the last/first row from registry_data table.
@@ -838,7 +838,7 @@ int fim_db_get_row_registry_key(fdb_t *fim_sql, int mode, char **path);
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_get_row_registry_data(fdb_t *fim_sql, int mode, char **path);
+int fim_db_get_row_registry_data(fdb_t* fim_sql, int mode, char** path);
 
 /**
  * @brief Set all entries from registry_key table to unscanned.
@@ -847,7 +847,7 @@ int fim_db_get_row_registry_data(fdb_t *fim_sql, int mode, char **path);
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_set_all_registry_key_unscanned(fdb_t *fim_sql);
+int fim_db_set_all_registry_key_unscanned(fdb_t* fim_sql);
 
 /**
  * @brief Set all entries from registry_data table to unscanned.
@@ -856,7 +856,7 @@ int fim_db_set_all_registry_key_unscanned(fdb_t *fim_sql);
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_set_all_registry_data_unscanned(fdb_t *fim_sql);
+int fim_db_set_all_registry_data_unscanned(fdb_t* fim_sql);
 
 /**
  * @brief Set a registry key as scanned.
@@ -866,7 +866,7 @@ int fim_db_set_all_registry_data_unscanned(fdb_t *fim_sql);
  * @param arch Architecture of the registry
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_set_registry_key_scanned(fdb_t *fim_sql, const char *path, unsigned int arch);
+int fim_db_set_registry_key_scanned(fdb_t* fim_sql, const char* path, unsigned int arch);
 
 /**
  * @brief Set a registry data as scanned.
@@ -878,7 +878,7 @@ int fim_db_set_registry_key_scanned(fdb_t *fim_sql, const char *path, unsigned i
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_set_registry_data_scanned(fdb_t *fim_sql, const char *name, unsigned int key_id);
+int fim_db_set_registry_data_scanned(fdb_t* fim_sql, const char* name, unsigned int key_id);
 
 /**
  * @brief Get all the unscanned registries keys by saving them in a temporal storage.
@@ -889,7 +889,7 @@ int fim_db_set_registry_data_scanned(fdb_t *fim_sql, const char *name, unsigned 
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_get_registry_keys_not_scanned(fdb_t * fim_sql, fim_tmp_file **file, int storage);
+int fim_db_get_registry_keys_not_scanned(fdb_t* fim_sql, fim_tmp_file** file, int storage);
 
 /**
  * @brief Get all the unscanned registries values by saving them in a temporal storage.
@@ -900,7 +900,7 @@ int fim_db_get_registry_keys_not_scanned(fdb_t * fim_sql, fim_tmp_file **file, i
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_get_registry_data_not_scanned(fdb_t * fim_sql, fim_tmp_file **file, int storage);
+int fim_db_get_registry_data_not_scanned(fdb_t* fim_sql, fim_tmp_file** file, int storage);
 
 /**
  * @brief Get count of all entries in registry data table.
@@ -909,7 +909,7 @@ int fim_db_get_registry_data_not_scanned(fdb_t * fim_sql, fim_tmp_file **file, i
  *
  * @return Number of entries in registry data table.
  */
-int fim_db_get_count_registry_data(fdb_t *fim_sql);
+int fim_db_get_count_registry_data(fdb_t* fim_sql);
 
 /**
  * @brief Get count of all entries in registry key table.
@@ -918,7 +918,7 @@ int fim_db_get_count_registry_data(fdb_t *fim_sql);
  *
  * @return Number of entries in registry data table.
  */
-int fim_db_get_count_registry_key(fdb_t *fim_sql);
+int fim_db_get_count_registry_key(fdb_t* fim_sql);
 
 /**
  * @brief Get registry keys between @start and @top. (stored in @file).
@@ -932,7 +932,7 @@ int fim_db_get_count_registry_key(fdb_t *fim_sql);
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  *
  */
-int fim_db_get_registry_value_range(fdb_t *fim_sql, const char *start, const char *top, fim_tmp_file **file,
+int fim_db_get_registry_value_range(fdb_t* fim_sql, const char* start, const char* top, fim_tmp_file** file,
                                     int storage);
 
 /**
@@ -947,7 +947,7 @@ int fim_db_get_registry_value_range(fdb_t *fim_sql, const char *start, const cha
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_delete_registry_key_range(fdb_t * fim_sql, fim_tmp_file *file, pthread_mutex_t *mutex, int storage);
+int fim_db_delete_registry_key_range(fdb_t* fim_sql, fim_tmp_file* file, pthread_mutex_t* mutex, int storage);
 
 /**
  * @brief Removes a range of registry data from the database.
@@ -961,7 +961,7 @@ int fim_db_delete_registry_key_range(fdb_t * fim_sql, fim_tmp_file *file, pthrea
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_delete_registry_value_range(fdb_t * fim_sql, fim_tmp_file *file, pthread_mutex_t *mutex, int storage);
+int fim_db_delete_registry_value_range(fdb_t* fim_sql, fim_tmp_file* file, pthread_mutex_t* mutex, int storage);
 /**
  * @brief Remove a range of registry keys from database if they have a
  * specific monitoring mode.
@@ -975,8 +975,8 @@ int fim_db_delete_registry_value_range(fdb_t * fim_sql, fim_tmp_file *file, pthr
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_process_missing_registry_key_entry(fdb_t *fim_sql, fim_tmp_file *file, pthread_mutex_t *mutex, int storage,
-                                              fim_event_mode mode, whodata_evt * w_evt);
+int fim_db_process_missing_registry_key_entry(fdb_t* fim_sql, fim_tmp_file* file, pthread_mutex_t* mutex, int storage,
+                                              fim_event_mode mode, whodata_evt* w_evt);
 
 /**
  * @brief Remove a range of registry data from database if they have a
@@ -991,8 +991,8 @@ int fim_db_process_missing_registry_key_entry(fdb_t *fim_sql, fim_tmp_file *file
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_process_missing_registry_data_entry(fdb_t *fim_sql, fim_tmp_file *file, pthread_mutex_t *mutex, int storage,
-                                               fim_event_mode mode, whodata_evt * w_evt);
+int fim_db_process_missing_registry_data_entry(fdb_t* fim_sql, fim_tmp_file* file, pthread_mutex_t* mutex, int storage,
+                                               fim_event_mode mode, whodata_evt* w_evt);
 
 
 /**
@@ -1002,7 +1002,7 @@ int fim_db_process_missing_registry_data_entry(fdb_t *fim_sql, fim_tmp_file *fil
  *
  * @return Number of entries in registry key table.
  */
-int fim_db_get_count_registry_key_data(fdb_t *fim_sql);
+int fim_db_get_count_registry_key_data(fdb_t* fim_sql);
 
 /**
  * @brief Delete registry using registry entry.
@@ -1010,7 +1010,7 @@ int fim_db_get_count_registry_key_data(fdb_t *fim_sql);
  * @param fim_sql FIM database struct.
  * @param entry Registry entry.
  */
-int fim_db_remove_registry_key(fdb_t *fim_sql, fim_entry *entry);
+int fim_db_remove_registry_key(fdb_t* fim_sql, fim_entry* entry);
 
 /**
  * @brief Delete registry data using fim_registry_value_data entry.
@@ -1020,7 +1020,7 @@ int fim_db_remove_registry_key(fdb_t *fim_sql, fim_entry *entry);
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_remove_registry_value_data(fdb_t *fim_sql, fim_registry_value_data *entry);
+int fim_db_remove_registry_value_data(fdb_t* fim_sql, fim_registry_value_data* entry);
 
 /**
  * @brief Get a registry using it's id.
@@ -1030,7 +1030,7 @@ int fim_db_remove_registry_value_data(fdb_t *fim_sql, fim_registry_value_data *e
  *
  * @return fim_registry_key structure.
  */
-fim_registry_key *fim_db_get_registry_key_using_id(fdb_t *fim_sql, unsigned int id);
+fim_registry_key* fim_db_get_registry_key_using_id(fdb_t* fim_sql, unsigned int id);
 
 /**
  * @brief Get all registry values from given id.
@@ -1044,7 +1044,7 @@ fim_registry_key *fim_db_get_registry_key_using_id(fdb_t *fim_sql, unsigned int 
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_get_values_from_registry_key(fdb_t * fim_sql, fim_tmp_file **file, int storage, unsigned long int key_id);
+int fim_db_get_values_from_registry_key(fdb_t* fim_sql, fim_tmp_file** file, int storage, unsigned long int key_id);
 
 /**
  * @brief Decodes a row from the database to be saved in a fim_registry_key structure.
@@ -1053,7 +1053,7 @@ int fim_db_get_values_from_registry_key(fdb_t * fim_sql, fim_tmp_file **file, in
  *
  * @return fim_registry_key* The filled structure.
  */
-fim_registry_key *fim_db_decode_registry_key(sqlite3_stmt *stmt);
+fim_registry_key* fim_db_decode_registry_key(sqlite3_stmt* stmt);
 
 /**
  * @brief Decodes a row from the database to be saved in a fim_registry_value_data structure.
@@ -1062,7 +1062,7 @@ fim_registry_key *fim_db_decode_registry_key(sqlite3_stmt *stmt);
  *
  * @return fim_registry_value_data* The filled structure.
  */
-fim_registry_value_data * fim_db_decode_registry_value(sqlite3_stmt *stmt);
+fim_registry_value_data* fim_db_decode_registry_value(sqlite3_stmt* stmt);
 
 /**
  * @brief Decodes a row from the registry database to be saved in a registry key structure.
@@ -1072,7 +1072,7 @@ fim_registry_value_data * fim_db_decode_registry_value(sqlite3_stmt *stmt);
  *
  * @return fim_entry* The filled structure.
  */
-fim_entry *fim_db_decode_registry(int index, sqlite3_stmt *stmt);
+fim_entry* fim_db_decode_registry(int index, sqlite3_stmt* stmt);
 
 #endif /* WIN32 */
 #ifdef __cplusplus

--- a/src/syscheckd/db/src/file.cpp
+++ b/src/syscheckd/db/src/file.cpp
@@ -16,12 +16,12 @@ extern "C" {
 #define static
 
 /* Replace assert with mock_assert */
-extern void mock_assert(const int result, const char *const expression, const char *const file, const int line);
+extern void mock_assert(const int result, const char* const expression, const char* const file, const int line);
 #undef assert
 #define assert(expression) mock_assert((int)(expression), #expression, __FILE__, __LINE__);
 #endif
 
-extern const char *SQL_STMT[];
+extern const char* SQL_STMT[];
 
 // Convenience macros
 #define fim_db_bind_set_scanned(fim_sql, path) fim_db_bind_path(fim_sql, FIMDB_STMT_SET_SCANNED, path)
@@ -39,7 +39,7 @@ extern const char *SQL_STMT[];
  * @param file_path File name of the file to insert.
  * @param entry FIM entry data structure.
  */
-static void fim_db_bind_replace_entry(fdb_t *fim_sql, const char *file_path, const fim_file_data *entry);
+static void fim_db_bind_replace_entry(fdb_t* fim_sql, const char* file_path, const fim_file_data* entry);
 
 
 /**
@@ -49,8 +49,8 @@ static void fim_db_bind_replace_entry(fdb_t *fim_sql, const char *file_path, con
  * @param index Index of the particular statement.
  * @param file_path File name of the file to insert.
  */
-static void fim_db_bind_path(fdb_t *fim_sql, int index,
-                             const char * file_path);
+static void fim_db_bind_path(fdb_t* fim_sql, int index,
+                             const char* file_path);
 
 
 /**
@@ -61,7 +61,7 @@ static void fim_db_bind_path(fdb_t *fim_sql, int index,
  * @param inode Inode of the file.
  * @param dev dev of the file.
  */
-static void fim_db_bind_get_inode(fdb_t *fim_sql, int index,
+static void fim_db_bind_get_inode(fdb_t* fim_sql, int index,
                                   unsigned long int inode,
                                   unsigned long int dev);
 
@@ -76,12 +76,12 @@ static void fim_db_bind_get_inode(fdb_t *fim_sql, int index,
  * @param configuration Position of the configuration that triggered the deletion of entries.
  * @param _unused_parameter Needed for this function to be a valid FIM DB callback.
  */
-void fim_db_remove_validated_path(fdb_t *fim_sql,
-                                  fim_entry *entry,
-                                  pthread_mutex_t *mutex,
-                                  void *evt_data,
-                                  void *configuration,
-                                  void *_unused_patameter);
+void fim_db_remove_validated_path(fdb_t* fim_sql,
+                                  fim_entry* entry,
+                                  pthread_mutex_t* mutex,
+                                  void* evt_data,
+                                  void* configuration,
+                                  void* _unused_patameter);
 
 /**
  * @brief Get the database info related to a given file_path
@@ -89,7 +89,7 @@ void fim_db_remove_validated_path(fdb_t *fim_sql,
  * @param fim_sql FIM database structure.
  * @param file_path Path reference to get db entry.
  */
-static fim_entry *_fim_db_get_path(fdb_t *fim_sql, const char *file_path);
+static fim_entry* _fim_db_get_path(fdb_t* fim_sql, const char* file_path);
 
 /**
  * @brief Check if database if full
@@ -98,7 +98,7 @@ static fim_entry *_fim_db_get_path(fdb_t *fim_sql, const char *file_path);
  * @param file_path Path reference to insert in db.
  * @param entry Entry data to be inserted.
  */
-static int fim_db_insert_entry(fdb_t *fim_sql, const char *file_path, const fim_file_data *entry);
+static int fim_db_insert_entry(fdb_t* fim_sql, const char* file_path, const fim_file_data* entry);
 
 /**
  * @brief Set file entry scanned.
@@ -108,10 +108,12 @@ static int fim_db_insert_entry(fdb_t *fim_sql, const char *file_path, const fim_
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-static int fim_db_set_scanned(fdb_t *fim_sql, const char *path);
+static int fim_db_set_scanned(fdb_t* fim_sql, const char* path);
 
-int fim_db_get_not_scanned(fdb_t * fim_sql, fim_tmp_file **file, int storage) {
-    if ((*file = fim_db_create_temp_file(storage)) == NULL) {
+int fim_db_get_not_scanned(fdb_t* fim_sql, fim_tmp_file** file, int storage)
+{
+    if ((*file = fim_db_create_temp_file(storage)) == NULL)
+    {
         return FIMDB_ERR;
     }
 
@@ -120,7 +122,8 @@ int fim_db_get_not_scanned(fdb_t * fim_sql, fim_tmp_file **file, int storage) {
 
     fim_db_check_transaction(fim_sql);
 
-    if (*file && (*file)->elements == 0) {
+    if (*file && (*file)->elements == 0)
+    {
         fim_db_clean_file(file, storage);
     }
 
@@ -129,7 +132,8 @@ int fim_db_get_not_scanned(fdb_t * fim_sql, fim_tmp_file **file, int storage) {
 }
 
 // LCOV_EXCL_START
-int fim_db_delete_not_scanned(fdb_t * fim_sql, fim_tmp_file *file, pthread_mutex_t *mutex, int storage) {
+int fim_db_delete_not_scanned(fdb_t* fim_sql, fim_tmp_file* file, pthread_mutex_t* mutex, int storage)
+{
     event_data_t evt_data;
     evt_data.report_event = TRUE;
     evt_data.mode = FIM_SCHEDULED;
@@ -139,65 +143,69 @@ int fim_db_delete_not_scanned(fdb_t * fim_sql, fim_tmp_file *file, pthread_mutex
     memset(&evt_data.statbuf, 0, sizeof(struct stat));
 
     return fim_db_process_read_file(fim_sql, file, FIM_TYPE_FILE, mutex, fim_delete_file_event, storage,
-                                    (void *)&evt_data, NULL, NULL);
+                                    (void*)&evt_data, NULL, NULL);
 }
 
-int fim_db_delete_range(fdb_t *fim_sql,
-                        fim_tmp_file *file,
-                        pthread_mutex_t *mutex,
+int fim_db_delete_range(fdb_t* fim_sql,
+                        fim_tmp_file* file,
+                        pthread_mutex_t* mutex,
                         int storage,
-                        event_data_t *evt_data,
-                        directory_t *configuration) {
+                        event_data_t* evt_data,
+                        directory_t* configuration)
+{
     return fim_db_process_read_file(fim_sql, file, FIM_TYPE_FILE, mutex, fim_db_remove_validated_path, storage,
                                     evt_data, configuration, NULL);
 }
 
-int fim_db_process_missing_entry(fdb_t *fim_sql,
-                                 fim_tmp_file *file,
-                                 pthread_mutex_t *mutex,
+int fim_db_process_missing_entry(fdb_t* fim_sql,
+                                 fim_tmp_file* file,
+                                 pthread_mutex_t* mutex,
                                  int storage,
-                                 event_data_t *evt_data) {
+                                 event_data_t* evt_data)
+{
     return fim_db_process_read_file(fim_sql, file, FIM_TYPE_FILE, mutex, fim_delete_file_event, storage, evt_data, NULL,
                                     NULL);
 }
 
-int fim_db_remove_wildcard_entry(fdb_t *fim_sql,
-                                 fim_tmp_file *file,
-                                 pthread_mutex_t *mutex,
+int fim_db_remove_wildcard_entry(fdb_t* fim_sql,
+                                 fim_tmp_file* file,
+                                 pthread_mutex_t* mutex,
                                  int storage,
-                                 event_data_t *evt_data,
-                                 directory_t *configuration) {
+                                 event_data_t* evt_data,
+                                 directory_t* configuration)
+{
     return fim_db_process_read_file(fim_sql, file, FIM_TYPE_FILE, mutex, fim_generate_delete_event, storage, evt_data,
                                     configuration, NULL);
 }
 // LCOV_EXCL_STOP
 
-fim_entry *fim_db_decode_full_row(sqlite3_stmt *stmt) {
+fim_entry* fim_db_decode_full_row(sqlite3_stmt* stmt)
+{
 
-    fim_entry *entry = NULL;
+    fim_entry* entry = NULL;
 
     os_calloc(1, sizeof(fim_entry), entry);
     entry->type = FIM_TYPE_FILE;
-    os_strdup((char *)sqlite3_column_text(stmt, 0), entry->file_entry.path);
+    os_strdup((char*)sqlite3_column_text(stmt, 0), entry->file_entry.path);
 
     os_calloc(1, sizeof(fim_file_data), entry->file_entry.data);
     entry->file_entry.data->mode = (fim_event_mode)sqlite3_column_int(stmt, 1);
     entry->file_entry.data->last_event = (time_t)sqlite3_column_int(stmt, 2);
     entry->file_entry.data->scanned = (time_t)sqlite3_column_int(stmt, 3);
     entry->file_entry.data->options = (time_t)sqlite3_column_int(stmt, 4);
-    strncpy(entry->file_entry.data->checksum, (char *)sqlite3_column_text(stmt, 5), sizeof(os_sha1) - 1);
+    strncpy(entry->file_entry.data->checksum, (char*)sqlite3_column_text(stmt, 5), sizeof(os_sha1) - 1);
     entry->file_entry.data->dev = (unsigned long int)sqlite3_column_int(stmt, 6);
     entry->file_entry.data->inode = (unsigned long int)sqlite3_column_int64(stmt, 7);
     entry->file_entry.data->size = (unsigned int)sqlite3_column_int(stmt, 8);
-    sqlite_strdup((char *)sqlite3_column_text(stmt, 9), entry->file_entry.data->perm);
-    sqlite_strdup((char *)sqlite3_column_text(stmt, 10), entry->file_entry.data->attributes);
-    sqlite_strdup((char *)sqlite3_column_text(stmt, 11), entry->file_entry.data->uid);
-    sqlite_strdup((char *)sqlite3_column_text(stmt, 12), entry->file_entry.data->gid);
-    sqlite_strdup((char *)sqlite3_column_text(stmt, 13), entry->file_entry.data->user_name);
-    sqlite_strdup((char *)sqlite3_column_text(stmt, 14), entry->file_entry.data->group_name);
-    strncpy(entry->file_entry.data->hash_md5, (char *)sqlite3_column_text(stmt, 15), sizeof(os_md5) - 1);
-    strncpy(entry->file_entry.data->hash_sha1, (char *)sqlite3_column_text(stmt, 16), sizeof(os_sha1) - 1);
-    strncpy(entry->file_entry.data->hash_sha256, (char *)sqlite3_column_text(stmt, 17), sizeof(os_sha256) - 1);
+    sqlite_strdup((char*)sqlite3_column_text(stmt, 9), entry->file_entry.data->perm);
+    sqlite_strdup((char*)sqlite3_column_text(stmt, 10), entry->file_entry.data->attributes);
+    sqlite_strdup((char*)sqlite3_column_text(stmt, 11), entry->file_entry.data->uid);
+    sqlite_strdup((char*)sqlite3_column_text(stmt, 12), entry->file_entry.data->gid);
+    sqlite_strdup((char*)sqlite3_column_text(stmt, 13), entry->file_entry.data->user_name);
+    sqlite_strdup((char*)sqlite3_column_text(stmt, 14), entry->file_entry.data->group_name);
+    strncpy(entry->file_entry.data->hash_md5, (char*)sqlite3_column_text(stmt, 15), sizeof(os_md5) - 1);
+    strncpy(entry->file_entry.data->hash_sha1, (char*)sqlite3_column_text(stmt, 16), sizeof(os_sha1) - 1);
+    strncpy(entry->file_entry.data->hash_sha256, (char*)sqlite3_column_text(stmt, 17), sizeof(os_sha256) - 1);
     entry->file_entry.data->mtime = (unsigned int)sqlite3_column_int(stmt, 18);
 
     return entry;
@@ -207,7 +215,8 @@ fim_entry *fim_db_decode_full_row(sqlite3_stmt *stmt) {
    FIMDB_STMT_SET_ALL_UNSCANNED, FIMDB_STMT_DELETE_UNSCANNED */
 
 /* FIMDB_STMT_REPLACE_ENTRY */
-void fim_db_bind_replace_entry(fdb_t *fim_sql, const char *file_path, const fim_file_data *entry) {
+void fim_db_bind_replace_entry(fdb_t* fim_sql, const char* file_path, const fim_file_data* entry)
+{
     sqlite3_bind_text(fim_sql->stmt[FIMDB_STMT_REPLACE_ENTRY], 1, file_path, -1, NULL);
     sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_REPLACE_ENTRY], 2, entry->mode);
     sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_REPLACE_ENTRY], 3, entry->last_event);
@@ -238,36 +247,41 @@ void fim_db_bind_replace_entry(fdb_t *fim_sql, const char *file_path, const fim_
  * FIMDB_STMT_DELETE_PATH
  * FIMDB_STMT_SET_SCANNED
  * FIMDB_STMT_GET_PATH_FROM_PATTERN */
-void fim_db_bind_path(fdb_t *fim_sql, int index, const char *path) {
+void fim_db_bind_path(fdb_t* fim_sql, int index, const char* path)
+{
     assert(index == FIMDB_STMT_SET_SCANNED || index == FIMDB_STMT_GET_PATH_FROM_PATTERN ||
            index == FIMDB_STMT_GET_PATH || index == FIMDB_STMT_DELETE_PATH);
     sqlite3_bind_text(fim_sql->stmt[index], 1, path, -1, NULL);
 }
 
 /* FIMDB_STMT_GET_PATHS_INODE */
-void fim_db_bind_get_inode(fdb_t *fim_sql, int index, unsigned long int inode, unsigned long int dev) {
+void fim_db_bind_get_inode(fdb_t* fim_sql, int index, unsigned long int inode, unsigned long int dev)
+{
     assert(index == FIMDB_STMT_GET_PATHS_INODE);
 
     sqlite3_bind_int64(fim_sql->stmt[index], 1, inode);
     sqlite3_bind_int(fim_sql->stmt[index], 2, dev);
 }
 
-fim_entry *_fim_db_get_path(fdb_t *fim_sql, const char *file_path) {
-    fim_entry *entry = NULL;
+fim_entry* _fim_db_get_path(fdb_t* fim_sql, const char* file_path)
+{
+    fim_entry* entry = NULL;
 
     // Clean and bind statements
     fim_db_clean_stmt(fim_sql, FIMDB_STMT_GET_PATH);
     fim_db_bind_path(fim_sql, FIMDB_STMT_GET_PATH, file_path);
 
-    if (sqlite3_step(fim_sql->stmt[FIMDB_STMT_GET_PATH]) == SQLITE_ROW) {
+    if (sqlite3_step(fim_sql->stmt[FIMDB_STMT_GET_PATH]) == SQLITE_ROW)
+    {
         entry = fim_db_decode_full_row(fim_sql->stmt[FIMDB_STMT_GET_PATH]);
     }
 
     return entry;
 }
 
-fim_entry *fim_db_get_path(fdb_t *fim_sql, const char *file_path) {
-    fim_entry *entry = NULL;
+fim_entry* fim_db_get_path(fdb_t* fim_sql, const char* file_path)
+{
+    fim_entry* entry = NULL;
 
     w_mutex_lock(&fim_sql->mutex);
     entry = _fim_db_get_path(fim_sql, file_path);
@@ -276,9 +290,10 @@ fim_entry *fim_db_get_path(fdb_t *fim_sql, const char *file_path) {
     return entry;
 }
 
-char **fim_db_get_paths_from_inode(fdb_t *fim_sql, unsigned long int inode, unsigned long int dev) {
+char** fim_db_get_paths_from_inode(fdb_t* fim_sql, unsigned long int inode, unsigned long int dev)
+{
     int i = 0;
-    char **paths = NULL;
+    char** paths = NULL;
 
     w_mutex_lock(&fim_sql->mutex);
 
@@ -286,13 +301,14 @@ char **fim_db_get_paths_from_inode(fdb_t *fim_sql, unsigned long int inode, unsi
     fim_db_clean_stmt(fim_sql, FIMDB_STMT_GET_PATHS_INODE);
     fim_db_bind_get_inode(fim_sql, FIMDB_STMT_GET_PATHS_INODE, inode, dev);
 
-    os_calloc(2, sizeof(char *), paths);
+    os_calloc(2, sizeof(char*), paths);
 
-    for (i = 0; sqlite3_step(fim_sql->stmt[FIMDB_STMT_GET_PATHS_INODE]) == SQLITE_ROW; i++) {
-        char *p;
-        os_realloc(paths, (i + 2) * sizeof(char *), paths);
+    for (i = 0; sqlite3_step(fim_sql->stmt[FIMDB_STMT_GET_PATHS_INODE]) == SQLITE_ROW; i++)
+    {
+        char* p;
+        os_realloc(paths, (i + 2) * sizeof(char*), paths);
 
-        p = (char *)sqlite3_column_text(fim_sql->stmt[FIMDB_STMT_GET_PATHS_INODE], 0);
+        p = (char*)sqlite3_column_text(fim_sql->stmt[FIMDB_STMT_GET_PATHS_INODE], 0);
         sqlite_strdup(p, paths[i]);
     }
 
@@ -304,11 +320,13 @@ char **fim_db_get_paths_from_inode(fdb_t *fim_sql, unsigned long int inode, unsi
     return paths;
 }
 
-int fim_db_check_limit(fdb_t *fim_sql) {
+int fim_db_check_limit(fdb_t* fim_sql)
+{
     int nodes_count;
     int retval = FIMDB_OK;
 
-    if (syscheck.file_limit_enabled == 0) {
+    if (syscheck.file_limit_enabled == 0)
+    {
         return FIMDB_OK;
     }
 
@@ -317,9 +335,13 @@ int fim_db_check_limit(fdb_t *fim_sql) {
 #else
     nodes_count = _fim_db_get_count(fim_sql, FIMDB_STMT_COUNT_DB_ENTRIES);
 #endif
-    if (nodes_count < 0) {
+
+    if (nodes_count < 0)
+    {
         retval = FIMDB_ERR;
-    } else if (nodes_count >= syscheck.file_limit) {
+    }
+    else if (nodes_count >= syscheck.file_limit)
+    {
         fim_sql->full = true;
         retval = FIMDB_FULL;
     }
@@ -327,21 +349,24 @@ int fim_db_check_limit(fdb_t *fim_sql) {
     return retval;
 }
 
-int fim_db_insert_entry(fdb_t *fim_sql, const char *file_path, const fim_file_data *entry) {
+int fim_db_insert_entry(fdb_t* fim_sql, const char* file_path, const fim_file_data* entry)
+{
     int res;
 
     fim_db_clean_stmt(fim_sql, FIMDB_STMT_REPLACE_ENTRY);
     fim_db_bind_replace_entry(fim_sql, file_path, entry);
 
-    if (res = sqlite3_step(fim_sql->stmt[FIMDB_STMT_REPLACE_ENTRY]), res != SQLITE_DONE) {
-            merror("Step error replacing path '%s': %s (%d)", file_path, sqlite3_errmsg(fim_sql->db), sqlite3_extended_errcode(fim_sql->db));
-            return FIMDB_ERR;
+    if (res = sqlite3_step(fim_sql->stmt[FIMDB_STMT_REPLACE_ENTRY]), res != SQLITE_DONE)
+    {
+        merror("Step error replacing path '%s': %s (%d)", file_path, sqlite3_errmsg(fim_sql->db), sqlite3_extended_errcode(fim_sql->db));
+        return FIMDB_ERR;
     }
 
     return FIMDB_OK;
 }
 
-int fim_db_remove_path(fdb_t *fim_sql, const char *path) {
+int fim_db_remove_path(fdb_t* fim_sql, const char* path)
+{
     int state = FIMDB_ERR;
 
     w_mutex_lock(&fim_sql->mutex);
@@ -349,7 +374,8 @@ int fim_db_remove_path(fdb_t *fim_sql, const char *path) {
     fim_db_clean_stmt(fim_sql, FIMDB_STMT_DELETE_PATH);
     fim_db_bind_path(fim_sql, FIMDB_STMT_DELETE_PATH, path);
 
-    if (sqlite3_step(fim_sql->stmt[FIMDB_STMT_DELETE_PATH]) != SQLITE_DONE) {
+    if (sqlite3_step(fim_sql->stmt[FIMDB_STMT_DELETE_PATH]) != SQLITE_DONE)
+    {
         goto end;
     }
 
@@ -363,21 +389,24 @@ end:
     return state;
 }
 
-void fim_db_remove_validated_path(fdb_t *fim_sql,
-                                  fim_entry *entry,
-                                  pthread_mutex_t *mutex,
-                                  void *evt_data,
-                                  void *configuration,
-                                  __attribute__((unused)) void *_unused_patameter) {
-    const directory_t *original_configuration = (const directory_t *)configuration;
-    directory_t *validated_configuration = fim_configuration_directory(entry->file_entry.path);
+void fim_db_remove_validated_path(fdb_t* fim_sql,
+                                  fim_entry* entry,
+                                  pthread_mutex_t* mutex,
+                                  void* evt_data,
+                                  void* configuration,
+                                  __attribute__((unused)) void* _unused_patameter)
+{
+    const directory_t* original_configuration = (const directory_t*)configuration;
+    directory_t* validated_configuration = fim_configuration_directory(entry->file_entry.path);
 
-    if (validated_configuration == original_configuration) {
+    if (validated_configuration == original_configuration)
+    {
         fim_delete_file_event(fim_sql, entry, mutex, evt_data, NULL, NULL);
     }
 }
 
-int fim_db_set_all_unscanned(fdb_t *fim_sql) {
+int fim_db_set_all_unscanned(fdb_t* fim_sql)
+{
     int retval;
 
     w_mutex_lock(&fim_sql->mutex);
@@ -388,12 +417,14 @@ int fim_db_set_all_unscanned(fdb_t *fim_sql) {
     return retval;
 }
 
-int fim_db_set_scanned(fdb_t *fim_sql, const char *path) {
+int fim_db_set_scanned(fdb_t* fim_sql, const char* path)
+{
     // Clean and bind statements
     fim_db_clean_stmt(fim_sql, FIMDB_STMT_SET_SCANNED);
     fim_db_bind_set_scanned(fim_sql, path);
 
-    if (sqlite3_step(fim_sql->stmt[FIMDB_STMT_SET_SCANNED]) != SQLITE_DONE) {
+    if (sqlite3_step(fim_sql->stmt[FIMDB_STMT_SET_SCANNED]) != SQLITE_DONE)
+    {
         merror("Step error setting scanned path '%s': %s (%d)", path, sqlite3_errmsg(fim_sql->db), sqlite3_extended_errcode(fim_sql->db));
         return FIMDB_ERR;
     }
@@ -401,26 +432,34 @@ int fim_db_set_scanned(fdb_t *fim_sql, const char *path) {
     return FIMDB_OK;
 }
 
-int fim_db_get_count_file_inode(fdb_t * fim_sql) {
+int fim_db_get_count_file_inode(fdb_t* fim_sql)
+{
     int res = fim_db_get_count(fim_sql, FIMDB_STMT_GET_COUNT_INODE);
 
-    if(res == FIMDB_ERR) {
+    if (res == FIMDB_ERR)
+    {
         merror("Step error getting count entry data: %s (%d)", sqlite3_errmsg(fim_sql->db), sqlite3_extended_errcode(fim_sql->db));
     }
+
     return res;
 }
 
-int fim_db_get_count_file_entry(fdb_t * fim_sql) {
+int fim_db_get_count_file_entry(fdb_t* fim_sql)
+{
     int res = fim_db_get_count(fim_sql, FIMDB_STMT_GET_COUNT_PATH);
 
-    if(res == FIMDB_ERR) {
+    if (res == FIMDB_ERR)
+    {
         merror("Step error getting count entry path: %s (%d)", sqlite3_errmsg(fim_sql->db), sqlite3_extended_errcode(fim_sql->db));
     }
+
     return res;
 }
 
-int fim_db_get_path_from_pattern(fdb_t *fim_sql, const char *pattern, fim_tmp_file **file, int storage) {
-    if ((*file = fim_db_create_temp_file(storage)) == NULL) {
+int fim_db_get_path_from_pattern(fdb_t* fim_sql, const char* pattern, fim_tmp_file** file, int storage)
+{
+    if ((*file = fim_db_create_temp_file(storage)) == NULL)
+    {
         return FIMDB_ERR;
     }
 
@@ -432,20 +471,22 @@ int fim_db_get_path_from_pattern(fdb_t *fim_sql, const char *pattern, fim_tmp_fi
     int ret = fim_db_multiple_row_query(fim_sql, FIMDB_STMT_GET_PATH_FROM_PATTERN,
                                         FIM_DB_DECODE_TYPE(fim_db_decode_string), free,
                                         FIM_DB_CALLBACK_TYPE(fim_db_callback_save_string),
-                                        storage, (void *)*file);
+                                        storage, (void*)*file);
 
     w_mutex_unlock(&fim_sql->mutex);
 
     fim_db_check_transaction(fim_sql);
 
-    if (*file && (*file)->elements == 0) {
+    if (*file && (*file)->elements == 0)
+    {
         fim_db_clean_file(file, storage);
     }
 
     return ret;
 }
 
-int fim_db_file_update(fdb_t *fim_sql, const char *path, const fim_file_data *data, fim_entry **saved) {
+int fim_db_file_update(fdb_t* fim_sql, const char* path, const fim_file_data* data, fim_entry** saved)
+{
     int retval;
     assert(saved != NULL);
 
@@ -453,23 +494,27 @@ int fim_db_file_update(fdb_t *fim_sql, const char *path, const fim_file_data *da
     *saved = _fim_db_get_path(fim_sql, path);
 
 
-    if (*saved == NULL) {
-        switch (fim_db_check_limit(fim_sql)) {
-        case FIMDB_FULL:
-            mdebug1("Couldn't insert '%s' entry into DB. The DB is full, please check your configuration.",
-                    path);
-            w_mutex_unlock(&fim_sql->mutex);
-            return FIMDB_FULL;
+    if (*saved == NULL)
+    {
+        switch (fim_db_check_limit(fim_sql))
+        {
+            case FIMDB_FULL:
+                mdebug1("Couldn't insert '%s' entry into DB. The DB is full, please check your configuration.",
+                        path);
+                w_mutex_unlock(&fim_sql->mutex);
+                return FIMDB_FULL;
 
-        case FIMDB_ERR:
-            mwarn(FIM_DATABASE_NODES_COUNT_FAIL);
-            w_mutex_unlock(&fim_sql->mutex);
-            return FIMDB_ERR;
+            case FIMDB_ERR:
+                mwarn(FIM_DATABASE_NODES_COUNT_FAIL);
+                w_mutex_unlock(&fim_sql->mutex);
+                return FIMDB_ERR;
 
-        default:
-            break;
+            default:
+                break;
         }
-    } else if (strcmp(data->checksum, (*saved)->file_entry.data->checksum) == 0) {
+    }
+    else if (strcmp(data->checksum, (*saved)->file_entry.data->checksum) == 0)
+    {
         // Entry up to date
         retval = fim_db_set_scanned(fim_sql, path);
         w_mutex_unlock(&fim_sql->mutex);

--- a/src/syscheckd/db/src/registry.cpp
+++ b/src/syscheckd/db/src/registry.cpp
@@ -11,9 +11,10 @@ extern "C" {
 
 #include "db.hpp"
 
-extern const char *SQL_STMT[];
+extern const char* SQL_STMT[];
 
-const char *registry_arch[] = {
+const char* registry_arch[] =
+{
     [ARCH_32BIT] = "[x32]",
     [ARCH_64BIT] = "[x64]"
 };
@@ -26,7 +27,7 @@ const char *registry_arch[] = {
  * @param name Registry name.
  * @param key_id Key id of the registry.
 */
-static void fim_db_bind_registry_data_name_key_id(fdb_t *fim_sql, int index, const char *name, int key_id);
+static void fim_db_bind_registry_data_name_key_id(fdb_t* fim_sql, int index, const char* name, int key_id);
 
 
 /**
@@ -37,7 +38,7 @@ static void fim_db_bind_registry_data_name_key_id(fdb_t *fim_sql, int index, con
  * @param path Path to registry.
  * @param arch architecture of the registry
 */
-static void fim_db_bind_registry_path(fdb_t *fim_sql, unsigned int index, const char *path, unsigned int arch);
+static void fim_db_bind_registry_path(fdb_t* fim_sql, unsigned int index, const char* path, unsigned int arch);
 
 /**
  * @brief Bind registry data into an insert registry data statement
@@ -46,7 +47,7 @@ static void fim_db_bind_registry_path(fdb_t *fim_sql, unsigned int index, const 
  * @param data Structure that contains the fields of the inserted data.
  * @param key_id Identifier of the key.
  */
-static void fim_db_bind_insert_registry_data(fdb_t *fim_sql, fim_registry_value_data *data, unsigned int key_id);
+static void fim_db_bind_insert_registry_data(fdb_t* fim_sql, fim_registry_value_data* data, unsigned int key_id);
 
 /**
  * @brief Bind registry data into an insert registry key statement
@@ -55,7 +56,7 @@ static void fim_db_bind_insert_registry_data(fdb_t *fim_sql, fim_registry_value_
  * @param registry_key Structure that contains the fields of the inserted key.
  * @param id Registry key identifier.
  */
-static void fim_db_bind_insert_registry_key(fdb_t *fim_sql, fim_registry_key *registry_key, unsigned int id);
+static void fim_db_bind_insert_registry_key(fdb_t* fim_sql, fim_registry_key* registry_key, unsigned int id);
 
 /**
  * @brief Bind id into get registry key statement.
@@ -63,7 +64,7 @@ static void fim_db_bind_insert_registry_key(fdb_t *fim_sql, fim_registry_key *re
  * @param fim_sql FIM database structure.
  * @param id ID of the registry key.
  */
-static void fim_db_bind_get_registry_key_id(fdb_t *fim_sql, unsigned int id);
+static void fim_db_bind_get_registry_key_id(fdb_t* fim_sql, unsigned int id);
 
 /**
  * @brief Bind id into get registry value statement.
@@ -71,10 +72,11 @@ static void fim_db_bind_get_registry_key_id(fdb_t *fim_sql, unsigned int id);
  * @param fim_sql FIM database structure.
  * @param key_id ID of the registry key.
  */
-static void fim_db_bind_get_registry_data_key_id(fdb_t *fim_sql, unsigned int key_id);
+static void fim_db_bind_get_registry_data_key_id(fdb_t* fim_sql, unsigned int key_id);
 
 // Registry sql queries bindings
-static void fim_db_bind_registry_data_name_key_id(fdb_t *fim_sql, int index, const char *name, int key_id) {
+static void fim_db_bind_registry_data_name_key_id(fdb_t* fim_sql, int index, const char* name, int key_id)
+{
     assert(index == FIMDB_STMT_SET_REG_DATA_UNSCANNED || index == FIMDB_STMT_DELETE_REG_DATA ||
            index == FIMDB_STMT_SET_REG_DATA_SCANNED || index == FIMDB_STMT_GET_REG_DATA);
 
@@ -82,7 +84,8 @@ static void fim_db_bind_registry_data_name_key_id(fdb_t *fim_sql, int index, con
     sqlite3_bind_int(fim_sql->stmt[index], 2, key_id);
 }
 
-static void fim_db_bind_registry_path(fdb_t *fim_sql, unsigned int index, const char *path, unsigned int arch) {
+static void fim_db_bind_registry_path(fdb_t* fim_sql, unsigned int index, const char* path, unsigned int arch)
+{
     assert(index == FIMDB_STMT_GET_REG_KEY || index == FIMDB_STMT_SET_REG_KEY_UNSCANNED ||
            index == FIMDB_STMT_GET_REG_ROWID || index == FIMDB_STMT_DELETE_REG_KEY_PATH ||
            index == FIMDB_STMT_DELETE_REG_DATA_PATH || index == FIMDB_STMT_SET_REG_KEY_SCANNED);
@@ -91,7 +94,8 @@ static void fim_db_bind_registry_path(fdb_t *fim_sql, unsigned int index, const 
     sqlite3_bind_text(fim_sql->stmt[index], 2, registry_arch[arch], -1, NULL);
 }
 
-static void fim_db_bind_insert_registry_data(fdb_t *fim_sql, fim_registry_value_data *data, unsigned int key_id) {
+static void fim_db_bind_insert_registry_data(fdb_t* fim_sql, fim_registry_value_data* data, unsigned int key_id)
+{
     sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_REPLACE_REG_DATA], 1, key_id);
     sqlite3_bind_text(fim_sql->stmt[FIMDB_STMT_REPLACE_REG_DATA], 2, data->name, -1, NULL);
     sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_REPLACE_REG_DATA], 3, data->type);
@@ -104,12 +108,17 @@ static void fim_db_bind_insert_registry_data(fdb_t *fim_sql, fim_registry_value_
     sqlite3_bind_text(fim_sql->stmt[FIMDB_STMT_REPLACE_REG_DATA], 10, data->checksum, -1, NULL);
 }
 
-static void fim_db_bind_insert_registry_key(fdb_t *fim_sql, fim_registry_key *registry_key, unsigned int id) {
-    if (id == 0) {
+static void fim_db_bind_insert_registry_key(fdb_t* fim_sql, fim_registry_key* registry_key, unsigned int id)
+{
+    if (id == 0)
+    {
         sqlite3_bind_null(fim_sql->stmt[FIMDB_STMT_REPLACE_REG_KEY], 1);
-    } else {
+    }
+    else
+    {
         sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_REPLACE_REG_KEY], 1, id);
     }
+
     sqlite3_bind_text(fim_sql->stmt[FIMDB_STMT_REPLACE_REG_KEY], 2, registry_key->path, -1, NULL);
     sqlite3_bind_text(fim_sql->stmt[FIMDB_STMT_REPLACE_REG_KEY], 3, registry_key->perm, -1, NULL);
     sqlite3_bind_text(fim_sql->stmt[FIMDB_STMT_REPLACE_REG_KEY], 4, registry_key->uid, -1, NULL);
@@ -123,17 +132,21 @@ static void fim_db_bind_insert_registry_key(fdb_t *fim_sql, fim_registry_key *re
     sqlite3_bind_text(fim_sql->stmt[FIMDB_STMT_REPLACE_REG_KEY], 12, registry_key->checksum, -1, NULL);
 }
 
-static void fim_db_bind_get_registry_key_id(fdb_t *fim_sql, unsigned int id) {
+static void fim_db_bind_get_registry_key_id(fdb_t* fim_sql, unsigned int id)
+{
     sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_GET_REG_KEY_ROWID], 1, id);
 }
 
-static void fim_db_bind_get_registry_data_key_id(fdb_t *fim_sql, unsigned int key_id) {
+static void fim_db_bind_get_registry_data_key_id(fdb_t* fim_sql, unsigned int key_id)
+{
     sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_GET_REG_DATA_ROWID], 1, key_id);
 }
 
-int fim_db_remove_registry_key(fdb_t *fim_sql, fim_entry *entry) {
+int fim_db_remove_registry_key(fdb_t* fim_sql, fim_entry* entry)
+{
 
-    if (entry->type != FIM_TYPE_REGISTRY) {
+    if (entry->type != FIM_TYPE_REGISTRY)
+    {
         return FIMDB_ERR;
     }
 
@@ -146,18 +159,21 @@ int fim_db_remove_registry_key(fdb_t *fim_sql, fim_entry *entry) {
     fim_db_bind_registry_path(fim_sql, FIMDB_STMT_DELETE_REG_KEY_PATH, entry->registry_entry.key->path,
                               entry->registry_entry.key->arch);
 
-    if (sqlite3_step(fim_sql->stmt[FIMDB_STMT_DELETE_REG_DATA_PATH]) != SQLITE_DONE) {
+    if (sqlite3_step(fim_sql->stmt[FIMDB_STMT_DELETE_REG_DATA_PATH]) != SQLITE_DONE)
+    {
         merror("Step error deleting data value from key '%s': %s (%d)", entry->registry_entry.key->path,
                sqlite3_errmsg(fim_sql->db), sqlite3_extended_errcode(fim_sql->db));
         w_mutex_unlock(&fim_sql->mutex);
         return FIMDB_ERR;
     }
 
-    if (sqlite3_step(fim_sql->stmt[FIMDB_STMT_DELETE_REG_KEY_PATH]) != SQLITE_DONE) {
+    if (sqlite3_step(fim_sql->stmt[FIMDB_STMT_DELETE_REG_KEY_PATH]) != SQLITE_DONE)
+    {
         merror("Step error deleting key path '%s': %s (%d)", entry->registry_entry.key->path, sqlite3_errmsg(fim_sql->db), sqlite3_extended_errcode(fim_sql->db));
         w_mutex_unlock(&fim_sql->mutex);
         return FIMDB_ERR;
     }
+
     w_mutex_unlock(&fim_sql->mutex);
 
     fim_db_check_transaction(fim_sql);
@@ -165,17 +181,20 @@ int fim_db_remove_registry_key(fdb_t *fim_sql, fim_entry *entry) {
     return FIMDB_OK;
 }
 
-int fim_db_remove_registry_value_data(fdb_t *fim_sql, fim_registry_value_data *entry) {
+int fim_db_remove_registry_value_data(fdb_t* fim_sql, fim_registry_value_data* entry)
+{
     w_mutex_lock(&fim_sql->mutex);
 
     fim_db_clean_stmt(fim_sql, FIMDB_STMT_DELETE_REG_DATA);
     fim_db_bind_registry_data_name_key_id(fim_sql, FIMDB_STMT_DELETE_REG_DATA, entry->name, entry->id);
 
-    if (sqlite3_step(fim_sql->stmt[FIMDB_STMT_DELETE_REG_DATA]) != SQLITE_DONE) {
+    if (sqlite3_step(fim_sql->stmt[FIMDB_STMT_DELETE_REG_DATA]) != SQLITE_DONE)
+    {
         merror("Step error deleting entry name '%s': %s (%d)", entry->name, sqlite3_errmsg(fim_sql->db), sqlite3_extended_errcode(fim_sql->db));
         w_mutex_unlock(&fim_sql->mutex);
         return FIMDB_ERR;
     }
+
     w_mutex_unlock(&fim_sql->mutex);
 
     fim_db_check_transaction(fim_sql);
@@ -183,50 +202,54 @@ int fim_db_remove_registry_value_data(fdb_t *fim_sql, fim_registry_value_data *e
     return FIMDB_OK;
 }
 
-fim_registry_key *fim_db_decode_registry_key(sqlite3_stmt *stmt) {
-    fim_registry_key *entry;
+fim_registry_key* fim_db_decode_registry_key(sqlite3_stmt* stmt)
+{
+    fim_registry_key* entry;
     os_calloc(1, sizeof(fim_registry_key), entry);
 
     entry->id = (unsigned int)sqlite3_column_int(stmt, 0);
-    sqlite_strdup((char *)sqlite3_column_text(stmt, 1), entry->path);
-    sqlite_strdup((char *)sqlite3_column_text(stmt, 2), entry->perm);
-    sqlite_strdup((char *)sqlite3_column_text(stmt, 3), entry->uid);
-    sqlite_strdup((char *)sqlite3_column_text(stmt, 4), entry->gid);
-    sqlite_strdup((char *)sqlite3_column_text(stmt, 5), entry->user_name);
-    sqlite_strdup((char *)sqlite3_column_text(stmt, 6), entry->group_name);
+    sqlite_strdup((char*)sqlite3_column_text(stmt, 1), entry->path);
+    sqlite_strdup((char*)sqlite3_column_text(stmt, 2), entry->perm);
+    sqlite_strdup((char*)sqlite3_column_text(stmt, 3), entry->uid);
+    sqlite_strdup((char*)sqlite3_column_text(stmt, 4), entry->gid);
+    sqlite_strdup((char*)sqlite3_column_text(stmt, 5), entry->user_name);
+    sqlite_strdup((char*)sqlite3_column_text(stmt, 6), entry->group_name);
     entry->mtime = (unsigned int)sqlite3_column_int(stmt, 7);
-    entry->arch = strcmp((char *)sqlite3_column_text(stmt, 8), "[x64]") == 0 ? ARCH_64BIT : ARCH_32BIT;
+    entry->arch = strcmp((char*)sqlite3_column_text(stmt, 8), "[x64]") == 0 ? ARCH_64BIT : ARCH_32BIT;
     entry->scanned = (unsigned int)sqlite3_column_int(stmt, 9);
     entry->last_event = sqlite3_column_int(stmt, 10);
-    strncpy(entry->checksum, (char *)sqlite3_column_text(stmt, 11), sizeof(os_sha1) - 1);
+    strncpy(entry->checksum, (char*)sqlite3_column_text(stmt, 11), sizeof(os_sha1) - 1);
 
     return entry;
 }
 
-fim_registry_value_data *_fim_db_decode_registry_value(sqlite3_stmt *stmt, int offset) {
-    fim_registry_value_data *entry;
+fim_registry_value_data* _fim_db_decode_registry_value(sqlite3_stmt* stmt, int offset)
+{
+    fim_registry_value_data* entry;
     os_calloc(1, sizeof(fim_registry_value_data), entry);
 
     entry->id = (unsigned int)sqlite3_column_int(stmt, offset + 0);
-    sqlite_strdup((char *)sqlite3_column_text(stmt, offset + 1), entry->name);
+    sqlite_strdup((char*)sqlite3_column_text(stmt, offset + 1), entry->name);
     entry->type = (unsigned int)sqlite3_column_int(stmt, offset + 2);
     entry->size = (unsigned int)sqlite3_column_int(stmt, offset + 3);
-    strncpy(entry->hash_md5, (char *)sqlite3_column_text(stmt, offset + 4), sizeof(os_md5) - 1);
-    strncpy(entry->hash_sha1, (char *)sqlite3_column_text(stmt, offset + 5), sizeof(os_sha1) - 1);
-    strncpy(entry->hash_sha256, (char *)sqlite3_column_text(stmt, offset + 6), sizeof(os_sha256) - 1);
+    strncpy(entry->hash_md5, (char*)sqlite3_column_text(stmt, offset + 4), sizeof(os_md5) - 1);
+    strncpy(entry->hash_sha1, (char*)sqlite3_column_text(stmt, offset + 5), sizeof(os_sha1) - 1);
+    strncpy(entry->hash_sha256, (char*)sqlite3_column_text(stmt, offset + 6), sizeof(os_sha256) - 1);
     entry->scanned = (unsigned int)sqlite3_column_int(stmt, offset + 7);
     entry->last_event = (unsigned int)sqlite3_column_int(stmt, offset + 8);
-    strncpy(entry->checksum, (char *)sqlite3_column_text(stmt, offset + 9), sizeof(os_sha1) - 1);
+    strncpy(entry->checksum, (char*)sqlite3_column_text(stmt, offset + 9), sizeof(os_sha1) - 1);
 
     return entry;
 }
 
-fim_registry_value_data * fim_db_decode_registry_value(sqlite3_stmt *stmt) {
+fim_registry_value_data* fim_db_decode_registry_value(sqlite3_stmt* stmt)
+{
     return _fim_db_decode_registry_value(stmt, 0);
 }
 
-fim_entry *fim_db_decode_registry(int index, sqlite3_stmt *stmt) {
-    fim_entry *entry = NULL;
+fim_entry* fim_db_decode_registry(int index, sqlite3_stmt* stmt)
+{
+    fim_entry* entry = NULL;
 
     os_calloc(1, sizeof(fim_entry), entry);
 
@@ -236,13 +259,15 @@ fim_entry *fim_db_decode_registry(int index, sqlite3_stmt *stmt) {
 
     // Registry key
     if (index == FIMDB_STMT_GET_REG_KEY_NOT_SCANNED ||
-        index == FIMDB_STMT_GET_REG_KEY_ROWID ||
-        index == FIMDB_STMT_GET_REG_KEY) {
+            index == FIMDB_STMT_GET_REG_KEY_ROWID ||
+            index == FIMDB_STMT_GET_REG_KEY)
+    {
 
         entry->registry_entry.key = fim_db_decode_registry_key(stmt);
     }
 
-    if (index == FIMDB_STMT_GET_REG_DATA || index == FIMDB_STMT_GET_REG_DATA_NOT_SCANNED) {
+    if (index == FIMDB_STMT_GET_REG_DATA || index == FIMDB_STMT_GET_REG_DATA_NOT_SCANNED)
+    {
         entry->registry_entry.value = fim_db_decode_registry_value(stmt);
     }
 
@@ -251,17 +276,21 @@ fim_entry *fim_db_decode_registry(int index, sqlite3_stmt *stmt) {
 
 // Registry callbacks
 
-void fim_db_callback_save_reg_data_name(__attribute__((unused))fdb_t * fim_sql, fim_entry *entry, int storage,
-                                        void *arg) {
+void fim_db_callback_save_reg_data_name(__attribute__((unused))fdb_t* fim_sql, fim_entry* entry, int storage,
+                                        void* arg)
+{
     int length;
-    if (entry->type != FIM_TYPE_REGISTRY || entry->registry_entry.value == NULL) {
+
+    if (entry->type != FIM_TYPE_REGISTRY || entry->registry_entry.value == NULL)
+    {
         return ;
     }
 
-    char *base = wstr_escape_json(entry->registry_entry.value->name);
-    char *buffer = NULL;
+    char* base = wstr_escape_json(entry->registry_entry.value->name);
+    char* buffer = NULL;
 
-    if (base == NULL) {
+    if (base == NULL)
+    {
         merror("Error escaping '%s'", entry->registry_entry.value->name);
         goto end;
     }
@@ -272,19 +301,23 @@ void fim_db_callback_save_reg_data_name(__attribute__((unused))fdb_t * fim_sql, 
 
     snprintf(buffer, length, "%d %s", entry->registry_entry.value->id, base);
 
-    if (storage == FIM_DB_DISK) { // disk storage enabled
-        if (fprintf(((fim_tmp_file *) arg)->fd, "%032ld%s\n", (unsigned long)(length), buffer) < 0) {
+    if (storage == FIM_DB_DISK)   // disk storage enabled
+    {
+        if (fprintf(((fim_tmp_file*) arg)->fd, "%032ld%s\n", (unsigned long)(length), buffer) < 0)
+        {
             merror("Can't save entry: %s %s", entry->registry_entry.value->name, strerror(errno));
             goto end;
         }
 
-        fflush(((fim_tmp_file *) arg)->fd);
+        fflush(((fim_tmp_file*) arg)->fd);
 
-    } else {
-        W_Vector_insert(((fim_tmp_file *) arg)->list, buffer);
+    }
+    else
+    {
+        W_Vector_insert(((fim_tmp_file*) arg)->list, buffer);
     }
 
-    ((fim_tmp_file *) arg)->elements++;
+    ((fim_tmp_file*) arg)->elements++;
 
 end:
     os_free(base);
@@ -292,7 +325,8 @@ end:
 }
 
 // Registry functions
-int fim_db_set_all_registry_data_unscanned(fdb_t *fim_sql) {
+int fim_db_set_all_registry_data_unscanned(fdb_t* fim_sql)
+{
     int retval;
 
     w_mutex_lock(&fim_sql->mutex);
@@ -304,7 +338,8 @@ int fim_db_set_all_registry_data_unscanned(fdb_t *fim_sql) {
     return retval;
 }
 
-int fim_db_set_all_registry_key_unscanned(fdb_t *fim_sql) {
+int fim_db_set_all_registry_key_unscanned(fdb_t* fim_sql)
+{
     int retval;
 
     w_mutex_lock(&fim_sql->mutex);
@@ -316,18 +351,21 @@ int fim_db_set_all_registry_key_unscanned(fdb_t *fim_sql) {
     return retval;
 }
 
-int fim_db_set_registry_key_scanned(fdb_t *fim_sql, const char *path, unsigned int arch) {
+int fim_db_set_registry_key_scanned(fdb_t* fim_sql, const char* path, unsigned int arch)
+{
     w_mutex_lock(&fim_sql->mutex);
 
     // Clean and bind statements
     fim_db_clean_stmt(fim_sql, FIMDB_STMT_SET_REG_KEY_SCANNED);
     fim_db_bind_registry_path(fim_sql, FIMDB_STMT_SET_REG_KEY_SCANNED, path, arch);
 
-    if (sqlite3_step(fim_sql->stmt[FIMDB_STMT_SET_REG_KEY_SCANNED]) != SQLITE_DONE) {
+    if (sqlite3_step(fim_sql->stmt[FIMDB_STMT_SET_REG_KEY_SCANNED]) != SQLITE_DONE)
+    {
         merror("Step error setting scanned key path '%s': %s (%d)", path, sqlite3_errmsg(fim_sql->db), sqlite3_extended_errcode(fim_sql->db));
         w_mutex_unlock(&fim_sql->mutex);
         return FIMDB_ERR;
     }
+
     w_mutex_unlock(&fim_sql->mutex);
 
     fim_db_check_transaction(fim_sql);
@@ -335,18 +373,21 @@ int fim_db_set_registry_key_scanned(fdb_t *fim_sql, const char *path, unsigned i
     return FIMDB_OK;
 }
 
-int fim_db_set_registry_data_scanned(fdb_t *fim_sql, const char *name, unsigned int key_id) {
+int fim_db_set_registry_data_scanned(fdb_t* fim_sql, const char* name, unsigned int key_id)
+{
     w_mutex_lock(&fim_sql->mutex);
 
     // Clean and bind statements
     fim_db_clean_stmt(fim_sql, FIMDB_STMT_SET_REG_DATA_SCANNED);
     fim_db_bind_registry_data_name_key_id(fim_sql, FIMDB_STMT_SET_REG_DATA_SCANNED, name, key_id);
 
-    if (sqlite3_step(fim_sql->stmt[FIMDB_STMT_SET_REG_DATA_SCANNED]) != SQLITE_DONE) {
+    if (sqlite3_step(fim_sql->stmt[FIMDB_STMT_SET_REG_DATA_SCANNED]) != SQLITE_DONE)
+    {
         merror("Step error setting scanned data name '%s': %s (%d)", name, sqlite3_errmsg(fim_sql->db), sqlite3_extended_errcode(fim_sql->db));
         w_mutex_unlock(&fim_sql->mutex);
         return FIMDB_ERR;
     }
+
     w_mutex_unlock(&fim_sql->mutex);
 
     fim_db_check_transaction(fim_sql);
@@ -354,7 +395,8 @@ int fim_db_set_registry_data_scanned(fdb_t *fim_sql, const char *name, unsigned 
     return FIMDB_OK;
 }
 
-int fim_db_get_registry_key_rowid(fdb_t *fim_sql, const char *path, unsigned int arch, unsigned int *rowid) {
+int fim_db_get_registry_key_rowid(fdb_t* fim_sql, const char* path, unsigned int arch, unsigned int* rowid)
+{
     int res;
 
     w_mutex_lock(&fim_sql->mutex);
@@ -364,65 +406,79 @@ int fim_db_get_registry_key_rowid(fdb_t *fim_sql, const char *path, unsigned int
 
     res = sqlite3_step(fim_sql->stmt[FIMDB_STMT_GET_REG_ROWID]);
 
-    if (res == SQLITE_ROW) {
+    if (res == SQLITE_ROW)
+    {
         *rowid = sqlite3_column_int(fim_sql->stmt[FIMDB_STMT_GET_REG_ROWID], 0);
-    } else if (res == SQLITE_DONE) {
+    }
+    else if (res == SQLITE_DONE)
+    {
         mdebug2("Key %s not found in DB", path);
         *rowid = 0;
     }
-    else {
+    else
+    {
         merror("Step error getting registry rowid %s: %s (%d)", path, sqlite3_errmsg(fim_sql->db), sqlite3_extended_errcode(fim_sql->db));
         w_mutex_unlock(&fim_sql->mutex);
         return FIMDB_ERR;
     }
+
     w_mutex_unlock(&fim_sql->mutex);
 
     return FIMDB_OK;
 }
 
-int fim_db_get_registry_keys_not_scanned(fdb_t * fim_sql, fim_tmp_file **file, int storage) {
-    if ((*file = fim_db_create_temp_file(storage)) == NULL) {
+int fim_db_get_registry_keys_not_scanned(fdb_t* fim_sql, fim_tmp_file** file, int storage)
+{
+    if ((*file = fim_db_create_temp_file(storage)) == NULL)
+    {
         return FIMDB_ERR;
     }
 
     int ret = fim_db_process_get_query(fim_sql, FIM_TYPE_REGISTRY, FIMDB_STMT_GET_REG_KEY_NOT_SCANNED,
                                        fim_db_callback_save_path, storage, (void*) *file);
 
-    if (*file && (*file)->elements == 0) {
+    if (*file && (*file)->elements == 0)
+    {
         fim_db_clean_file(file, storage);
     }
 
     return ret;
 }
 
-int fim_db_get_registry_data_not_scanned(fdb_t * fim_sql, fim_tmp_file **file, int storage) {
-    if ((*file = fim_db_create_temp_file(storage)) == NULL) {
+int fim_db_get_registry_data_not_scanned(fdb_t* fim_sql, fim_tmp_file** file, int storage)
+{
+    if ((*file = fim_db_create_temp_file(storage)) == NULL)
+    {
         return FIMDB_ERR;
     }
 
     int ret = fim_db_process_get_query(fim_sql, FIM_TYPE_REGISTRY, FIMDB_STMT_GET_REG_DATA_NOT_SCANNED,
                                        fim_db_callback_save_reg_data_name, storage, (void*) *file);
 
-    if (*file && (*file)->elements == 0) {
+    if (*file && (*file)->elements == 0)
+    {
         fim_db_clean_file(file, storage);
     }
 
     return ret;
 }
 
-fim_registry_value_data *_fim_db_get_registry_data(fdb_t *fim_sql, unsigned int key_id, const char *name) {
+fim_registry_value_data* _fim_db_get_registry_data(fdb_t* fim_sql, unsigned int key_id, const char* name)
+{
     fim_db_clean_stmt(fim_sql, FIMDB_STMT_GET_REG_DATA);
     fim_db_bind_registry_data_name_key_id(fim_sql, FIMDB_STMT_GET_REG_DATA, name, key_id);
 
-    if (sqlite3_step(fim_sql->stmt[FIMDB_STMT_GET_REG_DATA]) == SQLITE_ROW) {
+    if (sqlite3_step(fim_sql->stmt[FIMDB_STMT_GET_REG_DATA]) == SQLITE_ROW)
+    {
         return fim_db_decode_registry_value(fim_sql->stmt[FIMDB_STMT_GET_REG_DATA]);
     }
 
     return NULL;
 }
 
-fim_registry_value_data *fim_db_get_registry_data(fdb_t *fim_sql, unsigned int key_id, const char *name) {
-    fim_registry_value_data *value = NULL;
+fim_registry_value_data* fim_db_get_registry_data(fdb_t* fim_sql, unsigned int key_id, const char* name)
+{
+    fim_registry_value_data* value = NULL;
 
     w_mutex_lock(&fim_sql->mutex);
     value = _fim_db_get_registry_data(fim_sql, key_id, name);
@@ -431,19 +487,22 @@ fim_registry_value_data *fim_db_get_registry_data(fdb_t *fim_sql, unsigned int k
     return value;
 }
 
-fim_registry_key *_fim_db_get_registry_key(fdb_t *fim_sql, const char *path, unsigned int arch) {
+fim_registry_key* _fim_db_get_registry_key(fdb_t* fim_sql, const char* path, unsigned int arch)
+{
     fim_db_clean_stmt(fim_sql, FIMDB_STMT_GET_REG_KEY);
     fim_db_bind_registry_path(fim_sql, FIMDB_STMT_GET_REG_KEY, path, arch);
 
-    if (sqlite3_step(fim_sql->stmt[FIMDB_STMT_GET_REG_KEY]) == SQLITE_ROW) {
+    if (sqlite3_step(fim_sql->stmt[FIMDB_STMT_GET_REG_KEY]) == SQLITE_ROW)
+    {
         return fim_db_decode_registry_key(fim_sql->stmt[FIMDB_STMT_GET_REG_KEY]);
     }
 
     return NULL;
 }
 
-fim_registry_key *fim_db_get_registry_key(fdb_t *fim_sql, const char *path, unsigned int arch) {
-    fim_registry_key *reg_key = NULL;
+fim_registry_key* fim_db_get_registry_key(fdb_t* fim_sql, const char* path, unsigned int arch)
+{
+    fim_registry_key* reg_key = NULL;
 
     w_mutex_lock(&fim_sql->mutex);
     reg_key = _fim_db_get_registry_key(fim_sql, path, arch);
@@ -452,120 +511,139 @@ fim_registry_key *fim_db_get_registry_key(fdb_t *fim_sql, const char *path, unsi
     return reg_key;
 }
 
-fim_registry_key *fim_db_get_registry_key_using_id(fdb_t *fim_sql, unsigned int id) {
-    fim_registry_key *reg_key = NULL;
+fim_registry_key* fim_db_get_registry_key_using_id(fdb_t* fim_sql, unsigned int id)
+{
+    fim_registry_key* reg_key = NULL;
 
     w_mutex_lock(&fim_sql->mutex);
     fim_db_clean_stmt(fim_sql, FIMDB_STMT_GET_REG_KEY_ROWID);
     fim_db_bind_get_registry_key_id(fim_sql, id);
 
-    if (sqlite3_step(fim_sql->stmt[FIMDB_STMT_GET_REG_KEY_ROWID]) == SQLITE_ROW) {
+    if (sqlite3_step(fim_sql->stmt[FIMDB_STMT_GET_REG_KEY_ROWID]) == SQLITE_ROW)
+    {
         reg_key = fim_db_decode_registry_key(fim_sql->stmt[FIMDB_STMT_GET_REG_KEY_ROWID]);
     }
+
     w_mutex_unlock(&fim_sql->mutex);
 
     return reg_key;
 }
 
-int fim_db_get_count_registry_key(fdb_t *fim_sql) {
+int fim_db_get_count_registry_key(fdb_t* fim_sql)
+{
     int res = fim_db_get_count(fim_sql, FIMDB_STMT_GET_COUNT_REG_KEY);
 
-    if(res == FIMDB_ERR) {
+    if (res == FIMDB_ERR)
+    {
         merror("Step error getting count registry key: %s (%d)", sqlite3_errmsg(fim_sql->db), sqlite3_extended_errcode(fim_sql->db));
     }
 
     return res;
 }
 
-int fim_db_get_count_registry_data(fdb_t *fim_sql) {
+int fim_db_get_count_registry_data(fdb_t* fim_sql)
+{
     int res = fim_db_get_count(fim_sql, FIMDB_STMT_GET_COUNT_REG_DATA);
 
-    if(res == FIMDB_ERR) {
+    if (res == FIMDB_ERR)
+    {
         merror("Step error getting count registry data: %s (%d)", sqlite3_errmsg(fim_sql->db), sqlite3_extended_errcode(fim_sql->db));
     }
 
     return res;
 }
 
-int fim_db_insert_registry_data(fdb_t *fim_sql,
-                                fim_registry_value_data *data,
+int fim_db_insert_registry_data(fdb_t* fim_sql,
+                                fim_registry_value_data* data,
                                 unsigned int key_id,
-                                unsigned int replace_entry) {
+                                unsigned int replace_entry)
+{
     int res = 0;
 
     w_mutex_lock(&fim_sql->mutex);
 
     // Check there is room in the DB in case of insertion.
-    if (replace_entry == 0) {
-        switch (fim_db_check_limit(fim_sql)) {
-        case FIMDB_FULL:
-            mdebug2("Couldn't insert '%s' value entry into DB. The DB is full, please check your configuration.",
+    if (replace_entry == 0)
+    {
+        switch (fim_db_check_limit(fim_sql))
+        {
+            case FIMDB_FULL:
+                mdebug2("Couldn't insert '%s' value entry into DB. The DB is full, please check your configuration.",
                         data->name);
-            w_mutex_unlock(&fim_sql->mutex);
-            return FIMDB_FULL;
+                w_mutex_unlock(&fim_sql->mutex);
+                return FIMDB_FULL;
 
-        case FIMDB_ERR:
-            mwarn(FIM_DATABASE_NODES_COUNT_FAIL);
-            w_mutex_unlock(&fim_sql->mutex);
-            return FIMDB_ERR;
+            case FIMDB_ERR:
+                mwarn(FIM_DATABASE_NODES_COUNT_FAIL);
+                w_mutex_unlock(&fim_sql->mutex);
+                return FIMDB_ERR;
 
-        default:
-            break;
+            default:
+                break;
         }
     }
 
     fim_db_clean_stmt(fim_sql, FIMDB_STMT_REPLACE_REG_DATA);
     fim_db_bind_insert_registry_data(fim_sql, data, key_id);
 
-    if (res = sqlite3_step(fim_sql->stmt[FIMDB_STMT_REPLACE_REG_DATA]), res != SQLITE_DONE) {
+    if (res = sqlite3_step(fim_sql->stmt[FIMDB_STMT_REPLACE_REG_DATA]), res != SQLITE_DONE)
+    {
         merror("Step error replacing registry data '%d': %s (%d)", key_id, sqlite3_errmsg(fim_sql->db), sqlite3_extended_errcode(fim_sql->db));
         w_mutex_unlock(&fim_sql->mutex);
         return FIMDB_ERR;
     }
+
     w_mutex_unlock(&fim_sql->mutex);
 
     return FIMDB_OK;
 }
 
-int fim_db_insert_registry_key(fdb_t *fim_sql, fim_registry_key *entry, unsigned int rowid) {
+int fim_db_insert_registry_key(fdb_t* fim_sql, fim_registry_key* entry, unsigned int rowid)
+{
     int res = 0;
 
     w_mutex_lock(&fim_sql->mutex);
 
     // Check there is room in the DB in case of insertion.
-    if (rowid == 0) {
-        switch (fim_db_check_limit(fim_sql)) {
-        case FIMDB_FULL:
-            mdebug2("Couldn't insert '%s %s' entry into DB. The DB is full, please check your configuration.",
-                    registry_arch[entry->arch], entry->path);
-            w_mutex_unlock(&fim_sql->mutex);
-            return FIMDB_FULL;
+    if (rowid == 0)
+    {
+        switch (fim_db_check_limit(fim_sql))
+        {
+            case FIMDB_FULL:
+                mdebug2("Couldn't insert '%s %s' entry into DB. The DB is full, please check your configuration.",
+                        registry_arch[entry->arch], entry->path);
+                w_mutex_unlock(&fim_sql->mutex);
+                return FIMDB_FULL;
 
-        case FIMDB_ERR:
-            mwarn(FIM_DATABASE_NODES_COUNT_FAIL);
-            w_mutex_unlock(&fim_sql->mutex);
-            return FIMDB_ERR;
+            case FIMDB_ERR:
+                mwarn(FIM_DATABASE_NODES_COUNT_FAIL);
+                w_mutex_unlock(&fim_sql->mutex);
+                return FIMDB_ERR;
 
-        default:
-            break;
+            default:
+                break;
         }
     }
 
     fim_db_clean_stmt(fim_sql, FIMDB_STMT_REPLACE_REG_KEY);
     fim_db_bind_insert_registry_key(fim_sql, entry, rowid);
 
-    if (res = sqlite3_step(fim_sql->stmt[FIMDB_STMT_REPLACE_REG_KEY]), res != SQLITE_DONE) {
+    if (res = sqlite3_step(fim_sql->stmt[FIMDB_STMT_REPLACE_REG_KEY]), res != SQLITE_DONE)
+    {
         merror("Step error replacing registry key '%s': %s (%d)", entry->path, sqlite3_errmsg(fim_sql->db), sqlite3_extended_errcode(fim_sql->db));
         w_mutex_unlock(&fim_sql->mutex);
         return FIMDB_ERR;
     }
+
     w_mutex_unlock(&fim_sql->mutex);
 
     return FIMDB_OK;
 }
 
-int fim_db_get_values_from_registry_key(fdb_t * fim_sql, fim_tmp_file **file, int storage, unsigned long int key_id) {
-    if ((*file = fim_db_create_temp_file(storage)) == NULL) {
+int fim_db_get_values_from_registry_key(fdb_t* fim_sql, fim_tmp_file** file, int storage, unsigned long int key_id)
+{
+    if ((*file = fim_db_create_temp_file(storage)) == NULL)
+    {
         return FIMDB_ERR;
     }
 
@@ -581,38 +659,44 @@ int fim_db_get_values_from_registry_key(fdb_t * fim_sql, fim_tmp_file **file, in
 
     fim_db_check_transaction(fim_sql);
 
-    if (*file && (*file)->elements == 0) {
+    if (*file && (*file)->elements == 0)
+    {
         fim_db_clean_file(file, storage);
     }
 
     return ret;
 }
 
-int fim_db_process_read_registry_data_file(fdb_t *fim_sql, fim_tmp_file *file, pthread_mutex_t *mutex,
-                                           void (*callback)(fdb_t *, fim_entry *, pthread_mutex_t *, void *, void *, void *),
-                                           int storage, void * alert, void * mode, void * w_evt) {
+int fim_db_process_read_registry_data_file(fdb_t* fim_sql, fim_tmp_file* file, pthread_mutex_t* mutex,
+                                           void (*callback)(fdb_t*, fim_entry*, pthread_mutex_t*, void*, void*, void*),
+                                           int storage, void* alert, void* mode, void* w_evt)
+{
 
-    char *read_line = NULL;
+    char* read_line = NULL;
     int id;
     int i;
-    char *split;
+    char* split;
 
-    for (i = 0; i < file->elements; i++) {
+    for (i = 0; i < file->elements; i++)
+    {
         // Read line has to be: 234(row id of the key) some_reg(name of the registry). Get the rowid and the name
-        if(fim_db_read_line_from_file(file, storage, i, &read_line) != 0) {
+        if (fim_db_read_line_from_file(file, storage, i, &read_line) != 0)
+        {
             fim_db_clean_file(&file, storage);
             return FIMDB_ERR;
         }
 
         id = strtoul(read_line, &split, 10);
+
         // Skip if the fields couldn't be extracted.
-        if (split == NULL || *split != ' ') {
+        if (split == NULL || *split != ' ')
+        {
             mwarn("Temporary path file '%s' is corrupt: wrong line format", file->path);
             os_free(read_line);
             continue;
         }
 
-        fim_entry *entry;
+        fim_entry* entry;
         os_calloc(1, sizeof(fim_entry), entry);
         entry->type = FIM_TYPE_REGISTRY;
 
@@ -621,7 +705,8 @@ int fim_db_process_read_registry_data_file(fdb_t *fim_sql, fim_tmp_file *file, p
         entry->registry_entry.value = fim_db_get_registry_data(fim_sql, id, (split + 1));
         w_mutex_unlock(mutex);
 
-        if (entry->registry_entry.key != NULL && entry->registry_entry.value != NULL) {
+        if (entry->registry_entry.key != NULL && entry->registry_entry.value != NULL)
+        {
             callback(fim_sql, entry, mutex, alert, mode, w_evt);
         }
 


### PR DESCRIPTION
|Related issue|
|---|
|#9117|

Hi team!
## Description
As part of #9103, we need to add RTR checks to FIM db. This PR aims to add support for Astyle check. It also includes the necessary changes to the source code for the tests to pass

Closes #9117 


## Logs/Alerts example
```
root@23da20221c19:/share/wazuh/src# python3 build.py --scheck syscheckd/db
<syscheckd/db>=================== Running AStyle      ===================<syscheckd/db>
[Cleanfolder: PASSED]
<syscheckd/db>[AStyle Check: PASSED]<syscheckd/db>
root@23da20221c19:/share/wazuh/src# exit
```

