### PR TITLE
Clean the multigroup folder when reloading shared files

### DIFF
--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -547,7 +547,7 @@ void c_multi_group(char *multi_group,file_sum ***_f_sum,char *hash_multigroup) {
     char path[PATH_MAX + 1];
     char ** files;
     char ** subdir;
-    char agent_conf_multi_path[PATH_MAX + 1] = {0};
+    char multi_path[PATH_MAX] = { 0 };
 
     if (!hash_multigroup) {
         return;
@@ -558,8 +558,8 @@ void c_multi_group(char *multi_group,file_sum ***_f_sum,char *hash_multigroup) {
         group = strtok_r(multi_group, delim, &save_ptr);
 
         /* Delete agent.conf from multi group before appending to it */
-        snprintf(agent_conf_multi_path,PATH_MAX + 1,"%s/%s/%s",MULTIGROUPS_DIR,hash_multigroup,"agent.conf");
-        unlink(agent_conf_multi_path);
+        snprintf(multi_path, PATH_MAX,"%s/%s",MULTIGROUPS_DIR, hash_multigroup);
+        cldir_ex(multi_path);
 
         while( group != NULL ) {
             /* Now for each group copy the files to the multi-group folder */


### PR DESCRIPTION
|Related issue|
|---|
|#9919|

This PR aims to prevent Remoted from building merged files for multi-groups containing old files that the user deleted from the shared folder (_etc/shared_).

## Rationale

When Remoted updates the merged files, it copies the files from every single group to the multi-group folder (_var/multigroup/<hash>_), then it builds the merged files. The program repeats these steps every time it needs to update the merged files. Those files which may have changed in the shared directory will overwrite the previous ones in the multi-group folder.

However, if any of the files at _etc/shared/<group>_ gets removed, the previous version of it will remain in the multi-group folder. That will make Remoted send unwanted files to the agents.

## Proposed fix

Remoted cleans the file `agent.conf` only from the multi-group folder. We propose to clean the folder, and make a new copy of the files. They will be copied anyway.

## Tests

- [x] The steps shown at #9919 do not leave unwanted files in _merged.mg_.
- [x] Files deleted from _etc/shared/<group>_ also disappear in agents assigned to a multi-group.
