### PR TITLE
Remove cluster strings after use

### DIFF
--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -523,6 +523,9 @@ class Handler(asyncio.Protocol):
             exc_info = json.dumps(exception.WazuhClusterError(code=1000, extra_message=str(e)),
                                   cls=WazuhJSONEncoder).encode()
             res = await self.send_request(b'dapi_err', exc_info)
+        finally:
+            # Remove the string after using it
+            self.in_str.pop(string_id, None)
 
     async def forward_sendsync_response(self, data: bytes):
         """Forward a sendsync response from master node.
@@ -544,6 +547,9 @@ class Handler(asyncio.Protocol):
             exc_info = json.dumps(exception.WazuhClusterError(code=1000, extra_message=str(e)),
                                   cls=WazuhJSONEncoder).encode()
             await self.send_request(b'sendsync_err', exc_info)
+        finally:
+            # Remove the string after using it
+            self.in_str.pop(string_id, None)
 
     def data_received(self, message: bytes) -> None:
         """Handle received data from other peer.

--- a/framework/wazuh/core/cluster/local_client.py
+++ b/framework/wazuh/core/cluster/local_client.py
@@ -70,6 +70,8 @@ class LocalClientHandler(client.AbstractClient):
                 return b'err', self.process_error_from_peer(b'Error receiving string: ID ' + data + b' not found.')
             self.response = self.in_str[data].payload
             self.response_available.set()
+            # Remove the string after using it
+            self.in_str.pop(data, None)
             return b'ok', b'Distributed api response received'
         elif command == b'ok':
             if data.startswith(b'Error'):

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -364,6 +364,8 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         if req_id in self.server.pending_api_requests:
             self.server.pending_api_requests[req_id]['Response'] = self.in_str[string_id].payload.decode()
             self.server.pending_api_requests[req_id]['Event'].set()
+            # Remove the string after using it
+            self.in_str.pop(string_id, None)
             return b'ok', b'Forwarded response'
         elif req_id in self.server.local_server.clients:
             asyncio.create_task(self.forward_dapi_response(data))


### PR DESCRIPTION
|Related issue|
|---|
| Closes #9277 |

## Description

Hello team,

This PR fixes a memory leak in cluster environments that was reported in #9277. 

Until now, when any node sent a string to another one using the function `send_string` below, the string was correctly received and stored in a dict of the target node:
https://github.com/wazuh/wazuh/blob/c432b19247542b02b5153c7ed8fbda4545e2620f/framework/wazuh/core/cluster/common.py#L511-L532

However, once the strings were used, those were not removed from said dict so they were using up space "forever" (until the clusterd process was restarted). 

The `send_string` protocol is used for multiple purposes, like sending responses to `sendsync`, `local_client`, or even for distributed API. Therefore, every time an API request needed to be distributed to other nodes, the response would remain in the master's dict until restarted. 

What is explained above can be clearly seen in the following graph, where almost 20,000 API requests (`GET /cluster/worker1/configuration`) were performed in 7 minutes. The RAM usage of the `wazuh-clusterd` process reaches ~150 MiB in a short period:

![no_fix_dapi_20000](https://user-images.githubusercontent.com/23361101/125643707-a1215439-5292-4f0a-a6fe-c5b1397a62bd.png)

After the fix, which simply consisted of removing the strings after using them, the RAM usage remains stable under the same conditions (20,000 API requests in 7 minutes):

![fixed_dapi_20000](https://user-images.githubusercontent.com/23361101/125644487-66a24d4b-5efe-4cf9-b86f-2ef1caf9fbc5.png)

I have been doing multiple tests with `pympler` and the results clearly show that there is no constant growth of any type of data after the fix. These tests have been performed in a cluster environment with 1 worker, 100,000 agents pointing to the worker (so `agent-info` is tested) and a frequency of 1 second for both `agent-info` and `integrity` synchronization tasks. 

Regards,
Selu.