### PR TITLE
Add httpRequest.headers formatting for AWS WAF

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2010,6 +2010,14 @@ class CiscoUmbrella(AWSCustomBucket):
 
 
 class AWSWAFBucket(AWSCustomBucket):
+    standard_http_headers = ['a-im', 'accept', 'accept-charset', 'accept-encoding', 'accept-language',
+                             'access-control-request-method', 'access-control-request-headers', 'authorization',
+                             'cache-control', 'connection', 'content-encoding', 'content-length', 'content-type',
+                             'cookie', 'date', 'expect', 'forwarded', 'from', 'host', 'http2-settings', 'if-match',
+                             'if-modified-since', 'if-none-match', 'if-range', 'if-unmodified-since', 'max-forwards',
+                             'origin', 'pragma', 'prefer', 'proxy-authorization', 'range', 'referer', 'te', 'trailer',
+                             'transfer-encoding', 'user-agent', 'upgrade', 'via', 'warning', 'x-requested-with',
+                             'x-forwarded-for', 'x-forwarded-host', 'x-forwarded-proto']
 
     def __init__(self, **kwargs):
         db_table_name = 'waf'
@@ -2030,6 +2038,15 @@ class AWSWAFBucket(AWSCustomBucket):
                 try:
                     for event in json_event_generator(line.rstrip()):
                         event['source'] = 'waf'
+                        try:
+                            headers = {}
+                            for element in event['httpRequest']['headers']:
+                                name = element["name"]
+                                if name.lower() in self.standard_http_headers:
+                                    headers[name] = element["value"]
+                            event['httpRequest']['headers'] = headers
+                        except (KeyError, TypeError):
+                            pass
                         content.append(event)
                 except json.JSONDecodeError:
                     print("ERROR: Events from {} file could not be loaded.".format(log_key.split('/')[-1]))


### PR DESCRIPTION
This PR adds the functionality to properly change the format of the `httpRequest.headers` field of WAF events from a list of dictionaries to a dictionary containing the desired keys.

## Design

The idea is to parse WAF events to replace this:
```
    "httpRequest": {
        "headers": [{
            "name": "Host",
            "value": "localhost:1989"
        }, {
            "name": "User-Agent",
            "value": "curl/7.61.1"
        }, {
            "name": "Accept",
            "value": "*/*"
        }]
```
To this, discarding any unwanted pair of `name-value` present:
```
        "httpRequest": {
            "headers": {
                "Host": "localhost:1989",
                "User-Agent": "curl/7.61.1",
                "Accept": "*/*"
            },
```

The list of valid field names is specified in the `standard_http_headers` parameter for `AWSWAFBucket`

## Manual testing

This development was manually tested by adding a new large WAF log file to our `wazuh-aws-wodle-waf` in the Wazuh-dev environment. The existing WAF log files were used too. The test can be replicated by running the following command:

```
/var/ossec/wodles/aws/aws-s3 --bucket wazuh-aws-wodle-waf --aws_profile dev --only_logs_after 2019-OCT-22 --regions us-east-1 --type waf --skip_on_error -d 2
```

Here is the output of this command during our tests:
```
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Marker: 2019/10/22
DEBUG: ++ Found new log: 2019/10/22/10/aws-waf-logs-delivery-stream-1-2019-10-22-10-32-48-792c6d1f-bfed-4b00-9f5e-88ce44718193
DEBUG: ++ Found new log: 2019/10/23/10/aws-waf-logs-delivery-stream-1-2019-10-23-10-32-48-792c6d1f-bfed-4b00-9f5e-88ce44718194
DEBUG: ++ Found new log: 2019/10/23/11/aws-waf-logs-delivery-stream-1-2019-10-23-11-32-48-792c6d1f-bfed-4b00-9f5e-88ce44718194
DEBUG: ++ Found new log: 2021/09/17/11/aws-waf-logs-delivery-stream-1-2019-10-23-11-32-48-792c6d1f-bfed-4b00-9f5e-88ce44718194
DEBUG: ++ Found new log: 2021/09/17/11/aws-waf-logs-elb-co-2-2021-08-01-14-00-01-b66eb75e-6ddd-4419-96ac-c8d2716e5434
DEBUG: ++ Found new log: test_empty/
DEBUG: ++ Found new log: test_prefix/
DEBUG: ++ Found new log: test_prefix/2019/10/22/10/aws-waf-logs-delivery-stream-1-2019-10-22-10-32-48-792c6d1f-bfed-4b00-9f5e-88ce44718193
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
```

Finally, here is some example of events sent to `analysisd` by the AWS WAF implementation, obtained from the `/var/ossec/logs/archives/archives.log` file:

```
{
    "integration": "aws",
    "aws": {
        "log_info": {
            "aws_account_alias": "",
            "log_file": "2021/09/17/11/aws-waf-logs-delivery-stream-1-2019-10-23-11-32-48-792c6d1f-bfed-4b00-9f5e-88ce44718194",
            "s3bucket": "wazuh-aws-wodle-waf"
        },
        "timestamp": 1576280412771,
        "formatVersion": 1,
        "webaclId": "redacted",
        "terminatingRuleId": "STMTest_SQLi_XSS",
        "terminatingRuleType": "REGULAR",
        "action": "BLOCK",
        "terminatingRuleMatchDetails": {
            "conditionType": "SQL_INJECTION",
            "location": "HEADER",
            "matchedData": ["10", "AND", "1"]
        },
        "httpSourceName": "-",
        "httpSourceId": "-",
        "ruleGroupList": [],
        "rateBasedRuleList": [],
        "nonTerminatingMatchingRules": [],
        "httpRequest": {
            "clientIp": "1.1.1.1",
            "country": "AU",
            "headers": {
                "Host": "localhost:1989",
                "User-Agent": "curl/7.61.1",
                "Accept": "*/*"
            },
            "uri": "/foo",
            "args": "",
            "httpVersion": "HTTP/1.1",
            "httpMethod": "GET",
            "requestId": "rid"
        },
        "labels": {
            "name": "value"
        },
        "source": "waf"
    }
}
```

```
{
    "integration": "aws",
    "aws": {
        "log_info": {
            "aws_account_alias": "",
            "log_file": "2021/09/17/11/aws-waf-logs-elb-co-2-2021-08-01-14-00-01-b66eb75e-6ddd-4419-96ac-c8d2716e5434",
            "s3bucket": "wazuh-aws-wodle-waf"
        },
        "timestamp": 1627826501203,
        "formatVersion": 1,
        "webaclId": "redacted",
        "terminatingRuleId": "Default_Action",
        "terminatingRuleType": "REGULAR",
        "action": "ALLOW",
        "terminatingRuleMatchDetails": [],
        "httpSourceName": "ALB",
        "httpSourceId": "redacted",
        "ruleGroupList": [{
            "ruleGroupId": "redacted",
            "terminatingRule": null,
            "nonTerminatingMatchingRules": [],
            "excludedRules": null
        }, {
            "ruleGroupId": "AWS#AWSManagedRulesAdminProtectionRuleSet",
            "terminatingRule": null,
            "nonTerminatingMatchingRules": [],
            "excludedRules": null
        }, {
            "ruleGroupId": "AWS#AWSManagedRulesAmazonIpReputationList",
            "terminatingRule": null,
            "nonTerminatingMatchingRules": [],
            "excludedRules": null
        }, {
            "ruleGroupId": "AWS#AWSManagedRulesAnonymousIpList",
            "terminatingRule": {
                "ruleId": "HostingProviderIPList",
                "action": "BLOCK",
                "ruleMatchDetails": null
            },
            "nonTerminatingMatchingRules": [],
            "excludedRules": null
        }, {
            "ruleGroupId": "AWS#AWSManagedRulesCommonRuleSet",
            "terminatingRule": null,
            "nonTerminatingMatchingRules": [],
            "excludedRules": null
        }, {
            "ruleGroupId": "AWS#AWSManagedRulesKnownBadInputsRuleSet",
            "terminatingRule": null,
            "nonTerminatingMatchingRules": [],
            "excludedRules": null
        }, {
            "ruleGroupId": "AWS#AWSManagedRulesSQLiRuleSet",
            "terminatingRule": null,
            "nonTerminatingMatchingRules": [],
            "excludedRules": null
        }, {
            "ruleGroupId": "AWS#AWSManagedRulesLinuxRuleSet",
            "terminatingRule": null,
            "nonTerminatingMatchingRules": [],
            "excludedRules": null
        }],
        "rateBasedRuleList": [{
            "rateBasedRuleId": "redacted",
            "rateBasedRuleName": "RL_ALL",
            "limitKey": "FORWARDEDIP",
            "maxRateAllowed": 10000,
            "limitValue": "redacted"
        }, {
            "rateBasedRuleId": "redacted",
            "rateBasedRuleName": "HttpFlood",
            "limitKey": "IP",
            "maxRateAllowed": 15000,
            "limitValue": "redacted"
        }],
        "nonTerminatingMatchingRules": {
            "ruleId": "AWS-AWSManagedRulesAnonymousIpList",
            "action": "COUNT",
            "ruleMatchDetails": []
        },
        "httpRequest": {
            "clientIp": "redacted",
            "country": "US",
            "headers": {
                "Host": "redacted",
                "Connection": "Keep-Alive",
                "User-Agent": "redacted",
                "Via": "redacted",
                "X-Forwarded-For": "redacted",
                "Authorization": "redacted",
                "Accept-Language": "en-ES;q=1.0, es-MX;q=0.9",
                "Accept": "*/*",
                "Cookie": "JSESSIONID=redacted",
                "content-type": "application/json",
                "accept-encoding": "gzip;q=1.0, compress;q=0.5"
            },
            "uri": "redacted/",
            "args": "redacted",
            "httpVersion": "HTTP/1.1",
            "httpMethod": "GET",
            "requestId": "1-6106a945-14e5f7e82bd00a5c2550e32c"
        },
        "labels": {
            "name": "awswaf:managed:aws:anonymous-ip-list:HostingProviderIPList"
        },
        "source": "waf"
    }
}
```


## Performance

**Note:** We are referring to the performance of the `load_information_from_file`. The biggest bottleneck to the performance of this module is the function in charge of downloading the files themselves from AWS, which remains the same.

The inclusion of this change not only does not decrease performance when running large WAF files, but it has been improved by approximately 33%. This is because by casting the headers field from a list of dictionaries to a more manageable dictionary, the `json.loads` function requires less time to perform its task, which in turn translates into greater efficiency, compensating the performance penalty introduced by the function required to carry out the conversion of the `headers` field.

Here are some results from our tests using a large log file, comparing the performance from the current WAF implementation to the new one proposed in this PR. This results only reflects the time the `load_information_from_file` from `AWSWAFBucket` requires to process the entire log file. For this test, the log file contained `4833` events. 
`

|                  | Elapsed time (ms) |
|------------------|-------------------|
| Previous version | 875               |
| **New version**  | **657**           |
