### PR TITLE
Change the way how dbsync getDeletedRows works to return only PKs values

### DIFF
--- a/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -347,7 +347,14 @@ void SQLiteDBEngine::returnRowsMarkedForDelete(const nlohmann::json& tableNames,
 
         if (0 != loadTableData(table))
         {
-            const auto& tableFields { m_tableFields[table] };
+            auto tableFields { m_tableFields[table] };
+            // Remove uneeded fields before looking for the expected ones.
+            tableFields.erase(std::remove_if(tableFields.begin(), tableFields.end(), [](const ColumnData& column)
+                    {
+                        const auto isNotTxnStatusField { !std::get<TableHeader::TXNStatusField>(column) };
+                        const auto isNotPK             { !std::get<TableHeader::PK>(column) };
+                        return isNotTxnStatusField && isNotPK;
+                    }), tableFields.end());
             const auto& stmt { getStatement(getSelectAllQuery(table, tableFields)) };
 
             while (SQLITE_ROW == stmt->step())

--- a/src/shared_modules/dbsync/tests/interface/dbsync_test.cpp
+++ b/src/shared_modules/dbsync/tests/interface/dbsync_test.cpp
@@ -1543,7 +1543,7 @@ TEST_F(DBSyncTest, createTxnCPP)
     CallbackMock wrapper;
     EXPECT_CALL(wrapper, callbackMock(INSERTED, nlohmann::json::parse(R"([{"name":"System","pid":4}])"))).Times(1);
     EXPECT_CALL(wrapper, callbackMock(INSERTED, nlohmann::json::parse(R"([{"name":"Guake","pid":7}])"))).Times(1);
-    EXPECT_CALL(wrapper, callbackMock(DELETED, nlohmann::json::parse(R"({"name":"System","pid":4})"))).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(DELETED, nlohmann::json::parse(R"({"pid":4})"))).Times(1);
 
     ResultCallbackData callbackData
     {

--- a/src/shared_modules/dbsync/tests/pipelineFactory/dbsyncPipelineFactory_test.cpp
+++ b/src/shared_modules/dbsync/tests/pipelineFactory/dbsyncPipelineFactory_test.cpp
@@ -219,8 +219,8 @@ TEST_F(DBSyncPipelineFactoryTest, PipelineSyncRowAndGetDeleted)
     };
     EXPECT_CALL(wrapper, callback(MODIFIED, nlohmann::json::parse(R"([{"pid":4,"tid":101}])"))).Times(1);
     EXPECT_CALL(wrapper, callback(INSERTED, nlohmann::json::parse(R"([{"pid":6,"name":"System2","tid":105}])"))).Times(1);
-    EXPECT_CALL(wrapper, callback(DELETED, nlohmann::json::parse(R"({"pid":5,"name":"System1","tid":101})"))).Times(1);
-    EXPECT_CALL(wrapper, callback(DELETED, nlohmann::json::parse(R"({"pid":7,"name":"System7","tid":101})"))).Times(1);
+    EXPECT_CALL(wrapper, callback(DELETED, nlohmann::json::parse(R"({"pid":5})"))).Times(1);
+    EXPECT_CALL(wrapper, callback(DELETED, nlohmann::json::parse(R"({"pid":7})"))).Times(1);
     DBSyncImplementation::instance().syncRowData(m_dbHandle, nlohmann::json::parse(jsonInputNoTxn), nullptr);
     const auto& json{ nlohmann::json::parse(R"({"tables": ["processes"]})") };
     const int threadNumber{ 1 };
@@ -257,7 +257,7 @@ TEST_F(DBSyncPipelineFactoryTest, PipelineSyncRowAndGetDeletedSameData)
     };
     EXPECT_CALL(wrapper, callback(MODIFIED, nlohmann::json::parse(R"([{"pid":4,"tid":101}])"))).Times(1);
     EXPECT_CALL(wrapper, callback(INSERTED, nlohmann::json::parse(R"([{"pid":6,"name":"System2","tid":105}])"))).Times(1);
-    EXPECT_CALL(wrapper, callback(DELETED, nlohmann::json::parse(R"({"pid":7,"name":"System7","tid":101})"))).Times(1);
+    EXPECT_CALL(wrapper, callback(DELETED, nlohmann::json::parse(R"({"pid":7})"))).Times(1);
     DBSyncImplementation::instance().syncRowData(m_dbHandle, nlohmann::json::parse(jsonInputNoTxn), nullptr);
     const auto& json{ nlohmann::json::parse(R"({"tables": ["processes"]})") };
     const int threadNumber{ 1 };


### PR DESCRIPTION
|Related issue|
|---|
|Closes #10384 |

## Description
This issue aims to change the way how the deleted information is being returned in DBSync.
- **Actual Results:**
  When DBSync is consulted to get the deleted rows information from the DB it returns the whole deleted information rows.
- **Expected Results:**
  When DBSync is consulted to get the deleted rows information from the DB it returns **only** the PKs of the affected rows.

## DoD
- [X] Update dbsync get deleted information mechanism
- [X] UTs
- [X] Manual validations tests
- [ ] CI checks