### PR TITLE
Rules for PrintNightmare - CVE-2021-34527

### DIFF
--- a/ruleset/rules/0820-sysmon_id_7.xml
+++ b/ruleset/rules/0820-sysmon_id_7.xml
@@ -10,7 +10,7 @@
     <rule id="92031" level="12">
         <if_group>sysmon_event7</if_group>
         <field name="win.eventdata.originalFileName" type="pcre2">(?i)System.Management.Automation.dll</field>
-        <field name="win.eventdata.image" type="pcre2" negate="yes">(?i)[c-z]\:\\Windows\\Microsoft.NET\\.+\\csc\\.exe$</field>
+        <field name="win.eventdata.image" type="pcre2" negate="yes">(?i)[c-z]\:\\\\Windows\\\\Microsoft.NET\\.+\\csc\\.exe$</field>
         <field name="win.eventdata.image" type="pcre2" negate="yes">(?i)(devenv|node|SSMS|VSLauncher)\.exe$</field>
         <field name="win.eventdata.image" type="pcre2" negate="yes">(?i)(sdiagnhost|SmartAudio3)\.exe$</field>
         <field name="win.eventdata.image" type="pcre2" negate="yes">(?i)(pwsh\.dll|powershell(_ise)?\.exe)$</field>
@@ -20,5 +20,14 @@
         </mitre>
     </rule>
 
-
+    <!-- Sample: {"win":{"eventdata":{"originalFileName":"mimispool.dll","image":"C:\\\\Windows\\\\System32\\\\spoolsv.exe","product":"mimispool (mimikatz)","signature":"Open Source Developer, Benjamin Delpy","imageLoaded":"C:\\\\Windows\\\\System32\\\\spool\\\\drivers\\\\x64\\\\3\\\\mimispoolbis.dll","description":"mimispool for Windows (mimikatz)","signed":"true","signatureStatus":"Valid","processGuid":"{4dc16835-6534-60ec-92a4-010000000000}","processId":"1912","utcTime":"2021-07-12 15:58:13.023","hashes":"SHA1=BE9CB098C3331CC153E5E1BEA14B8D3B4D8CFD47,MD5=BB3DA838233101941460B5A8A85D326E,SHA256=C5CB049D25FAB0401C450F94A536898884681EE07C56B485BA4C6066B1DAE710,IMPHASH=D2007D8F257A5C5861BAB65684E7C6A3","ruleName":"technique_id=1210,technique_name=Exploitation of Remote Services","company":"gentilkiwi (Benjamin DELPY)","fileVersion":"0.3.0.0"},"system":{"eventID":"7","keywords":"0x8000000000000000","providerGuid":"{5770385f-c22a-43e0-bf4c-06f5698ffbd9}","level":"4","channel":"Microsoft-Windows-Sysmon/Operational","opcode":"0","message":"\"Image loaded:\r\nRuleName: technique_id=1210,technique_name=Exploitation of Remote Services\r\nUtcTime: 2021-07-12 15:58:13.023\r\nProcessGuid: {4dc16835-6534-60ec-92a4-010000000000}\r\nProcessId: 1912\r\nImage: C:\\Windows\\System32\\spoolsv.exe\r\nImageLoaded: C:\\Windows\\System32\\spool\\drivers\\x64\\3\\mimispoolbis.dll\r\nFileVersion: 0.3.0.0\r\nDescription: mimispool for Windows (mimikatz)\r\nProduct: mimispool (mimikatz)\r\nCompany: gentilkiwi (Benjamin DELPY)\r\nOriginalFileName: mimispool.dll\r\nHashes: SHA1=BE9CB098C3331CC153E5E1BEA14B8D3B4D8CFD47,MD5=BB3DA838233101941460B5A8A85D326E,SHA256=C5CB049D25FAB0401C450F94A536898884681EE07C56B485BA4C6066B1DAE710,IMPHASH=D2007D8F257A5C5861BAB65684E7C6A3\r\nSigned: true\r\nSignature: Open Source Developer, Benjamin Delpy\r\nSignatureStatus: Valid\"","version":"3","systemTime":"2021-07-12T15:58:13.0304995Z","eventRecordID":"267563","threadID":"3552","computer":"hrmanager.ExchangeTest.com","task":"7","processID":"2092","severityValue":"INFORMATION","providerName":"Microsoft-Windows-Sysmon"}}}-->
+    <rule id="92140" level="6">
+        <if_group>sysmon_event7</if_group>
+        <field name="win.eventdata.imageLoaded" type="pcre2">(?i)[c-z]:\\\\Windows\\\\System32\\\\spool\\\\drivers</field>
+        <field name="win.eventdata.image" type="pcre2">spoolsv\.exe$</field>
+        <description>Printer spooler service loaded a dll file. Possible PrintNightmare exploit: CVE-2021-34527</description>
+        <mitre>
+            <id>T1210</id>
+        </mitre>
+    </rule>
 </group>

--- a/ruleset/rules/0830-sysmon_id_11.xml
+++ b/ruleset/rules/0830-sysmon_id_11.xml
@@ -38,4 +38,15 @@
             <id>T1105</id>
         </mitre>
     </rule>
+
+    <!--Sample: {"win":{"eventdata":{"image":"C:\\\\Windows\\\\System32\\\\spoolsv.exe","processGuid":"{4dc16835-6534-60ec-92a4-010000000000}","processId":"1912","utcTime":"2021-07-12 15:58:13.001","targetFilename":"C:\\\\Windows\\\\System32\\\\spool\\\\drivers\\\\x64\\\\3\\\\New\\\\mimispoolbis.dll","ruleName":"technique_id=T1047,technique_name=File System Permissions Weakness","creationUtcTime":"2021-07-12 15:58:13.001"},"system":{"eventID":"11","keywords":"0x8000000000000000","providerGuid":"{5770385f-c22a-43e0-bf4c-06f5698ffbd9}","level":"4","channel":"Microsoft-Windows-Sysmon/Operational","opcode":"0","message":"\"File created:\r\nRuleName: technique_id=T1047,technique_name=File System Permissions Weakness\r\nUtcTime: 2021-07-12 15:58:13.001\r\nProcessGuid: {4dc16835-6534-60ec-92a4-010000000000}\r\nProcessId: 1912\r\nImage: C:\\Windows\\System32\\spoolsv.exe\r\nTargetFilename: C:\\Windows\\System32\\spool\\drivers\\x64\\3\\New\\mimispoolbis.dll\r\nCreationUtcTime: 2021-07-12 15:58:13.001\"","version":"2","systemTime":"2021-07-12T15:58:13.0067714Z","eventRecordID":"267528","threadID":"3548","computer":"hrmanager.ExchangeTest.com","task":"11","processID":"2092","severityValue":"INFORMATION","providerName":"Microsoft-Windows-Sysmon"}}}-->
+    <rule id="92200" level="12">
+        <if_group>sysmon_event_11</if_group>
+        <field name="win.eventdata.image" type="pcre2">\\spoolsv.exe$</field>
+        <field name="win.eventdata.targetFilename" type="pcre2">(?i)[c-z]:\\\\Windows\\\\System32\\\\spool\\\\drivers.+\.dll</field>
+        <description>DLL file created by printer spool service, possible malware binary drop from PrintNightmare exploit</description>
+        <mitre>
+            <id>T1574.010</id>
+        </mitre>
+    </rule>
 </group>

--- a/ruleset/rules/0840-win_event_channel.xml
+++ b/ruleset/rules/0840-win_event_channel.xml
@@ -53,4 +53,14 @@
         </mitre>
     </rule>
 
+    <!-- Sample: {"win":{"system":{"eventID":"808","keywords":"0x8000000000020000","providerGuid":"{747ef6fd-e535-4d16-b510-42c90f6873a1}","level":"2","channel":"Microsoft-Windows-PrintService/Admin","opcode":"12","message":"\"The print spooler failed to load a plug-in module C:\\Windows\\system32\\spool\\DRIVERS\\x64\\3\\mimispool.dll, error code 0x45A. See the event user data for context information.\"","version":"0","systemTime":"2021-07-12T14:40:42.8983599Z","eventRecordID":"3","threadID":"6544","computer":"hrmanager.ExchangeTest.com","task":"36","processID":"1804","severityValue":"ERROR","providerName":"Microsoft-Windows-PrintService"},"loadPluginFailed":{"context":"112","errorCode":"0x45a","pluginDllName":"C:\\\\Windows\\\\system32\\\\spool\\\\DRIVERS\\\\x64\\\\3\\\\mimispool.dll"}}}-->
+    <rule id="92170" level="15">
+        <if_sid>60011</if_sid>
+        <field name="win.system.eventID" type="pcre2">808</field>
+        <description>Printer driver failed to load, possible remote code execution using PrinterNightmare exploit: CVE-2021-34527</description>
+        <mitre>
+            <id>T1210</id>
+            <id>T1547.012</id>
+        </mitre>
+    </rule>
 </group>


### PR DESCRIPTION

|Related issue|
|---|
|closes #9258|



## Description

The added rules detect behavior associated with PrintNightmare exploit. This exploit leverages windows printer spooler service to do remote code execution with elevated privileges, by forcing the spooler service to load a malicious dll.

Rules:

92140: Detects when .dll file is dropped by spoolsv.exe in printer drivers folder
92170: Detection is based on printer driver failing to load (Id 808)
92200: Detects when a .dll file is loaded by spoolsv.exe

## Configuration options

For rules 92140 and 92200 Sysmon needs to be configured and enabled
For rule 92170 wazuh-agent must be forwarding Microsoft-Windows-PrintService/Admin los to wazuh-manager
