### PR TITLE
Fix missing import in Python GCP modules tools

### DIFF
--- a/wodles/gcloud/integration.py
+++ b/wodles/gcloud/integration.py
@@ -11,15 +11,14 @@
 import logging
 import socket
 import sys
-from os import path
+from os.path import abspath, dirname
 
 import google.api_core.exceptions
 from google.cloud import pubsub_v1 as pubsub
 
-sys.path.insert(0, path.dirname(path.dirname(path.abspath(__file__))))
+sys.path.insert(0, dirname(dirname(abspath(__file__))))
 import utils
 import tools
-from wazuh.core import common
 
 logger = logging.getLogger(tools.logger_name)
 
@@ -121,7 +120,7 @@ class WazuhGCloudSubscriber:
         :return: Number of processed messages
         """
         try:
-            self.wazuh_queue.connect(common.ANALYSISD)
+            self.wazuh_queue.connect(utils.ANALYSISD)
             with self.subscriber:
                 processed_messages = 0
                 pulled_messages = self.pull_request(max_messages)

--- a/wodles/gcloud/tools.py
+++ b/wodles/gcloud/tools.py
@@ -12,8 +12,9 @@ import argparse
 import logging
 import sys
 from logging.handlers import TimedRotatingFileHandler
+from os.path import abspath, dirname
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, dirname(dirname(abspath(__file__))))
 import utils
 
 logger_name = 'gcloud_wodle'


### PR DESCRIPTION
|Related issue|
|---|
| #10098 |


This PR fixes the GCP module by adding a missing import in `tools.py`. It also removes a reference to `wazuh.common` from the framework. The module was manually tested after applying these changes to ensure everything works as expected.