### PR TITLE
adding additional dovecot syntax matching

### DIFF
--- a/ruleset/decoders/0085-dovecot_decoders.xml
+++ b/ruleset/decoders/0085-dovecot_decoders.xml
@@ -15,6 +15,7 @@
   - Jun 17 10:15:24 hostname dovecot: Fatal: Auth process died too early - shutting down
   - dovecot: Jun 23 15:04:05 Info: imap-login: Login: user=<username>, method=PLAIN, rip=1.2.3.4, lip=1.2.3.5 Authentication Failure:
   - Jan 11 03:42:09 hostname dovecot: auth-worker(default): sql(user@example.com,1.2.3.4): Password mismatch
+  - Aug 26 01:06:11 mail dovecot[48879]: auth: passwd-file(purchasing,1.1.1.1): unknown user
   - dovecot: Jan 07 14:46:28 Warn: auth(default): userdb(username,::ffff:127.0.0.1): user not found from userdb
   - dovecot: Mar 13 15:25:07 Info: auth(default): pam(user@example.com,::ffff:1.2.3.4): pam_authenticate() failed: User not known to the underlying authentication module
   - dovecot: Mar 13 15:25:07 Info: auth(default): passwd-file(user@example.com,::ffff:1.2.3.4): unknown user
@@ -31,6 +32,16 @@
   - Dec 19 17:20:08 ny dovecot: imap-login: Aborted login (auth failed, 2 attempts in 18 secs): user=<test>, method=PLAIN, rip=109.201.200.201, lip=67.205.141.203, session=<i8uMIAZEDrdtycjJ>, secured
   - Dec 19 17:20:08 ny dovecot: imap-login: Aborted login (auth failed, 2 attempts in 18 secs): user=<test>, method=PLAIN, rip=109.201.200.201, lip=67.205.141.203, secured
   - Dec 19 17:20:08 ny dovecot: imap-login: Aborted login (auth failed, 2 attempts in 18 secs): user=<test>, method=PLAIN, rip=109.201.200.201, lip=67.205.141.203
+  - Aug 25 08:08:34 mail dovecot[1234]: imap-login: Login: user=<test@test.com>, method=CRAM-MD5, rip=1.1.1.1, lip=2.2.2.2, mpid=12345, TLS, session=<sdfoSHa1Cmqh8z>
+  - Aug 25 08:08:34 mail dovecot[1234]: imap-login: Login: user=<test>, method=CRAM-MD5, rip=1.1.1.1, lip=2.2.2.2, mpid=12345, TLS, session=<sdfoSHa1Cmqh8z>
+  - Aug 25 08:08:34 mail dovecot[1234]: imap-login: Login: user=test@test.com, method=CRAM-MD5, rip=1.1.1.1, lip=2.2.2.2, mpid=12345, TLS, session=<sdfoSHa1Cmqh8z>
+  - Aug 25 08:08:34 mail dovecot[1234]: imap-login: Login: user=test, method=CRAM-MD5, rip=1.1.1.1, lip=2.2.2.2, mpid=12345, TLS, session=<sdfoSHa1Cmqh8z>
+  - Aug 25 08:17:03 mail dovecot[48879]: imap-login: Disconnected (auth failed, 1 attempts in 2 secs): user=<user>, method=CRAM-MD5, rip=1.1.1.1, lip=2.2.2.2, TLS, session=<mu6OKsAv/BCD>
+  - Aug 25 08:17:03 mail dovecot[48879]: imap-login: Disconnected (auth failed, 1 attempts in 2 secs): user=<user@test.com>, method=CRAM-MD5, rip=1.1.1.1, lip=2.2.2.2, TLS, session=<mu6OKsAv/BCD>
+  - Aug 25 08:17:03 mail dovecot[48879]: imap-login: Disconnected (auth failed, 1 attempts in 2 secs): user=user, method=CRAM-MD5, rip=1.1.1.1, lip=2.2.2.2, TLS, session=<mu6OKsAv/BCD>
+  - Aug 25 08:17:03 mail dovecot[48879]: imap-login: Disconnected (auth failed, 1 attempts in 2 secs): user=user@test.com, method=CRAM-MD5, rip=1.1.1.1, lip=2.2.2.2, TLS, session=<mu6OKsAv/BCD>
+  - Aug 24 17:18:23 mail dovecot[48879]: imap-login: Disconnected: Inactivity (no auth attempts in 180 secs): user=<>, rip=1.1.1.1, lip=2.2.2.2, TLS, session=<R7uAFKNKWMmH>
+  - Aug 24 17:18:23 mail dovecot[48879]: imap-login: Disconnected: Inactivity (no auth attempts in 180 secs): user=, rip=1.1.1.1, lip=2.2.2.2, TLS, session=<R7uAFKNKWMmH>
 -->
 
 <decoder name="dovecot">
@@ -40,8 +51,14 @@
 <decoder name="dovecot-success">
   <parent>dovecot</parent>
   <prematch offset="after_parent">^\w\w\w\w-login: Login: </prematch>
-  <regex offset="after_prematch">^user=\p(\S+)\p, method=\S+, rip=(\S+), lip=(\S+), mpid=\S+, (\S*)$</regex>
+  <regex offset="after_prematch" type="pcre2">^user=(?:\<)?(\w*(?:\W\w+)*)(?:\>)?, method=\S+, rip=(\S+), lip=(\S+), mpid=\S+, (\w*)(?:,)?</regex>
   <order>user, srcip, dstip, protocol</order>
+</decoder>
+
+<decoder name="dovecot-success">
+  <parent>dovecot</parent>
+  <regex offset="after_regex">session=\p(\S+\S)></regex>
+  <order>session</order>
 </decoder>
 
 <decoder name="dovecot-aborted">
@@ -83,17 +100,17 @@
 
 <decoder name="dovecot-fail">
   <parent>dovecot</parent>
-  <prematch offset="after_parent">^auth\(default\)|auth-worker\(default\)</prematch>
+  <prematch offset="after_parent">^auth\(default\)|auth-worker\(default\)|auth</prematch>
   <regex offset="after_prematch">^: \S+\((\S+),(\S+)\)</regex>
   <order>user, srcip</order>
 </decoder>
 
- <decoder name="dovecot-disconnect-user">
+<decoder name="dovecot-disconnect-user">
    <parent>dovecot</parent>
    <prematch offset="after_parent">^\w\w\w\w-login: Disconnected\.+user=</prematch>
-   <regex offset="after_parent">user=(\S+), method=\S+, rip=(\S+), lip=(\S+),</regex>
-   <order>srcuser, srcip, dstip</order>
- </decoder>
+   <regex offset="after_parent" type="pcre2">user=(?:\<)?(\w*(?:\W\w+)*)(?:\>)?,(?: method=\S+,)? rip=(\S+), lip=(\S+),</regex>
+   <order>user, srcip, dstip</order>
+</decoder>
 
 <decoder name="dovecot-disconnect">
   <parent>dovecot</parent>


### PR DESCRIPTION
|Related issue|
|https://github.com/wazuh/wazuh-ruleset/issues/843|


<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors