### PR TITLE
Authd key hash parse and validation on local-server

### DIFF
--- a/src/config/authd-config.c
+++ b/src/config/authd-config.c
@@ -51,7 +51,7 @@ int Read_Authd(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
     }
     config->port = 1515;
     config->flags.use_source_ip = 0;
-    config->flags.force_insert = 0;
+    config->force_options.enabled = false;
     config->flags.clear_removed = 0;
     config->flags.use_password = 0;
     config->ciphers = strdup("HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH");
@@ -104,10 +104,10 @@ int Read_Authd(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
                 return OS_INVALID;
             }
 
-            config->flags.force_insert = b;
+            config->force_options.enabled = b;
         } else if (!strcmp(node[i]->element, xml_force_time)) {
             char *end;
-            config->force_time = strtol(node[i]->content, &end, 10);
+            config->force_options.connection_time = strtol(node[i]->content, &end, 10);
 
             if (*end != '\0') {
                 merror(XML_VALUEERR, node[i]->element, node[i]->content);

--- a/src/config/authd-config.h
+++ b/src/config/authd-config.h
@@ -12,10 +12,14 @@
 #define AD_CONF_UNPARSED 3
 #define AD_CONF_UNDEFINED 2
 
+typedef struct authd_force_options_t {
+    bool enabled;
+    int connection_time;
+} authd_force_options_t;
+
 typedef struct authd_flags_t {
     unsigned short disabled:3;
     unsigned short use_source_ip:1;
-    unsigned short force_insert:1;
     unsigned short clear_removed:1;
     unsigned short use_password:1;
     unsigned short verify_host:1;
@@ -26,7 +30,7 @@ typedef struct authd_flags_t {
 typedef struct authd_config_t {
     unsigned short port;
     authd_flags_t flags;
-    int force_time;
+    authd_force_options_t force_options;
     char *ciphers;
     char *agent_ca;
     char *manager_cert;

--- a/src/headers/agent_op.h
+++ b/src/headers/agent_op.h
@@ -85,7 +85,7 @@ int auth_connect();
 int auth_close(int sock);
 
 /**
- * @brief Send a local agent add request.
+ * @brief Send a local agent "add" request.
  * @param sock Socket where the request connection will be done.
  * @param id ID of the newly generated key.
  * @param name Name of the agent to request the new key.
@@ -93,7 +93,7 @@ int auth_close(int sock);
  * @param groups Groups list of the agent to request the new key.
  * @param key KEY of the newly generated key.
  * @param force Force option to be used during the registration. -1 means disabled. 0 or a positive value means enabled.
- * @param json_format Flag to identify if the response should be printed in json format.
+ * @param json_format Flag to identify if the response should be printed in JSON format.
  * @param agent_id ID of the agent when requesting a new key for a specific ID.
  * @param exit_on_error Flag to identify if the application should exit on any error.
  * @return 0 on success or a negative code on error.
@@ -112,7 +112,7 @@ int w_request_agent_add_local(int sock,
 #ifndef WIN32
 
 /**
- * @brief Send a clustered agent add request.
+ * @brief Send a clustered agent "add" request.
  * @param err_response A buffer where the error message will be stored in case of failure. If NULL, the message is ignored.
  * @param name Name of the agent to request the new key.
  * @param ip IP of the agent to request the new key.

--- a/src/headers/agent_op.h
+++ b/src/headers/agent_op.h
@@ -85,11 +85,30 @@ int auth_connect();
 int auth_close(int sock);
 
 // Send a local agent add request.
-int w_request_agent_add_local(int sock, char *id, const char *name, const char *ip, const char * groups, const char *key, const int force, const int json_format, const char *agent_id, int exit_on_error);
+//TODO: DOxyGen
+int w_request_agent_add_local(int sock,
+                              char *id,
+                              const char *name,
+                              const char *ip,
+                              const char * groups,
+                              const char *key,
+                              const int force,
+                              const int json_format,
+                              const char *agent_id,
+                              int exit_on_error);
 
 #ifndef WIN32
 // Send a clustered agent add request.
-int w_request_agent_add_clustered(char *err_response, const char *name, const char *ip, const char * groups, char **id, char **key, const int force, const char *agent_id);
+//TODO: DOxyGen
+int w_request_agent_add_clustered(char *err_response,
+                                  const char *name,
+                                  const char *ip,
+                                  const char *groups,
+                                  const char *key_hash,
+                                  char **id,
+                                  char **key,
+                                  const int force,
+                                  const char *agent_id);
 
 // Send a clustered agent remove request.
 int w_request_agent_remove_clustered(char *err_response, const char* agent_id, int purge);

--- a/src/headers/agent_op.h
+++ b/src/headers/agent_op.h
@@ -84,8 +84,20 @@ int auth_connect();
 // Close socket if valid.
 int auth_close(int sock);
 
-// Send a local agent add request.
-//TODO: DOxyGen
+/**
+ * @brief Send a local agent add request.
+ * @param sock Socket where the request connection will be done.
+ * @param id ID of the newly generated key.
+ * @param name Name of the agent to request the new key.
+ * @param ip IP of the agent to request the new key.
+ * @param groups Groups list of the agent to request the new key.
+ * @param key KEY of the newly generated key.
+ * @param force Force option to be used during the registration. -1 means disabled. 0 or a positive value means enabled.
+ * @param json_format Flag to identify if the response should be printed in json format.
+ * @param agent_id ID of the agent when requesting a new key for a specific ID.
+ * @param exit_on_error Flag to identify if the application should exit on any error.
+ * @return 0 on success or a negative code on error.
+ */
 int w_request_agent_add_local(int sock,
                               char *id,
                               const char *name,
@@ -98,8 +110,20 @@ int w_request_agent_add_local(int sock,
                               int exit_on_error);
 
 #ifndef WIN32
-// Send a clustered agent add request.
-//TODO: DOxyGen
+
+/**
+ * @brief Send a clustered agent add request.
+ * @param err_response A buffer where the error message will be stored in case of failure. If NULL, the message is ignored.
+ * @param name Name of the agent to request the new key.
+ * @param ip IP of the agent to request the new key.
+ * @param groups Groups list of the agent to request the new key.
+ * @param key_hash Hash of the key if the agent already has one.
+ * @param id ID of the newly generated key.
+ * @param key KEY of the newly generated key.
+ * @param force Force option to be used during the registration. -1 means disabled. 0 or a positive value means enabled.
+ * @param agent_id ID of the agent when requesting a new key for a specific ID.
+ * @return 0 on success or a negative code on error.
+ */
 int w_request_agent_add_clustered(char *err_response,
                                   const char *name,
                                   const char *ip,

--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -201,7 +201,7 @@ w_err_t w_auth_replace_agent(keyentry *key,
     /* Check if the agent key is the same than the existent in the manager */
     if (key_hash) {
         os_sha1 manager_key_hash;
-        w_auth_hash_key(key, manager_key_hash);
+        w_get_key_hash(key, manager_key_hash);
         if (!strcmp(manager_key_hash, key_hash)) {
             minfo("Agent '%s' key already exists on the manager.", key->id);
             return OS_INVALID;

--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -190,10 +190,16 @@ w_err_t w_auth_parse_data(const char* buf,
 w_err_t w_auth_replace_agent(keyentry *key,
                              const char *key_hash,
                              authd_force_options_t *force_options){
-    /* Check if the agent antiquity complies with the configuration to be removed*/
+
+    /* Check if the agent replacement is allowed */
+    if (!force_options->enabled) {
+        minfo("Agent '%s' won´t be removed because the force option is disabled.", key->id);
+        return OS_INVALID;
+    }
+
+    /* Check if the agent antiquity complies with the configuration to be removed */
     double antiquity = 0;
-    if (!force_options->enabled ||
-       (antiquity = OS_AgentAntiquity(key->name, key->ip->ip), antiquity > 0 && antiquity < force_options->connection_time)) {
+    if (antiquity = OS_AgentAntiquity(key->name, key->ip->ip), antiquity > 0 && antiquity < force_options->connection_time) {
         minfo("Agent '%s' doesn´t comply with the antiquity to be removed.", key->id);
         return OS_INVALID;
     }

--- a/src/os_auth/auth.h
+++ b/src/os_auth/auth.h
@@ -149,7 +149,8 @@ w_err_t w_auth_validate_data(char *response,
  * @param hash_key Hash of the key on the agent
  * */
 w_err_t w_auth_replace_agent(keyentry *key,
-                             const char *key_hash);
+                             const char *key_hash,
+                             authd_force_options_t *force_options);
 
 /**
  * @brief Adds new agent with provided enrollment data.

--- a/src/os_auth/auth.h
+++ b/src/os_auth/auth.h
@@ -147,6 +147,7 @@ w_err_t w_auth_validate_data(char *response,
  * @brief Validates if the old agent can be replaced and removes it.
  * @param key Key structure of the agent to be removed
  * @param hash_key Hash of the key on the agent
+ * @param force_options Force configuration structure to define how the agent replacement must be handled.
  * */
 w_err_t w_auth_replace_agent(keyentry *key,
                              const char *key_hash,

--- a/src/os_auth/config.c
+++ b/src/os_auth/config.c
@@ -16,7 +16,7 @@
 // Read configuration
 int authd_read_config(const char *path) {
     config.port = DEFAULT_PORT;
-    config.force_time = -1;
+    config.force_options.connection_time = -1;
 
     mdebug2("Reading configuration '%s'", path);
 
@@ -24,8 +24,8 @@ int authd_read_config(const char *path) {
         return OS_INVALID;
     }
 
-    if (!config.flags.force_insert) {
-        config.force_time = -1;
+    if (!config.force_options.enabled) {
+        config.force_options.connection_time = -1;
     }
 
     if (!config.ciphers) {
@@ -54,16 +54,16 @@ cJSON *getAuthdConfig(void) {
     cJSON *auth = cJSON_CreateObject();
 
     cJSON_AddNumberToObject(auth,"port",config.port);
-    if (config.force_time ==  -1)
+    if (config.force_options.connection_time ==  -1)
         cJSON_AddStringToObject(auth,"force_time","no");
-    else if (config.force_time ==  0)
+    else if (config.force_options.connection_time ==  0)
         cJSON_AddStringToObject(auth,"force_time","always");
     else
-        cJSON_AddNumberToObject(auth,"force_time",config.force_time);
+        cJSON_AddNumberToObject(auth,"force_time",config.force_options.connection_time);
     if (config.flags.disabled) cJSON_AddStringToObject(auth,"disabled","yes"); else cJSON_AddStringToObject(auth,"disabled","no");
     if (config.flags.remote_enrollment) cJSON_AddStringToObject(auth,"remote_enrollment","yes"); else cJSON_AddStringToObject(auth,"remote_enrollment","no");
     if (config.flags.use_source_ip) cJSON_AddStringToObject(auth,"use_source_ip","yes"); else cJSON_AddStringToObject(auth,"use_source_ip","no");
-    if (config.flags.force_insert) cJSON_AddStringToObject(auth,"force_insert","yes"); else cJSON_AddStringToObject(auth,"force_insert","no");
+    if (config.force_options.enabled) cJSON_AddStringToObject(auth,"force_insert","yes"); else cJSON_AddStringToObject(auth,"force_insert","no");
     if (config.flags.clear_removed) cJSON_AddStringToObject(auth,"purge","yes"); else cJSON_AddStringToObject(auth,"purge","no");
     if (config.flags.use_password) cJSON_AddStringToObject(auth,"use_password","yes"); else cJSON_AddStringToObject(auth,"use_password","no");
     if (config.flags.verify_host) cJSON_AddStringToObject(auth,"ssl_verify_host","yes"); else cJSON_AddStringToObject(auth,"ssl_verify_host","no");

--- a/src/os_auth/local-server.c
+++ b/src/os_auth/local-server.c
@@ -58,7 +58,13 @@ static const struct {
 static char* local_dispatch(const char *input);
 
 // Add a new agent
-static cJSON* local_add(const char *id, const char *name, const char *ip, char *groups, const char *key, int force);
+static cJSON* local_add(const char *id,
+                        const char *name,
+                        const char *ip,
+                        char *groups,
+                        const char *key,
+                        const char *key_hash,
+                        authd_force_options_t *force_options);
 
 // Remove an agent
 static cJSON* local_remove(const char *id, int purge);
@@ -195,13 +201,14 @@ char* local_dispatch(const char *input) {
         }
 
         if (!strcmp(function->valuestring, "add")) {
-            cJSON *item;
-            char *id;
-            char *name;
-            char *ip;
+            cJSON *item = NULL;
+            char *id = NULL;
+            char *name = NULL;
+            char *ip = NULL;
             char *groups = NULL;
+            char *key_hash = NULL;
             char *key = NULL;
-            int force = 0;
+            authd_force_options_t force_options = {0};
 
             if (arguments = cJSON_GetObjectItem(request, "arguments"), !arguments) {
                 ierror = ENOARGUMENT;
@@ -214,14 +221,12 @@ char* local_dispatch(const char *input) {
                 ierror = ENONAME;
                 goto fail;
             }
-
             name = item->valuestring;
 
             if (item = cJSON_GetObjectItem(arguments, "ip"), !item) {
                 ierror = ENOIP;
                 goto fail;
             }
-
             ip = item->valuestring;
 
             if (item = cJSON_GetObjectItem(arguments, "groups"), item) {
@@ -232,10 +237,23 @@ char* local_dispatch(const char *input) {
                 }
             }
 
+            key_hash = (item = cJSON_GetObjectItem(arguments, "key_hash"), item) ? item->valuestring : NULL;
             key = (item = cJSON_GetObjectItem(arguments, "key"), item) ? item->valuestring : NULL;
-            force = (item = cJSON_GetObjectItem(arguments, "force"), item) ? item->valueint : -1;
 
-            response = local_add(id, name, ip, groups, key, force);
+            if (item = cJSON_GetObjectItem(arguments, "force"), item) {
+                if (item->valueint == -1) {
+                    force_options.enabled = false;
+                }
+                else {
+                    force_options.enabled = true;
+                    force_options.connection_time = item->valueint;
+                }
+            }
+            else {
+                force_options.enabled = false;
+            }
+
+            response = local_add(id, name, ip, groups, key, key_hash, &force_options);
 
             os_free(groups);
         } else if (!strcmp(function->valuestring, "remove")) {
@@ -300,12 +318,16 @@ fail:
     return output;
 }
 
-cJSON* local_add(const char *id, const char *name, const char *ip, char *groups, const char *key, int force) {
+cJSON* local_add(const char *id,
+                 const char *name,
+                 const char *ip,
+                 char *groups,
+                 const char *key,
+                 const char *key_hash,
+                 authd_force_options_t *force_options) {
     int index;
-    char *id_exist;
     cJSON *response = NULL;
     int ierror;
-    double antiquity;
 
     mdebug2("add(%s)", name);
     w_mutex_lock(&mutex_keys);
@@ -319,29 +341,18 @@ cJSON* local_add(const char *id, const char *name, const char *ip, char *groups,
     }
 
     // Check for duplicated ID
-
     if (id && (index = OS_IsAllowedID(&keys, id), index >= 0)) {
-        if (force >= 0 && (antiquity = OS_AgentAntiquity(keys.keyentries[index]->name, keys.keyentries[index]->ip->ip), antiquity >= force || antiquity < 0)) {
-            id_exist = keys.keyentries[index]->id;
-            minfo("Duplicated ID '%s' (%s). Removing old agent.", id, id_exist);
-            add_remove(keys.keyentries[index]);
-            OS_DeleteKey(&keys, id_exist, 0);
-        } else {
+        minfo("Duplicated ID '%s'.", keys.keyentries[index]->id);
+        if (OS_SUCCESS != w_auth_replace_agent(keys.keyentries[index], key_hash, force_options)) {
             ierror = EDUPID;
             goto fail;
         }
     }
 
     /* Check for duplicated IP */
-
     if (strcmp(ip, "any")) {
         if (index = OS_IsAllowedIP(&keys, ip), index >= 0) {
-            if (force >= 0 && (antiquity = OS_AgentAntiquity(keys.keyentries[index]->name, keys.keyentries[index]->ip->ip), antiquity >= force || antiquity < 0)) {
-                id_exist = keys.keyentries[index]->id;
-                minfo("Duplicated IP '%s' (%s). Removing old agent.", ip, id_exist);
-                add_remove(keys.keyentries[index]);
-                OS_DeleteKey(&keys, id_exist, 0);
-            } else {
+            if (OS_SUCCESS != w_auth_replace_agent(keys.keyentries[index], key_hash, force_options)) {
                 ierror = EDUPIP;
                 goto fail;
             }
@@ -349,24 +360,17 @@ cJSON* local_add(const char *id, const char *name, const char *ip, char *groups,
     }
 
     /* Check whether the agent name is the same as the manager */
-
     if (!strcmp(name, shost)) {
         ierror = EDUPNAME;
         goto fail;
     }
 
     /* Check for duplicated names */
-
     if (index = OS_IsAllowedName(&keys, name), index >= 0) {
-        if (force >= 0 && (antiquity = OS_AgentAntiquity(keys.keyentries[index]->name, keys.keyentries[index]->ip->ip), antiquity >= force || antiquity < 0)) {
-            id_exist = keys.keyentries[index]->id;
-            minfo("Duplicated name '%s' (%s). Removing old agent.", name, id_exist);
-            add_remove(keys.keyentries[index]);
-            OS_DeleteKey(&keys, id_exist, 0);
-        } else {
-            ierror = EDUPNAME;
-            goto fail;
-        }
+        if (OS_SUCCESS != w_auth_replace_agent(keys.keyentries[index], key_hash, force_options)) {
+                ierror = EDUPNAME;
+                goto fail;
+            }
     }
 
     if (index = OS_AddNewAgent(&keys, id, name, ip, key), index < 0) {

--- a/src/os_auth/local-server.c
+++ b/src/os_auth/local-server.c
@@ -61,7 +61,7 @@ static char* local_dispatch(const char *input);
 static cJSON* local_add(const char *id,
                         const char *name,
                         const char *ip,
-                        char *groups,
+                        const char *groups,
                         const char *key,
                         const char *key_hash,
                         authd_force_options_t *force_options);
@@ -321,7 +321,7 @@ fail:
 cJSON* local_add(const char *id,
                  const char *name,
                  const char *ip,
-                 char *groups,
+                 const char *groups,
                  const char *key,
                  const char *key_hash,
                  authd_force_options_t *force_options) {

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -627,7 +627,7 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
         if (OS_SUCCESS == w_auth_parse_data(buf, response, authpass, ip, &agentname, &centralized_group, &key_hash)) {
             if (config.worker_node) {
                 minfo("Dispatching request to master node");
-                if (0 == w_request_agent_add_clustered(response, agentname, ip, centralized_group, key_hash, &new_id, &new_key, config.flags.force_insert?config.force_time:-1, NULL)) {
+                if (0 == w_request_agent_add_clustered(response, agentname, ip, centralized_group, key_hash, &new_id, &new_key, config.force_options.enabled?config.force_options.connection_time:-1, NULL)) {
                     enrollment_ok = TRUE;
                 }
             }

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -627,7 +627,7 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
         if (OS_SUCCESS == w_auth_parse_data(buf, response, authpass, ip, &agentname, &centralized_group, &key_hash)) {
             if (config.worker_node) {
                 minfo("Dispatching request to master node");
-                if (0 == w_request_agent_add_clustered(response, agentname, ip, centralized_group, &new_id, &new_key, config.flags.force_insert?config.force_time:-1, NULL)) {
+                if (0 == w_request_agent_add_clustered(response, agentname, ip, centralized_group, key_hash, &new_id, &new_key, config.flags.force_insert?config.force_time:-1, NULL)) {
                     enrollment_ok = TRUE;
                 }
             }

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -684,7 +684,6 @@ int w_get_key_hash(keyentry *key_entry, os_sha1 output) {
     }
 
     char *key = key_entry->key;
-
     if (key) {
         return OS_SHA1_Str(key, strlen(key), output);
     }

--- a/src/unit_tests/os_auth/test_auth_validate.c
+++ b/src/unit_tests/os_auth/test_auth_validate.c
@@ -104,12 +104,12 @@ static int teardown_group(void **state) {
 }
 
 int setup_validate_force_insert_0(void **state) {
-    config.flags.force_insert = 0;
+    config.force_options.enabled = 0;
     return 0;
 }
 
 int setup_validate_force_insert_1(void **state) {
-    config.flags.force_insert = 1;
+    config.force_options.enabled = 1;
     return 0;
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|#9567|

## Description
This PR adds the new logic of parsing the agent key hash sent into the JSON paylod with **"key_hash"** key.
This hash value is compared with the one of the matching key in the manager. If both hashes match, the agent won't be replaced because the agent already has a valid key. 

This PR also:
- Internally modifies the Authd structure to have a new **force_options_t** structure where the actual and new configuration will be placed. This change doesn´t modify the configuration file or the tags.
- Makes **w_auth_replace_agent()** capable to receive a force_option structure with the intention to use the Authd configuration or the specified in the command.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Package installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [] Scan-build report
  - [] Valgrind (memcheck and descriptor leaks check)