### PR TITLE
Make RBAC policies case insensitive

### DIFF
--- a/api/test/integration/test_security_POST_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_POST_endpoints.tavern.yaml
@@ -312,6 +312,41 @@ stages:
               roles: []
           total_affected_items: 1
 
+# POST /security/policies
+  - name: Add a policy to the system (case insensitive)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: POST
+      json:
+        name: "test_case_insensitive"
+        policy:
+          actions:
+            - "aGenT:rEaD"
+          resources:
+            - "aGenT:ID:555"
+            - "GroUp:iD:Group_Name"
+          effect: "aLLoW"
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - id: !anyint
+              name: test_case_insensitive
+              policy:
+                actions:
+                  - agent:read
+                effect: allow
+                resources:
+                  - agent:id:555
+                  - group:id:Group_Name
+              roles: []
+          total_affected_items: 1
+
   # POST /security/policies
   - name: Add a policy to the system
     request:

--- a/api/test/integration/test_security_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_PUT_endpoints.tavern.yaml
@@ -231,6 +231,42 @@ stages:
               roles: !anything
           total_affected_items: 1
 
+  # PUT /security/policies/{policy_id}
+  - name: Modify a policy in the system (case insensitive)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies/104"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+      json:
+        policy:
+          actions:
+            - "aGenT:dELEte"
+          resources:
+            - "aGeNt:ID:001"
+            - "AGENT:iD:002"
+            - "agEnT:Id:003"
+          effect: "dEnY"
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - id: 104
+              name: testModifiedPolicy2
+              policy:
+                actions:
+                  - agent:delete
+                effect: deny
+                resources:
+                  - agent:id:001
+                  - agent:id:002
+                  - agent:id:003
+              roles: !anything
+          total_affected_items: 1
+
   # PUT /security/policies/{non-existent policy_id}
   - name: Modify a non-existent policy in the system
     request:

--- a/framework/wazuh/core/security.py
+++ b/framework/wazuh/core/security.py
@@ -107,3 +107,25 @@ def revoke_tokens():
         tm.delete_all_rules()
 
     return {'result': 'True'}
+
+
+def sanitize_rbac_policy(policy):
+    try:
+        # Sanitize actions
+        policy['actions'] = [action for action in map(str.lower, policy['actions'])]
+
+        # Sanitize resources
+        for i, resource in enumerate(policy['resources']):
+            sanitized_resources = list()
+            for nested_resource in resource.split('&'):
+                split_resource = nested_resource.split(':')
+                sanitized_resources.append(':'.join([r.lower() for r in split_resource[:-1]] + split_resource[-1:]))
+
+            policy['resources'][i] = '&'.join(sanitized_resources)
+
+        # Sanitize effect
+        policy['effect'] = policy['effect'].lower()
+
+    except (IndexError, KeyError):
+        return False
+    return True

--- a/framework/wazuh/core/security.py
+++ b/framework/wazuh/core/security.py
@@ -110,11 +110,12 @@ def revoke_tokens():
 
 
 def sanitize_rbac_policy(policy):
-    try:
-        # Sanitize actions
+    # Sanitize actions
+    if 'actions' in policy:
         policy['actions'] = [action for action in map(str.lower, policy['actions'])]
 
-        # Sanitize resources
+    # Sanitize resources
+    if 'resources' in policy:
         for i, resource in enumerate(policy['resources']):
             sanitized_resources = list()
             for nested_resource in resource.split('&'):
@@ -123,9 +124,6 @@ def sanitize_rbac_policy(policy):
 
             policy['resources'][i] = '&'.join(sanitized_resources)
 
-        # Sanitize effect
+    # Sanitize effect
+    if 'effect' in policy:
         policy['effect'] = policy['effect'].lower()
-
-    except (IndexError, KeyError):
-        return False
-    return True

--- a/framework/wazuh/security.py
+++ b/framework/wazuh/security.py
@@ -11,7 +11,7 @@ from wazuh.core import common
 from wazuh.core.exception import WazuhError, WazuhResourceNotFound
 from wazuh.core.results import AffectedItemsWazuhResult, WazuhResult
 from wazuh.core.security import invalid_users_tokens, invalid_roles_tokens, invalid_run_as_tokens, revoke_tokens,\
-    load_spec, update_security_conf, REQUIRED_FIELDS, SORT_FIELDS, SORT_FIELDS_GET_USERS, sanitize_rbac_policy
+    load_spec, sanitize_rbac_policy, update_security_conf, REQUIRED_FIELDS, SORT_FIELDS, SORT_FIELDS_GET_USERS
 from wazuh.core.utils import process_array
 from wazuh.rbac.decorators import expose_resources
 from wazuh.rbac.orm import AuthenticationManager, PoliciesManager, RolesManager, RolesPoliciesManager, \

--- a/framework/wazuh/security.py
+++ b/framework/wazuh/security.py
@@ -496,18 +496,16 @@ def add_policy(name=None, policy=None):
     """
     result = AffectedItemsWazuhResult(none_msg='Policy was not created',
                                       all_msg='Policy was successfully created')
-    if sanitize_rbac_policy(policy):
-        with PoliciesManager() as pm:
-            status = pm.add_policy(name=name, policy=policy)
-            if status == SecurityError.ALREADY_EXIST:
-                result.add_failed_item(id_=name, error=WazuhError(4009))
-            elif status == SecurityError.INVALID:
-                result.add_failed_item(id_=name, error=WazuhError(4006))
-            else:
-                result.affected_items.append(pm.get_policy(name=name))
-                result.total_affected_items += 1
-    else:
-        result.add_failed_item(id_=name, error=WazuhError(4006))
+    sanitize_rbac_policy(policy)
+    with PoliciesManager() as pm:
+        status = pm.add_policy(name=name, policy=policy)
+        if status == SecurityError.ALREADY_EXIST:
+            result.add_failed_item(id_=name, error=WazuhError(4009))
+        elif status == SecurityError.INVALID:
+            result.add_failed_item(id_=name, error=WazuhError(4006))
+        else:
+            result.affected_items.append(pm.get_policy(name=name))
+            result.total_affected_items += 1
 
     return result
 
@@ -525,24 +523,22 @@ def update_policy(policy_id=None, name=None, policy=None):
         raise WazuhError(4001)
     result = AffectedItemsWazuhResult(none_msg='Policy was not updated',
                                       all_msg='Policy was successfully updated')
-    if sanitize_rbac_policy(policy):
-        with PoliciesManager() as pm:
-            status = pm.update_policy(policy_id=policy_id[0], name=name, policy=policy)
-            if status == SecurityError.ALREADY_EXIST:
-                result.add_failed_item(id_=int(policy_id[0]), error=WazuhError(4013))
-            elif status == SecurityError.INVALID:
-                result.add_failed_item(id_=int(policy_id[0]), error=WazuhError(4006))
-            elif status == SecurityError.POLICY_NOT_EXIST:
-                result.add_failed_item(id_=int(policy_id[0]), error=WazuhError(4007))
-            elif status == SecurityError.ADMIN_RESOURCES:
-                result.add_failed_item(id_=int(policy_id[0]), error=WazuhError(4008))
-            else:
-                updated = pm.get_policy_id(int(policy_id[0]))
-                result.affected_items.append(updated)
-                result.total_affected_items += 1
-                invalid_roles_tokens(roles=updated['roles'])
-    else:
-        result.add_failed_item(id_=int(policy_id[0]), error=WazuhError(4006))
+    policy is not None and sanitize_rbac_policy(policy)
+    with PoliciesManager() as pm:
+        status = pm.update_policy(policy_id=policy_id[0], name=name, policy=policy)
+        if status == SecurityError.ALREADY_EXIST:
+            result.add_failed_item(id_=int(policy_id[0]), error=WazuhError(4013))
+        elif status == SecurityError.INVALID:
+            result.add_failed_item(id_=int(policy_id[0]), error=WazuhError(4006))
+        elif status == SecurityError.POLICY_NOT_EXIST:
+            result.add_failed_item(id_=int(policy_id[0]), error=WazuhError(4007))
+        elif status == SecurityError.ADMIN_RESOURCES:
+            result.add_failed_item(id_=int(policy_id[0]), error=WazuhError(4008))
+        else:
+            updated = pm.get_policy_id(int(policy_id[0]))
+            result.affected_items.append(updated)
+            result.total_affected_items += 1
+            invalid_roles_tokens(roles=updated['roles'])
 
     return result
 

--- a/framework/wazuh/tests/data/security/policies_test_cases.yml
+++ b/framework/wazuh/tests/data/security/policies_test_cases.yml
@@ -113,6 +113,26 @@ add_policy:
           roles: []
       failed_items: {}
   - params:
+      name: new_policy_case_insensitive
+      policy:
+        actions:
+          - GrOUp:rEaD
+        effect: aLLoW
+        resources:
+          - gRouP:ID:Random_Group_Name&aGenT:iD:003
+    result:
+      affected_items:
+        - id: 110
+          name: new_policy_case_insensitive
+          policy:
+            actions:
+              - group:read
+            effect: allow
+            resources:
+              - group:id:Random_Group_Name&agent:id:003
+          roles: []
+      failed_items: {}
+  - params:
       name: ossecPolicy
       policy:
         actions:
@@ -138,6 +158,18 @@ add_policy:
       failed_items:
         "4009":
           - wazuhPolicy
+  - params:
+      name: ossecPolicy
+      policy:
+        actions:
+          - agent:delete
+        resources:
+          - agent
+    result:
+      affected_items: []
+      failed_items:
+        "4006":
+          - ossecPolicy
 update_policy:
   - params:
       policy_id:
@@ -172,6 +204,29 @@ update_policy:
       failed_items: {}
   - params:
       policy_id:
+        - 105
+      name: ossecPolicy2
+      policy:
+        actions:
+          - GrOUp:rEaD
+        effect: aLLoW
+        resources:
+          - gRouP:ID:Random_Group_Name&aGenT:iD:003
+    result:
+      affected_items:
+        - id: 105
+          name: ossecPolicy2
+          policy:
+            actions:
+              - group:read
+            effect: allow
+            resources:
+              - group:id:Random_Group_Name&agent:id:003
+          roles:
+            - 105
+      failed_items: {}
+  - params:
+      policy_id:
         - 950
       name: normalPolicy2
       policy:
@@ -185,6 +240,20 @@ update_policy:
       failed_items:
         "4007":
           - 950
+  - params:
+      policy_id:
+        - 105
+      name: invalid_policy
+      policy:
+        actions:
+          - agent:delete
+        resources:
+          - agent
+    result:
+      affected_items: []
+      failed_items:
+        "4006":
+          - 105
   - params:
       policy_id:
         - 103

--- a/framework/wazuh/tests/data/security/policies_test_cases.yml
+++ b/framework/wazuh/tests/data/security/policies_test_cases.yml
@@ -242,20 +242,6 @@ update_policy:
           - 950
   - params:
       policy_id:
-        - 105
-      name: invalid_policy
-      policy:
-        actions:
-          - agent:delete
-        resources:
-          - agent
-    result:
-      affected_items: []
-      failed_items:
-        "4006":
-          - 105
-  - params:
-      policy_id:
         - 103
       name: normalPolicy
       policy:

--- a/framework/wazuh/tests/data/security/sanitize_policies.yaml
+++ b/framework/wazuh/tests/data/security/sanitize_policies.yaml
@@ -5,7 +5,6 @@ policies:
       resources:
         - "agent:id:001"
       effect: "allow"
-    result: True
 
   - policy:
       actions:
@@ -13,7 +12,6 @@ policies:
       resources:
         - "AgENt:ID:001"
       effect: "DeNy"
-    result: True
 
   - policy:
       actions:
@@ -21,23 +19,8 @@ policies:
       resources:
         - "GRoup:ID:CAPS_name"
       effect: "aLLoW"
-    result: True
 
   - policy:
       resources:
         - "agent:id:001"
       effect: "allow"
-    result: False
-
-  - policy:
-      actions:
-        - "agent:read"
-      effect: "allow"
-    result: False
-
-  - policy:
-      actions:
-        - "agent:read"
-      resources:
-        - "agent:id:001"
-    result: False

--- a/framework/wazuh/tests/data/security/sanitize_policies.yaml
+++ b/framework/wazuh/tests/data/security/sanitize_policies.yaml
@@ -1,0 +1,43 @@
+policies:
+  - policy:
+      actions:
+        - "agent:read"
+      resources:
+        - "agent:id:001"
+      effect: "allow"
+    result: True
+
+  - policy:
+      actions:
+        - "aGenT:rEAd"
+      resources:
+        - "AgENt:ID:001"
+      effect: "DeNy"
+    result: True
+
+  - policy:
+      actions:
+        - "GrouP:rEAd"
+      resources:
+        - "GRoup:ID:CAPS_name"
+      effect: "aLLoW"
+    result: True
+
+  - policy:
+      resources:
+        - "agent:id:001"
+      effect: "allow"
+    result: False
+
+  - policy:
+      actions:
+        - "agent:read"
+      effect: "allow"
+    result: False
+
+  - policy:
+      actions:
+        - "agent:read"
+      resources:
+        - "agent:id:001"
+    result: False

--- a/framework/wazuh/tests/test_security.py
+++ b/framework/wazuh/tests/test_security.py
@@ -346,10 +346,9 @@ def test_migrate_default_policies(new_default_resources):
 def test_sanitize_rbac_policy(db_setup, policy_case):
     _, _, core_security = db_setup
     policy = policy_case['policy']
-    result = core_security.sanitize_rbac_policy(policy)
-    assert result == policy_case['result']
-    if result:
-        for element in ('actions', 'resources', 'effect'):
+    core_security.sanitize_rbac_policy(policy)
+    for element in ('actions', 'resources', 'effect'):
+        if element in policy:
             if element != 'resources':
                 assert all(p.islower() for p in policy[element])
             else:

--- a/framework/wazuh/tests/test_security.py
+++ b/framework/wazuh/tests/test_security.py
@@ -27,7 +27,7 @@ default_orm_engine = create_engine("sqlite:///:memory:")
 os.chdir(test_data_path)
 
 for file in glob.glob('*.yml'):
-    with open(os.path.join(test_data_path + file)) as f:
+    with open(os.path.join(test_data_path, file)) as f:
         tests_cases = safe_load(f)
 
     for function_, test_cases in tests_cases.items():
@@ -36,6 +36,9 @@ for file in glob.glob('*.yml'):
                 security_cases.append((function_, test_case['params'], test_case['result']))
             else:
                 rbac_cases.append((function_, test_case['params'], test_case['result']))
+
+with open(os.path.join(test_data_path, 'sanitize_policies.yaml')) as f:
+    sanitize_policies = safe_load(f)
 
 
 def create_memory_db(sql_file, session):
@@ -337,3 +340,17 @@ def test_migrate_default_policies(new_default_resources):
 
     assert role1_policies.index(user_policy_id) == new_role1_policies.index(user_policy_id)
     assert role2_policies.index(user_policy_id) == new_role2_policies.index(user_policy_id)
+
+
+@pytest.mark.parametrize('policy_case', sanitize_policies['policies'])
+def test_sanitize_rbac_policy(db_setup, policy_case):
+    _, _, core_security = db_setup
+    policy = policy_case['policy']
+    result = core_security.sanitize_rbac_policy(policy)
+    assert result == policy_case['result']
+    if result:
+        for element in ('actions', 'resources', 'effect'):
+            if element != 'resources':
+                assert all(p.islower() for p in policy[element])
+            else:
+                assert all(':'.join(p.split(':')[:-1]) for p in policy[element])


### PR DESCRIPTION
|Related issue|
|---|
| closes #9333 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
Hello team,

As it was discussed in the issue, we needed to make the RBAC policy comparison case insensitive. This does not include the resource IDs like `group:id:New_Group`.

### Example
#### JSON
```json
{
  "name": "testing",
  "policy": {
    "actions": [
      "Agent:Read"
    ],
    "resources": ["Agent:ID:001&gRouP:iD:CAPS_gRoup"],
    "effect": "aLLoW"
  }
}
```

#### Response
```json
{
  "data": {
    "affected_items": [
      {
        "id": 100,
        "name": "testing",
        "policy": {
          "actions": [
            "agent:read"
          ],
          "resources": [
            "agent:id:001&group:id:CAPS_gRoup"
          ],
          "effect": "allow"
        },
        "roles": []
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "Policy was successfully created",
  "error": 0
}
```

## Tests performed
### Unit tests
```
========================================= test session starts ==========================================
platform linux -- Python 3.9.6, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: cov-2.12.0, asyncio-0.15.1
collected 1599 items                                                                                   

wazuh/core/cluster/dapi/tests/test_dapi.py .......................                               [  1%]
wazuh/core/cluster/tests/test_cluster.py ...................                                     [  2%]
wazuh/core/cluster/tests/test_common.py .......                                                  [  3%]
wazuh/core/cluster/tests/test_control.py .....                                                   [  3%]
wazuh/core/cluster/tests/test_local_client.py .                                                  [  3%]
wazuh/core/cluster/tests/test_utils.py .......                                                   [  3%]
wazuh/core/cluster/tests/test_worker.py .................                                        [  4%]
wazuh/core/tests/test_active_response.py ..............                                          [  5%]
wazuh/core/tests/test_agent.py ................................................................. [  9%]
................................................................................................ [ 15%]
.....                                                                                            [ 16%]
wazuh/core/tests/test_cdb_list.py ......................................                         [ 18%]
wazuh/core/tests/test_common.py .......                                                          [ 19%]
wazuh/core/tests/test_configuration.py ....................................                      [ 21%]
wazuh/core/tests/test_decoder.py ................                                                [ 22%]
wazuh/core/tests/test_input_validator.py ...                                                     [ 22%]
wazuh/core/tests/test_logtest.py ..                                                              [ 22%]
wazuh/core/tests/test_manager.py ...............                                                 [ 23%]
wazuh/core/tests/test_mitre.py .............                                                     [ 24%]
wazuh/core/tests/test_pyDaemonModule.py .....                                                    [ 24%]
wazuh/core/tests/test_results.py ........................................                        [ 27%]
wazuh/core/tests/test_rootcheck.py ..........                                                    [ 27%]
wazuh/core/tests/test_rule.py ......................                                             [ 29%]
wazuh/core/tests/test_stats.py ....                                                              [ 29%]
wazuh/core/tests/test_syscollector.py ...                                                        [ 29%]
wazuh/core/tests/test_utils.py ................................................................. [ 33%]
................................................................................................ [ 39%]
...................................................................                              [ 43%]
wazuh/core/tests/test_vulnerability.py .                                                         [ 43%]
wazuh/core/tests/test_wazuh_queue.py ..................                                          [ 45%]
wazuh/core/tests/test_wazuh_socket.py ....................                                       [ 46%]
wazuh/core/tests/test_wdb.py ......................                                              [ 47%]
wazuh/rbac/tests/test_auth_context.py ..                                                         [ 47%]
wazuh/rbac/tests/test_decorators.py ............................................................ [ 51%]
.............................................                                                    [ 54%]
wazuh/rbac/tests/test_default_configuration.py ................................................. [ 57%]
......                                                                                           [ 57%]
wazuh/rbac/tests/test_orm.py ......................................................              [ 61%]
wazuh/rbac/tests/test_preprocessor.py ...........                                                [ 61%]
wazuh/tests/test_active_response.py ............                                                 [ 62%]
wazuh/tests/test_agent.py ...................................................................... [ 66%]
.......................................                                                          [ 69%]
wazuh/tests/test_cdb_list.py .....................................................               [ 72%]
wazuh/tests/test_ciscat.py .................................                                     [ 74%]
wazuh/tests/test_cluster.py .......                                                              [ 75%]
wazuh/tests/test_decoder.py ...................................                                  [ 77%]
wazuh/tests/test_group.py ........                                                               [ 77%]
wazuh/tests/test_logtest.py ......                                                               [ 78%]
wazuh/tests/test_manager.py ....................................                                 [ 80%]
wazuh/tests/test_mitre.py .......                                                                [ 80%]
wazuh/tests/test_rootcheck.py ..................................................                 [ 84%]
wazuh/tests/test_rule.py ........................................................                [ 87%]
wazuh/tests/test_sca.py .......                                                                  [ 88%]
wazuh/tests/test_security.py ................................................................... [ 92%]
...................                                                                              [ 93%]
wazuh/tests/test_stats.py ................                                                       [ 94%]
wazuh/tests/test_syscheck.py .......................                                             [ 95%]
wazuh/tests/test_syscollector.py ............                                                    [ 96%]
wazuh/tests/test_task.py ............................                                            [ 98%]
wazuh/tests/test_vulnerability.py ..........................                                     [100%]

============================ 1599 passed, 14 warnings in 260.77s (0:04:20) =============================
```

### Integration tests
```
Collected tests [2]:
test_security_POST_endpoints.tavern.yaml, test_security_PUT_endpoints.tavern.yaml


test_security_POST_endpoints.tavern.yaml 
	 7 passed, 9 warnings

test_security_PUT_endpoints.tavern.yaml 
	 9 passed, 11 warnings

```

Regards,
Víctor
