### PR TITLE
Fix xfail flags and responses

### DIFF
--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -706,9 +706,6 @@ stages:
 ---
 test_name: GET /cluster/configuration/validation
 
-marks:
-  - xfail # Sometimes fails due to https://github.com/wazuh/wazuh/issues/6746
-
 stages:
 
   - name: Request cluster validation

--- a/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
@@ -2545,9 +2545,6 @@ stages:
 ---
 test_name: DELETE /security/users/{user_id}/roles
 
-marks:
-  - xfail # Fails due to https://github.com/wazuh/wazuh/issues/7473
-
 stages:
   - name: Try to remove roles from user (generic)
     request:
@@ -2559,7 +2556,7 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
-      <<: *empty_response
+      <<: *permission_denied
 
   - name: Try to remove role from user (specific)
     request:
@@ -2608,9 +2605,6 @@ stages:
 ---
 test_name: DELETE /security/roles/{role_id}/policies
 
-marks:
-  - xfail # Fails due to https://github.com/wazuh/wazuh/issues/7473
-
 stages:
   - name: Try to remove policies from role (generic)
     request:
@@ -2622,7 +2616,7 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
-      <<: *empty_response
+      <<: *permission_denied
 
   - name: Try to remove policy from role (specific)
     request:
@@ -2638,9 +2632,6 @@ stages:
 
 ---
 test_name: DELETE /security/roles/{role_id}/rules
-
-marks:
-  - xfail # Fails due to https://github.com/wazuh/wazuh/issues/7473
 
 stages:
   - name: Try to remove rules from role (generic)


### PR DESCRIPTION
|Related issue|
|---|
| #9456 |

Hi !
`xfail` flag removed from `test_cluster_endpoints.tavern.yaml` and `test_rbac_white_all_endpoints.tavern.yaml`.
More precisely, these endpoints:

```python
DELETE /security/users/{user_id}/roles
DELETE /security/roles/{role_id}/policies
DELETE /security/roles/{role_id}/rules
GET /cluster/configuration/validation
```
Besides that, a few tests response were corrected too.

Regards,
Alexis