### PR TITLE
Fix dangling wdb agents databases

### DIFF
--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -120,12 +120,6 @@ void* wm_database_main(wm_database *data) {
         wm_sync_manager();
     }
 
-#ifndef LOCAL
-    wm_clean_dangling_groups();
-    wm_clean_dangling_legacy_dbs();
-    wm_clean_dangling_wdb_dbs();
-#endif
-
 #ifdef INOTIFY_ENABLED
     if (data->real_time) {
         char * path;
@@ -173,6 +167,9 @@ void* wm_database_main(wm_database *data) {
                 wm_check_agents();
                 wm_scan_directory(GROUPS_DIR);
                 wm_sync_multi_groups(SHAREDCFG_DIR);
+                wm_clean_dangling_groups();
+                wm_clean_dangling_legacy_dbs();
+                wm_clean_dangling_wdb_dbs();
             }
 #endif
             gettime(&spec1);
@@ -737,6 +734,9 @@ void wm_inotify_setup(wm_database * data) {
         wm_sync_agents();
         wm_sync_multi_groups(SHAREDCFG_DIR);
         wdb_agent_belongs_first_time(&wdb_wmdb_sock);
+        wm_clean_dangling_groups();
+        wm_clean_dangling_legacy_dbs();
+        wm_clean_dangling_wdb_dbs();
     }
 
 #endif


### PR DESCRIPTION
|Related issue|
|---|
|8605|

## Description
This PR brings Wazuh Modules Database the capability to eliminate dangling agents DBs.
Also, it completely removes the content of /var/agents as these are legacy and obsolete dummy DBs.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Package installation