### PR TITLE
Synchronize all files in the /var/ossec/etc/shared/ directory

### DIFF
--- a/framework/wazuh/core/cluster/cluster.json
+++ b/framework/wazuh/core/cluster/cluster.json
@@ -14,7 +14,7 @@
         "etc/shared/": {
             "permissions": "0o660",
             "source": "master",
-            "files": ["merged.mg"],
+            "files": ["all"],
             "recursive": true,
             "restart": false,
             "remove_subdirs_if_empty": true,

--- a/framework/wazuh/core/cluster/tests/test_utils.py
+++ b/framework/wazuh/core/cluster/tests/test_utils.py
@@ -126,7 +126,7 @@ def test_get_cluster_items():
     assert items == {'files': {'etc/': {'permissions': 416, 'source': 'master', 'files': ['client.keys'],
                                          'recursive': False, 'restart': False, 'remove_subdirs_if_empty': False,
                                          'extra_valid': False, 'description': 'client keys file database'},
-                               'etc/shared/': {'permissions': 432, 'source': 'master', 'files': ['merged.mg'],
+                               'etc/shared/': {'permissions': 432, 'source': 'master', 'files': ['all'],
                                                 'recursive': True, 'restart': False, 'remove_subdirs_if_empty': True,
                                                 'extra_valid': False, 'description': 'shared configuration files'},
                                'var/multigroups/': {'permissions': 432, 'source': 'master', 'files': ['merged.mg'],


### PR DESCRIPTION
|Related issue|
|---|
|#9920|

## Description

Hi team,

This PR closes #9920. In this PR, we have updated the file `cluster.json`, allowing all files in the `/var/ossec/etc/shared/` directory to be synchronized. 

## Tests results

### Cluster unit tests

```
================================================== test session starts ===================================================
platform linux -- Python 3.8.10, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: /home/yanazaeva/Documents/github/wazuh/framework
plugins: html-3.1.1, metadata-1.11.0, testinfra-5.0.0
collected 56 items                                                                                                       

framework/wazuh/core/cluster/tests/test_cluster.py ...................                                             [ 33%]
framework/wazuh/core/cluster/tests/test_common.py .......                                                          [ 46%]
framework/wazuh/core/cluster/tests/test_control.py sssss                                                           [ 55%]
framework/wazuh/core/cluster/tests/test_local_client.py .                                                          [ 57%]
framework/wazuh/core/cluster/tests/test_utils.py .......                                                           [ 69%]
framework/wazuh/core/cluster/tests/test_worker.py ............sss.s                                                [100%]

======================================= 47 passed, 9 skipped, 18 warnings in 0.48s =======================================
```

### QA system tests

```
================================================== test session starts ===================================================
platform linux -- Python 3.8.8, pytest-6.2.3, py-1.10.0, pluggy-0.13.1 -- /root/anaconda3/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.8', 'Platform': 'Linux-5.11.0-7633-generic-x86_64-with-glibc2.10', 'Packages': {'pytest': '6.2.3', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'cov': '2.12.1', 'metadata': '1.11.0', 'anyio': '2.2.0', 'testinfra': '5.0.0'}}
rootdir: /home/yanazaeva/Documents/github/wazuh-qa
plugins: html-3.1.1, cov-2.12.1, metadata-1.11.0, anyio-2.2.0, testinfra-5.0.0
collected 4 items                                                                                                        

tests/system/test_cluster/test_integrity_sync/test_integrity_sync.py::test_missing_file PASSED
tests/system/test_cluster/test_integrity_sync/test_integrity_sync.py::test_shared_files PASSED
tests/system/test_cluster/test_integrity_sync/test_integrity_sync.py::test_extra_files PASSED
tests/system/test_cluster/test_integrity_sync/test_integrity_sync.py::test_extra_valid_files PASSED

============================================= 4 passed in 348.73s (0:05:48) ==============================================
```