### PR TITLE
Fix agentless ssh_integrity_check_linux script typo

### DIFF
--- a/src/agentlessd/scripts/ssh_integrity_check_linux
+++ b/src/agentlessd/scripts/ssh_integrity_check_linux
@@ -26,7 +26,7 @@ source $sshsrc
 source $susrc
 
 set timeout 600
-send "unset HISTFILE echo \"INFO: Starting.\"; for i in `find $args 2>/dev/null`;do tail \$i >/dev/null 2>&1 && md5=`md5sum \$i | cut -d \" \" -f 1` && sha1=`sha1sum \$i | cut -d \" \" -f 1` && echo FWD: `stat --printf \"%s:%a:%u:%g\" \$i`:\$md5:\$sha1 \$i; done; exit\r"
+send "unset HISTFILE; echo \"INFO: Starting.\"; for i in `find $args 2>/dev/null`;do tail \$i >/dev/null 2>&1 && md5=`md5sum \$i | cut -d \" \" -f 1` && sha1=`sha1sum \$i | cut -d \" \" -f 1` && echo FWD: `stat --printf \"%s:%a:%u:%g\" \$i`:\$md5:\$sha1 \$i; done; exit\r"
 send "exit\r"
 
 expect {


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/9200|

## Description

This PR fixes a typo in the agentless script `ssh_integrity_check_linux`, which produces the following error messages:
```
bash: unset: `"INFO:': not a valid identifier
bash: unset: `Starting."': not a valid identifier
```

This have a low impact since script still works as expected, but now with this fix these error messages will stop appearing.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
