### PR TITLE
Add python3 compatibility to runtests.py

### DIFF
--- a/ruleset/testing/runtests.py
+++ b/ruleset/testing/runtests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (C) 2015-2021, Wazuh Inc.
 #
 # This program is a free software; you can redistribute it
@@ -6,7 +6,10 @@
 # License (version 2) as published by the FSF - Free Software
 # Foundation
 
-import ConfigParser
+try:
+    import configparser as ConfigParser
+except ImportError:
+    import ConfigParser
 import subprocess
 import os
 import sys
@@ -33,8 +36,11 @@ def getWazuhInfo(wazuh_home):
     try:
         proc = subprocess.Popen([wazuh_control, "info"], stdout=subprocess.PIPE)
         (stdout, stderr) = proc.communicate()
-    except:
-        print("Seems like there is no Wazuh installation.")
+        if sys.version_info[0] >= 3:
+            stdout = stdout.decode('utf-8')
+    except Exception as e:
+        print("Seems like there is no Wazuh installation:")
+        print(e)
         return None
 
     env_variables = stdout.rsplit("\n")
@@ -99,7 +105,11 @@ class OssecTester(object):
             stderr=subprocess.STDOUT,
             stdin=subprocess.PIPE,
             shell=False)
-        std_out = p.communicate(log)[0]
+        if sys.version_info[0] >= 3:
+            std_out, _ = p.communicate(log.encode())
+            std_out = std_out.decode('utf-8')
+        else:
+            std_out, _ = p.communicate(log)
         if (p.returncode != 0 and not negate) or (p.returncode == 0 and negate):
             self._error = True
             print("")


### PR DESCRIPTION
|Related issue|
|---|
|None|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

So far ruleset/tests/runtests.py was not compatible with python3 where configparser was renamed and proc.communicate produces binary output.
This patch should update runtests.py without breaking retro compat.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [X] runtests.py executed without errors