### PR TITLE
Fix merge.mg transfer loop when remote_conf is disabled

### DIFF
--- a/src/client-agent/receiver-win.c
+++ b/src/client-agent/receiver-win.c
@@ -272,13 +272,15 @@ void *receiver_thread(__attribute__((unused)) void *none)
                                         snprintf(msg_output, OS_MAXSTR, "%c:%s:%s:",  LOCALFILE_MQ, "wazuh-agent", AG_IN_UNMERGE);
                                         send_msg(msg_output, -1);
                                     }
-                                    else if (agt->flags.remote_conf && !verifyRemoteConf()) {
-                                        if (agt->flags.auto_restart) {
-                                            minfo("Agent is restarting due to shared configuration changes.");
-                                            restartAgent();
-                                        } else {
-                                            clear_merged_hash_cache();
-                                            minfo("Shared agent configuration has been updated.");
+                                    else {
+                                        clear_merged_hash_cache();
+                                        if (agt->flags.remote_conf && !verifyRemoteConf()) {
+                                            if (agt->flags.auto_restart) {
+                                                minfo("Agent is restarting due to shared configuration changes.");
+                                                restartAgent();
+                                            } else {
+                                                minfo("Shared agent configuration has been updated.");
+                                            }
                                         }
                                     }
                                 }

--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -285,13 +285,15 @@ int receive_msg()
                                     snprintf(msg_output, OS_MAXSTR, "%c:%s:%s",  LOCALFILE_MQ, "wazuh-agent", AG_IN_UNMERGE);
                                     send_msg(msg_output, -1);
                                 }
-                                else if (agt->flags.remote_conf && !verifyRemoteConf()) {
-                                    if (agt->flags.auto_restart) {
-                                        minfo("Agent is restarting due to shared configuration changes.");
-                                        restartAgent();
-                                    } else {
-                                        clear_merged_hash_cache();
-                                        minfo("Shared agent configuration has been updated.");
+                                else {
+                                    clear_merged_hash_cache();
+                                    if (agt->flags.remote_conf && !verifyRemoteConf()) {
+                                        if (agt->flags.auto_restart) {
+                                            minfo("Agent is restarting due to shared configuration changes.");
+                                            restartAgent();
+                                        } else {
+                                            minfo("Shared agent configuration has been updated.");
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #9684|

## Description

HI team!

This PR aims to solve the endless merge.mg transfer loop from manager to agent when agent's `agent.remote_conf=0` (internal option).


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors

Regards,
Nico