### PR TITLE
Optimized context_cached functions use

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -464,11 +464,12 @@ def get_agent_groups(group_list=None, offset=0, limit=None, sort=None, search=No
                                       )
     if group_list:
 
+        system_groups= get_groups()
         # Add failed items
-        for invalid_group in set(group_list) - get_groups():
+        for invalid_group in set(group_list) - system_groups:
             result.add_failed_item(id_=invalid_group, error=WazuhResourceNotFound(1710))
 
-        rbac_filters = get_rbac_filters(system_resources=get_groups(), permitted_resources=group_list)
+        rbac_filters = get_rbac_filters(system_resources=system_groups, permitted_resources=group_list)
 
         group_query = WazuhDBQueryGroup(offset=offset, limit=limit, sort=sort, search=search, **rbac_filters)
         query_data = group_query.run()

--- a/framework/wazuh/ciscat.py
+++ b/framework/wazuh/ciscat.py
@@ -41,9 +41,10 @@ def get_ciscat_results(agent_list=None, offset=0, limit=common.database_limit, s
                            'notchecked': 'notchecked', 'unknown': 'unknown', 'score': 'score'}
     table = 'ciscat_results'
 
+    system_agents = get_agents_info()
     for agent in agent_list:
         try:
-            if agent not in get_agents_info():
+            if agent not in system_agents:
                 raise WazuhResourceNotFound(1701)
             db_query = WazuhDBQuerySyscollector(agent_id=agent, offset=offset, limit=limit, select=select,
                                                 search=search,

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -237,6 +237,10 @@ def context_cached(key: str = '') -> Any:
     -------
     Any
         The result of the first call to the decorated function.
+
+    Notes
+    -----
+    The returned object will be a deep copy of the cached one.
     """
 
     def decorator(func) -> Any:

--- a/framework/wazuh/syscheck.py
+++ b/framework/wazuh/syscheck.py
@@ -82,8 +82,10 @@ def clear(agent_list=None):
                                       some_msg='Syscheck database was not cleared on some agents',
                                       none_msg="No syscheck database was cleared")
     wdb_conn = WazuhDBConnection()
+
+    system_agents = get_agents_info()
     for agent in agent_list:
-        if agent not in get_agents_info():
+        if agent not in system_agents:
             result.add_failed_item(id_=agent, error=WazuhResourceNotFound(1701))
         else:
             try:

--- a/framework/wazuh/syscollector.py
+++ b/framework/wazuh/syscollector.py
@@ -37,9 +37,10 @@ def get_item_agent(agent_list, offset=0, limit=common.database_limit, select=Non
         sort_ascending=[sort['order'] == 'asc' for _ in sort['fields']] if sort is not None else ['True']
     )
 
+    system_agents = get_agents_info()
     for agent in agent_list:
         try:
-            if agent not in get_agents_info():
+            if agent not in system_agents:
                 raise WazuhResourceNotFound(1701)
             table, valid_select_fields = get_valid_fields(Type(element_type), agent_id=agent)
             db_query = WazuhDBQuerySyscollector(agent_id=agent, offset=offset, limit=limit, select=select,


### PR DESCRIPTION
Hello team,
this PR closes issue #9234.

## Description
Since `context_cached` functions used deep copies of the cached objects, when the API managed a large amount of agents and groups, there was a little overload caused by the extensive use of these functions inside loops. In order to avoid this, I've tried to minimize the calls to these functions to a minimum, assigning the return value to a variable that will be called outside of the loop like in the following example. 
``` python
cached_value = func()
for i in range(100):
  return i in cached_value
```

