### PR TITLE
Add unittests for `local_client.py`

### DIFF
--- a/framework/wazuh/core/cluster/tests/test_local_client.py
+++ b/framework/wazuh/core/cluster/tests/test_local_client.py
@@ -2,24 +2,247 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-import asyncio
+from asyncio import Event, Transport
+from asyncio.transports import BaseTransport
+from collections import Callable
 from unittest.mock import patch
 
 import pytest
-import uvloop
+from uvloop import EventLoopPolicy, new_event_loop
 
 with patch('wazuh.common.wazuh_uid'):
     with patch('wazuh.common.wazuh_gid'):
-        from wazuh.core.exception import WazuhException
-        from wazuh.core.cluster.local_client import LocalClient
+        from wazuh.core.cluster.local_client import *
+        from wazuh.core.cluster.common import InBuffer
+        from wazuh.core.exception import WazuhInternalError
 
-asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
-loop = uvloop.new_event_loop()
+asyncio.set_event_loop_policy(EventLoopPolicy())
+loop = new_event_loop()
 
 
-@patch.object(loop, attribute='create_unix_connection', side_effect=MemoryError)
-@patch('asyncio.get_running_loop', return_value=loop)
-def test_crypto(mock_runningloop, mock_loop):
-    with pytest.raises(WazuhException, match=".* 1119 .*"):
-        local_client = LocalClient()
-        loop.run_until_complete(local_client.start())
+def test_localclienthandler_initialization():
+    """Check the correct initialization of the LocalClientHandler object."""
+    lc = LocalClientHandler(loop=None, on_con_lost=None, name="Unittest",
+                            logger=None, fernet_key=None, manager=None, cluster_items=None)
+    """Check the correct initialization of the LocalClientHandler object."""
+    assert isinstance(lc.response_available, Event)
+    assert lc.response == b""
+
+
+def test_localclienthandler_connection_made():
+    """Check that the connection_made function sets the transport parameter correctly."""
+    lc = LocalClientHandler(loop=None, on_con_lost=None, name="Unittest",
+                            logger=None, fernet_key=None, manager=None, cluster_items=None)
+
+    assert lc.transport is None
+    lc.connection_made(Transport())
+    assert isinstance(lc.transport, Transport)
+
+
+def test_localclienthandler_cancel_all_tasks():
+    """Check the proper functionality of the _cancel_all_tasks function."""
+    lc = LocalClientHandler(loop=None, on_con_lost=None, name="Unittest",
+                            logger=None, fernet_key=None, manager=None, cluster_items=None)
+    assert lc._cancel_all_tasks() is None
+
+
+@patch("asyncio.Event.set")
+def test_localclienthandler_process_request(mock_set):
+    """Check each of the possible behaviors inside the _process_request function."""
+    lc = LocalClientHandler(loop=None, on_con_lost=None, name="Unittest",
+                            logger=None, fernet_key=None, manager=None, cluster_items=None)
+    command = b"dapi_res"
+    assert lc.process_request(command=command, data=b"Error") == (b"err", b"Error")
+    assert lc.process_request(command=command, data=b"Testing") == \
+           (b"err", b"Error receiving string: ID Testing not found.")
+
+    data_example = InBuffer(total=1)
+    lc.in_str = {b"testing": data_example, b"test": InBuffer(total=2)}
+    mock_set.reset_mock()
+    assert lc.process_request(command=command, data=b"test") == (b"ok", b"Distributed api response received")
+    assert lc.in_str == {b"testing": data_example}
+    mock_set.assert_called_once()
+
+    mock_set.reset_mock()
+    assert lc.process_request(command=b"ok", data=b"Error") == (b"err", b"Error")
+    assert lc.in_str == {b"testing": data_example}
+    mock_set.assert_called_once()
+
+    mock_set.reset_mock()
+    assert lc.process_request(command=b"ok", data=b"test") == (b"ok", b"Sendsync response received")
+    assert lc.response == b"test"
+    mock_set.assert_called_once()
+
+    mock_set.reset_mock()
+    assert lc.process_request(command=b"control_res", data=b"Error") == (b"err", b"Error")
+    assert lc.in_str == {b"testing": data_example}
+    mock_set.assert_called_once()
+
+    mock_set.reset_mock()
+    assert lc.process_request(command=b"control_res", data=b"test1") == (b"ok", b"Response received")
+    assert lc.response == b"test1"
+    mock_set.assert_called_once()
+
+    mock_set.reset_mock()
+    assert lc.process_request(command=b"dapi_err", data=b"test2") == (b"ok", b"Response received")
+    assert lc.response == b"test2"
+    mock_set.assert_called_once()
+
+    mock_set.reset_mock()
+    assert lc.process_request(command=b"err", data=b"test3") == (b"ok", b"Error response received")
+    assert lc.response == b"test3"
+    mock_set.assert_called_once()
+
+    assert lc.process_request(command=b"another", data=b"test4") == (b"err", b"unknown command \'b'another'\'")
+
+
+@patch("asyncio.Event.set")
+def test_localclienthandler_process_error_from_peer(mock_set):
+    """Run the _process_error_from_peer function and check the correct value assignment for the response attribute."""
+    lc = LocalClientHandler(loop=None, on_con_lost=None, name="Unittest",
+                            logger=None, fernet_key=None, manager=None, cluster_items=None)
+    assert lc.process_error_from_peer(data=b"None") == b"None"
+    assert lc.response == b"None"
+    mock_set.assert_called_once()
+
+
+def test_localclienthandler_connection_lost():
+    """Check that the set_result method of the on_con_lost object is called once with the defined parameters."""
+    lc = LocalClientHandler(loop=None, on_con_lost=asyncio.Future(), name="Unittest",
+                            logger=None, fernet_key=None, manager=None, cluster_items=None)
+    with patch.object(lc.on_con_lost, "set_result") as mock_set_result:
+        lc.connection_lost(Exception())
+        mock_set_result.assert_called_once_with(True)
+
+
+@patch("wazuh.core.cluster.client.asyncio.get_running_loop")
+def test_localclient_initialization(mock_get_running_loop):
+    """Check the correct initialization of the LocalClient object."""
+    lc = LocalClient()
+    assert lc.request_result is None
+    assert lc.protocol is None
+    assert lc.transport is None
+
+
+async def test_localclient_start():
+    """Check that the start method works correctly. Exceptions are not tested."""
+
+    async def create_unix_connection(protocol_factory=None, path=None):
+        return "transport", "protocol"
+
+    with patch("uvloop.Loop.create_unix_connection", side_effect=create_unix_connection) as mock_create_unix_connection:
+        mocked_loop = new_event_loop()
+        with patch("os.path.join", return_value="path/test"):
+            with patch("wazuh.core.cluster.client.asyncio.get_running_loop", return_value=mocked_loop):
+                lc = LocalClient()
+                await lc.start()
+                assert mock_create_unix_connection.call_count == 1
+                assert mock_create_unix_connection.call_args[1]["path"] == "path/test"
+                assert isinstance(mock_create_unix_connection.call_args[1]["protocol_factory"], Callable)
+                assert lc.protocol == "protocol"
+                assert lc.transport == "transport"
+
+
+@patch("wazuh.core.cluster.client.asyncio.get_running_loop")
+async def test_localclient_start_ko(mock_get_running_loop):
+    """Check the behavior of the start function for the different types of exceptions that may occur."""
+    with pytest.raises(WazuhInternalError, match=r'.* 3009 .*'):
+        await LocalClient().start()
+
+    with patch("wazuh.core.cluster.local_client.os.path.join", side_effect=MemoryError):
+        with pytest.raises(WazuhInternalError, match=r'.* 1119 .*'):
+            await LocalClient().start()
+
+    with patch("wazuh.core.cluster.local_client.os.path.join", side_effect=FileNotFoundError):
+        with pytest.raises(WazuhInternalError, match=r'.* 3012 .*'):
+            await LocalClient().start()
+
+    with patch("wazuh.core.cluster.local_client.os.path.join", side_effect=ConnectionRefusedError):
+        with pytest.raises(WazuhInternalError, match=r'.* 3012 .*'):
+            await LocalClient().start()
+
+
+@pytest.mark.asyncio
+@patch("wazuh.core.cluster.client.asyncio.get_running_loop")
+async def test_localclient_send_api_request(mock_get_running_loop):
+    """Check the correct operation of the send_api_request function by mocking the protocol attribute.
+    Exceptions are not tested."""
+
+    class Protocol:
+        response = b"Async"
+
+        def __init__(self):
+            self.response_available = asyncio.Event()
+
+        @staticmethod
+        async def send_request(command, data):
+            return data
+
+    lc = LocalClient()
+    lc.protocol = Protocol()
+
+    with patch("wazuh.core.cluster.common.Handler.send_request", side_effect=Protocol.send_request):
+        result = b"There are no connected worker nodes"
+        assert await lc.send_api_request(command=b"dapi", data=result, wait_for_complete=True) == {}
+
+        result = b"Testing"
+        assert await lc.send_api_request(command=b"testing", data=result, wait_for_complete=True) == result.decode()
+
+    with patch("wazuh.core.cluster.common.Handler.send_request", side_effect=Protocol.send_request):
+        with patch("asyncio.wait_for"):
+            with patch("asyncio.Event.wait"):
+                result = b"Testing"
+                assert await lc.send_api_request(
+                    command=b"dapi", data=result, wait_for_complete=True) == Protocol.response.decode()
+
+
+@pytest.mark.asyncio
+@patch("wazuh.core.cluster.client.asyncio.get_running_loop")
+async def test_localclient_send_api_request_ko(mock_get_running_loop):
+    """Check the behavior of the send_api_request function for the different types of exceptions that may occur."""
+
+    class Protocol:
+        def __init__(self):
+            self.response_available = asyncio.Event()
+
+        @staticmethod
+        async def send_request(command, data):
+            return data
+
+    lc = LocalClient()
+    lc.protocol = Protocol()
+    with patch("wazuh.core.cluster.common.Handler.send_request", side_effect=Protocol.send_request):
+        with patch("asyncio.Event.wait", side_effect=asyncio.TimeoutError):
+            with pytest.raises(WazuhInternalError, match=rf".* 3020 .*"):
+                await lc.send_api_request(command=b"dapi", data=b"None", wait_for_complete=False)
+
+
+@pytest.mark.asyncio
+async def test_localclient_execute():
+    """Check that the execute function returns the expected value."""
+
+    class Protocol:
+        def __init__(self):
+            self.on_con_lost = Protocol.testing()
+
+        @staticmethod
+        async def testing():
+            return "test"
+
+    with patch("wazuh.core.cluster.local_client.LocalClient.start"):
+        with patch("wazuh.core.cluster.local_client.LocalClient.send_api_request", return_value="Test"):
+            with patch("asyncio.transports.BaseTransport.close"):
+                lc = LocalClient()
+                lc.transport = BaseTransport()
+                lc.protocol = Protocol()
+                assert await lc.execute(command=b"0", data=b"1", wait_for_complete=False) == "Test"
+
+
+@pytest.mark.asyncio
+async def test_localclient_send_file():
+    """Check that the function send_file returns the value returned by the
+    function send_api_request called with the command 'send_file'."""
+    with patch("wazuh.core.cluster.local_client.LocalClient.start"):
+        with patch("wazuh.core.cluster.local_client.LocalClient.send_api_request", return_value=b"wazuh/test python"):
+            lc = LocalClient()
+            assert await lc.send_file(path="wazuh/test", node_name="python") == b"wazuh/test python"


### PR DESCRIPTION
|Related issue|
|---|
|#10005|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR closes #10005. In this PR we have added unit tests that check and set the behavior of the [local_client.py](https://github.com/wazuh/wazuh/blob/master/framework/wazuh/core/cluster/local_client.py) file. This is the result of those tests:

```
adriiiprodri@wazuh pytest -xs -vv framework/wazuh/core/cluster/tests/test_local_client.py --disable-warnings -s                                      
================================================================================================ test session starts =================================================================================================
platform linux -- Python 3.9.6, pytest-6.2.5, py-1.10.0, pluggy-0.13.1 -- /home/adriiiprodri/.virtualenvs/wazuh/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.9.6', 'Platform': 'Linux-5.13.4-100.fc33.x86_64-x86_64-with-glibc2.32', 'Packages': {'pytest': '6.2.5', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.11.0', 'tavern': '1.0.0', 'testinfra': '6.3.0', 'cov': '2.12.0', 'asyncio': '0.15.1', 'html': '3.1.1', 'anyio': '3.3.3', 'trio': '0.7.0', 'aiohttp': '0.3.0'}}
rootdir: /home/adriiiprodri/git/wazuh/framework
plugins: metadata-1.11.0, tavern-1.0.0, testinfra-6.3.0, cov-2.12.0, asyncio-0.15.1, html-3.1.1, anyio-3.3.3, trio-0.7.0, aiohttp-0.3.0
collected 13 items                                                                                                                                                                                                   

framework/wazuh/core/cluster/tests/test_local_client.py::test_localclienthandler_initialization PASSED
framework/wazuh/core/cluster/tests/test_local_client.py::test_localclienthandler_connection_made PASSED
framework/wazuh/core/cluster/tests/test_local_client.py::test_localclienthandler_cancel_all_tasks PASSED
framework/wazuh/core/cluster/tests/test_local_client.py::test_localclienthandler_process_request PASSED
framework/wazuh/core/cluster/tests/test_local_client.py::test_localclienthandler_process_error_from_peer PASSED
framework/wazuh/core/cluster/tests/test_local_client.py::test_localclienthandler_connection_lost PASSED
framework/wazuh/core/cluster/tests/test_local_client.py::test_localclient_initialization PASSED
framework/wazuh/core/cluster/tests/test_local_client.py::test_localclient_start PASSED
framework/wazuh/core/cluster/tests/test_local_client.py::test_localclient_start_ko PASSED
framework/wazuh/core/cluster/tests/test_local_client.py::test_localclient_send_api_request PASSED
framework/wazuh/core/cluster/tests/test_local_client.py::test_localclient_send_api_request_ko PASSED
framework/wazuh/core/cluster/tests/test_local_client.py::test_localclient_execute PASSED
framework/wazuh/core/cluster/tests/test_local_client.py::test_localclient_send_file PASSED

=========================================================================================== 13 passed, 3 warnings in 0.19s ===========================================================================================
```

```
adriiiprodri@wazuh python3 -m coverage report -m
Name                                           Stmts   Miss  Cover   Missing
----------------------------------------------------------------------------
framework/wazuh/core/cluster/local_client.py      95      0   100%
----------------------------------------------------------------------------
TOTAL                                             95      0   100%
```