### PR TITLE
Fix graceful shutdown when agentd or analysisd is stopped.

### DIFF
--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -135,6 +135,7 @@
 #define INVALID_HOSTNAME        "(1275): Invalid hostname in syslog message: '%s'."
 #define INVALID_GEOIP_DB        "(1276): Cannot open GeoIP database: '%s'."
 #define FIM_INVALID_MESSAGE     "(1277): Invalid syscheck message received."
+#define UNABLE_TO_RECONNECT     "(1278): Unable to reconnect to '%s': %s (%d)."
 
 /* logcollector */
 #define SYSTEM_ERROR     "(1600): Internal error. Exiting.."

--- a/src/headers/mq_op.h
+++ b/src/headers/mq_op.h
@@ -85,4 +85,16 @@ void mq_log_builder_init();
 
 int mq_log_builder_update();
 
+/**
+ *  Reconnect a Message Queue.
+ *  @param key path where the message queue will be reconnect.
+ *  @param fn_ptr pointer to function that evaluates a predicate.
+ *  @return
+ *  UNIX -> OS_INVALID if queue failed to reconnect.
+ *  UNIX -> int(rc) file descriptor of initialized queue
+ *  WIN32 -> 0
+ */
+int MQReconnectPredicated(const char *key, bool (*fn_ptr)()) __attribute__((nonnull));
+
+
 #endif /* MQ_H */

--- a/src/wazuh_modules/wm_syscollector.c
+++ b/src/wazuh_modules/wm_syscollector.c
@@ -26,6 +26,8 @@ int wm_sync_message(const char *data);
 pthread_cond_t sys_stop_condition;
 pthread_mutex_t sys_stop_mutex;
 bool need_shutdown_wait = false;
+pthread_mutex_t sys_reconnect_mutex;
+bool shutdown_process_started = false;
 
 const wm_context WM_SYS_CONTEXT = {
     "syscollector",
@@ -44,6 +46,11 @@ syscollector_sync_message_func syscollector_sync_message_ptr = NULL;
 long syscollector_sync_max_eps = 10;    // Database syncrhonization number of events per seconds (default value)
 int queue_fd = 0;                       // Output queue file descriptor
 
+static bool is_shutdown_process_started() {
+    bool ret_val = shutdown_process_started;
+    return ret_val;
+}
+
 static void wm_sys_send_diff_message(/*const void* data*/) {
     // const int eps = 1000000/syscollector_sync_max_eps;
     // Sending deltas is disabled due to issue: 7322 - https://github.com/wazuh/wazuh/issues/7322
@@ -51,7 +58,7 @@ static void wm_sys_send_diff_message(/*const void* data*/) {
  }
 
 static void wm_sys_send_dbsync_message(const void* data) {
-    if(!os_iswait()) {
+    if(!os_iswait() && !is_shutdown_process_started()) {
         const int eps = 1000000/syscollector_sync_max_eps;
         if (wm_sendmsg(eps, queue_fd, data, WM_SYS_LOCATION, DBSYNC_MQ) < 0) {
 #ifdef CLIENT
@@ -59,14 +66,18 @@ static void wm_sys_send_dbsync_message(const void* data) {
 #else
             mterror(WM_SYS_LOGTAG, "Unable to send message to '%s' (wazuh-analysisd might be down). Attempting to reconnect.", DEFAULTQUEUE);
 #endif
-            if ((queue_fd = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
-                mterror(WM_SYS_LOGTAG, "Unable to connect to '%s'", DEFAULTQUEUE);
-            } else {
-                mtinfo(WM_SYS_LOGTAG, "Successfully reconnected to '%s'", DEFAULTQUEUE);
-                if (wm_sendmsg(eps, queue_fd, data, WM_SYS_LOCATION, DBSYNC_MQ) < 0) {
-                    mterror(WM_SYS_LOGTAG, "Unable to send message to '%s' after a successfull reconnection...", DEFAULTQUEUE);
+            // Since this method is beign called by multiple threads it's necessary this particular portion of code
+            // to be mutually exclusive. When one thread is successfully reconnected, the other ones will make use of it.
+            w_mutex_lock(&sys_reconnect_mutex);
+            if (!is_shutdown_process_started() && wm_sendmsg(eps, queue_fd, data, WM_SYS_LOCATION, DBSYNC_MQ) < 0) {
+                if (queue_fd = MQReconnectPredicated(DEFAULTQUEUE, &is_shutdown_process_started), 0 <= queue_fd) {
+                    mtinfo(WM_SYS_LOGTAG, "Successfully reconnected to '%s'", DEFAULTQUEUE);
+                    if (wm_sendmsg(eps, queue_fd, data, WM_SYS_LOCATION, DBSYNC_MQ) < 0) {
+                        mterror(WM_SYS_LOGTAG, "Unable to send message to '%s' after a successfull reconnection...", DEFAULTQUEUE);
+                    }
                 }
             }
+            w_mutex_unlock(&sys_reconnect_mutex);
         }
     }
 }
@@ -106,6 +117,8 @@ static void wm_sys_log_config(wm_sys_t *sys)
 void* wm_sys_main(wm_sys_t *sys) {
     w_cond_init(&sys_stop_condition, NULL);
     w_mutex_init(&sys_stop_mutex, NULL);
+    w_mutex_init(&sys_reconnect_mutex, NULL);
+
     if (!sys->flags.enabled) {
         mtinfo(WM_SYS_LOGTAG, "Module disabled. Exiting...");
         pthread_exit(NULL);
@@ -139,7 +152,6 @@ void* wm_sys_main(wm_sys_t *sys) {
         w_mutex_lock(&sys_stop_mutex);
         need_shutdown_wait = true;
         w_mutex_unlock(&sys_stop_mutex);
-
         const long max_eps = sys->sync.sync_max_eps;
         if (0 != max_eps) {
             syscollector_sync_max_eps = max_eps;
@@ -191,6 +203,7 @@ void wm_sys_stop(__attribute__((unused))wm_sys_t *data) {
     mtinfo(WM_SYS_LOGTAG, "Stop received for Syscollector.");
     syscollector_sync_message_ptr = NULL;
     if (syscollector_stop_ptr){
+        shutdown_process_started = true;
         syscollector_stop_ptr();
     }
     w_mutex_lock(&sys_stop_mutex);
@@ -201,6 +214,7 @@ void wm_sys_stop(__attribute__((unused))wm_sys_t *data) {
 
     w_cond_destroy(&sys_stop_condition);
     w_mutex_destroy(&sys_stop_mutex);
+    w_mutex_destroy(&sys_reconnect_mutex);
 }
 
 cJSON *wm_sys_dump(const wm_sys_t *sys) {

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -361,6 +361,12 @@ int StartMQ(__attribute__((unused)) const char *path, __attribute__((unused)) sh
     return (0);
 }
 
+/* MQReconnectPredicated for Windows */
+int MQReconnectPredicated(__attribute__((unused)) const char *path, __attribute__((unused)) bool (fn_ptr)())
+{
+    return (0);
+}
+
 char *get_agent_ip()
 {
     char agent_ip[IPSIZE + 1] = { '\0' };


### PR DESCRIPTION
|Related issue|
|---|
| Closes #10240|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Modulesd gets stuck on stopping.
<!--
Add a clear description of how the problem has been solved.
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [X] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors