### PR TITLE
Fix AIT healthcheck used in vulnerability test cases

### DIFF
--- a/api/test/integration/env/configurations/vulnerability/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/vulnerability/manager/healthcheck/healthcheck.py
@@ -64,16 +64,22 @@ if __name__ == '__main__':
         # Read state from file instead of api request.
         agents_node = get_healthcheck_state()
 
-    checks_list = list()
+    # Create a checks list with the manager health base at first
+    checks_list = [get_manager_health_base()]
+
     expected_log = "grep -q 'wazuh-modulesd:vulnerability-detector: INFO: (5471): Finished vulnerability assessment " \
         "for agent '\\''{}'\\''' /var/ossec/logs/ossec.log"
 
-    if socket.gethostname() == 'wazuh-master':
-        checks_list.append(get_manager_health_base())
-
     for agent in agents_to_check:
         if agents_node[agent] == socket.gethostname():
-            # Append only logs that are expected in the current node.
+            # Append only logs that are expected in the current node to the checks list
             checks_list.append(check(system(expected_log.format(agent))))
+
+    nodes_to_check = list(dict.fromkeys(list(agents_node.values())))
+    for node in nodes_to_check:
+        if node == socket.gethostname():
+            # Append the log showing the end of the scan to ensure the agents' database have the expected data
+            checks_list.append(check(system("grep -q 'wazuh-modulesd:vulnerability-detector: INFO: (5472): "
+                                            "Vulnerability scan finished.' /var/ossec/logs/ossec.log")))
 
     exit(any(checks_list))

--- a/api/test/integration/env/configurations/vulnerability/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/vulnerability/manager/healthcheck/healthcheck.py
@@ -68,7 +68,7 @@ if __name__ == '__main__':
     checks_list = [get_manager_health_base()]
 
     expected_log = "grep -q 'wazuh-modulesd:vulnerability-detector: INFO: (5471): Finished vulnerability assessment " \
-        "for agent '\\''{}'\\''' /var/ossec/logs/ossec.log"
+                   "for agent '\\''{}'\\''' /var/ossec/logs/ossec.log"
 
     for agent in agents_to_check:
         if agents_node[agent] == socket.gethostname():
@@ -76,10 +76,9 @@ if __name__ == '__main__':
             checks_list.append(check(system(expected_log.format(agent))))
 
     nodes_to_check = list(dict.fromkeys(list(agents_node.values())))
-    for node in nodes_to_check:
-        if node == socket.gethostname():
-            # Append the log showing the end of the scan to ensure the agents' database have the expected data
-            checks_list.append(check(system("grep -q 'wazuh-modulesd:vulnerability-detector: INFO: (5472): "
-                                            "Vulnerability scan finished.' /var/ossec/logs/ossec.log")))
+    if socket.gethostname() in nodes_to_check:
+        # Append the log showing the end of the scan to ensure the agents' database have the expected data
+        checks_list.append(check(system("grep -q 'wazuh-modulesd:vulnerability-detector: INFO: (5472): "
+                                        "Vulnerability scan finished.' /var/ossec/logs/ossec.log")))
 
     exit(any(checks_list))


### PR DESCRIPTION
|Related issue|
|---|
| #10100 |

This PR closes #10100.

In this pull request, I have updated the healthcheck used in the API integration tests testing the vulnerability endpoints.

As it was commented in  https://github.com/wazuh/wazuh/issues/10100#issuecomment-920811434, the problem was that we must be checking the last log shown by the vulnerability detector scan.

This log is:

```
wazuh-modulesd:vulnerability-detector: INFO: (5472): Vulnerability scan finished.
```

After checking it, the race condition will disappear as the database will have data when we run the test.


### Test results

```
test_rbac_black_vulnerability_endpoints.tavern.yaml 
	 1 passed, 3 warnings

test_rbac_white_vulnerability_endpoints.tavern.yaml 
	 1 passed, 3 warnings

test_vulnerability_endpoints.tavern.yaml 
	 1 passed, 3 warnings
```
