### PR TITLE
Add unit test for encoder.py

### DIFF
--- a/api/api/test/test_encoder.py
+++ b/api/api/test/test_encoder.py
@@ -1,0 +1,48 @@
+from unittest.mock import ANY, MagicMock, patch
+
+import pytest
+
+with patch('wazuh.common.wazuh_uid'):
+    with patch('wazuh.common.wazuh_gid'):
+        from api.encoder import WazuhJSONEncoder, dumps, prettify
+        from wazuh.core.results import AbstractWazuhResult
+
+SAMPLE_DICT = {'k1': 'v1', 'k2': 'v2'}
+
+
+@pytest.mark.parametrize('mock_method', ['default', 'model', 'abtractwazuhresult'])
+def test_wjson_encoder(mock_method):
+    wjson_encoder = WazuhJSONEncoder()
+    assert wjson_encoder.include_nulls is False
+    mock_obj = AbstractWazuhResult({}) if mock_method == 'abtractwazuhresult' else MagicMock()
+
+    if mock_method == 'default':
+        with patch('api.encoder.isinstance', return_value=False):
+            with patch('api.encoder.JSONEncoder.default', return_value=SAMPLE_DICT) as mock_default:
+                result = wjson_encoder.default(mock_obj)
+                assert result == mock_default.return_value
+                mock_default.assert_called_once_with(wjson_encoder, mock_obj)
+    elif mock_method == 'model':
+        with patch('api.encoder.Model', new=MagicMock):
+            with patch('api.encoder.six.iteritems', return_value=SAMPLE_DICT.items()) as mock_iter:
+                mock_obj.attribute_map = SAMPLE_DICT
+                mock_obj.k1 = 'v3'
+                mock_obj.k2 = None
+                result = wjson_encoder.default(mock_obj)
+                assert result == {'v1': 'v3'}
+                mock_iter.assert_called_once_with(mock_obj.swagger_types)
+    elif mock_method == 'abtractwazuhresult':
+        with patch('wazuh.core.results.AbstractWazuhResult.render', return_value=SAMPLE_DICT) as mock_render:
+            result = wjson_encoder.default(mock_obj)
+            assert result == mock_render.return_value
+            mock_render.assert_called_once_with()
+
+
+@pytest.mark.parametrize('mock_method', [dumps, prettify])
+def test_wjson_method(mock_method):
+    with patch('api.encoder.WazuhJSONEncoder') as mock_wjsonencoder:
+        with patch('api.encoder.json.dumps', return_value=f'{SAMPLE_DICT}') as mock_jsondumps:
+            result = mock_method({})
+            assert result == mock_jsondumps.return_value
+            mock_jsondumps.assert_called_once_with({}, cls=mock_wjsonencoder) if mock_method == dumps \
+                else mock_jsondumps.assert_called_once_with({}, cls=mock_wjsonencoder, indent=ANY)


### PR DESCRIPTION
|Related issue|
|---|
| This PR closes #10391 |

## Description
I added a new python unit test for the API encoder located at `api/encoder.py`.


## Test
```
↪ ~/git/wazuh/api/api/test ⊶ feature/10391-encoder-unittest ⨘ pytest -vv -x --disable-warnings test_encoder.py 
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.9.5, pytest-5.4.3, py-1.10.0, pluggy-0.13.1 -- /home/kondent/pythonEnv/unittest-env/bin/python3.9
cachedir: .pytest_cache
rootdir: /home/kondent/git/wazuh/api
plugins: asyncio-0.15.1, cov-2.12.0
collected 5 items                                                                                                                                                                            

test_encoder.py::test_wjson_encoder[default] PASSED                                                                                                                                    [ 20%]
test_encoder.py::test_wjson_encoder[model] PASSED                                                                                                                                      [ 40%]
test_encoder.py::test_wjson_encoder[abtractwazuhresult] PASSED                                                                                                                         [ 60%]
test_encoder.py::test_wjson_method[dumps] PASSED                                                                                                                                       [ 80%]
test_encoder.py::test_wjson_method[prettify] PASSED                                                                                                                                    [100%]

=============================================================================== 5 passed, 9 warnings in 0.34s ================================================================================
```

## Coverage
```
Name                                        Stmts   Miss  Cover   Missing
-------------------------------------------------------------------------
encoder.py                                     24      0   100%
```

Regards,
Alexis