### PR TITLE
Update agent_list when forwarding requests if it is an empty list

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -254,6 +254,7 @@ def restart_agents_by_node(agent_list=None):
     -------
     AffectedItemsWazuhResult
     """
+    '000' in agent_list and agent_list.remove('000')
     return restart_agents(agent_list=agent_list)
 
 

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -409,7 +409,7 @@ class DistributedAPI:
             if node_name == self.node_info['node']:
                 # The request will be executed locally if the the node to forward to is unknown, empty or the master
                 # itself
-                if agent_list:
+                if agent_list is not None and set(self.f_kwargs) & {'agent_id', 'agent_list'}:
                     self.f_kwargs['agent_id' if 'agent_id' in self.f_kwargs else 'agent_list'] = agent_list
                 result = await self.distribute_function()
             else:
@@ -418,7 +418,7 @@ class DistributedAPI:
                 client = self.get_client()
                 try:
                     kcopy = deepcopy(self.to_dict())
-                    if agent_list:
+                    if agent_list is not None and set(self.f_kwargs) & {'agent_id', 'agent_list'}:
                         kcopy['f_kwargs']['agent_id' if 'agent_id' in kcopy['f_kwargs'] else 'agent_list'] = agent_list
                     result = json.loads(await client.execute(b'dapi_fwd',
                                                              "{} {}".format(node_name,


### PR DESCRIPTION
|Related issue|
|---|
|#10105|

This PR closes #10105 .

This PR fixes the bug with cluster nodes without agents when using the restart agents by node endpoint. To do so, we just changed the condition to update the `agent_list` when forwarding the request to the node.

`worker2` has no agents reporting to it:

```shellsession
root@wazuh-master:/# /var/ossec/bin/cluster_control -l
NAME         TYPE    VERSION  ADDRESS       
master-node  master  4.2.2    wazuh-master  
worker1      worker  4.2.2    172.19.0.6    
worker2      worker  4.2.2    172.19.0.3    
root@wazuh-master:/# /var/ossec/bin/cluster_control -a
ID   NAME          IP          STATUS  VERSION       NODE NAME    
000  wazuh-master  127.0.0.1   active  Wazuh v4.2.2  master-node  
001  bd519ce92205  172.19.0.5  active  Wazuh v4.3.0  worker1
```

The endpoint returns an empty list as expected:

`PUT /agents/node/worker2/restart`

```json
{
  "data": {
    "affected_items": [],
    "total_affected_items": 0,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "Restart command was not sent to any agent",
  "error": 0
}
```
In addition, there was a bug when trying to restart all agents belonging to the node where the request was made. It would add the agent 000:

```json
{
  "data": {
    "affected_items": [],
    "total_affected_items": 0,
    "total_failed_items": 1,
    "failed_items": [
      {
        "error": {
          "code": 1703,
          "message": "Action not available for Manager (agent 000)",
          "remediation": "Please, use `GET /agents?select=id,name` to find all available agents and make sure you select an agent other than 000"
        },
        "id": [
          "000"
        ]
      }
    ]
  },
  "message": "Restart command was not sent to any agent",
  "error": 1
}
```

It has been fixed as well.

## Tests performed
### Unit tests
```
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.9.7, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: cov-2.12.0, asyncio-0.15.1
collected 1735 items                                                                                                                                                                                              

wazuh/core/cluster/dapi/tests/test_dapi.py .......................                                                                                                                                          [  1%]
wazuh/core/cluster/tests/test_cluster.py ...................                                                                                                                                                [  2%]
wazuh/core/cluster/tests/test_common.py .......                                                                                                                                                             [  2%]
wazuh/core/cluster/tests/test_control.py .....                                                                                                                                                              [  3%]
wazuh/core/cluster/tests/test_local_client.py .                                                                                                                                                             [  3%]
wazuh/core/cluster/tests/test_utils.py .......                                                                                                                                                              [  3%]
wazuh/core/cluster/tests/test_worker.py .................                                                                                                                                                   [  4%]
wazuh/core/tests/test_active_response.py ..............                                                                                                                                                     [  5%]
wazuh/core/tests/test_agent.py .........................................................................................................................................................................    [ 15%]
wazuh/core/tests/test_cdb_list.py ......................................                                                                                                                                    [ 17%]
wazuh/core/tests/test_common.py .......                                                                                                                                                                     [ 17%]
wazuh/core/tests/test_configuration.py ....................................                                                                                                                                 [ 19%]
wazuh/core/tests/test_decoder.py ................                                                                                                                                                           [ 20%]
wazuh/core/tests/test_input_validator.py ...                                                                                                                                                                [ 20%]
wazuh/core/tests/test_logtest.py ..                                                                                                                                                                         [ 20%]
wazuh/core/tests/test_manager.py ...............                                                                                                                                                            [ 21%]
wazuh/core/tests/test_pyDaemonModule.py ......                                                                                                                                                              [ 22%]
wazuh/core/tests/test_results.py ........................................                                                                                                                                   [ 24%]
wazuh/core/tests/test_rootcheck.py ..........                                                                                                                                                               [ 25%]
wazuh/core/tests/test_rule.py ......................                                                                                                                                                        [ 26%]
wazuh/core/tests/test_stats.py ....                                                                                                                                                                         [ 26%]
wazuh/core/tests/test_syscollector.py ...                                                                                                                                                                   [ 26%]
wazuh/core/tests/test_utils.py ............................................................................................................................................................................ [ 36%]
...............................................                                                                                                                                                             [ 39%]
wazuh/core/tests/test_vulnerability.py .                                                                                                                                                                    [ 39%]
wazuh/core/tests/test_wazuh_queue.py ...................                                                                                                                                                    [ 40%]
wazuh/core/tests/test_wazuh_socket.py ....................                                                                                                                                                  [ 41%]
wazuh/core/tests/test_wdb.py .....................                                                                                                                                                          [ 42%]
wazuh/rbac/tests/test_auth_context.py ..                                                                                                                                                                    [ 42%]
wazuh/rbac/tests/test_decorators.py .........................................................................................................                                                               [ 49%]
wazuh/rbac/tests/test_default_configuration.py .......................................................                                                                                                      [ 52%]
wazuh/rbac/tests/test_orm.py ......................................................                                                                                                                         [ 55%]
wazuh/rbac/tests/test_preprocessor.py ...........                                                                                                                                                           [ 55%]
wazuh/tests/test_active_response.py ............                                                                                                                                                            [ 56%]
wazuh/tests/test_agent.py .......................................................................................................                                                                           [ 62%]
wazuh/tests/test_cdb_list.py .....................................................                                                                                                                          [ 65%]
wazuh/tests/test_ciscat.py .................................                                                                                                                                                [ 67%]
wazuh/tests/test_cluster.py .......                                                                                                                                                                         [ 67%]
wazuh/tests/test_decoder.py ...................................                                                                                                                                             [ 69%]
wazuh/tests/test_group.py ........                                                                                                                                                                          [ 70%]
wazuh/tests/test_logtest.py ......                                                                                                                                                                          [ 70%]
wazuh/tests/test_manager.py ..................................                                                                                                                                              [ 72%]
wazuh/tests/test_mitre.py ................................................................................................................................................................................. [ 82%]
...                                                                                                                                                                                                         [ 83%]
wazuh/tests/test_rootcheck.py .................................................                                                                                                                             [ 85%]
wazuh/tests/test_rule.py ........................................................                                                                                                                           [ 89%]
wazuh/tests/test_sca.py .......                                                                                                                                                                             [ 89%]
wazuh/tests/test_security.py ...........................................................................                                                                                                    [ 93%]
wazuh/tests/test_stats.py ................                                                                                                                                                                  [ 94%]
wazuh/tests/test_syscheck.py ........................                                                                                                                                                       [ 96%]
wazuh/tests/test_syscollector.py ............                                                                                                                                                               [ 96%]
wazuh/tests/test_task.py ............................                                                                                                                                                       [ 98%]
wazuh/tests/test_vulnerability.py ..........................                                                                                                                                                [100%]

================================================================================== 1735 passed, 14 warnings in 330.65s (0:05:30) ==================================================================================

```

### Integration tests
```
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.9.7, pytest-5.4.3, py-1.10.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.9.7', 'Platform': 'Linux-5.13.15-100.fc33.x86_64-x86_64-with-glibc2.32', 'Packages': {'pytest': '5.4.3', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'tavern': '1.0.0', 'metadata': '1.11.0', 'html': '3.1.1'}}
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: tavern-1.0.0, metadata-1.11.0, html-3.1.1
collected 9 items                                                                                                                                                                                                 

test_agent_PUT_endpoints.tavern.yaml::PUT /agents/group PASSED                                                                                                                                              [ 11%]
test_agent_PUT_endpoints.tavern.yaml::PUT /groups/{group_id}/configuration PASSED                                                                                                                           [ 22%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/group/{group_id}/restart PASSED                                                                                                                           [ 33%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/restart PASSED                                                                                                                                            [ 44%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/{agent_id}/group/{group_id} PASSED                                                                                                                        [ 55%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/{agent_id}/restart PASSED                                                                                                                                 [ 66%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/node/{node_id}/restart PASSED                                                                                                                             [ 77%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/upgrade PASSED                                                                                                                                            [ 88%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/{agent_id}/upgrade_custom PASSED                                                                                                                          [100%]

=================================================================================== 9 passed, 11 warnings in 841.10s (0:14:01) ====================================================================================
```

Regards,
Víctor 


