### PR TITLE
Fix CA verification when disabled

### DIFF
--- a/src/config/wmodules-agent-upgrade.c
+++ b/src/config/wmodules-agent-upgrade.c
@@ -197,6 +197,12 @@ int wm_agent_upgrade_read(__attribute__((unused)) const OS_XML *xml, xml_node **
         }
     } else {
         minfo("WPK verification with CA is disabled.");
+        if (wcom_ca_store) {
+            for (int i = 0; wcom_ca_store[i]; ++i) {
+                os_free(wcom_ca_store[i]);
+            }
+            os_free(wcom_ca_store);
+        }
     }
     #endif
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/9537|

## Description

This PR solves a problem related to the disabled option of CA verification when upgrading an agent using a WPK file.

If disabled, all the certificates that may have been loaded needed to be released. This was necessary because they were being used later to verify the WPK signature, which was not correct to do.

## Configuration options

Disable sign:
```xml
<agent-upgrade>
  <enabled>yes</enabled>
  <ca_verification>
    <enabled>no</enabled>
  </ca_verification>
</agent-upgrade>
```

Enable but without cert:
```xml
<agent-upgrade>
  <enabled>yes</enabled>
  <ca_verification>
    <enabled>yes</enabled>
  </ca_verification>
</agent-upgrade>
```

## Logs/Alerts example

Disable sign:
```
2021/08/06 15:39:44 wazuh-modulesd: WARNING: No root CA defined to verify file 'var/incoming/LinuxAgent.wpk'.
```

Enable but without cert:
```
2021/08/06 15:42:48 wazuh-modulesd: ERROR: Error verifying WPK certificate.
2021/08/06 15:42:48 wazuh-modulesd:agent-upgrade: ERROR: (8139): At unsign(): Could not unsign package file 'var/incoming/LinuxAgent.wpk'
2021/08/06 15:42:48 wazuh-modulesd:agent-upgrade: ERROR: (8131): At upgrade: 'Could not verify signature'
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade