### PR TITLE
Fix version update problem from previous versions to 4.2

### DIFF
--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -489,7 +489,6 @@
         <DirectoryRef Id="TMP">
             <Component Id="CMP_TMP" Guid="EC4352C1-4110-4E6A-9A5E-E31F22702705" KeyPath="yes">
                 <CreateFolder />
-                <RemoveFile Id="purgue_tmp" Name="*.*" On="uninstall" />
                 <RemoveFolder Id="purgue_tmp_dir" On="uninstall" />
             </Component>
         </DirectoryRef>


### PR DESCRIPTION
|Related issue|
|---|
| Closes #9896 |

## Description
The fix it does is prevent the files under the TMP folder from being evaluated in InstallValidate Action during uninstallation.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [X] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [X] Package installation
- [ ] Source upgrade
- [X] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors