### PR TITLE
Refactored API's rootcheck and syscheck SDK code to make it clearer.

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -12385,7 +12385,7 @@ paths:
       tags:
         - Syscheck
       summary: "Clear results"
-      description: "Clear file integrity monitoring scan results for a specified agent"
+      description: "Clear file integrity monitoring scan results for a specified agent. Only available for agents < 3.12.0, it doesn't apply for more recent ones"
       operationId: api.controllers.syscheck_controller.delete_syscheck_agent
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/syscheck:clear'

--- a/api/test/integration/test_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_experimental_endpoints.tavern.yaml
@@ -77,25 +77,26 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 2
         data:
           affected_items:
-            - '000'
-            - '001'
-            - '002'
-            - '003'
-            - '004'
-            - '005'
-            - '006'
-            - '007'
-            - '008'
-            - '009'
-            - '010'
-            - '011'
-            - '012'
-          failed_items: []
-          total_affected_items: 13
-          total_failed_items: 0
+              - '009'
+              - '010'
+          failed_items:
+            - error:
+                code: 1760
+              id:
+                - '000'
+                - '001'
+                - '002'
+                - '003'
+                - '004'
+                - '005'
+                - '006'
+                - '007'
+                - '008'
+          total_affected_items: 2
+          total_failed_items: 11
 
   - name: Request
     request:
@@ -109,16 +110,19 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 1
         data:
-          affected_items:
-            - '001'
-            - '003'
-            - '005'
-            - '007'
-          failed_items: []
-          total_affected_items: 4
-          total_failed_items: 0
+          affected_items: []
+          failed_items:
+            - error:
+                code: 1760
+              id:
+                - '001'
+                - '003'
+                - '005'
+                - '007'
+          total_affected_items: 0
+          total_failed_items: 4
 
 ---
 test_name: GET /experimental/ciscat/results

--- a/api/test/integration/test_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_experimental_endpoints.tavern.yaml
@@ -65,7 +65,7 @@ test_name: DELETE /experimental/syscheck
 
 stages:
 
-  - name: Request
+  - name: Try to delete syscheck scans (Some failed, agents are newer than expected)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/experimental/syscheck"
@@ -98,7 +98,7 @@ stages:
           total_affected_items: 2
           total_failed_items: 11
 
-  - name: Request
+  - name: Try to delete syscheck scans (Failed, agents are newer than expected)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/experimental/syscheck"

--- a/api/test/integration/test_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_experimental_endpoints.tavern.yaml
@@ -77,26 +77,14 @@ stages:
     response:
       status_code: 200
       json:
-        error: 2
+        error: 0
         data:
           affected_items:
               - '009'
               - '010'
-          failed_items:
-            - error:
-                code: 1760
-              id:
-                - '000'
-                - '001'
-                - '002'
-                - '003'
-                - '004'
-                - '005'
-                - '006'
-                - '007'
-                - '008'
+          failed_items: []
           total_affected_items: 2
-          total_failed_items: 11
+          total_failed_items: 0
 
   - name: Try to delete syscheck scans (Failed, agents are newer than expected)
     request:

--- a/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
@@ -106,17 +106,20 @@ stages:
     response:
       status_code: 200
       json:
-        error: 0
+        error: 1
         data:
-          affected_items:
-            - '000'
-            - '002'
-            - '004'
-            - '006'
-            - '008'
-          failed_items: []
-          total_affected_items: 5
-          total_failed_items: 0
+          affected_items: []
+          failed_items:
+            - error:
+                code: 1760
+              id:
+                - '000'
+                - '002'
+                - '004'
+                - '006'
+                - '008'
+          total_affected_items: 0
+          total_failed_items: 5
 
   - name: Request a list of agents (Partially allowed, user aware)
     request:
@@ -130,19 +133,22 @@ stages:
     response:
       status_code: 200
       json:
-        error: 2
+        error: 1
         data:
-          affected_items:
-            - '002'
-            - '006'
+          affected_items: []
           failed_items:
+            - error:
+                code: 1760
+              id:
+                - '002'
+                - '006'
             - error:
                 code: 4000
               id:
                 - '001'
                 - '005'
-          total_affected_items: 2
-          total_failed_items: 2
+          total_affected_items: 0
+          total_failed_items: 4
 
 ---
 test_name: GET /experimental/ciscat/results

--- a/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
@@ -94,7 +94,7 @@ test_name: DELETE /experimental/syscheck
 
 stages:
 
-  - name: Request all agents (Partially allowed, user agnostic)
+  - name: Try to delete syscheck information of all agents (Denied, agents are newer than expected).
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/experimental/syscheck"
@@ -121,7 +121,7 @@ stages:
           total_affected_items: 0
           total_failed_items: 5
 
-  - name: Request a list of agents (Partially allowed, user aware)
+  - name: Try to delete syscheck information of a list of agents (Denied, agents are newer than expected or no permission)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/experimental/syscheck"

--- a/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
@@ -94,7 +94,7 @@ test_name: DELETE /experimental/syscheck
 
 stages:
 
-  - name: Try to delete syscheck information of all agents (Denied, agents are newer than expected).
+  - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/experimental/syscheck"
@@ -121,7 +121,7 @@ stages:
           total_affected_items: 0
           total_failed_items: 5
 
-  - name: Try to delete syscheck information of a list of agents (Denied, agents are newer than expected or no permission)
+  - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/experimental/syscheck"

--- a/api/test/integration/test_rbac_black_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_syscheck_endpoints.tavern.yaml
@@ -150,12 +150,16 @@ stages:
     response:
       status_code: 200
       json:
-        error: 0
+        error: 1
         data:
           affected_items: !anything
-          failed_items: []
-          total_affected_items: 1
-          total_failed_items: 0
+          failed_items:
+            - error:
+                code: 1760
+              id:
+                - '002'
+          total_affected_items: 0
+          total_failed_items: 1
 
   - name: Try to delete syscheck scans in agent 001 (Deny)
     request:

--- a/api/test/integration/test_rbac_black_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_syscheck_endpoints.tavern.yaml
@@ -140,7 +140,7 @@ test_name: DELETE /syscheck
 
 stages:
 
-  - name: Try to delete syscheck scans in agent 002 (Allow)
+  - name: Try to delete syscheck scans in agent 002 (Failed, agent is newer than expected)
     request:
       verify: False
       method: DELETE

--- a/api/test/integration/test_rbac_black_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_syscheck_endpoints.tavern.yaml
@@ -140,7 +140,7 @@ test_name: DELETE /syscheck
 
 stages:
 
-  - name: Try to delete syscheck scans in agent 002 (Failed, agent is newer than expected)
+  - name: Try to delete syscheck scans in agent 002 (Allow)
     request:
       verify: False
       method: DELETE

--- a/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
@@ -106,16 +106,19 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 1
         data:
-          affected_items:
-            - '001'
-            - '003'
-            - '005'
-            - '007'
-          failed_items: []
-          total_affected_items: 4
-          total_failed_items: 0
+          affected_items: []
+          failed_items:
+            - error:
+                code: 1760
+              id:
+                - '001'
+                - '003'
+                - '005'
+                - '007'
+          total_affected_items: 0
+          total_failed_items: 4
 
   - name: Request a list of agents (Partially allowed, user aware)
     request:
@@ -131,17 +134,20 @@ stages:
       json:
         error: !anyint
         data:
-          affected_items:
-            - '001'
-            - '005'
+          affected_items: []
           failed_items:
+            - error:
+                code: 1760
+              id:
+                - '001'
+                - '005'
             - error:
                 code: 4000
               id:
                 - '002'
                 - '006'
-          total_affected_items: 2
-          total_failed_items: 2
+          total_affected_items: 0
+          total_failed_items: 4
 
 ---
 test_name: GET /experimental/ciscat/results

--- a/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
@@ -94,7 +94,7 @@ test_name: DELETE /experimental/syscheck
 
 stages:
 
-  - name: Request all agents (Partially allowed, user agnostic)
+  - name: Try to delete syscheck scans in all agents (Failed, agents are newer than expected)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/experimental/syscheck"
@@ -120,7 +120,7 @@ stages:
           total_affected_items: 0
           total_failed_items: 4
 
-  - name: Request a list of agents (Partially allowed, user aware)
+  - name: Try to delete syscheck scans in agent list (Failed, agents are newer than expected or denied)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/experimental/syscheck"

--- a/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
@@ -94,7 +94,7 @@ test_name: DELETE /experimental/syscheck
 
 stages:
 
-  - name: Try to delete syscheck scans in all agents (Failed, agents are newer than expected)
+  - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/experimental/syscheck"
@@ -120,7 +120,7 @@ stages:
           total_affected_items: 0
           total_failed_items: 4
 
-  - name: Try to delete syscheck scans in agent list (Failed, agents are newer than expected or denied)
+  - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/experimental/syscheck"

--- a/api/test/integration/test_rbac_white_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_syscheck_endpoints.tavern.yaml
@@ -145,12 +145,16 @@ stages:
     response:
       status_code: 200
       json:
-        error: 0
+        error: 1
         data:
           affected_items: !anything
-          failed_items: []
-          total_affected_items: 1
-          total_failed_items: 0
+          failed_items:
+            - error:
+                code: 1760
+              id:
+                - '001'
+          total_affected_items: 0
+          total_failed_items: 1
 
   - name: Try to delete syscheck scans in agent 002 (Deny)
     request:

--- a/api/test/integration/test_rbac_white_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_syscheck_endpoints.tavern.yaml
@@ -135,7 +135,7 @@ test_name: DELETE /syscheck
 
 stages:
 
-  - name: Try to delete syscheck scans in agent 001 (Allow)
+  - name: Try to delete syscheck scans in agent 001 (Failed, agent is newer than expected)
     request:
       verify: False
       method: DELETE

--- a/api/test/integration/test_rbac_white_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_syscheck_endpoints.tavern.yaml
@@ -135,7 +135,7 @@ test_name: DELETE /syscheck
 
 stages:
 
-  - name: Try to delete syscheck scans in agent 001 (Failed, agent is newer than expected)
+  - name: Try to delete syscheck scans in agent 001 (Allow)
     request:
       verify: False
       method: DELETE

--- a/api/test/integration/test_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_syscheck_endpoints.tavern.yaml
@@ -995,13 +995,16 @@ stages:
     response:
       status_code: 200
       json:
-        error: 0
+        error: 1
         data:
           affected_items: !anything
-          failed_items: []
-          total_affected_items: 1
-          total_failed_items: 0
-
+          failed_items:
+            - error:
+                code: 1760
+              id:
+                - '001'
+          total_affected_items: 0
+          total_failed_items: 1
 ---
 test_name: PUT /syscheck
 

--- a/api/test/integration/test_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_syscheck_endpoints.tavern.yaml
@@ -985,7 +985,7 @@ test_name: DELETE /syscheck
 
 stages:
 
-  - name: Try to delete syscheck scans in agent 001
+  - name: Try to delete syscheck scans in agent 001 (Failed, agent is newer than expected)
     request:
       verify: False
       method: DELETE

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -339,6 +339,8 @@ class WazuhException(Exception):
                },
         1759: {'message': 'Timeout acquiring client.keys lock, another thread or process might be blocking it',
                },
+        1760: {'message': 'Feature only available for older agent versions, it doesn\'t apply for more recent ones.'
+               },
 
         # CDB List: 1800 - 1899
         1800: {'message': 'Bad format in CDB list {path}'},

--- a/framework/wazuh/core/rootcheck.py
+++ b/framework/wazuh/core/rootcheck.py
@@ -109,9 +109,5 @@ def last_scan(agent_id):
     return {'start': start, 'end': None if start is None else None if end is None or end < start else end}
 
 
-class WazuhDBRootcheckClear():
-    def __init__(self):
-        self.wdb_conn = WazuhDBConnection()
-
-    def delete_agent(self, agent: str) -> None:
-        self.wdb_conn.execute(f"agent {agent} rootcheck delete", delete=True)
+def rootcheck_delete_agent(agent: str, wdb_conn: WazuhDBConnection) -> None:
+    wdb_conn.execute(f"agent {agent} rootcheck delete", delete=True)

--- a/framework/wazuh/core/rootcheck.py
+++ b/framework/wazuh/core/rootcheck.py
@@ -3,7 +3,6 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from datetime import datetime
-
 from wazuh.core.agent import Agent
 from wazuh.core.common import date_format
 from wazuh.core.exception import WazuhException
@@ -57,7 +56,8 @@ class WazuhDBQueryRootcheck(WazuhDBQuery):
                      "'Starting syscheck scan.', 'Ending syscheck scan.'"
 
         if filter_status['value'] == 'all':
-            self.query += partial.format("'outstanding'", '>') + " UNION " + partial.format("'solved'", '<=') + log_not_in
+            self.query += partial.format("'outstanding'", '>') + " UNION " + partial.format("'solved'",
+                                                                                            '<=') + log_not_in
         elif filter_status['value'] == 'outstanding':
             self.query += partial.format("'outstanding'", '>') + log_not_in
         elif filter_status['value'] == 'solved':
@@ -107,3 +107,11 @@ def last_scan(agent_id):
     start = datetime.utcfromtimestamp(time).strftime(date_format) if time is not None else None
 
     return {'start': start, 'end': None if start is None else None if end is None or end < start else end}
+
+
+class WazuhDBRootcheckClear():
+    def __init__(self):
+        self.wdb_conn = WazuhDBConnection()
+
+    def delete_agent(self, agent: str) -> None:
+        self.wdb_conn.execute(f"agent {agent} rootcheck delete", delete=True)

--- a/framework/wazuh/core/syscheck.py
+++ b/framework/wazuh/core/syscheck.py
@@ -40,8 +40,3 @@ class WazuhDBQuerySyscheck(WazuhDBQuery):
 
 def syscheck_delete_agent(agent: str, wdb_conn: WazuhDBConnection) -> None:
     wdb_conn.execute(f"agent {agent} sql delete from fim_entry", delete=True)
-    # Update key fields which contains keys to value 000
-    wdb_conn.execute(f"agent {agent} sql update metadata set value = '000' "
-                     "where key like 'fim_db%'", update=True)
-    wdb_conn.execute(f"agent {agent} sql update metadata set value = '000' "
-                     "where key = 'syscheck-db-completed'", update=True)

--- a/framework/wazuh/core/syscheck.py
+++ b/framework/wazuh/core/syscheck.py
@@ -38,15 +38,11 @@ class WazuhDBQuerySyscheck(WazuhDBQuery):
         return super()._format_data_into_dictionary()
 
 
-class WazuhDBSyscheckClear():
-    def __init__(self):
-        self.wdb_conn = WazuhDBConnection()
-
-    def remove_agent(self, agent: str) -> None:
-        self.wdb_conn.execute(f"agent {agent} sql delete from fim_entry", delete=True)
-        # Update key fields which contains keys to value 000
-        self.wdb_conn.execute(f"agent {agent} sql update metadata set value = '000' "
-                              "where key like 'fim_db%'", update=True)
-        self.wdb_conn.execute(f"agent {agent} sql update metadata set value = '000' "
-                              "where key = 'syscheck-db-completed'", update=True)
-    
+def syscheck_delete_agent(agent: str, wdb_conn: WazuhDBConnection) -> None:
+    wdb_conn.execute(f"agent {agent} sql delete from fim_entry", delete=True)
+    # Update key fields which contains keys to value 000
+    wdb_conn.execute(f"agent {agent} sql update metadata set value = '000' "
+                     "where key like 'fim_db%'", update=True)
+    wdb_conn.execute(f"agent {agent} sql update metadata set value = '000' "
+                     "where key = 'syscheck-db-completed'", update=True)
+   

--- a/framework/wazuh/core/syscheck.py
+++ b/framework/wazuh/core/syscheck.py
@@ -3,8 +3,8 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GP
 
 from datetime import datetime
-
 from wazuh.core.utils import WazuhDBQuery, WazuhDBBackend, get_fields_to_nest, plain_dict_to_nested_dict
+from wazuh.core.wdb import WazuhDBConnection
 
 
 class WazuhDBQuerySyscheck(WazuhDBQuery):
@@ -36,3 +36,17 @@ class WazuhDBQuerySyscheck(WazuhDBQuery):
                           self._data]
 
         return super()._format_data_into_dictionary()
+
+
+class WazuhDBSyscheckClear():
+    def __init__(self):
+        self.wdb_conn = WazuhDBConnection()
+
+    def remove_agent(self, agent: str) -> None:
+        self.wdb_conn.execute(f"agent {agent} sql delete from fim_entry", delete=True)
+        # Update key fields which contains keys to value 000
+        self.wdb_conn.execute(f"agent {agent} sql update metadata set value = '000' "
+                              "where key like 'fim_db%'", update=True)
+        self.wdb_conn.execute(f"agent {agent} sql update metadata set value = '000' "
+                              "where key = 'syscheck-db-completed'", update=True)
+    

--- a/framework/wazuh/core/syscheck.py
+++ b/framework/wazuh/core/syscheck.py
@@ -45,4 +45,3 @@ def syscheck_delete_agent(agent: str, wdb_conn: WazuhDBConnection) -> None:
                      "where key like 'fim_db%'", update=True)
     wdb_conn.execute(f"agent {agent} sql update metadata set value = '000' "
                      "where key = 'syscheck-db-completed'", update=True)
-   

--- a/framework/wazuh/core/tests/test_rootcheck.py
+++ b/framework/wazuh/core/tests/test_rootcheck.py
@@ -182,7 +182,7 @@ remove_db(test_data_path)
 @pytest.mark.parametrize('agent', ['001', '002', '003'])
 @patch('wazuh.core.wdb.WazuhDBConnection')
 def test_rootcheck_delete_agent(mock_db_conn, agent):
-    """ Test if proper parameters are being sent to the wazuhdb socket
+    """Test if proper parameters are being sent to the wazuhdb socket.
 
     Parameters
     ----------

--- a/framework/wazuh/core/tests/test_rootcheck.py
+++ b/framework/wazuh/core/tests/test_rootcheck.py
@@ -161,9 +161,9 @@ def test_WazuhDBQueryRootcheck_format_data_into_dictionary(mock_info, mock_backe
                                            filters={'status': 'all', 'pci_dss': None, 'cis': None})
     test._add_select_to_query()
     test._data = [{'log': 'Testing', 'date_first': 1603645251, 'status': 'solved', 'date_last': 1603648851,
-         'cis': '2.3 Debian Linux', 'pci_dss': '4.1'}]
+                   'cis': '2.3 Debian Linux', 'pci_dss': '4.1'}]
     result = test._format_data_into_dictionary()
-    assert result['items'][0]['date_first'] == datetime.utcfromtimestamp(1603645251).strftime(date_format) and\
+    assert result['items'][0]['date_first'] == datetime.utcfromtimestamp(1603645251).strftime(date_format) and \
            result['items'][0]['date_last'] == datetime.utcfromtimestamp(1603648851).strftime(date_format)
 
 
@@ -177,3 +177,19 @@ def test_last_scan(mock_connect, mock_send, mock_info):
 
 
 remove_db(test_data_path)
+
+
+@pytest.mark.parametrize('agent', ['001', '002', '003'])
+@patch('wazuh.core.wdb.WazuhDBConnection')
+def test_rootcheck_delete_agent(mock_db_conn, agent):
+    """ Test if proper parameters are being sent to the wazuhdb socket
+
+    Parameters
+    ----------
+    agent : str
+        Agent whose information is being deleted from the db
+    mock_db_conn : WazuhDBConnection
+        Object used to send the delete message to the wazuhdb socket
+    """
+    rootcheck.rootcheck_delete_agent(agent, mock_db_conn)
+    mock_db_conn.execute.assert_called_with(f"agent {agent} rootcheck delete", delete=True)

--- a/framework/wazuh/core/tests/test_rootcheck.py
+++ b/framework/wazuh/core/tests/test_rootcheck.py
@@ -187,9 +187,9 @@ def test_rootcheck_delete_agent(mock_db_conn, agent):
     Parameters
     ----------
     agent : str
-        Agent whose information is being deleted from the db
+        Agent whose information is being deleted from the db.
     mock_db_conn : WazuhDBConnection
-        Object used to send the delete message to the wazuhdb socket
+        Object used to send the delete message to the wazuhdb socket.
     """
     rootcheck.rootcheck_delete_agent(agent, mock_db_conn)
     mock_db_conn.execute.assert_called_with(f"agent {agent} rootcheck delete", delete=True)

--- a/framework/wazuh/core/tests/test_syscheck.py
+++ b/framework/wazuh/core/tests/test_syscheck.py
@@ -45,3 +45,18 @@ def test_wazuh_db_syscheck_format_data_into_dictionary(mock_backend):
            result['items'][0]['module'] == 'api' and \
            result['items'][0]['date'] == datetime.utcfromtimestamp(1627893702) and \
            result['items'][0]['mtime'] == datetime.utcfromtimestamp(1627893600)
+
+
+@pytest.mark.parametrize('agent', ['001', '002', '003'])
+@patch('wazuh.core.wdb.WazuhDBConnection')
+def test_syscheck_delete_agent(mock_db_conn, agent):
+    """Test if proper parameters are being sent to the wdb socket.
+    Parameters
+    ----------
+    agent : str
+        Agent whose information is being deleted from the db.
+    mock_db_conn : WazuhDBConnection
+        Object used to send the delete message to the wazuhdb socket.
+    """
+    syscheck.syscheck_delete_agent(agent, mock_db_conn)
+    mock_db_conn.execute.assert_any_call(f"agent {agent} sql delete from fim_entry", delete=True)

--- a/framework/wazuh/core/tests/test_syscheck.py
+++ b/framework/wazuh/core/tests/test_syscheck.py
@@ -51,6 +51,7 @@ def test_wazuh_db_syscheck_format_data_into_dictionary(mock_backend):
 @patch('wazuh.core.wdb.WazuhDBConnection')
 def test_syscheck_delete_agent(mock_db_conn, agent):
     """Test if proper parameters are being sent to the wdb socket.
+
     Parameters
     ----------
     agent : str

--- a/framework/wazuh/rootcheck.py
+++ b/framework/wazuh/rootcheck.py
@@ -8,9 +8,8 @@ from wazuh import common
 from wazuh.core.agent import get_agents_info, get_rbac_filters, WazuhDBQueryAgents
 from wazuh.core.exception import WazuhError, WazuhResourceNotFound
 from wazuh.core.results import AffectedItemsWazuhResult
-from wazuh.core.rootcheck import WazuhDBQueryRootcheck, last_scan
+from wazuh.core.rootcheck import WazuhDBQueryRootcheck, last_scan, WazuhDBRootcheckClear
 from wazuh.core.wazuh_queue import WazuhQueue
-from wazuh.core.wdb import WazuhDBConnection
 from wazuh.rbac.decorators import expose_resources
 
 
@@ -81,7 +80,7 @@ def clear(agent_list=None):
                                       some_msg='Rootcheck database was not cleared on some agents',
                                       none_msg="No rootcheck database was cleared")
 
-    wdb_conn = WazuhDBConnection()
+    wdbq = WazuhDBRootcheckClear()
     system_agents = get_agents_info()
     agent_list = set(agent_list)
     not_found_agents = agent_list - system_agents
@@ -91,7 +90,7 @@ def clear(agent_list=None):
     eligible_agents = agent_list - not_found_agents
     for agent_id in eligible_agents:
         try:
-            wdb_conn.execute(f"agent {agent_id} rootcheck delete", delete=True)
+            wdbq.delete_agent(agent_id)
             result.affected_items.append(agent_id)
         except WazuhError as e:
             result.add_failed_item(id_=agent_id, error=e)

--- a/framework/wazuh/rootcheck.py
+++ b/framework/wazuh/rootcheck.py
@@ -3,13 +3,13 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from typing import Union
-
 from wazuh import common
 from wazuh.core.agent import get_agents_info, get_rbac_filters, WazuhDBQueryAgents
 from wazuh.core.exception import WazuhError, WazuhResourceNotFound
 from wazuh.core.results import AffectedItemsWazuhResult
