### PR TITLE
Fix API integration test agent healthchecks and rename ossec-totals file reading

### DIFF
--- a/api/test/integration/env/configurations/base/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/base/agent/healthcheck/healthcheck.py
@@ -4,10 +4,5 @@ sys.path.append('/tools')
 
 from healthcheck_utils import get_agent_health_base
 
-try:
-    agent_old = sys.argv[1]
-except IndexError:
-    agent_old = False
-
 if __name__ == "__main__":
-    exit(get_agent_health_base(agent_old=agent_old))
+    exit(get_agent_health_base())

--- a/api/test/integration/env/configurations/base/agent/healthcheck/legacy_healthcheck.py
+++ b/api/test/integration/env/configurations/base/agent/healthcheck/legacy_healthcheck.py
@@ -1,8 +1,8 @@
 import sys
+
 sys.path.append('/tools')
 
 from healthcheck_utils import get_agent_health_base
 
-
 if __name__ == "__main__":
-    exit(get_agent_health_base())
+    exit(get_agent_health_base(legacy=True))

--- a/api/test/integration/env/configurations/experimental/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/experimental/agent/healthcheck/healthcheck.py
@@ -5,16 +5,9 @@ sys.path.append('/tools')
 
 from healthcheck_utils import get_agent_health_base
 
-try:
-    agent_old = sys.argv[1]
-except IndexError:
-    agent_old = False
-
-wazuh_log_file = '/var/ossec/logs/wazuh.log' if not agent_old else '/var/ossec/logs/ossec.log'
-
 
 def get_health():
-    output = os.system(f"grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' {wazuh_log_file}")
+    output = os.system("grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/wazuh.log")
 
     if output == 0:
         return 0
@@ -23,4 +16,4 @@ def get_health():
 
 
 if __name__ == "__main__":
-    exit(get_health() or get_agent_health_base(agent_old=agent_old))
+    exit(get_health() or get_agent_health_base())

--- a/api/test/integration/env/configurations/experimental/agent/healthcheck/legacy_healthcheck.py
+++ b/api/test/integration/env/configurations/experimental/agent/healthcheck/legacy_healthcheck.py
@@ -15,4 +15,4 @@ def get_health():
 
 
 if __name__ == "__main__":
-    exit(get_health() or get_agent_health_base())
+    exit(get_health() or get_agent_health_base(legacy=True))

--- a/api/test/integration/env/configurations/sca/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/sca/agent/healthcheck/healthcheck.py
@@ -5,14 +5,7 @@ sys.path.append('/tools')
 
 from healthcheck_utils import get_agent_health_base
 
-try:
-    agent_old = sys.argv[1]
-except IndexError:
-    agent_old = False
-
-wazuh_log_file = '/var/ossec/logs/wazuh.log' if not agent_old else '/var/ossec/logs/ossec.log'
-
 if __name__ == "__main__":
     exit(os.system(
-        f"grep -q 'sca: INFO: Security Configuration Assessment scan finished.' {wazuh_log_file}")
-         or get_agent_health_base(agent_old=agent_old))
+        "grep -q 'sca: INFO: Security Configuration Assessment scan finished.' /var/ossec/logs/wazuh.log")
+         or get_agent_health_base())

--- a/api/test/integration/env/configurations/sca/agent/healthcheck/legacy_healthcheck.py
+++ b/api/test/integration/env/configurations/sca/agent/healthcheck/legacy_healthcheck.py
@@ -1,11 +1,11 @@
 import os
 import sys
+
 sys.path.append('/tools')
 
 from healthcheck_utils import get_agent_health_base
 
-
 if __name__ == "__main__":
     exit(os.system(
         "grep -q 'sca: INFO: Security Configuration Assessment scan finished.' /var/ossec/logs/ossec.log")
-         or get_agent_health_base())
+         or get_agent_health_base(legacy=True))

--- a/api/test/integration/env/configurations/syscheck/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/syscheck/agent/healthcheck/healthcheck.py
@@ -5,17 +5,10 @@ sys.path.append('/tools')
 
 from healthcheck_utils import get_agent_health_base
 
-try:
-    agent_old = sys.argv[1]
-except IndexError:
-    agent_old = False
-
-wazuh_log_file = '/var/ossec/logs/wazuh.log' if not agent_old else '/var/ossec/logs/ossec.log'
-
 
 def get_health():
     output = os.system(
-        f"grep -q 'syscheckd: INFO: (6009): File integrity monitoring scan ended.' {wazuh_log_file}")
+        "grep -q 'syscheckd: INFO: (6009): File integrity monitoring scan ended.' /var/ossec/logs/wazuh.log")
 
     if output == 0:
         return 0
@@ -24,4 +17,4 @@ def get_health():
 
 
 if __name__ == "__main__":
-    exit(get_health() or get_agent_health_base(agent_old=agent_old))
+    exit(get_health() or get_agent_health_base())

--- a/api/test/integration/env/configurations/syscheck/agent/healthcheck/legacy_healthcheck.py
+++ b/api/test/integration/env/configurations/syscheck/agent/healthcheck/legacy_healthcheck.py
@@ -16,4 +16,4 @@ def get_health():
 
 
 if __name__ == "__main__":
-    exit(get_health() or get_agent_health_base())
+    exit(get_health() or get_agent_health_base(legacy=True))

--- a/api/test/integration/env/configurations/syscollector/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/syscollector/agent/healthcheck/healthcheck.py
@@ -1,19 +1,13 @@
 import os
 import sys
+
 sys.path.append('/tools')
 
 from healthcheck_utils import get_agent_health_base
 
-try:
-    agent_old = sys.argv[1]
-except IndexError:
-    agent_old = False
-
-wazuh_log_file = '/var/ossec/logs/wazuh.log' if not agent_old else '/var/ossec/logs/ossec.log'
-
 
 def get_health():
-    output = os.system(f"grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' {wazuh_log_file}")
+    output = os.system("grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/wazuh.log")
 
     if output == 0:
         return 0
@@ -22,4 +16,4 @@ def get_health():
 
 
 if __name__ == "__main__":
-    exit(get_health() or get_agent_health_base(agent_old=agent_old))
+    exit(get_health() or get_agent_health_base())

--- a/api/test/integration/env/configurations/syscollector/agent/healthcheck/legacy_healthcheck.py
+++ b/api/test/integration/env/configurations/syscollector/agent/healthcheck/legacy_healthcheck.py
@@ -15,4 +15,4 @@ def get_health():
 
 
 if __name__ == "__main__":
-    exit(get_health() or get_agent_health_base())
+    exit(get_health() or get_agent_health_base(legacy=True))

--- a/api/test/integration/env/configurations/vulnerability/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/vulnerability/manager/healthcheck/healthcheck.py
@@ -79,6 +79,6 @@ if __name__ == '__main__':
     if socket.gethostname() in nodes_to_check:
         # Append the log showing the end of the scan to ensure the agents' database have the expected data
         checks_list.append(check(system("grep -q 'wazuh-modulesd:vulnerability-detector: INFO: (5472): "
-                                        "Vulnerability scan finished.' /var/ossec/logs/ossec.log")))
+                                        "Vulnerability scan finished.' /var/ossec/logs/wazuh.log")))
 
     exit(any(checks_list))

--- a/api/test/integration/env/tools/healthcheck_utils.py
+++ b/api/test/integration/env/tools/healthcheck_utils.py
@@ -16,7 +16,6 @@ base_url = "{}://{}:{}".format(protocol, host, port)
 login_url = "{}/security/user/authenticate".format(base_url)
 
 HEALTHCHECK_TOKEN_FILE = '/tmp/healthcheck/healthcheck.token'
-OSSEC_LOG_PATH = '/var/ossec/logs/ossec.log'
 
 
 def get_login_header(user, password):
@@ -50,13 +49,13 @@ def get_response(url, headers):
         return json.loads(request_result.content.decode())
 
 
-def get_agent_health_base(agent_old=False):
+def get_agent_health_base(legacy=False):
     # Get agent health. The agent will be healthy if it has been connected to the manager after been
     # restarted due to shared configuration changes.
     # Using agentd when using grep as the module name can vary between ossec-agentd and wazuh-agentd,
     # depending on the agent version.
 
-    wazuh_log_file = "/var/ossec/logs/wazuh.log" if not agent_old else "/var/ossec/logs/ossec.log"
+    wazuh_log_file = "/var/ossec/logs/wazuh.log" if not legacy else "/var/ossec/logs/ossec.log"
 
     shared_conf_restart = os.system(
         f"grep -q 'agentd: INFO: Agent is restarting due to shared configuration changes.' {wazuh_log_file}")

--- a/framework/wazuh/core/stats.py
+++ b/framework/wazuh/core/stats.py
@@ -92,7 +92,7 @@ def totals_(date=datetime.now()):
     try:
         stat_filename = os.path.join(
             common.stats_path, "totals", str(date.year), MONTHS[date.month - 1],
-            f"ossec-totals-{date.strftime('%d')}.log")
+            f"wazuh-totals-{date.strftime('%d')}.log")
         with open(stat_filename, mode='r') as statsf:
             stats = statsf.readlines()
     except IOError:


### PR DESCRIPTION
This PR fixes the API integration test healthchecks when it comes to legacy agents.

Legacy agents were staying in an unhealthy state during the API integration tests execution. This was caused by a wrong conflict solving.

In this pull request, a change has also been added to `stats.py` since the **wazuh-totals** file was being read as **ossec-totals**.

### Affected tests results:

```
test_ciscat_endpoints.tavern.yaml 
	 1 passed, 3 warnings

test_cluster_endpoints.tavern.yaml 
	 45 passed, 47 warnings

test_experimental_endpoints.tavern.yaml 
	 11 passed, 1 xpassed, 14 warnings

test_sca_endpoints.tavern.yaml 
	 2 passed, 4 warnings

test_syscheck_endpoints.tavern.yaml 
	 35 passed, 37 warnings

test_syscollector_endpoints.tavern.yaml 
	 159 passed, 161 warnings
	 
test_agent_PUT_endpoints.tavern.yaml 
	 8 passed, 2 xpassed, 12 warnings
```