### PR TITLE
Fix wrong values of external_id in MITRE resources

### DIFF
--- a/framework/wazuh/core/mitre.py
+++ b/framework/wazuh/core/mitre.py
@@ -59,10 +59,9 @@ class WazuhDBQueryMitre(WazuhDBQuery):
         mitre_resource : dict
             MITRE resource we want to update the reference from.
         """
-        # Take the reference with external_id checking it is not None
-        reference_external_id = next(
-            (row_no_id for row_no_id in mitre_resource['references'] if
-             'external_id' in row_no_id and row_no_id['external_id']), {})
+        # Take the reference with external_id checking it is not None and the source is mitre-attack
+        reference_external_id = next((row_no_id for row_no_id in mitre_resource['references'] if
+                                      row_no_id.get('external_id') and row_no_id.get('source') == 'mitre-attack'), {})
         if 'description' in reference_external_id:
             reference_external_id.pop('description')
 


### PR DESCRIPTION
|Related issue|
|---|
| #9348 |

Hi team,

This PR closes #9348.

In this pull request, I have forced the external_id shown in the MITRE objects returned in all MITRE endpoints to be the mitre-attack external_id.

With these changes, MITRE objects with 2 external_id in their references, will show the external_id from MITRE outside the references:

- Request:

`GET /mitre/techniques?technique_ids=attack-pattern--b17a1a56-e99c-403c-8948-561df0cffe81`

- Response:

```
{
  "data": {
    "affected_items": [
      {
        "id": "attack-pattern--b17a1a56-e99c-403c-8948-561df0cffe81",
        "name": "Valid Accounts",
        "mitre_version": "2.2",
        "modified_time": "2021-04-12T18:27:52.298000Z",
        "description": "Adversaries may obtain and abuse credentials of existing accounts as a means of gaining Initial Access, Persistence, Privilege Escalation, or Defense Evasion. Compromised credentials may be used to bypass access controls placed on various resources on systems within the network and may even be used for persistent access to remote systems and externally available services, such as VPNs, Outlook Web Access and remote desktop. Compromised credentials may also grant an adversary increased privilege to specific systems or access to restricted areas of the network. Adversaries may choose not to use malware or tools in conjunction with the legitimate access those credentials provide to make it harder to detect their presence.\n\nThe overlap of permissions for local, domain, and cloud accounts across a network of systems is of concern because the adversary may be able to pivot across accounts and systems to reach a high level of access (i.e., domain or enterprise administrator) to bypass access controls set within the enterprise. (Citation: TechNet Credential Theft)",
        "deprecated": 0,
        "mitre_detection": "Configure robust, consistent account activity audit policies across the enterprise and with externally accessible services. (Citation: TechNet Audit Policy) Look for suspicious account behavior across systems that share accounts, either user, admin, or service accounts. Examples: one account logged into multiple systems simultaneously; multiple accounts logged into the same machine simultaneously; accounts logged in at odd times or outside of business hours. Activity may be from interactive login sessions or process ownership from accounts being used to execute binaries on a remote system as a particular account. Correlate other security systems with login information (e.g., a user has an active login session but has not entered the building or does not have VPN access).\n\nPerform regular audits of domain and local system accounts to detect accounts that may have been created by an adversary for persistence. Checks on these accounts could also include whether default accounts such as Guest have been activated. These audits should also include checks on any appliances and applications for default credentials or SSH keys, and if any are discovered, they should be updated immediately.",
        "remote_support": 0,
        "network_requirements": 0,
        "created_time": "2017-05-31T21:31:00.645000Z",
        "tactics": [
          "x-mitre-tactic--5bc1d813-693e-4823-9961-abf9af4b0e92",
          "x-mitre-tactic--5e29b093-294e-49e9-a803-dab3d73b77dd",
          "x-mitre-tactic--78b23412-0651-46d7-a540-170a1ce8bd5a",
          "x-mitre-tactic--ffd5bcee-6e16-4dd2-8eca-7b3beedf33ca"
        ],
        "mitigations": [
          "course-of-action--25dc1ce8-eb55-4333-ae30-a7cb4f5894a1",
          "course-of-action--90c218c3-fbf8-4830-98a7-e8cfb7eaa485",
          "course-of-action--9bb9e696-bff8-4ae1-9454-961fc7d91d5f",
          "course-of-action--d45f03a8-790a-4f90-b956-cd7e5b8886bf"
        ],
        "software": [
          "malware--0efefea5-78da-4022-92bc-d726139e8883",
          "malware--67e6d66b-1b82-4699-b47a-e2efb6268d14",
          "malware--68dca94f-c11d-421e-9287-7c501108e18c",
          "malware--d6e55656-e43f-411f-a7af-45df650471c5",
          "malware--f8774023-8021-4ece-9aca-383ac89d2759"
        ],
        "groups": [
          "intrusion-set--06a11b7e-2a36-47fe-8d3e-82c265df3258",
          "intrusion-set--18854f55-ac7c-4634-bd9a-352dd07613b7",
          "intrusion-set--222fbd21-fc4f-4b7e-9f85-0e6e3a76c33f",
          "intrusion-set--23b6a0f5-fa95-46f9-a6f3-4549c5e45ec8",
          "intrusion-set--28f04ed3-8e91-4805-b1f6-869020517871",
          "intrusion-set--2a7914cf-dff3-428d-ab0f-1014d1c28aeb",
          "intrusion-set--381fcf73-60f6-4ab2-9991-6af3cbc35192",
          "intrusion-set--38fd6a28-3353-4f2b-bb2b-459fecd5c648",
          "intrusion-set--44e43fad-ffcb-4210-abcf-eaaed9735f80",
          "intrusion-set--4ca1929c-7d64-4aab-b849-badbfc0c760d",
          "intrusion-set--55033a4d-3ffe-46b2-99b4-2c1541e9ce1c",
          "intrusion-set--5cbe0d3b-6fb1-471f-b591-4b192915116d",
          "intrusion-set--7113eaa5-ba79-4fb3-b68a-398ee9cd698e",
          "intrusion-set--76d59913-1d24-4992-a8ac-05a3eb093f71",
          "intrusion-set--85403903-15e0-4f9f-9be4-a259ecad4022",
          "intrusion-set--899ce53f-13a0-479b-a0e4-67d46e241542",
          "intrusion-set--8c1f0187-0826-4320-bddc-5f326cfcfe2c",
          "intrusion-set--90784c1e-4aba-40eb-9adf-7556235e6384",
          "intrusion-set--9538b1a4-4120-4e2d-bf59-3b11fcab05a4",
          "intrusion-set--bef4c620-0787-42a8-a96d-b7eb6e85917c",
          "intrusion-set--c21dd6f1-1364-4a70-a1f7-783080ec34ee",
          "intrusion-set--d0b3393b-3bec-4ba3-bda9-199d30db47b6",
          "intrusion-set--d13c8a7f-740b-4efa-a232-de7d6bb05321",
          "intrusion-set--dc5e2999-ca1a-47d4-8d12-a6984b138a1b",
          "intrusion-set--dd2d9ca6-505b-4860-a604-233685b802c7",
          "intrusion-set--fb366179-766c-4a4a-afa1-52bff1fd601c",
          "intrusion-set--fbd29c89-18ba-4c2d-b792-51c0adee049f",
          "intrusion-set--fbe9387f-34e6-4828-ac28-3080020c597b",
          "intrusion-set--fd19bd82-1b14-49a1-a176-6cdc46b8a826",
          "intrusion-set--fe98767f-9df8-42b9-83c9-004b1dec8647"
        ],
        "references": [
          {
            "source": "TechNet Audit Policy",
            "url": "https://technet.microsoft.com/en-us/library/dn487457.aspx",
            "description": "Microsoft. (2016, April 15). Audit Policy Recommendations. Retrieved June 3, 2016."
          },
          {
            "source": "TechNet Credential Theft",
            "url": "https://technet.microsoft.com/en-us/library/dn535501.aspx",
            "description": "Microsoft. (2016, April 15). Attractive Accounts for Credential Theft. Retrieved June 3, 2016."
          },
          {
            "source": "capec",
            "url": "https://capec.mitre.org/data/definitions/560.html",
            "external_id": "CAPEC-560"
          }
        ],
        "source": "mitre-attack",
        "url": "https://attack.mitre.org/techniques/T1078",
        "external_id": "T1078"
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "MITRE techniques information was returned",
  "error": 0
}
```

- Test results:

```
framework/wazuh/tests/
================= 600 passed, 13 warnings in 70.89s (0:01:10) =================

framework/wazuh/core/tests/
================= 683 passed, 9 warnings in 4.34s =================

framework/wazuh/core/cluster/tests/
================= 56 passed, 4 warnings in 0.41s =================

framework/wazuh/core/cluster/dapi/tests/
================= 23 passed, 9 warnings in 0.63s =================

api/api/test/
================= 226 passed, 15 warnings in 1.18s =================
```

```
test_mitre_endpoints.tavern.yaml 
	 7 passed, 13 warnings

test_rbac_black_mitre_endpoints.tavern.yaml 
	 7 passed, 13 warnings

test_rbac_white_mitre_endpoints.tavern.yaml 
	 7 passed, 13 warnings
```

Regards,
Manuel.
