### PR TITLE
Enable agent IP reporting on FreeBSD and OpenBSD

### DIFF
--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -43,7 +43,7 @@ char *getsharedfiles()
 char *get_agent_ip()
 {
     static char agent_ip[IPSIZE + 1] = { '\0' };
-#if defined (__linux__) || defined (__MACH__) || defined (sun)
+#if defined (__linux__) || defined (__MACH__) || defined (sun) || defined(FreeBSD) || defined(OpenBSD)
     static time_t last_update = 0;
     time_t now = time(NULL);
     int sock;

--- a/src/headers/agent_op.h
+++ b/src/headers/agent_op.h
@@ -106,7 +106,7 @@ cJSON* w_create_sendsync_payload(const char *daemon_name, cJSON *message);
 char * get_agent_id_from_name(const char *agent_name);
 
 /* Check control module availability */
-#if defined (__linux__) || defined (__MACH__) || defined (sun)
+#if defined (__linux__) || defined (__MACH__) || defined (sun) || defined(FreeBSD) || defined(OpenBSD)
 int control_check_connection();
 #endif
 

--- a/src/shared/agent_op.c
+++ b/src/shared/agent_op.c
@@ -971,7 +971,7 @@ char * get_agent_id_from_name(const char *agent_name) {
 }
 
 /* Connect to the control socket if available */
-#if defined (__linux__) || defined (__MACH__) || defined(sun)
+#if defined (__linux__) || defined (__MACH__) || defined(sun) || defined(FreeBSD) || defined(OpenBSD)
 int control_check_connection() {
     int sock = OS_ConnectUnixDomain(CONTROL_SOCK, SOCK_STREAM, OS_SIZE_128);
 

--- a/src/shared/log_builder.c
+++ b/src/shared/log_builder.c
@@ -250,7 +250,7 @@ int log_builder_update_host_ip(log_builder_t * builder) {
         mdebug1("Cannot update host IP.");
     }
 
-#elif defined __linux__ || defined __MACH__ || defined sun
+#elif defined __linux__ || defined __MACH__ || defined sun || defined FreeBSD || defined OpenBSD
     const char * REQUEST = "host_ip";
     int sock = control_check_connection();
 

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -9,7 +9,7 @@
  * Foundation.
  */
 
-#if defined (__linux__) || defined (__MACH__) || defined (sun)
+#if defined (__linux__) || defined (__MACH__) || defined (sun) || defined(FreeBSD) || defined(OpenBSD)
 #include "wm_control.h"
 #include "sysInfo.h"
 #include "sym_load.h"
@@ -33,7 +33,7 @@ void *sysinfo_module = NULL;
 sysinfo_networks_func sysinfo_network_ptr = NULL;
 sysinfo_free_result_func sysinfo_free_result_ptr = NULL;
 
-#if defined (__linux__) || defined (__MACH__)
+#if defined (__linux__) || defined (__MACH__) || defined(FreeBSD) || defined(OpenBSD)
 #include <ifaddrs.h>
 #elif defined sun
 #include <net/if.h>
@@ -78,7 +78,7 @@ char* getPrimaryIP(){
      /* Get Primary IP */
     char * agent_ip = NULL;
 
-#if defined __linux__ || defined __MACH__
+#if defined __linux__ || defined __MACH__ || defined(FreeBSD) || defined(OpenBSD)
     cJSON *object;
     if (sysinfo_network_ptr && sysinfo_free_result_ptr) {
         const int error_code = sysinfo_network_ptr(&object);

--- a/src/wazuh_modules/wmodules.c
+++ b/src/wazuh_modules/wmodules.c
@@ -84,7 +84,7 @@ int wm_config() {
 
 #endif
 
-#if defined (__linux__) || (__MACH__) || defined (sun)
+#if defined (__linux__) || (__MACH__) || defined (sun) || defined(FreeBSD) || defined(OpenBSD)
     wmodule * control_module;
     control_module = wm_control_read();
     wm_add(control_module);


### PR DESCRIPTION
This PR aims to allow the agent to report its IP address in its heartbeat (which should make it visible in the API) and Logcollector on FreeBSD and OpenBSD.

IP gathering is already implemented on BSD (by the Data Provider library), however, IP reporting was disabled on those platforms.

This PR is similar to #7408 (when we enabled it on Solaris). The internal feature in the Data Provider library was tested at #9828.

## Tests

### Get the agent's IP via API

```json
# GET https://localhost:55000/agents?q=id=4113
{
  "data": {
    "affected_items": [
      {
        "os": {
          "arch": "amd64",
          "major": "13",
          "minor": "0",
          "name": "FreeBSD",
          "platform": "freebsd",
          "uname": "FreeBSD |freebsd |13.0-CURRENT |FreeBSD 13.0-CURRENT #0 main-c255641-gf2b794e1e90: Thu Jan  7 06:25:26 UTC 2021     root@releng1.nyi.freebsd.org:/usr/obj/usr/src/amd64.amd64/sys/GENERIC |amd64",
          "version": "13.0-CURRENT"
        },
        "id": "4113",
        "status": "active",
        "dateAdd": "2021-08-24T11:40:29Z",
        "mergedSum": "2c45c95db2954d2c7d0ea533f09e81a5",
        "name": "freebsd",
        "ip": "10.0.2.15",
        "version": "Wazuh v4.2.0",
        "lastKeepAlive": "2021-08-24T16:32:33Z",
        "registerIP": "any",
        "group": [
          "default"
        ],
        "manager": "Rocket",
        "node_name": "node01",
        "configSum": "ab73af41699f13fdd81903b5f23d8d00"
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents information was returned",
  "error": 0
}
```

### Report the agent's IP in a formatted log

Setting up a local file monitoring with this output pattern:
```xml
<out_format>[$(host_ip)] $(log)</out_format>
```

We get logs like this in _archives.log_:
```
2021 Aug 24 18:31:55 (freebsd) any->/root/test.log [10.0.2.15] This is a test.
```