### PR TITLE
Fix agent upgrade via WPK

### DIFF
--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -6,22 +6,58 @@ WAZUH_HOME=${1}
 WAZUH_VERSION=${2}
 
 # Generating Backup
+TMP_DIR_BACKUP="${WAZUH_HOME}/tmp_bkp"
+rm -rf "${WAZUH_HOME}/tmp_bkp/*"
+
 BDATE=$(date +"%m-%d-%Y_%H-%M-%S")
+declare -a FOLDERS_TO_BACKUP
 
 echo "$(date +"%Y/%m/%d %H:%M:%S") - Generating Backup." > ${WAZUH_HOME}/logs/upgrade.log
-mkdir -p ${WAZUH_HOME}/tmp_bkp/${WAZUH_HOME}/bin
-mkdir -p ${WAZUH_HOME}/tmp_bkp/${WAZUH_HOME}/etc
-mkdir -p ${WAZUH_HOME}/tmp_bkp/etc
 
-cp -rp ${WAZUH_HOME}/bin ${WAZUH_HOME}/tmp_bkp/${WAZUH_HOME}
-cp -rp ${WAZUH_HOME}/etc ${WAZUH_HOME}/tmp_bkp/${WAZUH_HOME}
+# Generate directory tree to backup
+FOLDERS_TO_BACKUP+=( ${WAZUH_HOME}/active-response )
+FOLDERS_TO_BACKUP+=( ${WAZUH_HOME}/bin )
+FOLDERS_TO_BACKUP+=( ${WAZUH_HOME}/etc )
+FOLDERS_TO_BACKUP+=( ${WAZUH_HOME}/lib )
+FOLDERS_TO_BACKUP+=( ${WAZUH_HOME}/queue )
+FOLDERS_TO_BACKUP+=( ${WAZUH_HOME}/ruleset )
+FOLDERS_TO_BACKUP+=( ${WAZUH_HOME}/wodles )
+
+for dir in ${FOLDERS_TO_BACKUP[@]};
+do
+  mkdir -p ${TMP_DIR_BACKUP}${dir}
+  cp -a ${dir}/* ${TMP_DIR_BACKUP}${dir}
+done
 
 if [ -f /etc/ossec-init.conf ]; then
+    mkdir -p ${WAZUH_HOME}/tmp_bkp/etc
     cp -p /etc/ossec-init.conf ${WAZUH_HOME}/tmp_bkp/etc
 fi
 
+
+# Check if systemd is used
+SYSTEMD_SERVICE_UNIT_PATH=/usr/lib/systemd/system/wazuh-agent.service
+if [ -f ${SYSTEMD_SERVICE_UNIT_PATH} ];
+then
+    mkdir -p "${TMP_DIR_BACKUP}/usr/lib/systemd/system/"
+    cp -a "${SYSTEMD_SERVICE_UNIT_PATH}" "${TMP_DIR_BACKUP}${SYSTEMD_SERVICE_UNIT_PATH}" 
+else
+    SYSTEMD_SERVICE_UNIT_PATH=""
+fi
+
+
+# Saves modes and owners of the directories
+BACKUP_LIST_FILES=$(find ${TMP_DIR_BACKUP}/ -type d)
+
+while read -r line; do
+   org=$(echo "${line}" | awk "sub(\"${TMP_DIR_BACKUP}\",\"\")")
+   eval $(echo chown --reference=\'$org\' \'$line\')
+   eval $(echo chmod --reference=\'$org\' \'$line\')
+done <<< "$BACKUP_LIST_FILES"
+
+# Generate Backup
 tar czf ${WAZUH_HOME}/backup/backup_${WAZUH_VERSION}_[${BDATE}].tar.gz -C ${WAZUH_HOME}/tmp_bkp . >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
-rm -rf ${WAZUH_HOME}/tmp_bkp
+#rm -rf ${WAZUH_HOME}/tmp_bkp
 
 # Installing upgrade
 echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade started." >> ${WAZUH_HOME}/logs/upgrade.log
@@ -29,7 +65,7 @@ chmod +x ${WAZUH_HOME}/var/upgrade/install.sh
 ${WAZUH_HOME}/var/upgrade/install.sh >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
 
 # Check installation result
-RESULT=$?
+RESULT=1
 echo "$(date +"%Y/%m/%d %H:%M:%S") - Installation result = ${RESULT}" >> ${WAZUH_HOME}/logs/upgrade.log
 
 # Wait connection
@@ -48,15 +84,24 @@ if [ "$status" = "connected" -a $RESULT -eq 0  ]; then
     echo -ne "0" > ${WAZUH_HOME}/var/upgrade/upgrade_result
     echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade finished successfully." >> ${WAZUH_HOME}/logs/upgrade.log
 else
-    # Restoring backup
+    # Restore backup
     echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. Restoring..." >> ${WAZUH_HOME}/logs/upgrade.log
 
+    # Cleanup before restore
     CONTROL="$WAZUH_HOME/bin/wazuh-control"
     if [ ! -f $CONTROL ]; then
         CONTROL="$WAZUH_HOME/bin/ossec-control"
     fi
-
     $CONTROL stop >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
+
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Deleting upgrade files..." >> ${WAZUH_HOME}/logs/upgrade.log
+    for dir in ${FOLDERS_TO_BACKUP[@]};
+    do
+        rm -rf ${dir} >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
+    done
+
+    # Restore backup
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Restoring backup...."
     tar xzf ${WAZUH_HOME}/backup/backup_${WAZUH_VERSION}_[${BDATE}].tar.gz -C / >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
     echo -ne "2" > ${WAZUH_HOME}/var/upgrade/upgrade_result
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/9406|

Hello team,

This PR is to fix the problem when restoring the agent version when the WPK update fails. At the moment, the script only backups the `/etc`, `WAZUH_PATH/bin` and `WAZUH_PATH/etc` folders, but this copy alone is insufficient.

## Description
The current backup is insufficient, as it only saves the contents of the `/etc`, `WAZUH_PATH/bin` and `WAZUH_PATH/etc` folders. In addition, it does not save the permissions and the user of these folders. Some things to keep in mind:
- [ ] For all folders that are backed up, the permissions and owner of the folder must be saved.
- [ ] System `systemd` and/or `sysvinit` files could be changed in the upgrading process, and, as the binaries changes their prefix from "ossec-" to "wazuh-", after the restoration, the services may not start again as they were modified and never restored to the previous values.
- [ ] Active Responses also change but, currently, they are not taken into account when doing the backup.
- [ ] The libraries (`/lib`) used vary between versions.
- [ ] A backup of `/queue` is required (includes the fim database)
- [ ] A backup of `/ruleset` (SCA) is required
- [ ] A backup of `/wodles` is required
- [ ] Windows services must be taken into account 
- [ ] In the 4.3 version o Wazuh, a change of users and groups of the files is also implemented, from `ossec` to `wazuh`. In a failed upgrade, the ossec user/group is deleted and this produces errors when trying to perform the restoring of the installation.


## Configuration options
Generate certificate in manager side:
```bash
# cd /root/
# mkdir certs
# cd certs
# openssl req -x509 -new -nodes -newkey rsa:2048 -keyout wpk_root.key -out wpk_root.pem -batch
# openssl req -new -nodes -newkey rsa:2048 -keyout wpkcert.key -out wpkcert.csr -subj '/C=US/ST=CA/O=Wazuh'
# openssl x509 -req -days 365 -in wpkcert.csr -CA wpk_root.pem -CAkey wpk_root.key -out wpkcert.pem -CAcreateserial
# ./generate_wpk_package.sh -t linux -b 9406-fix-WPK-agent-upgrate -d /tmp/wpk -k /root/certs -o LinuxAgent.wpk
```
Copy certificate to agent:
```bash
# scp ./wpk_root.pem root@AGENT_IP:/root/
```

Agent (`ossec.conf`):
```xml
<agent-upgrade>
    <ca_verification>
        <enabled>yes</enabled>
        <ca_store>/var/ossec/etc/wpk_root.pem</ca_store>
        <ca_store>/root/wpk_root.pem</ca_store>
    </ca_verification>
</agent-upgrade>
```

Execute the following command inmanager side to upgrade agent:
```bash
# ./generate_wpk_package.sh -t linux -b 4.2 -d /tmp/wpk -k /root/certs -o LinuxAgent.wpk
```

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors