### PR TITLE
Data provider callbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,11 +117,11 @@ src/win32/REVISION
 *.gcno
 *.gcda
 src/coverage-report/
-data_provider/coverage_report/
-shared_modules/dbsync/coverage_report/
-shared_modules/rsync/coverage_report/
-shared_modules/utils/coverage_report/
-wazuh_modules/syscollector/coverage_report/
+src/data_provider/coverage_report/
+src/shared_modules/dbsync/coverage_report/
+src/shared_modules/rsync/coverage_report/
+src/shared_modules/utils/coverage_report/
+src/wazuh_modules/syscollector/coverage_report/
 src/ossec.test
 src/tap_*
 etc/preloaded-vars.conf

--- a/src/data_provider/cppcheckSuppress.txt
+++ b/src/data_provider/cppcheckSuppress.txt
@@ -1,3 +1,3 @@
-*:*src/sysInfoLinux.cpp:257
+*:*src/sysInfoLinux.cpp:259
 *:*src/packages/pkgWrapper.h:105
 *:*src/packages/packagesWindowsParserHelper.h:53

--- a/src/data_provider/include/sysInfo.h
+++ b/src/data_provider/include/sysInfo.h
@@ -14,6 +14,7 @@
 #define _SYS_INFO_H
 
 // Define EXPORTED for any platform
+#include "commonDefs.h"
 #ifdef _WIN32
 #ifdef WIN_EXPORT
 #define EXPORTED __declspec(dllexport)
@@ -91,6 +92,25 @@ EXPORTED int sysinfo_ports(cJSON** js_result);
  * @param js_data Information to be freed.
  */
 EXPORTED void sysinfo_free_result(cJSON** js_data);
+
+/**
+ * @brief Obtains the processes information from the current OS being analyzed.
+ *
+ * @param callback Resulting single process data where the specific information will be stored.
+ *
+ * return 0 on success, -1 otherwhise.
+ */
+EXPORTED int sysinfo_processes_cb(callback_data_t cb);
+
+/**
+ * @brief Obtains the packages information from the current OS being analyzed.
+ *
+ * @param callback Resulting single package data where the specific information will be stored.
+ *
+ * return 0 on success, -1 otherwhise.
+ */
+EXPORTED int sysinfo_packages_cb(callback_data_t cb);
+
 
 typedef int(*sysinfo_networks_func)(cJSON** jsresult);
 typedef void(*sysinfo_free_result_func)(cJSON** jsresult);

--- a/src/data_provider/include/sysInfo.h
+++ b/src/data_provider/include/sysInfo.h
@@ -111,6 +111,15 @@ EXPORTED int sysinfo_processes_cb(callback_data_t cb);
  */
 EXPORTED int sysinfo_packages_cb(callback_data_t cb);
 
+/**
+ * @brief Obtains the hotfixes information from the current OS being analyzed.
+ *
+ * @param js_result Resulting json where the specific information will be stored.
+ *
+ * @return 0 on success, -1 otherwise.
+ */
+EXPORTED int sysinfo_hotfixes(cJSON** js_result);
+
 
 typedef int(*sysinfo_networks_func)(cJSON** jsresult);
 typedef void(*sysinfo_free_result_func)(cJSON** jsresult);

--- a/src/data_provider/include/sysInfo.hpp
+++ b/src/data_provider/include/sysInfo.hpp
@@ -42,6 +42,8 @@ public:
     nlohmann::json processes();
     nlohmann::json networks();
     nlohmann::json ports();
+    void packages(std::function<void(nlohmann::json &)>);
+    void processes(std::function<void(nlohmann::json &)>);
 private:
     virtual std::string getSerialNumber() const;
     virtual std::string getCpuName() const;
@@ -53,6 +55,8 @@ private:
     virtual nlohmann::json getProcessesInfo() const;
     virtual nlohmann::json getNetworks() const;
     virtual nlohmann::json getPorts() const;
+    virtual void getPackages(std::function<void(nlohmann::json &)>) const;
+    virtual void getProcessesInfo(std::function<void(nlohmann::json &)>) const;
 };
 
 #endif //_SYS_INFO_HPP

--- a/src/data_provider/include/sysInfo.hpp
+++ b/src/data_provider/include/sysInfo.hpp
@@ -44,6 +44,7 @@ public:
     nlohmann::json ports();
     void packages(std::function<void(nlohmann::json &)>);
     void processes(std::function<void(nlohmann::json &)>);
+    nlohmann::json hotfixes();
 private:
     virtual std::string getSerialNumber() const;
     virtual std::string getCpuName() const;
@@ -55,6 +56,7 @@ private:
     virtual nlohmann::json getProcessesInfo() const;
     virtual nlohmann::json getNetworks() const;
     virtual nlohmann::json getPorts() const;
+    virtual nlohmann::json getHotfixes() const;
     virtual void getPackages(std::function<void(nlohmann::json &)>) const;
     virtual void getProcessesInfo(std::function<void(nlohmann::json &)>) const;
 };

--- a/src/data_provider/include/sysInfoInterface.h
+++ b/src/data_provider/include/sysInfoInterface.h
@@ -27,6 +27,9 @@ class ISysInfo
         virtual nlohmann::json processes() = 0;
         virtual nlohmann::json networks() = 0;
         virtual nlohmann::json ports() = 0;
+        virtual void packages(std::function<void(nlohmann::json&)>) = 0;
+        virtual void processes(std::function<void(nlohmann::json&)>) = 0;
+
 };
 
 #endif //_SYS_INFO_INTERFACE

--- a/src/data_provider/include/sysInfoInterface.h
+++ b/src/data_provider/include/sysInfoInterface.h
@@ -27,6 +27,7 @@ class ISysInfo
         virtual nlohmann::json processes() = 0;
         virtual nlohmann::json networks() = 0;
         virtual nlohmann::json ports() = 0;
+        virtual nlohmann::json hotfixes() = 0;
         virtual void packages(std::function<void(nlohmann::json&)>) = 0;
         virtual void processes(std::function<void(nlohmann::json&)>) = 0;
 

--- a/src/data_provider/src/packages/packageLinuxDataRetriever.h
+++ b/src/data_provider/src/packages/packageLinuxDataRetriever.h
@@ -18,23 +18,23 @@
 
 /**
  * @brief Fills a JSON object with all available pacman-related information
- * @param libPath Path to pacman's database directory
- * @param jsonPackages JSON to be filled
+ * @param libPath  Path to pacman's database directory
+ * @param callback Callback to be called for every single element being found
  */
-void getPacmanInfo(const std::string& libPath, nlohmann::json& jsonPackages);
+void getPacmanInfo(const std::string& libPath, std::function<void(nlohmann::json&)> callback);
 
 /**
  * @brief Fills a JSON object with all available rpm-related information
- * @param jsonPackages JSON to be filled
+ * @param callback Callback to be called for every single element being found
  */
-void getRpmInfo(nlohmann::json& jsonPackages);
+void getRpmInfo(std::function<void(nlohmann::json&)> callback);
 
 /**
  * @brief Fills a JSON object with all available dpkg-related information
- * @param libPath Path to dpkg's database directory
- * @param jsonPackages JSON to be filled
+ * @param libPath  Path to dpkg's database directory
+ * @param callback Callback to be called for every single element being found
  */
-void getDpkgInfo(const std::string& libPath, nlohmann::json& jsonPackages);
+void getDpkgInfo(const std::string& libPath, std::function<void(nlohmann::json&)> callback);
 
 
 // Exception template
@@ -42,7 +42,7 @@ template <LinuxType linuxType>
 class FactoryPackagesCreator final
 {
     public:
-        static void getPackages(nlohmann::json& /* packages*/)
+        static void getPackages(std::function<void(nlohmann::json&)> /*callback*/)
         {
             throw std::runtime_error
             {
@@ -56,21 +56,21 @@ template <>
 class FactoryPackagesCreator<LinuxType::STANDARD> final
 {
     public:
-        static void getPackages(nlohmann::json& packages)
+        static void getPackages(std::function<void(nlohmann::json&)> callback)
         {
             if (Utils::existsDir(DPKG_PATH))
             {
-                getDpkgInfo(DPKG_STATUS_PATH, packages);
+                getDpkgInfo(DPKG_STATUS_PATH, callback);
             }
 
             if (Utils::existsDir(PACMAN_PATH))
             {
-                getPacmanInfo(PACMAN_PATH, packages);
+                getPacmanInfo(PACMAN_PATH, callback);
             }
 
             if (Utils::existsDir(RPM_PATH))
             {
-                getRpmInfo(packages);
+                getRpmInfo(callback);
             }
         }
 };
@@ -80,16 +80,16 @@ template <>
 class FactoryPackagesCreator<LinuxType::LEGACY> final
 {
     public:
-        static void getPackages(nlohmann::json& packages)
+        static void getPackages(std::function<void(nlohmann::json&)> callback)
         {
             if (Utils::existsDir(DPKG_PATH))
             {
-                getDpkgInfo(DPKG_STATUS_PATH, packages);
+                getDpkgInfo(DPKG_STATUS_PATH, callback);
             }
 
             if (Utils::existsDir(RPM_PATH))
             {
-                getRpmInfo(packages);
+                getRpmInfo(callback);
             }
         }
 };

--- a/src/data_provider/src/packages/packageLinuxParser.cpp
+++ b/src/data_provider/src/packages/packageLinuxParser.cpp
@@ -14,22 +14,22 @@
 #include "berkeleyRpmDbHelper.h"
 
 
-void getRpmInfo(nlohmann::json& packages)
+void getRpmInfo(std::function<void(nlohmann::json&)> callback)
 {
     BerkeleyRpmDBReader db {std::make_shared<BerkeleyDbWrapper>(RPM_DATABASE)};
 
     for (std::string row{db.getNext()}; !row.empty() ; row = db.getNext())
     {
-        const auto& package{ PackageLinuxHelper::parseRpm(row) };
+        auto package = PackageLinuxHelper::parseRpm(row);
 
         if (!package.empty())
         {
-            packages.push_back(package);
+            callback(package);
         }
     }
 }
 
-void getDpkgInfo(const std::string& fileName, nlohmann::json& packages)
+void getDpkgInfo(const std::string& fileName, std::function<void(nlohmann::json&)> callback)
 {
     std::fstream file{fileName, std::ios_base::in};
 
@@ -55,11 +55,11 @@ void getDpkgInfo(const std::string& fileName, nlohmann::json& packages)
             }
             while (!line.empty()); //end of package item info
 
-            const auto& packageInfo{ PackageLinuxHelper::parseDpkg(data) };
+            auto packageInfo = PackageLinuxHelper::parseDpkg(data);
 
             if (!packageInfo.empty())
             {
-                packages.push_back(packageInfo);
+                callback(packageInfo);
             }
         }
     }

--- a/src/data_provider/src/packages/packageLinuxParserExtra.cpp
+++ b/src/data_provider/src/packages/packageLinuxParserExtra.cpp
@@ -23,7 +23,7 @@ struct AlmpDeleter final
     }
 };
 
-void getPacmanInfo(const std::string& libPath, nlohmann::json& packages)
+void getPacmanInfo(const std::string& libPath, std::function<void(nlohmann::json&)> callback)
 {
     constexpr auto ROOT_PATH {"/"};
     alpm_errno_t err {ALPM_ERR_OK};
@@ -50,11 +50,11 @@ void getPacmanInfo(const std::string& libPath, nlohmann::json& packages)
 
     for (auto pArchItem{alpm_db_get_pkgcache(pDbLocal)}; pArchItem; pArchItem = alpm_list_next(pArchItem))
     {
-        const auto& packageInfo{ PackageLinuxHelper::parsePacman(pArchItem) };
+        auto packageInfo = PackageLinuxHelper::parsePacman(pArchItem);
 
         if (!packageInfo.empty())
         {
-            packages.push_back(packageInfo);
+            callback(packageInfo);
         }
     }
 }

--- a/src/data_provider/src/sysInfo.cpp
+++ b/src/data_provider/src/sysInfo.cpp
@@ -11,6 +11,18 @@
 #include "sysInfo.hpp"
 #include "sysInfo.h"
 
+struct CJsonDeleter
+{
+    void operator()(char* json)
+    {
+        cJSON_free(json);
+    }
+    void operator()(cJSON* json)
+    {
+        cJSON_Delete(json);
+    }
+};
+
 nlohmann::json SysInfo::hardware()
 {
     nlohmann::json ret;
@@ -45,6 +57,16 @@ nlohmann::json SysInfo::networks()
 nlohmann::json SysInfo::ports()
 {
     return getPorts();
+}
+
+void SysInfo::processes(std::function<void(nlohmann::json&)> callback)
+{
+    getProcessesInfo(callback);
+}
+
+void SysInfo::packages(std::function<void(nlohmann::json&)> callback)
+{
+    getPackages(callback);
 }
 
 #ifdef __cplusplus
@@ -182,6 +204,63 @@ void sysinfo_free_result(cJSON** js_data)
     {
         cJSON_Delete(*js_data);
     }
+}
+int sysinfo_packages_cb(callback_data_t callback_data)
+{
+    auto retVal { -1 };
+
+    try
+    {
+        if (callback_data.callback)
+        {
+            const auto callbackWrapper
+            {
+                [callback_data](nlohmann::json & jsonResult)
+                {
+                    const std::unique_ptr<cJSON, CJsonDeleter> spJson{ cJSON_Parse(jsonResult.dump().c_str()) };
+                    callback_data.callback(GENERIC, spJson.get(), callback_data.user_data);
+                }
+            };
+            SysInfo info;
+            info.packages(callbackWrapper);
+            retVal = 0;
+        }
+    }
+    // LCOV_EXCL_START
+    catch (...)
+    {}
+
+    // LCOV_EXCL_STOP
+    return retVal;
+}
+
+int sysinfo_processes_cb(callback_data_t callback_data)
+{
+    auto retVal { -1 };
+
+    try
+    {
+        if (callback_data.callback)
+        {
+            const auto callbackWrapper
+            {
+                [callback_data](nlohmann::json & jsonResult)
+                {
+                    const std::unique_ptr<cJSON, CJsonDeleter> spJson{ cJSON_Parse(jsonResult.dump().c_str()) };
+                    callback_data.callback(GENERIC, spJson.get(), callback_data.user_data);
+                }
+            };
+            SysInfo info;
+            info.processes(callbackWrapper);
+            retVal = 0;
+        }
+    }
+    // LCOV_EXCL_START
+    catch (...)
+    {}
+
+    // LCOV_EXCL_STOP
+    return retVal;
 }
 
 #ifdef __cplusplus

--- a/src/data_provider/src/sysInfo.cpp
+++ b/src/data_provider/src/sysInfo.cpp
@@ -250,7 +250,9 @@ int sysinfo_processes_cb(callback_data_t callback_data)
                     callback_data.callback(GENERIC, spJson.get(), callback_data.user_data);
                 }
             };
+            // LCOV_EXCL_START
             SysInfo info;
+            // LCOV_EXCL_STOP
             info.processes(callbackWrapper);
             retVal = 0;
         }

--- a/src/data_provider/src/sysInfo.cpp
+++ b/src/data_provider/src/sysInfo.cpp
@@ -69,6 +69,11 @@ void SysInfo::packages(std::function<void(nlohmann::json&)> callback)
     getPackages(callback);
 }
 
+nlohmann::json SysInfo::hotfixes()
+{
+    return getHotfixes();
+}
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -254,6 +259,28 @@ int sysinfo_processes_cb(callback_data_t callback_data)
             SysInfo info;
             // LCOV_EXCL_STOP
             info.processes(callbackWrapper);
+            retVal = 0;
+        }
+    }
+    // LCOV_EXCL_START
+    catch (...)
+    {}
+
+    // LCOV_EXCL_STOP
+    return retVal;
+}
+
+int sysinfo_hotfixes(cJSON** js_result)
+{
+    auto retVal { -1 };
+
+    try
+    {
+        if (js_result)
+        {
+            SysInfo info;
+            const auto& hotfixes       {info.hotfixes()};
+            *js_result = cJSON_Parse(hotfixes.dump().c_str());
             retVal = 0;
         }
     }

--- a/src/data_provider/src/sysInfo.cpp
+++ b/src/data_provider/src/sysInfo.cpp
@@ -96,6 +96,7 @@ int sysinfo_hardware(cJSON** js_result)
     {}
 
     // LCOV_EXCL_STOP
+
     return retVal;
 }
 int sysinfo_packages(cJSON** js_result)
@@ -117,6 +118,7 @@ int sysinfo_packages(cJSON** js_result)
     {}
 
     // LCOV_EXCL_STOP
+
     return retVal;
 }
 int sysinfo_os(cJSON** js_result)
@@ -138,6 +140,7 @@ int sysinfo_os(cJSON** js_result)
     {}
 
     // LCOV_EXCL_STOP
+
     return retVal;
 }
 int sysinfo_processes(cJSON** js_result)
@@ -159,6 +162,7 @@ int sysinfo_processes(cJSON** js_result)
     {}
 
     // LCOV_EXCL_STOP
+
     return retVal;
 }
 int sysinfo_networks(cJSON** js_result)
@@ -180,6 +184,7 @@ int sysinfo_networks(cJSON** js_result)
     {}
 
     // LCOV_EXCL_STOP
+
     return retVal;
 }
 int sysinfo_ports(cJSON** js_result)
@@ -201,6 +206,7 @@ int sysinfo_ports(cJSON** js_result)
     {}
 
     // LCOV_EXCL_STOP
+
     return retVal;
 }
 void sysinfo_free_result(cJSON** js_data)
@@ -226,7 +232,9 @@ int sysinfo_packages_cb(callback_data_t callback_data)
                     callback_data.callback(GENERIC, spJson.get(), callback_data.user_data);
                 }
             };
+            // LCOV_EXCL_START
             SysInfo info;
+            // LCOV_EXCL_STOP
             info.packages(callbackWrapper);
             retVal = 0;
         }
@@ -236,6 +244,7 @@ int sysinfo_packages_cb(callback_data_t callback_data)
     {}
 
     // LCOV_EXCL_STOP
+
     return retVal;
 }
 
@@ -267,6 +276,7 @@ int sysinfo_processes_cb(callback_data_t callback_data)
     {}
 
     // LCOV_EXCL_STOP
+
     return retVal;
 }
 
@@ -289,6 +299,7 @@ int sysinfo_hotfixes(cJSON** js_result)
     {}
 
     // LCOV_EXCL_STOP
+
     return retVal;
 }
 

--- a/src/data_provider/src/sysInfoFreeBSD.cpp
+++ b/src/data_provider/src/sysInfoFreeBSD.cpp
@@ -102,26 +102,10 @@ std::string SysInfo::getSerialNumber() const
 nlohmann::json SysInfo::getPackages() const
 {
     nlohmann::json ret;
-    const auto query{Utils::exec(R"(pkg query -a "%n|%m|%v|%q|%c")")};
-
-    if (!query.empty())
+    getPackages([&ret](nlohmann::json & data)
     {
-        const auto lines{Utils::split(query, '\n')};
-
-        for (const auto& line : lines)
-        {
-            const auto data{Utils::split(line, '|')};
-            nlohmann::json package;
-            package["name"] = data[0];
-            package["vendor"] = data[1];
-            package["version"] = data[2];
-            package["architecture"] = data[3];
-            package["description"] = data[4];
-            package["format"] = "pkg";
-            ret.push_back(package);
-        }
-    }
-
+        ret.push_back(data);
+    });
     return ret;
 }
 
@@ -167,9 +151,27 @@ void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)> /*callback*/
     // Currently not supported for this OS.
 }
 
-void SysInfo::getPackages(std::function<void(nlohmann::json&)> /*callback*/) const
+void SysInfo::getPackages(std::function<void(nlohmann::json&)> callback) const
 {
-    // Currently not supported for this OS.
+    const auto query{Utils::exec(R"(pkg query -a "%n|%m|%v|%q|%c")")};
+
+    if (!query.empty())
+    {
+        const auto lines{Utils::split(query, '\n')};
+
+        for (const auto& line : lines)
+        {
+            const auto data{Utils::split(line, '|')};
+            nlohmann::json package;
+            package["name"] = data[0];
+            package["vendor"] = data[1];
+            package["version"] = data[2];
+            package["architecture"] = data[3];
+            package["description"] = data[4];
+            package["format"] = "pkg";
+            callback(package);
+        }
+    }
 }
 
 nlohmann::json SysInfo::getHotfixes() const

--- a/src/data_provider/src/sysInfoFreeBSD.cpp
+++ b/src/data_provider/src/sysInfoFreeBSD.cpp
@@ -158,7 +158,7 @@ nlohmann::json SysInfo::getOsInfo() const
 
 nlohmann::json SysInfo::getPorts() const
 {
-    // Currently not supported for this OS
+    // Currently not supported for this OS.
     return nlohmann::json {};
 }
 
@@ -170,4 +170,10 @@ void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)> /*callback*/
 void SysInfo::getPackages(std::function<void(nlohmann::json&)> /*callback*/) const
 {
     // Currently not supported for this OS.
+}
+
+nlohmann::json SysInfo::getHotfixes() const
+{
+    // Currently not supported for this OS.
+    return nlohmann::json();
 }

--- a/src/data_provider/src/sysInfoFreeBSD.cpp
+++ b/src/data_provider/src/sysInfoFreeBSD.cpp
@@ -161,3 +161,13 @@ nlohmann::json SysInfo::getPorts() const
     // Currently not supported for this OS
     return nlohmann::json {};
 }
+
+void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)> /*callback*/) const
+{
+    // Currently not supported for this OS.
+}
+
+void SysInfo::getPackages(std::function<void(nlohmann::json&)> /*callback*/) const
+{
+    // Currently not supported for this OS.
+}

--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -390,3 +390,14 @@ nlohmann::json SysInfo::getPorts() const
 
     return ports;
 }
+
+void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)> /*callback*/) const
+{
+    // TO DO
+}
+
+void SysInfo::getPackages(std::function<void(nlohmann::json&)> /*callback*/) const
+{
+    // TO DO
+}
+

--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -318,16 +318,11 @@ nlohmann::json SysInfo::getProcessesInfo() const
 {
     nlohmann::json jsProcessesList{};
 
-    const auto callback
+    getProcessesInfo([&jsProcessesList](nlohmann::json & processInfo)
     {
-        [&jsProcessesList](nlohmann::json & processInfo)
-        {
-            // Append the current json process object to the list of processes
-            jsProcessesList.push_back(processInfo);
-        }
-    };
-
-    getProcessesInfo(callback);
+        // Append the current json process object to the list of processes
+        jsProcessesList.push_back(processInfo);
+    });
 
     return jsProcessesList;
 }

--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -223,11 +223,13 @@ void SysInfo::getMemory(nlohmann::json& info) const
     info["ram_usage"] = 100 - (100 * memFree / ramTotal);
 }
 
-
 nlohmann::json SysInfo::getPackages() const
 {
     nlohmann::json packages;
-    FactoryPackagesCreator<LINUX_TYPE>::getPackages(packages);
+    getPackages([&packages](nlohmann::json & data)
+    {
+        packages.push_back(data);
+    });
     return packages;
 }
 
@@ -407,9 +409,9 @@ void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)> callback) co
     }
 }
 
-void SysInfo::getPackages(std::function<void(nlohmann::json&)> /*callback*/) const
+void SysInfo::getPackages(std::function<void(nlohmann::json&)> callback) const
 {
-    // TO DO
+    FactoryPackagesCreator<LINUX_TYPE>::getPackages(callback);
 }
 
 nlohmann::json SysInfo::getHotfixes() const

--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -411,3 +411,9 @@ void SysInfo::getPackages(std::function<void(nlohmann::json&)> /*callback*/) con
 {
     // TO DO
 }
+
+nlohmann::json SysInfo::getHotfixes() const
+{
+    // Currently not supported for this OS.
+    return nlohmann::json();
+}

--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -375,7 +375,7 @@ nlohmann::json SysInfo::getPorts() const
                 Utils::replaceAll(row, "\t", " ");
                 Utils::replaceAll(row, "  ", " ");
                 std::make_unique<PortImpl>(std::make_shared<LinuxPortWrapper>(portType.first, row))->buildPortData(port);
-                ports["ports"].push_back(port);
+                ports.push_back(port);
             }
 
             fileBody = true;

--- a/src/data_provider/src/sysInfoMac.cpp
+++ b/src/data_provider/src/sysInfoMac.cpp
@@ -343,16 +343,16 @@ nlohmann::json SysInfo::getPorts() const
 
             const auto portFound
             {
-                std::find_if(ports["ports"].begin(), ports["ports"].end(),
+                std::find_if(ports.begin(), ports.end(),
                              [&port](const auto & element)
                 {
                     return 0 == port.dump().compare(element.dump());
                 })
             };
 
-            if (ports["ports"].end() == portFound)
+            if (ports.end() == portFound)
             {
-                ports["ports"].push_back(port);
+                ports.push_back(port);
             }
         }
     }

--- a/src/data_provider/src/sysInfoMac.cpp
+++ b/src/data_provider/src/sysInfoMac.cpp
@@ -385,3 +385,13 @@ nlohmann::json SysInfo::getPorts() const
 
     return ports;
 }
