### PR TITLE
Read ipAddress from win.eventdata in Windows Active Responses.

### DIFF
--- a/src/active-response/active_responses.c
+++ b/src/active-response/active_responses.c
@@ -17,6 +17,13 @@
  */
 static char* build_json_keys_message(const char *ar_name, char **keys);
 
+/**
+ * Get srcip from win eventdata
+ * @param data Input
+ * @return cJSON * with the ipAddress or NULL on fail
+ * */
+static cJSON* get_srcip_from_win_eventdata(const cJSON *data);
+
 void write_debug_file(const char *ar_name, const char *msg) {
     char *timestamp = w_get_timestamp(time(NULL));
 
@@ -245,7 +252,7 @@ const char* get_srcip_from_json(const cJSON *input) {
     return NULL;
 }
 
-cJSON* get_srcip_from_win_eventdata(const cJSON *data) {
+static cJSON* get_srcip_from_win_eventdata(const cJSON *data) {
     cJSON *win_json = NULL;
     cJSON *eventdata_json = NULL;
     cJSON *ipAddress_json = NULL;

--- a/src/active-response/active_responses.c
+++ b/src/active-response/active_responses.c
@@ -161,25 +161,29 @@ cJSON* get_json_from_input(const char *input) {
     }
 
     // Detect version
-    if (version_json = cJSON_GetObjectItem(input_json, "version"), !version_json || (version_json->type != cJSON_Number)) {
+    version_json = cJSON_GetObjectItem(input_json, "version");
+    if (!cJSON_IsNumber(version_json)) {
         cJSON_Delete(input_json);
         return NULL;
     }
 
     // Detect origin
-    if (origin_json = cJSON_GetObjectItem(input_json, "origin"), !origin_json || (origin_json->type != cJSON_Object)) {
+    origin_json = cJSON_GetObjectItem(input_json, "origin");
+    if (!cJSON_IsObject(origin_json)) {
         cJSON_Delete(input_json);
         return NULL;
     }
 
     // Detect command
-    if (command_json = cJSON_GetObjectItem(input_json, "command"), !command_json || (command_json->type != cJSON_String)) {
+    command_json = cJSON_GetObjectItem(input_json, "command");
+    if (!cJSON_IsString(command_json)) {
         cJSON_Delete(input_json);
         return NULL;
     }
 
     // Detect parameters
-    if (parameters_json = cJSON_GetObjectItem(input_json, "parameters"), !parameters_json || (parameters_json->type != cJSON_Object)) {
+    parameters_json = cJSON_GetObjectItem(input_json, "parameters");
+    if (!cJSON_IsObject(parameters_json)) {
         cJSON_Delete(input_json);
         return NULL;
     }
@@ -192,7 +196,7 @@ const char* get_command_from_json(const cJSON *input) {
 
     // Detect command
     command_json = cJSON_GetObjectItem(input, "command");
-    if (command_json && (command_json->type == cJSON_String)) {
+    if (cJSON_IsString(command_json)) {
         return command_json->valuestring;
     }
 
@@ -204,12 +208,14 @@ const cJSON* get_alert_from_json(const cJSON *input) {
     cJSON *alert_json = NULL;
 
     // Detect parameters
-    if (parameters_json = cJSON_GetObjectItem(input, "parameters"), !parameters_json || (parameters_json->type != cJSON_Object)) {
+    parameters_json = cJSON_GetObjectItem(input, "parameters");
+    if (!cJSON_IsObject(parameters_json)) {
         return NULL;
     }
 
     // Detect alert
-    if (alert_json = cJSON_GetObjectItem(parameters_json, "alert"), !alert_json || (alert_json->type != cJSON_Object)) {
+    alert_json = cJSON_GetObjectItem(parameters_json, "alert");
+    if (!cJSON_IsObject(alert_json)) {
         return NULL;
     }
 
@@ -223,17 +229,20 @@ const char* get_srcip_from_json(const cJSON *input) {
     cJSON *srcip_json = NULL;
 
     // Detect parameters
-    if (parameters_json = cJSON_GetObjectItem(input, "parameters"), !parameters_json || (parameters_json->type != cJSON_Object)) {
+    parameters_json = cJSON_GetObjectItem(input, "parameters");
+    if (!cJSON_IsObject(parameters_json)) {
         return NULL;
     }
 
     // Detect alert
-    if (alert_json = cJSON_GetObjectItem(parameters_json, "alert"), !alert_json || (alert_json->type != cJSON_Object)) {
+    alert_json = cJSON_GetObjectItem(parameters_json, "alert");
+    if (!cJSON_IsObject(alert_json)) {
         return NULL;
     }
 
     // Detect data
-    if (data_json = cJSON_GetObjectItem(alert_json, "data"), !data_json || (data_json->type != cJSON_Object)) {
+    data_json = cJSON_GetObjectItem(alert_json, "data");
+    if (!cJSON_IsObject(data_json)) {
         return NULL;
     }
 
@@ -258,17 +267,20 @@ static cJSON* get_srcip_from_win_eventdata(const cJSON *data) {
     cJSON *ipAddress_json = NULL;
 
     // Detect win
-    if (win_json = cJSON_GetObjectItem(data, "win"), !win_json || (win_json->type != cJSON_Object)) {
+    win_json = cJSON_GetObjectItem(data, "win");
+    if (!cJSON_IsObject(win_json)) {
         return NULL;
     }
 
     // Detect eventdata
-    if (eventdata_json = cJSON_GetObjectItem(win_json, "eventdata"), !eventdata_json || (eventdata_json->type != cJSON_Object)) {
+    eventdata_json = cJSON_GetObjectItem(win_json, "eventdata");
+    if (!cJSON_IsObject(eventdata_json)) {
         return NULL;
     }
 
     // Detect ipAddress
-    if (ipAddress_json = cJSON_GetObjectItem(eventdata_json, "ipAddress"), !ipAddress_json || (ipAddress_json->type != cJSON_String)) {
+    ipAddress_json = cJSON_GetObjectItem(eventdata_json, "ipAddress");
+    if (!cJSON_IsString(ipAddress_json)) {
         return NULL;
     }
 
@@ -282,23 +294,26 @@ const char* get_username_from_json(const cJSON *input) {
     cJSON *username_json = NULL;
 
     // Detect parameters
-    if (parameters_json = cJSON_GetObjectItem(input, "parameters"), !parameters_json || (parameters_json->type != cJSON_Object)) {
+    parameters_json = cJSON_GetObjectItem(input, "parameters");
+    if (!cJSON_IsObject(parameters_json)) {
         return NULL;
     }
 
     // Detect alert
-    if (alert_json = cJSON_GetObjectItem(parameters_json, "alert"), !alert_json || (alert_json->type != cJSON_Object)) {
+    alert_json = cJSON_GetObjectItem(parameters_json, "alert");
+    if (!cJSON_IsObject(alert_json)) {
         return NULL;
     }
 
     // Detect data
-    if (data_json = cJSON_GetObjectItem(alert_json, "data"), !data_json || (data_json->type != cJSON_Object)) {
+    data_json = cJSON_GetObjectItem(alert_json, "data");
+    if (!cJSON_IsObject(data_json)) {
         return NULL;
     }
 
     // Detect username
     username_json = cJSON_GetObjectItem(data_json, "dstuser");
-    if (username_json && (username_json->type == cJSON_String)) {
+    if (cJSON_IsString(username_json)) {
         return username_json->valuestring;
     }
 
@@ -312,12 +327,14 @@ char* get_extra_args_from_json(const cJSON *input) {
     char *extra_args = NULL;
 
     // Detect parameters
-    if (parameters_json = cJSON_GetObjectItem(input, "parameters"), !parameters_json || (parameters_json->type != cJSON_Object)) {
+    parameters_json = cJSON_GetObjectItem(input, "parameters");
+    if (!cJSON_IsObject(parameters_json)) {
         return NULL;
     }
 
     // Detect extra_args
-    if (extra_args_json = cJSON_GetObjectItem(parameters_json, "extra_args"), !extra_args_json || (extra_args_json->type != cJSON_Array)) {
+    extra_args_json = cJSON_GetObjectItem(parameters_json, "extra_args");
+    if (!cJSON_IsArray(extra_args_json)) {
         return NULL;
     }
 
@@ -349,12 +366,14 @@ char* get_keys_from_json(const cJSON *input) {
     char *keys = NULL;
 
     // Detect parameters
-    if (parameters_json = cJSON_GetObjectItem(input, "parameters"), !parameters_json || (parameters_json->type != cJSON_Object)) {
+    parameters_json = cJSON_GetObjectItem(input, "parameters");
+    if (!cJSON_IsObject(parameters_json)) {
         return NULL;
     }
 
     // Detect keys
-    if (keys_json = cJSON_GetObjectItem(parameters_json, "keys"), !keys_json || (keys_json->type != cJSON_Array)) {
+    keys_json = cJSON_GetObjectItem(parameters_json, "keys");
+    if (!cJSON_IsArray(keys_json)) {
         return NULL;
     }
 

--- a/src/active-response/active_responses.c
+++ b/src/active-response/active_responses.c
@@ -246,15 +246,14 @@ const char* get_srcip_from_json(const cJSON *input) {
         return NULL;
     }
 
-    // Detect srcip
-#ifdef WIN32
+    // Detect srcip from WWn eventdata
     srcip_json = get_srcip_from_win_eventdata(data_json);
-    if (srcip_json && (srcip_json->type == cJSON_String)) {
+    if (cJSON_IsString(srcip_json)) {
         return srcip_json->valuestring;
     }
-#endif
+    // Detect srcip from data
     srcip_json = cJSON_GetObjectItem(data_json, "srcip");
-    if (srcip_json && (srcip_json->type == cJSON_String)) {
+    if (cJSON_IsString(srcip_json)) {
         return srcip_json->valuestring;
     }
 
@@ -341,7 +340,7 @@ char* get_extra_args_from_json(const cJSON *input) {
     memset(args, '\0', COMMANDSIZE_4096);
     for (int i = 0; i < cJSON_GetArraySize(extra_args_json); i++) {
         cJSON *subitem = cJSON_GetArrayItem(extra_args_json, i);
-        if (subitem && (subitem->type == cJSON_String)) {
+        if (cJSON_IsString(subitem)) {
             if (strlen(args) + strlen(subitem->valuestring) + 2 > COMMANDSIZE_4096) {
                 break;
             }
@@ -380,7 +379,7 @@ char* get_keys_from_json(const cJSON *input) {
     memset(args, '\0', COMMANDSIZE_4096);
     for (int i = 0; i < cJSON_GetArraySize(keys_json); i++) {
         cJSON *subitem = cJSON_GetArrayItem(keys_json, i);
-        if (subitem && (subitem->type == cJSON_String)) {
+        if (cJSON_IsString(subitem)) {
             if (strlen(args) + strlen(subitem->valuestring) + 2 > COMMANDSIZE_4096) {
                 break;
             }

--- a/src/active-response/active_responses.c
+++ b/src/active-response/active_responses.c
@@ -231,12 +231,41 @@ const char* get_srcip_from_json(const cJSON *input) {
     }
 
     // Detect srcip
+#ifdef WIN32
+    srcip_json = get_srcip_from_win_eventdata(data_json);
+    if (srcip_json && (srcip_json->type == cJSON_String)) {
+        return srcip_json->valuestring;
+    }
+#endif
     srcip_json = cJSON_GetObjectItem(data_json, "srcip");
     if (srcip_json && (srcip_json->type == cJSON_String)) {
         return srcip_json->valuestring;
     }
 
     return NULL;
+}
+
+cJSON* get_srcip_from_win_eventdata(const cJSON *data) {
+    cJSON *win_json = NULL;
+    cJSON *eventdata_json = NULL;
+    cJSON *ipAddress_json = NULL;
+
+    // Detect win
+    if (win_json = cJSON_GetObjectItem(data, "win"), !win_json || (win_json->type != cJSON_Object)) {
+        return NULL;
+    }
+
+    // Detect eventdata
+    if (eventdata_json = cJSON_GetObjectItem(win_json, "eventdata"), !eventdata_json || (eventdata_json->type != cJSON_Object)) {
+        return NULL;
+    }
+
+    // Detect ipAddress
+    if (ipAddress_json = cJSON_GetObjectItem(eventdata_json, "ipAddress"), !ipAddress_json || (ipAddress_json->type != cJSON_String)) {
+        return NULL;
+    }
+
+    return ipAddress_json;
 }
 
 const char* get_username_from_json(const cJSON *input) {

--- a/src/active-response/active_responses.c
+++ b/src/active-response/active_responses.c
@@ -246,7 +246,7 @@ const char* get_srcip_from_json(const cJSON *input) {
         return NULL;
     }
 
-    // Detect srcip from WWn eventdata
+    // Detect srcip from win.eventdata
     srcip_json = get_srcip_from_win_eventdata(data_json);
     if (cJSON_IsString(srcip_json)) {
         return srcip_json->valuestring;

--- a/src/active-response/active_responses.h
+++ b/src/active-response/active_responses.h
@@ -88,6 +88,13 @@ const cJSON* get_alert_from_json(const cJSON *input);
 const char* get_srcip_from_json(const cJSON *input);
 
 /**
+ * Get srcip from win eventdata
+ * @param data Input
+ * @return cJSON * with the ipAddress or NULL on fail
+ * */
+cJSON* get_srcip_from_win_eventdata(const cJSON *data);
+
+/**
  * Get username from input
  * @param input Input
  * @return char * with the username or NULL on fail

--- a/src/active-response/active_responses.h
+++ b/src/active-response/active_responses.h
@@ -88,13 +88,6 @@ const cJSON* get_alert_from_json(const cJSON *input);
 const char* get_srcip_from_json(const cJSON *input);
 
 /**
- * Get srcip from win eventdata
- * @param data Input
- * @return cJSON * with the ipAddress or NULL on fail
- * */
-cJSON* get_srcip_from_win_eventdata(const cJSON *data);
-
-/**
  * Get username from input
  * @param input Input
  * @return char * with the username or NULL on fail


### PR DESCRIPTION
|Related issue|
|---|
|#10022|

## Description

This PR allows `Windows Active-Responses` to extract the `srcip `from `data.win.eventdata.ipAddress`, and in case it is not present try to extract it from `data.srcip`.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade

