### PR TITLE
Fix crash when verifying the syscheck remote configuration.

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -61,71 +61,73 @@ directory_t *fim_create_directory(const char *path,
 
 int initialize_syscheck_configuration(syscheck_config *syscheck) {
     if (syscheck == NULL) {
-        os_calloc(1, sizeof(syscheck_config), syscheck);
+        return OS_INVALID;
     }
 
-    syscheck->rootcheck      = 0;
-    syscheck->disabled       = SK_CONF_UNPARSED;
-    syscheck->database_store = FIM_DB_DISK;
-    syscheck->skip_fs.nfs    = 1;
-    syscheck->skip_fs.dev    = 1;
-    syscheck->skip_fs.sys    = 1;
-    syscheck->skip_fs.proc   = 1;
-    syscheck->scan_on_start  = 1;
-    syscheck->time           = 43200;
-    syscheck->ignore         = NULL;
-    syscheck->ignore_regex   = NULL;
-    syscheck->nodiff         = NULL;
-    syscheck->nodiff_regex   = NULL;
-    syscheck->scan_day       = NULL;
-    syscheck->scan_time      = NULL;
-    syscheck->file_limit_enabled = true;
-    syscheck->file_limit     = 100000;
-    syscheck->directories = OSList_Create();
+    syscheck->rootcheck                       = 0;
+    syscheck->disabled                        = SK_CONF_UNPARSED;
+    syscheck->database_store                  = FIM_DB_DISK;
+    syscheck->skip_fs.nfs                     = 1;
+    syscheck->skip_fs.dev                     = 1;
+    syscheck->skip_fs.sys                     = 1;
+    syscheck->skip_fs.proc                    = 1;
+    syscheck->scan_on_start                   = 1;
+    syscheck->time                            = 43200;
+    syscheck->ignore                          = NULL;
+    syscheck->ignore_regex                    = NULL;
+    syscheck->nodiff                          = NULL;
+    syscheck->nodiff_regex                    = NULL;
+    syscheck->scan_day                        = NULL;
+    syscheck->scan_time                       = NULL;
+    syscheck->file_limit_enabled              = true;
+    syscheck->file_limit                      = 100000;
+    syscheck->directories                     = OSList_Create();
+
     if (syscheck->directories == NULL) {
         return (OS_INVALID);
     }
+
     OSList_SetFreeDataPointer(syscheck->directories, (void (*)(void *))free_directory);
-    syscheck->wildcards = NULL;
-    syscheck->enable_synchronization = 1;
-    syscheck->restart_audit  = 1;
-    syscheck->enable_whodata = 0;
-    syscheck->realtime       = NULL;
-    syscheck->audit_healthcheck = 1;
-    syscheck->process_priority = 10;
+    syscheck->wildcards                       = NULL;
+    syscheck->enable_synchronization          = 1;
+    syscheck->restart_audit                   = 1;
+    syscheck->enable_whodata                  = 0;
+    syscheck->realtime                        = NULL;
+    syscheck->audit_healthcheck               = 1;
+    syscheck->process_priority                = 10;
 #ifdef WIN_WHODATA
-    syscheck->wdata.interval_scan = 0;
-    syscheck->wdata.fd      = NULL;
+    syscheck->wdata.interval_scan             = 0;
+    syscheck->wdata.fd                        = NULL;
 #endif
 #ifdef WIN32
-    syscheck->realtime_change = 0;
-    syscheck->registry       = NULL;
-    syscheck->key_ignore = NULL;
-    syscheck->key_ignore_regex = NULL;
-    syscheck->value_ignore = NULL;
-    syscheck->value_ignore_regex = NULL;
-    syscheck->max_fd_win_rt  = 0;
-    syscheck->registry_nodiff = NULL;
-    syscheck->registry_nodiff_regex = NULL;
+    syscheck->realtime_change                 = 0;
+    syscheck->registry                        = NULL;
+    syscheck->key_ignore                      = NULL;
+    syscheck->key_ignore_regex                = NULL;
+    syscheck->value_ignore                    = NULL;
+    syscheck->value_ignore_regex              = NULL;
+    syscheck->max_fd_win_rt                   = 0;
+    syscheck->registry_nodiff                 = NULL;
+    syscheck->registry_nodiff_regex           = NULL;
     syscheck->enable_registry_synchronization = 1;
 #endif
-    syscheck->prefilter_cmd  = NULL;
-    syscheck->sync_interval  = 300;
-    syscheck->max_sync_interval = 3600;
-    syscheck->sync_response_timeout = 30;
-    syscheck->sync_queue_size = 16384;
-    syscheck->sync_max_eps = 10;
-    syscheck->max_eps        = 100;
-    syscheck->max_files_per_second = 0;
-    syscheck->allow_remote_prefilter_cmd  = false;
-    syscheck->disk_quota_enabled = true;
-    syscheck->disk_quota_limit = 1024 * 1024; // 1 GB
-    syscheck->file_size_enabled = true;
-    syscheck->file_size_limit = 50 * 1024; // 50 MB
-    syscheck->diff_folder_size = 0;
-    syscheck->comp_estimation_perc = 0.9;    // 90%
-    syscheck->disk_quota_full_msg = true;
-    syscheck->audit_key = NULL;
+    syscheck->prefilter_cmd                   = NULL;
+    syscheck->sync_interval                   = 300;
+    syscheck->max_sync_interval               = 3600;
+    syscheck->sync_response_timeout           = 30;
+    syscheck->sync_queue_size                 = 16384;
+    syscheck->sync_max_eps                    = 10;
+    syscheck->max_eps                         = 100;
+    syscheck->max_files_per_second            = 0;
+    syscheck->allow_remote_prefilter_cmd      = false;
+    syscheck->disk_quota_enabled              = true;
+    syscheck->disk_quota_limit                = 1024 * 1024; // 1 GB
+    syscheck->file_size_enabled               = true;
+    syscheck->file_size_limit                 = 50 * 1024;   // 50 MB
+    syscheck->diff_folder_size                = 0;
+    syscheck->comp_estimation_perc            = 0.9;         // 90%
+    syscheck->disk_quota_full_msg             = true;
+    syscheck->audit_key                       = NULL;
 
     return OS_SUCCESS;
 }

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -445,6 +445,16 @@ typedef struct _config {
     bool allow_remote_prefilter_cmd;
 } syscheck_config;
 
+
+/**
+ * @brief Initializes the default configuration for syscheck.
+ *
+ * @param syscheck Configuration structure to initizalize. If NULL, the function will allocate the memory.
+ * @retval OS_SUCCESS if the default configuration was loaded successfully.
+ * @retval OS_INVALID if there is a problem allocating resources.
+ */
+int initialize_syscheck_configuration(syscheck_config *syscheck);
+
 /**
  * @brief Converts the value written in the configuration to a determined data unit in KB
  *

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -449,7 +449,7 @@ typedef struct _config {
 /**
  * @brief Initializes the default configuration for syscheck.
  *
- * @param syscheck Configuration structure to initizalize. If NULL, the function will allocate the memory.
+ * @param syscheck Configuration structure to initizalize. If NULL, the function will return OS_INVALID.
  * @retval OS_SUCCESS if the default configuration was loaded successfully.
  * @retval OS_INVALID if there is a problem allocating resources.
  */

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -26,68 +26,9 @@ int Read_Syscheck_Config(const char *cfgfile)
 
     modules |= CSYSCHECK;
 
-    syscheck.rootcheck      = 0;
-    syscheck.disabled       = SK_CONF_UNPARSED;
-    syscheck.database_store = FIM_DB_DISK;
-    syscheck.skip_fs.nfs    = 1;
-    syscheck.skip_fs.dev    = 1;
-    syscheck.skip_fs.sys    = 1;
-    syscheck.skip_fs.proc   = 1;
-    syscheck.scan_on_start  = 1;
-    syscheck.time           = 43200;
-    syscheck.ignore         = NULL;
-    syscheck.ignore_regex   = NULL;
-    syscheck.nodiff         = NULL;
-    syscheck.nodiff_regex   = NULL;
-    syscheck.scan_day       = NULL;
-    syscheck.scan_time      = NULL;
-    syscheck.file_limit_enabled = true;
-    syscheck.file_limit     = 100000;
-    syscheck.directories = OSList_Create();
-    if (syscheck.directories == NULL) {
-        return (OS_INVALID);
+    if (initialize_syscheck_configuration(&syscheck) == OS_INVALID) {
+        return OS_INVALID;
     }
-    OSList_SetFreeDataPointer(syscheck.directories, (void (*)(void *))free_directory);
-    syscheck.wildcards = NULL;
-    syscheck.enable_synchronization = 1;
-    syscheck.restart_audit  = 1;
-    syscheck.enable_whodata = 0;
-    syscheck.realtime       = NULL;
-    syscheck.audit_healthcheck = 1;
-    syscheck.process_priority = 10;
-#ifdef WIN_WHODATA
-    syscheck.wdata.interval_scan = 0;
-    syscheck.wdata.fd      = NULL;
-#endif
-#ifdef WIN32
-    syscheck.realtime_change = 0;
-    syscheck.registry       = NULL;
-    syscheck.key_ignore = NULL;
-    syscheck.key_ignore_regex = NULL;
-    syscheck.value_ignore = NULL;
-    syscheck.value_ignore_regex = NULL;
-    syscheck.max_fd_win_rt  = 0;
-    syscheck.registry_nodiff = NULL;
-    syscheck.registry_nodiff_regex = NULL;
-    syscheck.enable_registry_synchronization = 1;
-#endif
-    syscheck.prefilter_cmd  = NULL;
-    syscheck.sync_interval  = 300;
-    syscheck.max_sync_interval = 3600;
-    syscheck.sync_response_timeout = 30;
-    syscheck.sync_queue_size = 16384;
-    syscheck.sync_max_eps = 10;
-    syscheck.max_eps        = 100;
-    syscheck.max_files_per_second = 0;
-    syscheck.allow_remote_prefilter_cmd  = false;
-    syscheck.disk_quota_enabled = true;
-    syscheck.disk_quota_limit = 1024 * 1024; // 1 GB
-    syscheck.file_size_enabled = true;
-    syscheck.file_size_limit = 50 * 1024; // 50 MB
-    syscheck.diff_folder_size = 0;
-    syscheck.comp_estimation_perc = 0.9;    // 90%
-    syscheck.disk_quota_full_msg = true;
-    syscheck.audit_key = NULL;
 
     mdebug1(FIM_CONFIGURATION_FILE, cfgfile);
 


### PR DESCRIPTION
|Related issue|
|---|
|#10200|

Hi team, this PR aims to fix the crash described in #10200
## Description
The cause of the problem was that some fields of the `syscheck` structure weren't initialized when checking the remote configuration. To fix it, a new function has been created to fill all the defaults values and initialize the needed fields. 

## Shared configuration used for Windows
```xml
<agent_config>
  <syscheck>
    <directories realtime="yes">D:\Share Folder\4. DEPARTMENTS</directories>
</syscheck>

</agent_config>

```

## Logs/Alerts example
```
f:%WINDIR%\System32\Drivers\etc\HOSTS -> r:antivirus.com|sans.org;
f:%WINDIR%\Sysnative\Drivers\etc\HOSTS -> r:antivirus.com|sans.org;
'
2021/09/22 14:49:29 wazuh-agent[3800] receiver-win.c:128 at receiver_thread(): DEBUG: Received message: '#!-close file '
2021/09/22 14:49:29 wazuh-agent[3800] agent_op.c:215 at os_read_agent_profile(): DEBUG: Calling os_read_agent_profile().
2021/09/22 14:49:29 wazuh-agent[3800] agent_op.c:234 at os_read_agent_profile(): DEBUG: os_read_agent_profile() = [-]
2021/09/22 14:49:29 wazuh-agent[3800] config.c:390 at ReadConfig(): DEBUG: agent_config element does not have any attributes.
2021/09/22 14:49:29 wazuh-agent[3800] agent_op.c:215 at os_read_agent_profile(): DEBUG: Calling os_read_agent_profile().
2021/09/22 14:49:29 wazuh-agent[3800] agent_op.c:234 at os_read_agent_profile(): DEBUG: os_read_agent_profile() = [-]
2021/09/22 14:49:29 wazuh-agent[3800] config.c:390 at ReadConfig(): DEBUG: agent_config element does not have any attributes.
2021/09/22 14:49:29 wazuh-agent[3800] agent_op.c:215 at os_read_agent_profile(): DEBUG: Calling os_read_agent_profile().
2021/09/22 14:49:29 wazuh-agent[3800] agent_op.c:234 at os_read_agent_profile(): DEBUG: os_read_agent_profile() = [-]
2021/09/22 14:49:29 wazuh-agent[3800] config.c:390 at ReadConfig(): DEBUG: agent_config element does not have any attributes.
2021/09/22 14:49:29 wazuh-agent[3800] agent_op.c:215 at os_read_agent_profile(): DEBUG: Calling os_read_agent_profile().
2021/09/22 14:49:29 wazuh-agent[3800] agent_op.c:234 at os_read_agent_profile(): DEBUG: os_read_agent_profile() = [-]
2021/09/22 14:49:29 wazuh-agent[3800] config.c:390 at ReadConfig(): DEBUG: agent_config element does not have any attributes.
2021/09/22 14:49:29 wazuh-agent[3800] agent_op.c:215 at os_read_agent_profile(): DEBUG: Calling os_read_agent_profile().
2021/09/22 14:49:29 wazuh-agent[3800] agent_op.c:234 at os_read_agent_profile(): DEBUG: os_read_agent_profile() = [-]
2021/09/22 14:49:29 wazuh-agent[3800] config.c:390 at ReadConfig(): DEBUG: agent_config element does not have any attributes.
2021/09/22 14:49:29 wazuh-agent[3800] agent_op.c:215 at os_read_agent_profile(): DEBUG: Calling os_read_agent_profile().
2021/09/22 14:49:29 wazuh-agent[3800] agent_op.c:234 at os_read_agent_profile(): DEBUG: os_read_agent_profile() = [-]
2021/09/22 14:49:29 wazuh-agent[3800] config.c:390 at ReadConfig(): DEBUG: agent_config element does not have any attributes.
2021/09/22 14:49:29 wazuh-agent[3800] agent_op.c:215 at os_read_agent_profile(): DEBUG: Calling os_read_agent_profile().
2021/09/22 14:49:29 wazuh-agent[3800] agent_op.c:234 at os_read_agent_profile(): DEBUG: os_read_agent_profile() = [-]
2021/09/22 14:49:29 wazuh-agent[3800] config.c:390 at ReadConfig(): DEBUG: agent_config element does not have any attributes.
2021/09/22 14:49:29 wazuh-agent[3800] receiver-win.c:294 at receiver_thread(): INFO: Agent is restarting due to shared configuration changes.
2021/09/22 14:49:29 wazuh-agent[3800] exec_op.c:131 at wpopenv(): DEBUG: path = 'active-response/bin/restart-wazuh.exe', command = '"active-response/bin/restart-wazuh.exe"'
2021/09/22 14:49:30 wazuh-agent[3800] win_service.c:256 at OssecServiceCtrlHandler(): INFO: Received exit signal.
2021/09/22 14:49:30 wazuh-agent[3800] win_service.c:260 at OssecServiceCtrlHandler(): INFO: Set pending exit signal.
2021/09/22 14:49:30 wazuh-modulesd:syscollector[3800] wm_syscollector.c:191 at wm_sys_stop(): INFO: Stop received for Syscollector.
2021/09/22 14:49:30 wazuh-agent[3800] win_service.c:268 at OssecServiceCtrlHandler(): INFO: Exiting...
2021/09/22 14:49:30 wazuh-agent[3800] win_execd.c:41 at WinExecd_Shutdown(): INFO: (1314): Shutdown received. Deleting responses.
```
<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)

- Memory tests for Windows
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory