### PR TITLE
Cluster - refactor walk_dir method

### DIFF
--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -217,8 +217,10 @@ def walk_dir(dirname, recursive, files, excluded_files, excluded_extensions, get
                                 file_metadata['md5'] = md5(abs_file_path)
                             # Use the relative file path as a key to save its metadata dictionary.
                             walk_files[relative_file_path] = file_metadata
-                    except Exception as e:
-                        logger.debug(f"Could not get checksum of file {file_}: {e}")
+                    except FileNotFoundError as e:
+                        logger.debug(f"File {file_} was deleted in previous iteration: {e}")
+                    except PermissionError as e:
+                        logger.error(f"Can't read metadata from file {file_}: {e}")
             else:
                 break
     except OSError as err:

--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -223,8 +223,8 @@ def walk_dir(dirname, recursive, files, excluded_files, excluded_extensions, get
                         logger.error(f"Can't read metadata from file {file_}: {e}")
             else:
                 break
-    except OSError as err:
-        raise WazuhError(3015, f'{err}')
+    except OSError as e:
+        raise WazuhInternalError(3015, e)
     return walk_files
 
 

--- a/framework/wazuh/core/cluster/tests/test_cluster.py
+++ b/framework/wazuh/core/cluster/tests/test_cluster.py
@@ -5,10 +5,9 @@
 import sys
 from datetime import datetime
 from time import time
-from unittest.mock import patch, mock_open, MagicMock
+from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
-
 from wazuh.core import common
 
 with patch('wazuh.common.wazuh_uid'):
@@ -20,8 +19,8 @@ with patch('wazuh.common.wazuh_uid'):
         from wazuh.tests.util import RBAC_bypasser
 
         wazuh.rbac.decorators.expose_resources = RBAC_bypasser
-        import wazuh.core.cluster.utils
         import wazuh.core.cluster.cluster
+        import wazuh.core.cluster.utils
         from wazuh import WazuhException
 
 # Valid configurations

--- a/framework/wazuh/core/cluster/tests/test_cluster.py
+++ b/framework/wazuh/core/cluster/tests/test_cluster.py
@@ -124,7 +124,7 @@ def test_checking_configuration(read_config):
 agent_groups = b"default,windows-servers"
 
 
-@patch('os.listdir', return_value=['005', '006'])
+@patch('wazuh.core.cluster.cluster.listdir', return_value=['005', '006'])
 @patch('wazuh.core.cluster.cluster.stat')
 def test_merge_info(stat_mock, listdir_mock):
     """
@@ -151,7 +151,7 @@ def test_merge_info(stat_mock, listdir_mock):
 @patch('wazuh.core.cluster.cluster.stat')
 def test_unmerge_info(stat_mock, agent_info, exception):
     stat_mock.return_value.st_size = len(agent_info)
-    with patch('builtins.open', mock_open(read_data=agent_info)) as m:
+    with patch('builtins.open', mock_open(read_data=agent_info)):
         agent_groups = list(
             wazuh.core.cluster.cluster.unmerge_info('agent-groups', '/random/path', 'agent-groups-shared.merged'))
         assert len(agent_groups) == (1 if exception is None else 0)
@@ -165,6 +165,10 @@ def test_update_cluster_control_with_failed():
         'shared': {'/test_file1': 'test'},
         'extra': {'/test_file2': 'test'}
     }
-    wazuh.core.cluster.cluster.update_cluster_control_with_failed(['/test_file0', '/test_file1', 'test_file2'], ko_files)
+    wazuh.core.cluster.cluster.update_cluster_control_with_failed(['/test_file0', '/test_file1', 'test_file2'],
+                                                                  ko_files)
 
-    assert ko_files == {'missing': {'/test_file3': 'ok'}, 'shared': {}, 'extra': {'/test_file2': 'test', '/test_file1': 'test'}}
+    assert ko_files == {'missing': {'/test_file3': 'ok'},
+                        'shared': {},
+                        'extra': {'/test_file2': 'test', '/test_file1': 'test'}
+                        }


### PR DESCRIPTION
|Related issue|
|---|
| #9440 |

# Description
This PR closes #9440.
* `os.walk`: I made some changes on `walk_dir` method under `core/cluster/cluster.py`. After this refactor, it's using `os.walk` instead of recursive function.
* Few fixes following PEP8 standard on `core/cluster/cluster.py`.
* Fixes in related unit test.
* About the problem around the possibility of files being deleted while this method is running:
  * ![image](https://user-images.githubusercontent.com/84642680/129261744-40ea2e03-92aa-47bf-9edb-d7a2790021c8.png)
  * Its currently working like this, a log in debugger mode. I personally suggest this is a viable way to manage this problem. Other solution could be catching this exception and `pass` without a log.
* I checked the resulting values to be the same as before this refactor, maintaining output structure.
---
# Tests
## UNIT: Api
```
⬦⬦⬦ ~/git/wazuh/framework ⨘ cd ~/git/wazuh/api && python3 -m pytest -x -v api --disable-warnings
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.9.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /home/kondent/pythonEnv/unittest-env/bin/python3
cachedir: .pytest_cache
rootdir: /home/kondent/git/wazuh/api
plugins: asyncio-0.15.1, cov-2.12.1
collected 238 items                                                                                                                                                                          

api/models/test/test_model.py::test_model_from_dict PASSED                                                                                                                             [  0%]
...
...
...
api/test/test_validator.py::test_validation_json_ko[local_rules.xml,test_rule-xml_filename] PASSED                                                                                     [100%]

============================================================================== 238 passed, 14 warnings in 1.07s ==============================================================================
```

## UNIT: Framework
```
⬦⬦⬦ ~/git/wazuh/api ⨘ cd ~/git/wazuh/framework && python3 -m pytest -x -v wazuh --disable-warnings
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.9.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /home/kondent/pythonEnv/unittest-env/bin/python3
cachedir: .pytest_cache
rootdir: /home/kondent/git/wazuh/framework
plugins: asyncio-0.15.1, cov-2.12.1
collected 1596 items                                                                                                                                                                         

wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI[kwargs0] PASSED                                                                                                        [  0%]
...
...
...
wazuh/tests/test_vulnerability.py::test_get_agent_cve_select[params2-expected_fields2] PASSED                                                                                          [100%]

======================================================================= 1596 passed, 14 warnings in 234.01s (0:03:54) ========================================================================
```

## Integration: 
* test_cluster_endpoints
* test_rbac_black_cluster_endpoints
* test_rbac_white_cluster_endpoints
```
⬦⬦⬦ ~/git/wazuh/api/test/integration ⨘ pytest -vv test_cluster_endpoints.tavern.yaml --disable-warnings && pytest -vv test_rbac_black_cluster_endpoints.tavern.yaml --disable-warnings && pytest -vv test_rbac_white_cluster_endpoints.tavern.yaml --disable-warnings 
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.9.5, pytest-5.0.0, py-1.10.0, pluggy-0.13.1 -- /home/kondent/pythonEnv/inttest-env/bin/python3.9
cachedir: .pytest_cache
metadata: {'Python': '3.9.5', 'Platform': 'Linux-5.11.0-25-generic-x86_64-with-glibc2.31', 'Packages': {'pytest': '5.0.0', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'metadata': '1.11.0', 'tavern': '1.2.2'}}
rootdir: /home/kondent/git/wazuh/api/test/integration, inifile: pytest.ini
plugins: html-3.1.1, metadata-1.11.0, tavern-1.2.2
collected 45 items                                                                                                                                                                           

test_cluster_endpoints.tavern.yaml::GET /cluster/local/config PASSED                                                                                                                   [  2%]
...
...
...
test_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/configuration PASSED                                                                                                        [100%]

===================================================================== 44 passed, 1 xpassed, 1 warnings in 663.90 seconds =====================================================================
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.9.5, pytest-5.0.0, py-1.10.0, pluggy-0.13.1 -- /home/kondent/pythonEnv/inttest-env/bin/python3.9
cachedir: .pytest_cache
metadata: {'Python': '3.9.5', 'Platform': 'Linux-5.11.0-25-generic-x86_64-with-glibc2.31', 'Packages': {'pytest': '5.0.0', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'metadata': '1.11.0', 'tavern': '1.2.2'}}
rootdir: /home/kondent/git/wazuh/api/test/integration, inifile: pytest.ini
plugins: html-3.1.1, metadata-1.11.0, tavern-1.2.2
collected 17 items                                                                                                                                                                           

test_rbac_black_cluster_endpoints.tavern.yaml::/cluster/local/config PASSED                                                                                                            [  5%]
...
...
...
test_rbac_black_cluster_endpoints.tavern.yaml::PUT /cluster/restart PASSED                                                                                                             [100%]

========================================================================== 17 passed, 1 warnings in 120.49 seconds ===========================================================================
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.9.5, pytest-5.0.0, py-1.10.0, pluggy-0.13.1 -- /home/kondent/pythonEnv/inttest-env/bin/python3.9
cachedir: .pytest_cache
metadata: {'Python': '3.9.5', 'Platform': 'Linux-5.11.0-25-generic-x86_64-with-glibc2.31', 'Packages': {'pytest': '5.0.0', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'metadata': '1.11.0', 'tavern': '1.2.2'}}
rootdir: /home/kondent/git/wazuh/api/test/integration, inifile: pytest.ini
plugins: html-3.1.1, metadata-1.11.0, tavern-1.2.2
collected 17 items                                                                                                                                                                           

test_rbac_white_cluster_endpoints.tavern.yaml::/cluster/local/config PASSED                                                                                                            [  5%]
...
...
...
test_rbac_white_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/configuration PASSED                                                                                             [100%]

========================================================================== 17 passed, 1 warnings in 422.01 seconds ===========================================================================
```

## System test: Integrity sync
```
⬦⬦⬦ ~/git/wazuh-qa/tests/system/test_cluster/test_integrity_sync ⊶ master ⨘ python3 -m pytest test_integrity_sync.py -v
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.9.5, pytest-6.2.3, py-1.10.0, pluggy-0.13.1 -- /home/kondent/pythonEnv/qa-env/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.9.5', 'Platform': 'Linux-5.11.0-25-generic-x86_64-with-glibc2.31', 'Packages': {'pytest': '6.2.3', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'metadata': '1.11.0', 'testinfra': '5.0.0'}}
rootdir: /home/kondent/git/wazuh-qa/tests/system/test_cluster/test_integrity_sync
plugins: html-3.1.1, metadata-1.11.0, testinfra-5.0.0
collected 4 items                                                                                                                                                                            

test_integrity_sync.py::test_missing_file PASSED                                                                                                                                       [ 25%]
test_integrity_sync.py::test_shared_files PASSED                                                                                                                                       [ 50%]
test_integrity_sync.py::test_extra_files PASSED                                                                                                                                        [ 75%]
test_integrity_sync.py::test_extra_valid_files PASSED                                                                                                                                  [100%]

=============================================================================== 4 passed in 341.06s (0:05:41) ================================================================================
```