### PR TITLE
Remove freezegun from Python dependencies

### DIFF
--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -28,7 +28,6 @@ docutils==0.15.2
 ecdsa==0.16.1
 envparse==0.2.0
 Flask==1.1.2
-freezegun==1.1.0
 future==0.17.1
 google-api-core==1.30.0
 googleapis-common-protos==1.51.0


### PR DESCRIPTION
Recently we have added an incorrect dependency, the **freezegun** dependency is not necessary for Wazuh to work. 