### PR TITLE
Update API endpoints to adapt the new `force` field from authd

### DIFF
--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -19,10 +19,10 @@ from wazuh import agent, stats
 from wazuh.core.cluster.control import get_system_nodes
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 from wazuh.core.common import database_limit
-from wazuh.core.exception import WazuhResourceNotFound
 from wazuh.core.results import AffectedItemsWazuhResult
 
 logger = logging.getLogger('wazuh-api')
+use_only_auth = configuration.api_conf['use_only_authd']
 
 
 async def delete_agents(request, pretty=False, wait_for_complete=False, agents_list=None, purge=False, status=None,
@@ -68,7 +68,7 @@ async def delete_agents(request, pretty=False, wait_for_complete=False, agents_l
         agents_list = None
     f_kwargs = {'agent_list': agents_list,
                 'purge': purge,
-                'use_only_authd': configuration.api_conf['use_only_authd'],
+                'use_only_authd': use_only_auth,
                 'filters': {
                     'status': status,
                     'older_than': older_than,
@@ -166,16 +166,21 @@ async def get_agents(request, pretty=False, wait_for_complete=False, agents_list
 
 async def add_agent(request, pretty=False, wait_for_complete=False):
     """Add a new Wazuh agent.
+    
+    Parameters
+    ----------
+    pretty : bool
+        Show results in human-readable format.
+    wait_for_complete : bool
+        Disable timeout response.
 
-    :param pretty: Show results in human-readable format
-    :param wait_for_complete: Disable timeout response
-    :return: AgentIdKey
+    Returns
+    -------
+    Response
     """
     # Get body parameters
     Body.validate_content_type(request, expected_content_type='application/json')
-    f_kwargs = await AgentAddedModel.get_kwargs(request)
-
-    f_kwargs['use_only_authd'] = configuration.api_conf['use_only_authd']
+    f_kwargs = await AgentAddedModel.get_kwargs(request, additional_kwargs={"use_only_authd": use_only_auth})
 
     dapi = DistributedAPI(f=agent.add_agent,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -621,15 +626,22 @@ async def get_agent_upgrade(request, agents_list=None, pretty=False, wait_for_co
 
 async def post_new_agent(request, agent_name, pretty=False, wait_for_complete=False):
     """Add agent (quick method)
+    
+    Parameters
+    ----------
+    agent_name : str
+        Name used to register the agent.
+    pretty : bool
+        Show results in human-readable format.
+    wait_for_complete : bool
+        Disable timeout response.
 
-    Adds a new agent with name `agent_name`. This agent will use `any` as IP.'
-
-    :param pretty: Show results in human-readable format
-    :param wait_for_complete: Disable timeout response
-    :param agent_name: Agent name used when the agent was registered.
-    :return: AgentIdKeyData
+    Returns
+    -------
+    Response
     """
-    f_kwargs = {'name': agent_name, 'use_only_authd': configuration.api_conf['use_only_authd']}
+    f_kwargs = await AgentAddedModel.get_kwargs({'name': agent_name},
+                                                additional_kwargs={'use_only_authd': use_only_auth})
 
     dapi = DistributedAPI(f=agent.add_agent,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -1035,17 +1047,23 @@ async def restart_agents_by_group(request, group_id, pretty=False, wait_for_comp
 
 
 async def insert_agent(request, pretty=False, wait_for_complete=False):
-    """Insert a new agent
+    """Insert a new agent.
+    
+    Parameters
+    ----------
+    pretty : bool
+        Show results in human-readable format.
+    wait_for_complete : bool
+        Disable timeout response.
 
-    :param pretty: Show results in human-readable format
-    :param wait_for_complete: Disable timeout response
-    :return: AgentIdKey
+    Returns
+    -------
+    Response
     """
     # Get body parameters
     Body.validate_content_type(request, expected_content_type='application/json')
-    f_kwargs = await AgentInsertedModel.get_kwargs(request)
-
-    f_kwargs['use_only_authd'] = configuration.api_conf['use_only_authd']
+    f_kwargs = await AgentInsertedModel.get_kwargs(request,
+                                                   additional_kwargs={"use_only_authd": use_only_auth})
 
     dapi = DistributedAPI(f=agent.add_agent,
                           f_kwargs=remove_nones_to_dict(f_kwargs),

--- a/api/api/controllers/test/test_agent_controller.py
+++ b/api/api/controllers/test/test_agent_controller.py
@@ -11,7 +11,7 @@ with patch('wazuh.common.wazuh_uid'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
         import wazuh.rbac.decorators
         from api.controllers.agent_controller import (
-            add_agent, delete_agents, delete_groups,
+            use_only_auth, add_agent, delete_agents, delete_groups,
             delete_multiple_agent_single_group,
             delete_single_agent_multiple_groups,
             delete_single_agent_single_group, get_agent_config,
@@ -33,13 +33,12 @@ with patch('wazuh.common.wazuh_uid'):
 
 
 @pytest.mark.asyncio
-@patch('api.configuration.api_conf')
 @patch('api.controllers.agent_controller.DistributedAPI.distribute_function', return_value=AsyncMock())
 @patch('api.controllers.agent_controller.remove_nones_to_dict')
 @patch('api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
 @patch('api.controllers.agent_controller.raise_if_exc', return_value=CustomAffectedItems())
 @pytest.mark.parametrize('mock_alist', ['001', 'all'])
-async def test_delete_agents(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_exp, mock_alist,
+async def test_delete_agents(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_alist,
                              mock_request=MagicMock()):
     """Verify 'delete_agents' endpoint is working as expected."""
     result = await delete_agents(request=mock_request,
@@ -48,7 +47,7 @@ async def test_delete_agents(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_
         mock_alist = None
     f_kwargs = {'agent_list': mock_alist,
                 'purge': False,
-                'use_only_authd': mock_exp['use_only_authd'],
+                'use_only_authd': use_only_auth,
                 'filters': {
                     'status': None,
                     'older_than': None,
@@ -519,18 +518,28 @@ async def test_get_agent_upgrade(mock_exc, mock_dapi, mock_remove, mock_dfunc, m
 
 
 @pytest.mark.asyncio
-@patch('api.configuration.api_conf')
 @patch('api.controllers.agent_controller.DistributedAPI.distribute_function', return_value=AsyncMock())
 @patch('api.controllers.agent_controller.remove_nones_to_dict')
 @patch('api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
 @patch('api.controllers.agent_controller.raise_if_exc', return_value=CustomAffectedItems())
-async def test_post_new_agent(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_exp, mock_request=MagicMock()):
+async def test_post_new_agent(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_request=MagicMock()):
     """Verify 'post_new_agent' endpoint is working as expected."""
     result = await post_new_agent(request=mock_request,
                                   agent_name='agent_name_value')
-    f_kwargs = {'name': 'agent_name_value',
-                'use_only_authd': mock_exp['use_only_authd']
-                }
+    # `ip` and `force` come from the API model
+    f_kwargs = {
+        'name': 'agent_name_value',
+        'ip': None,
+        'use_only_authd': use_only_auth,
+        'force': {
+            'enabled': False,
+            'disconnected_time': {
+                'enabled': True,
+                'value': '1h'
+            },
+            'after_registration_time': '1h'
+        }
+    }
     mock_dapi.assert_called_once_with(f=agent.add_agent,
                                       f_kwargs=mock_remove.return_value,
                                       request_type='local_master',
@@ -927,7 +936,7 @@ async def test_restart_agents_by_group(mock_aiwr, mock_dapi, mock_remove, mock_d
 @patch('api.controllers.agent_controller.remove_nones_to_dict')
 @patch('api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
 @patch('api.controllers.agent_controller.raise_if_exc', return_value=CustomAffectedItems())
-async def test_insert_agent(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_exp, mock_request=MagicMock()):
+async def test_insert_agent(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_request=MagicMock()):
     """Verify 'insert_agent' endpoint is working as expected."""
     with patch('api.controllers.agent_controller.Body.validate_content_type'):
         with patch('api.controllers.agent_controller.AgentInsertedModel.get_kwargs',

--- a/api/api/models/agent_added_model.py
+++ b/api/api/models/agent_added_model.py
@@ -5,35 +5,121 @@ from __future__ import absolute_import
 from datetime import date, datetime  # noqa: F401
 from typing import List, Dict  # noqa: F401
 
-from api.models.base_model_ import Body
+from api.models.base_model_ import Body, Model
+
+
+class DisconnectedTime(Model):
+    def __init__(self, enabled=True, value="1h"):
+        self.swagger_types = {
+            'enabled': bool,
+            'value': str
+        }
+
+        self.attribute_map = {
+            'enabled': 'enabled',
+            'value': 'value'
+        }
+
+        self._enabled = enabled
+        self._value = value
+
+    @property
+    def enabled(self):
+        return self._enabled
+
+    @enabled.setter
+    def enabled(self, enabled):
+        self._enabled = enabled
+
+    @property
+    def value(self):
+        return self._value
+
+    @value.setter
+    def value(self, value):
+        self._value = value
+
+
+class AgentForce(Model):
+    def __init__(self, enabled=True, key_mismatch=True, disconnected_time=None, after_registration_time="1h"):
+        self.swagger_types = {
+            'enabled': bool,
+            'key_mismatch': bool,
+            'disconnected_time': DisconnectedTime,
+            'after_registration_time': str
+        }
+
+        self.attribute_map = {
+            'enabled': 'enabled',
+            'key_mismatch': 'key_mismatch',
+            'disconnected_time': 'disconnected_time',
+            'after_registration_time': 'after_registration_time'
+        }
+
+        self._enabled = enabled
+        self._key_mismatch = key_mismatch
+        self._disconnected_time = disconnected_time
+        self._after_registration_time = after_registration_time
+
+    @property
+    def enabled(self):
+        return self._enabled
+
+    @enabled.setter
+    def enabled(self, enabled):
+        self._enabled = enabled
+
+    @property
+    def key_mismatch(self):
+        return self._key_mismatch
+
+    @key_mismatch.setter
+    def key_mismatch(self, key_mismatch):
+        self._key_mismatch = key_mismatch
+
+    @property
+    def disconnected_time(self):
+        return self._disconnected_time
+
+    @disconnected_time.setter
+    def disconnected_time(self, disconnected_time):
+        self._disconnected_time = disconnected_time
+
+    @property
+    def after_registration_time(self):
+        return self._after_registration_time
+
+    @after_registration_time.setter
+    def after_registration_time(self, after_registration_time):
+        self._after_registration_time = after_registration_time
 
 
 class AgentAddedModel(Body):
 
-    def __init__(self, name: str = None, ip: str = None, force_time: int = None):
+    def __init__(self, name: str = None, ip: str = None, force: AgentForce = None):
         """AgentAddedModel body model
         :param name: Agent name.
         :type name: str
         :param ip: If this is not included, the API will get the IP automatically. If you are behind a proxy, you must set the option BehindProxyServer to yes at API configuration. Allowed values: IP, IP/NET, ANY
         :type ip: str
-        :param force_time: Remove the old agent with the same IP if disconnected since <force_time> seconds.
-        :type force_time: int
+        :param force: Remove the old agent if conditions are met.
+        :type force: AgentForce
         """
         self.swagger_types = {
             'name': str,
             'ip': str,
-            'force_time': int
+            'force': AgentForce
         }
 
         self.attribute_map = {
             'name': 'name',
             'ip': 'ip',
-            'force_time': 'force_time'
+            'force': 'force_time'
         }
 
         self._name = name
         self._ip = ip
-        self._force_time = force_time
+        self._force = force
 
     @property
     def name(self) -> str:
@@ -66,16 +152,16 @@ class AgentAddedModel(Body):
         self._ip = ip
 
     @property
-    def force_time(self) -> int:
+    def force(self) -> AgentForce:
         """
         :return: Limit time to disconnect an agent with the same IP.
         :rtype: int
         """
-        return self._force_time
+        return self._force
 
-    @force_time.setter
-    def force_time(self, force_time):
+    @force.setter
+    def force(self, force):
         """Limit time to disconnect an agent with the same IP.
-        :param force_time: Agents limit disconnection time. 
+        :param force: Agents limit disconnection time.
         """
-        self._force_time = force_time
+        self._force = force

--- a/api/api/models/agent_added_model.py
+++ b/api/api/models/agent_added_model.py
@@ -9,7 +9,7 @@ from api.models.base_model_ import Body, Model
 
 
 class DisconnectedTime(Model):
-    def __init__(self, enabled=True, value="1h"):
+    def __init__(self, enabled=None, value=None):
         self.swagger_types = {
             'enabled': bool,
             'value': str
@@ -41,23 +41,20 @@ class DisconnectedTime(Model):
 
 
 class AgentForce(Model):
-    def __init__(self, enabled=True, key_mismatch=True, disconnected_time=None, after_registration_time="1h"):
+    def __init__(self, enabled=None, disconnected_time=None, after_registration_time=None):
         self.swagger_types = {
             'enabled': bool,
-            'key_mismatch': bool,
             'disconnected_time': DisconnectedTime,
             'after_registration_time': str
         }
 
         self.attribute_map = {
             'enabled': 'enabled',
-            'key_mismatch': 'key_mismatch',
             'disconnected_time': 'disconnected_time',
             'after_registration_time': 'after_registration_time'
         }
 
         self._enabled = enabled
-        self._key_mismatch = key_mismatch
         self._disconnected_time = disconnected_time
         self._after_registration_time = after_registration_time
 
@@ -68,14 +65,6 @@ class AgentForce(Model):
     @enabled.setter
     def enabled(self, enabled):
         self._enabled = enabled
-
-    @property
-    def key_mismatch(self):
-        return self._key_mismatch
-
-    @key_mismatch.setter
-    def key_mismatch(self, key_mismatch):
-        self._key_mismatch = key_mismatch
 
     @property
     def disconnected_time(self):
@@ -96,30 +85,28 @@ class AgentForce(Model):
 
 class AgentAddedModel(Body):
 
-    def __init__(self, name: str = None, ip: str = None, force: AgentForce = None):
+    def __init__(self, name: str = None, ip: str = None):
         """AgentAddedModel body model
         :param name: Agent name.
         :type name: str
-        :param ip: If this is not included, the API will get the IP automatically. If you are behind a proxy, you must set the option BehindProxyServer to yes at API configuration. Allowed values: IP, IP/NET, ANY
+        :param ip: If this is not included, the API will get the IP automatically. If you are behind a proxy, you must
+        set the option BehindProxyServer to yes at API configuration. Allowed values: IP, IP/NET, ANY
         :type ip: str
         :param force: Remove the old agent if conditions are met.
         :type force: AgentForce
         """
         self.swagger_types = {
             'name': str,
-            'ip': str,
-            'force': AgentForce
+            'ip': str
         }
 
         self.attribute_map = {
             'name': 'name',
-            'ip': 'ip',
-            'force': 'force_time'
+            'ip': 'ip'
         }
 
         self._name = name
         self._ip = ip
-        self._force = force
 
     @property
     def name(self) -> str:
@@ -150,18 +137,3 @@ class AgentAddedModel(Body):
         :param ip: Agent IP.
         """
         self._ip = ip
-
-    @property
-    def force(self) -> AgentForce:
-        """
-        :return: Limit time to disconnect an agent with the same IP.
-        :rtype: int
-        """
-        return self._force
-
-    @force.setter
-    def force(self, force):
-        """Limit time to disconnect an agent with the same IP.
-        :param force: Agents limit disconnection time.
-        """
-        self._force = force

--- a/api/api/models/agent_added_model.py
+++ b/api/api/models/agent_added_model.py
@@ -9,7 +9,7 @@ from api.models.base_model_ import Body, Model
 
 
 class DisconnectedTime(Model):
-    def __init__(self, enabled=None, value=None):
+    def __init__(self, enabled=True, value="1h"):
         self.swagger_types = {
             'enabled': bool,
             'value': str
@@ -41,7 +41,7 @@ class DisconnectedTime(Model):
 
 
 class AgentForce(Model):
-    def __init__(self, enabled=None, disconnected_time=None, after_registration_time=None):
+    def __init__(self, enabled=True, disconnected_time=None, after_registration_time="1h"):
         self.swagger_types = {
             'enabled': bool,
             'disconnected_time': DisconnectedTime,
@@ -55,7 +55,7 @@ class AgentForce(Model):
         }
 
         self._enabled = enabled
-        self._disconnected_time = disconnected_time
+        self._disconnected_time = DisconnectedTime(**disconnected_time or {}).to_dict()
         self._after_registration_time = after_registration_time
 
     @property
@@ -86,27 +86,21 @@ class AgentForce(Model):
 class AgentAddedModel(Body):
 
     def __init__(self, name: str = None, ip: str = None):
-        """AgentAddedModel body model
-        :param name: Agent name.
-        :type name: str
-        :param ip: If this is not included, the API will get the IP automatically. If you are behind a proxy, you must
-        set the option BehindProxyServer to yes at API configuration. Allowed values: IP, IP/NET, ANY
-        :type ip: str
-        :param force: Remove the old agent if conditions are met.
-        :type force: AgentForce
-        """
         self.swagger_types = {
             'name': str,
-            'ip': str
+            'ip': str,
+            'force': AgentForce
         }
 
         self.attribute_map = {
             'name': 'name',
-            'ip': 'ip'
+            'ip': 'ip',
+            'force': 'force'
         }
 
         self._name = name
         self._ip = ip
+        self._force = AgentForce(enabled=False)
 
     @property
     def name(self) -> str:
@@ -137,3 +131,11 @@ class AgentAddedModel(Body):
         :param ip: Agent IP.
         """
         self._ip = ip
+
+    @property
+    def force(self):
+        return self._force
+
+    @force.setter
+    def force(self, force):
+        self._force = force

--- a/api/api/models/agent_inserted_model.py
+++ b/api/api/models/agent_inserted_model.py
@@ -2,6 +2,8 @@
 
 from __future__ import absolute_import
 
+from typing import Dict
+
 from api.models.agent_added_model import AgentForce
 from api.models.base_model_ import Body
 
@@ -21,7 +23,7 @@ class AgentInsertedModel(Body):
         :param key: Key to use when communicating with the manager. The agent must have the same key on its `client.keys` file.
         :type key: str
         :param force: Remove the old agent with the same IP if disconnected since <force_time> seconds.
-        :type force: AgentForce
+        :type force: dict
         """
         self.swagger_types = {
             'id': str,
@@ -46,7 +48,7 @@ class AgentInsertedModel(Body):
         self._ip = ip
         self._agent_id = agent_id
         self._key = key
-        self._force = force
+        self._force = AgentForce(**force or {}).to_dict()
 
     @property
     def id(self) -> str:
@@ -124,10 +126,10 @@ class AgentInsertedModel(Body):
         self._key = key
 
     @property
-    def force(self) -> AgentForce:
+    def force(self) -> Dict:
         """
         :return: Limit time to disconnect an agent with the same IP.
-        :rtype: AgentForce
+        :rtype: dict
         """
         return self._force
 

--- a/api/api/models/agent_inserted_model.py
+++ b/api/api/models/agent_inserted_model.py
@@ -2,12 +2,13 @@
 
 from __future__ import absolute_import
 
+from api.models.agent_added_model import AgentForce
 from api.models.base_model_ import Body
 
 
 class AgentInsertedModel(Body):
 
-    def __init__(self, id=None, name=None, ip=None, agent_id=None, key=None, force_time=None):
+    def __init__(self, id=None, name=None, ip=None, agent_id=None, key=None, force=None):
         """AgentAddedModel body model
         :param id: Agent id.
         :type id: str
@@ -19,8 +20,8 @@ class AgentInsertedModel(Body):
         :type agent_id: str
         :param key: Key to use when communicating with the manager. The agent must have the same key on its `client.keys` file.
         :type key: str
-        :param force_time: Remove the old agent with the same IP if disconnected since <force_time> seconds.
-        :type force_time: int
+        :param force: Remove the old agent with the same IP if disconnected since <force_time> seconds.
+        :type force: AgentForce
         """
         self.swagger_types = {
             'id': str,
@@ -28,7 +29,7 @@ class AgentInsertedModel(Body):
             'ip': str,
             'agent_id': str,
             'key': str,
-            'force_time': int
+            'force': AgentForce
         }
 
         self.attribute_map = {
@@ -37,7 +38,7 @@ class AgentInsertedModel(Body):
             'ip': 'ip',
             'agent_id': 'id',
             'key': 'key',
-            'force_time': 'force_time'
+            'force': 'force'
         }
 
         self._id = id
@@ -45,7 +46,7 @@ class AgentInsertedModel(Body):
         self._ip = ip
         self._agent_id = agent_id
         self._key = key
-        self._force_time = force_time
+        self._force = force
 
     @property
     def id(self) -> str:
@@ -123,16 +124,16 @@ class AgentInsertedModel(Body):
         self._key = key
 
     @property
-    def force_time(self) -> int:
+    def force(self) -> AgentForce:
         """
         :return: Limit time to disconnect an agent with the same IP.
-        :rtype: int
+        :rtype: AgentForce
         """
-        return self._force_time
+        return self._force
 
-    @force_time.setter
-    def force_time(self, force_time):
+    @force.setter
+    def force(self, force):
         """Limit time to disconnect an agent with the same IP.
-        :param force_time: Agents limit disconnection time. 
+        :param force: Agents limit disconnection time.
         """
-        self._force_time = force_time
+        self._force = force

--- a/api/api/models/agent_inserted_model.py
+++ b/api/api/models/agent_inserted_model.py
@@ -22,7 +22,7 @@ class AgentInsertedModel(Body):
         :type agent_id: str
         :param key: Key to use when communicating with the manager. The agent must have the same key on its `client.keys` file.
         :type key: str
-        :param force: Remove the old agent with the same IP if disconnected since <force_time> seconds.
+        :param force: Remove the old agent with the same name or IP if conditions are met.
         :type force: dict
         """
         self.swagger_types = {
@@ -136,6 +136,6 @@ class AgentInsertedModel(Body):
     @force.setter
     def force(self, force):
         """Limit time to disconnect an agent with the same IP.
-        :param force: Agents limit disconnection time.
+        :param force: Remove the old agent with the same name or IP if conditions are met.
         """
         self._force = force

--- a/api/api/models/base_model_.py
+++ b/api/api/models/base_model_.py
@@ -7,7 +7,7 @@ import six
 from connexion import ProblemException
 
 from api import util
-from api.util import raise_if_exc
+from api.util import raise_if_exc, get_invalid_keys
 from wazuh.core.exception import WazuhError, WazuhNotAcceptable
 
 T = typing.TypeVar('T')
@@ -199,7 +199,7 @@ class Body(Model):
         except JSONDecodeError:
             raise_if_exc(WazuhError(1018))
 
-        invalid = {key for key in dikt.keys() if key not in list(f_kwargs.keys())}
+        invalid = get_invalid_keys(dikt, f_kwargs)
 
         if invalid:
             raise ProblemException(status=400, title='Bad Request', detail='Invalid field found {}'.format(invalid))

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -5691,12 +5691,6 @@ paths:
                     IP, IP/NET, ANY"
                     type: string
                     format: alphanumeric
-                  force_time:
-                    description: "Remove the old agent with the same name or IP if disconnected for <force_time>
-                    seconds"
-                    type: integer
-                    format: int32
-                    minimum: 0
                 required:
                 - name
               example:
@@ -7087,12 +7081,10 @@ paths:
                     IP, IP/NET, ANY"
                     type: string
                     format: alphanumeric
-                  force_time:
+                  force: # TODO
                     description: "Remove the old agent with the same name, ID or IP if disconnected for <force_time>
                     seconds"
-                    type: integer
-                    format: int32
-                    minimum: 0
+                    type: object
                 required:
                   - name
               example:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1556,6 +1556,32 @@ components:
           type: object
           description: "Group configuration. The fields on this object depend on the actual group configuration"
 
+    AgentInsertForce:
+      type: object
+      description: "Remove the old agent with the same name, ID or IP if the configuration is matched"
+      properties:
+        enabled:
+          type: boolean
+          default: True
+          description: "Enable force option"
+        disconnected_time:
+          type: object
+          properties:
+            enabled:
+              type: boolean
+              default: True
+              description: "Enable force disconnected_time option"
+            value:
+              type: string
+              default: "1h"
+              description: "Time the agent must has been disconnected to force the insertion. Time in seconds, ‘[n_days]d’, ‘[n_hours]h’, ‘[n_minutes]m’ or ‘[n_seconds]s’. For example, `7d`, `10s` and `10` are valid values. If no time unit is specified, seconds are used"
+              format: timeframe
+        after_registration_time:
+          type: string
+          default: "1h"
+          description: "Time the agent must has been registered to force the insertion. Time in seconds, ‘[n_days]d’, ‘[n_hours]h’, ‘[n_minutes]m’ or ‘[n_seconds]s’. For example, `7d`, `10s` and `10` are valid values. If no time unit is specified, seconds are used"
+          format: timeframe
+
     ## CisCat models
     CiscatResults:
       type: object
@@ -7081,10 +7107,8 @@ paths:
                     IP, IP/NET, ANY"
                     type: string
                     format: alphanumeric
-                  force: # TODO
-                    description: "Remove the old agent with the same name, ID or IP if disconnected for <force_time>
-                    seconds"
-                    type: object
+                  force:
+                    $ref: '#/components/schemas/AgentInsertForce'
                 required:
                   - name
               example:
@@ -7092,6 +7116,13 @@ paths:
                 ip: 10.0.10.11
                 id: "123"
                 key: 1abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghi64
+                force:
+                  enabled: True
+                  disconnected_time:
+                    enabled: True
+                    value: "30m"
+                  after_registration_time: "2h"
+
       responses:
         '200':
           description: "Insert new agent"

--- a/api/api/test/test_util.py
+++ b/api/api/test/test_util.py
@@ -215,3 +215,34 @@ def test_raise_if_exc(mock_create_problem, obj, code):
         mock_create_problem.assert_called_once_with(obj, code)
     else:
         assert result == obj
+
+
+@pytest.mark.parametrize("dikt, f_kwargs, invalid_keys", [
+    ({"key1": 0, "key2": 0}, {"key1": 0}, {"key2"}),
+    ({
+         "key1": 0,
+         "key2": {
+             "key21": 0,
+             "key22": {
+                 "key221": 0,
+                 "key222": {
+                     "key2221": 0
+                 }
+             }
+         }
+     },
+     {
+         "key2": {
+             "key22": {
+                 "key221": 0
+             }
+         }
+     },
+     {"key1", "key21", "key222"}),
+    ({"key1": 0}, {"key1": 0, "key2": 0}, set())
+])
+def test_get_invalid_keys(dikt, f_kwargs, invalid_keys):
+    """Check that `get_invalid_keys` return the correct invalid keys when comparing two dictionaries with more
+    than one nesting level."""
+    invalid = util.get_invalid_keys(dikt, f_kwargs)
+    assert invalid == invalid_keys

--- a/api/api/util.py
+++ b/api/api/util.py
@@ -9,7 +9,6 @@ import typing
 import six
 from connexion import ProblemException
 
-from api.api_exception import APIError
 from wazuh.core.common import wazuh_path as WAZUH_PATH
 from wazuh.core.exception import WazuhException, WazuhInternalError, WazuhError, WazuhPermissionError, \
     WazuhResourceNotFound, WazuhTooManyRequests, WazuhNotAcceptable
@@ -294,3 +293,33 @@ def raise_if_exc(obj):
         _create_problem(obj)
     else:
         return obj
+
+
+def get_invalid_keys(original_dict, des_dict):
+    """Return a set with the keys from `original_dict` that are not present in `des_dict`.
+
+    Parameters
+    ----------
+    original_dict : dict
+        Original dictionary.
+    des_dict : dict
+        Deserialized dictionary with the model keys.
+
+    Returns
+    -------
+    set
+        Set with the invalid keys.
+    """
+    invalid_keys = set()
+
+    for key in original_dict:
+        if isinstance(original_dict[key], dict):
+            try:
+                invalid_keys.update(get_invalid_keys(original_dict[key], des_dict[key]))
+            except KeyError:
+                invalid_keys.add(key)
+        else:
+            if key not in set(des_dict):
+                invalid_keys.add(key)
+
+    return invalid_keys

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -1305,8 +1305,7 @@ stages:
           auth:
             ciphers: !anystr
             disabled: !anystr
-            force_insert: !anystr
-            force_time: !anystr
+            force: !anything
             port: !anyint
             purge: !anystr
             ssl_auto_negotiate: !anystr

--- a/api/test/integration/test_agent_POST_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_POST_endpoints.tavern.yaml
@@ -59,7 +59,12 @@ stages:
       json:
         name: "IhavetoolongofanamebecauseireallywantthisframeworktostopmeireallyhopeitdoesstopmeotherwiseiwillcauserealpainintheAPIandidontwantto"
         ip: "any"
-        force_time: 1
+        force:
+          enabled: True
+          disconnected_time:
+            enabled: True
+            value: "1s"
+          after_registration_time: "1s"
     response:
       status_code: 400
       json:
@@ -153,7 +158,12 @@ stages:
       json:
         name: "NewAgentPost3"
         ip: "any"
-        force_time: 1
+        force:
+          enabled: True
+          disconnected_time:
+            enabled: True
+            value: "1s"
+          after_registration_time: "1s"
     response:
       status_code: 200
       json:
@@ -432,18 +442,60 @@ stages:
         error: 1706
 
     # POST /agents/insert
-  - name: Create an agent using force time
+  - name: Create an agent using force
     request:
       verify: False
       <<: *agent_insert_request
       json:
         name: "NewAgentPostInsert"
         ip: "any"
-        force_time: 1
+        force:
+          enabled: True
+          disconnected_time:
+            enabled: True
+            value: "1s"
+          after_registration_time: "1s"
     response:
       status_code: 200
       json:
         <<: *agent_create_response
+
+    # POST /agents/insert
+  - name: Create an agent using force (requirements are not met)
+    request:
+      verify: False
+      <<: *agent_insert_request
+      json:
+        name: "NewAgentPostInsert"
+        ip: "any"
+        force:
+          enabled: True
+          disconnected_time:
+            enabled: True
+            value: "1d"
+    response:
+      status_code: 400
+      json:
+        error: 1705
+
+    # POST /agents/insert
+  - name: Create an agent using force (invalid parameters)
+    request:
+      verify: False
+      <<: *agent_insert_request
+      json:
+        name: "NewAgentPostInsert"
+        ip: "any"
+        force:
+          enabled: True
+          disconnected_time:
+            enabled: True
+            value: "1d"
+            invalid: True
+    response:
+      status_code: 400
+      json:
+        <<: *error_spec
 
 ---
 test_name: POST /agents/insert/quick

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -1018,8 +1018,7 @@ stages:
             - auth:
                 ciphers: !anystr
                 disabled: !anystr
-                force_insert: !anystr
-                force_time: !anystr
+                force: !anything
                 port: !anyint
                 purge: !anystr
                 ssl_auto_negotiate: !anystr

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -428,7 +428,7 @@ def delete_agents(agent_list=None, backup=False, purge=False, use_only_authd=Fal
 
 
 @expose_resources(actions=["agent:create"], resources=["*:*:*"], post_proc_func=None)
-def add_agent(name=None, agent_id=None, key=None, ip='any', force_time=-1, use_only_authd=False):
+def add_agent(name=None, agent_id=None, key=None, ip='any', force=None, use_only_authd=False):
     """Adds a new Wazuh agent.
 
     :param name: name of the new agent.
@@ -443,7 +443,7 @@ def add_agent(name=None, agent_id=None, key=None, ip='any', force_time=-1, use_o
     if len(name) > 128:
         raise WazuhError(1738)
 
-    new_agent = Agent(name=name, ip=ip, id=agent_id, key=key, force=force_time, use_only_authd=use_only_authd)
+    new_agent = Agent(name=name, ip=ip, id=agent_id, key=key, force=force, use_only_authd=use_only_authd)
 
     return WazuhResult({'data': {'id': new_agent.id, 'key': new_agent.key}})
 

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -326,7 +326,7 @@ class Agent:
               'node_name': 'node_name', 'lastKeepAlive': 'last_keepalive', 'internal_key': 'internal_key',
               'registerIP': 'register_ip'}
 
-    def __init__(self, id=None, name=None, ip=None, key=None, force=-1, use_only_authd=False):
+    def __init__(self, id=None, name=None, ip=None, key=None, force=None, use_only_authd=False):
         """Initialize an agent.
 
         :param: id: When the agent exists
@@ -636,7 +636,7 @@ class Agent:
         except Exception as e:
             raise WazuhInternalError(1748, extra_message=str(e))
 
-    def _add(self, name, ip, id=None, key=None, force=-1, use_only_authd=False):
+    def _add(self, name, ip, id=None, key=None, force=None, use_only_authd=False):
         """Add an agent to Wazuh.
         2 uses:
             - name and ip [force]: Add an agent like manage_agents (generate id and key).
@@ -699,7 +699,7 @@ class Agent:
         except Exception as e:
             raise WazuhInternalError(1725, extra_message=str(e))
 
-    def _add_authd(self, name, ip, id=None, key=None, force=-1):
+    def _add_authd(self, name, ip, id=None, key=None, force=None):
         """Add an agent to Wazuh using authd.
         2 uses:
             - name and ip [force]: Add an agent like manage_agents (generate id and key).
@@ -715,7 +715,7 @@ class Agent:
             ID of the new agent.
         key : str
             Key of the new agent.
-        force : int
+        force : dict
             Remove old agents with same IP if disconnected since <force> seconds.
 
         Raises
@@ -740,14 +740,15 @@ class Agent:
         if key and len(key) < 64:
             raise WazuhError(1709)
 
-        force = force if type(force) == int else int(force)
-
         msg = ""
         if name and ip:
+            msg = {"function": "add", "arguments": {"name": name, "ip": ip}}
+
+            if force is not None:
+                msg["arguments"]["force"] = force
+
             if id and key:
-                msg = {"function": "add", "arguments": {"name": name, "ip": ip, "id": id, "key": key, "force": force}}
-            else:
-                msg = {"function": "add", "arguments": {"name": name, "ip": ip, "force": force}}
+                msg["arguments"].update({"id": id, "key": key})
 
         try:
             authd_socket = WazuhSocketJSON(common.AUTHD_SOCKET)
@@ -866,6 +867,7 @@ class Agent:
 
                                 # If force is non-negative then we check to remove the agent using value of force as
                                 # the max age in seconds
+                                # TODO refactor this with the new force
                                 if force >= 0 and Agent.check_if_delete_agent(entry_id, force):
                                     self.delete_agent_files(entry_id, entry_name, entry_ip, backup=True)
                                     # We add a void entry

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -10,7 +10,6 @@ import re
 import tempfile
 import threading
 from base64 import b64encode
-from copy import deepcopy
 from datetime import date, datetime
 from functools import lru_cache
 from json import dumps, loads
@@ -652,8 +651,8 @@ class Agent:
             ID of the new agent.
         key : str
             Key of the new agent.
-        force : int
-            Remove old agents with same IP if disconnected since <force> seconds.
+        force : dict
+            Remove old agents with same name or IP if conditions are met.
         use_only_authd : bool
             Force the use of authd when adding and removing agents.
 
@@ -716,7 +715,7 @@ class Agent:
         key : str
             Key of the new agent.
         force : dict
-            Remove old agents with same IP if disconnected since <force> seconds.
+            Remove old agents with same name or IP if conditions are met.
 
         Raises
         ------
@@ -867,7 +866,6 @@ class Agent:
 
                                 # If force is non-negative then we check to remove the agent using value of force as
                                 # the max age in seconds
-                                # TODO refactor this with the new force
                                 if force >= 0 and Agent.check_if_delete_agent(entry_id, force):
                                     self.delete_agent_files(entry_id, entry_name, entry_ip, backup=True)
                                     # We add a void entry

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -744,6 +744,8 @@ class Agent:
             msg = {"function": "add", "arguments": {"name": name, "ip": ip}}
 
             if force is not None:
+                # This force field must always be present
+                force.update({"key_mismatch": True})
                 msg["arguments"]["force"] = force
 
             if id and key:

--- a/framework/wazuh/core/configuration.py
+++ b/framework/wazuh/core/configuration.py
@@ -212,7 +212,7 @@ def _read_option(section_name, opt):
     elif section_name == 'remote' and opt_name == 'protocol':
         opt_value = [elem.strip() for elem in opt.text.split(',')]
     else:
-        if opt.attrib:
+        if opt.attrib or list(opt):
             opt_value = {}
             for a in opt.attrib:
                 opt_value[a] = opt.attrib[a]

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -411,9 +411,9 @@ def test_agent_delete_agents(socket_mock, send_mock, mock_remove, agent_list, fi
         assert next(iter(result.failed_items)).code == error_code
 
 
-@pytest.mark.parametrize('name, agent_id, key', [
-    ('agent-1', '011', 'b3650e11eba2f27er4d160c69de533ee7eed601636a85ba2455d53a90927747f'),
-    ('a' * 129, '002', 'f304f582f2417a3fddad69d9ae2b4f3b6e6fda788229668af9a6934d454ef44d')
+@pytest.mark.parametrize('name, agent_id, key, force', [
+    ('agent-1', '011', 'b3650e11eba2f27er4d160c69de533ee7eed601636a85ba2455d53a90927747f', None),
+    ('a' * 129, '002', 'f304f582f2417a3fddad69d9ae2b4f3b6e6fda788229668af9a6934d454ef44d', {'enabled': True})
 ])
 @patch('wazuh.core.agent.fcntl.lockf')
 @patch('wazuh.core.common.client_keys', new=os.path.join(test_agent_path, 'client.keys'))
@@ -428,7 +428,7 @@ def test_agent_delete_agents(socket_mock, send_mock, mock_remove, agent_list, fi
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
 def test_agent_add_agent(socket_mock, send_mock, safe_move_mock, tempfile_mock, common_gid_mock, common_uid_mock,
-                         chmod_mock, chown_mock, release_mock, acquire_mock, fcntl_mock, name, agent_id, key):
+                         chmod_mock, chown_mock, release_mock, acquire_mock, fcntl_mock, name, agent_id, key, force):
     """Test `add_agent` from agent module.
 
     Parameters
@@ -439,6 +439,8 @@ def test_agent_add_agent(socket_mock, send_mock, safe_move_mock, tempfile_mock, 
         ID of the agent whose name is the specified one.
     key : str
         The agent key.
+    force : dict
+        Force parameters.
     """
     def mock_open(*args):
         """Mock open only if .write() is used"""
@@ -449,7 +451,7 @@ def test_agent_add_agent(socket_mock, send_mock, safe_move_mock, tempfile_mock, 
 
     with patch('wazuh.core.agent.open', new=mock_open):
         try:
-            add_result = add_agent(name=name, agent_id=agent_id, key=key, use_only_authd=False)
+            add_result = add_agent(name=name, agent_id=agent_id, key=key, force=force, use_only_authd=False)
             assert add_result.dikt['data']['id'] == agent_id
             assert add_result.dikt['data']['key']
         except WazuhError as e:


### PR DESCRIPTION
|Related issue|
|---|
|#9988|

This closes #9988 .

After the changes in the `authd` configuration, some endpoints were affected:
- `POST /agents`
- `POST /agents/insert`
- `POST /agents/insert/quick`
- `GET /manager/configuration`

Agent related endpoints now send a `force` block to the `authd` socket. If the endpoint did not accept any `force` option before, it will send the block with `enabled: False`.

As for the `GET /manager/configuration` endpoint, it now parses the `force` block correctly. More details about these changes can be seen in the issue, in addition to manual testing.

## Tests performed

### Unit tests

```
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.9.7, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: cov-2.12.0, asyncio-0.15.1
collected 454 items                                                                                                                                                                                               

api/api/controllers/test/test_active_response_controller.py .                                                                                                                                               [  0%]
api/api/controllers/test/test_agent_controller.py ........................................                                                                                                                  [  9%]
api/api/controllers/test/test_cdb_list_controller.py ......                                                                                                                                                 [ 10%]
api/api/controllers/test/test_ciscat_controller.py .                                                                                                                                                        [ 10%]
api/api/controllers/test/test_cluster_controller.py ......................                                                                                                                                  [ 15%]
api/api/controllers/test/test_decoder_controller.py .......                                                                                                                                                 [ 16%]
api/api/controllers/test/test_default_controller.py .                                                                                                                                                       [ 17%]
api/api/controllers/test/test_experimental_controller.py ...............                                                                                                                                    [ 20%]
api/api/controllers/test/test_manager_controller.py .................                                                                                                                                       [ 24%]
api/api/controllers/test/test_mitre_controller.py .......                                                                                                                                                   [ 25%]
api/api/controllers/test/test_overview_controller.py .                                                                                                                                                      [ 25%]
api/api/controllers/test/test_rootcheck_controller.py ....                                                                                                                                                  [ 26%]
api/api/controllers/test/test_rule_controller.py ........                                                                                                                                                   [ 28%]
api/api/controllers/test/test_sca_controller.py ..                                                                                                                                                          [ 29%]
api/api/controllers/test/test_security_controller.py ...................................................                                                                                                    [ 40%]
api/api/controllers/test/test_syscheck_controller.py ....                                                                                                                                                   [ 41%]
api/api/controllers/test/test_syscollector_controller.py .........                                                                                                                                          [ 43%]
api/api/controllers/test/test_task_controller.py .                                                                                                                                                          [ 43%]
api/api/controllers/test/test_vulnerability_controller.py .                                                                                                                                                 [ 43%]
api/api/models/test/test_model.py ...........................                                                                                                                                               [ 49%]
api/api/test/test_alogging.py ..........                                                                                                                                                                    [ 51%]
api/api/test/test_authentication.py ..........                                                                                                                                                              [ 53%]
api/api/test/test_configuration.py ..........................................                                                                                                                               [ 63%]
api/api/test/test_util.py ......................................                                                                                                                                            [ 71%]
api/api/test/test_validator.py .................................................................................................................................                                            [100%]

======================================================================================== 454 passed, 14 warnings in 2.13s =========================================================================================

```

```=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.9.7, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: cov-2.12.0, asyncio-0.15.1
collected 51 items                                                                                                                                                                                                

framework/wazuh/core/tests/test_manager.py ...............                                                                                                                                                  [ 29%]
framework/wazuh/tests/test_manager.py ....................................                                                                                                                                  [100%]

========================================================================================= 51 passed, 2 warnings in 0.23s ==========================================================================================


```

```
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.9.7, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: cov-2.12.0, asyncio-0.15.1
collected 275 items                                                                                                                                                                                               

framework/wazuh/core/tests/test_agent.py .................................................................................................................................................................. [ 58%]
....                                                                                                                                                                                                        [ 60%]
framework/wazuh/tests/test_agent.py .........................................F...................................................................                                                           [100%]

==================================================================================================== FAILURES =====================================================================================================

```

**NOTE:** There is a failing test within `wazuh/test/test_agent.py`. The `add_manual` function is not adapted to the changes in the `force` format and thus it is failing. This method will be deprecated, so we need to discuss if this deprecation can happen in this development or we need to adapt it in another issue.

### Integration tests

```
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.9.7, pytest-5.4.3, py-1.10.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.9.7', 'Platform': 'Linux-5.13.19-100.fc33.x86_64-x86_64-with-glibc2.32', 'Packages': {'pytest': '5.4.3', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'tavern': '1.0.0', 'metadata': '1.11.0', 'html': '3.1.1'}}
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: tavern-1.0.0, metadata-1.11.0, html-3.1.1
collected 5 items                                                                                                                                                                                                 

test_agent_POST_endpoints.tavern.yaml::POST /agents PASSED                                                                                                                                                  [ 20%]
test_agent_POST_endpoints.tavern.yaml::POST /agents (no IP) PASSED                                                                                                                                          [ 40%]
test_agent_POST_endpoints.tavern.yaml::POST /groups PASSED                                                                                                                                                  [ 60%]
test_agent_POST_endpoints.tavern.yaml::POST /agents/insert PASSED                                                                                                                                           [ 80%]
test_agent_POST_endpoints.tavern.yaml::POST /agents/insert/quick PASSED                                                                                                                                     [100%]

==================================================================================== 5 passed, 7 warnings in 566.25s (0:09:26) ====================================================================================

=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.9.7, pytest-5.4.3, py-1.10.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.9.7', 'Platform': 'Linux-5.13.19-100.fc33.x86_64-x86_64-with-glibc2.32', 'Packages': {'pytest': '5.4.3', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'tavern': '1.0.0', 'metadata': '1.11.0', 'html': '3.1.1'}}
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: tavern-1.0.0, metadata-1.11.0, html-3.1.1
collected 31 items                                                                                                                                                                                                

test_manager_endpoints.tavern.yaml::GET /manager/status PASSED                                                                                                                                              [  3%]
test_manager_endpoints.tavern.yaml::GET /manager/info PASSED                                                                                                                                                [  6%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[alerts] PASSED                                                                                                                     [  9%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[auth] PASSED                                                                                                                       [ 12%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cis-cat] PASSED                                                                                                                    [ 16%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cluster] PASSED                                                                                                                    [ 19%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[command] PASSED                                                                                                                    [ 22%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[global] PASSED                                                                                                                     [ 25%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[localfile] PASSED                                                                                                                  [ 29%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[osquery] PASSED                                                                                                                    [ 32%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[remote] PASSED                                                                                                                     [ 35%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[rootcheck] PASSED                                                                                                                  [ 38%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[ruleset] PASSED                                                                                                                    [ 41%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[sca] PASSED                                                                                                                        [ 45%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscheck] PASSED                                                                                                                   [ 48%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscollector] PASSED                                                                                                               [ 51%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[vulnerability-detector] PASSED                                                                                                     [ 54%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration PASSED                                                                                                                                       [ 58%]
test_manager_endpoints.tavern.yaml::GET /manager/stats PASSED                                                                                                                                               [ 61%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/hourly PASSED                                                                                                                                        [ 64%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/weekly PASSED                                                                                                                                        [ 67%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/analysisd PASSED                                                                                                                                     [ 70%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/remoted PASSED                                                                                                                                       [ 74%]
test_manager_endpoints.tavern.yaml::GET /manager/logs PASSED                                                                                                                                                [ 77%]
test_manager_endpoints.tavern.yaml::GET /manager/logs/summary PASSED                                                                                                                                        [ 80%]
test_manager_endpoints.tavern.yaml::GET /manager/api/config PASSED                                                                                                                                          [ 83%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration/validation (OK) PASSED                                                                                                                       [ 87%]
test_manager_endpoints.tavern.yaml::GET /manager/validation (KO) PASSED                                                                                                                                     [ 90%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration/{component}/{configuration} PASSED                                                                                                           [ 93%]
test_manager_endpoints.tavern.yaml::PUT /manager/configuration PASSED                                                                                                                                       [ 96%]
test_manager_endpoints.tavern.yaml::PUT /manager/restart PASSED                                                                                                                                             [100%]

=================================================================================== 31 passed, 34 warnings in 229.77s (0:03:49) ===================================================================================
```

Regards,
Víctor

