### PR TITLE
Fix AIT healthcheck auth flood

### DIFF
--- a/api/test/integration/env/configurations/vulnerability/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/vulnerability/manager/healthcheck/healthcheck.py
@@ -1,16 +1,18 @@
+import json
 import socket
 import sys
-from os import system
+from os import path, system
 
 sys.path.append('/tools')
 
-from healthcheck_utils import get_manager_health_base, get_login_header, check, get_response, base_url, login_url
+from healthcheck_utils import base_url, check, get_login_header, get_manager_health_base, get_response, login_url
 
 # Configuration
 user = 'wazuh'
 password = 'wazuh'
 headers = get_login_header(user, password)
 agents_to_check = ['001', '002']
+healthcheck_state_file = '/tmp/healthcheck/healthcheck.state'
 
 
 # Functions
@@ -37,13 +39,28 @@ def get_agents_node(status='active'):
     return {item['id']: item['manager'] for item in response}
 
 
+def get_healthcheck_state():
+    with open(healthcheck_state_file, mode='r') as f:
+        return json.loads(f.read())
+
+
+def set_healthcheck_state(state):
+    if state:
+        with open(healthcheck_state_file, mode='w') as f:
+            f.write(json.dumps(state, indent=4))
+
+
 if __name__ == '__main__':
     # Get dict of agent IDs and the manager they report to.
-    agents_node = get_agents_node()
-
-    # If not all requested agents were returned, exit with error code
-    if agents_node is None or not all(agent in agents_node for agent in agents_to_check):
-        exit(1)
+    if not path.isfile(healthcheck_state_file):
+        agents_node = get_agents_node()
+        # If not all requested agents were returned, exit with error code
+        if all(agent in agents_node.keys() for agent in agents_to_check):
+            set_healthcheck_state(agents_node)
+        else:
+            exit(1)
+    else:
+        agents_node = get_healthcheck_state()
 
     checks_list = list()
     expected_log = "grep -q 'wazuh-modulesd:vulnerability-detector: INFO: (5471): Finished vulnerability assessment " \

--- a/api/test/integration/env/configurations/vulnerability/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/vulnerability/manager/healthcheck/healthcheck.py
@@ -12,7 +12,7 @@ user = 'wazuh'
 password = 'wazuh'
 headers = get_login_header(user, password)
 agents_to_check = ['001', '002']
-healthcheck_state_file = '/tmp/healthcheck/healthcheck.state'
+HEALTHCHECK_STATE_FILE = '/tmp/healthcheck/healthcheck.state'
 
 
 # Functions
@@ -40,26 +40,28 @@ def get_agents_node(status='active'):
 
 
 def get_healthcheck_state():
-    with open(healthcheck_state_file, mode='r') as f:
+    with open(HEALTHCHECK_STATE_FILE, mode='r') as f:
         return json.loads(f.read())
 
 
 def set_healthcheck_state(state):
     if state:
-        with open(healthcheck_state_file, mode='w') as f:
+        with open(HEALTHCHECK_STATE_FILE, mode='w') as f:
             f.write(json.dumps(state, indent=4))
 
 
 if __name__ == '__main__':
     # Get dict of agent IDs and the manager they report to.
-    if not path.isfile(healthcheck_state_file):
+    if not path.isfile(HEALTHCHECK_STATE_FILE):
         agents_node = get_agents_node()
-        # If not all requested agents were returned, exit with error code
+        # If not all requested agents were returned, exit with error code.
+        # Otherwise, write state to file.
         if all(agent in agents_node.keys() for agent in agents_to_check):
             set_healthcheck_state(agents_node)
         else:
             exit(1)
     else:
+        # Read state from file instead of api request.
         agents_node = get_healthcheck_state()
 
     checks_list = list()

--- a/api/test/integration/env/configurations/vulnerability/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/vulnerability/manager/healthcheck/healthcheck.py
@@ -52,7 +52,7 @@ def set_healthcheck_state(state):
 
 if __name__ == '__main__':
     # Get dict of agent IDs and the manager they report to.
-    if not path.isfile(HEALTHCHECK_STATE_FILE):
+    if not path.exists(HEALTHCHECK_STATE_FILE):
         agents_node = get_agents_node()
         # If not all requested agents were returned, exit with error code.
         # Otherwise, write state to file.
@@ -64,16 +64,16 @@ if __name__ == '__main__':
         # Read state from file instead of api request.
         agents_node = get_healthcheck_state()
 
-    checks_list = list()
-    expected_log = "grep -q 'wazuh-modulesd:vulnerability-detector: INFO: (5471): Finished vulnerability assessment " \
-                   "for agent '\\''{}'\\''' /var/ossec/logs/ossec.log"
+        checks_list = list()
+        expected_log = "grep -q 'wazuh-modulesd:vulnerability-detector: INFO: (5471): Finished vulnerability " \
+            "assessment for agent '\\''{}'\\''' /var/ossec/logs/ossec.log"
 
-    if socket.gethostname() == 'wazuh-master':
-        checks_list.append(get_manager_health_base())
+        if socket.gethostname() == 'wazuh-master':
+            checks_list.append(get_manager_health_base())
 
-    for agent in agents_to_check:
-        if agents_node[agent] == socket.gethostname():
-            # Append only logs that are expected in the current node.
-            checks_list.append(check(system(expected_log.format(agent))))
+        for agent in agents_to_check:
+            if agents_node[agent] == socket.gethostname():
+                # Append only logs that are expected in the current node.
+                checks_list.append(check(system(expected_log.format(agent))))
 
-    exit(any(checks_list))
+        exit(any(checks_list))

--- a/api/test/integration/env/configurations/vulnerability/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/vulnerability/manager/healthcheck/healthcheck.py
@@ -64,16 +64,16 @@ if __name__ == '__main__':
         # Read state from file instead of api request.
         agents_node = get_healthcheck_state()
 
-        checks_list = list()
-        expected_log = "grep -q 'wazuh-modulesd:vulnerability-detector: INFO: (5471): Finished vulnerability " \
-            "assessment for agent '\\''{}'\\''' /var/ossec/logs/ossec.log"
+    checks_list = list()
+    expected_log = "grep -q 'wazuh-modulesd:vulnerability-detector: INFO: (5471): Finished vulnerability assessment " \
+        "for agent '\\''{}'\\''' /var/ossec/logs/ossec.log"
 
-        if socket.gethostname() == 'wazuh-master':
-            checks_list.append(get_manager_health_base())
+    if socket.gethostname() == 'wazuh-master':
+        checks_list.append(get_manager_health_base())
 
-        for agent in agents_to_check:
-            if agents_node[agent] == socket.gethostname():
-                # Append only logs that are expected in the current node.
-                checks_list.append(check(system(expected_log.format(agent))))
+    for agent in agents_to_check:
+        if agents_node[agent] == socket.gethostname():
+            # Append only logs that are expected in the current node.
+            checks_list.append(check(system(expected_log.format(agent))))
 
-        exit(any(checks_list))
+    exit(any(checks_list))

--- a/api/test/integration/env/tools/healthcheck_utils.py
+++ b/api/test/integration/env/tools/healthcheck_utils.py
@@ -92,14 +92,14 @@ def get_master_health():
     os.system("/var/ossec/bin/wazuh-control status > /tmp/daemons.txt")
     check0 = check(os.system("diff -q /tmp/output.txt /tmp/healthcheck/agent_control_check.txt"))
     check1 = check(os.system("diff -q /tmp/daemons.txt /tmp/healthcheck/daemons_check.txt"))
-    check2 = get_response(login_url, get_login_header(user, password)) is None
+    check2 = check(os.system("grep -qs 'Listening on ' /var/ossec/logs/api.log"))
     return check0 or check1 or check2
 
 
 def get_worker_health():
     os.system("/var/ossec/bin/wazuh-control status > /tmp/daemons.txt")
     check0 = check(os.system("diff -q /tmp/daemons.txt /tmp/healthcheck/daemons_check.txt"))
-    check1 = get_response(login_url, get_login_header(user, password)) is None
+    check1 = check(os.system("grep -qs 'Listening on ' /var/ossec/logs/api.log"))
     return check0 or check1
 
 

--- a/api/test/integration/env/tools/healthcheck_utils.py
+++ b/api/test/integration/env/tools/healthcheck_utils.py
@@ -111,9 +111,7 @@ def get_manager_health():
     if not os.path.isfile(HEALTHCHECK_TOKEN_FILE):
         check = get_response(login_url, get_login_header(user, password))
         if check:
-            with open(HEALTHCHECK_TOKEN_FILE, mode='w') as f:
-                f.write(f'{check}')
+            open(HEALTHCHECK_TOKEN_FILE, mode='w').close()
         return check
     else:
-        with open(HEALTHCHECK_TOKEN_FILE, mode='r') as f:
-            return f.read()
+        return True

--- a/api/test/integration/env/tools/healthcheck_utils.py
+++ b/api/test/integration/env/tools/healthcheck_utils.py
@@ -92,7 +92,7 @@ def get_master_health():
     os.system("/var/ossec/bin/wazuh-control status > /tmp/daemons.txt")
     check0 = check(os.system("diff -q /tmp/output.txt /tmp/healthcheck/agent_control_check.txt"))
     check1 = check(os.system("diff -q /tmp/daemons.txt /tmp/healthcheck/daemons_check.txt"))
-    check2 = get_api_health() is None
+    check2 = get_api_health()
     return check0 or check1 or check2
 
 
@@ -109,5 +109,8 @@ def get_api_health():
     if not os.path.exists(HEALTHCHECK_TOKEN_FILE):
         if get_response(login_url, get_login_header(user, password)):
             open(HEALTHCHECK_TOKEN_FILE, mode='w').close()
-            return True
-    return True
+            return 0
+        else:
+            return 1
+    else:
+        return 0

--- a/api/test/integration/env/tools/healthcheck_utils.py
+++ b/api/test/integration/env/tools/healthcheck_utils.py
@@ -92,26 +92,22 @@ def get_master_health():
     os.system("/var/ossec/bin/wazuh-control status > /tmp/daemons.txt")
     check0 = check(os.system("diff -q /tmp/output.txt /tmp/healthcheck/agent_control_check.txt"))
     check1 = check(os.system("diff -q /tmp/daemons.txt /tmp/healthcheck/daemons_check.txt"))
-    check2 = get_manager_health() is None
+    check2 = get_api_health() is None
     return check0 or check1 or check2
 
 
 def get_worker_health():
     os.system("/var/ossec/bin/wazuh-control status > /tmp/daemons.txt")
-    check0 = check(os.system("diff -q /tmp/daemons.txt /tmp/healthcheck/daemons_check.txt"))
-    check1 = get_manager_health() is None
-    return check0 or check1
+    return check(os.system("diff -q /tmp/daemons.txt /tmp/healthcheck/daemons_check.txt"))
 
 
 def get_manager_health_base():
     return get_master_health() if socket.gethostname() == 'wazuh-master' else get_worker_health()
 
 
-def get_manager_health():
-    if not os.path.isfile(HEALTHCHECK_TOKEN_FILE):
-        check = get_response(login_url, get_login_header(user, password))
-        if check:
+def get_api_health():
+    if not os.path.exists(HEALTHCHECK_TOKEN_FILE):
+        if get_response(login_url, get_login_header(user, password)):
             open(HEALTHCHECK_TOKEN_FILE, mode='w').close()
-        return check
-    else:
-        return True
+            return True
+    return True


### PR DESCRIPTION
|Related issue|
|---|
| Closes #9761 |

# Description
Under our AIT environment, Docker healthcheck was trying to obtain API's token each second for each container up and running.

# Fix
I decided to improve this behavior by using files on which it's saving data to be verified before requesting for a token again.
I discarded another possible solution that involves the use of environment variables in favor of files because of it's simplicity.

# Related Integration Tests:
* rbac_white_vulnerability_endpoints
* rbac_black_vulnerability_endpoints
* vulnerability_endpoints
```shell
↪ ~/git/wazuh/api/test/integration ⊶ fix/9761-ait-env-healthcheck ⨘ pytest -vv -x test_rbac_white_vulnerability_endpoints.tavern.yaml --disable-warnings && pytest -vv -x test_rbac_black_vulnerability_endpoints.tavern.yaml --disable-warnings && pytest -vv -x test_vulnerability_endpoints.tavern.yaml --disable-warnings
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.9.5, pytest-5.0.0, py-1.10.0, pluggy-0.13.1 -- /home/kondent/pythonEnv/inttest-env/bin/python3.9
cachedir: .pytest_cache
metadata: {'Python': '3.9.5', 'Platform': 'Linux-5.11.0-27-generic-x86_64-with-glibc2.31', 'Packages': {'pytest': '5.0.0', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'metadata': '1.11.0', 'tavern': '1.2.2'}}
rootdir: /home/kondent/git/wazuh/api/test/integration, inifile: pytest.ini
plugins: html-3.1.1, metadata-1.11.0, tavern-1.2.2
collected 1 item                                                                                                                                                                             

test_rbac_white_vulnerability_endpoints.tavern.yaml::GET /vulnerability/{agent_id} PASSED                                                                                              [100%]

=========================================================================== 1 passed, 1 warnings in 316.06 seconds ===========================================================================
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.9.5, pytest-5.0.0, py-1.10.0, pluggy-0.13.1 -- /home/kondent/pythonEnv/inttest-env/bin/python3.9
cachedir: .pytest_cache
metadata: {'Python': '3.9.5', 'Platform': 'Linux-5.11.0-27-generic-x86_64-with-glibc2.31', 'Packages': {'pytest': '5.0.0', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'metadata': '1.11.0', 'tavern': '1.2.2'}}
rootdir: /home/kondent/git/wazuh/api/test/integration, inifile: pytest.ini
plugins: html-3.1.1, metadata-1.11.0, tavern-1.2.2
collected 1 item                                                                                                                                                                             

test_rbac_black_vulnerability_endpoints.tavern.yaml::GET /vulnerability/{agent_id} PASSED                                                                                              [100%]

=========================================================================== 1 passed, 1 warnings in 273.63 seconds ===========================================================================
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.9.5, pytest-5.0.0, py-1.10.0, pluggy-0.13.1 -- /home/kondent/pythonEnv/inttest-env/bin/python3.9
cachedir: .pytest_cache
metadata: {'Python': '3.9.5', 'Platform': 'Linux-5.11.0-27-generic-x86_64-with-glibc2.31', 'Packages': {'pytest': '5.0.0', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'metadata': '1.11.0', 'tavern': '1.2.2'}}
rootdir: /home/kondent/git/wazuh/api/test/integration, inifile: pytest.ini
plugins: html-3.1.1, metadata-1.11.0, tavern-1.2.2
collected 1 item                                                                                                                                                                             

test_vulnerability_endpoints.tavern.yaml::GET /vulnerability/{agent_id} PASSED                                                                                                         [100%]

=========================================================================== 1 passed, 1 warnings in 273.99 seconds ===========================================================================
```

Regards