### PR TITLE
Parsing the new payload for the clustered and local agent additions

### DIFF
--- a/src/os_auth/local-server.c
+++ b/src/os_auth/local-server.c
@@ -202,6 +202,8 @@ char* local_dispatch(const char *input) {
 
         if (!strcmp(function->valuestring, "add")) {
             cJSON *item = NULL;
+            cJSON *force = NULL;
+            cJSON *disconnected_time = NULL;
             char *id = NULL;
             char *name = NULL;
             char *ip = NULL;
@@ -240,18 +242,27 @@ char* local_dispatch(const char *input) {
             key_hash = (item = cJSON_GetObjectItem(arguments, "key_hash"), item) ? item->valuestring : NULL;
             key = (item = cJSON_GetObjectItem(arguments, "key"), item) ? item->valuestring : NULL;
 
-            if (item = cJSON_GetObjectItem(arguments, "force"), item) {
-                if (item->valueint == -1) {
-                    force_options.enabled = false;
-                } else {
-                    force_options.enabled = true;
-                    force_options.connection_time = item->valueint;
+            if (force = cJSON_GetObjectItem(arguments, "force"), force) {
+                if (item = cJSON_GetObjectItem(force, "enabled"), item) {
+                    force_options.enabled = (bool)item->valueint;
                 }
-            } else {
-                force_options.enabled = false;
+                if (item = cJSON_GetObjectItem(force, "key_mismatch"), item) {
+                    force_options.key_mismatch = (bool)item->valueint;
+                }
+                if (disconnected_time = cJSON_GetObjectItem(force, "disconnected_time"), disconnected_time) {
+                    if (item = cJSON_GetObjectItem(disconnected_time, "enabled"), item) {
+                        force_options.disconnected_time_enabled = (bool)item->valueint;
+                    }
+                    if (item = cJSON_GetObjectItem(disconnected_time, "value"), item) {
+                        force_options.disconnected_time = (long)item->valueint;
+                    }
+                }
+                if (item = cJSON_GetObjectItem(force, "after_registration_time"), item) {
+                    force_options.after_registration_time = (long)item->valueint;
+                }
             }
 
-            response = local_add(id, name, ip, groups, key, key_hash, &force_options);
+            response = local_add(id, name, ip, groups, key, key_hash, force ? &force_options : &config.force_options);
 
             os_free(groups);
         } else if (!strcmp(function->valuestring, "remove")) {


### PR DESCRIPTION
|Related issue|
|---|
|#10150|

## Description

This PR adds the capability to parse the incoming message with force options from API and Wazuh tools.

## Logs/Alerts example

- Example from tool manage-agents
![1](https://user-images.githubusercontent.com/13010397/133647757-d1e15b22-6c46-460e-9d8f-0bb5bbb058e8.png)
- Local force_options structure set with received values.

  <img src="https://user-images.githubusercontent.com/13010397/133647762-7e4618b4-a175-4ca1-b4a2-2db60e969f98.png" width=700>

- Scan-Build
![3](https://user-images.githubusercontent.com/13010397/133647764-48a6a739-fc50-49bd-a31d-aae4f717d529.png)

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report