### PR TITLE
Implemetation of callback to get proccesses information on Windows

### DIFF
--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -565,14 +565,10 @@ static void fillProcessesData(std::function<void(PROCESSENTRY32)> func)
 nlohmann::json SysInfo::getProcessesInfo() const
 {
     nlohmann::json jsProcessesList{};
-    fillProcessesData([&jsProcessesList](const auto & processEntry)
-    {
-        const auto& processInfo { getProcessInfo(processEntry) };
 
-        if (!processInfo.empty())
-        {
-            jsProcessesList.push_back(processInfo);
-        }
+    getProcessesInfo([&jsProcessesList](nlohmann::json& data)
+    {
+        jsProcessesList.push_back(data);
     });
 
     return jsProcessesList;
@@ -756,9 +752,24 @@ nlohmann::json SysInfo::getPorts() const
     return ports;
 }
 
-void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)> /*callback*/) const
+void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)> callback) const
 {
-    // TO DO
+    fillProcessesData([&callback](const auto &processEntry)
+    {
+        auto processInfo { getProcessInfo(processEntry) };
+
+        if (!processInfo.empty())
+        {
+            if (processInfo.is_array() && processInfo.size() == 1)
+            {
+                callback(processInfo.at(0));  
+            }    
+            else
+            {
+                callback(processInfo);
+            }
+        }
+    });
 }
 
 void SysInfo::getPackages(std::function<void(nlohmann::json&)> /*callback*/) const

--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -566,7 +566,7 @@ nlohmann::json SysInfo::getProcessesInfo() const
 {
     nlohmann::json jsProcessesList{};
 
-    getProcessesInfo([&jsProcessesList](nlohmann::json& data)
+    getProcessesInfo([&jsProcessesList](nlohmann::json & data)
     {
         jsProcessesList.push_back(data);
     });
@@ -754,20 +754,13 @@ nlohmann::json SysInfo::getPorts() const
 
 void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)> callback) const
 {
-    fillProcessesData([&callback](const auto &processEntry)
+    fillProcessesData([&callback](const auto & processEntry)
     {
-        auto processInfo { getProcessInfo(processEntry) };
+        auto processInfo = getProcessInfo(processEntry);
 
         if (!processInfo.empty())
         {
-            if (processInfo.is_array() && processInfo.size() == 1)
-            {
-                callback(processInfo.at(0));  
-            }    
-            else
-            {
-                callback(processInfo);
-            }
+            callback(processInfo);
         }
     });
 }


### PR DESCRIPTION
|Related issue|
|---|
|#10029|

## Description

This PR aims to implement the new processes interface to supports callback-based data pushing.

## Configuration options

## Logs/Alerts example


## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors

Best Regards
Hanes