### PR TITLE
Support agent key polling on cluster environments

### DIFF
--- a/src/shared/agent_op.c
+++ b/src/shared/agent_op.c
@@ -849,8 +849,15 @@ int w_request_agent_add_clustered(char *err_response,
     char response[OS_MAXSTR + 1];
     char new_id[FILE_SIZE+1] = { '\0' };
     char new_key[KEYSIZE+1] = { '\0' };
+    cJSON* message;
 
-    cJSON* message = w_create_agent_add_payload(name, ip, groups, key_hash, *key, agent_id, force);
+    if (agent_id){
+        // Create key polling request
+        message = w_create_agent_add_payload(name, ip, groups, NULL, key_hash, agent_id, force);
+    } else {
+        // Create dispatching request
+        message = w_create_agent_add_payload(name, ip, groups, key_hash, *key, agent_id, force);
+    }
     cJSON* payload = w_create_sendsync_payload("authd", message);
     char* output = cJSON_PrintUnformatted(payload);
     cJSON_Delete(payload);

--- a/src/wazuh_modules/wm_keyrequest.c
+++ b/src/wazuh_modules/wm_keyrequest.c
@@ -380,24 +380,25 @@ int wm_key_request_dispatch(char * buffer, const wm_krequest_t * data) {
             return -1;
         }
 
-        int sock;
-        if (sock = auth_connect(), sock < 0) {
-            mwarn("Could not connect to authd socket. Is authd running?");
-        } else if(w_is_worker()) {
-            char response[2048];
-            response[2047] = '\0';
+        if(w_is_worker()) {
+            char response[OS_SIZE_2048] = {'\0'};
             char *new_id = NULL;
             char *new_key = NULL;
             if (0 == w_request_agent_add_clustered(response, agent_name->valuestring, agent_address->valuestring, NULL, agent_key->valuestring, &new_id, &new_key, data->force_insert, agent_id->valuestring)) {
-                mdebug1("Key poll request sent to master for agent %s", agent_id->valuestring);
+                mdebug1("Agent Key Polling response forwarded to the master node for agent '%s'", agent_id->valuestring);
+                os_free(new_id);
+                os_free(new_key);
             }
-            os_free(new_id);
-            os_free(new_key);
-            close(sock);
         } else {
-            w_request_agent_add_local(sock, id, agent_name->valuestring, agent_address->valuestring, NULL, agent_key->valuestring, data->force_insert, 1, agent_id->valuestring, 0);
-            close(sock);
+            int sock;
+            if (sock = auth_connect(), sock < 0) {
+                mwarn("Could not connect to authd socket. Is authd running?");
+            } else {
+                w_request_agent_add_local(sock, id, agent_name->valuestring, agent_address->valuestring, NULL, agent_key->valuestring, data->force_insert, 1, agent_id->valuestring, 0);
+                close(sock);
+            }
         }
+
         cJSON_Delete(agent_infoJSON);
     }
 

--- a/src/wazuh_modules/wm_keyrequest.c
+++ b/src/wazuh_modules/wm_keyrequest.c
@@ -383,6 +383,17 @@ int wm_key_request_dispatch(char * buffer, const wm_krequest_t * data) {
         int sock;
         if (sock = auth_connect(), sock < 0) {
             mwarn("Could not connect to authd socket. Is authd running?");
+        } else if(w_is_worker()) {
+            char response[2048];
+            response[2047] = '\0';
+            char *new_id = NULL;
+            char *new_key = NULL;
+            if (0 == w_request_agent_add_clustered(response, agent_name->valuestring, agent_address->valuestring, NULL, agent_key->valuestring, &new_id, &new_key, data->force_insert, agent_id->valuestring)) {
+                mdebug1("Key poll request sent to master for agent %s", agent_id->valuestring);
+            }
+            os_free(new_id);
+            os_free(new_key);
+            close(sock);
         } else {
             w_request_agent_add_local(sock, id, agent_name->valuestring, agent_address->valuestring, NULL, agent_key->valuestring, data->force_insert, 1, agent_id->valuestring, 0);
             close(sock);


### PR DESCRIPTION
|Related issue|
|---|
|#9092|

## Description

Hi team,

With this PR, support has been added for the key polling request functionality for cluster environments.

This new functionality, first verifies that the _agent key polling_ is properly configured and tries to offer it the key, but if it detects that it is a worker node, it sends both the ID and the agent key to the master to overwrite (or add) it and after syncing the `client.keys` file, the agent should connect successfully.

## Configuration options

It is necessary to have the agent key polling configured in the workers.

## Logs/Alerts example

### Wrong agent key
To simulate it quickly, we modify the agent key found in the `client.keys` file.

Original Agent Key: `bab983981a6cec7b2e989b3851d3e2c612103c60ca54d994cca327cbe2a0914b`

Modified key: `bab983981a6cec7b2e989b3851d3e2c612103c60ca54d994cca3270123456789`

This causes the master node to send a file sync to the worker node, getting exactly the same data:
> Master node
```
2021/09/29 15:05:34 wazuh-remoted: INFO: (1409): Authentication file changed. Updating.
2021/09/29 15:05:34 wazuh-remoted: INFO: (1410): Reading authentication keys file.
```

When this happens, the agent's connection to the worker node begins to fail, displaying the following messages:
> Worker node
```
2021/09/29 15:05:43 wazuh-remoted: INFO: (1409): Authentication file changed. Updating.
2021/09/29 15:05:43 wazuh-remoted: INFO: (1410): Reading authentication keys file.
```

> Agent
```
2021/09/29 15:05:51 wazuh-agentd: ERROR: (1137): Lost connection with manager. Setting lock.
2021/09/29 15:05:51 wazuh-agentd: INFO: Closing connection to server (172.17.0.2:1514/tcp).
2021/09/29 15:05:51 wazuh-agentd: INFO: Trying to connect to server (172.17.0.2:1514/tcp).
``` 

After that, the worker tries to obtain the agent's `ID`, `name,` `IP` and `key`. And when it gets it, it sends that information to the manager to overwrite the agent's data with that ID (or IP):
> Worker node
```
2021/09/29 15:05:52 wazuh-remoted: WARNING: (1404): Authentication error. Wrong key or corrupt payload. Message received from agent '010' at '172.17.0.1'.
2021/09/29 15:05:52 wazuh-modulesd:agent-key-polling[15273] wm_keyrequest.c:388 at wm_key_request_dispatch(): DEBUG: Agent Key Polling response forwarded to the master node for agent '010'
```

> Master node
```
2021/09/29 15:05:50 wazuh-authd: INFO: Duplicate ID '010'.
2021/09/29 15:05:50 wazuh-authd: INFO: Removing old agent '010'.
2021/09/29 15:05:50 wazuh-authd: INFO: Agent key generated for agent 'ubuntutest' (requested locally)
2021/09/29 15:05:54 wazuh-remoted: INFO: (1409): Authentication file changed. Updating.
2021/09/29 15:05:54 wazuh-remoted: INFO: (1410): Reading authentication keys file.
```

Once done, the master node will modify its `client.keys` file with the data it has received from the worker node and will send it another synchronization of the file so that the worker node updates the file and connects correctly with the agent.
> Worker node
```
2021/09/29 15:06:13 wazuh-remoted: INFO: (1409): Authentication file changed. Updating.
2021/09/29 15:06:13 wazuh-remoted: INFO: (1410): Reading authentication keys file.
```
"New" key: `bab983981a6cec7b2e989b3851d3e2c612103c60ca54d994cca327cbe2a0914b`

> Agent
```
2021/09/29 15:06:21 wazuh-agentd: INFO: Trying to connect to server (172.17.0.2:1514/tcp).
2021/09/29 15:06:21 wazuh-agentd: INFO: (4102): Connected to the server (172.17.0.2:1514/tcp).
2021/09/29 15:06:21 wazuh-agentd: INFO: Server responded. Releasing lock.
```

### Remove agent and reconnect

To simulate this second case, we delete the registered agent
> Master node
```
Choose your action: A,E,L,R or Q: R

Available agents: 
   ID: 010, Name: ubuntutest, IP: 172.17.0.1
Provide the ID of the agent to be removed (or '\q' to quit): 010
Confirm deleting it?(y/n): y
Agent '010' removed.
```

That will remove the agent entry in the client.keys file, and send the sync to the worker node.
> Master node
```
2021/09/29 15:52:46 wazuh-authd: INFO: Agent '010' (ubuntutest) deleted (requested locally)
2021/09/29 15:52:55 wazuh-remoted: INFO: (1409): Authentication file changed. Updating.
2021/09/29 15:52:55 wazuh-remoted: INFO: (1410): Reading authentication keys file.
```

When synchronized, the connection between the agent and the worker node will fail, the agent sends a message to the worker node to connect and it will check the data, obtain the agent key polling and send it to the master node.
> Worker node
```
2021/09/29 15:52:53 wazuh-remoted: INFO: (1409): Authentication file changed. Updating.
2021/09/29 15:52:53 wazuh-remoted: INFO: (1410): Reading authentication keys file.
```
> Agent
```
2021/09/29 15:53:02 wazuh-agentd: ERROR: (1137): Lost connection with manager. Setting lock.
2021/09/29 15:53:02 wazuh-agentd: INFO: Closing connection to server (172.17.0.2:1514/tcp).
```
> Worker node
```
2021/09/29 15:53:02 wazuh-remoted: WARNING: (1213): Message from '172.17.0.1' not allowed. Cannot find the ID of the agent. Source agent ID is unknown.
2021/09/29 15:53:03 wazuh-modulesd:agent-key-polling[15273] wm_keyrequest.c:388 at wm_key_request_dispatch(): DEBUG: Agent Key Polling response forwarded to the master node for agent '010'
```

Then the master node will overwrite the information in the `client.keys` file and send the sync.
> Master node
```
2021/09/29 15:53:01 wazuh-authd: INFO: Agent key generated for agent 'ubuntutest' (requested locally)
2021/09/29 15:53:05 wazuh-remoted: INFO: (1409): Authentication file changed. Updating.
2021/09/29 15:53:05 wazuh-remoted: INFO: (1410): Reading authentication keys file.
2021/09/29 15:53:11 wazuh-authd: INFO: Duplicate ID '010'.
2021/09/29 15:53:11 wazuh-authd: INFO: Removing old agent '010'.
2021/09/29 15:53:11 wazuh-authd: INFO: Agent key generated for agent 'ubuntutest' (requested locally)
2021/09/29 15:53:15 wazuh-remoted: INFO: (1409): Authentication file changed. Updating.
2021/09/29 15:53:15 wazuh-remoted: INFO: (1410): Reading authentication keys file.
```

Once synchronized, the connection will be successfully established again.
> Worker node
```
2021/09/29 15:53:13 wazuh-remoted: INFO: (1409): Authentication file changed. Updating.
2021/09/29 15:53:13 wazuh-remoted: INFO: (1410): Reading authentication keys file.
```
> Agent
```
2021/09/29 15:53:22 wazuh-agentd: INFO: Trying to connect to server (172.17.0.2:1514/tcp).
2021/09/29 15:53:22 wazuh-agentd: INFO: (4102): Connected to the server (172.17.0.2:1514/tcp).
2021/09/29 15:53:22 wazuh-agentd: INFO: Server responded. Releasing lock.
```


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [x] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
