### PR TITLE
Remove WPK rollback code section

### DIFF
--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -8,21 +8,6 @@ WAZUH_VERSION=${2}
 # Generating Backup
 BDATE=$(date +"%m-%d-%Y_%H-%M-%S")
 
-echo "$(date +"%Y/%m/%d %H:%M:%S") - Generating Backup." > ${WAZUH_HOME}/logs/upgrade.log
-mkdir -p ${WAZUH_HOME}/tmp_bkp/${WAZUH_HOME}/bin
-mkdir -p ${WAZUH_HOME}/tmp_bkp/${WAZUH_HOME}/etc
-mkdir -p ${WAZUH_HOME}/tmp_bkp/etc
-
-cp -rp ${WAZUH_HOME}/bin ${WAZUH_HOME}/tmp_bkp/${WAZUH_HOME}
-cp -rp ${WAZUH_HOME}/etc ${WAZUH_HOME}/tmp_bkp/${WAZUH_HOME}
-
-if [ -f /etc/ossec-init.conf ]; then
-    cp -p /etc/ossec-init.conf ${WAZUH_HOME}/tmp_bkp/etc
-fi
-
-tar czf ${WAZUH_HOME}/backup/backup_${WAZUH_VERSION}_[${BDATE}].tar.gz -C ${WAZUH_HOME}/tmp_bkp . >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
-rm -rf ${WAZUH_HOME}/tmp_bkp
-
 # Installing upgrade
 echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade started." >> ${WAZUH_HOME}/logs/upgrade.log
 chmod +x ${WAZUH_HOME}/var/upgrade/install.sh
@@ -48,17 +33,7 @@ if [ "$status" = "connected" -a $RESULT -eq 0  ]; then
     echo -ne "0" > ${WAZUH_HOME}/var/upgrade/upgrade_result
     echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade finished successfully." >> ${WAZUH_HOME}/logs/upgrade.log
 else
-    # Restoring backup
-    echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. Restoring..." >> ${WAZUH_HOME}/logs/upgrade.log
-
-    CONTROL="$WAZUH_HOME/bin/wazuh-control"
-    if [ ! -f $CONTROL ]; then
-        CONTROL="$WAZUH_HOME/bin/ossec-control"
-    fi
-
-    $CONTROL stop >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
-    tar xzf ${WAZUH_HOME}/backup/backup_${WAZUH_VERSION}_[${BDATE}].tar.gz -C / >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
-    echo -ne "2" > ${WAZUH_HOME}/var/upgrade/upgrade_result
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed..." >> ${WAZUH_HOME}/logs/upgrade.log
 
     CONTROL="$WAZUH_HOME/bin/wazuh-control"
     if [ ! -f $CONTROL ]; then
@@ -66,4 +41,6 @@ else
     fi
 
     $CONTROL start >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
+    echo -ne "2" > ${WAZUH_HOME}/var/upgrade/upgrade_result
+
 fi

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -5,9 +5,6 @@
 WAZUH_HOME=${1}
 WAZUH_VERSION=${2}
 
-# Generating Backup
-BDATE=$(date +"%m-%d-%Y_%H-%M-%S")
-
 # Installing upgrade
 echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade started." >> ${WAZUH_HOME}/logs/upgrade.log
 chmod +x ${WAZUH_HOME}/var/upgrade/install.sh
@@ -40,6 +37,7 @@ else
         CONTROL="$WAZUH_HOME/bin/ossec-control"
     fi
 
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Trying to start the agent on its current state..." >> ${WAZUH_HOME}/logs/upgrade.log
     $CONTROL start >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
     echo -ne "2" > ${WAZUH_HOME}/var/upgrade/upgrade_result
 

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -1,13 +1,3 @@
-function backup
-{
-    New-Item -ItemType directory -Path .\backup -ErrorAction SilentlyContinue
-    New-Item -ItemType directory -Path $env:temp\backup -ErrorAction SilentlyContinue
-    Copy-Item .\* $env:temp\backup -force
-    Remove-Item $env:temp\backup\backup -recurse -ErrorAction SilentlyContinue
-    Copy-Item $env:temp\backup\* .\backup -force
-    Remove-Item $env:temp\backup -recurse -ErrorAction SilentlyContinue
-}
-
 # Stop UI and launch the msi installer
 function install
 {
@@ -15,12 +5,6 @@ function install
     Remove-Item .\upgrade\upgrade_result -ErrorAction SilentlyContinue
     write-output "$(Get-Date -format u) - Starting upgrade processs." >> .\upgrade\upgrade.log
     cmd /c start (Get-Item ".\wazuh-agent*.msi").Name -quiet -norestart -log installer.log
-}
-
-function restore
-{
-    Copy-Item .\backup\* .\ -force
-    Remove-Item .\backup -recurse -ErrorAction SilentlyContinue
 }
 
 # Check new version and restart the Wazuh service
@@ -49,10 +33,6 @@ If (!(Test-Path ".\wazuh-agent.exe"))
 {
     $current_process = "ossec-agent"
 }
-
-# Generating backup
-write-output "$(Get-Date -format u) - Generating backup." >> .\upgrade\upgrade.log
-backup
 
 # Ensure implicated processes are stopped before launch the upgrade
 Get-Process msiexec | Stop-Process -ErrorAction SilentlyContinue -Force
@@ -101,26 +81,10 @@ write-output "$(Get-Date -format u) - Reading status file: $($status)" >> .\upgr
 If ($status -eq $null)
 {
     write-output "2" | out-file ".\upgrade\upgrade_result" -encoding ascii
-    Get-Service -Name "Wazuh" | Stop-Service
-    restore
-    write-output "$(Get-Date -format u) - Upgrade failed: Restoring." >> .\upgrade\upgrade.log
-    If ($current_process -eq "wazuh-agent")
-    {
-        .\wazuh-agent.exe install-service >> .\upgrade\upgrade.log
-    }
-    Else
-    {
-        sc.exe delete WazuhSvc -ErrorAction SilentlyContinue -Force
-        Remove-Item .\wazuh-agent.exe -ErrorAction SilentlyContinue
-        Remove-Item .\wazuh-agent.state -ErrorAction SilentlyContinue
-        .\ossec-agent.exe install-service >> .\upgrade\upgrade.log
-    }
-    Start-Service -Name "Wazuh" -ErrorAction SilentlyContinue
 }
 Else
 {
     write-output "0" | out-file ".\upgrade\upgrade_result" -encoding ascii
-    Remove-Item .\backup -recurse -ErrorAction SilentlyContinue
     write-output "$(Get-Date -format u) - Upgrade finished successfully." >> .\upgrade\upgrade.log
     $new_version = (Get-Content VERSION)
     write-output "$(Get-Date -format u) - New version: $($new_version)" >> .\upgrade\upgrade.log

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -81,6 +81,7 @@ write-output "$(Get-Date -format u) - Reading status file: $($status)" >> .\upgr
 If ($status -eq $null)
 {
     write-output "2" | out-file ".\upgrade\upgrade_result" -encoding ascii
+    write-output "$(Get-Date -format u) - Upgrade failed. Agent installation may be broken." >> .\upgrade\upgrade.log
 }
 Else
 {


### PR DESCRIPTION
|Related issue|
|---|
|Closes #9449 |

Hi team!,

This PR has 2 commits:
- The first commit removes the backup and rollback code section, which handles the case when upgrading with WPK fails.
- ~The second one is just for testing purposes, it forces the upgrade to fail.~

## Tests
### Linux
- [x] Centos 6: Upgrade failure 3.13 -> 4.2
- [x] Centos 6: Upgrade failure 4.0 -> 4.2
- [x] Centos 6: Upgrade failure 4.2 -> 4.2
- [x] Centos 8: Upgrade failure 3.13 -> 4.2
- [x] Centos 8: Upgrade failure 4.1.5 -> 4.2
- [x] Centos 8: Upgrade failure 4.2 -> 4.2
- [x] Ubuntu: Upgrade failure 3.13 -> 4.2
- [x] Ubuntu: Upgrade failure 4.0 -> 4.2
- [x] Ubuntu: Upgrade failure 4.2 -> 4.2


### Windows:
- [x] Windows 10: Upgrade failure 3.13 -> 4.2
- [x] Windows 10: Upgrade failure 4.0 -> 4.2
- [x] Windows 10: Upgrade failure 4.2 -> 4.2
- [x] Windows Server 2008: Upgrade failure 3.13 -> 4.2
- [x] Windows Server 2008: Upgrade failure 4.2 -> 4.2
- [x] WIndows Server 2008: Upgrade failure 4.0 -> 4.2
- [x] Windows Server 2012r2: Upgrade failure 3.13 -> 4.2
- [x] Windows Server 2012r2: Upgrade failure 4.2 -> 4.2
- [x] WIndows Server 2012r2: Upgrade failure 4.0 -> 4.2

