### PR TITLE
Add support for VPC endpoints usage in the AWS module

### DIFF
--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -32,6 +32,8 @@ static const char *XML_LOG_GROUP = "aws_log_groups";
 static const char *XML_REMOVE_LOG_STREAMS = "remove_log_streams";
 static const char *XML_DISCARD_FIELD = "field";
 static const char *XML_DISCARD_REGEX = "discard_regex";
+static const char *XML_STS_ENDPOINT = "sts_endpoint";
+static const char *XML_SERVICE_ENDPOINT = "service_endpoint";
 static const char *XML_BUCKET_TYPE = "type";
 static const char *XML_SERVICE_TYPE = "type";
 static const char *XML_BUCKET_NAME = "name";
@@ -291,6 +293,16 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                         } else {
                             mwarn("No value was provided for '%s'. No event will be skipped.", XML_DISCARD_REGEX);
                         }
+                    } else if (!strcmp(children[j]->element, XML_STS_ENDPOINT)) {
+                        if (strlen(children[j]->content) != 0) {
+                            free(cur_bucket->sts_endpoint);
+                            os_strdup(children[j]->content, cur_bucket->sts_endpoint);
+                        }
+                    } else if (!strcmp(children[j]->element, XML_SERVICE_ENDPOINT)) {
+                        if (strlen(children[j]->content) != 0) {
+                            free(cur_bucket->service_endpoint);
+                            os_strdup(children[j]->content, cur_bucket->service_endpoint);
+                        }
                     } else {
                         merror("No such child tag '%s' of bucket at module '%s'.", children[j]->element, WM_AWS_CONTEXT.name);
                         OS_ClearNode(children);
@@ -426,6 +438,16 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                         }
                     } else {
                         mwarn("No value was provided for '%s'. No event will be skipped.", XML_DISCARD_REGEX);
+                    }
+                } else if (!strcmp(children[j]->element, XML_STS_ENDPOINT)) {
+                    if (strlen(children[j]->content) != 0) {
+                        free(cur_service->sts_endpoint);
+                        os_strdup(children[j]->content, cur_service->sts_endpoint);
+                    }
+                } else if (!strcmp(children[j]->element, XML_SERVICE_ENDPOINT)) {
+                    if (strlen(children[j]->content) != 0) {
+                        free(cur_service->service_endpoint);
+                        os_strdup(children[j]->content, cur_service->service_endpoint);
                     }
                 } else {
                     merror("No such child tag '%s' of service at module '%s'.", children[j]->element, WM_AWS_CONTEXT.name);

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -203,6 +203,8 @@ cJSON *wm_aws_dump(const wm_aws *aws_config) {
             if (iter->remove_from_bucket) cJSON_AddStringToObject(buck,"remove_from_bucket","yes"); else cJSON_AddStringToObject(buck,"remove_from_bucket","no");
             if (iter->discard_field) cJSON_AddStringToObject(buck,"discard_field",iter->discard_field);
             if (iter->discard_regex) cJSON_AddStringToObject(buck,"discard_regex",iter->discard_regex);
+            if (iter->sts_endpoint) cJSON_AddStringToObject(buck,"sts_endpoint",iter->sts_endpoint);
+            if (iter->service_endpoint) cJSON_AddStringToObject(buck,"service_endpoint",iter->service_endpoint);
             cJSON_AddItemToArray(arr_buckets,buck);
         }
         if (cJSON_GetArraySize(arr_buckets) > 0) {
@@ -229,6 +231,8 @@ cJSON *wm_aws_dump(const wm_aws *aws_config) {
             if (iter->remove_log_streams) cJSON_AddStringToObject(service,"remove_log_streams","yes"); else cJSON_AddStringToObject(service,"remove_log_streams","no");
             if (iter->discard_field) cJSON_AddStringToObject(service,"discard_field",iter->discard_field);
             if (iter->discard_regex) cJSON_AddStringToObject(service,"discard_regex",iter->discard_regex);
+            if (iter->sts_endpoint) cJSON_AddStringToObject(service,"sts_endpoint",iter->sts_endpoint);
+            if (iter->service_endpoint) cJSON_AddStringToObject(service,"service_endpoint",iter->service_endpoint);
             cJSON_AddItemToArray(arr_services,service);
         }
         if (cJSON_GetArraySize(arr_services) > 0) {
@@ -379,6 +383,14 @@ void wm_aws_run_s3(wm_aws *aws_config, wm_aws_bucket *exec_bucket) {
     if (exec_bucket->discard_regex) {
         wm_strcat(&command, "--discard-regex", ' ');
         wm_strcat(&command, exec_bucket->discard_regex, ' ');
+    }
+    if (exec_bucket->sts_endpoint) {
+        wm_strcat(&command, "--sts_endpoint", ' ');
+        wm_strcat(&command, exec_bucket->sts_endpoint, ' ');
+    }
+    if (exec_bucket->service_endpoint) {
+        wm_strcat(&command, "--service_endpoint", ' ');
+        wm_strcat(&command, exec_bucket->service_endpoint, ' ');
     }
     if (exec_bucket->type) {
         wm_strcat(&command, "--type", ' ');
@@ -538,6 +550,14 @@ void wm_aws_run_service(wm_aws *aws_config, wm_aws_service *exec_service) {
     if (exec_service->discard_regex) {
         wm_strcat(&command, "--discard-regex", ' ');
         wm_strcat(&command, exec_service->discard_regex, ' ');
+    }
+    if (exec_service->sts_endpoint) {
+        wm_strcat(&command, "--sts_endpoint", ' ');
+        wm_strcat(&command, exec_service->sts_endpoint, ' ');
+    }
+    if (exec_service->service_endpoint) {
+        wm_strcat(&command, "--service_endpoint", ' ');
+        wm_strcat(&command, exec_service->service_endpoint, ' ');
     }
     if (isDebug()) {
         wm_strcat(&command, "--debug", ' ');

--- a/src/wazuh_modules/wm_aws.h
+++ b/src/wazuh_modules/wm_aws.h
@@ -38,6 +38,8 @@ typedef struct wm_aws_bucket {
     char *type;                         // String defining bucket type.
     char *discard_field;                // Name of the event's field to apply the discard_regex on
     char *discard_regex;                // REGEX to determine if an event should be skipped
+    char *sts_endpoint;                 // URL for the VPC endpoint to use to obtain the STS token
+    char *service_endpoint;             // URL for the VPC endpoint to use to obtain the logs
     unsigned int remove_from_bucket:1;  // Remove the logs from the bucket
     struct wm_aws_bucket *next;     // Pointer to next
 } wm_aws_bucket;
@@ -57,6 +59,8 @@ typedef struct wm_aws_service {
     char *discard_field;                // Name of the event's field to apply the discard_regex on
     char *discard_regex;                // REGEX to determine if an event should be skipped
     unsigned int remove_log_streams:1;  // Remove the log stream from the log group
+    char *sts_endpoint;                 // URL for the VPC endpoint to use to obtain the STS token
+    char *service_endpoint;             // URL for the VPC endpoint to use to obtain the logs
     struct wm_aws_service *next;     // Pointer to next
 } wm_aws_service;
 

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -79,7 +79,8 @@ class WazuhIntegration:
     """
 
     def __init__(self, access_key, secret_key, aws_profile, iam_role_arn,
-                 service_name=None, region=None, bucket=None, discard_field=None, discard_regex=None):
+                 service_name=None, region=None, bucket=None, discard_field=None,
+                 discard_regex=None, sts_endpoint=None, service_endpoint=None):
         # SQL queries
         self.sql_find_table_names = """
                             SELECT
@@ -152,7 +153,9 @@ class WazuhIntegration:
                                       iam_role_arn=iam_role_arn,
                                       service_name=service_name,
                                       bucket=bucket,
-                                      region=region
+                                      region=region,
+                                      sts_endpoint=sts_endpoint,
+                                      service_endpoint=service_endpoint
                                       )
 
         # db_name is an instance variable of subclass
@@ -215,7 +218,8 @@ class WazuhIntegration:
             elif 'trail_progress' in table:
                 self.db_connector.execute(self.sql_drop_table.format(table='trail_progress'))
 
-    def get_client(self, access_key, secret_key, profile, iam_role_arn, service_name, bucket, region=None):
+    def get_client(self, access_key, secret_key, profile, iam_role_arn, service_name, bucket, region=None,
+                   sts_endpoint=None, service_endpoint=None):
         conn_args = {}
 
         if access_key is not None and secret_key is not None:
@@ -234,11 +238,11 @@ class WazuhIntegration:
                 else None
 
         boto_session = boto3.Session(**conn_args)
-
+        service_name = "logs" if service_name == "cloudwatchlogs" else service_name
         # If using a role, create session using that
         try:
             if iam_role_arn:
-                sts_client = boto_session.client('sts')
+                sts_client = boto_session.client('sts', endpoint_url=sts_endpoint)
                 sts_role_assumption = sts_client.assume_role(RoleArn=iam_role_arn,
                                                              RoleSessionName='WazuhLogParsing'
                                                              )
@@ -247,12 +251,9 @@ class WazuhIntegration:
                                             aws_session_token=sts_role_assumption['Credentials']['SessionToken'],
                                             region_name=conn_args.get('region_name')
                                             )
-                client = sts_session.client(service_name='logs' if service_name == 'cloudwatchlogs' else service_name)
-            elif service_name == 'cloudwatchlogs':
-                client = boto3.client('logs', region_name=region,
-                                      aws_access_key_id=access_key, aws_secret_access_key=secret_key)
+                client = sts_session.client(service_name=service_name, endpoint_url=service_endpoint)
             else:
-                client = boto_session.client(service_name=service_name)
+                client = boto_session.client(service_name=service_name, endpoint_url=service_endpoint)
         except botocore.exceptions.ClientError as e:
             print("ERROR: Access error: {}".format(e))
             sys.exit(3)
@@ -347,7 +348,7 @@ class AWSBucket(WazuhIntegration):
     def __init__(self, reparse, access_key, secret_key, profile, iam_role_arn,
                  bucket, only_logs_after, skip_on_error, account_alias,
                  prefix, suffix, delete_file, aws_organization_id, region,
-                 discard_field, discard_regex):
+                 discard_field, discard_regex, sts_endpoint, service_endpoint):
         """
         AWS Bucket constructor.
 
@@ -471,7 +472,9 @@ class AWSBucket(WazuhIntegration):
                                   service_name='s3',
                                   region=region,
                                   discard_field=discard_field,
-                                  discard_regex=discard_regex
+                                  discard_regex=discard_regex,
+                                  sts_endpoint=sts_endpoint,
+                                  service_endpoint=service_endpoint
                                   )
         self.retain_db_records = 500
         self.reparse = reparse
@@ -2323,7 +2326,7 @@ class AWSService(WazuhIntegration):
 
     def __init__(self, access_key, secret_key, aws_profile, iam_role_arn,
                  service_name, only_logs_after, region, aws_log_groups=None, remove_log_streams=None,
-                 discard_field=None, discard_regex=None):
+                 discard_field=None, discard_regex=None, sts_endpoint=None, service_endpoint=None):
         # DB name
         self.db_name = 'aws_services'
         # table name
@@ -2332,7 +2335,7 @@ class AWSService(WazuhIntegration):
         WazuhIntegration.__init__(self, access_key=access_key, secret_key=secret_key,
                                   aws_profile=aws_profile, iam_role_arn=iam_role_arn,
                                   service_name=service_name, region=region, discard_field=discard_field,
-                                  discard_regex=discard_regex)
+                                  discard_regex=discard_regex, sts_endpoint=sts_endpoint, service_endpoint=service_endpoint)
 
         # get sts client (necessary for getting account ID)
         self.sts_client = self.get_sts_client(access_key, secret_key, aws_profile)
@@ -2428,7 +2431,8 @@ class AWSInspector(AWSService):
 
     def __init__(self, reparse, access_key, secret_key, aws_profile,
                  iam_role_arn, only_logs_after, region, aws_log_groups=None,
-                 remove_log_streams=None, discard_field=None, discard_regex=None):
+                 remove_log_streams=None, discard_field=None, discard_regex=None,
+                 sts_endpoint=None, service_endpoint=None):
 
         self.service_name = 'inspector'
         self.inspector_region = region
@@ -2437,7 +2441,7 @@ class AWSInspector(AWSService):
                             aws_profile=aws_profile, iam_role_arn=iam_role_arn, only_logs_after=only_logs_after,
                             service_name=self.service_name, region=region, aws_log_groups=aws_log_groups,
                             remove_log_streams=remove_log_streams, discard_field=discard_field,
-                            discard_regex=discard_regex)
+                            discard_regex=discard_regex, sts_endpoint=sts_endpoint, service_endpoint=service_endpoint)
 
         # max DB records for region
         self.retain_db_records = 5
@@ -2549,7 +2553,7 @@ class AWSCloudWatchLogs(AWSService):
 
     def __init__(self, reparse, access_key, secret_key, aws_profile,
                  iam_role_arn, only_logs_after, region, aws_log_groups,
-                 remove_log_streams, discard_field=None, discard_regex=None):
+                 remove_log_streams, discard_field=None, discard_regex=None, sts_endpoint=None, service_endpoint=None):
 
         self.sql_cloudwatch_create_table = """
                                 CREATE TABLE
@@ -3070,6 +3074,10 @@ def get_script_arguments():
                              'an event should be skipped.', )
     parser.add_argument('-dr', '--discard-regex', type=str, dest='discard_regex', default=None,
                         help='REGEX value to be applied to determine whether an event should be skipped.', )
+    parser.add_argument('-st', '--sts_endpoint', type=str, dest='sts_endpoint', default=None,
+                        help='URL for the VPC endpoint to use to obtain the STS token.')
+    parser.add_argument('-se', '--service_endpoint', type=str, dest='service_endpoint', default=None,
+                        help='URL for the VPC endpoint to use to obtain the logs.')
 
     return parser.parse_args()
 
@@ -3127,7 +3135,9 @@ def main(argv):
                                  aws_organization_id=options.aws_organization_id,
                                  region=options.regions[0] if options.regions else None,
                                  discard_field=options.discard_field,
-                                 discard_regex=options.discard_regex
+                                 discard_regex=options.discard_regex,
+                                 sts_endpoint=options.sts_endpoint,
+                                 service_endpoint=options.service_endpoint
                                  )
             # check if bucket is empty or credentials are wrong
             bucket.check_bucket()
@@ -3158,7 +3168,9 @@ def main(argv):
                                        aws_log_groups=options.aws_log_groups,
                                        remove_log_streams=options.deleteLogStreams,
                                        discard_field=options.discard_field,
-                                       discard_regex=options.discard_regex
+                                       discard_regex=options.discard_regex,
+                                       sts_endpoint=options.sts_endpoint,
+                                       service_endpoint=options.service_endpoint
                                        )
                 service.get_alerts()
 


### PR DESCRIPTION
Hello team,

This PR adds the option to use VPC endpoints in our aws module, so the users can reduce the cost of the constant requests to the AWS services when they happen to be in the same region, as explained in the [AWS documentation](https://aws.amazon.com/es/premiumsupport/knowledge-center/vpc-reduce-nat-gateway-transfer-costs/). 

## Changes introduced

Two new optional tags are available for the `bucket` and `service` configuration:

- `sts_endpoint` : Allows the user to specify a VPC endpoint to be used for the STS token request when a IAM role is provided.

- `service_endpoint`: Allows the user to specify a VPC endpoint to be used to obtain the data from buckets (S3) or the service required.

**Note:** The bucket data is obtained from S3 regardles of the source of the logs themselves, so the endpoint to be configured in AWS must be for the S3 service in case of the buckets integration. For service integrations, such as `cloudwatchlogs` or `Inspector` an endpoint for that particular service must be created.


## Testing

An Amazon Linux instance was deployed in Wazuh-dev to test this new development. Here is an example of a valid ossec.conf configuration to test this:

```
<wodle name="aws-s3">
  <disabled>no</disabled>
  <interval>10m</interval>
  <run_on_start>yes</run_on_start>
  <skip_on_error>yes</skip_on_error>

  <bucket type="cloudtrail">
    <name>wazuh-cloudtrail</name>
    <aws_profile>dev</aws_profile>
    <service_endpoint>https://bucket.xxxxxxxxxxx.s3.us-east-2.vpce.amazonaws.com</service_endpoint>
  </bucket>

    <service type="cloudwatchlogs">
    <aws_profile>dev</aws_profile>
    <regions>us-east-2</regions>
    <aws_log_groups>framework-test-apache</aws_log_groups>
    <service_endpoint>https://xxxxxxxxxxx.logs.us-east-2.vpce.amazonaws.com</service_endpoint>
  </service>

</wodle>
```


Finally, here is how to manually run the module to test it:

```
/var/ossec/wodles/aws/aws-s3 --aws_profile dev --type  cloudtrail --bucket wazuh-aws-wodle-cloudtrail -s 2021-JAN-01 --debug 2 --skip_on_error --service_endpoint https://bucket.xxxxxxxxxxx.s3.us-east-2.vpce.amazonaws.com
```

```
/var/ossec/wodles/aws/aws-s3 --aws_profile dev --service cloudwatchlogs -g framework-test-apache -r us-east-2 -d 3 --service_endpoint https://xxxxxxxxxxx.logs.us-east-2.vpce.amazonaws.com
```