### PR TITLE
Modify and remove old upgrade API integration test cases

### DIFF
--- a/api/test/integration/common.yaml
+++ b/api/test/integration/common.yaml
@@ -24,7 +24,7 @@ variables:
   global_db_delay: 30
   cluster_sync_delay: 20
 
-  custom_wpk_path: "/var/ossec/test_custom_upgrade_3.13.3.wpk"
+  custom_wpk_path: "/var/ossec/test.wpk"
 
   new_rules:
     "<!-- Local rules -->\n <group name=\"local,\">\n    <!--   NEW RULE    -->\n    <rule id=\"111111\" level=\"5\">\n      <if_sid>5716</if_sid>\n      <srcip>1.1.1.1</srcip>\n      <description>sshd: authentication failed from IP 1.1.1.1.</description>\n      <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>\n    </rule>\n  </group>\n"

--- a/api/test/integration/env/configurations/agent/manager/configuration_files/agents_config.sh
+++ b/api/test/integration/env/configurations/agent/manager/configuration_files/agents_config.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-wget https://packages.wazuh.com/wpk/linux/x86_64/wazuh_agent_v3.12.2_linux_x86_64.wpk
-mv ./wazuh_agent_v3.12.2_linux_x86_64.wpk /var/ossec/test_custom_upgrade_3.12.2.wpk

--- a/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
@@ -1192,7 +1192,6 @@ stages:
       params:
         agents_list: '005'
         file_path: "{custom_wpk_path:s}"
-        wait_for_complete: 'true'
     response:
       status_code: 200
       json:


### PR DESCRIPTION
|Related issue|
|---|
|#10328|

This pull request closes #10328.

In this PR some agent upgrade API integration test cases have been deleted or modified.

We had 2 test cases that were being skipped,

https://github.com/wazuh/wazuh/blob/09621f16e99c149bda4759c35bcf6b524afc40ed/api/test/integration/test_agent_PUT_endpoints.tavern.yaml#L919-L940

and

https://github.com/wazuh/wazuh/blob/09621f16e99c149bda4759c35bcf6b524afc40ed/api/test/integration/test_agent_PUT_endpoints.tavern.yaml#L942-L966

The first one has been modified as the test is correct, the task is created properly in spite of the lack of the WPK package in the production server. This is not a problem when talking about creating the task but it is when upgrading the agent. If we get the upgrade result of this agent, there will be a message telling the WPK does not exist.

The second one has been modified as the expected error code was **1819**, which means "`The WPK for this platform is not available`". This is not the expected error. For this case, the error that must be returned is the one with code **1822**, which means "`Current agent version is greater or equal`".

The test with name `Downgrade agent to an specific version using force` has been removed as downgrades are not supported.

Finally, the custom WPK package used has been changed from **3.12.2** to **3.13.3** to avoid a downgrade (agents being upgraded have version **3.13.2**).

### Test results

```
test_agent_PUT_endpoints.tavern.yaml 
	 8 passed, 2 xpassed, 12 warnings
```