### PR TITLE
Fixing memory leak after Coverity scan

### DIFF
--- a/src/os_auth/local-server.c
+++ b/src/os_auth/local-server.c
@@ -184,6 +184,7 @@ char* local_dispatch(const char *input) {
     cJSON *response = NULL;
     char *output = NULL;
     int ierror;
+    char *groups = NULL;
 
     if (input[0] == '{') {
         if (config.worker_node) {
@@ -209,7 +210,6 @@ char* local_dispatch(const char *input) {
             char *id = NULL;
             char *name = NULL;
             char *ip = NULL;
-            char *groups = NULL;
             char *key_hash = NULL;
             char *key = NULL;
             authd_force_options_t force_options = {0};
@@ -342,6 +342,7 @@ fail:
     output = cJSON_PrintUnformatted(response);
     cJSON_Delete(response);
     cJSON_Delete(request);
+    os_free(groups);
     return output;
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|#10400|

## Description

This PR frees the memory used by the `groups` variable in the `local_dispatch()` method in case the parsing fails.

## Tests

  - [x] Coverity
 