### PR TITLE
PR: Create rules and decoders for Wazuh API events

### DIFF
--- a/ruleset/decoders/0007-wazuh-api_decoders.xml
+++ b/ruleset/decoders/0007-wazuh-api_decoders.xml
@@ -1,0 +1,83 @@
+<!-- Sample log
+2021/04/20 16:00:35 INFO: wazuh 127.0.0.1 "PUT /agents/group" with parameters {"group_id": "group1", "agents_list": "629,650,654,682"} and body {} done in 0.075s: 200
+-->
+
+<decoder name="wazuh-api">
+   <prematch type="pcre2">\s\d+:\d+:\d+\s\w+:\s\w+\s\d+.\d+.\d+.\d+</prematch>
+</decoder>
+
+<decoder name="wazuh-api-block">
+  <prematch type="pcre2">^\d+\/\d+\/\d+\s\d+:\d+:\d+\s\w+:.+:\s\d+.\d+.\d+.\d+.\d+</prematch>
+</decoder>
+
+<decoder name="wazuh-api-son">
+  <parent>wazuh-api</parent>
+  <regex type="pcre2">^(\d+\/\d+\/\d+\s\d+:\d+:\d+)</regex>
+  <order>timestamp</order>
+</decoder>
+
+<decoder name="wazuh-api-son">
+  <parent>wazuh-api</parent>
+  <regex type="pcre2">^\d+\/\d+\/\d+\s\d+:\d+:\d+\s\w+:\s(\w+)</regex>
+  <order>user</order>
+</decoder>
+
+<decoder name="wazuh-api-son">
+  <parent>wazuh-api</parent>
+  <regex type="pcre2">\s(\w+):\s\w+</regex>
+  <order>type</order>
+</decoder>
+
+<decoder name="wazuh-api-son">
+  <parent>wazuh-api</parent>
+  <regex type="pcre2">(\d+.\d+.\d+.\d+)</regex>
+  <order>srcip</order>
+</decoder>
+
+<decoder name="wazuh-api-son">
+  <parent>wazuh-api</parent>
+  <regex type="pcre2">"(\w+)\s(.+)"\swith\sparameters\s\{(.+)\}\sand</regex>
+  <order>method,uri,parameters</order>
+</decoder>
+
+<decoder name="wazuh-api-son">
+  <parent>wazuh-api</parent>
+  <regex type="pcre2">"(.+)"\swith\sparameters\s\{.+\}\sand</regex>
+  <order>endpoint</order>
+</decoder>
+
+<decoder name="wazuh-api-son">
+  <parent>wazuh-api</parent>
+  <regex type="pcre2">and\sbody\s{(.+)}</regex>
+  <order>body</order>
+</decoder>
+
+<decoder name="wazuh-api-son">
+  <parent>wazuh-api</parent>
+  <regex type="pcre2">s:\s(\d+)</regex>
+  <order>http_status_code</order>
+</decoder>
+
+<decoder name="wazuh-api-son">
+  <parent>wazuh-api-block</parent>
+  <regex type="pcre2">^(\d+\/\d+\/\d+\s\d+:\d+:\d+)</regex>
+  <order>timestamp</order>
+</decoder>
+
+<decoder name="wazuh-api-son">
+  <parent>wazuh-api-block</parent>
+  <regex type="pcre2">\s(\w+):\s\w+</regex>
+  <order>type</order>
+</decoder>
+
+<decoder name="wazuh-api-son">
+  <parent>wazuh-api-block</parent>
+  <regex type="pcre2">:\s(\d+.\d+.\d+.\d+)</regex>
+  <order>srcip</order>
+</decoder>
+
+<decoder name="wazuh-api-son">
+  <parent>wazuh-api-block</parent>
+  <regex type="pcre2">:\s(.+):\s</regex>
+  <order>message</order>
+</decoder>

--- a/ruleset/rules/0017-wazuh-api_rules.xml
+++ b/ruleset/rules/0017-wazuh-api_rules.xml
@@ -10,7 +10,7 @@
  <description>Rules for Wazuh API events</description>
  <mitre>
   <id>T1102</id>
- <mitre>
+ </mitre>
 </rule>
 
 <rule id="401" level="3">
@@ -46,7 +46,7 @@
  <description>API blocking informative event</description>
  <mitre>
   <id>T1102</id>
-</mitre>
+ </mitre>
  <group>pci_dss_1.3.2,pci_dss_6.5.10,pci_dss_7.1,pci_dss_8.1,tsc_cc6.1,hipaa_164.312.a.1,gpg13_3.3,gpg13_7.1,nist_800_53_AC.7,nist_800_53_SC.5</group>
 </rule>
 
@@ -56,7 +56,7 @@
  <description>API blocking warning event</description>
  <mitre>
   <id>T1102</id>
-</mitre>
+ </mitre>
  <group>pci_dss_1.3.2,pci_dss_6.5.10,pci_dss_7.1,pci_dss_8.1,tsc_cc6.1,hipaa_164.312.a.1,gpg13_3.3,gpg13_7.1,nist_800_53_AC.7,nist_800_53_SC.5,gpg13_4.12</group>
 </rule>
 
@@ -66,7 +66,7 @@
  <description>API blocking error event</description>
  <mitre>
   <id>T1102</id>
-</mitre>
+ </mitre>
  <group>pci_dss_1.3.2,pci_dss_6.5.10,pci_dss_7.1,pci_dss_8.1,tsc_cc6.1,hipaa_164.312.a.1,gpg13_3.3,gpg13_7.1,nist_800_53_AC.7,nist_800_53_SC.5,gpg13_4.12,gpg13_4.3</group>
 </rule>
 
@@ -76,7 +76,7 @@
  <description>API blocking critical error event, requires inmediate atention</description>
  <mitre>
   <id>T1102</id>
-</mitre>
+ </mitre>
    <group>pci_dss_1.3.2,pci_dss_6.5.10,pci_dss_7.1,pci_dss_8.1,tsc_cc6.1,hipaa_164.312.a.1,gpg13_3.3,gpg13_7.1,nist_800_53_AC.7,nist_800_53_SC.5,gpg13_4.12,gpg13_4.3,pci_dss_10.6.1,gpg13_4.1</group>
 </rule>
 
@@ -100,7 +100,7 @@
  <group>gpg13_4.3,tsc_cc6.8,hipaa_164.312.e.1</group>
  <mitre>
   <id>T1102</id>
-</mitre>
+ </mitre>
 </rule>
 
 <rule id="412" level="7">
@@ -193,8 +193,7 @@
  <group>hipaa_164.312.e.1,gpg13_3.3,nist_800_53_AC.7,pci_dss_8.2</group>
  <mitre>
   <id>T1102</id>
-</mitre>
+ </mitre>
 </rule>
-
 
 </group>

--- a/ruleset/rules/0017-wazuh-api_rules.xml
+++ b/ruleset/rules/0017-wazuh-api_rules.xml
@@ -46,7 +46,7 @@
  <description>API blocking informative event</description>
  <mitre>
   <id>T1102</id>
- <mitre>
+</mitre>
  <group>pci_dss_1.3.2,pci_dss_6.5.10,pci_dss_7.1,pci_dss_8.1,tsc_cc6.1,hipaa_164.312.a.1,gpg13_3.3,gpg13_7.1,nist_800_53_AC.7,nist_800_53_SC.5</group>
 </rule>
 
@@ -56,7 +56,7 @@
  <description>API blocking warning event</description>
  <mitre>
   <id>T1102</id>
- <mitre>
+</mitre>
  <group>pci_dss_1.3.2,pci_dss_6.5.10,pci_dss_7.1,pci_dss_8.1,tsc_cc6.1,hipaa_164.312.a.1,gpg13_3.3,gpg13_7.1,nist_800_53_AC.7,nist_800_53_SC.5,gpg13_4.12</group>
 </rule>
 
@@ -66,7 +66,7 @@
  <description>API blocking error event</description>
  <mitre>
   <id>T1102</id>
- <mitre>
+</mitre>
  <group>pci_dss_1.3.2,pci_dss_6.5.10,pci_dss_7.1,pci_dss_8.1,tsc_cc6.1,hipaa_164.312.a.1,gpg13_3.3,gpg13_7.1,nist_800_53_AC.7,nist_800_53_SC.5,gpg13_4.12,gpg13_4.3</group>
 </rule>
 
@@ -76,7 +76,7 @@
  <description>API blocking critical error event, requires inmediate atention</description>
  <mitre>
   <id>T1102</id>
- <mitre>
+</mitre>
    <group>pci_dss_1.3.2,pci_dss_6.5.10,pci_dss_7.1,pci_dss_8.1,tsc_cc6.1,hipaa_164.312.a.1,gpg13_3.3,gpg13_7.1,nist_800_53_AC.7,nist_800_53_SC.5,gpg13_4.12,gpg13_4.3,pci_dss_10.6.1,gpg13_4.1</group>
 </rule>
 
@@ -100,7 +100,7 @@
  <group>gpg13_4.3,tsc_cc6.8,hipaa_164.312.e.1</group>
  <mitre>
   <id>T1102</id>
- <mitre>
+</mitre>
 </rule>
 
 <rule id="412" level="7">
@@ -193,7 +193,7 @@
  <group>hipaa_164.312.e.1,gpg13_3.3,nist_800_53_AC.7,pci_dss_8.2</group>
  <mitre>
   <id>T1102</id>
- <mitre>
+</mitre>
 </rule>
 
 

--- a/ruleset/rules/0017-wazuh-api_rules.xml
+++ b/ruleset/rules/0017-wazuh-api_rules.xml
@@ -23,18 +23,21 @@
  <if_sid>400</if_sid>
  <field name="type">WARNING</field>
  <description>API warning event</description>
+ <group>gpg13_4.12</group>
 </rule>
 
 <rule id="403" level="8">
  <if_sid>400</if_sid>
  <field name="type">ERROR</field>
  <description>API error event</description>
+ <groups>gpg13_4.3,gpg13_4.12</groups>
 </rule>
 
 <rule id="404" level="12">
  <if_sid>400</if_sid>
  <field name="type">CRITICAL</field>
  <description>API critical error event, requires inmediate atention</description>
+ <groups>pci_dss_10.6.1,gpg13_4.1,gpg13_4.3,gpg13_4.12</groups>
 </rule>
 
 <rule id="421" level="3">
@@ -44,6 +47,7 @@
  <mitre>
   <id>T1102</id>
  <mitre>
+ <group>pci_dss_1.3.2,pci_dss_6.5.10,pci_dss_7.1,pci_dss_8.1,tsc_cc6.1,hipaa_164.312.a.1,gpg13_3.3,gpg13_7.1,nist_800_53_AC.7,nist_800_53_SC.5</group>
 </rule>
 
 <rule id="422" level="5">
@@ -53,6 +57,7 @@
  <mitre>
   <id>T1102</id>
  <mitre>
+ <group>pci_dss_1.3.2,pci_dss_6.5.10,pci_dss_7.1,pci_dss_8.1,tsc_cc6.1,hipaa_164.312.a.1,gpg13_3.3,gpg13_7.1,nist_800_53_AC.7,nist_800_53_SC.5,gpg13_4.12</group>
 </rule>
 
 <rule id="423" level="8">
@@ -62,6 +67,7 @@
  <mitre>
   <id>T1102</id>
  <mitre>
+ <group>pci_dss_1.3.2,pci_dss_6.5.10,pci_dss_7.1,pci_dss_8.1,tsc_cc6.1,hipaa_164.312.a.1,gpg13_3.3,gpg13_7.1,nist_800_53_AC.7,nist_800_53_SC.5,gpg13_4.12,gpg13_4.3</group>
 </rule>
 
 <rule id="424" level="12">
@@ -71,12 +77,14 @@
  <mitre>
   <id>T1102</id>
  <mitre>
+   <group>pci_dss_1.3.2,pci_dss_6.5.10,pci_dss_7.1,pci_dss_8.1,tsc_cc6.1,hipaa_164.312.a.1,gpg13_3.3,gpg13_7.1,nist_800_53_AC.7,nist_800_53_SC.5,gpg13_4.12,gpg13_4.3,pci_dss_10.6.1,gpg13_4.1</group>
 </rule>
 
 <rule id="405" level="7">
  <if_sid>400</if_sid>
  <field name="http_status_code" negate="yes">200</field>
  <description>API's response code returned error</description>
+ <group>gpg13_4.3</group>
 </rule>
 
 <rule id="410" level="4">
@@ -89,6 +97,7 @@
  <if_sid>405</if_sid>
  <field name="http_status_code">401</field>
  <description>API's response code returned error: Unauthorized.</description>
+ <group>gpg13_4.3,tsc_cc6.8,hipaa_164.312.e.1</group>
  <mitre>
   <id>T1102</id>
  <mitre>
@@ -98,6 +107,7 @@
  <if_sid>405</if_sid>
  <field name="http_status_code">403</field>
  <description>API's response code returned error: Permission denied.</description>
+ <group>gpg13_4.3,tsc_cc6.8,hipaa_164.312.e.1,pci_dss_7.1,pci_dss_10.2.4,nist_800_53_AC.7</group>
 </rule>
 
 <rule id="413" level="4">
@@ -128,6 +138,7 @@
  <if_sid>405</if_sid>
  <field name="http_status_code">429</field>
  <description>API's response code: Max number of requests per minute reached</description>
+ <group>gpg13_4.3,tsc_cc6.8,hipaa_164.312.e.1,pci_dss_7.1,pci_dss_8.1.6,pci_dss_10.2.4,nist_800_53_AC.7</group>
 </rule>
 
 <rule id="418" level="4">
@@ -152,12 +163,14 @@
  <if_sid>400</if_sid>
  <field name="method">DELETE</field>
  <description>API's DELETE protocol event, data were deleted</description>
+ <group>pci_dss_8.1.2,hipaa_164.312.a.2.I,hipaa_164.312.c.1</group>
 </rule>
 
 <rule id="409" level="6">
  <if_sid>400</if_sid>
  <field name="method">POST</field>
  <description>API's POST protocol event, data were transfered</description>
+ <group>hipaa_164.312.c.1</group>
 </rule>
 
 <rule id="425" level="0">
@@ -170,12 +183,14 @@
  <if_sid>425</if_sid>
  <field name="http_status_code">200</field>
  <description>Authentication success to the API</description>
+ <group>hipaa_164.312.d,pci_dss_8.2</group>
 </rule>
 
 <rule id="427" level="7">
  <if_sid>425</if_sid>
  <field name="http_status_code" negate="yes">200</field>
  <description>API authentication failure</description>
+ <group>hipaa_164.312.e.1,gpg13_3.3,nist_800_53_AC.7,pci_dss_8.2</group>
  <mitre>
   <id>T1102</id>
  <mitre>

--- a/ruleset/rules/0017-wazuh-api_rules.xml
+++ b/ruleset/rules/0017-wazuh-api_rules.xml
@@ -8,6 +8,9 @@
 <rule id="420" level="0">
  <decoded_as>wazuh-api-block</decoded_as>
  <description>Rules for Wazuh API events</description>
+ <mitre>
+  <id>T1102</id>
+ <mitre>
 </rule>
 
 <rule id="401" level="3">
@@ -38,24 +41,36 @@
  <if_sid>420</if_sid>
  <field name="type">INFO</field>
  <description>API blocking informative event</description>
+ <mitre>
+  <id>T1102</id>
+ <mitre>
 </rule>
 
 <rule id="422" level="5">
  <if_sid>420</if_sid>
  <field name="type">WARNING</field>
  <description>API blocking warning event</description>
+ <mitre>
+  <id>T1102</id>
+ <mitre>
 </rule>
 
 <rule id="423" level="8">
  <if_sid>420</if_sid>
  <field name="type">ERROR</field>
  <description>API blocking error event</description>
+ <mitre>
+  <id>T1102</id>
+ <mitre>
 </rule>
 
 <rule id="424" level="12">
  <if_sid>420</if_sid>
  <field name="type">CRITICAL</field>
  <description>API blocking critical error event, requires inmediate atention</description>
+ <mitre>
+  <id>T1102</id>
+ <mitre>
 </rule>
 
 <rule id="405" level="7">
@@ -74,6 +89,9 @@
  <if_sid>405</if_sid>
  <field name="http_status_code">401</field>
  <description>API's response code returned error: Unauthorized.</description>
+ <mitre>
+  <id>T1102</id>
+ <mitre>
 </rule>
 
 <rule id="412" level="7">
@@ -158,6 +176,9 @@
  <if_sid>425</if_sid>
  <field name="http_status_code" negate="yes">200</field>
  <description>API authentication failure</description>
+ <mitre>
+  <id>T1102</id>
+ <mitre>
 </rule>
 
 

--- a/ruleset/rules/0017-wazuh-api_rules.xml
+++ b/ruleset/rules/0017-wazuh-api_rules.xml
@@ -1,0 +1,164 @@
+<group name="wazuh-api">
+
+<rule id="400" level="0">
+ <decoded_as>wazuh-api</decoded_as>
+ <description>Rules for Wazuh API events</description>
+</rule>
+
+<rule id="420" level="0">
+ <decoded_as>wazuh-api-block</decoded_as>
+ <description>Rules for Wazuh API events</description>
+</rule>
+
+<rule id="401" level="3">
+ <if_sid>400</if_sid>
+ <field name="type">INFO</field>
+ <description>API informative event</description>
+</rule>
+
+<rule id="402" level="5">
+ <if_sid>400</if_sid>
+ <field name="type">WARNING</field>
+ <description>API warning event</description>
+</rule>
+
+<rule id="403" level="8">
+ <if_sid>400</if_sid>
+ <field name="type">ERROR</field>
+ <description>API error event</description>
+</rule>
+
+<rule id="404" level="12">
+ <if_sid>400</if_sid>
+ <field name="type">CRITICAL</field>
+ <description>API critical error event, requires inmediate atention</description>
+</rule>
+
+<rule id="421" level="3">
+ <if_sid>420</if_sid>
+ <field name="type">INFO</field>
+ <description>API blocking informative event</description>
+</rule>
+
+<rule id="422" level="5">
+ <if_sid>420</if_sid>
+ <field name="type">WARNING</field>
+ <description>API blocking warning event</description>
+</rule>
+
+<rule id="423" level="8">
+ <if_sid>420</if_sid>
+ <field name="type">ERROR</field>
+ <description>API blocking error event</description>
+</rule>
+
+<rule id="424" level="12">
+ <if_sid>420</if_sid>
+ <field name="type">CRITICAL</field>
+ <description>API blocking critical error event, requires inmediate atention</description>
+</rule>
+
+<rule id="405" level="7">
+ <if_sid>400</if_sid>
+ <field name="http_status_code" negate="yes">200</field>
+ <description>API's response code returned error</description>
+</rule>
+
+<rule id="410" level="4">
+ <if_sid>405</if_sid>
+ <field name="http_status_code">400</field>
+ <description>API's response code returned error: Bad request.</description>
+</rule>
+
+<rule id="411" level="6">
+ <if_sid>405</if_sid>
+ <field name="http_status_code">401</field>
+ <description>API's response code returned error: Unauthorized.</description>
+</rule>
+
+<rule id="412" level="7">
+ <if_sid>405</if_sid>
+ <field name="http_status_code">403</field>
+ <description>API's response code returned error: Permission denied.</description>
+</rule>
+
+<rule id="413" level="4">
+ <if_sid>405</if_sid>
+ <field name="http_status_code">404</field>
+ <description>API's response code returned error: Resource not found.</description>
+</rule>
+
+<rule id="414" level="4">
+ <if_sid>405</if_sid>
+ <field name="http_status_code">405</field>
+ <description>API's response code returned error: Invalid HTTP method.</description>
+</rule>
+
+<rule id="415" level="4">
+ <if_sid>405</if_sid>
+ <field name="http_status_code">406</field>
+ <description>API's response code returned error: Invalid content-type</description>
+</rule>
+
+<rule id="416" level="4">
+ <if_sid>405</if_sid>
+ <field name="http_status_code">413</field>
+ <description>API's response code returned: Maximum request body size exceeded</description>
+</rule>
+
+<rule id="417" level="7">
+ <if_sid>405</if_sid>
+ <field name="http_status_code">429</field>
+ <description>API's response code: Max number of requests per minute reached</description>
+</rule>
+
+<rule id="418" level="4">
+ <if_sid>405</if_sid>
+ <field name="http_status_code">500</field>
+ <description>API's response code: Internal error</description>
+</rule>
+
+<rule id="406" level="4">
+ <if_sid>400</if_sid>
+ <field name="method">GET</field>
+ <description>API's GET protocol event, data were received</description>
+</rule>
+
+<rule id="407" level="6">
+ <if_sid>400</if_sid>
+ <field name="method">PUT</field>
+ <description>API's PUT protocol event, data were saved</description>
+</rule>
+
+<rule id="408" level="8">
+ <if_sid>400</if_sid>
+ <field name="method">DELETE</field>
+ <description>API's DELETE protocol event, data were deleted</description>
+</rule>
+
+<rule id="409" level="6">
+ <if_sid>400</if_sid>
+ <field name="method">POST</field>
+ <description>API's POST protocol event, data were transfered</description>
+</rule>
+
+<rule id="425" level="0">
+ <if_sid>400</if_sid>
+ <field name="uri">/security/user/authenticate</field>
+ <description>Authentication attempt</description>
+</rule>
+
+<rule id="426" level="3">
+ <if_sid>425</if_sid>
+ <field name="http_status_code">200</field>
+ <description>Authentication success to the API</description>
+</rule>
+
+<rule id="427" level="7">
+ <if_sid>425</if_sid>
+ <field name="http_status_code" negate="yes">200</field>
+ <description>API authentication failure</description>
+</rule>
+
+
+</group>


### PR DESCRIPTION
|Related issue|
|---|
| #8321 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR adds the rules and decoders for Wazuh API.

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

Rules made in a Wazuh manager with version 4.2.2.
Using the following sample logs:
```
2021/04/20 16:00:35 INFO: wazuh 127.0.0.1 "PUT /agents/group" with parameters {"group_id": "group1", "agents_list":629,650,654,682"} and body {} done in 0.075s: 200
2021/10/04 15:23:55 WARNING: IP blocked due to exceeded number of logins attempts: 172.18.0.1
2021/10/04 15:23:55 INFO: unknown_user 172.18.0.1 "GET /security/user/authenticate" with parameters {} and body {} done in 0.001s: 403
```

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

After running the `wazuh-logtest` facility we have the next results:
```
root@ubuntu20LTS:/home/vagrant# /var/ossec/bin/wazuh-logtest
Starting wazuh-logtest v4.2.2
Type one log per line

2021/10/04 15:23:55 WARNING: IP blocked due to exceeded number of logins attempts: 172.18.0.1

**Phase 1: Completed pre-decoding.
	full event: '2021/10/04 15:23:55 WARNING: IP blocked due to exceeded number of logins attempts: 172.18.0.1'

**Phase 2: Completed decoding.
	name: 'wazuh-api-block'
	message: 'IP blocked due to exceeded number of logins attempts'
	srcip: '172.18.0.1'
	timestamp: '2021/10/04 15:23:55'
	type: 'WARNING'

**Phase 3: Completed filtering (rules).
	id: '422'
	level: '5'
	description: 'API blocking warning event'
	groups: '['wazuh-apipci_dss_1.3.2']'
	firedtimes: '1'
	gpg13: '['3.3', '7.1', '4.12']'
	hipaa: '['164.312.a.1']'
	mail: 'False'
	mitre.id: '['T1102']'
	mitre.tactic: '['Command and Control', 'Defense Evasion']'
	mitre.technique: '['Web Service']'
	nist_800_53: '['AC.7', 'SC.5']'
	pci_dss: '['6.5.10', '7.1', '8.1']'
	tsc: '['cc6.1']'
**Alert to be generated.

2021/10/04 15:23:55 INFO: unknown_user 172.18.0.1 "GET /security/user/authenticate" with parameters {} and body {} done in 0.001s: 403

**Phase 1: Completed pre-decoding.
	full event: '2021/10/04 15:23:55 INFO: unknown_user 172.18.0.1 "GET /security/user/authenticate" with parameters {} and body {} done in 0.001s: 403'

**Phase 2: Completed decoding.
	name: 'wazuh-api'
	dstuser: 'unknown_user'
	http_status_code: '403'
	srcip: '2021/10/04 15'
	timestamp: '2021/10/04 15:23:55'
	type: 'INFO'

**Phase 3: Completed filtering (rules).
	id: '412'
	level: '7'
	description: 'API's response code returned error: Permission denied.'
	groups: '['wazuh-apigpg13_4.3']'
	firedtimes: '1'
	hipaa: '['164.312.e.1']'
	mail: 'False'
	nist_800_53: '['AC.7']'
	pci_dss: '['7.1', '10.2.4']'
	tsc: '['cc6.8']'
**Alert to be generated.

2021/10/04 15:23:55 INFO: unknown_user 172.18.0.1 "GET /security/user/authenticate" with parameters {} and body {} done in 0.001s: 403

**Phase 1: Completed pre-decoding.
	full event: '2021/10/04 15:23:55 INFO: unknown_user 172.18.0.1 "GET /security/user/authenticate" with parameters {} and body {} done in 0.001s: 403'

**Phase 2: Completed decoding.
	name: 'wazuh-api'
	dstuser: 'unknown_user'
	http_status_code: '403'
	srcip: '2021/10/04 15'
	timestamp: '2021/10/04 15:23:55'
	type: 'INFO'

**Phase 3: Completed filtering (rules).
	id: '412'
	level: '7'
	description: 'API's response code returned error: Permission denied.'
	groups: '['wazuh-apigpg13_4.3']'
	firedtimes: '2'
	hipaa: '['164.312.e.1']'
	mail: 'False'
	nist_800_53: '['AC.7']'
	pci_dss: '['7.1', '10.2.4']'
	tsc: '['cc6.8']'
**Alert to be generated.
```

<!--
Paste here related logs and alerts
-->

## Tests

The manager starts correctly and no errors nor warnings are shown with `wazuh-analysisd -t`
```
root@ubuntu20LTS:/home/vagrant# /var/ossec/bin/wazuh-analysisd -t
root@ubuntu20LTS:/home/vagrant# 
```