### PR TITLE
Reword AWS --service_endpoint parameter description to suit FIPS endpoints too

### DIFF
--- a/src/wazuh_modules/wm_aws.h
+++ b/src/wazuh_modules/wm_aws.h
@@ -40,7 +40,7 @@ typedef struct wm_aws_bucket {
     char *discard_field;                // Name of the event's field to apply the discard_regex on
     char *discard_regex;                // REGEX to determine if an event should be skipped
     char *sts_endpoint;                 // URL for the VPC endpoint to use to obtain the STS token
-    char *service_endpoint;             // URL for the VPC endpoint to use to obtain the logs
+    char *service_endpoint;             // URL for the endpoint to use to obtain the logs
     unsigned int remove_from_bucket:1;  // Remove the logs from the bucket
     struct wm_aws_bucket *next;     // Pointer to next
 } wm_aws_bucket;
@@ -62,7 +62,7 @@ typedef struct wm_aws_service {
     char *discard_regex;                // REGEX to determine if an event should be skipped
     unsigned int remove_log_streams:1;  // Remove the log stream from the log group
     char *sts_endpoint;                 // URL for the VPC endpoint to use to obtain the STS token
-    char *service_endpoint;             // URL for the VPC endpoint to use to obtain the logs
+    char *service_endpoint;             // URL for the endpoint to use to obtain the logs
     struct wm_aws_service *next;     // Pointer to next
 } wm_aws_service;
 

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -22,7 +22,7 @@
 #   12 - Invalid type of bucket
 #   13 - Unexpected error sending message to Wazuh
 #   14 - Empty bucket
-#   15 - Invalid VPC endpoint URL
+#   15 - Invalid endpoint URL
 
 import argparse
 import signal
@@ -3141,7 +3141,7 @@ def get_script_arguments():
     parser.add_argument('-st', '--sts_endpoint', type=str, dest='sts_endpoint', default=None,
                         help='URL for the VPC endpoint to use to obtain the STS token.')
     parser.add_argument('-se', '--service_endpoint', type=str, dest='service_endpoint', default=None,
-                        help='URL for the VPC endpoint to use to obtain the logs.')
+                        help='URL for the endpoint to use to obtain the logs.')
     parser.add_argument('-rd', '--iam_role_duration', type=arg_valid_iam_role_duration, dest='iam_role_duration', default=None,
                         help='The duration, in seconds, of the role session. Value can range from 900s to the max'
                         ' session duration set for the role.')


### PR DESCRIPTION
|Related issue|
|---|
|Closes #9087|

## Description
As shown in the following example execution, after adding support for the use of VPC endpoints for issue #8761, the user can specify any of the [FIPS endpoints](https://aws.amazon.com/compliance/fips/) to fetch the requested data.
```
root@532c1a3055f5:/var/ossec/wodles/aws# python3 ./aws-s3.py -sr cloudwatchlogs -r us-east-1 -se logs-fips.us-east-1.amazonaws.com -g framework-test -d1
DEBUG: +++ Debug mode on - Level: 1
DEBUG: +++ Getting alerts from "us-east-1" region.
DEBUG: only logs: 1632268800000
DEBUG: Getting log streams for "framework-test" log group
DEBUG: Getting data from DB for log stream "test-logstream-1" in log group "framework-test"
DEBUG: Getting CloudWatch logs from log stream "test-logstream-1" in log group "framework-test" using token "None", start_time "1632268800000" and end_time "None"
DEBUG: Saving data for log group "framework-test" and log stream "test-logstream-1".
DEBUG: Purging the BD
DEBUG: Getting log streams for "framework-test" log group
DEBUG: committing changes and closing the DB
```

In this PR we modify the description of the parameter so it's clear that it won't only work with VPC endpoints, but with others (like FIPS endpoints) too.
