### PR TITLE
Fix wrong agent timestamp data gathering in Wazuh DB

### DIFF
--- a/src/wazuh_db/helpers/wdb_global_helpers.c
+++ b/src/wazuh_db/helpers/wdb_global_helpers.c
@@ -1426,7 +1426,7 @@ time_t get_agent_date_added(int agent_id) {
             }
             t.tm_year -= 1900;
             t.tm_mon -= 1;
-            t.tm_isdst = 0;
+            t.tm_isdst = -1;
             t_of_sec = mktime(&t);
 
             free(date);


### PR DESCRIPTION
|Related issue|
|---|
|#9534|

This PR applies the fix proposed at #9534. Given that Wazuh DB is failing to get the right agent registration timestamp from file _agents-timestamp_, we're setting function `mktime()` to automatically select the daylight saving time flag.

In contrast with the condition described in the issue, this is the new result:

- Adding an agent at 18:25 PM:
```sh
# manage_agents -a any -n agent-18-25
```

- Agent registration timestamp:
```sh
# cat /var/ossec/queue/agents-timestamp
001 agent-18-25 any 2021-08-12 18:25:08
```

- Agent data reported by the API:
```json
# curl -X GET https://localhost:55000/agents?q=id=001
{
  "data": {
    "affected_items": [
      {
        "id": "001",
        "node_name": "unknown",
        "ip": "any",
        "registerIP": "any",
        "name": "agent-18-25",
        "status": "never_connected",
        "dateAdd": "2021-08-12T16:25:08Z"
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents information was returned",
  "error": 0
}
```

The UTC-based time "2021-08-12T16:25:08Z" is "2021-08-12 18:25:08" in our current location.