### PR TITLE
Refactor agent sync endpoint to admit list of agents

### DIFF
--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -342,18 +342,24 @@ async def delete_single_agent_multiple_groups(request, agent_id, groups_list=Non
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
-async def get_sync_agent(request, agent_id, pretty=False, wait_for_complete=False):
-    """Get agent configuration sync status.
+async def get_sync_agent(request, agents_list: list = None, pretty: bool = False,
+                         wait_for_complete: bool = False) -> web.Response:
+    """Get agents configuration sync status.
 
-    Returns whether the agent configuration has been synchronized with the agent
-    or not. This can be useful to check after updating a group configuration.
+    Parameters
+    ----------
+    agents_list : list
+        List of agent's IDs. All possible values from 000 onwards.
+    pretty : bool
+        Show results in human-readable format.
+    wait_for_complete : bool
+        Disable timeout response.
 
-    :param agent_id: Agent ID. All possible values from 000 onwards.
-    :param pretty: Show results in human-readable format
-    :param wait_for_complete: Disable timeout responseç
-    :return: AgentSync
+    Returns
+    -------
+    Response
     """
-    f_kwargs = {'agent_list': [agent_id]}
+    f_kwargs = {'agent_list': agents_list}
 
     dapi = DistributedAPI(f=agent.get_agents_sync_group,
                           f_kwargs=remove_nones_to_dict(f_kwargs),

--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -342,24 +342,30 @@ async def delete_single_agent_multiple_groups(request, agent_id, groups_list=Non
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
-async def get_sync_agent(request, agents_list: list = None, pretty: bool = False,
-                         wait_for_complete: bool = False) -> web.Response:
+async def get_sync_agent(request, pretty: bool = False, wait_for_complete: bool = False, agents_list: list = None,
+                         offset=0, limit=database_limit) -> web.Response:
     """Get agents configuration sync status.
 
     Parameters
     ----------
-    agents_list : list
-        List of agent's IDs. All possible values from 000 onwards.
     pretty : bool
         Show results in human-readable format.
     wait_for_complete : bool
         Disable timeout response.
+    agents_list : list
+        List of agent's IDs. All possible values from 000 onwards.
+    offset : int
+        First element to return in the collection.
+    limit : int
+        Maximum number of elements to return.
 
     Returns
     -------
     Response
     """
-    f_kwargs = {'agent_list': agents_list}
+    f_kwargs = {'agent_list': agents_list,
+                'offset': offset,
+                'limit': limit}
 
     dapi = DistributedAPI(f=agent.get_agents_sync_group,
                           f_kwargs=remove_nones_to_dict(f_kwargs),

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -5848,12 +5848,12 @@ paths:
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
 
-  /agents/{agent_id}/group/is_sync:
+  /agents/group/is_sync:
     get:
       tags:
         - Agents
       summary: "Get configuration sync status"
-      description: "Return whether the agent configuration has been synchronized with the agent or not. This can be
+      description: "Return whether the agent configuration has been synchronized across a list of agents. This can be
       useful to check after updating a group configuration"
       operationId: api.controllers.agent_controller.get_sync_agent
       x-rbac-actions:
@@ -5861,7 +5861,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/pretty'
         - $ref: '#/components/parameters/wait_for_complete'
-        - $ref: '#/components/parameters/agent_id'
+        - $ref: '#/components/parameters/agents_list'
       responses:
         '200':
           description: "Get agent sync"
@@ -5877,11 +5877,15 @@ paths:
               example:
                 data:
                   affected_items:
-                    - id: '002'
+                    - id: '001'
                       synced: true
-                  total_affected_items: 1
+                    - id: '002'
+                      synced: False
+                    - id: '004'
+                      synced: true
+                  total_affected_items: 3
                   total_failed_items: 0
-                  failed_items: []
+                  failed_items: [ ]
                 message: 'Sync info was returned for all selected agents'
                 error: 0
         '400':

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -5853,7 +5853,7 @@ paths:
       tags:
         - Agents
       summary: "Get configuration sync status"
-      description: "Return whether the agent configuration has been synchronized across a list of agents. This can be
+      description: "Return whether group configurations have been synchronized across a list of agents. This can be
       useful to check after updating a group configuration"
       operationId: api.controllers.agent_controller.get_sync_agent
       x-rbac-actions:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -5862,6 +5862,8 @@ paths:
         - $ref: '#/components/parameters/pretty'
         - $ref: '#/components/parameters/wait_for_complete'
         - $ref: '#/components/parameters/agents_list'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/limit'
       responses:
         '200':
           description: "Get agent sync"

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -1973,6 +1973,56 @@ stages:
           total_affected_items: 12
           total_failed_items: 0
 
+  - name: Get agent sync (limit=2)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group/is_sync"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 2
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - id: '001'
+              synced: !anybool
+            - id: '002'
+              synced: !anybool
+          failed_items: []
+          total_affected_items: 12
+          total_failed_items: 0
+
+  - name: Get agent sync (limit=3, offset=5)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group/is_sync"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 3
+        offset: 5
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - id: '006'
+              synced: !anybool
+            - id: '007'
+              synced: !anybool
+            - id: '008'
+              synced: !anybool
+          failed_items: [ ]
+          total_affected_items: 12
+          total_failed_items: 0
+
+
 ---
 test_name: GET /agents/{agent_id}/key
 

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -1822,17 +1822,19 @@ stages:
         <<: *error_spec
 
 ---
-test_name: GET /agents/{agent_id}/group/is_sync
+test_name: GET /agents/group/is_sync
 
 stages:
 
   - name: Try to get sync of agent 000 (manager)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/group/is_sync"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group/is_sync"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
+      params:
+        agents_list: '000'
     response:
       status_code: 200
       json:
@@ -1850,10 +1852,12 @@ stages:
   - name: Try to get sync of a non existing agent
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/999/group/is_sync"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group/is_sync"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
+      params:
+        agents_list: '999'
     response:
       status_code: 200
       json:
@@ -1871,19 +1875,67 @@ stages:
   - name: Try get sync agent by name
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/bad_id/group/is_sync"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group/is_sync"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
+      params:
+        agents_list: 'bad_id'
     response:
       status_code: 400
       json:
         <<: *error_spec
 
-  - name: Get agent sync
+  - name: Get one agent sync
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/group/is_sync"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group/is_sync"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        agents_list: '001'
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - id: '001'
+              synced: !anybool
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+
+  - name: Get multiple agent sync
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group/is_sync"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        agents_list: '001,003,009'
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - id: '001'
+              synced: !anybool
+            - id: '003'
+              synced: !anybool
+            - id: '009'
+              synced: !anybool
+          failed_items: []
+          total_affected_items: 3
+          total_failed_items: 0
+
+  - name: Get all agent sync
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group/is_sync"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1895,8 +1947,30 @@ stages:
           affected_items:
             - id: '001'
               synced: !anybool
+            - id: '002'
+              synced: !anybool
+            - id: '003'
+              synced: !anybool
+            - id: '004'
+              synced: !anybool
+            - id: '005'
+              synced: !anybool
+            - id: '006'
+              synced: !anybool
+            - id: '007'
+              synced: !anybool
+            - id: '008'
+              synced: !anybool
+            - id: '009'
+              synced: !anybool
+            - id: '010'
+              synced: !anybool
+            - id: '011'
+              synced: !anybool
+            - id: '012'
+              synced: !anybool
           failed_items: []
-          total_affected_items: 1
+          total_affected_items: 12
           total_failed_items: 0
 
 ---

--- a/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
@@ -154,27 +154,31 @@ stages:
       status_code: 200
 
 ---
-test_name: GET /agents/{agent_id}/group/is_sync
+test_name: GET /agents/group/is_sync
 
 stages:
 
   - name: Try to get sync of agent 008 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/008/group/is_sync"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group/is_sync"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
+      params:
+        agents_list: '008'
     response:
       <<: *permission_denied
 
   - name: Get agent sync (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/007/group/is_sync"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group/is_sync"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
+      params:
+        agents_list: '007'
     response:
       status_code: 200
       json:
@@ -185,6 +189,35 @@ stages:
               synced: !anybool
           failed_items: []
           total_affected_items: 1
+          total_failed_items: 0
+
+  - name: Get all agent sync (Partially allowed, user agnostic)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group/is_sync"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - id: '001'
+              synced: !anybool
+            - id: '003'
+              synced: !anybool
+            - id: '005'
+              synced: !anybool
+            - id: '007'
+              synced: !anybool
+            - id: '009'
+              synced: False
+            - id: '011'
+              synced: False
+          failed_items: [ ]
+          total_affected_items: 6
           total_failed_items: 0
 
 ---

--- a/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
@@ -158,27 +158,31 @@ stages:
       status_code: 200
 
 ---
-test_name: GET /agents/{agent_id}/group/is_sync
+test_name: GET /agents/group/is_sync
 
 stages:
 
   - name: Try to get sync of agent 011 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/011/group/is_sync"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group/is_sync"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
+      params:
+        agents_list: '011'
     response:
       <<: *permission_denied
 
   - name: Get agent sync (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/008/group/is_sync"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group/is_sync"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
+      params:
+        agents_list: '008'
     response:
       status_code: 200
       json:
@@ -189,6 +193,35 @@ stages:
               synced: !anybool
           failed_items: []
           total_affected_items: 1
+          total_failed_items: 0
+
+  - name: Get all agent sync (Partially allowed, user agnostic)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group/is_sync"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - id: '002'
+              synced: !anybool
+            - id: '004'
+              synced: !anybool
+            - id: '006'
+              synced: !anybool
+            - id: '008'
+              synced: !anybool
+            - id: '010'
+              synced: False
+            - id: '012'
+              synced: False
+          failed_items: [ ]
+          total_affected_items: 6
           total_failed_items: 0
 
 ---

--- a/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
@@ -170,16 +170,18 @@ stages:
       <<: *permission_denied
 
 ---
-test_name: GET /agents/{agent_id}/group/is_sync
+test_name: GET /agents/group/is_sync
 
 stages:
   - name: Try to get agent sync
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/group/is_sync"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group/is_sync"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
+      params:
+        agents_list: '001'
     response:
       <<: *permission_denied
 

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -939,13 +939,17 @@ def get_agent_config(agent_list=None, component=None, config=None):
 
 @expose_resources(actions=["agent:read"], resources=["agent:id:{agent_list}"],
                   post_proc_kwargs={'exclude_codes': [1701, 1703]})
-def get_agents_sync_group(agent_list: list = None) -> AffectedItemsWazuhResult:
+def get_agents_sync_group(agent_list: list = None, offset=0, limit=common.database_limit) -> AffectedItemsWazuhResult:
     """Get agents configuration sync status.
 
     Parameters
     ----------
     agent_list : list
         List of agents ID's.
+    offset : int
+        First item to return.
+    limit : int
+        Maximum number of items to return.
 
     Returns
     -------
@@ -974,7 +978,7 @@ def get_agents_sync_group(agent_list: list = None) -> AffectedItemsWazuhResult:
 
         # Get information of all agents and their groups
         rbac_filters = get_rbac_filters(system_resources=system_agents, permitted_resources=agent_list)
-        db_query = WazuhDBQueryAgents(limit=None, select=["id", "group", "mergedSum"], **rbac_filters)
+        db_query = WazuhDBQueryAgents(limit=limit, offset=offset, select=["id", "group", "mergedSum"], **rbac_filters)
         data = db_query.run()
 
         for agent_info in data['items']:
@@ -1001,7 +1005,7 @@ def get_agents_sync_group(agent_list: list = None) -> AffectedItemsWazuhResult:
             except WazuhException as e:
                 result.add_failed_item(id_=agent_info['id'], error=e)
 
-        result.total_affected_items = len(result.affected_items)
+        result.total_affected_items = data['totalItems']
 
     return result
 

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -1303,7 +1303,7 @@ def get_rbac_filters(system_resources=None, permitted_resources=None, filters=No
     non_permitted_resources = system_resources - set(permitted_resources)
 
     if len(permitted_resources) < len(non_permitted_resources):
-        filters['rbac_ids'] = permitted_resources
+        filters['rbac_ids'] = list(permitted_resources)
         negate = False
     else:
         filters['rbac_ids'] = list(non_permitted_resources)

--- a/framework/wazuh/tests/data/security/rbac_catalog.yml
+++ b/framework/wazuh/tests/data/security/rbac_catalog.yml
@@ -94,7 +94,7 @@ get_rbac_actions:
         related_endpoints:
           - GET /agents
           - GET /agents/{agent_id}/config/{component}/{configuration}
-          - GET /agents/{agent_id}/group/is_sync
+          - GET /agents/group/is_sync
           - GET /agents/{agent_id}/key
           - GET /agents/{agent_id}/stats/{component}
           - GET /groups/{group_id}/agents

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -1196,7 +1196,7 @@ def test_agent_get_agent_config_exceptions(socket_mock, send_mock, agent_list):
 ])
 @patch('wazuh.core.common.shared_path', new=test_shared_path)
 @patch('wazuh.core.common.multi_groups_path', new=test_multigroup_path)
-@patch('wazuh.agent.get_agents_info', return_value=full_agent_list)
+@patch('wazuh.agent.get_agents_info', return_value=set(full_agent_list))
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
 def test_agent_get_agents_sync_group(socket_mock, send_mock, get_agent_mock, agent_list):
@@ -1218,9 +1218,10 @@ def test_agent_get_agents_sync_group(socket_mock, send_mock, get_agent_mock, age
     (['000'], WazuhError(1703)),
     (['100'], WazuhResourceNotFound(1701))
 ])
+@patch('wazuh.agent.get_agents_info', return_value=set(full_agent_list))
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
-def test_agent_get_agents_sync_group_exceptions(socket_mock, send_mock, agent_list, expected_error):
+def test_agent_get_agents_sync_group_exceptions(socket_mock, send_mock, get_agents_mock, agent_list, expected_error):
     """Test `get_agents_sync_group` function from agent module returns the expected exceptions when using invalid
     parameters.
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes #9334 |

## Description

Hi team,

I refactored the `GET /agents/{agent_id}/group/is_sync` according to what was requested in #9334. Now, it accepts a list of agents (`agents_list`) as a query parameter, instead of just one (`agent_id`). Therefore the endpoint path has been renamed to:
```
GET /agents/group/is_sync
```

And it accepts the following parameters:
- pretty
- wait_for_complete
- agents_list
- limit
- offset

The function to calculate the sync status of the agents ([get_agents_sync_group(agent_list=None)](https://github.com/wazuh/wazuh/blob/15dbea626f0d19f5ed56041b11495a36fd4b84d2/framework/wazuh/agent.py#L934-L972)) was already thought to admit a list, although the slowness of the responses when many agents are requested has forced me to refactor it. The key changes in this improvement have been: 
- Obtain from the database all the IDs, groups and mergedSum of the agents requested by the user at once, instead of asking for all the information of each agent one by one, as it was done until now. 
- Store the MD5 of each calculated file. The [function](https://github.com/wazuh/wazuh/blob/15dbea626f0d19f5ed56041b11495a36fd4b84d2/framework/wazuh/core/utils.py#L640-L645) that is used to calculate this value needs to open each `merged.mg` file and do other slow operations. Since many agents share the same group list, a lot of time can be saved by reusing the MD5 when it is the same file.

In this way, we can expect the following response times when getting the sync status of 50,000 agents at once:
- **Worst-case scenario:** Each of the 50,000 agents belongs to a different combination of groups. It can take up to **96.8 seconds** to get them all. 
- **Best-case scenario:** All the 50,000 agents belong to the same groups. The response time will be **1,6 - 2,3 seconds** for this number of agents.

The most common use case is much closer to the best-case scenario than the worst-case scenario. Also, the number of agents is typically lower in most environments. 

## Example output

> GET /agents/group/is_sync?agents_list=000,001,002,003,004,005,100000

```JSON
{
  "data": {
    "affected_items": [
      {
        "id": "001",
        "synced": true
      },
      {
        "id": "002",
        "synced": false
      },
      {
        "id": "004",
        "synced": false
      },
      {
        "id": "005",
        "synced": false
      }
    ],
    "total_affected_items": 4,
    "total_failed_items": 3,
    "failed_items": [
      {
        "error": {
          "code": 1701,
          "message": "Agent does not exist",
          "remediation": "Please, use `GET /agents?select=id,name` to find all available agents"
        },
        "id": [
          "100000"
        ]
      },
      {
        "error": {
          "code": 1703,
          "message": "Action not available for Manager (agent 000)",
          "remediation": "Please, use `GET /agents?select=id,name` to find all available agents and make sure you select an agent other than 000"
        },
        "id": [
          "000"
        ]
      },
      {
        "error": {
          "code": 4000,
          "message": "Permission denied: Resource type: agent:id",
          "remediation": "Please, make sure you have permissions to execute the current request. For more information on how to set up permissions, please visit https://documentation.wazuh.com/current/user-manual/api/rbac/configuration.html"
        },
        "id": [
          "003"
        ]
      }
    ]
  },
  "message": "Sync info was not returned for some selected agents",
  "error": 2
}
```

Regards,
Selu.