### PR TITLE
Adding callback mechanism for linux packages' provider (deb, rpm and archlinux)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,11 +117,11 @@ src/win32/REVISION
 *.gcno
 *.gcda
 src/coverage-report/
-data_provider/coverage_report/
-shared_modules/dbsync/coverage_report/
-shared_modules/rsync/coverage_report/
-shared_modules/utils/coverage_report/
-wazuh_modules/syscollector/coverage_report/
+src/data_provider/coverage_report/
+src/shared_modules/dbsync/coverage_report/
+src/shared_modules/rsync/coverage_report/
+src/shared_modules/utils/coverage_report/
+src/wazuh_modules/syscollector/coverage_report/
 src/ossec.test
 src/tap_*
 etc/preloaded-vars.conf

--- a/src/data_provider/cppcheckSuppress.txt
+++ b/src/data_provider/cppcheckSuppress.txt
@@ -1,3 +1,3 @@
-*:*src/sysInfoLinux.cpp:257
+*:*src/sysInfoLinux.cpp:259
 *:*src/packages/pkgWrapper.h:105
 *:*src/packages/packagesWindowsParserHelper.h:53

--- a/src/data_provider/src/packages/packageLinuxDataRetriever.h
+++ b/src/data_provider/src/packages/packageLinuxDataRetriever.h
@@ -18,23 +18,23 @@
 
 /**
  * @brief Fills a JSON object with all available pacman-related information
- * @param libPath Path to pacman's database directory
- * @param jsonPackages JSON to be filled
+ * @param libPath  Path to pacman's database directory
+ * @param callback Callback to be called for every single element being found
  */
-void getPacmanInfo(const std::string& libPath, nlohmann::json& jsonPackages);
+void getPacmanInfo(const std::string& libPath, std::function<void(nlohmann::json&)> callback);
 
 /**
  * @brief Fills a JSON object with all available rpm-related information
- * @param jsonPackages JSON to be filled
+ * @param callback Callback to be called for every single element being found
  */
-void getRpmInfo(nlohmann::json& jsonPackages);
+void getRpmInfo(std::function<void(nlohmann::json&)> callback);
 
 /**
  * @brief Fills a JSON object with all available dpkg-related information
- * @param libPath Path to dpkg's database directory
- * @param jsonPackages JSON to be filled
+ * @param libPath  Path to dpkg's database directory
+ * @param callback Callback to be called for every single element being found
  */
-void getDpkgInfo(const std::string& libPath, nlohmann::json& jsonPackages);
+void getDpkgInfo(const std::string& libPath, std::function<void(nlohmann::json&)> callback);
 
 
 // Exception template
@@ -42,7 +42,7 @@ template <LinuxType linuxType>
 class FactoryPackagesCreator final
 {
     public:
-        static void getPackages(nlohmann::json& /* packages*/)
+        static void getPackages(std::function<void(nlohmann::json&)> /*callback*/)
         {
             throw std::runtime_error
             {
@@ -56,21 +56,21 @@ template <>
 class FactoryPackagesCreator<LinuxType::STANDARD> final
 {
     public:
-        static void getPackages(nlohmann::json& packages)
+        static void getPackages(std::function<void(nlohmann::json&)> callback)
         {
             if (Utils::existsDir(DPKG_PATH))
             {
-                getDpkgInfo(DPKG_STATUS_PATH, packages);
+                getDpkgInfo(DPKG_STATUS_PATH, callback);
             }
 
             if (Utils::existsDir(PACMAN_PATH))
             {
-                getPacmanInfo(PACMAN_PATH, packages);
+                getPacmanInfo(PACMAN_PATH, callback);
             }
 
             if (Utils::existsDir(RPM_PATH))
             {
-                getRpmInfo(packages);
+                getRpmInfo(callback);
             }
         }
 };
@@ -80,16 +80,16 @@ template <>
 class FactoryPackagesCreator<LinuxType::LEGACY> final
 {
     public:
-        static void getPackages(nlohmann::json& packages)
+        static void getPackages(std::function<void(nlohmann::json&)> callback)
         {
             if (Utils::existsDir(DPKG_PATH))
             {
-                getDpkgInfo(DPKG_STATUS_PATH, packages);
+                getDpkgInfo(DPKG_STATUS_PATH, callback);
             }
 
             if (Utils::existsDir(RPM_PATH))
             {
-                getRpmInfo(packages);
+                getRpmInfo(callback);
             }
         }
 };

--- a/src/data_provider/src/packages/packageLinuxParser.cpp
+++ b/src/data_provider/src/packages/packageLinuxParser.cpp
@@ -14,22 +14,22 @@
 #include "berkeleyRpmDbHelper.h"
 
 
-void getRpmInfo(nlohmann::json& packages)
+void getRpmInfo(std::function<void(nlohmann::json&)> callback)
 {
     BerkeleyRpmDBReader db {std::make_shared<BerkeleyDbWrapper>(RPM_DATABASE)};
 
     for (std::string row{db.getNext()}; !row.empty() ; row = db.getNext())
     {
-        const auto& package{ PackageLinuxHelper::parseRpm(row) };
+        auto package = PackageLinuxHelper::parseRpm(row);
 
         if (!package.empty())
         {
-            packages.push_back(package);
+            callback(package);
         }
     }
 }
 
-void getDpkgInfo(const std::string& fileName, nlohmann::json& packages)
+void getDpkgInfo(const std::string& fileName, std::function<void(nlohmann::json&)> callback)
 {
     std::fstream file{fileName, std::ios_base::in};
 
@@ -55,11 +55,11 @@ void getDpkgInfo(const std::string& fileName, nlohmann::json& packages)
             }
             while (!line.empty()); //end of package item info
 
-            const auto& packageInfo{ PackageLinuxHelper::parseDpkg(data) };
+            auto packageInfo = PackageLinuxHelper::parseDpkg(data);
 
             if (!packageInfo.empty())
             {
-                packages.push_back(packageInfo);
+                callback(packageInfo);
             }
         }
     }

--- a/src/data_provider/src/packages/packageLinuxParserExtra.cpp
+++ b/src/data_provider/src/packages/packageLinuxParserExtra.cpp
@@ -23,7 +23,7 @@ struct AlmpDeleter final
     }
 };
 
