### PR TITLE
Fix FIM synchronization of Windows Registry

### DIFF
--- a/src/syscheckd/db/fim_db.c
+++ b/src/syscheckd/db/fim_db.c
@@ -360,14 +360,12 @@ fim_entry *fim_db_get_entry_from_sync_msg(fdb_t *fim_sql, fim_type type, const c
     finder = find_key_value_limiter(value_name);
 
     if (finder == NULL) {
-        mdebug1("Separator ':' was not found in %s", full_path);
-        free(full_path);
-        return NULL;
+        value_name = NULL;
+    } else {
+        *finder = '\0';
+        value_name = filter_special_chars(finder + 1);
     }
 
-    *finder = '\0';
-
-    value_name = filter_special_chars(finder + 1);
     key_path = filter_special_chars(full_path);
     os_calloc(1, sizeof(fim_entry), entry);
     entry->type = FIM_TYPE_REGISTRY;
@@ -381,10 +379,9 @@ fim_entry *fim_db_get_entry_from_sync_msg(fdb_t *fim_sql, fim_type type, const c
         return NULL;
     }
 
-    if (value_name == NULL || *value_name == '\0') {
+    if (value_name == NULL) {
         free(key_path);
         free(full_path);
-        os_free(value_name);
         return entry;
     }
 

--- a/src/syscheckd/db/schema_fim_db.sql
+++ b/src/syscheckd/db/schema_fim_db.sql
@@ -76,6 +76,6 @@ CREATE TABLE IF NOT EXISTS registry_data (
 CREATE INDEX IF NOT EXISTS key_name_index ON registry_data (key_id, name);
 
 CREATE VIEW IF NOT EXISTS registry_view (path, checksum) AS
-    SELECT arch || ' ' || replace(replace(path, '\', '\\'), ':', '\:') || ':', checksum FROM registry_key
+    SELECT arch || ' ' || replace(replace(path, '\', '\\'), ':', '\:'), checksum FROM registry_key
     UNION ALL
     SELECT arch || ' ' || replace(replace(path, '\', '\\'), ':', '\:') || ':' || replace(replace(name, '\', '\\'), ':', '\:'), registry_data.checksum FROM registry_key INNER JOIN registry_data ON registry_key.id=registry_data.key_id;

--- a/src/unit_tests/syscheckd/db/test_fim_db.c
+++ b/src/unit_tests/syscheckd/db/test_fim_db.c
@@ -2197,7 +2197,7 @@ void test_fim_db_get_entry_from_sync_msg_get_registry_key(void **state) {
     expect_fim_db_get_registry_key(&data);
 
     entry =
-    fim_db_get_entry_from_sync_msg(&fim_sql, FIM_TYPE_REGISTRY, "[x64] HKEY_LOCAL_MACHINE\\\\software\\\\some\\:\\\\key:");
+    fim_db_get_entry_from_sync_msg(&fim_sql, FIM_TYPE_REGISTRY, "[x64] HKEY_LOCAL_MACHINE\\\\software\\\\some\\:\\\\key");
 
     *state = entry;
 
@@ -2287,35 +2287,6 @@ void test_fim_db_get_entry_from_sync_msg_two_dots_subkey(void **state) {
     assert_string_equal(entry->registry_entry.value->name, "some:value");
     assert_int_equal(entry->registry_entry.value->id, entry->registry_entry.key->id);
 }
-
-void test_fim_db_get_entry_from_sync_msg_no_separator(void **state) {
-    char *str = "[x64] a\\string\\without\\the\\separator\\:";
-    char debug_msg[OS_SIZE_128] = {0};
-    fdb_t fim_sql;
-    fim_entry *entry = NULL;
-
-    snprintf(debug_msg, OS_SIZE_128, "Separator ':' was not found in %s", "a\\string\\without\\the\\separator\\:");
-    expect_string(__wrap__mdebug1, formatted_msg, debug_msg);
-
-    entry = fim_db_get_entry_from_sync_msg(&fim_sql, FIM_TYPE_REGISTRY, str);
-
-    assert_null(entry);
-}
-
-void test_fim_db_get_entry_from_sync_msg_wrong_str(void **state) {
-    char *str = "[x64] \\\\\\\0:random_content";
-    char debug_msg[OS_SIZE_128] = {0};
-    fdb_t fim_sql;
-    fim_entry *entry = NULL;
-
-    snprintf(debug_msg, OS_SIZE_128, "Separator ':' was not found in %s", "\\\\\\");
-    expect_string(__wrap__mdebug1, formatted_msg, debug_msg);
-
-    entry = fim_db_get_entry_from_sync_msg(&fim_sql, FIM_TYPE_REGISTRY, str);
-
-    assert_null(entry);
-}
-
 
 #endif
 
@@ -2462,8 +2433,6 @@ int main(void) {
         cmocka_unit_test_teardown(test_fim_db_get_entry_from_sync_msg_get_registry_value_fail_to_get_data, teardown_fim_entry),
         cmocka_unit_test_teardown(test_fim_db_get_entry_from_sync_msg_get_registry_value_success, teardown_fim_entry),
         cmocka_unit_test_teardown(test_fim_db_get_entry_from_sync_msg_two_dots_subkey, teardown_fim_entry),
-        cmocka_unit_test(test_fim_db_get_entry_from_sync_msg_no_separator),
-        cmocka_unit_test(test_fim_db_get_entry_from_sync_msg_wrong_str),
 
 #endif
     };

--- a/src/unit_tests/wazuh_db/test_wdb_fim.c
+++ b/src/unit_tests/wazuh_db/test_wdb_fim.c
@@ -607,7 +607,7 @@ static void test_wdb_fim_insert_entry2_registry_key_succesful(void **state) {
     expect_sqlite3_bind_int64_call(3, 10, 0);
     expect_sqlite3_bind_text_call(18, "[x32]", 1);
     expect_sqlite3_bind_text_call(19, NULL, 1);
-    expect_sqlite3_bind_text_call(21, "[x32] HKEY_LOCAL_MACHINE\\\\System\\\\TEST\\\\key:", 1);
+    expect_sqlite3_bind_text_call(21, "[x32] HKEY_LOCAL_MACHINE\\\\System\\\\TEST\\\\key", 1);
 
     expect_sqlite3_step_call(SQLITE_DONE);
 

--- a/src/wazuh_db/wdb_fim.c
+++ b/src/wazuh_db/wdb_fim.c
@@ -562,11 +562,11 @@ int wdb_fim_insert_entry2(wdb_t * wdb, const cJSON * data) {
 
         if (strcmp(item_type + 9, "key") == 0) {
             value_name = NULL;
-            full_path_length = snprintf(NULL, 0, "%s %s:", arch, path_escaped);
+            full_path_length = snprintf(NULL, 0, "%s %s", arch, path_escaped);
 
             os_calloc(full_path_length + 1, sizeof(char), full_path);
 
-            snprintf(full_path, full_path_length + 1, "%s %s:", arch, path_escaped);
+            snprintf(full_path, full_path_length + 1, "%s %s", arch, path_escaped);
         } else if (strcmp(item_type + 9, "value") == 0) {
             char *value_name_escaped_slashes;
             char *value_name_escaped;


### PR DESCRIPTION
We found that sometimes the FIM synchronization didn't complete and fell into an infinite sync loop.

When performing a range checksum, the temporary registry path list held duplicate lines:
```
00000000000000000000000000000060[x32] HKEY_LOCAL_MACHINE\\\\Software\\\\Classes\\\\batfile:
00000000000000000000000000000060[x32] HKEY_LOCAL_MACHINE\\\\Software\\\\Classes\\\\batfile:
```

This happens because the keys' default value has no name, and this collides with the key path. That is produced by PR #8391, which removes a hardcoded `@` as the default value name because that could collide with an actual value with name "@".

This bug causes the synchronization to overwrite keys with default values, and vice-versa.

## Proposed fix

We need to uniquely identify Registry items, whether they are keys or values. Paths have this format:
```
key:value
```

We propose to remove the separator (`:`) when naming Registry keys, while values will keep the format above. Hence, the keys' default value will have this format:
```
key:
```

## Tests

- [X] Build manager for Linux.
- [X] Build agent for Windows.
- [X] The agent gets synced with the manager.
- [ ] Stress test.

### Stress configuration

<details>
<summary>ossec.conf</summary>

```xml
<syscheck>
  <disabled>no</disabled>
  <frequency>6000</frequency>
  <max_eps>0</max_eps>

  <windows_registry arch="both">HKEY_LOCAL_MACHINE\Software\Microsoft\Internet Explorer</windows_registry>
  <windows_registry arch="both">HKEY_LOCAL_MACHINE\Software\Classes\Protocols</windows_registry>
  <windows_registry arch="both">HKEY_LOCAL_MACHINE\Software\Policies</windows_registry>
  <windows_registry arch="both">HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Run</windows_registry>
  <windows_registry arch="both">HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\RunOnce</windows_registry>
  <windows_registry arch="both">HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\URL</windows_registry>
  <windows_registry arch="both">HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies</windows_registry>
  <windows_registry arch="both">HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Windows</windows_registry>
  <windows_registry arch="both">HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon</windows_registry>
  <windows_registry arch="both">HKEY_LOCAL_MACHINE\Software\Microsoft\Active Setup\Installed Components</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\.log</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\.db</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\.local</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\Accounts</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\AllProtocols</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\Applications</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\chkfile</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\DesktopBackground</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\DiagnosticLog</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\file</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\http</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\https</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\Installer</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\regedit</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\regfile</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\search</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\sysfile</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\txtfile</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\System\Setup</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\batfile</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\cmdfile</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\comfile</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\exefile</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\piffile</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\AllFilesystemObjects</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\Directory</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\Folder</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\Security</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\KnownDLLs</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\SecurePipeServers\winreg</windows_registry>
  <windows_registry>HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\RunOnceEx</windows_registry>
  <windows_registry>HKEY_CURRENT_USER\Console</windows_registry>
  <windows_registry>HKEY_CURRENT_USER\Environment</windows_registry>
  <windows_registry>HKEY_CURRENT_USER\Volatile Environment</windows_registry>

  <registry_ignore type="sregex">\Enum$</registry_ignore>
  <registry_ignore>HKEY_LOCAL_MACHINE\Security\Policy\Secrets</registry_ignore>
  <registry_ignore>HKEY_LOCAL_MACHINE\Security\SAM\Domains\Account\Users</registry_ignore>
  <registry_ignore>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\MpsSvc\Parameters\AppCs</registry_ignore>
  <registry_ignore>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\MpsSvc\Parameters\PortKeywords\DHCP</registry_ignore>
  <registry_ignore>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\MpsSvc\Parameters\PortKeywords\IPTLSIn</registry_ignore>
  <registry_ignore>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\MpsSvc\Parameters\PortKeywords\IPTLSOut</registry_ignore>
  <registry_ignore>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\MpsSvc\Parameters\PortKeywords\RPC-EPMap</registry_ignore>
  <registry_ignore>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\MpsSvc\Parameters\PortKeywords\Teredo</registry_ignore>
  <registry_ignore>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\PolicyAgent\Parameters\Cache</registry_ignore>
  <registry_ignore>HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\RunOnceEx</registry_ignore>
  <registry_ignore>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\ADOVMPPackage\Final</registry_ignore>
  <windows_audit_interval>300</windows_audit_interval>

  <synchronization>
    <enabled>yes</enabled>
    <interval>20</interval>
    <max_interval>1h</max_interval>
    <response_timeout>30</response_timeout>
    <queue_size>16384</queue_size>
    <max_eps>1000</max_eps>
  </synchronization>
</syscheck>
```

</details>