### PR TITLE
Improve `dapi.py` unittests and increase the overall coverage

### DIFF
--- a/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
+++ b/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
@@ -12,6 +12,7 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 from connexion import ProblemException
+from sqlalchemy.exc import OperationalError
 
 from wazuh.core import common
 
@@ -27,12 +28,13 @@ with patch('wazuh.common.wazuh_uid'):
         from wazuh.tests.util import RBAC_bypasser
 
         wazuh.rbac.decorators.expose_resources = RBAC_bypasser
-        from wazuh.core.cluster.dapi.dapi import DistributedAPI, APIRequestQueue
+        from wazuh.core.cluster.dapi.dapi import DistributedAPI, APIRequestQueue, SendSyncRequestQueue
         from wazuh.core.manager import get_manager_status
         from wazuh.core.results import WazuhResult, AffectedItemsWazuhResult
         from wazuh import agent, cluster, ciscat, manager, WazuhError, WazuhInternalError
         from wazuh.core.exception import WazuhClusterError
         from api.util import raise_if_exc
+        from wazuh.core.cluster import local_client
 
 logger = logging.getLogger('wazuh')
 loop = asyncio.get_event_loop()
@@ -85,20 +87,48 @@ def test_DistributedAPI(install_type_mock, kwargs):
     assert isinstance(dapi, DistributedAPI)
 
 
+def test_DistributedAPI_debug_log():
+    """Check that error messages are correctly sent to the logger in the DistributedAPI class."""
+    class TestingLogger:
+        def __init__(self, logger_name):
+            self.name = logger_name
+
+        def debug(self, message):
+            pass
+
+        def debug2(self, message):
+            pass
+
+    logger_ = TestingLogger(logger_name="wazuh-api")
+    message = "Testing debug2"
+    with patch.object(logger_, "debug2") as debug2_mock:
+        dapi = DistributedAPI(f=agent.get_agents_summary_status, logger=logger_)
+        dapi.debug_log(message)
+        debug2_mock.assert_called_once_with(message)
+
+    logger_ = TestingLogger(logger_name="wazuh")
+    message = "Testing debug"
+    with patch.object(logger_, "debug") as debug_mock:
+        dapi = DistributedAPI(f=agent.get_agents_summary_status, logger=logger_)
+        dapi.debug_log(message)
+        debug_mock.assert_called_once_with(message)
+
+
 @patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.execute_local_request',
        new=AsyncMock(return_value=WazuhResult({'result': 'local'})))
 @patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.forward_request',
        new=AsyncMock(return_value=WazuhResult({'result': 'forward'})))
 @patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.execute_remote_request',
        new=AsyncMock(return_value=WazuhResult({'result': 'remote'})))
-@pytest.mark.parametrize('api_request, request_type, node, expected, cluster_enabled', [
-    (agent.get_agents_summary_status, 'local_master', 'master', 'local', True),
-    (agent.restart_agents, 'distributed_master', 'master', 'forward', True),
-    (cluster.get_node_wrapper, 'local_any', 'worker', 'local', True),
-    (ciscat.get_ciscat_results, 'distributed_master', 'worker', 'remote', True),
-    (manager.status, 'local_master', 'worker', 'local', False)
+@pytest.mark.parametrize('api_request, request_type, node, expected, cluster_enabled, f_kwargs', [
+    (agent.get_agents_summary_status, 'local_master', 'master', 'local', True, None),
+    (agent.restart_agents, 'distributed_master', 'master', 'forward', True, None),
+    (cluster.get_node_wrapper, 'local_any', 'worker', 'local', True, 'token_nbf_time'),
+    (ciscat.get_ciscat_results, 'distributed_master', 'worker', 'remote', True, None),
+    (manager.status, 'local_master', 'worker', 'local', False, {'password': 'testing'}),
+    (manager.status, 'local_master', 'worker', 'local', False, None)
 ])
-def test_DistributedAPI_distribute_function(api_request, request_type, node, expected, cluster_enabled):
+def test_DistributedAPI_distribute_function(api_request, request_type, node, expected, cluster_enabled, f_kwargs):
     """Test distribute_function functionality with different test cases.
 
     Parameters
@@ -118,7 +148,7 @@ def test_DistributedAPI_distribute_function(api_request, request_type, node, exp
     # Mock check_cluster_status and get_node
     with patch('wazuh.core.cluster.dapi.dapi.check_cluster_status', return_value=cluster_enabled):
         with patch('wazuh.core.cluster.cluster.get_node', return_value={'type': node}):
-            dapi = DistributedAPI(f=api_request, logger=logger, request_type=request_type)
+            dapi = DistributedAPI(f=api_request, logger=logger, request_type=request_type, f_kwargs=f_kwargs)
             data = raise_if_exc(loop.run_until_complete(dapi.distribute_function()))
             assert data.render()['result'] == expected
 
@@ -151,10 +181,32 @@ def test_DistributedAPI_distribute_function_mock_solver(api_request, request_typ
 
 
 def test_DistributedAPI_distribute_function_exception():
-    """Test distribute_function when an exception is raised.
-    """
+    """Test distribute_function when an exception is raised."""
+
+    class NodeWrapper:
+        def __init__(self):
+            self.affected_items = []
+            self.failed_items = {Exception("test_get_error_info"): "abc"}
+
     dapi_kwargs = {'f': manager.restart, 'logger': logger}
     raise_if_exc_routine(dapi_kwargs=dapi_kwargs, expected_error=1017)
+
+    logger_ = logging.getLogger("wazuh")
+    with patch("wazuh.core.cluster.dapi.dapi.get_node_wrapper", side_effect=WazuhError(4000)):
+        dapi = DistributedAPI(f=agent.get_agents_summary_status, logger=logger_)
+        get_error_result = dapi.get_error_info(Exception("testing"))
+        assert 'unknown-node' in get_error_result
+        assert get_error_result['unknown-node']['error'] == 'Wazuh Internal Error. See log for more detail'
+
+    with patch("wazuh.core.cluster.dapi.dapi.get_node_wrapper", side_effect=WazuhError(4001)):
+        dapi = DistributedAPI(f=agent.get_agents_summary_status, logger=logger_)
+        with pytest.raises(WazuhError, match='.* 4001 .*'):
+            dapi.get_error_info(Exception("testing"))
+
+    with patch("wazuh.core.cluster.dapi.dapi.get_node_wrapper", return_value=NodeWrapper()):
+        dapi = DistributedAPI(f=agent.get_agents_summary_status, logger=logger_)
+        with pytest.raises(Exception, match='.*test_get_error_info.*'):
+            dapi.get_error_info(Exception("testing"))
 
 
 @patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.execute_local_request',
@@ -211,10 +263,11 @@ def test_DistributedAPI_local_request(mock_local_request):
     raise_if_exc_routine(dapi_kwargs=dapi_kwargs)
 
     with patch('asyncio.wait_for', new=AsyncMock(side_effect=TimeoutError('Testing'))):
-        dapi = DistributedAPI(f=manager.status, logger=logger)
+        dapi = DistributedAPI(f=manager.status, logger=logger, f_kwargs={'agent_list': '*'})
         try:
             raise_if_exc(loop.run_until_complete(dapi.distribute_function()))
         except ProblemException as e:
+            assert 'agent_list' not in dapi.f_kwargs
             assert e.ext['dapi_errors'][list(e.ext['dapi_errors'].keys())[0]]['error'] == \
                    'Timeout executing API request'
 
@@ -224,6 +277,14 @@ def test_DistributedAPI_local_request(mock_local_request):
 
         dapi_kwargs['debug'] = True
         raise_if_exc_routine(dapi_kwargs=dapi_kwargs, expected_error=1001)
+
+    with patch('asyncio.wait_for', new=AsyncMock(side_effect=asyncio.TimeoutError())):
+        dapi_kwargs = {'f': manager.status, 'logger': logger}
+        raise_if_exc_routine(dapi_kwargs=dapi_kwargs, expected_error=3021)
+
+    with patch('asyncio.wait_for', new=AsyncMock(side_effect=OperationalError(statement=None, params=[], orig=None))):
+        dapi_kwargs = {'f': manager.status, 'logger': logger}
+        raise_if_exc_routine(dapi_kwargs=dapi_kwargs, expected_error=2008)
 
     with patch('asyncio.wait_for', new=AsyncMock(side_effect=WazuhInternalError(1001))):
         dapi_kwargs = {'f': manager.status, 'logger': logger}
@@ -244,6 +305,25 @@ def test_DistributedAPI_local_request(mock_local_request):
             raise_if_exc(loop.run_until_complete(dapi.distribute_function()))
         except Exception as e:
             assert type(e) == KeyError
+
+
+@patch("asyncio.get_running_loop")
+def test_DistributedAPI_get_client(loop_mock):
+    """Test get_client function from DistributedAPI."""
+    class Node:
+        def __init__(self):
+            self.cluster_items = {"cluster_items": ["worker1", "worker2"]}
+
+        def get_node(self):
+            pass
+
+    logger = logging.getLogger("test")
+    dapi = DistributedAPI(f=agent.get_agents_summary_status, logger=logger)
+    assert isinstance(dapi.get_client(), local_client.LocalClient)
+
+    node = Node()
+    dapi = DistributedAPI(f=agent.get_agents_summary_status, node=node, logger=logger)
+    assert dapi.get_client() == node
 
 
 @patch('wazuh.core.cluster.cluster.get_node', return_value={'type': 'worker'})
@@ -341,7 +421,8 @@ def filter_node_mock(filter_node=None, *args, **kwargs):
 @patch('wazuh.core.cluster.local_client.LocalClient.execute',
        new=AsyncMock(return_value='{"items": [{"name": "master"}], "totalItems": 1}'))
 @patch('wazuh.agent.Agent.get_agents_overview', return_value={'items': [{'id': '001', 'node_name': 'master'},
-                                                                        {'id': '002', 'node_name': 'master'}]})
+                                                                        {'id': '002', 'node_name': 'master'},
+                                                                        {'id': '003', 'node_name': 'unknown'}]})
 @patch('wazuh.core.cluster.dapi.dapi.check_cluster_status', return_value=True)
 def test_DistributedAPI_get_solver_node(mock_cluster_status, mock_agents_overview):
     """Test `get_solver_node` function."""
@@ -353,6 +434,18 @@ def test_DistributedAPI_get_solver_node(mock_cluster_status, mock_agents_overvie
         with patch('wazuh.core.cluster.cluster.get_node', return_value={'type': 'master', 'node': 'unknown'}):
             dapi_kwargs = {'f': manager.status, 'logger': logger, 'request_type': 'distributed_master',
                            'f_kwargs': {'agent_list': ['001', '002']}, 'nodes': ['master']}
+            raise_if_exc_routine(dapi_kwargs=dapi_kwargs)
+
+            dapi_kwargs = {'f': manager.status, 'logger': logger, 'request_type': 'distributed_master',
+                           'f_kwargs': {'agent_list': ['003', '004']}, 'nodes': ['master']}
+            raise_if_exc_routine(dapi_kwargs=dapi_kwargs)
+
+            dapi_kwargs = {'f': manager.status, 'logger': logger, 'request_type': 'distributed_master',
+                           'f_kwargs': {'agent_list': ['003', '004'], 'node_id': 'worker1'}, 'nodes': ['master']}
+            raise_if_exc_routine(dapi_kwargs=dapi_kwargs)
+
+            dapi_kwargs = {'f': manager.status, 'logger': logger, 'request_type': 'distributed_master',
+                           'f_kwargs': {'agent_list': '*'}, 'nodes': ['master']}
             raise_if_exc_routine(dapi_kwargs=dapi_kwargs)
 
             dapi_kwargs = {'f': manager.status, 'logger': logger, 'request_type': 'distributed_master',
@@ -411,9 +504,122 @@ def test_DistributedAPI_check_wazuh_status_exception(node_info_mock, status_valu
             assert e._extra_message['not_ready_daemons'] == extra_message
 
 
-def test_APIRequestQueue():
+@patch("asyncio.get_event_loop")
+def test_APIRequestQueue_init(loop_mock):
     """Test `APIRequestQueue` constructor."""
     server = DistributedAPI(f=agent.get_agents_summary_status, logger=logger)
     api_request_queue = APIRequestQueue(server=server)
     api_request_queue.add_request(b'testing')
     assert api_request_queue.server == server
+
+
+@patch("wazuh.core.cluster.common.import_module", return_value="os.path")
+@patch("asyncio.get_event_loop")
+async def test_APIRequestQueue_run(loop_mock, import_module_mock):
+    """Test `APIRequestQueue.run` function."""
+    class DistributedAPI_mock:
+        def __init__(self):
+            pass
+
+        async def distribute_function(self):
+            pass
+
+    class NodeMock:
+        async def send_request(self, command, data):
+            pass
+
+        async def send_string(self, command):
+            return command
+
+    class ServerMock:
+        def __init__(self):
+            self.clients = {"names": ["w1", "w2"]}
+
+    class RequestQueueMock:
+        async def get(self):
+            return 'wazuh*request_queue*test ' \
+                   '{"f": {"__callable__": {"__name__": "join", "__qualname__": "join", "__module__": "join"}}}'
+
+    with patch.object(logger, "error", side_effect=Exception("break while true")) as logger_mock:
+        server = ServerMock()
+        apirequest = APIRequestQueue(server=server)
+        apirequest.logger = logger
+        apirequest.request_queue = RequestQueueMock()
+        with pytest.raises(Exception, match=".*break while true.*"):
+            await apirequest.run()
+            logger_mock.assert_called_once_with("Error in DAPI. The destination node is "
+                                                "not connected or does not exist: break while true.")
+
+        node = NodeMock()
+        with patch.object(node, "send_string", return_value=b"noerror"):
+            with patch.object(node, "send_request", return_value=b"Error"):
+                with patch("wazuh.core.cluster.dapi.dapi.DistributedAPI", return_value=DistributedAPI_mock()):
+                    server.clients = {"wazuh": node}
+                    with pytest.raises(Exception):
+                        await apirequest.run()
+
+        with patch.object(node, "send_string", return_value=b"noerror"):
+            with patch.object(node, "send_request", return_value=WazuhError(1000)):
+                with patch("wazuh.core.cluster.dapi.dapi.DistributedAPI", return_value=DistributedAPI_mock()):
+                    server.clients = {"wazuh": node}
+                    with pytest.raises(Exception):
+                        await apirequest.run()
+
+        with patch.object(node, "send_string", Exception("break while true")):
+            with patch("wazuh.core.cluster.dapi.dapi.DistributedAPI", return_value=DistributedAPI_mock()):
+                apirequest.logger = logging.getLogger("apirequest")
+                with pytest.raises(Exception):
+                    await apirequest.run()
+
+        with patch.object(node, "send_string", return_value=b"noerror"):
+            with patch("wazuh.core.cluster.dapi.dapi.DistributedAPI", return_value=DistributedAPI_mock()):
+                with pytest.raises(Exception):
+                    await apirequest.run()
+
+
+@patch("asyncio.get_event_loop")
+async def test_SendSyncRequestQueue_run(loop_mock):
+    """Test `SendSyncRequestQueue.run` function."""
+    class NodeMock:
+        async def send_request(self, command, data):
+            pass
+
+        async def send_string(self, command):
+            return command
+
+    class ServerMock:
+        def __init__(self):
+            self.clients = {"names": ["w1", "w2"]}
+
+    class RequestQueueMock:
+        async def get(self):
+            return "wazuh*request_queue*test {\"daemon_name\": \"test\"}"
+
+    with patch.object(logger, "error", side_effect=Exception("break while true")) as logger_mock:
+        server = ServerMock()
+        sendsync = SendSyncRequestQueue(server=server)
+        sendsync.logger = logger
+        sendsync.request_queue = RequestQueueMock()
+        with pytest.raises(Exception, match=".*break while true.*"):
+            await sendsync.run()
+            logger_mock.assert_called_with("Error in Sendsync. The destination node is "
+                                           "not connected or does not exist: break while true.")
+
+        node = NodeMock()
+        with patch.object(node, "send_request", Exception("break while true")) as node_mock:
+            with patch("wazuh.core.cluster.dapi.dapi.wazuh_sendsync", side_effect=Exception("break while true")):
+                server.clients = {"wazuh": node}
+                sendsync.logger = logging.getLogger("sendsync")
+                with pytest.raises(Exception):
+                    await sendsync.run()
+
+            with patch("wazuh.core.cluster.dapi.dapi.wazuh_sendsync", side_effect="noerror"):
+                with pytest.raises(Exception):
+                    await sendsync.run()
+                    node_mock.assert_called_with(b"sendsyn_res", "request_queue*test ")
+
+        with patch.object(node, "send_request", return_value=WazuhError(1000)):
+            with patch("wazuh.core.cluster.dapi.dapi.wazuh_sendsync", return_value="valid"):
+                sendsync.logger = logger
+                with pytest.raises(Exception, match=".*break while true.*"):
+                    await sendsync.run()


### PR DESCRIPTION
|Related issue|
|---|
|#10004|

This PR closes #10004. In this PR we have improved the existing unit tests for the dapi.py file. Now we set the behavior of the functions and improved the overall coverage of the file. The uncovered lines are not relevant because they are basic operations and make the complexity of the test to be greatly increased in case they are covered.

```
~/git/wazuh feature/10004-dapi-unittests *1 !1 ?2 ❯ PYTHONPATH=/mnt/c/Users/adr_i/git/wazuh/api:/mnt/c/Users/adr_i/git/wazuh/framework python3 -m coverage run --source=wazuh.core.cluster.dapi -m pytest -xs -vv framework/wazuh/core/cluster/dapi/tests/test_dapi.py
/home/adriiiprodri/.venvs/wazuh/lib/python3.9/site-packages/_testinfra_renamed.py:5: DeprecationWarning: testinfra package has been renamed to pytest-testinfra. Please `pip install pytest-testinfra` and `pip uninstall testinfra` and update your package requirements to avoid this message
  warnings.warn((
============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.9.5, pytest-6.2.5, py-1.10.0, pluggy-1.0.0 -- /home/adriiiprodri/.venvs/wazuh/bin/python3
cachedir: .pytest_cache
rootdir: /mnt/c/Users/adr_i/git/wazuh/framework
plugins: trio-0.7.0, asyncio-0.16.0, testinfra-6.0.0, testinfra-6.4.0, aiohttp-0.3.0
collected 30 items

framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI[kwargs0] PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI[kwargs1] PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_debug_log PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_distribute_function[get_agents_summary_status-local_master-master-local-True-None] PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_distribute_function[restart_agents-distributed_master-master-forward-True-None] PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_distribute_function[get_node_wrapper-local_any-worker-local-True-token_nbf_time] PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_distribute_function[get_ciscat_results-distributed_master-worker-remote-True-None] PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_distribute_function[status-local_master-worker-local-False-f_kwargs4] PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_distribute_function[status-local_master-worker-local-False-None] PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_distribute_function_mock_solver[restart_agents-distributed_master-master-local] PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_distribute_function_exception PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_invalid_json PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_local_request_errors PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_local_request PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_get_client PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_remote_request_errors PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_remote_request PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_forward_request_errors PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_logger PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_tmp_file PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_tmp_file_cluster_error PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_get_solver_node PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_check_wazuh_status[get_agents_summary_status] PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_check_wazuh_status[status] PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_check_wazuh_status_exception[failed] PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_check_wazuh_status_exception[restarting] PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_check_wazuh_status_exception[stopped] PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_APIRequestQueue_init PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_APIRequestQueue_run PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_SendSyncRequestQueue_run PASSED

========================================================================================= 30 passed, 9 warnings in 2.75s =========================================================================================
```
```
~/git/wazuh feature/10004-dapi-unittests *1 !1 ?2 ❯ python3 -m coverage report -m                                                                                                                     4s Py wazuh
Name                                            Stmts   Miss  Cover   Missing
-----------------------------------------------------------------------------
framework/wazuh/core/cluster/dapi/__init__.py       0      0   100%
framework/wazuh/core/cluster/dapi/dapi.py         375     17    95%   177, 421-423, 451, 484-486, 515-516, 535, 539-543, 590, 656
-----------------------------------------------------------------------------
TOTAL                                             375     17    95%
```