### PR TITLE
Improving log messages during agent replacement for cluster

### DIFF
--- a/src/os_auth/local-server.c
+++ b/src/os_auth/local-server.c
@@ -383,7 +383,7 @@ cJSON* local_add(const char *id,
     /* Check for duplicate names */
     if (index = OS_IsAllowedName(&keys, name), index >= 0) {
         if(OS_SUCCESS == w_auth_replace_agent(keys.keyentries[index], key_hash, force_options, &str_result)) {
-            minfo("Duplicate name '%s'. %s.", keys.keyentries[index]->name, str_result);
+            minfo("Duplicate name. %s", str_result);
         } else {
             mwarn("Duplicate name '%s', rejecting enrollment. %s", name, str_result);
             ierror = EDUPNAME;
@@ -419,7 +419,6 @@ cJSON* local_add(const char *id,
 
 fail:
     w_mutex_unlock(&mutex_keys);
-    merror("ERROR %d: %s.", ERRORS[ierror].code, ERRORS[ierror].message);
     response = local_create_error_response(ERRORS[ierror].code, ERRORS[ierror].message);
     os_free(str_result);
     return response;


### PR DESCRIPTION
|Related issue|
|---|
|#10268|

## Description

This PR removes an extra **ERROR** message printed during a failed agent replacement, leaving only a **WARNING** message with the cause of rejection.

The error code still is returned to the worker from the manager.

## Logs/Alerts example

A comment below shows the example logs after the implementation.

## Tests

The removal of these logs doesn't affect any test in the **main** repository, nor QA/Jenkins

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Working on cluster environments
