### PR TITLE
Add support for Debian Bullseye in Vulnerability Detector

### DIFF
--- a/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
+++ b/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
@@ -19,6 +19,7 @@
       <enabled>no</enabled>
       <os>stretch</os>
       <os>buster</os>
+      <os>bullseye</os>
       <update_interval>1h</update_interval>
     </provider>
 

--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -166,7 +166,12 @@ int wm_vuldet_set_feed_version(char *feed, char *version, update_node **upd_list
         }
         upd->dist_ref = FEED_UBUNTU;
     } else if (strcasestr(feed, vu_feed_tag[FEED_DEBIAN]) && version) {
-        if (!strcmp(version, "10") || strcasestr(version, vu_feed_tag[FEED_BUSTER])) {
+        if (!strcmp(version, "11") || strcasestr(version, vu_feed_tag[FEED_BULLSEYE])) {
+            os_index = CVE_BULLSEYE;
+            os_strdup(vu_feed_tag[FEED_BULLSEYE], upd->version);
+            upd->dist_tag_ref = FEED_BULLSEYE;
+            upd->dist_ext = vu_feed_ext[FEED_BULLSEYE];
+        } else if (!strcmp(version, "10") || strcasestr(version, vu_feed_tag[FEED_BUSTER])) {
             os_index = CVE_BUSTER;
             os_strdup(vu_feed_tag[FEED_BUSTER], upd->version);
             upd->dist_tag_ref = FEED_BUSTER;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -380,6 +380,7 @@ const char *vu_feed_tag[] = {
     // Debian versions
     "STRETCH",
     "BUSTER",
+    "BULLSEYE",
     // RedHat versions
     "RHEL5",
     "RHEL6",
@@ -428,6 +429,7 @@ const char *vu_feed_ext[] = {
     // Debian versions
     "Debian Stretch",
     "Debian Buster",
+    "Debian Bullseye",
     // RedHat versions
     "Red Hat Enterprise Linux 5",
     "Red Hat Enterprise Linux 6",
@@ -5032,6 +5034,8 @@ int wm_vuldet_set_agents_info(const char *node_name, agent_software **agents_sof
                 agent_dist_ver = FEED_STRETCH;
             } else if (strstr(os_major, "10")) {
                 agent_dist_ver = FEED_BUSTER;
+            } else if (strstr(os_major, "11")) {
+                agent_dist_ver = FEED_BULLSEYE;
             } else {
                 dist_error = FEED_DEBIAN;
             }
@@ -5601,6 +5605,7 @@ int wm_vuldet_generate_os_and_kernel_package(sqlite3 *db, agent_software *agent)
         break;
         case FEED_STRETCH:
         case FEED_BUSTER:
+        case FEED_BULLSEYE:
             product_name[0] = PR_DEBIAN;
             vendor = V_DEBIAN;
         break;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -226,6 +226,7 @@ typedef enum vu_feed {
     // Debian versions
     FEED_STRETCH,
     FEED_BUSTER,
+    FEED_BULLSEYE,
     // RedHat versions
     FEED_RHEL5,
     FEED_RHEL6,
@@ -369,6 +370,7 @@ typedef enum cve_db {
     CVE_FOCAL,
     CVE_STRETCH,
     CVE_BUSTER,
+    CVE_BULLSEYE,
     CVE_REDHAT5,
     CVE_REDHAT6,
     CVE_REDHAT7,


### PR DESCRIPTION
|Related issue|
|---|
|#10180|


## Description

The purpose of this PR is to add support for **Debian 11 (Bullseye)** in the _vulnerability detector_ module.

First, the OVAL provided by Debian is downloaded: https://www.debian.org/security/oval/oval-definitions-bullseye.xml

The vulnerabilities are then parsed and inserted into the database.

And finally, when a _Debian Bullseye_ agent is detected, then if the configuration is well set, it scans the agent and reports the vulnerabilities it contains.

## Configuration options

```xml
        <!-- Debian OS vulnerabilities -->
        <provider name="debian">
          <enabled>yes</enabled>
          <os>stretch</os>
          <os>buster</os>
          <os>bullseye</os>
          <update_interval>1h</update_interval>
        </provider>
```

## Logs/Alerts example

Next, I show the logs related to what is commented in the description (the OS of agent `002` is _Debian Bullseye_):

> Correct configuration check
```
2021/09/30 11:57:54 wazuh-modulesd[17839] wmodules-vuln-detector.c:556 at wm_vuldet_read_provider(): DEBUG: Added debian (bullseye) feed. Interval: 3600s | Path: 'none' | Url: 'none' | Timeout: 300s
```

> Download and insert vulnerabilities in the database
```
2021/09/30 11:44:07 wazuh-modulesd:vulnerability-detector[16321] wm_vuln_detector.c:4163 at wm_vuldet_check_feed(): INFO: (5400): Starting 'Debian Bullseye' database update.
2021/09/30 11:44:07 wazuh-modulesd:download[16321] wm_download.c:230 at wm_download_dispatch(): DEBUG: Downloading 'https://www.debian.org/security/oval/oval-definitions-bullseye.xml' to 'tmp/vuln-temp'
2021/09/30 11:44:09 wazuh-modulesd:download[16321] wm_download.c:250 at wm_download_dispatch(): DEBUG: Download of 'https://www.debian.org/security/oval/oval-definitions-bullseye.xml' finished.
2021/09/30 11:44:09 wazuh-modulesd:vulnerability-detector[16321] wm_vuln_detector.c:3931 at wm_vuldet_fetch_oval(): DEBUG: (5407): The feed 'Debian Bullseye' is outdated. Fetching the last version.
2021/09/30 11:44:09 wazuh-modulesd:vulnerability-detector[16321] wm_vuln_detector.c:3714 at wm_vuldet_oval_process(): DEBUG: (5411): Starting preparse step of feed 'BULLSEYE'
2021/09/30 11:44:10 wazuh-modulesd:vulnerability-detector[16321] wm_vuln_detector.c:3719 at wm_vuldet_oval_process(): DEBUG: (5412): Starting parse step of feed 'BULLSEYE'
2021/09/30 11:44:11 wazuh-modulesd:vulnerability-detector[16321] wm_vuln_detector.c:3859 at wm_vuldet_index_feed(): DEBUG: (5414): Refreshing 'Debian Bullseye' databases.
2021/09/30 11:44:11 wazuh-modulesd:vulnerability-detector[16321] wm_vuln_detector.c:2598 at wm_vuldet_insert(): DEBUG: (5415): Inserting vulnerabilities.
2021/09/30 11:44:11 wazuh-modulesd:vulnerability-detector[16321] wm_vuln_detector.c:2642 at wm_vuldet_insert(): DEBUG: (5419): Inserting Debian Bullseye vulnerabilities section.
2021/09/30 11:44:11 wazuh-modulesd:vulnerability-detector[16321] wm_vuln_detector.c:2383 at wm_vuldet_index_debian(): DEBUG: (5420): Indexing vulnerabilities from the Debian Security Tracker.
2021/09/30 11:44:11 wazuh-modulesd:vulnerability-detector[16321] wm_vuln_detector.c:4237 at wm_vuldet_get_debian_status_feed(): DEBUG: (5436): Fetching Debian Security Tracker from 'tmp/vuln-temp-deb'
2021/09/30 11:44:12 wazuh-modulesd:vulnerability-detector[16321] wm_vuln_detector.c:2893 at wm_vuldet_insert(): DEBUG: (5426): Inserting 'Debian Bullseye' vulnerabilities information.
2021/09/30 11:44:12 wazuh-modulesd:vulnerability-detector[16321] wm_vuln_detector.c:3865 at wm_vuldet_index_feed(): DEBUG: (5427): Refresh of 'Debian Bullseye' database finished.
2021/09/30 11:44:12 wazuh-modulesd:vulnerability-detector[16321] wm_vuln_detector.c:3876 at wm_vuldet_index_feed(): DEBUG: remove(tmp/vuln-temp.bz2): No such file or directory
2021/09/30 11:44:12 wazuh-modulesd:vulnerability-detector[16321] wm_vuln_detector.c:4186 at wm_vuldet_check_feed(): INFO: (5430): The update of the 'Debian Bullseye' feed finished successfully.
```
> Debian Bullseye agent scan
```
2021/09/30 12:58:28 wazuh-modulesd:vulnerability-detector[17839] wm_vuln_detector.c:2195 at wm_vuldet_check_agent_vulnerabilities(): INFO: (5450): Analyzing agent '002' vulnerabilities.
...
2021/09/30 12:58:32 wazuh-modulesd:vulnerability-detector[17839] wm_vuln_detector.c:1380 at wm_vuldet_send_agent_report(): DEBUG: (5482): A total of '38' vulnerabilities have been reported for agent '002' thanks to the 'NVD' feed.
2021/09/30 12:58:32 wazuh-modulesd:vulnerability-detector[17839] wm_vuln_detector.c:1381 at wm_vuldet_send_agent_report(): DEBUG: (5482): A total of '54' vulnerabilities have been reported for agent '002' thanks to the 'vendor' feed.
2021/09/30 12:58:32 wazuh-modulesd:vulnerability-detector[17839] wm_vuln_detector.c:1383 at wm_vuldet_send_agent_report(): DEBUG: (5469): A total of '54' vulnerabilities have been reported for agent '002'
...
2021/09/30 12:58:32 wazuh-modulesd:vulnerability-detector[17839] wm_vuln_detector.c:2244 at wm_vuldet_check_agent_vulnerabilities(): INFO: (5471): Finished vulnerability assessment for agent '002'
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
<!--
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
-->