### PR TITLE
Improve dynamic request slice calculation

### DIFF
--- a/framework/wazuh/core/tests/test_rootcheck.py
+++ b/framework/wazuh/core/tests/test_rootcheck.py
@@ -5,6 +5,7 @@
 import os
 import sqlite3
 from datetime import datetime
+from json import dumps
 from unittest.mock import patch, ANY
 
 import pytest
@@ -50,10 +51,10 @@ def remove_db(data_path):
 test_data = InitRootcheck()
 
 
-def send_msg_to_wdb(msg, raw=False, *args, **kwargs):
+def send_msg_to_wdb(msg, raw=False):
     query = ' '.join(msg.split(' ')[3:])
-    result = test_data.cur.execute(query).fetchall()
-    return list(map(remove_nones_to_dict, map(dict, result)))
+    result = list(map(remove_nones_to_dict, map(dict, test_data.cur.execute(query).fetchall())))
+    return ['ok', dumps(result)] if raw else result
 
 
 @patch("wazuh.core.rootcheck.WazuhDBBackend")

--- a/framework/wazuh/core/tests/test_wdb.py
+++ b/framework/wazuh/core/tests/test_wdb.py
@@ -151,10 +151,13 @@ def test_run_wdb_command_ko(connect_mock):
 @patch("socket.socket.send")
 @patch("wazuh.core.wdb.WazuhDBConnection._send")
 def test_execute(send_mock, socket_send_mock, connect_mock):
+    def send_mock(obj, msg, raw=False):
+        return ['ok', '{"total": 5}'] if raw else [{"total": 5}]
+
     mywdb = WazuhDBConnection()
     mywdb.execute('agent 000 sql delete from test', delete=True)
     mywdb.execute("agent 000 sql update test set value = 'test' where key = 'test'", update=True)
-    with patch("wazuh.core.wdb.WazuhDBConnection._send", return_value=[{'total': 5}]):
+    with patch("wazuh.core.wdb.WazuhDBConnection._send", new=send_mock):
         mywdb.execute("agent 000 sql select test from test offset 1 limit 1")
         mywdb.execute("agent 000 sql select test from test offset 1 limit 1", count=True)
         mywdb.execute("agent 000 sql select test from test offset 1 count")
@@ -167,7 +170,8 @@ def test_execute_pagination(socket_send_mock, connect_mock):
 
     # Test pagination
     with patch("wazuh.core.wdb.WazuhDBConnection._send",
-               side_effect=[[{'total': 5}], exception.WazuhInternalError(2009), [{'total': 5}], [{'total': 5}]]):
+               side_effect=[[{'total': 5}], exception.WazuhInternalError(2009), ['ok', '{"total": 5}'],
+                            ['ok', '{"total": 5}']]):
         mywdb.execute("agent 000 sql select test from test offset 1 limit 500")
 
     # Test pagination error

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import sys
 from grp import getgrnam
+from json import dumps
 from pwd import getpwnam
 from unittest.mock import MagicMock, patch
 
@@ -46,10 +47,10 @@ full_agent_list = ['000', '001', '002', '003', '004', '005', '006', '007', '008'
 short_agent_list = ['000', '001', '002', '003', '004', '005']
 
 
-def send_msg_to_wdb(msg, raw=False, *args, **kwargs):
+def send_msg_to_wdb(msg, raw=False):
     query = ' '.join(msg.split(' ')[2:])
-    result = test_data.cur.execute(query).fetchall()
-    return list(map(remove_nones_to_dict, map(dict, result)))
+    result = list(map(remove_nones_to_dict, map(dict, test_data.cur.execute(query).fetchall())))
+    return ['ok', dumps(result)] if raw else result
 
 
 @pytest.mark.parametrize('fields, expected_items', [

--- a/framework/wazuh/tests/test_vulnerability.py
+++ b/framework/wazuh/tests/test_vulnerability.py
@@ -5,6 +5,7 @@
 
 import os
 import sys
+from json import dumps
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -29,11 +30,12 @@ test_data = InitAgent(data_path=test_data_path)
 test_data_cve = InitAgent(data_path=test_data_path, db_name='schema_cve_test.sql')
 
 
-def send_msg_to_wdb(msg, raw=False, *args, **kwargs):
-    # Tests for CVE endpoint use a different schema and query
+def send_msg_to_wdb(msg, raw=False):
     query = msg[msg.find('sql') + len('sql '):]
-    result = test_data.cur.execute(query).fetchall() if msg.startswith('global') else test_data_cve.cur.execute(query).fetchall()
-    return list(map(remove_nones_to_dict, map(dict, result)))
+    result = test_data.cur.execute(query).fetchall() if msg.startswith('global') else test_data_cve.cur.execute(
+        query).fetchall()
+    result = list(map(remove_nones_to_dict, map(dict, result)))
+    return ['ok', dumps(result)] if raw else result
 
 
 @pytest.mark.parametrize('params, field_name, expected_items', [


### PR DESCRIPTION
|Related issue|
|---|
| Closes #9029 |

## Description

Hello team!

As requested in #9029, this PR is a refactor of the dynamic request slice calculation. Now, only one iteration is needed in order to update the `self.request_slice` value to its optimum, whereas before, multiple iterations were needed.

This change does not imply big-time improvements, although it can save several seconds when making many calls requesting more than 1000 items. 

![1000_limit_100000_agents](https://user-images.githubusercontent.com/23361101/125420072-ef21119f-af8e-4796-93f4-edc62624b2c4.png)

| Pagination-type | Total time | Average | Median | Max | Min | 
|--|--|--|--|--|--|
| **OLD BEHAVIOUR** | 79.498 | 0.795 | 0.788 | 1.05 | 0.526 |
| **NEW BEHAVIOUR** | 74.184 | 0.742 | 0.761 | 0.905 | 0.54 |

Regards,
Selu.