### PR TITLE
Restoring ping-pong enrollment logic in the manager to allow the proper registering of legacy agents

### DIFF
--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -435,6 +435,23 @@ STATIC void HandleSecureMessage(char *buffer, int recv_b, struct sockaddr_in *pe
 
             return;
         }
+    } else if (strncmp(buffer, "#ping", 5) == 0) {
+            int retval = 0;
+            char *msg = "#pong";
+            ssize_t msg_size = strlen(msg);
+
+            if (protocol == REMOTED_NET_PROTOCOL_UDP) {
+                retval = sendto(logr.udp_sock, msg, msg_size, 0, (struct sockaddr *)peer_info, logr.peer_size) == msg_size ? 0 : -1;
+            } else {
+                retval = OS_SendSecureTCP(sock_client, msg_size, msg);
+            }
+
+            if (retval < 0) {
+                mwarn("Ping operation could not be delivered completely (%d)", retval);
+            }
+
+            return;
+
     } else {
         key_lock_read();
         agentid = OS_IsAllowedIP(&keys, srcip);


### PR DESCRIPTION
|Related issue|
|---|
|#9717|

## Description

During the exploratory testing of the epic, it was found that the PR [9709](https://github.com/wazuh/wazuh/pull/9709) deleted the manager's side of the ping-pong logic. This PR brings it back to allow the legacy compatibility.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Package installation

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] Working on cluster environments

