### PR TITLE
Changing agentd and logcollector to dont overkill the data provider.

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -145,6 +145,9 @@ logcollector.exclude_files_interval=86400
 # 0 means state file creation and updating is disabled
 logcollector.state_interval=60
 
+# Logbuilder IP update interval [0..3600]
+logcollector.ip_update_interval=60
+
 # Remoted counter io flush.
 remoted.recv_counter_flush=128
 

--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -42,30 +42,20 @@ char *getsharedfiles()
 #ifndef WIN32
 char *get_agent_ip()
 {
-    static char agent_ip[IPSIZE + 1] = { '\0' };
+    char agent_ip[IPSIZE + 1] = { '\0' };
 #if defined (__linux__) || defined (__MACH__) || defined (sun) || defined(FreeBSD) || defined(OpenBSD)
-    static time_t last_update = 0;
-    time_t now = time(NULL);
     int sock;
     int i;
-
-    if ((now - last_update) < agt->main_ip_update_interval) {
-        return strdup(agent_ip);
-    }
-
-    last_update = now;
-    agent_ip[0] = '\0';
+    static const char * REQUEST = "host_ip";
 
     for (i = SOCK_ATTEMPTS; i > 0; --i) {
         if (sock = control_check_connection(), sock >= 0) {
-            if (OS_SendUnix(sock, agent_ip, IPSIZE) < 0) {
+            if (OS_SendUnix(sock, REQUEST, strlen(REQUEST)) < 0) {
                 mdebug1("Error sending msg to control socket (%d) %s", errno, strerror(errno));
-                last_update = 0;
             }
             else{
                 if (OS_RecvUnix(sock, IPSIZE, agent_ip) <= 0) {
                     mdebug1("Error receiving msg from control socket (%d) %s", errno, strerror(errno));
-                    last_update = 0;
                     agent_ip[0] = '\0';
                 }
             }
@@ -80,7 +70,6 @@ char *get_agent_ip()
 
     if(sock < 0) {
         mdebug1("Cannot get the agent host's IP because the control module is not available: (%d) %s.", errno, strerror(errno));
-        last_update = 0;
     }
 #endif
     return strdup(agent_ip);
@@ -95,7 +84,8 @@ void run_notify()
     char *shared_files;
     os_md5 md5sum;
     time_t curr_time;
-    char *agent_ip;
+    static char agent_ip[IPSIZE] = { '\0' };
+    static time_t last_update = 0;
 
     tmp_msg[OS_MAXSTR - OS_HEADER_SIZE + 1] = '\0';
     curr_time = time(0);
@@ -165,10 +155,22 @@ void run_notify()
         }
     }
 
-    agent_ip = get_agent_ip();
+    time_t now = time(NULL);
+    if ((now - last_update) >= agt->main_ip_update_interval) {
+        // Update agent_ip considering main_ip_update_interval value
+        last_update = now;
+        char *tmp_agent_ip = get_agent_ip();
 
+        if (tmp_agent_ip) {
+            strncpy(agent_ip, tmp_agent_ip, IPSIZE - 1);
+            os_free(tmp_agent_ip);
+        } else {
+           mdebug1("Cannot update host IP.");
+           *agent_ip = '\0';
+        }
+    }
     /* Create message */
-    if(agent_ip && strcmp(agent_ip, "Err")) {
+    if(*agent_ip != '\0' && strcmp(agent_ip, "Err")) {
         char label_ip[60];
         snprintf(label_ip, sizeof label_ip, "#\"_agent_ip\":%s", agent_ip);
         if ((File_DateofChange(AGENTCONFIG) > 0 ) &&
@@ -190,7 +192,6 @@ void run_notify()
                     getuname(), tmp_labels, shared_files);
         }
     }
-    os_free(agent_ip);
 
     /* Send status message */
     mdebug2("Sending keep alive: %s", tmp_msg);

--- a/src/shared/log_builder.c
+++ b/src/shared/log_builder.c
@@ -36,6 +36,9 @@ static int log_builder_update_hostname(log_builder_t * builder);
  */
 static int log_builder_update_host_ip(log_builder_t * builder);
 
+/* Number of seconds of how often the IP must be updated. */
+static int g_ip_update_interval = 0;
+
 // Initialize a log builder structure
 log_builder_t * log_builder_init(bool update) {
     log_builder_t * builder;
@@ -44,7 +47,7 @@ log_builder_t * log_builder_init(bool update) {
     {
         pthread_rwlockattr_t attr;
         pthread_rwlockattr_init(&attr);
-
+        g_ip_update_interval = getDefine_Int("logcollector","ip_update_interval", 0, 3600);
 #ifdef __linux__
         /* PTHREAD_RWLOCK_PREFER_WRITER_NP is ignored.
         * Do not use recursive locking.
@@ -241,49 +244,50 @@ int log_builder_update_hostname(log_builder_t * builder) {
 
 // Update the host's IP value
 int log_builder_update_host_ip(log_builder_t * builder) {
-    char * host_ip = NULL;
+    static char host_ip[IPSIZE] = { '\0' };
+    static time_t last_update = 0;
+    time_t now = time(NULL);
 
+    if ((now - last_update) >= g_ip_update_interval) {
+        last_update = now;
 #ifdef WIN32
-    host_ip = get_agent_ip();
+        char * tmp_host_ip = get_agent_ip();
 
-    if (host_ip == NULL) {
-        mdebug1("Cannot update host IP.");
-    }
+        if (tmp_host_ip) {
+            strncpy(host_ip, tmp_host_ip, IPSIZE - 1);
+            os_free(tmp_host_ip);
+        } else {
+            mdebug1("Cannot update host IP.");
+            *host_ip = '\0';
+        }
 
 #elif defined __linux__ || defined __MACH__ || defined sun || defined FreeBSD || defined OpenBSD
-    const char * REQUEST = "host_ip";
-    int sock = control_check_connection();
+        const char * REQUEST = "host_ip";
+        int sock = control_check_connection();
 
-    if (sock == -1) {
-        mdebug1("Cannot update host IP: The control module is not available: %s (%d)", strerror(errno), errno);
-    } else {
-        os_calloc(INET6_ADDRSTRLEN, sizeof(char), host_ip);
-
-        if (send(sock, REQUEST, strlen(REQUEST), 0) > 0) {
-            if (recv(sock, host_ip, INET6_ADDRSTRLEN - 1, 0) < 0) {
-                mdebug1("The control module did not respond: %s (%d).", strerror(errno), errno);
-                *host_ip = '\0';
+        if (sock == -1) {
+            mdebug1("Cannot update host IP: The control module is not available: %s (%d)", strerror(errno), errno);
+            last_update = 0;
+        } else {
+            if (send(sock, REQUEST, strlen(REQUEST), 0) > 0) {
+                if (recv(sock, host_ip, IPSIZE - 1, 0) < 0) {
+                    mdebug1("The control module did not respond: %s (%d).", strerror(errno), errno);
+                    *host_ip = '\0';
+                }
             }
+
+            close(sock);
         }
-
-        close(sock);
-
-        if (*host_ip == '\0') {
-            os_free(host_ip);
-        }
-    }
-
 #endif
+    }
     w_rwlock_wrlock(&builder->rwlock);
-
-    if (host_ip != NULL) {
-        strncpy(builder->host_ip, host_ip, INET6_ADDRSTRLEN - 1);
-        free(host_ip);
+    if (*host_ip != '\0' && strcmp(host_ip, "Err")) {
+        strcpy(builder->host_ip, host_ip);
     } else {
-        strncpy(builder->host_ip, "0.0.0.0", INET6_ADDRSTRLEN - 1);
+        strncpy(builder->host_ip, "0.0.0.0", IPSIZE - 1);
     }
 
-    builder->host_ip[INET6_ADDRSTRLEN - 1] = '\0';
+    builder->host_ip[IPSIZE - 1] = '\0';
     w_rwlock_unlock(&builder->rwlock);
 
     return 0;

--- a/src/unit_tests/client-agent/test_notify.c
+++ b/src/unit_tests/client-agent/test_notify.c
@@ -17,6 +17,7 @@
 #define TIME_INCREMENT ((time_t)(60))
 
 static time_t base_time = 123456;
+static const char * REQUEST = "host_ip";
 
 static agent global_config = { .main_ip_update_interval = (int)TIME_INCREMENT };
 
@@ -32,8 +33,6 @@ static void get_agent_ip_fail_to_connect(void **state) {
     char *retval;
 
     expect_any_count(__wrap__mdebug2, formatted_msg, SOCK_ATTEMPTS);
-
-    will_return(__wrap_time, base_time);
 
     for (int i = SOCK_ATTEMPTS; i > 0; i--) {
         will_return(__wrap_control_check_connection, -1);
@@ -53,13 +52,11 @@ static void get_agent_ip_fail_to_send_request(void **state) {
     char *retval;
     static const int socket = 8;
 
-    will_return(__wrap_time, base_time);
-
     will_return(__wrap_control_check_connection, socket);
 
     expect_value(__wrap_OS_SendUnix, socket, socket);
-    expect_string(__wrap_OS_SendUnix, msg, "");
-    expect_value(__wrap_OS_SendUnix, size, IPSIZE);
+    expect_string(__wrap_OS_SendUnix, msg, REQUEST);
+    expect_value(__wrap_OS_SendUnix, size, strlen(REQUEST));
     will_return(__wrap_OS_SendUnix, OS_SOCKTERR);
 
     expect_any(__wrap__mdebug1, formatted_msg);
@@ -75,13 +72,11 @@ static void get_agent_ip_fail_to_receive_response(void **state) {
     char *retval;
     static const int socket = 8;
 
-    will_return(__wrap_time, base_time);
-
     will_return(__wrap_control_check_connection, socket);
 
     expect_value(__wrap_OS_SendUnix, socket, socket);
-    expect_string(__wrap_OS_SendUnix, msg, "");
-    expect_value(__wrap_OS_SendUnix, size, IPSIZE);
+    expect_string(__wrap_OS_SendUnix, msg, REQUEST);
+    expect_value(__wrap_OS_SendUnix, size, strlen(REQUEST));
     will_return(__wrap_OS_SendUnix, OS_SUCCESS);
 
     expect_value(__wrap_OS_RecvUnix, socket, socket);
@@ -103,13 +98,11 @@ static void get_agent_ip_updated_successfully(void **state) {
     static const int socket = 8;
     static const char *const RESPONSE = "10.0.2.15";
 
-    will_return(__wrap_time, base_time);
-
     will_return(__wrap_control_check_connection, socket);
 
     expect_value(__wrap_OS_SendUnix, socket, socket);
-    expect_string(__wrap_OS_SendUnix, msg, "");
-    expect_value(__wrap_OS_SendUnix, size, IPSIZE);
+    expect_string(__wrap_OS_SendUnix, msg, REQUEST);
+    expect_value(__wrap_OS_SendUnix, size, strlen(REQUEST));
     will_return(__wrap_OS_SendUnix, OS_SUCCESS);
 
     expect_value(__wrap_OS_RecvUnix, socket, socket);
@@ -123,8 +116,17 @@ static void get_agent_ip_updated_successfully(void **state) {
 
     free(retval);
 
-    // Check the function uses the cache for the given interval
-    will_return(__wrap_time, base_time + (TIME_INCREMENT / 2));
+    will_return(__wrap_control_check_connection, socket);
+
+    expect_value(__wrap_OS_SendUnix, socket, socket);
+    expect_string(__wrap_OS_SendUnix, msg, REQUEST);
+    expect_value(__wrap_OS_SendUnix, size, strlen(REQUEST));
+    will_return(__wrap_OS_SendUnix, OS_SUCCESS);
+
+    expect_value(__wrap_OS_RecvUnix, socket, socket);
+    expect_value(__wrap_OS_RecvUnix, sizet, IPSIZE);
+    will_return(__wrap_OS_RecvUnix, RESPONSE);
+    will_return(__wrap_OS_RecvUnix, strlen(RESPONSE));
 
     retval = get_agent_ip();
 
@@ -135,13 +137,11 @@ static void get_agent_ip_updated_successfully(void **state) {
     // Check the IP gets refreshed after the interval
     base_time += TIME_INCREMENT;
 
-    will_return(__wrap_time, base_time + (TIME_INCREMENT / 2));
-
     will_return(__wrap_control_check_connection, socket);
 
     expect_value(__wrap_OS_SendUnix, socket, socket);
-    expect_string(__wrap_OS_SendUnix, msg, "");
-    expect_value(__wrap_OS_SendUnix, size, IPSIZE);
+    expect_string(__wrap_OS_SendUnix, msg, REQUEST);
+    expect_value(__wrap_OS_SendUnix, size, strlen(REQUEST));
     will_return(__wrap_OS_SendUnix, OS_SUCCESS);
 
     expect_value(__wrap_OS_RecvUnix, socket, socket);

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -79,7 +79,7 @@ list(APPEND shared_tests_names "test_utf8_op")
 list(APPEND shared_tests_flags " ")
 
 list(APPEND shared_tests_names "test_log_builder")
-list(APPEND shared_tests_flags " ")
+list(APPEND shared_tests_flags "-Wl,--wrap,getDefine_Int")
 
 list(APPEND shared_tests_names "test_custom_output_search_replace")
 list(APPEND shared_tests_flags " ")

--- a/src/unit_tests/shared/test_log_builder.c
+++ b/src/unit_tests/shared/test_log_builder.c
@@ -27,6 +27,8 @@ void test_log_builder(void **state)
     const char * LOCATION = "test";
     const char * EXPECTED_OUTPUT = "location: test, log: Hello \"World\", escaped: Hello \\\"World\\\"";
 
+    will_return(__wrap_getDefine_Int, 60);
+
     int retval = 1;
     log_builder_t * builder = log_builder_init(false);
 

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -363,17 +363,8 @@ int StartMQ(__attribute__((unused)) const char *path, __attribute__((unused)) sh
 
 char *get_agent_ip()
 {
-    static char agent_ip[IPSIZE + 1] = { '\0' };
-    static time_t last_update = 0;
-    time_t now = time(NULL);
+    char agent_ip[IPSIZE + 1] = { '\0' };
     cJSON *object;
-
-    if ((now - last_update) < agt->main_ip_update_interval) {
-        return strdup(agent_ip);
-    }
-
-    last_update = now;
-    agent_ip[0] = '\0';
 
     if (sysinfo_network_ptr && sysinfo_free_result_ptr) {
         const int error_code = sysinfo_network_ptr(&object);
@@ -406,7 +397,7 @@ char *get_agent_ip()
                                     break;
                                 }
                             }
-                            if (agent_ip) {
+                            if (*agent_ip != '\0') {
                                 break;
                             }
                         }
@@ -418,10 +409,6 @@ char *get_agent_ip()
         else {
             merror("Unable to get system network information. Error code: %d.", error_code);
         }
-    }
-
-    if (agent_ip[0] == '\0') {
-        last_update = 0;
     }
 
     return strdup(agent_ip);


### PR DESCRIPTION
|Related issue|
|---|
|Closes #9701 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Current behavior: Data provider is called each 1 second.
Expected behavior: Call data provider each 1 minute.
Steps to reproduce:

    Install agent.
    Set logcollector.vcheck_files=1
    Run strace to check read operations to get the machine IP.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [x] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors