### PR TITLE
Compiling Wazuh agent on FreeBSD 13 with architecture i386

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -854,6 +854,13 @@ endif
 
 OPENSSL_FLAGS = enable-weak-ssl-ciphers no-shared
 
+ifeq (${uname_M}, i386)
+ifeq ($(findstring BSD,${uname_S}), BSD)
+	OPENSSL_FLAGS += no-asm
+endif
+endif
+
+
 ${CRYPTO_LIB}: ${OPENSSL_LIB}
 
 ${OPENSSL_LIB}:


### PR DESCRIPTION
|Related issue|
|---|
|#10640|

## Description

This PR aims to solve a problem compilation raised by a community user. The user wants to compile the Wazuh agent in FreeBSD 13 with architecture i386. The following error appears when compiling agent:

![image](https://user-images.githubusercontent.com/58960358/139067858-523f68ee-0bfe-4bb6-8964-9c82aeb339b0.png)

After changing the Makefile was achieved compiling Wazuh agent on this OS:

![image](https://user-images.githubusercontent.com/58960358/139068725-724c1c7f-0016-40c3-9c94-96d64a094859.png)
![image](https://user-images.githubusercontent.com/14300208/139125089-d966178a-12d2-4370-8c94-a04115414154.png)

 
## Configuration options

## Logs/Alerts example

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] *BSD
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors