### PR TITLE
Fix a segmentation fault in Analysisd when building the rules configuration

### DIFF
--- a/src/analysisd/config_json.c
+++ b/src/analysisd/config_json.c
@@ -192,7 +192,7 @@ void _getRulesListJSON(RuleNode *list, cJSON *array) {
     RuleNode *node = NULL;
     u_int32_t same;
     u_int32_t different;
-    int i;
+    unsigned i;
 
     const char * same_fields[] = {
         "same_srcip",
@@ -469,7 +469,18 @@ void _getRulesListJSON(RuleNode *list, cJSON *array) {
         }
 
         if (same = node->ruleinfo->same_field, same) {
-            for (i = 0; same != 0; i++) {
+            if ((same & FIELD_DYNAMICS) == FIELD_DYNAMICS) {
+                cJSON * array = cJSON_CreateArray();
+                cJSON_AddItemToObject(rule, "same_field", array);
+
+                for (i = 0; node->ruleinfo->same_fields[i] != NULL; i++) {
+                    cJSON_AddItemToArray(array, cJSON_CreateString(node->ruleinfo->same_fields[i]));
+                }
+
+                same &= ~FIELD_DYNAMICS;
+            }
+
+            for (i = 0; i < sizeof(same_fields) / sizeof(char*) && same != 0; i++) {
                 if ((same & 1) == 1) {
                     cJSON_AddStringToObject(rule, same_fields[i], "");
                 }
@@ -478,7 +489,18 @@ void _getRulesListJSON(RuleNode *list, cJSON *array) {
         }
 
         if (different = node->ruleinfo->different_field, different) {
-            for (i = 0; different != 0; i++) {
+            if ((different & FIELD_DYNAMICS) == FIELD_DYNAMICS) {
+                cJSON * array = cJSON_CreateArray();
+                cJSON_AddItemToObject(rule, "different_field", array);
+
+                for (i = 0; node->ruleinfo->not_same_fields[i] != NULL; i++) {
+                    cJSON_AddItemToArray(array, cJSON_CreateString(node->ruleinfo->not_same_fields[i]));
+                }
+
+                different &= ~FIELD_DYNAMICS;
+            }
+
+            for (i = 0; i < sizeof(different_fields) / sizeof(char*) && different != 0; i++) {
                 if ((different & 1) == 1) {
                     cJSON_AddStringToObject(rule, different_fields[i], "");
                 }

--- a/src/analysisd/config_json.c
+++ b/src/analysisd/config_json.c
@@ -477,7 +477,7 @@ void _getRulesListJSON(RuleNode *list, cJSON *array) {
             }
         }
 
-        if (different = node->ruleinfo->same_field, different) {
+        if (different = node->ruleinfo->different_field, different) {
             for (i = 0; different != 0; i++) {
                 if ((different & 1) == 1) {
                     cJSON_AddStringToObject(rule, different_fields[i], "");


### PR DESCRIPTION
|Related issue|
|---|
|Closes #10729|

The segmentation fault described in #10729 is caused by a typo in Analysisd when building the `rules` configuration query response.

1. Variable `ruleinfo->same_field` is related to `same_fields[]` while `ruleinfo->different_field` helps scan array `different_fields[]`.
2. Dynamic fields (flag `FIELD_DYNAMICS`) were not considered, which made the loops run out of the arrays' bounds. Members `same_field` and `different_field` have been added to the `rule` object.
3. The value range of variable `i` has been restricted, in order to prevent further out-of-bounds array access.

## Rule sample

### Definition

```xml
<rule id="60204" level="10" frequency="$MS_FREQ" timeframe="240">
  <if_matched_group>authentication_failed</if_matched_group>
  <same_field>win.eventdata.ipAddress</same_field>
  <description>Multiple Windows Logon Failures</description>
  <mitre>
    <id>T1110</id>
  </mitre>
  <options>no_full_log</options>
  <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
</rule>
```

### Report

```json
{
  "sigid": 60204,
  "level": 10,
  "maxsize": 0,
  "frequency": 8,
  "timeframe": 240,
  "ignore_time": 0,
  "decoded_as": 0,
  "if_matched_sid": 0,
  "group": "windows,windows_security,authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,",
  "comment": "Multiple Windows Logon Failures",
  "if_matched_group": "authentication_failed",
  "rule_file": "ruleset/rules/0580-win-security_rules.xml",
  "category": "syslog",
  "same_field": [
    "win.eventdata.ipAddress"
  ]
}
```

## Tests

- [X] API query for `rules` configuration does no longer make Analysisd crash.
- [X] Run Analysisd on Valgrind and launch the previous query.