### PR TITLE
Fix memory leak in Vulnerability Detector

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5447,6 +5447,8 @@ int wm_vuldet_generate_win_cpe(agent_software *agent) {
 
     if (agent->os_display_version && *agent->os_display_version != ' ') {
         ver_aux = w_tolower_str(agent->os_display_version);
+        os_free(agent->os_display_version);
+        agent->os_display_version = ver_aux;
     } else {
         ver_aux = agent->os_release;
     }


### PR DESCRIPTION
|Related issue|
|---|
|#10407|

## Description

With this PR a fix has been applied to avoid the memory leak reported in Coverity.

The problem was found when applying the `w_tolower_str()` function which returned a pointer where its memory was never freed.
To avoid the problem, after using this function, the content that we convert to lowercase is eliminated (`agent->os_display_version`) and then assigned the new pointer with the lowercase content that will be freed together with the **`agent`** struct.

## Logs/Alerts example

After performing another analysis with Coverity, it reports that the memory leak has been eliminated as can be seen in the image (the other that has been eliminated is because it was in another branch):
![image](https://user-images.githubusercontent.com/37207742/136039169-59acbabc-bc01-4e28-9e01-185e3e756660.png)

And here I attach the link to the Coverity report:
https://u15810271.ct.sendgrid.net/ls/click?upn=HRESupC-2F2Czv4BOaCWWCy7my0P0qcxCbhZ31OYv50yqgxSCSCoUvZsyOQWelCN1eGu9HosOCYbyK-2BRVlIuFp0Q-3D-3DSy66_3yVA0AJkLK9RgkvZQZCJdHhspcw09JEPNyGmNvbjVXASwX1cjDRXj87W9lGLwtqqFcrF1m5rQwRnggJWzMPkOdaFezfBjCIv441VnFYYZrl6eXXjFnZjlJysyP-2FkbOPHW9Wsz-2FBQWyod3yBmbA3gCT5w6VZYH9c-2FFHsBkH475Kzqp3Jx-2BG4gS-2BFFZJWQMwpdD30kC53IQG4y0r6DnPUBJ8h2HQyjU8H5s5AuhBkli-2Fg-3D

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Source upgrade
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer

