### PR TITLE
Extend data provider testtool with cmdline arguments

### DIFF
--- a/src/data_provider/testtool/Readme.md
+++ b/src/data_provider/testtool/Readme.md
@@ -14,12 +14,11 @@ make TARGET=server|agent <DEBUG=1>
 ```
 
 ## How to use the tool
-In order to run the `sysinfo_test_tool` (located in `src/data_provider/build/bin` folder) utility the only step to be followed is just to execute the tool (without parameters):
 ```
-./sysinfo_test_tool
+Usage: sysinfo_test_tool [options]
 ```
 
-The information output will vary based on the Operating System the tool is being executed. 
+The information output will vary based on the Operating System the tool is being executed.
 A brief example could be similar to the following one:
 
 ```
@@ -30,3 +29,14 @@ A brief example could be similar to the following one:
 {"architecture":"x86_64","host_name":"martin-PC","os_codename":"focal","os_major":"20","os_minor":"04","os_name":"Ubuntu","os_patch":"2","os_platform":"ubuntu","os_version":"20.04.2 LTS (Focal Fossa)","release":"5.4.0-65-generic","sysname":"Linux","version":"#73-Ubuntu SMP Mon Jan 18 17:25:17 UTC 2021"},
 {"architecture":"x86_64","host_name":"martin-PC","os_codename":"focal","os_major":"20","os_minor":"04","os_name":"Ubuntu","os_patch":"2","os_platform":"ubuntu","os_version":"20.04.2 LTS (Focal Fossa)","release":"5.4.0-65-generic","sysname":"Linux","version":"#73-Ubuntu SMP Mon Jan 18 17:25:17 UTC 2021"}]
 ```
+
+### Optional arguments:
+
+|Argument|Description|
+|---|---|
+| `--hardware`  | Prints the current Operating System hardware information only. Example: `sysinfo_test_tool --hardware`   |
+| `--networks`  | Prints the current Operating System networks information only. Example: `sysinfo_test_tool --networks`   |
+| `--packages`  | Prints the current Operating System packages information only. Example: `sysinfo_test_tool --packages`   |
+| `--processes` | Prints the current Operating System processes information only. Example: `sysinfo_test_tool --processes` |
+| `--ports`     | Prints the current Operating System ports information only. Example: `sysinfo_test_tool --ports`         |
+| `--os`        | Prints the current Operating System information only. Example: `sysinfo_test_tool --os`                  |

--- a/src/data_provider/testtool/cmdLineActions.h
+++ b/src/data_provider/testtool/cmdLineActions.h
@@ -1,0 +1,133 @@
+/*
+ * Wazuh SYSINFO
+ * Copyright (C) 2015-2021, Wazuh Inc.
+ * September 13, 2021
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _CMD_LINE_ACTIONS_H_
+#define _CMD_LINE_ACTIONS_H_
+
+#include <string.h>
+
+class CmdLineActions final
+{
+    public:
+        CmdLineActions(const int argc, const char* argv[])
+            : m_hardware  { false }
+            , m_networks  { false }
+            , m_packages  { false }
+            , m_processes { false }
+            , m_ports     { false }
+            , m_os        { false }
+        {
+            const auto cmdArg { argv[1] };
+            if (argc == 2)
+            {
+                if (strncmp(cmdArg, "--hardware", 10) == 0)
+                {
+                    m_hardware = true;
+                }
+                else if (strncmp(cmdArg, "--networks", 10) == 0)
+                {
+                    m_networks = true;
+                }
+                else if (strncmp(cmdArg, "--packages", 10) == 0)
+                {
+                    m_packages = true;
+                }
+                else if (strncmp(cmdArg, "--processes", 11) == 0)
+                {
+                    m_processes = true;
+                }
+                else if (strncmp(cmdArg, "--ports", 7) == 0)
+                {
+                    m_ports = true;
+                }
+                else if (strncmp(cmdArg, "--os", 4) == 0)
+                {
+                    m_os = true;
+                }
+                else
+                {
+                    throw std::runtime_error
+                    {
+                        "Action value: " + std::string(cmdArg) + " not found."
+                    };
+                }
+            }
+            else
+            {
+                throw std::runtime_error
+                {
+                    "Multiple action are not allowed"
+                };
+            }
+        }
+
+        bool hardwareArg()
+        {
+            return m_hardware;
+        };
+
+        bool networksArg()
+        {
+            return m_networks;
+        };
+
+        bool packagesArg()
+        {
+            return m_packages;
+        };
+
+        bool processesArg()
+        {
+            return m_processes;
+        };
+
+        bool portsArg()
+        {
+            return m_ports;
+        };
+
+        bool osArg()
+        {
+            return m_os;
+        };
+
+        static void showHelp()
+        {
+            std::cout << "\nUsage: sysinfo_test_tool [options]\n"
+                      << "Options:\n"
+                      << "\t<without args> \tPrints the complete Operating System information.\n"
+                      << "\t--hardware \tPrints the current Operating System hardware information.\n"
+                      << "\t--networks \tPrints the current Operating System networks information.\n"
+                      << "\t--packages \tPrints the current Operating System packages information.\n"
+                      << "\t--processes \tPrints the current Operating System processes information.\n"
+                      << "\t--ports \tPrints the current Operating System ports information.\n"
+                      << "\t--os \t\tPrints the current Operating System information.\n"
+                      << "\nExamples:"
+                      << "\n\t./sysinfo_test_tool"
+                      << "\n\t./sysinfo_test_tool --hardware"
+                      << "\n\t./sysinfo_test_tool --networks"
+                      << "\n\t./sysinfo_test_tool --packages"
+                      << "\n\t./sysinfo_test_tool --processes"
+                      << "\n\t./sysinfo_test_tool --ports"
+                      << "\n\t./sysinfo_test_tool --os"
+                      << std::endl;
+        }
+
+    private:
+        bool m_hardware;
+        bool m_networks;
+        bool m_packages;
+        bool m_processes;
+        bool m_ports;
+        bool m_os;
+};
+
+#endif // _CMD_LINE_ACTIONS_H_

--- a/src/data_provider/testtool/cmdLineActions.h
+++ b/src/data_provider/testtool/cmdLineActions.h
@@ -14,87 +14,51 @@
 
 #include <string.h>
 
+constexpr auto HARDWARE_ACTION  { "--hardware"};
+constexpr auto NETWORKS_ACTION  { "--networks"};
+constexpr auto PACKAGES_ACTION  { "--packages"};
+constexpr auto PROCESSES_ACTION { "--processes"};
+constexpr auto PORTS_ACTION     { "--ports"};
+constexpr auto OS_ACTION        { "--os"};
+
 class CmdLineActions final
 {
     public:
-        CmdLineActions(const int argc, const char* argv[])
-            : m_hardware  { false }
-            , m_networks  { false }
-            , m_packages  { false }
-            , m_processes { false }
-            , m_ports     { false }
-            , m_os        { false }
-        {
-            const auto cmdArg { argv[1] };
-            if (argc == 2)
-            {
-                if (strncmp(cmdArg, "--hardware", 10) == 0)
-                {
-                    m_hardware = true;
-                }
-                else if (strncmp(cmdArg, "--networks", 10) == 0)
-                {
-                    m_networks = true;
-                }
-                else if (strncmp(cmdArg, "--packages", 10) == 0)
-                {
-                    m_packages = true;
-                }
-                else if (strncmp(cmdArg, "--processes", 11) == 0)
-                {
-                    m_processes = true;
-                }
-                else if (strncmp(cmdArg, "--ports", 7) == 0)
-                {
-                    m_ports = true;
-                }
-                else if (strncmp(cmdArg, "--os", 4) == 0)
-                {
-                    m_os = true;
-                }
-                else
-                {
-                    throw std::runtime_error
-                    {
-                        "Action value: " + std::string(cmdArg) + " not found."
-                    };
-                }
-            }
-            else
-            {
-                throw std::runtime_error
-                {
-                    "Multiple action are not allowed"
-                };
-            }
-        }
+        CmdLineActions(const char* argv[])
+            : m_hardware  { HARDWARE_ACTION  == std::string(argv[1]) }
+            , m_networks  { NETWORKS_ACTION  == std::string(argv[1]) }
+            , m_packages  { PACKAGES_ACTION  == std::string(argv[1]) }
+            , m_processes { PROCESSES_ACTION == std::string(argv[1]) }
+            , m_ports     { PORTS_ACTION     == std::string(argv[1]) }
+            , m_os        { OS_ACTION        == std::string(argv[1]) }
+        {}
 
-        bool hardwareArg()
+        bool hardwareArg() const
         {
             return m_hardware;
         };
 
-        bool networksArg()
+        bool networksArg() const
         {
             return m_networks;
         };
 
-        bool packagesArg()
+        bool packagesArg() const
         {
             return m_packages;
         };
 
-        bool processesArg()
+        bool processesArg() const
         {
             return m_processes;
         };
 
-        bool portsArg()
+        bool portsArg() const
         {
             return m_ports;
         };
 
-        bool osArg()
+        bool osArg() const
         {
             return m_os;
         };
@@ -122,12 +86,12 @@ class CmdLineActions final
         }
 
     private:
-        bool m_hardware;
-        bool m_networks;
-        bool m_packages;
-        bool m_processes;
-        bool m_ports;
-        bool m_os;
+        const bool m_hardware;
+        const bool m_networks;
+        const bool m_packages;
+        const bool m_processes;
+        const bool m_ports;
+        const bool m_os;
 };
 
 #endif // _CMD_LINE_ACTIONS_H_

--- a/src/data_provider/testtool/main.cpp
+++ b/src/data_provider/testtool/main.cpp
@@ -10,6 +10,7 @@
  */
 
 #include <iostream>
+#include "cmdLineActions.h"
 #include "sysInfo.hpp"
 #include "sysInfo.h"
 
@@ -18,37 +19,109 @@ constexpr auto JSON_PRETTY_SPACES
     2
 };
 
-int main()
+class SysInfoPrinter final
+{
+    public:
+        SysInfoPrinter() = default;
+
+        void printHardwareInfo()
+        {
+            m_data["hw"] = m_sysinfo.hardware();
+        }
+
+        void printNetworksInfo()
+        {
+            m_data["networks"] = m_sysinfo.networks();
+        }
+
+        void printOSInfo()
+        {
+            m_data["os"] = m_sysinfo.os();
+        }
+
+        void printPackagesInfo()
+        {
+            m_data["packages"] = m_sysinfo.packages();
+            m_sysinfo.packages([](nlohmann::json& package)
+            {
+                std::cout << package.dump(JSON_PRETTY_SPACES) << std::endl;
+            });
+        }
+
+        void printProcessesInfo()
+        {
+            m_data["processes"] = m_sysinfo.processes();
+            m_sysinfo.processes([](nlohmann::json& process)
+            {
+                std::cout << process.dump(JSON_PRETTY_SPACES) << std::endl;
+            });
+        }
+
+        void printPortsInfo()
+        {
+            m_data["ports"] = m_sysinfo.ports();
+        }
+
+        void printData()
+        {
+            std::cout << m_data.dump(JSON_PRETTY_SPACES) << std::endl;
+        }
+
+    private:
+        SysInfo m_sysinfo;
+        nlohmann::json m_data;
+};
+
+int main(int argc, const char* argv[])
 {
     try
     {
-        SysInfo info;
-        const auto& hw        {info.hardware()};
-        const auto& packages  {info.packages()};
-        const auto& processes {info.processes()};
-        const auto& networks  {info.networks()};
-        const auto& os        {info.os()};
-        const auto& ports     {info.ports()};
+        SysInfoPrinter printer;
 
-        std::cout << hw.dump(JSON_PRETTY_SPACES) << std::endl;
-        std::cout << packages.dump(JSON_PRETTY_SPACES) << std::endl;
-        std::cout << processes.dump(JSON_PRETTY_SPACES) << std::endl;
-        std::cout << networks.dump(JSON_PRETTY_SPACES) << std::endl;
-        std::cout << os.dump(JSON_PRETTY_SPACES) << std::endl;
-        std::cout << ports.dump(JSON_PRETTY_SPACES) << std::endl;
-
-        info.processes([](nlohmann::json & process)
+        if (argc == 1)
         {
-            std::cout << process.dump(JSON_PRETTY_SPACES) << std::endl;
-        });
-
-        info.packages([](nlohmann::json & package)
+            // Calling testtool without parameters - default all
+            printer.printHardwareInfo();
+            printer.printNetworksInfo();
+            printer.printOSInfo();
+            printer.printPackagesInfo();
+            printer.printProcessesInfo();
+            printer.printPortsInfo();
+            printer.printData();
+        }
+        else
         {
-            std::cout << package.dump(JSON_PRETTY_SPACES) << std::endl;
-        });
+            CmdLineActions cmdLineArgs(argc, argv);
+            if(cmdLineArgs.hardwareArg())
+            {
+                printer.printHardwareInfo();
+            }
+            else if (cmdLineArgs.networksArg())
+            {
+                printer.printNetworksInfo();
+            }
+            else if (cmdLineArgs.osArg())
+            {
+                printer.printOSInfo();
+            }
+            else if (cmdLineArgs.packagesArg())
+            {
+                printer.printPackagesInfo();
+            }
+            else if (cmdLineArgs.processesArg())
+            {
+                printer.printProcessesInfo();
+            }
+            else if (cmdLineArgs.portsArg())
+            {
+                printer.printPortsInfo();
+            }
+            printer.printData();
+        }
     }
     catch (const std::exception& e)
     {
         std::cerr << "Error getting system information: " << e.what() << std::endl;
+        CmdLineActions::showHelp();
     }
 }

--- a/src/data_provider/testtool/main.cpp
+++ b/src/data_provider/testtool/main.cpp
@@ -42,7 +42,7 @@ class SysInfoPrinter final
         void printPackagesInfo()
         {
             m_data["packages"] = m_sysinfo.packages();
-            m_sysinfo.packages([](nlohmann::json& package)
+            m_sysinfo.packages([](nlohmann::json & package)
             {
                 std::cout << package.dump(JSON_PRETTY_SPACES) << std::endl;
             });
@@ -51,7 +51,7 @@ class SysInfoPrinter final
         void printProcessesInfo()
         {
             m_data["processes"] = m_sysinfo.processes();
-            m_sysinfo.processes([](nlohmann::json& process)
+            m_sysinfo.processes([](nlohmann::json & process)
             {
                 std::cout << process.dump(JSON_PRETTY_SPACES) << std::endl;
             });
@@ -89,10 +89,11 @@ int main(int argc, const char* argv[])
             printer.printPortsInfo();
             printer.printData();
         }
-        else
+        else if (argc == 2)
         {
-            CmdLineActions cmdLineArgs(argc, argv);
-            if(cmdLineArgs.hardwareArg())
+            CmdLineActions cmdLineArgs(argv);
+
+            if (cmdLineArgs.hardwareArg())
             {
                 printer.printHardwareInfo();
             }
@@ -116,7 +117,22 @@ int main(int argc, const char* argv[])
             {
                 printer.printPortsInfo();
             }
+            else
+            {
+                throw std::runtime_error
+                {
+                    "Action value: " + std::string(argv[1]) + " not found."
+                };
+            }
+
             printer.printData();
+        }
+        else
+        {
+            throw std::runtime_error
+            {
+                "Multiple action are not allowed"
+            };
         }
     }
     catch (const std::exception& e)


### PR DESCRIPTION
|Related issue|
|---|
|Closes #10109 |

## Description
This issue aims to extend the sysinfo_test_tool in order to take cmdline arguments related to each particular provider. These changes will help to validate specific data while using the tool.

## DoD
- [x] Add provider arguments to be taken by the tool.
- [x] Validate results and previous behavior.
- [x] CI Checks
