### PR TITLE
Add callback implementation for windows packages.

### DIFF
--- a/src/data_provider/testtool/Readme.md
+++ b/src/data_provider/testtool/Readme.md
@@ -35,10 +35,12 @@ A brief example could be similar to the following one:
 
 |Argument|Description|
 |---|---|
-| `--hardware`  | Prints the current Operating System hardware information only. Example: `sysinfo_test_tool --hardware`   |
-| `--networks`  | Prints the current Operating System networks information only. Example: `sysinfo_test_tool --networks`   |
-| `--packages`  | Prints the current Operating System packages information only. Example: `sysinfo_test_tool --packages`   |
-| `--processes` | Prints the current Operating System processes information only. Example: `sysinfo_test_tool --processes` |
-| `--ports`     | Prints the current Operating System ports information only. Example: `sysinfo_test_tool --ports`         |
-| `--os`        | Prints the current Operating System information only. Example: `sysinfo_test_tool --os`                  |
-| `--hotfixes`  | Prints the current Operating System hotfixes information only. Example: `sysinfo_test_tool --hotfixes`   |
+| `--hardware`     | Prints the current Operating System hardware information only. Example: `sysinfo_test_tool --hardware`                               |
+| `--networks`     | Prints the current Operating System networks information only. Example: `sysinfo_test_tool --networks`                               |
+| `--packages`     | Prints the current Operating System packages information only. Example: `sysinfo_test_tool --packages`                               |
+| `--processes`    | Prints the current Operating System processes information only. Example: `sysinfo_test_tool --processes`                             |
+| `--packages-cb`  | Prints the current Operating System packages information only with callbacks mechanism. Example: `sysinfo_test_tool --packages-cb`   |
+| `--processes-cb` | Prints the current Operating System processes information only with callbacks mechanism. Example: `sysinfo_test_tool --processes-cb` |
+| `--ports`        | Prints the current Operating System ports information only. Example: `sysinfo_test_tool --ports`                                     |
+| `--os`           | Prints the current Operating System information only. Example: `sysinfo_test_tool --os`                                              |
+| `--hotfixes`     | Prints the current Operating System hotfixes information only. Example: `sysinfo_test_tool --hotfixes`                               |

--- a/src/data_provider/testtool/cmdLineActions.h
+++ b/src/data_provider/testtool/cmdLineActions.h
@@ -14,25 +14,30 @@
 
 #include <string.h>
 
-constexpr auto HARDWARE_ACTION  { "--hardware"};
-constexpr auto NETWORKS_ACTION  { "--networks"};
-constexpr auto PACKAGES_ACTION  { "--packages"};
-constexpr auto PROCESSES_ACTION { "--processes"};
-constexpr auto PORTS_ACTION     { "--ports"};
-constexpr auto OS_ACTION        { "--os"};
-constexpr auto HOTFIXES_ACTION  { "--hotfixes"};
+constexpr auto HARDWARE_ACTION     { "--hardware"};
+constexpr auto NETWORKS_ACTION     { "--networks"};
+constexpr auto PACKAGES_ACTION     { "--packages"};
+constexpr auto PROCESSES_ACTION    { "--processes"};
+constexpr auto PORTS_ACTION        { "--ports"};
+constexpr auto OS_ACTION           { "--os"};
+constexpr auto HOTFIXES_ACTION     { "--hotfixes"};
+constexpr auto PROCESSES_CB_ACTION { "--processes-cb"};
+constexpr auto PACKAGES_CB_ACTION  { "--packages-cb"};
 
 class CmdLineActions final
 {
     public:
         CmdLineActions(const char* argv[])
-            : m_hardware  { HARDWARE_ACTION  == std::string(argv[1]) }
-            , m_networks  { NETWORKS_ACTION  == std::string(argv[1]) }
-            , m_packages  { PACKAGES_ACTION  == std::string(argv[1]) }
-            , m_processes { PROCESSES_ACTION == std::string(argv[1]) }
-            , m_ports     { PORTS_ACTION     == std::string(argv[1]) }
-            , m_os        { OS_ACTION        == std::string(argv[1]) }
-            , m_hotfixes  { HOTFIXES_ACTION  == std::string(argv[1]) }
+            : m_hardware          { HARDWARE_ACTION     == std::string(argv[1]) }
+            , m_networks          { NETWORKS_ACTION     == std::string(argv[1]) }
+            , m_packages          { PACKAGES_ACTION     == std::string(argv[1]) }
+            , m_processes         { PROCESSES_ACTION    == std::string(argv[1]) }
+            , m_ports             { PORTS_ACTION        == std::string(argv[1]) }
+            , m_os                { OS_ACTION           == std::string(argv[1]) }
+            , m_hotfixes          { HOTFIXES_ACTION     == std::string(argv[1]) }
+            , m_processesCallback { PROCESSES_CB_ACTION == std::string(argv[1]) }
+            , m_packagesCallback  { PACKAGES_CB_ACTION  == std::string(argv[1]) }
+
         {}
 
         bool hardwareArg() const
@@ -70,6 +75,17 @@ class CmdLineActions final
             return m_hotfixes;
         };
 
+        bool packagesCallbackArg() const
+        {
+            return m_packagesCallback;
+        };
+
+        bool processesCallbackArg() const
+        {
+            return m_processesCallback;
+        };
+
+
         static void showHelp()
         {
             std::cout << "\nUsage: sysinfo_test_tool [options]\n"
@@ -79,6 +95,8 @@ class CmdLineActions final
                       << "\t--networks \tPrints the current Operating System networks information.\n"
                       << "\t--packages \tPrints the current Operating System packages information.\n"
                       << "\t--processes \tPrints the current Operating System processes information.\n"
+                      << "\t--packages-cb \tPrints the current Operating System packages using callbacks to return information.\n"
+                      << "\t--processes-cb \tPrints the current Operating System processes using callback to return information.\n"
                       << "\t--ports \tPrints the current Operating System ports information.\n"
                       << "\t--os \t\tPrints the current Operating System information.\n"
                       << "\t--hotfixes \tPrints the current Operating System hotfixes information.\n"
@@ -91,6 +109,8 @@ class CmdLineActions final
                       << "\n\t./sysinfo_test_tool --ports"
                       << "\n\t./sysinfo_test_tool --os"
                       << "\n\t./sysinfo_test_tool --hotfixes"
+                      << "\n\t./sysinfo_test_tool --processes-cb"
+                      << "\n\t./sysinfo_test_tool --packages-cb"
                       << std::endl;
         }
 
@@ -102,6 +122,9 @@ class CmdLineActions final
         const bool m_ports;
         const bool m_os;
         const bool m_hotfixes;
+        const bool m_processesCallback;
+        const bool m_packagesCallback;
+
 };
 
 #endif // _CMD_LINE_ACTIONS_H_

--- a/src/data_provider/testtool/main.cpp
+++ b/src/data_provider/testtool/main.cpp
@@ -42,19 +42,11 @@ class SysInfoPrinter final
         void printPackagesInfo()
         {
             m_data["packages"] = m_sysinfo.packages();
-            m_sysinfo.packages([](nlohmann::json & package)
-            {
-                std::cout << package.dump(JSON_PRETTY_SPACES) << std::endl;
-            });
         }
 
         void printProcessesInfo()
         {
             m_data["processes"] = m_sysinfo.processes();
-            m_sysinfo.processes([](nlohmann::json & process)
-            {
-                std::cout << process.dump(JSON_PRETTY_SPACES) << std::endl;
-            });
         }
 
         void printPortsInfo()
@@ -70,6 +62,22 @@ class SysInfoPrinter final
         void printData()
         {
             std::cout << m_data.dump(JSON_PRETTY_SPACES) << std::endl;
+        }
+
+        void printProcessesInfoCallback()
+        {
+            m_sysinfo.processes([this](nlohmann::json & process)
+            {
+                m_data["processes_cb"].push_back(process);
+            });
+        }
+
+        void printPackagesInfoCallback()
+        {
+            m_sysinfo.packages([this](nlohmann::json & package)
+            {
+                m_data["packages_cb"].push_back(package);
+            });
         }
 
     private:
@@ -94,6 +102,8 @@ int main(int argc, const char* argv[])
             printer.printPortsInfo();
             printer.printHotfixes();
             printer.printData();
+            printer.printPackagesInfoCallback();
+            printer.printProcessesInfoCallback();
         }
         else if (argc == 2)
         {
@@ -126,6 +136,14 @@ int main(int argc, const char* argv[])
             else if (cmdLineArgs.hotfixesArg())
             {
                 printer.printHotfixes();
+            }
+            else if (cmdLineArgs.packagesCallbackArg())
+            {
+                printer.printPackagesInfoCallback();
+            }
+            else if (cmdLineArgs.processesCallbackArg())
+            {
+                printer.printProcessesInfoCallback();
             }
             else
             {


### PR DESCRIPTION
|Related issue|
|---|
|Closes #10032 |


## Description

<!--
Add a clear description of how the problem has been solved.
-->




## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [X] Windows
  - [ ] MAC OS X
- [X] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors