### PR TITLE
Generate reports and log rotation charter for exploratory session

### DIFF
--- a/src/diagrams/architecture/generate_reports/001-sequence.puml
+++ b/src/diagrams/architecture/generate_reports/001-sequence.puml
@@ -1,0 +1,42 @@
+' Copyright (C) 2015-2021, Wazuh Inc.
+' Created by Wazuh, Inc. <info@wazuh.com>.
+' This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+@startuml monitord
+loop
+    monitord -> monitord : monitor_step_time()
+    monitord -> monitord : check_log_timer()
+    alt new day
+        monitord -> generate_reports : generate_reports()
+        alt mond.smtpserver && mond.reports
+            loop each report
+                generate_reports -> system : fork()
+                generate_reports -> reports_op : os_ReportdStart()
+                generate_reports -> sendcustomemail: OS_SendCustomEmail()
+                generate_reports -> generate_reports : sleep(20)
+                generate_reports -> generate_reports : childs++
+            end
+        
+            loop while child > 0
+                generate_reports -> system : waitpid()
+                generate_reports <- system : wp
+                alt wp < 0
+                    generate_reports -> debug_op : merror()
+                else wp = 0
+                    generate_reports -> generate_reports : sleep(5)
+                    alt between 2 and 9 wait retries
+                        generate_reports -> generate_reports : sleep(10)
+                    else more than 10 wait retries
+                        monitord <- generate_reports
+                    end
+                else
+                    generate_reports -> generate_reports : childs--
+                end
+            end
+
+        end
+    end
+    monitord -> monitord : sleep(1)
+end
+@enduml
+

--- a/src/diagrams/architecture/generate_reports/Readme.md
+++ b/src/diagrams/architecture/generate_reports/Readme.md
@@ -1,0 +1,27 @@
+<!--- 
+Copyright (C) 2015-2021, Wazuh Inc.
+Created by Wazuh, Inc. <info@wazuh.com>.
+This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+-->
+# Generate reports architecture
+## Index
+1. [Purpose](#purpose)
+2. [Sequence diagram](#sequence-diagram)
+3. [Findings](#findings)
+
+## Purpose
+Generate reports feature (Reportd) was created to generate and send reports via email based on several configurations.
+
+## Sequence diagram
+Sequence diagram shows the basic flow of generate reports feature hosted in monitord module. Each time the current day change is detected monitord module spawns a process per configured report to generate and send reports through email. Steps are:
+1. Create a new child process using fork.
+2. The process will generate and send the report through email.
+3. Repeat step 1 to 2 for each configured report.
+4. Wait until all the child processes terminates.
+5. If a process is taking to long to finish, sleep and try again later.
+6. If the wait retries reached 10 or all the processes terminated, return.
+
+## Findings
+A number of issues related to synchronization and timing were found during the code walkthrough when creating the sequence diagrams.
+* Generate reports and logs rotations runs on the same thread and both features has different timings and synchronization needs that are configured independently and should no be affected by others features configurations. This issue affects agents monitoring as well.
+* In the future each selfcontained feature that runs as part of monitord module should be isolated and executed in a dedicated thread to avoid coupling and timing/sync issues.

--- a/src/diagrams/architecture/log_rotation/001-sequence.puml
+++ b/src/diagrams/architecture/log_rotation/001-sequence.puml
@@ -1,0 +1,55 @@
+' Copyright (C) 2015-2021, Wazuh Inc.
+' Created by Wazuh, Inc. <info@wazuh.com>.
+' This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+@startuml monitord
+loop
+    monitord -> monitord : monitor_step_time()
+    monitord -> monitord : check_log_timer()
+    alt new day
+        monitord -> monitor_actions : monitor_logs(!CHECK_LOGS_SIZE)
+        alt mond.rotate_log
+            monitor_actions -> monitor_actions : sleep(mond.day_wait)
+            monitor_actions -> rotate_log : w_rotate_log(mond.compress, mond.keep_log_days, 1 (new_day), 0 (rotate_json), mond.daily_rotations)
+        else mond.rotate_log && mond.size_rotate
+            monitor_actions -> rotate_log : w_rotate_log(mond.compress, mond.keep_log_days, 0 (new_day), 0 (rotate_json), mond.daily_rotations)
+            monitor_actions -> rotate_log : w_rotate_log(mond.compress, mond.keep_log_days, 0 (new_day), 1 (rotate_json), mond.daily_rotations)
+        end
+        monitord -> manage_files : manage_files()
+        manage_files -> manage_files : manage_log(EVENTS, cday, cmon, cyear, &tm_result, "archive", "log")
+        manage_files -> sign_log : OS_SignLog()
+        alt mond.compress
+            manage_files -> compress_log : OS_CompressLog()
+        end
+        manage_files -> manage_files : manage_log(EVENTS, cday, cmon, cyear, &tm_result, "archive", "json")
+        manage_files -> sign_log : OS_SignLog()
+        alt mond.compress
+            manage_files -> compress_log : OS_CompressLog()
+        end
+        manage_files -> manage_files : manage_log(ALERTS, cday, cmon, cyear, &tm_result, "alerts", "log")
+        manage_files -> sign_log : OS_SignLog()
+        alt mond.compress
+            manage_files -> compress_log : OS_CompressLog()
+        end
+        manage_files -> manage_files : manage_log(ALERTS, cday, cmon, cyear, &tm_result, "alerts", "json")
+        manage_files -> sign_log : OS_SignLog()
+        alt mond.compress
+            manage_files -> compress_log : OS_CompressLog()
+        end
+        manage_files -> manage_files : manage_log(FWLOGS, cday, cmon, cyear, &tm_result, "firewall", "log")
+        manage_files -> sign_log : OS_SignLog()
+        alt mond.compress
+            manage_files -> compress_log : OS_CompressLog()
+        end
+        monitord -> monitord : monitor_update_date()
+    else
+        monitord -> monitor_actions : monitor_logs(CHECK_LOGS_SIZE)
+        alt mond.rotate_log && mond.size_rotate
+            monitor_actions -> rotate_log : w_rotate_log(mond.compress, mond.keep_log_days, 0 (new_day), 0 (rotate_json), mond.daily_rotations)
+            monitor_actions -> rotate_log : w_rotate_log(mond.compress, mond.keep_log_days, 0 (new_day), 1 (rotate_json), mond.daily_rotations)
+        end
+    end
+    monitord -> monitord : sleep(1)
+end
+@enduml
+

--- a/src/diagrams/architecture/log_rotation/Readme.md
+++ b/src/diagrams/architecture/log_rotation/Readme.md
@@ -1,0 +1,26 @@
+<!--- 
+Copyright (C) 2015-2021, Wazuh Inc.
+Created by Wazuh, Inc. <info@wazuh.com>.
+This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+-->
+
+# Logs rotation architecture
+## Index
+1. [Purpose](#purpose)
+2. [Sequence diagram](#sequence-diagram)
+3. [Findings](#findings)
+
+## Purpose
+Logs rotation feature was created to rotate the internal logs on daily basis or when they reach a configured max size. Logs rotation runs as part of monitord module and it's responsible of compressing and signing the old logs as well.
+
+## Sequence diagram
+Sequence diagram shows the basic flow of logs rotation feature hosted in monitord module. Each time the current day change is detected monitord module performs logs rotation, signing and compression based on the current configuration. Steps are:
+1. Rotate logs.
+2. Sign rotated logs.
+3. Compress rotated logs.
+Monitord checks every 1 seconds the size of the logs and decides if they need to be rotated based on the max size configured. In this case, logs are only rotated but not singed neither compressed.
+
+## Findings
+A number of issues related to synchronization and timing were found during the code walkthrough when creating the sequence diagrams.
+* Generate reports and logs rotations runs on the same thread and both features has different timings and synchronization needs that are configured independently and should no be affected by others features configurations. This issue affects agents monitoring as well.
+* In the future each selfcontained feature that runs as part of monitord module should be isolated and executed in a dedicated thread to avoid coupling and timing/sync issues.


### PR DESCRIPTION
|Related issue|
|---|
| #9202 |

This PR aims to add the monitord sequence diagram related to reports generation and logs rotation.