### PR TITLE
Fix AIT cluster race condition

### DIFF
--- a/api/test/integration/common.yaml
+++ b/api/test/integration/common.yaml
@@ -22,6 +22,7 @@ variables:
   restart_delay_cluster: 150
   upgrade_delay: 60
   global_db_delay: 30
+  cluster_sync_delay: 20
 
   custom_wpk_path: "/var/ossec/test_custom_upgrade_3.12.2.wpk"
 

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -16,7 +16,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - name: !anystr
@@ -49,7 +49,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - info:
@@ -80,7 +80,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - info:
@@ -122,7 +122,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - cluster: wazuh
@@ -149,7 +149,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: &cluster_nodes_response
             - name: !anystr
@@ -169,7 +169,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *cluster_nodes_response
@@ -188,7 +188,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *cluster_nodes_response
@@ -207,7 +207,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: []
           failed_items: []
@@ -263,7 +263,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *cluster_nodes_response
@@ -282,7 +282,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *cluster_nodes_response
@@ -300,7 +300,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *cluster_nodes_response
@@ -319,7 +319,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *cluster_nodes_response
@@ -351,7 +351,7 @@ stages:
           extra_kwargs:
             select_key: "name,version"
       json:
-        error: !anyint
+        error: 0
         data:
           failed_items: []
           total_affected_items: 3
@@ -370,7 +370,7 @@ stages:
           extra_kwargs:
             select_key: "type"
       json:
-        error: !anyint
+        error: 0
         data:
           failed_items: []
           total_affected_items: 3
@@ -410,7 +410,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - ip: !anystr
@@ -468,7 +468,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           enabled: "yes"
           running: "yes"
@@ -488,7 +488,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - alerts: !anything
@@ -520,7 +520,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - alerts: !anything
@@ -554,7 +554,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - alerts:
@@ -577,7 +577,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - syscheck:
@@ -606,7 +606,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - syscollector:
@@ -635,7 +635,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - alerts:
@@ -657,7 +657,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - syscheck:
@@ -686,7 +686,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - syscollector:
@@ -718,7 +718,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - name: master-node
@@ -743,6 +743,7 @@ stages:
         content-type: application/octet-stream
     response:
       status_code: 200
+    delay_after: !float "{cluster_sync_delay}"
 
   - name: Request validation
     request:
@@ -754,7 +755,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 1
         data:
           failed_items:
             - error:
@@ -765,7 +766,6 @@ stages:
                 - 'worker2'
           total_affected_items: 0
           total_failed_items: 3
-    delay_before: 12
 
     #### Delete corrupted rules file
   - name: Delete rules file
@@ -777,6 +777,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
     response:
       status_code: 200
+    delay_after: !float "{cluster_sync_delay}"
 
   - name: Request cluster validation
     request:
@@ -790,7 +791,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - name: worker1
@@ -800,7 +801,6 @@ stages:
           failed_items: []
           total_affected_items: 2
           total_failed_items: 0
-    delay_before: 12
 
   - name: Request cluster validation
     request:
@@ -814,7 +814,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - name: master-node
@@ -839,7 +839,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - node_name: "master-node"
@@ -896,7 +896,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - node_name: 'worker1'
@@ -924,7 +924,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - global:
@@ -957,7 +957,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - active-response: !anything
@@ -975,7 +975,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - alerts: !anything
@@ -994,7 +994,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - command: !anything
@@ -1012,7 +1012,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - auth:
@@ -1041,7 +1041,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - internal:
@@ -1062,7 +1062,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - internal:
@@ -1094,7 +1094,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - localfile: !anything
@@ -1112,7 +1112,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: []
           failed_items: []
@@ -1129,7 +1129,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - internal:
@@ -1163,7 +1163,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - monitord:
@@ -1190,7 +1190,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - remote:
@@ -1213,7 +1213,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - internal:
@@ -1254,7 +1254,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - syscheck:
@@ -1273,7 +1273,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - rootcheck:
@@ -1306,7 +1306,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - internal:
@@ -1333,7 +1333,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - wmodules: !anything
@@ -1364,7 +1364,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - path: !anystr
@@ -1402,7 +1402,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
@@ -1418,7 +1418,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - &cluster_log
@@ -1441,7 +1441,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *cluster_log
@@ -1491,7 +1491,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *cluster_log
@@ -1511,7 +1511,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *cluster_log
@@ -1530,7 +1530,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *cluster_log
@@ -1548,7 +1548,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *cluster_log
@@ -1569,7 +1569,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *cluster_log
@@ -1618,7 +1618,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
@@ -1660,7 +1660,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data: !anything
 
   - name: Cluster stats {node_id} day without stats
@@ -1722,7 +1722,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - total_events_decoded: !anyfloat
@@ -1798,7 +1798,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - averages: !anything
@@ -1830,7 +1830,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - queue_size: !anyfloat
@@ -1868,7 +1868,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - Sun:
@@ -1919,7 +1919,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
@@ -1943,7 +1943,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - 'worker1'
@@ -1963,7 +1963,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - 'master-node'
@@ -2014,7 +2014,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - alerts:
@@ -2037,7 +2037,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 1
         data:
           affected_items: []
           failed_items:
@@ -2061,7 +2061,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 1
         data:
           affected_items: []
           failed_items:
@@ -2086,7 +2086,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - alerts:

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -743,7 +743,6 @@ stages:
         content-type: application/octet-stream
     response:
       status_code: 200
-    delay_after: 10
 
   - name: Request validation
     request:
@@ -766,6 +765,7 @@ stages:
                 - 'worker2'
           total_affected_items: 0
           total_failed_items: 3
+    delay_before: 12
 
     #### Delete corrupted rules file
   - name: Delete rules file
@@ -777,7 +777,6 @@ stages:
         Authorization: "Bearer {test_login_token}"
     response:
       status_code: 200
-    delay_after: 10
 
   - name: Request cluster validation
     request:
@@ -801,6 +800,7 @@ stages:
           failed_items: []
           total_affected_items: 2
           total_failed_items: 0
+    delay_before: 12
 
   - name: Request cluster validation
     request:

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -743,6 +743,7 @@ stages:
         content-type: application/octet-stream
     response:
       status_code: 200
+    delay_after: 10
 
   - name: Request validation
     request:
@@ -756,18 +757,15 @@ stages:
       json:
         error: !anyint
         data:
-          affected_items:
-            - name: worker1
-              status: 'OK'
-            - name: worker2
-              status: 'OK'
           failed_items:
             - error:
                 code: 1908
               id:
                 - 'master-node'
-          total_affected_items: 2
-          total_failed_items: 1
+                - 'worker1'
+                - 'worker2'
+          total_affected_items: 0
+          total_failed_items: 3
 
     #### Delete corrupted rules file
   - name: Delete rules file
@@ -779,7 +777,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
     response:
       status_code: 200
-    delay_after: 5
+    delay_after: 10
 
   - name: Request cluster validation
     request:


### PR DESCRIPTION
|Related issue|
|---|
| This PR closes #10204 |

## Description
One of the API integration tests failed during a PR check. It only failed once.

## Solution
Test `GET /cluster/configuration/validation`.
Stages:
- Between `Upload corrupted configuration` and `Request validation`: a delay must be awaited between these two. At `Request validation` we were testing that both workers got a valid configuration but master got it corrupted. Here is a race condition between corrupted file sync and the test itself. So I think it should be awaited and after that, test these three nodes as invalid.
- Between `Delete rules file` and `Request validation`: exact same as before, but this time corrupted file is deleted. Here we should test all three nodes as valid after certain amount of time.

## Test results
```
↪ ~/git/wazuh/api/test/integration ⊶ fix/10204-cluster-validation-fail ⨘ pytest -vv -x --disable-warnings test_cluster_endpoints.tavern.yaml
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.9.5, pytest-5.0.0, py-1.10.0, pluggy-0.13.1 -- /home/kondent/pythonEnv/inttest-env/bin/python3.9
cachedir: .pytest_cache
metadata: {'Python': '3.9.5', 'Platform': 'Linux-5.11.0-36-generic-x86_64-with-glibc2.31', 'Packages': {'pytest': '5.0.0', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'metadata': '1.11.0', 'tavern': '1.2.2'}}
rootdir: /home/kondent/git/wazuh/api/test/integration, inifile: pytest.ini
plugins: html-3.1.1, metadata-1.11.0, tavern-1.2.2
collected 45 items                                                                                                                                                                           

test_cluster_endpoints.tavern.yaml::GET /cluster/local/config PASSED                                                                                                                   [  2%]
test_cluster_endpoints.tavern.yaml::GET /cluster/healthcheck PASSED                                                                                                                    [  4%]
test_cluster_endpoints.tavern.yaml::GET /cluster/local/info PASSED                                                                                                                     [  6%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes PASSED                                                                                                                          [  8%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[master-node] PASSED                                                                                                             [ 11%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker1] PASSED                                                                                                                 [ 13%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker2] PASSED                                                                                                                 [ 15%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[ip] PASSED                                                                                                               [ 17%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[name] PASSED                                                                                                             [ 20%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[type] PASSED                                                                                                             [ 22%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[version] PASSED                                                                                                          [ 24%]
test_cluster_endpoints.tavern.yaml::GET /cluster/status PASSED                                                                                                                         [ 26%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration PASSED                                                                                                        [ 28%]
test_cluster_endpoints.tavern.yaml::GET /cluster/configuration/validation PASSED                                                                                                       [ 31%]
test_cluster_endpoints.tavern.yaml::GET /cluster/api/config PASSED                                                                                                                     [ 33%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration/{component}/{configuration} PASSED                                                                            [ 35%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[master-node] PASSED                                                                                                    [ 37%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker1] PASSED                                                                                                        [ 40%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker2] PASSED                                                                                                        [ 42%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[master-node] PASSED                                                                                                    [ 44%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker1] PASSED                                                                                                        [ 46%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker2] PASSED                                                                                                        [ 48%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker1] PASSED                                                                                                [ 51%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker2] PASSED                                                                                                [ 53%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[master-node] PASSED                                                                                                   [ 55%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker1] PASSED                                                                                                       [ 57%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker2] PASSED                                                                                                       [ 60%]
test_cluster_endpoints.tavern.yaml::GET /cluster/wrong_node/stats PASSED                                                                                                               [ 62%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[master-node] PASSED                                                                                         [ 64%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker1] PASSED                                                                                             [ 66%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker2] PASSED                                                                                             [ 68%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[master-node] PASSED                                                                                            [ 71%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker1] PASSED                                                                                                [ 73%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker2] PASSED                                                                                                [ 75%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[master-node] PASSED                                                                                           [ 77%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker1] PASSED                                                                                               [ 80%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker2] PASSED                                                                                               [ 82%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[master-node] PASSED                                                                                            [ 84%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker1] PASSED                                                                                                [ 86%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker2] PASSED                                                                                                [ 88%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[master-node] PASSED                                                                                                  [ 91%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker1] PASSED                                                                                                      [ 93%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker2] PASSED                                                                                                      [ 95%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/restart PASSED                                                                                                                        [ 97%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/configuration PASSED                                                                                                        [100%]

========================================================================== 45 passed, 1 warnings in 449.17 seconds ===========================================================================
```

Regards,
Alexis