### PR TITLE
macOS segfault obtaining ip fix

### DIFF
--- a/src/data_provider/src/network/networkBSDWrapper.h
+++ b/src/data_provider/src/network/networkBSDWrapper.h
@@ -135,7 +135,7 @@ class NetworkBSDInterface final : public INetworkInterfaceWrapper
                     auto sa { reinterpret_cast<sockaddr *>(msg + 1) };
                     auto sdl { reinterpret_cast<sockaddr_dl *>(m_interfaceAddress->ifa_addr) };
 
-                    if (msg &&
+                    if (sdl &&
                         (msg->rtm_addrs & RTA_GATEWAY) == RTA_GATEWAY &&
                         msg->rtm_index == sdl->sdl_index)
                     {
@@ -171,7 +171,7 @@ class NetworkBSDInterface final : public INetworkInterfaceWrapper
 
     uint32_t mtu() const override
     {
-        return m_interfaceAddress ? reinterpret_cast<if_data *>(m_interfaceAddress->ifa_data)->ifi_mtu : 0;
+        return m_interfaceAddress->ifa_data ? reinterpret_cast<if_data *>(m_interfaceAddress->ifa_data)->ifi_mtu : 0;
     }
 
     LinkStats stats() const override

--- a/src/data_provider/src/network/networkInterfaceBSD.h
+++ b/src/data_provider/src/network/networkInterfaceBSD.h
@@ -24,9 +24,9 @@ class FactoryBSDNetwork
 template <unsigned short osNetworkType>
 class BSDNetworkImpl final : public IOSNetwork
 {
-    const std::shared_ptr<INetworkInterfaceWrapper>& m_interfaceAddress;
+    const std::shared_ptr<INetworkInterfaceWrapper> m_interfaceAddress;
 public:
-    explicit BSDNetworkImpl(const std::shared_ptr<INetworkInterfaceWrapper>& interfaceAddress) 
+    explicit BSDNetworkImpl(const std::shared_ptr<INetworkInterfaceWrapper>& interfaceAddress)
     : m_interfaceAddress(interfaceAddress)
     { }
     void buildNetworkData(nlohmann::json& /*network*/) override


### PR DESCRIPTION
|Related issue|
|---|
| Closes #9828 |

## Description
RCA
![image](https://user-images.githubusercontent.com/14300208/130549263-2544d181-57c3-4fed-8ca3-55b2273b31b6.png)

For correct operation of the reference counter of the object must be incremented by means of a value copy, and not a reference copy.

Added sanitys.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [X] MAC OS X
- [X] Source installation
- [X] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [X] Leaks
  - [X] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors