### PR TITLE
Add information about eventlog in API report

### DIFF
--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -121,6 +121,7 @@ typedef struct _logreader {
     w_multiline_config_t * multiline;
     long linecount;
     char *djb_program_name;
+    char * channel_str;
     char *command;
     char *alias;
     int reconnect_time;

--- a/src/logcollector/config.c
+++ b/src/logcollector/config.c
@@ -120,13 +120,19 @@ void _getLocalfilesListJSON(logreader *list, cJSON *array, int gl) {
         if (list[i].age_str) cJSON_AddStringToObject(file,"age",list[i].age_str);
         if (list[i].exclude) cJSON_AddStringToObject(file,"exclude",list[i].exclude);
 
-        if (list[i].future == 1){
-            cJSON_AddStringToObject(file, "only-future-events", "yes");
-        } else {
-            char offset[OFFSET_SIZE] = {0};
-            sprintf(offset, "%ld", list[i].diff_max_size);
-            cJSON_AddStringToObject(file, "only-future-events", "no");
-            cJSON_AddStringToObject(file, "max-size", offset);
+        if (list[i].logformat != NULL &&
+            strcmp(list[i].logformat, EVENTLOG) != 0 &&
+            strcmp(list[i].logformat, "command") != 0 &&
+            strcmp(list[i].logformat, "full_command") != 0) {
+
+            if (list[i].future == 1){
+                cJSON_AddStringToObject(file, "only-future-events", "yes");
+            } else {
+                char offset[OFFSET_SIZE] = {0};
+                sprintf(offset, "%ld", list[i].diff_max_size);
+                cJSON_AddStringToObject(file, "only-future-events", "no");
+                cJSON_AddStringToObject(file, "max-size", offset);
+            }
         }
 
         if (list[i].target && *list[i].target) {
@@ -158,7 +164,6 @@ void _getLocalfilesListJSON(logreader *list, cJSON *array, int gl) {
             cJSON_AddItemToObject(file,"labels",label);
         }
         if (list[i].ign && list[i].logformat != NULL && (strcmp(list[i].logformat,"command")==0 || strcmp(list[i].logformat,"full_command")==0)) cJSON_AddNumberToObject(file,"frequency",list[i].ign);
-        if (list[i].future && list[i].logformat != NULL && strcmp(list[i].logformat,"eventchannel")==0) cJSON_AddStringToObject(file,"only-future-events","yes");
         if (list[i].reconnect_time && list[i].logformat != NULL && strcmp(list[i].logformat,"eventchannel")==0) cJSON_AddNumberToObject(file,"reconnect_time",list[i].reconnect_time);
         if (list[i].multiline) {
             cJSON * multiline = cJSON_CreateObject();

--- a/src/logcollector/config.c
+++ b/src/logcollector/config.c
@@ -110,6 +110,7 @@ void _getLocalfilesListJSON(logreader *list, cJSON *array, int gl) {
         cJSON *file = cJSON_CreateObject();
 
         if (list[i].file) cJSON_AddStringToObject(file,"file",list[i].file);
+        if (list[i].channel_str != NULL) cJSON_AddStringToObject(file, "channel", list[i].channel_str);
         if (list[i].logformat) cJSON_AddStringToObject(file,"logformat",list[i].logformat);
         if (list[i].command) cJSON_AddStringToObject(file,"command",list[i].command);
         if (list[i].djb_program_name) cJSON_AddStringToObject(file,"djb_program_name",list[i].djb_program_name);

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -247,6 +247,7 @@ void LogCollectorStart()
 #ifdef WIN32
 
             minfo(READING_EVTLOG, current->file);
+            os_strdup(current->file, current->channel_str);
             win_startel(current->file);
 
             /* Mutexes are not previously initialized under Windows*/
@@ -262,6 +263,7 @@ void LogCollectorStart()
 
 #ifdef EVENTCHANNEL_SUPPORT
             minfo(READING_EVTLOG, current->file);
+            os_strdup(current->file, current->channel_str);
             win_start_event_channel(current->file, current->future, current->query, current->reconnect_time);
 #else
             mwarn("eventchannel not available on this version of Windows");


### PR DESCRIPTION
|Related issue|
|---|
| #6565 |

This PR aims to add the `location` parameter of the `localfile` (channel) to the `API` responses, when querying the `Logcollector's localfiles` configuration. These changes only affect the `localfiles` that have `eventchannel` or `eventlog` formats.

### Eventlog

Given the following configuration:

```xml
<localfile>
	<location>Application</location>
	<log_format>eventlog</log_format>
</localfile>

<localfile>
	<location>Security</location>
	<log_format>eventlog</log_format>
</localfile>

<localfile>
	<location>System</location>
	<log_format>eventlog</log_format>
</localfile>

<localfile>
	<location>active-response\active-responses.log</location>
	<log_format>syslog</log_format>
</localfile>
```

Then, querying the logcollector API' socket, the following response is obtained:

| socket | query |
| -- | -- |
| /var/ossec/queue/sockets/request  | 030 logcollector getconfig localfile |

```json
Response: ok
{
    "localfile":
     [{
          "channel":"Application",
          "logformat":"eventlog",
          "ignore_binaries":"no",
          "only-future-events":"yes",
          "target":["agent"]
     },
     {
          "channel":"Security",
          "logformat":"eventlog",
          "ignore_binaries":"no",
          "only-future-events":"yes",
          "target":["agent"]
     },
     {
          "channel":"System",
          "logformat":"eventlog",
          "ignore_binaries":"no",
          "only-future-events":"yes",
          "target":["agent"]
     },
     {
          "file":"active-response\\active-responses.log",
          "logformat":"syslog",
          "ignore_binaries":"no",
          "only-future-events":"yes",
          "target":["agent"]
     }]
}
```

### Eventchannel

Given the following configuration:

```xml
<localfile>
	<location>Application</location>
	<log_format>eventchannel</log_format>
</localfile>

<localfile>
	<location>Security</location>
	<log_format>eventchannel</log_format>
	<query>Event/System[EventID != 5145 and EventID != 5156 and EventID != 5447 and
	EventID != 4656 and EventID != 4658 and EventID != 4663 and EventID != 4660 and
	EventID != 4670 and EventID != 4690 and EventID != 4703 and EventID != 4907 and
	EventID != 5152 and EventID != 5157]</query>
</localfile>

<localfile>
	<location>System</location>
	<log_format>eventchannel</log_format>
</localfile>
```

Then, querying the logcollector API' socket, the following response is obtained:

| socket | query |
| -- | -- |
| /var/ossec/queue/sockets/request  | 002 logcollector getconfig localfile |

```json
Response: ok {
    "localfile": [
        {
            "channel": "Application",
            "logformat": "eventchannel",
            "ignore_binaries": "no",
            "only-future-events": "yes",
            "target": [
                "agent"
            ],
            "reconnect_time": 5
        },
        {
            "channel": "Security",
            "logformat": "eventchannel",
            "query": "Event/System[EventID != 5145 and EventID != 5156 and EventID != 5447 and\n      EventID != 4656 and EventID != 4658 and EventID != 4663 and EventID != 4660 and\n      EventID != 4670 and EventID != 4690 and EventID != 4703 and EventID != 4907 and\n      EventID != 5152 and EventID != 5157]",
            "ignore_binaries": "no",
            "only-future-events": "yes",
            "target": [
                "agent"
            ],
            "reconnect_time": 5
        },
        {
            "channel": "System",
            "logformat": "eventchannel",
            "ignore_binaries": "no",
            "only-future-events": "yes",
            "target": [
                "agent"
            ],
            "reconnect_time": 5
        },
        {
            "file": "active-response\\active-responses.log",
            "logformat": "syslog",
            "ignore_binaries": "no",
            "only-future-events": "yes",
            "target": [
                "agent"
            ]
        }
    ]
}
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] ~MAC OS X~
- [x] ~Source installation~
- [x] Package installation
- [x] ~Source upgrade~
- [x] Package upgrade
- [x] ~Review logs syntax and correct language~
- [x] ~QA templates contemplate the added capabilities~

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report ([Download](https://github.com/wazuh/wazuh/files/7383778/scan.zip))
  - [x] ~Coverity~
  - [x] ~Valgrind (memcheck and descriptor leaks check)~
  - [x] ~Dr. Memory~
  - [x] ~AddressSanitizer~
- Memory tests for Windows
  - [x] Scan-build report ([Download report](https://github.com/wazuh/wazuh/files/7383648/scan.zip))
  - [x] ~Coverity~
  - [x] ~Dr. Memory~
- Memory tests for macOS
  - [x] ~Scan-build report~
  - [x] ~Leaks~
  - [x] ~AddressSanitizer~

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] ~Working on cluster environments~
- [x] Configuration on demand reports new parameters
- [x] ~The data flow works as expected (agent-manager-api-app)~
- [x] Added unit tests (for new features)
- [x] ~Stress test for affected components~
