### PR TITLE
Fix memory leak in OS_StartCounter()

### DIFF
--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -234,6 +234,7 @@ static void w_agentd_keys_init (void) {
         }
     }
     else {
+        /* If the key store was empty, the counters will already be initialized in the enrollment process */
         OS_StartCounter(&keys);
     }
 

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -233,8 +233,9 @@ static void w_agentd_keys_init (void) {
             merror_exit(AG_NOKEYS_EXIT);
         }
     }
-
-    OS_StartCounter(&keys);
+    else {
+        OS_StartCounter(&keys);
+    }
 
     os_write_agent_info(keys.keyentries[0]->name, NULL, keys.keyentries[0]->id,
                         agt->profile);


### PR DESCRIPTION
|Related issue|
|---|
|#9744|

## Description
This PR fixes a memory leak possible when the agent keys file is empty and the agent requests the key for the first time.
In this scenario, **OS_StartCounter()** was called first in **OS_UpdateKeys()** and after that in **OS_KeysInit()** without a free, leading to a memory leak.
Now, the **OS_StartCounter()** in **OS_KeysInit()** is only called if the keys are not empty, leaving the other initialization scenario to **OS_UpdateKeys()** after a key arrives.

As described in https://github.com/wazuh/wazuh/issues/9744, the following fixes were handled with its' own pros and cons.
- Add a **linked_queue_free()** previous to **OS_StartCounter()** in **w_agentd_keys_init()**
  - Cons: 
    - The reason for this free isn´t clear, as **w_agentd_keys_init()** is supposed to be the first initializer, and it's difficult to understand why this, and only this structure can be already initialized.
- Call **OS_StartCounter()** right after **OS_ReadKeys()**
  - Pros:
    - The agent keys initialization keeps similarity with the manager initialization.
  - Cons:
    - There is duplicate code between windows and linux agents code.
- Call **OS_StartCounter()** inside an **else** statement if the keys structure isn´t empty.
  - Pros:
    -  **OS_StartCounter()** is only called if needed.
    - There isn´t code duplication between Windows and Linux agents code.
    
Finally, we decided to implement  _Call **OS_StartCounter()** inside an **else** statement if the keys structure isn´t empty_

## Tests
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
- [X] Source installation
- [X] Package installation
- [X] Source upgrade
- [X] Package upgrade
- [X] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
- Memory tests for Windows
  - [x] Scan-build report
