### PR TITLE
Fixing Wazuh DB not handling `sys_programs` items with empty fields

### DIFF
--- a/src/unit_tests/wazuh_db/test_wdb_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_parser.c
@@ -1859,9 +1859,9 @@ void test_packages_save_success_empty_items(void **state) {
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
     char* query = NULL;
-    os_strdup("save 0|1|2|3||5|6|7||9|10|11||13|14|15", query);
+    os_strdup("save |1|2|3||5|6|7||9|10|11||13|14|", query);
 
-    expect_string(__wrap_wdb_package_save, scan_id, "0");
+    expect_string(__wrap_wdb_package_save, scan_id, "");
     expect_string(__wrap_wdb_package_save, scan_time, "1");
     expect_string(__wrap_wdb_package_save, format, "2");
     expect_string(__wrap_wdb_package_save, name, "3");
@@ -1877,7 +1877,7 @@ void test_packages_save_success_empty_items(void **state) {
     expect_string(__wrap_wdb_package_save, description, "13");
     expect_string(__wrap_wdb_package_save, location, "14");
     expect_string(__wrap_wdb_package_save, checksum, SYSCOLLECTOR_LEGACY_CHECKSUM_VALUE);
-    expect_string(__wrap_wdb_package_save, item_id, "15");
+    expect_string(__wrap_wdb_package_save, item_id, "");
     expect_value(__wrap_wdb_package_save, replace, FALSE);
     will_return(__wrap_wdb_package_save, OS_SUCCESS);
 

--- a/src/unit_tests/wazuh_db/test_wdb_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_parser.c
@@ -1855,6 +1855,46 @@ void test_packages_save_success_null_items(void **state) {
     os_free(query);
 }
 
+void test_packages_save_success_empty_items(void **state) {
+    int ret = -1;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char* query = NULL;
+    os_strdup("save 0|1|2|3||5|6|7||9|10|11||13|14|15", query);
+
+    expect_string(__wrap_wdb_package_save, scan_id, "0");
+    expect_string(__wrap_wdb_package_save, scan_time, "1");
+    expect_string(__wrap_wdb_package_save, format, "2");
+    expect_string(__wrap_wdb_package_save, name, "3");
+    expect_string(__wrap_wdb_package_save, priority, "");
+    expect_string(__wrap_wdb_package_save, section, "5");
+    expect_value(__wrap_wdb_package_save, size, 6);
+    expect_string(__wrap_wdb_package_save, vendor, "7");
+    expect_string(__wrap_wdb_package_save, install_time, "");
+    expect_string(__wrap_wdb_package_save, version, "9");
+    expect_string(__wrap_wdb_package_save, architecture, "10");
+    expect_string(__wrap_wdb_package_save, multiarch, "11");
+    expect_string(__wrap_wdb_package_save, source, "");
+    expect_string(__wrap_wdb_package_save, description, "13");
+    expect_string(__wrap_wdb_package_save, location, "14");
+    expect_string(__wrap_wdb_package_save, checksum, SYSCOLLECTOR_LEGACY_CHECKSUM_VALUE);
+    expect_string(__wrap_wdb_package_save, item_id, "15");
+    expect_value(__wrap_wdb_package_save, replace, FALSE);
+    will_return(__wrap_wdb_package_save, OS_SUCCESS);
+
+    will_return(__wrap_time, 0);
+    expect_value(__wrap_wdbi_update_attempt, component, WDB_SYSCOLLECTOR_PACKAGES);
+    expect_value(__wrap_wdbi_update_attempt, timestamp, 0);
+    expect_value(__wrap_wdbi_update_attempt, legacy, TRUE);
+    expect_string(__wrap_wdbi_update_attempt, last_agent_checksum, "");
+
+    ret = wdb_parse_packages(data->wdb, query, data->output);
+
+    assert_string_equal(data->output, "ok");
+    assert_int_equal(ret, OS_SUCCESS);
+
+    os_free(query);
+}
+
 void test_packages_save_missing_items(void **state) {
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -2441,6 +2481,7 @@ int main()
         cmocka_unit_test_setup_teardown(test_packages_get_sock_err_response, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_packages_save_success, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_packages_save_success_null_items, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_packages_save_success_empty_items, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_packages_save_missing_items, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_packages_save_err, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_packages_del_success, test_setup, test_teardown),

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -3607,19 +3607,23 @@ int wdb_parse_packages(wdb_t * wdb, char * input, char * output) {
         /* The format of the data is scan_id|scan_time|format|name|priority|section|size|vendor|install_time|version|architecture|multiarch|source|description|location|item_id*/
         #define SAVE_PACKAGE_FIELDS_AMOUNT 16
         char* fields[SAVE_PACKAGE_FIELDS_AMOUNT] = {NULL};
-        char* last = tail;
+        char* last = NULL;
 
         for (int i = 0; i < SAVE_PACKAGE_FIELDS_AMOUNT; i++) {
-            if (!(next = strtok_r(NULL, "|", &tail))) {
-                mdebug1("Invalid package info query syntax.");
-                mdebug2("Package info query: %s", last);
-                snprintf(output, OS_MAXSTR + 1, "err Invalid package info query syntax, near '%.32s'", last);
-                return result;
+            last = tail;
+            if (i < SAVE_PACKAGE_FIELDS_AMOUNT-1) {
+                if (next = strchr(tail, '|'), !next) {
+                    mdebug1("Invalid package info query syntax.");
+                    mdebug2("Package info query: %s", last);
+                    snprintf(output, OS_MAXSTR + 1, "err Invalid package info query syntax, near '%.32s'", last);
+                    return result;
+                }
+                *next++ = '\0';
+                tail = next;
             }
-            last = next;
-            if (strcmp(next, "NULL"))
+            if (strcmp(last, "NULL"))
             {
-                fields[i] = next;
+                fields[i] = last;
             }
         }
 


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/9757 |

## Description

This pull request includes all the necessary changes to allow Wazuh DB to handle the case in which a `sys_programs` item being inserted contains empty fields.

In addition, the PR includes a new unit test case to cover the scenario.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade

- Memory tests for Linux
  - [x] Scan-build report
![image](https://user-images.githubusercontent.com/5703274/129980573-6a9f264f-b11b-47f6-a358-e3ee2547e9d1.png)

- [x] Added unit tests