### PR TITLE
Get correct version of Windows 11

### DIFF
--- a/src/data_provider/src/osinfo/sysOsInfoWin.cpp
+++ b/src/data_provider/src/osinfo/sysOsInfoWin.cpp
@@ -185,6 +185,31 @@ static std::string getName()
     if (currentVersion.string("ProductName", name))
     {
         name = Utils::startsWith(name, MSFT_PREFIX) ? name : MSFT_PREFIX + " " + name;
+
+        const auto build { getBuild() };
+        std::string errorMessage;
+
+        try
+        {
+            size_t valueSize = 0;
+            const auto value { std::stoi(build, &valueSize) };
+
+            if (build.size() == valueSize)
+            {
+                constexpr int FIRST_BUILD_WINDOWS11{ 22000 };
+
+                if (value >= FIRST_BUILD_WINDOWS11)
+                {
+                    constexpr auto MSFT_VERSION {"Microsoft Windows 10"};
+                    constexpr auto MSFT_VERSION_REPLACED {"Microsoft Windows 11"};
+                    Utils::replaceAll(name, MSFT_VERSION, MSFT_VERSION_REPLACED);
+                }
+            }
+        }
+        catch (...)
+        {
+
+        }
     }
     else if (IsWindowsVistaOrGreater())
     {

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -383,6 +383,10 @@
 #define PRODUCT_STORAGE_WORKGROUP_SERVER_CORE_C "Storage Server Workgroup (core installation) "
 #endif
 
+#ifndef FIRST_BUILD_WINDOWS_11
+#define FIRST_BUILD_WINDOWS_11 22000
+#endif
+
 #define mkstemp(x) 0
 #define mkdir(x, y) mkdir(x)
 #endif /* WIN32 */
@@ -1897,6 +1901,15 @@ const char *getuname()
                         }
                         else {
                             snprintf(__wp, 63, " [Ver: %d.%d.%s]", (unsigned int)winMajor, (unsigned int)winMinor, wincomp);
+
+                            char *endptr = NULL, *osVersion = NULL;
+                            const int buildNumber = (int) strtol(wincomp, endptr, 10);
+
+                            if ('\0' == endptr && buildNumber >= FIRST_BUILD_WINDOWS_11) {
+                                if (osVersion = strstr(ret, "Microsoft Windows 10"), osVersion != NULL) {
+                                    memcpy(osVersion, "Microsoft Windows 11", strlen("Microsoft Windows 11"));
+                                }
+                            }
                         }
                     }
                     RegCloseKey(RegistryKey);


### PR DESCRIPTION
|Related issue|
|---|
|#10464|



## Description

This PR aims to fix the issue when the agent gets the OS version on Windows 11. Before changes, the agent always shows the incorrect name OS as shown below:

![image](https://user-images.githubusercontent.com/58960358/138632638-9d4885c4-17cc-4376-9b1b-4f4acfe1e868.png)

Now, the Kibana app and inventory data dashboard shows:

![image](https://user-images.githubusercontent.com/58960358/138632858-5537aab9-7e7e-4d47-b34d-333490981710.png)

![image](https://user-images.githubusercontent.com/58960358/138632347-3dc31c92-0680-4686-bce4-0c3dfd7d0a0f.png)

## Configuration options

## Logs/Alerts example

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors