### PR TITLE
Adding registration time validation before agent replacement in authd

### DIFF
--- a/src/addagent/manage_agents.h
+++ b/src/addagent/manage_agents.h
@@ -50,7 +50,7 @@ void OS_AddAgentTimestamp(const char *id, const char *name, const char *ip, time
 void OS_RemoveAgentTimestamp(const char *id);
 void OS_RemoveAgentGroup(const char *id);
 void FormatID(char *id);
-time_t get_agent_registration_time(int id);
+time_t get_time_since_agent_registration(int id);
 
 /* Print available agents */
 int print_agents(int print_status, int active_only, int inactive_only, int csv_output, cJSON *json_output);

--- a/src/addagent/manage_agents.h
+++ b/src/addagent/manage_agents.h
@@ -50,6 +50,7 @@ void OS_AddAgentTimestamp(const char *id, const char *name, const char *ip, time
 void OS_RemoveAgentTimestamp(const char *id);
 void OS_RemoveAgentGroup(const char *id);
 void FormatID(char *id);
+time_t get_agent_registration_time(int id);
 
 /* Print available agents */
 int print_agents(int print_status, int active_only, int inactive_only, int csv_output, cJSON *json_output);

--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -8,9 +8,13 @@
  * Foundation
  */
 
+#include "cJSON.h"
 #include "manage_agents.h"
 #include "os_crypto/md5/md5_op.h"
 #include "os_crypto/sha256/sha256_op.h"
+#include "os_err.h"
+#include "wazuh_db/wdb.h"
+#include <time.h>
 #ifndef CLIENT
 #include "wazuh_db/helpers/wdb_global_helpers.h"
 #include "wazuhdb_op.h"
@@ -555,6 +559,38 @@ double get_time_since_agent_disconnection(const char *id) {
 
     return disconnected_time == 0 ? 0 : difftime(time(NULL), disconnected_time);
 }
+
+/**
+ * @brief Returns the number of seconds since agent registration
+ *
+ * @param id The ID of the agent to get the registration time
+ * @retval On success, it returns the difference between the current time and the date_add field in the DB
+ * @retval OS_INVALID On error: failed to get the agent's info
+ * @retval 0 On error: failed to get the date_add field from JSON response
+ */
+time_t get_agent_registration_time(int id) {
+    cJSON *root = NULL;
+    cJSON *j_date_add = NULL;
+    time_t date_add = 0;
+
+    root = wdb_get_agent_info(id, NULL);
+
+    if (!root){
+        mdebug1("Failed to get agent info for agent '%d'", id);
+        return OS_INVALID;
+    }
+
+    j_date_add = cJSON_GetObjectItem(root->child, "date_add");
+    if(!j_date_add){
+        mdebug1("Failed to get registration time for agent '%d'.", id);
+    } else {
+        date_add = j_date_add->valueint;
+    }
+
+    cJSON_Delete(root);
+    return date_add <= 0 ? 0 : difftime(time(NULL), date_add);
+}
+
 
  /* !CLIENT */
  #endif

--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -568,7 +568,7 @@ double get_time_since_agent_disconnection(const char *id) {
  * @retval OS_INVALID On error: failed to get the agent's info
  * @retval 0 On error: failed to get the date_add field from JSON response
  */
-time_t get_agent_registration_time(int id) {
+time_t get_time_since_agent_registration(int id) {
     cJSON *root = NULL;
     cJSON *j_date_add = NULL;
     time_t date_add = 0;

--- a/src/config/authd-config.h
+++ b/src/config/authd-config.h
@@ -12,6 +12,9 @@
 #define AD_CONF_UNPARSED 3
 #define AD_CONF_UNDEFINED 2
 
+/**
+ * @brief Structure that defines the force options for agent replacement.
+ **/
 typedef struct authd_force_options_t {
     bool enabled;
     int connection_time;

--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -217,7 +217,7 @@ w_err_t w_auth_replace_agent(keyentry *key,
 
     /* Check if the agent is old enough to be removed */
     if(force_options->after_registration_time > 0) {
-        time_t agent_registration_time = get_agent_registration_time(atoi(key->id));
+        time_t agent_registration_time = get_time_since_agent_registration(atoi(key->id));
         if(agent_registration_time > 0 && agent_registration_time <= force_options->after_registration_time){
             minfo("Agent '%s' doesn't comply with the registration time to be removed.", key->id);
             return OS_INVALID;

--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -215,6 +215,15 @@ w_err_t w_auth_replace_agent(keyentry *key,
         }
     }
 
+    /* Check if the agent is old enough to be removed */
+    if(force_options->after_registration_time > 0) {
+        time_t agent_registration_time = get_agent_registration_time(atoi(key->id));
+        if(agent_registration_time > 0 && agent_registration_time <= force_options->after_registration_time){
+            minfo("Agent '%s' doesn't comply with the registration time to be removed.", key->id);
+            return OS_INVALID;
+        }
+    }
+
     /* Check if the agent key is the same than the existent in the manager */
     if (key_hash && force_options->key_mismatch) {
         os_sha1 manager_key_hash;


### PR DESCRIPTION
|Related issue|
|---|
|#9955|

## Description

This PR reads the new `after_registration_time` setting in the **force** options block to reject an agent replacement during registration if its `date_add` is too recent.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report

