### PR TITLE
PR: Fix rule file rename not added to deprecated_rules

### DIFF
--- a/src/init/wazuh/deprecated_ruleset.txt
+++ b/src/init/wazuh/deprecated_ruleset.txt
@@ -8,3 +8,4 @@ rules/0470-suricata_rules.xml
 rules/0520-vulnerability-detector.xml
 rules/0565-ms_ipsec_rules_json.xml
 rules/0060-firewall_rules.xml
+rules/0390-fortigate_rules.xml


### PR DESCRIPTION
|Related issue|
|---|
| #10501  |

This PR adds the fix to solve the issue caused by renaming the rules for FortiNet in https://github.com/wazuh/wazuh/pull/10161.