### PR TITLE
Fix buffer overflow in firewall drop AR tools

### DIFF
--- a/src/active-response/firewalld-drop.c
+++ b/src/active-response/firewalld-drop.c
@@ -84,7 +84,7 @@ int main (int argc, char **argv) {
     if (!strcmp("Linux", uname_buffer.sysname)) {
         char arg1[COMMANDSIZE_4096];
         char fw_cmd[COMMANDSIZE_4096];
-        char fw_cmd_tmp[COMMANDSIZE_4096 - 5];
+        char fw_cmd_tmp[COMMANDSIZE_4096 - 5] = DEFAULT_FW_CMD;
 
         memset(arg1, '\0', COMMANDSIZE_4096);
         if (action == ADD_COMMAND) {
@@ -92,8 +92,6 @@ int main (int argc, char **argv) {
         } else {
             strcpy(arg1, "--remove-rich-rule=");
         }
-        memset(fw_cmd_tmp, '\0', COMMANDSIZE_4096);
-        strcpy(fw_cmd_tmp, DEFAULT_FW_CMD);
 
         memset(fw_cmd, '\0', COMMANDSIZE_4096);
 

--- a/src/active-response/firewalls/default-firewall-drop.c
+++ b/src/active-response/firewalls/default-firewall-drop.c
@@ -17,7 +17,7 @@
 int main (int argc, char **argv) {
     (void)argc;
     char iptables[COMMANDSIZE_4096];
-    char iptables_tmp[COMMANDSIZE_4096 - 5];
+    char iptables_tmp[COMMANDSIZE_4096 - 5] = "";
     char log_msg[OS_MAXSTR];
     int action = OS_INVALID;
     cJSON *input_json = NULL;
@@ -62,7 +62,6 @@ int main (int argc, char **argv) {
     }
 
     int ip_version = get_ip_version(srcip);
-    memset(iptables_tmp, '\0', COMMANDSIZE_4096);
     if (ip_version == 4) {
         strcpy(iptables_tmp, IP4TABLES);
     } else if (ip_version == 6) {


### PR DESCRIPTION
This PR aims to solve a bug in the firewall drop Active Response tools detected by Coverity. There was a `memset` operation to write 4096 bytes into a 4091-byte buffer.

## Proposed fix

- Statically initialize the affected arrays.

## Tests

- [x] Run a new Coverity scan.
- [x] Find further occurrences of this bug in other AR tools.