### PR TITLE
Prevent Analysisd from creating file resources when running in test mode

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -507,17 +507,19 @@ int main_analysisd(int argc, char **argv)
     mdebug1(PRIVSEP_MSG, home_path, user);
     os_free(home_path);
 
-    /* Signal manipulation */
-    StartSIG(ARGV0);
+    if (!test_config) {
+        /* Signal manipulation */
+        StartSIG(ARGV0);
 
-    /* Create the PID file */
-    if (CreatePID(ARGV0, getpid()) < 0) {
-        merror_exit(PID_ERROR);
-    }
+        /* Create the PID file */
+        if (CreatePID(ARGV0, getpid()) < 0) {
+            merror_exit(PID_ERROR);
+        }
 
-    /* Set the queue */
-    if ((m_queue = StartMQ(DEFAULTQUEUE, READ, 0)) < 0) {
-        merror_exit(QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
+        /* Set the queue */
+        if ((m_queue = StartMQ(DEFAULTQUEUE, READ, 0)) < 0) {
+            merror_exit(QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
+        }
     }
 
     Config.decoder_order_size = (size_t)getDefine_Int("analysisd", "decoder_order_size", MIN_ORDER_SIZE, MAX_DECODER_ORDER_SIZE);


### PR DESCRIPTION
|Related issue|
|---|
|Closes #9985|

This PR aims to disable the following stages in Analysisd startup when running in test mode (`wazuh-analysisd -t`):
- Create PID file.
- Set a PID file deletion callback at the exit.
- Listen to the input queue socket.

## Tests

- [x] The queue socket (`queue/sockets/queue`) is no longer recreated on testing mode.

```sh
# stat /var/ossec/queue/sockets/queue
  File: /var/ossec/queue/sockets/queue
  Size: 0               Blocks: 0          IO Block: 4096   socket
Device: 810h/2064d      Inode: 460449      Links: 1
Access: (0660/srw-rw----)  Uid: (  998/   ossec)   Gid: (  998/   ossec)
Access: 2021-09-06 18:00:21.137435300 +0200
Modify: 2021-09-06 18:00:20.137435300 +0200
Change: 2021-09-06 18:00:20.137435300 +0200
 Birth: -

# /var/ossec/bin/wazuh-analysisd -t
# stat /var/ossec/queue/sockets/queue
(same result)
```

- [x] The queue does not change when running the API query to validate the manager's configuration:
```sh
# ls --time-style=full-iso -l /var/ossec/queue/sockets/queue
srw-rw---- 1 ossec ossec 0 2021-09-07 10:14:24.480000000 +0200 /var/ossec/queue/sockets/queue

# curl -X GET https://localhost:55000/manager/configuration/validation
{"data": {"affected_items": [{"name": "manager", "status": "OK"}], "total_affected_items": 1, "total_failed_items": 0, "failed_items": []}, "message": "Validation was successfully checked", "error": 0}

# ls --time-style=full-iso -l /var/ossec/queue/sockets/queue
srw-rw---- 1 ossec ossec 0 2021-09-07 10:14:24.480000000 +0200 /var/ossec/queue/sockets/queue