### PR TITLE
Replaced bitfield by time_t datatype

### DIFF
--- a/src/client-agent/config.c
+++ b/src/client-agent/config.c
@@ -49,7 +49,7 @@ int ClientConf(const char *cfgfile)
 
     // Initialize enrollment_cfg
     agt->enrollment_cfg = w_enrollment_init(target_cfg, cert_cfg, &keys);
-    agt->enrollment_cfg->allow_localhost = 0; // Localhost not allowed in auto-enrollment
+    agt->enrollment_cfg->allow_localhost = false; // Localhost not allowed in auto-enrollment
 
     if (ReadConfig(modules, cfgfile, agt, NULL) < 0 ||
         ReadConfig(CLABELS | CBUFFER, cfgfile, &agt->labels, agt) < 0) {

--- a/src/config/client-config.c
+++ b/src/config/client-config.c
@@ -366,9 +366,9 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
             return (OS_INVALID);
         } else if (!strcmp(node[j]->element, xml_enabled)) {
             if (!strcmp(node[j]->content, "yes"))
-                logr->enrollment_cfg->enabled = 1;
+                logr->enrollment_cfg->enabled = true;
             else if (!strcmp(node[j]->content, "no")) {
-                logr->enrollment_cfg->enabled = 0;
+                logr->enrollment_cfg->enabled = false;
             } else {
                 merror("Invalid content for tag '%s'.", node[j]->element);
                 w_enrollment_target_destroy(target_cfg);

--- a/src/headers/enrollment_op.h
+++ b/src/headers/enrollment_op.h
@@ -64,13 +64,13 @@ typedef struct _enrollment_cert_cfg {
  * @brief Strcture that handles all the enrollment configuration
  * */
 typedef struct _enrollment_ctx {
-    w_enrollment_target *target_cfg;        /**> for details @see _enrollment_target_cfg */
-    w_enrollment_cert *cert_cfg;            /**> for details @see _enrollment_cert_cfg */
-    keystore *keys;                         /**> keys structure */
-    SSL *ssl;                               /**> will hold the connection instance with the manager */
-    unsigned int enabled:1;                 /**> enabled / disables auto enrollment */
-    unsigned int allow_localhost:1;         /**> 1 by default if this flag is in 0 using agent_name "localhost" will not be allowed */
-    unsigned int delay_after_enrollment:30; /**> 20 by default, number of seconds to wait for enrollment */
+    w_enrollment_target *target_cfg;                                        /**> for details @see _enrollment_target_cfg */
+    w_enrollment_cert *cert_cfg;                                                /**> for details @see _enrollment_cert_cfg */
+    keystore *keys;                                                                        /**> keys structure */
+    SSL *ssl;                                                                                     /**> will hold the connection instance with the manager */
+    unsigned int enabled:1;                                                          /**> enabled / disables auto enrollment */
+    unsigned int allow_localhost:1;                                             /**> 1 by default if this flag is in 0 using agent_name "localhost" will not be allowed */
+    time_t delay_after_enrollment;                                              /**> 20 by default, number of seconds to wait for enrollment */
 } w_enrollment_ctx;
 
 /**

--- a/src/headers/enrollment_op.h
+++ b/src/headers/enrollment_op.h
@@ -64,13 +64,13 @@ typedef struct _enrollment_cert_cfg {
  * @brief Strcture that handles all the enrollment configuration
  * */
 typedef struct _enrollment_ctx {
-    w_enrollment_target *target_cfg;                                        /**> for details @see _enrollment_target_cfg */
-    w_enrollment_cert *cert_cfg;                                                /**> for details @see _enrollment_cert_cfg */
-    keystore *keys;                                                                        /**> keys structure */
-    SSL *ssl;                                                                                     /**> will hold the connection instance with the manager */
-    bool enabled;                                                                           /**> enabled / disables auto enrollment */
-    bool allow_localhost;                                                               /**> true by default. If this flag is false, using agent_name "localhost" will not be allowed */
-    time_t delay_after_enrollment;                                              /**> 20 by default, number of seconds to wait for enrollment */
+    w_enrollment_target *target_cfg;    /**> for details @see _enrollment_target_cfg */
+    w_enrollment_cert *cert_cfg;        /**> for details @see _enrollment_cert_cfg */
+    keystore *keys;                     /**> keys structure */
+    SSL *ssl;                           /**> will hold the connection instance with the manager */
+    bool enabled;                       /**> enables / disables auto enrollment */
+    bool allow_localhost;               /**> true by default. If this flag is false, using agent_name "localhost" will not be allowed */
+    time_t delay_after_enrollment;      /**> 20 by default, number of seconds to wait for enrollment */
 } w_enrollment_ctx;
 
 /**

--- a/src/headers/enrollment_op.h
+++ b/src/headers/enrollment_op.h
@@ -68,8 +68,8 @@ typedef struct _enrollment_ctx {
     w_enrollment_cert *cert_cfg;                                                /**> for details @see _enrollment_cert_cfg */
     keystore *keys;                                                                        /**> keys structure */
     SSL *ssl;                                                                                     /**> will hold the connection instance with the manager */
-    unsigned int enabled:1;                                                          /**> enabled / disables auto enrollment */
-    unsigned int allow_localhost:1;                                             /**> 1 by default if this flag is in 0 using agent_name "localhost" will not be allowed */
+    bool enabled;                                                                           /**> enabled / disables auto enrollment */
+    bool allow_localhost;                                                               /**> true by default. If this flag is false, using agent_name "localhost" will not be allowed */
     time_t delay_after_enrollment;                                              /**> 20 by default, number of seconds to wait for enrollment */
 } w_enrollment_ctx;
 

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -102,9 +102,9 @@ w_enrollment_ctx * w_enrollment_init(w_enrollment_target *target, w_enrollment_c
     os_malloc(sizeof(w_enrollment_ctx), cfg);
     cfg->target_cfg = target;
     cfg->cert_cfg = cert;
-    cfg->enabled = 1;
+    cfg->enabled = true;
     cfg->ssl = NULL;
-    cfg->allow_localhost = 1;
+    cfg->allow_localhost = true;
     cfg->delay_after_enrollment = 20;
     cfg->keys = keys;
     return cfg;
@@ -139,7 +139,7 @@ int w_enrollment_request_key(w_enrollment_ctx *cfg, const char * server_address)
  * be obtained by obtaining hostname
  *
  * @param cfg configuration structure
- * @param allow_localhost 1 will allow localhost as name, 0 will throw an merror_exit
+ * @param allow_localhost true will allow localhost as name, false will throw an merror_exit
  * @return agent_name on succes
  *         NULL on errors
  * */

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -955,7 +955,7 @@ void test_w_enrollment_request_key(void **state) {
 
 void test_w_enrollment_extract_agent_name_localhost_allowed(void **state) {
     w_enrollment_ctx *cfg = *state;
-    cfg->allow_localhost = 1; // Allow localhost
+    cfg->allow_localhost = true; // Allow localhost
 #ifdef WIN32
     will_return(wrap_gethostname, "localhost");
     will_return(wrap_gethostname, 0);
@@ -970,7 +970,7 @@ void test_w_enrollment_extract_agent_name_localhost_allowed(void **state) {
 
 void test_w_enrollment_extract_agent_name_localhost_not_allowed(void **state) {
     w_enrollment_ctx *cfg = *state;
-    cfg->allow_localhost = 0; // Do not allow localhost
+    cfg->allow_localhost = false; // Do not allow localhost
 #ifdef WIN32
     will_return(wrap_gethostname, "localhost");
     will_return(wrap_gethostname, 0);


### PR DESCRIPTION
|Related issue|
|---|
|#9572|

## Description

This PR replaces the bitfield with a proper datatype time_t for interval time options.

## Dod

- `<enabled>no</enabled>`
After setting the manager IP address in a fresh installation. 
![1](https://user-images.githubusercontent.com/13010397/129731637-87492251-6a5f-4e62-92c8-e8a41ee94291.png)
![2](https://user-images.githubusercontent.com/13010397/129730435-75fa660a-427a-42b7-a5aa-b70570ebe5a1.png)
After a successful enrollment
![4](https://user-images.githubusercontent.com/13010397/129733910-6b733651-ef5d-41cf-9584-6d09fb6eb936.png)

- `<delay_after_enrollment>60</delay_after_enrollment>`
![3](https://user-images.githubusercontent.com/13010397/129730444-db2b9fc5-9cc6-4c6c-9350-4b8d8ac69c3a.png)

- `<agent_name>localhost</agent_name>`
![5](https://user-images.githubusercontent.com/13010397/129738381-375250b8-5ffa-4794-863f-7bedb429ff26.png)

- API request configuration from agent 
![6](https://user-images.githubusercontent.com/13010397/129742622-e1abdf0a-8204-4b78-b1ac-086e60f4793d.png)

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation