### PR TITLE
Fix rule option 'noalert' parsing

### DIFF
--- a/ruleset/testing/ruleset/test_decoders.xml
+++ b/ruleset/testing/ruleset/test_decoders.xml
@@ -19,3 +19,9 @@
   <regex>Test different_(\S+) '(\w+)' '(\w+)' logged from (\d+.\d+.\d+.\d+):(\d+) to (\d+.\d+.\d+.\d+):(\d+) pro:(\w+) act:(\w+) id:(\d+) url:(\w+) dat:(\w+) e_data:(\w+) sta:(\w+) systemname:(\w+)</regex>
   <order>test, srcuser, user, srcip, srcport, dstip, dstport, protocol, action, id, url, data, extra_data, status, system_name</order>
 </decoder>
+
+<decoder name="test_noalert">
+  <program_name>^test_noalert</program_name>
+  <regex>Test noalert=(\d)$</regex>
+  <order>noalert</order>
+</decoder>

--- a/ruleset/testing/ruleset/test_rules.xml
+++ b/ruleset/testing/ruleset/test_rules.xml
@@ -462,4 +462,20 @@
   <description>Different srcuser works</description>
 </rule>
 
+<!-- Trigger alerts which depend on noalert. -->
+<!-- Dec 19 17:20:08 User test_noalert[12345]:Test noalert=1 -->
+<!-- Dec 19 17:20:08 User test_noalert[12345]:Test noalert=0 -->
+
+<rule id="999273" level="3" noalert="1">
+  <decoded_as>test_noalert</decoded_as>
+  <field name="noalert">1</field>
+  <description>No-alerting enabled.</description>
+</rule>
+
+<rule id="999274" level="3" noalert="0">
+  <decoded_as>test_noalert</decoded_as>
+  <field name="noalert">0</field>
+  <description>No-alerting disabled.</description>
+</rule>
+
 </group>

--- a/ruleset/testing/tests/test_features.ini
+++ b/ruleset/testing/tests/test_features.ini
@@ -36,3 +36,17 @@ log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid us
 rule = 5712
 alert = 10
 decoder = sshd
+
+[noalert enabled]
+log 1 fail = Dec 19 17:20:08 User test_noalert[12345]:Test noalert=1
+
+rule =
+alert =
+decoder = test_noalert
+
+[noalert disabled]
+log 1 pass = Dec 19 17:20:08 User test_noalert[12345]:Test noalert=0
+
+rule = 999274
+alert = 3
+decoder = test_noalert

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -2226,7 +2226,13 @@ STATIC int getattributes(char **attributes, char **values,
         }
         /* Rule noalert */
         else if (strcasecmp(attributes[k], xml_noalert) == 0) {
-            *noalert = 1;
+            if (strcmp(values[k], "0") == 0) {
+                *noalert = 0;
+            } else if (strcmp(values[k], "1") == 0) {
+                *noalert = 1;
+            } else {
+                smwarn(log_msg, "Invalid value for attribute '%s'", xml_noalert);
+            }
         } else if (strcasecmp(attributes[k], xml_overwrite) == 0) {
             if (strcmp(values[k], "yes") == 0) {
                 *overwrite = 1;

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -92,7 +92,7 @@ void Rules_OP_CreateRules() {
 
 }
 
-int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_node, 
+int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_node,
                        EventList **last_event_list, OSStore **decoder_list, OSList* log_msg)
 {
     OS_XML xml;
@@ -313,8 +313,8 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 goto cleanup;
             }
             if ((!node[i]->attributes) || (!node[i]->values)
-                || (!node[i]->values[0]) || (!node[i]->attributes[0]) 
-                || (strcasecmp(node[i]->attributes[0], "name") != 0) 
+                || (!node[i]->values[0]) || (!node[i]->attributes[0])
+                || (strcasecmp(node[i]->attributes[0], "name") != 0)
                 || (node[i]->attributes[1])) {
                 smerror(log_msg, "rules_op: Invalid root element '%s'."
                        "Only the group name is allowed", node[i]->element);
@@ -589,7 +589,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
 
                     } else if (strcasecmp(rule_opt[k]->element, xml_group) == 0) {
                         config_ruleinfo->group = loadmemory(config_ruleinfo->group, rule_opt[k]->content, log_msg);
- 
+
                     } else if (strcasecmp(rule_opt[k]->element, xml_comment) == 0) {
 
                         char *newline;
@@ -823,7 +823,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                                         lookup_type = LR_ADDRESS_MATCH_VALUE;
                                     } else {
                                         smerror(log_msg, INVALID_CONFIG, rule_opt[k]->element, rule_opt[k]->content);
-                                        smerror(log_msg, "List match lookup=\"%s\" is not valid.", 
+                                        smerror(log_msg, "List match lookup=\"%s\" is not valid.",
                                                 rule_opt[k]->values[list_att_num]);
                                         goto cleanup;
                                     }
@@ -870,7 +870,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                                     os_calloc(1, sizeof(OSMatch), matcher);
                                     if (!OSMatch_Compile(rule_opt[k]->values[list_att_num], matcher, 0)) {
                                         smerror(log_msg, INVALID_CONFIG, rule_opt[k]->element, rule_opt[k]->content);
-                                        smerror(log_msg, REGEX_COMPILE, rule_opt[k]->values[list_att_num], 
+                                        smerror(log_msg, REGEX_COMPILE, rule_opt[k]->values[list_att_num],
                                             matcher->error);
                                         goto cleanup;
                                     }
@@ -1502,8 +1502,8 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 }
 
                 /* Check for valid use of frequency */
-                if ((config_ruleinfo->context_opts || config_ruleinfo->same_field 
-                    || config_ruleinfo->different_field || config_ruleinfo->frequency) 
+                if ((config_ruleinfo->context_opts || config_ruleinfo->same_field
+                    || config_ruleinfo->different_field || config_ruleinfo->frequency)
                     && !config_ruleinfo->context) {
                     smerror(log_msg, "Invalid use of frequency/context options. "
                            "Missing if_matched on rule '%d'.", config_ruleinfo->sigid);
@@ -1721,7 +1721,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
 
                     os_free(location);
                 }
-                
+
                 /* Add location */
                 if (action) {
                     w_calloc_expression_t(&config_ruleinfo->action, action_type);
@@ -1904,7 +1904,7 @@ cleanup:
     os_free(action)
     OS_ClearNode(rule);
     OS_ClearNode(rule_opt);
-    
+
     if (config_ruleinfo != NULL) {
         os_remove_ruleinfo(config_ruleinfo);
     }
@@ -3090,7 +3090,7 @@ w_exp_type_t w_check_attr_type(xml_node * node, w_exp_type_t default_type, int r
     const char * xml_type = "type";
     const char * str_type = w_get_attr_val_by_name(node, xml_type);
 
-    if (!str_type) { 
+    if (!str_type) {
         return default_type;
     }
 

--- a/src/shared/rules_op.c
+++ b/src/shared/rules_op.c
@@ -709,7 +709,7 @@ int OS_ReadXMLRules(const char *rulefile,
                     if (!(config_ruleinfo->alert_opts & SAME_EXTRAINFO)) {
                         config_ruleinfo->alert_opts |= SAME_EXTRAINFO;
                     }
-                } else if (strcmp(rule_opt[k]->element, xml_different_id) == 0 || 
+                } else if (strcmp(rule_opt[k]->element, xml_different_id) == 0 ||
                            strcmp(rule_opt[k]->element, xml_notsame_id) == 0) {
                     config_ruleinfo->different_field |= FIELD_ID;
 
@@ -777,7 +777,7 @@ int OS_ReadXMLRules(const char *rulefile,
                     }
                 } else if (strcasecmp(rule_opt[k]->element,
                                       xml_different_user) == 0 ||
-                           strcasecmp(rule_opt[k]->element, 
+                           strcasecmp(rule_opt[k]->element,
                                       xml_notsame_user) == 0) {
                     config_ruleinfo->different_field |= FIELD_USER;
 
@@ -793,7 +793,7 @@ int OS_ReadXMLRules(const char *rulefile,
 
                     if (!(config_ruleinfo->alert_opts & SAME_EXTRAINFO)) {
                         config_ruleinfo->alert_opts |= SAME_EXTRAINFO;
-                    } 
+                    }
                 } else if (strcasecmp(rule_opt[k]->element,
                                       xml_global_frequency) == 0) {
                     config_ruleinfo->context_opts |= FIELD_GFREQUENCY;
@@ -1007,7 +1007,7 @@ int OS_ReadXMLRules(const char *rulefile,
             }
 
             /* Check for a valid use of frequency */
-            if ((config_ruleinfo->context_opts || config_ruleinfo->same_field || 
+            if ((config_ruleinfo->context_opts || config_ruleinfo->same_field ||
                     config_ruleinfo->different_field ||
                     config_ruleinfo->frequency) &&
                     !config_ruleinfo->context) {

--- a/src/shared/rules_op.c
+++ b/src/shared/rules_op.c
@@ -1428,7 +1428,13 @@ static int _OS_GetRulesAttributes(char **attributes, char **values,
         }
         /* Rule noalert */
         else if (strcasecmp(attributes[k], xml_noalert) == 0) {
-            ruleinfo_pt->alert_opts |= NO_ALERT;
+            if (strcmp(values[k], "0") == 0) {
+                ruleinfo_pt->alert_opts &= ~NO_ALERT;
+            } else if (strcmp(values[k], "1") == 0) {
+                ruleinfo_pt->alert_opts |= NO_ALERT;
+            } else {
+                mwarn("Invalid value for attribute '%s'", xml_noalert);
+            }
         } else if (strcasecmp(attributes[k], xml_overwrite) == 0) {
             if (strcmp(values[k], "yes") == 0) {
                 ruleinfo_pt->alert_opts |= DO_OVERWRITE;


### PR DESCRIPTION
|Related issue|
|---|
|#9276|

This PR aims to fix issue #9276 by reading the actual value of option `noalert`:

```xml
<rule id="100001" noalert="1">
<rule id="100001" noalert="0">
```

- The first line shall disable alerting.
- The last line shall enable alerting back.
- Any other value of `noalert` must produce a warning:

```
wazuh-testrule: WARNING: Invalid value for attribute 'noalert'
```

## Tests

- [X] Added ruleset tests for this option.
- [X] Checked that a value different from `1` and `0` produces a warning.
