### PR TITLE
Fixing empty architecture in syscollector packages information for MacOS agents

### DIFF
--- a/src/data_provider/src/packages/brewWrapper.h
+++ b/src/data_provider/src/packages/brewWrapper.h
@@ -23,6 +23,7 @@ class BrewWrapper final : public IPackageWrapper
         explicit BrewWrapper(const PackageContext& ctx)
             : m_name{ctx.package}
             , m_version{Utils::splitIndex(ctx.version, '_', 0)}
+            , m_architecture{UNKNOWN_VALUE}
             , m_format{"pkg"}
             , m_source{"homebrew"}
             , m_location{ctx.filePath}

--- a/src/data_provider/src/packages/pkgWrapper.h
+++ b/src/data_provider/src/packages/pkgWrapper.h
@@ -128,7 +128,8 @@ class PKGWrapper final : public IPackageWrapper
                         }
                     }
 
-                    m_source   = filePath.find(UTILITIES_FOLDER) ? "utilities" : "applications";
+                    m_architecture = UNKNOWN_VALUE;
+                    m_source = filePath.find(UTILITIES_FOLDER) ? "utilities" : "applications";
                     m_location = filePath;
                 }
             };

--- a/src/data_provider/src/sysInfoMac.cpp
+++ b/src/data_provider/src/sysInfoMac.cpp
@@ -180,7 +180,7 @@ std::string SysInfo::getSerialNumber() const
 
 static void getPackagesFromPath(const std::string& pkgDirectory, const int pkgType, std::function<void(nlohmann::json&)> callback)
 {
-    const auto packages {Utils::enumerateDir(pkgDirectory) };
+    const auto packages { Utils::enumerateDir(pkgDirectory) };
 
     for (const auto& package : packages)
     {
@@ -202,7 +202,7 @@ static void getPackagesFromPath(const std::string& pkgDirectory, const int pkgTy
         {
             if (!Utils::startsWith(package, "."))
             {
-                const auto packageVersions {Utils::enumerateDir(pkgDirectory + "/" + package) };
+                const auto packageVersions { Utils::enumerateDir(pkgDirectory + "/" + package) };
 
                 for (const auto& version : packageVersions)
                 {


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/10523 |

## Description

This pull request implements a change in the **syscollector** module to avoid saving `NULL` data in the `architecture` field for the MacOS packages. This caused unexpected behavior of the `INSERT or REPLACE` SQL statements. Basically, SQLite will not have the ability to identify that should perform a `REPLACE` and will insert a new entry. This will happen on each synchronization having as a result, a table with multiples entries repeated.

- Now the **syscollector** synchronizations finalize correctly (check the date)
![image](https://user-images.githubusercontent.com/5703274/137405166-2452671a-9b57-47b4-a0ec-8de243752629.png)

- Now there aren't repeated entries for the packages reported in the issue.
![image](https://user-images.githubusercontent.com/5703274/137405231-170cb275-9c6a-4c5d-99d1-5840a1e8615c.png)

It is important to mention that we researched a bit to see whether this information is provided in the MacOS packages. The documentation doesn't specify anything about the architecture.
https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/AboutInformationPropertyListFiles.html

## Tests

- Compilation without warnings in every supported platform
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation