### PR TITLE
Update Osquery path management to support its new installation path

### DIFF
--- a/src/wazuh_modules/wm_osquery_monitor.c
+++ b/src/wazuh_modules/wm_osquery_monitor.c
@@ -261,8 +261,8 @@ void *Execute_Osquery(wm_osquery_monitor_t *osquery)
     // Windows agent needs the complete path to osqueryd
 #ifndef WIN32
     if (!(osquery->bin_path && *osquery->bin_path)) {
-        /* The Osquery installation path changed from /usr/local to /opt/osquery in Osquery v5.0.1,
-        * so we check both paths to support older and newer versions */
+        /* Osquery installation path was moved from /usr/local to /opt/osquery in Osquery v5.0.1,
+        so we check both paths by default to support older and newer versions */
         if (w_is_file("/opt/osquery/bin/" OSQUERYD_BIN)) {
             snprintf(osqueryd_path, sizeof(osqueryd_path), "%s/" OSQUERYD_BIN, "/opt/osquery/bin");
         } else {

--- a/src/wazuh_modules/wm_osquery_monitor.c
+++ b/src/wazuh_modules/wm_osquery_monitor.c
@@ -261,8 +261,14 @@ void *Execute_Osquery(wm_osquery_monitor_t *osquery)
     // Windows agent needs the complete path to osqueryd
 #ifndef WIN32
     if (!(osquery->bin_path && *osquery->bin_path)) {
-        strncpy(osqueryd_path, OSQUERYD_BIN, sizeof(osqueryd_path));
-        osqueryd_path[sizeof(osqueryd_path) - 1] = '\0';
+        /* The Osquery installation path changed from /usr/local to /opt/osquery in Osquery v5.0.1,
+        * so we check both paths to support older and newer versions */
+        if (w_is_file("/opt/osquery/bin/" OSQUERYD_BIN)) {
+            snprintf(osqueryd_path, sizeof(osqueryd_path), "%s/" OSQUERYD_BIN, "/opt/osquery/bin");
+        } else {
+            strncpy(osqueryd_path, OSQUERYD_BIN, sizeof(osqueryd_path));
+            osqueryd_path[sizeof(osqueryd_path) - 1] = '\0';
+        }
     } else
 #endif
     {


### PR DESCRIPTION
|Related issue|
|---|
|#10140|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hi team,

With the recent release of [Osquery v5.0.1](https://github.com/osquery/osquery/blob/master/CHANGELOG.md#501), its installation path has been moved from `/usr/local` into `/opt/osquery` on **macOS** and **Linux** systems, for portability reasons. This leads our **Osquery** integration to fail when [bin-path](https://documentation.wazuh.com/4.2/user-manual/reference/ossec-conf/wodle-osquery.html#bin-path) isn't set, as the integration tries to run the **osqueryd** binary assuming it is in the `PATH` variable.

That said, this PR aims to modify said mechanism in order to support both older and newer **Osquery** versions.

Best regards.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation


