### PR TITLE
Fix JWT Signed with Weak Algorithm

### DIFF
--- a/api/api/authentication.py
+++ b/api/api/authentication.py
@@ -11,7 +11,7 @@ from concurrent.futures import ThreadPoolExecutor
 from time import time
                                
 from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.asymmetric import ec
 from jose import JWTError, jwt
 from werkzeug.exceptions import Unauthorized
 
@@ -83,7 +83,7 @@ def check_user(user, password, required_scopes=None):
 
 # Set JWT settings
 JWT_ISSUER = 'wazuh'
-JWT_ALGORITHM = 'RS256'
+JWT_ALGORITHM = 'ES512'
 _private_key_path = os.path.join(SECURITY_PATH, 'private_key.pem')
 _public_key_path = os.path.join(SECURITY_PATH, 'public_key.pem')
 
@@ -113,7 +113,7 @@ def generate_keypair():
 
 def change_keypair():
     """Generate key files to keep safe."""
-    key_obj = rsa.generate_private_key(public_exponent=65537, key_size=4096)
+    key_obj = ec.generate_private_key(ec.SECP521R1())
     private_key = key_obj.private_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PrivateFormat.PKCS8,

--- a/api/api/authentication.py
+++ b/api/api/authentication.py
@@ -101,9 +101,9 @@ def generate_keypair():
             os.chmod(_private_key_path, 0o640)
             os.chmod(_public_key_path, 0o640)
         else:
-            with open(_private_key_path, 'r') as key_file:
+            with open(_private_key_path, mode='r') as key_file:
                 private_key = key_file.read()
-            with open(_public_key_path, 'r') as key_file:
+            with open(_public_key_path, mode='r') as key_file:
                 public_key = key_file.read()
     except IOError:
         raise WazuhInternalError(6003)
@@ -123,9 +123,9 @@ def change_keypair():
         encoding=serialization.Encoding.PEM,
         format=serialization.PublicFormat.SubjectPublicKeyInfo
     ).decode('utf-8')
-    with open(_private_key_path, 'w') as key_file:
+    with open(_private_key_path, mode='w') as key_file:
         key_file.write(private_key)
-    with open(_public_key_path, 'w') as key_file:
+    with open(_public_key_path, mode='w') as key_file:
         key_file.write(public_key)
 
     return private_key, public_key

--- a/api/api/authentication.py
+++ b/api/api/authentication.py
@@ -91,6 +91,7 @@ _public_key_path = os.path.join(SECURITY_PATH, 'publicKey.pem')
 
 
 def generate_keyPair():
+    """Create key pair to be used to generate and decode JWT"""
     try:
         if not os.path.exists(_private_key_path):
             [privateKey, publicKey] = change_keyPair()
@@ -113,6 +114,7 @@ def generate_keyPair():
 
 
 def change_keyPair():
+    """Create new key pair to be used to generate and decode JWT"""
     keyObj = rsa.generate_private_key( public_exponent = 65537, key_size = 4096 )
     privateKey = keyObj.private_bytes(
         encoding = serialization.Encoding.PEM,

--- a/api/api/test/test_authentication.py
+++ b/api/api/test/test_authentication.py
@@ -76,22 +76,21 @@ def test_check_user(mock_raise_if_exc, mock_submit, mock_distribute_function, mo
 @patch('os.chmod')
 @patch('os.chown')
 @patch('builtins.open')
-def test_generate_keyPair(mock_open, mock_chown, mock_chmod, mock_keyPair):
+def test_generate_keyPair(mock_open, mock_chown, mock_chmod, mock_change_keyPair):
     """Verify correct params when calling open method inside generate_keyPair"""
     result = authentication.generate_keyPair()
     assert isinstance(result[0], str)
     assert isinstance(result[1], str)
     assert result == ["b'-----BEGIN PRIVATE KEY-----\n'", "b'-----BEGIN PUBLIC KEY-----\n'"]
-
+    
     calls = [call(authentication._private_key_path, authentication.wazuh_uid(),authentication.wazuh_gid()),
         call(authentication._public_key_path, authentication.wazuh_uid(),authentication.wazuh_gid())]
-    mock_chown.has_calls(calls)
+    mock_chown.assert_has_calls(calls)
     calls = [call(authentication._private_key_path, 0o640),
         call(authentication._public_key_path, 0o640)]
-    mock_chmod.has_calls(calls)
+    mock_chmod.assert_has_calls(calls)
 
     with patch('os.path.exists', return_value=True):
-        authentication.generate_keyPair()
         calls = [call(authentication._private_key_path, mode='r'), call(authentication._public_key_path, mode='r')]
         mock_open.has_calls(calls)
 

--- a/api/api/test/test_authentication.py
+++ b/api/api/test/test_authentication.py
@@ -72,44 +72,46 @@ def test_check_user(mock_raise_if_exc, mock_submit, mock_distribute_function, mo
     mock_raise_if_exc.assert_called_once()
 
 
-@patch('api.authentication.token_urlsafe', return_value='test_token')
+@patch('api.authentication.change_keyPair', return_value=["b'-----BEGIN PRIVATE KEY-----\n'", "b'-----BEGIN PUBLIC KEY-----\n'"])
 @patch('os.chmod')
-@patch('api.authentication.chown')
+@patch('os.chown')
 @patch('builtins.open')
-def test_generate_secret(mock_open, mock_chown, mock_chmod, mock_token):
-    """Check if result's length and type are as expected and mocked function are called with correct params."""
-    result = authentication.generate_secret()
-    assert isinstance(result, str)
-    assert result == 'test_token'
+def test_generate_keyPair(mock_open, mock_chown, mock_chmod, mock_keyPair):
+    """Verify correct params when calling open method inside generate_keyPair"""
+    result = authentication.generate_keyPair()
+    assert isinstance(result[0], str)
+    assert isinstance(result[1], str)
+    assert result == ["b'-----BEGIN PRIVATE KEY-----\n'", "b'-----BEGIN PUBLIC KEY-----\n'"]
 
-    calls = [call(authentication._secret_file_path, mode='x')]
-    mock_open.has_calls(calls)
-    mock_chown.assert_called_once_with(authentication._secret_file_path, authentication.wazuh_uid(),
-                                       authentication.wazuh_gid())
-    mock_chmod.assert_called_once_with(authentication._secret_file_path, 0o640)
+    calls = [call(authentication._private_key_path, authentication.wazuh_uid(),authentication.wazuh_gid()),
+        call(authentication._public_key_path, authentication.wazuh_uid(),authentication.wazuh_gid())]
+    mock_chown.has_calls(calls)
+    calls = [call(authentication._private_key_path, 0o640),
+        call(authentication._public_key_path, 0o640)]
+    mock_chmod.has_calls(calls)
 
     with patch('os.path.exists', return_value=True):
-        authentication.generate_secret()
-
-        calls.append(call(authentication._secret_file_path, mode='r'))
+        authentication.generate_keyPair()
+        calls = [call(authentication._private_key_path, mode='r'), call(authentication._public_key_path, mode='r')]
         mock_open.has_calls(calls)
 
 
-def test_generate_secret_ko():
+def test_generate_keyPair_ko():
     """Verify expected exception is raised when IOError"""
     with patch('builtins.open'):
         with patch('os.chmod'):
-            with patch('api.authentication.chown', side_effect=PermissionError):
-                assert authentication.generate_secret()
+            with patch('os.chown', side_effect=PermissionError):
+                assert authentication.generate_keyPair()
 
 
-@patch('api.authentication.token_urlsafe', return_value='test_token')
 @patch('builtins.open')
-def test_change_secret(mock_open, mock_token):
-    """Verify correct params when calling open method inside change_secret"""
-    authentication.change_secret()
-    mock_open.assert_called_once_with(authentication._secret_file_path, mode='w')
-    mock_open.return_value.__enter__().write.assert_called_once_with('test_token')
+def test_change_keyPair(mock_open):
+    """Verify correct params when calling open method inside change_keyPair"""
+    result = authentication.change_keyPair()
+    assert isinstance(result[0], bytes)
+    assert isinstance(result[1], bytes)
+    calls = [call(authentication._private_key_path, mode='wb'), call(authentication._public_key_path, mode='wb')]
+    mock_open.has_calls(calls)
 
 
 def test_get_security_conf():
@@ -121,12 +123,12 @@ def test_get_security_conf():
 
 @patch('api.authentication.time', return_value=0)
 @patch('api.authentication.jwt.encode', return_value='test_token')
-@patch('api.authentication.generate_secret', return_value='test_secret_token')
+@patch('api.authentication.generate_keyPair', return_value=["b'-----BEGIN PRIVATE KEY-----\n'", "b'-----BEGIN PUBLIC KEY-----\n'"])
 @patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.__init__', return_value=None)
 @patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.distribute_function', side_effect=None)
 @patch('concurrent.futures.ThreadPoolExecutor.submit', side_effect=None)
 @patch('api.authentication.raise_if_exc', side_effect=None)
-def test_generate_token(mock_raise_if_exc, mock_submit, mock_distribute_function, mock_dapi, mock_generate_secret,
+def test_generate_token(mock_raise_if_exc, mock_submit, mock_distribute_function, mock_dapi, mock_generate_keyPair,
                         mock_encode, mock_time):
     """Verify if result is as expected"""
     mock_raise_if_exc.return_value = security_conf
@@ -138,8 +140,8 @@ def test_generate_token(mock_raise_if_exc, mock_submit, mock_distribute_function
                                       logger=ANY)
     mock_distribute_function.assert_called_once_with()
     mock_raise_if_exc.assert_called_once()
-    mock_generate_secret.assert_called_once()
-    mock_encode.assert_called_once_with(original_payload, 'test_secret_token', algorithm='HS256')
+    mock_generate_keyPair.assert_called_once()
+    mock_encode.assert_called_once_with(original_payload, "b'-----BEGIN PRIVATE KEY-----\n'", algorithm='RS256')
 
 
 @patch('api.authentication.TokenManager')
@@ -150,12 +152,12 @@ def test_check_token(mock_tokenmanager):
 
 
 @patch('api.authentication.jwt.decode')
-@patch('api.authentication.generate_secret', return_value='test_secret_token')
+@patch('api.authentication.generate_keyPair', return_value=["b'-----BEGIN PRIVATE KEY-----\n'", "b'-----BEGIN PUBLIC KEY-----\n'"])
 @patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.__init__', return_value=None)
 @patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.distribute_function', side_effect=None)
 @patch('concurrent.futures.ThreadPoolExecutor.submit', side_effect=None)
 @patch('api.authentication.raise_if_exc', side_effect=None)
-def test_decode_token(mock_raise_if_exc, mock_submit, mock_distribute_function, mock_dapi, mock_generate_secret,
+def test_decode_token(mock_raise_if_exc, mock_submit, mock_distribute_function, mock_dapi, mock_generate_keyPair,
                       mock_decode):
     mock_decode.return_value = deepcopy(original_payload)
     mock_raise_if_exc.side_effect = [WazuhResult({'valid': True, 'policies': {'value': 'test'}}),
@@ -171,8 +173,8 @@ def test_decode_token(mock_raise_if_exc, mock_submit, mock_distribute_function, 
                   request_type='local_master', is_async=False, wait_for_complete=False, logger=ANY),
              call(f=ANY, request_type='local_master', is_async=False, wait_for_complete=False, logger=ANY)]
     mock_dapi.assert_has_calls(calls)
-    mock_generate_secret.assert_called_once()
-    mock_decode.assert_called_once_with('test_token', 'test_secret_token', algorithms=['HS256'],
+    mock_generate_keyPair.assert_called_once()
+    mock_decode.assert_called_once_with('test_token', "b'-----BEGIN PUBLIC KEY-----\n'", algorithms=['RS256'],
                                         audience='Wazuh API REST')
     assert mock_distribute_function.call_count == 2
     assert mock_raise_if_exc.call_count == 2
@@ -181,14 +183,14 @@ def test_decode_token(mock_raise_if_exc, mock_submit, mock_distribute_function, 
 @patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.distribute_function', side_effect=None)
 @patch('concurrent.futures.ThreadPoolExecutor.submit', side_effect=None)
 @patch('api.authentication.raise_if_exc', side_effect=None)
-@patch('api.authentication.generate_secret', return_value='test_secret_token')
-def test_decode_token_ko(mock_generate_secret, mock_raise_if_exc, mock_submit, mock_distribute_function):
+@patch('api.authentication.generate_keyPair', return_value=["b'-----BEGIN PRIVATE KEY-----\n'", "b'-----BEGIN PUBLIC KEY-----\n'"])
+def test_decode_token_ko(mock_generate_keyPair, mock_raise_if_exc, mock_submit, mock_distribute_function):
     """Assert exceptions are handled as expected inside decode_token()"""
     with pytest.raises(Unauthorized):
         authentication.decode_token(token='test_token')
 
     with patch('api.authentication.jwt.decode') as mock_decode:
-        with patch('api.authentication.generate_secret', return_value='test_secret_token'):
+        with patch('api.authentication.generate_keyPair', return_value=["b'-----BEGIN PRIVATE KEY-----\n'", "b'-----BEGIN PUBLIC KEY-----\n'"]):
             with patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.__init__', return_value=None):
                 with patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.distribute_function'):
                     with patch('api.authentication.raise_if_exc') as mock_raise_if_exc:

--- a/api/api/test/test_authentication.py
+++ b/api/api/test/test_authentication.py
@@ -145,7 +145,7 @@ def test_generate_token(mock_raise_if_exc, mock_submit, mock_distribute_function
     mock_raise_if_exc.assert_called_once()
     mock_generate_keypair.assert_called_once()
     mock_encode.assert_called_once_with(original_payload, '-----BEGIN PRIVATE KEY-----',
-                                        algorithm='RS256')
+                                        algorithm='ES512')
 
 
 @patch('api.authentication.TokenManager')
@@ -180,7 +180,7 @@ def test_decode_token(mock_raise_if_exc, mock_submit, mock_distribute_function, 
     mock_dapi.assert_has_calls(calls)
     mock_generate_keypair.assert_called_once()
     mock_decode.assert_called_once_with('test_token', '-----BEGIN PUBLIC KEY-----',
-                                        algorithms=['RS256'],
+                                        algorithms=['ES512'],
                                         audience='Wazuh API REST')
     assert mock_distribute_function.call_count == 2
     assert mock_raise_if_exc.call_count == 2

--- a/api/api/test/test_authentication.py
+++ b/api/api/test/test_authentication.py
@@ -80,11 +80,9 @@ def test_check_user(mock_raise_if_exc, mock_submit, mock_distribute_function, mo
 def test_generate_keypair(mock_open, mock_chown, mock_chmod, mock_change_keypair):
     """Verify correct params when calling open method inside generate_keypair"""
     result = authentication.generate_keypair()
-    assert isinstance(result[0], str)
-    assert isinstance(result[1], str)
     assert result == ('-----BEGIN PRIVATE KEY-----',
                       '-----BEGIN PUBLIC KEY-----')
-    
+
     calls = [call(authentication._private_key_path, authentication.wazuh_uid(), authentication.wazuh_gid()),
              call(authentication._public_key_path, authentication.wazuh_uid(), authentication.wazuh_gid())]
     mock_chown.assert_has_calls(calls)
@@ -93,8 +91,10 @@ def test_generate_keypair(mock_open, mock_chown, mock_chmod, mock_change_keypair
     mock_chmod.assert_has_calls(calls)
 
     with patch('os.path.exists', return_value=True):
-        calls = [call(authentication._private_key_path, mode='rb'), call(authentication._public_key_path, mode='rb')]
-        mock_open.has_calls(calls)
+        authentication.generate_keypair()
+        calls = [call(authentication._private_key_path, mode='r'),
+                 call(authentication._public_key_path, mode='r')]
+        mock_open.assert_has_calls(calls, any_order=True)
 
 
 def test_generate_keypair_ko():
@@ -111,8 +111,9 @@ def test_change_keypair(mock_open):
     result = authentication.change_keypair()
     assert isinstance(result[0], str)
     assert isinstance(result[1], str)
-    calls = [call(authentication._private_key_path, mode='wb'), call(authentication._public_key_path, mode='wb')]
-    mock_open.has_calls(calls)
+    calls = [call(authentication._private_key_path, mode='w'),
+             call(authentication._public_key_path, mode='w')]
+    mock_open.assert_has_calls(calls, any_order=True)
 
 
 def test_get_security_conf():

--- a/api/api/test/test_authentication.py
+++ b/api/api/test/test_authentication.py
@@ -72,43 +72,45 @@ def test_check_user(mock_raise_if_exc, mock_submit, mock_distribute_function, mo
     mock_raise_if_exc.assert_called_once()
 
 
-@patch('api.authentication.change_keyPair', return_value=["b'-----BEGIN PRIVATE KEY-----\n'", "b'-----BEGIN PUBLIC KEY-----\n'"])
+@patch('api.authentication.change_keypair', return_value=('-----BEGIN PRIVATE KEY-----',
+                                                          '-----BEGIN PUBLIC KEY-----'))
 @patch('os.chmod')
 @patch('os.chown')
 @patch('builtins.open')
-def test_generate_keyPair(mock_open, mock_chown, mock_chmod, mock_change_keyPair):
-    """Verify correct params when calling open method inside generate_keyPair"""
-    result = authentication.generate_keyPair()
+def test_generate_keypair(mock_open, mock_chown, mock_chmod, mock_change_keypair):
+    """Verify correct params when calling open method inside generate_keypair"""
+    result = authentication.generate_keypair()
     assert isinstance(result[0], str)
     assert isinstance(result[1], str)
-    assert result == ["b'-----BEGIN PRIVATE KEY-----\n'", "b'-----BEGIN PUBLIC KEY-----\n'"]
+    assert result == ('-----BEGIN PRIVATE KEY-----',
+                      '-----BEGIN PUBLIC KEY-----')
     
-    calls = [call(authentication._private_key_path, authentication.wazuh_uid(),authentication.wazuh_gid()),
-        call(authentication._public_key_path, authentication.wazuh_uid(),authentication.wazuh_gid())]
+    calls = [call(authentication._private_key_path, authentication.wazuh_uid(), authentication.wazuh_gid()),
+             call(authentication._public_key_path, authentication.wazuh_uid(), authentication.wazuh_gid())]
     mock_chown.assert_has_calls(calls)
     calls = [call(authentication._private_key_path, 0o640),
-        call(authentication._public_key_path, 0o640)]
+             call(authentication._public_key_path, 0o640)]
     mock_chmod.assert_has_calls(calls)
 
     with patch('os.path.exists', return_value=True):
-        calls = [call(authentication._private_key_path, mode='r'), call(authentication._public_key_path, mode='r')]
+        calls = [call(authentication._private_key_path, mode='rb'), call(authentication._public_key_path, mode='rb')]
         mock_open.has_calls(calls)
 
 
-def test_generate_keyPair_ko():
+def test_generate_keypair_ko():
     """Verify expected exception is raised when IOError"""
     with patch('builtins.open'):
         with patch('os.chmod'):
             with patch('os.chown', side_effect=PermissionError):
-                assert authentication.generate_keyPair()
+                assert authentication.generate_keypair()
 
 
 @patch('builtins.open')
-def test_change_keyPair(mock_open):
-    """Verify correct params when calling open method inside change_keyPair"""
-    result = authentication.change_keyPair()
-    assert isinstance(result[0], bytes)
-    assert isinstance(result[1], bytes)
+def test_change_keypair(mock_open):
+    """Verify correct params when calling open method inside change_keypair"""
+    result = authentication.change_keypair()
+    assert isinstance(result[0], str)
+    assert isinstance(result[1], str)
     calls = [call(authentication._private_key_path, mode='wb'), call(authentication._public_key_path, mode='wb')]
     mock_open.has_calls(calls)
 
@@ -122,12 +124,13 @@ def test_get_security_conf():
 
 @patch('api.authentication.time', return_value=0)
 @patch('api.authentication.jwt.encode', return_value='test_token')
-@patch('api.authentication.generate_keyPair', return_value=["b'-----BEGIN PRIVATE KEY-----\n'", "b'-----BEGIN PUBLIC KEY-----\n'"])
+@patch('api.authentication.generate_keypair', return_value=('-----BEGIN PRIVATE KEY-----',
+                                                            '-----BEGIN PUBLIC KEY-----'))
 @patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.__init__', return_value=None)
 @patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.distribute_function', side_effect=None)
 @patch('concurrent.futures.ThreadPoolExecutor.submit', side_effect=None)
 @patch('api.authentication.raise_if_exc', side_effect=None)
-def test_generate_token(mock_raise_if_exc, mock_submit, mock_distribute_function, mock_dapi, mock_generate_keyPair,
+def test_generate_token(mock_raise_if_exc, mock_submit, mock_distribute_function, mock_dapi, mock_generate_keypair,
                         mock_encode, mock_time):
     """Verify if result is as expected"""
     mock_raise_if_exc.return_value = security_conf
@@ -139,8 +142,9 @@ def test_generate_token(mock_raise_if_exc, mock_submit, mock_distribute_function
                                       logger=ANY)
     mock_distribute_function.assert_called_once_with()
     mock_raise_if_exc.assert_called_once()
-    mock_generate_keyPair.assert_called_once()
-    mock_encode.assert_called_once_with(original_payload, "b'-----BEGIN PRIVATE KEY-----\n'", algorithm='RS256')
+    mock_generate_keypair.assert_called_once()
+    mock_encode.assert_called_once_with(original_payload, '-----BEGIN PRIVATE KEY-----',
+                                        algorithm='RS256')
 
 
 @patch('api.authentication.TokenManager')
@@ -151,12 +155,13 @@ def test_check_token(mock_tokenmanager):
 
 
 @patch('api.authentication.jwt.decode')
-@patch('api.authentication.generate_keyPair', return_value=["b'-----BEGIN PRIVATE KEY-----\n'", "b'-----BEGIN PUBLIC KEY-----\n'"])
+@patch('api.authentication.generate_keypair', return_value=('-----BEGIN PRIVATE KEY-----',
+                                                            '-----BEGIN PUBLIC KEY-----'))
 @patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.__init__', return_value=None)
 @patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.distribute_function', side_effect=None)
 @patch('concurrent.futures.ThreadPoolExecutor.submit', side_effect=None)
 @patch('api.authentication.raise_if_exc', side_effect=None)
-def test_decode_token(mock_raise_if_exc, mock_submit, mock_distribute_function, mock_dapi, mock_generate_keyPair,
+def test_decode_token(mock_raise_if_exc, mock_submit, mock_distribute_function, mock_dapi, mock_generate_keypair,
                       mock_decode):
     mock_decode.return_value = deepcopy(original_payload)
     mock_raise_if_exc.side_effect = [WazuhResult({'valid': True, 'policies': {'value': 'test'}}),
@@ -172,8 +177,9 @@ def test_decode_token(mock_raise_if_exc, mock_submit, mock_distribute_function, 
                   request_type='local_master', is_async=False, wait_for_complete=False, logger=ANY),
              call(f=ANY, request_type='local_master', is_async=False, wait_for_complete=False, logger=ANY)]
     mock_dapi.assert_has_calls(calls)
-    mock_generate_keyPair.assert_called_once()
-    mock_decode.assert_called_once_with('test_token', "b'-----BEGIN PUBLIC KEY-----\n'", algorithms=['RS256'],
+    mock_generate_keypair.assert_called_once()
+    mock_decode.assert_called_once_with('test_token', '-----BEGIN PUBLIC KEY-----',
+                                        algorithms=['RS256'],
                                         audience='Wazuh API REST')
     assert mock_distribute_function.call_count == 2
     assert mock_raise_if_exc.call_count == 2
@@ -182,14 +188,17 @@ def test_decode_token(mock_raise_if_exc, mock_submit, mock_distribute_function, 
 @patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.distribute_function', side_effect=None)
 @patch('concurrent.futures.ThreadPoolExecutor.submit', side_effect=None)
 @patch('api.authentication.raise_if_exc', side_effect=None)
-@patch('api.authentication.generate_keyPair', return_value=["b'-----BEGIN PRIVATE KEY-----\n'", "b'-----BEGIN PUBLIC KEY-----\n'"])
-def test_decode_token_ko(mock_generate_keyPair, mock_raise_if_exc, mock_submit, mock_distribute_function):
+@patch('api.authentication.generate_keypair', return_value=('-----BEGIN PRIVATE KEY-----',
+                                                            '-----BEGIN PUBLIC KEY-----'))
+def test_decode_token_ko(mock_generate_keypair, mock_raise_if_exc, mock_submit, mock_distribute_function):
     """Assert exceptions are handled as expected inside decode_token()"""
     with pytest.raises(Unauthorized):
         authentication.decode_token(token='test_token')
 
     with patch('api.authentication.jwt.decode') as mock_decode:
-        with patch('api.authentication.generate_keyPair', return_value=["b'-----BEGIN PRIVATE KEY-----\n'", "b'-----BEGIN PUBLIC KEY-----\n'"]):
+        with patch('api.authentication.generate_keypair',
+                   return_value=('-----BEGIN PRIVATE KEY-----',
+                                 '-----BEGIN PUBLIC KEY-----')):
             with patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.__init__', return_value=None):
                 with patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.distribute_function'):
                     with patch('api.authentication.raise_if_exc') as mock_raise_if_exc:

--- a/framework/wazuh/core/security.py
+++ b/framework/wazuh/core/security.py
@@ -9,7 +9,7 @@ import yaml
 
 import api.middlewares as middlewares
 from api import __path__ as api_path
-from api.authentication import change_secret
+from api.authentication import change_keyPair
 from api.constants import SECURITY_CONFIG_PATH
 from wazuh import WazuhInternalError, WazuhError
 from wazuh.rbac.orm import RolesManager, TokenManager
@@ -102,7 +102,7 @@ def invalid_roles_tokens(roles: list = None):
 
 def revoke_tokens():
     """Revoke all tokens in current node."""
-    change_secret()
+    change_keyPair()
     with TokenManager() as tm:
         tm.delete_all_rules()
 

--- a/framework/wazuh/core/security.py
+++ b/framework/wazuh/core/security.py
@@ -9,7 +9,7 @@ import yaml
 
 import api.middlewares as middlewares
 from api import __path__ as api_path
-from api.authentication import change_keyPair
+from api.authentication import change_keypair
 from api.constants import SECURITY_CONFIG_PATH
 from wazuh import WazuhInternalError, WazuhError
 from wazuh.rbac.orm import RolesManager, TokenManager
@@ -102,7 +102,7 @@ def invalid_roles_tokens(roles: list = None):
 
 def revoke_tokens():
     """Revoke all tokens in current node."""
-    change_keyPair()
+    change_keypair()
     with TokenManager() as tm:
         tm.delete_all_rules()
 

--- a/framework/wazuh/tests/test_security.py
+++ b/framework/wazuh/tests/test_security.py
@@ -171,7 +171,7 @@ def test_rbac_catalog(db_setup, security_function, params, expected_result):
 
 def test_revoke_tokens(db_setup):
     """Checks that the return value of revoke_tokens is a WazuhResult."""
-    with patch('wazuh.core.security.change_keyPair', side_effect=None):
+    with patch('wazuh.core.security.change_keypair', side_effect=None):
         security, WazuhResult, _ = db_setup
         mock_current_user = ContextVar('current_user', default='wazuh')
         with patch("wazuh.sca.common.current_user", new=mock_current_user):

--- a/framework/wazuh/tests/test_security.py
+++ b/framework/wazuh/tests/test_security.py
@@ -171,7 +171,7 @@ def test_rbac_catalog(db_setup, security_function, params, expected_result):
 
 def test_revoke_tokens(db_setup):
     """Checks that the return value of revoke_tokens is a WazuhResult."""
-    with patch('wazuh.core.security.change_secret', side_effect=None):
+    with patch('wazuh.core.security.change_keyPair', side_effect=None):
         security, WazuhResult, _ = db_setup
         mock_current_user = ContextVar('current_user', default='wazuh')
         with patch("wazuh.sca.common.current_user", new=mock_current_user):


### PR DESCRIPTION
|Related issue|
|---|
|#9321|

# Description
JWT signed algorithm updated form HS256 to RS256.
Now JWT is generated with a private key and decoded with a public one. This feature gives more security against brute force attacks within a leaked JWT as discussed in related issue.
This PR closes #9321.

# Tests
## API
```
========================================================== test session starts ===========================================================
platform linux -- Python 3.9.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /home/kondent/git/wazuh/api
plugins: asyncio-0.15.1, html-3.1.1, metadata-1.11.0, cov-2.12.1
collected 238 items                                                                                                                      

api/models/test/test_model.py ............                                                                                         [  5%]
api/test/test_alogging.py ..........                                                                                               [  9%]
api/test/test_authentication.py ..........                                                                                         [ 13%]
api/test/test_configuration.py ..........................................                                                          [ 31%]
api/test/test_util.py ...................................                                                                          [ 45%]
api/test/test_validator.py ....................................................................................................... [ 89%]
..........................                                                                                                         [100%]

==================================================== 238 passed, 14 warnings in 1.32s ====================================================
```
## Framework 
```
==================================== test session starts =====================================
platform linux -- Python 3.9.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /home/kondent/git/wazuh/framework
plugins: asyncio-0.15.1, html-3.1.1, metadata-1.11.0, cov-2.12.1
collected 1589 items

wazuh/core/cluster/dapi/tests/test_dapi.py .......................                     [  1%]
wazuh/core/cluster/tests/test_cluster.py ...................                           [  2%]
wazuh/core/cluster/tests/test_common.py .......                                        [  3%]
wazuh/core/cluster/tests/test_control.py .....                                         [  3%]
...
...
...
wazuh/tests/test_stats.py ................                                             [ 94%]
wazuh/tests/test_syscheck.py .......................                                   [ 95%]
wazuh/tests/test_syscollector.py ............                                          [ 96%]
wazuh/tests/test_task.py ............................                                  [ 98%]
wazuh/tests/test_vulnerability.py ..........................                           [100%]

======================= 1589 passed, 14 warnings in 201.16s (0:03:21) ========================
```