### PR TITLE
Fix information truncated showed on command line table

### DIFF
--- a/src/Readme.md
+++ b/src/Readme.md
@@ -34,17 +34,17 @@ usage: python3 build.py [-h] [-r READYTOREVIEW] [-m MAKE] [-t TESTS] [-c COVERAG
 |Argument|Description|
 |---|---|
 | `-h`, `--help`          | Show the help message and exit |
-| `-r`, `--readytoreview` | Run all the quality checks needed to create a PR. Example: `python3 build.py -r <data_provider|shared_modules/dbsync|shared_modules/rsync|shared_modules/utils|wazuh_modules/syscollector>` |
-| `-m`, `--make`          | Compile the lib. Example: `python3 build.py -m <data_provider|shared_modules/dbsync|shared_modules/rsync|shared_modules/utils|wazuh_modules/syscollector>` |
-| `-t`, `--tests`         | Run tests (should be configured with TEST=on). Example: `python3 build.py -t <data_provider|shared_modules/dbsync|shared_modules/rsync|shared_modules/utils|wazuh_modules/syscollector>` |
-| `-c`, `--coverage`      | Collect tests coverage and generates report. Example: `python3 build.py -c <data_provider|shared_modules/dbsync|shared_modules/rsync|shared_modules/utils|wazuh_modules/syscollector>` |
-| `-v`, `--valgrind`      | Run valgrind on tests. Example: `python3 build.py -v <data_provider|shared_modules/dbsync|shared_modules/rsync|shared_modules/utils|wazuh_modules/syscollector>` |
-| `-c`, `--coverage`      | Collect tests coverage and generates report. Example: `python3 build.py -c <data_provider|shared_modules/dbsync|shared_modules/rsync|shared_modules/utils|wazuh_modules/syscollector>` |
-| `--clean`               | Clean the lib. Example: `python3 build.py --clean <data_provider|shared_modules/dbsync|shared_modules/rsync|shared_modules/utils|wazuh_modules/syscollector>` |
-| `--cppcheck`            | Run cppcheck on the code. Example: `python3 build.py --cppcheck <data_provider|shared_modules/dbsync|shared_modules/rsync|shared_modules/utils|wazuh_modules/syscollector>` |
-| `--asan`                | Run ASAN on the code. Example: `python3 build.py --asan <data_provider|shared_modules/dbsync|shared_modules/rsync|shared_modules/utils|wazuh_modules/syscollector>` |
-| `--scheck`              | Run AStyle on the code for checking purposes. Example: `python3 build.py --scheck <data_provider|shared_modules/dbsync|shared_modules/rsync|shared_modules/utils|wazuh_modules/syscollector>` |
-| `--sformat`             | Run AStyle on the code formatting the needed files. Example: `python3 build.py --sformat <data_provider|shared_modules/dbsync|shared_modules/rsync|shared_modules/utils|wazuh_modules/syscollector>` |
+| `-r`, `--readytoreview` | Run all the quality checks needed to create a PR. Example: `python3 build.py -r <data_provider\|shared_modules/dbsync\|shared_modules/rsync\|shared_modules/utils\|wazuh_modules/syscollector>` |
+| `-m`, `--make`          | Compile the lib. Example: `python3 build.py -m <data_provider\|shared_modules/dbsync\|shared_modules/rsync\|shared_modules/utils\|wazuh_modules/syscollector>` |
+| `-t`, `--tests`         | Run tests (should be configured with TEST=on). Example: `python3 build.py -t <data_provider\|shared_modules/dbsync\|shared_modules/rsync\|shared_modules/utils\|wazuh_modules/syscollector>` |
+| `-c`, `--coverage`      | Collect tests coverage and generates report. Example: `python3 build.py -c <data_provider\|shared_modules/dbsync\|shared_modules/rsync\|shared_modules/utils\|wazuh_modules/syscollector>` |
+| `-v`, `--valgrind`      | Run valgrind on tests. Example: `python3 build.py -v <data_provider\|shared_modules/dbsync\|shared_modules/rsync\|shared_modules/utils\|wazuh_modules/syscollector>` |
+| `-c`, `--coverage`      | Collect tests coverage and generates report. Example: `python3 build.py -c <data_provider\|shared_modules/dbsync\|shared_modules/rsync\|shared_modules/utils\|wazuh_modules/syscollector>` |
+| `--clean`               | Clean the lib. Example: `python3 build.py --clean <data_provider\|shared_modules/dbsync\|shared_modules/rsync\|shared_modules/utils\|wazuh_modules/syscollector>` |
+| `--cppcheck`            | Run cppcheck on the code. Example: `python3 build.py --cppcheck <data_provider\|shared_modules/dbsync\|shared_modules/rsync\|shared_modules/utils\|wazuh_modules/syscollector>` |
+| `--asan`                | Run ASAN on the code. Example: `python3 build.py --asan <data_provider\|shared_modules/dbsync\|shared_modules/rsync\|shared_modules/utils\|wazuh_modules/syscollector>` |
+| `--scheck`              | Run AStyle on the code for checking purposes. Example: `python3 build.py --scheck <data_provider\|shared_modules/dbsync\|shared_modules/rsync\|shared_modules/utils\|wazuh_modules/syscollector>` |
+| `--sformat`             | Run AStyle on the code formatting the needed files. Example: `python3 build.py --sformat <data_provider\|shared_modules/dbsync\|shared_modules/rsync\|shared_modules/utils\|wazuh_modules/syscollector>` |
 
 Ready to review checks:
   1. Runs cppcheck on <data_provider|shared_modules/dbsync|shared_modules/rsync|shared_modules/utils|wazuh_modules/syscollector> folder.


### PR DESCRIPTION
|Related issue|
|---|
|#10129|

## Description

Hi Teams,

This PR aims to fix truncated information in the GitHub table when there are pipe characters, e.g. in the command line table.

## Configuration options

## Logs/Alerts example

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors
  
Best regards
Hanes