### PR TITLE
New registration option for agent that already got a key

### DIFF
--- a/src/client-agent/config.c
+++ b/src/client-agent/config.c
@@ -48,7 +48,7 @@ int ClientConf(const char *cfgfile)
     w_enrollment_target *target_cfg = w_enrollment_target_init();
 
     // Initialize enrollment_cfg
-    agt->enrollment_cfg = w_enrollment_init(target_cfg, cert_cfg);
+    agt->enrollment_cfg = w_enrollment_init(target_cfg, cert_cfg, &keys);
     agt->enrollment_cfg->allow_localhost = 0; // Localhost not allowed in auto-enrollment
 
     if (ReadConfig(modules, cfgfile, agt, NULL) < 0 ||

--- a/src/headers/enrollment_op.h
+++ b/src/headers/enrollment_op.h
@@ -23,6 +23,7 @@
 
 #include <openssl/ssl.h>
 #include <openssl/ossl_typ.h>
+#include "sec.h"
 
 #define ENROLLMENT_WRONG_CONFIGURATION -1
 #define ENROLLMENT_CONNECTION_FAILURE -2
@@ -65,6 +66,7 @@ typedef struct _enrollment_cert_cfg {
 typedef struct _enrollment_ctx {
     w_enrollment_target *target_cfg;        /**> for details @see _enrollment_target_cfg */
     w_enrollment_cert *cert_cfg;            /**> for details @see _enrollment_cert_cfg */
+    keystore *keys;                         /**> keys structure */
     SSL *ssl;                               /**> will hold the connection instance with the manager */
     unsigned int enabled:1;                 /**> enabled / disables auto enrollment */
     unsigned int allow_localhost:1;         /**> 1 by default if this flag is in 0 using agent_name "localhost" will not be allowed */
@@ -97,7 +99,7 @@ void w_enrollment_cert_destroy(w_enrollment_cert *cert);
  * Initializes parameters of an w_enrollment_ctx structure based
  * on a target and certificate configurations
  * */
-w_enrollment_ctx * w_enrollment_init(w_enrollment_target *target, w_enrollment_cert *cert);
+w_enrollment_ctx * w_enrollment_init(w_enrollment_target *target, w_enrollment_cert *cert, keystore *keys);
 
 /**
  * Frees parameers of an w_enrollment_ctx structure

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -274,7 +274,8 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    w_enrollment_ctx *cfg = w_enrollment_init(target_cfg, cert_cfg);
+    /* NULL until the agent-auth fix is implemented */
+    w_enrollment_ctx *cfg = w_enrollment_init(target_cfg, cert_cfg, NULL);
     int ret = w_enrollment_request_key(cfg, server_address);
 
     w_enrollment_target_destroy(target_cfg);

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -486,10 +486,10 @@ static void w_enrollment_verify_ca_certificate(const SSL *ssl, const char *ca_ce
 }
 
 /**
- * @brief Concats the current key of the agent, if exist, as  part of the enrollment message
+ * @brief Concatenates the current key of the agent, if exists, as  part of the enrollment message
  *
  * @param buff buffer where the KEY section will be concatenated
- * @param key key will be added
+ * @param key_entry The key that will be concatenated
  */
 static void w_enrollment_concat_key(char *buff, keyentry* key_entry) {
     assert(buff != NULL);
@@ -497,10 +497,10 @@ static void w_enrollment_concat_key(char *buff, keyentry* key_entry) {
 
     os_sha1 output;
     char* opt_buf = NULL;
-    os_calloc(OS_SIZE_65536, sizeof(char), opt_buf);
+    os_calloc(OS_SIZE_512, sizeof(char), opt_buf);
     w_get_key_hash(key_entry, output);
-    snprintf(opt_buf, OS_SIZE_65536, " K:'%s'", output);
-    strncat(buff,opt_buf,OS_SIZE_65536);
+    snprintf(opt_buf, OS_SIZE_512, " K:'%s'", output);
+    strncat(buff,opt_buf,OS_SIZE_512);
     free(opt_buf);
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|#9569|

## Description

If the agent already has a key, it will send it to the manager for validation.

## Dod

![1](https://user-images.githubusercontent.com/13010397/129027696-0d5c7629-484a-4059-bb8b-b96b2a29c83a.png)


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Review logs syntax and correct language