### PR TITLE
Fixed bad process command line path in data provider

### DIFF
--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -173,8 +173,9 @@ class SysInfoProcess final
 
             for (const auto& logicalDrive : logicalDrives)
             {
+                const auto normalizedName { logicalDrive.back() == L'\\' ? logicalDrive.substr(0, logicalDrive.length() - 1) : logicalDrive };
                 const auto spDosDevice { std::make_unique<char[]>(OS_MAXSTR) };
-                res = QueryDosDevice(logicalDrive.c_str(), spDosDevice.get(), OS_MAXSTR);
+                res = QueryDosDevice(normalizedName.c_str(), spDosDevice.get(), OS_MAXSTR);
 
                 if (res)
                 {


### PR DESCRIPTION
|Related issue|
|---|
|Closes #8329 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
An issue was found in syscollector processes' command line format. It should be displayed in win32 format (X:\) but is displayed in native/NT format (\Device\HarddiskVolumeX)
Example:
- Expected cmd:
C:\Windows\System32\svchost.exe
- Actual cmd:
\Device\HarddiskVolume4\Windows\System32\svchost.exe

## Tests
Results **before** Fix
![image](https://user-images.githubusercontent.com/54002291/115715836-ecc45b00-a34e-11eb-810a-eee10d5e6e8a.png)

Results **after** Fix
![image](https://user-images.githubusercontent.com/22640902/132404457-0bd0e897-2c56-499a-bdf6-17213d49475b.png)

Fix based on the following [Microsoft Official documentation](https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-querydosdevicew#:~:text=An%20MS-DOS%20device%20name%20string%20specifying%20the%20target%20of%20the%20query.%20The%20device%20name%20cannot%20have%20a%20trailing%20backslash%3B%20for%20example%2C%20use%20%22C%3A%22%2C%20not%20%22C%3A%5C%22)

## DoD

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors