### PR TITLE
Improve force block validation for API calls

### DIFF
--- a/src/config/authd-config.c
+++ b/src/config/authd-config.c
@@ -20,7 +20,6 @@
 
 static short eval_bool(const char *str);
 int w_read_force_config(XML_NODE node, authd_config_t *config);
-int get_time_interval(char *source, time_t *interval);
 
 int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
     /* XML Definitions */

--- a/src/config/authd-config.h
+++ b/src/config/authd-config.h
@@ -15,6 +15,8 @@
 #define AD_CONF_UNPARSED 3
 #define AD_CONF_UNDEFINED 2
 
+#include <time.h>
+
 /**
  * @brief Structure that defines the force options for agent replacement.
  **/
@@ -49,5 +51,7 @@ typedef struct authd_config_t {
     long timeout_usec;
     bool worker_node;
 } authd_config_t;
+
+int get_time_interval(char *source, time_t *interval);
 
 #endif

--- a/src/os_auth/local-server.c
+++ b/src/os_auth/local-server.c
@@ -14,6 +14,7 @@
 #include <sys/wait.h>
 #include "auth.h"
 #include "os_err.h"
+#include <config/authd-config.h>
 
 typedef enum auth_local_err {
     EINTERNAL = 0,
@@ -255,11 +256,17 @@ char* local_dispatch(const char *input) {
                         force_options.disconnected_time_enabled = (bool)item->valueint;
                     }
                     if (item = cJSON_GetObjectItem(disconnected_time, "value"), item) {
-                        force_options.disconnected_time = (long)item->valueint;
+                        if(get_time_interval(item->valuestring, &force_options.disconnected_time)){
+                            ierror = EJSON;
+                            goto fail;
+                        }
                     }
                 }
                 if (item = cJSON_GetObjectItem(force, "after_registration_time"), item) {
-                    force_options.after_registration_time = (long)item->valueint;
+                    if(get_time_interval(item->valuestring, &force_options.after_registration_time)){
+                        ierror = EJSON;
+                        goto fail;
+                    }
                 }
             }
 

--- a/src/os_auth/local-server.c
+++ b/src/os_auth/local-server.c
@@ -245,28 +245,39 @@ char* local_dispatch(const char *input) {
             key = (item = cJSON_GetObjectItem(arguments, "key"), item) ? item->valuestring : NULL;
 
             if (force = cJSON_GetObjectItem(arguments, "force"), force) {
-                if (item = cJSON_GetObjectItem(force, "enabled"), item) {
-                    force_options.enabled = (bool)item->valueint;
+                if (item = cJSON_GetObjectItem(force, "enabled"), !item) {
+                    ierror = EJSON;
+                    goto fail;
                 }
-                if (item = cJSON_GetObjectItem(force, "key_mismatch"), item) {
-                    force_options.key_mismatch = (bool)item->valueint;
+                force_options.enabled = (bool)item->valueint;
+
+                if (item = cJSON_GetObjectItem(force, "key_mismatch"), !item) {
+                    ierror = EJSON;
+                    goto fail;
                 }
-                if (disconnected_time = cJSON_GetObjectItem(force, "disconnected_time"), disconnected_time) {
-                    if (item = cJSON_GetObjectItem(disconnected_time, "enabled"), item) {
-                        force_options.disconnected_time_enabled = (bool)item->valueint;
-                    }
-                    if (item = cJSON_GetObjectItem(disconnected_time, "value"), item) {
-                        if(get_time_interval(item->valuestring, &force_options.disconnected_time)){
-                            ierror = EJSON;
-                            goto fail;
-                        }
-                    }
+                force_options.key_mismatch = (bool)item->valueint;
+
+                if (disconnected_time = cJSON_GetObjectItem(force, "disconnected_time"), !disconnected_time) {
+                    ierror = EJSON;
+                    goto fail;
                 }
-                if (item = cJSON_GetObjectItem(force, "after_registration_time"), item) {
-                    if(get_time_interval(item->valuestring, &force_options.after_registration_time)){
-                        ierror = EJSON;
-                        goto fail;
-                    }
+
+                if (item = cJSON_GetObjectItem(disconnected_time, "enabled"), !item) {
+                    ierror = EJSON;
+                    goto fail;
+                }
+                force_options.disconnected_time_enabled = (bool)item->valueint;
+
+                item = cJSON_GetObjectItem(disconnected_time, "value");
+                if (!item || get_time_interval(item->valuestring, &force_options.disconnected_time)) {
+                    ierror = EJSON;
+                    goto fail;
+                }
+
+                item = cJSON_GetObjectItem(force, "after_registration_time");
+                if (!item || get_time_interval(item->valuestring, &force_options.after_registration_time)) {
+                    ierror = EJSON;
+                    goto fail;
                 }
             }
 


### PR DESCRIPTION
|Related issue|
|---|
|#10367|

## Description

This PR improves the force parsing block in the `local_dispatch()` method. If any of the fields is missing, the request is rejected.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report

- [x] The data flow works as expected (agent-manager-api-app)
