### PR TITLE
Fixing enrollment message parsing when using the IP option 

### DIFF
--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -165,6 +165,9 @@ w_err_t w_auth_parse_data(const char* buf,
             snprintf(ip, IPSIZE, "%s", client_source_ip);
         }
 
+        /* Forward the string pointer to allow the proper key parsing IP:'........'
+           3 for IP:, 2 for '' */
+        buf+= 3 + strlen(client_source_ip) + 2;
     }
     else{
         buf--;

--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -165,8 +165,7 @@ w_err_t w_auth_parse_data(const char* buf,
             snprintf(ip, IPSIZE, "%s", client_source_ip);
         }
 
-        /* Forward the string pointer to allow the proper key parsing IP:'........'
-           3 for IP:, 2 for '' */
+        /* Forward the string pointer IP:'........' 3 for IP: , 2 for '' */
         buf+= 3 + strlen(client_source_ip) + 2;
     }
     else{


### PR DESCRIPTION
|Related issue|
|---|
|#9717|

## Description

This PR fixes the enrollment message parsing when an agent requests a key using the `I` option (IP).
The pointer to the buffer being parsed was not properly updated, so the **K** wasn't read even when it was present.

This means that, for example, the `agen_auth` binary could request many keys (even when the current one was valid) if the IP was set as an argument.

## Tests

This case was added in the corresponding UT.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Added unit tests (for new features)