### PR TITLE
Rework to `safe_move` function to make it atomic

### DIFF
--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -275,11 +275,10 @@ def update_cluster_control_with_failed(failed_files, ko_files):
         KO files dict with 'missing', 'shared' and 'extra' keys.
     """
     for f in failed_files:
-        if 'missing' in ko_files.keys() and f in ko_files['missing'].keys():
+        if 'missing' in ko_files.keys():
             ko_files['missing'].pop(f, None)
-        elif 'shared' in ko_files.keys() and 'extra' in ko_files.keys() and f in ko_files['shared'].keys():
-            ko_files['extra'][f] = ko_files['shared'][f]
-            ko_files['shared'].pop(f, None)
+        elif 'shared' in ko_files.keys() and 'extra' in ko_files.keys():
+            ko_files['extra'][f] = ko_files['shared'].pop(f, None)
 
 
 def compress_files(name, list_path, cluster_control_json=None):

--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -275,10 +275,11 @@ def update_cluster_control_with_failed(failed_files, ko_files):
         KO files dict with 'missing', 'shared' and 'extra' keys.
     """
     for f in failed_files:
-        if 'missing' in ko_files.keys():
+        if 'missing' in ko_files.keys() and f in ko_files['missing'].keys():
             ko_files['missing'].pop(f, None)
-        elif 'shared' in ko_files.keys() and 'extra' in ko_files.keys():
-            ko_files['extra'][f] = ko_files['shared'].pop(f, None)
+        elif 'shared' in ko_files.keys() and 'extra' in ko_files.keys() and f in ko_files['shared'].keys():
+            ko_files['extra'][f] = ko_files['shared'][f]
+            ko_files['shared'].pop(f, None)
 
 
 def compress_files(name, list_path, cluster_control_json=None):

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -453,11 +453,13 @@ def test_safe_move(mock_utime, mock_chmod, mock_chown, ownership, time, permissi
         target_file = join(tmpdirname, 'target')
         safe_move(tmp_file.name, target_file, ownership=ownership, time=time, permissions=permissions)
         assert (os.path.exists(target_file))
-        mock_chown.assert_called_once_with(target_file, *ownership)
+
+        tmp_path = os.path.join(os.path.dirname(tmp_file.name), ".target.tmp")
+        mock_chown.assert_called_once_with(tmp_path, *ownership)
         if time is not None:
-            mock_utime.assert_called_once_with(target_file, time)
+            mock_utime.assert_called_once_with(tmp_path, time)
         if permissions is not None:
-            mock_chmod.assert_called_once_with(target_file, permissions)
+            mock_chmod.assert_called_once_with(tmp_path, permissions)
 
 
 @patch('wazuh.core.utils.chown')

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -583,15 +583,15 @@ def safe_move(source, target, ownership=(common.wazuh_uid(), common.wazuh_gid())
     Parameters
     ----------
     source : str
-        Full path to source file
+        Full path to source file.
     target : str
-        Full path to target file
+        Full path to target file.
     ownership : tuple
-        Tuple in the form (user, group) to be set up after the file is moved
+        Tuple in the form (user, group) to be set up after the file is moved.
     time : tuple
-        Tuple in the form (addition_timestamp, modified_timestamp)
+        Tuple in the form (addition_timestamp, modified_timestamp).
     permissions : str
-        String mask in octal notation. I.e.: '0o640'
+        String mask in octal notation. I.e.: '0o640'.
     """
     # Create temp file. Move between
     tmp_path, tmp_filename = path.split(target)


### PR DESCRIPTION
|Related issue|
|---|
|#10332|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR closes #10332. In this PR we have modified the way the `safe_move` function handles files. Now, this function is able to replace files atomically. More information here: https://github.com/wazuh/wazuh/issues/10332#issuecomment-932102026