### PR TITLE
Fix invalid platform names in agent upgrade module

### DIFF
--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_validate.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_validate.c
@@ -198,7 +198,7 @@ void test_wm_agent_upgrade_validate_system_invalid_platform_darwin(void **state)
 void test_wm_agent_upgrade_validate_system_invalid_platform_solaris(void **state)
 {
     (void) state;
-    char *platform = "solaris";
+    char *platform = "sunos";
     char *os_major = "11";
     char *os_minor = "4";
     char *arch = "x64";

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.c
@@ -24,9 +24,9 @@ pthread_mutex_t download_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 static const char* invalid_platforms[] = {
     "darwin",
-    "solaris",
+    "sunos",
     "aix",
-    "hpux",
+    "hp-ux",
     "bsd"
 };
 


### PR DESCRIPTION
## Description

A problem has be found in `agent-upgrade` module.

The invalid platforms array that keeps the operating systems that don't support upgrade using WPK has two invalid platform names:

```c
static const char* invalid_platforms[] = {
    "darwin",
    "solaris",
    "aix",
    "hpux",
    "bsd"
};
```

The following platforms are incorrect:

- `solaris` -> `sunos`
- `hpux` -> `hp-ux`

This PR solves this issue modifying the wrong names with the correct ones:

```c
static const char* invalid_platforms[] = {
    "darwin",
    "sunos",
    "aix",
    "hp-ux",
    "bsd"
};
```

Also, UT have been updated to take into account this change.

## Logs

Execute upgrade on Solaris 11:

```
root@tomas-VirtualBox:/var/ossec/bin# ./agent_upgrade -a 007 -F
Agents that cannot be upgraded:
        Agent 007 upgrade failed. Status: Error 1819 - The WPK for this platform is not available
root@tomas-VirtualBox:/var/ossec/bin# ./agent_control -l

Wazuh agent_control. List of available agents:
   ID: 000, Name: tomas-VirtualBox (server), IP: 127.0.0.1, Active/Local
   ID: 004, Name: vagrants-iMac.local, IP: any, Disconnected
   ID: 005, Name: DESKTOP-JN5RQG2, IP: any, Disconnected
   ID: 007, Name: solaris11, IP: any, Active
```

Logs from the manager:

```
2021/08/02 15:51:22 wazuh-modulesd:agent-upgrade[20665] wm_agent_upgrade_manager.c:149 at wm_agent_upgrade_listen_messages(): DEBUG: (8155): Incomming message: '{"version": 1, "origin": {"module": "api"}, "command": "upgrade", "parameters": {"agents": [7], "force_upgrade": true, "use_http": false}}'
2021/08/02 15:51:22 wazuh-modulesd:agent-upgrade[20665] wm_agent_upgrade_commands.c:121 at wm_agent_upgrade_process_upgrade_command(): WARNING: (8160): There are no valid agents to upgrade.
2021/08/02 15:51:22 wazuh-modulesd:agent-upgrade[20665] wm_agent_upgrade_manager.c:196 at wm_agent_upgrade_listen_messages(): DEBUG: (8156): Response message: '{"error":0,"data":[{"error":9,"message":"The WPK for this platform is not available","agent":7}],"message":"Success"}'
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language