### PR TITLE
Allow the execution of batch files for Windows AR

### DIFF
--- a/src/shared/exec_op.c
+++ b/src/shared/exec_op.c
@@ -131,7 +131,7 @@ wfd_t * wpopenv(const char * path, char * const * argv, int flags) {
         mdebug2("path = '%s', command = '%s'", path, lpCommandLine);
     }
 
-    if (!CreateProcess(path, lpCommandLine, NULL, NULL, TRUE, 0, NULL, NULL, &sinfo, &pinfo)) {
+    if (!CreateProcess(NULL, lpCommandLine, NULL, NULL, TRUE, 0, NULL, NULL, &sinfo, &pinfo)) {
         mdebug1("CreateProcess(): %ld", GetLastError());
 
         if (flags & (W_BIND_STDOUT | W_BIND_STDERR)) {


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/9464|

## Description

There was a problem on Windows systems not being able to run batch files as active responses.

This PR includes a solution to this problem, which was related the way `CreateProcess` function was called.

The first argument, [`lpApplicationName`](https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa#parameters), needs to be `NULL` so the script is executed from the first argument `argv0`, as it was done in previous versions of Wazuh.

## Logs/Alerts example

- `AR_script.cmd`

```
PowerShell.exe -ExecutionPolicy ByPass -File "c:\tmp\active_response.ps1"
```

- `active_response.ps1`

```
$logFile="C:\tmp\test_active_response.log"

try{
  $lines=(cat $logFile | Measure-Object -line).lines
} catch {
  "ERROR: $_"
  "It seems that file isn't created yet..."
  $lines=0
}

write-output "Fired ${lines} times" | out-file $logFile -Append -encoding utf8
```

- Manager's `ossec.conf`

```xml
  <command>
    <name>test</name>
    <executable>AR_script.cmd</executable>
  </command>

  <active-response>
      <command>test</command>
      <location>local</location>
      <rules_id>100001</rules_id>
      <timeout>60</timeout>
  </active-response>
```

- Agent's `ossec.log`

```
2021/08/04 12:16:14 wazuh-agent[3864] receiver-win.c:128 at receiver_thread(): DEBUG: Received message: '#!-execd {"version":1,"origin":{"name":"node01","module":"wazuh-analysisd"},"command":"test0","parameters":{"extra_args":[],"alert":{...}}'
2021/08/04 12:16:14 wazuh-agent[3864] win_execd.c:228 at WinExecdRun(): DEBUG: Executing command 'active-response/bin/AR_script.cmd {"version":1,"origin":{"name":"node01","module":"wazuh-execd"},"command":"add","parameters":{"extra_args":[],"alert":{...},"program":"active-response/bin/AR_script.cmd"}}'
2021/08/04 12:16:14 wazuh-agent[3864] exec_op.c:131 at wpopenv(): DEBUG: path = 'active-response/bin/AR_script.cmd', command = '"active-response/bin/AR_script.cmd"'
```

- AR result

```
Fire AR
Fired 1 times
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade

## Tests of other components

- [x] `command`
- [x] `osquery`
- [x] `CIS-CAT`