### PR TITLE
Fix tempfiles handling at `framework/wazuh/core/configuration.py` and `framework/wazuh/core/utils.py`

### DIFF
--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -126,6 +126,7 @@ analysisd_stats = os.path.join(wazuh_path, 'var', 'run', 'wazuh-analysisd.state'
 remoted_stats = os.path.join(wazuh_path, 'var', 'run', 'wazuh-remoted.state')
 ar_conf_path = os.path.join(wazuh_path, 'etc', 'shared', 'ar.conf')
 pidfiles_path = os.path.join(wazuh_path, 'var', 'run')
+tmp_path = os.path.join(wazuh_path, 'tmp')
 
 # Ruleset
 # Ruleset paths

--- a/framework/wazuh/core/configuration.py
+++ b/framework/wazuh/core/configuration.py
@@ -673,10 +673,10 @@ def upload_group_configuration(group_id, file_content):
     if not os_path.exists(os_path.join(common.shared_path, group_id)):
         raise WazuhResourceNotFound(1710, group_id)
     # path of temporary files for parsing xml input
-    tmp_file_path = tempfile.NamedTemporaryFile(prefix='api_tmp_file_', suffix='.xml').name
+    handle, tmp_file_path = tempfile.mkstemp(prefix='api_tmp_file_', suffix='.xml', dir=common.tmp_path)
     # create temporary file for parsing xml input and validate XML format
     try:
-        with open(tmp_file_path, 'w') as tmp_file:
+        with open(handle, 'w') as tmp_file:
             custom_entities = {
                 '_custom_open_tag_': '\\<',
                 '_custom_close_tag_': '\\>',

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -1761,9 +1761,9 @@ def upload_file(content, path, check_xml_formula_values=True):
         return xml_string
 
     # Path of temporary files for parsing xml input
-    tmp_file_path = tempfile.NamedTemporaryFile(prefix='api_tmp_file_', suffix='.tmp').name
+    handle, tmp_file_path = tempfile.mkstemp(prefix='api_tmp_file_', suffix='.tmp', dir=common.tmp_path)
     try:
-        with open(tmp_file_path, 'w') as tmp_file:
+        with open(handle, 'w') as tmp_file:
             final_file = escape_formula_values(content) if check_xml_formula_values else content
             tmp_file.write(final_file)
         chmod(tmp_file_path, 0o660)


### PR DESCRIPTION
|Related issue|
|---|
| This PR closes #10115 |

## Description
We had few code flaws regarding the use of insecure usage of temp files and directories.
More precisely, this is a report from 'code_analysis' tool enumerating them:
```
{
    "code": "     # path of temporary files for parsing xml input\n     handle, tmp_file_path = tempfile.mkstemp(prefix=f'{common.wazuh_path}/tmp/api_tmp_file_', suffix=\".xml\")\n     # create temporary file for parsing xml input and validate XML format\n",
    "filename": "framework/wazuh/core/configuration.py",
    "issue_confidence": "MEDIUM",
    "issue_severity": "MEDIUM",
    "issue_text": "Probable insecure usage of temp file/directory.",
    "line_number": 676,
    "line_range": [
        676
    ],
    "more_info": "https://bandit.readthedocs.io/en/latest/plugins/b108_hardcoded_tmp_directory.html",
    "test_id": "B108",
    "test_name": "hardcoded_tmp_directory"
},
{
    "code": "     # Path of temporary files for parsing xml input\n     handle, tmp_file_path = tempfile.mkstemp(prefix=f'{common.wazuh_path}/tmp/api_tmp_file_', suffix=\".tmp\")\n     try:\n",
    "filename": "framework/wazuh/core/utils.py",
    "issue_confidence": "MEDIUM",
    "issue_severity": "MEDIUM",
    "issue_text": "Probable insecure usage of temp file/directory.",
    "line_number": 1762,
    "line_range": [
        1762
    ],
    "more_info": "https://bandit.readthedocs.io/en/latest/plugins/b108_hardcoded_tmp_directory.html",
    "test_id": "B108",
    "test_name": "hardcoded_tmp_directory"
}
```
Under this development I made some changes regarding the use of `tempfile` package.
I replaced `mkstemp` with `NamedTemporaryFile`, letting to `tempfile` package the file location handling.
In this case, temp files will now be temporary stored at `/tmp` instead of `/var/ossec/tmp`.

## UNITTEST: API
<details>
  <summary>Click to expand</summary>

```
↪ ~/git/wazuh/framework ⊶ fix/10115-framework-tempdirs ⨘ cd ~/git/wazuh/api && python3 -m pytest -x api --disable-warnings
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.9.5, pytest-5.4.3, py-1.10.0, pluggy-0.13.1
rootdir: /home/kondent/git/wazuh/api
plugins: asyncio-0.15.1, cov-2.12.0
collected 451 items                                                                                                                                                                          

api/controllers/test/test_active_response_controller.py .                                                                                                                              [  0%]
api/controllers/test/test_agent_controller.py ........................................                                                                                                 [  9%]
api/controllers/test/test_cdb_list_controller.py ......                                                                                                                                [ 10%]
api/controllers/test/test_ciscat_controller.py .                                                                                                                                       [ 10%]
api/controllers/test/test_cluster_controller.py ......................                                                                                                                 [ 15%]
api/controllers/test/test_decoder_controller.py .......                                                                                                                                [ 17%]
api/controllers/test/test_default_controller.py .                                                                                                                                      [ 17%]
api/controllers/test/test_experimental_controller.py ...............                                                                                                                   [ 20%]
api/controllers/test/test_manager_controller.py .................                                                                                                                      [ 24%]
api/controllers/test/test_mitre_controller.py .......                                                                                                                                  [ 25%]
api/controllers/test/test_overview_controller.py .                                                                                                                                     [ 26%]
api/controllers/test/test_rootcheck_controller.py ....                                                                                                                                 [ 27%]
api/controllers/test/test_rule_controller.py ........                                                                                                                                  [ 28%]
api/controllers/test/test_sca_controller.py ..                                                                                                                                         [ 29%]
api/controllers/test/test_security_controller.py ...................................................                                                                                   [ 40%]
api/controllers/test/test_syscheck_controller.py ....                                                                                                                                  [ 41%]
api/controllers/test/test_syscollector_controller.py .........                                                                                                                         [ 43%]
api/controllers/test/test_task_controller.py .                                                                                                                                         [ 43%]
api/controllers/test/test_vulnerability_controller.py .                                                                                                                                [ 43%]
api/models/test/test_model.py ...........................                                                                                                                              [ 49%]
api/test/test_alogging.py ..........                                                                                                                                                   [ 52%]
api/test/test_authentication.py ..........                                                                                                                                             [ 54%]
api/test/test_configuration.py ..........................................                                                                                                              [ 63%]
api/test/test_util.py ...................................                                                                                                                              [ 71%]
api/test/test_validator.py .................................................................................................................................                           [100%]

============================================================================== 451 passed, 14 warnings in 2.41s ==============================================================================
```
</details>

## UNITTEST: FRAMEWORK:
<details>
  <summary>Click to expand</summary>

```
↪ ~/git/wazuh/framework ⊶ fix/10115-framework-tempdirs ⨘ cd ~/git/wazuh/framework && python3 -m pytest -x wazuh --disable-warnings
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.9.5, pytest-5.4.3, py-1.10.0, pluggy-0.13.1
rootdir: /home/kondent/git/wazuh/framework
plugins: asyncio-0.15.1, cov-2.12.0
collected 1655 items                                                                                                                                                                         

wazuh/core/cluster/dapi/tests/test_dapi.py .........................                                                                                                                   [  1%]
wazuh/core/cluster/tests/test_cluster.py ...................                                                                                                                           [  2%]
wazuh/core/cluster/tests/test_common.py .......                                                                                                                                        [  3%]
wazuh/core/cluster/tests/test_control.py .....                                                                                                                                         [  3%]
wazuh/core/cluster/tests/test_local_client.py .                                                                                                                                        [  3%]
wazuh/core/cluster/tests/test_utils.py .......                                                                                                                                         [  3%]
wazuh/core/cluster/tests/test_worker.py ..................                                                                                                                             [  4%]
wazuh/core/tests/test_active_response.py ..............                                                                                                                                [  5%]
wazuh/core/tests/test_agent.py ....................................................................................................................................................... [ 14%]
...............                                                                                                                                                                        [ 15%]
wazuh/core/tests/test_cdb_list.py ......................................                                                                                                               [ 18%]
wazuh/core/tests/test_common.py .......                                                                                                                                                [ 18%]
wazuh/core/tests/test_configuration.py ....................................                                                                                                            [ 20%]
wazuh/core/tests/test_database.py .............                                                                                                                                        [ 21%]
wazuh/core/tests/test_decoder.py ................                                                                                                                                      [ 22%]
wazuh/core/tests/test_exception.py ...                                                                                                                                                 [ 22%]
wazuh/core/tests/test_input_validator.py ...                                                                                                                                           [ 22%]
wazuh/core/tests/test_logtest.py ..                                                                                                                                                    [ 22%]
wazuh/core/tests/test_manager.py ...............                                                                                                                                       [ 23%]
wazuh/core/tests/test_mitre.py .............                                                                                                                                           [ 24%]
wazuh/core/tests/test_pyDaemonModule.py .....                                                                                                                                          [ 24%]
wazuh/core/tests/test_results.py ........................................                                                                                                              [ 27%]
wazuh/core/tests/test_rootcheck.py .............                                                                                                                                       [ 28%]
wazuh/core/tests/test_rule.py ......................                                                                                                                                   [ 29%]
wazuh/core/tests/test_sca.py ............                                                                                                                                              [ 30%]
wazuh/core/tests/test_security.py ............                                                                                                                                         [ 30%]
wazuh/core/tests/test_stats.py ............                                                                                                                                            [ 31%]
wazuh/core/tests/test_syscheck.py ......                                                                                                                                               [ 32%]
wazuh/core/tests/test_syscollector.py ...                                                                                                                                              [ 32%]
wazuh/core/tests/test_task.py ........                                                                                                                                                 [ 32%]
wazuh/core/tests/test_utils.py ....................................................................................................................................................... [ 41%]
.............................................................................                                                                                                          [ 46%]
wazuh/core/tests/test_vulnerability.py .                                                                                                                                               [ 46%]
wazuh/core/tests/test_wazuh_queue.py ..................                                                                                                                                [ 47%]
wazuh/core/tests/test_wazuh_socket.py ....................                                                                                                                             [ 48%]
wazuh/core/tests/test_wdb.py ......................                                                                                                                                    [ 50%]
wazuh/core/tests/test_wlogging.py ........                                                                                                                                             [ 50%]
wazuh/rbac/tests/test_auth_context.py ..                                                                                                                                               [ 50%]
wazuh/rbac/tests/test_decorators.py .........................................................................................................                                          [ 57%]
wazuh/rbac/tests/test_default_configuration.py .......................................................                                                                                 [ 60%]
wazuh/rbac/tests/test_orm.py ......................................................                                                                                                    [ 63%]
wazuh/rbac/tests/test_preprocessor.py ...........                                                                                                                                      [ 64%]
wazuh/tests/test_active_response.py ............                                                                                                                                       [ 65%]
wazuh/tests/test_agent.py .............................................................................................................                                                [ 71%]
wazuh/tests/test_cdb_list.py .....................................................                                                                                                     [ 74%]
wazuh/tests/test_ciscat.py .................................                                                                                                                           [ 76%]
wazuh/tests/test_cluster.py .......                                                                                                                                                    [ 77%]
wazuh/tests/test_decoder.py ...................................                                                                                                                        [ 79%]
wazuh/tests/test_group.py ........                                                                                                                                                     [ 79%]
wazuh/tests/test_logtest.py ......                                                                                                                                                     [ 80%]
wazuh/tests/test_manager.py ....................................                                                                                                                       [ 82%]
wazuh/tests/test_mitre.py .......                                                                                                                                                      [ 82%]
wazuh/tests/test_rootcheck.py ..................................................                                                                                                       [ 85%]
wazuh/tests/test_rule.py ........................................................                                                                                                      [ 89%]
wazuh/tests/test_sca.py .......                                                                                                                                                        [ 89%]
wazuh/tests/test_security.py .........................................................................                                                                                 [ 94%]
wazuh/tests/test_stats.py .......                                                                                                                                                      [ 94%]
wazuh/tests/test_syscheck.py .........................                                                                                                                                 [ 96%]
wazuh/tests/test_syscollector.py ............                                                                                                                                          [ 96%]
wazuh/tests/test_task.py ............................                                                                                                                                  [ 98%]
wazuh/tests/test_vulnerability.py ..........................                                                                                                                           [100%]

======================================================================= 1655 passed, 12 warnings in 215.89s (0:03:35) ========================================================================
```
</details>

## Code Analysis Results
* Before - `pytest test_python_flaws.py --branch=master --repo=wazuh`
```
↪ ~/git/wazuh-qa/tests/scans/code_analysis ⊶ master ⨘ grep hardcoded_tmp known_flaws/known_flaws_framework.json
            "more_info": "https://bandit.readthedocs.io/en/latest/plugins/b108_hardcoded_tmp_directory.html",
            "test_name": "hardcoded_tmp_directory"
            "more_info": "https://bandit.readthedocs.io/en/latest/plugins/b108_hardcoded_tmp_directory.html",
            "test_name": "hardcoded_tmp_directory"
```
* After - `pytest test_python_flaws.py --branch=fix/10115-framework-tempdirs --repo=wazuh`
```
↪ ~/git/wazuh-qa/tests/scans/code_analysis ⊶ master ⨘ grep hardcoded_tmp known_flaws/known_flaws_framework.json
↪ ~/git/wazuh-qa/tests/scans/code_analysis ⊶ master ⨘ 
```

```
↪ ~/Desktop ⨘ diff after/known_flaws_framework.json before/known_flaws_framework.json 
76a77,104
>             "code": "     # path of temporary files for parsing xml input\n     handle, tmp_file_path = tempfile.mkstemp(prefix=f'{common.wazuh_path}/tmp/api_tmp_file_', suffix=\".xml\")\n     # create temporary file for parsing xml input and validate XML format\n",
>             "filename": "framework/wazuh/core/configuration.py",
>             "issue_confidence": "MEDIUM",
>             "issue_severity": "MEDIUM",
>             "issue_text": "Probable insecure usage of temp file/directory.",
>             "line_number": 676,
>             "line_range": [
>                 676
>             ],
>             "more_info": "https://bandit.readthedocs.io/en/latest/plugins/b108_hardcoded_tmp_directory.html",
>             "test_id": "B108",
>             "test_name": "hardcoded_tmp_directory"
>         },
>         {
>             "code": "     # Path of temporary files for parsing xml input\n     handle, tmp_file_path = tempfile.mkstemp(prefix=f'{common.wazuh_path}/tmp/api_tmp_file_', suffix=\".tmp\")\n     try:\n",
>             "filename": "framework/wazuh/core/utils.py",
>             "issue_confidence": "MEDIUM",
>             "issue_severity": "MEDIUM",
>             "issue_text": "Probable insecure usage of temp file/directory.",
>             "line_number": 1762,
>             "line_range": [
>                 1762
>             ],
>             "more_info": "https://bandit.readthedocs.io/en/latest/plugins/b108_hardcoded_tmp_directory.html",
>             "test_id": "B108",
>             "test_name": "hardcoded_tmp_directory"
>         },
>         {
```