### PR TITLE
Fixes the search of a current installation in the installation script

### DIFF
--- a/src/init/update.sh
+++ b/src/init/update.sh
@@ -35,20 +35,33 @@ getPreinstalledDirByType()
 {
     # Checking for Systemd
     if hash ps 2>&1 > /dev/null && hash grep 2>&1 > /dev/null && [ -n "$(ps -e | egrep ^\ *1\ .*systemd$)" ]; then
+
+        SED_EXTRACT_PREINSTALLEDDIR="s/^ExecStart=\/usr\/bin\/env \(.*\)\/bin\/wazuh-control start$/\1/p"
+
         if [ "X$pidir_service_name" = "Xwazuh-manager" ] || [ "X$pidir_service_name" = "Xwazuh-local" ]; then #manager, hibrid or local
             type="manager"
         else
             type="agent"
         fi
-        # RHEL 8 services should be installed in /usr/lib/systemd/system/
-        if [ "${DIST_NAME}" = "rhel" -a "${DIST_VER}" = "8" ] || [ "${DIST_NAME}" = "centos" -a "${DIST_VER}" = "8" ]; then
-            SERVICE_UNIT_PATH=/usr/lib/systemd/system/wazuh-$type.service
-        else
-            SERVICE_UNIT_PATH=/etc/systemd/system/wazuh-$type.service
+
+        # Get the unit file and extract the Wazuh home path
+        PREINSTALLEDDIR=$(systemctl cat wazuh-${type}.service 2>/dev/null | sed -n "${SED_EXTRACT_PREINSTALLEDDIR}")
+        if [ -n "${PREINSTALLEDDIR}" ] && [ -d "${PREINSTALLEDDIR}" ]; then
+            return 0;
+        fi
+
+        # If fail, find the service file
+        # RHEL 8 / Amazon / openSUSE Tumbleweed the services should be installed in /usr/lib/systemd/system/
+        if [ -f /usr/lib/systemd/system/wazuh-${type}.service ]; then
+            SERVICE_UNIT_PATH=/usr/lib/systemd/system/wazuh-${type}.service
+        fi
+        # Others
+        if [ -f /etc/systemd/system/wazuh-${type}.service ]; then
+            SERVICE_UNIT_PATH=/etc/systemd/system/wazuh-${type}.service
         fi
 
         if [ -f "$SERVICE_UNIT_PATH" ]; then
-            PREINSTALLEDDIR=`sed -n 's/^ExecStart=\/usr\/bin\/env \(.*\)\/bin\/wazuh-control start$/\1/p' $SERVICE_UNIT_PATH`
+            PREINSTALLEDDIR=$(sed -n "${SED_EXTRACT_PREINSTALLEDDIR}" "${SERVICE_UNIT_PATH}")
             if [ -d "$PREINSTALLEDDIR" ]; then
                 return 0;
             else


### PR DESCRIPTION
|Related issue|
|---|
|Closes #10186 |

## Description

For the detection of a current Wazuh installation, the installer script looks up for the Wazuh service files.
When a Linux distribution uses Systemd, the unit file (service file) can be found in one of the following paths:

- `/usr/lib/systemd/system/wazuh-XXX.service`
- `/etc/systemd/system/wazuh-XXX.service`

For 4.2.x, in some distributions like openSUSE Tumbleweed, the unit file path may change depending on whether it was installed by sources or through an RPM, so it is necessary to search in both paths and not just one.
This PR aims to, first, try to get the configuration file by using the command `systemctl cat wazuh-*.service` and, in case of that lookup fails, search the files on the previous mentioned paths.

## Tests

A test is marked green when:
-  The output of the install.sh script (by the standard output or upgrade.log, in the case of WPK), shows that it is an upgrade:
```
 - You already have Wazuh installed. Do you want to update it? (y/n):
 ```
- The PID of the wazuh processes (`ps -aux | grep -i wazuh`) before and after the upgrade changed.
- `$WAZUH_HOME/bin/wazuh-control info` show the new version:
```bash
# /var/ossec/bin/wazuh-control info
WAZUH_VERSION="v4.2.1"
WAZUH_REVISION="40213"
WAZUH_TYPE="server"
```

- [x] [openSUSE Tumbleweed](https://github.com/wazuh/wazuh/pull/10210#issuecomment-924337971)
- [x] [Ubuntu 20](https://github.com/wazuh/wazuh/pull/10210#issuecomment-924753042)
- [x] [Centos 7](https://github.com/wazuh/wazuh/pull/10210#issuecomment-924799505)
- [x] [Centos 8](https://github.com/wazuh/wazuh/pull/10210#issuecomment-925903712)
- [x] [Fedora XX](https://github.com/wazuh/wazuh/pull/10210#issuecomment-925904773)
- [x] [Amazon linux 2](https://github.com/wazuh/wazuh/pull/10210#issuecomment-925904902)