### PR TITLE
Added DBSync instance and create tables statements

### DIFF
--- a/src/syscheckd/db/include/db.hpp
+++ b/src/syscheckd/db/include/db.hpp
@@ -1,5 +1,5 @@
 /**
- * @file fim_db.h
+ * @file db.hpp
  * @brief Definition of FIM database library.
  * @date 2019-08-28
  *

--- a/src/syscheckd/db/include/db_statements.hpp
+++ b/src/syscheckd/db/include/db_statements.hpp
@@ -1,0 +1,70 @@
+/**
+ * @file db_statement.hpp
+ * @brief Definition of FIM database statements.
+ * @date 2021-09-06
+ *
+ * @copyright Copyright (C) 2015-2021 Wazuh, Inc.
+ */
+
+constexpr auto DATABASE_TEMP {"queue/fim/db/fim_dbsync.db"};
+
+constexpr auto CREATE_FILE_DB_STATEMENT
+{
+    R"(CREATE TABLE IF NOT EXISTS file_entry (
+    path TEXT NOT NULL,
+    mode INTEGER,
+    last_event INTEGER,
+    scanned INTEGER,
+    options INTEGER,
+    checksum TEXT NOT NULL,
+    dev INTEGER,
+    inode INTEGER,
+    size INTEGER,
+    perm TEXT,
+    attributes TEXT,
+    uid INTEGER,
+    gid INTEGER,
+    user_name TEXT,
+    group_name TEXT,
+    hash_md5 TEXT,
+    hash_sha1 TEXT,
+    hash_sha256 TEXT,
+    mtime INTEGER,
+    PRIMARY KEY(path));)"
+};
+
+constexpr auto CREATE_REGISTRY_KEY_DB_STATEMENT
+{
+    R"(CREATE TABLE IF NOT EXISTS registry_key (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    path TEXT NOT NULL,
+    perm TEXT,
+    uid INTEGER,
+    gid INTEGER,
+    user_name TEXT,
+    group_name TEXT,
+    mtime INTEGER,
+    arch TEXT CHECK (arch IN ('[x32]', '[x64]')),
+    scanned INTEGER,
+    last_event INTEGER,
+    checksum TEXT NOT NULL,
+    UNIQUE (arch, path));)"
+};
+
+constexpr auto CREATE_REGISTRY_VALUE_DB_STATEMENT
+{
+    R"(CREATE TABLE IF NOT EXISTS registry_data (
+    key_id INTEGER,
+    name TEXT,
+    type INTEGER,
+    size INTEGER,
+    hash_md5 TEXT,
+    hash_sha1 TEXT,
+    hash_sha256 TEXT,
+    scanned INTEGER,
+    last_event INTEGER,
+    checksum TEXT NOT NULL,
+
+    PRIMARY KEY(key_id, name)
+    FOREIGN KEY (key_id) REFERENCES registry_key(id));)"
+};


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/9106|


## Description
Created the database instantiation with the DBSync class.
Created the first "CREATE TABLE" queries to generate the basic tables of files and records.
This PR is in charge of leaving the DBSync database ready to work in parallel.


## Logs/Alerts example
Windows tables:
![image](https://user-images.githubusercontent.com/60003131/132522802-81fe3c06-8094-4f69-8cd3-956531e562d6.png)
