### PR TITLE
Change microsoft wrapper to standard function to get the current posi…

### DIFF
--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -3112,7 +3112,7 @@ int64_t w_ftell(FILE *x) {
 #ifndef WIN32
     int64_t z = ftell(x);
 #else
-    int64_t z = _ftelli64(x);
+    int64_t z = ftello64(x);
 #endif
 
     if (z < 0)  {
@@ -3128,7 +3128,7 @@ int w_fseek(FILE *x, int64_t pos, int mode) {
 #ifndef WIN32
     int64_t z = fseek(x, pos, mode);
 #else
-    int64_t z = _fseeki64(x, pos, mode);
+    int64_t z = fseeko64(x, pos, mode);
 #endif
     if (z < 0)  {
         mwarn("Fseek function failed due to [(%d)-(%s)]", errno, strerror(errno));


### PR DESCRIPTION
…tion.

|Related issue|
|---|
|Closes #9363 |

## Description
The problem arises because the old ftelli64 implementation in some situations generates problems, causing a segfault, changing to ftello64, which is a standard implementation, the problem is solved and the issue does not occur anymore.

https://github.com/mirror/mingw-w64/commit/edeeef2aadd9e2f4109dec3f624aafea60cee9bb


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [X] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors