### PR TITLE
Fix RBAC experimental API integration test expecting a 1760 code in implicit requests

### DIFF
--- a/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
@@ -106,20 +106,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: 1
+        error: 0
         data:
           affected_items: []
-          failed_items:
-            - error:
-                code: 1760
-              id:
-                - '000'
-                - '002'
-                - '004'
-                - '006'
-                - '008'
+          failed_items: []
           total_affected_items: 0
-          total_failed_items: 5
+          total_failed_items: 0
 
   - name: Request a list of agents (Partially allowed, user aware)
     request:

--- a/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
@@ -108,7 +108,7 @@ stages:
       json:
         error: 0
         data:
-          affected_items: []
+          affected_items: []  # Some agents are allowed but they raise error 1706, which is excluded as the agents newer than 3.12 are not affected.
           failed_items: []
           total_affected_items: 0
           total_failed_items: 0

--- a/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
@@ -106,19 +106,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: 1
+        error: 0
         data:
           affected_items: []
-          failed_items:
-            - error:
-                code: 1760
-              id:
-                - '001'
-                - '003'
-                - '005'
-                - '007'
+          failed_items: []
           total_affected_items: 0
-          total_failed_items: 4
+          total_failed_items: 0
 
   - name: Request a list of agents (Partially allowed, user aware)
     request:

--- a/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
@@ -108,7 +108,7 @@ stages:
       json:
         error: 0
         data:
-          affected_items: []
+          affected_items: []  # Some agents are allowed but they raise error 1706, which is excluded as the agents newer than 3.12 are not affected.
           failed_items: []
           total_affected_items: 0
           total_failed_items: 0


### PR DESCRIPTION
|Related issue|
|---|
| #10311  |

This PR closes #10311.

In this pull request, I have deleted the expected code 1760 in RBAC experimental syscheck test cases of our API integration tests as this code is excluded when using the endpoint with the `all` keyword (implicit request).

### Test results

```
test_rbac_black_rootcheck_endpoints.tavern.yaml 
	 4 passed, 6 warnings

test_rbac_black_syscheck_endpoints.tavern.yaml 
	 4 passed, 6 warnings

test_rbac_white_rootcheck_endpoints.tavern.yaml 
	 4 passed, 6 warnings

test_rbac_white_syscheck_endpoints.tavern.yaml 
	 4 passed, 6 warnings

test_rootcheck_endpoints.tavern.yaml 
	 4 passed, 6 warnings
	 
test_syscheck_endpoints.tavern.yaml 
	 35 passed, 37 warnings

test_experimental_endpoints.tavern.yaml 
	 11 passed, 1 xpassed, 14 warnings

test_rbac_black_experimental_endpoints.tavern.yaml 
	 12 passed, 14 warnings

test_rbac_white_experimental_endpoints.tavern.yaml 
	 12 passed, 14 warnings
```