### PR TITLE
Improving the logs generated during the agents' registration and replacement

### DIFF
--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -284,9 +284,7 @@ w_err_t w_auth_validate_data(char *response,
 
     /* Validate the group(s) name(s) */
     if (groups) {
-        if (OS_SUCCESS != w_auth_validate_groups(groups, response)) {
-            result = OS_INVALID;
-        }
+        result = w_auth_validate_groups(groups, response);
     }
 
     /* Check for duplicate IP */

--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -9,8 +9,11 @@
  */
 
 #include <shared.h>
+#include <stdio.h>
 #include "auth.h"
+#include "defs.h"
 #include "os_err.h"
+#include "string_op.h"
 #include "wazuh_db/helpers/wdb_global_helpers.h"
 #include "wazuh_db/wdb.h"
 
@@ -189,17 +192,20 @@ w_err_t w_auth_parse_data(const char* buf,
 
 w_err_t w_auth_replace_agent(keyentry *key,
                              const char *key_hash,
-                             authd_force_options_t *force_options) {
+                             authd_force_options_t *force_options,
+                             char** str_result) {
 
     cJSON *j_agent_info = NULL;
     cJSON *j_date_add = NULL;
     cJSON *j_disconnected_time = NULL;
     cJSON *j_connection_status = NULL;
     bool replace_agent = true;
+    char message[OS_SIZE_128] = {0};
 
     /* Check if the agent replacement is allowed */
     if (!force_options->enabled) {
-        minfo("Agent '%s' won't be removed because the force option is disabled.", key->id);
+        snprintf(message, OS_SIZE_128, "Agent '%s' won't be removed because the force option is disabled.", key->id);
+        os_strdup(message, *str_result);
         return OS_INVALID;
     }
 
@@ -212,7 +218,8 @@ w_err_t w_auth_replace_agent(keyentry *key,
 
     if (!j_agent_info || !j_connection_status || !j_disconnected_time || !j_date_add) {
         cJSON_Delete(j_agent_info);
-        minfo("Failed to get agent-info for agent '%s'", key->id);
+        snprintf(message, OS_SIZE_128, "Failed to get agent-info for agent '%s'", key->id);
+        os_strdup(message, *str_result);
         return OS_INVALID;
     }
 
@@ -221,31 +228,34 @@ w_err_t w_auth_replace_agent(keyentry *key,
         if (strcmp(j_connection_status->valuestring, AGENT_CS_NEVER_CONNECTED)) {
             time_t time_since_disconnected = difftime(time(NULL), j_disconnected_time->valueint);
             if (!strcmp(j_connection_status->valuestring, AGENT_CS_DISCONNECTED) && j_disconnected_time->valueint > 0 && time_since_disconnected < force_options->disconnected_time) {
-                minfo("Agent '%s' has not been disconnected long enough to be replaced.", key->id);
+                snprintf(message, OS_SIZE_128, "Agent '%s' has not been disconnected long enough to be replaced.", key->id);
+                os_strdup(message, *str_result);
                 replace_agent = false;
             } else if (j_disconnected_time->valueint == 0) {
-                minfo("Agent '%s' can't be replaced since it is not disconnected.", key->id);
+                snprintf(message, OS_SIZE_128, "Agent '%s' can't be replaced since it is not disconnected.", key->id);
+                os_strdup(message, *str_result);
                 replace_agent = false;
             }
         }
     }
 
     /* Check if the agent is old enough to be removed */
-    if (force_options->after_registration_time > 0) {
+    if (replace_agent && force_options->after_registration_time > 0) {
         time_t agent_registration_time = difftime(time(NULL), j_date_add->valueint);
-
         if (agent_registration_time < force_options->after_registration_time) {
-            minfo("Agent '%s' doesn't comply with the registration time to be removed.", key->id);
+            snprintf(message, OS_SIZE_128, "Agent '%s' doesn't comply with the registration time to be removed.", key->id);
+            os_strdup(message, *str_result);
             replace_agent = false;
         }
     }
 
     /* Check if the agent key is the same than the existent in the manager */
-    if (key_hash && force_options->key_mismatch) {
+    if (replace_agent && key_hash && force_options->key_mismatch) {
         os_sha1 manager_key_hash;
         w_get_key_hash(key, manager_key_hash);
         if (!strcmp(manager_key_hash, key_hash)) {
-            minfo("Agent '%s' key already exists on the manager.", key->id);
+            snprintf(message, OS_SIZE_128, "Agent '%s' key already exists on the manager.", key->id);
+            os_strdup(message, *str_result);
             replace_agent = false;
         }
     }
@@ -254,7 +264,8 @@ w_err_t w_auth_replace_agent(keyentry *key,
 
     /* Replace the agent */
     if (replace_agent) {
-        minfo("Removing old agent '%s'.", key->id);
+        snprintf(message, OS_SIZE_128, "Removing old agent '%s' (id '%s').", key->name, key->id);
+        os_strdup(message, *str_result);
         add_remove(key);
         OS_DeleteKey(&keys, key->id, 0);
         return OS_SUCCESS;
@@ -268,40 +279,47 @@ w_err_t w_auth_validate_data(char *response,
                              const char *groups,
                              const char *key_hash) {
     int index = 0;
+    char* str_result = NULL;
+    w_err_t result = OS_SUCCESS;
 
     /* Validate the group(s) name(s) */
     if (groups) {
         if (OS_SUCCESS != w_auth_validate_groups(groups, response)) {
-            return OS_INVALID;
+            result = OS_INVALID;
         }
     }
 
     /* Check for duplicate IP */
-    if (strcmp(ip, "any") != 0 && (index = OS_IsAllowedIP(&keys, ip), index >= 0)) {
-        minfo("Duplicate IP '%s' (%s).", ip, keys.keyentries[index]->id);
-        if (OS_SUCCESS != w_auth_replace_agent(keys.keyentries[index], key_hash, &config.force_options)) {
+    if (result != OS_INVALID && strcmp(ip, "any") != 0 && (index = OS_IsAllowedIP(&keys, ip), index >= 0)) {
+        if(OS_SUCCESS == w_auth_replace_agent(keys.keyentries[index], key_hash, &config.force_options, &str_result)) {
+            minfo("Duplicate IP '%s'. %s", ip, str_result);
+        } else {
+            mwarn("Duplicate IP '%s', rejecting enrollment. %s", ip, str_result);
             snprintf(response, 2048, "ERROR: Duplicate IP: %s", ip);
-            return OS_INVALID;
+            result = OS_INVALID;
         }
     }
 
     /* Check whether the agent name is the same as the manager */
-    if (!strcmp(agentname, shost)) {
+    if (result != OS_INVALID && !strcmp(agentname, shost)) {
         merror("Invalid agent name %s (same as manager)", agentname);
         snprintf(response, 2048, "ERROR: Invalid agent name: %s", agentname);
-        return OS_INVALID;
+        result = OS_INVALID;
     }
 
     /* Check for duplicate name */
-    if (index = OS_IsAllowedName(&keys, agentname), index >= 0) {
-        minfo("Duplicate name '%s' (%s).", agentname, keys.keyentries[index]->id);
-        if (OS_SUCCESS != w_auth_replace_agent(keys.keyentries[index], key_hash, &config.force_options)) {
+    if (result != OS_INVALID && (index = OS_IsAllowedName(&keys, agentname), index >= 0)) {
+        if(OS_SUCCESS == w_auth_replace_agent(keys.keyentries[index], key_hash, &config.force_options, &str_result)) {
+            minfo("Duplicate name. %s", str_result);
+        } else {
+            mwarn("Duplicate name '%s', rejecting enrollment. %s", agentname, str_result);
             snprintf(response, 2048, "ERROR: Duplicate agent name: %s", agentname);
-            return OS_INVALID;
+            result = OS_INVALID;
         }
     }
 
-    return OS_SUCCESS;
+    os_free(str_result);
+    return result;
 }
 
 w_err_t w_auth_add_agent(char *response, const char *ip, const char *agentname, const char *groups, char **id, char **key) {

--- a/src/os_auth/auth.h
+++ b/src/os_auth/auth.h
@@ -151,7 +151,8 @@ w_err_t w_auth_validate_data(char *response,
  * */
 w_err_t w_auth_replace_agent(keyentry *key,
                              const char *key_hash,
-                             authd_force_options_t *force_options);
+                             authd_force_options_t *force_options,
+                             char** str_result);
 
 /**
  * @brief Adds new agent with provided enrollment data.

--- a/src/os_auth/auth.h
+++ b/src/os_auth/auth.h
@@ -148,6 +148,7 @@ w_err_t w_auth_validate_data(char *response,
  * @param key Key structure of the agent to be removed
  * @param hash_key Hash of the key on the agent
  * @param force_options Force configuration structure to define how the agent replacement must be handled.
+ * @param str_result A message related to the result of the agent replacement. Must be freed by the caller.
  * */
 w_err_t w_auth_replace_agent(keyentry *key,
                              const char *key_hash,

--- a/src/unit_tests/os_auth/test_auth_validate.c
+++ b/src/unit_tests/os_auth/test_auth_validate.c
@@ -164,16 +164,16 @@ static void test_w_auth_validate_data(void **state) {
 
     /* Existent IP */
     response[0] = '\0';
-    expect_string(__wrap__minfo, formatted_msg, "Duplicate IP '"EXISTENT_IP1"' (001).");
-    expect_string(__wrap__minfo, formatted_msg, "Agent '001' won't be removed because the force option is disabled.");
+    expect_string(__wrap__mwarn, formatted_msg, "Duplicate IP '"EXISTENT_IP1"', rejecting enrollment. "
+                                                "Agent '001' won't be removed because the force option is disabled.");
     err = w_auth_validate_data(response, EXISTENT_IP1, NEW_AGENT1, NULL, NULL);
     assert_int_equal(err, OS_INVALID);
     assert_string_equal(response, "ERROR: Duplicate IP: "EXISTENT_IP1"");
 
     /* Existent Agent Name */
     response[0] = '\0';
-    expect_string(__wrap__minfo, formatted_msg, "Duplicate name '"EXISTENT_AGENT1"' (001).");
-    expect_string(__wrap__minfo, formatted_msg, "Agent '001' won't be removed because the force option is disabled.");
+    expect_string(__wrap__mwarn, formatted_msg, "Duplicate name '"EXISTENT_AGENT1"', rejecting enrollment. "
+                                                "Agent '001' won't be removed because the force option is disabled.");
     err = w_auth_validate_data(response, NEW_IP1, EXISTENT_AGENT1, NULL, NULL);
     assert_int_equal(err, OS_INVALID);
     assert_string_equal(response, "ERROR: Duplicate agent name: "EXISTENT_AGENT1"");
@@ -223,8 +223,8 @@ static void test_w_auth_validate_data_replace_agent(void **state) {
     will_return(__wrap_wdb_get_agent_info, j_agent_info_array);
 
     response[0] = '\0';
-    expect_string(__wrap__minfo, formatted_msg, "Duplicate IP '"EXISTENT_IP1"' (001).");
-    expect_string(__wrap__minfo, formatted_msg, "Removing old agent '001'.");
+    expect_string(__wrap__minfo, formatted_msg, "Duplicate IP '"EXISTENT_IP1"'. "
+                                                "Removing old agent '"EXISTENT_AGENT1"' (id '001').");
     err = w_auth_validate_data(response, EXISTENT_IP1, NEW_AGENT1, NULL, NULL);
     assert_int_equal(err, OS_SUCCESS);
     assert_string_equal(response, "");
@@ -241,8 +241,8 @@ static void test_w_auth_validate_data_replace_agent(void **state) {
     will_return(__wrap_wdb_get_agent_info, j_agent_info_array);
 
     response[0] = '\0';
-    expect_string(__wrap__minfo, formatted_msg, "Duplicate name '"EXISTENT_AGENT2"' (002).");
-    expect_string(__wrap__minfo, formatted_msg, "Removing old agent '002'.");
+    expect_string(__wrap__minfo, formatted_msg, "Duplicate name. "
+                                                "Removing old agent '"EXISTENT_AGENT2"' (id '002').");
     err = w_auth_validate_data(response, NEW_IP2, EXISTENT_AGENT2, NULL, NULL);
     assert_int_equal(err, OS_SUCCESS);
     assert_string_equal(response, "");
@@ -297,12 +297,33 @@ static void test_w_auth_replace_agent_force_disabled(void **state) {
     w_err_t err;
     keyentry key;
     keyentry_init(&key, NEW_AGENT1, AGENT1_ID, NEW_IP1, NULL);
+    char* str_result = NULL;
 
-    expect_string(__wrap__minfo, formatted_msg, "Agent '001' won't be removed because the force option is disabled.");
-    err = w_auth_replace_agent(&key, NULL, &config.force_options);
+    err = w_auth_replace_agent(&key, NULL, &config.force_options, &str_result);
 
     assert_int_equal(err, OS_INVALID);
+    assert_string_equal(str_result, "Agent '001' won't be removed because the force option is disabled.");
     free_keyentry(&key);
+    os_free(str_result);
+}
+
+static void test_w_auth_replace_agent_agent_info_failed(void **state) {
+    w_err_t err;
+    keyentry key;
+    keyentry_init(&key, NEW_AGENT1, AGENT1_ID, NEW_IP1, NULL);
+    char* str_result = NULL;
+
+    config.force_options.enabled = 1;
+    expect_value(__wrap_wdb_get_agent_info, id, 1);
+    will_return(__wrap_wdb_get_agent_info, NULL);
+
+    err = w_auth_replace_agent(&key, NULL, &config.force_options, &str_result);
+
+    config.force_options.enabled = 0;
+    assert_int_equal(err, OS_INVALID);
+    assert_string_equal(str_result, "Failed to get agent-info for agent '001'");
+    free_keyentry(&key);
+    os_free(str_result);
 }
 
 static void test_w_auth_replace_agent_not_disconnected(void **state) {
@@ -310,6 +331,7 @@ static void test_w_auth_replace_agent_not_disconnected(void **state) {
     keyentry key;
     keyentry_init(&key, NEW_AGENT1, AGENT1_ID, NEW_IP1, NULL);
     char *connection_status = "active";
+    char* str_result = NULL;
     time_t date_add = 1632255744;
     time_t disconnected_time = 0;
     cJSON *j_agent_info_array = NULL;
@@ -331,11 +353,12 @@ static void test_w_auth_replace_agent_not_disconnected(void **state) {
     config.force_options.disconnected_time_enabled = true;
     config.force_options.disconnected_time = 100;
 
-    expect_string(__wrap__minfo, formatted_msg, "Agent '001' can't be replaced since it is not disconnected.");
-    err = w_auth_replace_agent(&key, NULL, &config.force_options);
+    err = w_auth_replace_agent(&key, NULL, &config.force_options, &str_result);
 
     assert_int_equal(err, OS_INVALID);
+    assert_string_equal(str_result, "Agent '001' can't be replaced since it is not disconnected.");
     free_keyentry(&key);
+    os_free(str_result);
 }
 
 static void test_w_auth_replace_agent_not_disconnected_long_enough(void **state) {
@@ -343,6 +366,7 @@ static void test_w_auth_replace_agent_not_disconnected_long_enough(void **state)
     keyentry key;
     keyentry_init(&key, NEW_AGENT1, AGENT1_ID, NEW_IP1, NULL);
     char *connection_status = "disconnected";
+    char* str_result = NULL;
     time_t date_add = 1632255744;
     time_t disconnected_time = 1632258049;
     cJSON *j_agent_info_array = NULL;
@@ -364,45 +388,15 @@ static void test_w_auth_replace_agent_not_disconnected_long_enough(void **state)
     config.force_options.disconnected_time_enabled = true;
     config.force_options.disconnected_time = 100;
 
-    expect_string(__wrap__minfo, formatted_msg, "Agent '001' has not been disconnected long enough to be replaced.");
-    err = w_auth_replace_agent(&key, NULL, &config.force_options);
-
-    assert_int_equal(err, OS_INVALID);
-    free_keyentry(&key);
-}
-
-static void test_w_auth_replace_agent_registered_recent(void **state) {
-    w_err_t err;
-    keyentry key;
-    keyentry_init(&key, NEW_AGENT1, AGENT1_ID, NEW_IP1, NULL);
-    char *connection_status = "active";
-    time_t date_add = 1632255744;
-    time_t disconnected_time = 0;
-    cJSON *j_agent_info_array = NULL;
-    cJSON *j_agent_info = NULL;
-
-    j_agent_info_array = cJSON_CreateArray();
-    j_agent_info = cJSON_CreateObject();
-    cJSON_AddStringToObject(j_agent_info, "connection_status", connection_status);
-    cJSON_AddNumberToObject(j_agent_info, "disconnected_time", disconnected_time);
-    cJSON_AddNumberToObject(j_agent_info, "date_add", date_add);
-    cJSON_AddItemToArray(j_agent_info_array, j_agent_info);
-
-    expect_value(__wrap_wdb_get_agent_info, id, 1);
-    will_return(__wrap_wdb_get_agent_info, j_agent_info_array);
+    err = w_auth_replace_agent(&key, NULL, &config.force_options, &str_result);
 
     config.force_options.disconnected_time_enabled = false;
-
-    // time since registration
-    will_return(__wrap_difftime, 10);
-
-    config.force_options.after_registration_time = 100;
-
-    expect_string(__wrap__minfo, formatted_msg, "Agent '001' doesn't comply with the registration time to be removed.");
-    err = w_auth_replace_agent(&key, NULL, &config.force_options);
+    config.force_options.disconnected_time = 0;
 
     assert_int_equal(err, OS_INVALID);
+    assert_string_equal(str_result, "Agent '001' has not been disconnected long enough to be replaced.");
     free_keyentry(&key);
+    os_free(str_result);
 }
 
 static void test_w_auth_replace_agent_not_old_enough(void **state) {
@@ -410,6 +404,7 @@ static void test_w_auth_replace_agent_not_old_enough(void **state) {
     keyentry key;
     keyentry_init(&key, NEW_AGENT1, AGENT1_ID, NEW_IP1, NULL);
     char *connection_status = "active";
+    char* str_result = NULL;
     time_t date_add = 1632255744;
     time_t disconnected_time = 0;
     cJSON *j_agent_info_array = NULL;
@@ -425,8 +420,6 @@ static void test_w_auth_replace_agent_not_old_enough(void **state) {
     expect_value(__wrap_wdb_get_agent_info, id, 1);
     will_return(__wrap_wdb_get_agent_info, j_agent_info_array);
 
-    will_return(__wrap_OS_AgentAntiquity, 0);
-
     config.force_options.disconnected_time_enabled = false;
 
     // time since registration
@@ -434,11 +427,14 @@ static void test_w_auth_replace_agent_not_old_enough(void **state) {
 
     config.force_options.after_registration_time = 100;
 
-    expect_string(__wrap__minfo, formatted_msg, "Agent '001' doesn't comply with the registration time to be removed.");
-    err = w_auth_replace_agent(&key, NULL, &config.force_options);
+    err = w_auth_replace_agent(&key, NULL, &config.force_options, &str_result);
+
+    config.force_options.after_registration_time = 0;
 
     assert_int_equal(err, OS_INVALID);
+    assert_string_equal(str_result, "Agent '001' doesn't comply with the registration time to be removed.");
     free_keyentry(&key);
+    os_free(str_result);
 }
 
 static void test_w_auth_replace_agent_existent_key_hash(void **state) {
@@ -448,6 +444,7 @@ static void test_w_auth_replace_agent_existent_key_hash(void **state) {
     // This is the SHA1 hash of the string: IdNameKey
     char *key_hash = "15153d246b71789195b48778875af94f9378ecf9";
     char *connection_status = "never_connected";
+    char* str_result = NULL;
     time_t date_add = 1632255744;
     time_t disconnected_time = 0;
     cJSON *j_agent_info_array = NULL;
@@ -463,17 +460,18 @@ static void test_w_auth_replace_agent_existent_key_hash(void **state) {
     expect_value(__wrap_wdb_get_agent_info, id, 1);
     will_return(__wrap_wdb_get_agent_info, j_agent_info_array);
 
-    will_return(__wrap_difftime, 10);
-
     config.force_options.disconnected_time_enabled = false;
-    config.force_options.after_registration_time = 1;
+    config.force_options.after_registration_time = 0;
     config.force_options.key_mismatch = true;
 
-    expect_string(__wrap__minfo, formatted_msg, "Agent '001' key already exists on the manager.");
-    err = w_auth_replace_agent(&key, key_hash, &config.force_options);
+    err = w_auth_replace_agent(&key, key_hash, &config.force_options, &str_result);
+
+    config.force_options.key_mismatch = false;
 
     assert_int_equal(err, OS_INVALID);
+    assert_string_equal(str_result, "Agent '001' key already exists on the manager.");
     free_keyentry(&key);
+    os_free(str_result);
 }
 
 static void test_w_auth_replace_agent_success(void **state) {
@@ -481,6 +479,7 @@ static void test_w_auth_replace_agent_success(void **state) {
     keyentry key;
     keyentry_init(&key, NEW_AGENT1, AGENT1_ID, NEW_IP1, NULL);
     char *connection_status = "disconnected";
+    char* str_result = NULL;
     time_t date_add = 1632255744;
     time_t disconnected_time = 1632258049;
     cJSON *j_agent_info_array = NULL;
@@ -501,11 +500,14 @@ static void test_w_auth_replace_agent_success(void **state) {
     config.force_options.disconnected_time_enabled = false;
     config.force_options.after_registration_time = 1;
 
-    expect_string(__wrap__minfo, formatted_msg, "Removing old agent '001'.");
-    err = w_auth_replace_agent(&key, NULL, &config.force_options);
+    err = w_auth_replace_agent(&key, NULL, &config.force_options, &str_result);
+
+    config.force_options.after_registration_time = 0;
 
     assert_int_equal(err, OS_SUCCESS);
+    assert_string_equal(str_result, "Removing old agent '"NEW_AGENT1"' (id '001').");
     free_keyentry(&key);
+    os_free(str_result);
 }
 
 int main(void) {
@@ -514,9 +516,10 @@ int main(void) {
         cmocka_unit_test_setup(test_w_auth_validate_data, setup_validate_force_disabled),
         cmocka_unit_test_setup(test_w_auth_validate_data_replace_agent, setup_validate_force_enabled),
         cmocka_unit_test_setup(test_w_auth_replace_agent_force_disabled, setup_validate_force_disabled),
+        cmocka_unit_test_setup(test_w_auth_replace_agent_agent_info_failed, setup_validate_force_disabled),
         cmocka_unit_test_setup(test_w_auth_replace_agent_not_disconnected_long_enough, setup_validate_force_enabled),
         cmocka_unit_test_setup(test_w_auth_replace_agent_not_disconnected, setup_validate_force_enabled),
-        cmocka_unit_test_setup(test_w_auth_replace_agent_registered_recent, setup_validate_force_enabled),
+        cmocka_unit_test_setup(test_w_auth_replace_agent_not_old_enough, setup_validate_force_enabled),
         cmocka_unit_test_setup(test_w_auth_replace_agent_existent_key_hash, setup_validate_force_enabled),
         cmocka_unit_test_setup(test_w_auth_replace_agent_success, setup_validate_force_enabled),
     };


### PR DESCRIPTION
|Related issue|
|---|
|#10268|

## Description

This PR changes the logs generated when an agent tries to register and a duplicate is found
- If the replacement is successful, only one **INFO** message is printed
- If the replacement failed, only a **WARNING** message is printed indicating the cause

## Logs/Alerts example

All the messages generated are detailed in the comments.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)

- [x] Working on cluster environments
- [x] Added unit tests (for new features)
