### PR TITLE
Fix agent custom upgrade API integration test

### DIFF
--- a/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
@@ -1060,7 +1060,7 @@ stages:
               task_id: !anyint
               module: upgrade_module
               command: upgrade_custom
-              status: Updating
+              status: !anystr
               create_time: !anystr
               update_time: !anystr
           total_affected_items: 1


### PR DESCRIPTION
|Related issue|
|---|
| #9442  |

This PR closes #9442 .

In this PR, the expected `status` for the agent custom upgrade endpoint test has been changed to `!anystr`, as this test should not check it. That should be tested on a lower level.

## Tests performed
### Integration tests
```
Collected tests [1]:
test_agent_PUT_endpoints.tavern.yaml


test_agent_PUT_endpoints.tavern.yaml 
	 9 passed, 11 warnings

```

Regards,
Víctor