-void getPacmanInfo(const std::string& libPath, nlohmann::json& packages)
+void getPacmanInfo(const std::string& libPath, std::function<void(nlohmann::json&)> callback)
 {
     constexpr auto ROOT_PATH {"/"};
     alpm_errno_t err {ALPM_ERR_OK};
@@ -50,11 +50,11 @@ void getPacmanInfo(const std::string& libPath, nlohmann::json& packages)
 
     for (auto pArchItem{alpm_db_get_pkgcache(pDbLocal)}; pArchItem; pArchItem = alpm_list_next(pArchItem))
     {
-        const auto& packageInfo{ PackageLinuxHelper::parsePacman(pArchItem) };
+        auto packageInfo = PackageLinuxHelper::parsePacman(pArchItem);
 
         if (!packageInfo.empty())
         {
-            packages.push_back(packageInfo);
+            callback(packageInfo);
         }
     }
 }

--- a/src/data_provider/src/sysInfo.cpp
+++ b/src/data_provider/src/sysInfo.cpp
@@ -96,6 +96,7 @@ int sysinfo_hardware(cJSON** js_result)
     {}
 
     // LCOV_EXCL_STOP
+
     return retVal;
 }
 int sysinfo_packages(cJSON** js_result)
@@ -117,6 +118,7 @@ int sysinfo_packages(cJSON** js_result)
     {}
 
     // LCOV_EXCL_STOP
+
     return retVal;
 }
 int sysinfo_os(cJSON** js_result)
@@ -138,6 +140,7 @@ int sysinfo_os(cJSON** js_result)
     {}
 
     // LCOV_EXCL_STOP
+
     return retVal;
 }
 int sysinfo_processes(cJSON** js_result)
@@ -159,6 +162,7 @@ int sysinfo_processes(cJSON** js_result)
     {}
 
     // LCOV_EXCL_STOP
+
     return retVal;
 }
 int sysinfo_networks(cJSON** js_result)
@@ -180,6 +184,7 @@ int sysinfo_networks(cJSON** js_result)
     {}
 
     // LCOV_EXCL_STOP
+
     return retVal;
 }
 int sysinfo_ports(cJSON** js_result)
@@ -201,6 +206,7 @@ int sysinfo_ports(cJSON** js_result)
     {}
 
     // LCOV_EXCL_STOP
+
     return retVal;
 }
 void sysinfo_free_result(cJSON** js_data)
@@ -226,7 +232,9 @@ int sysinfo_packages_cb(callback_data_t callback_data)
                     callback_data.callback(GENERIC, spJson.get(), callback_data.user_data);
                 }
             };
+            // LCOV_EXCL_START
             SysInfo info;
+            // LCOV_EXCL_STOP
             info.packages(callbackWrapper);
             retVal = 0;
         }
@@ -236,6 +244,7 @@ int sysinfo_packages_cb(callback_data_t callback_data)
     {}
 
     // LCOV_EXCL_STOP
+
     return retVal;
 }
 
@@ -267,6 +276,7 @@ int sysinfo_processes_cb(callback_data_t callback_data)
     {}
 
     // LCOV_EXCL_STOP
+
     return retVal;
 }
 
@@ -289,6 +299,7 @@ int sysinfo_hotfixes(cJSON** js_result)
     {}
 
     // LCOV_EXCL_STOP
+
     return retVal;
 }
 

--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -223,11 +223,13 @@ void SysInfo::getMemory(nlohmann::json& info) const
     info["ram_usage"] = 100 - (100 * memFree / ramTotal);
 }
 
-
 nlohmann::json SysInfo::getPackages() const
 {
     nlohmann::json packages;
-    FactoryPackagesCreator<LINUX_TYPE>::getPackages(packages);
+    getPackages([&packages](nlohmann::json & data)
+    {
+        packages.push_back(data);
+    });
     return packages;
 }
 
@@ -407,9 +409,9 @@ void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)> callback) co
     }
 }
 
-void SysInfo::getPackages(std::function<void(nlohmann::json&)> /*callback*/) const
+void SysInfo::getPackages(std::function<void(nlohmann::json&)> callback) const
 {
-    // TO DO
+    FactoryPackagesCreator<LINUX_TYPE>::getPackages(callback);
 }
 
 nlohmann::json SysInfo::getHotfixes() const


### PR DESCRIPTION
|Related issues|
|---|
|Closes #10031 |
|Closes #10039  |
|Closes #10040  |

## Description

This issue suggests that a call to this interface of the data provider returns a callback per element, in this way not to have a large set allocated in memory at this time

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors