### PR TITLE
Fix fd leak AR

### DIFF
--- a/src/analysisd/alerts/exec.c
+++ b/src/analysisd/alerts/exec.c
@@ -22,7 +22,7 @@
 
 static const char* get_ip(const Eventinfo *lf);
 
-void OS_Exec(int execq, int *arq, const Eventinfo *lf, const active_response *ar)
+void OS_Exec(int execq, int *arq, int *sock, const Eventinfo *lf, const active_response *ar)
 {
     char * exec_msg = NULL;
     char * msg = NULL;
@@ -85,13 +85,11 @@ void OS_Exec(int execq, int *arq, const Eventinfo *lf, const active_response *ar
 
         if (ar->location & ALL_AGENTS) {
 
-            int sock = -1;
             int *id_array = NULL;
 
-            id_array = wdb_get_agents_by_connection_status(AGENT_CS_ACTIVE, &sock);
+            id_array = wdb_get_agents_by_connection_status(AGENT_CS_ACTIVE, sock);
             if(!id_array) {
                 merror("Unable to get agent's ID array.");
-                wdbc_close(&sock);
                 goto cleanup;
             }
 
@@ -107,11 +105,11 @@ void OS_Exec(int execq, int *arq, const Eventinfo *lf, const active_response *ar
 
                 snprintf(c_agent_id, OS_SIZE_16, "%.3d", id_array[i]);
 
-                agt_labels = labels_find(c_agent_id, &sock);
+                agt_labels = labels_find(c_agent_id, sock);
                 agt_version = labels_get(agt_labels, "_wazuh_version");
 
                 if (!agt_version) {
-                    json_agt_info = wdb_get_agent_info(id_array[i], &sock);
+                    json_agt_info = wdb_get_agent_info(id_array[i], sock);
                     if (!json_agt_info) {
                         merror("Failed to get agent '%d' information from Wazuh DB.", id_array[i]);
                         labels_free(agt_labels);
@@ -159,11 +157,9 @@ void OS_Exec(int execq, int *arq, const Eventinfo *lf, const active_response *ar
             }
 
             os_free(id_array);
-            wdbc_close(&sock);
 
         } else {
 
-            int sock = -1;
             cJSON *json_agt_info = NULL;
             cJSON *json_agt_version = NULL;
             char c_agent_id[OS_SIZE_16];
@@ -185,12 +181,11 @@ void OS_Exec(int execq, int *arq, const Eventinfo *lf, const active_response *ar
 
             snprintf(c_agent_id, OS_SIZE_16, "%.3d", agt_id);
 
-            agt_labels = labels_find(c_agent_id, &sock);
+            agt_labels = labels_find(c_agent_id, sock);
             agt_version = labels_get(agt_labels, "_wazuh_version");
 
             if (!agt_version) {
-                json_agt_info = wdb_get_agent_info(agt_id, &sock);
-                wdbc_close(&sock);
+                json_agt_info = wdb_get_agent_info(agt_id, sock);
                 if (!json_agt_info) {
                     merror("Failed to get agent '%d' information from Wazuh DB.", agt_id);
                     labels_free(agt_labels);

--- a/src/analysisd/alerts/exec.h
+++ b/src/analysisd/alerts/exec.h
@@ -14,7 +14,7 @@
 #include "eventinfo.h"
 #include "active-response.h"
 
-void OS_Exec(int execq, int *arq, const Eventinfo *lf, const active_response *ar);
+void OS_Exec(int execq, int *arq, int *sock, const Eventinfo *lf, const active_response *ar);
 void getActiveResponseInString(const Eventinfo *lf,
                                 const active_response *ar,
                                 const char *ip,

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -2120,7 +2120,7 @@ void * w_process_event_thread(__attribute__((unused)) void * id){
                     }
 
                     if (do_ar && execdq >= 0) {
-                        OS_Exec(execdq, &arq, lf, *rule_ar);
+                        OS_Exec(execdq, &arq, &sock, lf, *rule_ar);
                     }
                     rule_ar++;
                 }

--- a/src/unit_tests/analysisd/test_exec.c
+++ b/src/unit_tests/analysisd/test_exec.c
@@ -111,6 +111,7 @@ void test_server_success_json(void **state)
 
     int execq = 10;
     int arq = 11;
+    int sock = -1;
 
     data->ar->location = AS_ONLY;
 
@@ -133,7 +134,7 @@ void test_server_success_json(void **state)
     expect_value(__wrap_OS_SendUnix, size, 0);
     will_return(__wrap_OS_SendUnix, 1);
 
-    OS_Exec(execq, &arq, data->lf, data->ar);
+    OS_Exec(execq, &arq, &sock, data->lf, data->ar);
 }
 
 void test_all_agents_success_json_string(void **state)
@@ -142,6 +143,7 @@ void test_all_agents_success_json_string(void **state)
 
     int execq = 10;
     int arq = 11;
+    int sock = -1;
 
     char *version_1 = "Wazuh v4.2.0";
     char *version_2 = "Wazuh v4.0.0";
@@ -211,7 +213,7 @@ void test_all_agents_success_json_string(void **state)
     expect_value(__wrap_OS_SendUnix, size, 0);
     will_return(__wrap_OS_SendUnix, 1);
 
-    OS_Exec(execq, &arq, data->lf, data->ar);
+    OS_Exec(execq, &arq, &sock, data->lf, data->ar);
 }
 
 void test_all_agents_success_json_string_wdb(void **state)
@@ -220,6 +222,7 @@ void test_all_agents_success_json_string_wdb(void **state)
 
     int execq = 10;
     int arq = 11;
+    int sock = -1;
 
     char *version_1 = "Wazuh v4.2.0";
     char *version_2 = "Wazuh v4.0.0";
@@ -299,7 +302,7 @@ void test_all_agents_success_json_string_wdb(void **state)
     expect_value(__wrap_OS_SendUnix, size, 0);
     will_return(__wrap_OS_SendUnix, 1);
 
-    OS_Exec(execq, &arq, data->lf, data->ar);
+    OS_Exec(execq, &arq, &sock, data->lf, data->ar);
 }
 
 void test_all_agents_success_fail_agt_info1(void **state)
@@ -308,6 +311,7 @@ void test_all_agents_success_fail_agt_info1(void **state)
 
     int execq = 10;
     int arq = 11;
+    int sock = -1;
 
     data->ar->location = ALL_AGENTS;
 
@@ -354,7 +358,7 @@ void test_all_agents_success_fail_agt_info1(void **state)
 
     expect_string(__wrap__merror, formatted_msg, "Failed to get agent '5' information from Wazuh DB.");
 
-    OS_Exec(execq, &arq, data->lf, data->ar);
+    OS_Exec(execq, &arq, &sock, data->lf, data->ar);
 }
 
 void test_specific_agent_success_json(void **state)
@@ -363,6 +367,7 @@ void test_specific_agent_success_json(void **state)
 
     int execq = 10;
     int arq = 11;
+    int sock = -1;
 
     char *version = "Wazuh v4.2.0";
     data->ar->location = SPECIFIC_AGENT;
@@ -398,7 +403,7 @@ void test_specific_agent_success_json(void **state)
     expect_value(__wrap_OS_SendUnix, size, 0);
     will_return(__wrap_OS_SendUnix, 1);
 
-    OS_Exec(execq, &arq, data->lf, data->ar);
+    OS_Exec(execq, &arq, &sock, data->lf, data->ar);
 }
 
 void test_specific_agent_success_json_wdb(void **state)
@@ -407,6 +412,7 @@ void test_specific_agent_success_json_wdb(void **state)
 
     int execq = 10;
     int arq = 11;
+    int sock = -1;
 
     char *version = "Wazuh v4.2.0";
     data->ar->location = SPECIFIC_AGENT;
@@ -447,7 +453,7 @@ void test_specific_agent_success_json_wdb(void **state)
     expect_value(__wrap_OS_SendUnix, size, 0);
     will_return(__wrap_OS_SendUnix, 1);
 
-    OS_Exec(execq, &arq, data->lf, data->ar);
+    OS_Exec(execq, &arq, &sock, data->lf, data->ar);
 }
 
 void test_specific_agent_success_string(void **state)
@@ -456,6 +462,7 @@ void test_specific_agent_success_string(void **state)
 
     int execq = 10;
     int arq = 11;
+    int sock = -1;
 
     char *version = "Wazuh v4.0.0";
     data->ar->location = SPECIFIC_AGENT;
@@ -482,7 +489,7 @@ void test_specific_agent_success_string(void **state)
     expect_value(__wrap_OS_SendUnix, size, 0);
     will_return(__wrap_OS_SendUnix, 1);
 
-    OS_Exec(execq, &arq, data->lf, data->ar);
+    OS_Exec(execq, &arq, &sock, data->lf, data->ar);
 }
 
 void test_specific_agent_success_string_wdb(void **state)
@@ -491,6 +498,7 @@ void test_specific_agent_success_string_wdb(void **state)
 
     int execq = 10;
     int arq = 11;
+    int sock = -1;
 
     char *version = "Wazuh v4.0.0";
     data->ar->location = SPECIFIC_AGENT;
@@ -522,7 +530,7 @@ void test_specific_agent_success_string_wdb(void **state)
     expect_value(__wrap_OS_SendUnix, size, 0);
     will_return(__wrap_OS_SendUnix, 1);
 
-    OS_Exec(execq, &arq, data->lf, data->ar);
+    OS_Exec(execq, &arq, &sock, data->lf, data->ar);
 }
 
 void test_specific_agent_success_fail_agt_info1(void **state)
@@ -531,6 +539,7 @@ void test_specific_agent_success_fail_agt_info1(void **state)
 
     int execq = 10;
     int arq = 11;
+    int sock = -1;
 
     data->ar->location = SPECIFIC_AGENT;
 
@@ -550,7 +559,7 @@ void test_specific_agent_success_fail_agt_info1(void **state)
 
     expect_string(__wrap__merror, formatted_msg, "Failed to get agent '2' information from Wazuh DB.");
 
-    OS_Exec(execq, &arq, data->lf, data->ar);
+    OS_Exec(execq, &arq, &sock, data->lf, data->ar);
 }
 
 void test_remote_agent_success_json(void **state)
@@ -559,6 +568,7 @@ void test_remote_agent_success_json(void **state)
 
     int execq = 10;
     int arq = 11;
+    int sock = -1;
 
     char *version = "Wazuh v4.2.0";
     data->ar->location = REMOTE_AGENT;
@@ -594,7 +604,7 @@ void test_remote_agent_success_json(void **state)
 
     will_return(__wrap_OS_GetOneContentforElement, node);
 
-    OS_Exec(execq, &arq, data->lf, data->ar);
+    OS_Exec(execq, &arq, &sock, data->lf, data->ar);
 }
 
 void test_remote_agent_success_json_wdb(void **state)
@@ -603,6 +613,7 @@ void test_remote_agent_success_json_wdb(void **state)
 
     int execq = 10;
     int arq = 11;
+    int sock = -1;
 
     char *version = "Wazuh v4.2.0";
     data->ar->location = REMOTE_AGENT;
@@ -643,7 +654,7 @@ void test_remote_agent_success_json_wdb(void **state)
 
     will_return(__wrap_OS_GetOneContentforElement, node);
 
-    OS_Exec(execq, &arq, data->lf, data->ar);
+    OS_Exec(execq, &arq, &sock, data->lf, data->ar);
 }
 
 void test_remote_agent_success_string(void **state)
@@ -652,6 +663,7 @@ void test_remote_agent_success_string(void **state)
 
     int execq = 10;
     int arq = 11;
+    int sock = -1;
 
     char *version = "Wazuh v4.0.0";
     data->ar->location = REMOTE_AGENT;
@@ -678,7 +690,7 @@ void test_remote_agent_success_string(void **state)
     expect_value(__wrap_OS_SendUnix, size, 0);
     will_return(__wrap_OS_SendUnix, 1);
 
-    OS_Exec(execq, &arq, data->lf, data->ar);
+    OS_Exec(execq, &arq, &sock, data->lf, data->ar);
 }
 
 void test_remote_agent_success_string_wdb(void **state)
@@ -687,6 +699,7 @@ void test_remote_agent_success_string_wdb(void **state)
 
     int execq = 10;
     int arq = 11;
+    int sock = -1;
 
     char *version = "Wazuh v4.0.0";
     data->ar->location = REMOTE_AGENT;
@@ -718,7 +731,7 @@ void test_remote_agent_success_string_wdb(void **state)
     expect_value(__wrap_OS_SendUnix, size, 0);
     will_return(__wrap_OS_SendUnix, 1);
 
-    OS_Exec(execq, &arq, data->lf, data->ar);
+    OS_Exec(execq, &arq, &sock, data->lf, data->ar);
 }
 
 void test_remote_agent_success_fail_agt_info1(void **state)
@@ -727,6 +740,7 @@ void test_remote_agent_success_fail_agt_info1(void **state)
 
     int execq = 10;
     int arq = 11;
+    int sock = -1;
 
     data->ar->location = REMOTE_AGENT;
 
@@ -746,7 +760,7 @@ void test_remote_agent_success_fail_agt_info1(void **state)
 
     expect_string(__wrap__merror, formatted_msg, "Failed to get agent '1' information from Wazuh DB.");
 
-    OS_Exec(execq, &arq, data->lf, data->ar);
+    OS_Exec(execq, &arq, &sock, data->lf, data->ar);
 }
 
 void test_getActiveResponseInJSON_extra_args(void **state){


### PR DESCRIPTION

|Related issue|
|---|
|#10192|

## Description

This PR fix the FD leakage when executing an AR, the changes made were:
- OS_Exec() function: move the variable 'sock' as function argument.
- Fix UT.

## Logs/Alerts example
FD after 3 hs:
```
# ls -l /proc/proc_number/fd | wc -l
24
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade


<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Stress test for affected components
