### PR TITLE
9986 - Add passwd rules for Auditd

### DIFF
--- a/ruleset/rules/0365-auditd_rules.xml
+++ b/ruleset/rules/0365-auditd_rules.xml
@@ -434,5 +434,18 @@
         <group>audit_generic,</group>
     </rule>
     -->
-</group>
 
+    <!-- Passwd rules -->
+    <rule id="100042" level="8">
+      <if_sid>80700</if_sid>
+      <field name="audit.type">ACCT_LOCK</field>
+      <description>Account password access locked</description>
+    </rule>
+
+    <rule id="100043" level="8">
+      <if_sid>80700</if_sid>
+      <field name="audit.type">ACCT_UNLOCK</field>
+      <description>Account password access unlocked</description>
+    </rule>
+    
+</group>

--- a/ruleset/testing/tests/auditd.ini
+++ b/ruleset/testing/tests/auditd.ini
@@ -4,3 +4,18 @@ log 1 pass = type=SYSCALL msg=audit(1479982525.380:50): arch=c000003e syscall=2 
 rule = 80790
 alert = 3
 decoder = auditd
+
+[auditd: passwd lock]
+log 1 pass = type=ACCT_LOCK msg=audit(1630937849.448:891): pid=4171 uid=0 auid=1000 ses=3 subj=unconfined_u:unconfined_r:passwd_t:s0-s0:c0.c1023 msg='op=locked-password id=1001 exe="/usr/bin/passwd" hos>
+
+rule = 100042
+alert = 8
+decoder = auditd
+
+
+[auditd: passwd unlock]
+log 1 pass = type=ACCT_UNLOCK msg=audit(1630937871.591:892): pid=4172 uid=0 auid=1000 ses=3 subj=unconfined_u:unconfined_r:passwd_t:s0-s0:c0.c1023 msg='op=unlocked-password id=1001 exe="/usr/bin/passwd">
+
+rule = 100043
+alert = 8
+decoder = auditd


### PR DESCRIPTION
|Related issue|
|---|
| #9986 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR adds the rules written by @jctello for `Auditd passwd` events described in the Issue.
In addition, testing was added by adding two new entries to the `auditd.ini` file with the logs given.

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

Tests were made locally in a Wazuh manager with a 4.2.1 version.

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

The output of `/var/ossec/bin/wazuh-analysisd -t` is clear:
```
root@ubuntu20LTS:/home/vagrant/wazuh/ruleset/testing# /var/ossec/bin/wazuh-analysisd -t
root@ubuntu20LTS:/home/vagrant/wazuh/ruleset/testing# 
```


## Tests

Tested the logs in `wazuh-logtest`:
```
root@ubuntu20LTS:/home/vagrant/wazuh/ruleset/testing# /var/ossec/bin/wazuh-logtest
Starting wazuh-logtest v4.2.1
Type one log per line

type=ACCT_UNLOCK msg=audit(1630937871.591:892): pid=4172 uid=0 auid=1000 ses=3 subj=unconfined_u:unconfined_r:passwd_t:s0-s0:c0.c1023 msg='op=unlocked-password id=1001 exe="/usr/bin/passwd" hostname=clean addr=? terminal=pts/0 res=success'

**Phase 1: Completed pre-decoding.
	full event: 'type=ACCT_UNLOCK msg=audit(1630937871.591:892): pid=4172 uid=0 auid=1000 ses=3 subj=unconfined_u:unconfined_r:passwd_t:s0-s0:c0.c1023 msg='op=unlocked-password id=1001 exe="/usr/bin/passwd" hostname=clean addr=? terminal=pts/0 res=success''

**Phase 2: Completed decoding.
	name: 'auditd'
	audit.auid: '1000'
	audit.exe: '/usr/bin/passwd'
	audit.id: '892'
	audit.pid: '4172'
	audit.res: 'success'
	audit.session: '3'
	audit.srcip: '?'
	audit.type: 'ACCT_UNLOCK'
	audit.uid: '0'

**Phase 3: Completed filtering (rules).
	id: '100043'
	level: '8'
	description: 'Account password access unlocked'
	groups: '['audit']'
	firedtimes: '1'
	mail: 'False'
**Alert to be generated.

type=ACCT_LOCK msg=audit(1630937849.448:891): pid=4171 uid=0 auid=1000 ses=3 subj=unconfined_u:unconfined_r:passwd_t:s0-s0:c0.c1023 msg='op=locked-password id=1001 exe="/usr/bin/passwd" hostname=clean addr=? terminal=pts/0 res=success'

**Phase 1: Completed pre-decoding.
	full event: 'type=ACCT_LOCK msg=audit(1630937849.448:891): pid=4171 uid=0 auid=1000 ses=3 subj=unconfined_u:unconfined_r:passwd_t:s0-s0:c0.c1023 msg='op=locked-password id=1001 exe="/usr/bin/passwd" hostname=clean addr=? terminal=pts/0 res=success''

**Phase 2: Completed decoding.
	name: 'auditd'
	audit.auid: '1000'
	audit.exe: '/usr/bin/passwd'
	audit.id: '891'
	audit.pid: '4171'
	audit.res: 'success'
	audit.session: '3'
	audit.srcip: '?'
	audit.type: 'ACCT_LOCK'
	audit.uid: '0'

**Phase 3: Completed filtering (rules).
	id: '100042'
	level: '8'
	description: 'Account password access locked'
	groups: '['audit']'
	firedtimes: '1'
	mail: 'False'
**Alert to be generated.
```
After running the `runtest.py` test for the new `.ini` file, the result is the following:
```
root@ubuntu20LTS:/home/vagrant/wazuh/ruleset/testing# python runtests.py -t auditd.ini
- [ File = ./tests/auditd.ini ] ---------
...

```

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [x] Added unit testing files ".ini"
  - [x] runtests.py executed without errors