### PR TITLE
Increase Logcollector state file interval default value to one minute

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -143,7 +143,7 @@ logcollector.exclude_files_interval=86400
 
 # State generation updating interval, in seconds [0..3600]
 # 0 means state file creation and updating is disabled
-logcollector.state_interval=5
+logcollector.state_interval=60
 
 # Remoted counter io flush.
 remoted.recv_counter_flush=128


### PR DESCRIPTION
|Related issue|
|---|
|Closes #9559|

This PR increases the internal option `logcollector.state_interval` default value from 5 seconds to one minute.

## Tests

- [X] Check that _/var/ossec/var/run/wazuh-logcollector.state_ gets updated every minute.

```shell
# stat /var/ossec/var/run/wazuh-logcollector.state

  File: /var/ossec/var/run/wazuh-logcollector.state
  Size: 1654            Blocks: 8          IO Block: 4096   regular file
Device: 810h/2064d      Inode: 454887      Links: 1
Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (  998/   ossec)
Access: 2021-08-10 09:25:47.050000000 +0200
Modify: 2021-08-10 09:26:47.050000000 +0200
Change: 2021-08-10 09:26:47.050000000 +0200
 Birth: -
```