### PR TITLE
Bring Authd the capability to avoid re-registering agents that already has valid keys - Implementation

### DIFF
--- a/framework/wazuh/core/tests/data/rules/0015-ossec_rules.xml
+++ b/framework/wazuh/core/tests/data/rules/0015-ossec_rules.xml
@@ -150,8 +150,8 @@
 
   <rule id="520" level="3">
     <if_sid>500</if_sid>
-    <match>Duplicated IP</match>
-    <description>Trying to add an agent with duplicated IP.</description>
+    <match>Duplicate IP</match>
+    <description>Trying to add an agent with duplicate IP.</description>
     <group>pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 

--- a/ruleset/decoders/0200-ossec_decoders.xml
+++ b/ruleset/decoders/0200-ossec_decoders.xml
@@ -62,7 +62,7 @@
 <decoder name="ossec-authd">
   <parent>ossec</parent>
   <type>ossec</type>
-  <prematch offset="after_parent">^Duplicated IP</prematch>
+  <prematch offset="after_parent">^Duplicate IP</prematch>
   <regex offset="after_prematch">^ (\S+)$</regex>
   <order>srcip</order>
 </decoder>

--- a/ruleset/rules/0015-ossec_rules.xml
+++ b/ruleset/rules/0015-ossec_rules.xml
@@ -155,8 +155,8 @@
 
   <rule id="520" level="3">
     <if_sid>500</if_sid>
-    <match>Duplicated IP</match>
-    <description>Trying to add an agent with duplicated IP.</description>
+    <match>Duplicate IP</match>
+    <description>Trying to add an agent with duplicate IP.</description>
     <group>pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 

--- a/src/addagent/main.c
+++ b/src/addagent/main.c
@@ -44,7 +44,7 @@ __attribute__((noreturn)) static void helpmsg()
     print_out("    -e <id>     Extracts key for an agent (Manager only).");
     print_out("    -r <id>     Remove an agent (Manager only).");
     print_out("    -i <key>    Import authentication key (Agent only).");
-    print_out("    -F <sec>    Remove agents with duplicated IP if disconnected since <sec> seconds.");
+    print_out("    -F <sec>    Remove agents with duplicate IP if disconnected since <sec> seconds.");
     print_out("    -f <file>   Bulk generate client keys from file (Manager only).");
     print_out("                <file> contains lines in IP,NAME format.");
     exit(1);

--- a/src/addagent/manage_agents.c
+++ b/src/addagent/manage_agents.c
@@ -228,7 +228,7 @@ int add_agent(int json_output)
                 if (json_output) {
                     cJSON *json_root = cJSON_CreateObject();
                     cJSON_AddNumberToObject(json_root, "error", 79);
-                    cJSON_AddStringToObject(json_root, "message", "Duplicated IP for agent");
+                    cJSON_AddStringToObject(json_root, "message", "Duplicate IP for agent");
                     printf("%s", cJSON_PrintUnformatted(json_root));
                     exit(1);
                 } else {

--- a/src/addagent/manage_agents.h
+++ b/src/addagent/manage_agents.h
@@ -100,7 +100,7 @@ extern char shost[];
 #define ADD_ERROR_ID    "\n** ID '%s' already present. They must be unique.\n\n"
 #define ADD_ERROR_NAME  "\n** Name '%s' already present. Please enter a new name.\n\n"
 #define IP_ERROR        "\n** Invalid IP '%s'. Please enter a valid IP Address.\n\n"
-#define IP_DUP_ERROR    "\n** Duplicated IP '%s'. Please enter an unique IP Address.\n\n"
+#define IP_DUP_ERROR    "\n** Duplicate IP '%s'. Please enter an unique IP Address.\n\n"
 #define NO_AGENT        "\n** No agent available. You need to add one first.\n"
 #define NO_ID           "\n** Invalid ID '%s' given. ID is not present.\n"
 #define NO_KEY          "\n** Invalid authentication key. Starting over again.\n"

--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -55,7 +55,7 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
     }
     /* Read private keys  */
     minfo(ENC_READ);
-    OS_ReadKeys(&keys, 1, 0);
+    OS_ReadKeys(&keys, W_DUAL_KEY, 0);
 
     // Resolve hostnames
     rc = 0;

--- a/src/client-agent/config.c
+++ b/src/client-agent/config.c
@@ -49,7 +49,7 @@ int ClientConf(const char *cfgfile)
 
     // Initialize enrollment_cfg
     agt->enrollment_cfg = w_enrollment_init(target_cfg, cert_cfg, &keys);
-    agt->enrollment_cfg->allow_localhost = 0; // Localhost not allowed in auto-enrollment
+    agt->enrollment_cfg->allow_localhost = false; // Localhost not allowed in auto-enrollment
 
     if (ReadConfig(modules, cfgfile, agt, NULL) < 0 ||
         ReadConfig(CLABELS | CBUFFER, cfgfile, &agt->labels, agt) < 0) {

--- a/src/client-agent/config.c
+++ b/src/client-agent/config.c
@@ -48,7 +48,7 @@ int ClientConf(const char *cfgfile)
     w_enrollment_target *target_cfg = w_enrollment_target_init();
 
     // Initialize enrollment_cfg
-    agt->enrollment_cfg = w_enrollment_init(target_cfg, cert_cfg);
+    agt->enrollment_cfg = w_enrollment_init(target_cfg, cert_cfg, &keys);
     agt->enrollment_cfg->allow_localhost = 0; // Localhost not allowed in auto-enrollment
 
     if (ReadConfig(modules, cfgfile, agt, NULL) < 0 ||

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -307,7 +307,7 @@ int try_enroll_to_server(const char * server_rip) {
     int enroll_result = w_enrollment_request_key(agt->enrollment_cfg, server_rip);
     if (enroll_result == 0) {
         /* Wait for key update on agent side */
-        minfo("Waiting %d seconds before server connection", agt->enrollment_cfg->delay_after_enrollment);
+        minfo("Waiting %ld seconds before server connection", agt->enrollment_cfg->delay_after_enrollment);
         sleep(agt->enrollment_cfg->delay_after_enrollment);
         /* Successfull enroll, read keys */
         OS_UpdateKeys(&keys);

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -30,7 +30,6 @@ int timeout;    //timeout in seconds waiting for a server reply
 static ssize_t receive_message(char *buffer, unsigned int max_lenght);
 static void w_agentd_keys_init (void);
 static bool agent_handshake_to_server(int server_id, bool is_startup);
-static bool agent_ping_to_server(int server_id);
 static void send_msg_on_startup(void);
 
 /**
@@ -161,14 +160,10 @@ void start_agent(int is_startup)
         // Try to enroll and extra attempt
 
         if (agt->enrollment_cfg && agt->enrollment_cfg->enabled) {
-            if (agent_ping_to_server(current_server_id)) {
-                if (try_enroll_to_server(agt->server[current_server_id].rip) == 0) {
-                    if (agent_handshake_to_server(current_server_id, is_startup)) {
-                        return;
-                    }
+            if (try_enroll_to_server(agt->server[current_server_id].rip) == 0) {
+                if (agent_handshake_to_server(current_server_id, is_startup)) {
+                    return;
                 }
-            } else {
-                mwarn("Polling server '%s' failed. Skipping enrollment.", agt->server[current_server_id].rip);
             }
         }
 
@@ -210,11 +205,7 @@ static void w_agentd_keys_init (void) {
 
                 /* Try to enroll to server list */
                 while (agt->server[rc].rip && (registration_status != 0)) {
-                    if (agent_ping_to_server(rc)) {
-                        registration_status = try_enroll_to_server(agt->server[rc].rip);
-                    } else {
-                        mwarn("Polling server '%s' failed. Skipping enrollment.", agt->server[rc].rip);
-                    }
+                    registration_status = try_enroll_to_server(agt->server[rc].rip);
                     rc++;
                 }
 
@@ -311,42 +302,7 @@ static ssize_t receive_message(char *buffer, unsigned int max_lenght) {
     }
     return 0;
 }
-/**
- * @brief Check the server health using ping/pong operation.
- * @param server_id index of the specified server from agt servers list
- * @retval true on good health
- * @retval false when no response
- * */
-static bool agent_ping_to_server(int server_id) {
-    ssize_t recv_b = 0;
-    char *msg = "#ping";
-    char buffer[OS_MAXSTR + 1] = { '\0' };
 
-    if (connect_server(server_id, false)) {
-        /* Send the ping message */
-
-        if (agt->server[agt->rip_id].protocol == IPPROTO_UDP) {
-            recv_b = OS_SendUDPbySize(agt->sock, strlen(msg), msg);
-        } else {
-            recv_b = OS_SendSecureTCP(agt->sock, strlen(msg), msg);
-        }
-
-        if (recv_b != 0) {
-            return false;
-        }
-
-        /* Read until our reply comes back */
-        recv_b = receive_message(buffer, OS_MAXSTR);
-
-        if (recv_b > 0) {
-            if (strncmp(buffer, "#pong", 5) == 0) {
-                return true;
-            }
-        }
-    }
-
-    return false;
-}
 int try_enroll_to_server(const char * server_rip) {
     int enroll_result = w_enrollment_request_key(agt->enrollment_cfg, server_rip);
     if (enroll_result == 0) {
@@ -360,6 +316,7 @@ int try_enroll_to_server(const char * server_rip) {
     }
     return enroll_result;
 }
+
 /**
  * @brief Holds handshake logic for an attempt to connect to server
  * @param server_id index of the specified server from agt servers list

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -307,7 +307,7 @@ int try_enroll_to_server(const char * server_rip) {
     int enroll_result = w_enrollment_request_key(agt->enrollment_cfg, server_rip);
     if (enroll_result == 0) {
         /* Wait for key update on agent side */
-        minfo("Waiting %ld seconds before server connection", agt->enrollment_cfg->delay_after_enrollment);
+        minfo("Waiting %ld seconds before server connection", (long)agt->enrollment_cfg->delay_after_enrollment);
         sleep(agt->enrollment_cfg->delay_after_enrollment);
         /* Successfull enroll, read keys */
         OS_UpdateKeys(&keys);

--- a/src/config/authd-config.c
+++ b/src/config/authd-config.c
@@ -51,7 +51,7 @@ int Read_Authd(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
     }
     config->port = 1515;
     config->flags.use_source_ip = 0;
-    config->flags.force_insert = 0;
+    config->force_options.enabled = false;
     config->flags.clear_removed = 0;
     config->flags.use_password = 0;
     config->ciphers = strdup("HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH");
@@ -104,10 +104,10 @@ int Read_Authd(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
                 return OS_INVALID;
             }
 
-            config->flags.force_insert = b;
+            config->force_options.enabled = b;
         } else if (!strcmp(node[i]->element, xml_force_time)) {
             char *end;
-            config->force_time = strtol(node[i]->content, &end, 10);
+            config->force_options.connection_time = strtol(node[i]->content, &end, 10);
 
             if (*end != '\0') {
                 merror(XML_VALUEERR, node[i]->element, node[i]->content);

--- a/src/config/authd-config.h
+++ b/src/config/authd-config.h
@@ -12,10 +12,14 @@
 #define AD_CONF_UNPARSED 3
 #define AD_CONF_UNDEFINED 2
 
+typedef struct authd_force_options_t {
+    bool enabled;
+    int connection_time;
+} authd_force_options_t;
+
 typedef struct authd_flags_t {
     unsigned short disabled:3;
     unsigned short use_source_ip:1;
-    unsigned short force_insert:1;
     unsigned short clear_removed:1;
     unsigned short use_password:1;
     unsigned short verify_host:1;
@@ -26,7 +30,7 @@ typedef struct authd_flags_t {
 typedef struct authd_config_t {
     unsigned short port;
     authd_flags_t flags;
-    int force_time;
+    authd_force_options_t force_options;
     char *ciphers;
     char *agent_ca;
     char *manager_cert;

--- a/src/config/authd-config.h
+++ b/src/config/authd-config.h
@@ -12,6 +12,9 @@
 #define AD_CONF_UNPARSED 3
 #define AD_CONF_UNDEFINED 2
 
+/**
+ * @brief Structure that defines the force options for agent replacement.
+ * */
 typedef struct authd_force_options_t {
     bool enabled;
     int connection_time;

--- a/src/config/client-config.c
+++ b/src/config/client-config.c
@@ -366,9 +366,9 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
             return (OS_INVALID);
         } else if (!strcmp(node[j]->element, xml_enabled)) {
             if (!strcmp(node[j]->content, "yes"))
-                logr->enrollment_cfg->enabled = 1;
+                logr->enrollment_cfg->enabled = true;
             else if (!strcmp(node[j]->content, "no")) {
-                logr->enrollment_cfg->enabled = 0;
+                logr->enrollment_cfg->enabled = false;
             } else {
                 merror("Invalid content for tag '%s'.", node[j]->element);
                 w_enrollment_target_destroy(target_cfg);

--- a/src/headers/agent_op.h
+++ b/src/headers/agent_op.h
@@ -85,7 +85,7 @@ int auth_connect();
 int auth_close(int sock);
 
 /**
- * @brief Send a local agent add request.
+ * @brief Send a local agent "add" request.
  * @param sock Socket where the request connection will be done.
  * @param id ID of the newly generated key.
  * @param name Name of the agent to request the new key.
@@ -93,7 +93,7 @@ int auth_close(int sock);
  * @param groups Groups list of the agent to request the new key.
  * @param key KEY of the newly generated key.
  * @param force Force option to be used during the registration. -1 means disabled. 0 or a positive value means enabled.
- * @param json_format Flag to identify if the response should be printed in json format.
+ * @param json_format Flag to identify if the response should be printed in JSON format.
  * @param agent_id ID of the agent when requesting a new key for a specific ID.
  * @param exit_on_error Flag to identify if the application should exit on any error.
  * @return 0 on success or a negative code on error.
@@ -112,7 +112,7 @@ int w_request_agent_add_local(int sock,
 #ifndef WIN32
 
 /**
- * @brief Send a clustered agent add request.
+ * @brief Send a clustered agent "add" request.
  * @param err_response A buffer where the error message will be stored in case of failure. If NULL, the message is ignored.
  * @param name Name of the agent to request the new key.
  * @param ip IP of the agent to request the new key.

--- a/src/headers/agent_op.h
+++ b/src/headers/agent_op.h
@@ -85,11 +85,30 @@ int auth_connect();
 int auth_close(int sock);
 
 // Send a local agent add request.
-int w_request_agent_add_local(int sock, char *id, const char *name, const char *ip, const char * groups, const char *key, const int force, const int json_format, const char *agent_id, int exit_on_error);
+//TODO: DOxyGen
+int w_request_agent_add_local(int sock,
+                              char *id,
+                              const char *name,
+                              const char *ip,
+                              const char * groups,
+                              const char *key,
+                              const int force,
+                              const int json_format,
+                              const char *agent_id,
+                              int exit_on_error);
 
 #ifndef WIN32
 // Send a clustered agent add request.
-int w_request_agent_add_clustered(char *err_response, const char *name, const char *ip, const char * groups, char **id, char **key, const int force, const char *agent_id);
+//TODO: DOxyGen
+int w_request_agent_add_clustered(char *err_response,
+                                  const char *name,
+                                  const char *ip,
+                                  const char *groups,
+                                  const char *key_hash,
+                                  char **id,
+                                  char **key,
+                                  const int force,
+                                  const char *agent_id);
 
 // Send a clustered agent remove request.
 int w_request_agent_remove_clustered(char *err_response, const char* agent_id, int purge);

--- a/src/headers/agent_op.h
+++ b/src/headers/agent_op.h
@@ -84,8 +84,20 @@ int auth_connect();
 // Close socket if valid.
 int auth_close(int sock);
 
-// Send a local agent add request.
-//TODO: DOxyGen
+/**
+ * @brief Send a local agent add request.
+ * @param sock Socket where the request connection will be done.
+ * @param id ID of the newly generated key.
+ * @param name Name of the agent to request the new key.
+ * @param ip IP of the agent to request the new key.
+ * @param groups Groups list of the agent to request the new key.
+ * @param key KEY of the newly generated key.
+ * @param force Force option to be used during the registration. -1 means disabled. 0 or a positive value means enabled.
+ * @param json_format Flag to identify if the response should be printed in json format.
+ * @param agent_id ID of the agent when requesting a new key for a specific ID.
+ * @param exit_on_error Flag to identify if the application should exit on any error.
+ * @return 0 on success or a negative code on error.
+ */
 int w_request_agent_add_local(int sock,
                               char *id,
                               const char *name,
@@ -98,8 +110,20 @@ int w_request_agent_add_local(int sock,
                               int exit_on_error);
 
 #ifndef WIN32
-// Send a clustered agent add request.
-//TODO: DOxyGen
+
+/**
+ * @brief Send a clustered agent add request.
+ * @param err_response A buffer where the error message will be stored in case of failure. If NULL, the message is ignored.
+ * @param name Name of the agent to request the new key.
+ * @param ip IP of the agent to request the new key.
+ * @param groups Groups list of the agent to request the new key.
+ * @param key_hash Hash of the key if the agent already has one.
+ * @param id ID of the newly generated key.
+ * @param key KEY of the newly generated key.
+ * @param force Force option to be used during the registration. -1 means disabled. 0 or a positive value means enabled.
+ * @param agent_id ID of the agent when requesting a new key for a specific ID.
+ * @return 0 on success or a negative code on error.
+ */
 int w_request_agent_add_clustered(char *err_response,
                                   const char *name,
                                   const char *ip,

--- a/src/headers/enrollment_op.h
+++ b/src/headers/enrollment_op.h
@@ -64,13 +64,13 @@ typedef struct _enrollment_cert_cfg {
  * @brief Strcture that handles all the enrollment configuration
  * */
 typedef struct _enrollment_ctx {
-    w_enrollment_target *target_cfg;        /**> for details @see _enrollment_target_cfg */
-    w_enrollment_cert *cert_cfg;            /**> for details @see _enrollment_cert_cfg */
-    keystore *keys;                         /**> keys structure */
-    SSL *ssl;                               /**> will hold the connection instance with the manager */
-    unsigned int enabled:1;                 /**> enabled / disables auto enrollment */
-    unsigned int allow_localhost:1;         /**> 1 by default if this flag is in 0 using agent_name "localhost" will not be allowed */
-    unsigned int delay_after_enrollment:30; /**> 20 by default, number of seconds to wait for enrollment */
+    w_enrollment_target *target_cfg;                                        /**> for details @see _enrollment_target_cfg */
+    w_enrollment_cert *cert_cfg;                                                /**> for details @see _enrollment_cert_cfg */
+    keystore *keys;                                                                        /**> keys structure */
+    SSL *ssl;                                                                                     /**> will hold the connection instance with the manager */
+    unsigned int enabled:1;                                                          /**> enabled / disables auto enrollment */
+    unsigned int allow_localhost:1;                                             /**> 1 by default if this flag is in 0 using agent_name "localhost" will not be allowed */
+    time_t delay_after_enrollment;                                              /**> 20 by default, number of seconds to wait for enrollment */
 } w_enrollment_ctx;
 
 /**

--- a/src/headers/enrollment_op.h
+++ b/src/headers/enrollment_op.h
@@ -64,13 +64,13 @@ typedef struct _enrollment_cert_cfg {
  * @brief Strcture that handles all the enrollment configuration
  * */
 typedef struct _enrollment_ctx {
-    w_enrollment_target *target_cfg;                                        /**> for details @see _enrollment_target_cfg */
-    w_enrollment_cert *cert_cfg;                                                /**> for details @see _enrollment_cert_cfg */
-    keystore *keys;                                                                        /**> keys structure */
-    SSL *ssl;                                                                                     /**> will hold the connection instance with the manager */
-    bool enabled;                                                                           /**> enabled / disables auto enrollment */
-    bool allow_localhost;                                                               /**> true by default. If this flag is false, using agent_name "localhost" will not be allowed */
-    time_t delay_after_enrollment;                                              /**> 20 by default, number of seconds to wait for enrollment */
+    w_enrollment_target *target_cfg;    /**> for details @see _enrollment_target_cfg */
+    w_enrollment_cert *cert_cfg;        /**> for details @see _enrollment_cert_cfg */
+    keystore *keys;                     /**> keys structure */
+    SSL *ssl;                           /**> will hold the connection instance with the manager */
+    bool enabled;                       /**> enables / disables auto enrollment */
+    bool allow_localhost;               /**> true by default. If this flag is false, using agent_name "localhost" will not be allowed */
+    time_t delay_after_enrollment;      /**> 20 by default, number of seconds to wait for enrollment */
 } w_enrollment_ctx;
 
 /**

--- a/src/headers/enrollment_op.h
+++ b/src/headers/enrollment_op.h
@@ -68,8 +68,8 @@ typedef struct _enrollment_ctx {
     w_enrollment_cert *cert_cfg;                                                /**> for details @see _enrollment_cert_cfg */
     keystore *keys;                                                                        /**> keys structure */
     SSL *ssl;                                                                                     /**> will hold the connection instance with the manager */
-    unsigned int enabled:1;                                                          /**> enabled / disables auto enrollment */
-    unsigned int allow_localhost:1;                                             /**> 1 by default if this flag is in 0 using agent_name "localhost" will not be allowed */
+    bool enabled;                                                                           /**> enabled / disables auto enrollment */
+    bool allow_localhost;                                                               /**> true by default. If this flag is false, using agent_name "localhost" will not be allowed */
     time_t delay_after_enrollment;                                              /**> 20 by default, number of seconds to wait for enrollment */
 } w_enrollment_ctx;
 

--- a/src/headers/enrollment_op.h
+++ b/src/headers/enrollment_op.h
@@ -23,6 +23,7 @@
 
 #include <openssl/ssl.h>
 #include <openssl/ossl_typ.h>
+#include "sec.h"
 
 #define ENROLLMENT_WRONG_CONFIGURATION -1
 #define ENROLLMENT_CONNECTION_FAILURE -2
@@ -65,6 +66,7 @@ typedef struct _enrollment_cert_cfg {
 typedef struct _enrollment_ctx {
     w_enrollment_target *target_cfg;        /**> for details @see _enrollment_target_cfg */
     w_enrollment_cert *cert_cfg;            /**> for details @see _enrollment_cert_cfg */
+    keystore *keys;                         /**> keys structure */
     SSL *ssl;                               /**> will hold the connection instance with the manager */
     unsigned int enabled:1;                 /**> enabled / disables auto enrollment */
     unsigned int allow_localhost:1;         /**> 1 by default if this flag is in 0 using agent_name "localhost" will not be allowed */
@@ -97,7 +99,7 @@ void w_enrollment_cert_destroy(w_enrollment_cert *cert);
  * Initializes parameters of an w_enrollment_ctx structure based
  * on a target and certificate configurations
  * */
-w_enrollment_ctx * w_enrollment_init(w_enrollment_target *target, w_enrollment_cert *cert);
+w_enrollment_ctx * w_enrollment_init(w_enrollment_target *target, w_enrollment_cert *cert, keystore *keys);
 
 /**
  * Frees parameers of an w_enrollment_ctx structure

--- a/src/headers/enrollment_op.h
+++ b/src/headers/enrollment_op.h
@@ -32,12 +32,12 @@
  * @brief Struct that defines the connection target
  * */
 typedef struct _enrollment_target_cfg {
-    char *manager_name;       /**> Manager's direction or ip address */
-    int port;                 /**> Manager's port                     */
-    char *agent_name;         /**> (optional) Name of the agent. In case of NULL enrollment message will send local hostname */
-    char *centralized_group;  /**> (optional) In case the agent belong to a group */
-    char *sender_ip;          /**> (optional) IP adress or CIDR of the agent. In case of null the manager will use the source ip */
-    int use_src_ip;           /**> (optional) Forces manager to use source ip (-i option in agent_auth)*/
+    char *manager_name;       /**< Manager's direction or ip address */
+    int port;                 /**< Manager's port */
+    char *agent_name;         /**< (optional) Name of the agent. In case of NULL enrollment message will send local hostname */
+    char *centralized_group;  /**< (optional) In case the agent belong to a group */
+    char *sender_ip;          /**< (optional) IP adress or CIDR of the agent. In case of null the manager will use the source ip */
+    int use_src_ip;           /**< (optional) Forces manager to use source ip (-i option in agent_auth) */
 } w_enrollment_target;
 
 /**
@@ -51,26 +51,26 @@ typedef struct _enrollment_target_cfg {
  * 4. Manager and Agent Verification (uses agent_cert and agent_key params)
  */
 typedef struct _enrollment_cert_cfg {
-    char *ciphers;              /**> chipers string (default DEFAULT_CIPHERS) */
-    char *authpass_file;        /**> password file (default AUTHD_PASS) */
-    char *authpass;             /**> override password file for password verification */
-    char *agent_cert;           /**> Agent Certificate (null if not used) */
-    char *agent_key;            /**> Agent Key (null if not used) */
-    char *ca_cert;              /**> CA Certificate to verificate server (null if not used) */
-    unsigned int auto_method:1; /**> 0 for TLS v1.2 only (Default), 1 for Auto negotiate the most secure common SSL/TLS method with the client. */
+    char *ciphers;              /**< chipers string (default DEFAULT_CIPHERS) */
+    char *authpass_file;        /**< password file (default AUTHD_PASS) */
+    char *authpass;             /**< override password file for password verification */
+    char *agent_cert;           /**< Agent Certificate (null if not used) */
+    char *agent_key;            /**< Agent Key (null if not used) */
+    char *ca_cert;              /**< CA Certificate to verificate server (null if not used) */
+    unsigned int auto_method:1; /**< 0 for TLS v1.2 only (Default), 1 for Auto negotiate the most secure common SSL/TLS method with the client. */
 } w_enrollment_cert;
 
 /**
  * @brief Strcture that handles all the enrollment configuration
  * */
 typedef struct _enrollment_ctx {
-    w_enrollment_target *target_cfg;    /**> for details @see _enrollment_target_cfg */
-    w_enrollment_cert *cert_cfg;        /**> for details @see _enrollment_cert_cfg */
-    keystore *keys;                     /**> keys structure */
-    SSL *ssl;                           /**> will hold the connection instance with the manager */
-    bool enabled;                       /**> enables / disables auto enrollment */
-    bool allow_localhost;               /**> true by default. If this flag is false, using agent_name "localhost" will not be allowed */
-    time_t delay_after_enrollment;      /**> 20 by default, number of seconds to wait for enrollment */
+    w_enrollment_target *target_cfg;    /**< for details @see _enrollment_target_cfg */
+    w_enrollment_cert *cert_cfg;        /**< for details @see _enrollment_cert_cfg */
+    keystore *keys;                     /**< keys structure */
+    SSL *ssl;                           /**< will hold the connection instance with the manager */
+    bool enabled;                       /**< enables / disables auto enrollment */
+    bool allow_localhost;               /**< true by default. If this flag is false, using agent_name "localhost" will not be allowed */
+    time_t delay_after_enrollment;      /**< 20 by default, number of seconds to wait for enrollment */
 } w_enrollment_ctx;
 
 /**

--- a/src/headers/sec.h
+++ b/src/headers/sec.h
@@ -14,6 +14,7 @@
 #include <time.h>
 #include <pthread.h>
 #include "shared.h"
+#include "os_crypto/sha1/sha1_op.h"
 
 typedef enum _crypt_method{
     W_METH_BLOWFISH,W_METH_AES
@@ -189,6 +190,15 @@ int OS_DeleteSocket(keystore * keys, int sock);
  * @retval REMOTED_NET_PROTOCOL_UDP if agent protocol is UDP
  */
 int w_get_agent_net_protocol_from_keystore(keystore * keys, const char * agent_id);
+
+/**
+ * @brief Receives a keyentry structure and returns the SHA1 value of the agent's key.
+ *
+ * @param key_entry The agent's key structure
+ * @param output The variable where the hashed key will be stored
+ * @retval Returns OS_SUCCESS on success or OS_INVALID on error.
+ **/
+int w_auth_hash_key(keyentry *key_entry, os_sha1 output);
 
 /* Set the agent crypto method read from the ossec.conf file */
 void os_set_agent_crypto_method(keystore * keys,const int method);

--- a/src/headers/sec.h
+++ b/src/headers/sec.h
@@ -198,7 +198,7 @@ int w_get_agent_net_protocol_from_keystore(keystore * keys, const char * agent_i
  * @param output The variable where the hashed key will be stored
  * @retval Returns OS_SUCCESS on success or OS_INVALID on error.
  **/
-int w_auth_hash_key(keyentry *key_entry, os_sha1 output);
+int w_get_key_hash(keyentry *key_entry, os_sha1 output);
 
 /* Set the agent crypto method read from the ossec.conf file */
 void os_set_agent_crypto_method(keystore * keys,const int method);

--- a/src/headers/sec.h
+++ b/src/headers/sec.h
@@ -20,8 +20,12 @@ typedef enum _crypt_method{
     W_METH_BLOWFISH,W_METH_AES
 } crypt_method;
 
+typedef enum _key_mode{
+    W_RAW_KEY, W_ENCRYPTION_KEY, W_DUAL_KEY
+}key_mode_t;
+
 typedef struct keystore_flags_t {
-    unsigned int rehash_keys:1;     // Flag: rehash keys on adding
+    unsigned int key_mode:2;        // Type of key to be initialized
     unsigned int save_removed:1;    // Save removed keys into list
 } keystore_flags_t;
 
@@ -34,7 +38,8 @@ typedef struct _keyentry {
     time_t updating_time;
 
     char *id;
-    char *key;
+    char *raw_key;
+    char *encryption_key;
     char *name;
 
     ino_t inode;
@@ -95,7 +100,7 @@ typedef enum key_states {
 int OS_CheckKeys(void);
 
 /* Read the keys */
-void OS_ReadKeys(keystore *keys, int rehash_keys, int save_removed) __attribute((nonnull));
+void OS_ReadKeys(keystore *keys, key_mode_t key_mode, int save_removed) __attribute((nonnull));
 
 void OS_FreeKey(keyentry *key);
 

--- a/src/headers/sec.h
+++ b/src/headers/sec.h
@@ -16,13 +16,16 @@
 #include "shared.h"
 #include "os_crypto/sha1/sha1_op.h"
 
-typedef enum _crypt_method{
-    W_METH_BLOWFISH,W_METH_AES
+typedef enum _crypt_method {
+    W_METH_BLOWFISH, W_METH_AES
 } crypt_method;
 
-typedef enum _key_mode{
+/**
+ * @brief Enumerator that defines the key initialization modes.
+ */
+typedef enum _key_mode {
     W_RAW_KEY, W_ENCRYPTION_KEY, W_DUAL_KEY
-}key_mode_t;
+} key_mode_t;
 
 typedef struct keystore_flags_t {
     unsigned int key_mode:2;        // Type of key to be initialized

--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -201,7 +201,7 @@ w_err_t w_auth_replace_agent(keyentry *key,
     /* Check if the agent key is the same than the existent in the manager */
     if (key_hash) {
         os_sha1 manager_key_hash;
-        w_auth_hash_key(key, manager_key_hash);
+        w_get_key_hash(key, manager_key_hash);
         if (!strcmp(manager_key_hash, key_hash)) {
             minfo("Agent '%s' key already exists on the manager.", key->id);
             return OS_INVALID;

--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -57,12 +57,12 @@ void add_remove(const keyentry *entry) {
 
 
 w_err_t w_auth_parse_data(const char* buf,
-                          char *response,
-                          const char *authpass,
-                          char *ip,
-                          char **agentname,
-                          char **groups,
-                          char **key_hash){
+                                                  char *response,
+                                                  const char *authpass,
+                                                  char *ip,
+                                                  char **agentname,
+                                                  char **groups,
+                                                  char **key_hash){
 
     bool parseok = FALSE;
     /* Checking for shared password authentication. */
@@ -222,10 +222,10 @@ w_err_t w_auth_replace_agent(keyentry *key,
 }
 
 w_err_t w_auth_validate_data(char *response,
-                             const char *ip,
-                             const char *agentname,
-                             const char *groups,
-                             const char *key_hash){
+                                                      const char *ip,
+                                                      const char *agentname,
+                                                      const char *groups,
+                                                      const char *key_hash){
     int index = 0;
 
     /* Validate the group(s) name(s) */

--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -8,11 +8,9 @@
  * Foundation.
  */
 
+#include <shared.h>
 #include "auth.h"
 #include "os_err.h"
-#include "sec.h"
-#include <shared.h>
-#include <string.h>
 
 #ifdef WAZUH_UNIT_TESTING
 #define static
@@ -24,297 +22,280 @@ authd_config_t config;
 
 struct keynode *queue_insert = NULL;
 struct keynode *queue_remove = NULL;
-struct keynode *volatile *insert_tail;
-struct keynode *volatile *remove_tail;
+struct keynode * volatile *insert_tail;
+struct keynode * volatile *remove_tail;
 
 // Append key to insertion queue
-void add_insert(const keyentry *entry, const char *group) {
-  struct keynode *node;
+void add_insert(const keyentry *entry,const char *group) {
+    struct keynode *node;
 
-  os_calloc(1, sizeof(struct keynode), node);
-  node->id = strdup(entry->id);
-  node->name = strdup(entry->name);
-  node->ip = strdup(entry->ip->ip);
-  node->group = NULL;
+    os_calloc(1, sizeof(struct keynode), node);
+    node->id = strdup(entry->id);
+    node->name = strdup(entry->name);
+    node->ip = strdup(entry->ip->ip);
+    node->group = NULL;
 
-  if (group != NULL)
-    node->group = strdup(group);
+    if(group != NULL)
+        node->group = strdup(group);
 
-  (*insert_tail) = node;
-  insert_tail = &node->next;
+    (*insert_tail) = node;
+    insert_tail = &node->next;
 }
 
 // Append key to deletion queue
 void add_remove(const keyentry *entry) {
-  struct keynode *node;
+    struct keynode *node;
 
-  os_calloc(1, sizeof(struct keynode), node);
-  node->id = strdup(entry->id);
-  node->name = strdup(entry->name);
-  node->ip = strdup(entry->ip->ip);
+    os_calloc(1, sizeof(struct keynode), node);
+    node->id = strdup(entry->id);
+    node->name = strdup(entry->name);
+    node->ip = strdup(entry->ip->ip);
 
-  (*remove_tail) = node;
-  remove_tail = &node->next;
+    (*remove_tail) = node;
+    remove_tail = &node->next;
 }
 
-w_err_t w_auth_parse_data(const char *buf, char *response, const char *authpass,
-                          char *ip, char **agentname, char **groups) {
 
-  bool parseok = FALSE;
-  /* Checking for shared password authentication. */
-  if (authpass) {
-    /* Format is pretty simple: OSSEC PASS: PASS WHATEVERACTION */
-    parseok = FALSE;
-    if (strncmp(buf, "OSSEC PASS: ", 12) == 0) {
-      buf += 12;
-      if (strlen(buf) > strlen(authpass) &&
-          strncmp(buf, authpass, strlen(authpass)) == 0) {
-        buf += strlen(authpass);
-        if (*buf == ' ') {
-          buf++;
-          parseok = 1;
+w_err_t w_auth_parse_data(const char* buf, char *response,const char *authpass, char *ip, char **agentname, char **groups){
+
+    bool parseok = FALSE;
+    /* Checking for shared password authentication. */
+    if(authpass) {
+        /* Format is pretty simple: OSSEC PASS: PASS WHATEVERACTION */
+        parseok = FALSE;
+        if (strncmp(buf, "OSSEC PASS: ", 12) == 0) {
+            buf += 12;
+            if (strlen(buf) > strlen(authpass) && strncmp(buf, authpass, strlen(authpass)) == 0) {
+                buf += strlen(authpass);
+                if (*buf == ' ') {
+                    buf++;
+                    parseok = 1;
+                }
+            }
         }
-      }
+
+        if (parseok == 0) {
+            merror("Invalid password provided by %s. Closing connection.", ip);
+            snprintf(response, 2048, "ERROR: Invalid password");
+            return OS_INVALID;
+        }
     }
 
-    if (parseok == 0) {
-      merror("Invalid password provided by %s. Closing connection.", ip);
-      snprintf(response, 2048, "ERROR: Invalid password");
-      return OS_INVALID;
+    /* Checking for action A (add agent) */
+    parseok = FALSE;
+    if (strncmp(buf, "OSSEC A:'", 9) == 0) {
+        buf += 9;
+
+        unsigned len = 0;
+        while (*buf != '\0') {
+            if (*buf == '\'') {
+                os_malloc(len+1, *agentname);
+                memcpy(*agentname, buf-len, len);
+                (*agentname)[len] = '\0';
+                minfo("Received request for a new agent (%s) from: %s", *agentname, ip);
+                parseok = TRUE;
+                break;
+            }
+            len++;
+            buf++;
+        }
     }
-  }
+    buf++;
 
-  /* Checking for action A (add agent) */
-  parseok = FALSE;
-  if (strncmp(buf, "OSSEC A:'", 9) == 0) {
-    buf += 9;
-
-    unsigned len = 0;
-    while (*buf != '\0') {
-      if (*buf == '\'') {
-        os_malloc(len + 1, *agentname);
-        memcpy(*agentname, buf - len, len);
-        (*agentname)[len] = '\0';
-        minfo("Received request for a new agent (%s) from: %s", *agentname, ip);
-        parseok = TRUE;
-        break;
-      }
-      len++;
-      buf++;
-    }
-  }
-  buf++;
-
-  if (!parseok) {
-    merror("Invalid request for new agent from: %s", ip);
-    snprintf(response, 2048, "ERROR: Invalid request for new agent");
-    return OS_INVALID;
-  }
-
-  if (!OS_IsValidName(*agentname)) {
-    merror("Invalid agent name: %s from %s", *agentname, ip);
-    snprintf(response, 2048, "ERROR: Invalid agent name: %s", *agentname);
-    return OS_INVALID;
-  }
-
-  /* Check for valid centralized group */
-
-  char centralized_group_token[2] = "G:";
-
-  if (strncmp(++buf, centralized_group_token, 2) == 0) {
-    char tmp_groups[OS_SIZE_65536 + 1] = {0};
-    sscanf(buf, " G:\'%65536[^\']\"", tmp_groups);
-
-    /* Validate the group name */
-    if (0 > w_validate_group_name(tmp_groups, response)) {
-      merror("Invalid group name: %.255s... ,", tmp_groups);
-      return OS_INVALID;
-    }
-    *groups = wstr_delete_repeated_groups(tmp_groups);
-    if (!*groups) {
-      snprintf(response, 2048, "ERROR: Insuficient memory");
-      return OS_MEMERR;
-    }
-    mdebug1("Group(s) is: %s", *groups);
-
-    /*Forward the string pointer G:'........' 2 for G:, 2 for ''*/
-    buf += 2 + strlen(tmp_groups) + 2;
-
-  } else {
-    buf--;
-  }
-
-  /* Check for IP when client uses -i option */
-
-  char client_source_ip[IPSIZE + 1] = {0};
-  char client_source_ip_token[3] = "IP:";
-
-  if (strncmp(++buf, client_source_ip_token, 3) == 0) {
-    char format[15];
-    sprintf(format, " IP:\'%%%d[^\']\"", IPSIZE);
-    sscanf(buf, format, client_source_ip);
-
-    /* If IP: != 'src' overwrite the provided ip */
-    if (strncmp(client_source_ip, "src", 3) != 0) {
-      if (!OS_IsValidIP(client_source_ip, NULL)) {
-        merror("Invalid IP: '%s'", client_source_ip);
-        snprintf(response, 2048, "ERROR: Invalid IP: %s", client_source_ip);
+    if (!parseok) {
+        merror("Invalid request for new agent from: %s", ip);
+        snprintf(response, 2048, "ERROR: Invalid request for new agent");
         return OS_INVALID;
-      }
-      snprintf(ip, IPSIZE, "%s", client_source_ip);
     }
 
-  } else if (!config.flags.use_source_ip) {
-    // use_source-ip = 0 and no -I argument in agent
-    snprintf(ip, IPSIZE, "any");
-  }
-  // else -> agent IP is already on ip
+    if (!OS_IsValidName(*agentname)) {
+        merror("Invalid agent name: %s from %s", *agentname, ip);
+        snprintf(response, 2048, "ERROR: Invalid agent name: %s", *agentname);
+        return OS_INVALID;
+    }
 
-  return OS_SUCCESS;
+    /* Check for valid centralized group */
+
+    char centralized_group_token[2] = "G:";
+
+    if(strncmp(++buf,centralized_group_token,2)==0)
+    {
+        char tmp_groups[OS_SIZE_65536+1] = {0};
+        sscanf(buf," G:\'%65536[^\']\"",tmp_groups);
+
+        /* Validate the group name */
+        if(0 > w_validate_group_name(tmp_groups, response)) {
+            merror("Invalid group name: %.255s... ,",tmp_groups);
+            return OS_INVALID;
+        }
+        *groups = wstr_delete_repeated_groups(tmp_groups);
+        if(!*groups){
+            snprintf(response, 2048, "ERROR: Insuficient memory");
+            return OS_MEMERR;
+        }
+        mdebug1("Group(s) is: %s",*groups);
+
+        /*Forward the string pointer G:'........' 2 for G:, 2 for ''*/
+        buf+= 2+strlen(tmp_groups)+2;
+
+    }else{
+        buf--;
+    }
+
+    /* Check for IP when client uses -i option */
+
+    char client_source_ip[IPSIZE + 1] = {0};
+    char client_source_ip_token[3] = "IP:";
+
+    if(strncmp(++buf,client_source_ip_token,3)==0) {
+        char format[15];
+        sprintf(format, " IP:\'%%%d[^\']\"", IPSIZE);
+        sscanf(buf, format ,client_source_ip);
+
+        /* If IP: != 'src' overwrite the provided ip */
+        if(strncmp(client_source_ip,"src",3) != 0)
+        {
+            if (!OS_IsValidIP(client_source_ip, NULL)) {
+                merror("Invalid IP: '%s'", client_source_ip);
+                snprintf(response, 2048, "ERROR: Invalid IP: %s", client_source_ip);
+                return OS_INVALID;
+            }
+            snprintf(ip, IPSIZE, "%s", client_source_ip);
+        }
+
+    }
+    else if(!config.flags.use_source_ip) {
+        // use_source-ip = 0 and no -I argument in agent
+        snprintf(ip, IPSIZE, "any");
+    }
+    // else -> agent IP is already on ip
+
+    return OS_SUCCESS;
 }
 
-w_err_t w_auth_validate_data(char *response, const char *ip,
-                             const char *agentname, const char *groups) {
-  /* Validate the group(s) name(s) */
-  int index = 0;
-  char *id_exist = NULL;
-  double antiquity = 0;
-  if (groups) {
-    if (OS_SUCCESS != w_auth_validate_groups(groups, response)) {
-      return OS_INVALID;
+w_err_t w_auth_validate_data (char *response, const char *ip, const char *agentname, const char *groups){
+    /* Validate the group(s) name(s) */
+    int index = 0;
+    char *id_exist = NULL;
+    double antiquity = 0;
+    if (groups){
+        if (OS_SUCCESS != w_auth_validate_groups(groups, response)){
+            return OS_INVALID;
+        }
     }
-  }
 
-  /* Check for duplicated IP */
-  if (strcmp(ip, "any") != 0) {
-    if (index = OS_IsAllowedIP(&keys, ip), index >= 0) {
-      if (config.flags.force_insert &&
-          (antiquity = OS_AgentAntiquity(keys.keyentries[index]->name,
-                                         keys.keyentries[index]->ip->ip),
-           antiquity >= config.force_time || antiquity < 0)) {
-        id_exist = keys.keyentries[index]->id;
-        minfo("Duplicated IP '%s' (%s). Removing old agent.", ip, id_exist);
+    /* Check for duplicated IP */
+    if (strcmp(ip, "any") != 0 ) {
+        if (index = OS_IsAllowedIP(&keys, ip), index >= 0) {
+            if (config.flags.force_insert && (antiquity = OS_AgentAntiquity(keys.keyentries[index]->name, keys.keyentries[index]->ip->ip), antiquity >= config.force_time || antiquity < 0)) {
+                id_exist = keys.keyentries[index]->id;
+                minfo("Duplicated IP '%s' (%s). Removing old agent.", ip, id_exist);
 
-        add_remove(keys.keyentries[index]);
-        OS_DeleteKey(&keys, id_exist, 0);
-      } else {
-        merror("Duplicated IP %s", ip);
-        snprintf(response, 2048, "ERROR: Duplicated IP: %s", ip);
+                add_remove(keys.keyentries[index]);
+                OS_DeleteKey(&keys, id_exist, 0);
+            } else {
+                merror("Duplicated IP %s", ip);
+                snprintf(response, 2048, "ERROR: Duplicated IP: %s", ip);
+                return OS_INVALID;
+            }
+        }
+    }
+
+    /* Check whether the agent name is the same as the manager */
+
+    if (!strcmp(agentname, shost)) {
+        merror("Invalid agent name %s (same as manager)", agentname);
+        snprintf(response, 2048, "ERROR: Invalid agent name: %s", agentname);
         return OS_INVALID;
-      }
     }
-  }
 
-  /* Check whether the agent name is the same as the manager */
+    /* Check for duplicated names */
 
-  if (!strcmp(agentname, shost)) {
-    merror("Invalid agent name %s (same as manager)", agentname);
-    snprintf(response, 2048, "ERROR: Invalid agent name: %s", agentname);
-    return OS_INVALID;
-  }
+    if (index = OS_IsAllowedName(&keys, agentname), index >= 0) {
+        if (config.flags.force_insert && (antiquity = OS_AgentAntiquity(keys.keyentries[index]->name, keys.keyentries[index]->ip->ip), antiquity >= config.force_time || antiquity < 0)) {
+            id_exist = keys.keyentries[index]->id;
+            minfo("Duplicated name '%s' (%s). Removing old agent.", agentname, id_exist);
 
-  /* Check for duplicated names */
-
-  if (index = OS_IsAllowedName(&keys, agentname), index >= 0) {
-    if (config.flags.force_insert &&
-        (antiquity = OS_AgentAntiquity(keys.keyentries[index]->name,
-                                       keys.keyentries[index]->ip->ip),
-         antiquity >= config.force_time || antiquity < 0)) {
-      id_exist = keys.keyentries[index]->id;
-      minfo("Duplicated name '%s' (%s). Removing old agent.", agentname,
-            id_exist);
-
-      add_remove(keys.keyentries[index]);
-      OS_DeleteKey(&keys, id_exist, 0);
-    } else {
-      merror("Invalid agent name %s (duplicated)", agentname);
-      snprintf(response, 2048, "ERROR: Duplicated agent name: %s", agentname);
-      return OS_INVALID;
+            add_remove(keys.keyentries[index]);
+            OS_DeleteKey(&keys, id_exist, 0);
+        } else {
+            merror("Invalid agent name %s (duplicated)", agentname);
+            snprintf(response, 2048, "ERROR: Duplicated agent name: %s", agentname);
+            return OS_INVALID;
+        }
     }
-  }
 
-  return OS_SUCCESS;
+    return OS_SUCCESS;
 }
 
-w_err_t w_auth_add_agent(char *response, const char *ip, const char *agentname,
-                         const char *groups, char **id, char **key) {
+w_err_t w_auth_add_agent(char *response, const char *ip, const char *agentname, const char *groups, char **id, char **key){
 
-  /* Add the new agent */
-  int index;
+    /* Add the new agent */
+    int index;
 
-  if (index = OS_AddNewAgent(&keys, NULL, agentname, ip, NULL), index < 0) {
-    merror("Unable to add agent: %s (internal error)", agentname);
-    snprintf(response, 2048, "ERROR: Internal manager error adding agent: %s",
-             agentname);
-    return OS_INVALID;
-  }
-
-  /* Add the agent to the centralized configuration group */
-  if (groups) {
-    char path[PATH_MAX];
-    if (snprintf(path, PATH_MAX, GROUPS_DIR "/%s",
-                 keys.keyentries[index]->id) >= PATH_MAX) {
-      merror("At set_agent_group(): file path too large for agent '%s'.",
-             keys.keyentries[index]->id);
-      OS_RemoveAgent(keys.keyentries[index]->id);
-      merror("Unable to set agent centralized group: %s (internal error)",
-             groups);
-      snprintf(
-          response, 2048,
-          "ERROR: Internal manager error setting agent centralized group: %s",
-          groups);
-      return OS_INVALID;
+    if (index = OS_AddNewAgent(&keys, NULL, agentname, ip, NULL), index < 0) {
+        merror("Unable to add agent: %s (internal error)", agentname);
+        snprintf(response, 2048, "ERROR: Internal manager error adding agent: %s", agentname);
+        return OS_INVALID;
     }
-  }
 
-  os_strdup(keys.keyentries[index]->id, *id);
-  os_strdup(keys.keyentries[index]->key, *key);
+    /* Add the agent to the centralized configuration group */
+    if(groups) {
+        char path[PATH_MAX];
+        if (snprintf(path, PATH_MAX, GROUPS_DIR "/%s", keys.keyentries[index]->id) >= PATH_MAX) {
+            merror("At set_agent_group(): file path too large for agent '%s'.", keys.keyentries[index]->id);
+            OS_RemoveAgent(keys.keyentries[index]->id);
+            merror("Unable to set agent centralized group: %s (internal error)", groups);
+            snprintf(response, 2048, "ERROR: Internal manager error setting agent centralized group: %s", groups);
+            return OS_INVALID;
+        }
+    }
 
-  return OS_SUCCESS;
+    os_strdup(keys.keyentries[index]->id, *id);
+    os_strdup(keys.keyentries[index]->key, *key);
+
+    return OS_SUCCESS;
 }
 
 w_err_t w_auth_validate_groups(const char *groups, char *response) {
-  int max_multigroups = 0;
-  char *save_ptr = NULL;
-  char *tmp_groups = NULL;
-  const char delim[] = {MULTIGROUP_SEPARATOR, '\0'};
-  w_err_t ret = OS_SUCCESS;
+    int max_multigroups = 0;
+    char *save_ptr = NULL;
+    char *tmp_groups = NULL;
+    const char delim[] = {MULTIGROUP_SEPARATOR,'\0'};
+    w_err_t ret = OS_SUCCESS;
 
-  os_strdup(groups, tmp_groups);
-  char *group = strtok_r(tmp_groups, delim, &save_ptr);
+    os_strdup(groups, tmp_groups);
+    char *group = strtok_r(tmp_groups, delim, &save_ptr);
 
-  while (group != NULL) {
-    DIR *dp;
-    char dir[PATH_MAX + 1] = {0};
+    while( group != NULL ) {
+        DIR * dp;
+        char dir[PATH_MAX + 1] = {0};
 
-    /* Check limit */
-    if (max_multigroups > MAX_GROUPS_PER_MULTIGROUP) {
-      merror("Maximum multigroup reached: Limit is %d",
-             MAX_GROUPS_PER_MULTIGROUP);
-      if (response) {
-        snprintf(response, 2048,
-                 "ERROR: Maximum multigroup reached: Limit is %d",
-                 MAX_GROUPS_PER_MULTIGROUP);
-      }
-      ret = OS_INVALID;
-      break;
+        /* Check limit */
+        if(max_multigroups > MAX_GROUPS_PER_MULTIGROUP){
+            merror("Maximum multigroup reached: Limit is %d",MAX_GROUPS_PER_MULTIGROUP);
+            if (response) {
+                snprintf(response, 2048, "ERROR: Maximum multigroup reached: Limit is %d", MAX_GROUPS_PER_MULTIGROUP);
+            }
+            ret = OS_INVALID;
+            break;
+        }
+
+        snprintf(dir, PATH_MAX + 1, SHAREDCFG_DIR "/%s", group);
+        dp = opendir(dir);
+        if (!dp) {
+            merror("Invalid group: %.255s",group);
+            if (response){
+                snprintf(response, 2048, "ERROR: Invalid group: %s", group);
+            }
+            ret = OS_INVALID;
+            break;
+        }
+
+        group = strtok_r(NULL, delim, &save_ptr);
+        max_multigroups++;
+        closedir(dp);
     }
-
-    snprintf(dir, PATH_MAX + 1, SHAREDCFG_DIR "/%s", group);
-    dp = opendir(dir);
-    if (!dp) {
-      merror("Invalid group: %.255s", group);
-      if (response) {
-        snprintf(response, 2048, "ERROR: Invalid group: %s", group);
-      }
-      ret = OS_INVALID;
-      break;
-    }
-
-    group = strtok_r(NULL, delim, &save_ptr);
-    max_multigroups++;
-    closedir(dp);
-  }
-  os_free(tmp_groups);
-  return ret;
+    os_free(tmp_groups);
+    return ret;
 }

--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -8,9 +8,11 @@
  * Foundation.
  */
 
-#include <shared.h>
 #include "auth.h"
 #include "os_err.h"
+#include "sec.h"
+#include <shared.h>
+#include <string.h>
 
 #ifdef WAZUH_UNIT_TESTING
 #define static
@@ -22,280 +24,314 @@ authd_config_t config;
 
 struct keynode *queue_insert = NULL;
 struct keynode *queue_remove = NULL;
-struct keynode * volatile *insert_tail;
-struct keynode * volatile *remove_tail;
+struct keynode *volatile *insert_tail;
+struct keynode *volatile *remove_tail;
 
 // Append key to insertion queue
-void add_insert(const keyentry *entry,const char *group) {
-    struct keynode *node;
+void add_insert(const keyentry *entry, const char *group) {
+  struct keynode *node;
 
-    os_calloc(1, sizeof(struct keynode), node);
-    node->id = strdup(entry->id);
-    node->name = strdup(entry->name);
-    node->ip = strdup(entry->ip->ip);
-    node->group = NULL;
+  os_calloc(1, sizeof(struct keynode), node);
+  node->id = strdup(entry->id);
+  node->name = strdup(entry->name);
+  node->ip = strdup(entry->ip->ip);
+  node->group = NULL;
 
-    if(group != NULL)
-        node->group = strdup(group);
+  if (group != NULL)
+    node->group = strdup(group);
 
-    (*insert_tail) = node;
-    insert_tail = &node->next;
+  (*insert_tail) = node;
+  insert_tail = &node->next;
 }
 
 // Append key to deletion queue
 void add_remove(const keyentry *entry) {
-    struct keynode *node;
+  struct keynode *node;
 
-    os_calloc(1, sizeof(struct keynode), node);
-    node->id = strdup(entry->id);
-    node->name = strdup(entry->name);
-    node->ip = strdup(entry->ip->ip);
+  os_calloc(1, sizeof(struct keynode), node);
+  node->id = strdup(entry->id);
+  node->name = strdup(entry->name);
+  node->ip = strdup(entry->ip->ip);
 
-    (*remove_tail) = node;
-    remove_tail = &node->next;
+  (*remove_tail) = node;
+  remove_tail = &node->next;
 }
 
+w_err_t w_auth_parse_data(const char *buf, char *response, const char *authpass,
+                          char *ip, char **agentname, char **groups) {
 
-w_err_t w_auth_parse_data(const char* buf, char *response,const char *authpass, char *ip, char **agentname, char **groups){
-
-    bool parseok = FALSE;
-    /* Checking for shared password authentication. */
-    if(authpass) {
-        /* Format is pretty simple: OSSEC PASS: PASS WHATEVERACTION */
-        parseok = FALSE;
-        if (strncmp(buf, "OSSEC PASS: ", 12) == 0) {
-            buf += 12;
-            if (strlen(buf) > strlen(authpass) && strncmp(buf, authpass, strlen(authpass)) == 0) {
-                buf += strlen(authpass);
-                if (*buf == ' ') {
-                    buf++;
-                    parseok = 1;
-                }
-            }
-        }
-
-        if (parseok == 0) {
-            merror("Invalid password provided by %s. Closing connection.", ip);
-            snprintf(response, 2048, "ERROR: Invalid password");
-            return OS_INVALID;
-        }
-    }
-
-    /* Checking for action A (add agent) */
+  bool parseok = FALSE;
+  /* Checking for shared password authentication. */
+  if (authpass) {
+    /* Format is pretty simple: OSSEC PASS: PASS WHATEVERACTION */
     parseok = FALSE;
-    if (strncmp(buf, "OSSEC A:'", 9) == 0) {
-        buf += 9;
-
-        unsigned len = 0;
-        while (*buf != '\0') {
-            if (*buf == '\'') {
-                os_malloc(len+1, *agentname);
-                memcpy(*agentname, buf-len, len);
-                (*agentname)[len] = '\0';
-                minfo("Received request for a new agent (%s) from: %s", *agentname, ip);
-                parseok = TRUE;
-                break;
-            }
-            len++;
-            buf++;
+    if (strncmp(buf, "OSSEC PASS: ", 12) == 0) {
+      buf += 12;
+      if (strlen(buf) > strlen(authpass) &&
+          strncmp(buf, authpass, strlen(authpass)) == 0) {
+        buf += strlen(authpass);
+        if (*buf == ' ') {
+          buf++;
+          parseok = 1;
         }
+      }
     }
-    buf++;
 
-    if (!parseok) {
-        merror("Invalid request for new agent from: %s", ip);
-        snprintf(response, 2048, "ERROR: Invalid request for new agent");
+    if (parseok == 0) {
+      merror("Invalid password provided by %s. Closing connection.", ip);
+      snprintf(response, 2048, "ERROR: Invalid password");
+      return OS_INVALID;
+    }
+  }
+
+  /* Checking for action A (add agent) */
+  parseok = FALSE;
+  if (strncmp(buf, "OSSEC A:'", 9) == 0) {
+    buf += 9;
+
+    unsigned len = 0;
+    while (*buf != '\0') {
+      if (*buf == '\'') {
+        os_malloc(len + 1, *agentname);
+        memcpy(*agentname, buf - len, len);
+        (*agentname)[len] = '\0';
+        minfo("Received request for a new agent (%s) from: %s", *agentname, ip);
+        parseok = TRUE;
+        break;
+      }
+      len++;
+      buf++;
+    }
+  }
+  buf++;
+
+  if (!parseok) {
+    merror("Invalid request for new agent from: %s", ip);
+    snprintf(response, 2048, "ERROR: Invalid request for new agent");
+    return OS_INVALID;
+  }
+
+  if (!OS_IsValidName(*agentname)) {
+    merror("Invalid agent name: %s from %s", *agentname, ip);
+    snprintf(response, 2048, "ERROR: Invalid agent name: %s", *agentname);
+    return OS_INVALID;
+  }
+
+  /* Check for valid centralized group */
+
+  char centralized_group_token[2] = "G:";
+
+  if (strncmp(++buf, centralized_group_token, 2) == 0) {
+    char tmp_groups[OS_SIZE_65536 + 1] = {0};
+    sscanf(buf, " G:\'%65536[^\']\"", tmp_groups);
+
+    /* Validate the group name */
+    if (0 > w_validate_group_name(tmp_groups, response)) {
+      merror("Invalid group name: %.255s... ,", tmp_groups);
+      return OS_INVALID;
+    }
+    *groups = wstr_delete_repeated_groups(tmp_groups);
+    if (!*groups) {
+      snprintf(response, 2048, "ERROR: Insuficient memory");
+      return OS_MEMERR;
+    }
+    mdebug1("Group(s) is: %s", *groups);
+
+    /*Forward the string pointer G:'........' 2 for G:, 2 for ''*/
+    buf += 2 + strlen(tmp_groups) + 2;
+
+  } else {
+    buf--;
+  }
+
+  /* Check for IP when client uses -i option */
+
+  char client_source_ip[IPSIZE + 1] = {0};
+  char client_source_ip_token[3] = "IP:";
+
+  if (strncmp(++buf, client_source_ip_token, 3) == 0) {
+    char format[15];
+    sprintf(format, " IP:\'%%%d[^\']\"", IPSIZE);
+    sscanf(buf, format, client_source_ip);
+
+    /* If IP: != 'src' overwrite the provided ip */
+    if (strncmp(client_source_ip, "src", 3) != 0) {
+      if (!OS_IsValidIP(client_source_ip, NULL)) {
+        merror("Invalid IP: '%s'", client_source_ip);
+        snprintf(response, 2048, "ERROR: Invalid IP: %s", client_source_ip);
         return OS_INVALID;
+      }
+      snprintf(ip, IPSIZE, "%s", client_source_ip);
     }
 
-    if (!OS_IsValidName(*agentname)) {
-        merror("Invalid agent name: %s from %s", *agentname, ip);
-        snprintf(response, 2048, "ERROR: Invalid agent name: %s", *agentname);
-        return OS_INVALID;
-    }
+  } else if (!config.flags.use_source_ip) {
+    // use_source-ip = 0 and no -I argument in agent
+    snprintf(ip, IPSIZE, "any");
+  }
+  // else -> agent IP is already on ip
 
-    /* Check for valid centralized group */
-
-    char centralized_group_token[2] = "G:";
-
-    if(strncmp(++buf,centralized_group_token,2)==0)
-    {
-        char tmp_groups[OS_SIZE_65536+1] = {0};
-        sscanf(buf," G:\'%65536[^\']\"",tmp_groups);
-
-        /* Validate the group name */
-        if(0 > w_validate_group_name(tmp_groups, response)) {
-            merror("Invalid group name: %.255s... ,",tmp_groups);
-            return OS_INVALID;
-        }
-        *groups = wstr_delete_repeated_groups(tmp_groups);
-        if(!*groups){
-            snprintf(response, 2048, "ERROR: Insuficient memory");
-            return OS_MEMERR;
-        }
-        mdebug1("Group(s) is: %s",*groups);
-
-        /*Forward the string pointer G:'........' 2 for G:, 2 for ''*/
-        buf+= 2+strlen(tmp_groups)+2;
-
-    }else{
-        buf--;
-    }
-
-    /* Check for IP when client uses -i option */
-
-    char client_source_ip[IPSIZE + 1] = {0};
-    char client_source_ip_token[3] = "IP:";
-
-    if(strncmp(++buf,client_source_ip_token,3)==0) {
-        char format[15];
-        sprintf(format, " IP:\'%%%d[^\']\"", IPSIZE);
-        sscanf(buf, format ,client_source_ip);
-
-        /* If IP: != 'src' overwrite the provided ip */
-        if(strncmp(client_source_ip,"src",3) != 0)
-        {
-            if (!OS_IsValidIP(client_source_ip, NULL)) {
-                merror("Invalid IP: '%s'", client_source_ip);
-                snprintf(response, 2048, "ERROR: Invalid IP: %s", client_source_ip);
-                return OS_INVALID;
-            }
-            snprintf(ip, IPSIZE, "%s", client_source_ip);
-        }
-
-    }
-    else if(!config.flags.use_source_ip) {
-        // use_source-ip = 0 and no -I argument in agent
-        snprintf(ip, IPSIZE, "any");
-    }
-    // else -> agent IP is already on ip
-
-    return OS_SUCCESS;
+  return OS_SUCCESS;
 }
 
-w_err_t w_auth_validate_data (char *response, const char *ip, const char *agentname, const char *groups){
-    /* Validate the group(s) name(s) */
-    int index = 0;
-    char *id_exist = NULL;
-    double antiquity = 0;
-    if (groups){
-        if (OS_SUCCESS != w_auth_validate_groups(groups, response)){
-            return OS_INVALID;
-        }
+w_err_t w_auth_validate_data(char *response, const char *ip,
+                             const char *agentname, const char *groups) {
+  /* Validate the group(s) name(s) */
+  int index = 0;
+  char *id_exist = NULL;
+  double antiquity = 0;
+  if (groups) {
+    if (OS_SUCCESS != w_auth_validate_groups(groups, response)) {
+      return OS_INVALID;
     }
+  }
 
-    /* Check for duplicated IP */
-    if (strcmp(ip, "any") != 0 ) {
-        if (index = OS_IsAllowedIP(&keys, ip), index >= 0) {
-            if (config.flags.force_insert && (antiquity = OS_AgentAntiquity(keys.keyentries[index]->name, keys.keyentries[index]->ip->ip), antiquity >= config.force_time || antiquity < 0)) {
-                id_exist = keys.keyentries[index]->id;
-                minfo("Duplicated IP '%s' (%s). Removing old agent.", ip, id_exist);
+  /* Check for duplicated IP */
+  if (strcmp(ip, "any") != 0) {
+    if (index = OS_IsAllowedIP(&keys, ip), index >= 0) {
+      if (config.flags.force_insert &&
+          (antiquity = OS_AgentAntiquity(keys.keyentries[index]->name,
+                                         keys.keyentries[index]->ip->ip),
+           antiquity >= config.force_time || antiquity < 0)) {
+        id_exist = keys.keyentries[index]->id;
+        minfo("Duplicated IP '%s' (%s). Removing old agent.", ip, id_exist);
 
-                add_remove(keys.keyentries[index]);
-                OS_DeleteKey(&keys, id_exist, 0);
-            } else {
-                merror("Duplicated IP %s", ip);
-                snprintf(response, 2048, "ERROR: Duplicated IP: %s", ip);
-                return OS_INVALID;
-            }
-        }
-    }
-
-    /* Check whether the agent name is the same as the manager */
-
-    if (!strcmp(agentname, shost)) {
-        merror("Invalid agent name %s (same as manager)", agentname);
-        snprintf(response, 2048, "ERROR: Invalid agent name: %s", agentname);
+        add_remove(keys.keyentries[index]);
+        OS_DeleteKey(&keys, id_exist, 0);
+      } else {
+        merror("Duplicated IP %s", ip);
+        snprintf(response, 2048, "ERROR: Duplicated IP: %s", ip);
         return OS_INVALID;
+      }
     }
+  }
 
-    /* Check for duplicated names */
+  /* Check whether the agent name is the same as the manager */
 
-    if (index = OS_IsAllowedName(&keys, agentname), index >= 0) {
-        if (config.flags.force_insert && (antiquity = OS_AgentAntiquity(keys.keyentries[index]->name, keys.keyentries[index]->ip->ip), antiquity >= config.force_time || antiquity < 0)) {
-            id_exist = keys.keyentries[index]->id;
-            minfo("Duplicated name '%s' (%s). Removing old agent.", agentname, id_exist);
+  if (!strcmp(agentname, shost)) {
+    merror("Invalid agent name %s (same as manager)", agentname);
+    snprintf(response, 2048, "ERROR: Invalid agent name: %s", agentname);
+    return OS_INVALID;
+  }
 
-            add_remove(keys.keyentries[index]);
-            OS_DeleteKey(&keys, id_exist, 0);
-        } else {
-            merror("Invalid agent name %s (duplicated)", agentname);
-            snprintf(response, 2048, "ERROR: Duplicated agent name: %s", agentname);
-            return OS_INVALID;
-        }
+  /* Check for duplicated names */
+
+  if (index = OS_IsAllowedName(&keys, agentname), index >= 0) {
+    if (config.flags.force_insert &&
+        (antiquity = OS_AgentAntiquity(keys.keyentries[index]->name,
+                                       keys.keyentries[index]->ip->ip),
+         antiquity >= config.force_time || antiquity < 0)) {
+      id_exist = keys.keyentries[index]->id;
+      minfo("Duplicated name '%s' (%s). Removing old agent.", agentname,
+            id_exist);
+
+      add_remove(keys.keyentries[index]);
+      OS_DeleteKey(&keys, id_exist, 0);
+    } else {
+      merror("Invalid agent name %s (duplicated)", agentname);
+      snprintf(response, 2048, "ERROR: Duplicated agent name: %s", agentname);
+      return OS_INVALID;
     }
+  }
 
-    return OS_SUCCESS;
+  return OS_SUCCESS;
 }
 
-w_err_t w_auth_add_agent(char *response, const char *ip, const char *agentname, const char *groups, char **id, char **key){
+w_err_t w_auth_add_agent(char *response, const char *ip, const char *agentname,
+                         const char *groups, char **id, char **key) {
 
-    /* Add the new agent */
-    int index;
+  /* Add the new agent */
+  int index;
 
-    if (index = OS_AddNewAgent(&keys, NULL, agentname, ip, NULL), index < 0) {
-        merror("Unable to add agent: %s (internal error)", agentname);
-        snprintf(response, 2048, "ERROR: Internal manager error adding agent: %s", agentname);
-        return OS_INVALID;
+  if (index = OS_AddNewAgent(&keys, NULL, agentname, ip, NULL), index < 0) {
+    merror("Unable to add agent: %s (internal error)", agentname);
+    snprintf(response, 2048, "ERROR: Internal manager error adding agent: %s",
+             agentname);
+    return OS_INVALID;
+  }
+
+  /* Add the agent to the centralized configuration group */
+  if (groups) {
+    char path[PATH_MAX];
+    if (snprintf(path, PATH_MAX, GROUPS_DIR "/%s",
+                 keys.keyentries[index]->id) >= PATH_MAX) {
+      merror("At set_agent_group(): file path too large for agent '%s'.",
+             keys.keyentries[index]->id);
+      OS_RemoveAgent(keys.keyentries[index]->id);
+      merror("Unable to set agent centralized group: %s (internal error)",
+             groups);
+      snprintf(
+          response, 2048,
+          "ERROR: Internal manager error setting agent centralized group: %s",
+          groups);
+      return OS_INVALID;
     }
+  }
 
-    /* Add the agent to the centralized configuration group */
-    if(groups) {
-        char path[PATH_MAX];
-        if (snprintf(path, PATH_MAX, GROUPS_DIR "/%s", keys.keyentries[index]->id) >= PATH_MAX) {
-            merror("At set_agent_group(): file path too large for agent '%s'.", keys.keyentries[index]->id);
-            OS_RemoveAgent(keys.keyentries[index]->id);
-            merror("Unable to set agent centralized group: %s (internal error)", groups);
-            snprintf(response, 2048, "ERROR: Internal manager error setting agent centralized group: %s", groups);
-            return OS_INVALID;
-        }
-    }
+  os_strdup(keys.keyentries[index]->id, *id);
+  os_strdup(keys.keyentries[index]->key, *key);
 
-    os_strdup(keys.keyentries[index]->id, *id);
-    os_strdup(keys.keyentries[index]->key, *key);
-
-    return OS_SUCCESS;
+  return OS_SUCCESS;
 }
 
 w_err_t w_auth_validate_groups(const char *groups, char *response) {
-    int max_multigroups = 0;
-    char *save_ptr = NULL;
-    char *tmp_groups = NULL;
-    const char delim[] = {MULTIGROUP_SEPARATOR,'\0'};
-    w_err_t ret = OS_SUCCESS;
+  int max_multigroups = 0;
+  char *save_ptr = NULL;
+  char *tmp_groups = NULL;
+  const char delim[] = {MULTIGROUP_SEPARATOR, '\0'};
+  w_err_t ret = OS_SUCCESS;
 
-    os_strdup(groups, tmp_groups);
-    char *group = strtok_r(tmp_groups, delim, &save_ptr);
+  os_strdup(groups, tmp_groups);
+  char *group = strtok_r(tmp_groups, delim, &save_ptr);
 
-    while( group != NULL ) {
-        DIR * dp;
-        char dir[PATH_MAX + 1] = {0};
+  while (group != NULL) {
+    DIR *dp;
+    char dir[PATH_MAX + 1] = {0};
 
-        /* Check limit */
-        if(max_multigroups > MAX_GROUPS_PER_MULTIGROUP){
-            merror("Maximum multigroup reached: Limit is %d",MAX_GROUPS_PER_MULTIGROUP);
-            if (response) {
-                snprintf(response, 2048, "ERROR: Maximum multigroup reached: Limit is %d", MAX_GROUPS_PER_MULTIGROUP);
-            }
-            ret = OS_INVALID;
-            break;
-        }
-
-        snprintf(dir, PATH_MAX + 1, SHAREDCFG_DIR "/%s", group);
-        dp = opendir(dir);
-        if (!dp) {
-            merror("Invalid group: %.255s",group);
-            if (response){
-                snprintf(response, 2048, "ERROR: Invalid group: %s", group);
-            }
-            ret = OS_INVALID;
-            break;
-        }
-
-        group = strtok_r(NULL, delim, &save_ptr);
-        max_multigroups++;
-        closedir(dp);
+    /* Check limit */
+    if (max_multigroups > MAX_GROUPS_PER_MULTIGROUP) {
+      merror("Maximum multigroup reached: Limit is %d",
+             MAX_GROUPS_PER_MULTIGROUP);
+      if (response) {
+        snprintf(response, 2048,
+                 "ERROR: Maximum multigroup reached: Limit is %d",
+                 MAX_GROUPS_PER_MULTIGROUP);
+      }
+      ret = OS_INVALID;
+      break;
     }
-    os_free(tmp_groups);
-    return ret;
+
+    snprintf(dir, PATH_MAX + 1, SHAREDCFG_DIR "/%s", group);
+    dp = opendir(dir);
+    if (!dp) {
+      merror("Invalid group: %.255s", group);
+      if (response) {
+        snprintf(response, 2048, "ERROR: Invalid group: %s", group);
+      }
+      ret = OS_INVALID;
+      break;
+    }
+
+    group = strtok_r(NULL, delim, &save_ptr);
+    max_multigroups++;
+    closedir(dp);
+  }
+  os_free(tmp_groups);
+  return ret;
+}
+
+int w_auth_hash_key(keyentry *key_entry, os_sha1 output) {
+  if (!key_entry || !output) {
+    mdebug2("Unable to hash agent's key due to empty parameters.");
+    return OS_INVALID;
+  }
+
+  char *key = key_entry->key;
+
+  if (key) {
+    return OS_SHA1_Str(key, strlen(key), output);
+  }
+  else {
+    mdebug2("Unable to hash agent's key due to empty value.");
+    return OS_INVALID;
+  }
 }

--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -57,12 +57,12 @@ void add_remove(const keyentry *entry) {
 
 
 w_err_t w_auth_parse_data(const char* buf,
-                                                  char *response,
-                                                  const char *authpass,
-                                                  char *ip,
-                                                  char **agentname,
-                                                  char **groups,
-                                                  char **key_hash){
+                          char *response,
+                          const char *authpass,
+                          char *ip,
+                          char **agentname,
+                          char **groups,
+                          char **key_hash){
 
     bool parseok = FALSE;
     /* Checking for shared password authentication. */
@@ -222,10 +222,10 @@ w_err_t w_auth_replace_agent(keyentry *key,
 }
 
 w_err_t w_auth_validate_data(char *response,
-                                                      const char *ip,
-                                                      const char *agentname,
-                                                      const char *groups,
-                                                      const char *key_hash){
+                             const char *ip,
+                             const char *agentname,
+                             const char *groups,
+                             const char *key_hash){
     int index = 0;
 
     /* Validate the group(s) name(s) */

--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -287,7 +287,7 @@ w_err_t w_auth_add_agent(char *response, const char *ip, const char *agentname, 
     }
 
     os_strdup(keys.keyentries[index]->id, *id);
-    os_strdup(keys.keyentries[index]->key, *key);
+    os_strdup(keys.keyentries[index]->raw_key, *key);
 
     return OS_SUCCESS;
 }

--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -165,6 +165,9 @@ w_err_t w_auth_parse_data(const char* buf,
             snprintf(ip, IPSIZE, "%s", client_source_ip);
         }
 
+        /* Forward the string pointer to allow the proper key parsing IP:'........'
+           3 for IP:, 2 for '' */
+        buf+= 3 + strlen(client_source_ip) + 2;
     }
     else{
         buf--;

--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -190,10 +190,16 @@ w_err_t w_auth_parse_data(const char* buf,
 w_err_t w_auth_replace_agent(keyentry *key,
                              const char *key_hash,
                              authd_force_options_t *force_options){
-    /* Check if the agent antiquity complies with the configuration to be removed*/
+
+    /* Check if the agent replacement is allowed */
+    if (!force_options->enabled) {
+        minfo("Agent '%s' won´t be removed because the force option is disabled.", key->id);
+        return OS_INVALID;
+    }
+
+    /* Check if the agent antiquity complies with the configuration to be removed */
     double antiquity = 0;
-    if (!force_options->enabled ||
-       (antiquity = OS_AgentAntiquity(key->name, key->ip->ip), antiquity > 0 && antiquity < force_options->connection_time)) {
+    if (antiquity = OS_AgentAntiquity(key->name, key->ip->ip), antiquity > 0 && antiquity < force_options->connection_time) {
         minfo("Agent '%s' doesn´t comply with the antiquity to be removed.", key->id);
         return OS_INVALID;
     }

--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -165,8 +165,7 @@ w_err_t w_auth_parse_data(const char* buf,
             snprintf(ip, IPSIZE, "%s", client_source_ip);
         }
 
-        /* Forward the string pointer to allow the proper key parsing IP:'........'
-           3 for IP:, 2 for '' */
+        /* Forward the string pointer IP:'........' 3 for IP: , 2 for '' */
         buf+= 3 + strlen(client_source_ip) + 2;
     }
     else{

--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -318,20 +318,3 @@ w_err_t w_auth_validate_groups(const char *groups, char *response) {
   os_free(tmp_groups);
   return ret;
 }
-
-int w_auth_hash_key(keyentry *key_entry, os_sha1 output) {
-  if (!key_entry || !output) {
-    mdebug2("Unable to hash agent's key due to empty parameters.");
-    return OS_INVALID;
-  }
-
-  char *key = key_entry->key;
-
-  if (key) {
-    return OS_SHA1_Str(key, strlen(key), output);
-  }
-  else {
-    mdebug2("Unable to hash agent's key due to empty value.");
-    return OS_INVALID;
-  }
-}

--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -193,7 +193,7 @@ w_err_t w_auth_replace_agent(keyentry *key,
     double antiquity = 0;
     if (!config.flags.force_insert ||
        (antiquity = OS_AgentAntiquity(key->name, key->ip->ip), antiquity > 0 && antiquity < config.force_time)) {
-        minfo("Agent '%s' doesn´t complies with the antiquity to be removed.", key->id);
+        minfo("Agent '%s' doesn´t comply with the antiquity to be removed.", key->id);
         return OS_INVALID;
     }
 
@@ -202,7 +202,7 @@ w_err_t w_auth_replace_agent(keyentry *key,
         os_sha1 manager_key_hash;
         w_auth_hash_key(key, manager_key_hash);
         if (!strcmp(manager_key_hash, key_hash)) {
-            minfo("Key identified with hash '%s' already exists on the manager.", key_hash);
+            minfo("Agent '%s' key already exists on the manager.", key->id);
             return OS_INVALID;
         }
     }

--- a/src/os_auth/auth.h
+++ b/src/os_auth/auth.h
@@ -37,7 +37,6 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <openssl/bio.h>
-#include "os_crypto/sha1/sha1_op.h"
 
 extern BIO *bio_err;
 #define KEYFILE  "etc/sslmanager.key"
@@ -140,14 +139,6 @@ w_err_t w_auth_validate_data (char *response, const char *ip, const char *agentn
  * @param key Pointer where new Agent key will be allocated
  * */
 w_err_t w_auth_add_agent(char *response, const char *ip, const char *agentname, const char *groups, char **id, char **key);
-
-/**
- * @brief Receives a keyentry structure and returns the SHA1 value of the agent's key.
- * Return OS_SUCCESS or OS_INVALID on error.
- * @param key_entry The agent's key structure
- * @param output The variable where the hashed key will be stored
- **/
-int w_auth_hash_key(keyentry *key_entry, os_sha1 output);
 
 extern char shost[512];
 extern keystore keys;

--- a/src/os_auth/auth.h
+++ b/src/os_auth/auth.h
@@ -149,7 +149,8 @@ w_err_t w_auth_validate_data(char *response,
  * @param hash_key Hash of the key on the agent
  * */
 w_err_t w_auth_replace_agent(keyentry *key,
-                             const char *key_hash);
+                             const char *key_hash,
+                             authd_force_options_t *force_options);
 
 /**
  * @brief Adds new agent with provided enrollment data.

--- a/src/os_auth/auth.h
+++ b/src/os_auth/auth.h
@@ -72,8 +72,8 @@ int verify_callback(int ok, X509_STORE_CTX *store);
 
 /**
  * @brief Wraps SSL_read function to read block largers than a record (16K)
- *
- * Calls SSL_read and if the return value is exactly the size of a record
+ * 
+ * Calls SSL_read and if the return value is exactly the size of a record 
  * calls again with an offset in the buffer until reading is done or until
  * reaching a reading timeout
  * @param ssl ssl connection
@@ -108,7 +108,7 @@ void authd_sigblock();
 w_err_t w_auth_validate_groups(const char *groups, char *response);
 
 /**
- * @brief Parse a raw buffer from agent request into enrollment data.
+ * @brief Parse a raw buffer from agent request into enrollment data. 
  * @param buf Raw buffer to be parsed
  * @param response 2048 length buffer where the error response will be copied
  * @param authpass Authentication password expected on the buffer, NULL if there isn't password
@@ -135,10 +135,11 @@ w_err_t w_auth_validate_data (char *response, const char *ip, const char *agentn
  * @param ip New enrollment ip direction
  * @param agentname New enrollment agent name
  * @param groups New enrollment groups
- * @param id Pointer where new Agent ID will be allocated
- * @param key Pointer where new Agent key will be allocated
+ * @param id Pointer where new Agent ID will be allocated 
+ * @param key Pointer where new Agent key will be allocated 
  * */
 w_err_t w_auth_add_agent(char *response, const char *ip, const char *agentname, const char *groups, char **id, char **key);
+
 
 extern char shost[512];
 extern keystore keys;

--- a/src/os_auth/auth.h
+++ b/src/os_auth/auth.h
@@ -120,12 +120,12 @@ w_err_t w_auth_validate_groups(const char *groups, char *response);
  * @param key_hash Pointer where parsed key hash will be allocated
  * */
 w_err_t w_auth_parse_data(const char* buf,
-                          char *response,
-                          const char *authpass,
-                          char *ip,
-                          char **agentname,
-                          char **groups,
-                          char **key_hash);
+                                                  char *response,
+                                                  const char *authpass,
+                                                  char *ip,
+                                                  char **agentname,
+                                                  char **groups,
+                                                  char **key_hash);
 
 /**
  * @brief Validates if new enrollment is possible with provided data.
@@ -138,10 +138,10 @@ w_err_t w_auth_parse_data(const char* buf,
  * @param hash_key Hash of the key on the agent
  * */
 w_err_t w_auth_validate_data(char *response,
-                             const char *ip,
-                             const char *agentname,
-                             const char *groups,
-                             const char *hash_key);
+                                                      const char *ip,
+                                                      const char *agentname,
+                                                      const char *groups,
+                                                      const char *hash_key);
 
 /**
  * @brief Validates if the old agent can be replaced and removes it.
@@ -163,11 +163,11 @@ w_err_t w_auth_replace_agent(keyentry *key,
  * @param key Pointer where new Agent key will be allocated
  * */
 w_err_t w_auth_add_agent(char *response,
-                         const char *ip,
-                         const char *agentname,
-                         const char *groups,
-                         char **id,
-                         char **key);
+                                                 const char *ip,
+                                                 const char *agentname,
+                                                 const char *groups,
+                                                 char **id,
+                                                 char **key);
 
 
 extern char shost[512];

--- a/src/os_auth/auth.h
+++ b/src/os_auth/auth.h
@@ -147,6 +147,7 @@ w_err_t w_auth_validate_data(char *response,
  * @brief Validates if the old agent can be replaced and removes it.
  * @param key Key structure of the agent to be removed
  * @param hash_key Hash of the key on the agent
+ * @param force_options Force configuration structure to define how the agent replacement must be handled.
  * */
 w_err_t w_auth_replace_agent(keyentry *key,
                              const char *key_hash,

--- a/src/os_auth/auth.h
+++ b/src/os_auth/auth.h
@@ -120,12 +120,12 @@ w_err_t w_auth_validate_groups(const char *groups, char *response);
  * @param key_hash Pointer where parsed key hash will be allocated
  * */
 w_err_t w_auth_parse_data(const char* buf,
-                                                  char *response,
-                                                  const char *authpass,
-                                                  char *ip,
-                                                  char **agentname,
-                                                  char **groups,
-                                                  char **key_hash);
+                          char *response,
+                          const char *authpass,
+                          char *ip,
+                          char **agentname,
+                          char **groups,
+                          char **key_hash);
 
 /**
  * @brief Validates if new enrollment is possible with provided data.
@@ -138,10 +138,10 @@ w_err_t w_auth_parse_data(const char* buf,
  * @param hash_key Hash of the key on the agent
  * */
 w_err_t w_auth_validate_data(char *response,
-                                                      const char *ip,
-                                                      const char *agentname,
-                                                      const char *groups,
-                                                      const char *hash_key);
+                             const char *ip,
+                             const char *agentname,
+                             const char *groups,
+                             const char *hash_key);
 
 /**
  * @brief Validates if the old agent can be replaced and removes it.
@@ -163,11 +163,11 @@ w_err_t w_auth_replace_agent(keyentry *key,
  * @param key Pointer where new Agent key will be allocated
  * */
 w_err_t w_auth_add_agent(char *response,
-                                                 const char *ip,
-                                                 const char *agentname,
-                                                 const char *groups,
-                                                 char **id,
-                                                 char **key);
+                         const char *ip,
+                         const char *agentname,
+                         const char *groups,
+                         char **id,
+                         char **key);
 
 
 extern char shost[512];

--- a/src/os_auth/auth.h
+++ b/src/os_auth/auth.h
@@ -37,6 +37,7 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <openssl/bio.h>
+#include "os_crypto/sha1/sha1_op.h"
 
 extern BIO *bio_err;
 #define KEYFILE  "etc/sslmanager.key"
@@ -72,8 +73,8 @@ int verify_callback(int ok, X509_STORE_CTX *store);
 
 /**
  * @brief Wraps SSL_read function to read block largers than a record (16K)
- * 
- * Calls SSL_read and if the return value is exactly the size of a record 
+ *
+ * Calls SSL_read and if the return value is exactly the size of a record
  * calls again with an offset in the buffer until reading is done or until
  * reaching a reading timeout
  * @param ssl ssl connection
@@ -108,7 +109,7 @@ void authd_sigblock();
 w_err_t w_auth_validate_groups(const char *groups, char *response);
 
 /**
- * @brief Parse a raw buffer from agent request into enrollment data. 
+ * @brief Parse a raw buffer from agent request into enrollment data.
  * @param buf Raw buffer to be parsed
  * @param response 2048 length buffer where the error response will be copied
  * @param authpass Authentication password expected on the buffer, NULL if there isn't password
@@ -135,11 +136,18 @@ w_err_t w_auth_validate_data (char *response, const char *ip, const char *agentn
  * @param ip New enrollment ip direction
  * @param agentname New enrollment agent name
  * @param groups New enrollment groups
- * @param id Pointer where new Agent ID will be allocated 
- * @param key Pointer where new Agent key will be allocated 
+ * @param id Pointer where new Agent ID will be allocated
+ * @param key Pointer where new Agent key will be allocated
  * */
 w_err_t w_auth_add_agent(char *response, const char *ip, const char *agentname, const char *groups, char **id, char **key);
 
+/**
+ * @brief Receives a keyentry structure and returns the SHA1 value of the agent's key.
+ * Return OS_SUCCESS or OS_INVALID on error.
+ * @param key_entry The agent's key structure
+ * @param output The variable where the hashed key will be stored
+ **/
+int w_auth_hash_key(keyentry *key_entry, os_sha1 output);
 
 extern char shost[512];
 extern keystore keys;

--- a/src/os_auth/config.c
+++ b/src/os_auth/config.c
@@ -16,7 +16,7 @@
 // Read configuration
 int authd_read_config(const char *path) {
     config.port = DEFAULT_PORT;
-    config.force_time = -1;
+    config.force_options.connection_time = -1;
 
     mdebug2("Reading configuration '%s'", path);
 
@@ -24,8 +24,8 @@ int authd_read_config(const char *path) {
         return OS_INVALID;
     }
 
-    if (!config.flags.force_insert) {
-        config.force_time = -1;
+    if (!config.force_options.enabled) {
+        config.force_options.connection_time = -1;
     }
 
     if (!config.ciphers) {
@@ -54,16 +54,16 @@ cJSON *getAuthdConfig(void) {
     cJSON *auth = cJSON_CreateObject();
 
     cJSON_AddNumberToObject(auth,"port",config.port);
-    if (config.force_time ==  -1)
+    if (config.force_options.connection_time ==  -1)
         cJSON_AddStringToObject(auth,"force_time","no");
-    else if (config.force_time ==  0)
+    else if (config.force_options.connection_time ==  0)
         cJSON_AddStringToObject(auth,"force_time","always");
     else
-        cJSON_AddNumberToObject(auth,"force_time",config.force_time);
+        cJSON_AddNumberToObject(auth,"force_time",config.force_options.connection_time);
     if (config.flags.disabled) cJSON_AddStringToObject(auth,"disabled","yes"); else cJSON_AddStringToObject(auth,"disabled","no");
     if (config.flags.remote_enrollment) cJSON_AddStringToObject(auth,"remote_enrollment","yes"); else cJSON_AddStringToObject(auth,"remote_enrollment","no");
     if (config.flags.use_source_ip) cJSON_AddStringToObject(auth,"use_source_ip","yes"); else cJSON_AddStringToObject(auth,"use_source_ip","no");
-    if (config.flags.force_insert) cJSON_AddStringToObject(auth,"force_insert","yes"); else cJSON_AddStringToObject(auth,"force_insert","no");
+    if (config.force_options.enabled) cJSON_AddStringToObject(auth,"force_insert","yes"); else cJSON_AddStringToObject(auth,"force_insert","no");
     if (config.flags.clear_removed) cJSON_AddStringToObject(auth,"purge","yes"); else cJSON_AddStringToObject(auth,"purge","no");
     if (config.flags.use_password) cJSON_AddStringToObject(auth,"use_password","yes"); else cJSON_AddStringToObject(auth,"use_password","no");
     if (config.flags.verify_host) cJSON_AddStringToObject(auth,"ssl_verify_host","yes"); else cJSON_AddStringToObject(auth,"ssl_verify_host","no");

--- a/src/os_auth/local-server.c
+++ b/src/os_auth/local-server.c
@@ -58,7 +58,13 @@ static const struct {
 static char* local_dispatch(const char *input);
 
 // Add a new agent
-static cJSON* local_add(const char *id, const char *name, const char *ip, char *groups, const char *key, int force);
+static cJSON* local_add(const char *id,
+                        const char *name,
+                        const char *ip,
+                        char *groups,
+                        const char *key,
+                        const char *key_hash,
+                        authd_force_options_t *force_options);
 
 // Remove an agent
 static cJSON* local_remove(const char *id, int purge);
@@ -195,13 +201,14 @@ char* local_dispatch(const char *input) {
         }
 
         if (!strcmp(function->valuestring, "add")) {
-            cJSON *item;
-            char *id;
-            char *name;
-            char *ip;
+            cJSON *item = NULL;
+            char *id = NULL;
+            char *name = NULL;
+            char *ip = NULL;
             char *groups = NULL;
+            char *key_hash = NULL;
             char *key = NULL;
-            int force = 0;
+            authd_force_options_t force_options = {0};
 
             if (arguments = cJSON_GetObjectItem(request, "arguments"), !arguments) {
                 ierror = ENOARGUMENT;
@@ -214,14 +221,12 @@ char* local_dispatch(const char *input) {
                 ierror = ENONAME;
                 goto fail;
             }
-
             name = item->valuestring;
 
             if (item = cJSON_GetObjectItem(arguments, "ip"), !item) {
                 ierror = ENOIP;
                 goto fail;
             }
-
             ip = item->valuestring;
 
             if (item = cJSON_GetObjectItem(arguments, "groups"), item) {
@@ -232,10 +237,23 @@ char* local_dispatch(const char *input) {
                 }
             }
 
+            key_hash = (item = cJSON_GetObjectItem(arguments, "key_hash"), item) ? item->valuestring : NULL;
             key = (item = cJSON_GetObjectItem(arguments, "key"), item) ? item->valuestring : NULL;
-            force = (item = cJSON_GetObjectItem(arguments, "force"), item) ? item->valueint : -1;
 
-            response = local_add(id, name, ip, groups, key, force);
+            if (item = cJSON_GetObjectItem(arguments, "force"), item) {
+                if (item->valueint == -1) {
+                    force_options.enabled = false;
+                }
+                else {
+                    force_options.enabled = true;
+                    force_options.connection_time = item->valueint;
+                }
+            }
+            else {
+                force_options.enabled = false;
+            }
+
+            response = local_add(id, name, ip, groups, key, key_hash, &force_options);
 
             os_free(groups);
         } else if (!strcmp(function->valuestring, "remove")) {
@@ -300,12 +318,16 @@ fail:
     return output;
 }
 
-cJSON* local_add(const char *id, const char *name, const char *ip, char *groups, const char *key, int force) {
+cJSON* local_add(const char *id,
+                 const char *name,
+                 const char *ip,
+                 char *groups,
+                 const char *key,
+                 const char *key_hash,
+                 authd_force_options_t *force_options) {
     int index;
-    char *id_exist;
     cJSON *response = NULL;
     int ierror;
-    double antiquity;
 
     mdebug2("add(%s)", name);
     w_mutex_lock(&mutex_keys);
@@ -319,29 +341,18 @@ cJSON* local_add(const char *id, const char *name, const char *ip, char *groups,
     }
 
     // Check for duplicated ID
-
     if (id && (index = OS_IsAllowedID(&keys, id), index >= 0)) {
-        if (force >= 0 && (antiquity = OS_AgentAntiquity(keys.keyentries[index]->name, keys.keyentries[index]->ip->ip), antiquity >= force || antiquity < 0)) {
-            id_exist = keys.keyentries[index]->id;
-            minfo("Duplicated ID '%s' (%s). Removing old agent.", id, id_exist);
-            add_remove(keys.keyentries[index]);
-            OS_DeleteKey(&keys, id_exist, 0);
-        } else {
+        minfo("Duplicated ID '%s'.", keys.keyentries[index]->id);
+        if (OS_SUCCESS != w_auth_replace_agent(keys.keyentries[index], key_hash, force_options)) {
             ierror = EDUPID;
             goto fail;
         }
     }
 
     /* Check for duplicated IP */
-
     if (strcmp(ip, "any")) {
         if (index = OS_IsAllowedIP(&keys, ip), index >= 0) {
-            if (force >= 0 && (antiquity = OS_AgentAntiquity(keys.keyentries[index]->name, keys.keyentries[index]->ip->ip), antiquity >= force || antiquity < 0)) {
-                id_exist = keys.keyentries[index]->id;
-                minfo("Duplicated IP '%s' (%s). Removing old agent.", ip, id_exist);
-                add_remove(keys.keyentries[index]);
-                OS_DeleteKey(&keys, id_exist, 0);
-            } else {
+            if (OS_SUCCESS != w_auth_replace_agent(keys.keyentries[index], key_hash, force_options)) {
                 ierror = EDUPIP;
                 goto fail;
             }
@@ -349,24 +360,17 @@ cJSON* local_add(const char *id, const char *name, const char *ip, char *groups,
     }
 
     /* Check whether the agent name is the same as the manager */
-
     if (!strcmp(name, shost)) {
         ierror = EDUPNAME;
         goto fail;
     }
 
     /* Check for duplicated names */
-
     if (index = OS_IsAllowedName(&keys, name), index >= 0) {
-        if (force >= 0 && (antiquity = OS_AgentAntiquity(keys.keyentries[index]->name, keys.keyentries[index]->ip->ip), antiquity >= force || antiquity < 0)) {
-            id_exist = keys.keyentries[index]->id;
-            minfo("Duplicated name '%s' (%s). Removing old agent.", name, id_exist);
-            add_remove(keys.keyentries[index]);
-            OS_DeleteKey(&keys, id_exist, 0);
-        } else {
-            ierror = EDUPNAME;
-            goto fail;
-        }
+        if (OS_SUCCESS != w_auth_replace_agent(keys.keyentries[index], key_hash, force_options)) {
+                ierror = EDUPNAME;
+                goto fail;
+            }
     }
 
     if (index = OS_AddNewAgent(&keys, id, name, ip, key), index < 0) {

--- a/src/os_auth/local-server.c
+++ b/src/os_auth/local-server.c
@@ -61,7 +61,7 @@ static char* local_dispatch(const char *input);
 static cJSON* local_add(const char *id,
                         const char *name,
                         const char *ip,
-                        char *groups,
+                        const char *groups,
                         const char *key,
                         const char *key_hash,
                         authd_force_options_t *force_options);
@@ -321,7 +321,7 @@ fail:
 cJSON* local_add(const char *id,
                  const char *name,
                  const char *ip,
-                 char *groups,
+                 const char *groups,
                  const char *key,
                  const char *key_hash,
                  authd_force_options_t *force_options) {

--- a/src/os_auth/local-server.c
+++ b/src/os_auth/local-server.c
@@ -392,7 +392,7 @@ cJSON* local_add(const char *id,
     write_pending = 1;
     w_cond_signal(&cond_pending);
 
-    response = local_create_agent_response(keys.keyentries[index]->id, name, ip, keys.keyentries[index]->key);
+    response = local_create_agent_response(keys.keyentries[index]->id, name, ip, keys.keyentries[index]->raw_key);
     w_mutex_unlock(&mutex_keys);
 
     minfo("Agent key generated for agent '%s' (requested locally)", name);
@@ -444,7 +444,7 @@ cJSON* local_get(const char *id) {
         response = local_create_error_response(ERRORS[ENOAGENT].code, ERRORS[ENOAGENT].message);
     }
     else {
-        response = local_create_agent_response(id, keys.keyentries[index]->name, keys.keyentries[index]->ip->ip, keys.keyentries[index]->key);
+        response = local_create_agent_response(id, keys.keyentries[index]->name, keys.keyentries[index]->ip->ip, keys.keyentries[index]->raw_key);
     }
 
     w_mutex_unlock(&mutex_keys);

--- a/src/os_auth/local-server.c
+++ b/src/os_auth/local-server.c
@@ -43,12 +43,12 @@ static const struct {
     { 9004, "No such argument" },
     { 9005, "No such name" },
     { 9006, "No such IP" },
-    { 9007, "Duplicated IP" },
-    { 9008, "Duplicated name" },
+    { 9007, "Duplicate IP" },
+    { 9008, "Duplicate name" },
     { 9009, "Issue generating key" },
     { 9010, "No such agent ID" },
     { 9011, "Agent ID not found" },
-    { 9012, "Duplicated ID" },
+    { 9012, "Duplicate ID" },
     { 9013, "Maximum number of agents reached" },
     { 9014, "Invalid Group(s) Name(s)" },
     { 9015, "Cannot execute this request on a worker node" }
@@ -243,13 +243,11 @@ char* local_dispatch(const char *input) {
             if (item = cJSON_GetObjectItem(arguments, "force"), item) {
                 if (item->valueint == -1) {
                     force_options.enabled = false;
-                }
-                else {
+                } else {
                     force_options.enabled = true;
                     force_options.connection_time = item->valueint;
                 }
-            }
-            else {
+            } else {
                 force_options.enabled = false;
             }
 
@@ -301,9 +299,8 @@ char* local_dispatch(const char *input) {
         }
 
         cJSON_Delete(request);
-    }
-    // Read configuration commands
-    else {
+    } else {
+        // Read configuration commands
         authcom_dispatch(input,&output);
     }
 
@@ -340,16 +337,16 @@ cJSON* local_add(const char *id,
         }
     }
 
-    // Check for duplicated ID
+    // Check for duplicate ID
     if (id && (index = OS_IsAllowedID(&keys, id), index >= 0)) {
-        minfo("Duplicated ID '%s'.", keys.keyentries[index]->id);
+        minfo("Duplicate ID '%s'.", keys.keyentries[index]->id);
         if (OS_SUCCESS != w_auth_replace_agent(keys.keyentries[index], key_hash, force_options)) {
             ierror = EDUPID;
             goto fail;
         }
     }
 
-    /* Check for duplicated IP */
+    /* Check for duplicate IP */
     if (strcmp(ip, "any")) {
         if (index = OS_IsAllowedIP(&keys, ip), index >= 0) {
             if (OS_SUCCESS != w_auth_replace_agent(keys.keyentries[index], key_hash, force_options)) {
@@ -365,7 +362,7 @@ cJSON* local_add(const char *id,
         goto fail;
     }
 
-    /* Check for duplicated names */
+    /* Check for duplicate names */
     if (index = OS_IsAllowedName(&keys, name), index >= 0) {
         if (OS_SUCCESS != w_auth_replace_agent(keys.keyentries[index], key_hash, force_options)) {
                 ierror = EDUPNAME;

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -276,6 +276,7 @@ int main(int argc, char **argv)
 
     // Reading agent's key (if any) to send its hash to the manager
     keystore agent_keys = KEYSTORE_INITIALIZER;
+    OS_PassEmptyKeyfile();
     OS_ReadKeys(&agent_keys, 0, 0);
 
     w_enrollment_ctx *cfg = w_enrollment_init(target_cfg, cert_cfg, &agent_keys);

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -278,7 +278,7 @@ int main(int argc, char **argv)
     // Reading agent's key (if any) to send its hash to the manager
     keystore agent_keys = KEYSTORE_INITIALIZER;
     OS_PassEmptyKeyfile();
-    OS_ReadKeys(&agent_keys, 0, 0);
+    OS_ReadKeys(&agent_keys, W_RAW_KEY, 0);
 
     w_enrollment_ctx *cfg = w_enrollment_init(target_cfg, cert_cfg, &agent_keys);
     int ret = w_enrollment_request_key(cfg, server_address);

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -23,7 +23,6 @@
  *
  */
 
-#include "sec.h"
 #include "shared.h"
 #include <openssl/ssl.h>
 #include "auth.h"
@@ -275,11 +274,11 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    keystore keys = KEYSTORE_INITIALIZER;
-    w_enrollment_ctx *cfg = w_enrollment_init(target_cfg, cert_cfg, keys);
-
     // Reading agent's key (if any) to send its hash to the manager
-    OS_ReadKeys(&keys, 0, 0);
+    keystore agent_keys = KEYSTORE_INITIALIZER;
+    OS_ReadKeys(&agent_keys, 0, 0);
+
+    w_enrollment_ctx *cfg = w_enrollment_init(target_cfg, cert_cfg, &agent_keys);
     int ret = w_enrollment_request_key(cfg, server_address);
 
     w_enrollment_target_destroy(target_cfg);

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -274,7 +274,8 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    w_enrollment_ctx *cfg = w_enrollment_init(target_cfg, cert_cfg);
+    /* NULL until the agent-auth fix is implemented */
+    w_enrollment_ctx *cfg = w_enrollment_init(target_cfg, cert_cfg, NULL);
     int ret = w_enrollment_request_key(cfg, server_address);
 
     w_enrollment_target_destroy(target_cfg);

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -31,9 +31,6 @@
 #undef ARGV0
 #define ARGV0 "agent-auth"
 
-/*Global keys structure*/
-keystore keys = KEYSTORE_INITIALIZER;
-
 static void help_agent_auth(char * home_path) __attribute__((noreturn));
 
 /* Print help statement */
@@ -278,8 +275,11 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    /* NULL until the agent-auth fix is implemented */
-    w_enrollment_ctx *cfg = w_enrollment_init(target_cfg, cert_cfg, NULL);
+    keystore keys = KEYSTORE_INITIALIZER;
+    w_enrollment_ctx *cfg = w_enrollment_init(target_cfg, cert_cfg, keys);
+
+    // Reading agent's key (if any) to send its hash to the manager
+    OS_ReadKeys(&keys, 0, 0);
     int ret = w_enrollment_request_key(cfg, server_address);
 
     w_enrollment_target_destroy(target_cfg);

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -23,12 +23,16 @@
  *
  */
 
+#include "sec.h"
 #include "shared.h"
 #include <openssl/ssl.h>
 #include "auth.h"
 
 #undef ARGV0
 #define ARGV0 "agent-auth"
+
+/*Global keys structure*/
+keystore keys = KEYSTORE_INITIALIZER;
 
 static void help_agent_auth(char * home_path) __attribute__((noreturn));
 

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -23,6 +23,7 @@
  *
  */
 
+#include "sec.h"
 #include "shared.h"
 #include <openssl/ssl.h>
 #include "auth.h"
@@ -285,6 +286,7 @@ int main(int argc, char **argv)
     w_enrollment_target_destroy(target_cfg);
     w_enrollment_cert_destroy(cert_cfg);
     w_enrollment_destroy(cfg);
+    OS_FreeKeys(&agent_keys);
 
     exit((ret == 0) ? 0 : 1);
 }

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -23,10 +23,10 @@
  *
  */
 
-#include "sec.h"
 #include "shared.h"
 #include <openssl/ssl.h>
 #include "auth.h"
+#include "enrollment_op.h"
 
 #undef ARGV0
 #define ARGV0 "agent-auth"

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -633,7 +633,7 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
         if (OS_SUCCESS == w_auth_parse_data(buf, response, authpass, ip, &agentname, &centralized_group, &key_hash)) {
             if (config.worker_node) {
                 minfo("Dispatching request to master node");
-                if (0 == w_request_agent_add_clustered(response, agentname, ip, centralized_group, &new_id, &new_key, config.flags.force_insert?config.force_time:-1, NULL)) {
+                if (0 == w_request_agent_add_clustered(response, agentname, ip, centralized_group, key_hash, &new_id, &new_key, config.flags.force_insert?config.force_time:-1, NULL)) {
                     enrollment_ok = TRUE;
                 }
             }

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -28,7 +28,6 @@
 #include <pthread.h>
 #include <sys/wait.h>
 #include "check_cert.h"
-#include "os_crypto/md5/md5_op.h"
 #include "wazuh_db/helpers/wdb_global_helpers.h"
 #include "wazuhdb_op.h"
 #include "os_err.h"
@@ -627,9 +626,11 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
         bool enrollment_ok = FALSE;
         char *agentname = NULL;
         char *centralized_group = NULL;
+        char* key_hash = NULL;
         char* new_id = NULL;
         char* new_key = NULL;
-        if (OS_SUCCESS == w_auth_parse_data(buf, response, authpass, ip, &agentname, &centralized_group)) {
+
+        if (OS_SUCCESS == w_auth_parse_data(buf, response, authpass, ip, &agentname, &centralized_group, &key_hash)) {
             if (config.worker_node) {
                 minfo("Dispatching request to master node");
                 if (0 == w_request_agent_add_clustered(response, agentname, ip, centralized_group, &new_id, &new_key, config.flags.force_insert?config.force_time:-1, NULL)) {
@@ -638,7 +639,7 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
             }
             else {
                 w_mutex_lock(&mutex_keys);
-                if (OS_SUCCESS == w_auth_validate_data(response, ip, agentname, centralized_group)) {
+                if (OS_SUCCESS == w_auth_validate_data(response, ip, agentname, centralized_group, key_hash)) {
                     if (OS_SUCCESS == w_auth_add_agent(response, ip, agentname, centralized_group, &new_id, &new_key)) {
                         enrollment_ok = TRUE;
                     }
@@ -696,6 +697,7 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
         os_free(buf);
         os_free(agentname);
         os_free(centralized_group);
+        os_free(key_hash);
         os_free(new_id);
         os_free(new_key);
     }

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -633,7 +633,7 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
         if (OS_SUCCESS == w_auth_parse_data(buf, response, authpass, ip, &agentname, &centralized_group, &key_hash)) {
             if (config.worker_node) {
                 minfo("Dispatching request to master node");
-                if (0 == w_request_agent_add_clustered(response, agentname, ip, centralized_group, key_hash, &new_id, &new_key, config.flags.force_insert?config.force_time:-1, NULL)) {
+                if (0 == w_request_agent_add_clustered(response, agentname, ip, centralized_group, key_hash, &new_id, &new_key, config.force_options.enabled?config.force_options.connection_time:-1, NULL)) {
                     enrollment_ok = TRUE;
                 }
             }

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -494,7 +494,7 @@ int main(int argc, char **argv)
     /* Load client keys in master node */
     if (!config.worker_node) {
         OS_PassEmptyKeyfile();
-        OS_ReadKeys(&keys, 0, !config.flags.clear_removed);
+        OS_ReadKeys(&keys, W_RAW_KEY, !config.flags.clear_removed);
     }
 
     /* Start working threads */

--- a/src/os_crypto/sha1/sha1_op.c
+++ b/src/os_crypto/sha1/sha1_op.c
@@ -105,6 +105,7 @@ int OS_SHA1_strings(os_sha1 output, ...) {
     while(parameter = va_arg(parameters, char*), parameter) {
         SHA1_Update(&c, parameter, strlen(parameter));
     }
+    va_end(parameters);
     SHA1_Final(&(md[0]), &c);
 
     for (n = 0; n < SHA_DIGEST_LENGTH; n++) {

--- a/src/os_crypto/sha1/sha1_op.c
+++ b/src/os_crypto/sha1/sha1_op.c
@@ -93,8 +93,29 @@ int OS_SHA1_Str2(const char *str, ssize_t length, os_sha1 output)
     return (0);
 }
 
-// Get the hexadecimal result of a SHA-1 digest
+int OS_SHA1_strings(os_sha1 output, ...) {
+    unsigned char md[SHA_DIGEST_LENGTH];
+    size_t n;
+    SHA_CTX c;
+    SHA1_Init(&c);
 
+    va_list parameters;
+    char* parameter = NULL;
+    va_start(parameters, output);
+    while(parameter = va_arg(parameters, char*), parameter) {
+        SHA1_Update(&c, parameter, strlen(parameter));
+    }
+    SHA1_Final(&(md[0]), &c);
+
+    for (n = 0; n < SHA_DIGEST_LENGTH; n++) {
+        snprintf(output, 3, "%02x", md[n]);
+        output += 2;
+    }
+
+    return (0);
+}
+
+// Get the hexadecimal result of a SHA-1 digest
 void OS_SHA1_Hexdigest(const unsigned char * digest, os_sha1 output) {
     size_t n;
 

--- a/src/os_crypto/sha1/sha1_op.c
+++ b/src/os_crypto/sha1/sha1_op.c
@@ -25,8 +25,7 @@
 #endif
 */
 
-int OS_SHA1_File(const char *fname, os_sha1 output, int mode)
-{
+int OS_SHA1_File(const char *fname, os_sha1 output, int mode) {
     SHA_CTX c;
     FILE *fp;
     unsigned char buf[2048 + 2];
@@ -59,8 +58,7 @@ int OS_SHA1_File(const char *fname, os_sha1 output, int mode)
     return (0);
 }
 
-int OS_SHA1_Str(const char *str, ssize_t length, os_sha1 output)
-{
+int OS_SHA1_Str(const char *str, ssize_t length, os_sha1 output) {
     unsigned char md[SHA_DIGEST_LENGTH];
     size_t n;
 
@@ -77,8 +75,7 @@ int OS_SHA1_Str(const char *str, ssize_t length, os_sha1 output)
     return (0);
 }
 
-int OS_SHA1_Str2(const char *str, ssize_t length, os_sha1 output)
-{
+int OS_SHA1_Str2(const char *str, ssize_t length, os_sha1 output) {
     unsigned char temp[SHA_DIGEST_LENGTH];
     size_t n;
 
@@ -102,7 +99,7 @@ int OS_SHA1_strings(os_sha1 output, ...) {
     va_list parameters;
     char* parameter = NULL;
     va_start(parameters, output);
-    while(parameter = va_arg(parameters, char*), parameter) {
+    while (parameter = va_arg(parameters, char*), parameter) {
         SHA1_Update(&c, parameter, strlen(parameter));
     }
     va_end(parameters);

--- a/src/os_crypto/sha1/sha1_op.h
+++ b/src/os_crypto/sha1/sha1_op.h
@@ -24,6 +24,14 @@ int OS_SHA1_Str(const char *str, ssize_t length, os_sha1 output) __attribute((no
 int OS_SHA1_Str2(const char *str, ssize_t length, os_sha1 output) __attribute((nonnull));
 
 /**
+ * @brief Get the SHA-1 digest from a list of strings.
+ *
+ * @param output[out] Output string.
+ * @param ...   [in] List of strings to calculate the SHA-1.
+ */
+int OS_SHA1_strings(os_sha1 output, ...);
+
+/**
  * @brief Get the hexadecimal result of a SHA-1 digest
  *
  * @param digest[in] Binary SHA-1 digest.

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -107,7 +107,11 @@ int OS_AddKey(keystore *keys, const char *id, const char *name, const char *ip, 
     keys->keyentries[keys->keysize]->rids_node = NULL;
     w_mutex_init(&keys->keyentries[keys->keysize]->mutex, NULL);
 
-    if (keys->flags.rehash_keys) {
+    if (keys->flags.key_mode == W_RAW_KEY || keys->flags.key_mode == W_DUAL_KEY) {
+        os_strdup(key, keys->keyentries[keys->keysize]->raw_key);
+    }
+
+    if (keys->flags.key_mode == W_ENCRYPTION_KEY || keys->flags.key_mode == W_DUAL_KEY) {
         /** Generate final symmetric key **/
 
         /* MD5 from name, id and key */
@@ -129,12 +133,11 @@ int OS_AddKey(keystore *keys, const char *id, const char *name, const char *ip, 
         snprintf(_finalstr, sizeof(_finalstr), "%s%s", filesum2, filesum1);
 
         /* Final key is 48 * 4 = 192bits */
-        os_strdup(_finalstr, keys->keyentries[keys->keysize]->key);
+        os_strdup(_finalstr, keys->keyentries[keys->keysize]->encryption_key);
 
         /* Clean final string from memory */
         memset_secure(_finalstr, '\0', sizeof(_finalstr));
-    } else
-        os_strdup(key, keys->keyentries[keys->keysize]->key);
+    }
 
     /* Ready for next */
     return keys->keysize++;
@@ -167,7 +170,7 @@ int OS_CheckKeys()
 }
 
 /* Read the authentication keys */
-void OS_ReadKeys(keystore *keys, int rehash_keys, int save_removed)
+void OS_ReadKeys(keystore *keys, key_mode_t key_mode, int save_removed)
 {
     FILE *fp;
 
@@ -213,7 +216,7 @@ void OS_ReadKeys(keystore *keys, int rehash_keys, int save_removed)
     os_calloc(1, sizeof(keyentry*), keys->keyentries);
     keys->keysize = 0;
     keys->id_counter = 0;
-    keys->flags.rehash_keys = rehash_keys;
+    keys->flags.key_mode = key_mode;
     keys->flags.save_removed = save_removed;
 
     /* Zero the buffers */
@@ -340,8 +343,12 @@ void OS_FreeKey(keyentry *key) {
         free(key->id);
     }
 
-    if (key->key) {
-        free(key->key);
+    if (key->raw_key) {
+        free(key->raw_key);
+    }
+
+    if (key->encryption_key) {
+        free(key->encryption_key);
     }
 
     if (key->name) {
@@ -429,7 +436,7 @@ void OS_UpdateKeys(keystore *keys)
     /* Read keys */
     mdebug2("OS_ReadKeys");
     minfo(ENC_READ);
-    OS_ReadKeys(keys, keys->flags.rehash_keys, keys->flags.save_removed);
+    OS_ReadKeys(keys, keys->flags.key_mode, keys->flags.save_removed);
 
     mdebug2("OS_StartCounter");
     OS_StartCounter(keys);
@@ -516,8 +523,12 @@ void OS_PassEmptyKeyfile() {
 
 /* Delete a key */
 int OS_DeleteKey(keystore *keys, const char *id, int purge) {
-    int i = OS_IsAllowedID(keys, id);
+    if (keys->flags.key_mode != W_RAW_KEY && keys->flags.key_mode != W_DUAL_KEY) {
+        merror("Wrong key store usage, it should have been initialized in RAW or DUAL mode");
+        return -1;
+    }
 
+    int i = OS_IsAllowedID(keys, id);
 
     if (i < 0)
         return -1;
@@ -527,7 +538,7 @@ int OS_DeleteKey(keystore *keys, const char *id, int purge) {
     if (keys->flags.save_removed && !purge) {
         char buffer[OS_BUFFER_SIZE + 1];
         keyentry *entry = keys->keyentries[i];
-        snprintf(buffer, OS_BUFFER_SIZE, "%s !%s %s %s", entry->id, entry->name, entry->ip->ip, entry->key);
+        snprintf(buffer, OS_BUFFER_SIZE, "%s !%s %s %s", entry->id, entry->name, entry->ip->ip, entry->raw_key);
         save_removed_key(keys, buffer);
     }
 
@@ -554,6 +565,11 @@ int OS_DeleteKey(keystore *keys, const char *id, int purge) {
 
 /* Write keystore on client keys file */
 int OS_WriteKeys(const keystore *keys) {
+    if (keys->flags.key_mode != W_RAW_KEY && keys->flags.key_mode != W_DUAL_KEY) {
+        merror("Wrong key store usage, it should have been initialized in RAW or DUAL mode");
+        return -1;
+    }
+
     unsigned int i;
     File file;
     char cidr[20];
@@ -561,9 +577,9 @@ int OS_WriteKeys(const keystore *keys) {
     if (TempFile(&file, KEYS_FILE, 0) < 0)
         return -1;
 
-    for (i = 0; i < keys->keysize; i++) {
+   for (i = 0; i < keys->keysize; i++) {
         keyentry *entry = keys->keyentries[i];
-        fprintf(file.fp, "%s %s %s %s\n", entry->id, entry->name, OS_CIDRtoStr(entry->ip, cidr, 20) ? entry->ip->ip : cidr, entry->key);
+        fprintf(file.fp, "%s %s %s %s\n", entry->id, entry->name, OS_CIDRtoStr(entry->ip, cidr, 20) ? entry->ip->ip : cidr, entry->raw_key);
     }
 
     /* Write saved removed keys */
@@ -625,8 +641,11 @@ keyentry * OS_DupKeyEntry(const keyentry * key) {
     if (key->id)
         copy->id = strdup(key->id);
 
-    if (key->key)
-        copy->key = strdup(key->key);
+    if (key->raw_key)
+        copy->raw_key = strdup(key->raw_key);
+
+    if (key->encryption_key)
+        copy->encryption_key = strdup(key->encryption_key);
 
     if (key->name)
         copy->name = strdup(key->name);
@@ -765,17 +784,16 @@ int OS_WriteTimestamps(keystore * keys) {
 }
 
 int w_get_key_hash(keyentry *key_entry, os_sha1 output) {
-    if (!key_entry || !output) {
+    if (!key_entry || !key_entry->raw_key || !output) {
         mdebug2("Unable to hash agent's key due to empty parameters.");
         return OS_INVALID;
     }
 
-    char *key = key_entry->key;
-    if (key) {
-        return OS_SHA1_Str(key, strlen(key), output);
-    }
-    else {
+    if (!key_entry->id || !key_entry->name || !key_entry->raw_key) {
         mdebug2("Unable to hash agent's key due to empty value.");
         return OS_INVALID;
     }
+
+    OS_SHA1_strings(output, key_entry->id, key_entry->name, key_entry->raw_key, NULL);
+    return OS_SUCCESS;
 }

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -771,7 +771,6 @@ int w_get_key_hash(keyentry *key_entry, os_sha1 output) {
     }
 
     char *key = key_entry->key;
-
     if (key) {
         return OS_SHA1_Str(key, strlen(key), output);
     }

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -763,7 +763,8 @@ int OS_WriteTimestamps(keystore * keys) {
 
     return r;
 }
-int w_auth_hash_key(keyentry *key_entry, os_sha1 output) {
+
+int w_get_key_hash(keyentry *key_entry, os_sha1 output) {
   if (!key_entry || !output) {
     mdebug2("Unable to hash agent's key due to empty parameters.");
     return OS_INVALID;

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -765,18 +765,18 @@ int OS_WriteTimestamps(keystore * keys) {
 }
 
 int w_get_key_hash(keyentry *key_entry, os_sha1 output) {
-  if (!key_entry || !output) {
-    mdebug2("Unable to hash agent's key due to empty parameters.");
-    return OS_INVALID;
-  }
+    if (!key_entry || !output) {
+        mdebug2("Unable to hash agent's key due to empty parameters.");
+        return OS_INVALID;
+    }
 
-  char *key = key_entry->key;
+    char *key = key_entry->key;
 
-  if (key) {
-    return OS_SHA1_Str(key, strlen(key), output);
-  }
-  else {
-    mdebug2("Unable to hash agent's key due to empty value.");
-    return OS_INVALID;
-  }
+    if (key) {
+        return OS_SHA1_Str(key, strlen(key), output);
+    }
+    else {
+        mdebug2("Unable to hash agent's key due to empty value.");
+        return OS_INVALID;
+    }
 }

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -784,7 +784,7 @@ int OS_WriteTimestamps(keystore * keys) {
 }
 
 int w_get_key_hash(keyentry *key_entry, os_sha1 output) {
-    if (!key_entry || !key_entry->raw_key || !output) {
+    if (!key_entry || !output) {
         mdebug2("Unable to hash agent's key due to empty parameters.");
         return OS_INVALID;
     }

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -763,3 +763,19 @@ int OS_WriteTimestamps(keystore * keys) {
 
     return r;
 }
+int w_auth_hash_key(keyentry *key_entry, os_sha1 output) {
+  if (!key_entry || !output) {
+    mdebug2("Unable to hash agent's key due to empty parameters.");
+    return OS_INVALID;
+  }
+
+  char *key = key_entry->key;
+
+  if (key) {
+    return OS_SHA1_Str(key, strlen(key), output);
+  }
+  else {
+    mdebug2("Unable to hash agent's key due to empty value.");
+    return OS_INVALID;
+  }
+}

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -435,23 +435,6 @@ STATIC void HandleSecureMessage(char *buffer, int recv_b, struct sockaddr_in *pe
 
             return;
         }
-    } else if (strncmp(buffer, "#ping", 5) == 0) {
-            int retval = 0;
-            char *msg = "#pong";
-            ssize_t msg_size = strlen(msg);
-
-            if (protocol == REMOTED_NET_PROTOCOL_UDP) {
-                retval = sendto(logr.udp_sock, msg, msg_size, 0, (struct sockaddr *)peer_info, logr.peer_size) == msg_size ? 0 : -1;
-            } else {
-                retval = OS_SendSecureTCP(sock_client, msg_size, msg);
-            }
-
-            if (retval < 0) {
-                mwarn("Ping operation could not be delivered completely (%d)", retval);
-            }
-
-            return;
-
     } else {
         key_lock_read();
         agentid = OS_IsAllowedIP(&keys, srcip);

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -435,6 +435,23 @@ STATIC void HandleSecureMessage(char *buffer, int recv_b, struct sockaddr_in *pe
 
             return;
         }
+    } else if (strncmp(buffer, "#ping", 5) == 0) {
+            int retval = 0;
+            char *msg = "#pong";
+            ssize_t msg_size = strlen(msg);
+
+            if (protocol == REMOTED_NET_PROTOCOL_UDP) {
+                retval = sendto(logr.udp_sock, msg, msg_size, 0, (struct sockaddr *)peer_info, logr.peer_size) == msg_size ? 0 : -1;
+            } else {
+                retval = OS_SendSecureTCP(sock_client, msg_size, msg);
+            }
+
+            if (retval < 0) {
+                mwarn("Ping operation could not be delivered completely (%d)", retval);
+            }
+
+            return;
+
     } else {
         key_lock_read();
         agentid = OS_IsAllowedIP(&keys, srcip);

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -147,7 +147,7 @@ void HandleSecure()
 
     /* Read authentication keys */
     minfo(ENC_READ);
-    OS_ReadKeys(&keys, 1, 0);
+    OS_ReadKeys(&keys, W_ENCRYPTION_KEY, 0);
     OS_StartCounter(&keys);
 
     // Key reloader thread

--- a/src/shared/agent_op.c
+++ b/src/shared/agent_op.c
@@ -324,11 +324,11 @@ int set_agent_group(const char * id, const char * group) {
     return 0;
 }
 
-int set_agent_multigroup(char * group){
+int set_agent_multigroup(char * group) {
     int oldmask;
     char *multigroup = strchr(group,MULTIGROUP_SEPARATOR);
 
-    if(!multigroup){
+    if (!multigroup) {
         return 0;
     }
 
@@ -352,7 +352,7 @@ int set_agent_multigroup(char * group){
     DIR *dp;
     dp = opendir(multigroup_path);
 
-    if(!dp){
+    if (!dp) {
         if (errno == ENOENT) {
             oldmask = umask(0002);
             int retval = mkdir(multigroup_path, 0770);
@@ -365,7 +365,7 @@ int set_agent_multigroup(char * group){
         } else {
             mwarn("Could not create directory '%s': %s (%d)", multigroup_path, strerror(errno), errno);
         }
-    }else{
+    } else {
         closedir(dp);
     }
 
@@ -378,7 +378,7 @@ int create_multigroup_dir(const char * multigroup) {
     DIR *dp;
     char *has_multigroup =  strchr(multigroup,MULTIGROUP_SEPARATOR);
 
-    if(!has_multigroup){
+    if (!has_multigroup) {
         return 0;
     }
     mdebug1("Attempting to create multigroup dir: '%s'",multigroup);
@@ -391,13 +391,13 @@ int create_multigroup_dir(const char * multigroup) {
     dp = opendir(path);
 
     /* Multigroup doesnt exists, create the directory */
-    if(!dp){
+    if (!dp) {
        if (mkdir(path, 0770) == -1) {
             merror("At create_multigroup_dir(): couldn't create directory '%s'", path);
             return -1;
         }
 
-        if(chmod(path,0770) < 0){
+        if (chmod(path,0770) < 0) {
             merror("At create_multigroup_dir(): Error in chmod setting permissions for path: %s",path);
         }
 
@@ -409,8 +409,7 @@ int create_multigroup_dir(const char * multigroup) {
             return -1;
         }
         mdebug1("Multigroup dir created: '%s'",multigroup);
-    }
-    else{
+    } else {
         closedir(dp);
     }
 
@@ -431,27 +430,27 @@ int w_validate_group_name(const char *group, char *response) {
     os_calloc(OS_SIZE_65536,sizeof(char),multi_group_cpy);
     snprintf(multi_group_cpy,OS_SIZE_65536,"%s",group);
 
-    if(strlen(group) == 0) {
+    if (strlen(group) == 0) {
         free(multi_group_cpy);
         mdebug1("At w_validate_group_name(): Group length is 0");
-        if(response) {
+        if (response) {
             snprintf(response, 2048, "ERROR: Invalid group name: Empty Group");
         }
         return -8;
     }
 
-    if(!multigroup && (strlen(group) > MAX_GROUP_NAME)){
+    if (!multigroup && (strlen(group) > MAX_GROUP_NAME)) {
         free(multi_group_cpy);
         mdebug1("At w_validate_group_name(): Group length is over %d characters",MAX_GROUP_NAME);
-        if(response) {
+        if (response) {
             snprintf(response, 2048, "ERROR: Invalid group name: %.255s... group is too large", group);
         }
         return -2;
     }
-    else if(multigroup && strlen(group) > OS_SIZE_65536 -1 ){
+    else if (multigroup && strlen(group) > OS_SIZE_65536 -1 ) {
         free(multi_group_cpy);
         mdebug1("At w_validate_group_name(): Multigroup length is over %d characters",OS_SIZE_65536);
-        if(response) {
+        if (response) {
             snprintf(response, 2048, "ERROR: Invalid group name: %.255s... multigroup is too large", group);
         }
         return -3;
@@ -459,19 +458,19 @@ int w_validate_group_name(const char *group, char *response) {
 
     /* Check if the group is only composed by ',' */
     unsigned int comas = 0;
-    for(i = 0; i < strlen(group); i++){
-        if(group[i] == MULTIGROUP_SEPARATOR){
+    for (i = 0; i < strlen(group); i++) {
+        if (group[i] == MULTIGROUP_SEPARATOR) {
             comas++;
         }
     }
 
-    if(!multigroup){
+    if (!multigroup) {
         offset = 1;
         valid_chars[valid_chars_length - offset] = '\0';
     }
 
     /* Check if the multigroups are empty or have consecutive ',' */
-    if(multigroup){
+    if (multigroup) {
 
         const char delim[2] = ",";
         char *individual_group = strtok_r(multi_group_cpy, delim, &save_ptr);
@@ -479,10 +478,9 @@ int w_validate_group_name(const char *group, char *response) {
         while( individual_group != NULL ) {
 
             /* Spaces are not allowed */
-            if(strchr(individual_group,' '))
-            {
+            if (strchr(individual_group,' ')) {
                 free(multi_group_cpy);
-                if(response) {
+                if (response) {
                     snprintf(response, 2048, "ERROR: Invalid group name: %.255s... white spaces are not allowed", group);
                 }
                 return -4;
@@ -491,7 +489,7 @@ int w_validate_group_name(const char *group, char *response) {
             /* Validate the individual group length */
             if (strlen(individual_group) > MAX_GROUP_NAME) {
                 free(multi_group_cpy);
-                if (response){
+                if (response) {
                     snprintf(response, 2048, "ERROR: Invalid group name: %.255s... group is too large", individual_group);
                 }
                 return -7;
@@ -501,9 +499,9 @@ int w_validate_group_name(const char *group, char *response) {
         }
 
         /* Look for consecutive ',' */
-        if(strstr(group,",,")){
+        if (strstr(group,",,")) {
             free(multi_group_cpy);
-            if(response) {
+            if (response) {
                 snprintf(response, 2048, "ERROR: Invalid group name: %.255s... consecutive ',' are not allowed", group);
             }
             return -5;
@@ -511,26 +509,26 @@ int w_validate_group_name(const char *group, char *response) {
     }
 
     /* Check if the group is only composed by ',' */
-    if(comas == strlen(group)){
+    if (comas == strlen(group)) {
         free(multi_group_cpy);
-        if(response) {
+        if (response) {
             snprintf(response, 2048, "ERROR: Invalid group name: %.255s... characters '\\/:*?\"<>|,' are prohibited", group);
         }
         return -1;
     }
 
     /* Check if the group starts or ends with ',' */
-    if(group[0] == ',' || group[strlen(group) - 1] == ',' ){
+    if (group[0] == ',' || group[strlen(group) - 1] == ',' ) {
         free(multi_group_cpy);
-        if(response) {
+        if (response) {
             snprintf(response, 2048, "ERROR: Invalid group name: %.255s... cannot start or end with ','", group);
         }
         return -6;
     }
 
-    if(strspn(group,valid_chars) != strlen(group)){
+    if (strspn(group,valid_chars) != strlen(group)) {
         free(multi_group_cpy);
-        if(response) {
+        if (response) {
             snprintf(response, 2048, "ERROR: Invalid group name: %.255s... characters '\\/:*?\"<>|,' are prohibited", group);
         }
         return -1;
@@ -541,14 +539,14 @@ int w_validate_group_name(const char *group, char *response) {
 }
 
 #ifndef CLIENT
-void w_remove_multigroup(const char *group){
+void w_remove_multigroup(const char *group) {
     char *multigroup = strchr(group,MULTIGROUP_SEPARATOR);
     char path[PATH_MAX + 1] = {0};
 
-    if(multigroup){
+    if (multigroup) {
         sprintf(path, "%s", GROUPS_DIR);
 
-        if(wstr_find_in_folder(path,group,1) < 0){
+        if (wstr_find_in_folder(path,group,1) < 0) {
             /* Remove the DIR */
             os_sha256 multi_group_hash;
             OS_SHA256_String(group,multi_group_hash);
@@ -598,19 +596,19 @@ static cJSON* w_create_agent_add_payload(const char *name,
     cJSON_AddStringToObject(arguments, "name", name);
     cJSON_AddStringToObject(arguments, "ip", ip);
 
-    if(groups) {
+    if (groups) {
         cJSON_AddStringToObject(arguments, "groups", groups);
     }
 
-    if(key_hash) {
+    if (key_hash) {
         cJSON_AddStringToObject(arguments, "key_hash", key_hash);
     }
 
-    if(key) {
+    if (key) {
         cJSON_AddStringToObject(arguments, "key", key);
     }
 
-    if(id) {
+    if (id) {
         cJSON_AddStringToObject(arguments, "id", id);
     }
 
@@ -633,15 +631,14 @@ static int w_parse_agent_add_response(const char* buffer, char *err_response, ch
     // Parse response
     const char *jsonErrPtr;
     if (response = cJSON_ParseWithOpts(buffer, &jsonErrPtr, 0), !response) {
-        if(exit_on_error){
+        if (exit_on_error) {
             merror_exit("Parsing JSON response.");
         }
         result = -2;
-    }
-    else {
+    } else {
         // Get error field
         if (error = cJSON_GetObjectItem(response, "error"), !error) {
-            if(exit_on_error){
+            if (exit_on_error) {
                 merror_exit("No such status from response.");
             }
             result = -2;
@@ -662,7 +659,7 @@ static int w_parse_agent_add_response(const char* buffer, char *err_response, ch
             else {
                 // Get data field
                 if (data = cJSON_GetObjectItem(response, "data"), !data) {
-                    if(exit_on_error){
+                    if (exit_on_error) {
                         merror_exit("No data received.");
                     }
                     result = -2;
@@ -671,7 +668,7 @@ static int w_parse_agent_add_response(const char* buffer, char *err_response, ch
                     // Get data information if required
                     if (id) {
                         if (data_id = cJSON_GetObjectItem(data, "id"), !data_id) {
-                            if(exit_on_error){
+                            if (exit_on_error) {
                                 merror_exit("No id received.");
                             }
                             result = -2;
@@ -683,7 +680,7 @@ static int w_parse_agent_add_response(const char* buffer, char *err_response, ch
                     }
                     if (key && result == 0) {
                         if (data_key = cJSON_GetObjectItem(data, "key"), !data_key) {
-                            if(exit_on_error){
+                            if (exit_on_error) {
                                 merror_exit("No key received.");
                             }
                             result = -2;
@@ -699,8 +696,8 @@ static int w_parse_agent_add_response(const char* buffer, char *err_response, ch
     }
 
     // Create an error response if needed
-    if(err_response) {
-        if(result == -1) {
+    if (err_response) {
+        if (result == -1) {
             snprintf(err_response, 2048, "ERROR: %s", message ? message->valuestring : "(undefined)");
         }
         else if (result == -2) {
@@ -746,7 +743,7 @@ static int w_parse_agent_remove_response(const char* buffer, char *err_response,
     // Parse response
     const char *jsonErrPtr;
     if (response = cJSON_ParseWithOpts(buffer, &jsonErrPtr, 0), !response) {
-        if(exit_on_error){
+        if (exit_on_error) {
             merror_exit("Parsing JSON response.");
         }
         result = -2;
@@ -755,7 +752,7 @@ static int w_parse_agent_remove_response(const char* buffer, char *err_response,
 
     // Detect error field
     if (error = cJSON_GetObjectItem(response, "error"), !error) {
-        if(exit_on_error){
+        if (exit_on_error) {
             merror_exit("No such status from response.");
         }
         result = -2;
@@ -772,8 +769,8 @@ static int w_parse_agent_remove_response(const char* buffer, char *err_response,
     }
 
     // Create an error response if needed
-    if(err_response) {
-        if(result == -1) {
+    if (err_response) {
+        if (result == -1) {
             snprintf(err_response, 2048, "ERROR: %s", message ? message->valuestring : "(undefined)");
         }
         else if (result == -2) {
@@ -796,7 +793,7 @@ int w_send_clustered_message(const char* command, const char* payload, char* res
 
     if (sock = OS_ConnectUnixDomain(sockname, SOCK_STREAM, OS_MAXSTR), sock >= 0) {
         if (OS_SendSecureTCPCluster(sock, command, payload, strlen(payload)) >= 0) {
-            if(response_length = OS_RecvSecureClusterTCP(sock, response, OS_MAXSTR), response_length <= 0) {
+            if (response_length = OS_RecvSecureClusterTCP(sock, response, OS_MAXSTR), response_length <= 0) {
                 switch (response_length) {
                 case -2:
                     merror("Cluster error detected");
@@ -851,15 +848,15 @@ int w_request_agent_add_clustered(char *err_response,
     char* output = cJSON_PrintUnformatted(payload);
     cJSON_Delete(payload);
 
-    if(result = w_send_clustered_message("sendsync", output, response), result == 0) {
+    if (result = w_send_clustered_message("sendsync", output, response), result == 0) {
         result = w_parse_agent_add_response(response, err_response, new_id, new_key, FALSE, FALSE);
     }
-    else if(err_response) {
+    else if (err_response) {
         snprintf(err_response, 2048, "ERROR: Cannot comunicate with master");
     }
 
     free(output);
-    if(0 == result) {
+    if (0 == result) {
         os_strdup(new_id, *id);
         os_strdup(new_key, *key);
     }
@@ -869,7 +866,7 @@ int w_request_agent_add_clustered(char *err_response,
 }
 
 //Send a clustered agent remove request.
-int w_request_agent_remove_clustered(char *err_response, const char* agent_id, int purge){
+int w_request_agent_remove_clustered(char *err_response, const char* agent_id, int purge) {
     int result;
     char response[OS_MAXSTR + 1];
 
@@ -878,10 +875,10 @@ int w_request_agent_remove_clustered(char *err_response, const char* agent_id, i
     char* output = cJSON_PrintUnformatted(payload);
     cJSON_Delete(payload);
 
-    if(result = w_send_clustered_message("sendsync", output, response), result == 0) {
+    if (result = w_send_clustered_message("sendsync", output, response), result == 0) {
         result = w_parse_agent_remove_response(response, err_response, FALSE, FALSE);
     }
-    else if(err_response) {
+    else if (err_response) {
         snprintf(err_response, 2048, "ERROR: Cannot comunicate with master");
     }
 
@@ -892,7 +889,7 @@ int w_request_agent_remove_clustered(char *err_response, const char* agent_id, i
 #endif //!WIN32
 
 //Send a local agent add request.
-int w_request_agent_add_local(int sock, char *id, const char *name, const char *ip, const char *groups, const char *key, const int force, const int json_format, const char *agent_id, int exit_on_error){
+int w_request_agent_add_local(int sock, char *id, const char *name, const char *ip, const char *groups, const char *key, const int force, const int json_format, const char *agent_id, int exit_on_error) {
     int result;
 
     cJSON* payload = w_create_agent_add_payload(name, ip, groups, NULL, key, agent_id, force);
@@ -900,7 +897,7 @@ int w_request_agent_add_local(int sock, char *id, const char *name, const char *
     cJSON_Delete(payload);
 
     if (OS_SendSecureTCP(sock, strlen(output), output) < 0) {
-        if(exit_on_error){
+        if (exit_on_error) {
             merror_exit("OS_SendSecureTCP(): %s", strerror(errno));
         }
         free(output);
@@ -912,13 +909,13 @@ int w_request_agent_add_local(int sock, char *id, const char *name, const char *
     char response[OS_MAXSTR + 1];
     ssize_t length;
     if (length = OS_RecvSecureTCP(sock, response, OS_MAXSTR), length < 0) {
-        if(exit_on_error){
+        if (exit_on_error) {
             merror_exit("OS_RecvSecureTCP(): %s", strerror(errno));
         }
         result = -1;
         return result;
     } else if (length == 0) {
-        if(exit_on_error){
+        if (exit_on_error) {
             merror_exit("Empty message from local server.");
         }
         result = -1;
@@ -945,7 +942,7 @@ char * get_agent_id_from_name(const char *agent_name) {
 
     fp = fopen(path, "r");
 
-    if(!fp) {
+    if (!fp) {
         mdebug1("Couldnt open file '%s'", KEYS_FILE);
         os_free(path);
         os_free(buffer);
@@ -960,7 +957,7 @@ char * get_agent_id_from_name(const char *agent_name) {
 
         parts = OS_StrBreak(' ',buffer,4);
 
-        if(!parts) {
+        if (!parts) {
             continue;
         }
 
@@ -971,7 +968,7 @@ char * get_agent_id_from_name(const char *agent_name) {
             count++;
         }
 
-        if(count < 3) {
+        if (count < 3) {
             free_strarray(parts);
             os_free(buffer);
             fclose(fp);
@@ -979,7 +976,7 @@ char * get_agent_id_from_name(const char *agent_name) {
         }
 
         // If the agent name is the same, return its ID
-        if(strcmp(parts[1],agent_name) == 0){
+        if (strcmp(parts[1],agent_name) == 0) {
             char *id = strdup(parts[0]);
             fclose(fp);
             free_strarray(parts);

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -486,10 +486,10 @@ static void w_enrollment_verify_ca_certificate(const SSL *ssl, const char *ca_ce
 }
 
 /**
- * @brief Concats the current key of the agent, if exist, as  part of the enrollment message
+ * @brief Concatenates the current key of the agent, if exists, as  part of the enrollment message
  *
  * @param buff buffer where the KEY section will be concatenated
- * @param key key will be added
+ * @param key_entry The key that will be concatenated
  */
 static void w_enrollment_concat_key(char *buff, keyentry* key_entry) {
     assert(buff != NULL);
@@ -497,10 +497,10 @@ static void w_enrollment_concat_key(char *buff, keyentry* key_entry) {
 
     os_sha1 output;
     char* opt_buf = NULL;
-    os_calloc(OS_SIZE_65536, sizeof(char), opt_buf);
+    os_calloc(OS_SIZE_512, sizeof(char), opt_buf);
     w_get_key_hash(key_entry, output);
-    snprintf(opt_buf, OS_SIZE_65536, " K:'%s'", output);
-    strncat(buff,opt_buf,OS_SIZE_65536);
+    snprintf(opt_buf, OS_SIZE_512, " K:'%s'", output);
+    strncat(buff,opt_buf,OS_SIZE_512);
     free(opt_buf);
 }
 

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -102,9 +102,9 @@ w_enrollment_ctx * w_enrollment_init(w_enrollment_target *target, w_enrollment_c
     os_malloc(sizeof(w_enrollment_ctx), cfg);
     cfg->target_cfg = target;
     cfg->cert_cfg = cert;
-    cfg->enabled = 1;
+    cfg->enabled = true;
     cfg->ssl = NULL;
-    cfg->allow_localhost = 1;
+    cfg->allow_localhost = true;
     cfg->delay_after_enrollment = 20;
     cfg->keys = keys;
     return cfg;
@@ -139,7 +139,7 @@ int w_enrollment_request_key(w_enrollment_ctx *cfg, const char * server_address)
  * be obtained by obtaining hostname
  *
  * @param cfg configuration structure
- * @param allow_localhost 1 will allow localhost as name, 0 will throw an merror_exit
+ * @param allow_localhost true will allow localhost as name, false will throw an merror_exit
  * @return agent_name on succes
  *         NULL on errors
  * */

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -403,6 +403,7 @@ static int w_enrollment_store_key_entry(const char* keys) {
         merror(CHMOD_ERROR, file.name, errno, strerror(errno));
         fclose(file.fp);
         unlink(file.name);
+        os_free(file.name);
         return -1;
     }
 
@@ -410,10 +411,10 @@ static int w_enrollment_store_key_entry(const char* keys) {
     fclose(file.fp);
 
     if (OS_MoveFile(file.name, KEYS_FILE) < 0) {
-        free(file.name);
+        os_free(file.name);
         return -1;
     }
-    free(file.name);
+    os_free(file.name);
 
 #endif /* !WIN32 */
 

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -491,6 +491,8 @@ static void w_enrollment_verify_ca_certificate(const SSL *ssl, const char *ca_ce
  *
  * @param buff buffer where the KEY section will be concatenated
  * @param key_entry The key that will be concatenated
+ *
+ * @pre buff must be 69633 bytes long
  */
 static void w_enrollment_concat_key(char *buff, keyentry* key_entry) {
     assert(buff != NULL);
@@ -501,7 +503,9 @@ static void w_enrollment_concat_key(char *buff, keyentry* key_entry) {
     os_calloc(OS_SIZE_512, sizeof(char), opt_buf);
     w_get_key_hash(key_entry, output);
     snprintf(opt_buf, OS_SIZE_512, " K:'%s'", output);
-    strncat(buff,opt_buf,OS_SIZE_512);
+    if (strlen(buff) < (OS_SIZE_65536 + OS_SIZE_4096)) {
+        strncat(buff, opt_buf, OS_SIZE_65536 + OS_SIZE_4096 - strlen(buff));
+    }
     free(opt_buf);
 }
 

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -277,18 +277,18 @@ static int w_enrollment_send_message(w_enrollment_ctx *cfg) {
         snprintf(buf, 2048, "OSSEC A:'%s'", lhostname);
     }
 
-    if(cfg->target_cfg->centralized_group){
+    if (cfg->target_cfg->centralized_group) {
         w_enrollment_concat_group(buf, cfg->target_cfg->centralized_group);
     }
 
-    if(w_enrollment_concat_src_ip(buf, cfg->target_cfg->sender_ip, cfg->target_cfg->use_src_ip)) {
+    if (w_enrollment_concat_src_ip(buf, cfg->target_cfg->sender_ip, cfg->target_cfg->use_src_ip)) {
         os_free(buf);
         if(lhostname != cfg->target_cfg->agent_name)
             os_free(lhostname);
         return -1;
     }
 
-    if (cfg->keys->keysize > 0){
+    if (cfg->keys->keysize > 0) {
         w_enrollment_concat_key(buf, cfg->keys->keyentries[0]);
     }
 
@@ -307,7 +307,7 @@ static int w_enrollment_send_message(w_enrollment_ctx *cfg) {
     mdebug1("Request sent to manager");
 
     os_free(buf);
-    if(lhostname != cfg->target_cfg->agent_name)
+    if (lhostname != cfg->target_cfg->agent_name)
         os_free(lhostname);
     return 0;
 }

--- a/src/unit_tests/client-agent/test_start_agent.c
+++ b/src/unit_tests/client-agent/test_start_agent.c
@@ -115,7 +115,7 @@ void keys_init(keystore *keys) {
     os_calloc(1, sizeof(keyentry*), keys->keyentries);
     keys->keysize = 0;
     keys->id_counter = 0;
-    keys->flags.rehash_keys = 0;
+    keys->flags.key_mode = W_RAW_KEY;
     keys->flags.save_removed = 0;
 
     /* Add additional entry for sender == keysize */

--- a/src/unit_tests/os_auth/test_auth_add.c
+++ b/src/unit_tests/os_auth/test_auth_add.c
@@ -21,7 +21,7 @@
 
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 
-void keys_init(keystore *keys, int rehash_keys, int save_removed) {
+void keys_init(keystore *keys, key_mode_t key_mode, int save_removed) {
     /* Initialize hashes */
     keys->keyhash_id = OSHash_Create();
     keys->keyhash_ip = OSHash_Create();
@@ -35,7 +35,7 @@ void keys_init(keystore *keys, int rehash_keys, int save_removed) {
     os_calloc(1, sizeof(keyentry*), keys->keyentries);
     keys->keysize = 0;
     keys->id_counter = 0;
-    keys->flags.rehash_keys = rehash_keys;
+    keys->flags.key_mode = key_mode;
     keys->flags.save_removed = save_removed;
 
     /* Add additional entry for sender == keysize */

--- a/src/unit_tests/os_auth/test_auth_parse.c
+++ b/src/unit_tests/os_auth/test_auth_parse.c
@@ -58,7 +58,6 @@ typedef struct _enrollment_response {
     char* response;
 } enrollment_response;
 
-
 //parser arguments
 typedef struct _parse_evaluator {
     char* buffer;
@@ -69,7 +68,7 @@ typedef struct _parse_evaluator {
     mocked_log expected_log;
 } parse_evaluator;
 
-parse_evaluator parse_values_default_cfg []={
+parse_evaluator parse_values_default_cfg [] = {
     { "OSSEC A:'agent1'", "192.0.0.1", NULL,                                                      {"192.0.0.1", "agent1", NULL, NULL},                          {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent1) from: 192.0.0.1", NULL} },
     { "OSSEC A:'agent2' G:'Group1'", "192.0.0.1", NULL,                                           {"192.0.0.1", "agent2", "Group1", NULL},                      {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent2) from: 192.0.0.1", "Group(s) is: Group1"} },
     { "OSSEC A:'agent3' G:'Group1,Group2'", "192.0.0.1", NULL,                                    {"192.0.0.1", "agent3", "Group1,Group2", NULL},               {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent3) from: 192.0.0.1", "Group(s) is: Group1,Group2"} },
@@ -90,7 +89,7 @@ parse_evaluator parse_values_default_cfg []={
     {0}
 };
 
-parse_evaluator parse_values_without_use_src_ip_cfg []={
+parse_evaluator parse_values_without_use_src_ip_cfg [] = {
     {"OSSEC A:'agent1'", "192.0.0.1", NULL,                             {"any", "agent1", NULL, NULL},                    {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent1) from: 192.0.0.1", NULL} },
     {"OSSEC A:'agent2' IP:'192.0.0.2'", "192.0.0.1", NULL,              {"192.0.0.2", "agent2", NULL, NULL},              {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent2) from: 192.0.0.1", NULL} },
 

--- a/src/unit_tests/os_auth/test_auth_parse.c
+++ b/src/unit_tests/os_auth/test_auth_parse.c
@@ -25,7 +25,7 @@ typedef struct _mocked_log {
     char* merror;
     char* mwarn;
     char* minfo;
-    char* mdebug;    
+    char* mdebug;
 } mocked_log;
 
 //Sets all the expected log messages
@@ -81,7 +81,7 @@ parse_evaluator parse_values_default_cfg []={
     { "OSSEC PASS: pass124 OSSEC A:'agent0'", "192.0.0.1", NULL,        {NULL, NULL, NULL}, {OS_INVALID,"ERROR: Invalid request for new agent"}, {"Invalid request for new agent from: 192.0.0.1", NULL, NULL, NULL} },
     { "OSSEC A:''", "192.0.0.1", NULL,                                  {NULL, NULL, NULL}, {OS_INVALID,"ERROR: Invalid agent name: "},          {"Invalid agent name:  from 192.0.0.1", NULL, "Received request for a new agent () from: 192.0.0.1", NULL} },
     { "OSSEC A:'inv;agent'", "192.0.0.1", NULL,                         {NULL, NULL, NULL}, {OS_INVALID,"ERROR: Invalid agent name: inv;agent"}, {"Invalid agent name: inv;agent from 192.0.0.1", NULL, "Received request for a new agent (inv;agent) from: 192.0.0.1", NULL} },
-    
+
     {0}
 };
 
@@ -108,26 +108,32 @@ int setup_parse_use_src_ip_cfg_0(void **state) {
 }
 
 /* tests */
-extern w_err_t w_auth_parse_data(const char* buf, char *response, const char *authpass, char *ip, char **agentname, char **groups);
+extern w_err_t w_auth_parse_data(const char* buf,
+                                 char *response,
+                                 const char *authpass,
+                                 char *ip,
+                                 char **agentname,
+                                 char **groups,
+                                 char **key_hash);
 
-static void test_w_auth_parse_data(void **state) {    
-
+static void test_w_auth_parse_data(void **state) {
     char response[2048] = {0};
     char ip[IPSIZE + 1];
     char *agentname = NULL;
-    char *groups = NULL;    
+    char *groups = NULL;
+    char *key_hash = NULL;
     w_err_t err;
-    
+
     for(unsigned i=0; parse_values[i].buffer; i++) {
         set_expected_log(&parse_values[i].expected_log);
         response[0] = '\0';
-        strncpy(ip, parse_values[i].src_ip, IPSIZE);   
+        strncpy(ip, parse_values[i].src_ip, IPSIZE);
 
-        err = w_auth_parse_data(parse_values[i].buffer, response, parse_values[i].pass, ip, &agentname, &groups);
-        
+        err = w_auth_parse_data(parse_values[i].buffer, response, parse_values[i].pass, ip, &agentname, &groups, &key_hash);
+
         assert_int_equal(err, parse_values[i].expected_response.err);
         if(err == OS_SUCCESS) {
-            assert_string_equal(ip, parse_values[i].expected_params.ip);            
+            assert_string_equal(ip, parse_values[i].expected_params.ip);
             assert_string_equal(agentname, parse_values[i].expected_params.name);
             if(groups){
                 assert_string_equal(groups, parse_values[i].expected_params.groups);
@@ -139,18 +145,18 @@ static void test_w_auth_parse_data(void **state) {
         else {
             assert_string_equal(response, parse_values[i].expected_response.response);
         }
-        
+
         os_free(agentname);
         os_free(groups);
-
-    }    
+        os_free(key_hash);
+    }
 }
 
-int main(void) {     
+int main(void) {
     const struct CMUnitTest tests[] = {
         /* w_auth_parse_data tests*/
         cmocka_unit_test_setup(test_w_auth_parse_data, setup_parse_default),
-        cmocka_unit_test_setup(test_w_auth_parse_data, setup_parse_use_src_ip_cfg_0),        
+        cmocka_unit_test_setup(test_w_auth_parse_data, setup_parse_use_src_ip_cfg_0),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/os_auth/test_auth_parse.c
+++ b/src/unit_tests/os_auth/test_auth_parse.c
@@ -49,6 +49,7 @@ typedef struct _enrollment_param {
     char* ip;
     char* name;
     char* groups;
+    char* key;
 } enrollment_param;
 
 //Error responses
@@ -69,25 +70,29 @@ typedef struct _parse_evaluator {
 } parse_evaluator;
 
 parse_evaluator parse_values_default_cfg []={
-    { "OSSEC A:'agent1'", "192.0.0.1", NULL,                            {"192.0.0.1", "agent1", NULL},              {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent1) from: 192.0.0.1", NULL} },
-    { "OSSEC A:'agent2' G:'Group1'", "192.0.0.1", NULL,                 {"192.0.0.1", "agent2", "Group1"},          {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent2) from: 192.0.0.1", "Group(s) is: Group1"} },
-    { "OSSEC A:'agent3' G:'Group1,Group2'", "192.0.0.1", NULL,          {"192.0.0.1", "agent3", "Group1,Group2"},   {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent3) from: 192.0.0.1", "Group(s) is: Group1,Group2"} },
-    { "OSSEC A:'agent4' G:'Group1,Group2,Group1'", "192.0.0.1", NULL,   {"192.0.0.1", "agent4", "Group1,Group2"},   {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent4) from: 192.0.0.1", "Group(s) is: Group1,Group2"} },
-    { "OSSEC PASS: pass123 OSSEC A:'agent5'", "192.0.0.1", "pass123",   {"192.0.0.1", "agent5", NULL},              {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent5) from: 192.0.0.1", NULL} },
-    { "OSSEC A:'agent6' IP:'192.0.0.2'", "192.0.0.1", NULL,             {"192.0.0.2", "agent6", NULL},              {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent6) from: 192.0.0.1", NULL} },
+    { "OSSEC A:'agent1'", "192.0.0.1", NULL,                                                      {"192.0.0.1", "agent1", NULL, NULL},                          {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent1) from: 192.0.0.1", NULL} },
+    { "OSSEC A:'agent2' G:'Group1'", "192.0.0.1", NULL,                                           {"192.0.0.1", "agent2", "Group1", NULL},                      {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent2) from: 192.0.0.1", "Group(s) is: Group1"} },
+    { "OSSEC A:'agent3' G:'Group1,Group2'", "192.0.0.1", NULL,                                    {"192.0.0.1", "agent3", "Group1,Group2", NULL},               {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent3) from: 192.0.0.1", "Group(s) is: Group1,Group2"} },
+    { "OSSEC A:'agent4' G:'Group1,Group2,Group1'", "192.0.0.1", NULL,                             {"192.0.0.1", "agent4", "Group1,Group2", NULL},               {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent4) from: 192.0.0.1", "Group(s) is: Group1,Group2"} },
+    { "OSSEC PASS: pass123 OSSEC A:'agent5'", "192.0.0.1", "pass123",                             {"192.0.0.1", "agent5", NULL, NULL},                          {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent5) from: 192.0.0.1", NULL} },
+    { "OSSEC A:'agent6' IP:'192.0.0.2'", "192.0.0.1", NULL,                                       {"192.0.0.2", "agent6", NULL, NULL},                          {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent6) from: 192.0.0.1", NULL} },
+    { "OSSEC A:'agent7' K:'1234'", "192.0.0.1", NULL,                                             {"192.0.0.1", "agent7", NULL, "1234"},                        {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent7) from: 192.0.0.1", NULL} },
+    { "OSSEC A:'agent8' IP:'192.0.0.3' K:'ABC123'", "192.0.0.1", NULL,                            {"192.0.0.3", "agent8", NULL, "ABC123"},                      {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent8) from: 192.0.0.1", NULL} },
+    { "OSSEC PASS: pass123 OSSEC A:'agent9' IP:'192.0.0.3' K:'ABC123'", "192.0.0.1", "pass123",   {"192.0.0.3", "agent9", NULL, "ABC123"},                      {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent9) from: 192.0.0.1", NULL} },
+    { "OSSEC A:'agent10' G:'Group1,Group2' IP:'192.0.0.3' K:'ABC123'", "192.0.0.1", NULL,         {"192.0.0.3", "agent10", "Group1,Group2", "ABC123"},          {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent10) from: 192.0.0.1", "Group(s) is: Group1,Group2"} },
 
-    { "OSSEC A:'agent0'", "192.0.0.1", "pass123",                       {NULL, NULL, NULL}, {OS_INVALID,"ERROR: Invalid password"},              {"Invalid password provided by 192.0.0.1. Closing connection.", NULL, NULL, NULL} },
-    { "OSSEC PASS: pass124 OSSEC A:'agent0'", "192.0.0.1", "pass123",   {NULL, NULL, NULL}, {OS_INVALID,"ERROR: Invalid password"},              {"Invalid password provided by 192.0.0.1. Closing connection.", NULL, NULL, NULL} },
-    { "OSSEC PASS: pass124 OSSEC A:'agent0'", "192.0.0.1", NULL,        {NULL, NULL, NULL}, {OS_INVALID,"ERROR: Invalid request for new agent"}, {"Invalid request for new agent from: 192.0.0.1", NULL, NULL, NULL} },
-    { "OSSEC A:''", "192.0.0.1", NULL,                                  {NULL, NULL, NULL}, {OS_INVALID,"ERROR: Invalid agent name: "},          {"Invalid agent name:  from 192.0.0.1", NULL, "Received request for a new agent () from: 192.0.0.1", NULL} },
-    { "OSSEC A:'inv;agent'", "192.0.0.1", NULL,                         {NULL, NULL, NULL}, {OS_INVALID,"ERROR: Invalid agent name: inv;agent"}, {"Invalid agent name: inv;agent from 192.0.0.1", NULL, "Received request for a new agent (inv;agent) from: 192.0.0.1", NULL} },
+    { "OSSEC A:'agent0'", "192.0.0.1", "pass123",                       {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Invalid password"},              {"Invalid password provided by 192.0.0.1. Closing connection.", NULL, NULL, NULL} },
+    { "OSSEC PASS: pass124 OSSEC A:'agent0'", "192.0.0.1", "pass123",   {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Invalid password"},              {"Invalid password provided by 192.0.0.1. Closing connection.", NULL, NULL, NULL} },
+    { "OSSEC PASS: pass124 OSSEC A:'agent0'", "192.0.0.1", NULL,        {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Invalid request for new agent"}, {"Invalid request for new agent from: 192.0.0.1", NULL, NULL, NULL} },
+    { "OSSEC A:''", "192.0.0.1", NULL,                                  {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Invalid agent name: "},          {"Invalid agent name:  from 192.0.0.1", NULL, "Received request for a new agent () from: 192.0.0.1", NULL} },
+    { "OSSEC A:'inv;agent'", "192.0.0.1", NULL,                         {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Invalid agent name: inv;agent"}, {"Invalid agent name: inv;agent from 192.0.0.1", NULL, "Received request for a new agent (inv;agent) from: 192.0.0.1", NULL} },
 
     {0}
 };
 
 parse_evaluator parse_values_without_use_src_ip_cfg []={
-    {"OSSEC A:'agent1'", "192.0.0.1", NULL,                             {"any", "agent1", NULL},                    {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent1) from: 192.0.0.1", NULL} },
-    {"OSSEC A:'agent2' IP:'192.0.0.2'", "192.0.0.1", NULL,              {"192.0.0.2", "agent2", NULL},              {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent2) from: 192.0.0.1", NULL} },
+    {"OSSEC A:'agent1'", "192.0.0.1", NULL,                             {"any", "agent1", NULL, NULL},                    {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent1) from: 192.0.0.1", NULL} },
+    {"OSSEC A:'agent2' IP:'192.0.0.2'", "192.0.0.1", NULL,              {"192.0.0.2", "agent2", NULL, NULL},              {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent2) from: 192.0.0.1", NULL} },
 
     {0}
 };
@@ -140,6 +145,12 @@ static void test_w_auth_parse_data(void **state) {
             }
             else{
                 assert_null(parse_values[i].expected_params.groups);
+            }
+            if(key_hash){
+                assert_string_equal(key_hash, parse_values[i].expected_params.key);
+            }
+            else{
+                assert_null(parse_values[i].expected_params.key);
             }
         }
         else {

--- a/src/unit_tests/os_auth/test_auth_parse.c
+++ b/src/unit_tests/os_auth/test_auth_parse.c
@@ -30,16 +30,16 @@ typedef struct _mocked_log {
 
 //Sets all the expected log messages
 void set_expected_log (mocked_log* log) {
-    if(log->merror) {
+    if (log->merror) {
             expect_string(__wrap__merror, formatted_msg, log->merror);
     }
-    if(log->mwarn) {
+    if (log->mwarn) {
             expect_string(__wrap__mwarn, formatted_msg, log->mwarn);
     }
-    if(log->minfo) {
+    if (log->minfo) {
             expect_string(__wrap__minfo, formatted_msg, log->minfo);
     }
-    if(log->mdebug) {
+    if (log->mdebug) {
             expect_string(__wrap__mdebug1, formatted_msg, log->mdebug);
     }
 }
@@ -128,7 +128,7 @@ static void test_w_auth_parse_data(void **state) {
     char *key_hash = NULL;
     w_err_t err;
 
-    for(unsigned i=0; parse_values[i].buffer; i++) {
+    for (unsigned i=0; parse_values[i].buffer; i++) {
         set_expected_log(&parse_values[i].expected_log);
         response[0] = '\0';
         strncpy(ip, parse_values[i].src_ip, IPSIZE);
@@ -136,23 +136,20 @@ static void test_w_auth_parse_data(void **state) {
         err = w_auth_parse_data(parse_values[i].buffer, response, parse_values[i].pass, ip, &agentname, &groups, &key_hash);
 
         assert_int_equal(err, parse_values[i].expected_response.err);
-        if(err == OS_SUCCESS) {
+        if (err == OS_SUCCESS) {
             assert_string_equal(ip, parse_values[i].expected_params.ip);
             assert_string_equal(agentname, parse_values[i].expected_params.name);
-            if(groups){
+            if (groups) {
                 assert_string_equal(groups, parse_values[i].expected_params.groups);
-            }
-            else{
+            } else {
                 assert_null(parse_values[i].expected_params.groups);
             }
-            if(key_hash){
+            if (key_hash) {
                 assert_string_equal(key_hash, parse_values[i].expected_params.key);
-            }
-            else{
+            } else {
                 assert_null(parse_values[i].expected_params.key);
             }
-        }
-        else {
+        } else {
             assert_string_equal(response, parse_values[i].expected_response.response);
         }
 

--- a/src/unit_tests/os_auth/test_auth_validate.c
+++ b/src/unit_tests/os_auth/test_auth_validate.c
@@ -37,7 +37,7 @@
 #define EXISTENT_GROUP2 "ExistentGroup2"
 #define UNKNOWN_GROUP   "UnknownGroup"
 
-void keys_init(keystore *keys, int rehash_keys, int save_removed) {
+void keys_init(keystore *keys, key_mode_t key_mode, int save_removed) {
     /* Initialize hashes */
     keys->keyhash_id = OSHash_Create();
     keys->keyhash_ip = OSHash_Create();
@@ -51,7 +51,7 @@ void keys_init(keystore *keys, int rehash_keys, int save_removed) {
     os_calloc(1, sizeof(keyentry*), keys->keyentries);
     keys->keysize = 0;
     keys->id_counter = 0;
-    keys->flags.rehash_keys = rehash_keys;
+    keys->flags.key_mode = key_mode;
     keys->flags.save_removed = save_removed;
 
     /* Add additional entry for sender == keysize */

--- a/src/unit_tests/os_auth/test_auth_validate.c
+++ b/src/unit_tests/os_auth/test_auth_validate.c
@@ -112,7 +112,7 @@ int setup_validate_force_insert_1(void **state) {
     config.force_options.enabled = 1;
     return 0;
 }
-#if 0
+
 /* tests */
 static void test_w_auth_validate_data(void **state) {
     char response[2048] = {0};
@@ -120,27 +120,29 @@ static void test_w_auth_validate_data(void **state) {
 
     /* New agent / IP*/
     response[0] = '\0';
-    err = w_auth_validate_data(response,NEW_IP1, NEW_AGENT1, NULL, NULL);
+    err = w_auth_validate_data(response, NEW_IP1, NEW_AGENT1, NULL, NULL);
     assert_int_equal(err, OS_SUCCESS);
     assert_string_equal(response, "");
 
     /* any IP*/
     response[0] = '\0';
-    err = w_auth_validate_data(response,ANY_IP, NEW_AGENT1, NULL, NULL);
+    err = w_auth_validate_data(response, ANY_IP, NEW_AGENT1, NULL, NULL);
     assert_int_equal(err, OS_SUCCESS);
     assert_string_equal(response, "");
 
     /* Existent IP */
     response[0] = '\0';
-    expect_string(__wrap__merror, formatted_msg, "Duplicated IP "EXISTENT_IP1);
-    err = w_auth_validate_data(response,EXISTENT_IP1, NEW_AGENT1, NULL, NULL);
+    expect_string(__wrap__minfo, formatted_msg, "Duplicated IP '"EXISTENT_IP1"' (001).");
+    expect_string(__wrap__minfo, formatted_msg, "Agent '001' won´t be removed because the force option is disabled.");
+    err = w_auth_validate_data(response, EXISTENT_IP1, NEW_AGENT1, NULL, NULL);
     assert_int_equal(err, OS_INVALID);
     assert_string_equal(response, "ERROR: Duplicated IP: "EXISTENT_IP1"");
 
     /* Existent Agent Name */
     response[0] = '\0';
-    expect_string(__wrap__merror, formatted_msg, "Invalid agent name "EXISTENT_AGENT1" (duplicated)");
-    err = w_auth_validate_data(response,NEW_IP1, EXISTENT_AGENT1, NULL, NULL);
+    expect_string(__wrap__minfo, formatted_msg, "Duplicated name '"EXISTENT_AGENT1"' (001).");
+    expect_string(__wrap__minfo, formatted_msg, "Agent '001' won´t be removed because the force option is disabled.");
+    err = w_auth_validate_data(response, NEW_IP1, EXISTENT_AGENT1, NULL, NULL);
     assert_int_equal(err, OS_INVALID);
     assert_string_equal(response, "ERROR: Duplicated agent name: "EXISTENT_AGENT1"");
 
@@ -174,14 +176,16 @@ static void test_w_auth_validate_data_force_insert(void **state) {
 
     /* Duplicated IP*/
     response[0] = '\0';
-    expect_string(__wrap__minfo, formatted_msg, "Duplicated IP '"EXISTENT_IP1"' (001). Removing old agent.");
+    expect_string(__wrap__minfo, formatted_msg, "Duplicated IP '"EXISTENT_IP1"' (001).");
+    expect_string(__wrap__minfo, formatted_msg, "Removing old agent '001'.");
     err = w_auth_validate_data(response, EXISTENT_IP1, NEW_AGENT1, NULL, NULL);
     assert_int_equal(err, OS_SUCCESS);
     assert_string_equal(response, "");
 
      /* Duplicated Name*/
     response[0] = '\0';
-    expect_string(__wrap__minfo, formatted_msg, "Duplicated name '"EXISTENT_AGENT2"' (002). Removing old agent.");
+    expect_string(__wrap__minfo, formatted_msg, "Duplicated name '"EXISTENT_AGENT2"' (002).");
+    expect_string(__wrap__minfo, formatted_msg, "Removing old agent '002'.");
     err = w_auth_validate_data(response, NEW_IP2, EXISTENT_AGENT2, NULL, NULL);
     assert_int_equal(err, OS_SUCCESS);
     assert_string_equal(response, "");
@@ -216,7 +220,6 @@ static void test_w_auth_validate_data_register_limit(void **state) {
         OS_AddNewAgent(&keys, NULL, agent_name, ANY_IP, NULL);
     }
 }
-#endif
 
 static void test_w_auth_validate_groups(void **state) {
     w_err_t err;
@@ -260,9 +263,9 @@ int main(void) {
 
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_w_auth_validate_groups),
-        //cmocka_unit_test_setup(test_w_auth_validate_data, setup_validate_force_insert_0),
-        //cmocka_unit_test_setup(test_w_auth_validate_data_force_insert, setup_validate_force_insert_1),
-        //cmocka_unit_test_setup(test_w_auth_validate_data_register_limit, setup_validate_force_insert_0),
+        cmocka_unit_test_setup(test_w_auth_validate_data, setup_validate_force_insert_0),
+        cmocka_unit_test_setup(test_w_auth_validate_data_force_insert, setup_validate_force_insert_1),
+        cmocka_unit_test_setup(test_w_auth_validate_data_register_limit, setup_validate_force_insert_0),
 
     };
 

--- a/src/unit_tests/os_auth/test_auth_validate.c
+++ b/src/unit_tests/os_auth/test_auth_validate.c
@@ -90,7 +90,6 @@ typedef struct _enrollment_response {
     char* response;
 } enrollment_response;
 
-
 extern struct keynode *queue_insert;
 extern struct keynode *queue_remove;
 extern struct keynode * volatile *insert_tail;
@@ -325,7 +324,6 @@ static void test_w_auth_replace_agent_success(void **state) {
 }
 
 int main(void) {
-
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_w_auth_validate_groups),
         cmocka_unit_test_setup(test_w_auth_validate_data, setup_validate_force_insert_0),

--- a/src/unit_tests/os_auth/test_auth_validate.c
+++ b/src/unit_tests/os_auth/test_auth_validate.c
@@ -104,12 +104,12 @@ static int teardown_group(void **state) {
 }
 
 int setup_validate_force_insert_0(void **state) {
-    config.flags.force_insert = 0;
+    config.force_options.enabled = 0;
     return 0;
 }
 
 int setup_validate_force_insert_1(void **state) {
-    config.flags.force_insert = 1;
+    config.force_options.enabled = 1;
     return 0;
 }
 

--- a/src/unit_tests/os_auth/test_auth_validate.c
+++ b/src/unit_tests/os_auth/test_auth_validate.c
@@ -112,37 +112,35 @@ int setup_validate_force_insert_1(void **state) {
     config.force_options.enabled = 1;
     return 0;
 }
-
+#if 0
 /* tests */
-
 static void test_w_auth_validate_data(void **state) {
-
     char response[2048] = {0};
     w_err_t err;
 
     /* New agent / IP*/
     response[0] = '\0';
-    err = w_auth_validate_data(response,NEW_IP1, NEW_AGENT1, NULL);
+    err = w_auth_validate_data(response,NEW_IP1, NEW_AGENT1, NULL, NULL);
     assert_int_equal(err, OS_SUCCESS);
     assert_string_equal(response, "");
 
     /* any IP*/
     response[0] = '\0';
-    err = w_auth_validate_data(response,ANY_IP, NEW_AGENT1, NULL);
+    err = w_auth_validate_data(response,ANY_IP, NEW_AGENT1, NULL, NULL);
     assert_int_equal(err, OS_SUCCESS);
     assert_string_equal(response, "");
 
     /* Existent IP */
     response[0] = '\0';
     expect_string(__wrap__merror, formatted_msg, "Duplicated IP "EXISTENT_IP1);
-    err = w_auth_validate_data(response,EXISTENT_IP1, NEW_AGENT1, NULL);
+    err = w_auth_validate_data(response,EXISTENT_IP1, NEW_AGENT1, NULL, NULL);
     assert_int_equal(err, OS_INVALID);
     assert_string_equal(response, "ERROR: Duplicated IP: "EXISTENT_IP1"");
 
     /* Existent Agent Name */
     response[0] = '\0';
     expect_string(__wrap__merror, formatted_msg, "Invalid agent name "EXISTENT_AGENT1" (duplicated)");
-    err = w_auth_validate_data(response,NEW_IP1, EXISTENT_AGENT1, NULL);
+    err = w_auth_validate_data(response,NEW_IP1, EXISTENT_AGENT1, NULL, NULL);
     assert_int_equal(err, OS_INVALID);
     assert_string_equal(response, "ERROR: Duplicated agent name: "EXISTENT_AGENT1"");
 
@@ -157,7 +155,7 @@ static void test_w_auth_validate_data(void **state) {
     char merror_message[2048];
     snprintf(merror_message, 2048, "Invalid agent name %s (same as manager)", host_name);
     expect_string(__wrap__merror, formatted_msg, merror_message);
-    err = w_auth_validate_data(response,NEW_IP1, host_name, NULL);
+    err = w_auth_validate_data(response,NEW_IP1, host_name, NULL, NULL);
     assert_int_equal(err, OS_INVALID);
     assert_string_equal(response, err_response);
 
@@ -171,21 +169,20 @@ static void test_w_auth_validate_data(void **state) {
 }
 
 static void test_w_auth_validate_data_force_insert(void **state) {
-
     char response[2048] = {0};
     w_err_t err;
 
     /* Duplicated IP*/
     response[0] = '\0';
     expect_string(__wrap__minfo, formatted_msg, "Duplicated IP '"EXISTENT_IP1"' (001). Removing old agent.");
-    err = w_auth_validate_data(response, EXISTENT_IP1, NEW_AGENT1, NULL);
+    err = w_auth_validate_data(response, EXISTENT_IP1, NEW_AGENT1, NULL, NULL);
     assert_int_equal(err, OS_SUCCESS);
     assert_string_equal(response, "");
 
      /* Duplicated Name*/
     response[0] = '\0';
     expect_string(__wrap__minfo, formatted_msg, "Duplicated name '"EXISTENT_AGENT2"' (002). Removing old agent.");
-    err = w_auth_validate_data(response, NEW_IP2, EXISTENT_AGENT2, NULL);
+    err = w_auth_validate_data(response, NEW_IP2, EXISTENT_AGENT2, NULL, NULL);
     assert_int_equal(err, OS_SUCCESS);
     assert_string_equal(response, "");
 
@@ -203,7 +200,6 @@ static void test_w_auth_validate_data_register_limit(void **state) {
     char error_message[2048];
     w_err_t err;
 
-
     //Filling most of keys element with a fixed key to reduce computing time
     char fixed_key[KEYSIZE] = "1234";
     for(unsigned i=0; i<100000; i++) {
@@ -214,12 +210,13 @@ static void test_w_auth_validate_data_register_limit(void **state) {
     for(unsigned i=0; i<10; i++) {
         snprintf(agent_name, 2048, "__agent_%d", i);
         response[0] = '\0';
-        err = w_auth_validate_data(response,ANY_IP, agent_name, NULL);
+        err = w_auth_validate_data(response,ANY_IP, agent_name, NULL, NULL);
         assert_int_equal(err, OS_SUCCESS);
         assert_string_equal(response, "");
         OS_AddNewAgent(&keys, NULL, agent_name, ANY_IP, NULL);
     }
 }
+#endif
 
 static void test_w_auth_validate_groups(void **state) {
     w_err_t err;
@@ -257,17 +254,15 @@ static void test_w_auth_validate_groups(void **state) {
     err = w_auth_validate_groups(EXISTENT_GROUP1","EXISTENT_GROUP2","UNKNOWN_GROUP, response);
     assert_int_equal(err, OS_INVALID);
     assert_string_equal(response, "ERROR: Invalid group: "UNKNOWN_GROUP"");
-
 }
-
 
 int main(void) {
 
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_w_auth_validate_groups),
-        cmocka_unit_test_setup(test_w_auth_validate_data, setup_validate_force_insert_0),
-        cmocka_unit_test_setup(test_w_auth_validate_data_force_insert, setup_validate_force_insert_1),
-        cmocka_unit_test_setup(test_w_auth_validate_data_register_limit, setup_validate_force_insert_0),
+        //cmocka_unit_test_setup(test_w_auth_validate_data, setup_validate_force_insert_0),
+        //cmocka_unit_test_setup(test_w_auth_validate_data_force_insert, setup_validate_force_insert_1),
+        //cmocka_unit_test_setup(test_w_auth_validate_data_register_limit, setup_validate_force_insert_0),
 
     };
 

--- a/src/unit_tests/os_auth/test_auth_validate.c
+++ b/src/unit_tests/os_auth/test_auth_validate.c
@@ -160,19 +160,19 @@ static void test_w_auth_validate_data(void **state) {
 
     /* Existent IP */
     response[0] = '\0';
-    expect_string(__wrap__minfo, formatted_msg, "Duplicated IP '"EXISTENT_IP1"' (001).");
-    expect_string(__wrap__minfo, formatted_msg, "Agent '001' won´t be removed because the force option is disabled.");
+    expect_string(__wrap__minfo, formatted_msg, "Duplicate IP '"EXISTENT_IP1"' (001).");
+    expect_string(__wrap__minfo, formatted_msg, "Agent '001' won't be removed because the force option is disabled.");
     err = w_auth_validate_data(response, EXISTENT_IP1, NEW_AGENT1, NULL, NULL);
     assert_int_equal(err, OS_INVALID);
-    assert_string_equal(response, "ERROR: Duplicated IP: "EXISTENT_IP1"");
+    assert_string_equal(response, "ERROR: Duplicate IP: "EXISTENT_IP1"");
 
     /* Existent Agent Name */
     response[0] = '\0';
-    expect_string(__wrap__minfo, formatted_msg, "Duplicated name '"EXISTENT_AGENT1"' (001).");
-    expect_string(__wrap__minfo, formatted_msg, "Agent '001' won´t be removed because the force option is disabled.");
+    expect_string(__wrap__minfo, formatted_msg, "Duplicate name '"EXISTENT_AGENT1"' (001).");
+    expect_string(__wrap__minfo, formatted_msg, "Agent '001' won't be removed because the force option is disabled.");
     err = w_auth_validate_data(response, NEW_IP1, EXISTENT_AGENT1, NULL, NULL);
     assert_int_equal(err, OS_INVALID);
-    assert_string_equal(response, "ERROR: Duplicated agent name: "EXISTENT_AGENT1"");
+    assert_string_equal(response, "ERROR: Duplicate agent name: "EXISTENT_AGENT1"");
 
    /* Manager name */
    char host_name[512];
@@ -202,18 +202,18 @@ static void test_w_auth_validate_data_force_insert(void **state) {
     char response[2048] = {0};
     w_err_t err;
 
-    /* Duplicated IP*/
+    /* Duplicate IP*/
     response[0] = '\0';
-    expect_string(__wrap__minfo, formatted_msg, "Duplicated IP '"EXISTENT_IP1"' (001).");
+    expect_string(__wrap__minfo, formatted_msg, "Duplicate IP '"EXISTENT_IP1"' (001).");
     expect_string(__wrap__minfo, formatted_msg, "Removing old agent '001'.");
     will_return(__wrap_OS_AgentAntiquity, 0);
     err = w_auth_validate_data(response, EXISTENT_IP1, NEW_AGENT1, NULL, NULL);
     assert_int_equal(err, OS_SUCCESS);
     assert_string_equal(response, "");
 
-     /* Duplicated Name*/
+     /* Duplicate Name*/
     response[0] = '\0';
-    expect_string(__wrap__minfo, formatted_msg, "Duplicated name '"EXISTENT_AGENT2"' (002).");
+    expect_string(__wrap__minfo, formatted_msg, "Duplicate name '"EXISTENT_AGENT2"' (002).");
     expect_string(__wrap__minfo, formatted_msg, "Removing old agent '002'.");
     will_return(__wrap_OS_AgentAntiquity, 0);
     err = w_auth_validate_data(response, NEW_IP2, EXISTENT_AGENT2, NULL, NULL);
@@ -271,7 +271,7 @@ static void test_w_auth_replace_agent_force_disabled(void **state) {
     keyentry key;
     keyentry_init(&key, NEW_AGENT1, AGENT1_ID, NEW_IP1, NULL);
 
-    expect_string(__wrap__minfo, formatted_msg, "Agent '001' won´t be removed because the force option is disabled.");
+    expect_string(__wrap__minfo, formatted_msg, "Agent '001' won't be removed because the force option is disabled.");
     err = w_auth_replace_agent(&key, NULL, &config.force_options);
 
     assert_int_equal(err, OS_INVALID);
@@ -287,7 +287,7 @@ static void test_w_auth_replace_agent_not_comply_antiquity(void **state) {
     will_return(__wrap_OS_AgentAntiquity, 10);
     config.force_options.connection_time = 100;
 
-    expect_string(__wrap__minfo, formatted_msg, "Agent '001' doesn´t comply with the antiquity to be removed.");
+    expect_string(__wrap__minfo, formatted_msg, "Agent '001' doesn't comply with the antiquity to be removed.");
     err = w_auth_replace_agent(&key, NULL, &config.force_options);
 
     assert_int_equal(err, OS_INVALID);

--- a/src/unit_tests/os_crypto/shared/CMakeLists.txt
+++ b/src/unit_tests/os_crypto/shared/CMakeLists.txt
@@ -12,7 +12,8 @@ list(APPEND os_crypto_shared_tests_names "test_keys")
 list(APPEND os_crypto_shared_tests_flags "-Wl,--wrap,OSHash_Get -Wl,--wrap,OSHash_Add_ex -Wl,--wrap,OSHash_Create \
                                 -Wl,--wrap,OSHash_Delete_ex -Wl,--wrap,OSHash_Delete \
                                 -Wl,--wrap,fopen,--wrap,fclose,--wrap,fflush,--wrap,fgets,--wrap,fgetpos,--wrap,fread,--wrap,fseek,--wrap,fwrite,--wrap,remove,--wrap,fgetc,--wrap,fprintf \
-                                -Wl,--wrap,TempFile,--wrap,OS_MoveFile -Wl,--wrap,_merror")
+                                -Wl,--wrap,TempFile,--wrap,OS_MoveFile -Wl,--wrap,_merror \
+                                -Wl,--wrap,_mdebug2")
 
 # Compiling tests
 list(LENGTH os_crypto_shared_tests_names count)

--- a/src/unit_tests/os_crypto/shared/test_keys.c
+++ b/src/unit_tests/os_crypto/shared/test_keys.c
@@ -368,6 +368,8 @@ void test_w_get_key_hash_success(void **state){
     keys->raw_key = "6dd186d1740f6c80d4d380ebe72c8061db175881e07e809eb44404c836a7ef96";
 
     ret = w_get_key_hash(keys, output);
+
+    assert_string_equal(output, "e0735a4a2c9bf633bac9b58f194cc8649537b394");
     assert_int_equal(ret, OS_SUCCESS);
 
     os_free(keys);

--- a/src/unit_tests/os_crypto/shared/test_keys.c
+++ b/src/unit_tests/os_crypto/shared/test_keys.c
@@ -329,6 +329,50 @@ void test_OS_WriteTimestamps_file_write(void **state)
     assert_int_equal(r, 0);
 }
 
+// Test w_get_key_hash
+
+void test_w_get_key_hash_empty_parameters(void **state){
+    keyentry *keys = NULL;
+    os_sha1 output = {0};
+    int ret;
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Unable to hash agent's key due to empty parameters.");
+    ret = w_get_key_hash(keys, output);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_w_get_key_hash_empty_value(void **state){
+    keyentry *keys = NULL;
+    os_sha1 output = {0};
+    int ret;
+    os_calloc(1, sizeof (keyentry), keys);
+    keys->id = "001";
+    keys->name = "debian10";
+    keys->raw_key = NULL;
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Unable to hash agent's key due to empty value.");
+    ret = w_get_key_hash(keys, output);
+    assert_int_equal(ret, OS_INVALID);
+
+    os_free(keys);
+}
+
+void test_w_get_key_hash_success(void **state){
+    keyentry *keys = NULL;
+    os_sha1 output = {0};
+    int ret;
+    os_calloc(1, sizeof (keyentry), keys);
+    keys->id = "001";
+    keys->name = "debian10";
+    keys->raw_key = "6dd186d1740f6c80d4d380ebe72c8061db175881e07e809eb44404c836a7ef96";
+
+    ret = w_get_key_hash(keys, output);
+    assert_int_equal(ret, OS_SUCCESS);
+
+    os_free(keys);
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -347,7 +391,10 @@ int main(void)
         // Test OS_WriteTimestamps
         cmocka_unit_test_setup_teardown(test_OS_WriteTimestamps_file_error, setup_config, teardown_config),
         cmocka_unit_test_setup_teardown(test_OS_WriteTimestamps_file_write, setup_config, teardown_config),
-
+        // Test w_get_key_hash
+        cmocka_unit_test(test_w_get_key_hash_empty_parameters),
+        cmocka_unit_test(test_w_get_key_hash_empty_value),
+        cmocka_unit_test(test_w_get_key_hash_success)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/shared/test_agent_op.c
+++ b/src/unit_tests/shared/test_agent_op.c
@@ -31,7 +31,7 @@ extern cJSON* w_create_sendsync_payload(const char *daemon_name, cJSON *message)
 extern int w_parse_agent_add_response(const char* buffer, char *err_response, char* id, char* key, const int json_format, const int exit_on_error);
 extern int w_parse_agent_remove_response(const char* buffer, char *err_response, const int json_format, const int exit_on_error);
 
-
+#if 0
 static void test_create_agent_add_payload(void **state) {
     char* agent = "agent1";
     char* ip = "192.0.0.0";
@@ -71,7 +71,7 @@ static void test_create_agent_add_payload(void **state) {
 
     cJSON_Delete(payload);
 }
-
+#endif
 #ifndef WIN32
 static void test_create_agent_remove_payload(void **state) {
     char* id = "001";
@@ -220,7 +220,7 @@ static void test_parse_agent_add_response(void **state) {
 
 int main(void) {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test(test_create_agent_add_payload),
+        //cmocka_unit_test(test_create_agent_add_payload),
         cmocka_unit_test(test_parse_agent_add_response),
         #ifndef WIN32
         cmocka_unit_test(test_create_agent_remove_payload),

--- a/src/unit_tests/shared/test_agent_op.c
+++ b/src/unit_tests/shared/test_agent_op.c
@@ -25,22 +25,22 @@
 
 /* redefinitons/wrapping */
 
-extern cJSON* w_create_agent_add_payload(const char *name, const char *ip, const char * groups, const char *key, const int force, const char *id);
+extern cJSON* w_create_agent_add_payload(const char *name, const char *ip, const char *groups, const char *key_hash, const char *key, const char *id, const int force);
 extern cJSON* w_create_agent_remove_payload(const char *id, const int purge);
 extern cJSON* w_create_sendsync_payload(const char *daemon_name, cJSON *message);
 extern int w_parse_agent_add_response(const char* buffer, char *err_response, char* id, char* key, const int json_format, const int exit_on_error);
 extern int w_parse_agent_remove_response(const char* buffer, char *err_response, const int json_format, const int exit_on_error);
 
-#if 0
 static void test_create_agent_add_payload(void **state) {
     char* agent = "agent1";
     char* ip = "192.0.0.0";
     char* groups = "Group1,Group2";
     char* key = "1234";
+    char* key_hash = "7110eda4d09e062aa5e4a390b0a572ac0d2c0220";
     int force = 1;
     char* id = "001";
     cJSON* payload = NULL;
-    payload = w_create_agent_add_payload(agent, ip, groups, key, force, id);
+    payload = w_create_agent_add_payload(agent, ip, groups, key_hash, key, id, force);
 
     assert_non_null(payload);
     cJSON* function = cJSON_GetObjectItem(payload, "function");
@@ -71,7 +71,7 @@ static void test_create_agent_add_payload(void **state) {
 
     cJSON_Delete(payload);
 }
-#endif
+
 #ifndef WIN32
 static void test_create_agent_remove_payload(void **state) {
     char* id = "001";
@@ -220,7 +220,7 @@ static void test_parse_agent_add_response(void **state) {
 
 int main(void) {
     const struct CMUnitTest tests[] = {
-        //cmocka_unit_test(test_create_agent_add_payload),
+        cmocka_unit_test(test_create_agent_add_payload),
         cmocka_unit_test(test_parse_agent_add_response),
         #ifndef WIN32
         cmocka_unit_test(test_create_agent_remove_payload),

--- a/src/unit_tests/shared/test_agent_op.c
+++ b/src/unit_tests/shared/test_agent_op.c
@@ -55,11 +55,13 @@ static void test_create_agent_add_payload(void **state) {
     assert_non_null(item);
     assert_string_equal(item->valuestring, groups);
 
-
     item = cJSON_GetObjectItem(arguments, "key");
     assert_non_null(item);
     assert_string_equal(item->valuestring, key);
 
+    item = cJSON_GetObjectItem(arguments, "key_hash");
+    assert_non_null(item);
+    assert_string_equal(item->valuestring, key_hash);
 
     item = cJSON_GetObjectItem(arguments, "id");
     assert_non_null(item);

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -118,6 +118,7 @@ int test_teardown_concats(void **state) {
 }
 
 // Setup
+#if 0
 int test_setup_context(void **state) {
     w_enrollment_target* local_target;
     local_target = w_enrollment_target_init();
@@ -135,7 +136,7 @@ int test_setup_context(void **state) {
     *state = cfg;
     return 0;
 }
-
+#endif
 //Teardown
 int test_teardown_context(void **state) {
     w_enrollment_ctx *cfg = *state;
@@ -155,6 +156,7 @@ int test_teardown_context(void **state) {
 }
 
 //Setup
+#if 0
 int test_setup_context_2(void **state) {
     w_enrollment_target* local_target;
     local_target = w_enrollment_target_init();
@@ -214,7 +216,7 @@ int test_setup_w_enrolment_request_key(void **state) {
     test_mode = 1;
     return 0;
 }
-
+#endif
 //Teardown
 int test_teardown_w_enrolment_request_key(void **state){
     w_enrollment_ctx *cfg = *state;
@@ -374,6 +376,7 @@ void test_verificy_ca_certificate_valid_certificate(void **state) {
 }
 /**********************************************/
 /********** w_enrollment_connect *******/
+#if 0
 void test_w_enrollment_connect_empty_address(void **state) {
     w_enrollment_ctx *cfg = *state;
     expect_assert_failure(w_enrollment_connect(cfg, NULL));
@@ -516,6 +519,7 @@ void test_w_enrollment_connect_success(void **state) {
     int ret = w_enrollment_connect(cfg, cfg->target_cfg->manager_name);
     assert_int_equal(ret, 5);
 }
+#endif
 
 /**********************************************/
 /********** w_enrollment_send_message *******/
@@ -523,7 +527,7 @@ void test_w_enrollment_connect_success(void **state) {
 void test_w_enrollment_send_message_empty_config(void **state) {
     expect_assert_failure(w_enrollment_send_message(NULL));
 }
-
+#if 0
 void test_w_enrollment_send_message_wrong_hostname(void **state) {
     w_enrollment_ctx *cfg = *state;
 #ifdef WIN32
@@ -537,7 +541,7 @@ void test_w_enrollment_send_message_wrong_hostname(void **state) {
     int ret = w_enrollment_send_message(cfg);
     assert_int_equal(ret, -1);
 }
-
+#endif
 void test_w_enrollment_send_message_invalid_hostname(void **state) {
     w_enrollment_ctx *cfg = *state;
     expect_string(__wrap__merror, formatted_msg, "Invalid agent name \"Invalid\'!@Hostname\'\". Please pick a valid name.");
@@ -845,7 +849,7 @@ void test_w_enrollment_process_response_success(void **state) {
 void test_w_enrollment_request_key_null_cfg(void **state) {
     expect_assert_failure(w_enrollment_request_key(NULL, "server_adress"));
 }
-
+#if 0
 void test_w_enrollment_request_key(void **state) {
     w_enrollment_ctx *cfg = *state;
     SSL_CTX *ctx = get_ssl_context(DEFAULT_CIPHERS, 0);
@@ -983,6 +987,8 @@ void test_w_enrollment_extract_agent_name_localhost_not_allowed(void **state) {
     char *lhostname = w_enrollment_extract_agent_name(cfg);
     assert_int_equal( lhostname, NULL);
 }
+#endif
+
 /******* w_enrollment_load_pass ********/
 void test_w_enrollment_load_pass_null_cert(void **state) {
     expect_assert_failure(w_enrollment_load_pass(NULL));
@@ -1056,20 +1062,20 @@ int main()
         cmocka_unit_test_setup_teardown(test_verificy_ca_certificate_invalid_certificate, test_setup_ssl_context, test_teardown_ssl_context),
         cmocka_unit_test_setup_teardown(test_verificy_ca_certificate_valid_certificate, test_setup_ssl_context, test_teardown_ssl_context),
         // w_enrollment_connect
-        cmocka_unit_test_setup_teardown(test_w_enrollment_connect_empty_address, test_setup_context, test_teardown_context),
-        cmocka_unit_test_setup_teardown(test_w_enrollment_connect_empty_config, test_setup_context, test_teardown_context),
-        cmocka_unit_test_setup_teardown(test_w_enrollment_connect_invalid_hostname, test_setup_context, test_teardown_context),
-        cmocka_unit_test_setup_teardown(test_w_enrollment_connect_could_not_setup, test_setup_context, test_teardown_context),
-        cmocka_unit_test_setup_teardown(test_w_enrollment_connect_socket_error, test_setup_context, test_teardown_context),
-        cmocka_unit_test_setup_teardown(test_w_enrollment_connect_SSL_connect_error, test_setup_context, test_teardown_context),
-        cmocka_unit_test_setup_teardown(test_w_enrollment_connect_success, test_setup_context, test_teardown_context),
+        //cmocka_unit_test_setup_teardown(test_w_enrollment_connect_empty_address, test_setup_context, test_teardown_context),
+        //cmocka_unit_test_setup_teardown(test_w_enrollment_connect_empty_config, test_setup_context, test_teardown_context),
+        //cmocka_unit_test_setup_teardown(test_w_enrollment_connect_invalid_hostname, test_setup_context, test_teardown_context),
+        //cmocka_unit_test_setup_teardown(test_w_enrollment_connect_could_not_setup, test_setup_context, test_teardown_context),
+        //cmocka_unit_test_setup_teardown(test_w_enrollment_connect_socket_error, test_setup_context, test_teardown_context),
+        //cmocka_unit_test_setup_teardown(test_w_enrollment_connect_SSL_connect_error, test_setup_context, test_teardown_context),
+        //cmocka_unit_test_setup_teardown(test_w_enrollment_connect_success, test_setup_context, test_teardown_context),
         // w_enrollment_send_message
         cmocka_unit_test(test_w_enrollment_send_message_empty_config),
-        cmocka_unit_test_setup_teardown(test_w_enrollment_send_message_wrong_hostname, test_setup_context, test_teardown_context),
-        cmocka_unit_test_setup_teardown(test_w_enrollment_send_message_invalid_hostname, test_setup_context_3, test_teardown_context),
-        cmocka_unit_test_setup_teardown(test_w_enrollment_send_message_fix_invalid_hostname, test_setup_context, test_teardown_context),
-        cmocka_unit_test_setup_teardown(test_w_enrollment_send_message_ssl_error, test_setup_context, test_teardown_context),
-        cmocka_unit_test_setup_teardown(test_w_enrollment_send_message_success, test_setup_context_2, test_teardown_context),
+        //cmocka_unit_test_setup_teardown(test_w_enrollment_send_message_wrong_hostname, test_setup_context, test_teardown_context),
+        //cmocka_unit_test_setup_teardown(test_w_enrollment_send_message_invalid_hostname, test_setup_context_3, test_teardown_context),
+        //cmocka_unit_test_setup_teardown(test_w_enrollment_send_message_fix_invalid_hostname, test_setup_context, test_teardown_context),
+        //cmocka_unit_test_setup_teardown(test_w_enrollment_send_message_ssl_error, test_setup_context, test_teardown_context),
+        //cmocka_unit_test_setup_teardown(test_w_enrollment_send_message_success, test_setup_context_2, test_teardown_context),
         // w_enrollment_store_key_entry
         cmocka_unit_test_setup_teardown(test_w_enrollment_store_key_entry_null_key, setup_file_ops, teardown_file_ops),
         cmocka_unit_test_setup_teardown(test_w_enrollment_store_key_entry_cannot_open, setup_file_ops, teardown_file_ops),
@@ -1090,10 +1096,10 @@ int main()
         cmocka_unit_test_setup_teardown(test_w_enrollment_process_response_success, test_setup_ssl_context, test_teardown_ssl_context),
         // w_enrollment_request_key (wrapper)
         cmocka_unit_test(test_w_enrollment_request_key_null_cfg),
-        cmocka_unit_test_setup_teardown(test_w_enrollment_request_key, test_setup_w_enrolment_request_key, test_teardown_w_enrolment_request_key),
+        //cmocka_unit_test_setup_teardown(test_w_enrollment_request_key, test_setup_w_enrolment_request_key, test_teardown_w_enrolment_request_key),
         // w_enrollment_extract_agent_name
-        cmocka_unit_test_setup_teardown(test_w_enrollment_extract_agent_name_localhost_allowed, test_setup_context, test_teardown_context),
-        cmocka_unit_test_setup_teardown(test_w_enrollment_extract_agent_name_localhost_not_allowed, test_setup_context, test_teardown_context),
+        //cmocka_unit_test_setup_teardown(test_w_enrollment_extract_agent_name_localhost_allowed, test_setup_context, test_teardown_context),
+        //cmocka_unit_test_setup_teardown(test_w_enrollment_extract_agent_name_localhost_not_allowed, test_setup_context, test_teardown_context),
         // w_enrollment_load_pass
         cmocka_unit_test(test_w_enrollment_load_pass_null_cert),
         cmocka_unit_test_setup_teardown(test_w_enrollment_load_pass_empty_file, test_setup_enrollment_load_pass, test_teardown_enrollment_load_pass),

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -1127,7 +1127,7 @@ int main()
         cmocka_unit_test_setup_teardown(test_w_enrollment_store_key_entry_null_key, setup_file_ops, teardown_file_ops),
         cmocka_unit_test_setup_teardown(test_w_enrollment_store_key_entry_cannot_open, setup_file_ops, teardown_file_ops),
 #ifndef WIN32
-        //cmocka_unit_test_setup_teardown(test_w_enrollment_store_key_entry_chmod_fail, setup_file_ops, teardown_file_ops),
+        cmocka_unit_test_setup_teardown(test_w_enrollment_store_key_entry_chmod_fail, setup_file_ops, teardown_file_ops),
 #endif
         cmocka_unit_test_setup_teardown(test_w_enrollment_store_key_entry_success, setup_file_ops, teardown_file_ops),
         // w_enrollment_process_agent_key

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -133,8 +133,10 @@ int test_setup_context(void **state) {
     local_cert->agent_key = strdup("KEY");
     local_cert->ca_cert = strdup("CA_CERT");
     // Keys initialization
-    keystore keys = KEYSTORE_INITIALIZER;
-    w_enrollment_ctx *cfg = w_enrollment_init(local_target, local_cert, &keys);
+    keystore *keys = NULL;
+    os_calloc(1, sizeof(keystore), keys);
+    keys->keysize = 0;
+    w_enrollment_ctx *cfg = w_enrollment_init(local_target, local_cert, keys);
     *state = cfg;
     return 0;
 }
@@ -150,6 +152,7 @@ int test_teardown_context(void **state) {
     os_free(cfg->cert_cfg->ca_cert);
     os_free(cfg->cert_cfg->ciphers);
     os_free(cfg->cert_cfg);
+    os_free(cfg->keys);
     if(cfg->ssl) {
         SSL_free(cfg->ssl);
     }
@@ -173,8 +176,10 @@ int test_setup_context_2(void **state) {
     local_cert->agent_key = strdup("KEY");
     local_cert->ca_cert = strdup("CA_CERT");
     // Keys initialization
-    keystore keys = KEYSTORE_INITIALIZER;
-    w_enrollment_ctx *cfg = w_enrollment_init(local_target, local_cert, &keys);
+    keystore *keys = NULL;
+    os_calloc(1, sizeof(keystore), keys);
+    keys->keysize = 0;
+    w_enrollment_ctx *cfg = w_enrollment_init(local_target, local_cert, keys);
     *state = cfg;
     return 0;
 }
@@ -194,8 +199,10 @@ int test_setup_context_3(void **state) {
     local_cert->agent_key = strdup("KEY");
     local_cert->ca_cert = strdup("CA_CERT");
     // Keys initialization
-    keystore keys = KEYSTORE_INITIALIZER;
-    w_enrollment_ctx *cfg = w_enrollment_init(local_target, local_cert, &keys);
+    keystore *keys = NULL;
+    os_calloc(1, sizeof(keystore), keys);
+    keys->keysize = 0;
+    w_enrollment_ctx *cfg = w_enrollment_init(local_target, local_cert, keys);
     *state = cfg;
     return 0;
 }
@@ -236,6 +243,7 @@ int test_teardown_w_enrolment_request_key(void **state){
     os_free(cfg->cert_cfg->ca_cert);
     os_free(cfg->cert_cfg->ciphers);
     os_free(cfg->cert_cfg);
+    os_free(cfg->keys);
     w_enrollment_destroy(cfg);
     test_mode = 0;
     return 0;

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -955,7 +955,7 @@ void test_w_enrollment_request_key(void **state) {
 
 void test_w_enrollment_extract_agent_name_localhost_allowed(void **state) {
     w_enrollment_ctx *cfg = *state;
-    cfg->allow_localhost = 1; // Allow localhost
+    cfg->allow_localhost = true; // Allow localhost
 #ifdef WIN32
     will_return(wrap_gethostname, "localhost");
     will_return(wrap_gethostname, 0);
@@ -970,7 +970,7 @@ void test_w_enrollment_extract_agent_name_localhost_allowed(void **state) {
 
 void test_w_enrollment_extract_agent_name_localhost_not_allowed(void **state) {
     w_enrollment_ctx *cfg = *state;
-    cfg->allow_localhost = 0; // Do not allow localhost
+    cfg->allow_localhost = false; // Do not allow localhost
 #ifdef WIN32
     will_return(wrap_gethostname, "localhost");
     will_return(wrap_gethostname, 0);

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -151,6 +151,7 @@ int test_teardown_context(void **state) {
     os_free(cfg->cert_cfg->agent_key);
     os_free(cfg->cert_cfg->ca_cert);
     os_free(cfg->cert_cfg->ciphers);
+    os_free(cfg->cert_cfg->authpass_file);
     os_free(cfg->cert_cfg);
     os_free(cfg->keys);
     if(cfg->ssl) {
@@ -208,7 +209,7 @@ int test_setup_context_3(void **state) {
 }
 
 //Setup
-int test_setup_w_enrolment_request_key(void **state) {
+int test_setup_w_enrollment_request_key(void **state) {
     w_enrollment_target* local_target;
     local_target = w_enrollment_target_init();
     local_target->manager_name = strdup("valid_hostname");
@@ -234,7 +235,7 @@ int test_setup_w_enrolment_request_key(void **state) {
 }
 
 //Teardown
-int test_teardown_w_enrolment_request_key(void **state){
+int test_teardown_w_enrollment_request_key(void **state){
     w_enrollment_ctx *cfg = *state;
     os_free(cfg->target_cfg->manager_name);
     os_free(cfg->target_cfg);
@@ -242,6 +243,7 @@ int test_teardown_w_enrolment_request_key(void **state){
     os_free(cfg->cert_cfg->agent_key);
     os_free(cfg->cert_cfg->ca_cert);
     os_free(cfg->cert_cfg->ciphers);
+    os_free(cfg->cert_cfg->authpass_file);
     os_free(cfg->cert_cfg);
     os_free(cfg->keys);
     w_enrollment_destroy(cfg);
@@ -276,6 +278,7 @@ int test_setup_enrollment_load_pass(void **state) {
 int test_teardown_enrollment_load_pass(void **state) {
     w_enrollment_cert *cert_cfg;
     cert_cfg = *state;
+    os_free(cert_cfg->ciphers);
     os_free(cert_cfg->authpass);
     os_free(cert_cfg->authpass_file);
     os_free(cert_cfg);
@@ -1124,7 +1127,7 @@ int main()
         cmocka_unit_test_setup_teardown(test_w_enrollment_store_key_entry_null_key, setup_file_ops, teardown_file_ops),
         cmocka_unit_test_setup_teardown(test_w_enrollment_store_key_entry_cannot_open, setup_file_ops, teardown_file_ops),
 #ifndef WIN32
-        cmocka_unit_test_setup_teardown(test_w_enrollment_store_key_entry_chmod_fail, setup_file_ops, teardown_file_ops),
+        //cmocka_unit_test_setup_teardown(test_w_enrollment_store_key_entry_chmod_fail, setup_file_ops, teardown_file_ops),
 #endif
         cmocka_unit_test_setup_teardown(test_w_enrollment_store_key_entry_success, setup_file_ops, teardown_file_ops),
         // w_enrollment_process_agent_key
@@ -1140,7 +1143,7 @@ int main()
         cmocka_unit_test_setup_teardown(test_w_enrollment_process_response_success, test_setup_ssl_context, test_teardown_ssl_context),
         // w_enrollment_request_key (wrapper)
         cmocka_unit_test(test_w_enrollment_request_key_null_cfg),
-        cmocka_unit_test_setup_teardown(test_w_enrollment_request_key, test_setup_w_enrolment_request_key, test_teardown_w_enrolment_request_key),
+        cmocka_unit_test_setup_teardown(test_w_enrollment_request_key, test_setup_w_enrollment_request_key, test_teardown_w_enrollment_request_key),
         // w_enrollment_extract_agent_name
         cmocka_unit_test_setup_teardown(test_w_enrollment_extract_agent_name_localhost_allowed, test_setup_context, test_teardown_context),
         cmocka_unit_test_setup_teardown(test_w_enrollment_extract_agent_name_localhost_not_allowed, test_setup_context, test_teardown_context),

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -20,6 +20,7 @@
 
 extern int w_enrollment_concat_src_ip(char *buff, const char* sender_ip, const int use_src_ip);
 extern void w_enrollment_concat_group(char *buff, const char* centralized_group);
+extern void w_enrollment_concat_key(char *buff, keyentry* key_entry);
 extern void w_enrollment_verify_ca_certificate(const SSL *ssl, const char *ca_cert, const char *hostname);
 extern int w_enrollment_connect(w_enrollment_ctx *cfg, const char * server_address);
 extern int w_enrollment_send_message(w_enrollment_ctx *cfg);
@@ -347,6 +348,31 @@ void test_w_enrollment_concat_group(void **state) {
     w_enrollment_concat_group(buf, group);
     assert_string_equal(buf, " G:'EXAMPLE_GROUP'");
 }
+/**********************************************/
+/************* w_enrollment_concat_key ****************/
+void test_w_enrollment_concat_key_empty_buff(void **state) {
+    expect_assert_failure(w_enrollment_concat_key(NULL, (keyentry *)1));
+}
+
+void test_w_enrollment_concat_key_empty_key_structure(void **state) {
+    char *buf = *state;
+    expect_assert_failure(w_enrollment_concat_key(buf, NULL));
+}
+
+void test_w_enrollment_concat_key(void **state) {
+    char *buf = *state;
+    keyentry *keys = NULL;
+    os_calloc(1, sizeof(keyentry), keys);
+    keys->id = "001";
+    keys->name = "debian10";
+    keys->raw_key = "6dd186d1740f6c80d4d380ebe72c8061db175881e07e809eb44404c836a7ef96";
+
+    w_enrollment_concat_key(buf, keys);
+    assert_string_equal(buf, " K:'e0735a4a2c9bf633bac9b58f194cc8649537b394'");
+
+    os_free(keys);
+}
+
 /**********************************************/
 /********** w_enrollment_verify_ca_certificate *************/
 void test_w_enrollment_verify_ca_certificate_null_connection(void **state) {
@@ -1062,6 +1088,10 @@ int main()
         cmocka_unit_test(test_w_enrollment_concat_group_empty_buff),
         cmocka_unit_test_setup_teardown(test_w_enrollment_concat_group_empty_group, test_setup_concats, test_teardown_concats),
         cmocka_unit_test_setup_teardown(test_w_enrollment_concat_group, test_setup_concats, test_teardown_concats),
+        // w_enrollment_concat_key
+        cmocka_unit_test(test_w_enrollment_concat_key_empty_buff),
+        cmocka_unit_test_setup_teardown(test_w_enrollment_concat_key_empty_key_structure, test_setup_concats, test_teardown_concats),
+        cmocka_unit_test_setup_teardown(test_w_enrollment_concat_key, test_setup_concats, test_teardown_concats),
         //  w_enrollment_verify_ca_certificate
         cmocka_unit_test_setup_teardown(test_w_enrollment_verify_ca_certificate_null_connection, test_setup_ssl_context, test_teardown_ssl_context),
         cmocka_unit_test_setup_teardown(test_w_enrollment_verify_ca_certificate_no_certificate, test_setup_ssl_context, test_teardown_ssl_context),

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -342,6 +342,7 @@ void test_w_enrollment_concat_src_ip_default(void **state) {
 void test_w_enrollment_concat_src_ip_empty_buff(void **state) {
     expect_assert_failure(w_enrollment_concat_src_ip(NULL, NULL, 0));
 }
+
 /**********************************************/
 /************* w_enrollment_concat_group ****************/
 void test_w_enrollment_concat_group_empty_buff(void **state) {
@@ -359,6 +360,7 @@ void test_w_enrollment_concat_group(void **state) {
     w_enrollment_concat_group(buf, group);
     assert_string_equal(buf, " G:'EXAMPLE_GROUP'");
 }
+
 /**********************************************/
 /************* w_enrollment_concat_key ****************/
 void test_w_enrollment_concat_key_empty_buff(void **state) {
@@ -419,9 +421,9 @@ void test_verificy_ca_certificate_valid_certificate(void **state) {
     expect_string(__wrap__minfo, formatted_msg, "Manager has been verified successfully");
     w_enrollment_verify_ca_certificate(ssl, "GOOD_CERTIFICATE", "hostname");
 }
+
 /**********************************************/
 /********** w_enrollment_connect *******/
-
 void test_w_enrollment_connect_empty_address(void **state) {
     w_enrollment_ctx *cfg = *state;
     expect_assert_failure(w_enrollment_connect(cfg, NULL));

--- a/src/unit_tests/wrappers/wazuh/addagent/manage_agents_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/addagent/manage_agents_wrappers.c
@@ -13,8 +13,9 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-int __wrap_OS_AgentAntiquity() {
-    return -1;
+double __wrap_OS_AgentAntiquity(__attribute__((unused)) const char *name,
+                             __attribute__((unused)) const char *ip) {
+    return mock();
 }
 
 void __wrap_OS_RemoveAgentGroup(__attribute__((unused)) const char *id) {

--- a/src/unit_tests/wrappers/wazuh/addagent/manage_agents_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/addagent/manage_agents_wrappers.h
@@ -11,7 +11,7 @@
 #ifndef MANAGE_AGENTS_WRAPPERS_H
 #define MANAGE_AGENTS_WRAPPERS_H
 
-int __wrap_OS_AgentAntiquity();
+double __wrap_OS_AgentAntiquity(const char *name, const char *ip);
 void __wrap_OS_RemoveAgentGroup(const char *id);
 
 #endif

--- a/src/util/agent_control.c
+++ b/src/util/agent_control.c
@@ -329,7 +329,7 @@ int main(int argc, char **argv)
     if (agent_id != NULL) {
         if (strcmp(agent_id, "000") != 0) {
             OS_PassEmptyKeyfile();
-            OS_ReadKeys(&keys, 1, 0);
+            OS_ReadKeys(&keys, W_RAW_KEY, 0);
 
             agt_id = OS_IsAllowedID(&keys, agent_id);
             if (agt_id < 0) {

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -264,7 +264,7 @@ void wm_sync_agents() {
 
     mtdebug1(WM_DATABASE_LOGTAG, "Synchronizing agents.");
     OS_PassEmptyKeyfile();
-    OS_ReadKeys(&keys, 0, 0);
+    OS_ReadKeys(&keys, W_RAW_KEY, 0);
 
     os_calloc(OS_SIZE_65536 + 1, sizeof(char), group);
 
@@ -286,7 +286,7 @@ void wm_sync_agents() {
         }
 
         if (wdb_insert_agent(id, entry->name, NULL, OS_CIDRtoStr(entry->ip, cidr, 20) ?
-                             entry->ip->ip : cidr, entry->key, *group ? group : NULL,1, &wdb_wmdb_sock)) {
+                             entry->ip->ip : cidr, entry->raw_key, *group ? group : NULL,1, &wdb_wmdb_sock)) {
             // The agent already exists, update group only.
             wm_sync_agent_group(id, entry->id);
         }

--- a/src/win32/agent_auth.c
+++ b/src/win32/agent_auth.c
@@ -474,13 +474,13 @@ int main(int argc, char **argv)
     printf("INFO: Using agent name as: %s\n", agentname);
 
     // Send request
-    char *secure_msg;
-    os_calloc(OS_SIZE_6144, sizeof(char), secure_msg);
+    char *enrollment_msg = NULL;
+    os_calloc(OS_SIZE_65536, sizeof(char), enrollment_msg);
     if (authpass) {
-        snprintf(secure_msg, OS_SIZE_6144, "OSSEC PASS: %s OSSEC A:'%s'\n", authpass, agentname);
+        snprintf(enrollment_msg, OS_SIZE_65536, "OSSEC PASS: %s OSSEC A:'%s'\n", authpass, agentname);
     }
     else {
-        snprintf(secure_msg, OS_SIZE_6144, "OSSEC A:'%s'\n", agentname);
+        snprintf(enrollment_msg, OS_SIZE_65536, "OSSEC A:'%s'\n", agentname);
     }
 
     // Reading agent's key (if any) to send its hash to the manager
@@ -488,11 +488,11 @@ int main(int argc, char **argv)
     OS_PassEmptyKeyfile();
     OS_ReadKeys(&agent_keys, 0, 0);
     if (agent_keys.keysize > 0) {
-        w_enrollment_concat_key(secure_msg, agent_keys.keyentries[0]);
+        w_enrollment_concat_key(enrollment_msg, agent_keys.keyentries[0]);
     }
 
-    SendSecureMessage(socket, &context, secure_msg);
-    os_free(secure_msg);
+    SendSecureMessage(socket, &context, enrollment_msg);
+    os_free(enrollment_msg);
     OS_FreeKeys(&agent_keys);
 
     printf("INFO: Sent request to manager. Waiting for reply.\n");

--- a/src/win32/agent_auth.c
+++ b/src/win32/agent_auth.c
@@ -484,10 +484,10 @@ int main(int argc, char **argv)
     }
 
     // Reading agent's key (if any) to send its hash to the manager
-    keystore keys = KEYSTORE_INITIALIZER;
-    OS_ReadKeys(&keys, 0, 0);
-    if (keys.keysize > 0) {
-        w_enrollment_concat_key(secure_msg, keys.keyentries[0]);
+    keystore agent_keys = KEYSTORE_INITIALIZER;
+    OS_ReadKeys(&agent_keys, 0, 0);
+    if (agent_keys.keysize > 0) {
+        w_enrollment_concat_key(secure_msg, agent_keys.keyentries[0]);
     }
 
     SendSecureMessage(socket, &context, secure_msg);

--- a/src/win32/agent_auth.c
+++ b/src/win32/agent_auth.c
@@ -485,6 +485,7 @@ int main(int argc, char **argv)
 
     // Reading agent's key (if any) to send its hash to the manager
     keystore agent_keys = KEYSTORE_INITIALIZER;
+    OS_PassEmptyKeyfile();
     OS_ReadKeys(&agent_keys, 0, 0);
     if (agent_keys.keysize > 0) {
         w_enrollment_concat_key(secure_msg, agent_keys.keyentries[0]);

--- a/src/win32/agent_auth.c
+++ b/src/win32/agent_auth.c
@@ -493,6 +493,7 @@ int main(int argc, char **argv)
 
     SendSecureMessage(socket, &context, secure_msg);
     os_free(secure_msg);
+    OS_FreeKeys(&agent_keys);
 
     printf("INFO: Sent request to manager. Waiting for reply.\n");
 

--- a/src/win32/agent_auth.c
+++ b/src/win32/agent_auth.c
@@ -28,9 +28,6 @@
 
 #define IO_BUFFER_SIZE  0x10000
 
-/*Global keys structure*/
-keystore keys = KEYSTORE_INITIALIZER;
-
 void report_help()
 {
     printf("\n%s %s: Connects to the manager to extract the agent key.\n", __ossec_name, ARGV0);
@@ -478,15 +475,16 @@ int main(int argc, char **argv)
 
     // Send request
     char *secure_msg;
-    os_calloc(OS_SIZE_65536, sizeof(char), secure_msg);
+    os_calloc(OS_SIZE_6144, sizeof(char), secure_msg);
     if (authpass) {
-        snprintf(secure_msg, OS_SIZE_65536, "OSSEC PASS: %s OSSEC A:'%s'\n", authpass, agentname);
+        snprintf(secure_msg, OS_SIZE_6144, "OSSEC PASS: %s OSSEC A:'%s'\n", authpass, agentname);
     }
     else {
-        snprintf(secure_msg, OS_SIZE_65536, "OSSEC A:'%s'\n", agentname);
+        snprintf(secure_msg, OS_SIZE_6144, "OSSEC A:'%s'\n", agentname);
     }
 
     // Reading agent's key (if any) to send its hash to the manager
+    keystore keys = KEYSTORE_INITIALIZER;
     OS_ReadKeys(&keys, 0, 0);
     if (keys.keysize > 0) {
         w_enrollment_concat_key(secure_msg, keys.keyentries[0]);

--- a/src/win32/agent_auth.c
+++ b/src/win32/agent_auth.c
@@ -486,7 +486,7 @@ int main(int argc, char **argv)
     // Reading agent's key (if any) to send its hash to the manager
     keystore agent_keys = KEYSTORE_INITIALIZER;
     OS_PassEmptyKeyfile();
-    OS_ReadKeys(&agent_keys, 0, 0);
+    OS_ReadKeys(&agent_keys, W_RAW_KEY, 0);
     if (agent_keys.keysize > 0) {
         w_enrollment_concat_key(enrollment_msg, agent_keys.keyentries[0]);
     }

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -140,7 +140,7 @@ int local_start()
     }
     /* Read keys */
     minfo(ENC_READ);
-    OS_ReadKeys(&keys, W_RAW_KEY, 0);
+    OS_ReadKeys(&keys, W_DUAL_KEY, 0);
 
     /* If there is no file to monitor, create a clean entry
      * for the mark messages.

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -140,7 +140,7 @@ int local_start()
     }
     /* Read keys */
     minfo(ENC_READ);
-    OS_ReadKeys(&keys, 1, 0);
+    OS_ReadKeys(&keys, W_RAW_KEY, 0);
 
     /* If there is no file to monitor, create a clean entry
      * for the mark messages.


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/9549 |

## Description

This pull request includes all the changes implemented as part of the epic [Bring Authd the capability to avoid re-registering agents that already has valid keys](https://github.com/wazuh/wazuh/issues/9549).

- For details on the design and requirements, check the **description** of the issue: https://github.com/wazuh/wazuh/issues/9549.
- For details on the QA plan, check the issue: https://github.com/wazuh/wazuh/issues/9718

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
- Memory tests for Windows
  - [x] Scan-build report
  - [x] Coverity
- Memory tests for macOS
  - [x] Scan-build report

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] Working on cluster environments
- [x] Added unit tests (for new features)