-from wazuh.core.rootcheck import WazuhDBQueryRootcheck, last_scan, WazuhDBRootcheckClear
+from wazuh.core.rootcheck import WazuhDBQueryRootcheck, last_scan, rootcheck_delete_agent
 from wazuh.core.wazuh_queue import WazuhQueue
+from wazuh.core.wdb import WazuhDBConnection
 from wazuh.rbac.decorators import expose_resources
 
 
@@ -80,7 +80,7 @@ def clear(agent_list=None):
                                       some_msg='Rootcheck database was not cleared on some agents',
                                       none_msg="No rootcheck database was cleared")
 
-    wdbq = WazuhDBRootcheckClear()
+    wdb_conn = WazuhDBConnection()
     system_agents = get_agents_info()
     agent_list = set(agent_list)
     not_found_agents = agent_list - system_agents
@@ -90,7 +90,7 @@ def clear(agent_list=None):
     eligible_agents = agent_list - not_found_agents
     for agent_id in eligible_agents:
         try:
-            wdbq.delete_agent(agent_id)
+            rootcheck_delete_agent(agent_id, wdb_conn)
             result.affected_items.append(agent_id)
         except WazuhError as e:
             result.add_failed_item(id_=agent_id, error=e)

--- a/framework/wazuh/syscheck.py
+++ b/framework/wazuh/syscheck.py
@@ -85,17 +85,25 @@ def clear(agent_list=None):
 
     system_agents = get_agents_info()
     wdb_conn = None
-    for agent in agent_list:
-        if agent not in system_agents:
-            result.add_failed_item(id_=agent, error=WazuhResourceNotFound(1701))
+    for agent_id in agent_list:
+        if agent_id not in system_agents:
+            result.add_failed_item(id_=agent_id, error=WazuhResourceNotFound(1701))
         else:
-            try:
-                if wdb_conn is None:
-                    wdb_conn = WazuhDBConnection()
-                syscheck_delete_agent(agent, wdb_conn)
-                result.affected_items.append(agent)
-            except WazuhError as e:
-                result.add_failed_item(id_=agent, error=e)
+            agent = Agent(agent_id)
+            agent.load_info_from_db()
+            if agent.version is not None:
+                if WazuhVersion(agent.version) < WazuhVersion('v3.12.0'):
+                    try:
+                        if wdb_conn is None:
+                            wdb_conn = WazuhDBConnection()
+                        syscheck_delete_agent(agent_id, wdb_conn)
+                        result.affected_items.append(agent_id)
+                    except WazuhError as e:
+                        result.add_failed_item(id_=agent_id, error=e)
+                else:
+                    result.add_failed_item(id_=agent_id, error=WazuhError(1760))
+            else:
+                result.add_failed_item(id_=agent_id, error=WazuhError(1015))
 
     if wdb_conn is not None:
         wdb_conn.close()

--- a/framework/wazuh/syscheck.py
+++ b/framework/wazuh/syscheck.py
@@ -84,17 +84,21 @@ def clear(agent_list=None):
                                       none_msg="No syscheck database was cleared")
 
     system_agents = get_agents_info()
-    wdb_conn = WazuhDBConnection()
+    wdb_conn = None
     for agent in agent_list:
         if agent not in system_agents:
             result.add_failed_item(id_=agent, error=WazuhResourceNotFound(1701))
         else:
             try:
+                if wdb_conn is None:
+                    wdb_conn = WazuhDBConnection()
                 syscheck_delete_agent(agent, wdb_conn)
                 result.affected_items.append(agent)
             except WazuhError as e:
                 result.add_failed_item(id_=agent, error=e)
 
+    if wdb_conn is not None:
+        wdb_conn.close()
     result.affected_items.sort(key=int)
     result.total_affected_items = len(result.affected_items)
 

--- a/framework/wazuh/syscheck.py
+++ b/framework/wazuh/syscheck.py
@@ -101,7 +101,7 @@ def clear(agent_list=None):
                     except WazuhError as e:
                         result.add_failed_item(id_=agent_id, error=e)
                 else:
-                    result.add_failed_item(id_=agent_id, error=WazuhError(1760))
+                    result.add_failed_item(id_=agent_id, error=WazuhError(1760, extra_message="Only available for agents < v3.12.0."))
             else:
                 result.add_failed_item(id_=agent_id, error=WazuhError(1015))
 

--- a/framework/wazuh/syscheck.py
+++ b/framework/wazuh/syscheck.py
@@ -94,7 +94,7 @@ def clear(agent_list: list = None):
 
     for item in data['items']:
         agent_id = item['id']
-        agent_version = item['version']
+        agent_version = item.get('version', None)  # If the value was NULL in the DB the key might not exist
         if agent_version is not None:
             if WazuhVersion(agent_version) < WazuhVersion('v3.12.0'):
                 try:

--- a/framework/wazuh/syscheck.py
+++ b/framework/wazuh/syscheck.py
@@ -66,7 +66,7 @@ def run(agent_list: Union[str, None] = None) -> AffectedItemsWazuhResult:
 
 
 @expose_resources(actions=["syscheck:clear"], resources=["agent:id:{agent_list}"],
-                  post_proc_kwargs={'exclude_codes': [1760]})
+                  post_proc_kwargs={'exclude_codes': [1760, 1015]})
 def clear(agent_list: list = None):
     """Clear the syscheck database of the specified agents.
 

--- a/framework/wazuh/syscheck.py
+++ b/framework/wazuh/syscheck.py
@@ -65,7 +65,8 @@ def run(agent_list: Union[str, None] = None) -> AffectedItemsWazuhResult:
     return result
 
 
-@expose_resources(actions=["syscheck:clear"], resources=["agent:id:{agent_list}"])
+@expose_resources(actions=["syscheck:clear"], resources=["agent:id:{agent_list}"],
+                  post_proc_kwargs={'exclude_codes': [1760]})
 def clear(agent_list: list = None):
     """Clear the syscheck database of the specified agents.
 

--- a/framework/wazuh/tests/test_syscheck.py
+++ b/framework/wazuh/tests/test_syscheck.py
@@ -109,7 +109,8 @@ def test_syscheck_run(close_mock, send_mock, connect_mock, agent_init_mock, agen
 ])
 @patch('wazuh.core.wdb.WazuhDBConnection.__init__', return_value=None)
 @patch('wazuh.core.wdb.WazuhDBConnection.execute', return_value=None)
-def test_syscheck_clear(wdb_execute_mock, wdb_init_mock, agent_list, expected_result, agent_info_list):
+@patch('wazuh.core.wdb.WazuhDBConnection.close')
+def test_syscheck_clear(wdb_close_mock, wdb_execute_mock, wdb_init_mock, agent_list, expected_result, agent_info_list):
     """Test function `clear` from syscheck module.
 
     Parameters
@@ -131,6 +132,7 @@ def test_syscheck_clear(wdb_execute_mock, wdb_init_mock, agent_list, expected_re
         else:
             assert result.failed_items == expected_result['failed_items']
         assert result.total_failed_items == expected_result['total_failed_items']
+        wdb_close_mock.assert_called()
 
 
 @pytest.mark.parametrize('agent_list, expected_result, agent_info_list', [
@@ -138,7 +140,8 @@ def test_syscheck_clear(wdb_execute_mock, wdb_init_mock, agent_list, expected_re
 ])
 @patch('wazuh.core.wdb.WazuhDBConnection.__init__', return_value=None)
 @patch('wazuh.core.wdb.WazuhDBConnection.execute', side_effect=WazuhError(1000))
-def test_syscheck_clear_exception(execute_mock, wdb_init_mock, agent_list, expected_result, agent_info_list):
+@patch('wazuh.core.wdb.WazuhDBConnection.close')
+def test_syscheck_clear_exception(wdb_close_mock, execute_mock, wdb_init_mock, agent_list, expected_result, agent_info_list):
     """Test function `clear` from syscheck module.
 
     It will force an exception.


### PR DESCRIPTION
|Related issue|
|---|
|Closes #9300 |

Hello team!
To improve the usability of the API's SDK we thought about refactoring some functions that used queries to the Wazuh DB socket into the core of the API.
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Tests performed
### Unit tests
#### Framework
```
============================= test session starts ==============================
platform linux -- Python 3.9.6, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /home/gonzz/git/wazuh/framework
plugins: asyncio-0.15.1
collected 1595 items

framework/wazuh/core/cluster/dapi/tests/test_dapi.py ................... [  1%]
....                                                                     [  1%]
framework/wazuh/core/cluster/tests/test_cluster.py ...................   [  2%]
framework/wazuh/core/cluster/tests/test_common.py .......                [  3%]
framework/wazuh/core/cluster/tests/test_control.py .....                 [  3%]
framework/wazuh/core/cluster/tests/test_local_client.py .                [  3%]
framework/wazuh/core/cluster/tests/test_utils.py .......                 [  3%]
framework/wazuh/core/cluster/tests/test_worker.py .................      [  4%]
framework/wazuh/core/tests/test_active_response.py ..............        [  5%]
framework/wazuh/core/tests/test_agent.py ............................... [  7%]
........................................................................ [ 12%]
...............................................................          [ 16%]
framework/wazuh/core/tests/test_cdb_list.py ............................ [ 17%]
..........                                                               [ 18%]
framework/wazuh/core/tests/test_common.py .......                        [ 19%]
framework/wazuh/core/tests/test_configuration.py ....................... [ 20%]
.............                                                            [ 21%]
framework/wazuh/core/tests/test_decoder.py ................              [ 22%]
framework/wazuh/core/tests/test_input_validator.py ...                   [ 22%]
framework/wazuh/core/tests/test_logtest.py ..                            [ 22%]
framework/wazuh/core/tests/test_manager.py ...............               [ 23%]
framework/wazuh/core/tests/test_mitre.py .............                   [ 24%]
framework/wazuh/core/tests/test_pyDaemonModule.py .....                  [ 24%]
framework/wazuh/core/tests/test_results.py ............................. [ 26%]
...........                                                              [ 27%]
framework/wazuh/core/tests/test_rootcheck.py .............               [ 28%]
framework/wazuh/core/tests/test_rule.py ......................           [ 29%]
framework/wazuh/core/tests/test_stats.py ....                            [ 29%]
framework/wazuh/core/tests/test_syscheck.py ...                          [ 29%]
framework/wazuh/core/tests/test_syscollector.py ...                      [ 30%]
framework/wazuh/core/tests/test_utils.py ............................... [ 31%]
........................................................................ [ 36%]
........................................................................ [ 41%]
.....................................................                    [ 44%]
framework/wazuh/core/tests/test_vulnerability.py .                       [ 44%]
framework/wazuh/core/tests/test_wazuh_queue.py ..................        [ 45%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................     [ 46%]
framework/wazuh/core/tests/test_wdb.py ......................            [ 48%]
framework/wazuh/rbac/tests/test_auth_context.py ..                       [ 48%]
framework/wazuh/rbac/tests/test_decorators.py .......................... [ 49%]
........................................................................ [ 54%]
.......                                                                  [ 54%]
framework/wazuh/rbac/tests/test_default_configuration.py ............... [ 55%]
........................................                                 [ 58%]
framework/wazuh/rbac/tests/test_orm.py ................................. [ 60%]
.....................                                                    [ 61%]
framework/wazuh/rbac/tests/test_preprocessor.py ...........              [ 62%]
framework/wazuh/tests/test_active_response.py ............               [ 63%]
framework/wazuh/tests/test_agent.py .................................... [ 65%]
........................................................................ [ 69%]
.                                                                        [ 69%]
framework/wazuh/tests/test_cdb_list.py ................................. [ 72%]
....................                                                     [ 73%]
framework/wazuh/tests/test_ciscat.py .................................   [ 75%]
framework/wazuh/tests/test_cluster.py .......                            [ 75%]
framework/wazuh/tests/test_decoder.py .................................. [ 77%]
.                                                                        [ 77%]
framework/wazuh/tests/test_group.py ........                             [ 78%]
framework/wazuh/tests/test_logtest.py ......                             [ 78%]
framework/wazuh/tests/test_manager.py .................................. [ 81%]
..                                                                       [ 81%]
framework/wazuh/tests/test_mitre.py .......                              [ 81%]
framework/wazuh/tests/test_rootcheck.py ................................ [ 83%]
..................                                                       [ 84%]
framework/wazuh/tests/test_rule.py ..................................... [ 87%]
...................                                                      [ 88%]
framework/wazuh/tests/test_sca.py .......                                [ 88%]
framework/wazuh/tests/test_security.py ................................. [ 90%]
...........................................                              [ 93%]
framework/wazuh/tests/test_stats.py ................                     [ 94%]
framework/wazuh/tests/test_syscheck.py .......................           [ 95%]
framework/wazuh/tests/test_syscollector.py ............                  [ 96%]
framework/wazuh/tests/test_task.py ............................          [ 98%]
framework/wazuh/tests/test_vulnerability.py ..........................   [100%]

================ 1595 passed, 14 warnings in 164.18s (0:02:44) =================
```
#### API
```
============================= test session starts ==============================
platform linux -- Python 3.9.6, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /home/gonzz/git/wazuh/api
plugins: asyncio-0.15.1
collected 238 items

api/api/models/test/test_model.py ............                           [  5%]
api/api/test/test_alogging.py ..........                                 [  9%]
api/api/test/test_authentication.py ..........                           [ 13%]
api/api/test/test_configuration.py ..................................... [ 28%]
.....                                                                    [ 31%]
api/api/test/test_util.py ...................................            [ 45%]
api/api/test/test_validator.py ......................................... [ 63%]
........................................................................ [ 93%]
................                                                         [100%]

======================= 238 passed, 14 warnings in 0.84s =======================
```

### Integration tests
```
Collected tests [6]:
test_rbac_black_rootcheck_endpoints.tavern.yaml, test_rbac_black_syscheck_endpoints.tavern.yaml, test_rbac_white_rootcheck_endpoints.tavern.yaml, test_rbac_white_syscheck_endpoints.tavern.yaml, test_rootcheck_endpoints.tavern.yaml, test_syscheck_endpoints.tavern.yaml


test_rbac_black_rootcheck_endpoints.tavern.yaml 
	 4 passed, 1 warnings

test_rbac_black_syscheck_endpoints.tavern.yaml 
	 4 passed, 1 warnings

test_rbac_white_rootcheck_endpoints.tavern.yaml 
	 4 passed, 1 warnings

test_rbac_white_syscheck_endpoints.tavern.yaml 
	 4 passed, 1 warnings

test_rootcheck_endpoints.tavern.yaml 
	 4 passed, 1 warnings

test_syscheck_endpoints.tavern.yaml 
	 35 passed, 1 warnings
```

Regards, 
Gonzalo.