### PR TITLE
Fix Authd's startup to set up PID file before loading keys

### DIFF
--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -407,6 +407,13 @@ int main(int argc, char **argv)
         sigaction(SIGINT, &action, NULL);
     }
 
+    /* Create PID files */
+    if (CreatePID(ARGV0, getpid()) < 0) {
+        merror_exit(PID_ERROR);
+    }
+
+    atexit(cleanup);
+
     /* Start up message */
     minfo(STARTUP_MSG, (int)getpid());
 
@@ -520,13 +527,6 @@ int main(int argc, char **argv)
             return EXIT_FAILURE;
         }
     }
-
-    /* Create PID files */
-    if (CreatePID(ARGV0, getpid()) < 0) {
-        merror_exit(PID_ERROR);
-    }
-
-    atexit(cleanup);
 
     /* Join threads */
     pthread_join(thread_local_server, NULL);


### PR DESCRIPTION
@Selutario reported this error in `wazuh-control` when starting the manager:

```
wazuh-authd did not start correctly.
```

However, Authd was running correctly. This problem was caused by an unexpected delay in the Authd startup, which loaded the file _client.keys_ before creating the daemon's PID file.

## Rationale

The service's startup procedure is to run every daemon and wait up to 10 seconds for it to create its PID file. Should any daemon take more than 10 seconds to create the PID file, `wazuh-control` will report that it did not start correctly.

## Proposed fix

This issue is related to #8719, which reported the same problem in Analysisd. PR #8828 fixed that by advancing the creation of the PID file before any long-running operation, such as loading the ruleset.

In the same way, we propose to advance the creation of the PID file in Authd. Damons shall create their PID file just after parsing the configuration, and before running a long-running operation.

## Tests

- [x] Build the manager on Linux.
- [x] Verify that the reported problem does not happen anymore in this branch.