### PR TITLE
Updating agent_auth binary to send agent's key's hash in every request

### DIFF
--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -276,6 +276,7 @@ int main(int argc, char **argv)
 
     // Reading agent's key (if any) to send its hash to the manager
     keystore agent_keys = KEYSTORE_INITIALIZER;
+    OS_PassEmptyKeyfile();
     OS_ReadKeys(&agent_keys, 0, 0);
 
     w_enrollment_ctx *cfg = w_enrollment_init(target_cfg, cert_cfg, &agent_keys);

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -23,7 +23,6 @@
  *
  */
 
-#include "sec.h"
 #include "shared.h"
 #include <openssl/ssl.h>
 #include "auth.h"
@@ -275,11 +274,11 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    keystore keys = KEYSTORE_INITIALIZER;
-    w_enrollment_ctx *cfg = w_enrollment_init(target_cfg, cert_cfg, keys);
-
     // Reading agent's key (if any) to send its hash to the manager
-    OS_ReadKeys(&keys, 0, 0);
+    keystore agent_keys = KEYSTORE_INITIALIZER;
+    OS_ReadKeys(&agent_keys, 0, 0);
+
+    w_enrollment_ctx *cfg = w_enrollment_init(target_cfg, cert_cfg, &agent_keys);
     int ret = w_enrollment_request_key(cfg, server_address);
 
     w_enrollment_target_destroy(target_cfg);

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -31,9 +31,6 @@
 #undef ARGV0
 #define ARGV0 "agent-auth"
 
-/*Global keys structure*/
-keystore keys = KEYSTORE_INITIALIZER;
-
 static void help_agent_auth(char * home_path) __attribute__((noreturn));
 
 /* Print help statement */
@@ -278,8 +275,11 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    /* NULL until the agent-auth fix is implemented */
-    w_enrollment_ctx *cfg = w_enrollment_init(target_cfg, cert_cfg, NULL);
+    keystore keys = KEYSTORE_INITIALIZER;
+    w_enrollment_ctx *cfg = w_enrollment_init(target_cfg, cert_cfg, keys);
+
+    // Reading agent's key (if any) to send its hash to the manager
+    OS_ReadKeys(&keys, 0, 0);
     int ret = w_enrollment_request_key(cfg, server_address);
 
     w_enrollment_target_destroy(target_cfg);

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -23,12 +23,16 @@
  *
  */
 
+#include "sec.h"
 #include "shared.h"
 #include <openssl/ssl.h>
 #include "auth.h"
 
 #undef ARGV0
 #define ARGV0 "agent-auth"
+
+/*Global keys structure*/
+keystore keys = KEYSTORE_INITIALIZER;
 
 static void help_agent_auth(char * home_path) __attribute__((noreturn));
 

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -23,6 +23,7 @@
  *
  */
 
+#include "sec.h"
 #include "shared.h"
 #include <openssl/ssl.h>
 #include "auth.h"
@@ -285,6 +286,7 @@ int main(int argc, char **argv)
     w_enrollment_target_destroy(target_cfg);
     w_enrollment_cert_destroy(cert_cfg);
     w_enrollment_destroy(cfg);
+    OS_FreeKeys(&agent_keys);
 
     exit((ret == 0) ? 0 : 1);
 }

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -23,10 +23,10 @@
  *
  */
 
-#include "sec.h"
 #include "shared.h"
 #include <openssl/ssl.h>
 #include "auth.h"
+#include "enrollment_op.h"
 
 #undef ARGV0
 #define ARGV0 "agent-auth"

--- a/src/win32/agent_auth.c
+++ b/src/win32/agent_auth.c
@@ -474,13 +474,13 @@ int main(int argc, char **argv)
     printf("INFO: Using agent name as: %s\n", agentname);
 
     // Send request
-    char *secure_msg;
-    os_calloc(OS_SIZE_6144, sizeof(char), secure_msg);
+    char *enrollment_msg = NULL;
+    os_calloc(OS_SIZE_65536, sizeof(char), enrollment_msg);
     if (authpass) {
-        snprintf(secure_msg, OS_SIZE_6144, "OSSEC PASS: %s OSSEC A:'%s'\n", authpass, agentname);
+        snprintf(enrollment_msg, OS_SIZE_65536, "OSSEC PASS: %s OSSEC A:'%s'\n", authpass, agentname);
     }
     else {
-        snprintf(secure_msg, OS_SIZE_6144, "OSSEC A:'%s'\n", agentname);
+        snprintf(enrollment_msg, OS_SIZE_65536, "OSSEC A:'%s'\n", agentname);
     }
 
     // Reading agent's key (if any) to send its hash to the manager
@@ -488,11 +488,11 @@ int main(int argc, char **argv)
     OS_PassEmptyKeyfile();
     OS_ReadKeys(&agent_keys, 0, 0);
     if (agent_keys.keysize > 0) {
-        w_enrollment_concat_key(secure_msg, agent_keys.keyentries[0]);
+        w_enrollment_concat_key(enrollment_msg, agent_keys.keyentries[0]);
     }
 
-    SendSecureMessage(socket, &context, secure_msg);
-    os_free(secure_msg);
+    SendSecureMessage(socket, &context, enrollment_msg);
+    os_free(enrollment_msg);
     OS_FreeKeys(&agent_keys);
 
     printf("INFO: Sent request to manager. Waiting for reply.\n");

--- a/src/win32/agent_auth.c
+++ b/src/win32/agent_auth.c
@@ -484,10 +484,10 @@ int main(int argc, char **argv)
     }
 
     // Reading agent's key (if any) to send its hash to the manager
-    keystore keys = KEYSTORE_INITIALIZER;
-    OS_ReadKeys(&keys, 0, 0);
-    if (keys.keysize > 0) {
-        w_enrollment_concat_key(secure_msg, keys.keyentries[0]);
+    keystore agent_keys = KEYSTORE_INITIALIZER;
+    OS_ReadKeys(&agent_keys, 0, 0);
+    if (agent_keys.keysize > 0) {
+        w_enrollment_concat_key(secure_msg, agent_keys.keyentries[0]);
     }
 
     SendSecureMessage(socket, &context, secure_msg);

--- a/src/win32/agent_auth.c
+++ b/src/win32/agent_auth.c
@@ -485,6 +485,7 @@ int main(int argc, char **argv)
 
     // Reading agent's key (if any) to send its hash to the manager
     keystore agent_keys = KEYSTORE_INITIALIZER;
+    OS_PassEmptyKeyfile();
     OS_ReadKeys(&agent_keys, 0, 0);
     if (agent_keys.keysize > 0) {
         w_enrollment_concat_key(secure_msg, agent_keys.keyentries[0]);

--- a/src/win32/agent_auth.c
+++ b/src/win32/agent_auth.c
@@ -493,6 +493,7 @@ int main(int argc, char **argv)
 
     SendSecureMessage(socket, &context, secure_msg);
     os_free(secure_msg);
+    OS_FreeKeys(&agent_keys);
 
     printf("INFO: Sent request to manager. Waiting for reply.\n");
 

--- a/src/win32/agent_auth.c
+++ b/src/win32/agent_auth.c
@@ -28,9 +28,6 @@
 
 #define IO_BUFFER_SIZE  0x10000
 
-/*Global keys structure*/
-keystore keys = KEYSTORE_INITIALIZER;
-
 void report_help()
 {
     printf("\n%s %s: Connects to the manager to extract the agent key.\n", __ossec_name, ARGV0);
@@ -478,15 +475,16 @@ int main(int argc, char **argv)
 
     // Send request
     char *secure_msg;
-    os_calloc(OS_SIZE_65536, sizeof(char), secure_msg);
+    os_calloc(OS_SIZE_6144, sizeof(char), secure_msg);
     if (authpass) {
-        snprintf(secure_msg, OS_SIZE_65536, "OSSEC PASS: %s OSSEC A:'%s'\n", authpass, agentname);
+        snprintf(secure_msg, OS_SIZE_6144, "OSSEC PASS: %s OSSEC A:'%s'\n", authpass, agentname);
     }
     else {
-        snprintf(secure_msg, OS_SIZE_65536, "OSSEC A:'%s'\n", agentname);
+        snprintf(secure_msg, OS_SIZE_6144, "OSSEC A:'%s'\n", agentname);
     }
 
     // Reading agent's key (if any) to send its hash to the manager
+    keystore keys = KEYSTORE_INITIALIZER;
     OS_ReadKeys(&keys, 0, 0);
     if (keys.keysize > 0) {
         w_enrollment_concat_key(secure_msg, keys.keyentries[0]);


### PR DESCRIPTION
|Related issue|
|---|
|#9570|

## Description

This PR updates the **agent_auth** binary for Linux and Windows to send the key's hash (if any) during a new key request.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
- Memory tests for Windows
  - [x] Scan-build report
  - [ ] Dr. Memory
