### PR TITLE
Refactor the cluster Integrity sync behavior when there are extra-valid files

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1694,8 +1694,6 @@ components:
                           format: int32
                 sync_agentinfo_free:
                   type: boolean
-                sync_extravalid_free:
-                  type: boolean
                 sync_integrity_free:
                   type: boolean
 
@@ -7830,7 +7828,6 @@ paths:
                         n_active_agents: 3
                       status:
                         sync_integrity_free: true
-                        sync_extravalid_free: true
                         last_check_integrity:
                           date_start_master: 2021-05-27T10:50:51.325656Z
                           date_end_master: 2021-05-27T10:50:51.342140Z
@@ -7857,7 +7854,6 @@ paths:
                         n_active_agents: 1
                       status:
                         sync_integrity_free: true
-                        sync_extravalid_free: true
                         last_check_integrity:
                           date_start_master: 2021-05-27T10:50:51.939323Z
                           date_end_master: 2021-05-27T10:50:51.955007Z

--- a/framework/scripts/cluster_control.py
+++ b/framework/scripts/cluster_control.py
@@ -111,8 +111,6 @@ async def print_health(config, more, filter_node):
             msg2 += "                Synchronized files: Shared: {} | Missing: {} | Extra: {} | Extra valid: {}.\n".format(
                 n_shared, n_missing, n_extra, n_extra_valid)
 
-            msg2 += "                Permission to sync extra valid files: {}.\n".format(
-                str(node_info['status']['sync_extravalid_free']))
             msg2 += "                Extra valid files correctly updated in master: {}.\n".format(
                 str(node_info['status']['last_sync_integrity']['total_extra_valid']))
 

--- a/framework/wazuh/core/cluster/cluster.json
+++ b/framework/wazuh/core/cluster/cluster.json
@@ -113,10 +113,6 @@
         }
     },
 
-    "sync_options": {
-        "get_agentinfo_newer_than": 1800
-    },
-
     "distributed_api": {
         "enabled": true
     }

--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -198,6 +198,7 @@ class ReceiveFileTask:
             Pre-defined task_id to identify this object. If not specified, a random task_id will be used.
         """
         self.wazuh_common = wazuh_common
+        self.wazuh_common.extra_valid_requested = False
         self.coro = self.set_up_coro()
         self.task_id = task_id.decode() if task_id else str(uuid4())
         self.received_information = asyncio.Event()

--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -198,7 +198,6 @@ class ReceiveFileTask:
             Pre-defined task_id to identify this object. If not specified, a random task_id will be used.
         """
         self.wazuh_common = wazuh_common
-        self.wazuh_common.extra_valid_requested = False
         self.coro = self.set_up_coro()
         self.task_id = task_id.decode() if task_id else str(uuid4())
         self.received_information = asyncio.Event()

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -56,7 +56,8 @@ class ReceiveIntegrityTask(c_common.ReceiveFileTask):
             Synchronization process result.
         """
         super().done_callback(future)
-        self.wazuh_common.sync_integrity_free = True
+        if not self.wazuh_common.extra_valid_requested:
+            self.wazuh_common.sync_integrity_free = True
 
 
 class ReceiveExtraValidTask(c_common.ReceiveFileTask):
@@ -92,7 +93,7 @@ class ReceiveExtraValidTask(c_common.ReceiveFileTask):
             Synchronization process result.
         """
         super().done_callback(future)
-        self.wazuh_common.sync_extra_valid_free = True
+        self.wazuh_common.sync_integrity_free = True
 
 
 class ReceiveAgentInfoTask(c_common.ReceiveStringTask):
@@ -146,9 +147,12 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         """
         super().__init__(**kwargs, tag="Worker")
         # Sync availability variables. Used to prevent sync process from overlapping.
-        self.sync_integrity_free = True  # the worker isn't currently synchronizing integrity
-        self.sync_extra_valid_free = True
         self.sync_agent_info_free = True
+        self.sync_integrity_free = True
+
+        # Variable used to check when integrity sync process includes extra_valid files.
+        self.extra_valid_requested = False
+
         # Sync status variables. Used in cluster_control -i and GET/cluster/healthcheck.
         default_date = datetime.fromtimestamp(0).strftime(decimals_date_format)
         self.integrity_check_status = {'date_start_master': default_date, 'date_end_master': default_date}
@@ -176,7 +180,6 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         """
         return {'info': {'name': self.name, 'type': self.node_type, 'version': self.version, 'ip': self.ip},
                 'status': {'sync_integrity_free': self.sync_integrity_free,
-                           'sync_extravalid_free': self.sync_extra_valid_free,
                            'last_check_integrity': {key: value for key, value in self.integrity_check_status.items() if
                                                     not key.startswith('tmp')},
                            'last_sync_integrity': {key: value for key, value in self.integrity_sync_status.items() if
@@ -203,14 +206,14 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             Response message.
         """
         self.logger.debug(f"Command received: {command}")
-        if command == b'syn_i_w_m_p' or command == b'syn_e_w_m_p' or command == b'syn_a_w_m_p':
+        if command == b'syn_i_w_m_p' or command == b'syn_a_w_m_p':
             return self.get_permission(command)
         elif command == b'syn_i_w_m' or command == b'syn_e_w_m' or command == b'syn_a_w_m':
             return self.setup_sync_integrity(command, data)
         elif command == b'syn_i_w_m_e' or command == b'syn_e_w_m_e':
             return self.end_receiving_integrity_checksums(data.decode())
-        elif command == b'syn_i_w_m_r' or command == b'syn_e_w_m_r':
-            return self.process_sync_error_from_worker(command, data)
+        elif command == b'syn_i_w_m_r':
+            return self.process_sync_error_from_worker(data)
         elif command == b'dapi':
             self.server.dapi.add_request(self.name.encode() + b'*' + data)
             return b'ok', b'Added request to API requests queue'
@@ -428,8 +431,6 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         """
         if sync_type == b'syn_i_w_m_p':
             permission = self.sync_integrity_free
-        elif sync_type == b'syn_e_w_m_p':
-            permission = self.sync_extra_valid_free
         elif sync_type == b'syn_a_w_m_p':
             permission = self.sync_agent_info_free
         else:
@@ -455,7 +456,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         if sync_type == b'syn_i_w_m':
             self.sync_integrity_free, sync_function = False, ReceiveIntegrityTask
         elif sync_type == b'syn_e_w_m':
-            self.sync_extra_valid_free, sync_function = False, ReceiveExtraValidTask
+            sync_function = ReceiveExtraValidTask
         elif sync_type == b'syn_a_w_m':
             self.sync_agent_info_free, sync_function = False, ReceiveAgentInfoTask
         else:
@@ -463,15 +464,13 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
 
         return super().setup_receive_file(sync_function, data)
 
-    def process_sync_error_from_worker(self, command: bytes, error_msg: bytes) -> Tuple[bytes, bytes]:
+    def process_sync_error_from_worker(self, error_msg: bytes) -> Tuple[bytes, bytes]:
         """Manage error during synchronization process reported by a worker.
 
         Mark the process as free so a new one can start.
 
         Parameters
         ----------
-        command : bytes
-            Specify synchronization process where the error happened.
         error_msg : bytes
             Error information.
 
@@ -482,11 +481,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         bytes
             Response message.
         """
-        if command == b'syn_i_w_m_r':
-            sync_type, self.sync_integrity_free = "Integrity", True
-        else:  # command == b'syn_e_w_m_r':
-            sync_type, self.sync_extra_valid_free = "Extra valid", True
-
+        self.sync_integrity_free = True
         return super().error_receiving_file(error_msg.decode())
 
     def end_receiving_integrity_checksums(self, task_and_file_names: str) -> Tuple[bytes, bytes]:
@@ -608,7 +603,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         """
         logger = self.task_loggers['Integrity sync']
         await self.sync_worker_files(task_id, received_file, logger)
-        self.sync_extra_valid_free = True
+        self.sync_integrity_free = True
         self.integrity_sync_status['date_start_master'] = self.integrity_sync_status['tmp_date_start_master']
         self.integrity_sync_status['date_end_master'] = datetime.now()
         logger.info("Finished in {:.3f}s.".format((self.integrity_sync_status['date_end_master'] -
@@ -666,6 +661,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                                                                            files_metadata, self.name)
 
         total_time = (datetime.now() - date_start_master).total_seconds()
+        self.extra_valid_requested = bool(worker_files_ko['extra_valid'])
         self.integrity_check_status.update({'date_start_master': date_start_master.strftime(decimals_date_format),
                                             'date_end_master': datetime.now().strftime(decimals_date_format)})
 
@@ -729,7 +725,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                 os.unlink(compressed_data)
                 logger.debug("Finished sending files to worker.")
                 # Log 'Finished in' message only if there are no extra_valid files to sync.
-                if not worker_files_ko['extra_valid']:
+                if not self.extra_valid_requested:
                     self.integrity_sync_status['date_start_master'] = self.integrity_sync_status[
                         'tmp_date_start_master']
                     self.integrity_sync_status['date_end_master'] = datetime.now()
@@ -737,7 +733,6 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                                                                self.integrity_sync_status['date_start_master'])
                                                               .total_seconds()))
 
-        self.sync_integrity_free = True
         return result
 
     async def process_files_from_worker(self, files_metadata: Dict, decompressed_files_path: str, logger):
@@ -776,9 +771,8 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
 
                 # If the file is merged, create individual files from it.
                 if data['merged']:
-                    for file_path, file_data, file_time in wazuh.core.cluster.cluster.unmerge_info(data['merge_type'],
-                                                                                                   decompressed_files_path,
-                                                                                                   data['merge_name']):
+                    for file_path, file_data, file_time in wazuh.core.cluster.cluster.unmerge_info(
+                            data['merge_type'], decompressed_files_path, data['merge_name']):
                         # Destination path.
                         full_unmerged_name = os.path.join(common.wazuh_path, file_path)
                         # Path where to create the file before moving it to the destination path (with safe_move).
@@ -827,7 +821,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                             n_errors['errors'][data['cluster_item_key']] = 1 \
                                 if n_errors['errors'].get(data['cluster_item_key']) is None \
                                 else n_errors['errors'][data['cluster_item_key']] + 1
-                        await asyncio.sleep(0.0001)
+                        await asyncio.sleep(0.000000001)
 
                 # If the file is not merged, move it directly to the destination path.
                 else:
@@ -858,15 +852,17 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             agents = Agent.get_agents_overview(select=['name'], limit=None)['items']
             agent_ids = set(map(operator.itemgetter('id'), agents))
         except Exception as e:
-            logger.debug2(f"Error getting agent ids: {e}")
-            agent_ids = {}
+            logger.error(f"Error getting agent ids: {e}")
+            await self.send_request(command=b'syn_m_e_err', data=str(e).encode())
+            raise e
 
         # Iterate and update each file specified in 'files_metadata' if conditions are meets.
         try:
             for filename, data in files_metadata.items():
                 await update_file(data=data, name=filename)
         except Exception as e:
-            self.logger.error(f"Error updating worker files: '{e}'.")
+            self.logger.error(f"Error updating worker files (extra valid): '{e}'.")
+            await self.send_request(command=b'syn_m_e_err', data=str(e).encode())
             raise e
 
         # Log errors if any.
@@ -879,6 +875,8 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             for key, value in n_errors['warnings'].items():
                 if key == 'queue/agent-groups/':
                     logger.debug2(f"Received {value} group assignments for non-existent agents. Skipping.")
+
+        await self.send_request(command=b'syn_m_e_ok', data=b'')
 
     def get_logger(self, logger_tag: str = ''):
         """Get a logger object.

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -854,7 +854,6 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             agent_ids = set(map(operator.itemgetter('id'), agents))
         except Exception as e:
             logger.error(f"Error getting agent ids: {e}")
-            await self.send_request(command=b'syn_m_e_err', data=str(e).encode())
             raise e
 
         # Iterate and update each file specified in 'files_metadata' if conditions are meets.
@@ -863,7 +862,6 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                 await update_file(data=data, name=filename)
         except Exception as e:
             self.logger.error(f"Error updating worker files (extra valid): '{e}'.")
-            await self.send_request(command=b'syn_m_e_err', data=str(e).encode())
             raise e
 
         # Log errors if any.
@@ -876,8 +874,6 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             for key, value in n_errors['warnings'].items():
                 if key == 'queue/agent-groups/':
                     logger.debug2(f"Received {value} group assignments for non-existent agents. Skipping.")
-
-        await self.send_request(command=b'syn_m_e_ok', data=b'')
 
     def get_logger(self, logger_tag: str = ''):
         """Get a logger object.

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -94,6 +94,7 @@ class ReceiveExtraValidTask(c_common.ReceiveFileTask):
             Synchronization process result.
         """
         super().done_callback(future)
+        self.wazuh_common.extra_valid_requested = False
         self.wazuh_common.sync_integrity_free = True
 
 
@@ -604,11 +605,12 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         """
         logger = self.task_loggers['Integrity sync']
         await self.sync_worker_files(task_id, received_file, logger)
-        self.sync_integrity_free = True
         self.integrity_sync_status['date_start_master'] = self.integrity_sync_status['tmp_date_start_master']
         self.integrity_sync_status['date_end_master'] = datetime.now()
         logger.info("Finished in {:.3f}s.".format((self.integrity_sync_status['date_end_master'] -
                                                    self.integrity_sync_status['date_start_master']).total_seconds()))
+        self.extra_valid_requested = False
+        self.sync_integrity_free = True
 
     async def sync_integrity(self, task_id: str, received_file: asyncio.Event):
         """Perform the integrity synchronization process by comparing local and received files.

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -853,8 +853,8 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             agents = Agent.get_agents_overview(select=['name'], limit=None)['items']
             agent_ids = set(map(operator.itemgetter('id'), agents))
         except Exception as e:
-            logger.error(f"Error getting agent ids: {e}")
-            raise e
+            logger.debug2(f"Error getting agent ids: {e}")
+            agent_ids = {}
 
         # Iterate and update each file specified in 'files_metadata' if conditions are meets.
         try:

--- a/framework/wazuh/core/cluster/tests/test_utils.py
+++ b/framework/wazuh/core/cluster/tests/test_utils.py
@@ -155,7 +155,7 @@ def test_get_cluster_items():
                                               'max_allowed_time_without_keepalive': 120},
                                    'communication': {'timeout_cluster_request': 20, 'timeout_dapi_request': 200,
                                                      'timeout_receiving_file': 120}},
-                     'sync_options': {'get_agentinfo_newer_than': 1800}, 'distributed_api': {'enabled': True}}
+                     'distributed_api': {'enabled': True}}
 
 
 def test_ClusterFilter():

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -180,8 +180,8 @@ async def test_SyncWorker(create_log, caplog):
 
     worker_handler = get_worker_handler()
 
-    sync_worker = worker.SyncWorker(cmd=b'testing', files_to_sync={'files': ['testing']}, files_metadata={'testing': '0'},
-                                    logger=logger, worker=worker_handler)
+    sync_worker = worker.SyncFiles(cmd=b'testing', files_to_sync={'files': ['testing']}, files_metadata={'testing': '0'},
+                                   logger=logger, worker=worker_handler)
 
     send_request_mock = KeyError(1)
     await check_message(mock=send_request_mock, expected_message=f"Error asking for permission: 1")

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -561,7 +561,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
             Response message.
         """
         integrity_logger = self.task_loggers['Integrity sync']
-        integrity_logger.info(f"Finished in {(time.time() - self.integrity_check_status['date_start']):.3f}s.")
+        integrity_logger.info(f"Finished in {(time.time() - self.integrity_sync_status['date_start']):.3f}s.")
         return b'ok', b'Thanks'
 
     def sync_extravalid_err_from_master(self, response) -> Tuple[bytes, bytes]:

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -128,8 +128,9 @@ class SyncFiles(SyncTask):
             await self.worker.send_request(command=self.cmd + b'_r', data=b'None ' + exc_info)
             return
 
-        self.logger.debug("Compressing files and 'files_metadata.json'." if files_to_sync else
-                          "Compressing 'files_metadata.json'.")
+        self.logger.debug(
+            f"Compressing {'files and ' if files_to_sync else ''}'files_metadata.json' of {len(files_metadata)} files."
+        )
         compressed_data_path = wazuh.core.cluster.cluster.compress_files(name=self.worker.name, list_path=files_to_sync,
                                                                          cluster_control_json=files_metadata)
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes #10123 |

## Description

This PR changes the way Integrity check and Integrity sync behaves (cluster). Until now, this was the Integrity process:
1. Worker asks for permission to start Integrity (check).
2. If the master grants it, the worker sends a JSON with the MD5 of each file. The **master forbids new synchronizations** from now on. 
3. The master compares the MD5 of its files with that of the worker and decides which are missing, shared, extra and extra-valid.
4. The master sends that list along with the files the worker needs.
5. **The master is free again to start new synchronizations.**
6. The worker processes the received files. 
7. If there are extra-valid files, the worker creates a new task to send them to the master.

This PR includes a change in step 5. In case there are extra-valid files, the master will not allow new synchronizations until it receives and processes those files from the worker. 

In addition, with the aim of solving the race condition when calculating the duration of tasks that was reported in https://github.com/wazuh/wazuh/issues/10038, the Integrity and Agent info tasks in the worker have been refactored, so that now they ask for permission and if they have it, it is calculated the MD5 of the files (not before, as it happened until now). This new behavior can be seen in the logs:
```
2021/09/22 11:58:59 INFO: [Worker worker1] [Integrity check] Starting.
2021/09/22 11:59:01 INFO: [Worker worker1] [Integrity check] Finished in 2.776s. Sync required.
2021/09/22 11:59:01 INFO: [Worker worker1] [Agent-info sync] Starting.
2021/09/22 11:59:01 INFO: [Worker worker1] [Agent-info sync] Finished in 0.166817s (0 chunks sent).
2021/09/22 11:59:02 INFO: [Worker worker1] [Integrity sync] Starting.
2021/09/22 11:59:02 INFO: [Worker worker1] [Integrity sync] Files to create: 0 | Files to update: 0 | Files to delete: 0 | Files to send: 49999
2021/09/22 11:59:03 INFO: [Worker worker1] [Integrity sync] Finished in 1.219s.
2021/09/22 11:59:10 DEBUG: [Worker worker1] [Integrity check] Master didn't grant permission to start a new synchronization because there is one still in progress.
2021/09/22 11:59:11 INFO: [Worker worker1] [Agent-info sync] Starting.
2021/09/22 11:59:11 INFO: [Worker worker1] [Agent-info sync] Finished in 0.011065s (0 chunks sent).
2021/09/22 11:59:19 INFO: [Worker worker1] [Integrity check] Starting.
2021/09/22 11:59:20 INFO: [Worker worker1] [Integrity check] Finished in 1.533s. Sync not required.
```

These changes have **advantages** and some disadvantages:
- The duration of the tasks shown in the logs is more realistic.
- If the master is busy processing extra-valid files, it doesn't get saturated with new syncs.
- It is more logical that new synchronizations cannot be started until the previous one has completely finished.
- Race conditions are avoided when calculating the duration of Integrity, which could make it difficult to measure the cluster performance.

As a **disadvantage**:
-  New synchronizations of missing, shared and extra files cannot be performed until the master finishes processing all extra-valid. It was possible before.

Regards,
Selu.