### PR TITLE
Fix wdb NULL retrieving and updating from agent inventory during delta handing

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -21,7 +21,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                         -Wl,--wrap,sqlite3_step -Wl,--wrap,wdb_open_agent2 -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_agents_insert_vuln_cve \
                         -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_agents_clear_vuln_cve -Wl,--wrap,sqlite3_reset -Wl,--wrap,sqlite3_prepare_v2 \
                         -Wl,--wrap,sqlite3_clear_bindings -Wl,--wrap,wdb_get_cache_stmt -Wl,--wrap,sqlite3_column_text \
-                        -Wl,--wrap,sqlite3_column_int -Wl,--wrap,sqlite3_column_double -Wl,--wrap,sqlite3_errmsg")
+                        -Wl,--wrap,sqlite3_column_int -Wl,--wrap,sqlite3_column_double -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,sqlite3_bind_null")
 
 list(APPEND wdb_tests_names "test_wdb_global_parser")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \

--- a/src/unit_tests/wazuh_db/test_wdb_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_parser.c
@@ -1216,6 +1216,166 @@ void test_dbsync_modify_type_exists_data_real_value(void **state) {
     os_free(query);
 }
 
+void test_dbsync_modify_type_exists_data_integer_null_value(void ** state) {
+    int ret = -1;
+    test_struct_t * data = (test_struct_t *) *state;
+    char * query = NULL;
+
+    os_strdup("hwinfo MODIFIED data1|data2|data3||NULL|NULL|NULL|NULL|NULL|", query);
+
+    will_return_always(__wrap_wdb_get_cache_stmt, 1);
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "data1");
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "data3");
+    expect_value(__wrap_sqlite3_bind_null, index, 3);
+    will_return(__wrap_sqlite3_bind_null, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 4);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "data2");
+
+    will_return_always(__wrap_sqlite3_bind_text, SQLITE_OK);
+    will_return(__wrap_sqlite3_changes, 1);
+
+    will_return(__wrap_wdb_step, SQLITE_DONE);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "data2");
+
+    will_return(__wrap_wdb_step, SQLITE_ROW);
+
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "data1");
+    expect_value(__wrap_sqlite3_column_text, iCol, 1);
+    will_return(__wrap_sqlite3_column_text, "data2");
+    expect_value(__wrap_sqlite3_column_text, iCol, 2);
+    will_return(__wrap_sqlite3_column_text, "data3");
+    expect_value(__wrap_sqlite3_column_text, iCol, 3);
+    will_return(__wrap_sqlite3_column_text, NULL);
+    expect_value(__wrap_sqlite3_column_text, iCol, 4);
+    will_return(__wrap_sqlite3_column_text, "5.0");
+    expect_value(__wrap_sqlite3_column_text, iCol, 5);
+    will_return(__wrap_sqlite3_column_text, "6");
+    expect_value(__wrap_sqlite3_column_text, iCol, 6);
+    will_return(__wrap_sqlite3_column_text, "7");
+    expect_value(__wrap_sqlite3_column_text, iCol, 7);
+    will_return(__wrap_sqlite3_column_text, "8");
+    expect_value(__wrap_sqlite3_column_text, iCol, 8);
+    will_return(__wrap_sqlite3_column_text, "data9");
+
+    ret = wdb_parse_dbsync(data->wdb, query, data->output);
+
+    assert_string_equal(data->output, "ok data1|data2|data3||5.0|6|7|8|data9|");
+    assert_int_equal(ret, OS_SUCCESS);
+
+    os_free(query);
+}
+
+void test_dbsync_modify_type_exists_data_float_null_value(void ** state) {
+    int ret = -1;
+    test_struct_t * data = (test_struct_t *) *state;
+    char * query = NULL;
+
+    os_strdup("hwinfo MODIFIED data1|data2|data3|NULL||NULL|NULL|NULL|NULL|", query);
+
+    will_return_always(__wrap_wdb_get_cache_stmt, 1);
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "data1");
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "data3");
+    expect_value(__wrap_sqlite3_bind_null, index, 3);
+    will_return(__wrap_sqlite3_bind_null, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 4);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "data2");
+
+    will_return_always(__wrap_sqlite3_bind_text, SQLITE_OK);
+    will_return(__wrap_sqlite3_changes, 1);
+
+    will_return(__wrap_wdb_step, SQLITE_DONE);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "data2");
+
+    will_return(__wrap_wdb_step, SQLITE_ROW);
+
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "data1");
+    expect_value(__wrap_sqlite3_column_text, iCol, 1);
+    will_return(__wrap_sqlite3_column_text, "data2");
+    expect_value(__wrap_sqlite3_column_text, iCol, 2);
+    will_return(__wrap_sqlite3_column_text, "data3");
+    expect_value(__wrap_sqlite3_column_text, iCol, 3);
+    will_return(__wrap_sqlite3_column_text, "4");
+    expect_value(__wrap_sqlite3_column_text, iCol, 4);
+    will_return(__wrap_sqlite3_column_text, NULL);
+    expect_value(__wrap_sqlite3_column_text, iCol, 5);
+    will_return(__wrap_sqlite3_column_text, "6");
+    expect_value(__wrap_sqlite3_column_text, iCol, 6);
+    will_return(__wrap_sqlite3_column_text, "7");
+    expect_value(__wrap_sqlite3_column_text, iCol, 7);
+    will_return(__wrap_sqlite3_column_text, "8");
+    expect_value(__wrap_sqlite3_column_text, iCol, 8);
+    will_return(__wrap_sqlite3_column_text, "data9");
+
+    ret = wdb_parse_dbsync(data->wdb, query, data->output);
+
+    assert_string_equal(data->output, "ok data1|data2|data3|4||6|7|8|data9|");
+    assert_int_equal(ret, OS_SUCCESS);
+
+    os_free(query);
+}
+
+void test_dbsync_modify_type_exists_data_text_null_value(void ** state) {
+    int ret = -1;
+    test_struct_t * data = (test_struct_t *) *state;
+    char * query = NULL;
+
+    os_strdup("hwinfo MODIFIED data1|data2||NULL|NULL|NULL|NULL|NULL|NULL|", query);
+
+    will_return_always(__wrap_wdb_get_cache_stmt, 1);
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "data1");
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "");
+    expect_value(__wrap_sqlite3_bind_text, pos, 3);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "data2");
+
+    will_return_always(__wrap_sqlite3_bind_text, SQLITE_OK);
+    will_return(__wrap_sqlite3_changes, 1);
+
+    will_return(__wrap_wdb_step, SQLITE_DONE);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "data2");
+
+    will_return(__wrap_wdb_step, SQLITE_ROW);
+
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "data1");
+    expect_value(__wrap_sqlite3_column_text, iCol, 1);
+    will_return(__wrap_sqlite3_column_text, NULL);
+    expect_value(__wrap_sqlite3_column_text, iCol, 2);
+    will_return(__wrap_sqlite3_column_text, "data3");
+    expect_value(__wrap_sqlite3_column_text, iCol, 3);
+    will_return(__wrap_sqlite3_column_text, "4");
+    expect_value(__wrap_sqlite3_column_text, iCol, 4);
+    will_return(__wrap_sqlite3_column_text, "5.0");
+    expect_value(__wrap_sqlite3_column_text, iCol, 5);
+    will_return(__wrap_sqlite3_column_text, "6");
+    expect_value(__wrap_sqlite3_column_text, iCol, 6);
+    will_return(__wrap_sqlite3_column_text, "7");
+    expect_value(__wrap_sqlite3_column_text, iCol, 7);
+    will_return(__wrap_sqlite3_column_text, "8");
+    expect_value(__wrap_sqlite3_column_text, iCol, 8);
+    will_return(__wrap_sqlite3_column_text, "data9");
+
+    ret = wdb_parse_dbsync(data->wdb, query, data->output);
+
+    assert_string_equal(data->output, "ok data1||data3|4|5.0|6|7|8|data9|");
+    assert_int_equal(ret, OS_SUCCESS);
+
+    os_free(query);
+}
+
 void test_dbsync_modify_type_exists_data_compound_pk(void **state) {
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -2114,6 +2274,9 @@ int main()
         cmocka_unit_test_setup_teardown(test_dbsync_modify_type_exists_data_1, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_dbsync_insert_type_exists_null_stmt, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_dbsync_modify_type_exists_data_real_value, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_dbsync_modify_type_exists_data_float_null_value, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_dbsync_modify_type_exists_data_text_null_value, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_dbsync_modify_type_exists_data_integer_null_value, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_dbsync_delete_type_exists_data_compound_pk, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_dbsync_modify_type_exists_data_compound_pk, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_dbsync_modify_type_exists_data_stmt_fail, test_setup, test_teardown),

--- a/src/unit_tests/wazuh_db/test_wdb_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_parser.c
@@ -1195,22 +1195,22 @@ void test_dbsync_modify_type_exists_data_real_value(void **state) {
     will_return(__wrap_sqlite3_column_text, "data2");
     expect_value(__wrap_sqlite3_column_text, iCol, 2);
     will_return(__wrap_sqlite3_column_text, "data3");
-    expect_value(__wrap_sqlite3_column_int, iCol, 3);
-    will_return(__wrap_sqlite3_column_int, 4);
-    expect_value(__wrap_sqlite3_column_double, iCol, 4);
-    will_return(__wrap_sqlite3_column_double, 5.0);
-    expect_value(__wrap_sqlite3_column_int, iCol, 5);
-    will_return(__wrap_sqlite3_column_int, 6);
-    expect_value(__wrap_sqlite3_column_int, iCol, 6);
-    will_return(__wrap_sqlite3_column_int, 7);
-    expect_value(__wrap_sqlite3_column_int, iCol, 7);
-    will_return(__wrap_sqlite3_column_int, 8);
+    expect_value(__wrap_sqlite3_column_text, iCol, 3);
+    will_return(__wrap_sqlite3_column_text, "4");
+    expect_value(__wrap_sqlite3_column_text, iCol, 4);
+    will_return(__wrap_sqlite3_column_text, "5.0");
+    expect_value(__wrap_sqlite3_column_text, iCol, 5);
+    will_return(__wrap_sqlite3_column_text, "6");
+    expect_value(__wrap_sqlite3_column_text, iCol, 6);
+    will_return(__wrap_sqlite3_column_text, "7");
+    expect_value(__wrap_sqlite3_column_text, iCol, 7);
+    will_return(__wrap_sqlite3_column_text, "8");
     expect_value(__wrap_sqlite3_column_text, iCol, 8);
     will_return(__wrap_sqlite3_column_text, "data9");
 
     ret = wdb_parse_dbsync(data->wdb, query, data->output);
 
-    assert_string_equal(data->output, "ok data1|data2|data3|4|5.000000|6|7|8|data9|");
+    assert_string_equal(data->output, "ok data1|data2|data3|4|5.0|6|7|8|data9|");
     assert_int_equal(ret, OS_SUCCESS);
 
     os_free(query);
@@ -1253,8 +1253,8 @@ void test_dbsync_modify_type_exists_data_compound_pk(void **state) {
     will_return(__wrap_sqlite3_column_text, "data3");
     expect_value(__wrap_sqlite3_column_text, iCol, 3);
     will_return(__wrap_sqlite3_column_text, "data4");
-    expect_value(__wrap_sqlite3_column_int, iCol, 4);
-    will_return(__wrap_sqlite3_column_int, 5);
+    expect_value(__wrap_sqlite3_column_text, iCol, 4);
+    will_return(__wrap_sqlite3_column_text, "5");
     expect_value(__wrap_sqlite3_column_text, iCol, 5);
     will_return(__wrap_sqlite3_column_text, "data6");
     expect_value(__wrap_sqlite3_column_text, iCol, 6);
@@ -1543,8 +1543,8 @@ void test_dbsync_delete_type_exists_data_compound_pk_select_data(void **state) {
     will_return(__wrap_sqlite3_column_text, "data3");
     expect_value(__wrap_sqlite3_column_text, iCol, 3);
     will_return(__wrap_sqlite3_column_text, "data4");
-    expect_value(__wrap_sqlite3_column_int, iCol, 4);
-    will_return(__wrap_sqlite3_column_int, 5);
+    expect_value(__wrap_sqlite3_column_text, iCol, 4);
+    will_return(__wrap_sqlite3_column_text, "5");
     expect_value(__wrap_sqlite3_column_text, iCol, 5);
     will_return(__wrap_sqlite3_column_text, "data6");
     expect_value(__wrap_sqlite3_column_text, iCol, 6);

--- a/src/wazuh_db/wdb_delta_event.c
+++ b/src/wazuh_db/wdb_delta_event.c
@@ -333,35 +333,26 @@ void wdb_select_dbsync(wdb_t * wdb, struct kv const *kv_value, const char *data,
             index = 0;
             int len = strlen(output);
             switch (wdb_step(stmt)) {
-                case SQLITE_ROW:
-                    for (column = kv_value->column_list; column ; column=column->next) {
-                        if (!column->value.is_old_implementation) {
-                            if (FIELD_TEXT == column->value.type) {
-                                char * value = wstr_replace((char *)sqlite3_column_text(stmt, index),
-                                                            FIELD_SEPARATOR_DBSYNC, FIELD_SEPARATOR_DBSYNC_ESCAPE);
-                                len += snprintf(output + len, OS_SIZE_6144 - len - WDB_RESPONSE_OK_SIZE - 1, "%s",
-                                                value);
-                                os_free(value);
-                            }
-                            else if (FIELD_INTEGER == column->value.type) {
-                                len += snprintf(output + len, OS_SIZE_6144 - len - WDB_RESPONSE_OK_SIZE - 1, "%d",
-                                                sqlite3_column_int(stmt, index));
-                            }
-                            else if (FIELD_REAL == column->value.type) {
-                                len += snprintf(output + len, OS_SIZE_6144 - len - WDB_RESPONSE_OK_SIZE - 1, "%f",
-                                                sqlite3_column_double(stmt, index));
-                            }
-                            len += snprintf(output + len, OS_SIZE_6144 - len - WDB_RESPONSE_OK_SIZE - 1,
-                                            FIELD_SEPARATOR_DBSYNC);
-                            ++index;
+            case SQLITE_ROW:
+                for (column = kv_value->column_list; column; column = column->next) {
+                    if (!column->value.is_old_implementation) {
+                        char * value = wstr_replace((char *) sqlite3_column_text(stmt, index), FIELD_SEPARATOR_DBSYNC,
+                                                    FIELD_SEPARATOR_DBSYNC_ESCAPE);
+                        if (NULL != value) {
+                            len += snprintf(output + len, OS_SIZE_6144 - len - WDB_RESPONSE_OK_SIZE - 1, "%s", value);
+                            os_free(value);
                         }
+                        len += snprintf(output + len, OS_SIZE_6144 - len - WDB_RESPONSE_OK_SIZE - 1,
+                                        FIELD_SEPARATOR_DBSYNC);
+                        ++index;
                     }
-                    break;
-                case SQLITE_DONE:
-                    break;
-                default:
-                    merror(DB_AGENT_SQL_ERROR, wdb->id, sqlite3_errmsg(wdb->db));
-                    break;
+                }
+                break;
+            case SQLITE_DONE:
+                break;
+            default:
+                merror(DB_AGENT_SQL_ERROR, wdb->id, sqlite3_errmsg(wdb->db));
+                break;
             }
 
             os_free(data_temp);

--- a/src/wazuh_db/wdb_delta_event.c
+++ b/src/wazuh_db/wdb_delta_event.c
@@ -383,18 +383,26 @@ STATIC bool wdb_dbsync_stmt_bind_from_string(sqlite3_stmt * stmt, int index, fie
             }
             break;
         case FIELD_INTEGER: {
-            char * endptr;
-            const int integer_number = (int) strtol(replaced_value_escape_pipe, &endptr, 10);
-            if ('\0' == *endptr && SQLITE_OK == sqlite3_bind_int(stmt, index, integer_number)) {
-                ret_val = true;
+            if ('\0' == *replaced_value_escape_pipe) {
+                ret_val = sqlite3_bind_null(stmt, index) == SQLITE_OK ? true : false;
+            } else {
+                char * endptr;
+                const int integer_number = (int) strtol(replaced_value_escape_pipe, &endptr, 10);
+                if (NULL != endptr && '\0' == *endptr && SQLITE_OK == sqlite3_bind_int(stmt, index, integer_number)) {
+                    ret_val = true;
+                }
             }
             break;
         }
         case FIELD_REAL: {
-            char * endptr;
-            const double real_value = strtod(replaced_value_escape_pipe, &endptr);
-            if ('\0' == *endptr && SQLITE_OK == sqlite3_bind_double(stmt, index, real_value)) {
-                ret_val = true;
+            if ('\0' == *replaced_value_escape_pipe) {
+                ret_val = sqlite3_bind_null(stmt, index) == SQLITE_OK ? true : false;
+            } else {
+                char * endptr;
+                const double real_value = strtod(replaced_value_escape_pipe, &endptr);
+                if (NULL != endptr && '\0' == *endptr && SQLITE_OK == sqlite3_bind_double(stmt, index, real_value)) {
+                    ret_val = true;
+                }
             }
             break;
         }


### PR DESCRIPTION
|Related issue|
|---|
|Closing #10741|
|Closing #10778|


## Description

HI team!

This PR aims to solve #10741 by changing the approach to retrieve NULL information during agent DB query, part of wazuh-db delta handling.
 According to the next table(ref [here](https://www.sqlite.org/c3ref/column_blob.html)), accessing db fields using `sqlite3_column_text` allows to get NULL pointer if underlying db value is NULL (no matter the type), otherwise a string representation will be returned, perfectly fitting our type needs.

![image](https://user-images.githubusercontent.com/1791430/140503209-b024d21d-ec6f-4059-b7be-a74103b60ceb.png)


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors