### PR TITLE
Parsing logic for the new force block in the Wazuh settings

### DIFF
--- a/src/config/authd-config.h
+++ b/src/config/authd-config.h
@@ -12,12 +12,13 @@
 #define AD_CONF_UNPARSED 3
 #define AD_CONF_UNDEFINED 2
 
-/**
- * @brief Structure that defines the force options for agent replacement.
- * */
 typedef struct authd_force_options_t {
     bool enabled;
     int connection_time;
+    bool key_mismatch;
+    bool disconnected_time_enabled;
+    time_t disconnected_time;
+    time_t after_registration_time;
 } authd_force_options_t;
 
 typedef struct authd_flags_t {

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -177,7 +177,7 @@ static int read_main_elements(const OS_XML *xml, int modules,
                 goto fail;
             }
         } else if (strcmp(node[i]->element, osauthd) == 0) {
-            if ((modules & CAUTHD) && (Read_Authd(chld_node, d1, d2) < 0)) {
+            if ((modules & CAUTHD) && (Read_Authd(xml, chld_node, d1, d2) < 0)) {
                 goto fail;
             }
         }

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -72,7 +72,7 @@ int Read_GCP(const OS_XML *xml, xml_node *node, void *d1);
 #ifndef WIN32
 int Read_Rules(XML_NODE node, void *d1, void *d2);
 int Read_Fluent_Forwarder(const OS_XML *xml, xml_node *node, void *d1);
-int Read_Authd(XML_NODE node, void *d1, void *d2);
+int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, void *d2);
 #endif
 int Read_Labels(XML_NODE node, void *d1, void *d2);
 int Read_Cluster(XML_NODE node, void *d1, void *d2);

--- a/src/os_auth/config.c
+++ b/src/os_auth/config.c
@@ -52,6 +52,8 @@ cJSON *getAuthdConfig(void) {
 
     cJSON *root = cJSON_CreateObject();
     cJSON *auth = cJSON_CreateObject();
+    cJSON *force = cJSON_CreateObject();
+    cJSON *disconnected_time = cJSON_CreateObject();
 
     cJSON_AddNumberToObject(auth,"port",config.port);
     if (config.force_options.connection_time ==  -1)
@@ -73,6 +75,13 @@ cJSON *getAuthdConfig(void) {
     if (config.manager_cert) cJSON_AddStringToObject(auth,"ssl_manager_cert",config.manager_cert);
     if (config.manager_key) cJSON_AddStringToObject(auth,"ssl_manager_key",config.manager_key);
 
+    if (config.force_options.enabled) cJSON_AddStringToObject(force, "enabled", "yes"); else cJSON_AddStringToObject(force, "enabled", "no");
+    if (config.force_options.key_mismatch) cJSON_AddStringToObject(force, "key_mismatch", "yes"); else cJSON_AddStringToObject(force, "key_mismatch", "no");
+    if (config.force_options.disconnected_time_enabled) cJSON_AddStringToObject(disconnected_time, "enabled", "yes"); else cJSON_AddStringToObject(disconnected_time, "enabled", "no");
+    if (config.force_options.disconnected_time) cJSON_AddNumberToObject(disconnected_time, "disconnected_time", config.force_options.disconnected_time);
+    cJSON_AddItemToObject(force, "disconnected_time", disconnected_time);
+    if (config.force_options.after_registration_time) cJSON_AddNumberToObject(force, "after_registration_time", config.force_options.after_registration_time);
+    cJSON_AddItemToObject(auth, "force", force);
     cJSON_AddItemToObject(root,"auth",auth);
 
     return root;

--- a/src/os_auth/config.c
+++ b/src/os_auth/config.c
@@ -78,7 +78,7 @@ cJSON *getAuthdConfig(void) {
     if (config.force_options.enabled) cJSON_AddStringToObject(force, "enabled", "yes"); else cJSON_AddStringToObject(force, "enabled", "no");
     if (config.force_options.key_mismatch) cJSON_AddStringToObject(force, "key_mismatch", "yes"); else cJSON_AddStringToObject(force, "key_mismatch", "no");
     if (config.force_options.disconnected_time_enabled) cJSON_AddStringToObject(disconnected_time, "enabled", "yes"); else cJSON_AddStringToObject(disconnected_time, "enabled", "no");
-    if (config.force_options.disconnected_time) cJSON_AddNumberToObject(disconnected_time, "disconnected_time", config.force_options.disconnected_time);
+    if (config.force_options.disconnected_time) cJSON_AddNumberToObject(disconnected_time, "value", config.force_options.disconnected_time);
     cJSON_AddItemToObject(force, "disconnected_time", disconnected_time);
     if (config.force_options.after_registration_time) cJSON_AddNumberToObject(force, "after_registration_time", config.force_options.after_registration_time);
     cJSON_AddItemToObject(auth, "force", force);


### PR DESCRIPTION
|Related issue|
|---|
|#9953|

## Description

This PR adds the parsing block for the new `authd` options. 

## Logs/Alerts example

- Default values
![image](https://user-images.githubusercontent.com/13010397/133444298-a2d8a3a0-785a-4019-be3e-cc017a8591b9.png)
- Enabled false. The other options with default values.
![image](https://user-images.githubusercontent.com/13010397/133444612-ee534656-4218-45ed-b9e8-b2fdb9486752.png)
- If the disconnected_time option is disabled the time value is the default one.
![image](https://user-images.githubusercontent.com/13010397/133445183-9b63f638-3cfa-4550-9681-026e98663ea3.png)
- Different time values. disconnected_time = 10h, after_registration_time = 365 days.
![image](https://user-images.githubusercontent.com/13010397/133445488-f757a769-6a7f-415a-8920-8b1e110e4bdd.png)
- Scan Build
![image](https://user-images.githubusercontent.com/13010397/133448667-87a85605-9c8c-45f7-8c30-eef4b9dc0287.png)
- JSON response.
![image](https://user-images.githubusercontent.com/13010397/133445780-83551e93-4af9-4e0e-8f5b-8c6a1c8b93d5.png)
- Invalid option in force block.
![image](https://user-images.githubusercontent.com/13010397/133446150-c36ad6aa-5959-45fb-ad10-8277996f2abe.png)
- disconnected_time without attribute.
![image](https://user-images.githubusercontent.com/13010397/133446320-f2464934-c692-4849-ac2b-664957579fe4.png)
- disconnected_time with invalid attribute name.
![image](https://user-images.githubusercontent.com/13010397/133446493-af296545-cf1a-418a-9a06-43859926015f.png)
- disconnected_time with invalid value for attributed enabled.
![image](https://user-images.githubusercontent.com/13010397/133446632-f3b01e7b-a3e6-4443-8df9-b57a68878df9.png)


<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Source upgrade
- [X] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report