### PR TITLE
Load FIM perm field as JSON 

### DIFF
--- a/framework/wazuh/core/syscheck.py
+++ b/framework/wazuh/core/syscheck.py
@@ -3,6 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GP
 
 from datetime import datetime
+from json import loads, JSONDecodeError
 
 from wazuh.core.utils import WazuhDBQuery, WazuhDBBackend, get_fields_to_nest, plain_dict_to_nested_dict
 
@@ -23,8 +24,13 @@ class WazuhDBQuerySyscheck(WazuhDBQuery):
         def format_fields(field_name, value):
             if field_name == 'mtime' or field_name == 'date':
                 return datetime.utcfromtimestamp(value)
-            if field_name == 'end' or field_name == 'start':
+            elif field_name == 'end' or field_name == 'start':
                 return None if not value else datetime.utcfromtimestamp(value)
+            elif field_name == 'perm':
+                try:
+                    return loads(value)
+                except JSONDecodeError:
+                    return value
             else:
                 return value
 


### PR DESCRIPTION
|Related issue|
|---|
| #9006  |

This PR closes #9006 .

It includes the necessary changes to load FIM `perm` entries as JSON when it comes from Windows agents. The new response is:

```json
{
  "data": {
    "affected_items": [
      {
        "file": "c:\\windows\\sysnative\\drivers\\etc\\services",
        "date": "2021-09-16T11:58:57Z",
        "uid": "S-1-5-18",
        "uname": "SYSTEM",
        "changes": 1,
        "perm": {
          "S-1-5-18": {
            "name": "SYSTEM",
            "allowed": [
              "delete",
              "read_control",
              "write_dac",
              "write_owner",
              "synchronize",
              "read_data",
              "write_data",
              "append_data",
              "read_ea",
              "write_ea",
              "execute",
              "read_attributes",
              "write_attributes"
            ]
          },
          "S-1-5-32-544": {
            "name": "Admins",
            "allowed": [
              "delete",
              "read_control",
              "write_dac",
              "write_owner",
              "synchronize",
              "read_data",
              "write_data",
              "append_data",
              "read_ea",
              "write_ea",
              "execute",
              "read_attributes",
              "write_attributes"
            ]
          },
          "S-1-5-32-545": {
            "name": "Users",
            "allowed": [
              "read_control",
              "synchronize",
              "read_data",
              "read_ea",
              "execute",
              "read_attributes"
            ]
          }
        }
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "FIM findings of the agent were returned",
  "error": 0
}
``` 

## Tests performed
### Unit tests

```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.9.7, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: cov-2.12.0, asyncio-0.15.1
collected 27 items                                                                                                                                                                          

wazuh/core/tests/test_syscheck.py ....                                                                                                                                                [ 14%]
wazuh/tests/test_syscheck.py .......................                                                                                                                                  [100%]

============================================================================== 27 passed, 4 warnings in 0.22s ===============================================================================

```

Regards,
Víctor