### PR TITLE
Fix incorrect default date field when quering cluster info and add total time calculation

### DIFF
--- a/framework/scripts/cluster_control.py
+++ b/framework/scripts/cluster_control.py
@@ -70,10 +70,6 @@ async def print_health(config, more, filter_node):
         Indicate whether additional information is desired or not.
     filter_node : str, list
         Node to return.
-
-    Returns
-    -------
-
     """
     def calculate_seconds(start_time, end_time):
         """Calculate the time difference between two dates.

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -605,10 +605,13 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         """
         logger = self.task_loggers['Integrity sync']
         await self.sync_worker_files(task_id, received_file, logger)
-        self.integrity_sync_status['date_start_master'] = self.integrity_sync_status['tmp_date_start_master']
         self.integrity_sync_status['date_end_master'] = datetime.now()
         logger.info("Finished in {:.3f}s.".format((self.integrity_sync_status['date_end_master'] -
-                                                   self.integrity_sync_status['date_start_master']).total_seconds()))
+                                                   self.integrity_sync_status['tmp_date_start_master']).total_seconds()))
+        self.integrity_sync_status['date_start_master'] = \
+            self.integrity_sync_status['tmp_date_start_master'].strftime(decimals_date_format)
+        self.integrity_sync_status['date_end_master'] = \
+            self.integrity_sync_status['date_end_master'].strftime(decimals_date_format)
         self.extra_valid_requested = False
         self.sync_integrity_free = True
 
@@ -714,9 +717,8 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             except exception.WazuhException as e:
                 # Notify error to worker and delete its received file.
                 self.logger.error(f"Error sending files information: {e}")
-                result = await self.send_request(command=b'syn_m_c_r', data=task_id + b' ' +
-                                                                            json.dumps(e,
-                                                                                       cls=c_common.WazuhJSONEncoder).encode())
+                result = await self.send_request(
+                    command=b'syn_m_c_r', data=task_id + b' ' + json.dumps(e, cls=c_common.WazuhJSONEncoder).encode())
             except Exception as e:
                 # Notify error to worker and delete its received file.
                 self.logger.error(f"Error sending files information: {e}")
@@ -729,12 +731,14 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                 logger.debug("Finished sending files to worker.")
                 # Log 'Finished in' message only if there are no extra_valid files to sync.
                 if not self.extra_valid_requested:
-                    self.integrity_sync_status['date_start_master'] = self.integrity_sync_status[
-                        'tmp_date_start_master']
                     self.integrity_sync_status['date_end_master'] = datetime.now()
                     logger.info("Finished in {:.3f}s.".format((self.integrity_sync_status['date_end_master'] -
-                                                               self.integrity_sync_status['date_start_master'])
+                                                               self.integrity_sync_status['tmp_date_start_master'])
                                                               .total_seconds()))
+                    self.integrity_sync_status['date_start_master'] = self.integrity_sync_status[
+                        'tmp_date_start_master'].strftime(decimals_date_format)
+                    self.integrity_sync_status['date_end_master'] = \
+                        self.integrity_sync_status['date_end_master'].strftime(decimals_date_format)
 
         return result
 


### PR DESCRIPTION
|Related issue|
|---|
|#10141|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR closes #10141. In this PR we have fixed the problem when one of the dates in the cluster information did not exist. 
Now when a date does not exist because the cluster task has not finished, it will appear as `n/a`.

We have also added a total time calculation when running the `cluster_control -i more` command:
```
root@wazuh-master:/# /var/ossec/bin/cluster_control -i more
Cluster name: wazuh

Connected nodes (2):

    master-node (wazuh-master)
        Version: 4.3.0
        Type: master
        Active agents: 1

    worker1 (172.18.0.6)
        Version: 4.3.0
        Type: worker
        Active agents: 0
        Status:
            Last keep Alive:
                Last received: 2021-10-13T07:41:22.287642Z.
            Integrity check:
                Last integrity check: n/a (n/a - n/a).
                Permission to check integrity: True.
            Integrity sync:
                Last integrity synchronization: n/a (n/a - n/a).
                Synchronized files: Shared: 0 | Missing: 0 | Extra: 0 | Extra valid: 0.
                Extra valid files correctly updated in master: 0.
            Agents-info:
                Last synchronization: n/a (n/a - n/a).
                Number of synchronized chunks: 0.

    worker2 (172.18.0.3)
        Version: 4.3.0
        Type: worker
        Active agents: 4
        Status:
            Last keep Alive:
                Last received: 2021-10-13T07:41:20.716935Z.
            Integrity check:
                Last integrity check: 0.015s (2021-10-13T07:41:29.766421Z - 2021-10-13T07:41:29.781543Z).
                Permission to check integrity: True.
            Integrity sync:
                Last integrity synchronization: n/a (n/a - n/a).
                Synchronized files: Shared: 0 | Missing: 0 | Extra: 0 | Extra valid: 0.
                Extra valid files correctly updated in master: 0.
            Agents-info:
                Last synchronization: 0.003s (2021-10-13T07:41:30.740869Z - 2021-10-13T07:41:30.743404Z).
                Number of synchronized chunks: 1.
```