### PR TITLE
Fix premature agent group file cleanup in DB sync module

### DIFF
--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -120,7 +120,6 @@ void* wm_database_main(wm_database *data) {
     }
 
 #ifndef LOCAL
-    wm_clean_dangling_groups();
     wm_clean_dangling_db();
 #endif
 
@@ -131,6 +130,9 @@ void* wm_database_main(wm_database *data) {
 
         wm_inotify_setup(data);
 
+#ifndef LOCAL
+        wm_clean_dangling_groups();
+#endif
         while (1) {
             path = wm_inotify_pop();
 
@@ -171,6 +173,7 @@ void* wm_database_main(wm_database *data) {
                 wm_check_agents();
                 wm_scan_directory(GROUPS_DIR);
                 wm_sync_multi_groups(SHAREDCFG_DIR);
+                wm_clean_dangling_groups();
             }
 #endif
             gettime(&spec1);


### PR DESCRIPTION
|Related issue|
|---|
|#10365|

This PR aims to switch the synchronization order of the agent data elements.

## Rationale

The DB sync module searches for dangling agent group assignation files (at _queue/agent-groups_) to clean up this folder. However, it first cleans up the folder and then synchronizes the database from the file _client.keys_. That may potentially cause two problems:

1. Files from agents that are no longer in _client.keys_ but have not been synced up in the database yet, will remain dangling until the manager gets restarted twice.
2. Valid group files whose agent has not been inserted in the database yet, will be wrongly deleted.

## Proposed fix

- Let the module sync up the agent database from _client.keys_ before cleaning up the groups folder.
- Apply this change in both real-time and iterative modes.

## Tests

- [X] Dangling group files get deleted.
- [X] Dangling group files of unsynced removed agents get deleted.
- [X] Valid files of unsynced agents remain in the folder.