### PR TITLE
[9414] Syscollector hotfixes missing fix

### DIFF
--- a/src/data_provider/src/packages/packagesWindowsParserHelper.h
+++ b/src/data_provider/src/packages/packagesWindowsParserHelper.h
@@ -55,7 +55,7 @@ namespace PackageWindowsHelper
                         {
                             hotfixes.insert(std::move(hfValue));
                         }
-                        else if(package.find("RollupFix") != std::string::npos)
+                        else if (package.find("RollupFix") != std::string::npos)
                         {
                             std::string value;
                             Utils::Registry packageReg{key, subKey + "\\" + package, KEY_WOW64_64KEY | KEY_READ};

--- a/src/data_provider/src/packages/packagesWindowsParserHelper.h
+++ b/src/data_provider/src/packages/packagesWindowsParserHelper.h
@@ -50,14 +50,22 @@ namespace PackageWindowsHelper
                 {
                     if (Utils::startsWith(package, "Package_"))
                     {
-                        std::string value;
-                        Utils::Registry packageReg{key, subKey + "\\" + package, KEY_WOW64_64KEY | KEY_READ};
-                        if (packageReg.string("InstallLocation", value))
+                        auto hfValue { extractHFValue(package) };
+                        if (!hfValue.empty())
                         {
-                            auto hfValue { extractHFValue(value) };
-                            if (!hfValue.empty())
+                            hotfixes.insert(std::move(hfValue));
+                        }
+                        if(package.find("RollupFix") != std::string::npos)
+                        {
+                            std::string value;
+                            Utils::Registry packageReg{key, subKey + "\\" + package, KEY_WOW64_64KEY | KEY_READ};
+                            if (packageReg.string("InstallLocation", value))
                             {
-                                hotfixes.insert(std::move(hfValue));
+                                auto rollUpValue { extractHFValue(value) };
+                                if (!rollUpValue.empty())
+                                {
+                                    hotfixes.insert(std::move(rollUpValue));
+                                }
                             }
                         }
                     }

--- a/src/data_provider/src/packages/packagesWindowsParserHelper.h
+++ b/src/data_provider/src/packages/packagesWindowsParserHelper.h
@@ -55,7 +55,7 @@ namespace PackageWindowsHelper
                         {
                             hotfixes.insert(std::move(hfValue));
                         }
-                        if(package.find("RollupFix") != std::string::npos)
+                        else if(package.find("RollupFix") != std::string::npos)
                         {
                             std::string value;
                             Utils::Registry packageReg{key, subKey + "\\" + package, KEY_WOW64_64KEY | KEY_READ};


### PR DESCRIPTION
|Related issue|
|---|
| Closes #9414 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR aims to fix the issue found during dev testing in issue #9386 related to some missing hotfixes in the items reported by sysinfo.

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors