### PR TITLE
Collect missing hotfixes related to Microsoft products

### DIFF
--- a/src/data_provider/src/packages/packagesWindowsParserHelper.h
+++ b/src/data_provider/src/packages/packagesWindowsParserHelper.h
@@ -130,13 +130,13 @@ namespace PackageWindowsHelper
             std::set<std::string> hotfixes;
             const auto callback
             {
-                [&key, &subKey, &hotfixes](const std::string & package)
+                [&key, &subKey, &hotfixes](const std::string & packageKey)
                 {
-                    const auto callback2
+                    const auto callbackKey
                     {
-                        [&key, &subKey, &package,&hotfixes](const std::string & package2)
+                        [&key, &subKey, &packageKey,&hotfixes](const std::string & package)
                         {
-                            auto hfValue { extractHFValue(package2) };
+                            auto hfValue { extractHFValue(package) };
 
                             if (!hfValue.empty())
                             {
@@ -144,8 +144,8 @@ namespace PackageWindowsHelper
                             }
                         }
                     };
-                    Utils::Registry root{key, subKey + "\\" + package, KEY_WOW64_64KEY | KEY_ENUMERATE_SUB_KEYS | KEY_READ};
-                    root.enumerate(callback2);
+                    Utils::Registry packageReg{key, subKey + "\\" + packageKey, KEY_WOW64_64KEY | KEY_ENUMERATE_SUB_KEYS | KEY_READ};
+                    packageReg.enumerate(callbackKey);
                 }
             };
             Utils::Registry root{key, subKey, KEY_WOW64_64KEY | KEY_ENUMERATE_SUB_KEYS | KEY_READ};
@@ -170,19 +170,19 @@ namespace PackageWindowsHelper
             std::set<std::string> hotfixes;
             const auto callback
             {
-                [&key, &subKey, &hotfixes](const std::string & package)
+                [&key, &subKey, &hotfixes](const std::string & packageKey)
                 {
-                    const auto callback2
+                    const auto callbackKey
                     {
-                        [&key, &subKey, &package,&hotfixes](const std::string & package2)
+                        [&key, &subKey, &packageKey,&hotfixes](const std::string & package)
                         {
                             
-                            if (Utils::startsWith(package2, "InstallProperties"))
+                            if (Utils::startsWith(package, "InstallProperties"))
                             {
                                 
-                                Utils::Registry root{key, subKey + "\\" + package + "\\" + package2, KEY_WOW64_64KEY | KEY_ENUMERATE_SUB_KEYS | KEY_READ};
+                                Utils::Registry packageReg{key, subKey + "\\" + packageKey + "\\" + package, KEY_WOW64_64KEY | KEY_ENUMERATE_SUB_KEYS | KEY_READ};
                                 std::string value;
-                                if (root.string("DisplayName", value))
+                                if (packageReg.string("DisplayName", value))
                                 {
                                     auto hfValue { extractHFValue(value) };
 
@@ -194,8 +194,8 @@ namespace PackageWindowsHelper
                             }
                         }
                     };
-                    Utils::Registry root{key, subKey + "\\" + package, KEY_WOW64_64KEY | KEY_ENUMERATE_SUB_KEYS | KEY_READ};
-                    root.enumerate(callback2);
+                    Utils::Registry rootKey{key, subKey + "\\" + packageKey, KEY_WOW64_64KEY | KEY_ENUMERATE_SUB_KEYS | KEY_READ};
+                    rootKey.enumerate(callbackKey);
                 }
             };
             Utils::Registry root{key, subKey, KEY_WOW64_64KEY | KEY_ENUMERATE_SUB_KEYS | KEY_READ};

--- a/src/data_provider/src/packages/packagesWindowsParserHelper.h
+++ b/src/data_provider/src/packages/packagesWindowsParserHelper.h
@@ -22,6 +22,7 @@ namespace PackageWindowsHelper
 {
     constexpr auto WIN_REG_HOTFIX {"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Component Based Servicing\\Packages"};
     constexpr auto VISTA_REG_HOTFIX {"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\HotFix"};
+    constexpr auto WIN_REG_WOW_HOTFIX {"SOFTWARE\\WOW6432Node\\Microsoft\\Updates"};
 
     static std::string extractHFValue(std::string input)
     {
@@ -120,6 +121,46 @@ namespace PackageWindowsHelper
         catch (...)
         {
         }
+    }
+
+    static void getHotFixFromRegWOW(const HKEY key, const std::string& subKey, nlohmann::json& data){
+        try
+        {
+            std::set<std::string> hotfixes;
+            const auto callback
+            {
+                [&key, &subKey, &hotfixes](const std::string & package)
+                {
+                    const auto callback2
+                    {
+                        [&key, &subKey, &package,&hotfixes](const std::string & package2)
+                        {
+                            auto hfValue { extractHFValue(package2) };
+
+                            if (!hfValue.empty())
+                            {
+                                hotfixes.insert(std::move(hfValue));
+                            }
+                        }
+                    };
+                    Utils::Registry root{key, subKey + "\\" + package, KEY_WOW64_64KEY | KEY_ENUMERATE_SUB_KEYS | KEY_READ};
+                    root.enumerate(callback2);
+                }
+            };
+            Utils::Registry root{key, subKey, KEY_WOW64_64KEY | KEY_ENUMERATE_SUB_KEYS | KEY_READ};
+            root.enumerate(callback);
+
+            for (auto& hotfix : hotfixes)
+            {
+                nlohmann::json hotfixValue;
+                hotfixValue["hotfix"] = std::move(hotfix);
+                data.push_back(std::move(hotfixValue));
+            }  
+        }
+        catch(...)
+        {
+        }
+        
     }
 };
 

--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -591,6 +591,7 @@ nlohmann::json SysInfo::getPackages() const
     PackageWindowsHelper::getHotFixFromReg(HKEY_LOCAL_MACHINE, PackageWindowsHelper::WIN_REG_HOTFIX, ret);
     PackageWindowsHelper::getHotFixFromRegNT(HKEY_LOCAL_MACHINE, PackageWindowsHelper::VISTA_REG_HOTFIX, ret);
     PackageWindowsHelper::getHotFixFromRegWOW(HKEY_LOCAL_MACHINE, PackageWindowsHelper::WIN_REG_WOW_HOTFIX, ret);
+    PackageWindowsHelper::getHotFixFromRegProduct(HKEY_LOCAL_MACHINE, PackageWindowsHelper::WIN_REG_PRODUCT_HOTFIX, ret);
     return ret;
 }
 

--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -173,9 +173,8 @@ class SysInfoProcess final
 
             for (const auto& logicalDrive : logicalDrives)
             {
-                const auto normalizedName { logicalDrive.back() == L'\\' ? logicalDrive.substr(0, logicalDrive.length() - 1) : logicalDrive };
                 const auto spDosDevice { std::make_unique<char[]>(OS_MAXSTR) };
-                res = QueryDosDevice(normalizedName.c_str(), spDosDevice.get(), OS_MAXSTR);
+                res = QueryDosDevice(logicalDrive.c_str(), spDosDevice.get(), OS_MAXSTR);
 
                 if (res)
                 {
@@ -591,6 +590,7 @@ nlohmann::json SysInfo::getPackages() const
     }
     PackageWindowsHelper::getHotFixFromReg(HKEY_LOCAL_MACHINE, PackageWindowsHelper::WIN_REG_HOTFIX, ret);
     PackageWindowsHelper::getHotFixFromRegNT(HKEY_LOCAL_MACHINE, PackageWindowsHelper::VISTA_REG_HOTFIX, ret);
+    PackageWindowsHelper::getHotFixFromRegWOW(HKEY_LOCAL_MACHINE, PackageWindowsHelper::WIN_REG_WOW_HOTFIX, ret);
     return ret;
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|#6871|

## Description
Hi team,

This PR aims to modify the data provider for Windows to get missing hotfixes that were not collected from different path in the Windows registry.

To check the new paths included for the collection of the hotfixes, we have added a new method per path that goes through them for hotfixes.

The new path added are the following:
- `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Products`
- `HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Updates`


## Use cases
In the following example, we will be able to check that the changes implemented let us collect the missing hotfixes:

### Windows registry
![image](https://user-images.githubusercontent.com/74183704/134670569-9838627e-cba1-442b-806d-66ea3d751258.png)

![image](https://user-images.githubusercontent.com/74183704/134670503-65c88073-cb15-48b4-a03c-531fa760237a.png)

### Agent DB
```
select * from sys_hotfixes;
0|2021/09/24 11:29:45|KB2468871|8f99821b9e79bc2258cb56cd14cfcaf9bbeda8e5
0|2021/09/24 11:29:45|KB2478063|8511235ae3ab3b642d8ba429599092634fdde3a8
0|2021/09/24 11:29:45|KB2533523|b8c4cb9a2aeb6a64269e88f6116765420a65cd80
0|2021/09/24 11:29:45|KB2544514|8e468309f00c0f31b8a0f12a6a79d2658652e9e9
0|2021/09/24 11:29:46|KB2600211|cb13c01ba11045aabbb074fc3e61b0a3b2d88dd4
0|2021/09/24 11:29:46|KB2600217|8253af775746f8545784d27edb852281c9a06955
0|2021/09/24 11:29:46|KB4023057|91418b42c05d4f7f36ff48da7bb0923e93fde4d8
0|2021/09/24 11:29:46|KB4562830|c651fa941c06383364d7d47f8d7046499cc099fb
0|2021/09/24 11:29:46|KB4577586|5c4da70cbf846d4c84b94bee7ae7bd4ca5957d93
0|2021/09/24 11:29:46|KB4580325|971b360361a480d5a5be94a472dd8cf2d01ef4c0
0|2021/09/24 11:29:46|KB5001405|0ac906284183061e56f0d883fdb6fd46647c3bd0
0|2021/09/24 11:29:46|KB5001679|a9046dd7583721f3f6234e0bde092ad729490b67
0|2021/09/24 11:29:46|KB5003242|02bc5b16d80d9120806839da024132c88ca22a0d
0|2021/09/24 11:29:46|KB5003503|b608b0991ede7626e1d84473598147d98053380d
0|2021/09/24 11:29:47|KB5003742|9b1d8e0f90436d583371d27f46d9bf69c459f897
0|2021/09/24 11:29:47|KB5004331|222f14c3216c9ba03c0d986818bec6edad64d16a
0|2021/09/24 11:29:47|KB5005033|93494b3e0283ab397c1a582628a321bd948cb41f
0|2021/09/24 11:29:47|KB5005260|d9fbc6a677f5fcbfd1bcf017d93f73c3cf991533
0|2021/09/24 11:29:47|KB5005565|e3ce78c7b07b30ed0b27e525de85d42fe4f3b519
0|2021/09/24 11:29:47|KB5005699|607c96d9ee795a1d30612b9c34c3dc694f8a2c68
````
## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
- Memory tests for Windows
  - [x] Scan-build report

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Added unit tests (for new features)
