### PR TITLE
Remove files after WPK upgrade

### DIFF
--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -125,3 +125,6 @@ Else
     $new_version = (Get-Content VERSION)
     write-output "$(Get-Date -format u) - New version: $($new_version)" >> .\upgrade\upgrade.log
 }
+
+Remove-Item -Path ".\upgrade\*msi" -ErrorAction SilentlyContinue
+Remove-Item -Path ".\upgrade\*wpk" -ErrorAction SilentlyContinue

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -126,5 +126,4 @@ Else
     write-output "$(Get-Date -format u) - New version: $($new_version)" >> .\upgrade\upgrade.log
 }
 
-Remove-Item -Path ".\upgrade\*msi" -ErrorAction SilentlyContinue
-Remove-Item -Path ".\upgrade\*wpk" -ErrorAction SilentlyContinue
+Remove-Item -Path ".\upgrade\*"  -Exclude "*.log", "upgrade_result" -ErrorAction SilentlyContinue

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -16,4 +16,4 @@ if [ "X${WAZUH_VERSION}" = "X" ] ; then
     fi
 fi
 
-(sleep 5 && chmod +x ${WAZUH_HOME}/var/upgrade/src/init/*.sh && ${WAZUH_HOME}/var/upgrade/src/init/pkg_installer.sh ${WAZUH_HOME} ${WAZUH_VERSION} && rm -rf ${WAZUH_HOME}/var/upgrade/*) >/dev/null 2>&1 &
+(sleep 5 && chmod +x ${WAZUH_HOME}/var/upgrade/src/init/*.sh && ${WAZUH_HOME}/var/upgrade/src/init/pkg_installer.sh ${WAZUH_HOME} ${WAZUH_VERSION} && find ${WAZUH_HOME}/var/upgrade/* -not -name upgrade_result -delete) >/dev/null 2>&1 &

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -16,4 +16,4 @@ if [ "X${WAZUH_VERSION}" = "X" ] ; then
     fi
 fi
 
-(sleep 5 && chmod +x ${WAZUH_HOME}/var/upgrade/src/init/*.sh && ${WAZUH_HOME}/var/upgrade/src/init/pkg_installer.sh ${WAZUH_HOME} ${WAZUH_VERSION}) >/dev/null 2>&1 &
+(sleep 5 && chmod +x ${WAZUH_HOME}/var/upgrade/src/init/*.sh && ${WAZUH_HOME}/var/upgrade/src/init/pkg_installer.sh ${WAZUH_HOME} ${WAZUH_VERSION} && rm -rf ${WAZUH_HOME}/var/upgrade/*) >/dev/null 2>&1 &


### PR DESCRIPTION
|Related issue|
|---|
|#5086|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR adds the necessary changes to the WPK so the files used for the upgrade such as the compiled sources or the MSI packages are deleted after the upgrade.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Package upgrade



