### PR TITLE
Change GCP logger format

### DIFF
--- a/wodles/gcloud/tools.py
+++ b/wodles/gcloud/tools.py
@@ -26,7 +26,7 @@ log_levels = {0: logging.NOTSET,
               4: logging.ERROR,
               5: logging.CRITICAL,
               }
-logging_format = logging.Formatter('%(name)s: %(levelname)s: %(message)s', '%Y/%m/%d %H:%M:%S')
+logging_format = logging.Formatter('%(name)s - %(levelname)s - %(message)s')
 min_num_threads = 1
 min_num_messages = 1
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-qa/issues/1906|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->
This PR closes https://github.com/wazuh/wazuh-qa/issues/1906.

## Description

The QA integration tests were failing due to a change in the GCP original logger format. Reverting this change makes the tests pass again. 

## Tests performed
```

=========================================================== test session starts ===========================================================
platform linux -- Python 3.6.8, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.6.8', 'Platform': 'Linux-4.18.0-240.1.1.el8_3.x86_64-x86_64-with-centos-8.3.2011', 'Packages': {'pytest': '6.2.2', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '2.0.1', 'metadata': '1.11.0', 'testinfra': '5.0.0'}}
rootdir: /home/vagrant/wazuh-qa/tests/integration, configfile: pytest.ini
plugins: html-2.0.1, metadata-1.11.0, testinfra-5.0.0
collected 88 items                                                                                                                        

test_gcloud/test_configuration/test_invalid.py::test_invalid[get_configuration0] PASSED                                             [  1%]
test_gcloud/test_configuration/test_invalid.py::test_invalid[get_configuration1] PASSED                                             [  2%]
test_gcloud/test_configuration/test_invalid.py::test_invalid[get_configuration2] PASSED                                             [  3%]
test_gcloud/test_configuration/test_invalid.py::test_invalid[get_configuration3] PASSED                                             [  4%]
test_gcloud/test_configuration/test_invalid.py::test_invalid[get_configuration4] PASSED                                             [  5%]
test_gcloud/test_configuration/test_invalid.py::test_invalid[get_configuration5] PASSED                                             [  6%]
test_gcloud/test_configuration/test_invalid.py::test_invalid[get_configuration6] PASSED                                             [  7%]
test_gcloud/test_configuration/test_invalid.py::test_invalid[get_configuration7] PASSED                                             [  9%]
test_gcloud/test_configuration/test_invalid.py::test_invalid[get_configuration8] PASSED                                             [ 10%]
test_gcloud/test_configuration/test_invalid.py::test_invalid[get_configuration9] PASSED                                             [ 11%]
test_gcloud/test_configuration/test_invalid.py::test_invalid[get_configuration10] PASSED                                            [ 12%]
test_gcloud/test_configuration/test_invalid.py::test_invalid[get_configuration11] PASSED                                            [ 13%]
test_gcloud/test_configuration/test_invalid.py::test_invalid[get_configuration12] PASSED                                            [ 14%]
test_gcloud/test_configuration/test_invalid.py::test_invalid[get_configuration13] PASSED                                            [ 15%]
test_gcloud/test_configuration/test_invalid.py::test_invalid[get_configuration14] PASSED                                            [ 17%]
test_gcloud/test_configuration/test_invalid.py::test_invalid[get_configuration15] PASSED                                            [ 18%]
test_gcloud/test_configuration/test_invalid.py::test_invalid[get_configuration16] PASSED                                            [ 19%]
test_gcloud/test_configuration/test_invalid.py::test_invalid[get_configuration17] PASSED                                            [ 20%]
test_gcloud/test_configuration/test_invalid.py::test_invalid[get_configuration18] PASSED                                            [ 21%]
test_gcloud/test_configuration/test_invalid.py::test_invalid[get_configuration19] PASSED                                            [ 22%]
test_gcloud/test_configuration/test_invalid.py::test_invalid[get_configuration20] PASSED                                            [ 23%]
test_gcloud/test_configuration/test_invalid.py::test_invalid[get_configuration21] PASSED                                            [ 25%]
test_gcloud/test_configuration/test_invalid.py::test_invalid[get_configuration22] PASSED                                            [ 26%]
test_gcloud/test_configuration/test_invalid.py::test_invalid[get_configuration23] PASSED                                            [ 27%]
test_gcloud/test_configuration/test_invalid.py::test_invalid[get_configuration24] PASSED                                            [ 28%]
test_gcloud/test_configuration/test_invalid.py::test_invalid[get_configuration25] PASSED                                            [ 29%]
test_gcloud/test_configuration/test_invalid.py::test_invalid[get_configuration26] PASSED                                            [ 30%]
test_gcloud/test_configuration/test_remote_configuration.py::test_remote_configuration[get_configuration0] PASSED                   [ 31%]
test_gcloud/test_configuration/test_remote_configuration.py::test_remote_configuration[get_configuration1] PASSED                   [ 32%]
test_gcloud/test_configuration/test_remote_configuration.py::test_remote_configuration[get_configuration2] PASSED                   [ 34%]
test_gcloud/test_configuration/test_schedule.py::test_schedule[get_configuration0] PASSED                                           [ 35%]
test_gcloud/test_configuration/test_schedule.py::test_schedule[get_configuration1] PASSED                                           [ 36%]
test_gcloud/test_configuration/test_schedule.py::test_schedule[get_configuration2] PASSED                                           [ 37%]
test_gcloud/test_configuration/test_schedule.py::test_schedule[get_configuration3] PASSED                                           [ 38%]
test_gcloud/test_configuration/test_schedule.py::test_schedule[get_configuration4] PASSED                                           [ 39%]
test_gcloud/test_configuration/test_schedule.py::test_schedule[get_configuration5] PASSED                                           [ 40%]
test_gcloud/test_configuration/test_schedule.py::test_schedule[get_configuration6] PASSED                                           [ 42%]
test_gcloud/test_configuration/test_schedule.py::test_schedule[get_configuration7] PASSED                                           [ 43%]
test_gcloud/test_configuration/test_schedule.py::test_schedule[get_configuration8] PASSED                                                                                                                                                                                          [ 44%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday[get_configuration0-tags_to_apply0] PASSED                                                                                                                                                                           [ 45%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday[get_configuration0-tags_to_apply1] SKIPPED (Does not apply to this config file)                                                                                                                                     [ 46%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday[get_configuration0-tags_to_apply2] SKIPPED (Does not apply to this config file)                                                                                                                                     [ 47%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday_multiple[get_configuration0-tags_to_apply0] SKIPPED (Does not apply to this config file)                                                                                                                            [ 48%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday_multiple[get_configuration0-tags_to_apply1] SKIPPED (Does not apply to this config file)                                                                                                                            [ 50%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday_multiple[get_configuration0-tags_to_apply2] SKIPPED (Does not apply to this config file)                                                                                                                            [ 51%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday[get_configuration1-tags_to_apply0] SKIPPED (Does not apply to this config file)                                                                                                                                     [ 52%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday[get_configuration1-tags_to_apply1] PASSED                                                                                                                                                                           [ 53%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday[get_configuration1-tags_to_apply2] SKIPPED (Does not apply to this config file)                                                                                                                                     [ 54%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday_multiple[get_configuration1-tags_to_apply0] SKIPPED (Does not apply to this config file)                                                                                                                            [ 55%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday_multiple[get_configuration1-tags_to_apply1] SKIPPED (Does not apply to this config file)                                                                                                                            [ 56%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday_multiple[get_configuration1-tags_to_apply2] SKIPPED (Does not apply to this config file)                                                                                                                            [ 57%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday[get_configuration2-tags_to_apply0] SKIPPED (Does not apply to this config file)                                                                                                                                     [ 59%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday[get_configuration2-tags_to_apply1] SKIPPED (Does not apply to this config file)                                                                                                                                     [ 60%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday[get_configuration2-tags_to_apply2] PASSED                                                                                                                                                                           [ 61%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday_multiple[get_configuration2-tags_to_apply0] SKIPPED (Does not apply to this config file)                                                                                                                            [ 62%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday_multiple[get_configuration2-tags_to_apply1] SKIPPED (Does not apply to this config file)                                                                                                                            [ 63%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday_multiple[get_configuration2-tags_to_apply2] SKIPPED (Does not apply to this config file)                                                                                                                            [ 64%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday[get_configuration3-tags_to_apply0] SKIPPED (Does not apply to this config file)                                                                                                                                     [ 65%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday[get_configuration3-tags_to_apply1] SKIPPED (Does not apply to this config file)                                                                                                                                     [ 67%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday[get_configuration3-tags_to_apply2] SKIPPED (Does not apply to this config file)                                                                                                                                     [ 68%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday_multiple[get_configuration3-tags_to_apply0] PASSED                                                                                                                                                                  [ 69%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday_multiple[get_configuration3-tags_to_apply1] SKIPPED (Does not apply to this config file)                                                                                                                            [ 70%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday_multiple[get_configuration3-tags_to_apply2] SKIPPED (Does not apply to this config file)                                                                                                                            [ 71%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday[get_configuration4-tags_to_apply0] SKIPPED (Does not apply to this config file)                                                                                                                                     [ 72%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday[get_configuration4-tags_to_apply1] SKIPPED (Does not apply to this config file)                                                                                                                                     [ 73%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday[get_configuration4-tags_to_apply2] SKIPPED (Does not apply to this config file)                                                                                                                                     [ 75%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday_multiple[get_configuration4-tags_to_apply0] SKIPPED (Does not apply to this config file)                                                                                                                            [ 76%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday_multiple[get_configuration4-tags_to_apply1] PASSED                                                                                                                                                                  [ 77%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday_multiple[get_configuration4-tags_to_apply2] SKIPPED (Does not apply to this config file)                                                                                                                            [ 78%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday[get_configuration5-tags_to_apply0] SKIPPED (Does not apply to this config file)                                                                                                                                     [ 79%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday[get_configuration5-tags_to_apply1] SKIPPED (Does not apply to this config file)                                                                                                                                     [ 80%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday[get_configuration5-tags_to_apply2] SKIPPED (Does not apply to this config file)                                                                                                                                     [ 81%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday_multiple[get_configuration5-tags_to_apply0] SKIPPED (Does not apply to this config file)                                                                                                                            [ 82%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday_multiple[get_configuration5-tags_to_apply1] SKIPPED (Does not apply to this config file)                                                                                                                            [ 84%]
test_gcloud/test_functionality/test_day_wday.py::test_day_wday_multiple[get_configuration5-tags_to_apply2] PASSED                                                                                                                                                                  [ 85%]
test_gcloud/test_functionality/test_interval.py::test_interval[get_configuration0] PASSED                                                                                                                                                                                          [ 86%]
test_gcloud/test_functionality/test_interval.py::test_interval[get_configuration1] PASSED                                                                                                                                                                                          [ 87%]
test_gcloud/test_functionality/test_logging.py::test_logging[get_configuration0-publish_messages0] PASSED                                                                                                                                                                          [ 88%]
test_gcloud/test_functionality/test_logging.py::test_logging[get_configuration1-publish_messages0] PASSED                                                                                                                                                                          [ 89%]
test_gcloud/test_functionality/test_logging.py::test_logging[get_configuration2-publish_messages0] PASSED                                                                                                                                                                          [ 90%]
test_gcloud/test_functionality/test_logging.py::test_logging[get_configuration3-publish_messages0] PASSED                                                                                                                                                                          [ 92%]
test_gcloud/test_functionality/test_logging.py::test_logging[get_configuration4-publish_messages0] PASSED                                                                                                                                                                          [ 93%]
test_gcloud/test_functionality/test_max_messages.py::test_max_messages[get_configuration0-publish_messages0] PASSED                                                                                                                                                                [ 94%]
test_gcloud/test_functionality/test_max_messages.py::test_max_messages[get_configuration0-publish_messages1] PASSED                                                                                                                                                                [ 95%]
test_gcloud/test_functionality/test_max_messages.py::test_max_messages[get_configuration0-publish_messages2] PASSED                                                                                                                                                                [ 96%]
test_gcloud/test_functionality/test_pull_on_start.py::test_pull_on_start[get_configuration0] PASSED                                                                                                                                                                                [ 97%]
test_gcloud/test_functionality/test_pull_on_start.py::test_pull_on_start[get_configuration1] PASSED                                                                                                                                                                                [ 98%]
test_gcloud/test_functionality/test_rules.py::test_rules[get_configuration0] PASSED                                                                                                                                                                                                [100%]

====================================================================================================================== 58 passed, 30 skipped in 2601.81s (0:43:21) =======================================================================================================================


```

Regards,
Víctor