### PR TITLE
A potential issue in os_zlib was fixed and new unit tests were added.

### DIFF
--- a/src/os_zlib/os_zlib.c
+++ b/src/os_zlib/os_zlib.c
@@ -16,11 +16,12 @@ unsigned long int os_zlib_compress(const char *src, char *dst,
                                    unsigned long int src_size,
                                    unsigned long int dst_size)
 {
-    if (compress2((Bytef *)dst,
-                  &dst_size,
-                  (const Bytef *)src,
-                  src_size,
-                  Z_BEST_COMPRESSION) == Z_OK) {
+    if ((compressBound(src_size) <= dst_size) && \
+        (compress2((Bytef *)dst,
+                      &dst_size,
+                      (const Bytef *)src,
+                      src_size,
+                      Z_BEST_COMPRESSION) == Z_OK)) {
         dst[dst_size] = '\0';
         return (dst_size);
     }

--- a/src/unit_tests/os_zlib/test_os_zlib.c
+++ b/src/unit_tests/os_zlib/test_os_zlib.c
@@ -135,6 +135,27 @@ void test_fail_uncompress_no_dest_size(void **state) {
     assert_int_equal(i2, 0);
 }
 
+void test_fail_compress_smaller_bound_dst_buffer(void ** state) {
+    char src[40] = "This is a test string to be compressed.";
+    char dst[52];
+
+    assert_int_equal(0, os_zlib_compress(src, dst, 40, 52));
+}
+
+void test_success_compress_equal_bound_dst_buffer(void ** state) {
+    char src[40] = "This is a test string to be compressed.";
+    char dst[53];
+
+    assert_int_equal(46, os_zlib_compress(src, dst, 40, 53));
+}
+
+void test_success_compress_bigger_bound_dst_buffer(void ** state) {
+    char src[40] = "This is a test string to be compressed.";
+    char dst[54];
+
+    assert_int_equal(46, os_zlib_compress(src, dst, 40, 54));
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_success_compress_string),
@@ -142,6 +163,9 @@ int main(void) {
         cmocka_unit_test(test_fail_compress_null_src),
         cmocka_unit_test(test_fail_compress_no_dest),
         cmocka_unit_test(test_fail_compress_no_dest_size),
+        cmocka_unit_test(test_fail_compress_smaller_bound_dst_buffer),
+        cmocka_unit_test(test_success_compress_equal_bound_dst_buffer),
+        cmocka_unit_test(test_success_compress_bigger_bound_dst_buffer),
         cmocka_unit_test_setup_teardown(test_success_uncompress, setup_uncompress_string1, teardown_uncompress),
         cmocka_unit_test_setup_teardown(test_success_uncompress_special_string, setup_uncompress_string2, teardown_uncompress),
         cmocka_unit_test_setup_teardown(test_fail_uncompress_null_src, setup_uncompress_string1, teardown_uncompress),


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

There was a potential issue in `os_zlib.c` in `os_zlib_compress()` function:
```cpp
unsigned long int os_zlib_compress(const char *src, char *dst,
                                   unsigned long int src_size,
                                   unsigned long int dst_size)
{
    if ((compress2((Bytef *)dst,
                   &dst_size,
                   (const Bytef *)src,
                   src_size,
                   Z_BEST_COMPRESSION) == Z_OK) {
        dst[dst_size] = '\0';
        return (dst_size);
    }

    return (0);
}
```

Before calling `compress2()` function it must be ensured the destination buffer has a minimal size, otherwise it can be incurred in an invalid memory access in line `dst[dst_size] = '\0';`. This is done using the `compressBound()` function provided by the same zlib library.

Three new unit tests were added to test this scenario in boundary conditions.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors