### PR TITLE
Add a variable for agent name length limit

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -491,7 +491,7 @@ def add_agent(name=None, agent_id=None, key=None, ip='any', force=None):
         Added agent information.
     """
     # Check length of agent name
-    if len(name) > 128:
+    if len(name) > common.agent_name_len_limit:
         raise WazuhError(1738)
 
     new_agent = Agent(name=name, ip=ip, id=agent_id, key=key, force=force)

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -179,6 +179,7 @@ agent_info_retries = 100  # Retries to detect when agent_info file is updated
 agent_info_sleep = 2  # Seconds between retries
 
 # Common variables
+agent_name_len_limit = 128
 database_limit = 500
 maximum_database_limit = 100000
 limit_seconds = 1800  # 600*3

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -4,7 +4,7 @@
 
 
 from copy import deepcopy
-from wazuh.core.common import MAX_SOCKET_BUFFER_SIZE, wazuh_version as wazuh_full_version
+from wazuh.core.common import MAX_SOCKET_BUFFER_SIZE, wazuh_version as wazuh_full_version, agent_name_len_limit
 
 GENERIC_ERROR_MSG = "Wazuh Internal Error. See log for more detail"
 WAZUH_VERSION = 'current' if wazuh_full_version == '' else '.'.join(wazuh_full_version.split('.')[:2]).lstrip('v')
@@ -301,7 +301,7 @@ class WazuhException(Exception):
                'remediation': 'Please choose another group or remove an agent from the target group'
                },
         1738: {'message': 'Agent name is too long',
-               'remediation': 'Max length allowed for agent name is 128'
+               'remediation': f'Max length allowed for agent name is {agent_name_len_limit}'
                },
         1739: {'message': 'Error getting agents group sync',
                'remediation': f'Please check that the agent and the group are correctly created. Official documentation: https://documentation.wazuh.com/{WAZUH_VERSION}/user-manual/agents/grouping-agents.html'

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -19,7 +19,7 @@ with patch('wazuh.core.common.wazuh_uid'):
         from wazuh.core.utils import *
         from wazuh.core import exception
         from wazuh.core.agent import WazuhDBQueryAgents
-        from wazuh.core.common import wazuh_path
+        from wazuh.core.common import wazuh_path, agent_name_len_limit
 
 # all necessary params
 
@@ -557,7 +557,7 @@ def test_get_hash_str():
     result = get_hash_str('test')
 
     assert isinstance(result, str)
-    assert all(ord(char) < 128 for char in result)
+    assert all(ord(char) < agent_name_len_limit for char in result)
 
 
 def test_get_fields_to_nest():


### PR DESCRIPTION
|Related issue|
|---|
| This PR closes #10427 |

After this PR, the maximum permitted length for an agent name is set under a variable at `/core/common.py`.

Regards,
Alexis