### PR TITLE
Unify wazuh exceptions

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -7437,8 +7437,11 @@ paths:
                     failed_items:
                       - error:
                           code: 1707
-                          message: "Impossible to restart non-active agent: never_connected"
-                          remediation: "Please, make sure agent is active before attempting to restart"
+                          message: "Cannot send request, agent is not active"
+                          remediation: "Please, check non-active agents connection and try again. 
+                           Visit https://documentation.wazuh.com/current/user-manual/registering/index.html 
+                           and https://documentation.wazuh.com/current/user-manual/agents/agent-connection.html
+                           to obtain more information on registering and connecting agents"
                         id:
                           - '009'
                           - '010'

--- a/api/test/integration/test_active_response_endpoints.tavern.yaml
+++ b/api/test/integration/test_active_response_endpoints.tavern.yaml
@@ -78,10 +78,6 @@ stages:
                 code: 1707
               id:
                 - '010'
-            # Separated errors as the message is not the same (different status)
-            - error:
-                code: 1707
-              id:
                 - '012'
           total_affected_items: 4
           total_failed_items: 2
@@ -231,10 +227,6 @@ stages:
               id:
                 - '009'
                 - '010'
-            # Separated errors as the message is not the same (different status)
-            - error:
-                code: 1707
-              id:
                 - '011'
                 - '012'
             - error:

--- a/api/test/integration/test_active_response_endpoints.tavern.yaml
+++ b/api/test/integration/test_active_response_endpoints.tavern.yaml
@@ -75,12 +75,12 @@ stages:
           affected_items: !anything
           failed_items:
             - error:
-                code: 1651
+                code: 1707
               id:
                 - '010'
             # Separated errors as the message is not the same (different status)
             - error:
-                code: 1651
+                code: 1707
               id:
                 - '012'
           total_affected_items: 4
@@ -107,7 +107,7 @@ stages:
           affected_items: []
           failed_items:
             - error:
-                code: 1651
+                code: 1707
               id:
                 - 009
           total_affected_items: 0
@@ -227,13 +227,13 @@ stages:
             - '008'
           failed_items:
             - error:
-                code: 1651
+                code: 1707
               id:
                 - '009'
                 - '010'
             # Separated errors as the message is not the same (different status)
             - error:
-                code: 1651
+                code: 1707
               id:
                 - '011'
                 - '012'

--- a/api/test/integration/test_rbac_black_active_response_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_active_response_endpoints.tavern.yaml
@@ -71,7 +71,7 @@ stages:
             - '005'
           failed_items:
             - error:
-                code: 1651
+                code: 1707
               id:
                 - '010'
             - error:
@@ -152,12 +152,12 @@ stages:
           affected_items: !anything
           failed_items:
             - error:
-                code: 1651
+                code: 1707
               id:
                 - '010'
             # Separated errors as the message is not the same (different status)
             - error:
-                code: 1651
+                code: 1707
               id:
                 - '012'
           total_affected_items: 4

--- a/api/test/integration/test_rbac_black_active_response_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_active_response_endpoints.tavern.yaml
@@ -155,10 +155,6 @@ stages:
                 code: 1707
               id:
                 - '010'
-            # Separated errors as the message is not the same (different status)
-            - error:
-                code: 1707
-              id:
                 - '012'
           total_affected_items: 4
           total_failed_items: 2

--- a/api/test/integration/test_rbac_black_rootcheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_rootcheck_endpoints.tavern.yaml
@@ -125,9 +125,6 @@ stages:
               id:
                 - '009'
                 - '010'
-            - error:
-                code: 1707
-              id:
                 - '011'
                 - '012'
           total_affected_items: 5

--- a/api/test/integration/test_rbac_black_rootcheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_rootcheck_endpoints.tavern.yaml
@@ -121,12 +121,12 @@ stages:
           affected_items: !anything
           failed_items:
             - error:
-                code: 1601
+                code: 1707
               id:
                 - '009'
                 - '010'
             - error:
-                code: 1601
+                code: 1707
               id:
                 - '011'
                 - '012'

--- a/api/test/integration/test_rbac_black_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_syscheck_endpoints.tavern.yaml
@@ -93,9 +93,6 @@ stages:
               id:
                 - '009'
                 - '010'
-            - error:
-                code: 1707
-              id:
                 - '011'
                 - '012'
           total_affected_items: 5

--- a/api/test/integration/test_rbac_black_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_syscheck_endpoints.tavern.yaml
@@ -89,12 +89,12 @@ stages:
           affected_items: !anything
           failed_items:
             - error:
-                code: 1601
+                code: 1707
               id:
                 - '009'
                 - '010'
             - error:
-                code: 1601
+                code: 1707
               id:
                 - '011'
                 - '012'

--- a/api/test/integration/test_rbac_white_active_response_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_active_response_endpoints.tavern.yaml
@@ -157,10 +157,6 @@ stages:
                 code: 1707
               id:
                 - '009'
-            # Separated errors as the message is not the same (different status)
-            - error:
-                code: 1707
-              id:
                 - '011'
             - error:
                 code: 1750

--- a/api/test/integration/test_rbac_white_active_response_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_active_response_endpoints.tavern.yaml
@@ -74,7 +74,7 @@ stages:
             - '007'
           failed_items:
             - error:
-                code: 1651
+                code: 1707
               id:
                 - '011'
             - error:
@@ -107,7 +107,7 @@ stages:
           affected_items: []
           failed_items:
             - error:
-                code: 1651
+                code: 1707
               id:
                 - '009'
           total_affected_items: 0
@@ -154,12 +154,12 @@ stages:
           affected_items: !anything
           failed_items:
             - error:
-                code: 1651
+                code: 1707
               id:
                 - '009'
             # Separated errors as the message is not the same (different status)
             - error:
-                code: 1651
+                code: 1707
               id:
                 - '011'
             - error:

--- a/api/test/integration/test_rootcheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rootcheck_endpoints.tavern.yaml
@@ -521,9 +521,6 @@ stages:
               id:
                 - "009"
                 - "010"
-            - error:
-                code: 1707
-              id:
                 - "011"
                 - "012"
           total_affected_items: 9

--- a/api/test/integration/test_rootcheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rootcheck_endpoints.tavern.yaml
@@ -517,12 +517,12 @@ stages:
             - "008"
           failed_items:
             - error:
-                code: 1601
+                code: 1707
               id:
                 - "009"
                 - "010"
             - error:
-                code: 1601
+                code: 1707
               id:
                 - "011"
                 - "012"

--- a/api/test/integration/test_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_syscheck_endpoints.tavern.yaml
@@ -534,11 +534,11 @@ stages:
             - '008'
           failed_items:
             - error:
-                code: 1601
+                code: 1707
               id:
                 - '010'
             - error:
-                code: 1601
+                code: 1707
               id:
                 - '012'
           total_affected_items: 5
@@ -1026,12 +1026,12 @@ stages:
           affected_items: !anything
           failed_items:
             - error:
-                code: 1601
+                code: 1707
               id:
                 - '009'
                 - '010'
             - error:
-                code: 1601
+                code: 1707
               id:
                 - '011'
                 - '012'

--- a/api/test/integration/test_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_syscheck_endpoints.tavern.yaml
@@ -537,9 +537,6 @@ stages:
                 code: 1707
               id:
                 - '010'
-            - error:
-                code: 1707
-              id:
                 - '012'
           total_affected_items: 5
           total_failed_items: 2
@@ -1030,9 +1027,6 @@ stages:
               id:
                 - '009'
                 - '010'
-            - error:
-                code: 1707
-              id:
                 - '011'
                 - '012'
           total_affected_items: 9

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -218,7 +218,7 @@ def restart_agents(agent_list: list = None) -> AffectedItemsWazuhResult:
 
         # Add non active agents to failed_items
         non_active_agents = [agent for agent in agents_with_data if agent['status'] != 'active']
-        [result.add_failed_item(id_=agent['id'], error=WazuhError(1707, extra_message=f'{agent["status"]}'))
+        [result.add_failed_item(id_=agent['id'], error=WazuhError(1707))
          for agent in non_active_agents]
 
         eligible_agents = [agent for agent in agents_with_data if agent not in non_active_agents] if non_active_agents \
@@ -464,7 +464,7 @@ def get_agent_groups(group_list=None, offset=0, limit=None, sort=None, search=No
                                       )
     if group_list:
 
-        system_groups= get_groups()
+        system_groups = get_groups()
         # Add failed items
         for invalid_group in set(group_list) - system_groups:
             result.add_failed_item(id_=invalid_group, error=WazuhResourceNotFound(1710))
@@ -604,7 +604,8 @@ def delete_groups(group_list=None):
                 raise WazuhResourceNotFound(1710)
             elif group_id == 'default':
                 raise WazuhError(1712)
-            agent_list = [agent['id'] for agent in WazuhDBQueryMultigroups(group_id=group_id, limit=None).run()['items']]
+            agent_list = [agent['id'] for agent in WazuhDBQueryMultigroups(group_id=group_id,
+                                                                           limit=None).run()['items']]
             try:
                 affected_agents_result = remove_agents_from_group(agent_list=agent_list, group_list=[group_id])
                 if affected_agents_result.total_failed_items != 0:

--- a/framework/wazuh/core/active_response.py
+++ b/framework/wazuh/core/active_response.py
@@ -111,7 +111,7 @@ def send_ar_message(agent_id: str = '', wq: WazuhQueue = None, command: str = ''
 
     Raises
     ------
-    WazuhError(1651)
+    WazuhError(1707)
         If the agent with ID agent_id is not active.
     """
     # Agent basic information
@@ -119,7 +119,7 @@ def send_ar_message(agent_id: str = '', wq: WazuhQueue = None, command: str = ''
 
     # Check if agent is active
     if agent_info['status'].lower() != 'active':
-        raise WazuhError(1651, extra_message='{0}'.format(agent_info['status']))
+        raise WazuhError(1707)
 
     # Once we know the agent is active, store version
     agent_version = agent_info['version']

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -199,18 +199,11 @@ class WazuhException(Exception):
                               f'https://documentation.wazuh.com/{WAZUH_VERSION}/upgrade-guide/index.html'
                               ' to obtain more information on upgrading wazuh'
                },
-        1601: {'message': 'Impossible to run FIM scan, agent is not active',
-               'remediation': 'Please, ensure selected agent is active and connected to the manager. Visit '
-                              f'https://documentation.wazuh.com/{WAZUH_VERSION}/user-manual/registering/index.html and '
-                              f'https://documentation.wazuh.com/{WAZUH_VERSION}/user-manual/agents/agent-connection.html'
-                              'to obtain more information on registering and connecting agents'
-               },
+
         1603: 'Invalid status. Valid statuses are: all, solved and outstanding',
         1605: 'Impossible to run policy monitoring scan due to agent is not active',
         1650: 'Active response - Command not specified',
-        1651: {'message': 'Cannot send Active Response message to non-active agent, agent status is',
-               'remediation': f'Check non-active agents connection and try again. Please, visit the official '
-                              f'documentation (https://documentation.wazuh.com/{WAZUH_VERSION}/user-manual/agents/agent-connection.html)'},
+
         1652: 'Active response - Unable to run command',
         1653: 'Active response - Agent ID not specified',
         1655: 'Active response - Command not available',
@@ -234,8 +227,11 @@ class WazuhException(Exception):
         1706: {'message': 'There is an agent with the same IP or the IP is invalid',
                'remediation': 'Please choose another IP'
                },
-        1707: {'message': 'Impossible to restart non-active agent',
-               'remediation': 'Please, make sure agent is active before attempting to restart'
+        1707: {'message': 'Cannot send request, agent is not active',
+               'remediation': 'Please, check non-active agents connection and try again. Visit '
+               f'https://documentation.wazuh.com/{WAZUH_VERSION}/user-manual/registering/index.html and '
+               f'https://documentation.wazuh.com/{WAZUH_VERSION}/user-manual/agents/agent-connection.html'
+               ' to obtain more information on registering and connecting agents'
                },
         1708: {'message': 'There is an agent with the same ID',
                'remediation': 'Please choose another ID'

--- a/framework/wazuh/core/tests/test_active_response.py
+++ b/framework/wazuh/core/tests/test_active_response.py
@@ -20,7 +20,7 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
 # Functions
 
 def agent_info(expected_exception: int = None) -> dict:
-    """Return dict to cause or not a exception code 1651 on active_response.send_command().
+    """Return dict to cause or not a exception code 1707 on active_response.send_command().
 
     Parameters
     ----------
@@ -32,14 +32,14 @@ def agent_info(expected_exception: int = None) -> dict:
     dict
         Agent basic information with status depending on the expected_exception.
     """
-    if expected_exception == 1651:
+    if expected_exception == 1707:
         return {'status': 'random'}
     else:
         return {'status': 'active'}
 
 
 def agent_info_exception_and_version(expected_exception: int = None, version: str = '') -> dict:
-    """Return dict with status and version to cause or not a exception code 1651 on active_response.send_command().
+    """Return dict with status and version to cause or not a exception code 1707 on active_response.send_command().
 
     Parameters
     ----------
@@ -53,7 +53,7 @@ def agent_info_exception_and_version(expected_exception: int = None, version: st
     dict
         Agent basic information with status depending on the expected_exception.
     """
-    if expected_exception == 1651:
+    if expected_exception == 1707:
         return {'status': 'random', 'version': version} if version else {'status': 'random'}
     else:
         return {'status': 'active', 'version': version} if version else {'status': 'active'}

--- a/framework/wazuh/rootcheck.py
+++ b/framework/wazuh/rootcheck.py
@@ -41,11 +41,11 @@ def run(agent_list: Union[list, None] = None) -> AffectedItemsWazuhResult:
     [result.add_failed_item(id_=agent, error=WazuhResourceNotFound(1701)) for agent in not_found_agents]
 
     # Add non eligible agents to failed_items
-    non_eligible_agents = WazuhDBQueryAgents(limit=None, select=["id", "status"], query=f'status!=active',
+    non_eligible_agents = WazuhDBQueryAgents(limit=None, select=["id", "status"], query='status!=active',
                                              **rbac_filters).run()['items']
     [result.add_failed_item(
         id_=agent['id'],
-        error=WazuhError(1601, extra_message=f'Status - {agent["status"]}')) for agent in non_eligible_agents]
+        error=WazuhError(1707)) for agent in non_eligible_agents]
 
     wq = WazuhQueue(common.ARQUEUE)
     eligible_agents = agent_list - not_found_agents - {d['id'] for d in non_eligible_agents}

--- a/framework/wazuh/syscheck.py
+++ b/framework/wazuh/syscheck.py
@@ -47,7 +47,7 @@ def run(agent_list: Union[str, None] = None) -> AffectedItemsWazuhResult:
                                              **rbac_filters).run()['items']
     [result.add_failed_item(
         id_=agent['id'],
-        error=WazuhError(1601, extra_message=f'Status - {agent["status"]}')) for agent in non_eligible_agents]
+        error=WazuhError(1707)) for agent in non_eligible_agents]
 
     wq = WazuhQueue(common.ARQUEUE)
     eligible_agents = agent_list - not_found_agents - {d['id'] for d in non_eligible_agents}

--- a/framework/wazuh/tests/test_active_response.py
+++ b/framework/wazuh/tests/test_active_response.py
@@ -32,7 +32,7 @@ full_agent_list = ['000', '001', '002', '003', '004', '005', '006', '007', '008'
     (1703, None, ['000'], 'restart-wazuh0', [], False, None, 'Wazuh v4.0.0'),
     (1650, None, ['001'], None, [], False, None, 'Wazuh v4.0.0'),
     (1652, None, ['002'], 'random', [], False, None, 'Wazuh v4.0.0'),
-    (None, 1651, ['003'], 'restart-wazuh0', [], False, None, None),
+    (None, 1707, ['003'], 'restart-wazuh0', [], False, None, None),
     (None, 1750, ['004'], 'restart-wazuh0', [], False, None, 'Wazuh v4.0.0'),
     (None, None, ['005'], 'restart-wazuh0', [], False, None, 'Wazuh v4.0.0'),
     (None, None, ['006'], 'custom-ar', [], True, None, 'Wazuh v4.0.0'),


### PR DESCRIPTION
|Related issue|
|---|
|#9326|

## Description
This PR closes #9326.
I unified three wazuh exceptions into one because all of them were exceptions raised if an agent can't be reached within a request.
Exceptions `1601`, `1651` and `1707` merged into `1707` since exceptions range from `1700` to `1799` are bounded to agent operations and unit and integration tests related were modified too.

On the other hand, I made some adjustments about how non-connected agents are shown within a request. More precisely and as we know there's 4 agent status: 
![image](https://user-images.githubusercontent.com/84642680/127555842-9fbf76dc-a01e-40f0-977d-c89a2987e82b.png)
So, for those endpoints that can raise exception `1707` (the new one), they will raise it by grouping agents as "non-connected" instead of grouping by status.
By doing this we end up with an almost exact same result but with fewer lines and more simple structure.
| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/84642680/127557375-b9b3c117-58db-491d-a1d6-6b4bab46348e.png)  | ![image](https://user-images.githubusercontent.com/84642680/127557205-020cb711-c652-43b0-ad70-dc968fdb07b6.png) |
```
root@1d75f6388944:/var/ossec/bin# ./agent_control -l

Wazuh agent_control. List of available agents:
   ID: 000, Name: 1d75f6388944 (server), IP: 127.0.0.1, Active/Local
   ID: 001, Name: 62ee8947192b, IP: any, Disconnected
   ID: 004, Name: e9cc412a18f7, IP: any, Never connected
```

regards,
Alexis