### PR TITLE
Avoid memory leaks after scanning a Windows agent

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2249,7 +2249,7 @@ int wm_vuldet_report_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd_report
         wm_vuldet_send_cve_report(report);
         wm_vuldet_free_nvd_report(f_report_node);
         os_free(f_report_node);
-        os_free(cpe_data);
+        wm_vuldet_free_cpe(cpe_data);
     }
 
     if (OS_INVALID == cve_insert_result) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -403,20 +403,20 @@ void wm_vuldet_free_cpe(cpe *node) {
 
     if(node != NULL){
         // CPE fields
-        free(node->part);
-        free(node->vendor);
-        free(node->product);
-        free(node->version);
-        free(node->update);
-        free(node->edition);
-        free(node->language);
-        free(node->sw_edition);
-        free(node->target_sw);
-        free(node->target_hw);
-        free(node->other);
+        os_free(node->part);
+        os_free(node->vendor);
+        os_free(node->product);
+        os_free(node->version);
+        os_free(node->update);
+        os_free(node->edition);
+        os_free(node->language);
+        os_free(node->sw_edition);
+        os_free(node->target_sw);
+        os_free(node->target_hw);
+        os_free(node->other);
         // Extra fields
-        free(node->msu_name);
-        free(node->raw);
+        os_free(node->msu_name);
+        os_free(node->raw);
         // Multi-fields
         if (node->cm_product) {
             for (i = 0; (node->cm_product + i)->translation; i++) {
@@ -425,11 +425,10 @@ void wm_vuldet_free_cpe(cpe *node) {
                 free((void *) (node->cm_product + i)->condition);
             }
 
-            free(node->cm_product);
+            os_free(node->cm_product);
         }
 
-
-        free(node);
+        os_free(node);
     }
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|#10213|

## Description

This PR avoids the memory leak found after performing a scan in _vulnerability detector_ with a Windows agent.

To fix this, the memory of the entire `cpe_data` structure has been freed.

## Valgrind report

```
==37688== LEAK SUMMARY:
==37688==    definitely lost: 0 bytes in 0 blocks
==37688==    indirectly lost: 0 bytes in 0 blocks
==37688==      possibly lost: 2,021,864 bytes in 476 blocks
==37688==    still reachable: 566,796 bytes in 631 blocks
==37688==                       of which reachable via heuristic:
==37688==                         length64           : 263,040 bytes in 534 blocks
==37688==         suppressed: 0 bytes in 0 blocks
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Valgrind (memcheck and descriptor leaks check)
