### PR TITLE
Improve Windows ACLs comparison

### DIFF
--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -434,6 +434,15 @@ void decode_win_attributes(char *str, unsigned int attrs);
 char *decode_win_permissions(char *raw_perm);
 
 /**
+ * @brief Compares 2 Windows ACLs in JSON format
+ *
+ * @param [in] acl1 A cJSON object holding a Windows ACL
+ * @param [in] acl2 A cJSON object holding a Windows ACL
+ * @return `true` if ACLs are equal to each other, `false` otherwise
+ */
+bool compare_win_permissions(const cJSON * const acl1, const cJSON * const acl2);
+
+/**
  * @brief Decodes a permission string and converts it to a human readable format
  *
  * @param [out] acl_json A cJSON with the permissions to decode

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -1396,6 +1396,74 @@ error:
     return NULL;
 }
 
+static bool compare_win_aces(const cJSON * const ace1, const cJSON * const ace2) {
+    cJSON *ace1_helper, *ace2_helper;
+
+    assert(ace1 != NULL && ace2 != NULL);
+
+    ace1_helper = cJSON_GetObjectItem(ace1, "allowed");
+    ace2_helper = cJSON_GetObjectItem(ace2, "allowed");
+
+    if (ace1_helper == NULL) {
+        if (ace2_helper != NULL) {
+            return false;
+        }
+        // Both ace helpers are NULL, we consider them to be equal
+    } else if (ace2_helper == NULL) {
+        return false;
+    } else if (cJSON_Compare(ace1_helper, ace2_helper, true) == false) {
+        return false;
+    }
+
+    ace1_helper = cJSON_GetObjectItem(ace1, "denied");
+    ace2_helper = cJSON_GetObjectItem(ace2, "denied");
+
+    if (ace1_helper == NULL) {
+        if (ace2_helper != NULL) {
+            return false;
+        }
+        // Both ace helpers are NULL, we consider them to be equal
+    } else if (ace2_helper == NULL) {
+        return false;
+    } else if (cJSON_Compare(ace1_helper, ace2_helper, true) == false) {
+        return false;
+    }
+
+    return true;
+}
+
+bool compare_win_permissions(const cJSON * const acl1, const cJSON * const acl2) {
+    cJSON *ace1;
+    cJSON *ace2;
+
+    if (acl1 == NULL) {
+        return acl2 == NULL;
+    }
+
+    if (acl2 == NULL) {
+        return false;
+    }
+
+    if (cJSON_GetArraySize(acl1) != cJSON_GetArraySize(acl2)) {
+        return false;
+    }
+
+    cJSON_ArrayForEach(ace1, acl1) {
+        ace2 = cJSON_GetObjectItem(acl2, ace1->string);
+
+        if (ace2 == NULL) {
+            return false;
+        }
+
+        if (compare_win_aces(ace1, ace2) == false) {
+            return false;
+        }
+    }
+
+    // If we get here, both ACLs are identical
+    return true;
+}
+
 cJSON *attrs_to_json(const char *attributes) {
     cJSON *attrs_array;
 

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -1499,9 +1499,17 @@ cJSON * fim_json_compare_attrs(const fim_file_data * old_data, const fim_file_da
             cJSON_AddItemToArray(changed_attributes, cJSON_CreateString("uid"));
         }
 
+#ifndef WIN32
         if (old_data->user_name && new_data->user_name && strcmp(old_data->user_name, new_data->user_name) != 0) {
             cJSON_AddItemToArray(changed_attributes, cJSON_CreateString("user_name"));
         }
+#else
+        // AD might fail to solve the user name, we don't trigger an event if the user name is empty
+        if (old_data->user_name && *old_data->user_name != '\0' && new_data->user_name &&
+            *new_data->user_name != '\0' && strcmp(old_data->user_name, new_data->user_name) != 0) {
+            cJSON_AddItemToArray(changed_attributes, cJSON_CreateString("user_name"));
+        }
+#endif
     }
 
     if (old_data->options & CHECK_GROUP) {

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -1480,11 +1480,15 @@ cJSON * fim_json_compare_attrs(const fim_file_data * old_data, const fim_file_da
         cJSON_AddItemToArray(changed_attributes, cJSON_CreateString("size"));
     }
 
+#ifndef WIN32
     if ( (old_data->options & CHECK_PERM) && strcmp(old_data->perm, new_data->perm) != 0 ) {
         cJSON_AddItemToArray(changed_attributes, cJSON_CreateString("permission"));
     }
+#else
+    if ( (old_data->options & CHECK_PERM) && compare_win_permissions(old_data->perm_json, new_data->perm_json) == false ) {
+        cJSON_AddItemToArray(changed_attributes, cJSON_CreateString("permission"));
+    }
 
-#ifdef WIN32
     if ( (old_data->options & CHECK_ATTRS) && strcmp(old_data->attributes, new_data->attributes) != 0 ) {
         cJSON_AddItemToArray(changed_attributes, cJSON_CreateString("attributes"));
     }
@@ -1531,7 +1535,6 @@ cJSON * fim_json_compare_attrs(const fim_file_data * old_data, const fim_file_da
     if ( (old_data->options & CHECK_SHA256SUM) && (strcmp(old_data->hash_sha256, new_data->hash_sha256) != 0) ) {
         cJSON_AddItemToArray(changed_attributes, cJSON_CreateString("sha256"));
     }
-
 
     return changed_attributes;
 }

--- a/src/syscheckd/registry/events.c
+++ b/src/syscheckd/registry/events.c
@@ -232,7 +232,9 @@ cJSON *fim_registry_compare_key_attrs(const fim_registry_key *new_data,
             cJSON_AddItemToArray(changed_attributes, cJSON_CreateString("uid"));
         }
 
-        if (old_data->user_name && new_data->user_name && strcmp(old_data->user_name, new_data->user_name) != 0) {
+        // AD might fail to solve the user name, we don't trigger an event if the user name is empty
+        if (old_data->user_name && *old_data->user_name != '\0' && new_data->user_name &&
+            *new_data->user_name != '\0' && strcmp(old_data->user_name, new_data->user_name) != 0) {
             cJSON_AddItemToArray(changed_attributes, cJSON_CreateString("user_name"));
         }
     }


### PR DESCRIPTION
|Related issue|
|---|
|#9005|

## Description

This PR closes #9005 by building on the changes added in #8585 and implementing a comparison between Windows ACLs that does not take the user name into account. We do this in order to prevent machines that might move in and out of an AD domain from triggering false positives. In addition to the ACL improvement, we also need to ignore empty user names when comparing the ownership of a file or register.

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer
- Memory tests for Windows
  - [x] Scan-build report

- [x] Added unit tests (for new features)
