### PR TITLE
Improve the key store initialization to support DUAL mode

### DIFF
--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -55,7 +55,7 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
     }
     /* Read private keys  */
     minfo(ENC_READ);
-    OS_ReadKeys(&keys, 1, 0);
+    OS_ReadKeys(&keys, W_DUAL_KEY, 0);
 
     // Resolve hostnames
     rc = 0;

--- a/src/headers/sec.h
+++ b/src/headers/sec.h
@@ -20,8 +20,12 @@ typedef enum _crypt_method{
     W_METH_BLOWFISH,W_METH_AES
 } crypt_method;
 
+typedef enum _key_mode{
+    W_RAW_KEY, W_ENCRYPTION_KEY, W_DUAL_KEY
+}key_mode_t;
+
 typedef struct keystore_flags_t {
-    unsigned int rehash_keys:1;     // Flag: rehash keys on adding
+    unsigned int key_mode:2;        // Type of key to be initialized
     unsigned int save_removed:1;    // Save removed keys into list
 } keystore_flags_t;
 
@@ -34,7 +38,8 @@ typedef struct _keyentry {
     time_t updating_time;
 
     char *id;
-    char *key;
+    char *raw_key;
+    char *encryption_key;
     char *name;
 
     ino_t inode;
@@ -94,7 +99,7 @@ typedef enum key_states {
 int OS_CheckKeys(void);
 
 /* Read the keys */
-void OS_ReadKeys(keystore *keys, int rehash_keys, int save_removed) __attribute((nonnull));
+void OS_ReadKeys(keystore *keys, key_mode_t key_mode, int save_removed) __attribute((nonnull));
 
 void OS_FreeKey(keyentry *key);
 

--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -287,7 +287,7 @@ w_err_t w_auth_add_agent(char *response, const char *ip, const char *agentname, 
     }
 
     os_strdup(keys.keyentries[index]->id, *id);
-    os_strdup(keys.keyentries[index]->key, *key);
+    os_strdup(keys.keyentries[index]->raw_key, *key);
 
     return OS_SUCCESS;
 }

--- a/src/os_auth/local-server.c
+++ b/src/os_auth/local-server.c
@@ -392,7 +392,7 @@ cJSON* local_add(const char *id,
     write_pending = 1;
     w_cond_signal(&cond_pending);
 
-    response = local_create_agent_response(keys.keyentries[index]->id, name, ip, keys.keyentries[index]->key);
+    response = local_create_agent_response(keys.keyentries[index]->id, name, ip, keys.keyentries[index]->raw_key);
     w_mutex_unlock(&mutex_keys);
 
     minfo("Agent key generated for agent '%s' (requested locally)", name);
@@ -444,7 +444,7 @@ cJSON* local_get(const char *id) {
         response = local_create_error_response(ERRORS[ENOAGENT].code, ERRORS[ENOAGENT].message);
     }
     else {
-        response = local_create_agent_response(id, keys.keyentries[index]->name, keys.keyentries[index]->ip->ip, keys.keyentries[index]->key);
+        response = local_create_agent_response(id, keys.keyentries[index]->name, keys.keyentries[index]->ip->ip, keys.keyentries[index]->raw_key);
     }
 
     w_mutex_unlock(&mutex_keys);

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -278,7 +278,7 @@ int main(int argc, char **argv)
     // Reading agent's key (if any) to send its hash to the manager
     keystore agent_keys = KEYSTORE_INITIALIZER;
     OS_PassEmptyKeyfile();
-    OS_ReadKeys(&agent_keys, 0, 0);
+    OS_ReadKeys(&agent_keys, W_RAW_KEY, 0);
 
     w_enrollment_ctx *cfg = w_enrollment_init(target_cfg, cert_cfg, &agent_keys);
     int ret = w_enrollment_request_key(cfg, server_address);

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -487,7 +487,7 @@ int main(int argc, char **argv)
     /* Load client keys in master node */
     if (!config.worker_node) {
         OS_PassEmptyKeyfile();
-        OS_ReadKeys(&keys, 0, !config.flags.clear_removed);
+        OS_ReadKeys(&keys, W_RAW_KEY, !config.flags.clear_removed);
     }
 
     /* Start working threads */

--- a/src/os_crypto/sha1/sha1_op.c
+++ b/src/os_crypto/sha1/sha1_op.c
@@ -93,8 +93,29 @@ int OS_SHA1_Str2(const char *str, ssize_t length, os_sha1 output)
     return (0);
 }
 
-// Get the hexadecimal result of a SHA-1 digest
+int OS_SHA1_strings(os_sha1 output, ...) {
+    unsigned char md[SHA_DIGEST_LENGTH];
+    size_t n;
+    SHA_CTX c;
+    SHA1_Init(&c);
 
+    va_list parameters;
+    char* parameter = NULL;
+    va_start(parameters, output);
+    while(parameter = va_arg(parameters, char*), parameter) {
+        SHA1_Update(&c, parameter, strlen(parameter));
+    }
+    SHA1_Final(&(md[0]), &c);
+
+    for (n = 0; n < SHA_DIGEST_LENGTH; n++) {
+        snprintf(output, 3, "%02x", md[n]);
+        output += 2;
+    }
+
+    return (0);
+}
+
+// Get the hexadecimal result of a SHA-1 digest
 void OS_SHA1_Hexdigest(const unsigned char * digest, os_sha1 output) {
     size_t n;
 

--- a/src/os_crypto/sha1/sha1_op.h
+++ b/src/os_crypto/sha1/sha1_op.h
@@ -24,6 +24,14 @@ int OS_SHA1_Str(const char *str, ssize_t length, os_sha1 output) __attribute((no
 int OS_SHA1_Str2(const char *str, ssize_t length, os_sha1 output) __attribute((nonnull));
 
 /**
+ * @brief Get the SHA-1 digest from a list of strings.
+ *
+ * @param output[out] Output string.
+ * @param ...   [in] List of strings to calculate the SHA-1.
+ */
+int OS_SHA1_strings(os_sha1 output, ...);
+
+/**
  * @brief Get the hexadecimal result of a SHA-1 digest
  *
  * @param digest[in] Binary SHA-1 digest.

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -147,7 +147,7 @@ void HandleSecure()
 
     /* Read authentication keys */
     minfo(ENC_READ);
-    OS_ReadKeys(&keys, 1, 0);
+    OS_ReadKeys(&keys, W_ENCRYPTION_KEY, 0);
     OS_StartCounter(&keys);
 
     // Key reloader thread

--- a/src/unit_tests/client-agent/test_start_agent.c
+++ b/src/unit_tests/client-agent/test_start_agent.c
@@ -115,7 +115,7 @@ void keys_init(keystore *keys) {
     os_calloc(1, sizeof(keyentry*), keys->keyentries);
     keys->keysize = 0;
     keys->id_counter = 0;
-    keys->flags.rehash_keys = 0;
+    keys->flags.key_mode = W_RAW_KEY;
     keys->flags.save_removed = 0;
 
     /* Add additional entry for sender == keysize */

--- a/src/unit_tests/os_auth/test_auth_add.c
+++ b/src/unit_tests/os_auth/test_auth_add.c
@@ -21,7 +21,7 @@
 
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 
-void keys_init(keystore *keys, int rehash_keys, int save_removed) {
+void keys_init(keystore *keys, key_mode_t key_mode, int save_removed) {
     /* Initialize hashes */
     keys->keyhash_id = OSHash_Create();
     keys->keyhash_ip = OSHash_Create();
@@ -35,7 +35,7 @@ void keys_init(keystore *keys, int rehash_keys, int save_removed) {
     os_calloc(1, sizeof(keyentry*), keys->keyentries);
     keys->keysize = 0;
     keys->id_counter = 0;
-    keys->flags.rehash_keys = rehash_keys;
+    keys->flags.key_mode = key_mode;
     keys->flags.save_removed = save_removed;
 
     /* Add additional entry for sender == keysize */

--- a/src/unit_tests/os_auth/test_auth_validate.c
+++ b/src/unit_tests/os_auth/test_auth_validate.c
@@ -37,7 +37,7 @@
 #define EXISTENT_GROUP2 "ExistentGroup2"
 #define UNKNOWN_GROUP   "UnknownGroup"
 
-void keys_init(keystore *keys, int rehash_keys, int save_removed) {
+void keys_init(keystore *keys, key_mode_t key_mode, int save_removed) {
     /* Initialize hashes */
     keys->keyhash_id = OSHash_Create();
     keys->keyhash_ip = OSHash_Create();
@@ -51,7 +51,7 @@ void keys_init(keystore *keys, int rehash_keys, int save_removed) {
     os_calloc(1, sizeof(keyentry*), keys->keyentries);
     keys->keysize = 0;
     keys->id_counter = 0;
-    keys->flags.rehash_keys = rehash_keys;
+    keys->flags.key_mode = key_mode;
     keys->flags.save_removed = save_removed;
 
     /* Add additional entry for sender == keysize */

--- a/src/util/agent_control.c
+++ b/src/util/agent_control.c
@@ -329,7 +329,7 @@ int main(int argc, char **argv)
     if (agent_id != NULL) {
         if (strcmp(agent_id, "000") != 0) {
             OS_PassEmptyKeyfile();
-            OS_ReadKeys(&keys, 1, 0);
+            OS_ReadKeys(&keys, W_RAW_KEY, 0);
 
             agt_id = OS_IsAllowedID(&keys, agent_id);
             if (agt_id < 0) {

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -264,7 +264,7 @@ void wm_sync_agents() {
 
     mtdebug1(WM_DATABASE_LOGTAG, "Synchronizing agents.");
     OS_PassEmptyKeyfile();
-    OS_ReadKeys(&keys, 0, 0);
+    OS_ReadKeys(&keys, W_RAW_KEY, 0);
 
     os_calloc(OS_SIZE_65536 + 1, sizeof(char), group);
 
@@ -286,7 +286,7 @@ void wm_sync_agents() {
         }
 
         if (wdb_insert_agent(id, entry->name, NULL, OS_CIDRtoStr(entry->ip, cidr, 20) ?
-                             entry->ip->ip : cidr, entry->key, *group ? group : NULL,1, &wdb_wmdb_sock)) {
+                             entry->ip->ip : cidr, entry->raw_key, *group ? group : NULL,1, &wdb_wmdb_sock)) {
             // The agent already exists, update group only.
             wm_sync_agent_group(id, entry->id);
         }

--- a/src/win32/agent_auth.c
+++ b/src/win32/agent_auth.c
@@ -486,7 +486,7 @@ int main(int argc, char **argv)
     // Reading agent's key (if any) to send its hash to the manager
     keystore agent_keys = KEYSTORE_INITIALIZER;
     OS_PassEmptyKeyfile();
-    OS_ReadKeys(&agent_keys, 0, 0);
+    OS_ReadKeys(&agent_keys, W_RAW_KEY, 0);
     if (agent_keys.keysize > 0) {
         w_enrollment_concat_key(enrollment_msg, agent_keys.keyentries[0]);
     }

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -140,7 +140,7 @@ int local_start()
     }
     /* Read keys */
     minfo(ENC_READ);
-    OS_ReadKeys(&keys, W_RAW_KEY, 0);
+    OS_ReadKeys(&keys, W_DUAL_KEY, 0);
 
     /* If there is no file to monitor, create a clean entry
      * for the mark messages.

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -140,7 +140,7 @@ int local_start()
     }
     /* Read keys */
     minfo(ENC_READ);
-    OS_ReadKeys(&keys, 1, 0);
+    OS_ReadKeys(&keys, W_RAW_KEY, 0);
 
     /* If there is no file to monitor, create a clean entry
      * for the mark messages.


### PR DESCRIPTION
|Related issue|
|---|
|#9720|

## Description
This PR improves the initialization of the keys store done in **OS_ReadKeys()**.
Previously, **OS_ReadKeys()** had a flag option **rehash_keys** that makes **key** value of **keyentry** change the value that holds. With **rehash_keys==0**, **key** holds the raw value of the key same as found in **client.keys**. With **rehash_keys==1**, **key** holds a calculus between the name, the ID, and the raw key (the encryption key).
From the modules using and initializing a key store, among others:
Remoted used the encryption key, Authd used the raw key and Agentd used the encryption key.
The difference between the initialization in Authd and Agentd didn´t let us calculate the key hash equally in both daemons to implement the hash check of https://github.com/wazuh/wazuh/issues/9549.
Also, the possibility of having two different values in the same variable makes the library difficult to use, because some keys.c methods such as **OS_WriteKeys()** will fail without notification if the key store structure was initialized for encryption.
Now, we have three types of initialization **W_RAW_KEY**, **W_ENCRYPTION_KEY**, and **W_DUAL_KEY**, and two different variables for each type of key **raw_key** and **encryption_key**.
Doing this we can initialize Authd in RAW mode and avoid unnecessary hash calculus making the encryption keys, initialize Remoted in ENCRYPTION mode and avoid unnecessary memory allocation of the RAW key, and initialize Agentd in DUAL mode and have both keys, the encryption key to encrypt and communicate, and the raw key to request new keys to Authd.
Also, with this improvement, the code is easier to interpret because the key variable isn´t reused and is safer because the methods that are limited to a type of initialization like **OS_WriteKeys()** now checks the type of initialization.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
- [X] Source installation
- [X] Package installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)