### PR TITLE
Add pipe separator verification for syscollector deltas.

### DIFF
--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -323,6 +323,7 @@
 #define DB_CACHE_ERROR        "(5213): Cannot cache statement."
 #define DB_CACHE_NULL_STMT    "(5214): Null statement on internal cache."
 #define DB_AGENT_SQL_ERROR    "(5215): DB(%s) SQL Error: '%s'."
+#define DB_INVALID_DELTA_MSG  "(5216): Delta (%s) field count mismatch: expect %zu, received %zu."
 
 /* vulnerability-detector messages*/
 #define VU_FETCH_ERROR              "(5500): The '%s' database could not be fetched."

--- a/src/unit_tests/wazuh_db/test_wdb_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_parser.c
@@ -986,39 +986,31 @@ void test_dbsync_insert_type_not_exists(void **state) {
     os_free(query);
 }
 
-void test_dbsync_insert_type_exists_data_1(void **state) {
+void test_dbsync_insert_type_exists_data_incorrect(void **state) {
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
     char *query = NULL;
+    char error_message[128] = { "\0" };
 
-    os_strdup("osinfo INSERTED data?", query);
+    os_strdup("hotfixes INSERTED data?", query);
+    sprintf(error_message, DB_INVALID_DELTA_MSG, "data?", 3ul, 0ul);
 
-    will_return(__wrap_wdb_get_cache_stmt, 1);
-
-    expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, 0);
-    will_return_always(__wrap_sqlite3_bind_int, SQLITE_OK);
-
-    expect_value(__wrap_sqlite3_bind_text, pos, 2);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "data?");
-    will_return_always(__wrap_sqlite3_bind_text, SQLITE_OK);
-
-    will_return(__wrap_wdb_step, SQLITE_DONE);
+    expect_string(__wrap__merror, formatted_msg, error_message);
 
     ret = wdb_parse_dbsync(data->wdb, query, data->output);
 
-    assert_string_equal(data->output, "ok ");
-    assert_int_equal(ret, OS_SUCCESS);
+    assert_string_equal(data->output, "error");
+    assert_int_equal(ret, OS_INVALID);
 
     os_free(query);
 }
 
-void test_dbsync_insert_type_exists_data_2(void **state) {
+void test_dbsync_insert_type_exists_data_correct(void **state) {
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
     char *query = NULL;
 
-    os_strdup("osinfo INSERTED data?|data2?", query);
+    os_strdup("hotfixes INSERTED data1|data2|data3|", query);
 
     will_return(__wrap_wdb_get_cache_stmt, 1);
 
@@ -1027,44 +1019,15 @@ void test_dbsync_insert_type_exists_data_2(void **state) {
     will_return_always(__wrap_sqlite3_bind_int, SQLITE_OK);
 
     expect_value(__wrap_sqlite3_bind_text, pos, 2);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "data?");
-    will_return_always(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "data1");
 
     expect_value(__wrap_sqlite3_bind_text, pos, 3);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "data2?");
-
-    will_return(__wrap_wdb_step, SQLITE_DONE);
-
-    ret = wdb_parse_dbsync(data->wdb, query, data->output);
-
-    assert_string_equal(data->output, "ok ");
-    assert_int_equal(ret, OS_SUCCESS);
-
-    os_free(query);
-}
-
-void test_dbsync_insert_type_exists_data_3(void **state) {
-    int ret = -1;
-    test_struct_t *data  = (test_struct_t *)*state;
-    char *query = NULL;
-
-    os_strdup("osinfo INSERTED data?|data2?|data3?", query);
-
-    will_return(__wrap_wdb_get_cache_stmt, 1);
-
-    expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, 0);
-    will_return_always(__wrap_sqlite3_bind_int, SQLITE_OK);
-
-    expect_value(__wrap_sqlite3_bind_text, pos, 2);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "data?");
-    will_return_always(__wrap_sqlite3_bind_text, SQLITE_OK);
-
-    expect_value(__wrap_sqlite3_bind_text, pos, 3);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "data2?");
+    expect_string(__wrap_sqlite3_bind_text, buffer, "data2");
 
     expect_value(__wrap_sqlite3_bind_text, pos, 4);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "data3?");
+    expect_string(__wrap_sqlite3_bind_text, buffer, "data3");
+
+    will_return_always(__wrap_sqlite3_bind_text, SQLITE_OK);
 
     will_return(__wrap_wdb_step, SQLITE_DONE);
 
@@ -1081,7 +1044,7 @@ void test_dbsync_delete_type_exists_data_1(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     char *query = NULL;
 
-    os_strdup("osinfo DELETED NULL|NULL|NULL|data5", query);
+    os_strdup("hotfixes DELETED NULL|data5|NULL|", query);
 
     will_return(__wrap_wdb_get_cache_stmt, 1);
 
@@ -1111,24 +1074,22 @@ void test_dbsync_modify_type_exists_data_1(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     char *query = NULL;
 
-    os_strdup("osinfo MODIFIED data1|data2|data3|data4", query);
+    os_strdup("hotfixes MODIFIED data1|data2|data3|", query);
 
     will_return_always(__wrap_wdb_get_cache_stmt, 1);
 
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
     expect_string(__wrap_sqlite3_bind_text, buffer, "data1");
     expect_value(__wrap_sqlite3_bind_text, pos, 2);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "data2");
-    expect_value(__wrap_sqlite3_bind_text, pos, 3);
     expect_string(__wrap_sqlite3_bind_text, buffer, "data3");
-    expect_value(__wrap_sqlite3_bind_text, pos, 4);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "data4");
+    expect_value(__wrap_sqlite3_bind_text, pos, 3);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "data2");
 
     will_return_always(__wrap_sqlite3_bind_text, SQLITE_OK);
 
     will_return(__wrap_wdb_step, SQLITE_DONE);
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "data4");
+    expect_string(__wrap_sqlite3_bind_text, buffer, "data2");
 
     will_return(__wrap_wdb_step, SQLITE_DONE);
     ret = wdb_parse_dbsync(data->wdb, query, data->output);
@@ -1144,7 +1105,7 @@ void test_dbsync_insert_type_exists_null_stmt(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     char *query = NULL;
 
-    os_strdup("osinfo INSERTED data?|data2?|data3?", query);
+    os_strdup("hotfixes INSERTED data?|data2?|data3?|", query);
 
     will_return(__wrap_wdb_get_cache_stmt, 0);
 
@@ -1163,7 +1124,7 @@ void test_dbsync_delete_type_exists_data_compound_pk(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     char *query = NULL;
 
-    os_strdup("network_protocol DELETED data1|data2", query);
+    os_strdup("network_protocol DELETED data1|data2|NULL|NULL|NULL|NULL|NULL|", query);
 
     will_return(__wrap_wdb_get_cache_stmt, 1);
 
@@ -1201,7 +1162,7 @@ void test_dbsync_modify_type_exists_data_real_value(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     char *query = NULL;
 
-    os_strdup("hwinfo MODIFIED data1|data2|data3", query);
+    os_strdup("hwinfo MODIFIED data1|data2|data3|NULL|NULL|NULL|NULL|NULL|NULL|", query);
 
     will_return_always(__wrap_wdb_get_cache_stmt, 1);
 
@@ -1252,7 +1213,7 @@ void test_dbsync_modify_type_exists_data_compound_pk(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     char *query = NULL;
 
-    os_strdup("network_protocol MODIFIED data1|data2|data3|NULL", query);
+    os_strdup("network_protocol MODIFIED data1|data2|data3|NULL|NULL|NULL|NULL|", query);
 
     will_return_always(__wrap_wdb_get_cache_stmt, 1);
 
@@ -1302,7 +1263,7 @@ void test_dbsync_modify_type_exists_data_stmt_fail(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     char *query = NULL;
 
-    os_strdup("network_protocol MODIFIED data1|data2|data3|NULL", query);
+    os_strdup("network_protocol MODIFIED data1|data2|data3|NULL|NULL|NULL|NULL|", query);
 
     will_return_always(__wrap_wdb_get_cache_stmt, 0);
 
@@ -1320,7 +1281,7 @@ void test_dbsync_delete_type_exists_data_select_stmt_fail(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     char *query = NULL;
 
-    os_strdup("network_protocol DELETED data1|data2", query);
+    os_strdup("network_protocol DELETED data1|data2|NULL|NULL|NULL|NULL|NULL|", query);
 
     will_return(__wrap_wdb_get_cache_stmt, 0);
 
@@ -1349,7 +1310,7 @@ void test_dbsync_delete_type_exists_data_stmt_fail(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     char *query = NULL;
 
-    os_strdup("network_protocol DELETED data1|data2", query);
+    os_strdup("network_protocol DELETED data1|data2|NULL|NULL|NULL|NULL|NULL|", query);
 
     will_return(__wrap_wdb_get_cache_stmt, 0);
     expect_string(__wrap__merror, formatted_msg, DB_CACHE_NULL_STMT);
@@ -1374,7 +1335,7 @@ void test_dbsync_delete_type_exists_data_bind_error(void **state) {
 
     sprintf(error_message, DB_AGENT_SQL_ERROR, "000", error_value);
 
-    os_strdup("osinfo DELETED NULL|NULL|NULL|data5", query);
+    os_strdup("osinfo DELETED NULL|NULL|NULL|data5|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|", query);
 
     will_return(__wrap_wdb_get_cache_stmt, 1);
     will_return_always(__wrap_sqlite3_errmsg, error_value);
@@ -1410,7 +1371,7 @@ void test_dbsync_modify_type_exists_data_bind_error(void **state) {
 
     sprintf(error_message, DB_AGENT_SQL_ERROR, "000", error_value);
 
-    os_strdup("hwinfo MODIFIED data1|data2|data3|0", query);
+    os_strdup("hwinfo MODIFIED data1|data2|data3|0|NULL|NULL|NULL|NULL|NULL|", query);
 
     will_return_always(__wrap_wdb_get_cache_stmt, 1);
 
@@ -1453,7 +1414,7 @@ void test_dbsync_delete_type_exists_data_bind_error_ports(void **state) {
 
     sprintf(error_message, DB_AGENT_SQL_ERROR, "000", error_value);
 
-    os_strdup("ports DELETED NULL|data1|data2|0|NULL|NULL|NULL|NULL|1", query);
+    os_strdup("ports DELETED NULL|data1|data2|0|NULL|NULL|NULL|NULL|1|NULL|NULL|NULL|NULL|NULL|", query);
 
     will_return(__wrap_wdb_get_cache_stmt, 1);
     will_return_always(__wrap_sqlite3_errmsg, error_value);
@@ -1510,7 +1471,7 @@ void test_dbsync_modify_type_exists_data_bind_error_ports(void **state) {
 
     sprintf(error_message, DB_AGENT_SQL_ERROR, "000", error_value);
 
-    os_strdup("ports MODIFIED MMM|data1|data2|0|NULL|NULL|NULL|NULL|1", query);
+    os_strdup("ports MODIFIED MMM|data1|data2|0|NULL|NULL|NULL|NULL|1|NULL|NULL|NULL|NULL|NULL|", query);
 
     will_return_always(__wrap_wdb_get_cache_stmt, 1);
 
@@ -1555,7 +1516,7 @@ void test_dbsync_delete_type_exists_data_compound_pk_select_data(void **state) {
 
     sprintf(error_message, DB_AGENT_SQL_ERROR, "000", error_value);
 
-    os_strdup("network_protocol DELETED data1|data2", query);
+    os_strdup("network_protocol DELETED data1|data2|NULL|NULL|NULL|NULL|NULL|", query);
 
     will_return(__wrap_wdb_get_cache_stmt, 1);
 
@@ -1612,7 +1573,7 @@ void test_dbsync_delete_type_exists_data_compound_pk_select_data_fail(void **sta
 
     sprintf(error_message, DB_AGENT_SQL_ERROR, "000", error_value);
 
-    os_strdup("network_protocol DELETED data1|data2", query);
+    os_strdup("network_protocol DELETED data1|data2|NULL|NULL|NULL|NULL|NULL|", query);
 
     will_return(__wrap_wdb_get_cache_stmt, 1);
 
@@ -1657,17 +1618,18 @@ void test_dbsync_insert_type_exists_data_return_values(void **state) {
 
     sprintf(error_message, DB_AGENT_SQL_ERROR, "000", error_value);
 
-    os_strdup("ports INSERTED data?|data2?|data3?|4", query);
+    os_strdup("ports INSERTED data?|data2?|data3?|4|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|", query);
 
     will_return(__wrap_wdb_get_cache_stmt, 1);
 
+    will_return_always(__wrap_sqlite3_bind_int, SQLITE_ERROR);
+    will_return_always(__wrap_sqlite3_bind_text, SQLITE_ERROR);
+
     expect_value(__wrap_sqlite3_bind_int, index, 1);
     expect_value(__wrap_sqlite3_bind_int, value, 0);
-    will_return_always(__wrap_sqlite3_bind_int, SQLITE_ERROR);
 
     expect_value(__wrap_sqlite3_bind_text, pos, 2);
     expect_string(__wrap_sqlite3_bind_text, buffer, "data?");
-    will_return_always(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     expect_value(__wrap_sqlite3_bind_text, pos, 3);
     expect_string(__wrap_sqlite3_bind_text, buffer, "data2?");
@@ -1678,8 +1640,48 @@ void test_dbsync_insert_type_exists_data_return_values(void **state) {
     expect_value(__wrap_sqlite3_bind_int, index, 5);
     expect_value(__wrap_sqlite3_bind_int, value, 4);
 
+    expect_value(__wrap_sqlite3_bind_text, pos, 6);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "");
+
+    expect_value(__wrap_sqlite3_bind_int, index, 7);
+    expect_value(__wrap_sqlite3_bind_int, value, 0);
+
+    expect_value(__wrap_sqlite3_bind_int, index, 8);
+    expect_value(__wrap_sqlite3_bind_int, value, 0);
+
+    expect_value(__wrap_sqlite3_bind_int, index, 9);
+    expect_value(__wrap_sqlite3_bind_int, value, 0);
+
+    expect_value(__wrap_sqlite3_bind_int, index, 10);
+    expect_value(__wrap_sqlite3_bind_int, value, 0);
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 11);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "");
+
+    expect_value(__wrap_sqlite3_bind_int, index, 12);
+    expect_value(__wrap_sqlite3_bind_int, value, 0);
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 13);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "");
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 14);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "");
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 15);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "");
+
     will_return_always(__wrap_sqlite3_errmsg, error_value);
 
+    expect_string(__wrap__merror, formatted_msg, error_message);
+    expect_string(__wrap__merror, formatted_msg, error_message);
+    expect_string(__wrap__merror, formatted_msg, error_message);
+    expect_string(__wrap__merror, formatted_msg, error_message);
+    expect_string(__wrap__merror, formatted_msg, error_message);
+    expect_string(__wrap__merror, formatted_msg, error_message);
+    expect_string(__wrap__merror, formatted_msg, error_message);
+    expect_string(__wrap__merror, formatted_msg, error_message);
+    expect_string(__wrap__merror, formatted_msg, error_message);
+    expect_string(__wrap__merror, formatted_msg, error_message);
     expect_string(__wrap__merror, formatted_msg, error_message);
     expect_string(__wrap__merror, formatted_msg, error_message);
     expect_string(__wrap__merror, formatted_msg, error_message);
@@ -1758,11 +1760,10 @@ int main()
         cmocka_unit_test_setup_teardown(test_dbsync_insert_fail_1_arguments, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_dbsync_insert_fail_2_arguments, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_dbsync_insert_type_not_exists, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_dbsync_insert_type_exists_data_1, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_dbsync_insert_type_exists_data_incorrect, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_dbsync_insert_type_exists_data_correct, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_dbsync_delete_type_exists_data_1, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_dbsync_modify_type_exists_data_1, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_dbsync_insert_type_exists_data_2, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_dbsync_insert_type_exists_data_3, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_dbsync_insert_type_exists_null_stmt, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_dbsync_modify_type_exists_data_real_value, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_dbsync_delete_type_exists_data_compound_pk, test_setup, test_teardown),

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -349,6 +349,7 @@ struct kv {
     char value[OS_SIZE_256];
     bool single_row_table;
     struct column_list const *column_list;
+    size_t field_count;
 };
 
 struct kv_list {

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -9,6 +9,7 @@
  * Foundation.
  */
 
+#include "wazuhdb_op.h"
 #include "wdb.h"
 #include "wdb_agents.h"
 #include "external/cJSON/cJSON.h"
@@ -21,6 +22,7 @@ static struct column_list const TABLE_HOTFIXES[] = {
     { .value = {FIELD_TEXT, 3, false, true, "hotfix" }, .next = &TABLE_HOTFIXES[3] },
     { .value = {FIELD_TEXT, 4, false, false, "checksum" }, .next = NULL },
 };
+#define HOTFIXES_FIELD_COUNT 3
 
 static struct column_list const TABLE_PROCESSES[] = {
     { .value = { FIELD_INTEGER, 1,true,false, "scan_id" }, .next = &TABLE_PROCESSES[1] },
@@ -55,6 +57,7 @@ static struct column_list const TABLE_PROCESSES[] = {
     { .value = { FIELD_INTEGER, 30,false,false,"processor"}, .next = &TABLE_PROCESSES[30] },
     { .value = { FIELD_TEXT, 31, false, false, "checksum" }, .next = NULL }
 };
+#define PROCESSES_FIELD_COUNT 30
 
 static struct column_list const TABLE_NETIFACE[] = {
     { .value = { FIELD_INTEGER, 1, true, false, "scan_id" }, .next = &TABLE_NETIFACE[1] } ,
@@ -76,6 +79,7 @@ static struct column_list const TABLE_NETIFACE[] = {
     { .value = { FIELD_TEXT, 17, false, false, "checksum" }, .next = &TABLE_NETIFACE[17] } ,
     { .value = { FIELD_TEXT, 18, false, false, "item_id" }, .next = NULL }
 };
+#define NETIFACE_FIELD_COUNT 17
 
 static struct column_list const TABLE_NETPROTO[] = {
     { .value = { FIELD_INTEGER,1, true, false, "scan_id" }, .next = &TABLE_NETPROTO[1]},
@@ -87,6 +91,7 @@ static struct column_list const TABLE_NETPROTO[] = {
     { .value = { FIELD_TEXT,7, false, false, "checksum" }, .next = &TABLE_NETPROTO[7]},
     { .value = { FIELD_TEXT,8, false, false, "item_id" }, .next = NULL }
 };
+#define NETPROTO_FIELD_COUNT 7
 
 static struct column_list const TABLE_NETADDR[] = {
     { .value = { FIELD_INTEGER,1, true, false, "scan_id" }, .next = &TABLE_NETADDR[1]},
@@ -98,6 +103,7 @@ static struct column_list const TABLE_NETADDR[] = {
     { .value = { FIELD_TEXT,7, false, false, "checksum" }, .next = &TABLE_NETADDR[7]},
     { .value = { FIELD_TEXT,8, false, false, "item_id" }, .next = NULL},
 };
+#define NETADDR_FIELD_COUNT 7
 
 static struct column_list const TABLE_PORTS[] = {
     { .value = { FIELD_INTEGER,1, true, false, "scan_id" }, .next = &TABLE_PORTS[1]},
@@ -116,6 +122,7 @@ static struct column_list const TABLE_PORTS[] = {
     { .value = { FIELD_TEXT,14, false, false, "checksum" }, .next = &TABLE_PORTS[14]},
     { .value = { FIELD_TEXT,15, false, false, "item_id" }, .next = NULL},
 };
+#define PORTS_FIELD_COUNT 14
 
 static struct column_list const TABLE_PACKAGES[] = {
     { .value = { FIELD_INTEGER, 1, true, true, "scan_id" }, .next = &TABLE_PACKAGES[1] },
@@ -139,6 +146,7 @@ static struct column_list const TABLE_PACKAGES[] = {
     { .value = { FIELD_TEXT, 19, false, false, "checksum" }, .next = &TABLE_PACKAGES[19] },
     { .value = { FIELD_TEXT, 20, false, false, "item_id" }, .next = NULL },
 };
+#define PACKAGES_FIELD_COUNT 19
 
 static struct column_list const TABLE_OS[] = {
     { .value = { FIELD_INTEGER, 1, true, false, "scan_id" }, .next = &TABLE_OS[1] },
@@ -160,6 +168,7 @@ static struct column_list const TABLE_OS[] = {
     { .value = { FIELD_TEXT, 17, false, false, "os_display_version" }, .next = &TABLE_OS[17] },
     { .value = { FIELD_TEXT, 18, false, false, "checksum" }, .next = NULL }
 };
+#define OS_FIELD_COUNT 17
 
 static struct column_list const TABLE_HARDWARE[] = {
     { .value = { FIELD_INTEGER, 1, true, false, "scan_id" }, .next = &TABLE_HARDWARE[1] },
@@ -173,19 +182,19 @@ static struct column_list const TABLE_HARDWARE[] = {
     { .value = { FIELD_INTEGER, 9, false, false, "ram_usage" }, .next = &TABLE_HARDWARE[9] },
     { .value = { FIELD_TEXT, 10, false, false, "checksum" }, .next = NULL }
 };
-
+#define HARDWARE_FIELD_COUNT 9
 
 
 static struct kv_list const TABLE_MAP[] = {
-    { .current = { "network_iface", "sys_netiface", false, TABLE_NETIFACE }, .next = &TABLE_MAP[1]},
-    { .current = { "network_protocol", "sys_netproto", false, TABLE_NETPROTO }, .next = &TABLE_MAP[2]},
-    { .current = { "network_address", "sys_netaddr", false, TABLE_NETADDR }, .next = &TABLE_MAP[3]},
-    { .current = { "osinfo", "sys_osinfo", false, TABLE_OS }, .next = &TABLE_MAP[4]},
-    { .current = { "hwinfo", "sys_hwinfo", false, TABLE_HARDWARE }, .next = &TABLE_MAP[5]},
-    { .current = { "ports", "sys_ports", false, TABLE_PORTS }, .next = &TABLE_MAP[6]},
-    { .current = { "packages", "sys_programs", false, TABLE_PACKAGES }, .next = &TABLE_MAP[7]},
-    { .current = { "hotfixes", "sys_hotfixes",  false, TABLE_HOTFIXES }, .next = &TABLE_MAP[8]},
-    { .current = { "processes", "sys_processes",  false, TABLE_PROCESSES}, .next = NULL},
+    { .current = { "network_iface", "sys_netiface", false, TABLE_NETIFACE, NETIFACE_FIELD_COUNT }, .next = &TABLE_MAP[1]},
+    { .current = { "network_protocol", "sys_netproto", false, TABLE_NETPROTO, NETPROTO_FIELD_COUNT }, .next = &TABLE_MAP[2]},
+    { .current = { "network_address", "sys_netaddr", false, TABLE_NETADDR, NETADDR_FIELD_COUNT }, .next = &TABLE_MAP[3]},
+    { .current = { "osinfo", "sys_osinfo", false, TABLE_OS, OS_FIELD_COUNT }, .next = &TABLE_MAP[4]},
+    { .current = { "hwinfo", "sys_hwinfo", false, TABLE_HARDWARE, HARDWARE_FIELD_COUNT }, .next = &TABLE_MAP[5]},
+    { .current = { "ports", "sys_ports", false, TABLE_PORTS, PORTS_FIELD_COUNT }, .next = &TABLE_MAP[6]},
+    { .current = { "packages", "sys_programs", false, TABLE_PACKAGES, PACKAGES_FIELD_COUNT }, .next = &TABLE_MAP[7]},
+    { .current = { "hotfixes", "sys_hotfixes",  false, TABLE_HOTFIXES, HOTFIXES_FIELD_COUNT }, .next = &TABLE_MAP[8]},
+    { .current = { "processes", "sys_processes",  false, TABLE_PROCESSES, PROCESSES_FIELD_COUNT }, .next = NULL},
 };
 
 
@@ -5705,7 +5714,12 @@ int wdb_parse_dbsync(wdb_t * wdb, char * input, char * output) {
     struct kv_list const *head = TABLE_MAP;
     while (NULL != head) {
         if (strncmp(head->current.key, table_key, OS_SIZE_256 - 1) == 0) {
-            ret_val = process_dbsync_data(wdb, &head->current, operation, data, select_output) ? OS_SUCCESS : OS_NOTFOUND;
+            const size_t field_count = os_strcnt(data, *FIELD_SEPARATOR_DBSYNC);
+            if (field_count == head->current.field_count) {
+                ret_val = process_dbsync_data(wdb, &head->current, operation, data, select_output) ? OS_SUCCESS : OS_NOTFOUND;
+            } else {
+                merror(DB_INVALID_DELTA_MSG, data, head->current.field_count, field_count);
+            }
             break;
         }
         head = head->next;


### PR DESCRIPTION
|Related issue|
|---|
|Closes #10606 |

## Description


This issue aims to solve some fixes related to wazuh-db input sanitization. This information comes from wazuh-analysisd during handling syscollector delta information by syscollector implicit decoder.

The fact that queries are pipe-separated values indicates that are also positional. Invalid field count will lead to unexpected behaviour. 

