### PR TITLE
Let wpopen communicate in duplex mode

### DIFF
--- a/src/active-response/active_responses.c
+++ b/src/active-response/active_responses.c
@@ -270,7 +270,7 @@ int lock (const char *lock_path, const char *lock_pid_path, const char *log_path
             char *command_ex_1[4] = {"pgrep", "-f", (char *)proc_name, NULL};
             if (wfd = wpopenv(*command_ex_1, command_ex_1, W_BIND_STDOUT), wfd) {
                 char output_buf[BUFFERSIZE];
-                while (fgets(output_buf, BUFFERSIZE, wfd->file)) {
+                while (fgets(output_buf, BUFFERSIZE, wfd->file_out)) {
                     int pid = atoi(output_buf);
                     if (pid == current_pid) {
                         wfd_t *wfd2 = NULL;

--- a/src/active-response/firewalls/default-firewall-drop.c
+++ b/src/active-response/firewalls/default-firewall-drop.c
@@ -223,14 +223,14 @@ int main (int argc, char **argv) {
         if (wfd = wpopenv(*command_ex_1, command_ex_1, W_BIND_STDIN), !wfd) {
             write_debug_file(argv[0], "Unable to run ipf");
         } else {
-            fprintf(wfd->file, "%s\n", arg1);
+            fprintf(wfd->file_in, "%s\n", arg1);
             wpclose(wfd);
         }
 
         if (wfd = wpopenv(*command_ex_2, command_ex_2, W_BIND_STDIN), !wfd) {
             write_debug_file(argv[0], "Unable to run ipf");
         } else {
-            fprintf(wfd->file, "%s\n", arg2);
+            fprintf(wfd->file_in, "%s\n", arg2);
             wpclose(wfd);
         }
 
@@ -304,7 +304,7 @@ int main (int argc, char **argv) {
             char *command_ex_1[5] = {lsfilt_path, "-v", "4", "-O", NULL};
             if (wfd = wpopenv(*command_ex_1, command_ex_1, W_BIND_STDOUT), wfd) {
                 char output_buf[BUFFERSIZE];
-                while (fgets(output_buf, BUFFERSIZE, wfd->file)) {
+                while (fgets(output_buf, BUFFERSIZE, wfd->file_out)) {
                     if (strstr(output_buf, srcip) != NULL) {
                         // removing a specific rule
                         wfd_t *wfd2 = NULL;

--- a/src/active-response/firewalls/ipfw.c
+++ b/src/active-response/firewalls/ipfw.c
@@ -22,7 +22,7 @@ int main (int argc, char **argv) {
     cJSON *input_json = NULL;
     struct utsname uname_buffer;
     char *home_path = w_homedir(argv[0]);
-        
+
     /* Trim absolute path to get Wazuh's installation directory */
     home_path = w_strtok_r_str_delim("/active-response", &home_path);
 
@@ -95,7 +95,7 @@ int main (int argc, char **argv) {
         char *command_ex_1[3] = { IPFW, "show", NULL };
         if (wfd = wpopenv(*command_ex_1, command_ex_1, W_BIND_STDOUT), wfd) {
             char output_buf[BUFFERSIZE];
-            while (fgets(output_buf, BUFFERSIZE, wfd->file)) {
+            while (fgets(output_buf, BUFFERSIZE, wfd->file_out)) {
                 if ((strncmp(output_buf, TABLE_ID, 5) == 0) && (strstr(output_buf, table_name) != NULL)) {
                     add_table = false;
                     break;

--- a/src/active-response/firewalls/npf.c
+++ b/src/active-response/firewalls/npf.c
@@ -22,7 +22,7 @@ int main (int argc, char **argv) {
 
     /* Trim absolute path to get Wazuh's installation directory */
     home_path = w_strtok_r_str_delim("/active-response", &home_path);
-    
+
     /* Change working directory */
     if (chdir(home_path) == -1) {
         merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
@@ -77,7 +77,7 @@ int main (int argc, char **argv) {
     if (wfd1 = wpopenv(NPFCTL, cmd, W_BIND_STDOUT), wfd1) {
         char output_buf[BUFFERSIZE];
         int flag = false;
-        while (fgets(output_buf, BUFFERSIZE, wfd1->file)) {
+        while (fgets(output_buf, BUFFERSIZE, wfd1->file_out)) {
             const char *pos = strstr(output_buf, "filtering:");
             if (pos != NULL) {
                 char state[15];
@@ -124,7 +124,7 @@ int main (int argc, char **argv) {
     if (wfd2 = wpopenv(NPFCTL, cmd, W_BIND_STDOUT), wfd2) {
         char output_buf[BUFFERSIZE];
         int flag = false;
-        while (fgets(output_buf, BUFFERSIZE, wfd2->file)) {
+        while (fgets(output_buf, BUFFERSIZE, wfd2->file_out)) {
             const char *pos = strstr(output_buf, "table <wazuh_blacklist>");
             if (pos != NULL) {
                 flag = true;

--- a/src/agentlessd/agentlessd.c
+++ b/src/agentlessd/agentlessd.c
@@ -227,7 +227,7 @@ static int check_diff_file(const char *host, const char *script)
         return 0;
     }
 
-    while (zread = fread(buffer, 1, sizeof(buffer), wfd->file), zread) {
+    while (zread = fread(buffer, 1, sizeof(buffer), wfd->file_out), zread) {
         if (fwrite(buffer, 1, zread, fp) != zread) {
             merror("Unable to write diff file '%s': %s (%d)", diff_location, strerror(errno), errno);
             break;
@@ -370,7 +370,7 @@ static int run_periodic_cmd(agentlessd_entries *entry, int test_it)
         free_strarray(argv);
 
         if (wfd) {
-            while (fgets(buf, OS_SIZE_2048, wfd->file) != NULL) {
+            while (fgets(buf, OS_SIZE_2048, wfd->file_out) != NULL) {
                 /* Remove newlines and carriage returns */
                 tmp_str = strchr(buf, '\r');
                 if (tmp_str) {

--- a/src/headers/exec_op.h
+++ b/src/headers/exec_op.h
@@ -22,13 +22,13 @@
 #endif
 
 typedef struct wfd_t {
-    FILE * file;
+    FILE * file_in;
+    FILE * file_out;
 #ifdef WIN32
     PROCESS_INFORMATION pinfo;
 #else
     pid_t pid;
 #endif
-    unsigned int append_pool:1;
 } wfd_t;
 
 // Open a stream from a process without shell (execvp form)

--- a/src/os_execd/execd.c
+++ b/src/os_execd/execd.c
@@ -77,7 +77,7 @@ STATIC void execd_shutdown(int sig)
         mdebug2("Delete pending AR: '%s' '%s'", list_entry->command[0], list_entry->parameters);
         wfd_t *wfd = wpopenv(list_entry->command[0], list_entry->command, W_BIND_STDIN);
         if (wfd) {
-            fwrite(list_entry->parameters, 1, strlen(list_entry->parameters), wfd->file);
+            fwrite(list_entry->parameters, 1, strlen(list_entry->parameters), wfd->file_in);
             wpclose(wfd);
         } else {
             merror(EXEC_CMD_FAIL, strerror(errno), errno);
@@ -346,7 +346,7 @@ STATIC void ExecdStart(int q)
 
                 wfd_t *wfd = wpopenv(list_entry->command[0], list_entry->command, W_BIND_STDIN);
                 if (wfd) {
-                    fwrite(list_entry->parameters, 1, strlen(list_entry->parameters), wfd->file);
+                    fwrite(list_entry->parameters, 1, strlen(list_entry->parameters), wfd->file_in);
                     wpclose(wfd);
                 } else {
                     merror(EXEC_CMD_FAIL, strerror(errno), errno);
@@ -463,7 +463,7 @@ STATIC void ExecdStart(int q)
 
         wfd_t *wfd = wpopenv(cmd[0], cmd, W_BIND_STDIN);
         if (wfd) {
-            fwrite(cmd_parameters, 1, strlen(cmd_parameters), wfd->file);
+            fwrite(cmd_parameters, 1, strlen(cmd_parameters), wfd->file_in);
             wpclose(wfd);
         } else {
             merror(EXEC_CMD_FAIL, strerror(errno), errno);

--- a/src/os_execd/wcom.c
+++ b/src/os_execd/wcom.c
@@ -226,7 +226,7 @@ size_t wcom_restart(char ** output) {
         char *cmd_parameters = "{\"version\":1,\"origin\":{\"name\":\"\",\"module\":\"wazuh-execd\"},\"command\":\"add\",\"parameters\":{\"extra_args\":[],\"alert\":{},\"program\":\"restart-wazuh.exe\"}}";
         wfd_t *wfd = wpopenv(cmd[0], cmd, W_BIND_STDIN);
         if (wfd) {
-            fwrite(cmd_parameters, 1, strlen(cmd_parameters), wfd->file);
+            fwrite(cmd_parameters, 1, strlen(cmd_parameters), wfd->file_in);
             wpclose(wfd);
         } else {
             merror("At WCOM restart: Cannot execute restart process");

--- a/src/os_execd/win_execd.c
+++ b/src/os_execd/win_execd.c
@@ -45,7 +45,7 @@ static void WinExecd_Shutdown()
 
         wfd_t *wfd = wpopenv(list_entry->command[0], list_entry->command, W_BIND_STDIN);
         if (wfd) {
-            fwrite(list_entry->parameters, 1, strlen(list_entry->parameters), wfd->file);
+            fwrite(list_entry->parameters, 1, strlen(list_entry->parameters), wfd->file_in);
             wpclose(wfd);
         } else {
             merror(EXEC_CMD_FAIL, strerror(errno), errno);
@@ -128,7 +128,7 @@ void WinTimeoutRun()
 
             wfd_t *wfd = wpopenv(list_entry->command[0], list_entry->command, W_BIND_STDIN);
             if (wfd) {
-                fwrite(list_entry->parameters, 1, strlen(list_entry->parameters), wfd->file);
+                fwrite(list_entry->parameters, 1, strlen(list_entry->parameters), wfd->file_in);
                 wpclose(wfd);
             } else {
                 merror(EXEC_CMD_FAIL, strerror(errno), errno);
@@ -208,7 +208,7 @@ void WinExecdRun(char *exec_msg)
 
     wfd_t *wfd = wpopenv(cmd[0], cmd, W_BIND_STDIN);
     if (wfd) {
-        fwrite(cmd_parameters, 1, strlen(cmd_parameters), wfd->file);
+        fwrite(cmd_parameters, 1, strlen(cmd_parameters), wfd->file_in);
         wpclose(wfd);
     } else {
         merror(EXEC_CMD_FAIL, strerror(errno), errno);

--- a/src/os_integrator/integrator.c
+++ b/src/os_integrator/integrator.c
@@ -399,7 +399,7 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
                     wfd_t * wfd = wpopenv(integrator_config[s]->path, cmd, W_BIND_STDOUT | W_BIND_STDERR | W_CHECK_WRITE);
                     if(wfd){
                         char buffer[4096];
-                        while (fgets(buffer, sizeof(buffer), wfd->file)) {
+                        while (fgets(buffer, sizeof(buffer), wfd->file_out)) {
                             mdebug2("integratord: %s", buffer);
                         }
                         int wp_closefd = wpclose(wfd);

--- a/src/shared/audit_op.c
+++ b/src/shared/audit_op.c
@@ -223,7 +223,7 @@ int audit_restart(void) {
     }
 
     // Print stderr
-    while (fgets(buffer, sizeof(buffer), wfd->file)) {
+    while (fgets(buffer, sizeof(buffer), wfd->file_out)) {
         mdebug1("auditd: %s", buffer);
     }
 

--- a/src/shared/exec_op.c
+++ b/src/shared/exec_op.c
@@ -14,7 +14,8 @@
 // Open a stream from a process without shell (execvp form)
 wfd_t * wpopenv(const char * path, char * const * argv, int flags) {
     wfd_t * wfd;
-    FILE * fp = NULL;
+    FILE * fp_in = NULL;
+    FILE * fp_out = NULL;
 
 #ifdef WIN32
     int fd;
@@ -140,32 +141,50 @@ wfd_t * wpopenv(const char * path, char * const * argv, int flags) {
 #else
 
     pid_t pid;
-    int pipe_fd[2] = { 0, 0 };
+    int pipe_in[2] = { -1, -1 };
+    int pipe_out[2] = { -1, -1 };
 
     if (flags & (W_BIND_STDOUT | W_BIND_STDERR)) {
-        if (pipe(pipe_fd) < 0) {
+        if (pipe(pipe_out) < 0) {
             return NULL;
         }
 
-        if (fp = fdopen(pipe_fd[0], "r"), !fp) {
-            close(pipe_fd[0]);
-            close(pipe_fd[1]);
+        fp_out = fdopen(pipe_out[0], "r");
+
+        if (fp_out == NULL) {
+            close(pipe_out[0]);
+            close(pipe_out[1]);
             return NULL;
         }
-    } else if (flags & W_BIND_STDIN) {
-        if (pipe(pipe_fd) < 0) {
+    }
+
+    if (flags & W_BIND_STDIN) {
+        if (pipe(pipe_in) < 0) {
+            if (flags & (W_BIND_STDOUT | W_BIND_STDERR)) {
+                fclose(fp_out);
+                close(pipe_out[1]);
+            }
+
             return NULL;
         }
 
-        if (fp = fdopen(pipe_fd[1], "w"), !fp) {
-            close(pipe_fd[0]);
-            close(pipe_fd[1]);
+        fp_in = fdopen(pipe_in[1], "w");
+        if (fp_in == NULL) {
+            close(pipe_in[0]);
+            close(pipe_in[1]);
+
+            if (flags & (W_BIND_STDOUT | W_BIND_STDERR)) {
+                fclose(fp_out);
+                close(pipe_out[1]);
+            }
+
             return NULL;
         }
     }
 
     os_calloc(1, sizeof(wfd_t), wfd);
-    wfd->file = fp;
+    wfd->file_in = fp_in;
+    wfd->file_out = fp_out;
 
     switch (pid = fork(), pid) {
     case -1:
@@ -180,40 +199,38 @@ wfd_t * wpopenv(const char * path, char * const * argv, int flags) {
             _exit(127);
         }
 
-        int fd = open("/dev/null", O_RDWR, 0);
+        int fd_null = open("/dev/null", O_RDWR, 0);
 
-        if (fd < 0) {
+        if (fd_null < 0) {
             merror_exit(FOPEN_ERROR, "/dev/null", errno, strerror(errno));
         }
 
-        if (flags & (W_BIND_STDOUT | W_BIND_STDERR | W_BIND_STDIN)) {
-            if (flags & W_BIND_STDOUT) {
-                dup2(pipe_fd[1], STDOUT_FILENO);
-            } else {
-                dup2(fd, STDOUT_FILENO);
-            }
-
-            if (flags & W_BIND_STDERR) {
-                dup2(pipe_fd[1], STDERR_FILENO);
-            } else {
-                dup2(fd, STDERR_FILENO);
-            }
-
-            if (flags & W_BIND_STDIN) {
-                dup2(pipe_fd[0], STDIN_FILENO);
-            } else {
-                dup2(fd, STDIN_FILENO);
-            }
-
-            close(pipe_fd[0]);
-            close(pipe_fd[1]);
+        if (flags & W_BIND_STDOUT) {
+            dup2(pipe_out[1], STDOUT_FILENO);
         } else {
-            dup2(fd, STDOUT_FILENO);
-            dup2(fd, STDERR_FILENO);
-            dup2(fd, STDIN_FILENO);
+            dup2(fd_null, STDOUT_FILENO);
         }
 
-        close(fd);
+        if (flags & W_BIND_STDERR) {
+            dup2(pipe_out[1], STDERR_FILENO);
+        } else {
+            dup2(fd_null, STDERR_FILENO);
+        }
+
+        if (flags & (W_BIND_STDOUT | W_BIND_STDERR)) {
+            close(pipe_out[0]); // Used by parent process.
+            close(pipe_out[1]); // Already duplicated.
+        }
+
+        if (flags & W_BIND_STDIN) {
+            dup2(pipe_in[0], STDIN_FILENO);
+            close(pipe_in[0]);  // Already duplicated.
+            close(pipe_in[1]);  // Used by parent process.
+        } else {
+            dup2(fd_null, STDIN_FILENO);
+        }
+
+        close(fd_null);
         setsid();
         execvp(path, argv);
         _exit(127);
@@ -222,11 +239,11 @@ wfd_t * wpopenv(const char * path, char * const * argv, int flags) {
         // Parent code
 
         if (flags & (W_BIND_STDOUT | W_BIND_STDERR)) {
-            close(pipe_fd[1]);
+            close(pipe_out[1]);
         }
 
         if (flags & W_BIND_STDIN) {
-            close(pipe_fd[0]);
+            close(pipe_in[0]);
         }
 
         wfd->pid = pid;
@@ -235,10 +252,14 @@ wfd_t * wpopenv(const char * path, char * const * argv, int flags) {
 
     // Error
 
-    if (flags & (W_BIND_STDOUT | W_BIND_STDERR | W_BIND_STDIN)) {
-        fclose(wfd->file);
-        close(pipe_fd[0]);
-        close(pipe_fd[1]);
+    if (flags & (W_BIND_STDOUT | W_BIND_STDERR)) {
+        fclose(fp_out);
+        close(pipe_out[1]);
+    }
+
+    if (flags & W_BIND_STDIN) {
+        fclose(fp_in);
+        close(pipe_in[0]);
     }
 
     free(wfd);
@@ -278,8 +299,12 @@ wfd_t * wpopenl(const char * path, int flags, ...) {
 int wpclose(wfd_t * wfd) {
     int wstatus;
 
-    if (wfd->file) {
-        fclose(wfd->file);
+    if (wfd->file_in) {
+        fclose(wfd->file_in);
+    }
+
+    if (wfd->file_out) {
+        fclose(wfd->file_out);
     }
 
 #ifdef WIN32

--- a/src/unit_tests/shared/test_audit_op.c
+++ b/src/unit_tests/shared/test_audit_op.c
@@ -239,16 +239,16 @@ static void test_audit_clean_path(void **state) {
 
 static void test_audit_restart(void **state) {
     wfd_t * wfd = *state;
-    wfd->file = (FILE*) 1234;
+    wfd->file_out = (FILE*) 1234;
 
     will_return(__wrap_wpopenv, wfd);
 
-    expect_value(__wrap_fgets, __stream, wfd->file);
+    expect_value(__wrap_fgets, __stream, wfd->file_out);
     will_return(__wrap_fgets, "test");
 
     expect_string(__wrap__mdebug1, formatted_msg, "auditd: test");
 
-    expect_value(__wrap_fgets, __stream, wfd->file);
+    expect_value(__wrap_fgets, __stream, wfd->file_out);
     will_return(__wrap_fgets, NULL);
 
     will_return(__wrap_wpclose, 0);
@@ -270,16 +270,16 @@ static void test_audit_restart_open_error(void **state) {
 
 static void test_audit_restart_close_exec_error(void **state) {
     wfd_t * wfd = *state;
-    wfd->file = (FILE*) 1234;
+    wfd->file_out = (FILE*) 1234;
 
     will_return(__wrap_wpopenv, wfd);
 
-    expect_value(__wrap_fgets, __stream, wfd->file);
+    expect_value(__wrap_fgets, __stream, wfd->file_out);
     will_return(__wrap_fgets, "test");
 
     expect_string(__wrap__mdebug1, formatted_msg, "auditd: test");
 
-    expect_value(__wrap_fgets, __stream, wfd->file);
+    expect_value(__wrap_fgets, __stream, wfd->file_out);
     will_return(__wrap_fgets, NULL);
 
     will_return(__wrap_wpclose, 0x7f00);
@@ -293,16 +293,16 @@ static void test_audit_restart_close_exec_error(void **state) {
 
 static void test_audit_restart_close_error(void **state) {
     wfd_t * wfd = *state;
-    wfd->file = (FILE*) 1234;
+    wfd->file_out = (FILE*) 1234;
 
     will_return(__wrap_wpopenv, wfd);
 
-    expect_value(__wrap_fgets, __stream, wfd->file);
+    expect_value(__wrap_fgets, __stream, wfd->file_out);
     will_return(__wrap_fgets, "test");
 
     expect_string(__wrap__mdebug1, formatted_msg, "auditd: test");
 
-    expect_value(__wrap_fgets, __stream, wfd->file);
+    expect_value(__wrap_fgets, __stream, wfd->file_out);
     will_return(__wrap_fgets, NULL);
 
     will_return(__wrap_wpclose, 0xff00);

--- a/src/wazuh_modules/wm_docker.c
+++ b/src/wazuh_modules/wm_docker.c
@@ -78,7 +78,7 @@ void* wm_docker_main(wm_docker_t *docker_conf) {
 
         char buffer[4096];
 
-        while (fgets(buffer, sizeof(buffer), wfd->file)) {
+        while (fgets(buffer, sizeof(buffer), wfd->file_out)) {
             char * end = strchr(buffer, '\n');
             if (end) {
                 *end = '\0';

--- a/src/wazuh_modules/wm_keyrequest.c
+++ b/src/wazuh_modules/wm_keyrequest.c
@@ -505,7 +505,7 @@ void * w_socket_launcher(void * args) {
 
         // Pick stderr
 
-        while (fgets(buffer, sizeof(buffer), wfd->file)) {
+        while (fgets(buffer, sizeof(buffer), wfd->file_out)) {
 
             // Remove newline
 

--- a/src/wazuh_modules/wm_osquery_monitor.c
+++ b/src/wazuh_modules/wm_osquery_monitor.c
@@ -315,7 +315,7 @@ void *Execute_Osquery(wm_osquery_monitor_t *osquery)
 
         // Get stderr
 
-        while (fgets(buffer, sizeof(buffer), wfd->file)) {
+        while (fgets(buffer, sizeof(buffer), wfd->file_out)) {
             // Filter Bash colors: \e[*m
             text = buffer[0] == '\e' && buffer[1] == '[' && (end = strchr(buffer + 2, 'm'), end) ? end + 1 : buffer;
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #9383|

Until now, the `wpopen` function family (`wpopenl` and `wpopenv`) only allowed one-way communication, either:
- From the caller to the subprocess (`W_BIND_STDIN`).
- From the subprocess to the caller (`W_BIND_STDOUT` and `W_BIND_STDERR`). Both flags are allowed together.

This PR aims to extend `wpopen` to let the caller to use both input and output at the same time. We're replacing the member `file` with:
- `file_in`, connected to the subprocess' standard input, when `W_BIND_STDIN` enabled.
- `file_out`, connected to the subprocess' standard input and/or error stream, when `W_BIND_STDOUT` and/or `W_BIND_STDERR` enabled.

### Remarks

The pipe communication is full-buffered, meaning that writing `\n` into `file_in` may not flush the buffer. We should use `fflush(wfd->file_in)` after a write operation if we're interleaving read and write operations.

## Tests

- [X] Build manager for Linux.
- [X] Build agent for Windows.
- [X] Run unit tests on Linux.
- [X] Run unit tests for Windows.
- [X] Run Execd on Valgrind and deliver valid and invalid AR requests.
- [X] Deliver valid and invalid AR requests to an agent running on Windows.
- [X] Run a Coverity scan.
- [X] PoC to test the new implementation of `wpopen`.

### Unit tests for Linux manager

```
100% tests passed, 0 tests failed out of 42
```

### Unit tests for Windows agent

```
100% tests passed, 0 tests failed out of 123
```

### Valgrind

<details><summary>Valgrind report</summary>

```
==22403== FILE DESCRIPTORS: 7 open at exit.
==22403== Open AF_UNIX socket 6: queue/sockets/com
==22403==    at 0x50EF90B: socket (syscall-template.S:78)
==22403==    by 0x136598: OS_BindUnixDomain (os_net.c:153)
==22403==    by 0x11C60E: wcom_main (wcom.c:396)
==22403==    by 0x4FB2608: start_thread (pthread_create.c:477)
==22403==    by 0x50EE292: clone (clone.S:95)
==22403==
==22403== Open AF_UNIX socket 5: queue/alerts/execq
==22403==    at 0x50EF90B: socket (syscall-template.S:78)
==22403==    by 0x136598: OS_BindUnixDomain (os_net.c:153)
==22403==    by 0x12E2E0: StartMQ (mq_op.c:24)
==22403==    by 0x11D37A: main (execd.c:225)
==22403==
==22403== Open file descriptor 4: /proc/stat
==22403==    at 0x4FBDA5B: open (open64.c:48)
==22403==    by 0x494AE8F: init_libproc (in /var/ossec/lib/libwazuhext.so)
==22403==    by 0x4011B89: call_init.part.0 (dl-init.c:72)
==22403==    by 0x4011C90: call_init (dl-init.c:30)
==22403==    by 0x4011C90: _dl_init (dl-init.c:119)
==22403==    by 0x4001139: ??? (in /usr/lib/x86_64-linux-gnu/ld-2.31.so)
==22403==    by 0x1: ???
==22403==    by 0x1FFF00043A: ???
==22403==    by 0x1FFF00044A: ???
==22403==
==22403== Open file descriptor 3: /proc/uptime
==22403==    at 0x4FBDA5B: open (open64.c:48)
==22403==    by 0x494AE3B: init_libproc (in /var/ossec/lib/libwazuhext.so)
==22403==    by 0x4011B89: call_init.part.0 (dl-init.c:72)
==22403==    by 0x4011C90: call_init (dl-init.c:30)
==22403==    by 0x4011C90: _dl_init (dl-init.c:119)
==22403==    by 0x4001139: ??? (in /usr/lib/x86_64-linux-gnu/ld-2.31.so)
==22403==    by 0x1: ???
==22403==    by 0x1FFF00043A: ???
==22403==    by 0x1FFF00044A: ???
==22403==
==22403== Open file descriptor 2: /dev/pts/0
==22403==    <inherited from parent>
==22403==
==22403== Open file descriptor 1: /dev/pts/0
==22403==    <inherited from parent>
==22403==
==22403== Open file descriptor 0: /dev/pts/0
==22403==    <inherited from parent>
==22403==
==22403==
==22403== HEAP SUMMARY:
==22403==     in use at exit: 416 bytes in 2 blocks
==22403==   total heap usage: 7,715 allocs, 7,713 frees, 30,154,042 bytes allocated
==22403==
==22403== 144 bytes in 1 blocks are still reachable in loss record 1 of 2
==22403==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==22403==    by 0x125C15: OSList_Create (list_op.c:22)
==22403==    by 0x11D543: ExecdStart (execd.c:289)
==22403==    by 0x11D3C9: main (execd.c:230)
==22403==
==22403== 272 bytes in 1 blocks are possibly lost in loss record 2 of 2
==22403==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==22403==    by 0x40149CA: allocate_dtv (dl-tls.c:286)
==22403==    by 0x40149CA: _dl_allocate_tls (dl-tls.c:532)
==22403==    by 0x4FB3322: allocate_stack (allocatestack.c:622)
==22403==    by 0x4FB3322: pthread_create@@GLIBC_2.2.5 (pthread_create.c:660)
==22403==    by 0x11FF67: CreateThreadJoinable (pthreads_op.c:47)
==22403==    by 0x11D309: main (execd.c:211)
==22403==
==22403== LEAK SUMMARY:
==22403==    definitely lost: 0 bytes in 0 blocks
==22403==    indirectly lost: 0 bytes in 0 blocks
==22403==      possibly lost: 272 bytes in 1 blocks
==22403==    still reachable: 144 bytes in 1 blocks
==22403==         suppressed: 0 bytes in 0 blocks
==22403==
==22403== For lists of detected and suppressed errors, rerun with: -s
==22403== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

</details>

### Proof of concept

#### Caller (using `wpopen`)

<details><summary>test.c</summary>

```c
#include <stdio.h>
#include <stdlib.h>
#include <signal.h>
#include "headers/exec_op.h"
​
int main(int argc, char ** argv) {
    if (argc < 2) {
        return EXIT_FAILURE;
    }
​
    wfd_t * wfd = wpopenl(argv[1], W_BIND_STDIN | W_BIND_STDOUT, argv[1]);
​
    if (wfd == NULL) {
        fprintf(stderr, "wpopen() failed.\n");
        return EXIT_FAILURE;
    }
​
    signal(SIGPIPE, SIG_IGN);
​
    char buffer[1024];
​
    fprintf(wfd->file_in, "Hello world.\n");
    fflush(wfd->file_in);
    printf("Received: %s", fgets(buffer, sizeof(buffer), wfd->file_out) ? buffer : "(None)\n");
​
    fprintf(wfd->file_in, "Hola mundo.\n");
    fflush(wfd->file_in);
    printf("Received: %s", fgets(buffer, sizeof(buffer), wfd->file_out) ? buffer : "(None)\n");
​
    fprintf(wfd->file_in, "Ciao mondo.\n");
    fflush(wfd->file_in);
    printf("Received: %s", fgets(buffer, sizeof(buffer), wfd->file_out) ? buffer : "(None)\n");
​
    int r = wpclose(wfd);
    printf("Exit code: %d.\n", r);
    return EXIT_SUCCESS;
}
```

</details>

#### Callee

<details><summary>test.py</summary>

```python
#! /usr/bin/python3
​
while True:
    try:
        s = input()
    except EOFError:
        exit(0)
​
    print(s)
```

</details>
