### PR TITLE
Fix Wazuh path error in Azure logs module

### DIFF
--- a/wodles/azure/azure-logs.py
+++ b/wodles/azure/azure-logs.py
@@ -48,7 +48,7 @@ except Exception as e:
 	print("Azure Storage SDK for Python is missing: '{}', try 'pip install azure-storage-blob'.".format(e))
 	sys.exit(1)
 
-ADDR = '{}/queue/sockets/queue'.format(utils.wazuh_path)
+ADDR = '{}/queue/sockets/queue'.format(utils.find_wazuh_path())
 BLEN = 212992
 
 utc = pytz.UTC
@@ -113,7 +113,7 @@ def set_logger():
 	if args.verbose:
 		logging.basicConfig(level = logging.DEBUG, format = '%(asctime)s %(levelname)s: AZURE %(message)s', datefmt = '%m/%d/%Y %I:%M:%S %p')
 	else:
-		log_path = "{}/logs/azure_logs.log".format(utils.wazuh_path)
+		log_path = "{}/logs/azure_logs.log".format(utils.find_wazuh_path())
 		logging.basicConfig(filename=log_path, level = logging.DEBUG, format = '%(asctime)s %(levelname)s: AZURE %(message)s', datefmt = '%m/%d/%Y %I:%M:%S %p')
 
 


### PR DESCRIPTION
|Related issue|
|---|
|#10246|


## Description

This closes #10246 .

There was an error in the `azure-logs.py` module where we were using `utils.wazuh_path` instead of `utils.find_wazuh_path()`. Using that function fixes it.

## Tests performed

As the `find_wazuh_path` is used to access both the `Analysisd` socket and the `logs/azure_logs.log` file we have manually tested that both paths resolve correctly by running the module, checking there are no errors related and checking the `azure_logs.logs` was correctly updated within the expected path. Everything worked as expected.

Here is the command used for this manual test:
```
/var/ossec/wodles/azure/azure-logs --graph --graph_auth_path /var/ossec/wodles/azure/credentials --graph_tenant_domain wazuh.onmicrosoft.com --graph_tag azure-active_directory --graph_query 'auditLogs/directoryAudits' --graph_time_offset 1d
```