### PR TITLE
Fix memory leaks during the management of pthread_mutex and wazuh states for logcollector.

### DIFF
--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -706,6 +706,7 @@ int Remove_Localfile(logreader **logf, int i, int gl, int fr, logreader_glob *gl
                 if ((*logf)[i].h && (*logf)[i].h != INVALID_HANDLE_VALUE) {
                     CloseHandle((*logf)[i].h);
                 }
+                pthread_mutex_destroy(&(*logf)[i].mutex);
             #endif
             }
 

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -744,12 +744,14 @@ void LogCollectorStart()
                             }
                             mdebug1(FILE_ERROR, current->file);
                             file_exists = 0;
+                            w_logcollector_state_delete_file(current->file);
                         } else if (GetFileInformationByHandle(h1, &lpFileInformation) == 0) {
                             if (current->h) {
                                 CloseHandle(current->h);
                             }
                             mdebug1(FILE_ERROR, current->file);
                             file_exists = 0;
+                            w_logcollector_state_delete_file(current->file);
                         }
 
                         CloseHandle(h1);


### PR DESCRIPTION
|Related issue|
|---|
|Closes #9362 |

## Description
This PR troubleshoot memory leaks.

1- Misuse of pthread_mutex.
2- The information status information that comes out from logcollector it is not removed whenever it should.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors