### PR TITLE
New decoders for Cisco IOS

### DIFF
--- a/ruleset/decoders/0065-cisco-ios_decoders.xml
+++ b/ruleset/decoders/0065-cisco-ios_decoders.xml
@@ -270,3 +270,22 @@ Details: https://www.cisco.com/c/en/us/td/docs/routers/access/wireless/software/
   <regex>%(\w+)-(\d)-(\w+):</regex>
   <order>cisco.facility, cisco.severity, cisco.mnemonic</order>
 </decoder>
+
+<!-- Cisco IOS
+  - Extracts the ID of cisco ios messages IF NOT IDS/ACL log.
+
+- Modified according CISCO documentation: https://www.cisco.com/c/en/us/td/docs/routers/access/wireless/software/guide/SysMsgLogging.html
+- Log line: Jul 29 20:08:37 UTC: %FTD-session-6-305012: Teardown dynamic TCP translation from INTF-INSIDE-1:10.40.1.239/60914 to INTF-INET-SWKO:209.137.221.2/60914 duration 0:00:00
+  -->
+
+<decoder name="cisco-ios-default">
+  <parent>cisco-ios</parent>
+  <regex>%(\w+)-session-(\d)-(\w+): </regex>
+  <order>cisco.facility,cisco.severity,cisco.mnemonic</order>
+</decoder>
+
+<decoder name="cisco-ios-default">
+  <parent>cisco-ios</parent>
+  <regex>%\w+-session-\d-\w+: (\.*) duration (\d+:\d+:\d+)</regex>
+  <order>message,duration</order>
+</decoder>


### PR DESCRIPTION
|Related issue|
|---|
|Closes #9499 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Adapted and added proposed decoders for Cisco IOS with `session` header.
<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors