### PR TITLE
Avoid syscheck db creation when syscheck is disabled

### DIFF
--- a/src/syscheckd/main.c
+++ b/src/syscheckd/main.c
@@ -268,9 +268,9 @@ int main(int argc, char **argv)
 #endif
             }
         }
-    }
 
-    fim_initialize();
+        fim_initialize();
+    }
 
     if (start_realtime == 1) {
         realtime_start();

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -275,10 +275,9 @@ int Start_win32_Syscheck() {
                 }
             }
         }
-    }
 
-    /* Some sync time */
-    fim_initialize();
+        fim_initialize();
+    }
 
     /* Wait if agent started properly */
     os_wait();

--- a/src/unit_tests/syscheckd/test_syscheck.c
+++ b/src/unit_tests/syscheckd/test_syscheck.c
@@ -156,11 +156,6 @@ void test_Start_win32_Syscheck_no_config_file(void **state) {
 
     will_return(__wrap_rootcheck_init, 1);
 
-    expect_value(__wrap_fim_db_init, memory, 0);
-    will_return(__wrap_fim_db_init, NULL);
-
-    expect_string(__wrap__merror_exit, formatted_msg, "(6698): Creating Data Structure: sqlite3 db. Exiting.");
-
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_rwlock_unlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
@@ -187,9 +182,7 @@ void test_Start_win32_Syscheck_corrupted_config_file(void **state) {
     expect_string(__wrap__merror, formatted_msg, "(1207): syscheck remote configuration in 'ossec.conf' is corrupted.");
 
     will_return(__wrap_rootcheck_init, 1);
-    expect_value(__wrap_fim_db_init, memory, 0);
-    will_return(__wrap_fim_db_init, NULL);
-    expect_string(__wrap__merror_exit, formatted_msg, "(6698): Creating Data Structure: sqlite3 db. Exiting.");
+
     expect_function_call(__wrap_os_wait);
     expect_function_call(__wrap_start_daemon);
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #9376 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hi team!

This issue solves syscheck's db creation when its disabled.

## Manual Tests
### Syscheck disabled
- Default configuration
- FIM DB directory inspection
### Syscheck enabled
- Default configuration
- FIM DB directory inspection
## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [x] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors

Regards,
Nico