### PR TITLE
Logcollector file handling message scope and description changed

### DIFF
--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -30,7 +30,7 @@
 #define SELECT_ERROR  "(1114): Error during select()-call due to [(%d)-(%s)]."
 #define FREAD_ERROR   "(1115): Could not read from file '%s' due to [(%d)-(%s)]."
 #define FSEEK_ERROR   "(1116): Could not set position in file '%s' due to [(%d)-(%s)]."
-#define FILE_ERROR    "(1117): Error handling file '%s' (date)."
+#define FILE_ERROR    "(1117): Error handling file '%s'."
 #define FSTAT_ERROR   "(1118): Could not retrieve information of file '%s' due to [(%d)-(%s)]."
 #define FGETS_ERROR   "(1119): Invalid line on file '%s': %s."
 //#define PIPE_ERROR    "%s(1120): ERROR: Pipe error."

--- a/src/error_messages/information_messages.h
+++ b/src/error_messages/information_messages.h
@@ -69,4 +69,7 @@
 #define LOGTEST_INFO_LOG_NOLEVEL            "(7205): Rule without alert level"
 #define LOGTEST_INFO_SESSION_REMOVE         "(7206): The session '%s' was closed successfully"
 
+/* Logcollector info messages */
+#define LOGCOLLECTOR_INVALID_HANDLE_VALUE   "(9200): File '%s' can not be handled."
+
 #endif /* INFO_MESSAGES_H */

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -614,13 +614,13 @@ void LogCollectorStart()
                         fclose(current->fp);
                         CloseHandle(current->h);
                         current->fp = NULL;
-                        merror(FILE_ERROR, current->file);
+                        minfo(LOGCOLLECTOR_INVALID_HANDLE_VALUE, current->file);
                     } else if (GetFileInformationByHandle(h1, &lpFileInformation) == 0) {
                         fclose(current->fp);
                         CloseHandle(current->h);
                         CloseHandle(h1);
                         current->fp = NULL;
-                        merror(FILE_ERROR, current->file);
+                        minfo(LOGCOLLECTOR_INVALID_HANDLE_VALUE, current->file);
                     }
 
                     if (!current->fp) {
@@ -742,14 +742,14 @@ void LogCollectorStart()
                             if (current->h) {
                                 CloseHandle(current->h);
                             }
-                            mdebug1(FILE_ERROR, current->file);
+                            mdebug1(LOGCOLLECTOR_INVALID_HANDLE_VALUE, current->file);
                             file_exists = 0;
                             w_logcollector_state_delete_file(current->file);
                         } else if (GetFileInformationByHandle(h1, &lpFileInformation) == 0) {
                             if (current->h) {
                                 CloseHandle(current->h);
                             }
-                            mdebug1(FILE_ERROR, current->file);
+                            mdebug1(LOGCOLLECTOR_INVALID_HANDLE_VALUE, current->file);
                             file_exists = 0;
                             w_logcollector_state_delete_file(current->file);
                         }


### PR DESCRIPTION
|Related issue|
|---|
| Closes #9590 |

## Description

As the Issue #9590 exposes, before, when trying to access a file to collect logs with logcollector, an error message was reported in the `ossec.log` file, from time to time, when the file no longer exists. This could happen due to file rotation, so the message should not be an error but information.

## Logs/Alerts example

### Former message (example):
```
2021/05/13 09:28:37 wazuh-agent: ERROR: (1117): Error handling file 'C:\example.log' (date).
2021/05/13 09:28:37 wazuh-agent: INFO: (1959): File 'C:\example.log' no longer exists.
```

### New message (example):
```
2021/05/13 09:28:37 wazuh-agent: INFO: (9200): File 'C:\example.log' can not be handled.
2021/05/13 09:28:37 wazuh-agent: INFO: (1959): File 'C:\example.log' no longer exists.
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] ~Coverity~
  - [ ] ~Valgrind (memcheck and descriptor leaks check)~
  - [ ] ~Dr. Memory~
  - [ ] ~AddressSanitizer~
- Memory tests for Windows
  - [x] Scan-build report~
  - [ ] ~Coverity~
  - [ ] ~Dr. Memory~
- Memory tests for macOS
  - [ ] ~Scan-build report~
  - [ ] ~Leaks~
  - [ ] ~AddressSanitizer~

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] ~Retrocompatibility with older Wazuh versions~
- [ ] ~Working on cluster environments~
- [ ] ~Configuration on demand reports new parameters~
- [ ] ~The data flow works as expected (agent-manager-api-app)~
- [ ] ~Added unit tests (for new features)~
- [ ] ~Stress test for affected components~

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] ~Added unit testing files ".ini"~
  - [ ] ~runtests.py executed without errors~

Best Regards,

Mariano Koremblum