### PR TITLE
Fix in error and exit log function for Windows agents

### DIFF
--- a/src/shared/debug_op.c
+++ b/src/shared/debug_op.c
@@ -446,16 +446,16 @@ void _merror_exit(const char * file, int line, const char * func, const char *ms
     int level = LOGLEVEL_CRITICAL;
     const char *tag = __local_name;
 
+    va_start(args, msg);
+    _log(level, tag, file, line, func, msg, args);
+    va_end(args);
+
 #ifdef WIN32
     /* If not MA */
 #ifndef MA
     WinSetError();
 #endif
 #endif
-
-    va_start(args, msg);
-    _log(level, tag, file, line, func, msg, args);
-    va_end(args);
 
     exit(1);
 }
@@ -465,16 +465,16 @@ void _mterror_exit(const char *tag, const char * file, int line, const char * fu
     va_list args;
     int level = LOGLEVEL_CRITICAL;
 
+    va_start(args, msg);
+    _log(level, tag, file, line, func, msg, args);
+    va_end(args);
+
 #ifdef WIN32
     /* If not MA */
 #ifndef MA
     WinSetError();
 #endif
 #endif
-
-    va_start(args, msg);
-    _log(level, tag, file, line, func, msg, args);
-    va_end(args);
 
     exit(1);
 }


### PR DESCRIPTION
|Related issue|
|---|
|#8746|


## Description

With this PR, the problem described in issue #8746 has been fixed, where the expected error message was not always displayed when an invalid internal option is selected in a Windows agent.

This problem was found in the debug function `merror_exit` and affected all messages using this function (for Windows agents). It was caused because before showing the log message, a stop request was sent to the Wazuh handler, so that if it stopped before executing the log, then it did not show the message, while in other cases it could have a little more delay and run the log, displaying it correctly.

The change applied is that the log is always executed before the stop request and the exit are executed.

## Logs/Alerts example

Restarting the agent several times with the value of `logcollector.state_interval = -2` would show the following logs:

![Screenshot from 2021-10-01 16-52-23](https://user-images.githubusercontent.com/37207742/135645572-b1c1dbd9-3bc8-45f1-bd0e-575d6fead82e.png)

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Windows
- [x] Source installation
- [x] Source upgrade
- [ ] QA templates contemplate the added capabilities

