### PR TITLE
Bringing scan-build in RTR tool changes back from 5.0 into master

### DIFF
--- a/src/Readme.md
+++ b/src/Readme.md
@@ -15,6 +15,7 @@ There are several modules needed in order to the tool to work correctly.
   - lcov
   - gcov
   - astyle
+  - scan-build-10
 
 ## Compile Wazuh
 In order to run unit tests on a specific wazuh target, the project needs to be built with the `DEBUG` and `TEST` options as shown below:
@@ -26,7 +27,7 @@ make TARGET=server|agent DEBUG=1 TEST=1
 Once the code is compiled and built successfully the following line should be executed:
 
 ```
-usage: python3 build.py [-h] [-r READYTOREVIEW] [-m MAKE] [-t TESTS] [-c COVERAGE] [-v VALGRIND] [--clean CLEAN] [--cppcheck CPPCHECK]
+usage: python3 build.py [-h] [-r READYTOREVIEW] [-m MAKE] [-t TESTS] [-c COVERAGE] [-v VALGRIND] [--clean CLEAN] [--cppcheck CPPCHECK] [--scanbuild SCANBUILD]
 ```
 
 ### Optional arguments:
@@ -45,6 +46,7 @@ usage: python3 build.py [-h] [-r READYTOREVIEW] [-m MAKE] [-t TESTS] [-c COVERAG
 | `--asan`                | Run ASAN on the code. Example: `python3 build.py --asan <data_provider|shared_modules/dbsync|shared_modules/rsync|shared_modules/utils|wazuh_modules/syscollector>` |
 | `--scheck`              | Run AStyle on the code for checking purposes. Example: `python3 build.py --scheck <data_provider|shared_modules/dbsync|shared_modules/rsync|shared_modules/utils|wazuh_modules/syscollector>` |
 | `--sformat`             | Run AStyle on the code formatting the needed files. Example: `python3 build.py --sformat <data_provider|shared_modules/dbsync|shared_modules/rsync|shared_modules/utils|wazuh_modules/syscollector>` |
+| `--scanbuild` SCANBUILD | Run scan-build on the code. Example: `python3 build.py --scanbuild <agent\|server\|winagent>` |
 
 Ready to review checks:
   1. Runs cppcheck on <data_provider|shared_modules/dbsync|shared_modules/rsync|shared_modules/utils|wazuh_modules/syscollector> folder.
@@ -147,4 +149,42 @@ shared_modules/dbsync > [make: PASSED]
 [Cleanfolder: PASSED]
 [TestTool: PASSED]
 <shared_modules/dbsync>[ASAN: PASSED]<shared_modules/dbsync>
+```
+
+Scan-build analysis agent/server:
+  1. Clean previous compiled binaries.
+  2. Remove externals libraries.
+  3. Download externals libraries based on the specified target.
+  4. Run scan-build on the specified target.
+If all the checks passed it returns 0 and prints a "[SCANBUILD: PASSED]", otherwise it stops the execution checking on the first failure, prints the info related to the failure and returns an error code.
+
+Scan-build analysis winagent:
+  1. Clean previous compiled binaries.
+  2. Remove externals libraries.
+  3. Download externals libraries for windows.
+  4. Compile winagent.
+  5. Clean internals.
+  6. Run scan-build for winagent specifying the cc and cxx compiler and the target.
+Steps 4-5 were added to fix an issue found running scan-build on winagent using pre-compiled externals libraries. If all the checks passed it returns 0 and prints a "[SCANBUILD: PASSED]", otherwise it stops the execution of the checking on the first failure, prints the info related to the failure and returns an error code.
+Output Example executing the SCANBUILD analysis with `agent` target:
+```
+#> python3 build.py --scanbuild agent
+<agent>=================== Running Scanbuild   ===================<agent>
+[CleanAll: PASSED]
+[CleanExternals: PASSED]
+[MakeDeps: PASSED]
+[ScanBuild: PASSED]
+<agent>[SCANBUILD: PASSED]<agent>
+```
+Output Example executing the SCANBUILD analysis with `winagent` target:
+```
+#> python3 build.py --scanbuild winagent
+<winagent>=================== Running Scanbuild   ===================<winagent>
+[CleanAll: PASSED]
+[CleanExternals: PASSED]
+[MakeDeps: PASSED]
+[MakeTarget: PASSED]
+[CleanInternals: PASSED]
+[ScanBuild: PASSED]
+<winagent>[SCANBUILD: PASSED]<winagent>
 ```

--- a/src/build.py
+++ b/src/build.py
@@ -25,6 +25,18 @@ class CommandLineParser:
         """
         return arg in module_list
 
+    def _targetIsValid(self, arg):
+        """
+        Checks if the argument being selected is a correct one.
+
+        :param arg: Argument being selected in the command line.
+        :return True is 'arg' is a correct one, False otherwise.
+        """
+        validArguments = ['agent',
+                          'server',
+                          'winagent']
+        return arg in validArguments
+
     def processArgs(self):
         """
         Process the command line arguments and executes the corresponding argument's utility.
@@ -41,6 +53,7 @@ class CommandLineParser:
         parser.add_argument("--asan", help="Run ASAN on the code. Example: python3 build.py --asan <data_provider|shared_modules/dbsync|shared_modules/rsync|shared_modules/utils|wazuh_modules/syscollector>")
         parser.add_argument("--scheck", help="Run AStyle on the code for checking purposes. Example: python3 build.py --scheck <data_provider|shared_modules/dbsync|shared_modules/rsync|shared_modules/utils|wazuh_modules/syscollector>")
         parser.add_argument("--sformat", help="Run AStyle on the code formatting the needed files. Example: python3 build.py --sformat <data_provider|shared_modules/dbsync|shared_modules/rsync|shared_modules/utils|wazuh_modules/syscollector>")
+        parser.add_argument("--scanbuild", help="Run scan-build on the code. Example: python3 build.py --scanbuild <agent|server|winagent>")
 
         args = parser.parse_args()
         if self._argIsValid(args.readytoreview):
@@ -73,6 +86,9 @@ class CommandLineParser:
                 action = True
             if self._argIsValid(args.sformat):
                 utils.runAStyleFormat(args.sformat)
+                action = True
+            if self._targetIsValid(args.scanbuild):
+                utils.runScanBuild(args.scanbuild)
                 action = True
             if not action:
                 parser.print_help()

--- a/src/ci/input/rtr_input.json
+++ b/src/ci/input/rtr_input.json
@@ -19,6 +19,21 @@
         {
             "name":"wazuh_modules/syscollector",
             "flags":"-r"
+        },
+        {
+            "name":"server",
+            "flags":"--scanbuild",
+            "compile":false
+        },
+        {
+            "name":"agent",
+            "flags":"--scanbuild",
+            "compile":false
+        },
+        {
+            "name":"winagent",
+            "flags":"--scanbuild",
+            "compile":false
         }
     ]
 }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #9917 |


## Description

This PR aims to bring changes being done as part of the issue [#8045](https://github.com/wazuh/wazuh/issues/8045) into the current branch to get scanbuild executed automatically as part of the RTR CI checks.
**Related PR:** https://github.com/wazuh/wazuh/pull/8289## Configuration options

This will run for TARGET: `agent`, `server `and `winagent`
![image](https://user-images.githubusercontent.com/22640902/133843852-2a5e077e-5e16-4438-9970-456c4320c782.png)


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [X] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors