### PR TITLE
Added syscollector sequence diagram from the manager side view

### DIFF
--- a/architecture/syscollector/003-sequence-manager-side.puml
+++ b/architecture/syscollector/003-sequence-manager-side.puml
@@ -1,0 +1,52 @@
+' Copyright (C) 2015-2021, Wazuh Inc.
+' Created by Wazuh, Inc. <info@wazuh.com>.
+' This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+@startuml syscollector-manager-side
+group Analysisd
+
+== Initialization ==
+analysisd -> syscollector_decoder : start
+analysisd -> dbsync_decoder : start
+analysisd -> wdb : start_dispatcher
+
+== Decoding ==
+
+group old syscollector model
+syscollector_decoder -> syscollector_decoder : decode_networks
+syscollector_decoder -> json_plugin_decoder : populate event info (fillData)
+
+syscollector_decoder -> syscollector_decoder : decode_osinfo
+syscollector_decoder -> json_plugin_decoder : populate event info (fillData)
+
+syscollector_decoder -> syscollector_decoder : decode_ports
+syscollector_decoder -> json_plugin_decoder : populate event info (fillData)
+
+syscollector_decoder -> syscollector_decoder : decode_hardware
+syscollector_decoder -> json_plugin_decoder : populate event info (fillData)
+
+syscollector_decoder -> syscollector_decoder : decode_processes
+syscollector_decoder -> json_plugin_decoder : populate event info (fillData)
+
+syscollector_decoder -> syscollector_decoder : decode_packages
+syscollector_decoder -> json_plugin_decoder : populate event info (fillData)
+end
+
+group new syscollector model
+syscollector_decoder -> syscollector_decoder : decode_dbsync
+syscollector_decoder -> json_plugin_decoder : populate event info (fillData)
+end
+
+/ note over json_plugin_decoder: Used for alerts generation
+
+
+end
+== DB Synchronization ==
+
+dbsync_decoder --> analysisd : dispatch message
+analysisd -> wdb
+database DB
+wdb -> wdb : parse_data
+wdb -> DB : save info
+
+@enduml

--- a/architecture/syscollector/Readme.md
+++ b/architecture/syscollector/Readme.md
@@ -26,4 +26,5 @@ The System Inventory feature interacts with different modules to split responsab
 The different sequence diagrams ilustrate the flow of the different modules interacting on the syscollector general use.the configuration.
 - 001-sequence-wm-syscollector: It explains the wazuh module syscollector initialization, construction, use, destruction and stop from the wazuh modules daemon perspective.
 - 002-sequence-syscollector: It explains the syscollector internal interactions with modules like dbsync, rsync and normalizer. This diagram shows how is the flow for data synchronization, checksum calculation, scan starting, etc.
+- 003-sequence-manager-side: It explains the modules interaction (analysisd, wdb) when a syscollector message arrives from the manager perspective. This diagram shows how is the flow from the modules initialization to the database storage.
 

--- a/architecture/wm_azure/001-sequence.puml
+++ b/architecture/wm_azure/001-sequence.puml
@@ -33,3 +33,5 @@
     end note
     Microsoft_Azure --> azure_logs.py
     azure_logs.py --> user
+
+@enduml


### PR DESCRIPTION
|Related issue|
|---|
|Closes #10382 |

## Description
This PR aims to review the sequence diagram being added to reflect the interaction of the modules involved since a message is received until the information is being processed and stored in the corresponding database.

## DoD
- [x] Create a plantUML sequence diagram in the corresponding folder
- [X] PR and team validation
![image](https://user-images.githubusercontent.com/22640902/136052802-91972891-d800-4e43-81b3-85de9317dcb0.png)

