### PR TITLE
Make API SSL ciphers configurable and rename SSL protocol option

### DIFF
--- a/api/api/configuration.py
+++ b/api/api/configuration.py
@@ -38,7 +38,8 @@ default_api_configuration = {
         "cert": "api/configuration/ssl/server.crt",
         "use_ca": False,
         "ca": "api/configuration/ssl/ca.crt",
-        "ssl_cipher": "TLSv1.2"
+        "ssl_protocol": "TLSv1.2",
+        "ssl_ciphers": ""
     },
     "logs": {
         "level": "info",

--- a/api/api/configuration/api.yaml
+++ b/api/api/configuration/api.yaml
@@ -11,7 +11,8 @@
 #  cert: "api/configuration/ssl/server.crt"
 #  use_ca: False
 #  ca: "api/configuration/ssl/ca.crt"
-#  ssl_cipher: "TLSv1.2"
+#  ssl_protocol: "TLSv1.2"
+#  ssl_ciphers: ""
 
 # Logging configuration
 # Values for API log level: disabled, info, warning, error, debug, debug2 (each level includes the previous level).

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -10358,7 +10358,8 @@ paths:
                           cert: "/var/ossec/api/configuration/ssl/server.crt"
                           use_ca: false
                           ca: "/var/ossec/api/configuration/ssl/ca.crt"
-                          ssl_cipher: "TLSv1.2"
+                          ssl_protocol: "TLSv1.2"
+                          ssl_ciphers: ""
                         access:
                           max_login_attempts: 50
                           block_time: 300

--- a/api/api/test/test_configuration.py
+++ b/api/api/test/test_configuration.py
@@ -22,7 +22,8 @@ custom_api_configuration = {
         "cert": "api/configuration/ssl/server.crt",
         "use_ca": False,
         "ca": "api/configuration/ssl/ca.crt",
-        "ssl_cipher": "TLSv1.2"
+        "ssl_protocol": "TLSv1.2",
+        "ssl_ciphers": ""
     },
     "logs": {
         "level": "info",

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -72,7 +72,9 @@ api_config_schema = {
                 "cert": {"type": "string"},
                 "use_ca": {"type": "boolean"},
                 "ca": {"type": "string"},
-                "ssl_cipher": {"type": "string"},
+                "ssl_protocol": {"type": "string", "enum": ["tls", "tlsv1", "tlsv1.1", "tlsv1.2", "TLS",
+                                                            "TLSv1", "TLSv1.1", "TLSv1.2"]},
+                "ssl_ciphers": {"type": "string"}
             },
         },
         "logs": {

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -75,26 +75,31 @@ def start(foreground, root, config_file):
                 logger.info(f"Generated certificate file in WAZUH_PATH/{to_relative_path(api_conf['https']['cert'])}")
 
             # Load SSL context
-            allowed_ssl_ciphers = {
+            allowed_ssl_protocols = {
                 'tls': ssl.PROTOCOL_TLS,
                 'tlsv1': ssl.PROTOCOL_TLSv1,
                 'tlsv1.1': ssl.PROTOCOL_TLSv1_1,
                 'tlsv1.2': ssl.PROTOCOL_TLSv1_2
             }
-            try:
-                ssl_cipher = allowed_ssl_ciphers[api_conf['https']['ssl_cipher'].lower()]
-            except (KeyError, AttributeError):
-                # KeyError: invalid string value
-                # AttributeError: invalid boolean value
-                logger.error(str(APIError(2003, details='SSL cipher is not valid. Allowed values: '
-                                                        'TLS, TLSv1, TLSv1.1, TLSv1.2')))
-                sys.exit(1)
-            ssl_context = ssl.SSLContext(protocol=ssl_cipher)
+
+            ssl_protocol = allowed_ssl_protocols[api_conf['https']['ssl_protocol'].lower()]
+            ssl_context = ssl.SSLContext(protocol=ssl_protocol)
+
             if api_conf['https']['use_ca']:
                 ssl_context.verify_mode = ssl.CERT_REQUIRED
                 ssl_context.load_verify_locations(api_conf['https']['ca'])
-            ssl_context.load_cert_chain(certfile=api_conf['https']['cert'],
-                                        keyfile=api_conf['https']['key'])
+
+            ssl_context.load_cert_chain(certfile=api_conf['https']['cert'], keyfile=api_conf['https']['key'])
+
+            # Load SSL ciphers if any has been specified
+            if api_conf['https']['ssl_ciphers']:
+                ssl_ciphers = api_conf['https']['ssl_ciphers'].upper()
+                try:
+                    ssl_context.set_ciphers(ssl_ciphers)
+                except ssl.SSLError:
+                    logger.error(str(APIError(2003, details='SSL ciphers cannot be selected')))
+                    sys.exit(1)
+
         except ssl.SSLError:
             logger.error(str(APIError(2003, details='Private key does not match with the certificate')))
             sys.exit(1)

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -883,7 +883,8 @@ stages:
                   cert: !anystr
                   use_ca: !anybool
                   ca: !anystr
-                  ssl_cipher: !anystr
+                  ssl_protocol: !anystr
+                  ssl_ciphers: !anystr
                 logs:
                   level: !anystr
                   path: !anystr

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -743,7 +743,8 @@ stages:
                   cert: !anystr
                   use_ca: !anybool
                   ca: !anystr
-                  ssl_cipher: !anystr
+                  ssl_protocol: !anystr
+                  ssl_ciphers: !anystr
                 logs:
                   level: !anystr
                   path: !anystr


### PR DESCRIPTION
|Related issue|
|---|
|#10216|

This PR closes #10216 .

## Description

This PR introduces a new option to configure SSL ciphers allowing to disable weak cipher suites. In addition, the former `ssl_cipher` option has been renamed to `ssl_protocol`.

## Configuration options

The new API configuration for the `https` section will have these new options:

```yaml
https:
  ssl_protocol: "VALUE"
  ssl_ciphers: "VALUE1:VALUE2:VALUE3"
```

## Tests performed

### Manual tests

- Default configuration

```yaml
 https:
  ssl_protocol: "TLSv1.2"
  ssl_ciphers: ""
```

```shellsession
root@wazuh-master:/# nmap -sV --script +ssl-enum-ciphers  localhost -p 55000

PORT      STATE SERVICE  VERSION
55000/tcp open  ssl/http aiohttp 3.7.4 (Python 3.9)
|_http-server-header: Python/3.9 aiohttp/3.7.4
| ssl-enum-ciphers: 
|   TLSv1.2: 
|     ciphers: 
|       TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 (ecdh_x25519) - A
|       TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 (ecdh_x25519) - A
|       TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 (ecdh_x25519) - A
|       TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384 (ecdh_x25519) - A
|       TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 (ecdh_x25519) - A
|       TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (ecdh_x25519) - A
|       TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA (ecdh_x25519) - A
|       TLS_RSA_WITH_AES_256_GCM_SHA384 (rsa 2048) - A
|       TLS_RSA_WITH_AES_128_GCM_SHA256 (rsa 2048) - A
|       TLS_RSA_WITH_AES_256_CBC_SHA256 (rsa 2048) - A
|       TLS_RSA_WITH_AES_128_CBC_SHA256 (rsa 2048) - A
|       TLS_RSA_WITH_AES_256_CBC_SHA (rsa 2048) - A
|       TLS_RSA_WITH_AES_128_CBC_SHA (rsa 2048) - A
|     compressors: 
|       NULL
|     cipher preference: server
|_  least strength: A

```

- Custom ciphers

```yaml
 https:
  ssl_protocol: "TLSv1.2"
  ssl_ciphers: "ECDHE+AESGCM:!ECDSA"
```

```shellsession
root@wazuh-master:/# nmap -sV --script +ssl-enum-ciphers  localhost -p 55000

PORT      STATE SERVICE VERSION
55000/tcp open  unknown
| ssl-enum-ciphers: 
|   TLSv1.2: 
|     ciphers: 
|       TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 (ecdh_x25519) - A
|       TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 (ecdh_x25519) - A
|     compressors: 
|       NULL
|     cipher preference: server
|_  least strength: A
```

- Wrong ciphers

```yaml
 https:
  ssl_protocol: "TLSv1.2"
  ssl_ciphers: "invalid"
```

```shellsession
root@wazuh-master:/# service wazuh-manager restart

Killing wazuh-clusterd...
Killing wazuh-modulesd...
Killing wazuh-monitord...
Killing wazuh-logcollector...
Killing wazuh-remoted...
Killing wazuh-syscheckd...
Killing wazuh-analysisd...
wazuh-maild not running...
Killing wazuh-execd...
Killing wazuh-db...
Killing wazuh-authd...
wazuh-agentlessd not running...
wazuh-integratord not running...
wazuh-dbd not running...
wazuh-csyslogd not running...
Killing wazuh-apid...
Wazuh v4.2.2 Stopped
2021/09/22 08:52:54 wazuh-db[3133] debug_op.c:70 at _log(): DEBUG: Logging module auto-initialized
2021/09/22 08:52:54 wazuh-db[3133] main.c:101 at main(): DEBUG: Wazuh home directory: /var/ossec
2021/09/22 08:52:54 wazuh-remoted[3138] debug_op.c:70 at _log(): DEBUG: Logging module auto-initialized
2021/09/22 08:52:54 wazuh-remoted[3138] main.c:130 at main(): DEBUG: Wazuh home directory: /var/ossec
2021/09/22 08:52:54 wazuh-remoted[3138] main.c:148 at main(): DEBUG: This is not a worker
Starting Wazuh v4.2.2...
wazuh-apid did not start correctly.


root@wazuh-master:/#     
root@wazuh-master:/# tail -n2 /var/ossec/logs/api.log

2021/09/22 08:45:27 INFO: Listening on 0.0.0.0:55000..
2021/09/22 08:52:57 ERROR: 2003 - Error loading SSL/TLS certificates: SSL ciphers cannot be selected.

```

Regards,
Víctor

