### PR TITLE
Fix agent python modules 

### DIFF
--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -1072,6 +1072,9 @@ InstallServer()
     fi
 
     # Install the plugins files
+    ${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} ../wodles/__init__.py ${INSTALLDIR}/wodles/__init__.py
+    ${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} ../wodles/utils.py ${INSTALLDIR}/wodles/utils.py
+
     ${INSTALL} -d -m 0750 -o root -g ${OSSEC_GROUP} ${INSTALLDIR}/wodles/aws
     ${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} ../wodles/aws/aws_s3.py ${INSTALLDIR}/wodles/aws/aws-s3.py
     ${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} ../framework/wrappers/generic_wrapper.sh ${INSTALLDIR}/wodles/aws/aws-s3
@@ -1117,6 +1120,9 @@ InstallAgent()
     # Install the plugins files
     # Don't install the plugins if they are already installed. This check affects
     # hybrid installation mode
+    ${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} ../wodles/__init__.py ${INSTALLDIR}/wodles/__init__.py
+    ${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} ../wodles/utils.py ${INSTALLDIR}/wodles/utils.py
+
     if [ ! -d ${INSTALLDIR}/wodles/aws ]; then
         ${INSTALL} -d -m 0750 -o root -g ${OSSEC_GROUP} ${INSTALLDIR}/wodles/aws
         ${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} ../wodles/aws/aws_s3.py ${INSTALLDIR}/wodles/aws/aws-s3

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -47,7 +47,9 @@ from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
 from time import mktime
-from wazuh.core import common
+
+sys.path.insert(0, path.dirname(path.dirname(path.abspath(__file__))))
+import utils
 
 # Python 2/3 compatibility
 if sys.version_info[0] == 3:
@@ -139,8 +141,8 @@ class WazuhIntegration:
                             DROP TABLE {table};
                             """
 
-        self.wazuh_path = common.find_wazuh_path()
-        self.wazuh_version = common.get_wazuh_version()
+        self.wazuh_path = utils.find_wazuh_path()
+        self.wazuh_version = utils.get_wazuh_version()
         self.wazuh_queue = '{0}/queue/sockets/queue'.format(self.wazuh_path)
         self.wazuh_wodle = '{0}/wodles/aws'.format(self.wazuh_path)
         self.msg_header = "1:Wazuh-AWS:"

--- a/wodles/aws/tests/test_aws.py
+++ b/wodles/aws/tests/test_aws.py
@@ -48,8 +48,8 @@ def test_metadata_version_buckets(mocked_db, class_):
     """
     with patch(f'aws_s3.{class_.__name__}.get_client'), \
         patch(f'aws_s3.{class_.__name__}.get_sts_client'), \
-        patch(f'aws_s3.common.find_wazuh_path', return_value=wazuh_installation_path), \
-        patch(f'aws_s3.common.get_wazuh_version', return_value=wazuh_version):
+        patch(f'aws_s3.utils.find_wazuh_path', return_value=wazuh_installation_path), \
+        patch(f'aws_s3.utils.get_wazuh_version', return_value=wazuh_version):
         ins = class_(**{'reparse': False, 'access_key': None, 'secret_key': None,
                         'profile': None, 'iam_role_arn': None, 'bucket': 'test',
                         'only_logs_after': '19700101', 'skip_on_error': True,
@@ -73,8 +73,8 @@ def test_metadata_version_services(mocked_db, class_):
     """
     with patch(f'aws_s3.{class_.__name__}.get_client'), \
         patch(f'aws_s3.{class_.__name__}.get_sts_client'), \
-        patch(f'aws_s3.common.find_wazuh_path', return_value=wazuh_installation_path), \
-        patch(f'aws_s3.common.get_wazuh_version', return_value=wazuh_version):
+        patch(f'aws_s3.utils.find_wazuh_path', return_value=wazuh_installation_path), \
+        patch(f'aws_s3.utils.get_wazuh_version', return_value=wazuh_version):
         ins = class_(**{'reparse': False, 'access_key': None, 'secret_key': None,
                         'aws_profile': None, 'iam_role_arn': None,
                         'only_logs_after': '19700101', 'region': None})
@@ -99,8 +99,8 @@ def test_db_maintenance(class_, sql_file, db_name):
     with patch(f'aws_s3.{class_.__name__}.get_client'), \
         patch(f'aws_s3.{class_.__name__}.get_sts_client'), \
         patch('sqlite3.connect', side_effect=get_fake_s3_db(sql_file)), \
-        patch(f'aws_s3.common.find_wazuh_path', return_value=wazuh_installation_path), \
-        patch(f'aws_s3.common.get_wazuh_version', return_value=wazuh_version):
+        patch(f'aws_s3.utils.find_wazuh_path', return_value=wazuh_installation_path), \
+        patch(f'aws_s3.utils.get_wazuh_version', return_value=wazuh_version):
         ins = class_(**{'reparse': False, 'access_key': None, 'secret_key': None,
                         'profile': None, 'iam_role_arn': None, 'bucket': 'test-bucket',
                         'only_logs_after': '19700101', 'skip_on_error': True,

--- a/wodles/azure/azure-logs.py
+++ b/wodles/azure/azure-logs.py
@@ -25,7 +25,9 @@ import os
 import datetime
 import argparse
 import hashlib
-from wazuh.core import common
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import utils
 
 try:
 	import requests
@@ -46,7 +48,7 @@ except Exception as e:
 	print("Azure Storage SDK for Python is missing: '{}', try 'pip install azure-storage-blob'.".format(e))
 	sys.exit(1)
 
-ADDR = '{}/queue/sockets/queue'.format(common.wazuh_path)
+ADDR = '{}/queue/sockets/queue'.format(utils.wazuh_path)
 BLEN = 212992
 
 utc = pytz.UTC
@@ -111,7 +113,7 @@ def set_logger():
 	if args.verbose:
 		logging.basicConfig(level = logging.DEBUG, format = '%(asctime)s %(levelname)s: AZURE %(message)s', datefmt = '%m/%d/%Y %I:%M:%S %p')
 	else:
-		log_path = "{}/logs/azure_logs.log".format(common.wazuh_path)
+		log_path = "{}/logs/azure_logs.log".format(utils.wazuh_path)
 		logging.basicConfig(filename=log_path, level = logging.DEBUG, format = '%(asctime)s %(levelname)s: AZURE %(message)s', datefmt = '%m/%d/%Y %I:%M:%S %p')
 
 

--- a/wodles/gcloud/integration.py
+++ b/wodles/gcloud/integration.py
@@ -11,15 +11,14 @@
 import logging
 import socket
 import sys
-import os
+from os import path
 
-import google.api_core.exceptions
+from google.api_core import exceptions as google_exceptions
 from google.cloud import pubsub_v1 as pubsub
 
-import tools
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, path.dirname(path.dirname(path.abspath(__file__))))
 import utils
+import tools
 
 logger = logging.getLogger(tools.logger_name)
 
@@ -39,16 +38,14 @@ class WazuhGCloudSubscriber:
         """
         # get Wazuh paths
         self.wazuh_path = utils.find_wazuh_path()
+        self.wazuh_queue = tools.get_wazuh_queue()
         self.wazuh_version = utils.get_wazuh_version()
         # get subscriber
-        self.subscriber = self.get_subscriber_client(credentials_file)
+        self.subscriber = self.get_subscriber_client(credentials_file).api
         self.subscription_path = self.get_subscription_path(project,
                                                             subscription_id)
-        # Analysisd queue
-        self.wazuh_queue = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
 
-    @staticmethod
-    def get_subscriber_client(credentials_file: str) \
+    def get_subscriber_client(self, credentials_file: str) \
             -> pubsub.subscriber.Client:
         """Get a subscriber client.
         :param credentials_file: Path to credentials file
@@ -66,71 +63,16 @@ class WazuhGCloudSubscriber:
         """
         return self.subscriber.subscription_path(project, subscription_id)
 
-    def check_permissions(self):
-        """Check if permissions are OK for executing the wodle."""
-        required_permissions = {'pubsub.subscriptions.consume'}
-        response = self.subscriber.test_iam_permissions(request={'resource': self.subscription_path,
-                                                                 'permissions': required_permissions})
-        if required_permissions.difference(response.permissions) != set():
-            error_message = 'ERROR: No permissions for executing the ' \
-                            'wodle from this subscription'
-            raise Exception(error_message)
-
-    def format_msg(self, msg: bytes) -> str:
-        """Format a message.
-        :param msg: Message to be formatted
+    def send_msg(self, msg: str):
+        """Send an event to the Wazuh queue.
+        :param msg: Event to be sent
         """
-        # Insert msg as value of self.key_name key.
-        return f'{{"integration": "gcp", "{self.key_name}": {msg.decode(errors="replace")}}}'
-
-    def send_message(self, message):
-        """Send a message with a header to the analysisd queue.
-        :param message: Message to send to the analysisd queue
-        """
-        self.wazuh_queue.send(f'{self.header}{message}'.encode(errors='replace'))
-
-    def pull_request(self, max_messages) -> int:
-        """Make request for pulling messages from the subscription and acknowledge them.
-        :param max_messages: Maximum number of messages to retrieve
-        :return: Number of processed messages
-        """
+        event_json = f'{self.header}{msg}'.encode(errors='replace')  # noqa: E501
         try:
-            response = self.subscriber.pull(
-                request={'subscription': self.subscription_path,
-                         'max_messages': max_messages}
-            )
-        except google.api_core.exceptions.DeadlineExceeded:
-            return 0
-
-        ack_ids = []
-        for received_message in response.received_messages:
-            formatted_message = self.format_msg(received_message.message.data)
-            logger.debug(f'Processing event: {formatted_message}')
-            ack_ids.append(received_message.ack_id)
-            self.send_message(formatted_message)
-
-        ack_ids and self.subscriber.acknowledge(
-            request={'subscription': self.subscription_path, 'ack_ids': ack_ids}
-        )
-
-        return len(response.received_messages)
-
-    def process_messages(self, max_messages: int = 100) -> int:
-        """Process the available messages in the subscription.
-        :param max_messages: Maximum number of messages to retrieve
-        :return: Number of processed messages
-        """
-        try:
-            self.wazuh_queue.connect(utils.ANALYSISD)
-            with self.subscriber:
-                processed_messages = 0
-                pulled_messages = self.pull_request(max_messages)
-                while pulled_messages > 0 and processed_messages < max_messages:
-                    processed_messages += pulled_messages
-                    # get more messages
-                    if processed_messages < max_messages:
-                        pulled_messages = self.pull_request(max_messages - processed_messages)
-                return processed_messages
+            s = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+            s.connect(self.wazuh_queue)
+            s.send(event_json)
+            s.close()
         except socket.error as e:
             if e.errno == 111:
                 logger.critical('Wazuh must be running')
@@ -138,5 +80,67 @@ class WazuhGCloudSubscriber:
             else:
                 logger.critical('Error sending event to Wazuh')
                 raise e
-        finally:
-            self.wazuh_queue.close()
+
+    def format_msg(self, msg: str) -> str:
+        """Format a message.
+        :param msg: Message to be formatted
+        """
+        # Insert msg as value of self.key_name key.
+        return f'{{"integration": "gcp", "{self.key_name}": {msg}}}'
+
+    def process_message(self, ack_id: str, data: bytes):
+        """Send a message to Wazuh queue.
+        :param ack_id: ACK_ID from event
+        :param data: Data to be sent to Wazuh
+        """
+        formatted_msg = self.format_msg(data.decode(errors='replace'))
+        self.send_msg(formatted_msg)
+        self.subscriber.acknowledge(self.subscription_path, [ack_id])
+
+    def check_permissions(self):
+        """Check if permissions are OK for executing the wodle."""
+        required_permissions = {'pubsub.subscriptions.consume'}
+        response = self.subscriber.test_iam_permissions(self.subscription_path,
+                                                        required_permissions)
+        if required_permissions.difference(response.permissions) != set():
+            error_message = 'ERROR: No permissions for executing the ' \
+                'wodle from this subscription'
+            raise Exception(error_message)
+
+    def pull_request(self, max_messages: int = 100) \
+            -> pubsub.types.PullResponse:
+        """Make request for pulling messages from the subscription.
+        :param max_messages: Maximum number of messages to retrieve
+        :return: Response of pull request. If the deadline is exceeded,
+            the method will return an empty PullResponse object
+        """
+        try:
+            response = self.subscriber.pull(self.subscription_path,
+                                            max_messages=max_messages,
+                                            return_immediately=True)
+        except google_exceptions.DeadlineExceeded:
+            logger.warning('Deadline exceeded when pulling messages. '
+                           'No more messages will be retrieved on this '
+                           'execution')
+            response = pubsub.types.PullResponse()
+
+        return response
+
+    def process_messages(self, max_messages: int = 100) -> int:
+        """Process the available messages in the subscription.
+        :param max_messages: Maximum number of messages to retrieve
+        :return: Number of processed messages
+        """
+        processed_messages = 0
+        response = self.pull_request(max_messages)
+        while len(response.received_messages) > 0 and processed_messages < max_messages:
+            for message in response.received_messages:
+                message_data: bytes = message.message.data
+                if logger.getEffectiveLevel() == logging.DEBUG:
+                    logger.debug(f'Processing event:\n{self.format_msg(message_data.decode(errors="replace"))}')
+                self.process_message(message.ack_id, message_data)
+                processed_messages += 1  # increment processed_messages counter
+            # get more messages
+            if processed_messages < max_messages:
+                response = self.pull_request(max_messages - processed_messages)
+        return processed_messages

--- a/wodles/gcloud/integration.py
+++ b/wodles/gcloud/integration.py
@@ -10,12 +10,16 @@
 
 import logging
 import socket
+import sys
+import os
 
-from google.api_core import exceptions as google_exceptions
+import google.api_core.exceptions
 from google.cloud import pubsub_v1 as pubsub
-from wazuh.core import common
 
 import tools
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import utils
 
 logger = logging.getLogger(tools.logger_name)
 
@@ -34,15 +38,17 @@ class WazuhGCloudSubscriber:
         :params subscription_id: Subscription ID
         """
         # get Wazuh paths
-        self.wazuh_path = common.find_wazuh_path()
-        self.wazuh_queue = tools.get_wazuh_queue()
-        self.wazuh_version = common.get_wazuh_version()
+        self.wazuh_path = utils.find_wazuh_path()
+        self.wazuh_version = utils.get_wazuh_version()
         # get subscriber
-        self.subscriber = self.get_subscriber_client(credentials_file).api
+        self.subscriber = self.get_subscriber_client(credentials_file)
         self.subscription_path = self.get_subscription_path(project,
                                                             subscription_id)
+        # Analysisd queue
+        self.wazuh_queue = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
 
-    def get_subscriber_client(self, credentials_file: str) \
+    @staticmethod
+    def get_subscriber_client(credentials_file: str) \
             -> pubsub.subscriber.Client:
         """Get a subscriber client.
         :param credentials_file: Path to credentials file
@@ -60,16 +66,71 @@ class WazuhGCloudSubscriber:
         """
         return self.subscriber.subscription_path(project, subscription_id)
 
-    def send_msg(self, msg: str):
-        """Send an event to the Wazuh queue.
-        :param msg: Event to be sent
+    def check_permissions(self):
+        """Check if permissions are OK for executing the wodle."""
+        required_permissions = {'pubsub.subscriptions.consume'}
+        response = self.subscriber.test_iam_permissions(request={'resource': self.subscription_path,
+                                                                 'permissions': required_permissions})
+        if required_permissions.difference(response.permissions) != set():
+            error_message = 'ERROR: No permissions for executing the ' \
+                            'wodle from this subscription'
+            raise Exception(error_message)
+
+    def format_msg(self, msg: bytes) -> str:
+        """Format a message.
+        :param msg: Message to be formatted
         """
-        event_json = f'{self.header}{msg}'.encode(errors='replace')  # noqa: E501
+        # Insert msg as value of self.key_name key.
+        return f'{{"integration": "gcp", "{self.key_name}": {msg.decode(errors="replace")}}}'
+
+    def send_message(self, message):
+        """Send a message with a header to the analysisd queue.
+        :param message: Message to send to the analysisd queue
+        """
+        self.wazuh_queue.send(f'{self.header}{message}'.encode(errors='replace'))
+
+    def pull_request(self, max_messages) -> int:
+        """Make request for pulling messages from the subscription and acknowledge them.
+        :param max_messages: Maximum number of messages to retrieve
+        :return: Number of processed messages
+        """
         try:
-            s = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
-            s.connect(self.wazuh_queue)
-            s.send(event_json)
-            s.close()
+            response = self.subscriber.pull(
+                request={'subscription': self.subscription_path,
+                         'max_messages': max_messages}
+            )
+        except google.api_core.exceptions.DeadlineExceeded:
+            return 0
+
+        ack_ids = []
+        for received_message in response.received_messages:
+            formatted_message = self.format_msg(received_message.message.data)
+            logger.debug(f'Processing event: {formatted_message}')
+            ack_ids.append(received_message.ack_id)
+            self.send_message(formatted_message)
+
+        ack_ids and self.subscriber.acknowledge(
+            request={'subscription': self.subscription_path, 'ack_ids': ack_ids}
+        )
+
+        return len(response.received_messages)
+
+    def process_messages(self, max_messages: int = 100) -> int:
+        """Process the available messages in the subscription.
+        :param max_messages: Maximum number of messages to retrieve
+        :return: Number of processed messages
+        """
+        try:
+            self.wazuh_queue.connect(utils.ANALYSISD)
+            with self.subscriber:
+                processed_messages = 0
+                pulled_messages = self.pull_request(max_messages)
+                while pulled_messages > 0 and processed_messages < max_messages:
+                    processed_messages += pulled_messages
+                    # get more messages
+                    if processed_messages < max_messages:
+                        pulled_messages = self.pull_request(max_messages - processed_messages)
+                return processed_messages
         except socket.error as e:
             if e.errno == 111:
                 logger.critical('Wazuh must be running')
@@ -77,67 +138,5 @@ class WazuhGCloudSubscriber:
             else:
                 logger.critical('Error sending event to Wazuh')
                 raise e
-
-    def format_msg(self, msg: str) -> str:
-        """Format a message.
-        :param msg: Message to be formatted
-        """
-        # Insert msg as value of self.key_name key.
-        return f'{{"integration": "gcp", "{self.key_name}": {msg}}}'
-
-    def process_message(self, ack_id: str, data: bytes):
-        """Send a message to Wazuh queue.
-        :param ack_id: ACK_ID from event
-        :param data: Data to be sent to Wazuh
-        """
-        formatted_msg = self.format_msg(data.decode(errors='replace'))
-        self.send_msg(formatted_msg)
-        self.subscriber.acknowledge(self.subscription_path, [ack_id])
-
-    def check_permissions(self):
-        """Check if permissions are OK for executing the wodle."""
-        required_permissions = {'pubsub.subscriptions.consume'}
-        response = self.subscriber.test_iam_permissions(self.subscription_path,
-                                                        required_permissions)
-        if required_permissions.difference(response.permissions) != set():
-            error_message = 'ERROR: No permissions for executing the ' \
-                'wodle from this subscription'
-            raise Exception(error_message)
-
-    def pull_request(self, max_messages: int = 100) \
-            -> pubsub.types.PullResponse:
-        """Make request for pulling messages from the subscription.
-        :param max_messages: Maximum number of messages to retrieve
-        :return: Response of pull request. If the deadline is exceeded,
-            the method will return an empty PullResponse object
-        """
-        try:
-            response = self.subscriber.pull(self.subscription_path,
-                                            max_messages=max_messages,
-                                            return_immediately=True)
-        except google_exceptions.DeadlineExceeded:
-            logger.warning('Deadline exceeded when pulling messages. '
-                           'No more messages will be retrieved on this '
-                           'execution')
-            response = pubsub.types.PullResponse()
-
-        return response
-
-    def process_messages(self, max_messages: int = 100) -> int:
-        """Process the available messages in the subscription.
-        :param max_messages: Maximum number of messages to retrieve
-        :return: Number of processed messages
-        """
-        processed_messages = 0
-        response = self.pull_request(max_messages)
-        while len(response.received_messages) > 0 and processed_messages < max_messages:
-            for message in response.received_messages:
-                message_data: bytes = message.message.data
-                if logger.getEffectiveLevel() == logging.DEBUG:
-                    logger.debug(f'Processing event:\n{self.format_msg(message_data.decode(errors="replace"))}')
-                self.process_message(message.ack_id, message_data)
-                processed_messages += 1  # increment processed_messages counter
-            # get more messages
-            if processed_messages < max_messages:
-                response = self.pull_request(max_messages - processed_messages)
-        return processed_messages
+        finally:
+            self.wazuh_queue.close()

--- a/wodles/gcloud/tools.py
+++ b/wodles/gcloud/tools.py
@@ -14,7 +14,8 @@ import os
 import sys
 from logging.handlers import TimedRotatingFileHandler
 
-from wazuh.core import common
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import utils
 
 logger_name = 'gcloud_wodle'
 logger = logging.getLogger(logger_name)
@@ -95,4 +96,4 @@ def get_file_logger(output_file: str, level: int = 3) -> logging.Logger:
 
 def get_wazuh_queue() -> str:
     """Get Wazuh queue"""
-    return os.path.join(common.find_wazuh_path(), 'queue', 'sockets', 'queue')
+    return os.path.join(utils.find_wazuh_path(), 'queue', 'sockets', 'queue')

--- a/wodles/utils.py
+++ b/wodles/utils.py
@@ -1,0 +1,74 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import subprocess
+from functools import lru_cache
+
+
+@lru_cache(maxsize=None)
+def find_wazuh_path():
+    """
+    Gets the path where Wazuh is installed dinamically
+
+    :return: str path where Wazuh is installed or empty string if there is no framework in the environment
+    """
+    abs_path = os.path.abspath(os.path.dirname(__file__))
+    allparts = []
+    while 1:
+        parts = os.path.split(abs_path)
+        if parts[0] == abs_path:  # sentinel for absolute paths
+            allparts.insert(0, parts[0])
+            break
+        elif parts[1] == abs_path:  # sentinel for relative paths
+            allparts.insert(0, parts[1])
+            break
+        else:
+            abs_path = parts[0]
+            allparts.insert(0, parts[1])
+
+    wazuh_path = ''
+    try:
+        for i in range(0, allparts.index('wodles')):
+            wazuh_path = os.path.join(wazuh_path, allparts[i])
+    except ValueError:
+        pass
+
+    return wazuh_path
+
+
+def call_wazuh_control(option) -> str:
+    wazuh_control = os.path.join(find_wazuh_path(), "bin", "wazuh-control")
+    try:
+        proc = subprocess.Popen([wazuh_control, option], stdout=subprocess.PIPE)
+        (stdout, stderr) = proc.communicate()
+        return stdout.decode()
+    except Exception:
+        pass
+
+
+def get_wazuh_info(field) -> str:
+    wazuh_info = call_wazuh_control("info")
+    if not wazuh_info:
+        return "ERROR"
+
+    if not field:
+        return wazuh_info
+
+    env_variables = wazuh_info.rsplit("\n")
+    env_variables.remove("")
+    wazuh_env_vars = dict()
+    for env_variable in env_variables:
+        key, value = env_variable.split("=")
+        wazuh_env_vars[key] = value.replace("\"", "")
+
+    return wazuh_env_vars[field]
+
+
+@lru_cache(maxsize=None)
+def get_wazuh_version() -> str:
+    return get_wazuh_info("WAZUH_VERSION")
+
+
+ANALYSISD = os.path.join(find_wazuh_path(), 'queue', 'sockets', 'queue')


### PR DESCRIPTION
### Fix description:
This PR fixes an error in the Python wodles for Wazuh Agents. Currently, the wodles try to import from `wazuh.core`, which requires the Wazuh embedded python package which is only available in Wazuh Managers.

This fix adds a new `utils.py` file to the wodles folder structure. These utils will be used by all python modules (`aws`, `azure`, `gcloud`, etc).

### Unit test results:
```
/usr/bin/python3.8 /snap/pycharm-community/250/plugins/python-ce/helpers/pycharm/_jb_pytest_runner.py --target test_aws.py::test_db_maintenance
Testing started at 16:58 ...
Launching pytest with arguments test_aws.py::test_db_maintenance --no-header --no-summary -q in /home/david/git/wazuh/wodles/aws/tests

============================= test session starts ==============================
collecting ... collected 5 items

test_aws.py::test_db_maintenance[AWSCloudTrailBucket-schema_cloudtrail_test.sql-cloudtrail] PASSED [ 20%]
test_aws.py::test_db_maintenance[AWSConfigBucket-schema_config_test.sql-config] PASSED [ 40%]
test_aws.py::test_db_maintenance[AWSVPCFlowBucket-schema_vpcflow_test.sql-vpcflow] PASSED [ 60%]
test_aws.py::test_db_maintenance[AWSCustomBucket-schema_custom_test.sql-custom] PASSED [ 80%]
test_aws.py::test_db_maintenance[AWSGuardDutyBucket-schema_guardduty_test.sql-guardduty] PASSED [100%]

============================== 5 passed in 0.08s ===============================

```


