### PR TITLE
Add `source` to cloudwatch events

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2545,7 +2545,7 @@ class AWSCloudWatchLogs(AWSService):
             for event in response['events']:
                 debug('+++ Sending events to Analysd...', 1)
                 debug('The message is "{}"'.format(event['message']), 2)
-                self.send_msg(event['message'], dump_json=False)
+                self.send_msg(self.format_message(event['message']))
 
                 if min_start_time is None:
                     min_start_time = event['timestamp']
@@ -2731,6 +2731,21 @@ class AWSCloudWatchLogs(AWSService):
                                                                     aws_region=self.region,
                                                                     aws_log_group=log_group,
                                                                     aws_log_stream=log_stream))
+
+    def format_message(self, msg):
+        """Add the message to a dict with additional fields.
+
+        Parameters
+        ----------
+        msg : str
+            Original message to be wrapped.
+
+        Returns
+        -------
+        dict
+            Dictionary with the message and additional fields.
+        """
+        return {'integration': 'aws', 'source': 'cloudwatch', 'aws': msg}
 
     def close_database(self):
         """Commit the changes to the DB and close the connection."""


### PR DESCRIPTION
|Related issue|
|---|
| Closes #9725 |

## Description

This PR adds a wrapper for the Cloudwatch events which adds some metadata, like the integration and the information source. This way, events like the one below:
```
2021 Aug 18 10:24:19 wazuh-master->Wazuh-AWS Access Denied
```
become 
```JSON
2021 Aug 18 10:24:19 wazuh-master->Wazuh-AWS {"integration": "aws", "source": "cloudwatch", "aws": "Access Denied"}
```

This, although it allows knowing the integration used to extract the events, has some drawbacks: 
- Before the events could be strings, JSON, etc. and they could match with any decoder and rule in the ruleset. Now they are always JSON and a specific set of decoders and rules for them will be necessary, which will also be much more limited than the full Wazuh ruleset. 
- Rules and decoders already created by clients and users for the current format of Cloudwatch events will be deprecated.

Regards.