### PR TITLE
Read destinationIp from win.eventdata in Active Responses.

### DIFF
--- a/src/active-response/active_responses.c
+++ b/src/active-response/active_responses.c
@@ -279,11 +279,17 @@ static cJSON* get_srcip_from_win_eventdata(const cJSON *data) {
 
     // Detect ipAddress
     ipAddress_json = cJSON_GetObjectItem(eventdata_json, "ipAddress");
-    if (!cJSON_IsString(ipAddress_json)) {
-        return NULL;
+    if (cJSON_IsString(ipAddress_json)) {
+        return ipAddress_json;
     }
 
-    return ipAddress_json;
+    // Detect destinationIp
+    ipAddress_json = cJSON_GetObjectItem(eventdata_json, "destinationIp");
+    if (cJSON_IsString(ipAddress_json)) {
+        return ipAddress_json;
+    }
+
+    return NULL;
 }
 
 const char* get_username_from_json(const cJSON *input) {


### PR DESCRIPTION
|Related issue|
|---|
|#10022|



## Description

This PR allows `Active-Responses` to extract the `srcip `from `data.win.eventdata.destinationIp`.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade

