### PR TITLE
Fix decrease default monitoring limit

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -802,6 +802,30 @@ void LogCollectorStart()
 
                     current->fp = NULL;
                     current->ign = 999;
+
+                    if (j >= 0) {
+#ifndef WIN32
+                        struct stat stat_fd;
+                        if (stat(current->file, &stat_fd) == -1 && ENOENT == errno) {
+#else
+                        if (!PathFileExists(current->file)) {
+#endif
+                            os_file_status_t * old_file_status = OSHash_Delete_ex(files_status, current->file);
+                            os_free(old_file_status);
+                            w_logcollector_state_delete_file(current->file);
+
+                            if (Remove_Localfile(&(globs[j].gfiles), i, 1, 0,&globs[j])) {
+                                merror(REM_ERROR, current->file);
+                            } else {
+                                mdebug1(CURRENT_FILES, current_files, maximum_files);
+                                i--;
+                            }
+                        } else {
+#ifndef WIN32
+                            merror(FSTAT_ERROR, current->file, errno, strerror(errno));
+#endif
+                        }
+                    }
                     continue;
                 }
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #9432 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors