### PR TITLE
Update copyright notice at Windows agent About UI panel

### DIFF
--- a/src/win32/ui/win32ui.rc
+++ b/src/win32/ui/win32ui.rc
@@ -22,7 +22,7 @@ CAPTION "About Wazuh"
 FONT 8, "MS Sans Serif"
 BEGIN
     DEFPUSHBUTTON  "&Close",UI_ID_CLOSE,90,90,50,14
-    GROUPBOX       " Copyright (C) 2015-2020, Wazuh Inc.",
+    GROUPBOX       " Copyright (C) 2015-2021, Wazuh Inc.",
                    IDC_STATIC,7,7,245,82
     CTEXT   "This program is a free software; you can redistribute it" \
             " and/or modify it under the terms of the GNU General" \


### PR DESCRIPTION
This PR aims to fix the following copyright notice in the Windows agent:

![image](https://user-images.githubusercontent.com/10536251/128359972-d594a7b1-3f2c-4365-b7de-e08915ce3b8c.png)

Fixed text:

![image](https://user-images.githubusercontent.com/10536251/128360639-7680befe-5a7a-422a-82c6-cb2c21cf7225.png)