+
+void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)> /*callback*/) const
+{
+    // TODO.
+}
+
+void SysInfo::getPackages(std::function<void(nlohmann::json&)> /*callback*/) const
+{
+    // TODO.
+}

--- a/src/data_provider/src/sysInfoMac.cpp
+++ b/src/data_provider/src/sysInfoMac.cpp
@@ -395,3 +395,9 @@ void SysInfo::getPackages(std::function<void(nlohmann::json&)> /*callback*/) con
 {
     // TODO.
 }
+
+nlohmann::json SysInfo::getHotfixes() const
+{
+    // Currently not supported for this OS.
+    return nlohmann::json();
+}

--- a/src/data_provider/src/sysInfoOpenBSD.cpp
+++ b/src/data_provider/src/sysInfoOpenBSD.cpp
@@ -154,3 +154,9 @@ void SysInfo::getPackages(std::function<void(nlohmann::json&)> /*callback*/) con
 {
     // Currently not supported for this OS.
 }
+
+nlohmann::json SysInfo::getHotfixes() const
+{
+    // Currently not supported for this OS.
+    return nlohmann::json();
+}

--- a/src/data_provider/src/sysInfoOpenBSD.cpp
+++ b/src/data_provider/src/sysInfoOpenBSD.cpp
@@ -144,3 +144,13 @@ nlohmann::json SysInfo::getPorts() const
     // Currently not supported for this OS
     return nlohmann::json {};
 }
+
+void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)> /*callback*/) const
+{
+    // Currently not supported for this OS.
+}
+
+void SysInfo::getPackages(std::function<void(nlohmann::json&)> /*callback*/) const
+{
+    // Currently not supported for this OS.
+}

--- a/src/data_provider/src/sysInfoUnix.cpp
+++ b/src/data_provider/src/sysInfoUnix.cpp
@@ -106,3 +106,9 @@ void SysInfo::getPackages(std::function<void(nlohmann::json&)> /*callback*/) con
 {
     // TODO
 }
+
+nlohmann::json SysInfo::getHotfixes() const
+{
+    // Currently not supported for this OS.
+    return nlohmann::json();
+}

--- a/src/data_provider/src/sysInfoUnix.cpp
+++ b/src/data_provider/src/sysInfoUnix.cpp
@@ -97,3 +97,12 @@ nlohmann::json SysInfo::getPorts() const
 {
     return nlohmann::json();
 }
+void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)> /*callback*/) const
+{
+    // TODO
+}
+
+void SysInfo::getPackages(std::function<void(nlohmann::json&)> /*callback*/) const
+{
+    // TODO
+}

--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -689,7 +689,7 @@ void expandPortData(T data, const std::map<pid_t, std::string>& processDataList,
         {
             nlohmann::json port;
             std::make_unique<PortImpl>(std::make_shared<WindowsPortWrapper>(data->table[i], processDataList))->buildPortData(port);
-            result["ports"].push_back(port);
+            result.push_back(port);
         }
     }
 }

--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -589,8 +589,6 @@ nlohmann::json SysInfo::getPackages() const
     {
         getPackagesFromReg(HKEY_USERS, user + "\\" + UNINSTALL_REGISTRY, ret);
     }
-    PackageWindowsHelper::getHotFixFromReg(HKEY_LOCAL_MACHINE, PackageWindowsHelper::WIN_REG_HOTFIX, ret);
-    PackageWindowsHelper::getHotFixFromRegNT(HKEY_LOCAL_MACHINE, PackageWindowsHelper::VISTA_REG_HOTFIX, ret);
     return ret;
 }
 
@@ -765,4 +763,12 @@ void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)> /*callback*/
 void SysInfo::getPackages(std::function<void(nlohmann::json&)> /*callback*/) const
 {
     // TO DO
+}
+
+nlohmann::json SysInfo::getHotfixes() const
+{
+    nlohmann::json ret;
+    PackageWindowsHelper::getHotFixFromReg(HKEY_LOCAL_MACHINE, PackageWindowsHelper::WIN_REG_HOTFIX, ret);
+    PackageWindowsHelper::getHotFixFromRegNT(HKEY_LOCAL_MACHINE, PackageWindowsHelper::VISTA_REG_HOTFIX, ret);
+    return ret;
 }

--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -566,14 +566,10 @@ static void fillProcessesData(std::function<void(PROCESSENTRY32)> func)
 nlohmann::json SysInfo::getProcessesInfo() const
 {
     nlohmann::json jsProcessesList{};
-    fillProcessesData([&jsProcessesList](const auto & processEntry)
-    {
-        const auto& processInfo { getProcessInfo(processEntry) };
 
-        if (!processInfo.empty())
-        {
-            jsProcessesList.push_back(processInfo);
-        }
+    getProcessesInfo([&jsProcessesList](nlohmann::json & data)
+    {
+        jsProcessesList.push_back(data);
     });
 
     return jsProcessesList;
@@ -752,9 +748,17 @@ nlohmann::json SysInfo::getPorts() const
     return ports;
 }
 
-void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)> /*callback*/) const
+void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)> callback) const
 {
-    // TO DO
+    fillProcessesData([&callback](const auto & processEntry)
+    {
+        auto processInfo = getProcessInfo(processEntry);
+
+        if (!processInfo.empty())
+        {
+            callback(processInfo);
+        }
+    });
 }
 
 void SysInfo::getPackages(std::function<void(nlohmann::json&)> callback) const

--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -355,7 +355,7 @@ static nlohmann::json getProcessInfo(const PROCESSENTRY32& processEntry)
     return jsProcessInfo;
 }
 
-static void getPackagesFromReg(const HKEY key, const std::string& subKey, nlohmann::json& data, const REGSAM access = 0)
+static void getPackagesFromReg(const HKEY key, const std::string& subKey, std::function<void(nlohmann::json&)> returnCallback, const REGSAM access = 0)
 {
     try
     {
@@ -422,7 +422,7 @@ static void getPackagesFromReg(const HKEY key, const std::string& subKey, nlohma
                     packageJson["architecture"] = std::move(architecture);
                     packageJson["format"]       = "win";
 
-                    data.push_back(std::move(packageJson));
+                    returnCallback(packageJson);
                 }
             }
         };
@@ -582,13 +582,10 @@ nlohmann::json SysInfo::getProcessesInfo() const
 nlohmann::json SysInfo::getPackages() const
 {
     nlohmann::json ret;
-    getPackagesFromReg(HKEY_LOCAL_MACHINE, UNINSTALL_REGISTRY, ret, KEY_WOW64_64KEY);
-    getPackagesFromReg(HKEY_LOCAL_MACHINE, UNINSTALL_REGISTRY, ret, KEY_WOW64_32KEY);
-
-    for (const auto& user : Utils::Registry{HKEY_USERS, "", KEY_READ | KEY_ENUMERATE_SUB_KEYS}.enumerate())
+    getPackages([&ret](nlohmann::json & data)
     {
-        getPackagesFromReg(HKEY_USERS, user + "\\" + UNINSTALL_REGISTRY, ret);
-    }
+        ret.push_back(data);
+    });
     return ret;
 }
 
@@ -760,9 +757,15 @@ void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)> /*callback*/
     // TO DO
 }
 
-void SysInfo::getPackages(std::function<void(nlohmann::json&)> /*callback*/) const
+void SysInfo::getPackages(std::function<void(nlohmann::json&)> callback) const
 {
-    // TO DO
+    getPackagesFromReg(HKEY_LOCAL_MACHINE, UNINSTALL_REGISTRY, callback, KEY_WOW64_64KEY);
+    getPackagesFromReg(HKEY_LOCAL_MACHINE, UNINSTALL_REGISTRY, callback, KEY_WOW64_32KEY);
+
+    for (const auto& user : Utils::Registry{HKEY_USERS, "", KEY_READ | KEY_ENUMERATE_SUB_KEYS}.enumerate())
+    {
+        getPackagesFromReg(HKEY_USERS, user + "\\" + UNINSTALL_REGISTRY, callback);
+    }
 }
 
 nlohmann::json SysInfo::getHotfixes() const

--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -756,3 +756,13 @@ nlohmann::json SysInfo::getPorts() const
 
     return ports;
 }
+
+void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)> /*callback*/) const
+{
+    // TO DO
+}
+
+void SysInfo::getPackages(std::function<void(nlohmann::json&)> /*callback*/) const
+{
+    // TO DO
+}

--- a/src/data_provider/tests/sysInfo/sysInfo_test.cpp
+++ b/src/data_provider/tests/sysInfo/sysInfo_test.cpp
@@ -58,6 +58,9 @@ nlohmann::json SysInfo::getPorts() const
 {
     return {};
 }
+void SysInfo::getPackages(std::function<void(nlohmann::json&)>) const {}
+void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)>) const {}
+
 
 class SysInfoWrapper: public SysInfo
 {
@@ -74,6 +77,9 @@ class SysInfoWrapper: public SysInfo
         MOCK_METHOD(nlohmann::json, getProcessesInfo, (), (const override));
         MOCK_METHOD(nlohmann::json, getNetworks, (), (const override));
         MOCK_METHOD(nlohmann::json, getPorts, (), (const override));
+        MOCK_METHOD(void, getPackages, (std::function<void(nlohmann::json&)>), (const override));
+        MOCK_METHOD(void, getProcessesInfo, (std::function<void(nlohmann::json&)>), (const override));
+
 };
 
 TEST_F(SysInfoTest, hardware)

--- a/src/data_provider/tests/sysInfo/sysInfo_test.cpp
+++ b/src/data_provider/tests/sysInfo/sysInfo_test.cpp
@@ -63,6 +63,10 @@ nlohmann::json SysInfo::getPorts() const
 {
     return {};
 }
+nlohmann::json SysInfo::getHotfixes() const
+{
+    return {};
+}
 void SysInfo::getPackages(std::function<void(nlohmann::json&)>) const {}
 
 void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)>callback) const
@@ -111,6 +115,7 @@ class SysInfoWrapper: public SysInfo
         MOCK_METHOD(nlohmann::json, getProcessesInfo, (), (const override));
         MOCK_METHOD(nlohmann::json, getNetworks, (), (const override));
         MOCK_METHOD(nlohmann::json, getPorts, (), (const override));
+        MOCK_METHOD(nlohmann::json, getHotfixes, (), (const override));
         MOCK_METHOD(void, getPackages, (std::function<void(nlohmann::json&)>), (const override));
         MOCK_METHOD(void, getProcessesInfo, (std::function<void(nlohmann::json&)>), (const override));
 
@@ -198,6 +203,14 @@ TEST_F(SysInfoTest, os)
     EXPECT_FALSE(result.empty());
 }
 
+TEST_F(SysInfoTest, hotfixes)
+{
+    SysInfoWrapper info;
+    EXPECT_CALL(info, getHotfixes()).WillOnce(Return("hotfixes"));
+    const auto result {info.hotfixes()};
+    EXPECT_FALSE(result.empty());
+}
+
 TEST_F(SysInfoTest, hardware_c_interface)
 {
     cJSON* object = NULL;
@@ -263,6 +276,14 @@ TEST_F(SysInfoTest, os_c_interface)
     EXPECT_NO_THROW(sysinfo_free_result(&object));
 }
 
+TEST_F(SysInfoTest, hotfixes_c_interface)
+{
+    cJSON* object = NULL;
+    EXPECT_EQ(0, sysinfo_hotfixes(&object));
+    EXPECT_TRUE(object);
+    EXPECT_NO_THROW(sysinfo_free_result(&object));
+}
+
 TEST_F(SysInfoTest, c_interfaces_bad_params)
 {
     EXPECT_EQ(-1, sysinfo_hardware(NULL));
@@ -270,4 +291,5 @@ TEST_F(SysInfoTest, c_interfaces_bad_params)
     EXPECT_EQ(-1, sysinfo_processes(NULL));
     EXPECT_EQ(-1, sysinfo_ports(NULL));
     EXPECT_EQ(-1, sysinfo_os(NULL));
+    EXPECT_EQ(-1, sysinfo_hotfixes(NULL));
 }

--- a/src/data_provider/tests/sysInfo/sysInfo_test.cpp
+++ b/src/data_provider/tests/sysInfo/sysInfo_test.cpp
@@ -18,6 +18,11 @@ void SysInfoTest::TearDown()
 {
 };
 
+auto PROCESSES_EXPECTED
+{
+    R"([{"test":"processes"}])"_json
+};
+
 using ::testing::_;
 using ::testing::Return;
 
@@ -59,8 +64,37 @@ nlohmann::json SysInfo::getPorts() const
     return {};
 }
 void SysInfo::getPackages(std::function<void(nlohmann::json&)>) const {}
-void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)>) const {}
 
+void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)>callback) const
+{
+    callback(PROCESSES_EXPECTED);
+}
+
+class CallbackMock
+{
+    public:
+        CallbackMock() = default;
+        ~CallbackMock() = default;
+        MOCK_METHOD(void, callbackMock, (ReturnTypeCallback type, std::string), ());
+        MOCK_METHOD(void, callbackMock, (nlohmann::json&), ());
+};
+
+struct CJsonDeleter final
+{
+    void operator()(char* json)
+    {
+        cJSON_free(json);
+    }
+};
+
+static void callback(const ReturnTypeCallback type,
+                     const cJSON* json,
+                     void* ctx)
+{
+    CallbackMock* wrapper { reinterpret_cast<CallbackMock*>(ctx)};
+    const std::unique_ptr<char, CJsonDeleter> spJsonBytes{ cJSON_PrintUnformatted(json) };
+    wrapper->callbackMock(type, std::string(spJsonBytes.get()));
+}
 
 class SysInfoWrapper: public SysInfo
 {
@@ -100,6 +134,36 @@ TEST_F(SysInfoTest, packages)
     EXPECT_CALL(info, getPackages()).WillOnce(Return("packages"));
     const auto result {info.packages()};
     EXPECT_FALSE(result.empty());
+}
+
+TEST_F(SysInfoTest, processes_cb)
+{
+    SysInfoWrapper info;
+    CallbackMock wrapper;
+
+    auto expectedValue1
+    {
+        R"({"argvs":"180","cmd":"sleep","egroup":"root","euser":"root","fgroup":"root","name":"sleep","nice":0,"nlwp":1,"pgrp":2478,"pid":"193797","ppid":2480,"priority":20,"processor":2,"resident":148,"rgroup":"root","ruser":"root","session":2478,"sgroup":"root","share":132,"size":2019,"start_time":6244007,"state":"S","stime":0,"suser":"root","tgid":193797,"tty":0,"utime":0,"vm_size":8076})"_json
+    };
+
+    auto expectedValue2
+    {
+        R"({"argvs":"181","cmd":"ls","egroup":"dword","euser":"dword","fgroup":"dword","name":"sleep","nice":0,"nlwp":1,"pgrp":2478,"pid":"193797","ppid":2480,"priority":20,"processor":2,"resident":148,"rgroup":"root","ruser":"root","session":2478,"sgroup":"root","share":132,"size":2019,"start_time":6244007,"state":"S","stime":0,"suser":"root","tgid":193797,"tty":0,"utime":0,"vm_size":8076})"_json
+    };
+
+    const auto processesCallback
+    {
+        [&wrapper](nlohmann::json & data)
+        {
+            wrapper.callbackMock(data);
+        }
+    };
+    EXPECT_CALL(info, getProcessesInfo(_)).WillOnce(DoAll(
+                                                        testing::InvokeArgument<0>(expectedValue1),
+                                                        testing::InvokeArgument<0>(expectedValue2)));
+    EXPECT_CALL(wrapper, callbackMock(expectedValue1)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedValue2)).Times(1);
+    info.processes(processesCallback);
 }
 
 TEST_F(SysInfoTest, processes)
@@ -152,14 +216,31 @@ TEST_F(SysInfoTest, packages_c_interface)
 
 TEST_F(SysInfoTest, processes_c_interface)
 {
+
     cJSON* object = NULL;
     EXPECT_EQ(0, sysinfo_processes(&object));
     EXPECT_TRUE(object);
     EXPECT_NO_THROW(sysinfo_free_result(&object));
 }
 
+
+TEST_F(SysInfoTest, processes_cb_c_interface)
+{
+    CallbackMock wrapper;
+    callback_data_t callbackData { callback, &wrapper };
+    EXPECT_CALL(wrapper, callbackMock(GENERIC, PROCESSES_EXPECTED.dump())).Times(1);
+    EXPECT_EQ(0, sysinfo_processes_cb(callbackData));
+}
+
+TEST_F(SysInfoTest, processes_cb_c_interface_test_empty_callback)
+{
+    callback_data_t cb_data = { .callback = NULL, .user_data = NULL };
+    EXPECT_EQ(-1, sysinfo_processes_cb(cb_data));
+}
+
 TEST_F(SysInfoTest, network_c_interface)
 {
+
     cJSON* object = NULL;
     EXPECT_EQ(0, sysinfo_networks(&object));
     EXPECT_TRUE(object);

--- a/src/data_provider/testtool/Readme.md
+++ b/src/data_provider/testtool/Readme.md
@@ -14,12 +14,11 @@ make TARGET=server|agent <DEBUG=1>
 ```
 
 ## How to use the tool
-In order to run the `sysinfo_test_tool` (located in `src/data_provider/build/bin` folder) utility the only step to be followed is just to execute the tool (without parameters):
 ```
-./sysinfo_test_tool
+Usage: sysinfo_test_tool [options]
 ```
 
-The information output will vary based on the Operating System the tool is being executed. 
+The information output will vary based on the Operating System the tool is being executed.
 A brief example could be similar to the following one:
 
 ```
@@ -30,3 +29,14 @@ A brief example could be similar to the following one:
 {"architecture":"x86_64","host_name":"martin-PC","os_codename":"focal","os_major":"20","os_minor":"04","os_name":"Ubuntu","os_patch":"2","os_platform":"ubuntu","os_version":"20.04.2 LTS (Focal Fossa)","release":"5.4.0-65-generic","sysname":"Linux","version":"#73-Ubuntu SMP Mon Jan 18 17:25:17 UTC 2021"},
 {"architecture":"x86_64","host_name":"martin-PC","os_codename":"focal","os_major":"20","os_minor":"04","os_name":"Ubuntu","os_patch":"2","os_platform":"ubuntu","os_version":"20.04.2 LTS (Focal Fossa)","release":"5.4.0-65-generic","sysname":"Linux","version":"#73-Ubuntu SMP Mon Jan 18 17:25:17 UTC 2021"}]
 ```
+
+### Optional arguments:
+
+|Argument|Description|
+|---|---|
+| `--hardware`  | Prints the current Operating System hardware information only. Example: `sysinfo_test_tool --hardware`   |
+| `--networks`  | Prints the current Operating System networks information only. Example: `sysinfo_test_tool --networks`   |
+| `--packages`  | Prints the current Operating System packages information only. Example: `sysinfo_test_tool --packages`   |
+| `--processes` | Prints the current Operating System processes information only. Example: `sysinfo_test_tool --processes` |
+| `--ports`     | Prints the current Operating System ports information only. Example: `sysinfo_test_tool --ports`         |
+| `--os`        | Prints the current Operating System information only. Example: `sysinfo_test_tool --os`                  |

--- a/src/data_provider/testtool/Readme.md
+++ b/src/data_provider/testtool/Readme.md
@@ -35,10 +35,12 @@ A brief example could be similar to the following one:
 
 |Argument|Description|
 |---|---|
-| `--hardware`  | Prints the current Operating System hardware information only. Example: `sysinfo_test_tool --hardware`   |
-| `--networks`  | Prints the current Operating System networks information only. Example: `sysinfo_test_tool --networks`   |
-| `--packages`  | Prints the current Operating System packages information only. Example: `sysinfo_test_tool --packages`   |
-| `--processes` | Prints the current Operating System processes information only. Example: `sysinfo_test_tool --processes` |
-| `--ports`     | Prints the current Operating System ports information only. Example: `sysinfo_test_tool --ports`         |
-| `--os`        | Prints the current Operating System information only. Example: `sysinfo_test_tool --os`                  |
-| `--hotfixes`  | Prints the current Operating System hotfixes information only. Example: `sysinfo_test_tool --hotfixes`   |
+| `--hardware`     | Prints the current Operating System hardware information only. Example: `sysinfo_test_tool --hardware`                               |
+| `--networks`     | Prints the current Operating System networks information only. Example: `sysinfo_test_tool --networks`                               |
+| `--packages`     | Prints the current Operating System packages information only. Example: `sysinfo_test_tool --packages`                               |
+| `--processes`    | Prints the current Operating System processes information only. Example: `sysinfo_test_tool --processes`                             |
+| `--packages-cb`  | Prints the current Operating System packages information only with callbacks mechanism. Example: `sysinfo_test_tool --packages-cb`   |
+| `--processes-cb` | Prints the current Operating System processes information only with callbacks mechanism. Example: `sysinfo_test_tool --processes-cb` |
+| `--ports`        | Prints the current Operating System ports information only. Example: `sysinfo_test_tool --ports`                                     |
+| `--os`           | Prints the current Operating System information only. Example: `sysinfo_test_tool --os`                                              |
+| `--hotfixes`     | Prints the current Operating System hotfixes information only. Example: `sysinfo_test_tool --hotfixes`                               |

--- a/src/data_provider/testtool/Readme.md
+++ b/src/data_provider/testtool/Readme.md
@@ -22,6 +22,7 @@ The information output will vary based on the Operating System the tool is being
 A brief example could be similar to the following one:
 
 ```
