### PR TITLE
Add healtcheck to verify that logcollector stats are ready

### DIFF
--- a/api/test/integration/env/configurations/agent/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/agent/agent/healthcheck/healthcheck.py
@@ -1,0 +1,17 @@
+import os
+import sys
+sys.path.append('/tools')
+
+from healthcheck_utils import get_agent_health_base, is_old_agent
+
+
+def get_health():
+    stats_files = ['/var/ossec/var/run/wazuh-logcollector.state']
+    if all(os.path.exists(file) and os.path.getsize(file) > 0 for file in stats_files) or is_old_agent():
+        return 0
+    else:
+        return 1
+
+
+if __name__ == "__main__":
+    exit(get_health() or get_agent_health_base())

--- a/api/test/integration/env/configurations/agent/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/agent/agent/healthcheck/healthcheck.py
@@ -2,12 +2,12 @@ import os
 import sys
 sys.path.append('/tools')
 
-from healthcheck_utils import get_agent_health_base, is_old_agent
+from healthcheck_utils import get_agent_health_base
 
 
 def get_health():
     stats_files = ['/var/ossec/var/run/wazuh-logcollector.state']
-    if all(os.path.exists(file) and os.path.getsize(file) > 0 for file in stats_files) or is_old_agent():
+    if all(os.path.exists(file) and os.path.getsize(file) > 0 for file in stats_files):
         return 0
     else:
         return 1

--- a/api/test/integration/env/tools/healthcheck_utils.py
+++ b/api/test/integration/env/tools/healthcheck_utils.py
@@ -105,3 +105,7 @@ def get_worker_health():
 
 def get_manager_health_base():
     return get_master_health() if socket.gethostname() == 'wazuh-master' else get_worker_health()
+
+
+def is_old_agent():
+    return os.path.exists('/var/ossec/etc/ossec-init.conf')

--- a/api/test/integration/env/tools/healthcheck_utils.py
+++ b/api/test/integration/env/tools/healthcheck_utils.py
@@ -105,7 +105,3 @@ def get_worker_health():
 
 def get_manager_health_base():
     return get_master_health() if socket.gethostname() == 'wazuh-master' else get_worker_health()
-
-
-def is_old_agent():
-    return os.path.exists('/var/ossec/etc/ossec-init.conf')

--- a/api/test/integration/mapping/integration_test_api_endpoints.json
+++ b/api/test/integration/mapping/integration_test_api_endpoints.json
@@ -1812,6 +1812,22 @@
                 ]
             },
             {
+                "name": "sanitize_policies.yaml",
+                "tag": "sanitize",
+                "tests": [
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml"
+                ]
+            },
+            {
                 "name": "schema_security_test.sql",
                 "tag": "schema",
                 "tests": [
@@ -2535,6 +2551,27 @@
             {
                 "name": "agent3_config.sh",
                 "tag": "agent3",
+                "tests": [
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/agent/agent/healthcheck",
+        "files": [
+            {
+                "name": "healthcheck.py",
+                "tag": "healthcheck",
                 "tests": [
                     "test_agent_DELETE_endpoints.tavern.yaml",
                     "test_agent_GET_endpoints.tavern.yaml",

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -1979,9 +1979,6 @@ stages:
 ---
 test_name: GET /agents/{agent_id}/stats/{component}
 
-marks:
-  - xfail  # https://github.com/wazuh/wazuh/issues/9665
-
 stages:
 
   - name: Get logcollector stats from agent 000 (manager)


### PR DESCRIPTION
|Related issue|
|---|
| Closes #9665 |

## Description

This PR adds a new healthcheck for agents that verifies whether the `logcollector` stats file is ready and if it is empty before starting the test. 

The fact that the file does not exist means that the stats are not ready yet and therefore cannot be obtained through the `GET /agents/{agent_id}/stats/logcollector` API endpoint, so the test would fail as reported in #9665. 

In my testing, stats can sometimes be retrieved even before the file has been generated. The writing of the file is, therefore, done after the are stats available, so by verifying its existence we make sure that the stats are ready. 

Regards.