### PR TITLE
Fix syscollector exception log prefix

### DIFF
--- a/src/wazuh_modules/syscollector/cppcheckSuppress.txt
+++ b/src/wazuh_modules/syscollector/cppcheckSuppress.txt
@@ -1,3 +1,3 @@
 *:*.c
 *:*syscollector.h
-*:*src/syscollectorImp.cpp:953
+*:*src/syscollectorImp.cpp:952

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -30,8 +30,7 @@ do                                                                      \
     {                                                                   \
         if(m_logFunction)                                               \
         {                                                               \
-            const std::string error{"task: " + std::string{ex.what()}}; \
-            m_logFunction(SYS_LOG_ERROR, error);                        \
+            m_logFunction(SYS_LOG_ERROR, std::string{ex.what()});       \
         }                                                               \
     }                                                                   \
 }while(0)


### PR DESCRIPTION
|Related issue|
|---|
|Closes #9656|

## Description

Hi team!

This PR aims to remove syscollector exception log prefix to keep backward compatibility with old syscollector and their installation test on OpenSuse

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors