### PR TITLE
Ignore rules if dependant rules/groups are missing (if_sid/group options)

### DIFF
--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -328,6 +328,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
         /* Get all rules for a global group */
         rule = OS_GetElementsbyNode(&xml, node[i]);
         if (rule == NULL) {
+            // TODO: Skip rule?
             smerror(log_msg, "Group '%s' without any rule.", node[i]->element);
             goto cleanup;
         }
@@ -629,7 +630,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                             config_ruleinfo->alert_opts |= DO_EXTRAINFO;
                         }
 
-                    } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element,xml_srcgeoip) == 0) {
+                    } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_srcgeoip) == 0) {
 
                         rule_tmp_params.srcgeoip = loadmemory(rule_tmp_params.srcgeoip, rule_tmp_params.rule_arr_opt[k]->content, log_msg);
                         negate_srcgeoip = w_check_attr_negate(rule_tmp_params.rule_arr_opt[k], config_ruleinfo->sigid, log_msg);
@@ -640,7 +641,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                             config_ruleinfo->alert_opts |= DO_EXTRAINFO;
                         }
 
-                    } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element,xml_dstgeoip) == 0) {
+                    } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_dstgeoip) == 0) {
 
                         rule_tmp_params.dstgeoip = loadmemory(rule_tmp_params.dstgeoip, rule_tmp_params.rule_arr_opt[k]->content, log_msg);
                         negate_dstgeoip = w_check_attr_negate(rule_tmp_params.rule_arr_opt[k], config_ruleinfo->sigid, log_msg);
@@ -735,14 +736,14 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         negate_action = w_check_attr_negate(rule_tmp_params.rule_arr_opt[k], config_ruleinfo->sigid, log_msg);
                         action_type = w_check_attr_type(rule_tmp_params.rule_arr_opt[k], EXP_TYPE_STRING, config_ruleinfo->sigid, log_msg);
 
-                    } else if(strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_system_name) == 0){
+                    } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_system_name) == 0){
 
                         rule_tmp_params.system_name = loadmemory(rule_tmp_params.system_name, rule_tmp_params.rule_arr_opt[k]->content, log_msg);
                         negate_system_name = w_check_attr_negate(rule_tmp_params.rule_arr_opt[k], config_ruleinfo->sigid, log_msg);
                         system_name_type = w_check_attr_type(rule_tmp_params.rule_arr_opt[k], EXP_TYPE_OSMATCH,
                                                              config_ruleinfo->sigid, log_msg);
 
-                    } else if(strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_protocol) == 0){
+                    } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_protocol) == 0){
 
                         rule_tmp_params.protocol = loadmemory(rule_tmp_params.protocol, rule_tmp_params.rule_arr_opt[k]->content, log_msg);
                         negate_protocol = w_check_attr_negate(rule_tmp_params.rule_arr_opt[k], config_ruleinfo->sigid, log_msg);
@@ -931,6 +932,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         } else if (strcmp(rule_tmp_params.rule_arr_opt[k]->content, "ossec") == 0) {
                             config_ruleinfo->category = OSSEC_RL;
                         } else {
+                            // TODO: Skip Rule?
                             merror(INVALID_CAT, rule_tmp_params.rule_arr_opt[k]->content);
                             goto cleanup;
                         }
@@ -938,7 +940,8 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                     } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_if_sid) == 0) {
                         config_ruleinfo->if_sid =
                             loadmemory(config_ruleinfo->if_sid,
-                                       rule_tmp_params.rule_arr_opt[k]->content, log_msg);
+                                       rule_tmp_params.rule_arr_opt[k]->content,
+                                       log_msg);
 
                     } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_if_level) == 0) {
                         if (!OS_StrIsNum(rule_tmp_params.rule_arr_opt[k]->content)) {
@@ -953,7 +956,8 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                     } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_if_group) == 0) {
                         config_ruleinfo->if_group =
                             loadmemory(config_ruleinfo->if_group,
-                                       rule_tmp_params.rule_arr_opt[k]->content, log_msg);
+                                       rule_tmp_params.rule_arr_opt[k]->content,
+                                       log_msg);
 
                     } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_if_matched_regex) == 0) {
                         config_ruleinfo->context = 1;
@@ -965,18 +969,18 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         config_ruleinfo->context = 1;
                         rule_tmp_params.if_matched_group =
                             loadmemory(rule_tmp_params.if_matched_group,
-                                       rule_tmp_params.rule_arr_opt[k]->content, log_msg);
+                                       rule_tmp_params.rule_arr_opt[k]->content,
+                                       log_msg);
 
 
-                    } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element,
-                                          xml_if_matched_sid) == 0) {
+                    } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_if_matched_sid) == 0) {
                         config_ruleinfo->context = 1;
                         if (!OS_StrIsNum(rule_tmp_params.rule_arr_opt[k]->content)) {
+                            // TODO: Skip rule?
                             smerror(log_msg, INVALID_CONFIG, "if_matched_sid", rule_tmp_params.rule_arr_opt[k]->content);
                             goto cleanup;
                         }
-                        config_ruleinfo->if_matched_sid =
-                            atoi(rule_tmp_params.rule_arr_opt[k]->content);
+                        config_ruleinfo->if_matched_sid = atoi(rule_tmp_params.rule_arr_opt[k]->content);
 
                     } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_same_source_ip) == 0 ||
                                strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_same_srcip) == 0) {
@@ -1107,9 +1111,10 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                             config_ruleinfo->alert_opts |= DO_EXTRAINFO;
                         }
 
-                    } else if (strcmp(rule_tmp_params.rule_arr_opt[k]->element, xml_different_srcip) == 0 ||
+                    } else if (strcmp(rule_tmp_params.rule_arr_opt[k]->element, 
+                                    xml_different_srcip) == 0 ||
                                strcmp(rule_tmp_params.rule_arr_opt[k]->element,
-                                      xml_notsame_source_ip) == 0) {
+                                    xml_notsame_source_ip) == 0) {
                         config_ruleinfo->different_field |= FIELD_SRCIP;
 
                         if(!(config_ruleinfo->alert_opts & SAME_EXTRAINFO)) {
@@ -1577,8 +1582,10 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         }
                         OS_ClearNode(mitre_opt);
                     } else {
-                        smerror(log_msg, "Invalid option '%s' for rule '%d'.", rule_tmp_params.rule_arr_opt[k]->element,
-                               config_ruleinfo->sigid);
+                        // TODO: Skip Rule?
+                        smerror(log_msg, "Invalid option '%s' for rule '%d'.",
+                                rule_tmp_params.rule_arr_opt[k]->element,
+                                config_ruleinfo->sigid);
                         goto cleanup;
                     }
                 }
@@ -1594,10 +1601,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                     && (config_ruleinfo->alert_opts & DO_OVERWRITE)) {
                     smwarn(log_msg, ANALYSISD_INV_OVERWRITE, config_ruleinfo->sigid);
                     goto cleanup;
-                    // w_free_rules_tmp_params(rule_tmp_params);
-                    // os_remove_ruleinfo(config_ruleinfo);
-                    // j++; // Next rule
-                    // continue;
                 }
 
                 /* Check for valid use of frequency */
@@ -1906,7 +1909,10 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 }
             } else {
                 if (OS_AddChild(config_ruleinfo, r_node, log_msg) == -1) {
-                    goto cleanup;
+                    // Skip rule's logic, without having to abort analysisd execution
+                    os_remove_ruleinfo(config_ruleinfo);
+                    config_ruleinfo = NULL;
+                    continue;
                 }
             }
 

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -49,13 +49,10 @@ EventList *os_analysisd_last_events;
 
 /* Prototypes */
 // TODO Docu
-STATIC int getattributes(char **attributes,
-                  char **values,
-                  int *id, int *level,
-                  int *maxsize, int *timeframe,
-                  int *frequency, int *accuracy,
-                  int *noalert, int *ignore_time, int *overwrite,
-                  OSList* log_msg);
+STATIC int getattributes(char **attributes, char **values, int *id, int *level,
+                         int *maxsize, int *timeframe, int *frequency,
+                         int *accuracy, int *noalert, int *ignore_time,
+                         int *overwrite, OSList* log_msg);
 STATIC int doesRuleExist(int sid, RuleNode *r_node);
 STATIC void Rule_AddAR(RuleInfo *config_rule);
 STATIC char *loadmemory(char *at, const char *str, OSList* log_msg);
@@ -338,6 +335,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
 
             /* Check if the rule element is correct */
             if (!rule[j]->element) {
+                smerror(log_msg, INVALID_RULE_ELEMENT);
                 goto cleanup;
             }
 
@@ -389,9 +387,9 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 }
 
                 /* Allocate memory and initialize structure */
-                config_ruleinfo = zerorulemember(id, level, maxsize,
-                                                 frequency, timeframe,
-                                                 noalert, ignore_time, overwrite, last_event_list);
+                config_ruleinfo = zerorulemember(id, level, maxsize, frequency,
+                                                 timeframe, noalert, ignore_time,
+                                                 overwrite, last_event_list);
 
                 /* If rule is 0, set it to level 99 to have high priority.
                  * Set it to 0 again later.
@@ -480,6 +478,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
 
                 rule_tmp_params.rule_arr_opt =  OS_GetElementsbyNode(&xml, rule[j]);
                 if (rule_tmp_params.rule_arr_opt == NULL) {
+                    // TODO: Skip rule?
                     smerror(log_msg, "Rule '%d' without any option. It may lead to false positives and some "
                            "other problems for the system. Exiting.", config_ruleinfo->sigid);
                     goto cleanup;
@@ -506,6 +505,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
 
                         config_ruleinfo->decoded_as = getDecoderfromlist(rule_tmp_params.rule_arr_opt[k]->content, decoder_list);
                         if (config_ruleinfo->decoded_as == 0) {
+                            // TODO: Skip rule?
                             smerror(log_msg, "Invalid decoder name: '%s'.", rule_tmp_params.rule_arr_opt[k]->content);
                             goto cleanup;
                         }
@@ -581,8 +581,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
 
                     } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_comment) == 0) {
 
-                        char *newline;
-                        newline = strchr(rule_tmp_params.rule_arr_opt[k]->content, '\n');
+                        char * newline = strchr(rule_tmp_params.rule_arr_opt[k]->content, '\n');
                         if (newline) {
                             *newline = ' ';
                         }
@@ -1651,8 +1650,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_regex, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.regex);
                 }
 
                 /* Add in match */
@@ -1664,8 +1661,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_match, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.match);
                 }
 
                 /* Add in id */
@@ -1677,8 +1672,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_id, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.id);
                 }
 
                 /* Add srcport */
@@ -1690,8 +1683,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_srcport, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.srcport);
                 }
 
                 /* Add dstport */
@@ -1704,8 +1695,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         goto cleanup;
                     }
 
-                    os_free(rule_tmp_params.dstport);
-
                 }
 
                 /* Add in status */
@@ -1717,8 +1706,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_status, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.status);
                 }
 
                 /* Add in hostname */
@@ -1730,8 +1717,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_hostname, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.hostname);
                 }
 
                 /* Add data */
@@ -1743,8 +1728,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_data, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.data);
                 }
 
                 /* Add extra data */
@@ -1756,8 +1739,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_extra_data, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.extra_data);
                 }
 
                 /* Add in program name */
@@ -1769,8 +1750,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_program_name, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.program_name);
                 }
 
                 /* Add in user */
@@ -1782,8 +1761,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_user, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.user);
                 }
 
                 /* Adding in srcgeoip */
@@ -1795,8 +1772,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_srcgeoip, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.srcgeoip);
                 }
 
                 /* Adding in dstgeoip */
@@ -1808,8 +1783,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_dstgeoip, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.dstgeoip);
                 }
 
                 /* Add in URL */
@@ -1821,8 +1794,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_url, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.url);
                 }
 
                 /* Add location */
@@ -1834,8 +1805,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_location, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.location);
                 }
 
                 /* Add location */
@@ -1847,8 +1816,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_action, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.action);
                 }
 
                 /* Add matched_group */
@@ -1858,8 +1825,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, REGEX_COMPILE, rule_tmp_params.if_matched_group, config_ruleinfo->if_matched_group->error);
                         goto cleanup;
                     }
-                    os_free(rule_tmp_params.if_matched_group);
-                    rule_tmp_params.if_matched_group = NULL;
                 }
 
                 /* Add matched_regex */
@@ -1869,8 +1834,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, REGEX_COMPILE, rule_tmp_params.if_matched_regex, config_ruleinfo->if_matched_regex->error);
                         goto cleanup;
                     }
-                    os_free(rule_tmp_params.if_matched_regex);
-                    rule_tmp_params.if_matched_regex = NULL;
                 }
 
                 /* Add protocol */
@@ -1882,8 +1845,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, rule_tmp_params.protocol, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.protocol);
                 }
 
                 /* Add system_name */
@@ -1895,8 +1856,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         smerror(log_msg, RL_REGEX_SYNTAX, xml_system_name, config_ruleinfo->sigid);
                         goto cleanup;
                     }
-
-                    os_free(rule_tmp_params.system_name);
                 }
 
                 w_free_rules_tmp_params(&rule_tmp_params);
@@ -1917,14 +1876,19 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
             if (config_ruleinfo->sigid < 10) {
                 OS_AddRule(config_ruleinfo, r_node);
             } else if (config_ruleinfo->alert_opts & DO_OVERWRITE) {
+
                 if (!OS_AddRuleInfo(*r_node, config_ruleinfo, config_ruleinfo->sigid)) {
-                    /* TODO: It should never reach this point, but if it happens,
-                            should the rule be skiped? Add it anyway as on the
-                            following else? */
-                    smerror(log_msg, "Overwrite rule '%d' not found.", config_ruleinfo->sigid);
-                    goto cleanup;
+
+                    // If there is no rule to overwrite, then the rule is added as any other rule
+                    if (OS_AddChild(config_ruleinfo, r_node, log_msg) == -1) {
+                        // Skip rule, without having to abort analysisd execution
+                        os_remove_ruleinfo(config_ruleinfo);
+                        config_ruleinfo = NULL;
+                        continue;
+                    }
                 }
             } else {
+
                 if (OS_AddChild(config_ruleinfo, r_node, log_msg) == -1) {
                     // Skip rule, without having to abort analysisd execution
                     os_remove_ruleinfo(config_ruleinfo);
@@ -2230,12 +2194,10 @@ int get_info_attributes(char **attributes, char **values, OSList* log_msg)
 }
 
 /* Get the attributes */
-STATIC int getattributes(char **attributes, char **values,
-                  int *id, int *level,
-                  int *maxsize, int *timeframe,
-                  int *frequency, int *accuracy,
-                  int *noalert, int *ignore_time, int *overwrite,
-                  OSList* log_msg)
+STATIC int getattributes(char **attributes, char **values, int *id, int *level,
+                         int *maxsize, int *timeframe, int *frequency,
+                         int *accuracy, int *noalert, int *ignore_time,
+                         int *overwrite, OSList* log_msg)
 {
     int k = 0;
 

--- a/src/analysisd/rules_list.c
+++ b/src/analysisd/rules_list.c
@@ -124,6 +124,7 @@ STATIC int _AddtoRule(int sid, int level, int none, const char *group,
 int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, OSList* log_msg)
 {
     if (!read_rule) {
+        // TODO: shouldn't it return -1? Leak?
         smerror(log_msg, "rules_list: Passing a NULL rule. Inconsistent state");
         return (1);
     }
@@ -131,46 +132,51 @@ int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, OSList* log_msg)
     /* Adding for if_sid */
     if (read_rule->if_sid) {
         int val = 0;
-        const char *sid;
-
-        sid  = read_rule->if_sid;
+        const char * sid_ptr = read_rule->if_sid;
 
         /* Loop to read all the rules (comma or space separated) */
         do {
-            int rule_id = 0;
-            if ((*sid == ',') || (*sid == ' ')) {
+            if ((*sid_ptr == ',') || (*sid_ptr == ' ')) {
                 val = 0;
                 continue;
-            } else if ((isdigit((int)*sid)) || (*sid == '\0')) {
+            } else if ((isdigit((int)*sid_ptr)) || (*sid_ptr == '\0')) {
                 if (val == 0) {
-                    rule_id = atoi(sid);
-                    if (!_AddtoRule(rule_id, 0, 0, NULL, *r_node, read_rule)) {
-                        smerror(log_msg, "rules_list: Signature ID '%d' not found. Invalid 'if_sid'.", rule_id);
+                    int if_sid_rule_id = atoi(sid_ptr);
+                    if (!_AddtoRule(if_sid_rule_id, 0, 0, NULL, *r_node, read_rule)) {
+                        smwarn(log_msg, ANALYSISD_SIG_ID_NOT_FOUND,
+                               if_sid_rule_id, read_rule->if_matched_sid != 0 ? 
+                                                    "if_matched_sid" : "if_sid",
+                               read_rule->sigid);
                         return -1;
                     }
                     val = 1;
                 }
             } else {
-                smerror(log_msg, "rules_list: Signature ID must be an integer. Exiting...");
+                smwarn(log_msg, ANALYSISD_INV_SIG_ID,
+                        read_rule->if_matched_sid != 0 ? "if_matched_sid" 
+                                                       : "if_sid",
+                        read_rule->sigid);
                 return -1;
             }
-        } while (*sid++ != '\0');
+        } while (*sid_ptr++ != '\0');
     }
 
     /* Adding for if_level */
     else if (read_rule->if_level) {
-        int ilevel = 0;
 
-        ilevel = atoi(read_rule->if_level);
+        int ilevel = atoi(read_rule->if_level);
+
         if (ilevel == 0) {
+            // TODO: shouldn't it return -1? Leak?
             smerror(log_msg, "Invalid level (atoi)");
             return (1);
         }
 
+        // TODO: why does it multiply the ilevel?
         ilevel *= 100;
 
         if (!_AddtoRule(0, ilevel, 0, NULL, *r_node, read_rule)) {
-            smerror(log_msg, "rules_list: Level ID '%d' not found. Invalid 'if_level'.", ilevel);
+            smwarn(log_msg, ANALYSISD_LEVEL_NOT_FOUND, ilevel, read_rule->sigid);
             return -1;
         }
     }
@@ -178,7 +184,7 @@ int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, OSList* log_msg)
     /* Adding for if_group */
     else if (read_rule->if_group) {
         if (!_AddtoRule(0, 0, 0, read_rule->if_group, *r_node, read_rule)) {
-            smerror(log_msg, "rules_list: Group '%s' not found. Invalid 'if_group'.", read_rule->if_group);
+            smwarn(log_msg, ANALYSISD_GROUP_NOT_FOUND, read_rule->if_group, read_rule->sigid);
             return -1;
         }
     }
@@ -186,7 +192,9 @@ int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, OSList* log_msg)
     /* Just add based on the category */
     else {
         if (!_AddtoRule(0, 0, 0, NULL, *r_node, read_rule)) {
-            smerror(log_msg, "rules_list: Category '%d' not found. Invalid 'category'.", read_rule->category);
+            // TODO: It should never reach this point as the CATEGORY is checked in rules.c (look for "xml_category" )
+            // TODO: Why is it asumed that if _AddtoRule fails is it because the category?
+            smwarn(log_msg, ANALYSISD_CATEGORY_NOT_FOUND, read_rule->category, read_rule->sigid);
             return -1;
         }
     }

--- a/src/analysisd/rules_list.c
+++ b/src/analysisd/rules_list.c
@@ -194,7 +194,7 @@ int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, OSList* log_msg)
         if (!_AddtoRule(0, 0, 0, NULL, *r_node, read_rule)) {
             // TODO: It should never reach this point as the CATEGORY is checked in rules.c (look for "xml_category" )
             // TODO: Why is it asumed that if _AddtoRule fails is it because the category?
-            smwarn(log_msg, ANALYSISD_CATEGORY_NOT_FOUND, read_rule->category, read_rule->sigid);
+            smwarn(log_msg, ANALYSISD_CATEGORY_NOT_FOUND, read_rule->sigid);
             return -1;
         }
     }

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -136,6 +136,7 @@
 #define INVALID_GEOIP_DB        "(1276): Cannot open GeoIP database: '%s'."
 #define FIM_INVALID_MESSAGE     "(1277): Invalid syscheck message received."
 #define UNABLE_TO_RECONNECT     "(1278): Unable to reconnect to '%s': %s (%d)."
+#define INVALID_RULE_ELEMENT    "(1279): Invalid rule element."
 
 /* logcollector */
 #define SYSTEM_ERROR     "(1600): Internal error. Exiting.."

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -89,7 +89,17 @@
 #define ANALYSISD_IGNORE_RULE                   "(7604): Rule '%d' will be ignored."
 #define ANALYSISD_INV_OVERWRITE                 "(7605): Invalid use of overwrite option. " \
                                                         "Could not overwrite parent rule at rule '%d'."
-
+#define ANALYSISD_SIG_ID_NOT_FOUND              "(7606): Signature ID '%d' was not found. Invalid '%s'. " \
+                                                        "Rule '%d' will be ignored."
+#define ANALYSISD_INV_SIG_ID                    "(7607): Invalid '%s'. Signature ID must be an integer. " \
+                                                        "Rule '%d' will be ignored."
+#define ANALYSISD_LEVEL_NOT_FOUND               "(7608): Level ID '%d' was not found. Invalid 'if_level'. " \
+                                                        "Rule '%d' will be ignored."
+#define ANALYSISD_INV_LEVEL                     "(7609): Invalid 'if_level' value: '%s'. Rule '%d' will be ignored."
+#define ANALYSISD_GROUP_NOT_FOUND               "(7610): Group '%s' was not found. Invalid 'if_group'. " \
+                                                        "Rule '%d' will be ignored."
+#define ANALYSISD_CATEGORY_NOT_FOUND            "(7611): Category was not found. Invalid 'category'. " \
+                                                        "Rule '%d' will be ignored."
 
 
 /* Logcollector */

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -79,13 +79,13 @@
 
 
 /* Ruleset reading warnings */
-#define ANALYSISD_INV_VALUE_RULE                "(7600): Invalid value '%s' for attribute '%s' in rule %d"
+#define ANALYSISD_INV_VALUE_RULE                "(7600): Invalid value '%s' for attribute '%s' in rule %d."
 #define ANALYSISD_INV_VALUE_DEFAULT             "(7601): Invalid value for attribute '%s' in '%s' option " \
-                                                        "(decoder `%s`). Default value will be used"
+                                                        "(decoder `%s`). Default value will be used."
 #define ANALYSISD_INV_OPT_VALUE_DEFAULT         "(7602): Invalid value '%s' in '%s' option " \
-                                                        "(decoder `%s`). Default value will be used"
+                                                        "(decoder `%s`). Default value will be used."
 #define ANALYSISD_DEC_DEPRECATED_OPT_VALUE      "(7603): Deprecated value '%s' in '%s' option " \
-                                                        "(decoder `%s`). Default value will be used"
+                                                        "(decoder `%s`). Default value will be used."
 #define ANALYSISD_IGNORE_RULE                   "(7604): Rule '%d' will be ignored."
 #define ANALYSISD_INV_OVERWRITE                 "(7605): Invalid use of overwrite option. " \
                                                         "Could not overwrite parent rule at rule '%d'."
@@ -100,6 +100,10 @@
                                                         "Rule '%d' will be ignored."
 #define ANALYSISD_CATEGORY_NOT_FOUND            "(7611): Category was not found. Invalid 'category'. " \
                                                         "Rule '%d' will be ignored."
+#define ANALYSISD_DUPLICATED_SIG_ID             "(7612): Rule ID '%d' is duplicated. Only the first occurrence will be "\
+                                                        "considered."
+#define ANALYSISD_OVERWRITE_MISSING_RULE        "(7613): Rule ID '%d' does not exist but 'overwrite' is set to 'yes'. "\
+                                                        "Still, the rule will be loaded."
 
 
 /* Logcollector */

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -95,7 +95,7 @@
                                                         "Rule '%d' will be ignored."
 #define ANALYSISD_LEVEL_NOT_FOUND               "(7608): Level ID '%d' was not found. Invalid 'if_level'. " \
                                                         "Rule '%d' will be ignored."
-#define ANALYSISD_INV_LEVEL                     "(7609): Invalid 'if_level' value: '%s'. Rule '%d' will be ignored."
+#define ANALYSISD_INV_IF_LEVEL                  "(7609): Invalid 'if_level' value: '%s'. Rule '%d' will be ignored."
 #define ANALYSISD_GROUP_NOT_FOUND               "(7610): Group '%s' was not found. Invalid 'if_group'. " \
                                                         "Rule '%d' will be ignored."
 #define ANALYSISD_CATEGORY_NOT_FOUND            "(7611): Category was not found. Invalid 'category'. " \
@@ -104,7 +104,7 @@
                                                         "considered."
 #define ANALYSISD_OVERWRITE_MISSING_RULE        "(7613): Rule ID '%d' does not exist but 'overwrite' is set to 'yes'. "\
                                                         "Still, the rule will be loaded."
-
+#define ANALYSISD_NULL_RULE                     "(7614): Rule pointer is NULL. Skipping."
 
 /* Logcollector */
 #define LOGCOLLECTOR_INV_VALUE_DEFAULT          "(8000): Invalid value '%s' for attribute '%s' in '%s' option. " \


### PR DESCRIPTION
|Related issue|
|---|
|Close #10615 |


## Description

This PR prevent Analysisd from rejecting the manager startup when:

1) creating a rule and using the rule's `if_` options if the dependant rules or groups are missing. The new implementation will discard the new rule when the dependant rules or groups are missing.
 2) ...
3) ...



## Configuration options, output and behaviour 

<!--
When proceed, this section should include new configuration parameters.
-->


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors