### PR TITLE
Handle more exceptions in the wodles and remove duplicated functions from framework file

### DIFF
--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -29,7 +29,7 @@ except (FileNotFoundError, PermissionError):
 @lru_cache(maxsize=None)
 def find_wazuh_path() -> str:
     """
-    Dynamically gets the Wazuh installation path.
+    Get the Wazuh installation path.
 
     Returns
     -------

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -29,9 +29,12 @@ except (FileNotFoundError, PermissionError):
 @lru_cache(maxsize=None)
 def find_wazuh_path():
     """
-    Gets the path where Wazuh is installed dinamically
+    Returns the version of Wazuh installed.
 
-    :return: str path where Wazuh is installed or empty string if there is no framework in the environment
+    Returns
+    -------
+    str
+        The version of Wazuh installed.
     """
     abs_path = os.path.abspath(os.path.dirname(__file__))
     allparts = []
@@ -55,49 +58,6 @@ def find_wazuh_path():
         pass
 
     return wazuh_path
-
-
-def call_wazuh_control(option) -> str:
-    wazuh_control = os.path.join(find_wazuh_path(), "bin", "wazuh-control")
-    try:
-        proc = subprocess.Popen([wazuh_control, option], stdout=subprocess.PIPE)
-        (stdout, stderr) = proc.communicate()
-        return stdout.decode()
-    except:
-        return None
-
-
-def get_wazuh_info(field) -> str:
-    wazuh_info = call_wazuh_control("info")
-    if not wazuh_info:
-        return "ERROR"
-
-    if not field:
-        return wazuh_info
-
-    env_variables = wazuh_info.rsplit("\n")
-    env_variables.remove("")
-    wazuh_env_vars = dict()
-    for env_variable in env_variables:
-        key, value = env_variable.split("=")
-        wazuh_env_vars[key] = value.replace("\"", "")
-
-    return wazuh_env_vars[field]
-
-
-@lru_cache(maxsize=None)
-def get_wazuh_version() -> str:
-    return get_wazuh_info("WAZUH_VERSION")
-
-
-@lru_cache(maxsize=None)
-def get_wazuh_revision() -> str:
-    return get_wazuh_info("WAZUH_REVISION")
-
-
-@lru_cache(maxsize=None)
-def get_wazuh_type() -> str:
-    return get_wazuh_info("WAZUH_TYPE")
 
 
 wazuh_path = find_wazuh_path()

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -27,14 +27,14 @@ except (FileNotFoundError, PermissionError):
 
 
 @lru_cache(maxsize=None)
-def find_wazuh_path():
+def find_wazuh_path() -> str:
     """
-    Returns the version of Wazuh installed.
+    Dynamically gets the Wazuh installation path.
 
     Returns
     -------
     str
-        The version of Wazuh installed.
+        Path where Wazuh is installed or empty string if there is no framework in the environment.
     """
     abs_path = os.path.abspath(os.path.dirname(__file__))
     allparts = []

--- a/wodles/utils.py
+++ b/wodles/utils.py
@@ -11,7 +11,7 @@ from sys import exit
 @lru_cache(maxsize=None)
 def find_wazuh_path() -> str:
     """
-    Dynamically gets the Wazuh installation path.
+    Get the Wazuh installation path.
 
     Returns
     -------
@@ -44,7 +44,7 @@ def find_wazuh_path() -> str:
 
 def call_wazuh_control(option: str) -> str:
     """
-    Executes the wazuh-control script with the parameters specified.
+    Execute the wazuh-control script with the parameters specified.
 
     Parameters
     ----------
@@ -68,7 +68,7 @@ def call_wazuh_control(option: str) -> str:
 
 def get_wazuh_info(field: str) -> str:
     """
-    Executes the wazuh-control script with the 'info' argument, filtering by field if specified.
+    Execute the wazuh-control script with the 'info' argument, filtering by field if specified.
 
     Parameters
     ----------
@@ -101,7 +101,7 @@ def get_wazuh_info(field: str) -> str:
 @lru_cache(maxsize=None)
 def get_wazuh_version() -> str:
     """
-    Returns the version of Wazuh installed.
+    Return the version of Wazuh installed.
 
     Returns
     -------
@@ -114,7 +114,7 @@ def get_wazuh_version() -> str:
 @lru_cache(maxsize=None)
 def get_wazuh_revision() -> str:
     """
-    Returns the revision of the Wazuh instance installed.
+    Return the revision of the Wazuh instance installed.
 
     Returns
     -------
@@ -127,7 +127,7 @@ def get_wazuh_revision() -> str:
 @lru_cache(maxsize=None)
 def get_wazuh_type() -> str:
     """
-    Returns the type of Wazuh instance installed.
+    Return the type of Wazuh instance installed.
 
     Returns
     -------

--- a/wodles/utils.py
+++ b/wodles/utils.py
@@ -66,7 +66,7 @@ def call_wazuh_control(option: str) -> str:
         exit(1)
 
 
-def get_wazuh_info(field) -> str:
+def get_wazuh_info(field: str) -> str:
     """
     Executes the wazuh-control script with the 'info' argument, filtering by field if specified.
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #10155 |

## Description
In this PR we start handling exceptions that were in a `try: except: pass` block in the external integration modules, and move some unused and duplicated code out of the framework code.

The fixed vulnerabilities has been removed in [this PR](https://github.com/wazuh/wazuh-qa/pull/2339) from the wazuh-qa's `known_flaws` files.
## Tests performed

### Unit tests
<details><summary>Framework unit tests</summary>
<p><pre>
==================================== test session starts ====================================
platform linux -- Python 3.9.7, pytest-6.0.1, py-1.10.0, pluggy-0.13.1
rootdir: /home/wazuh/git/wazuh/framework
collected 1655 items                                                                        

framework/wazuh/core/cluster/dapi/tests/test_dapi.py .........................        [  1%]
framework/wazuh/core/cluster/tests/test_cluster.py ...................                [  2%]
framework/wazuh/core/cluster/tests/test_common.py .......                             [  3%]
framework/wazuh/core/cluster/tests/test_control.py sssss                              [  3%]
framework/wazuh/core/cluster/tests/test_local_client.py .                             [  3%]
framework/wazuh/core/cluster/tests/test_utils.py .......                              [  3%]
framework/wazuh/core/cluster/tests/test_worker.py ............ssss.s                  [  4%]
framework/wazuh/core/tests/test_active_response.py ..............                     [  5%]
framework/wazuh/core/tests/test_agent.py ............................................ [  8%]
..................................................................................... [ 13%]
.....................................                                                 [ 15%]
framework/wazuh/core/tests/test_cdb_list.py ......................................    [ 18%]
framework/wazuh/core/tests/test_common.py .......                                     [ 18%]
framework/wazuh/core/tests/test_configuration.py .................................... [ 20%]
                                                                                      [ 20%]
framework/wazuh/core/tests/test_database.py .............                             [ 21%]
framework/wazuh/core/tests/test_decoder.py ................                           [ 22%]
framework/wazuh/core/tests/test_exception.py ...                                      [ 22%]
framework/wazuh/core/tests/test_input_validator.py ...                                [ 22%]
framework/wazuh/core/tests/test_logtest.py ..                                         [ 22%]
framework/wazuh/core/tests/test_manager.py ...............                            [ 23%]
framework/wazuh/core/tests/test_mitre.py .............                                [ 24%]
framework/wazuh/core/tests/test_pyDaemonModule.py .....                               [ 24%]
framework/wazuh/core/tests/test_results.py ........................................   [ 27%]
framework/wazuh/core/tests/test_rootcheck.py .............                            [ 28%]
framework/wazuh/core/tests/test_rule.py ......................                        [ 29%]
framework/wazuh/core/tests/test_sca.py ............                                   [ 30%]
framework/wazuh/core/tests/test_security.py ............                              [ 30%]
framework/wazuh/core/tests/test_stats.py ............                                 [ 31%]
framework/wazuh/core/tests/test_syscheck.py ......                                    [ 32%]
framework/wazuh/core/tests/test_syscollector.py ...                                   [ 32%]
framework/wazuh/core/tests/test_task.py ........                                      [ 32%]
framework/wazuh/core/tests/test_utils.py ............................................ [ 35%]
..................................................................................... [ 40%]
..................................................................................... [ 45%]
..............                                                                        [ 46%]
framework/wazuh/core/tests/test_vulnerability.py .                                    [ 46%]
framework/wazuh/core/tests/test_wazuh_queue.py ..................                     [ 47%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................                  [ 48%]
framework/wazuh/core/tests/test_wdb.py ......................                         [ 50%]
framework/wazuh/core/tests/test_wlogging.py ........                                  [ 50%]
framework/wazuh/rbac/tests/test_auth_context.py ..                                    [ 50%]
framework/wazuh/rbac/tests/test_decorators.py ....................................... [ 53%]
..................................................................                    [ 57%]
framework/wazuh/rbac/tests/test_default_configuration.py ............................ [ 58%]
...........................                                                           [ 60%]
framework/wazuh/rbac/tests/test_orm.py .............................................. [ 63%]
........                                                                              [ 63%]
framework/wazuh/rbac/tests/test_preprocessor.py ...........                           [ 64%]
framework/wazuh/tests/test_active_response.py ............                            [ 65%]
framework/wazuh/tests/test_agent.py ................................................. [ 68%]
............................................................                          [ 71%]
framework/wazuh/tests/test_cdb_list.py .............................................. [ 74%]
.......                                                                               [ 74%]
framework/wazuh/tests/test_ciscat.py .................................                [ 76%]
framework/wazuh/tests/test_cluster.py .....ss                                         [ 77%]
framework/wazuh/tests/test_decoder.py ...................................             [ 79%]
framework/wazuh/tests/test_group.py ........                                          [ 79%]
framework/wazuh/tests/test_logtest.py ......                                          [ 80%]
framework/wazuh/tests/test_manager.py ....................................            [ 82%]
framework/wazuh/tests/test_mitre.py .......                                           [ 82%]
framework/wazuh/tests/test_rootcheck.py ............................................. [ 85%]
.....                                                                                 [ 85%]
framework/wazuh/tests/test_rule.py .................................................. [ 88%]
......                                                                                [ 89%]
framework/wazuh/tests/test_sca.py .......                                             [ 89%]
framework/wazuh/tests/test_security.py .............................................. [ 92%]
...........................                                                           [ 94%]
framework/wazuh/tests/test_stats.py .......                                           [ 94%]
framework/wazuh/tests/test_syscheck.py .........................                      [ 96%]
framework/wazuh/tests/test_syscollector.py ............                               [ 96%]
framework/wazuh/tests/test_task.py ............................                       [ 98%]
framework/wazuh/tests/test_vulnerability.py ..........................                [100%]

================= 1643 passed, 12 skipped, 36 warnings in 265.13s (0:04:25) =================
</pre></p>
</details>  

#### API
<details><summary>API unit tests</summary>
<p><pre>
==================================== test session starts ====================================
platform linux -- Python 3.9.7, pytest-6.0.1, py-1.10.0, pluggy-0.13.1
rootdir: /home/wazuh/git/wazuh/api
collected 451 items                                                                         

api/api/controllers/test/test_active_response_controller.py s                         [  0%]
api/api/controllers/test/test_agent_controller.py sssssssssssssssssssssssssssssssssss [  7%]
sssss                                                                                 [  9%]
api/api/controllers/test/test_cdb_list_controller.py ssssss                           [ 10%]
api/api/controllers/test/test_ciscat_controller.py s                                  [ 10%]
api/api/controllers/test/test_cluster_controller.py ssssssssssssssssssssss            [ 15%]
api/api/controllers/test/test_decoder_controller.py sssssss                           [ 17%]
api/api/controllers/test/test_default_controller.py s                                 [ 17%]
api/api/controllers/test/test_experimental_controller.py ssssssssssssss.              [ 20%]
api/api/controllers/test/test_manager_controller.py sssssssssssssssss                 [ 24%]
api/api/controllers/test/test_mitre_controller.py sssssss                             [ 25%]
api/api/controllers/test/test_overview_controller.py s                                [ 26%]
api/api/controllers/test/test_rootcheck_controller.py ssss                            [ 27%]
api/api/controllers/test/test_rule_controller.py ssssssss                             [ 28%]
api/api/controllers/test/test_sca_controller.py ss                                    [ 29%]
api/api/controllers/test/test_security_controller.py ssssssssssssssssssssssssssssssss [ 36%]
sssssssssssssssssss                                                                   [ 40%]
api/api/controllers/test/test_syscheck_controller.py ssss                             [ 41%]
api/api/controllers/test/test_syscollector_controller.py sssssssss                    [ 43%]
api/api/controllers/test/test_task_controller.py s                                    [ 43%]
api/api/controllers/test/test_vulnerability_controller.py s                           [ 43%]
api/api/models/test/test_model.py ..........sss..............                         [ 49%]
api/api/test/test_alogging.py ..........                                              [ 52%]
api/api/test/test_authentication.py ..........                                        [ 54%]
api/api/test/test_configuration.py ..........................................         [ 63%]
api/api/test/test_util.py ...................................                         [ 71%]
api/api/test/test_validator.py ...................................................... [ 83%]
...........................................................................           [100%]

====================== 251 passed, 200 skipped, 387 warnings in 1.83s =======================
</pre></p>
</details>  
 
### Integration tests
<details><p><pre>
test_agent_DELETE_endpoints.tavern.yaml 
	 6 passed, 8 warnings

test_agent_GET_endpoints.tavern.yaml 
	 91 passed, 98 warnings

test_agent_POST_endpoints.tavern.yaml 
man nc	 5 passed, 7 warnings

test_agent_PUT_endpoints.tavern.yaml 
	 8 passed, 2 xpassed, 12 warnings

test_manager_endpoints.tavern.yaml 
	 31 passed, 34 warnings

test_rbac_black_agent_endpoints.tavern.yaml 
	 41 passed, 43 warnings

test_rbac_black_manager_endpoints.tavern.yaml 
	 15 passed, 17 warnings

test_rbac_white_agent_endpoints.tavern.yaml 
	 41 passed, 43 warnings

test_rbac_white_manager_endpoints.tavern.yaml 
	 15 passed, 17 warnings
</pre></p></details>  


### Manual tests
Only the AWS and GCP module were tested since those are the only modules that used any of the affected functions.  

#### AWS
Everything was working as expected. 
<details><summary>AWS tests</summary>
<p><pre>
root@f40a4bffa9c7:/var/ossec/wodles/aws# ./aws-s3 -sr cloudwatchlogs -d 1 -r us-east-1 -s 2020-sep-01  -g wazuh-test
DEBUG: +++ Debug mode on - Level: 1
DEBUG: +++ Getting alerts from "us-east-1" region.
DEBUG: only logs: 1598918400000
DEBUG: +++ Table does not exist; create
DEBUG: Getting log streams for "wazuh-test" log group
DEBUG: Getting data from DB for log stream "stream-1" in log group "wazuh-test"
DEBUG: Getting CloudWatch logs from log stream "stream-1" in log group "wazuh-test" using token "None", start_time "1598918400000" and end_time "None"
DEBUG: +++ Sending events to Analysd...
DEBUG: +++ Sending events to Analysd...
DEBUG: +++ Sending events to Analysd...
DEBUG: Getting CloudWatch logs from log stream "stream-1" in log group "wazuh-test" using token "f/XXXXXXXXX/s", start_time "1598918400000" and end_time "None"
DEBUG: Saving data for log group "wazuh-test" and log stream "stream-1".
DEBUG: Getting data from DB for log stream "stream-2" in log group "wazuh-test"
DEBUG: Getting CloudWatch logs from log stream "stream-2" in log group "wazuh-test" using token "None", start_time "1598918400000" and end_time "None"
DEBUG: +++ Sending events to Analysd...
DEBUG: +++ Sending events to Analysd...
DEBUG: +++ Sending events to Analysd...
DEBUG: Getting CloudWatch logs from log stream "stream-2" in log group "wazuh-test" using token "f/XXXXXXXXX/s", start_time "1598918400000" and end_time "None"
DEBUG: Saving data for log group "wazuh-test" and log stream "stream-2".
DEBUG: Purging the BD
DEBUG: Getting log streams for "wazuh-test" log group
DEBUG: committing changes and closing the DB
</pre></p>
</details>  

#### GCP
Everything worked fine too.
<details><summary>GCP tests</summary><p>
<pre>
root@f40a4bffa9c7:/# /var/ossec/wodles/gcloud/gcloud -p wazuh-test -s test_gcloud_blog -c /var/ossec/wodles/gcloud/credentials.json -l 2
gcloud_wodle - INFO - Received and acknowledged 100 messages
</pre></p></details>

#### test_python_flaws.py
The `test_python_flaws.py` test was executed for the branch developed for this PR and no new issues were detected. Also, the flaws reported by this issue were succesfully removed by the test.
```
(venv) ➜  wazuh-qa git:(feature/2230-mark-wazuh-10155-solved) ✗ pytest tests/scans/code_analysis/test_python_flaws.py --branch feature/10155-handle-exception-wodles                   
==================================== test session starts ====================================
platform linux -- Python 3.9.9, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /home/gonzz/git/wazuh-qa
plugins: html-2.0.1, metadata-1.11.0, testinfra-5.0.0
collected 1 item                                                                            

tests/scans/code_analysis/test_python_flaws.py .                                      [100%]

===================================== warnings summary ======================================
tests/scans/code_analysis/test_python_flaws.py::test_check_security_flaws
  invalid escape sequence \g

tests/scans/code_analysis/test_python_flaws.py::test_check_security_flaws
  invalid escape sequence \d

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=============================== 1 passed, 2 warnings in 9.27s ===============================
```