### PR TITLE
Update run_test script to run the API integration tests in the new standalone environment

### DIFF
--- a/api/test/integration/run_tests.py
+++ b/api/test/integration/run_tests.py
@@ -214,10 +214,10 @@ def get_script_arguments():
                        help='Get result summary from the already run tests.')
     parser.add_argument('-k', '--keyword', dest='keyword', default=None,
                         help='Specify the keyword to filter tests out. Default None.', action='store')
-    parser.add_argument('-rbac', dest='rbac', default='both', choices=rbac_choices,
+    parser.add_argument('-b', '--rbac', dest='rbac', default='both', choices=rbac_choices,
                         help='Specify what to do with RBAC tests. Run everything, only RBAC ones or no RBAC. Default '
                              '"both".', action='store')
-    parser.add_argument('-mode', dest='mode', default='both', choices=mode_choices,
+    parser.add_argument('-m', '--mode', dest='mode', default='both', choices=mode_choices,
                         help='Specify where to pass API integration tests. Run tests in both environments, standalone '
                              'environment or Wazuh cluster environment. Default "both".', action='store')
     parser.add_argument('-i', '--iterations', dest='iterations', default=1, type=int,

--- a/api/test/integration/run_tests.py
+++ b/api/test/integration/run_tests.py
@@ -4,13 +4,25 @@ import os
 import re
 import subprocess
 
-
-RESULTS_PATH = '_test_results'
 PYTEST_COMMAND = 'pytest -vv'
+
+PYTEST_MARK_STANDALONE = '-m standalone'
+PYTEST_MARK_CLUSTER = '-m cluster'
+STANDALONE_SUFFIX = '_standalone'
+CLUSTER_SUFFIX = '_cluster'
+
+RESULTS_FOLDER = '_test_results'
 TESTS_PATH = os.path.dirname(os.path.abspath(__file__))
 
 
-def calculate_result(file_name):
+def calculate_result(file_name: str):
+    """Extract and print a test result from its result file.
+
+    Parameters
+    ----------
+    file_name : str
+        Indicates the name of the file from which the test result is going to be parsed.
+    """
     with open(file_name, 'r') as f:
         file = f.read()
     try:
@@ -20,70 +32,163 @@ def calculate_result(file_name):
         print('\tCould not retrieve results from this test')
 
 
-def collect_tests(test_list=None, keyword=None, rbac='both'):
+def collect_tests(test_list: str = None, keyword: str = None, rbac: str = 'both') -> list:
+    """Collect API integration tests from the test path filtering by the given parameters.
+
+    Parameters
+    ----------
+    test_list : str
+        List of tests substrings used to match and collect API integration tests. They must be separated by comma.
+    keyword : str
+        Keyword used to match and collect API integration tests.
+    rbac : str
+        Indicates whether RBAC tests are going to be collected or not. The possible values are `yes`, `no`, and `both`.
+
+    Returns
+    -------
+    list
+        List with the API integration tests collected.
+    """
     os.chdir(TESTS_PATH)
 
-    def filter_tests(kw, rb, t_list=None):
+    def filter_tests(kw: str, rb: str, t_list: str = None) -> list:
+        """Filter API integration tests by the given parameters.
+
+        Parameters
+        ----------
+        t_list : str
+            List of tests substrings used to match and collect API integration tests. They must be separated by comma.
+        kw : str
+            Keyword used to match and collect API integration tests.
+        rb : str
+            Indicates whether RBAC tests are going to be collected or not. The possible values are `yes`, `no`, and
+            `both`.
+
+        Returns
+        -------
+        list
+            Sorted list with the API integration tests collected.
+        """
         kw = kw if kw is not None else ''
         t_list = t_list.split(',') if t_list else None
         collected_items = []
         candidate_tests = [test for test in glob.glob('test_*.yaml') for t in t_list if t in test] \
             if t_list else glob.glob('test_*.yaml')
         for file in candidate_tests:
-            if rb == 'yes':
-                if kw in file and 'rbac' in file:
+            if kw in file:
+                if rb == 'yes' and 'rbac' in file:
                     collected_items.append(file)
-            elif kw in file and rb == 'no':
-                if 'rbac' not in file:
+                elif rb == 'no' and 'rbac' not in file:
                     collected_items.append(file)
-            else:
-                if kw in file:
+                elif rb == 'both':
                     collected_items.append(file)
         return sorted(collected_items)
 
     collected_tests = filter_tests(keyword, rbac, t_list=test_list)
     print(f'Collected tests [{len(collected_tests)}]:')
-    print('{}\n\n'.format(", ".join([t for t in collected_tests])))
+    print('{}\n\n'.format(", ".join(collected_tests)))
 
     return collected_tests
 
 
-def collect_non_excluded_tests():
-    os.chdir(f'{TESTS_PATH}/{RESULTS_PATH}')
+def collect_non_excluded_tests() -> list:
+    """Collect API integration tests without any results in the results folder.
+
+    Returns
+    -------
+    list
+        Sorted list with the API integration tests collected.
+    """
+    os.chdir(f'{TESTS_PATH}/{RESULTS_FOLDER}')
     done_tests = glob.glob(f'test_*')
     os.chdir(TESTS_PATH)
-    collected_tests = sorted([test for test in glob.glob('test_*') if test.rstrip('.tavern.yaml') not in done_tests])
+    collected_tests = sorted([test for test in glob.glob('test_*') if
+                              f"{test.rstrip('.tavern.yaml')}{STANDALONE_SUFFIX}" not in done_tests or
+                              f"{test.rstrip('.tavern.yaml')}{CLUSTER_SUFFIX}" not in done_tests or
+                              f"{test.rstrip('.tavern.yaml')}" not in done_tests])
     print(f'Collected tests [{len(collected_tests)}]:')
-    print('{}\n\n'.format(", ".join([t for t in collected_tests])))
+    print('{}\n\n'.format(", ".join(collected_tests)))
 
     return collected_tests
 
 
-def run_tests(collected_tests, n_iterations=1):
+def run_tests(collected_tests: list, n_iterations: int = 1):
+    """Run a certain number of iterations of API integration tests.
+
+    Parameters
+    ----------
+    collected_tests : list
+        Collected API integration tests that are going to be run.
+    n_iterations : int
+        Number of iterations for the API integration tests to be run.
+    """
+
+    def run_test(test: str, iteration: int, pytest_mark: str = None):
+        """Run a single API integration test once.
+
+        Parameters
+        ----------
+        test : str
+            API integration test to be run.
+        iteration : int
+            Number indicating the iteration to be run.
+        pytest_mark : str
+            Extra mark used to pass the API integration test in a cluster or standalone environment.
+        """
+        test_name = \
+            f'{test.rsplit(".")[0]}' \
+            f'{STANDALONE_SUFFIX if pytest_mark == PYTEST_MARK_STANDALONE else CLUSTER_SUFFIX if pytest_mark == PYTEST_MARK_CLUSTER else ""}' \
+            f'{iteration if iteration != 1 else ""}'
+        html_params = [f"--html={RESULTS_FOLDER}/html_reports/{test_name}.html", '--self-contained-html']
+        with open(os.path.join(RESULTS_FOLDER, test_name), 'w') as f:
+            command = PYTEST_COMMAND.split(' ') + html_params + [test]
+            if pytest_mark:
+                command += pytest_mark.split(' ')
+            subprocess.call(command, stdout=f)
+        get_results(filename=os.path.join(RESULTS_FOLDER, test_name))
+
     os.chdir(TESTS_PATH)
     for test in collected_tests:
         for i in range(1, n_iterations + 1):
             iteration_info = f'[{i}/{n_iterations}]' if n_iterations > 1 else ''
-            test_name = f'{test.rsplit(".")[0]}{i if i != 1 else ""}'
-            print(f'{test} {iteration_info}')
-            f = open(os.path.join(RESULTS_PATH, test_name), 'w')
-            html_params = [f"--html={RESULTS_PATH}/html_reports/{test_name}.html", '--self-contained-html']
-            subprocess.call(PYTEST_COMMAND.split(' ') + html_params + [test], stdout=f)
-            f.close()
-            get_results(filename=os.path.join(RESULTS_PATH, test_name))
+            if 'rbac' not in test:
+                # Run test with a standalone environment
+                print(f'{test} - Standalone environment {iteration_info}')
+                run_test(test=test, iteration=i, pytest_mark=PYTEST_MARK_STANDALONE)
+                # Run test with a cluster environment
+                print(f'{test} - Cluster environment {iteration_info}')
+                run_test(test=test, iteration=i, pytest_mark=PYTEST_MARK_CLUSTER)
+            else:
+                # Run test with the default environment
+                print(f'{test} {iteration_info}')
+                run_test(test=test, iteration=i)
 
 
-def get_results(filename=None):
+def get_results(filename: str = None):
+    """Get API integration tests results. Unless `filename` is given, all API integration tests results will be got.
+
+    Parameters
+    ----------
+    filename : str
+        Indicates the result test file to get the result from.
+    """
     if filename:
         calculate_result(filename)
     else:
-        os.chdir(RESULTS_PATH)
-        for file in sorted(glob.glob('test_*')):
+        os.chdir(RESULTS_FOLDER)
+        for file in sorted(glob.glob('test_*_standalone*')):
+            print(f"{file} - Standalone environment")
+            calculate_result(file)
+        for file in sorted(glob.glob('test_*_cluster*')):
+            print(f"{file} - Cluster environment")
+            calculate_result(file)
+        for file in sorted(glob.glob('test_rbac*')):
             print(file)
             calculate_result(file)
 
 
 def get_script_arguments():
+    """Get command line arguments given to the script."""
     rbac_choices = ['both', 'yes', 'no']
     parser = argparse.ArgumentParser(usage="%(prog)s [options]",
                                      description="API integration tests",
@@ -92,7 +197,7 @@ def get_script_arguments():
     group.add_argument('-l', '--list', dest='test_list', default=None,
                        help='Specify a list of tests separated by a comma.', action='store')
     group.add_argument('-e', '--exclude', dest='exclude', action='store_true', default=None,
-                       help='Run every test excluding the already saved in the RESULTS_PATH.')
+                       help='Run every test excluding the already saved in the RESULTS_FOLDER.')
     group.add_argument('-r', '--results', dest='results', action='store_true', default=None,
                        help='Get result summary from the already run tests.')
     parser.add_argument('-k', '--keyword', dest='keyword', default=None,
@@ -107,8 +212,8 @@ def get_script_arguments():
 
 
 if __name__ == '__main__':
-    os.makedirs(os.path.join(TESTS_PATH, RESULTS_PATH), exist_ok=True)
-    os.makedirs(os.path.join(TESTS_PATH, RESULTS_PATH, 'html_reports'), exist_ok=True)
+    os.makedirs(os.path.join(TESTS_PATH, RESULTS_FOLDER), exist_ok=True)
+    os.makedirs(os.path.join(TESTS_PATH, RESULTS_FOLDER, 'html_reports'), exist_ok=True)
     options = get_script_arguments()
     key = options.keyword
     tl = options.test_list

--- a/api/test/integration/run_tests.py
+++ b/api/test/integration/run_tests.py
@@ -227,7 +227,6 @@ def get_script_arguments():
 
 
 if __name__ == '__main__':
-    os.makedirs(os.path.join(TESTS_PATH, RESULTS_FOLDER), exist_ok=True)
     os.makedirs(os.path.join(TESTS_PATH, RESULTS_FOLDER, 'html_reports'), exist_ok=True)
     options = get_script_arguments()
     key = options.keyword

--- a/api/test/integration/run_tests.py
+++ b/api/test/integration/run_tests.py
@@ -214,7 +214,7 @@ def get_script_arguments():
                        help='Get result summary from the already run tests.')
     parser.add_argument('-k', '--keyword', dest='keyword', default=None,
                         help='Specify the keyword to filter tests out. Default None.', action='store')
-    parser.add_argument('-b', '--rbac', dest='rbac', default='both', choices=rbac_choices,
+    parser.add_argument('-R', '--rbac', dest='rbac', default='both', choices=rbac_choices,
                         help='Specify what to do with RBAC tests. Run everything, only RBAC ones or no RBAC. Default '
                              '"both".', action='store')
     parser.add_argument('-m', '--mode', dest='mode', default='both', choices=mode_choices,


### PR DESCRIPTION
|Related issue|
|---|
|#10594|


This PR closes #10594.

The run_test.py script has been updated to pass AIT using the new `standalone` and `cluster` marks.

The usage is the same, there aren't any new parameters or different behaviours. 

Some of the functions or code we already had in the script have been improved. Docstrings have also been added to make the code more human-readable.


`run_tests.py` examples:

### `-l` parameter

```
$ python3 run_tests.py -l test_cdb_list,test_overview
Collected tests [2]:
test_cdb_list_endpoints.tavern.yaml, test_overview_endpoints.tavern.yaml


test_cdb_list_endpoints.tavern.yaml - Standalone environment 
	 1 passed, 4 deselected, 9 warnings

test_cdb_list_endpoints.tavern.yaml - Cluster environment 
	 2 passed, 3 deselected, 9 warnings

test_overview_endpoints.tavern.yaml - Standalone environment 
	 1 passed, 4 warnings

test_overview_endpoints.tavern.yaml - Cluster environment 
	 1 deselected, 4 warnings
```

### `-k` and `-i`

```
$ python3 run_tests.py -k test_cdb -i 2
Collected tests [1]:
test_cdb_list_endpoints.tavern.yaml


test_cdb_list_endpoints.tavern.yaml - Standalone environment [1/2]
	 1 passed, 4 deselected, 9 warnings

test_cdb_list_endpoints.tavern.yaml - Cluster environment [1/2]
	 2 passed, 3 deselected, 9 warnings

test_cdb_list_endpoints.tavern.yaml - Standalone environment [2/2]
	 1 passed, 4 deselected, 9 warnings

test_cdb_list_endpoints.tavern.yaml - Cluster environment [2/2]
	 2 passed, 3 deselected, 9 warnings
```

```
$ ls _test_results/
 html_reports   logs  'test_cdb_list_endpoints_cluster'  'test_cdb_list_endpoints_cluster2'  'test_cdb_list_endpoints_standalone'  'test_cdb_list_endpoints_standalone2'
```

```
$ ls _test_results/html_reports/
'test_cdb_list_endpoints_cluster.html'  'test_cdb_list_endpoints_cluster2.html'  'test_cdb_list_endpoints_standalone.html'  'test_cdb_list_endpoints_standalone2.html'
```

### `-e` parameter

I only added the standalone and cluster marks to overview and cdb list endpoints API integration tests. This is why all are deselected.

```
$ python3 run_tests.py -e
Collected tests [64]:
test_active_response_endpoints.tavern.yaml, test_agent_DELETE_endpoints.tavern.yaml, test_agent_GET_endpoints.tavern.yaml, test_agent_POST_endpoints.tavern.yaml, test_agent_PUT_endpoints.tavern.yaml, test_ciscat_endpoints.tavern.yaml, test_cluster_endpoints.tavern.yaml, test_decoder_endpoints.tavern.yaml, test_default_endpoints.tavern.yaml, test_experimental_endpoints.tavern.yaml, test_logtest_endpoints.tavern.yaml, test_manager_endpoints.tavern.yaml, test_mitre_endpoints.tavern.yaml, test_overview_endpoints.tavern.yaml, test_rbac_black_active_response_endpoints.tavern.yaml, test_rbac_black_agent_endpoints.tavern.yaml, test_rbac_black_cdb_list_endpoints.tavern.yaml, test_rbac_black_ciscat_endpoints.tavern.yaml, test_rbac_black_cluster_endpoints.tavern.yaml, test_rbac_black_decoder_endpoints.tavern.yaml, test_rbac_black_experimental_endpoints.tavern.yaml, test_rbac_black_logtest_endpoints.tavern.yaml, test_rbac_black_manager_endpoints.tavern.yaml, test_rbac_black_mitre_endpoints.tavern.yaml, test_rbac_black_overview_endpoints.tavern.yaml, test_rbac_black_rootcheck_endpoints.tavern.yaml, test_rbac_black_rule_endpoints.tavern.yaml, test_rbac_black_sca_endpoints.tavern.yaml, test_rbac_black_security_endpoints.tavern.yaml, test_rbac_black_syscheck_endpoints.tavern.yaml, test_rbac_black_syscollector_endpoints.tavern.yaml, test_rbac_black_task_endpoints.tavern.yaml, test_rbac_black_vulnerability_endpoints.tavern.yaml, test_rbac_white_active_response_endpoints.tavern.yaml, test_rbac_white_agent_endpoints.tavern.yaml, test_rbac_white_all_endpoints.tavern.yaml, test_rbac_white_cdb_list_endpoints.tavern.yaml, test_rbac_white_ciscat_endpoints.tavern.yaml, test_rbac_white_cluster_endpoints.tavern.yaml, test_rbac_white_decoder_endpoints.tavern.yaml, test_rbac_white_experimental_endpoints.tavern.yaml, test_rbac_white_logtest_endpoints.tavern.yaml, test_rbac_white_manager_endpoints.tavern.yaml, test_rbac_white_mitre_endpoints.tavern.yaml, test_rbac_white_overview_endpoints.tavern.yaml, test_rbac_white_rootcheck_endpoints.tavern.yaml, test_rbac_white_rule_endpoints.tavern.yaml, test_rbac_white_sca_endpoints.tavern.yaml, test_rbac_white_security_endpoints.tavern.yaml, test_rbac_white_syscheck_endpoints.tavern.yaml, test_rbac_white_syscollector_endpoints.tavern.yaml, test_rbac_white_task_endpoints.tavern.yaml, test_rbac_white_vulnerability_endpoints.tavern.yaml, test_rootcheck_endpoints.tavern.yaml, test_rule_endpoints.tavern.yaml, test_sca_endpoints.tavern.yaml, test_security_DELETE_endpoints.tavern.yaml, test_security_GET_endpoints.tavern.yaml, test_security_POST_endpoints.tavern.yaml, test_security_PUT_endpoints.tavern.yaml, test_syscheck_endpoints.tavern.yaml, test_syscollector_endpoints.tavern.yaml, test_task_endpoints.tavern.yaml, test_vulnerability_endpoints.tavern.yaml


test_active_response_endpoints.tavern.yaml - Standalone environment 
	 2 deselected, 4 warnings

test_active_response_endpoints.tavern.yaml - Cluster environment 
	 2 deselected, 4 warnings

test_agent_DELETE_endpoints.tavern.yaml - Standalone environment 
	 6 deselected, 8 warnings

test_agent_DELETE_endpoints.tavern.yaml - Cluster environment 
	 6 deselected, 8 warnings

...

test_mitre_endpoints.tavern.yaml - Standalone environment 
	 7 deselected, 13 warnings

test_mitre_endpoints.tavern.yaml - Cluster environment 
	 7 deselected, 13 warnings

test_overview_endpoints.tavern.yaml - Standalone environment 
	 1 passed, 4 warnings

test_overview_endpoints.tavern.yaml - Cluster environment 
	 1 deselected, 4 warnings

...

test_vulnerability_endpoints.tavern.yaml - Standalone environment 
	 1 deselected, 3 warnings

test_vulnerability_endpoints.tavern.yaml - Cluster environment 
	 1 deselected, 3 warnings
```


### `-r` parameter

```
$ python3 run_tests.py -r
test_cdb_list_endpoints_standalone- Standalone environment
	 1 passed, 4 deselected, 9 warnings

test_cdb_list_endpoints_standalone2- Standalone environment
	 1 passed, 4 deselected, 9 warnings

test_cdb_list_endpoints_cluster- Cluster environment
	 2 passed, 3 deselected, 9 warnings

test_cdb_list_endpoints_cluster2- Cluster environment
	 2 passed, 3 deselected, 9 warnings
```

### `-rbac` parameter

```
$ python3 run_tests.py -k cdb -rbac yes
Collected tests [2]:
test_rbac_black_cdb_list_endpoints.tavern.yaml, test_rbac_white_cdb_list_endpoints.tavern.yaml


test_rbac_black_cdb_list_endpoints.tavern.yaml 
	 5 passed, 7 warnings

test_rbac_white_cdb_list_endpoints.tavern.yaml 
	 5 passed, 7 warnings
```

```
$ python3 run_tests.py -k cdb -rbac no
Collected tests [1]:
test_cdb_list_endpoints.tavern.yaml


test_cdb_list_endpoints.tavern.yaml - Standalone environment 
	 1 passed, 4 deselected, 9 warnings

test_cdb_list_endpoints.tavern.yaml - Cluster environment 
	 2 passed, 3 deselected, 9 warnings
```

```
$ python3 run_tests.py -k cdb -rbac both
Collected tests [3]:
test_cdb_list_endpoints.tavern.yaml, test_rbac_black_cdb_list_endpoints.tavern.yaml, test_rbac_white_cdb_list_endpoints.tavern.yaml


test_cdb_list_endpoints.tavern.yaml - Standalone environment 
	 1 passed, 4 deselected, 9 warnings

test_cdb_list_endpoints.tavern.yaml - Cluster environment 
	 2 passed, 3 deselected, 9 warnings

test_rbac_black_cdb_list_endpoints.tavern.yaml 
	 5 passed, 7 warnings

test_rbac_white_cdb_list_endpoints.tavern.yaml 
	 5 passed, 7 warnings
```