### PR TITLE
Authd key hash logic Coverity fixes

### DIFF
--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -305,7 +305,7 @@ int try_enroll_to_server(const char * server_rip) {
     int enroll_result = w_enrollment_request_key(agt->enrollment_cfg, server_rip);
     if (enroll_result == 0) {
         /* Wait for key update on agent side */
-        minfo("Waiting %d seconds before server connection", agt->enrollment_cfg->delay_after_enrollment);
+        minfo("Waiting %ld seconds before server connection", agt->enrollment_cfg->delay_after_enrollment);
         sleep(agt->enrollment_cfg->delay_after_enrollment);
         /* Successfull enroll, read keys */
         OS_UpdateKeys(&keys);

--- a/src/os_crypto/sha1/sha1_op.c
+++ b/src/os_crypto/sha1/sha1_op.c
@@ -105,6 +105,7 @@ int OS_SHA1_strings(os_sha1 output, ...) {
     while(parameter = va_arg(parameters, char*), parameter) {
         SHA1_Update(&c, parameter, strlen(parameter));
     }
+    va_end(parameters);
     SHA1_Final(&(md[0]), &c);
 
     for (n = 0; n < SHA_DIGEST_LENGTH; n++) {


### PR DESCRIPTION
|Related issue|
|---|
|#9719|

## Description
This PR implements the fixes for the following issues detected during the Coverity scan:
- **CID 239255** (# 1 of 1): Printf arg type mismatch (PW.PRINTF_ARG_MISMATCH) 1. printf_arg_mismatch: argument is incompatible with corresponding format string conversion.
  **Fix:** The print format is now implemented as "**%ld**" to match with the change of **delay_after_enrollment** from **unsigned int** to **time_t**
- **CID 239256** (# 1 of 1): Missing varargs init or cleanup (VARARGS) 8. missing_va_end: va_end was not called for parameters.
  **Fix:** In **OS_SHA1_strings()** **va_end()** was missing after **va_start()**. Is now implemented.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
- [X] Source installation
- [X] Package installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Coverity
- Memory tests for Windows
  - [X] Coverity