### PR TITLE
Add unit tests for API models

### DIFF
--- a/api/api/models/test/test_model.py
+++ b/api/api/models/test/test_model.py
@@ -21,35 +21,18 @@ with patch('wazuh.core.common.wazuh_uid'):
 class TestModel(bm.Body):
     """Test class for custom Model. Body inherits from Model and has all the attributes required for testing."""
 
-    def __init__(self, arg_1: str = None, arg_2: int = None):
-        self.swagger_types = {
-            'arg_1': str,
-            'arg_2': int
-        }
+    def __init__(self, *args):
 
-        self.attribute_map = {
-            'arg_1': 'arg_1',
-            'arg_2': 'arg_2'
-        }
+        self.swagger_types = {f"arg_{i + 1}": type(arg) for i, arg in enumerate(args)}
 
-        self._arg_1 = arg_1
-        self._arg_2 = arg_2
+        if not self.swagger_types:
+            self.swagger_types = {'arg_1': str}
+            args = ('value1',)
 
-    @property
-    def arg_1(self):
-        return self._arg_1
+        self.attribute_map = {arg: arg for arg in self.swagger_types}
 
-    @arg_1.setter
-    def arg_1(self, arg_1):
-        self._arg_1 = arg_1
-
-    @property
-    def arg_2(self):
-        return self._arg_2
-
-    @arg_2.setter
-    def arg_2(self, arg_2):
-        self._arg_2 = arg_2
+        for arg, value in zip(self.swagger_types.keys(), args):
+            setattr(self, arg, value)
 
 
 class RequestMock:
@@ -60,6 +43,20 @@ class RequestMock:
     @property
     def content_type(self):
         return self._content_type
+
+
+class ToDictObject:
+    def __init__(self, value):
+        self.value = value
+
+    def to_dict(self):
+        return {'value': self.value}
+
+    def __repr__(self):
+        return self.to_dict()
+
+    def __eq__(self, other):
+        return other == self.to_dict()
 
 
 def test_model_from_dict():
@@ -74,10 +71,11 @@ def test_model_from_dict():
 
 def test_model_to_dict():
     """Test class Model `to_dict` method."""
-    test_model = TestModel('value1', 2)
+    model_params = ('value1', 2, [3, {'key3': 'value3'}], {'key1': 'value_dict_1'}, ToDictObject(999))
+    test_model = TestModel(*model_params)
     dikt = test_model.to_dict()
     assert isinstance(dikt, dict)
-    assert dikt == {'arg_1': 'value1', 'arg_2': 2}
+    assert dikt == {f"arg_{i + 1}": value for i, value in enumerate(model_params)}
 
 
 def test_model_to_str():
@@ -99,7 +97,7 @@ def test_model_operator_overloading():
     print(test_model)
 
     equal_model = TestModel(*list(original_dict.values()))
-    not_equal_model = TestModel()
+    not_equal_model = TestModel('test')
 
     # Operator == (__eq__)
     assert test_model == equal_model
@@ -112,24 +110,77 @@ def test_model_operator_overloading():
         assert test_model != equal_model
 
 
-def test_model_properties():
-    """Test setters and getters (properties) from class Model."""
-    test_model = TestModel()
-    value = 'test'
+def test_allof():
+    model1 = TestModel('a', 1)
+    model2 = TestModel('a', 2)
 
-    assert test_model.arg_1 is None
-    test_model.arg_1 = value
-    assert test_model.arg_1 == value
+    allof = bm.AllOf(model1, model2)
+    assert allof.models == (model1, model2)
+
+
+def test_allof_to_dict():
+    """Test class AllOf class `to_dict` method."""
+    args1 = ('one', 1)
+    args2 = ('two', 2)
+
+    allof = bm.AllOf(TestModel(*args1), TestModel(*args2))
+    # Same model means that the second model values will overwrite the first
+    assert tuple(allof.to_dict().values()) == args2
+
+    allof = bm.AllOf(TestModel(*args2), TestModel(*args1))
+    assert tuple(allof.to_dict().values()) == args1
+
+
+def test_data():
+    """Test class Data."""
+    model = TestModel('one', 1)
+    data_model = bm.Data(model)
+
+    assert data_model.swagger_types == {'data': bm.Model}
+    assert data_model.attribute_map == {'data': 'data'}
+    assert data_model._data == model
+
+    # Test class properties
+    new_data = {'new': 'data'}
+    data_model.data = new_data
+    assert data_model.data == new_data
+
+
+def test_data_from_dict():
+    """Test class Data `from_dict` class method."""
+    test_dict = {'test_key': 'test_value'}
+    assert bm.Data.from_dict(test_dict) == deserialize_model(test_dict, bm.Data)
+
+
+def test_items():
+    """Test class Items."""
+    l = [TestModel('one', 2)]
+    items_model = bm.Items(l)
+
+    assert items_model.swagger_types == {'items': bm.List[bm.Model]}
+    assert items_model.attribute_map == {'items': 'items'}
+    assert items_model._items == l
+
+    # Test class properties
+    new_items = [TestModel('new', 9)]
+    items_model.items = new_items
+    assert items_model.items == new_items
+
+
+def test_items_from_dict():
+    """Test class Items `from_dict` class method."""
+    test_dict_list = [{'test_key': 'test_value'}, {'test_key2': 'test_value2'}]
+    assert bm.Items.from_dict(test_dict_list) == deserialize_model(test_dict_list, bm.Items)
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize('additional_kwargs', [
     {},
-    {'additional': 'test'}
+    {'arg_2': 'test'}
 ])
 async def test_body_get_kwargs(additional_kwargs):
     """Test class Body `get_kwargs` class method."""
-    request = {'arg_1': 'value1'}  # Missing arg_2
+    request = {'arg_1': 'value1'}
     test_model = TestModel(*list(request.values()))
 
     kwargs = await TestModel.get_kwargs(request, additional_kwargs=additional_kwargs)
@@ -156,6 +207,12 @@ async def test_body_get_kwargs_ko():
 
     # Custom exception. Very specific detail
     assert 'Invalid field found' in exc.value.detail
+
+
+def test_body_from_dict():
+    """Test class Body `from_dict` method."""
+    test_dict = {'test_key1': 'test_value1', 'test_key2': [{'test_key21': 'test_value21'}]}
+    assert bm.Body.from_dict(test_dict) == deserialize_model(test_dict, bm.Body)
 
 
 def test_body_decode_body():


### PR DESCRIPTION
|Related issue|
|---|
|#10008|

This closes #10008 .

New API unit tests have been added to cover all the API models.

| | | | | |
|--|--|--|--|--|
| **Name** | **Stmts** | **Miss** | **Cover** | **Status** |
| models/__init__.py | 3 | 0 | 100% | :green_square: |
| models/active_response_model.py | 36 | 0 | 100% | :green_square: |
| models/agent_added_model.py | 29 | 0 | 100% | :green_square: |
| models/agent_inserted_model.py | 48 | 0 | 100% | :green_square: |
| models/base_model_.py | 104 | 0 | 100% | :green_square: |
| models/basic_info_model.py | 59 | 0 | 100% | :green_square: |
| models/configuration_model.py | 212 | 0 | 100% | :green_square: |
| models/group_added_model.py | 15 | 0 | 100% | :green_square: |
| models/security_model.py | 72 | 0 | 100% | :green_square: |
| models/security_token_response_model.py | 19 | 0 | 100% | :green_square: |
| TOTAL | 597 | 0 | 100% | :green_square: |

## Test results
```shellsession
========================================= test session starts ==========================================
platform linux -- Python 3.9.6, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /home/vicferpoy/venvs/unittest-env/bin/python3
cachedir: .pytest_cache
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: cov-2.12.0, asyncio-0.15.1
collected 27 items                                                                                     

models/test/test_model.py::test_model_from_dict PASSED                                           [  3%]
models/test/test_model.py::test_model_to_dict PASSED                                             [  7%]
models/test/test_model.py::test_model_to_str PASSED                                              [ 11%]
models/test/test_model.py::test_model_operator_overloading PASSED                                [ 14%]
models/test/test_model.py::test_allof PASSED                                                     [ 18%]
models/test/test_model.py::test_allof_to_dict PASSED                                             [ 22%]
models/test/test_model.py::test_data PASSED                                                      [ 25%]
models/test/test_model.py::test_data_from_dict PASSED                                            [ 29%]
models/test/test_model.py::test_items PASSED                                                     [ 33%]
models/test/test_model.py::test_items_from_dict PASSED                                           [ 37%]
models/test/test_model.py::test_body_get_kwargs[additional_kwargs0] PASSED                       [ 40%]
models/test/test_model.py::test_body_get_kwargs[additional_kwargs1] PASSED                       [ 44%]
models/test/test_model.py::test_body_get_kwargs_ko PASSED                                        [ 48%]
models/test/test_model.py::test_body_from_dict PASSED                                            [ 51%]
models/test/test_model.py::test_body_decode_body PASSED                                          [ 55%]
models/test/test_model.py::test_body_decode_body_ko PASSED                                       [ 59%]
models/test/test_model.py::test_body_validate_content_type PASSED                                [ 62%]
models/test/test_model.py::test_body_validate_content_type_ko PASSED                             [ 66%]
models/test/test_model.py::test_all_models[agent_added_model.py] PASSED                          [ 70%]
models/test/test_model.py::test_all_models[agent_inserted_model.py] PASSED                       [ 74%]
models/test/test_model.py::test_all_models[basic_info_model.py] PASSED                           [ 77%]
models/test/test_model.py::test_all_models[logtest_model.py] PASSED                              [ 81%]
models/test/test_model.py::test_all_models[security_token_response_model.py] PASSED              [ 85%]
models/test/test_model.py::test_all_models[active_response_model.py] PASSED                      [ 88%]
models/test/test_model.py::test_all_models[configuration_model.py] PASSED                        [ 92%]
models/test/test_model.py::test_all_models[security_model.py] PASSED                             [ 96%]
models/test/test_model.py::test_all_models[group_added_model.py] PASSED                          [100%]

=================================== 27 passed, 10 warnings in 0.94s ====================================
```

Regards,
Víctor
