### PR TITLE
Fix AWS Custom integration prefix filtering

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -890,7 +890,7 @@ class AWSBucket(WazuhIntegration):
                 debug(f"+++ Unexpected error: {err.message}", 2)
             else:
                 debug(f"+++ Unexpected error: {err}", 2)
-            print(f"ERROR: Unexpected error querying/working with objects in S3: {err}".format(err)
+            print(f"ERROR: Unexpected error querying/working with objects in S3: {err}")
             sys.exit(7)
 
     def check_bucket(self):

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -503,7 +503,7 @@ class AWSBucket(WazuhIntegration):
 
     def _same_prefix(self, match_start: int or None, aws_account_id: str, aws_region: str) -> bool:
         """
-        Returns if the prefix of a file key is the same as the one expected.
+        Check if the prefix of a file key is the same as the one expected.
 
         Parameters
         ----------
@@ -524,7 +524,7 @@ class AWSBucket(WazuhIntegration):
 
     def _get_last_key_processed(self, aws_account_id: str) -> str or None:
         """
-        Returns the key of the last file processed by the module.
+        Get the key of the last file processed by the module.
 
         Parameters
         ----------
@@ -740,10 +740,10 @@ class AWSBucket(WazuhIntegration):
 
         if filter_args.get('StartAfter'):
             if custom_delimiter:
-                prefix_len = len(filter_args.get('Prefix'))
-                filter_args['StartAfter'] = filter_args.get('StartAfter')[:prefix_len] + \
-                                            filter_args.get('StartAfter')[prefix_len:].replace('/', custom_delimiter)
-            debug(f"+++ Marker: {filter_args.get('StartAfter')}", 2)
+                prefix_len = len(filter_args['Prefix'])
+                filter_args['StartAfter'] = filter_args['StartAfter'][:prefix_len] + \
+                                            filter_args['StartAfter'][prefix_len:].replace('/', custom_delimiter)
+            debug(f"+++ Marker: {filter_args['StartAfter']}", 2)
 
         return filter_args
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #10597 |

## Description
In this PR we fix a bug that made the `Macie`, `Trusted advisor`, `KMS`, `ALB`, `CLB`, `NLB`, `GuardDuty`, and `WAF` buckets process files with another prefix when specifying no prefix. Since the new additions were made in the `AWSBucket` class, which is the parent class of all buckets, every kind of bucket has been tested.  

We also removed the `build_s3_filter_args` method from the `AWSCustomBucket`, since it was copy-pasted from the one in its parent class, `AWSBucket`. The only difference between both is that the removed one had a functionality that allowed it to specify a custom delimiter, but since it could be used by other classes that inherit from `AWSBucket`, we moved it to the parent class.  

Finally, we refactored this method of the `AWSBucket` class.  

https://github.com/wazuh/wazuh/blob/4e0026ff35b1ec6209b1d16fd6a30e15b87f3d89/wodles/aws/aws_s3.py#L792  

Even though the method should have been implemented as a do-while loop, it was designed in the following fashion:
```
block of code A

while condition:
    block of code A repeated
```  

We reworked that method to ease its maintenability since we were working with it for this PR.

## Tests performed
**NOTE**: every execution has been performed in a clean environment, i.e., an environment without an `s3_cloudtrail.db` database. It was done this way to emulate the environment which cause the bug to occur.
### Previously working buckets
#### Cloudtrail
As can be seen in the different examples, the module is working as expected.
**NOTE**: The messages 'DEBUG: +++ Working on test_empty...' and 'DEBUG: +++ Working on test_suffix...' are due to a known issue and don't affect the correctness of the module.

<details>
<summary>Clean execution with one log file without specifying a prefix</summary>
<p>
It should only fetch that log and not the ones pertaining other folders.

```
root@da140fd275b3:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-cloudtrail -d2 -t cloudtrail 
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/03
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/03/XXXXXXXXXXXX_CloudTrail_us-west-1_20211103T0000Z_OtoPYJqXyVMnScng.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_empty - us-west-1
DEBUG: +++ Marker: AWSLogs/test_empty/CloudTrail/us-west-1/2021/11/03
DEBUG: +++ No logs to process in bucket: test_empty/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_suffix - us-west-1
DEBUG: +++ Marker: AWSLogs/test_suffix/CloudTrail/us-west-1/2021/11/03
DEBUG: +++ No logs to process in bucket: test_suffix/us-west-1
DEBUG: +++ DB Maintenance
```
</p>
</details>

<details>
<summary>Clean execution with one log file specifying a prefix</summary>
<p>
It should only fetch and process the log inside the `test_prefix` folder, as it does.

```
root@da140fd275b3:/var/ossec/wodles/aws#  ./aws-s3 -b wazuh-aws-wodle-cloudtrail -d2 -t cloudtrail  -l test_prefix
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: test_prefix/AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/03
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/03/XXXXXXXXXXXX_CloudTrail_us-west-1_20211103T0000Z_OtoPYJqXyVMnScng.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_empty - us-west-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_empty/CloudTrail/us-west-1/2021/11/03
DEBUG: +++ No logs to process in bucket: test_empty/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_suffix - us-west-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_suffix/CloudTrail/us-west-1/2021/11/03
DEBUG: +++ No logs to process in bucket: test_suffix/us-west-1
DEBUG: +++ DB Maintenance
```
</p>
</details>

#### Config
<details>
<summary>Execution in bucket with logs without specifying prefix</summary>
<p>
It doesn't fetch the logs pertainint the `test_prefix/AWSLogs/...`, only the ones inside `AWSLogs/...`, as expected.

```
root@da140fd275b3:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-config -d2 -t config  -s 2021-oct-17  
root@da140fd275b3:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-config -d2 -t config  -s 2021-oct-17  
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/17
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/17/ConfigHistory/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20200601T004303Z_20211017T025123Z_1.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/17/ConfigSnapshot/XXXXXXXXXXXX_Config_us-east-1_ConfigSnapshot_20200601T105550Z_6e2fd7f4-e9dd-4730-b0da-d1f90ab2b363.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/18
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/18/ConfigHistory/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20200601T004303Z_20211018T025123Z_1.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/18/ConfigSnapshot/XXXXXXXXXXXX_Config_us-east-1_ConfigSnapshot_20200601T105550Z_6e2fd7f4-e9dd-4730-b0da-d1f90ab2b363.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/19
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/19/ConfigHistory/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20200601T004303Z_20211019T025123Z_1.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/19/ConfigSnapshot/XXXXXXXXXXXX_Config_us-east-1_ConfigSnapshot_20200601T105550Z_6e2fd7f4-e9dd-4730-b0da-d1f90ab2b363.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/20
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/21
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/22
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/23
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/24
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/25
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/26
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/27
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/28
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/29
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/30
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/31
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/1
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/2
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/3
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_empty - us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/10/17
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/10/18
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/10/19
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/10/20
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/10/21
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/10/22
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/10/23
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/10/24
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/10/25
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/10/26
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/10/27
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/10/28
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/10/29
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/10/30
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/10/31
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/11/1
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/11/2
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/11/3
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_suffix - us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/10/17
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/10/18
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/10/19
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/10/20
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/10/21
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/10/22
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/10/23
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/10/24
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/10/25
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/10/26
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/10/27
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/10/28
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/10/29
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/10/30
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/10/31
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/11/1
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/11/2
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/11/3
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ DB Maintenance
```

</p>
</details>


<details>
<summary>Execution in bucket with logs specifying prefix</summary>
<p>
It parses the logs inside the `test_prefix/...` folders, as expected.	

```
root@da140fd275b3:/var/ossec/wodles/aws#  ./aws-s3 -b wazuh-aws-wodle-config -d2 -t config  -s 2021-oct-17 -l test_prefix
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/17
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/17/ConfigHistory/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20200601T004303Z_20211017T025123Z_1.json.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/17/ConfigSnapshot/XXXXXXXXXXXX_Config_us-east-1_ConfigSnapshot_20200601T105550Z_6e2fd7f4-e9dd-4730-b0da-d1f90ab2b363.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ Marker: test_prefix/AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/18
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/19
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/20
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/21
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/22
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/23
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/24
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/25
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/26
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/27
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/28
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/29
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/30
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/10/31
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/1
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/2
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/3
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_empty - us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_empty/Config/us-east-1/2021/10/17
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_empty/Config/us-east-1/2021/10/18
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_empty/Config/us-east-1/2021/10/19
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_empty/Config/us-east-1/2021/10/20
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_empty/Config/us-east-1/2021/10/21
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_empty/Config/us-east-1/2021/10/22
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_empty/Config/us-east-1/2021/10/23
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_empty/Config/us-east-1/2021/10/24
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_empty/Config/us-east-1/2021/10/25
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_empty/Config/us-east-1/2021/10/26
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_empty/Config/us-east-1/2021/10/27
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_empty/Config/us-east-1/2021/10/28
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_empty/Config/us-east-1/2021/10/29
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_empty/Config/us-east-1/2021/10/30
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_empty/Config/us-east-1/2021/10/31
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_empty/Config/us-east-1/2021/11/1
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_empty/Config/us-east-1/2021/11/2
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_empty/Config/us-east-1/2021/11/3
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_suffix - us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_suffix/Config/us-east-1/2021/10/17
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_suffix/Config/us-east-1/2021/10/18
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_suffix/Config/us-east-1/2021/10/19
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_suffix/Config/us-east-1/2021/10/20
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_suffix/Config/us-east-1/2021/10/21
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_suffix/Config/us-east-1/2021/10/22
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_suffix/Config/us-east-1/2021/10/23
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_suffix/Config/us-east-1/2021/10/24
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_suffix/Config/us-east-1/2021/10/25
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_suffix/Config/us-east-1/2021/10/26
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_suffix/Config/us-east-1/2021/10/27
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_suffix/Config/us-east-1/2021/10/28
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_suffix/Config/us-east-1/2021/10/29
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_suffix/Config/us-east-1/2021/10/30
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_suffix/Config/us-east-1/2021/10/31
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_suffix/Config/us-east-1/2021/11/1
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_suffix/Config/us-east-1/2021/11/2
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_suffix/Config/us-east-1/2021/11/3
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ DB Maintenance
```
</p>
</details>

### Buckets affected by the bug
#### ALB
<details>
<summary>Execution in bucket with logs without specifying prefix</summary>
<p>
It only collects logs starting with `AWSLogs`, as expected.

```
oot@da140fd275b3:/var/ossec/wodles/aws#  ./aws-s3 -b wazuh-aws-wodle-alb -d2 -t alb  -s 2020-nov-24
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0000Z_52.52.208.49_14pczeay.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0005Z_52.52.208.49_4ufjauyv.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0010Z_52.52.208.49_3y3kmwy9.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0035Z_54.183.224.192_2pvouvk5.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0050Z_54.183.224.192_3y2rm8x8.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0105Z_52.52.208.49_hqtwz2fm.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0115Z_52.52.208.49_5e69fblu.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0115Z_54.183.224.192_3szj8oof.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0220Z_52.52.208.49_4g2aq7gx.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0235Z_54.183.224.192_66qzj35g.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0245Z_52.52.208.49_ze3001l8.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0305Z_52.52.208.49_6c4lz8qi.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0320Z_54.183.224.192_40azmfe3.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0335Z_52.52.208.49_1sdyrgsu.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0405Z_52.52.208.49_3cjalv3z.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0405Z_54.183.224.192_5bnjpiry.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0410Z_52.52.208.49_5sd9sa85.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0420Z_52.52.208.49_3srmgupa.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0440Z_54.183.224.192_3ya2fg97.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0510Z_54.183.224.192_83fcbx9t.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0550Z_52.52.208.49_28kcbdji.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0600Z_54.183.224.192_5meem9vr.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0610Z_54.183.224.192_25mjfiv6.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0625Z_54.183.224.192_1urf21p5.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0640Z_54.183.224.192_4f9mqbp4.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0645Z_52.52.208.49_5uw230pl.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0725Z_52.52.208.49_1u80gfhx.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0750Z_52.52.208.49_5bev8b0n.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0805Z_54.183.224.192_183fpwud.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0820Z_54.183.224.192_392iruuw.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0850Z_54.183.224.192_1f5apg8y.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0855Z_54.183.224.192_1cfug8w1.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0900Z_52.52.208.49_2rwkh8x0.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0925Z_52.52.208.49_5lnvwjm1.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0945Z_52.52.208.49_2pjaq5nm.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T1035Z_52.52.208.49_ap2j49xo.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T1050Z_52.52.208.49_2snajfgx.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T1105Z_52.52.208.49_zxr5l6dz.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T1115Z_52.52.208.49_66lcfnew.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T1135Z_54.183.224.192_2k4fb5kb.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T1145Z_54.183.224.192_210b62hd.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T1150Z_52.52.208.49_4rpcaukt.log.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
```
</p>
</details>



<details>
<summary>Execution in bucket with logs specifying prefix</summary>
<p>
It only parses logs with a path starting with `test_prefix`, as it should.

```
root@da140fd275b3:/var/ossec/wodles/aws#  ./aws-s3 -b wazuh-aws-wodle-alb -d2 -t alb  -s 2020-nov-24 -l test_prefix
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0000Z_52.52.208.49_14pczeay.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0005Z_52.52.208.49_4ufjauyv.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0010Z_52.52.208.49_3y3kmwy9.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0035Z_54.183.224.192_2pvouvk5.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0050Z_54.183.224.192_3y2rm8x8.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0105Z_52.52.208.49_hqtwz2fm.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0115Z_52.52.208.49_5e69fblu.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0115Z_54.183.224.192_3szj8oof.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0220Z_52.52.208.49_4g2aq7gx.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0235Z_54.183.224.192_66qzj35g.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0245Z_52.52.208.49_ze3001l8.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0305Z_52.52.208.49_6c4lz8qi.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0320Z_54.183.224.192_40azmfe3.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0335Z_52.52.208.49_1sdyrgsu.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0405Z_52.52.208.49_3cjalv3z.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0405Z_54.183.224.192_5bnjpiry.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0410Z_52.52.208.49_5sd9sa85.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0420Z_52.52.208.49_3srmgupa.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0440Z_54.183.224.192_3ya2fg97.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0510Z_54.183.224.192_83fcbx9t.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0550Z_52.52.208.49_28kcbdji.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0600Z_54.183.224.192_5meem9vr.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0610Z_54.183.224.192_25mjfiv6.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0625Z_54.183.224.192_1urf21p5.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0640Z_54.183.224.192_4f9mqbp4.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0645Z_52.52.208.49_5uw230pl.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0725Z_52.52.208.49_1u80gfhx.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0750Z_52.52.208.49_5bev8b0n.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0805Z_54.183.224.192_183fpwud.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0820Z_54.183.224.192_392iruuw.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0850Z_54.183.224.192_1f5apg8y.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0855Z_54.183.224.192_1cfug8w1.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0900Z_52.52.208.49_2rwkh8x0.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0925Z_52.52.208.49_5lnvwjm1.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0945Z_52.52.208.49_2pjaq5nm.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T1035Z_52.52.208.49_ap2j49xo.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T1050Z_52.52.208.49_2snajfgx.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T1105Z_52.52.208.49_zxr5l6dz.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T1115Z_52.52.208.49_66lcfnew.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T1135Z_54.183.224.192_2k4fb5kb.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T1145Z_54.183.224.192_210b62hd.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T1150Z_52.52.208.49_4rpcaukt.log.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance

```
</p>
</details>

#### CLB


<details>
<summary>Execution in bucket with logs without specifying prefix</summary>
<p>
It only collects logs starting with `AWSLogs`, as expected.

```
root@da140fd275b3:/var/ossec/wodles/aws#  ./aws-s3 -b wazuh-aws-wodle-clb -d2 -t clb  -s 2020-nov-24  
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20201124T0350Z_52.8.103.172_1pnal677.log
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20201124T0510Z_13.57.171.118_5h6gk9w0.log
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance

```
</p>
</details>

<details>
<summary>Execution in bucket with logs specigying a prefix</summary>
<p>
It only parses the logs starting with `test_prefix`, as it should.

```
root@da140fd275b3:/var/ossec/wodles/aws#  ./aws-s3 -b wazuh-aws-wodle-clb -d2 -t clb  -s 2020-nov-24 -l test_prefix
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20201124T0350Z_52.8.103.172_1pnal677.log
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20201124T0510Z_13.57.171.118_5h6gk9w0.log
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance

```
</p>
</details>


#### NLB
<details>
<summary>Execution in bucket with logs without specifying prefix</summary>
<p>
It only collects logs starting with `AWSLogs`, as expected.

```
root@da140fd275b3:/var/ossec/wodles/aws#  ./aws-s3 -b wazuh-aws-wodle-nlb -d2 -t nlb  -s 2020-nov-24 
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_net.fram-dev-N-Wazuh.9d0fcf192ea215c3_20201124T0305Z_beb2c861.log.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_net.fram-dev-N-Wazuh.9d0fcf192ea215c3_20201124T0800Z_6755103b.log.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
```
</p>
</details>

<details>
<summary>Execution in bucket with logs specifying a prefix</summary>
<p>
It only parses the logs starting with `test_prefix`, as expected.

```
root@da140fd275b3:/var/ossec/wodles/aws#  ./aws-s3 -b wazuh-aws-wodle-nlb -d2 -t nlb  -s 2020-nov-24 -l test_prefix
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_net.fram-dev-N-Wazuh.9d0fcf192ea215c3_20201124T0305Z_beb2c861.log.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_net.fram-dev-N-Wazuh.9d0fcf192ea215c3_20201124T0800Z_6755103b.log.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance

```
</p>
</details>

#### KMS
<details>
<summary>Execution in bucket with logs without specifying a prefix</summary>
<p>
It only parses the logs starting without a prefix, as expected.

```
root@da140fd275b3:/var/ossec/wodles/aws#  ./aws-s3 -b wazuh-aws-wodle-kms -d2 -t custom  -s 2018-nov-07 
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Marker: 2018/11/07
DEBUG: ++ Found new log: 2018/11/07/17/firehose_kms-1-2018-11-07-17-27-26-756d81b8-7031-4a07-a50c-db292e6db64b
DEBUG: ++ Skipping file with another prefix: kms/2018/11/07/17/firehose_kms-1-2018-11-07-17-27-26-756d81b8-7031-4a07-a50c-db292e6db64b
DEBUG: ++ Skipping file with another prefix: kms_compress_encrypted/2018/11/12/08/firehose_kms-1-2018-11-12-08-16-58-975f1ad7-14e4-41ce-a805-3310fdf07f61.zip
DEBUG: ++ Skipping file with another prefix: kms_compress_encrypted/2018/11/12/08/firehose_kms-1-2018-11-12-08-22-53-164142bf-2a5b-421a-b9f2-9b3f28e414ed.zip
DEBUG: ++ Skipping file with another prefix: kms_compress_encrypted/2018/11/12/08/firehose_kms-1-2018-11-12-08-28-26-519d543d-9ae8-4576-b84b-f9e06fd6946a.zip
DEBUG: ++ Skipping file with another prefix: kms_compress_encrypted/2018/11/12/08/firehose_kms-1-2018-11-12-08-33-49-8a5efcc0-c8f5-46ed-b918-b33cca5d6efe.zip
DEBUG: ++ Skipping file with another prefix: kms_compress_encrypted/2018/11/12/08/firehose_kms-1-2018-11-12-08-39-21-b0e5071c-d43b-4287-84fe-ab0e2a1a1296.zip
DEBUG: ++ Skipping file with another prefix: kms_compress_encrypted/2018/11/12/08/firehose_kms-1-2018-11-12-08-44-48-65507332-2a54-456e-96b0-2cbab23a9b64.zip
DEBUG: ++ Skipping file with another prefix: kms_compress_encrypted/2018/11/12/08/firehose_kms-1-2018-11-12-08-50-10-6ae44014-2227-4508-ab4a-d57cf21ff28f.zip
DEBUG: ++ Skipping file with another prefix: kms_compress_encrypted/2018/11/12/08/firehose_kms-1-2018-11-12-08-55-36-7b9b6a85-dc33-4adb-9ac8-fe8ed583a3e8.zip
DEBUG: ++ Skipping file with another prefix: kms_compress_encrypted/2018/11/12/09/firehose_kms-1-2018-11-12-09-01-36-df26fbe3-421b-447c-8549-8399c42a770a.zip
DEBUG: ++ Skipping file with another prefix: kms_compress_encrypted/2018/11/12/09/firehose_kms-1-2018-11-12-09-07-03-15823fc4-c670-4f27-9a2a-da6dc75d42cc.zip
....
....
DEBUG: ++ Skipping file with another prefix: test_prefix/kms_compress_encrypted/2018/12/03/14/firehose_kms-1-2018-12-03-14-36-06-c9ded56a-daee-42fb-a45e-63bee4330927.zip
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
```
</p>
</details>

<details>
<summary>Execution in bucket with logs specifying a prefix</summary>
<p>
It only parses the logs starting with `kms`, as expected.

```
root@da140fd275b3:/var/ossec/wodles/aws#  ./aws-s3 -b wazuh-aws-wodle-kms -d2 -t custom  -s 2018-nov-07 -l kms
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Marker: kms/2018/11/07
DEBUG: ++ Found new log: kms/2018/11/07/17/firehose_kms-1-2018-11-07-17-27-26-756d81b8-7031-4a07-a50c-db292e6db64b
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
```
</p>
</details>

#### Macie
<details>
<summary>Execution in bucket with logs without specifying a prefix</summary>
<p>
It only parses the logs starting without a prefix and skips the rest, as expected.

```
root@da140fd275b3:/var/ossec/wodles/aws#  ./aws-s3 -b wazuh-aws-wodle-macie -d2 -t custom  -s 2021-oct-15
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Marker: 2021/10/15
DEBUG: ++ Found new log: 2021/10/17/00/firehose_macie-1-2021-10-17-00-40-40-e269348f-0b8e-4f61-a4e9-995424ftest1.json
DEBUG: ++ Failed to parse file 2021/10/17/00/firehose_macie-1-2021-10-17-00-40-40-e269348f-0b8e-4f61-a4e9-995424ftest1.json: Expecting value: line 1 column 1 (char 0); skipping...
DEBUG: ++ Found new log: 2021/10/18/00/firehose_macie-1-2021-10-18-00-40-40-e269348f-0b8e-4f61-a4e9-995424ftest1
DEBUG: ++ Failed to parse file 2021/10/18/00/firehose_macie-1-2021-10-18-00-40-40-e269348f-0b8e-4f61-a4e9-995424ftest1: Expecting value: line 1 column 1 (char 0); skipping...
DEBUG: ++ Found new log: 2021/10/19/00/firehose_macie-1-2021-10-19-00-40-40-e269348f-0b8e-4f61-a4e9-995424ftest1
DEBUG: ++ Failed to parse file 2021/10/19/00/firehose_macie-1-2021-10-19-00-40-40-e269348f-0b8e-4f61-a4e9-995424ftest1: Expecting value: line 1 column 1 (char 0); skipping...
DEBUG: ++ Skipping file with another prefix: test_empty/
DEBUG: ++ Skipping file with another prefix: test_prefix/
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/01/00/firehose_macie-1-2021-01-01-00-20-42-eb1f80bc-5d9d-426b-a0a1-e0ad8d3ef656
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/01/00/firehose_macie-1-2021-01-01-00-40-35-0f4dd6e8-e374-4295-a0e6-23a6a6da4729
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/02/00/firehose_macie-1-2021-01-02-00-21-04-e29c7d70-a931-47d0-a74c-f2a187fd1035
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/02/00/firehose_macie-1-2021-01-02-00-41-11-2fd1297a-e57e-449f-8434-b48ea04c3f35
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/03/00/firehose_macie-1-2021-01-03-00-20-43-97c9b612-b9e2-419d-b91f-2a664e18ef7c
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/03/00/firehose_macie-1-2021-01-03-00-40-44-9f6f6f56-4888-4188-b07d-b7d5c6ddbe87
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/04/00/firehose_macie-1-2021-01-04-00-20-39-b70a12ae-4504-421f-b03e-143cfbe9c3be
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/04/00/firehose_macie-1-2021-01-04-00-40-33-41c1da05-6da6-4583-8daf-8907bb3a3eb8
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/05/00/firehose_macie-1-2021-01-05-00-20-30-7d8674bc-dc93-412a-8e28-916457c93d78
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/05/00/firehose_macie-1-2021-01-05-00-40-32-6b6e6bef-ce0a-497b-aee2-75cb116c8604
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/06/00/firehose_macie-1-2021-01-06-00-20-42-a47dbc6a-0dd8-4572-b182-0cfdf0a112af
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/06/00/firehose_macie-1-2021-01-06-00-40-29-fa7459d2-5c93-43e1-b260-587c02bbfa06
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/07/00/firehose_macie-1-2021-01-07-00-21-04-f4c9ac47-2a66-4cb2-b698-34cf57dc88ba
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/07/00/firehose_macie-1-2021-01-07-00-40-51-9d427d32-0274-449b-969f-3c533d11b726
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/08/00/firehose_macie-1-2021-01-08-00-20-39-74370459-d74e-430c-9d86-2358ecb49936
....
....
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
root@da140fd275b3:/var/ossec/wodles/aws
```
</p>
</details>

<details>
<summary>Execution in bucket with logs specifying a prefix</summary>
<p>
It only parses the logs starting with `test_prefix`, as expected.

```
root@da140fd275b3:/var/ossec/wodles/aws#  ./aws-s3 -b wazuh-aws-wodle-macie -d2 -t custom  -s 2021-mar-15 -l test_prefix
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Marker: test_prefix/2021/03/15
DEBUG: ++ Found new log: test_prefix/2021/05/04/00/firehose_macie-1-2021-12-01-00-40-40-e269348f-0b8e-4f61-a4e9-995424ftest1
DEBUG: ++ Failed to parse file test_prefix/2021/05/04/00/firehose_macie-1-2021-12-01-00-40-40-e269348f-0b8e-4f61-a4e9-995424ftest1: Expecting value: line 1 column 1 (char 0); skipping...
DEBUG: ++ Found new log: test_prefix/2021/05/04/00/firehose_macie-1-2021-12-01-00-40-40-e269348f-0b8e-4f61-a4e9-995424ftest2
DEBUG: ++ Failed to parse file test_prefix/2021/05/04/00/firehose_macie-1-2021-12-01-00-40-40-e269348f-0b8e-4f61-a4e9-995424ftest2: Expecting value: line 1 column 1 (char 0); skipping...
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
```
</p>
</details>

#### Guard Duty
<details>
<summary>Execution in bucket with logs without specifying a prefix</summary>
<p>
It only parses the logs starting without a prefix adnd skips the rest, as expected.

```
root@da140fd275b3:/var/ossec/wodles/aws#  ./aws-s3 -b wazuh-aws-wodle-guardduty -d2 -t guardduty  -s 2021-aug-18
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Marker: 2021/08/18
DEBUG: ++ Found new log: 2021/08/31/03/community
DEBUG: ++ Skipping file with another prefix: test_empty/
DEBUG: ++ Skipping file with another prefix: test_prefix/
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/04/18/firehose_guardduty-1-2021-01-04-18-41-08-e2577422-dc3f-451b-b89b-bb1baaed7cb5.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/11/09/firehose_guardduty-1-2021-01-11-09-45-05-76d475ef-9510-4941-a0b5-138919ae052f.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/11/10/firehose_guardduty-1-2021-01-11-10-00-09-c38bf863-b670-4568-95a6-2452d150a4bd.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/15/01/firehose_guardduty-1-2021-01-15-01-31-07-6cf7b535-e336-402b-9fa6-4ffa7ffbe997.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/16/02/firehose_guardduty-1-2021-01-16-02-45-04-05e11e95-6b3c-4ba8-a136-15de57dad8ee.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/16/03/firehose_guardduty-1-2021-01-16-03-00-10-87e4f0c9-a4a4-43e1-8112-e7c9cdf3160f.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/16/03/firehose_guardduty-1-2021-01-16-03-15-06-549ab675-b377-4796-b35a-5b4d1ad9f883.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/20/10/firehose_guardduty-1-2021-01-20-10-30-04-9e818891-8bb8-49fb-b0a9-a0e66e51bb21.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/24/18/firehose_guardduty-1-2021-01-24-18-00-03-4d1c9099-d427-4358-ac4d-f357e8ab4229.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/02/05/15/firehose_guardduty-1-2021-02-05-15-45-04-eb59e7d4-d473-4cb3-ada6-b600451d0e4d.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/02/08/23/firehose_guardduty-1-2021-02-08-23-01-05-362add83-34fc-43b5-a301-cd677995de6e.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/02/08/23/firehose_guardduty-1-2021-02-08-23-16-01-91e6d068-7da7-4fa7-94a8-2de08a8dd03a.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/02/08/23/firehose_guardduty-1-2021-02-08-23-31-01-03494fca-8e94-446c-b30d-8b1bc19cda9b.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/02/08/23/firehose_guardduty-1-2021-02-08-23-46-01-39764d2a-1d6f-4f62-a22a-2db4f16597ed.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/02/09/00/firehose_guardduty-1-2021-02-09-00-01-02-6b48222c-5874-41c8-967b-d125d4ef1367.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/02/09/00/firehose_guardduty-1-2021-02-09-00-16-01-c83cad9b-7660-447b-9ccd-2e44269fd3a6.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/02/09/00/firehose_guardduty-1-2021-02-09-00-31-01-8dfaccf3-cb53-4177-89a1-118063db90e8.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/02/09/00/firehose_guardduty-1-2021-02-09-00-46-02-9861e3d5-f23d-46ac-8005-73065a76958d.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/02/09/01/firehose_guardduty-1-2021-02-09-01-01-02-9ef698b1-fd72-43fa-be93-ec565082fbdf.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/02/09/01/firehose_guardduty-1-2021-02-09-01-16-02-ac333147-d85b-4ccc-8d79-dbcd8c334117.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/02/09/01/firehose_guardduty-1-2021-02-09-01-31-01-6786f5fd-ba0b-4ff3-b8af-923df97f58a8.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/02/09/01/firehose_guardduty-1-2021-02-09-01-46-01-92a5df26-645c-4c32-bad4-da950581204c.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/02/09/02/firehose_guardduty-1-2021-02-09-02-01-02-f1b9c000-1676-4614-abdc-a72bd656f81d.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/02/09/02/firehose_guardduty-1-2021-02-09-02-16-02-6d2a026b-1e44-41d0-9d4d-988af0f43317.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/02/09/02/firehose_guardduty-1-2021-02-09-02-31-02-6613a7b1-ff6f-47ea-956a-a7a553e25add.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/02/09/02/firehose_guardduty-1-2021-02-09-02-46-01-064fc60b-cb80-444f-b12f-aaf180b78c6e.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/02/09/03/firehose_guardduty-1-2021-02-09-03-01-02-6eccdcb6-018a-477c-84b3-657e6ffadc23.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/02/09/03/firehose_guardduty-1-2021-02-09-03-16-02-1b779d45-971b-48df-a256-d098327d187d.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/02/09/03/firehose_guardduty-1-2021-02-09-03-31-01-62dcf225-b3d7-4789-bd8d-906cf0e90216.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/02/09/03/firehose_guardduty-1-2021-02-09-03-46-02-26e08c26-e69e-41d9-9220-fa9e5c2519fd.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/02/09/04/firehose_guardduty-1-2021-02-09-04-01-02-96bc848a-9156-491c-af5c-92c547d0f0d2.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/02/09/04/firehose_guardduty-1-2021-02-09-04-16-02-118661f2-81ee-45a0-ad34-5c960fed91bf.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/02/09/04/firehose_guardduty-1-2021-02-09-04-31-01-6d5fc7de-a28b-4fff-8c42-733a8a7ed589.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/02/09/04/firehose_guardduty-1-2021-02-09-04-46-01-6f7e3203-9d84-44b5-b9bf-3efc026382b2.zip
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/02/09/05/firehose_guardduty-1-2021-02-09-05-01-01-b015d6b7-0413-41ae-933f-fd61a9606428.zip
....
....
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance

```
</p>
</details>

<details>
<summary>Execution in bucket with logs specifying a prefix</summary>
<p>
It only parses the logs starting with `test_prefix`, as expected.

```
root@da140fd275b3:/var/ossec/wodles/aws#  ./aws-s3 -b wazuh-aws-wodle-guardduty -d2 -t guardduty  -s 2021-aug-18 -l test_prefix
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Marker: test_prefix/2021/08/18
DEBUG: ++ Found new log: test_prefix/2021/08/31/03/community
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
```
</p>
</details>

#### WAF
<details>
<summary>Execution in bucket with logs without specifying a prefix</summary>
<p>
It only parses the logs starting without a prefix and skips the rest, as expected.

```
root@da140fd275b3:/var/ossec/wodles/aws#  ./aws-s3 -b wazuh-aws-wodle-waf -d2 -t guardduty  -s 2019-oct-01
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Marker: 2019/10/01
DEBUG: ++ Found new log: 2019/10/22/10/aws-waf-logs-delivery-stream-1-2019-10-22-10-32-48-792c6d1f-bfed-4b00-9f5e-88ce44718193
DEBUG: ++ Skipping file with another prefix: community-test/
DEBUG: ++ Skipping file with another prefix: community-test/test_waf_log
DEBUG: ++ Skipping file with another prefix: test_empty/
DEBUG: ++ Skipping file with another prefix: test_prefix/
DEBUG: ++ Skipping file with another prefix: test_prefix/2019/10/22/10/aws-waf-logs-delivery-stream-1-2019-10-22-10-32-48-792c6d1f-bfed-4b00-9f5e-88ce44718193
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance

```
</p>
</details>

<details>
<summary>Execution in bucket with logs specifying a prefix</summary>
<p>
It only parses the logs starting with `test_prefix`, as expected.

```
root@da140fd275b3:/var/ossec/wodles/aws#  ./aws-s3 -b wazuh-aws-wodle-waf -d2 -t guardduty  -s 2019-oct-01 -l test_prefix
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Marker: test_prefix/2019/10/01
DEBUG: ++ Found new log: test_prefix/2019/10/22/10/aws-waf-logs-delivery-stream-1-2019-10-22-10-32-48-792c6d1f-bfed-4b00-9f5e-88ce44718193
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance

```
</p>
</details>

## Conclusions
The module is now working as expected and the bug has been fixed.
