### PR TITLE
Handle JSONDecodeError in Distributed API class methods

### DIFF
--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -181,7 +181,7 @@ class DistributedAPI:
             e.dapi_errors = self.get_error_info(e)
             if self.debug:
                 raise
-            self.logger.error(f'{e.message}', exc_info=True)
+            self.logger.error(f"{e.message}", exc_info=True)
             return e
         except Exception as e:
             if self.debug:
@@ -279,7 +279,7 @@ class DistributedAPI:
         except exception.WazuhInternalError as e:
             e.dapi_errors = self.get_error_info(e)
             # Avoid exception info if it is an asyncio timeout or JSONDecodeError
-            self.logger.error(f'{e.message}', exc_info=e.code not in {3021, 3036})
+            self.logger.error(f"{e.message}", exc_info=e.code not in {3021, 3036})
             if self.debug:
                 raise
             return json.dumps(e, cls=c_common.WazuhJSONEncoder)

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -173,6 +173,9 @@ class DistributedAPI:
         except json.decoder.JSONDecodeError:
             e = exception.WazuhInternalError(3036)
             e.dapi_errors = self.get_error_info(e)
+            if self.debug:
+                raise
+            self.logger.error(f"{e.message}")
             return e
         except exception.WazuhError as e:
             e.dapi_errors = self.get_error_info(e)

--- a/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
+++ b/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
@@ -2,6 +2,7 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import asyncio
+import json
 import logging
 import os
 import sys
@@ -189,6 +190,12 @@ def test_DistributedAPI_local_request_errors():
         except KeyError as e:
             assert 'KeyError' in repr(e)
 
+    # Test execute_local_request when the dapi function (dapi.f) raises a JSONDecodeError
+    with patch('wazuh.cluster.get_nodes_info', side_effect=json.decoder.JSONDecodeError('test', 'test', 1)):
+        with patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.check_wazuh_status'):
+            dapi_kwargs = {'f': cluster.get_nodes_info, 'logger': logger, 'is_async': True}
+            raise_if_exc_routine(dapi_kwargs=dapi_kwargs, expected_error=3036)
+
 
 @patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.check_wazuh_status', side_effect=None)
 @patch('asyncio.wait_for', new=AsyncMock(return_value='Testing'))
@@ -239,11 +246,33 @@ def test_DistributedAPI_local_request(mock_local_request):
             assert type(e) == KeyError
 
 
+@patch('wazuh.core.cluster.cluster.get_node', return_value={'type': 'worker'})
+@patch('wazuh.core.cluster.dapi.dapi.check_cluster_status', return_value=True)
+@patch('wazuh.core.cluster.local_client.LocalClient.execute', return_value='invalid_json')
+def test_DistributedAPI_remote_request_errors(mock_client_execute, mock_check_cluster_status, mock_get_node):
+    """Check the behaviour when the execute_remote_request function raised an error"""
+    # Test execute_remote_request when it raises a JSONDecodeError
+    dapi_kwargs = {'f': manager.status, 'logger': logger, 'request_type': 'local_master'}
+    raise_if_exc_routine(dapi_kwargs=dapi_kwargs, expected_error=3036)
+
+
 @patch('wazuh.core.cluster.local_client.LocalClient.execute', new=AsyncMock(return_value='{"Testing": 1}'))
 def test_DistributedAPI_remote_request():
     """Test `execute_remote_request` method from class DistributedAPI."""
     dapi_kwargs = {'f': manager.status, 'logger': logger, 'request_type': 'remote'}
     raise_if_exc_routine(dapi_kwargs=dapi_kwargs)
+
+
+@patch('wazuh.core.cluster.cluster.get_node', return_value={'type': 'master', 'node': 'master-node'})
+@patch('wazuh.core.cluster.dapi.dapi.check_cluster_status', return_value=True)
+@patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.get_solver_node', return_value={'worker1': ['001', '002']})
+@patch('wazuh.core.cluster.local_client.LocalClient.execute', return_value='invalid_json')
+def test_DistributedAPI_forward_request_errors(mock_client_execute, mock_get_solver_node, mock_check_cluster_status,
+                                               mock_get_node):
+    """Check the behaviour when the forward_request function raised an error"""
+    # Test forward_request when it raises a JSONDecodeError
+    dapi_kwargs = {'f': agent.reconnect_agents, 'logger': logger, 'request_type': 'distributed_master'}
+    raise_if_exc_routine(dapi_kwargs=dapi_kwargs, expected_error=3036)
 
 
 @patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.execute_local_request',


### PR DESCRIPTION
|Related issue|
|---|
| #10212 |

This PR closes #10212.

