### PR TITLE
Fix broadcasting on distributed API requests with disabled cluster

### DIFF
--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -233,6 +233,9 @@ class DistributedAPI:
             return data
 
         try:
+            if self.f_kwargs.get('agent_list') == '*':
+                del self.f_kwargs['agent_list']
+
             before = time.time()
             self.check_wazuh_status()
 


### PR DESCRIPTION
|Related issue|
|---|
| closes #9980  |

Hello team, 

This PR fixes the error reported in the issue #9980 for environments with both cluster enabled and disabled.

## Manual testing

### Cluster enabled

```xml
  <cluster>
    <name>wazuh</name>
        <node_name>master-node</node_name>
        <node_type>master</node_type>
        <key>9d273b53510fef702b54a92e9cffc82e</key>
        <port>1516</port>
        <bind_addr>0.0.0.0</bind_addr>
        <nodes>
            <node>wazuh-master</node>
        </nodes>
        <hidden>no</hidden>
        <disabled>no</disabled>
     </cluster>

```
`PUT  /agents/restart` (agent is disconnected)

```json
{
  "data": {
    "affected_items": [],
    "total_affected_items": 0,
    "total_failed_items": 1,
    "failed_items": [
      {
        "error": {
          "code": 1707,
          "message": "Impossible to restart non-active agent: disconnected",
          "remediation": "Please, make sure agent is active before attempting to restart"
        },
        "id": [
          "001"
        ]
      }
    ]
  },
  "message": "Restart command was not sent to any agent",
  "error": 1
}
```

### Cluster disabled

```xml
  <cluster>
    <name>wazuh</name>
        <node_name>master-node</node_name>
        <node_type>master</node_type>
        <key>9d273b53510fef702b54a92e9cffc82e</key>
        <port>1516</port>
        <bind_addr>0.0.0.0</bind_addr>
        <nodes>
            <node>wazuh-master</node>
        </nodes>
        <hidden>no</hidden>
        <disabled>yes</disabled>
     </cluster>

```
`PUT  /agents/restart` (agent is disconnected)

```json
{
  "data": {
    "affected_items": [],
    "total_affected_items": 0,
    "total_failed_items": 1,
    "failed_items": [
      {
        "error": {
          "code": 1707,
          "message": "Impossible to restart non-active agent: disconnected",
          "remediation": "Please, make sure agent is active before attempting to restart"
        },
        "id": [
          "001"
        ]
      }
    ]
  },
  "message": "Restart command was not sent to any agent",
  "error": 1
}
```


Regards,
Víctor
