### PR TITLE
Added improvements in nlohmann copies in syscollector.

### DIFF
--- a/src/shared_modules/dbsync/testtool/action.h
+++ b/src/shared_modules/dbsync/testtool/action.h
@@ -75,7 +75,7 @@ struct UpdateWithSnapshotAction final : public IAction
     void execute(std::unique_ptr<TestContext>& ctx, const nlohmann::json& value) override
     {
         const std::unique_ptr<cJSON, TestDeleters::CJsonDeleter> currentSnapshotPtr
-        { 
+        {
             cJSON_Parse(value["body"].dump().c_str())
         };
         cJSON* snapshotLambda{ nullptr };
@@ -83,7 +83,7 @@ struct UpdateWithSnapshotAction final : public IAction
         {
             // Create and flush snapshot diff data in files like: snapshot_<#idx>.json
             const std::unique_ptr<cJSON, TestDeleters::ResultDeleter> snapshotLambdaPtr(snapshotLambda);
-            
+
             std::stringstream oFileName;
             oFileName << "action_" << ctx->currentId << ".json";
             const std::string outputFileName{ ctx->outputPath +"/"+oFileName.str() };
@@ -113,7 +113,7 @@ static void txnCallback(ReturnTypeCallback type, const cJSON* json, void* user_d
         const std::unique_ptr<char, TestDeleters::CJsonDeleter> spJsonBytes{cJSON_PrintUnformatted(json)};
         const auto newJson{nlohmann::json::parse(spJsonBytes.get())};
         nlohmann::json jsonResult;
-        jsonResult.push_back(newJson.is_array() ? newJson : newJson);
+        jsonResult.push_back(newJson);
         jsonResult.push_back({{"result", type}});
 
         std::ofstream outputFile{ outputFileName, std::ofstream::app};
@@ -123,14 +123,14 @@ static void txnCallback(ReturnTypeCallback type, const cJSON* json, void* user_d
 
 struct CreateTransactionAction final : public IAction
 {
-    void execute(std::unique_ptr<TestContext>& ctx, 
+    void execute(std::unique_ptr<TestContext>& ctx,
                  const nlohmann::json& value) override
     {
         const std::unique_ptr<cJSON, TestDeleters::CJsonDeleter> jsonTables
-        { 
+        {
             cJSON_Parse(value["body"]["tables"].dump().c_str())
         };
-        
+
         callback_data_t callbackData { txnCallback, ctx.get() };
 
         ctx->txnContext = dbsync_create_txn(ctx->handle,
@@ -151,10 +151,10 @@ struct CreateTransactionAction final : public IAction
 
 struct CloseTransactionAction final : public IAction
 {
-    void execute(std::unique_ptr<TestContext>& ctx, 
+    void execute(std::unique_ptr<TestContext>& ctx,
                  const nlohmann::json& /*value*/) override
     {
-        
+
 
         const auto retVal { dbsync_close_txn(ctx->txnContext)} ;
 
@@ -217,7 +217,7 @@ static void getCallbackCtx(ReturnTypeCallback /*type*/,
     }
     const std::unique_ptr<char, TestDeleters::CJsonDeleter> spJsonBytes{cJSON_PrintUnformatted(json)};
     const auto& newJson { nlohmann::json::parse(spJsonBytes.get()) };
-    jsonResult.push_back(newJson.is_array() ? newJson : newJson);
+    jsonResult.push_back(newJson);
 
     std::ofstream outputFile{ loggerContext->m_fileName };
     outputFile << jsonResult.dump() << std::endl;
@@ -236,13 +236,13 @@ struct GetDeletedRowsAction final : public IAction
 
         const auto& loggerContext { std::make_unique<GetCallbackLogger>(outputFileNameCallback) };
         callback_data_t callbackData { getCallbackCtx, loggerContext.get() } ;
-        
+
         const auto retVal
         {
             dbsync_get_deleted_rows(ctx->txnContext,
                                     callbackData)
         };
-        
+
         std::ofstream outputFile{ outputFileName };
         const nlohmann::json& jsonResult { {"dbsync_get_deleted_rows", retVal } };
         outputFile << jsonResult.dump() << std::endl;
@@ -676,7 +676,7 @@ struct SyncRowActionCPP final : public IAction
                 outputFile << jsonResult.dump() << std::endl;
             }
         };
- 
+
         int retVal { 0 };
 
         try

--- a/src/wazuh_modules/syscollector/include/syscollector.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector.hpp
@@ -81,7 +81,7 @@ private:
 
     void registerWithRsync();
     void updateAndNotifyChanges(const std::string& table,
-                                const nlohmann::json& values);
+                                const nlohmann::json& input);
     void scanHardware();
     void scanOs();
     void scanNetwork();

--- a/src/wazuh_modules/syscollector/include/syscollectorNormalizer.h
+++ b/src/wazuh_modules/syscollector/include/syscollectorNormalizer.h
@@ -20,10 +20,10 @@ public:
     SysNormalizer(const std::string& configFile,
                   const std::string& target);
     ~SysNormalizer() = default;
-    nlohmann::json normalize(const std::string& type,
-                             const nlohmann::json& data) const;
-    nlohmann::json removeExcluded(const std::string& type,
-                                  const nlohmann::json& data) const;
+    void normalize(const std::string& type,
+                   nlohmann::json& data) const;
+    void removeExcluded(const std::string& type,
+                        nlohmann::json& data) const;
 private:
     static std::map<std::string, nlohmann::json> getTypeValues(const std::string& configFile,
                                                                const std::string& target,

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -931,7 +931,7 @@ static bool isElementDuplicated(const nlohmann::json & input, const std::pair<st
 }
 
 void Syscollector::updateAndNotifyChanges(const std::string& table,
-                                          const nlohmann::json& values)
+                                          const nlohmann::json& input)
 {
     const std::map<ReturnTypeCallback, std::string> operationsMap
     {
@@ -995,10 +995,6 @@ void Syscollector::updateAndNotifyChanges(const std::string& table,
         queueSize,
         callback
     };
-    nlohmann::json jsResult;
-    nlohmann::json input;
-    input["table"] = table;
-    input["data"] = values;
     txn.syncTxnRow(input);
     txn.getDeletedRows(callback);
 }
@@ -1218,8 +1214,10 @@ void Syscollector::scanHardware()
     if (m_hardware)
     {
         m_logFunction(SYS_LOG_DEBUG_VERBOSE, "Starting hardware scan");
-        const auto& hwData{getHardwareData()};
-        updateAndNotifyChanges(HW_TABLE, hwData);
+        nlohmann::json input;
+        input["table"] = HW_TABLE;
+        input["data"] = getHardwareData();
+        updateAndNotifyChanges(HW_TABLE, input);
         m_logFunction(SYS_LOG_DEBUG_VERBOSE, "Ending hardware scan");
     }
 }
@@ -1245,8 +1243,10 @@ void Syscollector::scanOs()
     if (m_os)
     {
         m_logFunction(SYS_LOG_DEBUG_VERBOSE, "Starting os scan");
-        const auto& osData{getOSData()};
-        updateAndNotifyChanges(OS_TABLE, osData);
+        nlohmann::json input;
+        input["table"] = OS_TABLE;
+        input["data"] = getOSData();
+        updateAndNotifyChanges(OS_TABLE, input);
         m_logFunction(SYS_LOG_DEBUG_VERBOSE, "Ending os scan");
     }
 }
@@ -1294,7 +1294,7 @@ nlohmann::json Syscollector::getNetworkData()
                 ifaceTableData["rx_dropped"] = item.at("rx_dropped");
                 ifaceTableData["checksum"]   = getItemChecksum(ifaceTableData);
                 ifaceTableData["item_id"]    = getItemId(ifaceTableData, NETIFACE_ITEM_ID_FIELDS);
-                ifaceTableDataList.push_back(ifaceTableData);
+                ifaceTableDataList.push_back(std::move(ifaceTableData));
 
                 // "dbsync_network_protocol" table data to update and notify
                 nlohmann::json protoTableData {};
@@ -1314,7 +1314,7 @@ nlohmann::json Syscollector::getNetworkData()
                         addressTableData["proto"]     = 0;
                         addressTableData["checksum"]  = getItemChecksum(addressTableData);
                         addressTableData["item_id"]   = getItemId(addressTableData, NETADDRESS_ITEM_ID_FIELDS);
-                        addressTableDataList.push_back(addressTableData);
+                        addressTableDataList.push_back(std::move(addressTableData));
                     }
                 }
 
@@ -1330,16 +1330,16 @@ nlohmann::json Syscollector::getNetworkData()
                         addressTableData["proto"]     = 1;
                         addressTableData["checksum"]  = getItemChecksum(addressTableData);
                         addressTableData["item_id"]   = getItemId(addressTableData, NETADDRESS_ITEM_ID_FIELDS);
-                        addressTableDataList.push_back(addressTableData);
+                        addressTableDataList.push_back(std::move(addressTableData));
                     }
                 }
                 protoTableData["checksum"]  = getItemChecksum(protoTableData);
                 protoTableData["item_id"]   = getItemId(protoTableData, NETPROTO_ITEM_ID_FIELDS);
-                protoTableDataList.push_back(protoTableData);
+                protoTableDataList.push_back(std::move(protoTableData));
             }
-            ret[NET_IFACE_TABLE] = ifaceTableDataList;
-            ret[NET_PROTOCOL_TABLE] = protoTableDataList;
-            ret[NET_ADDRESS_TABLE] = addressTableDataList;
+            ret[NET_IFACE_TABLE] = std::move(ifaceTableDataList);
+            ret[NET_PROTOCOL_TABLE] = std::move(protoTableDataList);
+            ret[NET_ADDRESS_TABLE] = std::move(addressTableDataList);
         }
     }
     return ret;
@@ -1350,23 +1350,32 @@ void Syscollector::scanNetwork()
     if (m_network)
     {
         m_logFunction(SYS_LOG_DEBUG_VERBOSE, "Starting network scan");
-        const auto& networkData{getNetworkData()};
+        auto networkData(getNetworkData());
         if (!networkData.is_null())
         {
-            const auto itIface { networkData.find(NET_IFACE_TABLE) };
+            auto itIface { networkData.find(NET_IFACE_TABLE) };
             if (itIface != networkData.end())
             {
-                updateAndNotifyChanges(NET_IFACE_TABLE, itIface.value());
+                nlohmann::json input;
+                input["table"] = NET_IFACE_TABLE;
+                input["data"] = std::move(*itIface);
+                updateAndNotifyChanges(NET_IFACE_TABLE, input);
             }
-            const auto itProtocol { networkData.find(NET_PROTOCOL_TABLE) };
+            auto itProtocol { networkData.find(NET_PROTOCOL_TABLE) };
             if (itProtocol != networkData.end())
             {
-                updateAndNotifyChanges(NET_PROTOCOL_TABLE, itProtocol.value());
+                nlohmann::json input;
+                input["table"] = NET_PROTOCOL_TABLE;
+                input["data"] = std::move(*itProtocol);
+                updateAndNotifyChanges(NET_PROTOCOL_TABLE, input);
             }
-            const auto itAddress { networkData.find(NET_ADDRESS_TABLE) };
+            auto itAddress { networkData.find(NET_ADDRESS_TABLE) };
             if (itAddress != networkData.end())
             {
-                updateAndNotifyChanges(NET_ADDRESS_TABLE, itAddress.value());
+                nlohmann::json input;
+                input["table"] = NET_ADDRESS_TABLE;
+                input["data"] = std::move(*itAddress);
+                updateAndNotifyChanges(NET_ADDRESS_TABLE, input);
             }
         }
         m_logFunction(SYS_LOG_DEBUG_VERBOSE, "Ending network scan");
@@ -1388,20 +1397,18 @@ nlohmann::json Syscollector::getPackagesData()
     nlohmann::json ret;
     nlohmann::json packagesList;
     nlohmann::json hotfixesList;
-    const auto& packagesData { m_spInfo->packages() };
+    auto packagesData (m_spInfo->packages());
 
     if (!packagesData.is_null())
     {
-        const auto& normalizedPackagesData
-        {
-            m_spNormalizer->normalize("packages", m_spNormalizer->removeExcluded("packages", packagesData))
-        };
-        for (auto item : normalizedPackagesData)
+        m_spNormalizer->removeExcluded("packages", packagesData);
+        m_spNormalizer->normalize("packages", packagesData);
+        for (auto& item : packagesData)
         {
             item["checksum"] = getItemChecksum(item);
             if(item.find("hotfix") != item.end())
             {
-                hotfixesList.push_back(item);
+                hotfixesList.push_back(std::move(item));
             }
             else
             {
@@ -1409,12 +1416,12 @@ nlohmann::json Syscollector::getPackagesData()
                 if(!isElementDuplicated(packagesList, std::make_pair("item_id", itemId)))
                 {
                     item["item_id"] = itemId;
-                    packagesList.push_back(item);
+                    packagesList.push_back(std::move(item));
                 }
             }
         }
-        ret[HOTFIXES_TABLE] = hotfixesList;
-        ret[PACKAGES_TABLE] = packagesList;
+        ret[HOTFIXES_TABLE] = std::move(hotfixesList);
+        ret[PACKAGES_TABLE] = std::move(packagesList);
     }
     return ret;
 }
@@ -1424,20 +1431,26 @@ void Syscollector::scanPackages()
     if (m_packages)
     {
         m_logFunction(SYS_LOG_DEBUG_VERBOSE, "Starting packages scan");
-        const auto& packagesData { getPackagesData() };
+        auto packagesData (getPackagesData());
         if (!packagesData.is_null())
         {
-            const auto itPackages { packagesData.find(PACKAGES_TABLE) };
+            auto itPackages { packagesData.find(PACKAGES_TABLE) };
             if (itPackages != packagesData.end())
             {
-                updateAndNotifyChanges(PACKAGES_TABLE, itPackages.value());
+                nlohmann::json input;
+                input["table"] = PACKAGES_TABLE;
+                input["data"] = std::move(*itPackages);
+                updateAndNotifyChanges(PACKAGES_TABLE, input);
             }
             if (m_hotfixes)
             {
-                const auto itHotFixes { packagesData.find(HOTFIXES_TABLE) };
+                auto itHotFixes { packagesData.find(HOTFIXES_TABLE) };
                 if (itHotFixes != packagesData.end())
                 {
-                    updateAndNotifyChanges(HOTFIXES_TABLE, itHotFixes.value());
+                    nlohmann::json input;
+                    input["table"] = HOTFIXES_TABLE;
+                    input["data"] = std::move(*itHotFixes);
+                    updateAndNotifyChanges(HOTFIXES_TABLE, input);
                 }
             }
         }
@@ -1527,8 +1540,10 @@ void Syscollector::scanPorts()
     if (m_ports)
     {
         m_logFunction(SYS_LOG_DEBUG_VERBOSE, "Starting ports scan");
-        const auto& portsData { getPortsData() };
-        updateAndNotifyChanges(PORTS_TABLE, portsData);
+        nlohmann::json input;
+        input["table"] = PORTS_TABLE;
+        input["data"] = getPortsData();
+        updateAndNotifyChanges(PORTS_TABLE, input);
         m_logFunction(SYS_LOG_DEBUG_VERBOSE, "Ending ports scan");
     }
 }
@@ -1544,13 +1559,13 @@ void Syscollector::syncPorts()
 nlohmann::json Syscollector::getProcessesData()
 {
     nlohmann::json ret;
-    const auto& processes{m_spInfo->processes()};
+    auto processes(m_spInfo->processes());
     if (!processes.is_null())
     {
-        for (auto item : processes)
+        for (auto& item : processes)
         {
             item["checksum"] = getItemChecksum(item);
-            ret.push_back(item);
+            ret.push_back(std::move(item));
         }
     }
     return ret;
@@ -1561,8 +1576,10 @@ void Syscollector::scanProcesses()
     if (m_processes)
     {
         m_logFunction(SYS_LOG_DEBUG_VERBOSE, "Starting processes scan");
-        const auto& processesData{getProcessesData()};
-        updateAndNotifyChanges(PROCESSES_TABLE, processesData);
+        nlohmann::json input;
+        input["table"] = PROCESSES_TABLE;
+        input["data"] = getProcessesData();
+        updateAndNotifyChanges(PROCESSES_TABLE, input);
         m_logFunction(SYS_LOG_DEBUG_VERBOSE, "Ending processes scan");
     }
 }

--- a/src/wazuh_modules/syscollector/src/syscollectorNormalizer.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorNormalizer.cpp
@@ -20,10 +20,9 @@ SysNormalizer::SysNormalizer(const std::string& configFile,
 {
 }
 
-nlohmann::json SysNormalizer::removeExcluded(const std::string& type,
-                                             const nlohmann::json& data) const
+void SysNormalizer::removeExcluded(const std::string& type,
+                                   nlohmann::json& data) const
 {
-    nlohmann::json ret(data);
     const auto exclusionsIt{m_typeExclusions.find(type)};
     if (exclusionsIt != m_typeExclusions.cend())
     {
@@ -33,23 +32,23 @@ nlohmann::json SysNormalizer::removeExcluded(const std::string& type,
             {
                 std::regex pattern{exclusionItem["pattern"].get_ref<const std::string&>()};
                 const auto& fieldName{exclusionItem["field_name"].get_ref<const std::string&>()};
-                if (ret.is_array())
+                if (data.is_array())
                 {
-                    for (auto item{ret.begin()}; item != ret.end(); ++item)
+                    for (auto item{data.begin()}; item != data.end(); ++item)
                     {
                         const auto fieldIt{item->find(fieldName)};
                         if (fieldIt != item->end() && std::regex_match(fieldIt->get_ref<const std::string&>(), pattern))
                         {
-                            ret.erase(item);
+                            data.erase(item);
                         }
                     }
                 }
                 else
                 {
-                    const auto fieldIt{ret.find(fieldName)};
-                    if (fieldIt != ret.end() && std::regex_match(fieldIt->get_ref<const std::string&>(), pattern))
+                    const auto fieldIt{data.find(fieldName)};
+                    if (fieldIt != data.end() && std::regex_match(fieldIt->get_ref<const std::string&>(), pattern))
                     {
-                        ret.clear();
+                        data.clear();
                     }
                 }
             }
@@ -59,7 +58,6 @@ nlohmann::json SysNormalizer::removeExcluded(const std::string& type,
             // LCOV_EXCL_STOP
         }
     }
-    return ret;
 }
 
 
@@ -107,26 +105,24 @@ static void normalizeItem(const nlohmann::json& dictionary,
     }
 }
 
-nlohmann::json SysNormalizer::normalize(const std::string& type,
-                                        const nlohmann::json& data) const
+void SysNormalizer::normalize(const std::string& type,
+                              nlohmann::json& data) const
 {
-    nlohmann::json ret(data);
     const auto dictionaryIt{m_typeDictionary.find(type)};
     if (dictionaryIt != m_typeDictionary.cend())
     {
-        if (ret.is_array())
+        if (data.is_array())
         {
-            for (auto& item : ret)
+            for (auto& item : data)
             {
                 normalizeItem(dictionaryIt->second, item);
             }
         }
         else
         {
-            normalizeItem(dictionaryIt->second, ret);
+            normalizeItem(dictionaryIt->second, data);
         }
     }
-    return ret;
 }
 
 std::map<std::string, nlohmann::json> SysNormalizer::getTypeValues(const std::string& configFile,

--- a/src/wazuh_modules/syscollector/tests/sysNormalizer/sysNormalizer_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysNormalizer/sysNormalizer_test.cpp
@@ -57,197 +57,189 @@ TEST_F(SysNormalizerTest, ctorWrongFormatConfig)
 
 TEST_F(SysNormalizerTest, excludeSiriAndiTunes)
 {
-    const auto& inputJson{nlohmann::json::parse(TEST_INPUT_DATA)};
+    auto inputJson(nlohmann::json::parse(TEST_INPUT_DATA));
     const auto size{inputJson.size()};
     SysNormalizer normalizer{TEST_CONFIG_FILE_NAME, "macos"};
-    const auto& result{normalizer.removeExcluded("packages", inputJson)};
-    EXPECT_EQ(size, result.size()+2);
+    normalizer.removeExcluded("packages", inputJson);
+    EXPECT_EQ(size, inputJson.size()+2);
 }
 
 TEST_F(SysNormalizerTest, excludeSingleItemNoMatch)
 {
-    const auto& inputJson{nlohmann::json::parse(R"(
+    const auto& origJson{nlohmann::json::parse(R"(
         {
             "description": "com.apple.FaceTime",
             "group": "public.app-category.social-networking",
             "name": "FaceTime",
             "version": "3.0"
         })")};
+    nlohmann::json normalized(origJson);
     SysNormalizer normalizer{TEST_CONFIG_FILE_NAME, "macos"};
-    const auto& result{normalizer.removeExcluded("packages", inputJson)};
-    EXPECT_EQ(inputJson, result);
+    normalizer.removeExcluded("packages", normalized);
+    EXPECT_EQ(normalized, origJson);
 }
 
 TEST_F(SysNormalizerTest, excludeSingleItemMatch)
 {
-    const auto& inputJson{nlohmann::json::parse(R"(
+    auto inputJson(nlohmann::json::parse(R"(
         {
             "description": "com.apple.siri.launcher",
             "group": "public.app-category.utilities",
             "name": "Siri",
             "version": "1.0"
-        })")};
+        })"));
     SysNormalizer normalizer{TEST_CONFIG_FILE_NAME, "macos"};
-    const auto& result{normalizer.removeExcluded("packages", inputJson)};
-    EXPECT_NE(inputJson, result);
-    EXPECT_TRUE(result.empty());
+    normalizer.removeExcluded("packages", inputJson);
+    EXPECT_TRUE(inputJson.empty());
 }
 
 TEST_F(SysNormalizerTest, normalizeSingleMicosoft)
 {
-    const auto& inputJson{nlohmann::json::parse(R"(
+    auto inputJson(nlohmann::json::parse(R"(
         {
             "description": "com.microsoft.antivirus",
             "group": "public.app-category.security",
             "name": "Microsoft Defender",
             "version": "1.0"
-        })")};
+        })"));
     SysNormalizer normalizer{TEST_CONFIG_FILE_NAME, "macos"};
-    const auto& result{normalizer.normalize("packages", inputJson)};
-    EXPECT_NE(inputJson, result);
-    EXPECT_FALSE(result.empty());
-    EXPECT_EQ(result["vendor"], "Microsoft");
+    normalizer.normalize("packages", inputJson);
+    EXPECT_FALSE(inputJson.empty());
+    EXPECT_EQ(inputJson["vendor"], "Microsoft");
 }
 
 TEST_F(SysNormalizerTest, normalizeSingleMcAfee1)
 {
-    const auto& inputJson{nlohmann::json::parse(R"(
+    auto inputJson(nlohmann::json::parse(R"(
         {
             "description": "com.mcafee.antivirus",
             "group": "public.app-category.security",
             "name": "McAfee Antivirus For Mac",
             "version": "1.0"
-        })")};
+        })"));
     SysNormalizer normalizer{TEST_CONFIG_FILE_NAME, "macos"};
-    const auto& result{normalizer.normalize("packages", inputJson)};
-    EXPECT_NE(inputJson, result);
-    EXPECT_FALSE(result.empty());
-    EXPECT_EQ(result["vendor"], "McAfee");
-    EXPECT_EQ(result["name"], "Antivirus");
+    normalizer.normalize("packages", inputJson);
+    EXPECT_FALSE(inputJson.empty());
+    EXPECT_EQ(inputJson["vendor"], "McAfee");
+    EXPECT_EQ(inputJson["name"], "Antivirus");
 }
 
 TEST_F(SysNormalizerTest, normalizeSingleMcAfee2)
 {
-    const auto& inputJson{nlohmann::json::parse(R"(
+    auto inputJson(nlohmann::json::parse(R"(
         {
             "description": "com.mcafee.antivirus",
             "group": "public.app-category.security",
             "name": "McAfee Endpoint Protection For Mac",
             "version": "1.0"
-        })")};
+        })"));
     SysNormalizer normalizer{TEST_CONFIG_FILE_NAME, "macos"};
-    const auto& result{normalizer.normalize("packages", inputJson)};
-    EXPECT_NE(inputJson, result);
-    EXPECT_FALSE(result.empty());
-    EXPECT_EQ(result["vendor"], "McAfee");
-    EXPECT_EQ(result["name"], "Endpoint Protection");
+    normalizer.normalize("packages", inputJson);
+    EXPECT_FALSE(inputJson.empty());
+    EXPECT_EQ(inputJson["vendor"], "McAfee");
+    EXPECT_EQ(inputJson["name"], "Endpoint Protection");
 }
 
 TEST_F(SysNormalizerTest, normalizeSingleTotalDefense1)
 {
-    const auto& inputJson{nlohmann::json::parse(R"(
+    auto inputJson(nlohmann::json::parse(R"(
         {
             "description": "com.totaldefense.antivirus",
             "group": "public.app-category.security",
             "name": "TotalDefenseAntivirusforMac",
             "version": "1.0"
-        })")};
+        })"));
     SysNormalizer normalizer{TEST_CONFIG_FILE_NAME, "macos"};
-    const auto& result{normalizer.normalize("packages", inputJson)};
-    EXPECT_NE(inputJson, result);
-    EXPECT_FALSE(result.empty());
-    EXPECT_EQ(result["vendor"], "TotalDefense");
-    EXPECT_EQ(result["name"], "Anti-Virus");
+    normalizer.normalize("packages", inputJson);
+    EXPECT_FALSE(inputJson.empty());
+    EXPECT_EQ(inputJson["vendor"], "TotalDefense");
+    EXPECT_EQ(inputJson["name"], "Anti-Virus");
 }
 
 TEST_F(SysNormalizerTest, normalizeSingleTotalDefense2)
 {
-    const auto& inputJson{nlohmann::json::parse(R"(
+    auto inputJson(nlohmann::json::parse(R"(
         {
             "description": "com.totaldefense.antivirus",
             "group": "public.app-category.security",
             "name": "TotalDefenseOtherProductforMac",
             "version": "1.0"
-        })")};
+        })"));
     SysNormalizer normalizer{TEST_CONFIG_FILE_NAME, "macos"};
-    const auto& result{normalizer.normalize("packages", inputJson)};
-    EXPECT_NE(inputJson, result);
-    EXPECT_FALSE(result.empty());
-    EXPECT_EQ(result["vendor"], "TotalDefense");
-    EXPECT_EQ(result["name"], "OtherProduct");
+    normalizer.normalize("packages", inputJson);
+    EXPECT_FALSE(inputJson.empty());
+    EXPECT_EQ(inputJson["vendor"], "TotalDefense");
+    EXPECT_EQ(inputJson["name"], "OtherProduct");
 }
 
 TEST_F(SysNormalizerTest, normalizeSingleAVG1)
 {
-    const auto& inputJson{nlohmann::json::parse(R"(
+    auto inputJson(nlohmann::json::parse(R"(
         {
             "description": "com.avg.antivirus",
             "group": "public.app-category.security",
             "name": "AVGAntivirus",
             "version": "1.0"
-        })")};
+        })"));
     SysNormalizer normalizer{TEST_CONFIG_FILE_NAME, "macos"};
-    const auto& result{normalizer.normalize("packages", inputJson)};
-    EXPECT_NE(inputJson, result);
-    EXPECT_FALSE(result.empty());
-    EXPECT_EQ(result["vendor"], "AVG");
-    EXPECT_EQ(result["name"], "Anti-Virus");
+    normalizer.normalize("packages", inputJson);
+    EXPECT_FALSE(inputJson.empty());
+    EXPECT_EQ(inputJson["vendor"], "AVG");
+    EXPECT_EQ(inputJson["name"], "Anti-Virus");
 }
 
 TEST_F(SysNormalizerTest, normalizeSingleAVG2)
 {
-    const auto& inputJson{nlohmann::json::parse(R"(
+    auto inputJson(nlohmann::json::parse(R"(
         {
             "description": "com.avg.antivirus",
             "group": "public.app-category.security",
             "name": "AVGOtherProduct",
             "version": "1.0"
-        })")};
+        })"));
     SysNormalizer normalizer{TEST_CONFIG_FILE_NAME, "macos"};
-    const auto& result{normalizer.normalize("packages", inputJson)};
-    EXPECT_NE(inputJson, result);
-    EXPECT_FALSE(result.empty());
-    EXPECT_EQ(result["vendor"], "AVG");
-    EXPECT_EQ(result["name"], "OtherProduct");
+    normalizer.normalize("packages", inputJson);
+    EXPECT_FALSE(inputJson.empty());
+    EXPECT_EQ(inputJson["vendor"], "AVG");
+    EXPECT_EQ(inputJson["name"], "OtherProduct");
 }
 
 TEST_F(SysNormalizerTest, normalizeSingleKaspersky1)
 {
-    const auto& inputJson{nlohmann::json::parse(R"(
+    auto inputJson(nlohmann::json::parse(R"(
         {
             "description": "com.kaspersky.antivirus",
             "group": "public.app-category.security",
             "name": "Kaspersky Antivirus For Mac",
             "version": "1.0"
-        })")};
+        })"));
     SysNormalizer normalizer{TEST_CONFIG_FILE_NAME, "macos"};
-    const auto& result{normalizer.normalize("packages", inputJson)};
-    EXPECT_NE(inputJson, result);
-    EXPECT_FALSE(result.empty());
-    EXPECT_EQ(result["name"], "Kaspersky Antivirus");
+    normalizer.normalize("packages", inputJson);
+    EXPECT_FALSE(inputJson.empty());
+    EXPECT_EQ(inputJson["name"], "Kaspersky Antivirus");
 }
 
 TEST_F(SysNormalizerTest, normalizeSingleKaspersky2)
 {
-    const auto& inputJson{nlohmann::json::parse(R"(
+    auto inputJson(nlohmann::json::parse(R"(
         {
             "description": "com.kaspersky.internetsecurity",
             "group": "public.app-category.security",
             "name": "Kaspersky Internet Security For Mac",
             "version": "1.0"
-        })")};
+        })"));
     SysNormalizer normalizer{TEST_CONFIG_FILE_NAME, "macos"};
-    const auto& result{normalizer.normalize("packages", inputJson)};
-    EXPECT_NE(inputJson, result);
-    EXPECT_FALSE(result.empty());
-    EXPECT_EQ(result["name"], "Kaspersky Internet Security");
+    normalizer.normalize("packages", inputJson);
+    EXPECT_FALSE(inputJson.empty());
+    EXPECT_EQ(inputJson["name"], "Kaspersky Internet Security");
 }
 
 TEST_F(SysNormalizerTest, normalizeItemMatch)
 {
-    const auto& inputJson{nlohmann::json::parse(TEST_INPUT_DATA)};
+    auto inputJson(nlohmann::json::parse(TEST_INPUT_DATA));
+    const auto origJson(inputJson);
     SysNormalizer normalizer{TEST_CONFIG_FILE_NAME, "macos"};
-    const auto& result{normalizer.normalize("packages", inputJson)};
-    EXPECT_EQ(inputJson.size(), result.size());
-    EXPECT_NE(inputJson, result);
+    normalizer.normalize("packages", inputJson);
+    EXPECT_EQ(inputJson.size(), origJson.size());
+    EXPECT_NE(inputJson, origJson);
 }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #9393|


<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR aims to improve the copy and move of nlohmann objects within syscollector.

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [x] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [x] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors