### PR TITLE
Fix agent healthcheck error in API integration tests environment

### DIFF
--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -1899,6 +1899,9 @@ stages:
 ---
 test_name: GET /agents/{agent_id}/stats/{component}
 
+marks:
+  - xfail  # https://github.com/wazuh/wazuh/issues/9665
+
 stages:
 
   - name: Get logcollector stats from agent 000 (manager)


### PR DESCRIPTION
|Related issue|
|---|
| #9451 |

This PR closes #9451.

**This fix was already included in master in https://github.com/wazuh/wazuh/pull/9071.**

In this PR, I have updated the `get_agent_health` function of `healthcheck_utils` to fix the race condition mentioned in the related issue.

I have removed the timestamp check. Now we will iterate over the logs we need to check the agent health and will return healthy if a `'Connected to server'` log is found after a `'Restarting due to shared configuration...'` log.

Regards,
Manuel.