+[{"hotfix":"KB12345678"},{"hotfix":"KB87654321"}]
 {"board_serial":" ","cpu_cores":6,"cpu_mhz":801.0,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":4659652,"ram_total":32746472,"ram_usage":86}
 [{"architecture":"amd64","description":"query and manipulate user account information\n The AccountService project provides a set of D-Bus\n interfaces for querying and manipulating user account\n information and an implementation of these interfaces,\n based on the useradd, usermod and userdel commands.","format":"deb","groups":"admin","multiarch":" ","name":"accountsservice","priority":"optional","size":"452","source":" ","vendor":"Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>","version":"0.6.55-0ubuntu12~20.04.4"}],
 [{"argvs":"splash","cmd":"/sbin/init","egroup":"root","euser":"root","fgroup":"root","name":"systemd","nice":0,"nlwp":1,"pgrp":1,"pid":"1","ppid":0,"priority":20,"processor":2,"resident":3438,"rgroup":"root","ruser":"root","session":1,"sgroup":"root","share":2149,"size":42401,"start_time":23,"state":"S","stime":11365,"suser":"root","tgid":1,"tty":0,"utime":1005,"vm_size":169604},{"argvs":"","cmd":"","egroup":"root","euser":"root","fgroup":"root","name":"kthreadd","nice":0,"nlwp":1,"pgrp":0,"pid":"2","ppid":0,"priority":20,"processor":4,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":23,"state":"S","stime":7,"suser":"root","tgid":2,"tty":0,"utime":0,"vm_size":0}],
@@ -40,3 +41,4 @@ A brief example could be similar to the following one:
 | `--processes` | Prints the current Operating System processes information only. Example: `sysinfo_test_tool --processes` |
 | `--ports`     | Prints the current Operating System ports information only. Example: `sysinfo_test_tool --ports`         |
 | `--os`        | Prints the current Operating System information only. Example: `sysinfo_test_tool --os`                  |
+| `--hotfixes`  | Prints the current Operating System hotfixes information only. Example: `sysinfo_test_tool --hotfixes`   |

--- a/src/data_provider/testtool/cmdLineActions.h
+++ b/src/data_provider/testtool/cmdLineActions.h
@@ -14,25 +14,30 @@
 
 #include <string.h>
 
-constexpr auto HARDWARE_ACTION  { "--hardware"};
-constexpr auto NETWORKS_ACTION  { "--networks"};
-constexpr auto PACKAGES_ACTION  { "--packages"};
-constexpr auto PROCESSES_ACTION { "--processes"};
-constexpr auto PORTS_ACTION     { "--ports"};
-constexpr auto OS_ACTION        { "--os"};
-constexpr auto HOTFIXES_ACTION  { "--hotfixes"};
+constexpr auto HARDWARE_ACTION     { "--hardware"};
+constexpr auto NETWORKS_ACTION     { "--networks"};
+constexpr auto PACKAGES_ACTION     { "--packages"};
+constexpr auto PROCESSES_ACTION    { "--processes"};
+constexpr auto PORTS_ACTION        { "--ports"};
+constexpr auto OS_ACTION           { "--os"};
+constexpr auto HOTFIXES_ACTION     { "--hotfixes"};
+constexpr auto PROCESSES_CB_ACTION { "--processes-cb"};
+constexpr auto PACKAGES_CB_ACTION  { "--packages-cb"};
 
 class CmdLineActions final
 {
     public:
         CmdLineActions(const char* argv[])
-            : m_hardware  { HARDWARE_ACTION  == std::string(argv[1]) }
-            , m_networks  { NETWORKS_ACTION  == std::string(argv[1]) }
-            , m_packages  { PACKAGES_ACTION  == std::string(argv[1]) }
-            , m_processes { PROCESSES_ACTION == std::string(argv[1]) }
-            , m_ports     { PORTS_ACTION     == std::string(argv[1]) }
-            , m_os        { OS_ACTION        == std::string(argv[1]) }
-            , m_hotfixes  { HOTFIXES_ACTION  == std::string(argv[1]) }
+            : m_hardware          { HARDWARE_ACTION     == std::string(argv[1]) }
+            , m_networks          { NETWORKS_ACTION     == std::string(argv[1]) }
+            , m_packages          { PACKAGES_ACTION     == std::string(argv[1]) }
+            , m_processes         { PROCESSES_ACTION    == std::string(argv[1]) }
+            , m_ports             { PORTS_ACTION        == std::string(argv[1]) }
+            , m_os                { OS_ACTION           == std::string(argv[1]) }
+            , m_hotfixes          { HOTFIXES_ACTION     == std::string(argv[1]) }
+            , m_processesCallback { PROCESSES_CB_ACTION == std::string(argv[1]) }
+            , m_packagesCallback  { PACKAGES_CB_ACTION  == std::string(argv[1]) }
+
         {}
 
         bool hardwareArg() const
@@ -70,6 +75,17 @@ class CmdLineActions final
             return m_hotfixes;
         };
 
+        bool packagesCallbackArg() const
+        {
+            return m_packagesCallback;
+        };
+
+        bool processesCallbackArg() const
+        {
+            return m_processesCallback;
+        };
+
+
         static void showHelp()
         {
             std::cout << "\nUsage: sysinfo_test_tool [options]\n"
@@ -79,6 +95,8 @@ class CmdLineActions final
                       << "\t--networks \tPrints the current Operating System networks information.\n"
                       << "\t--packages \tPrints the current Operating System packages information.\n"
                       << "\t--processes \tPrints the current Operating System processes information.\n"
+                      << "\t--packages-cb \tPrints the current Operating System packages using callbacks to return information.\n"
+                      << "\t--processes-cb \tPrints the current Operating System processes using callback to return information.\n"
                       << "\t--ports \tPrints the current Operating System ports information.\n"
                       << "\t--os \t\tPrints the current Operating System information.\n"
                       << "\t--hotfixes \tPrints the current Operating System hotfixes information.\n"
@@ -91,6 +109,8 @@ class CmdLineActions final
                       << "\n\t./sysinfo_test_tool --ports"
                       << "\n\t./sysinfo_test_tool --os"
                       << "\n\t./sysinfo_test_tool --hotfixes"
+                      << "\n\t./sysinfo_test_tool --processes-cb"
+                      << "\n\t./sysinfo_test_tool --packages-cb"
                       << std::endl;
         }
 
@@ -102,6 +122,9 @@ class CmdLineActions final
         const bool m_ports;
         const bool m_os;
         const bool m_hotfixes;
+        const bool m_processesCallback;
+        const bool m_packagesCallback;
+
 };
 
 #endif // _CMD_LINE_ACTIONS_H_

--- a/src/data_provider/testtool/cmdLineActions.h
+++ b/src/data_provider/testtool/cmdLineActions.h
@@ -1,0 +1,97 @@
+/*
+ * Wazuh SYSINFO
+ * Copyright (C) 2015-2021, Wazuh Inc.
+ * September 13, 2021
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _CMD_LINE_ACTIONS_H_
+#define _CMD_LINE_ACTIONS_H_
+
+#include <string.h>
+
+constexpr auto HARDWARE_ACTION  { "--hardware"};
+constexpr auto NETWORKS_ACTION  { "--networks"};
+constexpr auto PACKAGES_ACTION  { "--packages"};
+constexpr auto PROCESSES_ACTION { "--processes"};
+constexpr auto PORTS_ACTION     { "--ports"};
+constexpr auto OS_ACTION        { "--os"};
+
+class CmdLineActions final
+{
+    public:
+        CmdLineActions(const char* argv[])
+            : m_hardware  { HARDWARE_ACTION  == std::string(argv[1]) }
+            , m_networks  { NETWORKS_ACTION  == std::string(argv[1]) }
+            , m_packages  { PACKAGES_ACTION  == std::string(argv[1]) }
+            , m_processes { PROCESSES_ACTION == std::string(argv[1]) }
+            , m_ports     { PORTS_ACTION     == std::string(argv[1]) }
+            , m_os        { OS_ACTION        == std::string(argv[1]) }
+        {}
+
+        bool hardwareArg() const
+        {
+            return m_hardware;
+        };
+
+        bool networksArg() const
+        {
+            return m_networks;
+        };
+
+        bool packagesArg() const
+        {
+            return m_packages;
+        };
+
+        bool processesArg() const
+        {
+            return m_processes;
+        };
+
+        bool portsArg() const
+        {
+            return m_ports;
+        };
+
+        bool osArg() const
+        {
+            return m_os;
+        };
+
+        static void showHelp()
+        {
+            std::cout << "\nUsage: sysinfo_test_tool [options]\n"
+                      << "Options:\n"
+                      << "\t<without args> \tPrints the complete Operating System information.\n"
+                      << "\t--hardware \tPrints the current Operating System hardware information.\n"
+                      << "\t--networks \tPrints the current Operating System networks information.\n"
+                      << "\t--packages \tPrints the current Operating System packages information.\n"
+                      << "\t--processes \tPrints the current Operating System processes information.\n"
+                      << "\t--ports \tPrints the current Operating System ports information.\n"
+                      << "\t--os \t\tPrints the current Operating System information.\n"
+                      << "\nExamples:"
+                      << "\n\t./sysinfo_test_tool"
+                      << "\n\t./sysinfo_test_tool --hardware"
+                      << "\n\t./sysinfo_test_tool --networks"
+                      << "\n\t./sysinfo_test_tool --packages"
+                      << "\n\t./sysinfo_test_tool --processes"
+                      << "\n\t./sysinfo_test_tool --ports"
+                      << "\n\t./sysinfo_test_tool --os"
+                      << std::endl;
+        }
+
+    private:
+        const bool m_hardware;
+        const bool m_networks;
+        const bool m_packages;
+        const bool m_processes;
+        const bool m_ports;
+        const bool m_os;
+};
+
+#endif // _CMD_LINE_ACTIONS_H_

--- a/src/data_provider/testtool/cmdLineActions.h
+++ b/src/data_provider/testtool/cmdLineActions.h
@@ -20,6 +20,7 @@ constexpr auto PACKAGES_ACTION  { "--packages"};
 constexpr auto PROCESSES_ACTION { "--processes"};
 constexpr auto PORTS_ACTION     { "--ports"};
 constexpr auto OS_ACTION        { "--os"};
+constexpr auto HOTFIXES_ACTION  { "--hotfixes"};
 
 class CmdLineActions final
 {
@@ -31,6 +32,7 @@ class CmdLineActions final
             , m_processes { PROCESSES_ACTION == std::string(argv[1]) }
             , m_ports     { PORTS_ACTION     == std::string(argv[1]) }
             , m_os        { OS_ACTION        == std::string(argv[1]) }
+            , m_hotfixes  { HOTFIXES_ACTION  == std::string(argv[1]) }
         {}
 
         bool hardwareArg() const
@@ -63,6 +65,11 @@ class CmdLineActions final
             return m_os;
         };
 
+        bool hotfixesArg() const
+        {
+            return m_hotfixes;
+        };
+
         static void showHelp()
         {
             std::cout << "\nUsage: sysinfo_test_tool [options]\n"
@@ -74,6 +81,7 @@ class CmdLineActions final
                       << "\t--processes \tPrints the current Operating System processes information.\n"
                       << "\t--ports \tPrints the current Operating System ports information.\n"
                       << "\t--os \t\tPrints the current Operating System information.\n"
+                      << "\t--hotfixes \tPrints the current Operating System hotfixes information.\n"
                       << "\nExamples:"
                       << "\n\t./sysinfo_test_tool"
                       << "\n\t./sysinfo_test_tool --hardware"
@@ -82,6 +90,7 @@ class CmdLineActions final
                       << "\n\t./sysinfo_test_tool --processes"
                       << "\n\t./sysinfo_test_tool --ports"
                       << "\n\t./sysinfo_test_tool --os"
+                      << "\n\t./sysinfo_test_tool --hotfixes"
                       << std::endl;
         }
 
@@ -92,6 +101,7 @@ class CmdLineActions final
         const bool m_processes;
         const bool m_ports;
         const bool m_os;
+        const bool m_hotfixes;
 };
 
 #endif // _CMD_LINE_ACTIONS_H_

--- a/src/data_provider/testtool/main.cpp
+++ b/src/data_provider/testtool/main.cpp
@@ -42,19 +42,11 @@ class SysInfoPrinter final
         void printPackagesInfo()
         {
             m_data["packages"] = m_sysinfo.packages();
-            m_sysinfo.packages([](nlohmann::json & package)
-            {
-                std::cout << package.dump(JSON_PRETTY_SPACES) << std::endl;
-            });
         }
 
         void printProcessesInfo()
         {
             m_data["processes"] = m_sysinfo.processes();
-            m_sysinfo.processes([](nlohmann::json & process)
-            {
-                std::cout << process.dump(JSON_PRETTY_SPACES) << std::endl;
-            });
         }
 
         void printPortsInfo()
@@ -70,6 +62,22 @@ class SysInfoPrinter final
         void printData()
         {
             std::cout << m_data.dump(JSON_PRETTY_SPACES) << std::endl;
+        }
+
+        void printProcessesInfoCallback()
+        {
+            m_sysinfo.processes([this](nlohmann::json & process)
+            {
+                m_data["processes_cb"].push_back(process);
+            });
+        }
+
+        void printPackagesInfoCallback()
+        {
+            m_sysinfo.packages([this](nlohmann::json & package)
+            {
+                m_data["packages_cb"].push_back(package);
+            });
         }
 
     private:
@@ -94,6 +102,8 @@ int main(int argc, const char* argv[])
             printer.printPortsInfo();
             printer.printHotfixes();
             printer.printData();
+            printer.printPackagesInfoCallback();
+            printer.printProcessesInfoCallback();
         }
         else if (argc == 2)
         {
@@ -126,6 +136,14 @@ int main(int argc, const char* argv[])
             else if (cmdLineArgs.hotfixesArg())
             {
                 printer.printHotfixes();
+            }
+            else if (cmdLineArgs.packagesCallbackArg())
+            {
+                printer.printPackagesInfoCallback();
+            }
+            else if (cmdLineArgs.processesCallbackArg())
+            {
+                printer.printProcessesInfoCallback();
             }
             else
             {

--- a/src/data_provider/testtool/main.cpp
+++ b/src/data_provider/testtool/main.cpp
@@ -36,6 +36,16 @@ int main()
         std::cout << networks.dump(JSON_PRETTY_SPACES) << std::endl;
         std::cout << os.dump(JSON_PRETTY_SPACES) << std::endl;
         std::cout << ports.dump(JSON_PRETTY_SPACES) << std::endl;
+
+        info.processes([](nlohmann::json & process)
+        {
+            std::cout << process.dump(JSON_PRETTY_SPACES) << std::endl;
+        });
+
+        info.packages([](nlohmann::json & package)
+        {
+            std::cout << package.dump(JSON_PRETTY_SPACES) << std::endl;
+        });
     }
     catch (const std::exception& e)
     {

--- a/src/data_provider/testtool/main.cpp
+++ b/src/data_provider/testtool/main.cpp
@@ -62,6 +62,11 @@ class SysInfoPrinter final
             m_data["ports"] = m_sysinfo.ports();
         }
 
+        void printHotfixes()
+        {
+            m_data["hotfixes"] = m_sysinfo.hotfixes();
+        }
+
         void printData()
         {
             std::cout << m_data.dump(JSON_PRETTY_SPACES) << std::endl;
@@ -87,6 +92,7 @@ int main(int argc, const char* argv[])
             printer.printPackagesInfo();
             printer.printProcessesInfo();
             printer.printPortsInfo();
+            printer.printHotfixes();
             printer.printData();
         }
         else if (argc == 2)
@@ -116,6 +122,10 @@ int main(int argc, const char* argv[])
             else if (cmdLineArgs.portsArg())
             {
                 printer.printPortsInfo();
+            }
+            else if (cmdLineArgs.hotfixesArg())
+            {
+                printer.printHotfixes();
             }
             else
             {

--- a/src/shared_modules/common/commonDefs.h
+++ b/src/shared_modules/common/commonDefs.h
@@ -42,7 +42,8 @@ typedef enum
     INSERTED = 2,   /*< Database insertion operation.           */
     MAX_ROWS = 3,   /*< Database has reached max rows number.   */
     DB_ERROR = 4,   /*< Internal failure.                       */
-    SELECTED = 5    /*< Database select operation.              */
+    SELECTED = 5,   /*< Database select operation.              */
+    GENERIC = 6     /*< Generic result for reuse.               */
 } ReturnTypeCallback;
 
 /**

--- a/src/shared_modules/rsync/src/messageChecksum.h
+++ b/src/shared_modules/rsync/src/messageChecksum.h
@@ -60,7 +60,11 @@ namespace RSync
                     }
 
                     outputMessage["data"] = outputData;
-                    callback(outputMessage.dump());
+
+                    if (!data.checksum.empty())
+                    {
+                        callback(outputMessage.dump());
+                    }
                 }
                 // LCOV_EXCL_START
                 else

--- a/src/shared_modules/rsync/src/rsyncImplementation.cpp
+++ b/src/shared_modules/rsync/src/rsyncImplementation.cpp
@@ -195,13 +195,13 @@ void RSyncImplementation::sendChecksumFail(const std::shared_ptr<DBSyncWrapper>&
 {
     const auto size { getRangeCount(spDBSyncWrapper, jsonSyncConfiguration, syncData) };
 
-    if (1 == size)
+    if (1 == size && syncData.begin.compare(syncData.end) == 0)
     {
         const auto& rowData{ getRowData(spDBSyncWrapper, jsonSyncConfiguration, syncData.begin) };
 
         FactoryMessageCreator<nlohmann::json, MessageType::ROW_DATA>::create()->send(callbackWrapper, jsonSyncConfiguration, rowData);
     }
-    else if (1 < size)
+    else if (1 <= size)
     {
         auto messageCreator { FactoryMessageCreator<SplitContext, MessageType::CHECKSUM>::create() };
 

--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -18,6 +18,7 @@ include_directories(${SRC_FOLDER}/external/audit-userspace/lib)
 include_directories(${SRC_FOLDER}/external/bzip2)
 include_directories(${SRC_FOLDER}/external/cJSON)
 include_directories(${SRC_FOLDER}/external/msgpack/include)
+include_directories(${SRC_FOLDER}/shared_modules/common)
 include_directories(${SRC_FOLDER})
 add_definitions(-DWAZUH_UNIT_TESTING)
 

--- a/src/wazuh_modules/syscollector/cppcheckSuppress.txt
+++ b/src/wazuh_modules/syscollector/cppcheckSuppress.txt
@@ -1,3 +1,4 @@
 *:*.c
 *:*syscollector.h
-*:*src/syscollectorImp.cpp:952
+*:*src/syscollectorImp.cpp:1056
+*:*tests/sysCollectorImp/syscollectorImp_test.cpp

--- a/src/wazuh_modules/syscollector/include/syscollector.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector.hpp
@@ -75,23 +75,26 @@ private:
     nlohmann::json getOSData();
     nlohmann::json getHardwareData();
     nlohmann::json getNetworkData();
-    nlohmann::json getPackagesData();
     nlohmann::json getPortsData();
-    nlohmann::json getProcessesData();
 
     void registerWithRsync();
-    void updateAndNotifyChanges(const std::string& table,
-                                const nlohmann::json& input);
+    void updateChanges(const std::string& table,
+                       const nlohmann::json& values);
+    void notifyChange(ReturnTypeCallback result,
+                      const nlohmann::json& data,
+                      const std::string& table);
     void scanHardware();
     void scanOs();
     void scanNetwork();
     void scanPackages();
+    void scanHotfixes();
     void scanPorts();
     void scanProcesses();
     void syncOs();
     void syncHardware();
     void syncNetwork();
     void syncPackages();
+    void syncHotfixes();
     void syncPorts();
     void syncProcesses();
     void scan();

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -35,6 +35,23 @@ do                                                                      \
     }                                                                   \
 }while(0)
 
+constexpr auto QUEUE_SIZE
+{
+    4096
+};
+
+static const std::map<ReturnTypeCallback, std::string> OPERATION_MAP
+{
+    // LCOV_EXCL_START
+    {MODIFIED, "MODIFIED"},
+    {DELETED, "DELETED"},
+    {INSERTED, "INSERTED"},
+    {MAX_ROWS, "MAX_ROWS"},
+    {DB_ERROR, "DB_ERROR"},
+    {SELECTED, "SELECTED"},
+    // LCOV_EXCL_STOP
+};
+
 constexpr auto OS_SQL_STATEMENT
 {
     R"(CREATE TABLE dbsync_osinfo (
@@ -930,61 +947,54 @@ static bool isElementDuplicated(const nlohmann::json& input, const std::pair<std
     return it != input.end();
 }
 
-void Syscollector::updateAndNotifyChanges(const std::string& table,
-                                          const nlohmann::json& input)
+void Syscollector::notifyChange(ReturnTypeCallback result, const nlohmann::json& data, const std::string& table)
 {
-    const std::map<ReturnTypeCallback, std::string> operationsMap
+    if (DB_ERROR == result)
     {
-        // LCOV_EXCL_START
-        {MODIFIED, "MODIFIED"},
-        {DELETED, "DELETED"},
-        {INSERTED, "INSERTED"},
-        {MAX_ROWS, "MAX_ROWS"},
-        {DB_ERROR, "DB_ERROR"},
-        {SELECTED, "SELECTED"},
-        // LCOV_EXCL_STOP
-    };
-    constexpr auto queueSize{4096};
+        m_logFunction(SYS_LOG_ERROR, data.dump());
+    }
+    else if (m_notify && !m_stopping)
+    {
+        if (data.is_array())
+        {
+            for (const auto& item : data)
+            {
+                nlohmann::json msg;
+                msg["type"] = table;
+                msg["operation"] = OPERATION_MAP.at(result);
+                msg["data"] = item;
+                msg["data"]["scan_time"] = m_scanTime;
+                removeKeysWithEmptyValue(msg["data"]);
+                const auto msgToSend{msg.dump()};
+                m_reportDiffFunction(msgToSend);
+                m_logFunction(SYS_LOG_DEBUG_VERBOSE, "Delta sent: " + msgToSend);
+            }
+        }
+        else
+        {
+            // LCOV_EXCL_START
+            nlohmann::json msg;
+            msg["type"] = table;
+            msg["operation"] = OPERATION_MAP.at(result);
+            msg["data"] = data;
+            msg["data"]["scan_time"] = m_scanTime;
+            removeKeysWithEmptyValue(msg["data"]);
+            const auto msgToSend{msg.dump()};
+            m_reportDiffFunction(msgToSend);
+            m_logFunction(SYS_LOG_DEBUG_VERBOSE, "Delta sent: " + msgToSend);
+            // LCOV_EXCL_STOP
+        }
+    }
+}
+
+void Syscollector::updateChanges(const std::string& table,
+                                 const nlohmann::json& values)
+{
     const auto callback
     {
-        [this, table, operationsMap](ReturnTypeCallback result, const nlohmann::json & data)
+        [this, table](ReturnTypeCallback result, const nlohmann::json & data)
         {
-            if (result == DB_ERROR)
-            {
-                m_logFunction(SYS_LOG_ERROR, data.dump());
-            }
-            else if (m_notify && !m_stopping)
-            {
-                if (data.is_array())
-                {
-                    for (const auto& item : data)
-                    {
-                        nlohmann::json msg;
-                        msg["type"] = table;
-                        msg["operation"] = operationsMap.at(result);
-                        msg["data"] = item;
-                        msg["data"]["scan_time"] = m_scanTime;
-                        removeKeysWithEmptyValue(msg["data"]);
-                        const auto msgToSend{msg.dump()};
-                        m_reportDiffFunction(msgToSend);
-                        m_logFunction(SYS_LOG_DEBUG_VERBOSE, "Delta sent: " + msgToSend);
-                    }
-                }
-                else
-                {
-                    // LCOV_EXCL_START
-                    nlohmann::json msg;
-                    msg["type"] = table;
-                    msg["operation"] = operationsMap.at(result);
-                    msg["data"] = data;
-                    msg["data"]["scan_time"] = m_scanTime;
-                    removeKeysWithEmptyValue(msg["data"]);
-                    const auto msgToSend{msg.dump()};
-                    m_reportDiffFunction(msgToSend);
-                    m_logFunction(SYS_LOG_DEBUG_VERBOSE, "Delta sent: " + msgToSend);
-                    // LCOV_EXCL_STOP
-                }
-            }
+            notifyChange(result, data, table);
         }
     };
     DBSyncTxn txn
@@ -992,9 +1002,12 @@ void Syscollector::updateAndNotifyChanges(const std::string& table,
         m_spDBSync->handle(),
         nlohmann::json{table},
         0,
-        queueSize,
+        QUEUE_SIZE,
         callback
     };
+    nlohmann::json input;
+    input["table"] = table;
+    input["data"] = values;
     txn.syncTxnRow(input);
     txn.getDeletedRows(callback);
 }
@@ -1017,6 +1030,7 @@ Syscollector::Syscollector()
 std::string Syscollector::getCreateStatement() const
 {
     std::string ret;
+
     ret += OS_SQL_STATEMENT;
     ret += HW_SQL_STATEMENT;
     ret += PACKAGES_SQL_STATEMENT;
@@ -1102,14 +1116,14 @@ void Syscollector::registerWithRsync()
                                   m_spDBSync->handle(),
                                   nlohmann::json::parse(PACKAGES_SYNC_CONFIG_STATEMENT),
                                   reportSyncWrapper);
+    }
 
-        if (m_hotfixes)
-        {
-            m_spRsync->registerSyncID("syscollector_hotfixes",
-                                      m_spDBSync->handle(),
-                                      nlohmann::json::parse(HOTFIXES_SYNC_CONFIG_STATEMENT),
-                                      reportSyncWrapper);
-        }
+    if (m_hotfixes)
+    {
+        m_spRsync->registerSyncID("syscollector_hotfixes",
+                                  m_spDBSync->handle(),
+                                  nlohmann::json::parse(HOTFIXES_SYNC_CONFIG_STATEMENT),
+                                  reportSyncWrapper);
     }
 
     if (m_ports)
@@ -1201,10 +1215,8 @@ void Syscollector::scanHardware()
     if (m_hardware)
     {
         m_logFunction(SYS_LOG_DEBUG_VERBOSE, "Starting hardware scan");
-        nlohmann::json input;
-        input["table"] = HW_TABLE;
-        input["data"] = getHardwareData();
-        updateAndNotifyChanges(HW_TABLE, input);
+        const auto& hwData{getHardwareData()};
+        updateChanges(HW_TABLE, hwData);
         m_logFunction(SYS_LOG_DEBUG_VERBOSE, "Ending hardware scan");
     }
 }
@@ -1227,10 +1239,8 @@ void Syscollector::scanOs()
     if (m_os)
     {
         m_logFunction(SYS_LOG_DEBUG_VERBOSE, "Starting os scan");
-        nlohmann::json input;
-        input["table"] = OS_TABLE;
-        input["data"] = getOSData();
-        updateAndNotifyChanges(OS_TABLE, input);
+        const auto& osData{getOSData()};
+        updateChanges(OS_TABLE, osData);
         m_logFunction(SYS_LOG_DEBUG_VERBOSE, "Ending os scan");
     }
 }
@@ -1334,38 +1344,29 @@ void Syscollector::scanNetwork()
     if (m_network)
     {
         m_logFunction(SYS_LOG_DEBUG_VERBOSE, "Starting network scan");
-        auto networkData(getNetworkData());
+        const auto networkData(getNetworkData());
 
         if (!networkData.is_null())
         {
-            auto itIface { networkData.find(NET_IFACE_TABLE) };
+            const auto itIface { networkData.find(NET_IFACE_TABLE) };
 
             if (itIface != networkData.end())
             {
-                nlohmann::json input;
-                input["table"] = NET_IFACE_TABLE;
-                input["data"] = std::move(*itIface);
-                updateAndNotifyChanges(NET_IFACE_TABLE, input);
+                updateChanges(NET_IFACE_TABLE, itIface.value());
             }
 
-            auto itProtocol { networkData.find(NET_PROTOCOL_TABLE) };
+            const auto itProtocol { networkData.find(NET_PROTOCOL_TABLE) };
 
             if (itProtocol != networkData.end())
             {
-                nlohmann::json input;
-                input["table"] = NET_PROTOCOL_TABLE;
-                input["data"] = std::move(*itProtocol);
-                updateAndNotifyChanges(NET_PROTOCOL_TABLE, input);
+                updateChanges(NET_PROTOCOL_TABLE, itProtocol.value());
             }
 
-            auto itAddress { networkData.find(NET_ADDRESS_TABLE) };
+            const auto itAddress { networkData.find(NET_ADDRESS_TABLE) };
 
             if (itAddress != networkData.end())
             {
-                nlohmann::json input;
-                input["table"] = NET_ADDRESS_TABLE;
-                input["data"] = std::move(*itAddress);
-                updateAndNotifyChanges(NET_ADDRESS_TABLE, input);
+                updateChanges(NET_ADDRESS_TABLE, itAddress.value());
             }
         }
 
@@ -1380,92 +1381,77 @@ void Syscollector::syncNetwork()
     m_spRsync->startSync(m_spDBSync->handle(), nlohmann::json::parse(NETADDRESS_START_CONFIG_STATEMENT), m_reportSyncFunction);
 }
 
-nlohmann::json Syscollector::getPackagesData()
-{
-    nlohmann::json ret;
-    nlohmann::json packagesList;
-    nlohmann::json hotfixesList;
-    auto packagesData (m_spInfo->packages());
-
-    if (!packagesData.is_null())
-    {
-        m_spNormalizer->removeExcluded("packages", packagesData);
-        m_spNormalizer->normalize("packages", packagesData);
-
-        for (auto& item : packagesData)
-        {
-            item["checksum"] = getItemChecksum(item);
-
-            if (item.find("hotfix") != item.end())
-            {
-                hotfixesList.push_back(std::move(item));
-            }
-            else
-            {
-                const auto itemId{ getItemId(item, PACKAGES_ITEM_ID_FIELDS) };
-                const auto it
-                {
-                    std::find_if(packagesList.begin(), packagesList.end(), [&itemId](const auto & elem)
-                    {
-                        return elem.at("item_id") == itemId;
-                    })
-                };
-
-                if (packagesList.end() == it)
-                {
-                    item["item_id"] = itemId;
-                    packagesList.push_back(std::move(item));
-                }
-            }
-        }
-
-        ret[HOTFIXES_TABLE] = std::move(hotfixesList);
-        ret[PACKAGES_TABLE] = std::move(packagesList);
-    }
-
-    return ret;
-}
-
 void Syscollector::scanPackages()
 {
     if (m_packages)
     {
         m_logFunction(SYS_LOG_DEBUG_VERBOSE, "Starting packages scan");
-        auto packagesData (getPackagesData());
-
-        if (!packagesData.is_null())
+        const auto callback
         {
-            auto itPackages { packagesData.find(PACKAGES_TABLE) };
-
-            if (itPackages != packagesData.end())
+            [this](ReturnTypeCallback result, const nlohmann::json & data)
             {
-                nlohmann::json input;
-                input["table"] = PACKAGES_TABLE;
-                input["data"] = std::move(*itPackages);
-                updateAndNotifyChanges(PACKAGES_TABLE, input);
+                notifyChange(result, data, PACKAGES_TABLE);
             }
+        };
+        DBSyncTxn txn
+        {
+            m_spDBSync->handle(),
+            nlohmann::json{PACKAGES_TABLE},
+            0,
+            QUEUE_SIZE,
+            callback
+        };
+        m_spInfo->packages([this, &txn](nlohmann::json & rawData)
+        {
+            nlohmann::json input;
 
-            if (m_hotfixes)
+            rawData["checksum"] = getItemChecksum(rawData);
+            rawData["item_id"] = getItemId(rawData, PACKAGES_ITEM_ID_FIELDS);
+
+            input["table"] = PACKAGES_TABLE;
+            m_spNormalizer->normalize("packages", rawData);
+            m_spNormalizer->removeExcluded("packages", rawData);
+
+            if (!rawData.empty())
             {
-                auto itHotFixes { packagesData.find(HOTFIXES_TABLE) };
-
-                if (itHotFixes != packagesData.end())
-                {
-                    nlohmann::json input;
-                    input["table"] = HOTFIXES_TABLE;
-                    input["data"] = std::move(*itHotFixes);
-                    updateAndNotifyChanges(HOTFIXES_TABLE, input);
-                }
+                input["data"] = nlohmann::json::array( { rawData } );
+                txn.syncTxnRow(input);
             }
-        }
+        });
+        txn.getDeletedRows(callback);
 
         m_logFunction(SYS_LOG_DEBUG_VERBOSE, "Ending packages scan");
+    }
+}
+
+void Syscollector::scanHotfixes()
+{
+    if (m_hotfixes)
+    {
+        m_logFunction(SYS_LOG_DEBUG_VERBOSE, "Starting hotfixes scan");
+        auto hotfixes = m_spInfo->hotfixes();
+
+        if (!hotfixes.is_null())
+        {
+            for (auto& hotfix : hotfixes)
+            {
+                hotfix["checksum"] = getItemChecksum(hotfix);
+            }
+
+            updateChanges(HOTFIXES_TABLE, hotfixes);
+        }
+
+        m_logFunction(SYS_LOG_DEBUG_VERBOSE, "Ending hotfixes scan");
     }
 }
 
 void Syscollector::syncPackages()
 {
     m_spRsync->startSync(m_spDBSync->handle(), nlohmann::json::parse(PACKAGES_START_CONFIG_STATEMENT), m_reportSyncFunction);
+}
+
+void Syscollector::syncHotfixes()
+{
     m_spRsync->startSync(m_spDBSync->handle(), nlohmann::json::parse(HOTFIXES_START_CONFIG_STATEMENT), m_reportSyncFunction);
 }
 
@@ -1479,18 +1465,30 @@ nlohmann::json Syscollector::getPortsData()
 
     if (!data.is_null())
     {
-        const auto& itPorts { data.find("ports") };
-
-        if (data.end() != itPorts)
+        for (auto item : data)
         {
-            for (auto item : itPorts.value())
-            {
-                const auto protocol { item.at("protocol").get_ref<const std::string&>() };
+            const auto protocol { item.at("protocol").get_ref<const std::string&>() };
 
-                if (Utils::startsWith(protocol, TCP_PROTOCOL))
+            if (Utils::startsWith(protocol, TCP_PROTOCOL))
+            {
+                // All ports.
+                if (m_portsAll)
                 {
-                    // All ports.
-                    if (m_portsAll)
+                    const auto& itemId { getItemId(item, PORTS_ITEM_ID_FIELDS) };
+
+                    if (!isElementDuplicated(ret, std::make_pair("item_id", itemId)))
+                    {
+                        item["checksum"] = getItemChecksum(item);
+                        item["item_id"] = itemId;
+                        ret.push_back(item);
+                    }
+                }
+                else
+                {
+                    // Only listening ports.
+                    const auto isListeningState { item.at("state") == PORT_LISTENING_STATE };
+
+                    if (isListeningState)
                     {
                         const auto& itemId { getItemId(item, PORTS_ITEM_ID_FIELDS) };
 
@@ -1501,34 +1499,17 @@ nlohmann::json Syscollector::getPortsData()
                             ret.push_back(item);
                         }
                     }
-                    else
-                    {
-                        // Only listening ports.
-                        const auto isListeningState { item.at("state") == PORT_LISTENING_STATE };
-
-                        if (isListeningState)
-                        {
-                            const auto& itemId { getItemId(item, PORTS_ITEM_ID_FIELDS) };
-
-                            if (!isElementDuplicated(ret, std::make_pair("item_id", itemId)))
-                            {
-                                item["checksum"] = getItemChecksum(item);
-                                item["item_id"] = itemId;
-                                ret.push_back(item);
-                            }
-                        }
-                    }
                 }
-                else if (Utils::startsWith(protocol, UDP_PROTOCOL))
-                {
-                    const auto& itemId { getItemId(item, PORTS_ITEM_ID_FIELDS) };
+            }
+            else if (Utils::startsWith(protocol, UDP_PROTOCOL))
+            {
+                const auto& itemId { getItemId(item, PORTS_ITEM_ID_FIELDS) };
 
-                    if (!isElementDuplicated(ret, std::make_pair("item_id", itemId)))
-                    {
-                        item["checksum"] = getItemChecksum(item);
-                        item["item_id"] = itemId;
-                        ret.push_back(item);
-                    }
+                if (!isElementDuplicated(ret, std::make_pair("item_id", itemId)))
+                {
+                    item["checksum"] = getItemChecksum(item);
+                    item["item_id"] = itemId;
+                    ret.push_back(item);
                 }
             }
         }
@@ -1542,10 +1523,8 @@ void Syscollector::scanPorts()
     if (m_ports)
     {
         m_logFunction(SYS_LOG_DEBUG_VERBOSE, "Starting ports scan");
-        nlohmann::json input;
-        input["table"] = PORTS_TABLE;
-        input["data"] = getPortsData();
-        updateAndNotifyChanges(PORTS_TABLE, input);
+        const auto& portsData { getPortsData() };
+        updateChanges(PORTS_TABLE, portsData);
         m_logFunction(SYS_LOG_DEBUG_VERBOSE, "Ending ports scan");
     }
 }
@@ -1555,32 +1534,39 @@ void Syscollector::syncPorts()
     m_spRsync->startSync(m_spDBSync->handle(), nlohmann::json::parse(PORTS_START_CONFIG_STATEMENT), m_reportSyncFunction);
 }
 
-nlohmann::json Syscollector::getProcessesData()
-{
-    nlohmann::json ret;
-    auto processes(m_spInfo->processes());
-
-    if (!processes.is_null())
-    {
-        for (auto& item : processes)
-        {
-            item["checksum"] = getItemChecksum(item);
-            ret.push_back(std::move(item));
-        }
-    }
-
-    return ret;
-}
-
 void Syscollector::scanProcesses()
 {
     if (m_processes)
     {
         m_logFunction(SYS_LOG_DEBUG_VERBOSE, "Starting processes scan");
-        nlohmann::json input;
-        input["table"] = PROCESSES_TABLE;
-        input["data"] = getProcessesData();
-        updateAndNotifyChanges(PROCESSES_TABLE, input);
+        const auto callback
+        {
+            [this](ReturnTypeCallback result, const nlohmann::json & data)
+            {
+                notifyChange(result, data, PROCESSES_TABLE);
+            }
+        };
+        DBSyncTxn txn
+        {
+            m_spDBSync->handle(),
+            nlohmann::json{PROCESSES_TABLE},
+            0,
+            QUEUE_SIZE,
+            callback
+        };
+        m_spInfo->processes([&txn](nlohmann::json & rawData)
+        {
+            nlohmann::json input;
+
+            rawData["checksum"] = getItemChecksum(rawData);
+
+            input["table"] = PROCESSES_TABLE;
+            input["data"] = nlohmann::json::array( { rawData } );
+
+            txn.syncTxnRow(input);
+        });
+        txn.getDeletedRows(callback);
+
         m_logFunction(SYS_LOG_DEBUG_VERBOSE, "Ending processes scan");
     }
 }
@@ -1594,10 +1580,12 @@ void Syscollector::scan()
 {
     m_logFunction(SYS_LOG_INFO, "Starting evaluation.");
     m_scanTime = Utils::getCurrentTimestamp();
+
     TRY_CATCH_TASK(scanHardware);
     TRY_CATCH_TASK(scanOs);
     TRY_CATCH_TASK(scanNetwork);
     TRY_CATCH_TASK(scanPackages);
+    TRY_CATCH_TASK(scanHotfixes);
     TRY_CATCH_TASK(scanPorts);
     TRY_CATCH_TASK(scanProcesses);
     m_notify = true;
@@ -1611,6 +1599,7 @@ void Syscollector::sync()
     TRY_CATCH_TASK(syncOs);
     TRY_CATCH_TASK(syncNetwork);
     TRY_CATCH_TASK(syncPackages);
+    TRY_CATCH_TASK(syncHotfixes);
     TRY_CATCH_TASK(syncPorts);
     TRY_CATCH_TASK(syncProcesses);
     m_logFunction(SYS_LOG_DEBUG, "Ending syscollector sync");

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -75,7 +75,7 @@ TEST_F(SyscollectorImpTest, defaultCtor)
     EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                       R"({"iface":[{"address":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "mac":"d4:5d:64:51:07:5d", "gateway":"192.168.0.1|600","broadcast":"127.255.255.255", "name":"ens1", "mtu":1500, "name":"enp4s0", "adapter":" ", "type":"ethernet", "state":"up", "dhcp":"disabled","iface":"Loopback Pseudo-Interface 1","metric":"75","netmask":"255.0.0.0","proto":"IPv4","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0, "IPv4":[{"address":"192.168.153.1","broadcast":"192.168.153.255","dhcp":"unknown","metric":" ","netmask":"255.255.255.0"}], "IPv6":[{"address":"fe80::250:56ff:fec0:8","dhcp":"unknown","metric":" ","netmask":"ffff:ffff:ffff:ffff::"}]}]})")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                   R"({"ports":[{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}]})")));
+                                                                   R"([{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}])")));
     EXPECT_CALL(*spInfoWrapper, packages(_))
     .Times(::testing::AtLeast(1))
     .WillOnce(::testing::InvokeArgument<0>
@@ -247,7 +247,7 @@ TEST_F(SyscollectorImpTest, intervalSeconds)
     EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                       R"({"iface":[{"address":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "mac":"d4:5d:64:51:07:5d", "gateway":"192.168.0.1|600","broadcast":"127.255.255.255", "name":"ens1", "mtu":1500, "name":"enp4s0", "adapter":" ", "type":"ethernet", "state":"up", "dhcp":"disabled","iface":"Loopback Pseudo-Interface 1","metric":"75","netmask":"255.0.0.0","proto":"IPv4","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0, "IPv4":[{"address":"192.168.153.1","broadcast":"192.168.153.255","dhcp":"unknown","metric":" ","netmask":"255.255.255.0"}], "IPv6":[{"address":"fe80::250:56ff:fec0:8","dhcp":"unknown","metric":" ","netmask":"ffff:ffff:ffff:ffff::"}]}]})")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                   R"({"ports":[{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}]})")));
+                                                                   R"([{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}])")));
     EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(R"([{"hotfix":"KB12345678"},{"hotfix":"KB87654321"}])"_json));
     EXPECT_CALL(*spInfoWrapper, processes(_))
     .Times(::testing::AtLeast(2))
@@ -328,7 +328,7 @@ TEST_F(SyscollectorImpTest, noHardware)
     EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                       R"({"iface":[{"address":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "mac":"d4:5d:64:51:07:5d", "gateway":"192.168.0.1|600","broadcast":"127.255.255.255", "name":"ens1", "mtu":1500, "name":"enp4s0", "adapter":" ", "type":"ethernet", "state":"up", "dhcp":"disabled","iface":"Loopback Pseudo-Interface 1","metric":"75","netmask":"255.0.0.0","proto":"IPv4","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0, "IPv4":[{"address":"192.168.153.1","broadcast":"192.168.153.255","dhcp":"unknown","metric":" ","netmask":"255.255.255.0"}], "IPv6":[{"address":"fe80::250:56ff:fec0:8","dhcp":"unknown","metric":" ","netmask":"ffff:ffff:ffff:ffff::"}]}]})")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                   R"({"ports":[{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}]})")));
+                                                                   R"([{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}])")));
     EXPECT_CALL(*spInfoWrapper, packages(_))
     .Times(::testing::AtLeast(1))
     .WillOnce(::testing::InvokeArgument<0>
@@ -489,7 +489,7 @@ TEST_F(SyscollectorImpTest, noOs)
     EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                       R"({"iface":[{"address":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "mac":"d4:5d:64:51:07:5d", "gateway":"192.168.0.1|600","broadcast":"127.255.255.255", "name":"ens1", "mtu":1500, "name":"enp4s0", "adapter":" ", "type":"ethernet", "state":"up", "dhcp":"disabled","iface":"Loopback Pseudo-Interface 1","metric":"75","netmask":"255.0.0.0","proto":"IPv4","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0, "IPv4":[{"address":"192.168.153.1","broadcast":"192.168.153.255","dhcp":"unknown","metric":" ","netmask":"255.255.255.0"}], "IPv6":[{"address":"fe80::250:56ff:fec0:8","dhcp":"unknown","metric":" ","netmask":"ffff:ffff:ffff:ffff::"}]}]})")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                   R"({"ports":[{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}]})")));
+                                                                   R"([{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}])")));
     EXPECT_CALL(*spInfoWrapper, os()).Times(0);
     EXPECT_CALL(*spInfoWrapper, packages(_))
     .Times(::testing::AtLeast(1))
@@ -651,7 +651,7 @@ TEST_F(SyscollectorImpTest, noNetwork)
                                                                 R"({"architecture":"x86_64","scan_time":"2020/12/28 21:49:50", "hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
     EXPECT_CALL(*spInfoWrapper, networks()).Times(0);
     EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                   R"({"ports":[{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}]})")));
+                                                                   R"([{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}])")));
     EXPECT_CALL(*spInfoWrapper, packages(_))
     .Times(::testing::AtLeast(1))
     .WillOnce(::testing::InvokeArgument<0>
@@ -789,7 +789,7 @@ TEST_F(SyscollectorImpTest, noPackages)
     EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                       R"({"iface":[{"address":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "mac":"d4:5d:64:51:07:5d", "gateway":"192.168.0.1|600","broadcast":"127.255.255.255", "name":"ens1", "mtu":1500, "name":"enp4s0", "adapter":" ", "type":"ethernet", "state":"up", "dhcp":"disabled","iface":"Loopback Pseudo-Interface 1","metric":"75","netmask":"255.0.0.0","proto":"IPv4","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0, "IPv4":[{"address":"192.168.153.1","broadcast":"192.168.153.255","dhcp":"unknown","metric":" ","netmask":"255.255.255.0"}], "IPv6":[{"address":"fe80::250:56ff:fec0:8","dhcp":"unknown","metric":" ","netmask":"ffff:ffff:ffff:ffff::"}]}]})")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                   R"({"ports":[{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}]})")));
+                                                                   R"([{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}])")));
     EXPECT_CALL(*spInfoWrapper, packages(_)).Times(0);
 
     EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(R"([{"hotfix":"KB12345678"}])"_json));
@@ -1111,7 +1111,7 @@ TEST_F(SyscollectorImpTest, noPortsAll)
     EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                       R"({"iface":[{"address":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "mac":"d4:5d:64:51:07:5d", "gateway":"192.168.0.1|600","broadcast":"127.255.255.255", "name":"ens1", "mtu":1500, "name":"enp4s0", "adapter":" ", "type":"ethernet", "state":"up", "dhcp":"disabled","iface":"Loopback Pseudo-Interface 1","metric":"75","netmask":"255.0.0.0","proto":"IPv4","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0, "IPv4":[{"address":"192.168.153.1","broadcast":"192.168.153.255","dhcp":"unknown","metric":" ","netmask":"255.255.255.0"}], "IPv6":[{"address":"fe80::250:56ff:fec0:8","dhcp":"unknown","metric":" ","netmask":"ffff:ffff:ffff:ffff::"}]}]})")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                   R"({"ports":[{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"udp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"","tx_queue":0},{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}]})")));
+                                                                   R"([{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"udp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"","tx_queue":0},{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}])")));
     EXPECT_CALL(*spInfoWrapper, packages(_))
     .Times(::testing::AtLeast(1))
     .WillOnce(::testing::InvokeArgument<0>
@@ -1288,7 +1288,7 @@ TEST_F(SyscollectorImpTest, noProcesses)
     EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                       R"({"iface":[{"address":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "mac":"d4:5d:64:51:07:5d", "gateway":"192.168.0.1|600","broadcast":"127.255.255.255", "name":"ens1", "mtu":1500, "name":"enp4s0", "adapter":" ", "type":"ethernet", "state":"up", "dhcp":"disabled","iface":"Loopback Pseudo-Interface 1","metric":"75","netmask":"255.0.0.0","proto":"IPv4","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0, "IPv4":[{"address":"192.168.153.1","broadcast":"192.168.153.255","dhcp":"unknown","metric":" ","netmask":"255.255.255.0"}], "IPv6":[{"address":"fe80::250:56ff:fec0:8","dhcp":"unknown","metric":" ","netmask":"ffff:ffff:ffff:ffff::"}]}]})")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                   R"({"ports":[{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}]})")));
+                                                                   R"([{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}])")));
     EXPECT_CALL(*spInfoWrapper, packages(_))
     .Times(::testing::AtLeast(1))
     .WillOnce(::testing::InvokeArgument<0>
@@ -1448,7 +1448,7 @@ TEST_F(SyscollectorImpTest, noHotfixes)
     EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                       R"({"iface":[{"address":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "mac":"d4:5d:64:51:07:5d", "gateway":"192.168.0.1|600","broadcast":"127.255.255.255", "name":"ens1", "mtu":1500, "name":"enp4s0", "adapter":" ", "type":"ethernet", "state":"up", "dhcp":"disabled","iface":"Loopback Pseudo-Interface 1","metric":"75","netmask":"255.0.0.0","proto":"IPv4","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0, "IPv4":[{"address":"192.168.153.1","broadcast":"192.168.153.255","dhcp":"unknown","metric":" ","netmask":"255.255.255.0"}], "IPv6":[{"address":"fe80::250:56ff:fec0:8","dhcp":"unknown","metric":" ","netmask":"ffff:ffff:ffff:ffff::"}]}]})")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                   R"({"ports":[{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}]})")));
+                                                                   R"([{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}])")));
     EXPECT_CALL(*spInfoWrapper, packages(_))
     .Times(::testing::AtLeast(1))
     .WillOnce(::testing::InvokeArgument<0>
@@ -1614,7 +1614,7 @@ TEST_F(SyscollectorImpTest, pushMessageOk)
     EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                 R"({"architecture":"x86_64","scan_time":"2020/12/28 21:49:50", "hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                   R"({"ports":[{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}]})")));
+                                                                   R"([{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}])")));
     EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(R"([{"hotfix":"KB12345678"}])"_json));
     EXPECT_CALL(*spInfoWrapper, packages(_))
     .Times(::testing::AtLeast(1))
@@ -1661,7 +1661,7 @@ TEST_F(SyscollectorImpTest, pushMessageOk1)
     EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                 R"({"architecture":"x86_64","scan_time":"2020/12/28 21:49:50", "hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                   R"({"ports":[{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}]})")));
+                                                                   R"([{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}])")));
     EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(R"([{"hotfix":"KB12345678"}])"_json));
     EXPECT_CALL(*spInfoWrapper, packages(_))
     .Times(::testing::AtLeast(1))
@@ -1839,7 +1839,7 @@ TEST_F(SyscollectorImpTest, pushMessageInvalid)
     EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                 R"({"architecture":"x86_64","scan_time":"2020/12/28 21:49:50", "hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                   R"({"ports":[{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}]})")));
+                                                                   R"([{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}])")));
     EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(R"([{"hotfix":"KB12345678"},{"hotfix":"KB87654321"}])"_json));
     EXPECT_CALL(*spInfoWrapper, packages(_))
     .Times(::testing::AtLeast(1))
@@ -1886,7 +1886,7 @@ TEST_F(SyscollectorImpTest, scanInvalidData)
     EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                 R"({"architecture":"x86_64","scan_time":"2020/12/28 21:49:50", "hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                   R"({"ports":[{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}]})")));
+                                                                   R"([{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}])")));
     EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(R"([{"hotfix":"KB12345678"},{"hotfix":"KB87654321"}])"_json));
     EXPECT_CALL(*spInfoWrapper, packages(_))
     .Times(::testing::AtLeast(1))
@@ -1926,8 +1926,8 @@ TEST_F(SyscollectorImpTest, scanInvalidData)
 TEST_F(SyscollectorImpTest, portAllEnable)
 {
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
-    EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(R"({
-    "ports":[
+    EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(R"(
+    [
         {
             "inode":43481,
             "local_ip":"0.0.0.0",
@@ -1993,8 +1993,7 @@ TEST_F(SyscollectorImpTest, portAllEnable)
             "state":"established",
             "tx_queue":0
         }
-    ]
-    })")));
+    ])")));
 
     CallbackMock wrapper;
     std::function<void(const std::string&)> callbackData
@@ -2059,8 +2058,8 @@ TEST_F(SyscollectorImpTest, portAllEnable)
 TEST_F(SyscollectorImpTest, portAllDisable)
 {
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
-    EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(R"({
-    "ports":[
+    EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(R"(
+    [
         {
             "inode":43481,
             "local_ip":"0.0.0.0",
@@ -2126,8 +2125,7 @@ TEST_F(SyscollectorImpTest, portAllDisable)
             "state":"established",
             "tx_queue":0
         }
-    ]
-    })")));
+    ])")));
 
     CallbackMock wrapper;
     std::function<void(const std::string&)> callbackData

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -34,6 +34,8 @@ class SysInfoWrapper: public ISysInfo
         MOCK_METHOD(nlohmann::json, os, (), (override));
         MOCK_METHOD(nlohmann::json, networks, (), (override));
         MOCK_METHOD(nlohmann::json, processes, (), (override));
+        MOCK_METHOD(void, processes, (std::function<void(nlohmann::json&)>), (override));
+        MOCK_METHOD(void, packages, (std::function<void(nlohmann::json&)>), (override));
         MOCK_METHOD(nlohmann::json, ports, (), (override));
 };
 

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -31,12 +31,21 @@ class SysInfoWrapper: public ISysInfo
         ~SysInfoWrapper() = default;
         MOCK_METHOD(nlohmann::json, hardware, (), (override));
         MOCK_METHOD(nlohmann::json, packages, (), (override));
+        MOCK_METHOD(void, packages, (std::function<void(nlohmann::json&)>), (override));
         MOCK_METHOD(nlohmann::json, os, (), (override));
         MOCK_METHOD(nlohmann::json, networks, (), (override));
         MOCK_METHOD(nlohmann::json, processes, (), (override));
         MOCK_METHOD(void, processes, (std::function<void(nlohmann::json&)>), (override));
-        MOCK_METHOD(void, packages, (std::function<void(nlohmann::json&)>), (override));
         MOCK_METHOD(nlohmann::json, ports, (), (override));
+        MOCK_METHOD(nlohmann::json, hotfixes, (), (override));
+};
+
+class CallbackMock
+{
+    public:
+        CallbackMock() = default;
+        ~CallbackMock() = default;
+        MOCK_METHOD(void, callbackMock, (const std::string&), ());
 };
 
 void reportFunction(const std::string& /*payload*/)
@@ -61,29 +70,161 @@ TEST_F(SyscollectorImpTest, defaultCtor)
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
     EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                       R"({"board_serial":"Intel Corporation","scan_time":"2020/12/28 21:49:50", "cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz", "ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
-    EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"([{"name":"TEXT", "scan_time":"2020/12/28 21:49:50", "version":"TEXT", "vendor":"TEXT", "install_time":"TEXT", "location":"TEXT", "architecture":"TEXT", "groups":"TEXT", "description":"TEXT", "size":"TEXT", "priority":"TEXT", "multiarch":"TEXT", "source":"TEXT", "os_patch":"TEXT"}])")));
     EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                 R"({"architecture":"x86_64","scan_time":"2020/12/28 21:49:50", "hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
     EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                       R"({"iface":[{"address":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "mac":"d4:5d:64:51:07:5d", "gateway":"192.168.0.1|600","broadcast":"127.255.255.255", "name":"ens1", "mtu":1500, "name":"enp4s0", "adapter":" ", "type":"ethernet", "state":"up", "dhcp":"disabled","iface":"Loopback Pseudo-Interface 1","metric":"75","netmask":"255.0.0.0","proto":"IPv4","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0, "IPv4":[{"address":"192.168.153.1","broadcast":"192.168.153.255","dhcp":"unknown","metric":" ","netmask":"255.255.255.0"}], "IPv6":[{"address":"fe80::250:56ff:fec0:8","dhcp":"unknown","metric":" ","netmask":"ffff:ffff:ffff:ffff::"}]}]})")));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                       R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-", "scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                    R"({"ports":[{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}]})")));
+    EXPECT_CALL(*spInfoWrapper, packages(_))
+    .Times(::testing::AtLeast(1))
+    .WillOnce(::testing::InvokeArgument<0>
+              (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"})"_json));
+
+    EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(R"([{"hotfix":"KB12345678"}])"_json));
+
+    EXPECT_CALL(*spInfoWrapper, processes(_))
+    .Times(testing::AtLeast(1))
+    .WillOnce(::testing::InvokeArgument<0>
+              (R"({"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":"431625","ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0})"_json));
+
+    CallbackMock wrapper;
+    std::function<void(const std::string&)> callbackData
+    {
+        [&wrapper](const std::string & data)
+        {
+            auto delta = nlohmann::json::parse(data);
+            delta["data"].erase("checksum");
+            delta["data"].erase("id");
+            wrapper.callbackMock(delta.dump());
+        }
+    };
+
+    CallbackMock wrapperDelta;
+    std::function<void(const std::string&)> callbackDataDelta
+    {
+        [&wrapperDelta](const std::string & data)
+        {
+            auto delta = nlohmann::json::parse(data);
+
+            if (delta.at("type").get_ref<const std::string&>().compare("dbsync_osinfo") == 0)
+            {
+                delta["data"].erase("checksum");
+            }
+
+            delta["data"].erase("scan_time");
+            wrapperDelta.callbackMock(delta.dump());
+        }
+    };
+
+    const auto expectedResult1
+    {
+        R"({"data":{"board_serial":"Intel Corporation","checksum":"af7b22eef8f5e06c04af4db49c9f8d1d28963918","cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54},"operation":"INSERTED","type":"dbsync_hwinfo"})"
+    };
+    const auto expectedResult2
+    {
+        R"({"data":{"architecture":"x86_64","hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"},"operation":"INSERTED","type":"dbsync_osinfo"})"
+    };
+    const auto expectedResult3
+    {
+        R"({"data":{"adapter":" ","checksum":"165f7160ecd2838479ee4c43c1012b723736d90a","item_id":"25eef9a0a422a9b644fb6b73650453148bc6151c","mac":"d4:5d:64:51:07:5d","mtu":1500,"name":"enp4s0","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"state":"up","tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0,"type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_iface"})"
+    };
+    const auto expectedResult4
+    {
+        R"({"data":{"checksum":"2ab0e1d3980d80e11fd5262236a662b9726151a8","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"338a8e51ab095707973bb34d85a22208c7284490","metric":" ","type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
+    };
+    const auto expectedResult5
+    {
+        R"({"data":{"address":"192.168.153.1","broadcast":"192.168.153.255","checksum":"72dfd66759bd8062cdc17607d760a48c906189b3","dhcp":"unknown","iface":"enp4s0","item_id":"3d48ddc47fac84c62a19746af66fbfcf78547de9","metric":" ","netmask":"255.255.255.0","proto":0},"operation":"INSERTED","type":"dbsync_network_address"})"
+    };
+    const auto expectedResult6
+    {
+        R"({"data":{"address":"fe80::250:56ff:fec0:8","checksum":"f606d1a1c551874d8fab33e4e5cfaa0370673ec8","dhcp":"unknown","iface":"enp4s0","item_id":"65973316a5dc8615a6d20b2d6c4ce52ecd074496","metric":" ","netmask":"ffff:ffff:ffff:ffff::","proto":1},"operation":"INSERTED","type":"dbsync_network_address"})"
+    };
+    const auto expectedResult7
+    {
+        R"({"data":{"checksum":"f25348b1ce5310f36c1ed859d13138fbb4e6bacb","inode":0,"item_id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba","local_ip":"127.0.0.1","local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0},"operation":"INSERTED","type":"dbsync_ports"})"
+    };
+    const auto expectedResult8
+    {
+        R"({"data":{"checksum":"039934723aa69928b52e470c8d27365b0924b615","egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":"431625","ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0},"operation":"INSERTED","type":"dbsync_processes"})"
+    };
+    const auto expectedResult9
+    {
+        R"({"data":{"architecture":"amd64","checksum":"561243cbb871f6d842c1d2c1533892a3339252d4","group":"x11","item_id":"7a119de04989606ebae116083afc1ec2579b0631","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+    };
+    const auto expectedResult10
+    {
+        R"({"component":"syscollector_osinfo","data":{"begin":"Microsoft Windows 7","end":"Microsoft Windows 7"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult11
+    {
+        R"({"component":"syscollector_network_iface","data":{"begin":"25eef9a0a422a9b644fb6b73650453148bc6151c","end":"25eef9a0a422a9b644fb6b73650453148bc6151c"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult12
+    {
+        R"({"component":"syscollector_network_protocol","data":{"begin":"338a8e51ab095707973bb34d85a22208c7284490","end":"338a8e51ab095707973bb34d85a22208c7284490"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult13
+    {
+        R"({"component":"syscollector_network_address","data":{"begin":"3d48ddc47fac84c62a19746af66fbfcf78547de9","end":"65973316a5dc8615a6d20b2d6c4ce52ecd074496"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult14
+    {
+        R"({"component":"syscollector_ports","data":{"begin":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba","end":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult15
+    {
+        R"({"component":"syscollector_processes","data":{"begin":"431625","end":"431625"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult16
+    {
+        R"({"component":"syscollector_hwinfo","data":{"begin":"Intel Corporation","end":"Intel Corporation"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult17
+    {
+        R"({"component":"syscollector_packages","data":{"begin":"7a119de04989606ebae116083afc1ec2579b0631","end":"7a119de04989606ebae116083afc1ec2579b0631"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult18
+    {
+        R"({"data":{"checksum":"56162cd7bb632b4728ec868e8e271b01222ff131","hotfix":"KB12345678"},"operation":"INSERTED","type":"dbsync_hotfixes"})"
+    };
+    const auto expectedResult19
+    {
+        R"({"component":"syscollector_hotfixes","data":{"begin":"KB12345678","end":"KB12345678"},"type":"integrity_check_global"})"
+    };
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult2)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult3)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult4)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult5)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult6)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult7)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult8)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult9)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult10)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult11)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult12)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult13)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult14)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult15)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult16)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult17)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult18)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult19)).Times(1);
 
     std::thread t
     {
-        [&spInfoWrapper]()
+        [&spInfoWrapper, &callbackData, &callbackDataDelta]()
         {
             Syscollector::instance().init(spInfoWrapper,
-                                          reportFunction,
-                                          reportFunction,
+                                          callbackDataDelta,
+                                          callbackData,
                                           logFunction,
                                           SYSCOLLECTOR_DB_PATH,
                                           "",
                                           "",
-                                          5);
+                                          5, true, true, true, true, true, true, true, true, true, true);
         }
     };
 
@@ -101,16 +242,23 @@ TEST_F(SyscollectorImpTest, intervalSeconds)
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
     EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                       R"({"board_serial":"Intel Corporation","scan_time":"2020/12/28 21:49:50", "cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
-    EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"([{"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14","os_patch":""},{"hotfix":"KB4586786"}])")));
     EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                 R"({"architecture":"x86_64","scan_time":"2020/12/28 21:49:50", "hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
     EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                       R"({"iface":[{"address":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "mac":"d4:5d:64:51:07:5d", "gateway":"192.168.0.1|600","broadcast":"127.255.255.255", "name":"ens1", "mtu":1500, "name":"enp4s0", "adapter":" ", "type":"ethernet", "state":"up", "dhcp":"disabled","iface":"Loopback Pseudo-Interface 1","metric":"75","netmask":"255.0.0.0","proto":"IPv4","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0, "IPv4":[{"address":"192.168.153.1","broadcast":"192.168.153.255","dhcp":"unknown","metric":" ","netmask":"255.255.255.0"}], "IPv6":[{"address":"fe80::250:56ff:fec0:8","dhcp":"unknown","metric":" ","netmask":"ffff:ffff:ffff:ffff::"}]}]})")));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                       R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                    R"({"ports":[{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}]})")));
+    EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(R"([{"hotfix":"KB12345678"},{"hotfix":"KB87654321"}])"_json));
+    EXPECT_CALL(*spInfoWrapper, processes(_))
+    .Times(::testing::AtLeast(2))
+    .WillRepeatedly(testing::InvokeArgument<0>(nlohmann::json::parse(
+                                                   R"({"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0})")));
+
+    EXPECT_CALL(*spInfoWrapper, packages(_))
+    .Times(::testing::AtLeast(2))
+    .WillRepeatedly(::testing::InvokeArgument<0>
+                    (R"({"name":"TEXT", "scan_time":"2020/12/28 21:49:50", "version":"TEXT", "vendor":"TEXT", "install_time":"TEXT", "location":"TEXT", "architecture":"TEXT", "groups":"TEXT", "description":"TEXT", "size":"TEXT", "priority":"TEXT", "multiarch":"TEXT", "source":"TEXT", "os_patch":"TEXT"})"_json));
+
     std::thread t
     {
         [&spInfoWrapper]()
@@ -122,11 +270,12 @@ TEST_F(SyscollectorImpTest, intervalSeconds)
                                           SYSCOLLECTOR_DB_PATH,
                                           "",
                                           "",
-                                          100);
+                                          1, true, true, true, true, true, true, true, true, true, true);
+
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds{2});
+    std::this_thread::sleep_for(std::chrono::seconds{10});
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -140,10 +289,12 @@ TEST_F(SyscollectorImpTest, noScanOnStart)
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
     EXPECT_CALL(*spInfoWrapper, hardware()).Times(0);
     EXPECT_CALL(*spInfoWrapper, os()).Times(0);
-    EXPECT_CALL(*spInfoWrapper, packages()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, packages(_)).Times(0);
     EXPECT_CALL(*spInfoWrapper, networks()).Times(0);
-    EXPECT_CALL(*spInfoWrapper, processes()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, processes(_)).Times(0);
     EXPECT_CALL(*spInfoWrapper, ports()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, hotfixes()).Times(0);
+
     std::thread t
     {
         [&spInfoWrapper]()
@@ -172,70 +323,317 @@ TEST_F(SyscollectorImpTest, noHardware)
 {
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
     EXPECT_CALL(*spInfoWrapper, hardware()).Times(0);
-    EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"([{"architecture":" ","checksum":"e992398126de35d38e97ee7b3cb0a640c93dad1b","description":"A terminal handling library","format":"rpm","groups":"System Environment/Libraries","install_time":"Sun 23 Feb 2014 04:12:17 AM EST","item_id":"90221e4c15213672852cd6367f754a65ea18e905","name":"ncurses","size":"3022251","vendor":"CentOS","version":"24.20060715-5.5"},{"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14","os_patch":""},{"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14","os_patch":""},{"hotfix":"KB4586786"}])")));
     EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                 R"({"architecture":"x86_64","scan_time":"2020/12/28 21:49:50", "hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
     EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                       R"({"iface":[{"address":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "mac":"d4:5d:64:51:07:5d", "gateway":"192.168.0.1|600","broadcast":"127.255.255.255", "name":"ens1", "mtu":1500, "name":"enp4s0", "adapter":" ", "type":"ethernet", "state":"up", "dhcp":"disabled","iface":"Loopback Pseudo-Interface 1","metric":"75","netmask":"255.0.0.0","proto":"IPv4","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0, "IPv4":[{"address":"192.168.153.1","broadcast":"192.168.153.255","dhcp":"unknown","metric":" ","netmask":"255.255.255.0"}], "IPv6":[{"address":"fe80::250:56ff:fec0:8","dhcp":"unknown","metric":" ","netmask":"ffff:ffff:ffff:ffff::"}]}]})")));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                       R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                    R"({"ports":[{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}]})")));
+    EXPECT_CALL(*spInfoWrapper, packages(_))
+    .Times(::testing::AtLeast(1))
+    .WillOnce(::testing::InvokeArgument<0>
+              (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"})"_json));
+
+    EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(R"([{"hotfix":"KB12345678"}])"_json));
+
+    EXPECT_CALL(*spInfoWrapper, processes(_))
+    .Times(testing::AtLeast(1))
+    .WillOnce(::testing::InvokeArgument<0>
+              (R"({"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":"431625","ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0})"_json));
+
+    CallbackMock wrapper;
+    std::function<void(const std::string&)> callbackData
+    {
+        [&wrapper](const std::string & data)
+        {
+            auto delta = nlohmann::json::parse(data);
+            delta["data"].erase("checksum");
+            delta["data"].erase("id");
+            wrapper.callbackMock(delta.dump());
+        }
+    };
+
+    CallbackMock wrapperDelta;
+    std::function<void(const std::string&)> callbackDataDelta
+    {
+        [&wrapperDelta](const std::string & data)
+        {
+            auto delta = nlohmann::json::parse(data);
+
+            if (delta["type"].get_ref<const std::string&>().compare("dbsync_osinfo") == 0)
+            {
+                delta["data"].erase("checksum");
+            }
+
+            delta["data"].erase("scan_time");
+            wrapperDelta.callbackMock(delta.dump());
+        }
+    };
+
+    const auto expectedResult2
+    {
+        R"({"data":{"architecture":"x86_64","hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"},"operation":"INSERTED","type":"dbsync_osinfo"})"
+    };
+    const auto expectedResult3
+    {
+        R"({"data":{"adapter":" ","checksum":"165f7160ecd2838479ee4c43c1012b723736d90a","item_id":"25eef9a0a422a9b644fb6b73650453148bc6151c","mac":"d4:5d:64:51:07:5d","mtu":1500,"name":"enp4s0","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"state":"up","tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0,"type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_iface"})"
+    };
+    const auto expectedResult4
+    {
+        R"({"data":{"checksum":"2ab0e1d3980d80e11fd5262236a662b9726151a8","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"338a8e51ab095707973bb34d85a22208c7284490","metric":" ","type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
+    };
+    const auto expectedResult5
+    {
+        R"({"data":{"address":"192.168.153.1","broadcast":"192.168.153.255","checksum":"72dfd66759bd8062cdc17607d760a48c906189b3","dhcp":"unknown","iface":"enp4s0","item_id":"3d48ddc47fac84c62a19746af66fbfcf78547de9","metric":" ","netmask":"255.255.255.0","proto":0},"operation":"INSERTED","type":"dbsync_network_address"})"
+    };
+    const auto expectedResult6
+    {
+        R"({"data":{"address":"fe80::250:56ff:fec0:8","checksum":"f606d1a1c551874d8fab33e4e5cfaa0370673ec8","dhcp":"unknown","iface":"enp4s0","item_id":"65973316a5dc8615a6d20b2d6c4ce52ecd074496","metric":" ","netmask":"ffff:ffff:ffff:ffff::","proto":1},"operation":"INSERTED","type":"dbsync_network_address"})"
+    };
+    const auto expectedResult7
+    {
+        R"({"data":{"checksum":"f25348b1ce5310f36c1ed859d13138fbb4e6bacb","inode":0,"item_id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba","local_ip":"127.0.0.1","local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0},"operation":"INSERTED","type":"dbsync_ports"})"
+    };
+    const auto expectedResult8
+    {
+        R"({"data":{"checksum":"039934723aa69928b52e470c8d27365b0924b615","egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":"431625","ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0},"operation":"INSERTED","type":"dbsync_processes"})"
+    };
+    const auto expectedResult9
+    {
+        R"({"data":{"architecture":"amd64","checksum":"561243cbb871f6d842c1d2c1533892a3339252d4","group":"x11","item_id":"7a119de04989606ebae116083afc1ec2579b0631","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+    };
+    const auto expectedResult10
+    {
+        R"({"component":"syscollector_osinfo","data":{"begin":"Microsoft Windows 7","end":"Microsoft Windows 7"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult11
+    {
+        R"({"component":"syscollector_network_iface","data":{"begin":"25eef9a0a422a9b644fb6b73650453148bc6151c","end":"25eef9a0a422a9b644fb6b73650453148bc6151c"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult12
+    {
+        R"({"component":"syscollector_network_protocol","data":{"begin":"338a8e51ab095707973bb34d85a22208c7284490","end":"338a8e51ab095707973bb34d85a22208c7284490"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult13
+    {
+        R"({"component":"syscollector_network_address","data":{"begin":"3d48ddc47fac84c62a19746af66fbfcf78547de9","end":"65973316a5dc8615a6d20b2d6c4ce52ecd074496"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult14
+    {
+        R"({"component":"syscollector_ports","data":{"begin":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba","end":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult15
+    {
+        R"({"component":"syscollector_processes","data":{"begin":"431625","end":"431625"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult17
+    {
+        R"({"component":"syscollector_packages","data":{"begin":"7a119de04989606ebae116083afc1ec2579b0631","end":"7a119de04989606ebae116083afc1ec2579b0631"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult18
+    {
+        R"({"data":{"checksum":"56162cd7bb632b4728ec868e8e271b01222ff131","hotfix":"KB12345678"},"operation":"INSERTED","type":"dbsync_hotfixes"})"
+    };
+    const auto expectedResult19
+    {
+        R"({"component":"syscollector_hotfixes","data":{"begin":"KB12345678","end":"KB12345678"},"type":"integrity_check_global"})"
+    };
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult2)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult3)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult4)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult5)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult6)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult7)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult8)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult9)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult10)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult11)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult12)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult13)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult14)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult15)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult17)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult18)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult19)).Times(1);
+
     std::thread t
     {
-        [&spInfoWrapper]()
+        [&spInfoWrapper, &callbackData, &callbackDataDelta]()
         {
             Syscollector::instance().init(spInfoWrapper,
-                                          reportFunction,
-                                          reportFunction,
+                                          callbackDataDelta,
+                                          callbackData,
                                           logFunction,
                                           SYSCOLLECTOR_DB_PATH,
                                           "",
                                           "",
-                                          3600, true, false);
+                                          3600, true, false, true, true, true, true, true, true, true, true);
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds{2});
+    std::this_thread::sleep_for(std::chrono::seconds(1));
     Syscollector::instance().destroy();
 
     if (t.joinable())
     {
         t.join();
     }
+
 }
 
 TEST_F(SyscollectorImpTest, noOs)
 {
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
     EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"({"board_serial":"Intel Corporation","scan_time":"2020/12/28 21:49:50", "cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
-    EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"([{"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14","os_patch":""},{"hotfix":"KB4586786"}])")));
-    EXPECT_CALL(*spInfoWrapper, os()).Times(0);
+                                                                      R"({"board_serial":"Intel Corporation","scan_time":"2020/12/28 21:49:50", "cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz", "ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
     EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                       R"({"iface":[{"address":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "mac":"d4:5d:64:51:07:5d", "gateway":"192.168.0.1|600","broadcast":"127.255.255.255", "name":"ens1", "mtu":1500, "name":"enp4s0", "adapter":" ", "type":"ethernet", "state":"up", "dhcp":"disabled","iface":"Loopback Pseudo-Interface 1","metric":"75","netmask":"255.0.0.0","proto":"IPv4","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0, "IPv4":[{"address":"192.168.153.1","broadcast":"192.168.153.255","dhcp":"unknown","metric":" ","netmask":"255.255.255.0"}], "IPv6":[{"address":"fe80::250:56ff:fec0:8","dhcp":"unknown","metric":" ","netmask":"ffff:ffff:ffff:ffff::"}]}]})")));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                       R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                    R"({"ports":[{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}]})")));
+    EXPECT_CALL(*spInfoWrapper, os()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, packages(_))
+    .Times(::testing::AtLeast(1))
+    .WillOnce(::testing::InvokeArgument<0>
+              (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"})"_json));
+
+    EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(R"([{"hotfix":"KB12345678"}])"_json));
+
+    EXPECT_CALL(*spInfoWrapper, processes(_))
+    .Times(testing::AtLeast(1))
+    .WillOnce(::testing::InvokeArgument<0>
+              (R"({"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":"431625","ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0})"_json));
+
+    CallbackMock wrapper;
+    std::function<void(const std::string&)> callbackData
+    {
+        [&wrapper](const std::string & data)
+        {
+            auto delta = nlohmann::json::parse(data);
+            delta["data"].erase("checksum");
+            delta["data"].erase("id");
+            wrapper.callbackMock(delta.dump());
+        }
+    };
+
+    CallbackMock wrapperDelta;
+    std::function<void(const std::string&)> callbackDataDelta
+    {
+        [&wrapperDelta](const std::string & data)
+        {
+            auto delta = nlohmann::json::parse(data);
+
+            if (delta["type"].get_ref<const std::string&>().compare("dbsync_osinfo") == 0)
+            {
+                delta["data"].erase("checksum");
+            }
+
+            delta["data"].erase("scan_time");
+            wrapperDelta.callbackMock(delta.dump());
+        }
+    };
+
+    const auto expectedResult1
+    {
+        R"({"data":{"board_serial":"Intel Corporation","checksum":"af7b22eef8f5e06c04af4db49c9f8d1d28963918","cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54},"operation":"INSERTED","type":"dbsync_hwinfo"})"
+    };
+    const auto expectedResult3
+    {
+        R"({"data":{"adapter":" ","checksum":"165f7160ecd2838479ee4c43c1012b723736d90a","item_id":"25eef9a0a422a9b644fb6b73650453148bc6151c","mac":"d4:5d:64:51:07:5d","mtu":1500,"name":"enp4s0","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"state":"up","tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0,"type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_iface"})"
+    };
+    const auto expectedResult4
+    {
+        R"({"data":{"checksum":"2ab0e1d3980d80e11fd5262236a662b9726151a8","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"338a8e51ab095707973bb34d85a22208c7284490","metric":" ","type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
+    };
+    const auto expectedResult5
+    {
+        R"({"data":{"address":"192.168.153.1","broadcast":"192.168.153.255","checksum":"72dfd66759bd8062cdc17607d760a48c906189b3","dhcp":"unknown","iface":"enp4s0","item_id":"3d48ddc47fac84c62a19746af66fbfcf78547de9","metric":" ","netmask":"255.255.255.0","proto":0},"operation":"INSERTED","type":"dbsync_network_address"})"
+    };
+    const auto expectedResult6
+    {
+        R"({"data":{"address":"fe80::250:56ff:fec0:8","checksum":"f606d1a1c551874d8fab33e4e5cfaa0370673ec8","dhcp":"unknown","iface":"enp4s0","item_id":"65973316a5dc8615a6d20b2d6c4ce52ecd074496","metric":" ","netmask":"ffff:ffff:ffff:ffff::","proto":1},"operation":"INSERTED","type":"dbsync_network_address"})"
+    };
+    const auto expectedResult7
+    {
+        R"({"data":{"checksum":"f25348b1ce5310f36c1ed859d13138fbb4e6bacb","inode":0,"item_id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba","local_ip":"127.0.0.1","local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0},"operation":"INSERTED","type":"dbsync_ports"})"
+    };
+    const auto expectedResult8
+    {
+        R"({"data":{"checksum":"039934723aa69928b52e470c8d27365b0924b615","egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":"431625","ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0},"operation":"INSERTED","type":"dbsync_processes"})"
+    };
+    const auto expectedResult9
+    {
+        R"({"data":{"architecture":"amd64","checksum":"561243cbb871f6d842c1d2c1533892a3339252d4","group":"x11","item_id":"7a119de04989606ebae116083afc1ec2579b0631","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+    };
+    const auto expectedResult11
+    {
+        R"({"component":"syscollector_network_iface","data":{"begin":"25eef9a0a422a9b644fb6b73650453148bc6151c","end":"25eef9a0a422a9b644fb6b73650453148bc6151c"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult12
+    {
+        R"({"component":"syscollector_network_protocol","data":{"begin":"338a8e51ab095707973bb34d85a22208c7284490","end":"338a8e51ab095707973bb34d85a22208c7284490"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult13
+    {
+        R"({"component":"syscollector_network_address","data":{"begin":"3d48ddc47fac84c62a19746af66fbfcf78547de9","end":"65973316a5dc8615a6d20b2d6c4ce52ecd074496"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult14
+    {
+        R"({"component":"syscollector_ports","data":{"begin":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba","end":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult15
+    {
+        R"({"component":"syscollector_processes","data":{"begin":"431625","end":"431625"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult16
+    {
+        R"({"component":"syscollector_hwinfo","data":{"begin":"Intel Corporation","end":"Intel Corporation"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult17
+    {
+        R"({"component":"syscollector_packages","data":{"begin":"7a119de04989606ebae116083afc1ec2579b0631","end":"7a119de04989606ebae116083afc1ec2579b0631"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult18
+    {
+        R"({"data":{"checksum":"56162cd7bb632b4728ec868e8e271b01222ff131","hotfix":"KB12345678"},"operation":"INSERTED","type":"dbsync_hotfixes"})"
+    };
+    const auto expectedResult19
+    {
+        R"({"component":"syscollector_hotfixes","data":{"begin":"KB12345678","end":"KB12345678"},"type":"integrity_check_global"})"
+    };
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult3)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult4)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult5)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult6)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult7)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult8)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult9)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult11)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult12)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult13)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult14)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult15)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult16)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult17)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult18)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult19)).Times(1);
+
     std::thread t
     {
-        [&spInfoWrapper]()
+        [&spInfoWrapper, &callbackData, &callbackDataDelta]()
         {
             Syscollector::instance().init(spInfoWrapper,
-                                          reportFunction,
-                                          reportFunction,
+                                          callbackDataDelta,
+                                          callbackData,
                                           logFunction,
                                           SYSCOLLECTOR_DB_PATH,
                                           "",
                                           "",
-                                          3600, true, true, false);
+                                          3600, true, true, false, true, true, true, true, true, true, true);
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds{2});
+    std::this_thread::sleep_for(std::chrono::seconds(2));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -248,32 +646,131 @@ TEST_F(SyscollectorImpTest, noNetwork)
 {
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
     EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"({"board_serial":"Intel Corporation","scan_time":"2020/12/28 21:49:50", "cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
-    EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"([{"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14","os_patch":""},{"hotfix":"KB4586786"}])")));
+                                                                      R"({"board_serial":"Intel Corporation","scan_time":"2020/12/28 21:49:50", "cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz", "ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
     EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                 R"({"architecture":"x86_64","scan_time":"2020/12/28 21:49:50", "hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
     EXPECT_CALL(*spInfoWrapper, networks()).Times(0);
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                       R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                    R"({"ports":[{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}]})")));
+    EXPECT_CALL(*spInfoWrapper, packages(_))
+    .Times(::testing::AtLeast(1))
+    .WillOnce(::testing::InvokeArgument<0>
+              (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"})"_json));
+
+    EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(R"([{"hotfix":"KB12345678"}])"_json));
+
+    EXPECT_CALL(*spInfoWrapper, processes(_))
+    .Times(testing::AtLeast(1))
+    .WillOnce(::testing::InvokeArgument<0>
+              (R"({"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":"431625","ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0})"_json));
+
+    CallbackMock wrapper;
+    std::function<void(const std::string&)> callbackData
+    {
+        [&wrapper](const std::string & data)
+        {
+            auto delta = nlohmann::json::parse(data);
+            delta["data"].erase("checksum");
+            delta["data"].erase("id");
+            wrapper.callbackMock(delta.dump());
+        }
+    };
+
+    CallbackMock wrapperDelta;
+    std::function<void(const std::string&)> callbackDataDelta
+    {
+        [&wrapperDelta](const std::string & data)
+        {
+            auto delta = nlohmann::json::parse(data);
+
+            if (delta["type"].get_ref<const std::string&>().compare("dbsync_osinfo") == 0)
+            {
+                delta["data"].erase("checksum");
+            }
+
+            delta["data"].erase("scan_time");
+            wrapperDelta.callbackMock(delta.dump());
+        }
+    };
+
+    const auto expectedResult1
+    {
+        R"({"data":{"board_serial":"Intel Corporation","checksum":"af7b22eef8f5e06c04af4db49c9f8d1d28963918","cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54},"operation":"INSERTED","type":"dbsync_hwinfo"})"
+    };
+    const auto expectedResult2
+    {
+        R"({"data":{"architecture":"x86_64","hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"},"operation":"INSERTED","type":"dbsync_osinfo"})"
+    };
+    const auto expectedResult7
+    {
+        R"({"data":{"checksum":"f25348b1ce5310f36c1ed859d13138fbb4e6bacb","inode":0,"item_id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba","local_ip":"127.0.0.1","local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0},"operation":"INSERTED","type":"dbsync_ports"})"
+    };
+    const auto expectedResult8
+    {
+        R"({"data":{"checksum":"039934723aa69928b52e470c8d27365b0924b615","egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":"431625","ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0},"operation":"INSERTED","type":"dbsync_processes"})"
+    };
+    const auto expectedResult9
+    {
+        R"({"data":{"architecture":"amd64","checksum":"561243cbb871f6d842c1d2c1533892a3339252d4","group":"x11","item_id":"7a119de04989606ebae116083afc1ec2579b0631","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+    };
+    const auto expectedResult10
+    {
+        R"({"component":"syscollector_osinfo","data":{"begin":"Microsoft Windows 7","end":"Microsoft Windows 7"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult14
+    {
+        R"({"component":"syscollector_ports","data":{"begin":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba","end":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult15
+    {
+        R"({"component":"syscollector_processes","data":{"begin":"431625","end":"431625"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult16
+    {
+        R"({"component":"syscollector_hwinfo","data":{"begin":"Intel Corporation","end":"Intel Corporation"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult17
+    {
+        R"({"component":"syscollector_packages","data":{"begin":"7a119de04989606ebae116083afc1ec2579b0631","end":"7a119de04989606ebae116083afc1ec2579b0631"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult18
+    {
+        R"({"data":{"checksum":"56162cd7bb632b4728ec868e8e271b01222ff131","hotfix":"KB12345678"},"operation":"INSERTED","type":"dbsync_hotfixes"})"
+    };
+    const auto expectedResult19
+    {
+        R"({"component":"syscollector_hotfixes","data":{"begin":"KB12345678","end":"KB12345678"},"type":"integrity_check_global"})"
+    };
+
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult2)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult7)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult8)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult9)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult10)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult14)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult15)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult16)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult17)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult18)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult19)).Times(1);
+
     std::thread t
     {
-        [&spInfoWrapper]()
+        [&spInfoWrapper, &callbackData, &callbackDataDelta]()
         {
             Syscollector::instance().init(spInfoWrapper,
-                                          reportFunction,
-                                          reportFunction,
+                                          callbackDataDelta,
+                                          callbackData,
                                           logFunction,
                                           SYSCOLLECTOR_DB_PATH,
                                           "",
                                           "",
-                                          3600, true, true, true, false);
+                                          3600, true, true, true, false, true, true, true, true, true, true);
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds{2});
+    std::this_thread::sleep_for(std::chrono::seconds(1));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -286,28 +783,150 @@ TEST_F(SyscollectorImpTest, noPackages)
 {
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
     EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"({"board_serial":"Intel Corporation","scan_time":"2020/12/28 21:49:50", "cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
-    EXPECT_CALL(*spInfoWrapper, packages()).Times(0);
-    EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"({"iface":[{"address":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "mac":"d4:5d:64:51:07:5d", "gateway":"192.168.0.1|600","broadcast":"127.255.255.255", "name":"ens1", "mtu":1500, "name":"enp4s0", "adapter":" ", "type":"ethernet", "state":"up", "dhcp":"disabled","iface":"Loopback Pseudo-Interface 1","metric":"75","netmask":"255.0.0.0","proto":"IPv4","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0, "IPv4":[{"address":"192.168.153.1","broadcast":"192.168.153.255","dhcp":"unknown","metric":" ","netmask":"255.255.255.0"}], "IPv6":[{"address":"fe80::250:56ff:fec0:8","dhcp":"unknown","metric":" ","netmask":"ffff:ffff:ffff:ffff::"}]}]})")));
+                                                                      R"({"board_serial":"Intel Corporation","scan_time":"2020/12/28 21:49:50", "cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz", "ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
     EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                 R"({"architecture":"x86_64","scan_time":"2020/12/28 21:49:50", "hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                       R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
+    EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(
+                                                                      R"({"iface":[{"address":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "mac":"d4:5d:64:51:07:5d", "gateway":"192.168.0.1|600","broadcast":"127.255.255.255", "name":"ens1", "mtu":1500, "name":"enp4s0", "adapter":" ", "type":"ethernet", "state":"up", "dhcp":"disabled","iface":"Loopback Pseudo-Interface 1","metric":"75","netmask":"255.0.0.0","proto":"IPv4","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0, "IPv4":[{"address":"192.168.153.1","broadcast":"192.168.153.255","dhcp":"unknown","metric":" ","netmask":"255.255.255.0"}], "IPv6":[{"address":"fe80::250:56ff:fec0:8","dhcp":"unknown","metric":" ","netmask":"ffff:ffff:ffff:ffff::"}]}]})")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                    R"({"ports":[{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}]})")));
+    EXPECT_CALL(*spInfoWrapper, packages(_)).Times(0);
+
+    EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(R"([{"hotfix":"KB12345678"}])"_json));
+
+    EXPECT_CALL(*spInfoWrapper, processes(_))
+    .Times(testing::AtLeast(1))
+    .WillOnce(::testing::InvokeArgument<0>
+              (R"({"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":"431625","ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0})"_json));
+
+    CallbackMock wrapper;
+    std::function<void(const std::string&)> callbackData
+    {
+        [&wrapper](const std::string & data)
+        {
+            auto delta = nlohmann::json::parse(data);
+            delta["data"].erase("checksum");
+            delta["data"].erase("id");
+            wrapper.callbackMock(delta.dump());
+        }
+    };
+
+    CallbackMock wrapperDelta;
+    std::function<void(const std::string&)> callbackDataDelta
+    {
+        [&wrapperDelta](const std::string & data)
+        {
+            auto delta = nlohmann::json::parse(data);
+
+            if (delta["type"].get_ref<const std::string&>().compare("dbsync_osinfo") == 0)
+            {
+                delta["data"].erase("checksum");
+            }
+
+            delta["data"].erase("scan_time");
+            wrapperDelta.callbackMock(delta.dump());
+        }
+    };
+
+    const auto expectedResult1
+    {
+        R"({"data":{"board_serial":"Intel Corporation","checksum":"af7b22eef8f5e06c04af4db49c9f8d1d28963918","cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54},"operation":"INSERTED","type":"dbsync_hwinfo"})"
+    };
+    const auto expectedResult2
+    {
+        R"({"data":{"architecture":"x86_64","hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"},"operation":"INSERTED","type":"dbsync_osinfo"})"
+    };
+    const auto expectedResult3
+    {
+        R"({"data":{"adapter":" ","checksum":"165f7160ecd2838479ee4c43c1012b723736d90a","item_id":"25eef9a0a422a9b644fb6b73650453148bc6151c","mac":"d4:5d:64:51:07:5d","mtu":1500,"name":"enp4s0","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"state":"up","tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0,"type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_iface"})"
+    };
+    const auto expectedResult4
+    {
+        R"({"data":{"checksum":"2ab0e1d3980d80e11fd5262236a662b9726151a8","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"338a8e51ab095707973bb34d85a22208c7284490","metric":" ","type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
+    };
+    const auto expectedResult5
+    {
+        R"({"data":{"address":"192.168.153.1","broadcast":"192.168.153.255","checksum":"72dfd66759bd8062cdc17607d760a48c906189b3","dhcp":"unknown","iface":"enp4s0","item_id":"3d48ddc47fac84c62a19746af66fbfcf78547de9","metric":" ","netmask":"255.255.255.0","proto":0},"operation":"INSERTED","type":"dbsync_network_address"})"
+    };
+    const auto expectedResult6
+    {
+        R"({"data":{"address":"fe80::250:56ff:fec0:8","checksum":"f606d1a1c551874d8fab33e4e5cfaa0370673ec8","dhcp":"unknown","iface":"enp4s0","item_id":"65973316a5dc8615a6d20b2d6c4ce52ecd074496","metric":" ","netmask":"ffff:ffff:ffff:ffff::","proto":1},"operation":"INSERTED","type":"dbsync_network_address"})"
+    };
+    const auto expectedResult7
+    {
+        R"({"data":{"checksum":"f25348b1ce5310f36c1ed859d13138fbb4e6bacb","inode":0,"item_id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba","local_ip":"127.0.0.1","local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0},"operation":"INSERTED","type":"dbsync_ports"})"
+    };
+    const auto expectedResult8
+    {
+        R"({"data":{"checksum":"039934723aa69928b52e470c8d27365b0924b615","egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":"431625","ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0},"operation":"INSERTED","type":"dbsync_processes"})"
+    };
+    const auto expectedResult10
+    {
+        R"({"component":"syscollector_osinfo","data":{"begin":"Microsoft Windows 7","end":"Microsoft Windows 7"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult11
+    {
+        R"({"component":"syscollector_network_iface","data":{"begin":"25eef9a0a422a9b644fb6b73650453148bc6151c","end":"25eef9a0a422a9b644fb6b73650453148bc6151c"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult12
+    {
+        R"({"component":"syscollector_network_protocol","data":{"begin":"338a8e51ab095707973bb34d85a22208c7284490","end":"338a8e51ab095707973bb34d85a22208c7284490"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult13
+    {
+        R"({"component":"syscollector_network_address","data":{"begin":"3d48ddc47fac84c62a19746af66fbfcf78547de9","end":"65973316a5dc8615a6d20b2d6c4ce52ecd074496"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult14
+    {
+        R"({"component":"syscollector_ports","data":{"begin":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba","end":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult15
+    {
+        R"({"component":"syscollector_processes","data":{"begin":"431625","end":"431625"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult16
+    {
+        R"({"component":"syscollector_hwinfo","data":{"begin":"Intel Corporation","end":"Intel Corporation"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult18
+    {
+        R"({"data":{"checksum":"56162cd7bb632b4728ec868e8e271b01222ff131","hotfix":"KB12345678"},"operation":"INSERTED","type":"dbsync_hotfixes"})"
+    };
+    const auto expectedResult19
+    {
+        R"({"component":"syscollector_hotfixes","data":{"begin":"KB12345678","end":"KB12345678"},"type":"integrity_check_global"})"
+    };
+
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult2)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult3)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult4)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult5)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult6)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult7)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult8)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult10)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult11)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult12)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult13)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult14)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult15)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult16)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult18)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult19)).Times(1);
+
     std::thread t
     {
-        [&spInfoWrapper]()
+        [&spInfoWrapper, &callbackDataDelta, &callbackData]()
         {
             Syscollector::instance().init(spInfoWrapper,
-                                          reportFunction,
-                                          reportFunction,
+                                          callbackDataDelta,
+                                          callbackData,
                                           logFunction,
                                           SYSCOLLECTOR_DB_PATH,
                                           "",
                                           "",
-                                          3600, true, true, true, true, false);
+                                          3600, true, true, true, true, false, true, true, true, true, true);
         }
     };
 
@@ -324,32 +943,156 @@ TEST_F(SyscollectorImpTest, noPorts)
 {
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
     EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"({"board_serial":"Intel Corporation","scan_time":"2020/12/28 21:49:50", "cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
-    EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"([{"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14","os_patch":""}])")));
-    EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"({"iface":[{"address":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "mac":"d4:5d:64:51:07:5d", "gateway":"192.168.0.1|600","broadcast":"127.255.255.255", "name":"ens1", "mtu":1500, "name":"enp4s0", "adapter":" ", "type":"ethernet", "state":"up", "dhcp":"disabled","iface":"Loopback Pseudo-Interface 1","metric":"75","netmask":"255.0.0.0","proto":"IPv4","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0, "IPv4":[{"address":"192.168.153.1","broadcast":"192.168.153.255","dhcp":"unknown","metric":" ","netmask":"255.255.255.0"}], "IPv6":[{"address":"fe80::250:56ff:fec0:8","dhcp":"unknown","metric":" ","netmask":"ffff:ffff:ffff:ffff::"}]}]})")));
+                                                                      R"({"board_serial":"Intel Corporation","scan_time":"2020/12/28 21:49:50", "cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz", "ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
     EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                 R"({"architecture":"x86_64","scan_time":"2020/12/28 21:49:50", "hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                       R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
+    EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(
+                                                                      R"({"iface":[{"address":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "mac":"d4:5d:64:51:07:5d", "gateway":"192.168.0.1|600","broadcast":"127.255.255.255", "name":"ens1", "mtu":1500, "name":"enp4s0", "adapter":" ", "type":"ethernet", "state":"up", "dhcp":"disabled","iface":"Loopback Pseudo-Interface 1","metric":"75","netmask":"255.0.0.0","proto":"IPv4","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0, "IPv4":[{"address":"192.168.153.1","broadcast":"192.168.153.255","dhcp":"unknown","metric":" ","netmask":"255.255.255.0"}], "IPv6":[{"address":"fe80::250:56ff:fec0:8","dhcp":"unknown","metric":" ","netmask":"ffff:ffff:ffff:ffff::"}]}]})")));
     EXPECT_CALL(*spInfoWrapper, ports()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, packages(_))
+    .Times(::testing::AtLeast(1))
+    .WillOnce(::testing::InvokeArgument<0>
+              (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"})"_json));
+
+    EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(R"([{"hotfix":"KB12345678"}])"_json));
+
+    EXPECT_CALL(*spInfoWrapper, processes(_))
+    .Times(testing::AtLeast(1))
+    .WillOnce(::testing::InvokeArgument<0>
+              (R"({"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":"431625","ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0})"_json));
+
+    CallbackMock wrapper;
+    std::function<void(const std::string&)> callbackData
+    {
+        [&wrapper](const std::string & data)
+        {
+            auto delta = nlohmann::json::parse(data);
+            delta["data"].erase("checksum");
+            delta["data"].erase("id");
+            wrapper.callbackMock(delta.dump());
+        }
+    };
+
+    CallbackMock wrapperDelta;
+    std::function<void(const std::string&)> callbackDataDelta
+    {
+        [&wrapperDelta](const std::string & data)
+        {
+            auto delta = nlohmann::json::parse(data);
+
+            if (delta["type"].get_ref<const std::string&>().compare("dbsync_osinfo") == 0)
+            {
+                delta["data"].erase("checksum");
+            }
+
+            delta["data"].erase("scan_time");
+            wrapperDelta.callbackMock(delta.dump());
+        }
+    };
+
+    const auto expectedResult1
+    {
+        R"({"data":{"board_serial":"Intel Corporation","checksum":"af7b22eef8f5e06c04af4db49c9f8d1d28963918","cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54},"operation":"INSERTED","type":"dbsync_hwinfo"})"
+    };
+    const auto expectedResult2
+    {
+        R"({"data":{"architecture":"x86_64","hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"},"operation":"INSERTED","type":"dbsync_osinfo"})"
+    };
+    const auto expectedResult3
+    {
+        R"({"data":{"adapter":" ","checksum":"165f7160ecd2838479ee4c43c1012b723736d90a","item_id":"25eef9a0a422a9b644fb6b73650453148bc6151c","mac":"d4:5d:64:51:07:5d","mtu":1500,"name":"enp4s0","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"state":"up","tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0,"type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_iface"})"
+    };
+    const auto expectedResult4
+    {
+        R"({"data":{"checksum":"2ab0e1d3980d80e11fd5262236a662b9726151a8","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"338a8e51ab095707973bb34d85a22208c7284490","metric":" ","type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
+    };
+    const auto expectedResult5
+    {
+        R"({"data":{"address":"192.168.153.1","broadcast":"192.168.153.255","checksum":"72dfd66759bd8062cdc17607d760a48c906189b3","dhcp":"unknown","iface":"enp4s0","item_id":"3d48ddc47fac84c62a19746af66fbfcf78547de9","metric":" ","netmask":"255.255.255.0","proto":0},"operation":"INSERTED","type":"dbsync_network_address"})"
+    };
+    const auto expectedResult6
+    {
+        R"({"data":{"address":"fe80::250:56ff:fec0:8","checksum":"f606d1a1c551874d8fab33e4e5cfaa0370673ec8","dhcp":"unknown","iface":"enp4s0","item_id":"65973316a5dc8615a6d20b2d6c4ce52ecd074496","metric":" ","netmask":"ffff:ffff:ffff:ffff::","proto":1},"operation":"INSERTED","type":"dbsync_network_address"})"
+    };
+    const auto expectedResult8
+    {
+        R"({"data":{"checksum":"039934723aa69928b52e470c8d27365b0924b615","egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":"431625","ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0},"operation":"INSERTED","type":"dbsync_processes"})"
+    };
+    const auto expectedResult9
+    {
+        R"({"data":{"architecture":"amd64","checksum":"561243cbb871f6d842c1d2c1533892a3339252d4","group":"x11","item_id":"7a119de04989606ebae116083afc1ec2579b0631","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+    };
+    const auto expectedResult10
+    {
+        R"({"component":"syscollector_osinfo","data":{"begin":"Microsoft Windows 7","end":"Microsoft Windows 7"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult11
+    {
+        R"({"component":"syscollector_network_iface","data":{"begin":"25eef9a0a422a9b644fb6b73650453148bc6151c","end":"25eef9a0a422a9b644fb6b73650453148bc6151c"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult12
+    {
+        R"({"component":"syscollector_network_protocol","data":{"begin":"338a8e51ab095707973bb34d85a22208c7284490","end":"338a8e51ab095707973bb34d85a22208c7284490"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult13
+    {
+        R"({"component":"syscollector_network_address","data":{"begin":"3d48ddc47fac84c62a19746af66fbfcf78547de9","end":"65973316a5dc8615a6d20b2d6c4ce52ecd074496"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult15
+    {
+        R"({"component":"syscollector_processes","data":{"begin":"431625","end":"431625"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult16
+    {
+        R"({"component":"syscollector_hwinfo","data":{"begin":"Intel Corporation","end":"Intel Corporation"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult17
+    {
+        R"({"component":"syscollector_packages","data":{"begin":"7a119de04989606ebae116083afc1ec2579b0631","end":"7a119de04989606ebae116083afc1ec2579b0631"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult18
+    {
+        R"({"data":{"checksum":"56162cd7bb632b4728ec868e8e271b01222ff131","hotfix":"KB12345678"},"operation":"INSERTED","type":"dbsync_hotfixes"})"
+    };
+    const auto expectedResult19
+    {
+        R"({"component":"syscollector_hotfixes","data":{"begin":"KB12345678","end":"KB12345678"},"type":"integrity_check_global"})"
+    };
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult2)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult3)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult4)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult5)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult6)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult8)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult9)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult10)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult11)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult12)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult13)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult15)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult16)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult17)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult18)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult19)).Times(1);
+
+
     std::thread t
     {
-        [&spInfoWrapper]()
+        [&spInfoWrapper, &callbackData, &callbackDataDelta]()
         {
             Syscollector::instance().init(spInfoWrapper,
-                                          reportFunction,
-                                          reportFunction,
+                                          callbackDataDelta,
+                                          callbackData,
                                           logFunction,
                                           SYSCOLLECTOR_DB_PATH,
                                           "",
                                           "",
-                                          3600, true, true, true, true, true, false);
+                                          5, true, true, true, true, true, false, true, true, true, true);
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds{2});
+    std::this_thread::sleep_for(std::chrono::seconds(1));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -362,33 +1105,171 @@ TEST_F(SyscollectorImpTest, noPortsAll)
 {
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
     EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"({"board_serial":"Intel Corporation","scan_time":"2020/12/28 21:49:50", "cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
-    EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"([{"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14","os_patch":""}])")));
-    EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"({"iface":[{"address":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "mac":"d4:5d:64:51:07:5d", "gateway":"192.168.0.1|600","broadcast":"127.255.255.255", "name":"ens1", "mtu":1500, "name":"enp4s0", "adapter":" ", "type":"ethernet", "state":"up", "dhcp":"disabled","iface":"Loopback Pseudo-Interface 1","metric":"75","netmask":"255.0.0.0","proto":"IPv4","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0, "IPv4":[{"address":"192.168.153.1","broadcast":"192.168.153.255","dhcp":"unknown","metric":" ","netmask":"255.255.255.0"}], "IPv6":[{"address":"fe80::250:56ff:fec0:8","dhcp":"unknown","metric":" ","netmask":"ffff:ffff:ffff:ffff::"}]}]})")));
+                                                                      R"({"board_serial":"Intel Corporation","scan_time":"2020/12/28 21:49:50", "cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz", "ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
     EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                 R"({"architecture":"x86_64","scan_time":"2020/12/28 21:49:50", "hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                       R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
+    EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(
+                                                                      R"({"iface":[{"address":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "mac":"d4:5d:64:51:07:5d", "gateway":"192.168.0.1|600","broadcast":"127.255.255.255", "name":"ens1", "mtu":1500, "name":"enp4s0", "adapter":" ", "type":"ethernet", "state":"up", "dhcp":"disabled","iface":"Loopback Pseudo-Interface 1","metric":"75","netmask":"255.0.0.0","proto":"IPv4","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0, "IPv4":[{"address":"192.168.153.1","broadcast":"192.168.153.255","dhcp":"unknown","metric":" ","netmask":"255.255.255.0"}], "IPv6":[{"address":"fe80::250:56ff:fec0:8","dhcp":"unknown","metric":" ","netmask":"ffff:ffff:ffff:ffff::"}]}]})")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                   R"({"ports":[{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}]})")));
+                                                                   R"({"ports":[{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"udp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"","tx_queue":0},{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}]})")));
+    EXPECT_CALL(*spInfoWrapper, packages(_))
+    .Times(::testing::AtLeast(1))
+    .WillOnce(::testing::InvokeArgument<0>
+              (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"})"_json));
+
+    EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(R"([{"hotfix":"KB12345678"}])"_json));
+
+    EXPECT_CALL(*spInfoWrapper, processes(_))
+    .Times(testing::AtLeast(1))
+    .WillOnce(::testing::InvokeArgument<0>
+              (R"({"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":"431625","ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0})"_json));
+
+    CallbackMock wrapper;
+    std::function<void(const std::string&)> callbackData
+    {
+        [&wrapper](const std::string & data)
+        {
+            auto delta = nlohmann::json::parse(data);
+            delta["data"].erase("checksum");
+            delta["data"].erase("id");
+            wrapper.callbackMock(delta.dump());
+        }
+    };
+
+    CallbackMock wrapperDelta;
+    std::function<void(const std::string&)> callbackDataDelta
+    {
+        [&wrapperDelta](const std::string & data)
+        {
+            auto delta = nlohmann::json::parse(data);
+
+            if (delta["type"].get_ref<const std::string&>().compare("dbsync_osinfo") == 0)
+            {
+                delta["data"].erase("checksum");
+            }
+
+            delta["data"].erase("scan_time");
+            wrapperDelta.callbackMock(delta.dump());
+        }
+    };
+
+    const auto expectedResult1
+    {
+        R"({"data":{"board_serial":"Intel Corporation","checksum":"af7b22eef8f5e06c04af4db49c9f8d1d28963918","cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54},"operation":"INSERTED","type":"dbsync_hwinfo"})"
+    };
+    const auto expectedResult2
+    {
+        R"({"data":{"architecture":"x86_64","hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"},"operation":"INSERTED","type":"dbsync_osinfo"})"
+    };
+    const auto expectedResult3
+    {
+        R"({"data":{"adapter":" ","checksum":"165f7160ecd2838479ee4c43c1012b723736d90a","item_id":"25eef9a0a422a9b644fb6b73650453148bc6151c","mac":"d4:5d:64:51:07:5d","mtu":1500,"name":"enp4s0","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"state":"up","tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0,"type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_iface"})"
+    };
+    const auto expectedResult4
+    {
+        R"({"data":{"checksum":"2ab0e1d3980d80e11fd5262236a662b9726151a8","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"338a8e51ab095707973bb34d85a22208c7284490","metric":" ","type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
+    };
+    const auto expectedResult5
+    {
+        R"({"data":{"address":"192.168.153.1","broadcast":"192.168.153.255","checksum":"72dfd66759bd8062cdc17607d760a48c906189b3","dhcp":"unknown","iface":"enp4s0","item_id":"3d48ddc47fac84c62a19746af66fbfcf78547de9","metric":" ","netmask":"255.255.255.0","proto":0},"operation":"INSERTED","type":"dbsync_network_address"})"
+    };
+    const auto expectedResult6
+    {
+        R"({"data":{"address":"fe80::250:56ff:fec0:8","checksum":"f606d1a1c551874d8fab33e4e5cfaa0370673ec8","dhcp":"unknown","iface":"enp4s0","item_id":"65973316a5dc8615a6d20b2d6c4ce52ecd074496","metric":" ","netmask":"ffff:ffff:ffff:ffff::","proto":1},"operation":"INSERTED","type":"dbsync_network_address"})"
+    };
+    const auto expectedResult7
+    {
+        R"({"data":{"checksum":"f25348b1ce5310f36c1ed859d13138fbb4e6bacb","inode":0,"item_id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba","local_ip":"127.0.0.1","local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0},"operation":"INSERTED","type":"dbsync_ports"})"
+    };
+    const auto expectedResult8
+    {
+        R"({"data":{"checksum":"039934723aa69928b52e470c8d27365b0924b615","egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":"431625","ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0},"operation":"INSERTED","type":"dbsync_processes"})"
+    };
+    const auto expectedResult9
+    {
+        R"({"data":{"architecture":"amd64","checksum":"561243cbb871f6d842c1d2c1533892a3339252d4","group":"x11","item_id":"7a119de04989606ebae116083afc1ec2579b0631","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+    };
+    const auto expectedResult10
+    {
+        R"({"component":"syscollector_osinfo","data":{"begin":"Microsoft Windows 7","end":"Microsoft Windows 7"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult11
+    {
+        R"({"component":"syscollector_network_iface","data":{"begin":"25eef9a0a422a9b644fb6b73650453148bc6151c","end":"25eef9a0a422a9b644fb6b73650453148bc6151c"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult12
+    {
+        R"({"component":"syscollector_network_protocol","data":{"begin":"338a8e51ab095707973bb34d85a22208c7284490","end":"338a8e51ab095707973bb34d85a22208c7284490"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult13
+    {
+        R"({"component":"syscollector_network_address","data":{"begin":"3d48ddc47fac84c62a19746af66fbfcf78547de9","end":"65973316a5dc8615a6d20b2d6c4ce52ecd074496"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult14
+    {
+        R"({"component":"syscollector_ports","data":{"begin":"7046b3f9cda975eb6567259c2469748e634dde49","end":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult15
+    {
+        R"({"component":"syscollector_processes","data":{"begin":"431625","end":"431625"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult16
+    {
+        R"({"component":"syscollector_hwinfo","data":{"begin":"Intel Corporation","end":"Intel Corporation"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult17
+    {
+        R"({"component":"syscollector_packages","data":{"begin":"7a119de04989606ebae116083afc1ec2579b0631","end":"7a119de04989606ebae116083afc1ec2579b0631"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult18
+    {
+        R"({"data":{"checksum":"56162cd7bb632b4728ec868e8e271b01222ff131","hotfix":"KB12345678"},"operation":"INSERTED","type":"dbsync_hotfixes"})"
+    };
+    const auto expectedResult19
+    {
+        R"({"component":"syscollector_hotfixes","data":{"begin":"KB12345678","end":"KB12345678"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult20
+    {
+        R"({"data":{"checksum":"09d591fb0ed092c387f77b24af5bada43b5d519d","inode":0,"item_id":"7046b3f9cda975eb6567259c2469748e634dde49","local_ip":"127.0.0.1","local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"udp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":null,"tx_queue":0},"operation":"INSERTED","type":"dbsync_ports"})"
+    };
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult2)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult3)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult4)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult5)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult6)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult7)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult8)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult9)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult10)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult11)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult12)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult13)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult14)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult15)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult16)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult17)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult18)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult19)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult20)).Times(1);
+
     std::thread t
     {
-        [&spInfoWrapper]()
+        [&spInfoWrapper, &callbackData, &callbackDataDelta]()
         {
             Syscollector::instance().init(spInfoWrapper,
-                                          reportFunction,
-                                          reportFunction,
+                                          callbackDataDelta,
+                                          callbackData,
                                           logFunction,
                                           SYSCOLLECTOR_DB_PATH,
                                           "",
                                           "",
-                                          3600, true, true, true, true, true, true, false);
+                                          3600, true, true, true, true, true, true, false, true, true, true);
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds{2});
+    std::this_thread::sleep_for(std::chrono::seconds(1));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -401,28 +1282,150 @@ TEST_F(SyscollectorImpTest, noProcesses)
 {
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
     EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"({"board_serial":"Intel Corporation","scan_time":"2020/12/28 21:49:50", "cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
-    EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"([{"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14","os_patch":""}])")));
-    EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"({"iface":[{"address":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "mac":"d4:5d:64:51:07:5d", "gateway":"192.168.0.1|600","broadcast":"127.255.255.255", "name":"ens1", "mtu":1500, "name":"enp4s0", "adapter":" ", "type":"ethernet", "state":"up", "dhcp":"disabled","iface":"Loopback Pseudo-Interface 1","metric":"75","netmask":"255.0.0.0","proto":"IPv4","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0, "IPv4":[{"address":"192.168.153.1","broadcast":"192.168.153.255","dhcp":"unknown","metric":" ","netmask":"255.255.255.0"}], "IPv6":[{"address":"fe80::250:56ff:fec0:8","dhcp":"unknown","metric":" ","netmask":"ffff:ffff:ffff:ffff::"}]}]})")));
+                                                                      R"({"board_serial":"Intel Corporation","scan_time":"2020/12/28 21:49:50", "cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz", "ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
     EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                 R"({"architecture":"x86_64","scan_time":"2020/12/28 21:49:50", "hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
-    EXPECT_CALL(*spInfoWrapper, processes()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(
+                                                                      R"({"iface":[{"address":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "mac":"d4:5d:64:51:07:5d", "gateway":"192.168.0.1|600","broadcast":"127.255.255.255", "name":"ens1", "mtu":1500, "name":"enp4s0", "adapter":" ", "type":"ethernet", "state":"up", "dhcp":"disabled","iface":"Loopback Pseudo-Interface 1","metric":"75","netmask":"255.0.0.0","proto":"IPv4","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0, "IPv4":[{"address":"192.168.153.1","broadcast":"192.168.153.255","dhcp":"unknown","metric":" ","netmask":"255.255.255.0"}], "IPv6":[{"address":"fe80::250:56ff:fec0:8","dhcp":"unknown","metric":" ","netmask":"ffff:ffff:ffff:ffff::"}]}]})")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                    R"({"ports":[{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}]})")));
+    EXPECT_CALL(*spInfoWrapper, packages(_))
+    .Times(::testing::AtLeast(1))
+    .WillOnce(::testing::InvokeArgument<0>
+              (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"})"_json));
+
+    EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(R"([{"hotfix":"KB12345678"}])"_json));
+
+    EXPECT_CALL(*spInfoWrapper, processes(_)).Times(0);
+
+    CallbackMock wrapper;
+    std::function<void(const std::string&)> callbackData
+    {
+        [&wrapper](const std::string & data)
+        {
+            auto delta = nlohmann::json::parse(data);
+            delta["data"].erase("checksum");
+            delta["data"].erase("id");
+            wrapper.callbackMock(delta.dump());
+        }
+    };
+
+    CallbackMock wrapperDelta;
+    std::function<void(const std::string&)> callbackDataDelta
+    {
+        [&wrapperDelta](const std::string & data)
+        {
+            auto delta = nlohmann::json::parse(data);
+
+            if (delta["type"].get_ref<const std::string&>().compare("dbsync_osinfo") == 0)
+            {
+                delta["data"].erase("checksum");
+            }
+
+            delta["data"].erase("scan_time");
+            wrapperDelta.callbackMock(delta.dump());
+        }
+    };
+
+    const auto expectedResult1
+    {
+        R"({"data":{"board_serial":"Intel Corporation","checksum":"af7b22eef8f5e06c04af4db49c9f8d1d28963918","cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54},"operation":"INSERTED","type":"dbsync_hwinfo"})"
+    };
+    const auto expectedResult2
+    {
+        R"({"data":{"architecture":"x86_64","hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"},"operation":"INSERTED","type":"dbsync_osinfo"})"
+    };
+    const auto expectedResult3
+    {
+        R"({"data":{"adapter":" ","checksum":"165f7160ecd2838479ee4c43c1012b723736d90a","item_id":"25eef9a0a422a9b644fb6b73650453148bc6151c","mac":"d4:5d:64:51:07:5d","mtu":1500,"name":"enp4s0","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"state":"up","tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0,"type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_iface"})"
+    };
+    const auto expectedResult4
+    {
+        R"({"data":{"checksum":"2ab0e1d3980d80e11fd5262236a662b9726151a8","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"338a8e51ab095707973bb34d85a22208c7284490","metric":" ","type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
+    };
+    const auto expectedResult5
+    {
+        R"({"data":{"address":"192.168.153.1","broadcast":"192.168.153.255","checksum":"72dfd66759bd8062cdc17607d760a48c906189b3","dhcp":"unknown","iface":"enp4s0","item_id":"3d48ddc47fac84c62a19746af66fbfcf78547de9","metric":" ","netmask":"255.255.255.0","proto":0},"operation":"INSERTED","type":"dbsync_network_address"})"
+    };
+    const auto expectedResult6
+    {
+        R"({"data":{"address":"fe80::250:56ff:fec0:8","checksum":"f606d1a1c551874d8fab33e4e5cfaa0370673ec8","dhcp":"unknown","iface":"enp4s0","item_id":"65973316a5dc8615a6d20b2d6c4ce52ecd074496","metric":" ","netmask":"ffff:ffff:ffff:ffff::","proto":1},"operation":"INSERTED","type":"dbsync_network_address"})"
+    };
+    const auto expectedResult7
+    {
+        R"({"data":{"checksum":"f25348b1ce5310f36c1ed859d13138fbb4e6bacb","inode":0,"item_id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba","local_ip":"127.0.0.1","local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0},"operation":"INSERTED","type":"dbsync_ports"})"
+    };
+    const auto expectedResult9
+    {
+        R"({"data":{"architecture":"amd64","checksum":"561243cbb871f6d842c1d2c1533892a3339252d4","group":"x11","item_id":"7a119de04989606ebae116083afc1ec2579b0631","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+    };
+    const auto expectedResult10
+    {
+        R"({"component":"syscollector_osinfo","data":{"begin":"Microsoft Windows 7","end":"Microsoft Windows 7"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult11
+    {
+        R"({"component":"syscollector_network_iface","data":{"begin":"25eef9a0a422a9b644fb6b73650453148bc6151c","end":"25eef9a0a422a9b644fb6b73650453148bc6151c"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult12
+    {
+        R"({"component":"syscollector_network_protocol","data":{"begin":"338a8e51ab095707973bb34d85a22208c7284490","end":"338a8e51ab095707973bb34d85a22208c7284490"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult13
+    {
+        R"({"component":"syscollector_network_address","data":{"begin":"3d48ddc47fac84c62a19746af66fbfcf78547de9","end":"65973316a5dc8615a6d20b2d6c4ce52ecd074496"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult14
+    {
+        R"({"component":"syscollector_ports","data":{"begin":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba","end":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult16
+    {
+        R"({"component":"syscollector_hwinfo","data":{"begin":"Intel Corporation","end":"Intel Corporation"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult17
+    {
+        R"({"component":"syscollector_packages","data":{"begin":"7a119de04989606ebae116083afc1ec2579b0631","end":"7a119de04989606ebae116083afc1ec2579b0631"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult18
+    {
+        R"({"data":{"checksum":"56162cd7bb632b4728ec868e8e271b01222ff131","hotfix":"KB12345678"},"operation":"INSERTED","type":"dbsync_hotfixes"})"
+    };
+    const auto expectedResult19
+    {
+        R"({"component":"syscollector_hotfixes","data":{"begin":"KB12345678","end":"KB12345678"},"type":"integrity_check_global"})"
+    };
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult2)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult3)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult4)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult5)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult6)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult7)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult9)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult10)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult11)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult12)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult13)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult14)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult16)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult17)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult18)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult19)).Times(1);
+
+
     std::thread t
     {
-        [&spInfoWrapper]()
+        [&spInfoWrapper, &callbackData, &callbackDataDelta]()
         {
             Syscollector::instance().init(spInfoWrapper,
-                                          reportFunction,
-                                          reportFunction,
+                                          callbackDataDelta,
+                                          callbackData,
                                           logFunction,
                                           SYSCOLLECTOR_DB_PATH,
                                           "",
                                           "",
-                                          3600, true, true, true, true, true, true, true, false);
+                                          3600, true, true, true, true, true, true, true, false, true, true);
         }
     };
 
@@ -439,30 +1442,154 @@ TEST_F(SyscollectorImpTest, noHotfixes)
 {
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
     EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"({"board_serial":"Intel Corporation","scan_time":"2020/12/28 21:49:50", "cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
-    EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"([{"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14","os_patch":""}])")));
-    EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"({"iface":[{"address":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "mac":"d4:5d:64:51:07:5d", "gateway":"192.168.0.1|600","broadcast":"127.255.255.255", "name":"ens1", "mtu":1500, "name":"enp4s0", "adapter":" ", "type":"ethernet", "state":"up", "dhcp":"disabled","iface":"Loopback Pseudo-Interface 1","metric":"75","netmask":"255.0.0.0","proto":"IPv4","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0, "IPv4":[{"address":"192.168.153.1","broadcast":"192.168.153.255","dhcp":"unknown","metric":" ","netmask":"255.255.255.0"}], "IPv6":[{"address":"fe80::250:56ff:fec0:8","dhcp":"unknown","metric":" ","netmask":"ffff:ffff:ffff:ffff::"}]}]})")));
+                                                                      R"({"board_serial":"Intel Corporation","scan_time":"2020/12/28 21:49:50", "cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz", "ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
     EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                 R"({"architecture":"x86_64","scan_time":"2020/12/28 21:49:50", "hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                       R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
+    EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(
+                                                                      R"({"iface":[{"address":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "mac":"d4:5d:64:51:07:5d", "gateway":"192.168.0.1|600","broadcast":"127.255.255.255", "name":"ens1", "mtu":1500, "name":"enp4s0", "adapter":" ", "type":"ethernet", "state":"up", "dhcp":"disabled","iface":"Loopback Pseudo-Interface 1","metric":"75","netmask":"255.0.0.0","proto":"IPv4","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0, "IPv4":[{"address":"192.168.153.1","broadcast":"192.168.153.255","dhcp":"unknown","metric":" ","netmask":"255.255.255.0"}], "IPv6":[{"address":"fe80::250:56ff:fec0:8","dhcp":"unknown","metric":" ","netmask":"ffff:ffff:ffff:ffff::"}]}]})")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                    R"({"ports":[{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}]})")));
+    EXPECT_CALL(*spInfoWrapper, packages(_))
+    .Times(::testing::AtLeast(1))
+    .WillOnce(::testing::InvokeArgument<0>
+              (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"})"_json));
+
+    EXPECT_CALL(*spInfoWrapper, hotfixes()).Times(0);
+
+    EXPECT_CALL(*spInfoWrapper, processes(_))
+    .Times(testing::AtLeast(1))
+    .WillOnce(::testing::InvokeArgument<0>
+              (R"({"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":"431625","ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0})"_json));
+
+    CallbackMock wrapper;
+    std::function<void(const std::string&)> callbackData
+    {
+        [&wrapper](const std::string & data)
+        {
+            auto delta = nlohmann::json::parse(data);
+            delta["data"].erase("checksum");
+            delta["data"].erase("id");
+            wrapper.callbackMock(delta.dump());
+        }
+    };
+
+    CallbackMock wrapperDelta;
+    std::function<void(const std::string&)> callbackDataDelta
+    {
+        [&wrapperDelta](const std::string & data)
+        {
+            auto delta = nlohmann::json::parse(data);
+
+            if (delta["type"].get_ref<const std::string&>().compare("dbsync_osinfo") == 0)
+            {
+                delta["data"].erase("checksum");
+            }
+
+            delta["data"].erase("scan_time");
+            wrapperDelta.callbackMock(delta.dump());
+        }
+    };
+
+    const auto expectedResult1
+    {
+        R"({"data":{"board_serial":"Intel Corporation","checksum":"af7b22eef8f5e06c04af4db49c9f8d1d28963918","cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54},"operation":"INSERTED","type":"dbsync_hwinfo"})"
+    };
+    const auto expectedResult2
+    {
+        R"({"data":{"architecture":"x86_64","hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"},"operation":"INSERTED","type":"dbsync_osinfo"})"
+    };
+    const auto expectedResult3
+    {
+        R"({"data":{"adapter":" ","checksum":"165f7160ecd2838479ee4c43c1012b723736d90a","item_id":"25eef9a0a422a9b644fb6b73650453148bc6151c","mac":"d4:5d:64:51:07:5d","mtu":1500,"name":"enp4s0","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"state":"up","tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0,"type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_iface"})"
+    };
+    const auto expectedResult4
+    {
+        R"({"data":{"checksum":"2ab0e1d3980d80e11fd5262236a662b9726151a8","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"338a8e51ab095707973bb34d85a22208c7284490","metric":" ","type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
+    };
+    const auto expectedResult5
+    {
+        R"({"data":{"address":"192.168.153.1","broadcast":"192.168.153.255","checksum":"72dfd66759bd8062cdc17607d760a48c906189b3","dhcp":"unknown","iface":"enp4s0","item_id":"3d48ddc47fac84c62a19746af66fbfcf78547de9","metric":" ","netmask":"255.255.255.0","proto":0},"operation":"INSERTED","type":"dbsync_network_address"})"
+    };
+    const auto expectedResult6
+    {
+        R"({"data":{"address":"fe80::250:56ff:fec0:8","checksum":"f606d1a1c551874d8fab33e4e5cfaa0370673ec8","dhcp":"unknown","iface":"enp4s0","item_id":"65973316a5dc8615a6d20b2d6c4ce52ecd074496","metric":" ","netmask":"ffff:ffff:ffff:ffff::","proto":1},"operation":"INSERTED","type":"dbsync_network_address"})"
+    };
+    const auto expectedResult7
+    {
+        R"({"data":{"checksum":"f25348b1ce5310f36c1ed859d13138fbb4e6bacb","inode":0,"item_id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba","local_ip":"127.0.0.1","local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0},"operation":"INSERTED","type":"dbsync_ports"})"
+    };
+    const auto expectedResult8
+    {
+        R"({"data":{"checksum":"039934723aa69928b52e470c8d27365b0924b615","egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":"431625","ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0},"operation":"INSERTED","type":"dbsync_processes"})"
+    };
+    const auto expectedResult9
+    {
+        R"({"data":{"architecture":"amd64","checksum":"561243cbb871f6d842c1d2c1533892a3339252d4","group":"x11","item_id":"7a119de04989606ebae116083afc1ec2579b0631","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+    };
+    const auto expectedResult10
+    {
+        R"({"component":"syscollector_osinfo","data":{"begin":"Microsoft Windows 7","end":"Microsoft Windows 7"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult11
+    {
+        R"({"component":"syscollector_network_iface","data":{"begin":"25eef9a0a422a9b644fb6b73650453148bc6151c","end":"25eef9a0a422a9b644fb6b73650453148bc6151c"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult12
+    {
+        R"({"component":"syscollector_network_protocol","data":{"begin":"338a8e51ab095707973bb34d85a22208c7284490","end":"338a8e51ab095707973bb34d85a22208c7284490"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult13
+    {
+        R"({"component":"syscollector_network_address","data":{"begin":"3d48ddc47fac84c62a19746af66fbfcf78547de9","end":"65973316a5dc8615a6d20b2d6c4ce52ecd074496"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult14
+    {
+        R"({"component":"syscollector_ports","data":{"begin":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba","end":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult15
+    {
+        R"({"component":"syscollector_processes","data":{"begin":"431625","end":"431625"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult16
+    {
+        R"({"component":"syscollector_hwinfo","data":{"begin":"Intel Corporation","end":"Intel Corporation"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult17
+    {
+        R"({"component":"syscollector_packages","data":{"begin":"7a119de04989606ebae116083afc1ec2579b0631","end":"7a119de04989606ebae116083afc1ec2579b0631"},"type":"integrity_check_global"})"
+    };
+
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult2)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult3)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult4)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult5)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult6)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult7)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult8)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult9)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult10)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult11)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult12)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult13)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult14)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult15)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult16)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult17)).Times(1);
+
 
     std::thread t
     {
-        [&spInfoWrapper]()
+        [&spInfoWrapper, &callbackData, &callbackDataDelta]()
         {
             Syscollector::instance().init(spInfoWrapper,
-                                          reportFunction,
-                                          reportFunction,
+                                          callbackDataDelta,
+                                          callbackData,
                                           logFunction,
                                           SYSCOLLECTOR_DB_PATH,
                                           "",
                                           "",
-                                          3600, true, true, true, true, true, true, true, true, false);
+                                          3600, true, true, true, true, true, true, true, true, false, true);
         }
     };
 
@@ -475,77 +1602,29 @@ TEST_F(SyscollectorImpTest, noHotfixes)
     }
 
 }
-
-TEST_F(SyscollectorImpTest, scanOnInverval)
-{
-    const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
-    EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"({"board_serial":"Intel Corporation","scan_time":"2020/12/28 21:49:50", "cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
-    EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"([{"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14","os_patch":""}])")));
-    EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"({"iface":[{"address":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "mac":"d4:5d:64:51:07:5d", "gateway":"192.168.0.1|600","broadcast":"127.255.255.255", "name":"ens1", "mtu":1500, "name":"enp4s0", "adapter":" ", "type":"ethernet", "state":"up", "dhcp":"disabled","iface":"Loopback Pseudo-Interface 1","metric":"75","netmask":"255.0.0.0","proto":"IPv4","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0, "IPv4":[{"address":"192.168.153.1","broadcast":"192.168.153.255","dhcp":"unknown","metric":" ","netmask":"255.255.255.0"}], "IPv6":[{"address":"fe80::250:56ff:fec0:8","dhcp":"unknown","metric":" ","netmask":"ffff:ffff:ffff:ffff::"}]}]})")));
-    EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                R"({"architecture":"x86_64","scan_time":"2020/12/28 21:49:50", "hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                       R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                       R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":20,"vm_size":0}])")));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                       R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":20,"vm_size":0}])")));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                       R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":20,"vm_size":0}])")));
-    EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                   R"({"ports":[{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}]})")));
-    std::thread t
-    {
-        [&spInfoWrapper]()
-        {
-            Syscollector::instance().init(spInfoWrapper,
-                                          reportFunction,
-                                          reportFunction,
-                                          logFunction,
-                                          SYSCOLLECTOR_DB_PATH,
-                                          "",
-                                          "",
-                                          1);
-        }
-    };
-
-    std::this_thread::sleep_for(std::chrono::seconds{2});
-    Syscollector::instance().destroy();
-
-    if (t.joinable())
-    {
-        t.join();
-    }
-
-    std::this_thread::sleep_for(std::chrono::seconds{5});
-}
-
 
 TEST_F(SyscollectorImpTest, pushMessageOk)
 {
-    constexpr auto messageToPush{R"(syscollector_network_iface dbsync checksum_fail {"begin":"8026abed91dee13057cbbafaa98918d827fc5698","end":"8026abed91dee13057cbbafaa98918d827fc5698","id":1606851004})"};
+    constexpr auto messageToPush{R"(syscollector_network_iface dbsync checksum_fail {"begin":"25eef9a0a422a9b644fb6b73650453148bc6151c","end":"25eef9a0a422a9b644fb6b73650453148bc6151c","id":1606851004})"};
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
     EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                       R"({"board_serial":"Intel Corporation","scan_time":"2020/12/28 21:49:50", "cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
-    EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"([{"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14", "os_patch":""}])")));
     EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                       R"({"iface":[{"address":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "mac":"d4:5d:64:51:07:5d", "gateway":"192.168.0.1|600","broadcast":"127.255.255.255", "name":"ens1", "mtu":1500, "name":"enp4s0", "adapter":" ", "type":"ethernet", "state":"up", "dhcp":"disabled","iface":"Loopback Pseudo-Interface 1","metric":"75","netmask":"255.0.0.0","proto":"IPv4","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0, "IPv4":[{"address":"192.168.153.1","broadcast":"192.168.153.255","dhcp":"unknown","metric":" ","netmask":"255.255.255.0"}], "IPv6":[{"address":"fe80::250:56ff:fec0:8","dhcp":"unknown","metric":" ","netmask":"ffff:ffff:ffff:ffff::"}]}]})")));
     EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                 R"({"architecture":"x86_64","scan_time":"2020/12/28 21:49:50", "hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                       R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                       R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":20,"vm_size":0}])")));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                       R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":20,"vm_size":0}])")));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                       R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":20,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                    R"({"ports":[{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}]})")));
+    EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(R"([{"hotfix":"KB12345678"}])"_json));
+    EXPECT_CALL(*spInfoWrapper, packages(_))
+    .Times(::testing::AtLeast(1))
+    .WillOnce(::testing::InvokeArgument<0>
+              (R"({"name":"TEXT", "scan_time":"2020/12/28 21:49:50", "version":"TEXT", "vendor":"TEXT", "install_time":"TEXT", "location":"TEXT", "architecture":"TEXT", "groups":"TEXT", "description":"TEXT", "size":"TEXT", "priority":"TEXT", "multiarch":"TEXT", "source":"TEXT", "os_patch":"TEXT"})"_json));
+    EXPECT_CALL(*spInfoWrapper, processes(_))
+    .Times(testing::AtLeast(1))
+    .WillOnce(::testing::InvokeArgument<0>
+              (R"({"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0})"_json));
+
     std::thread t
     {
         [&spInfoWrapper]()
@@ -557,7 +1636,7 @@ TEST_F(SyscollectorImpTest, pushMessageOk)
                                           SYSCOLLECTOR_DB_PATH,
                                           "",
                                           "",
-                                          1);
+                                          60, true, true, true, true, true, true, true, true, true, true);
         }
     };
     std::this_thread::sleep_for(std::chrono::seconds{1});
@@ -577,34 +1656,165 @@ TEST_F(SyscollectorImpTest, pushMessageOk1)
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
     EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                       R"({"board_serial":"Intel Corporation","scan_time":"2020/12/28 21:49:50", "cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
-    EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"([{"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14", "os_patch":""}])")));
     EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                       R"({"iface":[{"address":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "mac":"d4:5d:64:51:07:5d", "gateway":"192.168.0.1|600","broadcast":"127.255.255.255", "name":"ens1", "mtu":1500, "name":"enp4s0", "adapter":" ", "type":"ethernet", "state":"up", "dhcp":"disabled","iface":"Loopback Pseudo-Interface 1","metric":"75","netmask":"255.0.0.0","proto":"IPv4","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0, "IPv4":[{"address":"192.168.153.1","broadcast":"192.168.153.255","dhcp":"unknown","metric":" ","netmask":"255.255.255.0"}], "IPv6":[{"address":"fe80::250:56ff:fec0:8","dhcp":"unknown","metric":" ","netmask":"ffff:ffff:ffff:ffff::"}]}]})")));
     EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                 R"({"architecture":"x86_64","scan_time":"2020/12/28 21:49:50", "hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                       R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                       R"([{"argvs":"--use-gnome-session","cmd":"/usr/libexec/at-spi2-registryd","egroup":"fedegc","euser":"fedegc","fgroup":"fedegc","name":"at-spi2-registr","nice":0,"nlwp":3,"pgrp":2102,"pid":"2223","ppid":1912,"priority":20,"processor":0,"resident":1427,"rgroup":"fedegc","ruser":"fedegc","session":2102,"sgroup":"fedegc","share":1344,"size":40726,"start_time":13687,"state":"S","stime":128,"suser":"fedegc","tgid":2223,"tty":0,"utime":105,"vm_size":162904},{"argvs":"","cmd":"/usr/libexec/xdg-permission-store","egroup":"fedegc","euser":"fedegc","fgroup":"fedegc","name":"xdg-permission-","nice":0,"nlwp":3,"pgrp":2227,"pid":"2227","ppid":1912,"priority":20,"processor":1,"resident":761,"rgroup":"fedegc","ruser":"fedegc","session":2227,"sgroup":"fedegc","share":713,"size":58897,"start_time":13733,"state":"S","stime":0,"suser":"fedegc","tgid":2227,"tty":0,"utime":0,"vm_size":235588}])")));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                       R"([{"argvs":"--use-gnome-session","cmd":"/usr/libexec/at-spi2-registryd","egroup":"fedegc","euser":"fedegc","fgroup":"fedegc","name":"at-spi2-registr","nice":0,"nlwp":3,"pgrp":2102,"pid":"2223","ppid":1912,"priority":20,"processor":0,"resident":1427,"rgroup":"fedegc","ruser":"fedegc","session":2102,"sgroup":"fedegc","share":1344,"size":40726,"start_time":13687,"state":"S","stime":128,"suser":"fedegc","tgid":2223,"tty":0,"utime":105,"vm_size":162904},{"argvs":"","cmd":"/usr/libexec/xdg-permission-store","egroup":"fedegc","euser":"fedegc","fgroup":"fedegc","name":"xdg-permission-","nice":0,"nlwp":3,"pgrp":2227,"pid":"2227","ppid":1912,"priority":20,"processor":1,"resident":761,"rgroup":"fedegc","ruser":"fedegc","session":2227,"sgroup":"fedegc","share":713,"size":58897,"start_time":13733,"state":"S","stime":0,"suser":"fedegc","tgid":2227,"tty":0,"utime":0,"vm_size":235588}])")));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                       R"([{"argvs":"--use-gnome-session","cmd":"/usr/libexec/at-spi2-registryd","egroup":"fedegc","euser":"fedegc","fgroup":"fedegc","name":"at-spi2-registr","nice":0,"nlwp":3,"pgrp":2102,"pid":"2223","ppid":1912,"priority":20,"processor":0,"resident":1427,"rgroup":"fedegc","ruser":"fedegc","session":2102,"sgroup":"fedegc","share":1344,"size":40726,"start_time":13687,"state":"S","stime":128,"suser":"fedegc","tgid":2223,"tty":0,"utime":105,"vm_size":162904},{"argvs":"","cmd":"/usr/libexec/xdg-permission-store","egroup":"fedegc","euser":"fedegc","fgroup":"fedegc","name":"xdg-permission-","nice":0,"nlwp":3,"pgrp":2227,"pid":"2227","ppid":1912,"priority":20,"processor":1,"resident":761,"rgroup":"fedegc","ruser":"fedegc","session":2227,"sgroup":"fedegc","share":713,"size":58897,"start_time":13733,"state":"S","stime":0,"suser":"fedegc","tgid":2227,"tty":0,"utime":0,"vm_size":235588}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                    R"({"ports":[{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}]})")));
+    EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(R"([{"hotfix":"KB12345678"}])"_json));
+    EXPECT_CALL(*spInfoWrapper, packages(_))
+    .Times(::testing::AtLeast(1))
+    .WillOnce(::testing::InvokeArgument<0>
+              (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14", "os_patch":""})"_json));
+    EXPECT_CALL(*spInfoWrapper, processes(_))
+    .Times(testing::AtLeast(1))
+    .WillOnce(::testing::InvokeArgument<0>
+              (R"({"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":"45","ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0})"_json));
+
+    CallbackMock wrapper;
+    std::function<void(const std::string&)> callbackData
+    {
+        [&wrapper](const std::string & data)
+        {
+            auto delta = nlohmann::json::parse(data);
+            delta["data"].erase("checksum");
+            delta["data"].erase("id");
+            wrapper.callbackMock(delta.dump());
+        }
+    };
+
+    CallbackMock wrapperDelta;
+    std::function<void(const std::string&)> callbackDataDelta
+    {
+        [&wrapperDelta](const std::string & data)
+        {
+            auto delta = nlohmann::json::parse(data);
+
+            if (delta["type"].get_ref<const std::string&>().compare("dbsync_osinfo") == 0)
+            {
+                delta["data"].erase("checksum");
+            }
+
+            delta["data"].erase("scan_time");
+            wrapperDelta.callbackMock(delta.dump());
+        }
+    };
+
+    const auto expectedResult1
+    {
+        R"({"component":"syscollector_hwinfo","data":{"begin":"Intel Corporation","end":"Intel Corporation"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult2
+    {
+        R"({"component":"syscollector_osinfo","data":{"begin":"Microsoft Windows 7","end":"Microsoft Windows 7"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult3
+    {
+        R"({"component":"syscollector_network_iface","data":{"begin":"25eef9a0a422a9b644fb6b73650453148bc6151c","end":"25eef9a0a422a9b644fb6b73650453148bc6151c"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult4
+    {
+        R"({"component":"syscollector_network_protocol","data":{"begin":"338a8e51ab095707973bb34d85a22208c7284490","end":"338a8e51ab095707973bb34d85a22208c7284490"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult5
+    {
+        R"({"component":"syscollector_packages","data":{"begin":"7a119de04989606ebae116083afc1ec2579b0631","end":"7a119de04989606ebae116083afc1ec2579b0631"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult6
+    {
+        R"({"component":"syscollector_hotfixes","data":{"begin":"KB12345678","end":"KB12345678"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult7
+    {
+        R"({"component":"syscollector_ports","data":{"begin":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba","end":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult8
+    {
+        R"({"component":"syscollector_processes","data":{"begin":"45","end":"45"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult9
+    {
+        R"({"component":"syscollector_processes","data":{"begin":"45","end":"99"},"type":"integrity_check_right"})"
+    };
+    const auto expectedResult10
+    {
+        R"({"component":"syscollector_network_address","data":{"begin":"3d48ddc47fac84c62a19746af66fbfcf78547de9","end":"65973316a5dc8615a6d20b2d6c4ce52ecd074496"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult11
+    {
+        R"({"data":{"board_serial":"Intel Corporation","checksum":"af7b22eef8f5e06c04af4db49c9f8d1d28963918","cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54},"operation":"INSERTED","type":"dbsync_hwinfo"})"
+    };
+    const auto expectedResult12
+    {
+        R"({"data":{"architecture":"x86_64","hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"},"operation":"INSERTED","type":"dbsync_osinfo"})"
+    };
+    const auto expectedResult13
+    {
+        R"({"data":{"adapter":" ","checksum":"165f7160ecd2838479ee4c43c1012b723736d90a","item_id":"25eef9a0a422a9b644fb6b73650453148bc6151c","mac":"d4:5d:64:51:07:5d","mtu":1500,"name":"enp4s0","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"state":"up","tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0,"type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_iface"})"
+    };
+    const auto expectedResult14
+    {
+        R"({"data":{"checksum":"2ab0e1d3980d80e11fd5262236a662b9726151a8","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"338a8e51ab095707973bb34d85a22208c7284490","metric":" ","type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
+    };
+    const auto expectedResult15
+    {
+        R"({"data":{"address":"192.168.153.1","broadcast":"192.168.153.255","checksum":"72dfd66759bd8062cdc17607d760a48c906189b3","dhcp":"unknown","iface":"enp4s0","item_id":"3d48ddc47fac84c62a19746af66fbfcf78547de9","metric":" ","netmask":"255.255.255.0","proto":0},"operation":"INSERTED","type":"dbsync_network_address"})"
+    };
+    const auto expectedResult16
+    {
+        R"({"data":{"address":"fe80::250:56ff:fec0:8","checksum":"f606d1a1c551874d8fab33e4e5cfaa0370673ec8","dhcp":"unknown","iface":"enp4s0","item_id":"65973316a5dc8615a6d20b2d6c4ce52ecd074496","metric":" ","netmask":"ffff:ffff:ffff:ffff::","proto":1},"operation":"INSERTED","type":"dbsync_network_address"})"
+    };
+    const auto expectedResult17
+    {
+        R"({"data":{"architecture":"amd64","checksum":"031f048e87e1b1ebb4e33b68d3198527a60b4b41","group":"x11","item_id":"7a119de04989606ebae116083afc1ec2579b0631","name":"xserver-xorg","os_patch":null,"priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+    };
+    const auto expectedResult18
+    {
+        R"({"data":{"checksum":"56162cd7bb632b4728ec868e8e271b01222ff131","hotfix":"KB12345678"},"operation":"INSERTED","type":"dbsync_hotfixes"})"
+    };
+    const auto expectedResult19
+    {
+        R"({"data":{"checksum":"f25348b1ce5310f36c1ed859d13138fbb4e6bacb","inode":0,"item_id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba","local_ip":"127.0.0.1","local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0},"operation":"INSERTED","type":"dbsync_ports"})"
+    };
+    const auto expectedResult20
+    {
+        R"({"data":{"checksum":"af3801fac517cf9ae30f746092ce3e4058574454","egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":"45","ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0},"operation":"INSERTED","type":"dbsync_processes"})"
+    };
+
+    EXPECT_CALL(wrapper, callbackMock(expectedResult1)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult2)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult3)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult4)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult5)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult6)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult7)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult8)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult9)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult10)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult11)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult12)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult13)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult14)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult15)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult16)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult17)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult18)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult19)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult20)).Times(1);
+
     std::thread t
     {
-        [&spInfoWrapper]()
+        [&callbackData, &callbackDataDelta, &spInfoWrapper]()
         {
             Syscollector::instance().init(spInfoWrapper,
-                                          reportFunction,
-                                          reportFunction,
+                                          callbackDataDelta,
+                                          callbackData,
                                           logFunction,
                                           SYSCOLLECTOR_DB_PATH,
                                           "",
                                           "",
-                                          1);
+                                          60, true, true, true, true, true, true, true, true, true, true);
         }
     };
     std::this_thread::sleep_for(std::chrono::seconds{1});
@@ -618,29 +1828,28 @@ TEST_F(SyscollectorImpTest, pushMessageOk1)
     }
 }
 
-
 TEST_F(SyscollectorImpTest, pushMessageInvalid)
 {
     constexpr auto messageToPush{R"(syscollector_network_iface dbsync checksum_fail {"end":"Loopback Pseudo-Interface 1","id":1606851004})"};
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
     EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                       R"({"board_serial":"Intel Corporation","scan_time":"2020/12/28 21:49:50", "cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
-    EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"([{"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"}])")));
     EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                       R"({"iface":[{"address":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "mac":"d4:5d:64:51:07:5d", "gateway":"192.168.0.1|600","broadcast":"127.255.255.255", "name":"ens1", "mtu":1500, "name":"enp4s0", "adapter":" ", "type":"ethernet", "state":"up", "dhcp":"disabled","iface":"Loopback Pseudo-Interface 1","metric":"75","netmask":"255.0.0.0","proto":"IPv4","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0, "IPv4":[{"address":"192.168.153.1","broadcast":"192.168.153.255","dhcp":"unknown","metric":" ","netmask":"255.255.255.0"}], "IPv6":[{"address":"fe80::250:56ff:fec0:8","dhcp":"unknown","metric":" ","netmask":"ffff:ffff:ffff:ffff::"}]}]})")));
     EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                 R"({"architecture":"x86_64","scan_time":"2020/12/28 21:49:50", "hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                       R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                       R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":20,"vm_size":0}])")));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                       R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":20,"vm_size":0}])")));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                       R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":20,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                    R"({"ports":[{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}]})")));
+    EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(R"([{"hotfix":"KB12345678"},{"hotfix":"KB87654321"}])"_json));
+    EXPECT_CALL(*spInfoWrapper, packages(_))
+    .Times(::testing::AtLeast(1))
+    .WillOnce(::testing::InvokeArgument<0>
+              (R"({"name":"TEXT", "scan_time":"2020/12/28 21:49:50", "version":"TEXT", "vendor":"TEXT", "install_time":"TEXT", "location":"TEXT", "architecture":"TEXT", "groups":"TEXT", "description":"TEXT", "size":"TEXT", "priority":"TEXT", "multiarch":"TEXT", "source":"TEXT", "os_patch":"TEXT"})"_json));
+    EXPECT_CALL(*spInfoWrapper, processes(_))
+    .Times(testing::AtLeast(1))
+    .WillOnce(::testing::InvokeArgument<0>
+              (R"({"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0})"_json));
+
     std::thread t
     {
         [&spInfoWrapper]()
@@ -652,7 +1861,7 @@ TEST_F(SyscollectorImpTest, pushMessageInvalid)
                                           SYSCOLLECTOR_DB_PATH,
                                           "",
                                           "",
-                                          1);
+                                          60, true, true, true, true, true, true, true, true, true, true);
         }
     };
     std::this_thread::sleep_for(std::chrono::seconds{1});
@@ -672,22 +1881,22 @@ TEST_F(SyscollectorImpTest, scanInvalidData)
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
     EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                       R"({"board_serial":"Intel Corporation","scan_time":"2020/12/28 21:49:50", "cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
-    EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"([{"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"}])")));
     EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                       R"({"iface":[{"address":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "mac":"d4:5d:64:51:07:5d", "gateway":"192.168.0.1|600","broadcast":"127.255.255.255", "name":"ens1", "mtu":1500, "name":"enp4s0", "adapter":" ", "type":"ethernet", "state":"up", "dhcp":"disabled","iface":"Loopback Pseudo-Interface 1","metric":"75","netmask":"255.0.0.0","proto":"IPv4","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0, "IPv4":[{"address":"192.168.153.1","broadcast":"192.168.153.255","dhcp":"unknown","metric":" ","netmask":"255.255.255.0"}], "IPv6":[{"address":"fe80::250:56ff:fec0:8","dhcp":"unknown","metric":" ","netmask":"ffff:ffff:ffff:ffff::"}]}]})")));
     EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                 R"({"architecture":"x86_64","scan_time":"2020/12/28 21:49:50", "hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                       R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                       R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":20,"vm_size":0}])")));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                       R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":20,"vm_size":0}])")));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                       R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":20,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                    R"({"ports":[{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}]})")));
+    EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(R"([{"hotfix":"KB12345678"},{"hotfix":"KB87654321"}])"_json));
+    EXPECT_CALL(*spInfoWrapper, packages(_))
+    .Times(::testing::AtLeast(1))
+    .WillOnce(::testing::InvokeArgument<0>
+              (R"({"name":"TEXT", "scan_time":"2020/12/28 21:49:50", "version":"TEXT", "vendor":"TEXT", "install_time":"TEXT", "location":"TEXT", "architecture":"TEXT", "groups":"TEXT", "description":"TEXT", "size":"TEXT", "priority":"TEXT", "multiarch":"TEXT", "source":"TEXT", "os_patch":"TEXT"})"_json));
+    EXPECT_CALL(*spInfoWrapper, processes(_))
+    .Times(testing::AtLeast(1))
+    .WillOnce(::testing::InvokeArgument<0>
+              (R"({"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0})"_json));
+
     std::thread t
     {
         [&spInfoWrapper]()
@@ -699,7 +1908,7 @@ TEST_F(SyscollectorImpTest, scanInvalidData)
                                           SYSCOLLECTOR_DB_PATH,
                                           "",
                                           "",
-                                          1);
+                                          60, true, true, true, true, true, true, true, true, true, true);
         }
     };
     std::this_thread::sleep_for(std::chrono::seconds{1});
@@ -713,13 +1922,6 @@ TEST_F(SyscollectorImpTest, scanInvalidData)
     }
 }
 
-class CallbackMock
-{
-    public:
-        CallbackMock() = default;
-        ~CallbackMock() = default;
-        MOCK_METHOD(void, callbackMock, (const std::string&), ());
-};
 
 TEST_F(SyscollectorImpTest, portAllEnable)
 {
@@ -981,11 +2183,20 @@ TEST_F(SyscollectorImpTest, portAllDisable)
     }
 }
 
+
 TEST_F(SyscollectorImpTest, PackagesDuplicated)
 {
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
-    EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"([{"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"},{"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"}])")));
+
+    EXPECT_CALL(*spInfoWrapper, packages(_))
+    .Times(::testing::AtLeast(1))
+    .WillOnce(::testing::DoAll(
+                  ::testing::InvokeArgument<0>
+                  (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"})"_json),
+                  ::testing::InvokeArgument<0>
+                  (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"})"_json)));
+
+
 
     CallbackMock wrapper;
     std::function<void(const std::string&)> callbackData
@@ -1001,7 +2212,7 @@ TEST_F(SyscollectorImpTest, PackagesDuplicated)
 
     const auto expectedResult1
     {
-        R"({"data":{"architecture":"amd64","group":"x11","item_id":"7a119de04989606ebae116083afc1ec2579b0631","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","group":"x11","item_id":"7a119de04989606ebae116083afc1ec2579b0631","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
 
     EXPECT_CALL(wrapper, callbackMock(expectedResult1)).Times(1);


### PR DESCRIPTION
|Related issue|
|---|
|Closes #9268 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill in the table above. Feel free to extend it at your convenience.
-->

## Description
This issue aims to extend the data provider (sysinfo) interface to provide callback-based methods in order to reduce the amount of memory required to retrieve the system info.
<!--
Add a clear description of how the problem has been solved.
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [x] AddressSanitizer
- Memory tests for Windows
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [x] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors