### PR TITLE
Remove the limit of agents to upgrade with PUT /agents/upgrade and PUT /agents/upgrade_custom

### DIFF
--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -496,6 +496,8 @@ async def put_upgrade_agents(request, agents_list=None, pretty=False, wait_for_c
     ApiResponse
         Upgrade message after trying to upgrade the agents.
     """
+    if 'all' in agents_list:
+        agents_list = None
     f_kwargs = {'agent_list': agents_list,
                 'wpk_repo': wpk_repo,
                 'version': version,
@@ -537,6 +539,8 @@ async def put_upgrade_custom_agents(request, agents_list=None, pretty=False, wai
     ApiResponse
         Upgrade message after trying to upgrade the agents.
     """
+    if 'all' in agents_list:
+        agents_list = None
     f_kwargs = {'agent_list': agents_list,
                 'file_path': file_path,
                 'installer': installer}

--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -499,7 +499,7 @@ async def put_upgrade_agents(request, agents_list=None, pretty=False, wait_for_c
     # If we use the 'all' keyword and the request is distributed_master, agents_list must be '*'
     if 'all' in agents_list:
         agents_list = '*'
-        
+
     f_kwargs = {'agent_list': agents_list,
                 'wpk_repo': wpk_repo,
                 'version': version,
@@ -513,7 +513,7 @@ async def put_upgrade_agents(request, agents_list=None, pretty=False, wait_for_c
                           wait_for_complete=wait_for_complete,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies'],
-                          broadcasting=agents_list == '*',
+                          broadcasting=agents_list == '*'
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -542,8 +542,10 @@ async def put_upgrade_custom_agents(request, agents_list=None, pretty=False, wai
     ApiResponse
         Upgrade message after trying to upgrade the agents.
     """
+    # If we use the 'all' keyword and the request is distributed_master, agents_list must be '*'
     if 'all' in agents_list:
-        agents_list = None
+        agents_list = '*'
+
     f_kwargs = {'agent_list': agents_list,
                 'file_path': file_path,
                 'installer': installer}
@@ -554,7 +556,8 @@ async def put_upgrade_custom_agents(request, agents_list=None, pretty=False, wai
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          broadcasting=agents_list == '*'
                           )
     data = raise_if_exc(await dapi.distribute_function())
 

--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -496,8 +496,10 @@ async def put_upgrade_agents(request, agents_list=None, pretty=False, wait_for_c
     ApiResponse
         Upgrade message after trying to upgrade the agents.
     """
+    # If we use the 'all' keyword and the request is distributed_master, agents_list must be '*'
     if 'all' in agents_list:
-        agents_list = None
+        agents_list = '*'
+        
     f_kwargs = {'agent_list': agents_list,
                 'wpk_repo': wpk_repo,
                 'version': version,
@@ -510,7 +512,8 @@ async def put_upgrade_agents(request, agents_list=None, pretty=False, wait_for_c
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          broadcasting=agents_list == '*',
                           )
     data = raise_if_exc(await dapi.distribute_function())
 

--- a/api/api/controllers/experimental_controller.py
+++ b/api/api/controllers/experimental_controller.py
@@ -47,6 +47,7 @@ async def clear_rootcheck_database(request, pretty=False, wait_for_complete=Fals
     -------
     web.Response
     """
+    # If we use the 'all' keyword and the request is distributed_master, agents_list must be '*'
     if 'all' in agents_list:
         agents_list = '*'
 
@@ -75,6 +76,7 @@ async def clear_syscheck_database(request, pretty=False, wait_for_complete=False
     :param agents_list: List of agent's IDs.
     :return: AllItemsResponseAgentIDs
     """
+    # If we use the 'all' keyword and the request is distributed_master, agents_list must be '*'
     if 'all' in agents_list:
         agents_list = '*'
 

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -3982,16 +3982,6 @@ components:
         type: array
         items:
           $ref: '#/components/schemas/AgentID'
-    agents_list_upgrade:
-      in: query
-      name: agents_list
-      description: "List of agent IDs (separated by comma), select a list of agents with size less or equal than 100"
-      required: true
-      schema:
-        type: array
-        items:
-          $ref: '#/components/schemas/AgentID'
-        maxItems: 100
     agents_list_all:
       in: query
       name: agents_list
@@ -6177,7 +6167,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/pretty'
         - $ref: '#/components/parameters/wait_for_complete'
-        - $ref: '#/components/parameters/agents_list_upgrade'
+        - $ref: '#/components/parameters/agents_list_all'
         - $ref: '#/components/parameters/wpk_repo'
         - $ref: '#/components/parameters/upgrade_version'
         - $ref: '#/components/parameters/use_http'
@@ -6224,7 +6214,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/pretty'
         - $ref: '#/components/parameters/wait_for_complete'
-        - $ref: '#/components/parameters/agents_list_upgrade'
+        - $ref: '#/components/parameters/agents_list_all'
         - $ref: '#/components/parameters/file_path'
         - $ref: '#/components/parameters/installer'
       responses:

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -849,22 +849,24 @@ def upgrade_agents(agent_list=None, wpk_repo=None, version=None, force=False, us
     if version and not version.startswith('v'):
         version = f'v{version}'
 
-    agent_results = core_upgrade_agents(command='upgrade' if not (installer or file_path) else 'upgrade_custom',
-                                        agents_list=agent_list, wpk_repo=wpk_repo, version=version, force=force,
-                                        use_http=use_http, file_path=file_path, installer=installer)
+    # Check if the list is not empty after the padding
+    if agent_list:
+        agent_results = core_upgrade_agents(command='upgrade' if not (installer or file_path) else 'upgrade_custom',
+                                            agents_list=agent_list, wpk_repo=wpk_repo, version=version, force=force,
+                                            use_http=use_http, file_path=file_path, installer=installer)
 
-    for agent_result in agent_results['data']:
-        if agent_result['error'] == 0:
-            task_agent = {
-                'agent': str(agent_result['agent']).zfill(3),
-                'task_id': agent_result['task_id']
-            }
-            result.affected_items.append(task_agent)
-            result.total_affected_items += 1
-        else:
-            error = WazuhError(code=1810 + agent_result['error'], cmd_error=True,
-                               extra_message=agent_result['message'])
-            result.add_failed_item(id_=str(agent_result['agent']).zfill(3), error=error)
+        for agent_result in agent_results['data']:
+            if agent_result['error'] == 0:
+                task_agent = {
+                    'agent': str(agent_result['agent']).zfill(3),
+                    'task_id': agent_result['task_id']
+                }
+                result.affected_items.append(task_agent)
+                result.total_affected_items += 1
+            else:
+                error = WazuhError(code=1810 + agent_result['error'], cmd_error=True,
+                                   extra_message=agent_result['message'])
+                result.add_failed_item(id_=str(agent_result['agent']).zfill(3), error=error)
     result.affected_items = sorted(result.affected_items, key=lambda k: k['agent'])
 
     return result

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -892,17 +892,19 @@ def get_upgrade_result(agent_list=None):
 
     agent_list = list(map(int, agents_padding(result=result, agent_list=agent_list)))
 
-    task_results = core_upgrade_agents(agents_list=agent_list, get_result=True)
+    # Check if the list is not empty after the padding
+    if agent_list:
+        task_results = core_upgrade_agents(agents_list=agent_list, get_result=True)
 
-    for task_result in task_results['data']:
-        task_error = task_result.pop('error')
-        if task_error == 0:
-            task_result['agent'] = str(task_result['agent']).zfill(3)
-            result.affected_items.append(task_result)
-            result.total_affected_items += 1
-        else:
-            error = WazuhError(code=1810 + task_error, cmd_error=True, extra_message=task_result['message'])
-            result.add_failed_item(id_=str(task_result.pop('agent')).zfill(3), error=error)
+        for task_result in task_results['data']:
+            task_error = task_result.pop('error')
+            if task_error == 0:
+                task_result['agent'] = str(task_result['agent']).zfill(3)
+                result.affected_items.append(task_result)
+                result.total_affected_items += 1
+            else:
+                error = WazuhError(code=1810 + task_error, cmd_error=True, extra_message=task_result['message'])
+                result.add_failed_item(id_=str(task_result.pop('agent')).zfill(3), error=error)
     result.affected_items = sorted(result.affected_items, key=lambda k: k['agent'])
 
     return result

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -1333,13 +1333,13 @@ def agents_padding(result, agent_list):
     return agent_list
 
 
-def core_upgrade_agents(agents_chunk, command='upgrade_result', wpk_repo=None, version=None,
+def core_upgrade_agents(agents_list, command='upgrade_result', wpk_repo=None, version=None,
                         force=False, use_http=False, file_path=None, installer=None, get_result=False):
     """Send command to upgrade module / task module
 
     Parameters
     ----------
-    agents_chunk : list
+    agents_list : list
         List of agents ID's.
     command : str
         Command sent to the socket.
@@ -1367,7 +1367,7 @@ def core_upgrade_agents(agents_chunk, command='upgrade_result', wpk_repo=None, v
                'origin': {'module': 'api'},
                'command': command,
                'parameters': {
-                   'agents': agents_chunk,
+                   'agents': agents_list,
                    'version': version,
                    'force_upgrade': force,
                    'use_http': use_http,
@@ -1378,7 +1378,7 @@ def core_upgrade_agents(agents_chunk, command='upgrade_result', wpk_repo=None, v
                }
     else:
         msg = {'version': 1, 'origin': {'module': 'api'}, 'command': command,
-               'module': 'api', 'parameters': {'agents': agents_chunk}}
+               'module': 'api', 'parameters': {'agents': agents_list}}
 
     msg['parameters'] = {k: v for k, v in msg['parameters'].items() if v is not None}
 

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -1390,9 +1390,9 @@ def core_upgrade_agents(agents_chunk, command='upgrade_result', wpk_repo=None, v
     s.close()
 
     # Update agent information when getting upgrade results
-    date_format_from_socket = "%Y/%m/%d %H:%M:%S"
+    # When the task has status "In Queue", the value update_time will have value 0
     [agent_info.update(
-        (k, datetime.strptime(v, date_format_from_socket).strftime(date_format)) for k, v in agent_info.items() if
-        k in {'create_time', 'update_time'} and re.match(date_format_from_socket, v)) for agent_info in data['data']]
+        (k, datetime.strptime(v, "%Y/%m/%d %H:%M:%S").strftime(date_format)) for k, v in agent_info.items() if
+        k in {'create_time', 'update_time'} and v != '0') for agent_info in data['data']]
 
     return data

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -1389,8 +1389,10 @@ def core_upgrade_agents(agents_chunk, command='upgrade_result', wpk_repo=None, v
     data = loads(s.receive().decode())
     s.close()
 
-    [agent_info.update((k, datetime.strptime(v, "%Y/%m/%d %H:%M:%S").strftime(date_format))
-                       for k, v in agent_info.items() if k in {'create_time', 'update_time'})
-     for agent_info in data['data']]
+    # Update agent information when getting upgrade results
+    date_format_from_socket = "%Y/%m/%d %H:%M:%S"
+    [agent_info.update(
+        (k, datetime.strptime(v, date_format_from_socket).strftime(date_format)) for k, v in agent_info.items() if
+        k in {'create_time', 'update_time'} and re.match(date_format_from_socket, v)) for agent_info in data['data']]
 
     return data

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -465,7 +465,6 @@ class Agent:
 
         return ret_msg
 
-
     def remove(self, backup=False, purge=False, use_only_authd=False):
         """Delete the agent.
 
@@ -1385,10 +1384,15 @@ def core_upgrade_agents(agents_list, command='upgrade_result', wpk_repo=None, ve
     # Send upgrading command
     s = WazuhSocket(common.UPGRADE_SOCKET)
     s.send(dumps(msg).encode())
+
+    # Receive upgrade information from socket
     data = loads(s.receive().decode())
     s.close()
-    [agent_info.update((k, datetime.strptime(v, "%Y/%m/%d %H:%M:%S").strftime(date_format))
-                       for k, v in agent_info.items() if k in {'create_time', 'update_time'})
-     for agent_info in data['data']]
+
+    # Update agent information when getting upgrade results
+    date_format_from_socket = "%Y/%m/%d %H:%M:%S"
+    [agent_info.update(
+        (k, datetime.strptime(v, date_format_from_socket).strftime(date_format)) for k, v in agent_info.items() if
+        k in {'create_time', 'update_time'} and re.match(date_format_from_socket, v)) for agent_info in data['data']]
 
     return data

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -1390,9 +1390,9 @@ def core_upgrade_agents(agents_chunk, command='upgrade_result', wpk_repo=None, v
     s.close()
 
     # Update agent information when getting upgrade results
-    # When the task has status "In Queue", the value update_time will have value 0
+    # When a task has status "In Queue", update_time has value "0" as the task has not been updated yet
     [agent_info.update(
         (k, datetime.strptime(v, "%Y/%m/%d %H:%M:%S").strftime(date_format)) for k, v in agent_info.items() if
-        k in {'create_time', 'update_time'} and v != '0') for agent_info in data['data']]
+        k in {"create_time", "update_time"} and v != "0") for agent_info in data["data"]]
 
     return data

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -1332,13 +1332,13 @@ def agents_padding(result, agent_list):
     return agent_list
 
 
-def core_upgrade_agents(agents_list, command='upgrade_result', wpk_repo=None, version=None,
+def core_upgrade_agents(agents_chunk, command='upgrade_result', wpk_repo=None, version=None,
                         force=False, use_http=False, file_path=None, installer=None, get_result=False):
     """Send command to upgrade module / task module
 
     Parameters
     ----------
-    agents_list : list
+    agents_chunk : list
         List of agents ID's.
     command : str
         Command sent to the socket.
@@ -1366,7 +1366,7 @@ def core_upgrade_agents(agents_list, command='upgrade_result', wpk_repo=None, ve
                'origin': {'module': 'api'},
                'command': command,
                'parameters': {
-                   'agents': agents_list,
+                   'agents': agents_chunk,
                    'version': version,
                    'force_upgrade': force,
                    'use_http': use_http,
@@ -1377,7 +1377,7 @@ def core_upgrade_agents(agents_list, command='upgrade_result', wpk_repo=None, ve
                }
     else:
         msg = {'version': 1, 'origin': {'module': 'api'}, 'command': command,
-               'module': 'api', 'parameters': {'agents': agents_list}}
+               'module': 'api', 'parameters': {'agents': agents_chunk}}
 
     msg['parameters'] = {k: v for k, v in msg['parameters'].items() if v is not None}
 
@@ -1389,10 +1389,8 @@ def core_upgrade_agents(agents_list, command='upgrade_result', wpk_repo=None, ve
     data = loads(s.receive().decode())
     s.close()
 
-    # Update agent information when getting upgrade results
-    date_format_from_socket = "%Y/%m/%d %H:%M:%S"
-    [agent_info.update(
-        (k, datetime.strptime(v, date_format_from_socket).strftime(date_format)) for k, v in agent_info.items() if
-        k in {'create_time', 'update_time'} and re.match(date_format_from_socket, v)) for agent_info in data['data']]
+    [agent_info.update((k, datetime.strptime(v, "%Y/%m/%d %H:%M:%S").strftime(date_format))
+                       for k, v in agent_info.items() if k in {'create_time', 'update_time'})
+     for agent_info in data['data']]
 
     return data


### PR DESCRIPTION
|Related issue|
|---|
|  #9501 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR closes #9501.



In this pull request I have removed the limitation of agents to upgrade when using the Wazuh API.

Now we can upgrade all the agents in the same request. In order to do that, the `all` keyword can now be used in the upgrade and custom upgrade API requests.

I have tested this with a docker environment with 105 agents. All the tasks have been created successfully.

## Testing

### API integration tests


```
test_agent_DELETE_endpoints.tavern.yaml 
	 6 passed, 8 warnings

test_agent_GET_endpoints.tavern.yaml 
	 90 passed, 1 xpassed, 93 warnings

test_agent_POST_endpoints.tavern.yaml 
	 5 passed, 7 warnings

test_agent_PUT_endpoints.tavern.yaml 
	 10 passed, 12 warnings

test_rbac_black_agent_endpoints.tavern.yaml 
	 41 passed, 43 warnings

test_rbac_white_agent_endpoints.tavern.yaml 
	 41 passed, 43 warnings

```

### Unittests

All unittest are passing.
