### PR TITLE
Add xfail marks to restart by node and custom upgrade AIT

### DIFF
--- a/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
@@ -788,6 +788,9 @@ stages:
 ---
 test_name: PUT /agents/node/{node_id}/restart
 
+marks:
+  - xfail # Agents stay with "pending" status for too long - https://github.com/wazuh/wazuh/issues/10162
+
 stages:
 
   - name: Get agents belonging to a node
@@ -1036,6 +1039,9 @@ stages:
 
 ---
 test_name: PUT /agents/{agent_id}/upgrade_custom
+
+marks:
+  - xfail # Agents stay with "pending" status for too long - https://github.com/wazuh/wazuh/issues/10162
 
 stages:
 


### PR DESCRIPTION
|Related issue|
|---|
| #9943 |

This closes #9943 .

As it was reported in https://github.com/wazuh/wazuh/issues/10162, some API integration tests fail randomly when agents are still `pending`. To prevent more blocking situations we are going to temporarily mark these tests as `xfail`.

- PUT /agents/node/{node_id}/restart
- PUT /agents/{agent_id}/upgrade_custom

## Tests performed
### Integration tests
```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.9.7, pytest-5.4.3, py-1.10.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.9.7', 'Platform': 'Linux-5.13.15-100.fc33.x86_64-x86_64-with-glibc2.32', 'Packages': {'pytest': '5.4.3', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'tavern': '1.0.0', 'metadata': '1.11.0', 'html': '3.1.1'}}
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: tavern-1.0.0, metadata-1.11.0, html-3.1.1
collected 10 items                                                                                                                                                                          

test_agent_PUT_endpoints.tavern.yaml::PUT /agents/group PASSED                                                                                                                        [ 10%]
test_agent_PUT_endpoints.tavern.yaml::PUT /groups/{group_id}/configuration PASSED                                                                                                     [ 20%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/group/{group_id}/restart PASSED                                                                                                     [ 30%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/reconnect PASSED                                                                                                                    [ 40%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/restart PASSED                                                                                                                      [ 50%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/{agent_id}/group/{group_id} PASSED                                                                                                  [ 60%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/{agent_id}/restart PASSED                                                                                                           [ 70%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/node/{node_id}/restart XPASS                                                                                                        [ 80%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/upgrade PASSED                                                                                                                      [ 90%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/{agent_id}/upgrade_custom XPASS                                                                                                     [100%]

=================================================================== 8 passed, 2 xpassed, 12 warnings in 964.99s (0:16:04) ===================================================================
```

Regards,
Víctor
