### PR TITLE
Add parameter to control the maximum memory that can be allocated by wazuh-apid

### DIFF
--- a/api/api/api_exception.py
+++ b/api/api/api_exception.py
@@ -36,7 +36,7 @@ class APIException(Exception):
             2009: 'Semicolon (;) is a reserved character and must '
                   'be percent-encoded (%3B) to use it.',
             2010: f'Error loading max_memory_usage. Minimum value '
-                  f'must be {MIN_VALUE_MAX_MEMORY_USAGE}.'
+                  f'must be {MIN_VALUE_MAX_MEMORY_USAGE}'
         }
 
     def __str__(self):

--- a/api/api/api_exception.py
+++ b/api/api/api_exception.py
@@ -2,7 +2,7 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-from api.constants import RELATIVE_CONFIG_FILE_PATH, RELATIVE_SECURITY_PATH
+from api.constants import RELATIVE_CONFIG_FILE_PATH, RELATIVE_SECURITY_PATH, MIN_VALUE_MAX_MEMORY_USAGE
 
 
 class APIException(Exception):
@@ -34,7 +34,9 @@ class APIException(Exception):
             2008: 'Experimental features are disabled. '
                   'It can be changed in the API configuration',
             2009: 'Semicolon (;) is a reserved character and must '
-                  'be percent-encoded (%3B) to use it.'
+                  'be percent-encoded (%3B) to use it.',
+            2010: f'Error loading max_memory_usage. Minimum value '
+                  f'must be {MIN_VALUE_MAX_MEMORY_USAGE}.'
         }
 
     def __str__(self):

--- a/api/api/api_exception.py
+++ b/api/api/api_exception.py
@@ -35,8 +35,8 @@ class APIException(Exception):
                   'It can be changed in the API configuration',
             2009: 'Semicolon (;) is a reserved character and must '
                   'be percent-encoded (%3B) to use it.',
-            2010: f'Error loading max_memory_usage. Minimum value '
-                  f'must be {MIN_VALUE_MAX_MEMORY_USAGE}'
+            2010: f'Error loading max_memory_usage. Value must be 0 (limitless) or greater than '
+                  f'{MIN_VALUE_MAX_MEMORY_USAGE}'
         }
 
     def __str__(self):

--- a/api/api/configuration.py
+++ b/api/api/configuration.py
@@ -63,7 +63,8 @@ default_api_configuration = {
     "access": {
         "max_login_attempts": 50,
         "block_time": 300,
-        "max_request_per_minute": 300
+        "max_request_per_minute": 300,
+        "max_memory_usage": 1073741824
     },
     "remote_commands": {
         "localfile": {

--- a/api/api/configuration/api.yaml
+++ b/api/api/configuration/api.yaml
@@ -42,6 +42,7 @@
 #  max_login_attempts: 50
 #  block_time: 300
 #  max_request_per_minute: 300
+#  max_memory_usage: 1073741824
 
 # Force the use of authd when adding and removing agents. Values: yes, no
 # use_only_authd: no

--- a/api/api/constants.py
+++ b/api/api/constants.py
@@ -14,3 +14,4 @@ SECURITY_PATH = os.path.join(CONFIG_PATH, 'security')
 SECURITY_CONFIG_PATH = os.path.join(SECURITY_PATH, 'security.yaml')
 RELATIVE_SECURITY_PATH = os.path.relpath(SECURITY_PATH, common.wazuh_path)
 API_LOG_FILE_PATH = os.path.join(common.wazuh_path, 'logs', 'api.log')
+MIN_VALUE_MAX_MEMORY_USAGE = 1073741824

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -8086,6 +8086,7 @@ paths:
                           max_login_attempts: 50
                           block_time: 300
                           max_request_per_minute: 300
+                          max_memory_usage: 1073741824
                         remote_commands:
                           localfile:
                             enabled: True
@@ -8124,6 +8125,7 @@ paths:
                           max_login_attempts: 50
                           block_time: 300
                           max_request_per_minute: 300
+                          max_memory_usage: 1073741824
                         remote_commands:
                           localfile:
                             enabled: True
@@ -8162,6 +8164,7 @@ paths:
                           max_login_attempts: 50
                           block_time: 300
                           max_request_per_minute: 300
+                          max_memory_usage: 1073741824
                         remote_commands:
                           localfile:
                             enabled: True
@@ -10691,6 +10694,7 @@ paths:
                           max_login_attempts: 50
                           block_time: 300
                           max_request_per_minute: 300
+                          max_memory_usage: 1073741824
                         logs:
                           path: /var/ossec/logs/api.log
                           level: info

--- a/api/api/test/test_configuration.py
+++ b/api/api/test/test_configuration.py
@@ -44,7 +44,8 @@ custom_api_configuration = {
     "access": {
         "max_login_attempts": 50,
         "block_time": 300,
-        "max_request_per_minute": 300
+        "max_request_per_minute": 300,
+        "max_memory_usage": 1073741824
     },
     "remote_commands": {
         "localfile": {
@@ -128,6 +129,7 @@ def test_read_configuration(mock_open, mock_exists, read_config):
     {'access': {'max_login_attempts': 'invalid_type'}},
     {'access': {'block_time': 'invalid_type'}},
     {'access': {'max_request_per_minute': 'invalid_type'}},
+    {'access': {'max_memory_usage': 'invalid_type'}},
     {'access': {'invalid_subkey': 'invalid_type'}},
     {'remote_commands': {'localfile': {'enabled': 'invalid_type'}}},
     {'remote_commands': {'localfile': {'exceptions': [0, 1, 2]}}},

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -129,6 +129,7 @@ api_config_schema = {
                 "max_login_attempts": {"type": "integer"},
                 "block_time": {"type": "integer"},
                 "max_request_per_minute": {"type": "integer"},
+                "max_memory_usage": {"type": "integer"},
             },
         },
         "remote_commands": {

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -9,6 +9,7 @@ from typing import Dict, List
 from defusedxml import ElementTree as ET
 from jsonschema import draft4_format_checker
 
+from api.constants import MIN_VALUE_MAX_MEMORY_USAGE
 from wazuh.core import common
 
 _alphanumeric_param = re.compile(r'^[\w,\-\.\+\s\:]+$')
@@ -129,7 +130,7 @@ api_config_schema = {
                 "max_login_attempts": {"type": "integer"},
                 "block_time": {"type": "integer"},
                 "max_request_per_minute": {"type": "integer"},
-                "max_memory_usage": {"type": "integer"},
+                "max_memory_usage": {"type": "integer", "minimum": MIN_VALUE_MAX_MEMORY_USAGE},
             },
         },
         "remote_commands": {

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -130,7 +130,7 @@ api_config_schema = {
                 "max_login_attempts": {"type": "integer"},
                 "block_time": {"type": "integer"},
                 "max_request_per_minute": {"type": "integer"},
-                "max_memory_usage": {"type": "integer", "minimum": MIN_VALUE_MAX_MEMORY_USAGE},
+                "max_memory_usage": {"type": "integer"},
             },
         },
         "remote_commands": {

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -84,7 +84,7 @@ def start(foreground, root, config_file):
     if max_memory_usage >= MIN_VALUE_MAX_MEMORY_USAGE:
         limit_memory(max_memory_usage)
     else:
-        logger.error(str(APIError(1105)))
+        logger.error(str(APIError(2010)))
         sys.exit(1)
 
     # Set correct permissions on api.log file

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -83,7 +83,7 @@ def start(foreground, root, config_file):
     max_memory_usage = int(api_conf['access']['max_memory_usage'])
     if max_memory_usage >= MIN_VALUE_MAX_MEMORY_USAGE:
         limit_memory(max_memory_usage)
-    else:
+    elif max_memory_usage != 0:
         logger.error(str(APIError(2010)))
         sys.exit(1)
 

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -256,6 +256,8 @@ class DistributedAPI:
                 data = await asyncio.wait_for(task, timeout=timeout)
             except asyncio.TimeoutError:
                 raise exception.WazuhInternalError(3021)
+            except MemoryError:
+                raise exception.WazuhInternalError(6005)
             except OperationalError:
                 raise exception.WazuhInternalError(2008)
 
@@ -269,7 +271,7 @@ class DistributedAPI:
         except exception.WazuhInternalError as e:
             e.dapi_errors = self.get_error_info(e)
             # Avoid exception info if it is an asyncio timeout
-            self.logger.error(f"{e.message}", exc_info=True if e.code != 3021 else False)
+            self.logger.error(f"{e.message}", exc_info=True if e.code not in [3021, 6005] else False)
             if self.debug:
                 raise
             return json.dumps(e, cls=c_common.WazuhJSONEncoder)

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -543,12 +543,17 @@ class WazuhException(Exception):
         6000: {'message': 'Limit of login attempts reached. '
                           'The current IP has been blocked due to a high number of login attempts'},
         6001: {'message': 'Maximum number of requests per minute reached',
-               'remediation': f'This limit can be changed in api.yaml file. More information here: https://documentation.wazuh.com/{WAZUH_VERSION}/user-manual/api/configuration.html#configuration-file'},
+               'remediation': f'This limit can be changed in the api.yaml file. '
+                              f'More information here: https://documentation.wazuh.com/{WAZUH_VERSION}/user-manual/api/configuration.html#configuration-file'},
         6002: {'message': 'The body type is not the one specified in the content-type'},
         6003: {'message': 'Error trying to load the JWT secret',
                'remediation': 'Make sure you have the right permissions: WAZUH_PATH/api/configuration/security/jwt_secret'},
         6004: {'message': 'The current user does not have authentication enabled through authorization context',
                'remediation': f'You can enable it using the following endpoint: https://documentation.wazuh.com/{WAZUH_VERSION}/user-manual/api/reference.html#operation/api.controllers.security_controller.edit_run_as'},
+        6005: {'message': 'Error executing the distributed API function, the memory allocated by wazuh-apid has '
+                          'reached its limit.',
+               'remediation': f'This limit can be changed in the api.yaml file. '
+                              f'More information here: https://documentation.wazuh.com/{WAZUH_VERSION}/user-manual/api/configuration.html#configuration-file'},
 
         # Logtest
         7000: {'message': 'Error trying to get logtest response'},


### PR DESCRIPTION
|Related issue|
|---|
| #9055 |

Hi team,

This PR closes #9055.

In the related issue, an investigation can be found where I commented the details of the solution implemented.

In this pull request, I have added a parameter to control the maximum amount of memory that can be allocated by the `wazuh-apid` process. This will also be inherited to childs in case we implement multiprocess in the future (notes can be found on the related issue).

This parameter will be 1 GB by default and this value is the minimum of the parameter. A new API exception was created (2010) to indicate the value must be 1GB or more (in bytes).

```
root@wazuh-master:/# /var/ossec/bin/wazuh-apid -f
2021/07/20 07:14:14 ERROR: 2010 - Error loading max_memory_usage. Minimum value must be 1073741824.
```

Also in `/var/ossec/logs/api.log`:

```
2021/07/20 07:14:14 ERROR: 2010 - Error loading max_memory_usage. Minimum value must be 1073741824.
```

If the allocated memory reaches the maximum while executing a DAPI function, a WazuhInternalError is raised with a new code (6005).

API response when the maximum memory usage is reached:

```
{
  "title": "Wazuh Internal Error",
  "detail": "Error executing the distributed API function, the memory allocated by wazuh-apid has reached its limit.",
  "remediation": "This limit can be changed in the api.yaml file. More information here: https://documentation.wazuh.com/4.3/user-manual/api/configuration.html#configuration-file",
  "dapi_errors": {
    "master-node": {
      "error": "Error executing the distributed API function, the memory allocated by wazuh-apid has reached its limit.",
      "logfile": "WAZUH_HOME/logs/api.log"
    }
  },
  "error": 6005
}
```

In the `api.log`:

```
2021/07/20 10:59:16 ERROR: Error executing the distributed API function, the memory allocated by wazuh-apid has reached its limit.
2021/07/20 10:59:16 INFO: wazuh 172.18.0.1 "GET /agents" with parameters {} and body {} done in 0.054s: 500
```

Apart from this PR, new tests should be added to the wazuh-qa repository as well as new documentation in wazuh-docu.

Regards,
Manuel.