### PR TITLE
Adapt fim_sync.c to instantiate Rsync and g++ compilation

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1864,7 +1864,7 @@ syscheckd/%-event.o: syscheckd/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} ${DEFINES_EVENTCHANNEL} -DEVENTCHANNEL_SUPPORT -DARGV0=\"wazuh-syscheckd\" -c $^ -o $@
 
 wazuh-syscheckd: ${syscheck_o} rootcheck.a ${FIMDB_LIB}
-	${OSSEC_CXXBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} ${DBSYNC_LIB} -o $@
+	${OSSEC_CXXBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} ${DBSYNC_LIB} ${RSYNC_LIB} -o $@
 
 #### Monitor #######
 
@@ -2204,10 +2204,10 @@ win32/ui/%.o: win32/ui/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -UOSSECHIDS -DARGV0=\"wazuh-win32ui\" -c $^ -o $@
 
 win32/wazuh-agent.exe: win32/icon.o win32/win_agent.o win32/win_service.o win32/win_utils.o ${syscheck_o} ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main.o, ${os_logcollector_o}) ${os_execd_o} active-response/active_responses.o monitord/rotate_log.o monitord/compress_log.o ${FIMDB_LIB}
-	${OSSEC_CXXBIN} -DARGV0=\"wazuh-agent\" -DOSSECHIDS ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} ${DBSYNC_LIB} -o $@
+	${OSSEC_CXXBIN} -DARGV0=\"wazuh-agent\" -DOSSECHIDS ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} ${DBSYNC_LIB} ${RSYNC_LIB} -o $@
 
 win32/wazuh-agent-eventchannel.exe: win32/icon.o win32/win_agent.o win32/win_service.o win32/win_utils.o $(filter-out syscheckd/main-event.o, ${syscheck_eventchannel_o}) ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main-event.o, ${os_logcollector_eventchannel_o}) ${os_execd_o} active-response/active_responses.o monitord/rotate_log.o monitord/compress_log.o ${FIMDB_LIB}
-	${OSSEC_CXXBIN} -DARGV0=\"wazuh-agent\" -DOSSECHIDS -DEVENTCHANNEL_SUPPORT ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} ${DBSYNC_LIB} -o $@
+	${OSSEC_CXXBIN} -DARGV0=\"wazuh-agent\" -DOSSECHIDS -DEVENTCHANNEL_SUPPORT ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} ${DBSYNC_LIB} ${RSYNC_LIB} -o $@
 
 win32/manage_agents.exe: win32/win_service_rk.o ${addagent_o}
 	${OSSEC_CCBIN} -DARGV0=\"manage-agents\" -DMA ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@

--- a/src/syscheckd/db/CMakeLists.txt
+++ b/src/syscheckd/db/CMakeLists.txt
@@ -71,7 +71,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   add_definitions(-DWIN32=1 -D_WIN32_WINNT=0x600 -DWIN_EXPORT)
 endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 
-add_library(fimdb STATIC ${CMAKE_SOURCE_DIR}/src/db.cpp
+add_library(fimdb STATIC ${CMAKE_SOURCE_DIR}/src/sync.cpp
+                         ${CMAKE_SOURCE_DIR}/src/db.cpp
                          ${CMAKE_SOURCE_DIR}/src/file.cpp)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")

--- a/src/syscheckd/db/src/registry.cpp
+++ b/src/syscheckd/db/src/registry.cpp
@@ -637,3 +637,6 @@ int fim_db_process_read_registry_data_file(fdb_t *fim_sql, fim_tmp_file *file, p
 #ifdef __cplusplus
 }
 #endif
+#ifdef __cplusplus
+}
+#endif

--- a/src/syscheckd/db/src/sync.cpp
+++ b/src/syscheckd/db/src/sync.cpp
@@ -74,7 +74,7 @@ void * fim_run_integrity(void * args) {
 #endif
         gettime(&end);
 
-        struct timespec timeout = { .tv_sec = time(NULL) + sync_interval };
+        struct timespec timeout = { .tv_sec = time(NULL) + sync_interval, .tv_nsec = 0 };
 
         mdebug2("Finished calculating FIM integrity. Time: %.3f seconds.", time_diff(&start, &end));
 


### PR DESCRIPTION
|Related issue|
|---|
|#9115|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
fim_sync.c moved to syscheckd/db/src/ and renamed to sync.cpp. Applied changes to make an instance of RemoteSync in function fim_run_integrity

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
  - [ ] MAC OS X
- [X] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [X] Valgrind (memcheck and descriptor leaks check)

- Memory tests for Windows
  - [ ] Scan-build report

