### PR TITLE
Fix Windows agent upgrade via WPK

### DIFF
--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -90,8 +90,7 @@ chmod +x ${WAZUH_HOME}/var/upgrade/install.sh
 ${WAZUH_HOME}/var/upgrade/install.sh >>${WAZUH_HOME}/logs/upgrade.log 2>&1
 
 # Check installation result
-# RESULT=$?
-RESULT=1
+RESULT=$?
 
 echo "$(date +"%Y/%m/%d %H:%M:%S") - Installation result = ${RESULT}" >>${WAZUH_HOME}/logs/upgrade.log
 
@@ -101,7 +100,7 @@ COUNTER=30
 while [ "$status" != "connected" -a $COUNTER -gt 0 ]; do
     . ${WAZUH_HOME}/var/run/wazuh-agentd.state >>${WAZUH_HOME}/logs/upgrade.log 2>&1
     sleep 1
-    COUNTER=$((COUNTER - 1))
+    COUNTER=$[COUNTER - 1]
     echo "$(date +"%Y/%m/%d %H:%M:%S") - Waiting connection... Status = "${status}". Remaining attempts: ${COUNTER}." >>${WAZUH_HOME}/logs/upgrade.log
 done
 
@@ -129,9 +128,12 @@ else
     # Cleaning for old versions
     [ -d "${WAZUH_HOME}/ruleset" ] && rm -rf ${WAZUH_HOME}/ruleset
 
-    # Clean 4.2 SUSE Tumbleweed
+    # Clean systemd unit service
     if [ -f /etc/systemd/system/${SERVICE}.service ]; then
         rm -f /etc/systemd/system/${SERVICE}.service
+    fi
+    if [ -f /usr/lib/systemd/system/${SERVICE}.service ]; then
+        rm -f /usr/lib/systemd/system/${SERVICE}.service
     fi
 
     # Restore backup

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -57,17 +57,13 @@ fi
 # Init backup
 INIT_PATH=""
 CHK_CONFIG=0
-# REHL <= 6
-if [ -r "/etc/redhat-release" ]; then
-    if [ -f "/etc/rc.d/init.d/${SERVICE}" ]; then
-        CHK_CONFIG=1
-        INIT_PATH="/etc/rc.d/init.d/${SERVICE}"
-        mkdir -p "${TMP_DIR_BACKUP}/etc/rc.d/init.d/"
-    fi
-fi
 
-# Others
-if [ -f "/etc/init.d/${SERVICE}" ]; then
+# REHL <= 6 / Amazon linux
+if [ -f "/etc/rc.d/init.d/${SERVICE}" ]; then
+    CHK_CONFIG=1
+    INIT_PATH="/etc/rc.d/init.d/${SERVICE}"
+    mkdir -p "${TMP_DIR_BACKUP}/etc/rc.d/init.d/"
+elif [ -f "/etc/init.d/${SERVICE}" ]; then
     CHK_CONFIG=1
     INIT_PATH="/etc/init.d/${SERVICE}"
     mkdir -p "${TMP_DIR_BACKUP}/etc/init.d/"
@@ -97,8 +93,7 @@ chmod +x ${WAZUH_HOME}/var/upgrade/install.sh
 ${WAZUH_HOME}/var/upgrade/install.sh >>${WAZUH_HOME}/logs/upgrade.log 2>&1
 
 # Check installation result
-RESULT=1
-# RESULT=$?
+RESULT=$?
 
 echo "$(date +"%Y/%m/%d %H:%M:%S") - Installation result = ${RESULT}" >>${WAZUH_HOME}/logs/upgrade.log
 

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -8,12 +8,12 @@ WAZUH_VERSION=${2}
 SERVICE=wazuh-agent
 # Generating Backup
 TMP_DIR_BACKUP=${WAZUH_HOME}/tmp_bkp
-rm -rf ${WAZUH_HOME}/tmp_bkp/*
+rm -rf ${WAZUH_HOME}/tmp_bkp/
 
 BDATE=$(date +"%m-%d-%Y_%H-%M-%S")
 declare -a FOLDERS_TO_BACKUP
 
-echo "$(date +"%Y/%m/%d %H:%M:%S") - Generating Backup." > "${WAZUH_HOME}/logs/upgrade.log"
+echo "$(date +"%Y/%m/%d %H:%M:%S") - Generating Backup." >"${WAZUH_HOME}/logs/upgrade.log"
 
 # Generate wazuh home directory tree to backup
 FOLDERS_TO_BACKUP+=(${WAZUH_HOME}/active-response)
@@ -39,7 +39,7 @@ fi
 
 # Check if systemd is used
 SYSTEMD_SERVICE_UNIT_PATH=""
-# RHEL 8 services must must be installed in /usr/lib/systemd/system/
+# RHEL 8 >= services must must be installed in /usr/lib/systemd/system/
 if [ -f /usr/lib/systemd/system/${SERVICE}.service ]; then
     SYSTEMD_SERVICE_UNIT_PATH=/usr/lib/systemd/system/${SERVICE}.service
     mkdir -p "${TMP_DIR_BACKUP}/usr/lib/systemd/system/"
@@ -54,11 +54,10 @@ if [ -n "${SYSTEMD_SERVICE_UNIT_PATH}" ]; then
     cp -a "${SYSTEMD_SERVICE_UNIT_PATH}" "${TMP_DIR_BACKUP}${SYSTEMD_SERVICE_UNIT_PATH}"
 fi
 
-
 # Init backup
 INIT_PATH=""
 CHK_CONFIG=0
-# REHL
+# REHL <= 6
 if [ -r "/etc/redhat-release" ]; then
     if [ -f "/etc/rc.d/init.d/${SERVICE}" ]; then
         CHK_CONFIG=1
@@ -67,18 +66,16 @@ if [ -r "/etc/redhat-release" ]; then
     fi
 fi
 
-# Suse
-if [ -r "/etc/SuSE-release" ]; then
-    if [ -f "/etc/init.d/${SERVICE}" ]; then
-        CHK_CONFIG=1
-        INIT_PATH="/etc/init.d/${SERVICE}"
-        mkdir -p "${TMP_DIR_BACKUP}/etc/rc.d/init.d/"
-    fi
+# Others
+if [ -f "/etc/init.d/${SERVICE}" ]; then
+    CHK_CONFIG=1
+    INIT_PATH="/etc/init.d/${SERVICE}"
+    mkdir -p "${TMP_DIR_BACKUP}/etc/init.d/"
 fi
 
 # Backup the unit file
 if [ -n "${INIT_PATH}" ]; then
-     cp -a "${INIT_PATH}" "${TMP_DIR_BACKUP}${INIT_PATH}"
+    cp -a "${INIT_PATH}" "${TMP_DIR_BACKUP}${INIT_PATH}"
 fi
 
 # Saves modes and owners of the directories
@@ -91,25 +88,25 @@ while read -r line; do
 done <<<"$BACKUP_LIST_FILES"
 
 # Generate Backup
-tar czf "${WAZUH_HOME}/backup/backup_${WAZUH_VERSION}_[${BDATE}].tar.gz" -C "${WAZUH_HOME}/tmp_bkp" . >> "${WAZUH_HOME}/logs/upgrade.log" 2>&1
-#rm -rf ${WAZUH_HOME}/tmp_bkp
+tar czf "${WAZUH_HOME}/backup/backup_${WAZUH_VERSION}_[${BDATE}].tar.gz" -C "${WAZUH_HOME}/tmp_bkp" . >>"${WAZUH_HOME}/logs/upgrade.log" 2>&1
+rm -rf ${WAZUH_HOME}/tmp_bkp/
 
 # Installing upgrade
-echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade started." >> ${WAZUH_HOME}/logs/upgrade.log
+echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade started." >>${WAZUH_HOME}/logs/upgrade.log
 chmod +x ${WAZUH_HOME}/var/upgrade/install.sh
-${WAZUH_HOME}/var/upgrade/install.sh >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
+${WAZUH_HOME}/var/upgrade/install.sh >>${WAZUH_HOME}/logs/upgrade.log 2>&1
 
 # Check installation result
 RESULT=1
 # RESULT=$?
 
-echo "$(date +"%Y/%m/%d %H:%M:%S") - Installation result = ${RESULT}" >> ${WAZUH_HOME}/logs/upgrade.log
+echo "$(date +"%Y/%m/%d %H:%M:%S") - Installation result = ${RESULT}" >>${WAZUH_HOME}/logs/upgrade.log
 
 # Wait connection
 status="pending"
 COUNTER=30
 while [ "$status" != "connected" -a $COUNTER -gt 0 ]; do
-    . ${WAZUH_HOME}/var/run/wazuh-agentd.state >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
+    . ${WAZUH_HOME}/var/run/wazuh-agentd.state >>${WAZUH_HOME}/logs/upgrade.log 2>&1
     sleep 1
     COUNTER=$((COUNTER - 1))
     echo "$(date +"%Y/%m/%d %H:%M:%S") - Waiting connection... Status = "${status}". Remaining attempts: ${COUNTER}." >>${WAZUH_HOME}/logs/upgrade.log
@@ -117,21 +114,21 @@ done
 
 # Check connection
 if [ "$status" = "connected" -a $RESULT -eq 0 ]; then
-    echo "$(date +"%Y/%m/%d %H:%M:%S") - Connected to manager." >> ${WAZUH_HOME}/logs/upgrade.log
-    echo -ne "0" > ${WAZUH_HOME}/var/upgrade/upgrade_result
-    echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade finished successfully." >> ${WAZUH_HOME}/logs/upgrade.log
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Connected to manager." >>${WAZUH_HOME}/logs/upgrade.log
+    echo -ne "0" >${WAZUH_HOME}/var/upgrade/upgrade_result
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade finished successfully." >>${WAZUH_HOME}/logs/upgrade.log
 else
     # Restore backup
-    echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. Restoring..." >> ${WAZUH_HOME}/logs/upgrade.log
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. Restoring..." >>${WAZUH_HOME}/logs/upgrade.log
 
     # Cleanup before restore
     CONTROL="$WAZUH_HOME/bin/wazuh-control"
     if [ ! -f $CONTROL ]; then
         CONTROL="$WAZUH_HOME/bin/ossec-control"
     fi
-    $CONTROL stop >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
+    $CONTROL stop >>${WAZUH_HOME}/logs/upgrade.log 2>&1
 
-    echo "$(date +"%Y/%m/%d %H:%M:%S") - Deleting upgrade files..." >> ${WAZUH_HOME}/logs/upgrade.log
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Deleting upgrade files..." >>${WAZUH_HOME}/logs/upgrade.log
     for dir in ${FOLDERS_TO_BACKUP[@]}; do
         rm -rf ${dir} >>${WAZUH_HOME}/logs/upgrade.log 2>&1
     done
@@ -139,37 +136,41 @@ else
     # Cleaning for old versions
     [ -d "${WAZUH_HOME}/ruleset" ] && rm -rf ${WAZUH_HOME}/ruleset
 
-    # Restore backup
-    echo "$(date +"%Y/%m/%d %H:%M:%S") - Restoring backup...."
-    tar xzf ${WAZUH_HOME}/backup/backup_${WAZUH_VERSION}_[${BDATE}].tar.gz -C / >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
-
-    # Restore SELinuxPolicy
-    if command -v semodule > /dev/null && command -v getenforce > /dev/null; then
-        if [ $(getenforce) != "Disabled" ]; then
-            if [ -f ${WAZUH_HOME}/var/selinux/wazuh.pp ]; then
-                echo "$(date +"%Y/%m/%d %H:%M:%S") - Restoring SELinux policy ...." >> ${WAZUH_HOME}/logs/upgrade.log
-                semodule -i ${WAZUH_HOME}/var/selinux/wazuh.pp >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
-                semodule -e wazuh >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
-            else
-                echo "$(date +"%Y/%m/%d %H:%M:%S") - ERROR: Wazuh SELinux module not found." >> ${WAZUH_HOME}/logs/upgrade.log
-            fi
-        else
-            echo "$(date +"%Y/%m/%d %H:%M:%S") - Wazuh SELinux module installation is skipped (SELinux is disabled)." >> ${WAZUH_HOME}/logs/upgrade.log
-        fi
+    # Clean 4.2 SUSE Tumbleweed
+    if [ -f /etc/systemd/system/${SERVICE}.service ]; then
+        rm -f /etc/systemd/system/${SERVICE}.service
     fi
 
+    # Restore backup
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Restoring backup...."
+    tar xzf ${WAZUH_HOME}/backup/backup_${WAZUH_VERSION}_[${BDATE}].tar.gz -C / >>${WAZUH_HOME}/logs/upgrade.log 2>&1
+
+    # Restore SELinuxPolicy
+    if command -v semodule >/dev/null && command -v getenforce >/dev/null; then
+        if [ $(getenforce) != "Disabled" ]; then
+            if [ -f ${WAZUH_HOME}/var/selinux/wazuh.pp ]; then
+                echo "$(date +"%Y/%m/%d %H:%M:%S") - Restoring SELinux policy ...." >>${WAZUH_HOME}/logs/upgrade.log
+                semodule -i ${WAZUH_HOME}/var/selinux/wazuh.pp >>${WAZUH_HOME}/logs/upgrade.log 2>&1
+                semodule -e wazuh >>${WAZUH_HOME}/logs/upgrade.log 2>&1
+            else
+                echo "$(date +"%Y/%m/%d %H:%M:%S") - ERROR: Wazuh SELinux module not found." >>${WAZUH_HOME}/logs/upgrade.log
+            fi
+        else
+            echo "$(date +"%Y/%m/%d %H:%M:%S") - Wazuh SELinux module installation is skipped (SELinux is disabled)." >>${WAZUH_HOME}/logs/upgrade.log
+        fi
+    fi
 
     echo -ne "2" >${WAZUH_HOME}/var/upgrade/upgrade_result
 
     # Restore service
     if [ -n "${INIT_PATH}" ]; then
         if [ $CHK_CONFIG -eq 1 ]; then
-            /sbin/chkconfig --add ${SERVICE} >> "${WAZUH_HOME}/logs/upgrade.log" 2>&1
+            /sbin/chkconfig --add ${SERVICE} >>"${WAZUH_HOME}/logs/upgrade.log" 2>&1
         fi
     fi
 
     if [ -n "${SYSTEMD_SERVICE_UNIT_PATH}" ]; then
-        systemctl daemon-reload >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
+        systemctl daemon-reload >>${WAZUH_HOME}/logs/upgrade.log 2>&1
     fi
 
     CONTROL="$WAZUH_HOME/bin/wazuh-control"

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -5,40 +5,177 @@
 WAZUH_HOME=${1}
 WAZUH_VERSION=${2}
 
+SERVICE=wazuh-agent
+# Generating Backup
+TMP_DIR_BACKUP=${WAZUH_HOME}/tmp_bkp
+rm -rf ${WAZUH_HOME}/tmp_bkp/*
+
+BDATE=$(date +"%m-%d-%Y_%H-%M-%S")
+declare -a FOLDERS_TO_BACKUP
+
+echo "$(date +"%Y/%m/%d %H:%M:%S") - Generating Backup." > "${WAZUH_HOME}/logs/upgrade.log"
+
+# Generate wazuh home directory tree to backup
+FOLDERS_TO_BACKUP+=(${WAZUH_HOME}/active-response)
+FOLDERS_TO_BACKUP+=(${WAZUH_HOME}/bin)
+FOLDERS_TO_BACKUP+=(${WAZUH_HOME}/etc)
+FOLDERS_TO_BACKUP+=(${WAZUH_HOME}/lib)
+FOLDERS_TO_BACKUP+=(${WAZUH_HOME}/queue)
+[ -d "${WAZUH_HOME}/ruleset" ] && FOLDERS_TO_BACKUP+=(${WAZUH_HOME}/ruleset)
+[ -d "${WAZUH_HOME}/wodles" ] && FOLDERS_TO_BACKUP+=(${WAZUH_HOME}/wodles)
+[ -d "${WAZUH_HOME}/agentless" ] && FOLDERS_TO_BACKUP+=(${WAZUH_HOME}/agentless)
+[ -d "${WAZUH_HOME}/logs/ossec" ] && FOLDERS_TO_BACKUP+=(${WAZUH_HOME}/logs/ossec)
+[ -d "${WAZUH_HOME}/var/selinux" ] && FOLDERS_TO_BACKUP+=(${WAZUH_HOME}/var/selinux)
+
+for dir in "${FOLDERS_TO_BACKUP[@]}"; do
+    mkdir -p "${TMP_DIR_BACKUP}${dir}"
+    cp -a ${dir}/* "${TMP_DIR_BACKUP}${dir}"
+done
+
+if [ -f /etc/ossec-init.conf ]; then
+    mkdir -p "${WAZUH_HOME}/tmp_bkp/etc"
+    cp -p /etc/ossec-init.conf "${WAZUH_HOME}/tmp_bkp/etc"
+fi
+
+# Check if systemd is used
+SYSTEMD_SERVICE_UNIT_PATH=""
+# RHEL 8 services must must be installed in /usr/lib/systemd/system/
+if [ -f /usr/lib/systemd/system/${SERVICE}.service ]; then
+    SYSTEMD_SERVICE_UNIT_PATH=/usr/lib/systemd/system/${SERVICE}.service
+    mkdir -p "${TMP_DIR_BACKUP}/usr/lib/systemd/system/"
+# Others
+elif [ -f /etc/systemd/system/${SERVICE}.service ]; then
+    SYSTEMD_SERVICE_UNIT_PATH=/etc/systemd/system/${SERVICE}.service
+    mkdir -p "${TMP_DIR_BACKUP}/etc/systemd/system/"
+fi
+
+# Backup the unit file
+if [ -n "${SYSTEMD_SERVICE_UNIT_PATH}" ]; then
+    cp -a "${SYSTEMD_SERVICE_UNIT_PATH}" "${TMP_DIR_BACKUP}${SYSTEMD_SERVICE_UNIT_PATH}"
+fi
+
+
+# Init backup
+INIT_PATH=""
+CHK_CONFIG=0
+# REHL
+if [ -r "/etc/redhat-release" ]; then
+    if [ -f "/etc/rc.d/init.d/${SERVICE}" ]; then
+        CHK_CONFIG=1
+        INIT_PATH="/etc/rc.d/init.d/${SERVICE}"
+        mkdir -p "${TMP_DIR_BACKUP}/etc/rc.d/init.d/"
+    fi
+fi
+
+# Suse
+if [ -r "/etc/SuSE-release" ]; then
+    if [ -f "/etc/init.d/${SERVICE}" ]; then
+        CHK_CONFIG=1
+        INIT_PATH="/etc/init.d/${SERVICE}"
+        mkdir -p "${TMP_DIR_BACKUP}/etc/rc.d/init.d/"
+    fi
+fi
+
+# Backup the unit file
+if [ -n "${INIT_PATH}" ]; then
+     cp -a "${INIT_PATH}" "${TMP_DIR_BACKUP}${INIT_PATH}"
+fi
+
+# Saves modes and owners of the directories
+BACKUP_LIST_FILES=$(find "${TMP_DIR_BACKUP}/" -type d)
+
+while read -r line; do
+    org=$(echo "${line}" | awk "sub(\"${TMP_DIR_BACKUP}\",\"\")")
+    chown --reference=$org $line
+    chmod --reference=$org $line
+done <<<"$BACKUP_LIST_FILES"
+
+# Generate Backup
+tar czf "${WAZUH_HOME}/backup/backup_${WAZUH_VERSION}_[${BDATE}].tar.gz" -C "${WAZUH_HOME}/tmp_bkp" . >> "${WAZUH_HOME}/logs/upgrade.log" 2>&1
+#rm -rf ${WAZUH_HOME}/tmp_bkp
+
 # Installing upgrade
 echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade started." >> ${WAZUH_HOME}/logs/upgrade.log
 chmod +x ${WAZUH_HOME}/var/upgrade/install.sh
 ${WAZUH_HOME}/var/upgrade/install.sh >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
 
 # Check installation result
-RESULT=$?
+RESULT=1
+# RESULT=$?
+
 echo "$(date +"%Y/%m/%d %H:%M:%S") - Installation result = ${RESULT}" >> ${WAZUH_HOME}/logs/upgrade.log
 
 # Wait connection
 status="pending"
 COUNTER=30
-while [ "$status" != "connected" -a $COUNTER -gt 0  ]; do
+while [ "$status" != "connected" -a $COUNTER -gt 0 ]; do
     . ${WAZUH_HOME}/var/run/wazuh-agentd.state >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
     sleep 1
-    COUNTER=$[COUNTER - 1]
-    echo "$(date +"%Y/%m/%d %H:%M:%S") - Waiting connection... Status = "${status}". Remaining attempts: ${COUNTER}." >> ${WAZUH_HOME}/logs/upgrade.log
+    COUNTER=$((COUNTER - 1))
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Waiting connection... Status = "${status}". Remaining attempts: ${COUNTER}." >>${WAZUH_HOME}/logs/upgrade.log
 done
 
 # Check connection
-if [ "$status" = "connected" -a $RESULT -eq 0  ]; then
+if [ "$status" = "connected" -a $RESULT -eq 0 ]; then
     echo "$(date +"%Y/%m/%d %H:%M:%S") - Connected to manager." >> ${WAZUH_HOME}/logs/upgrade.log
     echo -ne "0" > ${WAZUH_HOME}/var/upgrade/upgrade_result
     echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade finished successfully." >> ${WAZUH_HOME}/logs/upgrade.log
 else
-    echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed..." >> ${WAZUH_HOME}/logs/upgrade.log
+    # Restore backup
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. Restoring..." >> ${WAZUH_HOME}/logs/upgrade.log
+
+    # Cleanup before restore
+    CONTROL="$WAZUH_HOME/bin/wazuh-control"
+    if [ ! -f $CONTROL ]; then
+        CONTROL="$WAZUH_HOME/bin/ossec-control"
+    fi
+    $CONTROL stop >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
+
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Deleting upgrade files..." >> ${WAZUH_HOME}/logs/upgrade.log
+    for dir in ${FOLDERS_TO_BACKUP[@]}; do
+        rm -rf ${dir} >>${WAZUH_HOME}/logs/upgrade.log 2>&1
+    done
+
+    # Cleaning for old versions
+    [ -d "${WAZUH_HOME}/ruleset" ] && rm -rf ${WAZUH_HOME}/ruleset
+
+    # Restore backup
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Restoring backup...."
+    tar xzf ${WAZUH_HOME}/backup/backup_${WAZUH_VERSION}_[${BDATE}].tar.gz -C / >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
+
+    # Restore SELinuxPolicy
+    if command -v semodule > /dev/null && command -v getenforce > /dev/null; then
+        if [ $(getenforce) != "Disabled" ]; then
+            if [ -f ${WAZUH_HOME}/var/selinux/wazuh.pp ]; then
+                echo "$(date +"%Y/%m/%d %H:%M:%S") - Restoring SELinux policy ...." >> ${WAZUH_HOME}/logs/upgrade.log
+                semodule -i ${WAZUH_HOME}/var/selinux/wazuh.pp >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
+                semodule -e wazuh >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
+            else
+                echo "$(date +"%Y/%m/%d %H:%M:%S") - ERROR: Wazuh SELinux module not found." >> ${WAZUH_HOME}/logs/upgrade.log
+            fi
+        else
+            echo "$(date +"%Y/%m/%d %H:%M:%S") - Wazuh SELinux module installation is skipped (SELinux is disabled)." >> ${WAZUH_HOME}/logs/upgrade.log
+        fi
+    fi
+
+
+    echo -ne "2" >${WAZUH_HOME}/var/upgrade/upgrade_result
+
+    # Restore service
+    if [ -n "${INIT_PATH}" ]; then
+        if [ $CHK_CONFIG -eq 1 ]; then
+            /sbin/chkconfig --add ${SERVICE} >> "${WAZUH_HOME}/logs/upgrade.log" 2>&1
+        fi
+    fi
+
+    if [ -n "${SYSTEMD_SERVICE_UNIT_PATH}" ]; then
+        systemctl daemon-reload >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
+    fi
 
     CONTROL="$WAZUH_HOME/bin/wazuh-control"
     if [ ! -f $CONTROL ]; then
         CONTROL="$WAZUH_HOME/bin/ossec-control"
     fi
 
-    echo "$(date +"%Y/%m/%d %H:%M:%S") - Trying to start the agent on its current state..." >> ${WAZUH_HOME}/logs/upgrade.log
-    $CONTROL start >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
-    echo -ne "2" > ${WAZUH_HOME}/var/upgrade/upgrade_result
-
+    $CONTROL start >>${WAZUH_HOME}/logs/upgrade.log 2>&1
 fi

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -40,17 +40,15 @@ fi
 # Check if systemd is used
 SYSTEMD_SERVICE_UNIT_PATH=""
 # RHEL 8 >= services must must be installed in /usr/lib/systemd/system/
-if [ -f /usr/lib/systemd/system/${SERVICE}.service ]; then
+if [ -f /usr/lib/systemd/system/${SERVICE}.service ] && [ ! -h /usr/lib/systemd/system ]; then
     SYSTEMD_SERVICE_UNIT_PATH=/usr/lib/systemd/system/${SERVICE}.service
     mkdir -p "${TMP_DIR_BACKUP}/usr/lib/systemd/system/"
+    cp -a "${SYSTEMD_SERVICE_UNIT_PATH}" "${TMP_DIR_BACKUP}${SYSTEMD_SERVICE_UNIT_PATH}"
+fi
 # Others
-elif [ -f /etc/systemd/system/${SERVICE}.service ]; then
+if [ -f /etc/systemd/system/${SERVICE}.service ] && [ ! -h /etc/systemd/system ]; then
     SYSTEMD_SERVICE_UNIT_PATH=/etc/systemd/system/${SERVICE}.service
     mkdir -p "${TMP_DIR_BACKUP}/etc/systemd/system/"
-fi
-
-# Backup the unit file
-if [ -n "${SYSTEMD_SERVICE_UNIT_PATH}" ]; then
     cp -a "${SYSTEMD_SERVICE_UNIT_PATH}" "${TMP_DIR_BACKUP}${SYSTEMD_SERVICE_UNIT_PATH}"
 fi
 
@@ -59,18 +57,17 @@ INIT_PATH=""
 CHK_CONFIG=0
 
 # REHL <= 6 / Amazon linux
-if [ -f "/etc/rc.d/init.d/${SERVICE}" ]; then
+if [ -f "/etc/rc.d/init.d/${SERVICE}" ] && [ ! -h /etc/rc.d/init.d ]; then
     CHK_CONFIG=1
     INIT_PATH="/etc/rc.d/init.d/${SERVICE}"
     mkdir -p "${TMP_DIR_BACKUP}/etc/rc.d/init.d/"
-elif [ -f "/etc/init.d/${SERVICE}" ]; then
+    cp -a "${INIT_PATH}" "${TMP_DIR_BACKUP}${INIT_PATH}"
+fi
+
+if [ -f "/etc/init.d/${SERVICE}" ] && [ ! -h /etc/init.d ]; then
     CHK_CONFIG=1
     INIT_PATH="/etc/init.d/${SERVICE}"
     mkdir -p "${TMP_DIR_BACKUP}/etc/init.d/"
-fi
-
-# Backup the unit file
-if [ -n "${INIT_PATH}" ]; then
     cp -a "${INIT_PATH}" "${TMP_DIR_BACKUP}${INIT_PATH}"
 fi
 
@@ -93,7 +90,8 @@ chmod +x ${WAZUH_HOME}/var/upgrade/install.sh
 ${WAZUH_HOME}/var/upgrade/install.sh >>${WAZUH_HOME}/logs/upgrade.log 2>&1
 
 # Check installation result
-RESULT=$?
+# RESULT=$?
+RESULT=1
 
 echo "$(date +"%Y/%m/%d %H:%M:%S") - Installation result = ${RESULT}" >>${WAZUH_HOME}/logs/upgrade.log
 

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -90,7 +90,8 @@ chmod +x ${WAZUH_HOME}/var/upgrade/install.sh
 ${WAZUH_HOME}/var/upgrade/install.sh >>${WAZUH_HOME}/logs/upgrade.log 2>&1
 
 # Check installation result
-RESULT=$?
+# RESULT=$?
+RESULT=1
 
 echo "$(date +"%Y/%m/%d %H:%M:%S") - Installation result = ${RESULT}" >>${WAZUH_HOME}/logs/upgrade.log
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/9735|

The file restore system when an upgrade via WPK fails is not working properly.

Currently, as for the permissions, the restoring would only work in the case of upgrading to the same version, eg. from 4.1.3 to 4.1.4.

The file restore should be fixed when an update fails via WPK. 