### PR TITLE
Fix profile usage for CloudWatchLogs

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -224,7 +224,7 @@ class WazuhIntegration:
             conn_args['profile_name'] = profile
 
         # set region name
-        if region and service_name == 'inspector':
+        if region and service_name in ('inspector', 'cloudwatchlogs'):
             conn_args['region_name'] = region
         else:
             # it is necessary to set region_name for GovCloud regions
@@ -232,7 +232,7 @@ class WazuhIntegration:
                 else None
 
         boto_session = boto3.Session(**conn_args)
-
+        service_name = "logs" if service_name == "cloudwatchlogs" else service_name
         # If using a role, create session using that
         try:
             if iam_role_arn:
@@ -245,10 +245,7 @@ class WazuhIntegration:
                                             aws_session_token=sts_role_assumption['Credentials']['SessionToken'],
                                             region_name=conn_args.get('region_name')
                                             )
-                client = sts_session.client(service_name='logs' if service_name == 'cloudwatchlogs' else service_name)
-            elif service_name == 'cloudwatchlogs':
-                client = boto3.client('logs', region_name=region,
-                                      aws_access_key_id=access_key, aws_secret_access_key=secret_key)
+                client = sts_session.client(service_name=service_name)
             else:
                 client = boto_session.client(service_name=service_name)
         except botocore.exceptions.ClientError as e:


### PR DESCRIPTION
Hello team,

This PR closes #9330. This PR fixes the bug that prevented the use of profiles with names other than "default" in the credentials file. The reason was that the `boto_session` object, which receives the credentials parameters, was not being used correctly.

We have been able to run the module correctly after this change with the following commands, without any issues:
```
/var/ossec/wodles/aws/aws-s3 --service cloudwatchlogs -p prod -g framework-test-apache -d 2
```
```
/var/ossec/wodles/aws/aws-s3 --service cloudwatchlogs -p dev -g framework-test-apache -d 2
```
```
/var/ossec/wodles/aws/aws-s3 --service cloudwatchlogs -p default -g framework-test-apache -d 2
```