### PR TITLE
Add legacy agent healthchecks to API integration tests

### DIFF
--- a/api/test/integration/env/base/agent/old.Dockerfile
+++ b/api/test/integration/env/base/agent/old.Dockerfile
@@ -2,4 +2,4 @@ FROM public.ecr.aws/o5x5t0j3/amd64/api_development:integration_test_wazuh-agent_
 
 COPY base/agent/entrypoint.sh /scripts/entrypoint.sh
 
-HEALTHCHECK --retries=600 --interval=1s --timeout=30s --start-period=30s CMD /usr/bin/python3 /tmp/healthcheck/healthcheck.py || exit 1
+HEALTHCHECK --retries=600 --interval=1s --timeout=30s --start-period=30s CMD /usr/bin/python3 /tmp/healthcheck/legacy_healthcheck.py || exit 1

--- a/api/test/integration/env/configurations/base/agent/healthcheck/legacy_healthcheck.py
+++ b/api/test/integration/env/configurations/base/agent/healthcheck/legacy_healthcheck.py
@@ -1,0 +1,8 @@
+import sys
+sys.path.append('/tools')
+
+from healthcheck_utils import get_agent_health_base
+
+
+if __name__ == "__main__":
+    exit(get_agent_health_base())

--- a/api/test/integration/env/configurations/experimental/agent/healthcheck/legacy_healthcheck.py
+++ b/api/test/integration/env/configurations/experimental/agent/healthcheck/legacy_healthcheck.py
@@ -1,0 +1,18 @@
+import os
+import sys
+sys.path.append('/tools')
+
+from healthcheck_utils import get_agent_health_base
+
+
+def get_health():
+    output = os.system("grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
+
+    if output == 0:
+        return 0
+    else:
+        return 1
+
+
+if __name__ == "__main__":
+    exit(get_health() or get_agent_health_base())

--- a/api/test/integration/env/configurations/manager/agent/healthcheck/legacy_healthcheck.py
+++ b/api/test/integration/env/configurations/manager/agent/healthcheck/legacy_healthcheck.py
@@ -1,0 +1,2 @@
+# No checks are needed as manager tests don't depend on agents
+exit(0)

--- a/api/test/integration/env/configurations/sca/agent/healthcheck/legacy_healthcheck.py
+++ b/api/test/integration/env/configurations/sca/agent/healthcheck/legacy_healthcheck.py
@@ -1,0 +1,11 @@
+import os
+import sys
+sys.path.append('/tools')
+
+from healthcheck_utils import get_agent_health_base
+
+
+if __name__ == "__main__":
+    exit(os.system(
+        "grep -q 'sca: INFO: Security Configuration Assessment scan finished.' /var/ossec/logs/ossec.log")
+         or get_agent_health_base())

--- a/api/test/integration/env/configurations/security/agent/healthcheck/legacy_healthcheck.py
+++ b/api/test/integration/env/configurations/security/agent/healthcheck/legacy_healthcheck.py
@@ -1,0 +1,2 @@
+# No checks are needed as security tests don't depend on agents
+exit(0)

--- a/api/test/integration/env/configurations/syscheck/agent/healthcheck/legacy_healthcheck.py
+++ b/api/test/integration/env/configurations/syscheck/agent/healthcheck/legacy_healthcheck.py
@@ -1,0 +1,19 @@
+import os
+import sys
+sys.path.append('/tools')
+
+from healthcheck_utils import get_agent_health_base
+
+
+def get_health():
+    output = os.system(
+        "grep -q 'syscheckd: INFO: (6009): File integrity monitoring scan ended.' /var/ossec/logs/ossec.log")
+
+    if output == 0:
+        return 0
+    else:
+        return 1
+
+
+if __name__ == "__main__":
+    exit(get_health() or get_agent_health_base())

--- a/api/test/integration/env/configurations/syscollector/agent/healthcheck/legacy_healthcheck.py
+++ b/api/test/integration/env/configurations/syscollector/agent/healthcheck/legacy_healthcheck.py
@@ -1,0 +1,18 @@
+import os
+import sys
+sys.path.append('/tools')
+
+from healthcheck_utils import get_agent_health_base
+
+
+def get_health():
+    output = os.system("grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
+
+    if output == 0:
+        return 0
+    else:
+        return 1
+
+
+if __name__ == "__main__":
+    exit(get_health() or get_agent_health_base())

--- a/api/test/integration/mapping/integration_test_api_endpoints.json
+++ b/api/test/integration/mapping/integration_test_api_endpoints.json
@@ -2610,6 +2610,22 @@
                     "test_security_POST_endpoints.tavern.yaml",
                     "test_security_PUT_endpoints.tavern.yaml"
                 ]
+            },
+            {
+                "name": "legacy_healthcheck.py",
+                "tag": "legacy",
+                "tests": [
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml"
+                ]
             }
         ]
     },
@@ -2765,6 +2781,22 @@
                     "test_security_POST_endpoints.tavern.yaml",
                     "test_security_PUT_endpoints.tavern.yaml"
                 ]
+            },
+            {
+                "name": "legacy_healthcheck.py",
+                "tag": "legacy",
+                "tests": [
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml"
+                ]
             }
         ]
     },
@@ -2795,6 +2827,22 @@
             {
                 "name": "healthcheck.py",
                 "tag": "healthcheck",
+                "tests": [
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "legacy_healthcheck.py",
+                "tag": "legacy",
                 "tests": [
                     "test_agent_DELETE_endpoints.tavern.yaml",
                     "test_agent_GET_endpoints.tavern.yaml",
@@ -3534,6 +3582,22 @@
                     "test_security_POST_endpoints.tavern.yaml",
                     "test_security_PUT_endpoints.tavern.yaml"
                 ]
+            },
+            {
+                "name": "legacy_healthcheck.py",
+                "tag": "legacy",
+                "tests": [
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml"
+                ]
             }
         ]
     },
@@ -3543,6 +3607,22 @@
             {
                 "name": "healthcheck.py",
                 "tag": "healthcheck",
+                "tests": [
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "legacy_healthcheck.py",
+                "tag": "legacy",
                 "tests": [
                     "test_agent_DELETE_endpoints.tavern.yaml",
                     "test_agent_GET_endpoints.tavern.yaml",
@@ -3630,6 +3710,22 @@
                     "test_security_POST_endpoints.tavern.yaml",
                     "test_security_PUT_endpoints.tavern.yaml"
                 ]
+            },
+            {
+                "name": "legacy_healthcheck.py",
+                "tag": "legacy",
+                "tests": [
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml"
+                ]
             }
         ]
     },
@@ -3660,6 +3756,22 @@
             {
                 "name": "healthcheck.py",
                 "tag": "healthcheck",
+                "tests": [
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "legacy_healthcheck.py",
+                "tag": "legacy",
                 "tests": [
                     "test_agent_DELETE_endpoints.tavern.yaml",
                     "test_agent_GET_endpoints.tavern.yaml",


### PR DESCRIPTION
|Related issue|
|---|
| closes #9236 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Hello team,

To improve maintainability in the AIT we decided to add custom healthchecks for the legacy agents. This way, we do not need to use too broad callbacks for both current and legacy agent logs. These new healthchecks must be added as `legacy_healthcheck.py` under the same directory as the main ones. Currently, legacy healthchecks have the same logic as the main ones. The structure is the following (base case for instance):

```
env/configurations/base/agent/
├── configuration_files
│   ├── ossec_4.x.conf
│   ├── ossec_base.conf
│   └── test.keys
└── healthcheck
    ├── healthcheck.py
    └── legacy_healthcheck.py
```

Regards,
Víctor