As it was commented in the issue, this error can also appear in the `get_nodes` function in `control.py` and it is unhandled too. This would affect the endpoint `GET /cluster/nodes`. It can appear in the rest of functions in `control.py` but `get_system_nodes`. Because of this, it affects `GET /cluster/healthcheck`.

These requests are `local_master`, so the exception is caught in the `execute_local_request` function and not outside (`distribute_function`).

To sum up, we have 2 situations where the `JSONDecodeError` can be caught: **forward_request and execute_remote_request**; and **execute_local_request**.


In both cases the `JSONDecodeError` is caught as a generic `Exception` and a `WazuhInternalError` is generated with code **1000** (unhandled exception).


### Solution

To handle these exceptions, I have added a try except block in `distribute_function` to raise a **WazuhInternalError with code 3036** when we have a JSONDecodeError in `execute:remote_request` or `forward_request` (problem reported in the issue) .

In `execute_local_request`, I have added a new try except block to catch the JSONDecodeError when using `run_local` or `run_local` in the `threadpool`. Again **WazuhInternalError with code 3036**. In this case, we cannot catch the error at a higher level because we catch a generic exception inside the `execute_local_request` function.



#### Examples:

- Remote request (local_master from a worker's API):

```
root@wazuh-worker1:/# curl -k -X GET "https://localhost:55000/cluster/healthcheck" -H "Authorization: Bearer $TOKEN"
{"title": "Wazuh Internal Error", "detail": "JSON couldn't be loaded", "dapi_errors": {"master-node": {"error": "JSON couldn't be loaded", "logfile": "WAZUH_HOME/logs/cluster.log"}}, "error": 3036}
```

worker's api.log:

`2021/09/29 08:35:47 INFO: wazuh 127.0.0.1 "GET /cluster/healthcheck" with parameters {} and body {} done in 0.095s: 500
`

master's cluster.log:

`2021/09/29 08:35:47 ERROR: [Local Client] [D API] JSON couldn't be loaded
`

- Local request (local_master or local_any):

```
root@wazuh-master:/# curl -k -X GET "https://localhost:55000/cluster/healthcheck" -H "Authorization: Bearer $TOKEN"
{"title": "Wazuh Internal Error", "detail": "JSON couldn't be loaded", "dapi_errors": {"master-node": {"error": "JSON couldn't be loaded", "logfile": "WAZUH_HOME/logs/api.log"}}, "error": 3036}
```


master's api.log:

```
2021/09/29 08:33:09 ERROR: JSON couldn't be loaded
2021/09/29 08:33:09 INFO: wazuh 127.0.0.1 "GET /cluster/healthcheck" with parameters {} and body {} done in 0.062s: 500
```

- Forward request (distributed_master):

```
root@wazuh-master:/# curl -k -X PUT "https://localhost:55000/security/user/revoke" -H "Authorization: Bearer $TOKEN"
{"title": "Wazuh Internal Error", "detail": "JSON couldn't be loaded", "dapi_errors": {"master-node": {"error": "JSON couldn't be loaded", "logfile": "WAZUH_HOME/logs/api.log"}}, "error": 3036}
```


master's api.log:

```
2021/09/29 08:38:56 ERROR: JSON couldn't be loaded
2021/09/29 08:38:56 INFO: wazuh 127.0.0.1 "PUT /security/user/revoke" with parameters {} and body {} done in 0.082s: 500
```

### Test results

```
test_agent_DELETE_endpoints.tavern.yaml 
	 6 passed, 8 warnings

test_agent_GET_endpoints.tavern.yaml 
	 91 passed, 93 warnings

test_agent_POST_endpoints.tavern.yaml 
	 5 passed, 7 warnings

test_agent_PUT_endpoints.tavern.yaml 
	 8 passed, 2 xpassed, 12 warnings

test_security_DELETE_endpoints.tavern.yaml 
	 15 passed, 17 warnings

test_security_GET_endpoints.tavern.yaml 
	 11 passed, 13 warnings

test_security_POST_endpoints.tavern.yaml 
	 7 passed, 9 warnings

test_security_PUT_endpoints.tavern.yaml 
	 9 passed, 11 warnings

test_cluster_endpoints.tavern.yaml 
	 45 passed, 47 warnings

test_experimental_endpoints.tavern.yaml 
	 11 passed, 1 xpassed, 14 warnings
```

```
pytest framework/wazuh/core/cluster/dapi/tests/ --disable-warnings 
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: /home/manuel/git/wazuh/framework
plugins: html-3.1.1, metadata-1.11.0, cov-2.12.0, testinfra-5.0.0, asyncio-0.14.0
collected 25 items                                                             

framework/wazuh/core/cluster/dapi/tests/test_dapi.py ................... [ 76%]
......                                                                   [100%]

======================== 25 passed, 9 warnings in 0.60s ========================
```


