### PR TITLE
Add Mellanox Onyx decoder/ruleset

### DIFF
--- a/ruleset/decoders/0580-mellanox_decoders.xml
+++ b/ruleset/decoders/0580-mellanox_decoders.xml
@@ -1,0 +1,19 @@
+<!-- Sample logs for Mellanox Onyx switch systems
+cli[27174]: [cli.NOTICE]: user admin: Executing command: logging format standard 
+cli[27174]: [cli.NOTICE]: user admin: Executing command: wr memory 
+mgmtd[1299]: [mgmtd.NOTICE]: Action ID 990: requested by: user admin (System Administrator) via CLI
+ztpd[2491]: [ztpd.NOTICE]: handling event '/mgmtd/notify/db_save'
+metad[2513]: TID 139897022437184: [metad.NOTICE]: Sending final query response for msg_id '306679984' (no error, has resp)
+ztpd[2491]: [ztpd.NOTICE]: handling db-save event
+mgmtd[1299]: [mgmtd.NOTICE]: zero-touch becomes deactive after db save operation
+chad[2223]: [chad.NOTICE]: chad_handle_sm_dbsave: handling DB save
+chad[2223]: [chad.NOTICE]: chad_handle_sm_dbsave: finished handling DB save , return code : 0
+issd[2584]: TID 140450212899456: [issd.NOTICE]: NPAPI_NOTICE: notice AstValidateReceivedBpdu invalid protocol ID 12970, u2PortNum 258 
+-->
+<decoder name="mlnx-onyx">
+    <prematch>^\w+[\.+]: TID \.+:</prematch>
+</decoder>
+
+<decoder name="mlnx-onyx">
+    <prematch>^\w+[\.+]: [\.+]:</prematch>
+</decoder>

--- a/ruleset/rules/0930-mellanox_rules.xml
+++ b/ruleset/rules/0930-mellanox_rules.xml
@@ -1,0 +1,16 @@
+<!-- Mellanox Onyx rules to log most kind of generated logs and explicitly command execution -->
+
+<group name="mlnx-onyx,">
+
+  <rule id="92500" level="3">
+    <decoded_as>mlnx-onyx</decoded_as>
+    <description>Mellanox Onyx Logs</description>
+  </rule>
+
+  <rule id="92501" level="10">
+    <if_sid>92500</if_sid>
+    <match>Executing command</match>
+    <description>Mellanox Onyx command execution detected</description>
+  </rule>
+  
+</group>


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Enclosed a decoder for Mellanox Onxy logs and 2 rules for detecting logs in general and explicit executing commands.
More rules can follow if this gets accepted

## Configuration options

See PR

## Logs/Alerts example

I added example logs to decoder:
```
cli[27174]: [cli.NOTICE]: user admin: Executing command: logging format standard 
cli[27174]: [cli.NOTICE]: user admin: Executing command: wr memory 
mgmtd[1299]: [mgmtd.NOTICE]: Action ID 990: requested by: user admin (System Administrator) via CLI
ztpd[2491]: [ztpd.NOTICE]: handling event '/mgmtd/notify/db_save'
metad[2513]: TID 139897022437184: [metad.NOTICE]: Sending final query response for msg_id '306679984' (no error, has resp)
ztpd[2491]: [ztpd.NOTICE]: handling db-save event
mgmtd[1299]: [mgmtd.NOTICE]: zero-touch becomes deactive after db save operation
chad[2223]: [chad.NOTICE]: chad_handle_sm_dbsave: handling DB save
chad[2223]: [chad.NOTICE]: chad_handle_sm_dbsave: finished handling DB save , return code : 0
issd[2584]: TID 140450212899456: [issd.NOTICE]: NPAPI_NOTICE: notice AstValidateReceivedBpdu invalid protocol ID 12970, u2PortNum 258 

```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors