### PR TITLE
Add callbacks implementation for bsd packages.

### DIFF
--- a/src/data_provider/src/sysInfoFreeBSD.cpp
+++ b/src/data_provider/src/sysInfoFreeBSD.cpp
@@ -102,26 +102,10 @@ std::string SysInfo::getSerialNumber() const
 nlohmann::json SysInfo::getPackages() const
 {
     nlohmann::json ret;
-    const auto query{Utils::exec(R"(pkg query -a "%n|%m|%v|%q|%c")")};
-
-    if (!query.empty())
+    getPackages([&ret](nlohmann::json & data)
     {
-        const auto lines{Utils::split(query, '\n')};
-
-        for (const auto& line : lines)
-        {
-            const auto data{Utils::split(line, '|')};
-            nlohmann::json package;
-            package["name"] = data[0];
-            package["vendor"] = data[1];
-            package["version"] = data[2];
-            package["architecture"] = data[3];
-            package["description"] = data[4];
-            package["format"] = "pkg";
-            ret.push_back(package);
-        }
-    }
-
+        ret.push_back(data);
+    });
     return ret;
 }
 
@@ -167,9 +151,27 @@ void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)> /*callback*/
     // Currently not supported for this OS.
 }
 
-void SysInfo::getPackages(std::function<void(nlohmann::json&)> /*callback*/) const
+void SysInfo::getPackages(std::function<void(nlohmann::json&)> callback) const
 {
-    // Currently not supported for this OS.
+    const auto query{Utils::exec(R"(pkg query -a "%n|%m|%v|%q|%c")")};
+
+    if (!query.empty())
+    {
+        const auto lines{Utils::split(query, '\n')};
+
+        for (const auto& line : lines)
+        {
+            const auto data{Utils::split(line, '|')};
+            nlohmann::json package;
+            package["name"] = data[0];
+            package["vendor"] = data[1];
+            package["version"] = data[2];
+            package["architecture"] = data[3];
+            package["description"] = data[4];
+            package["format"] = "pkg";
+            callback(package);
+        }
+    }
 }
 
 nlohmann::json SysInfo::getHotfixes() const

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -1446,10 +1446,13 @@ void Syscollector::scanPackages()
             rawData["item_id"] = getItemId(rawData, PACKAGES_ITEM_ID_FIELDS);
 
             input["table"] = PACKAGES_TABLE;
-            input["data"] = nlohmann::json::array( { m_spNormalizer->normalize("packages",
-                                                                               m_spNormalizer->removeExcluded("packages", rawData)) } );
+            const auto& data { m_spNormalizer->normalize("packages", m_spNormalizer->removeExcluded("packages", rawData)) };
 
-            txn.syncTxnRow(input);
+            if (!data.empty())
+            {
+                input["data"] = nlohmann::json::array( { data } );
+                txn.syncTxnRow(input);
+            }
         });
         txn.getDeletedRows(callback);
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #10033|

## Description
This issue suggests that a call to this interface of the data provider returns a callback per element, in this way not to have a large set allocated in memory at this time.

JSON callback return example:

```
{
    "architecture": "amd64",
    "description": "shell with lots of features",
    "format": "deb",
    "groups": "shells",
    "multiarch": "",
    "name": "zsh",
    "priority": "optional",
    "size": 2334,
    "source": "",
    "vendor": "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
    "version": "5.8-3ubuntu1"
}
```



## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [X] MAC OS X
- [X] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors