### PR TITLE
Avoid the resource leaks described in the footprint metrics for vulnerability detector

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -3467,6 +3467,7 @@ vu_logic wm_vuldet_check_hotfix(sqlite3 *db, agent_software *agent, wm_vuldet_fl
                 if (subtype) {
                     if (strcasestr(subtype, "Setup DU")) {
                         mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_DISCARD_DU, cve, atoi(agent->agent_id), super);
+                        wdb_finalize(htfx_stmt);
                         continue;
                     }
                 }


### PR DESCRIPTION
|Related issue|
|---|
|#10557|

## Description

Hi team,

This PR aims to solve the memory and file descriptor leaks observed in the footprint metrics https://github.com/wazuh/wazuh/issues/10551 and https://github.com/wazuh/wazuh/issues/10550, for **Vulnerability Detector**. This behavior seemed to be introduced in https://github.com/wazuh/wazuh/pull/10016, where a mechanism to avoid scans to hotfixes related to **Dynamic Updates** was included in the vulnerability scan.

## RCA

The leaks are apparently caused by some unfinalized statements during the hotfix scan for **Windows** agents. As seen in the documentation of the **SQLite** _API_ for `C`, leaving unfinished statements before an additional `[prepared statement]` can lead to resource leaks:
```c
/*
** ...
** The application must finalize every [prepared statement] in order to avoid
** resource leaks.
** ...
*/
````

These unfinished statements can also lead to conflicts when trying to close the database, thus explaining the existence of **FD** leaks:
```C
/*
** Ideally, applications should [sqlite3_finalize | finalize] all
** [prepared statements], [sqlite3_blob_close | close] all [BLOB handles], and
** [sqlite3_backup_finish | finish] all [sqlite3_backup] objects associated
** with the [sqlite3] object prior to attempting to close the object.
** ^If the database connection is associated with unfinalized prepared
** statements, BLOB handlers, and/or unfinished sqlite3_backup objects then
** sqlite3_close() will leave the database connection open and return
** [SQLITE_BUSY]. ^If sqlite3_close_v2() is called with unfinalized prepared
** statements, unclosed BLOB handlers, and/or unfinished sqlite3_backups,
** it returns [SQLITE_OK] regardless, but instead of deallocating the database
** connection immediately, it marks the database connection as an unusable
** "zombie" and makes arrangements to automatically deallocate the database
** connection after all prepared statements are finalized, all BLOB handles
** are closed, and all backups have finished. The sqlite3_close_v2() interface
** is intended for use with host languages that are garbage collected, and
** where the order in which destructors are called is arbitrary.
*/
````



## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)