### PR TITLE
Adjust RBAC API integration test responses

### DIFF
--- a/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
@@ -152,17 +152,6 @@ stages:
         Authorization: "Bearer {test_login_token}"
     response:
       status_code: 200
-      json:
-        error: 0
-        data:
-          client:
-            auto_restart: !anystr
-            config-profile: !anystr
-            crypto_method: !anystr
-            notify_time: !anyint
-            remote_conf: !anystr
-            server: !anything
-            time-reconnect: !anyint
 
 ---
 test_name: GET /agents/{agent_id}/group/is_sync
@@ -255,21 +244,6 @@ stages:
        Authorization: "Bearer {test_login_token}"
    response:
      status_code: 200
-     json:
-       error: 0
-       data:
-         affected_items:
-           - global:
-               start: !anystr
-               end: !anystr
-               files: !anything
-             interval:
-               start: !anystr
-               end: !anystr
-               files: !anything
-         failed_items: []
-         total_affected_items: 1
-         total_failed_items: 0
 
 ---
 test_name: GET /groups
@@ -401,13 +375,6 @@ stages:
        Authorization: "Bearer {test_login_token}"
    response:
      status_code: 200
-     json:
-       error: 0
-       data:
-         affected_items:
-           - config: !anything
-             filters: !anything
-         total_affected_items: !anyint
 
 ---
 test_name: GET /groups/{group_id}/files
@@ -472,9 +439,6 @@ stages:
        Authorization: "Bearer {test_login_token}"
    response:
      status_code: 200
-     json:
-       error: 0
-       data: !anything
 
 ---
 test_name: GET /groups/{group_id}/files/{filename}/xml
@@ -1586,9 +1550,6 @@ stages:
       status_code: 403
       json:
         error: 4000
-        dapi_errors:
-          master-node: # We have permission to see node name
-            error: !anystr
 
 ---
 test_name: PUT /agents/node/{node_id}/restart

--- a/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
@@ -1550,6 +1550,9 @@ stages:
       status_code: 403
       json:
         error: 4000
+        dapi_errors:
+          master-node: # We have permission to see node name
+            error: !anystr
 
 ---
 test_name: PUT /agents/node/{node_id}/restart

--- a/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
@@ -43,9 +43,6 @@ stages:
       status_code: 403
       json:
         error: 4000
-        dapi_errors:
-          unknown-node: # No permission to see node
-            error: !anystr
 
   - name: Get a list of agents (Partially allowed, user aware)
     request:
@@ -156,17 +153,6 @@ stages:
         Authorization: "Bearer {test_login_token}"
     response:
       status_code: 200
-      json:
-        error: 0
-        data:
-          client:
-            auto_restart: !anystr
-            config-profile: !anystr
-            crypto_method: !anystr
-            notify_time: !anyint
-            remote_conf: !anystr
-            server: !anything
-            time-reconnect: !anyint
 
 ---
 test_name: GET /agents/{agent_id}/group/is_sync
@@ -249,21 +235,6 @@ stages:
        Authorization: "Bearer {test_login_token}"
    response:
      status_code: 200
-     json:
-       error: 0
-       data:
-         affected_items:
-           - global:
-               start: !anystr
-               end: !anystr
-               files: !anything
-             interval:
-               start: !anystr
-               end: !anystr
-               files: !anything
-         failed_items: []
-         total_affected_items: 1
-         total_failed_items: 0
 
  - name: Try to get logcollector stats from agent 003 (Denied)
    request:
@@ -408,13 +379,6 @@ stages:
        Authorization: "Bearer {test_login_token}"
    response:
      status_code: 200
-     json:
-       error: 0
-       data:
-         affected_items:
-           - config: !anything
-             filters: !anything
-         total_affected_items: !anyint
 
 ---
 test_name: GET /groups/{group_id}/files
@@ -479,9 +443,6 @@ stages:
        Authorization: "Bearer {test_login_token}"
    response:
      status_code: 200
-     json:
-       error: 0
-       data: !anything
 
 ---
 test_name: GET /groups/{group_id}/files/{filename}/xml
@@ -742,8 +703,6 @@ stages:
         Authorization: "Bearer {test_login_token}"
     response:
       status_code: 200
-      json:
-        message: !anystr
 
 ---
 test_name: DELETE /agents/{agent_id}/group
@@ -1393,8 +1352,6 @@ stages:
         "{file_xml:s}"
     response:
       status_code: 200
-      json:
-        message: !anystr
 
   - name: Try to update group1 configuration (Denied)
     request:

--- a/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
@@ -43,6 +43,9 @@ stages:
       status_code: 403
       json:
         error: 4000
+        dapi_errors:
+        unknown-node: # No permission to see node
+          error: !anystr
 
   - name: Get a list of agents (Partially allowed, user aware)
     request:

--- a/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
@@ -44,8 +44,8 @@ stages:
       json:
         error: 4000
         dapi_errors:
-        unknown-node: # No permission to see node
-          error: !anystr
+          unknown-node: # No permission to see node
+            error: !anystr
 
   - name: Get a list of agents (Partially allowed, user aware)
     request:


### PR DESCRIPTION
|Related issue|
|---|
| #9695 |

# Description
This PR closes #9695.
I updated `test_rbac_white_agent_endpoints.tavern.yaml` and `test_rbac_black_agent_endpoints.tavern.yaml`.
Generic responses were deleted since for testing purposes we only need status codes.

## Int test: test_rbac_black_agent & test_rbac_white_agent
```
↪ ~/git/wazuh/api/test/integration ⊶ fix/9695-rbac-integration ⨘ pytest -vv -x --disable-warnings test_rbac_black_agent_endpoints.tavern.yaml && pytest -vv -x --disable-warnings test_rbac_white_agent_endpoints.tavern.yaml
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.9.5, pytest-5.0.0, py-1.10.0, pluggy-0.13.1 -- /home/kondent/pythonEnv/inttest-env/bin/python3.9
cachedir: .pytest_cache
metadata: {'Python': '3.9.5', 'Platform': 'Linux-5.11.0-27-generic-x86_64-with-glibc2.31', 'Packages': {'pytest': '5.0.0', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'metadata': '1.11.0', 'tavern': '1.2.2'}}
rootdir: /home/kondent/git/wazuh/api/test/integration, inifile: pytest.ini
plugins: html-3.1.1, metadata-1.11.0, tavern-1.2.2
collected 40 items                                                                                                                                                                           

test_rbac_black_agent_endpoints.tavern.yaml::GET /agents PASSED                                                                                                                        [  2%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents?agents_list=agent_id PASSED                                                                                                   [  5%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} PASSED                                                                          [  7%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/group/is_sync PASSED                                                                                               [ 10%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/key PASSED                                                                                                         [ 12%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/stats/{component} PASSED                                                                                           [ 15%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups PASSED                                                                                                                        [ 17%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups/{group_id}/agents PASSED                                                                                                      [ 20%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups/{group_id}/configuration PASSED                                                                                               [ 22%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files PASSED                                                                                                       [ 25%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/json PASSED                                                                                       [ 27%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/xml PASSED                                                                                        [ 30%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents?name=agent_name PASSED                                                                                                        [ 32%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/no_group PASSED                                                                                                               [ 35%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/outdated PASSED                                                                                                               [ 37%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED                                                                                                         [ 40%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/summary/status PASSED                                                                                                         [ 42%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/summary/os PASSED                                                                                                             [ 45%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/upgrade_result PASSED                                                                                                         [ 47%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group/{group_id} PASSED                                                                                         [ 50%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group PASSED                                                                                                    [ 52%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents/group?group_id=group_id PASSED                                                                                             [ 55%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE groups?groups_list=group_id PASSED                                                                                                 [ 57%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /groups PASSED                                                                                                                     [ 60%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents?agents_list=agent_id PASSED                                                                                                [ 62%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents PASSED                                                                                                                     [ 65%]
test_rbac_black_agent_endpoints.tavern.yaml::POST /agents PASSED                                                                                                                       [ 67%]
test_rbac_black_agent_endpoints.tavern.yaml::POST /agents/insert PASSED                                                                                                                [ 70%]
test_rbac_black_agent_endpoints.tavern.yaml::POST /agents/insert/quick PASSED                                                                                                          [ 72%]
test_rbac_black_agent_endpoints.tavern.yaml::POST /groups PASSED                                                                                                                       [ 75%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/group?group_id={group_id} PASSED                                                                                              [ 77%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /groups/{group_id}/configuration PASSED                                                                                               [ 80%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/group/{group_id}/restart PASSED                                                                                               [ 82%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/restart PASSED                                                                                                                [ 85%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/{agent_id}/group/{group_id} PASSED                                                                                            [ 87%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/{agent_id}/restart PASSED                                                                                                     [ 90%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/upgrade PASSED                                                                                                                [ 92%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/upgrade_custom PASSED                                                                                                         [ 95%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents (allow cluster:read) PASSED                                                                                                   [ 97%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/node/{node_id}/restart PASSED                                                                                                 [100%]

========================================================================== 40 passed, 1 warnings in 750.20 seconds ===========================================================================
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.9.5, pytest-5.0.0, py-1.10.0, pluggy-0.13.1 -- /home/kondent/pythonEnv/inttest-env/bin/python3.9
cachedir: .pytest_cache
metadata: {'Python': '3.9.5', 'Platform': 'Linux-5.11.0-27-generic-x86_64-with-glibc2.31', 'Packages': {'pytest': '5.0.0', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'metadata': '1.11.0', 'tavern': '1.2.2'}}
rootdir: /home/kondent/git/wazuh/api/test/integration, inifile: pytest.ini
plugins: html-3.1.1, metadata-1.11.0, tavern-1.2.2
collected 40 items                                                                                                                                                                           

test_rbac_white_agent_endpoints.tavern.yaml::GET /agents PASSED                                                                                                                        [  2%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents?agents_list=agent_id PASSED                                                                                                   [  5%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} PASSED                                                                          [  7%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/group/is_sync PASSED                                                                                               [ 10%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/key PASSED                                                                                                         [ 12%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/stats/{component} PASSED                                                                                           [ 15%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /groups PASSED                                                                                                                        [ 17%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /groups/{group_id}/agents PASSED                                                                                                      [ 20%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /groups/{group_id}/configuration PASSED                                                                                               [ 22%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files PASSED                                                                                                       [ 25%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/json PASSED                                                                                       [ 27%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/xml PASSED                                                                                        [ 30%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents?name=agent_name PASSED                                                                                                        [ 32%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/no_group PASSED                                                                                                               [ 35%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/outdated PASSED                                                                                                               [ 37%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED                                                                                                         [ 40%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/summary/status PASSED                                                                                                         [ 42%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/summary/os PASSED                                                                                                             [ 45%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group/{group_id} PASSED                                                                                         [ 47%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group PASSED                                                                                                    [ 50%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /agents/group?group_id={group_id} PASSED                                                                                           [ 52%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /groups?groups_list={group_id} PASSED                                                                                              [ 55%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /groups PASSED                                                                                                                     [ 57%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /agents?agents_list=agent_id&status=all PASSED                                                                                     [ 60%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /agents PASSED                                                                                                                     [ 62%]
test_rbac_white_agent_endpoints.tavern.yaml::POST /agents PASSED                                                                                                                       [ 65%]
test_rbac_white_agent_endpoints.tavern.yaml::POST /agents/insert PASSED                                                                                                                [ 67%]
test_rbac_white_agent_endpoints.tavern.yaml::POST /agents/insert/quick PASSED                                                                                                          [ 70%]
test_rbac_white_agent_endpoints.tavern.yaml::POST /groups PASSED                                                                                                                       [ 72%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/group PASSED                                                                                                                  [ 75%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /groups/{group_id}/configuration PASSED                                                                                               [ 77%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/group/{group_id}/restart PASSED                                                                                               [ 80%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/restart PASSED                                                                                                                [ 82%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/{agent_id}/group/{group_id} PASSED                                                                                            [ 85%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/{agent_id}/restart PASSED                                                                                                     [ 87%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/upgrade PASSED                                                                                                                [ 90%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/upgrade_custom PASSED                                                                                                         [ 92%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/upgrade_result PASSED                                                                                                         [ 95%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents (deny cluster:read) PASSED                                                                                                    [ 97%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/node/{node_id}/restart PASSED                                                                                                 [100%]

========================================================================== 40 passed, 1 warnings in 542.79 seconds ===========================================================================
```