### PR TITLE
Rules and Decoders for ESET Protect Console

### DIFF
--- a/ruleset/decoders/0575-eset-remote_decoders.xml
+++ b/ruleset/decoders/0575-eset-remote_decoders.xml
@@ -3,22 +3,6 @@
 {"timestamp":"2021-08-17T16:20:55.344+0000","agent":{"id":"000","name":"soc"},"manager":{"name":"soc"},"id":"1629217255.9550906","full_log":"<12>1 2021-08-17T16:20:54.899Z esmc ERAServer 11836 - -   {\"event_type\":\"FilteredWebsites_Event\",\"ipv4\":\"192.168.56.127\",\"hostname\":\"tpc56127.tpcallao.gob.pe\",\"source_uuid\":\"d148de73-6c6f-400b-af16-1ea9a05636fb\",\"occured\":\"17-Aug-2021 16:19:47\",\"severity\":\"Warning\",\"event\":\"An attempt to connect to URL\",\"target_address\":\"52.109.12.24\",\"target_address_type\":\"IPv4\",\"scanner_id\":\"HTTP filter\",\"action_taken\":\"Blocked\",\"handled\":true,\"object_uri\":\"nexus.officeapps.live.com\",\"hash\":\"6ED9FC3387359BAFC128E2715326FC1C175AE6B1\",\"username\":\"TPCALLAO\\\\sfcloc1\",\"processname\":\"C:\\\\Program Files\\\\Microsoft Office\\\\Office15\\\\WINWORD.EXE\",\"rule_id\":\"Website certificate revoked\"}","decoder":{},"location":"xxx.yy.zz.aaa"}
 {"timestamp":"2021-08-17T17:01:18.985+0000","rule":{"level":2,"id":"1002","firedtimes":2,"mail":false,"groups":["syslog","errors"],"gpg13":["4.3"]},"agent":{"id":"000","name":"soc"},"manager":{"name":"soc"},"id":"1629219678.9701348","full_log":"<12>1 2021-08-17T17:01:18.773Z esmc ERAServer 11836 - - {\"event_type\":\"FirewallAggregated_Event\",\"ipv4\":\"192.168.1.52\",\"hostname\":\"desktop-s720l3s\",\"source_uuid\":\"e58a4e1c-192a-4b4f-bc78-2e7c2abbd4cc\",\"occured\":\"17-Aug-2021 16:32:38\",\"severity\":\"Warning\",\"event\":\"ARP Cache Poisoning attack\",\"source_address\":\"192.168.1.170\",\"source_address_type\":\"IPv4\",\"target_address\":\"192.168.1.170\",\"target_address_type\":\"IPv4\",\"protocol\":\"ARP\",\"action\":\"Blocked\",\"handled\":true,\"inbound\":true,\"aggregate_count\":3}","decoder":{},"location":"xxx.yy.zz.aaa"}
 -->
-<decoder name="eset-main">
-  <prematch>^\<\d+>\d+ \d+-\d+-\d+T\d+:\d+:\d+.\d+\w \w+ \w+ \d+</prematch>
-</decoder>
-
-<decoder name="eset-main-child">
-  <parent>eset-main</parent>
-  <prematch>-\s+</prematch>
-  <plugin_decoder offset="after_prematch">JSON_Decoder</plugin_decoder>
-</decoder>
-
-<decoder name="eset-main-child">
-  <parent>eset-main</parent>
-  <regex>^\<\d+>\d+ (\d+-\d+-\d+T\d+:\d+:\d+.\d+\w) (\w+) (\w+) (\d+)</regex>
-  <order>timestamp,type,source,msg_id</order>
-</decoder>
-
 <decoder name="eset-bsd">
   <program_name>ERAServer</program_name>
 </decoder>

--- a/ruleset/rules/0925-eset-remote_rules.xml
+++ b/ruleset/rules/0925-eset-remote_rules.xml
@@ -1,82 +1,69 @@
+<!-- Reference: https://help.eset.com/protect_admin/81/en-US/events-exported-to-json-format.html -->
 <group name="eset,">
 
-  <rule id="770000" level="0">
-      <decoded_as>eset-bsd</decoded_as>
-      <description>Eset Console Logs</description>
-  </rule>
+    <rule id="770000" level="0">
+        <decoded_as>eset-bsd</decoded_as>
+        <description>Eset Console Logs</description>
+    </rule>
 
-  <rule id="770001" level="3">
-      <if_sid>770000</if_sid>
-      <field name="event_type">^Threat_Event$</field>
-      <description>Eset: Threat Event rules Group</description>
-      <group>threat_event,</group>
-  </rule>
+    <rule id="770001" level="3">
+        <if_sid>770000</if_sid>
+        <field name="event_type">^Threat_Event$</field>
+        <description>Eset: Threat Event rules Group</description>
+        <group>threat_event,</group>
+    </rule>
 
-  <rule id="770002" level="3">
-      <if_sid>770000</if_sid>
-      <field name="event_type">^FirewallAggregated_Event$</field>
-      <description>Eset: Firewall Aggregated rules Group</description>
-      <group>firewallaggregated_event,</group>
-  </rule>
+    <rule id="770002" level="3">
+        <if_sid>770000</if_sid>
+        <field name="event_type">^FirewallAggregated_Event$</field>
+        <description>Eset: Firewall Aggregated rules Group</description>
+        <group>firewallaggregated_event,</group>
+    </rule>
 
     <rule id="770003" level="3">
-       <if_sid>770000</if_sid>
-       <field name="event_type">^HipsAggregated_Event$</field>
-       <description>Eset: HIPS Aggregated rules Group</description>
-       <group>hipsaggregated_event,</group>
-   </rule>
+        <if_sid>770000</if_sid>
+        <field name="event_type">^HipsAggregated_Event$</field>
+        <description>Eset: HIPS Aggregated rules Group</description>
+        <group>hipsaggregated_event,</group>
+    </rule>
 
-   <rule id="770004" level="2">
-       <if_sid>770000</if_sid>
-       <field name="event_type">^Audit_Event$</field>
-       <description>Eset: Audit rules Group</description>
-       <group>audit_event,</group>
-   </rule>
+    <rule id="770004" level="2">
+        <if_sid>770000</if_sid>
+        <field name="event_type">^Audit_Event$</field>
+        <description>Eset: Audit rules Group</description>
+        <group>audit_event,</group>
+    </rule>
 
-   <rule id="770005" level="3">
-       <if_sid>770000</if_sid>
-       <field name="event_type">^EnterpriseInspectorAlert_Event$</field>
-       <description>Eset: Enterprise Inspector Alert rules Group</description>
-       <group>enterpriseinspectoralert_event,</group>
-   </rule>
+    <rule id="770005" level="3">
+        <if_sid>770000</if_sid>
+        <field name="event_type">^EnterpriseInspectorAlert_Event$</field>
+        <description>Eset: Enterprise Inspector Alert rules Group</description>
+        <group>enterpriseinspectoralert_event,</group>
+    </rule>
 
-   <rule id="770006" level="3">
-       <if_sid>770000</if_sid>
-       <field name="event_type">^EnterpriseInspectorAlert_Event$</field>
-       <description>Eset: Enterprise Inspector Alert rules Group</description>
-       <group>enterpriseinspectoralert_event,</group>
-   </rule>
+    <rule id="770006" level="3">
+        <if_sid>770000</if_sid>
+        <field name="event_type">^EnterpriseInspectorAlert_Event$</field>
+        <description>Eset: Enterprise Inspector Alert rules Group</description>
+        <group>enterpriseinspectoralert_event,</group>
+    </rule>
 
-   <rule id="770010" level="5">
-       <if_sid>770000</if_sid>
-       <field name="severity">^Warning$</field>
-       <description>Eset: Warning message was logged from $(hostname)</description>
-   </rule>
+    <rule id="770010" level="5">
+        <if_sid>770000</if_sid>
+        <field name="severity">^Warning$</field>
+        <description>Eset: Warning message was logged from $(hostname)</description>
+    </rule>
 
-   <rule id="770011" level="7">
-       <if_sid>770000</if_sid>
-       <field name="severity">^Error$</field>
-       <description>Eset: Error message was logged from $(hostname)</description>
-   </rule>
+    <rule id="770011" level="7">
+        <if_sid>770000</if_sid>
+        <field name="severity">^Error$</field>
+        <description>Eset: Error message was logged from $(hostname)</description>
+    </rule>
 
-   <rule id="770012" level="9">
-       <if_sid>770000</if_sid>
-       <field name="severity">^Critical$</field>
-       <description>Eset: Critical message was logged from $(hostname)</description>
-   </rule>
+    <rule id="770012" level="9">
+        <if_sid>770000</if_sid>
+        <field name="severity">^Critical$</field>
+        <description>Eset: Critical message was logged from $(hostname)</description>
+    </rule>
 
-   <rule id="770020" level="3">
-       <if_sid>770001</if_sid>
-       <field name="action_taken">^Blocked$</field>
-       <description>Eset: Filter Web Control has $(action_taken) for $(hostname)</description>
-       <group>threat_event,</group>
-   </rule>
-
-   <rule id="770021" level="3">
-       <if_sid>770001</if_sid>
-       <field name="threat_type">^Trojan$|Application$</field>
-       <field name="scanner_id">^HTTP filter$</field>
-       <description>Eset: $(scanner_id) $(threat_type) on $(hostname)</description>
-       <group>threat_event,</group>
-   </rule>
 </group>


### PR DESCRIPTION
|Related issue|
|---|
| #9991 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Closes #9991 
<!--
Add a clear description of how the problem has been solved.
-->

This PR fix and upgrades the rules and decoders for ESET as indicates in the issue @dariommr.

## Configuration options

Changes tested in a manager with 4.2.1 version.

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

Tested with this sample log:
```
May  6 10:59:37 XXXXX ERAServer[5032]: {"event_type":"Audit_Event","ipv4":"XXX.XXX.XXX.XXX","hostname":"XXXXX","source_uuid":"9416183d-3XX3-4776-9783-9532a3a027bb","occured":"06-May-2021 09:59:37","severity":"Information","domain":"Domain group","action":"Login attempt","target":"a49d257e-ecc6-4063-95c6-5eb5e6b3e5df","detail":"Authenticating domain user 'XXXXXXXX'.","user":"","result":"Success"}
```

<!--
Paste here related logs and alerts
-->

## Tests

Tested with `wazuh-logtest`  and had the following results:
```
root@ubuntu20LTS:/home/vagrant# /var/ossec/bin/wazuh-logtest
Starting wazuh-logtest v4.2.1
Type one log per line

May  6 10:59:37 XXXXX ERAServer[5032]: {"event_type":"Audit_Event","ipv4":"XXX.XXX.XXX.XXX","hostname":"XXXXX","source_uuid":"9416183d-3XX3-4776-9783-9532a3a027bb","occured":"06-May-2021 09:59:37","severity":"Information","domain":"Domain group","action":"Login attempt","target":"a49d257e-ecc6-4063-95c6-5eb5e6b3e5df","detail":"Authenticating domain user 'XXXXXXXX'.","user":"","result":"Success"}

**Phase 1: Completed pre-decoding.
	full event: 'May  6 10:59:37 XXXXX ERAServer[5032]: {"event_type":"Audit_Event","ipv4":"XXX.XXX.XXX.XXX","hostname":"XXXXX","source_uuid":"9416183d-3XX3-4776-9783-9532a3a027bb","occured":"06-May-2021 09:59:37","severity":"Information","domain":"Domain group","action":"Login attempt","target":"a49d257e-ecc6-4063-95c6-5eb5e6b3e5df","detail":"Authenticating domain user 'XXXXXXXX'.","user":"","result":"Success"}'
	timestamp: 'May  6 10:59:37'
	hostname: 'XXXXX'
	program_name: 'ERAServer'

**Phase 2: Completed decoding.
	name: 'eset-bsd'
	action: 'Login attempt'
	detail: 'Authenticating domain user 'XXXXXXXX'.'
	domain: 'Domain group'
	event_type: 'Audit_Event'
	hostname: 'XXXXX'
	ipv4: 'XXX.XXX.XXX.XXX'
	occured: '06-May-2021 09:59:37'
	result: 'Success'
	severity: 'Information'
	source_uuid: '9416183d-3XX3-4776-9783-9532a3a027bb'
	target: 'a49d257e-ecc6-4063-95c6-5eb5e6b3e5df'

**Phase 3: Completed filtering (rules).
	id: '770004'
	level: '2'
	description: 'Eset: Audit rules Group'
	groups: '['eset', 'audit_event']'
	firedtimes: '1'
	mail: 'False'

```