### PR TITLE
Fix `agent_upgrade` script

### DIFF
--- a/api/api/configuration.py
+++ b/api/api/configuration.py
@@ -240,7 +240,7 @@ def read_yaml_config(config_file=CONFIG_FILE_PATH, default_conf=None) -> Dict:
     if default_conf is None:
         default_conf = default_api_configuration
 
-    if os.path.exists(config_file):
+    if config_file and os.path.exists(config_file):
         try:
             with open(config_file) as f:
                 configuration = yaml.safe_load(f)

--- a/api/api/configuration.py
+++ b/api/api/configuration.py
@@ -274,5 +274,5 @@ except ValidationError as e:
     raise APIError(2000, details=e.message)
 
 # Configuration - global object
-api_conf = dict()
+api_conf = read_yaml_config()
 security_conf = read_yaml_config(config_file=SECURITY_CONFIG_PATH, default_conf=default_security_configuration)

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -57,7 +57,8 @@ def start(foreground, root, config_file):
             )
             api_logger.setup_logger()
 
-    configuration.api_conf.update(configuration.read_yaml_config(config_file=config_file))
+    if config_file:
+        configuration.api_conf.update(configuration.read_yaml_config(config_file=config_file))
     api_conf = configuration.api_conf
     security_conf = configuration.security_conf
     log_path = api_conf['logs']['path']
@@ -237,7 +238,7 @@ if __name__ == '__main__':
     parser.add_argument('-t', help="Test configuration", action='store_true', dest='test_config')
     parser.add_argument('-r', help="Run as root", action='store_true', dest='root')
     parser.add_argument('-c', help="Configuration file to use", type=str, metavar='config', dest='config_file',
-                        default=common.api_config_path)
+                        default='')
     parser.add_argument('-d', help="Enable debug messages. Use twice to increase verbosity.", action='count',
                         dest='debug_level')
     args = parser.parse_args()

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -57,7 +57,7 @@ def start(foreground, root, config_file):
             )
             api_logger.setup_logger()
 
-    if config_file:
+    if config_file is not None:
         configuration.api_conf.update(configuration.read_yaml_config(config_file=config_file))
     api_conf = configuration.api_conf
     security_conf = configuration.security_conf
@@ -237,8 +237,7 @@ if __name__ == '__main__':
     parser.add_argument('-V', help="Print version", action='store_true', dest="version")
     parser.add_argument('-t', help="Test configuration", action='store_true', dest='test_config')
     parser.add_argument('-r', help="Run as root", action='store_true', dest='root')
-    parser.add_argument('-c', help="Configuration file to use", type=str, metavar='config', dest='config_file',
-                        default='')
+    parser.add_argument('-c', help="Configuration file to use", type=str, metavar='config', dest='config_file')
     parser.add_argument('-d', help="Enable debug messages. Use twice to increase verbosity.", action='count',
                         dest='debug_level')
     args = parser.parse_args()

--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -148,14 +148,10 @@ if __name__ == '__main__':
     if args.test_config:
         sys.exit(0)
 
-    from api import configuration
-
     cluster_status = wazuh.core.cluster.utils.get_cluster_status()
     if cluster_status['running'] == 'yes':
         main_logger.error("Cluster is already running.")
         sys.exit(1)
-
-    configuration.api_conf.update(configuration.read_yaml_config())
 
     # clean
     wazuh.core.cluster.cluster.clean_up()


### PR DESCRIPTION
|Related issue|
|---|
| Closes #10314 |

## Description

This PR fixes the error reported in #10314 when `/var/ossec/bin/agent_upgrade` script is used. The problem appeared after the changes performed in https://github.com/wazuh/wazuh/pull/8919, when API configuration started being used in the `dapi.py` module:
https://github.com/wazuh/wazuh/blob/a59b4e3f19b5689e582496bd62fe747b3abd176d/framework/wazuh/core/cluster/dapi/dapi.py#L107

The `api_conf` variable is an empty dict by default:
https://github.com/wazuh/wazuh/blob/a59b4e3f19b5689e582496bd62fe747b3abd176d/api/api/configuration.py#L277

It is after being updated in the `wazuh-apid.py` or `wazuh-clusterd.py` when it can be correctly used, inside those processes:
https://github.com/wazuh/wazuh/blob/a59b4e3f19b5689e582496bd62fe747b3abd176d/api/scripts/wazuh-apid.py#L60

However, it was not being updated in the `agent_upgrade` script. As it is a different process, the `api_conf` variable remained empty, so a KeyError was raised:
https://github.com/wazuh/wazuh/blob/a59b4e3f19b5689e582496bd62fe747b3abd176d/framework/scripts/agent_upgrade.py#L111-L115

Instead of loading the content of the `api.yaml` in `agent_upgrade`, we decided to load it when starting the `api/configuration.py` module, so it has the default configuration.

The bug seems to be fixed now:
```
root@wazuh-master:/# /var/ossec/bin/agent_upgrade -a 001 -f /wazuh_agent_v4.2.1_windows.wpk -F

Upgrading...

Upgraded agents:
	Agent 001 upgraded: Wazuh v4.2.1 -> Wazuh v4.2.1

```