### PR TITLE
Fix a segmentation fault in Remoted when retrieving an agent's group

### DIFF
--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -1047,11 +1047,6 @@ STATIC int lookfor_agent_group(const char *agent_id, char *msg, char **r_group)
     char *message;
     char *fmsg;
 
-    if (!groups) {
-        mdebug2("Nothing to share with agent");
-        return OS_INVALID;
-    }
-
     // Get agent group
     if (agt_group = w_parser_get_agent(agent_id), agt_group) {
         strncpy(group, agt_group->group, OS_SIZE_65536);
@@ -1067,9 +1062,6 @@ STATIC int lookfor_agent_group(const char *agent_id, char *msg, char **r_group)
         return OS_SUCCESS;
     }
 
-    /* Lock mutex */
-    w_mutex_lock(&files_mutex);
-
     // make a copy to keep original msg for read_controlmsg
     os_strdup(msg, message);
     fmsg = message;
@@ -1077,7 +1069,6 @@ STATIC int lookfor_agent_group(const char *agent_id, char *msg, char **r_group)
     // Skip agent-info and label data
     if (message = strchr(message, '\n'), !message) {
         merror("Invalid message from agent ID '%s' (strchr \\n)", agent_id);
-        w_mutex_unlock(&files_mutex);
         os_free(fmsg);
         return OS_INVALID;
     }
@@ -1117,12 +1108,20 @@ STATIC int lookfor_agent_group(const char *agent_id, char *msg, char **r_group)
 
         // If group was not got, guess it by matching sum
         mdebug2("Agent '%s' with group '%s' file '%s' MD5 '%s'", agent_id, group, file, md5);
-        if (!guess_agent_group || (f_sum = find_group(file, md5, group), !f_sum)) {
+
+        /* Lock mutex */
+        w_mutex_lock(&files_mutex);
+
+        if (!guess_agent_group || groups == NULL || (f_sum = find_group(file, md5, group), !f_sum)) {
             // If the group could not be guessed, set to "default"
             // or if the user requested not to guess the group, through the internal
             // option 'guess_agent_group', set to "default"
             strncpy(group, "default", OS_SIZE_65536);
         }
+
+        /* Unlock mutex */
+        w_mutex_unlock(&files_mutex);
+
         set_agent_group(agent_id, group);
         os_strdup(group, *r_group);
         ret = OS_SUCCESS;
@@ -1130,8 +1129,6 @@ STATIC int lookfor_agent_group(const char *agent_id, char *msg, char **r_group)
         break;
     }
 
-    /* Unlock mutex */
-    w_mutex_unlock(&files_mutex);
     os_free(fmsg);
     return ret;
 }

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -1302,7 +1302,7 @@ void *wait_for_msgs(__attribute__((unused)) void *none)
 
         if (data = OSHash_Get(pending_data, agent_id), data) {
             os_strdup(data->message, msg);
-            os_strdup(data->group, group);
+            w_strdup(data->group, group);
         } else {
             merror("Couldn't get pending data from hash table for agent ID '%s'.", agent_id);
             os_free(agent_id);

--- a/src/unit_tests/remoted/test_manager.c
+++ b/src/unit_tests/remoted/test_manager.c
@@ -31,11 +31,27 @@ void test_lookfor_agent_group_null_groups(void **state)
     char *msg = "Linux |localhost.localdomain |4.18.0-240.22.1.el8_3.x86_64 |#1 SMP Thu Apr 8 19:01:30 UTC 2021 |x86_64 [CentOS Linux|centos: 8.3] - Wazuh v4.2.0 / ab73af41699f13fdd81903b5f23d8d00\nc2305e0ac17e7176e924294c69cc7a24 merged.mg\n#\"_agent_ip\":10.0.2.4";
     char *r_group = NULL;
 
-    expect_string(__wrap__mdebug2, formatted_msg, "Nothing to share with agent");
+    expect_string(__wrap_w_parser_get_agent, name, agent_id);
+    will_return(__wrap_w_parser_get_agent, NULL);
+
+    expect_string(__wrap_get_agent_group, id, agent_id);
+    will_return(__wrap_get_agent_group, "");
+    will_return(__wrap_get_agent_group, -1);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Agent '001' group is ''");
+    expect_string(__wrap__mdebug2, formatted_msg, "Agent '001' with group '' file 'merged.mg' MD5 'c2305e0ac17e7176e924294c69cc7a24'");
+
+    expect_string(__wrap_set_agent_group, id, agent_id);
+    expect_string(__wrap_set_agent_group, group, "default");
+    will_return(__wrap_set_agent_group, 0);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Group assigned: 'default'");
 
     int ret = lookfor_agent_group(agent_id, msg, &r_group);
-    assert_int_equal(OS_INVALID, ret);
-    assert_null(r_group);
+    assert_int_equal(OS_SUCCESS, ret);
+    assert_string_equal(r_group, "default");
+
+    os_free(r_group);
 }
 
 void test_lookfor_agent_group_set_default_group(void **state)


### PR DESCRIPTION
|Related issue|
|---|
|Closes #10387|

This PR aims to prevent Remoted from unexpectedly crashing if any of the failure conditions of function `lookfor_agent_group()` lead to leave member `group` of the structure `pending_data_t` set to `null`.

In addition, we found that the first check of the global variable `groups` is a race condition as `c_files` may be writing (and zeroing) that, which would make function `lookfor_agent_group()` return failure.

In summary, we're introducing two changes:
1. Let Remoted allow null values for the agent's group.
2. Properly protect read of `groups` through its mutex.

## Tests

- [X] Compile Remoted on Linux.
- [X] ThreadSanitizer.
- [x] Coverity.