### PR TITLE
Linux support for data_provider callback-based processes interface 

### DIFF
--- a/src/data_provider/src/sysInfo.cpp
+++ b/src/data_provider/src/sysInfo.cpp
@@ -250,7 +250,9 @@ int sysinfo_processes_cb(callback_data_t callback_data)
                     callback_data.callback(GENERIC, spJson.get(), callback_data.user_data);
                 }
             };
+            // LCOV_EXCL_START
             SysInfo info;
+            // LCOV_EXCL_STOP
             info.processes(callbackWrapper);
             retVal = 0;
         }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #10028 |

## Description

Hi team!

This PR aims to implement and test the new packages interface that support callback-based data pushing.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors

Regards,
Nico