### PR TITLE
Fix stored `creation_time` in Google storage module

### DIFF
--- a/wodles/gcloud/buckets/bucket.py
+++ b/wodles/gcloud/buckets/bucket.py
@@ -115,7 +115,13 @@ class WazuhGCloudBucket(WazuhGCloudIntegration):
                                             blob_name;"""
 
     def _get_last_processed_files(self):
-        """Get the names of the blobs processed during the last execution."""
+        """Get the names of the blobs processed during the last execution.
+
+        Returns
+        -------
+        List of str
+            List with the filenames of all the previously processed blobs.
+        """
         processed_files = self.db_connector.execute(
             self.sql_find_processed_files.format(table_name=self.db_table_name,
                                                  project_id=self.project_id,
@@ -127,7 +133,13 @@ class WazuhGCloudBucket(WazuhGCloudIntegration):
             return list()
 
     def _update_last_processed_files(self, processed_files: list[storage.blob]):
-        """Remove the records for the previous execution and store the new values from the current one."""
+        """Remove the records for the previous execution and store the new values from the current one.
+
+        Parameters
+        ----------
+        processed_files : List of storage.blob
+            List with all the blobs successfully processed by the module.
+        """
         if processed_files:
             self.logger.info('Updating previously processed files.')
             try:

--- a/wodles/gcloud/buckets/bucket.py
+++ b/wodles/gcloud/buckets/bucket.py
@@ -114,6 +114,39 @@ class WazuhGCloudBucket(WazuhGCloudIntegration):
                                         ORDER BY
                                             blob_name;"""
 
+    def _get_last_processed_files(self):
+        """Get the names of the blobs processed during the last execution."""
+        processed_files = self.db_connector.execute(
+            self.sql_find_processed_files.format(table_name=self.db_table_name,
+                                                 project_id=self.project_id,
+                                                 bucket_name=self.bucket_name,
+                                                 prefix=self.prefix))
+        try:
+            return [p[0] for p in processed_files.fetchall()]
+        except (TypeError, IndexError):
+            return list()
+
+    def _update_last_processed_files(self, processed_files: list[storage.blob]):
+        """Remove the records for the previous execution and store the new values from the current one."""
+        if processed_files:
+            self.logger.info('Updating previously processed files.')
+            try:
+                self.db_connector.execute(self.sql_delete_processed_files.format(table_name=self.db_table_name,
+                                                                                 project_id=self.project_id,
+                                                                                 bucket_name=self.bucket_name,
+                                                                                 prefix=self.prefix))
+            except sqlite3.IntegrityError:
+                pass
+
+            for blob in processed_files:
+                self.db_connector.execute(self.sql_insert_processed_file.format(table_name=self.db_table_name,
+                                                                                project_id=self.project_id,
+                                                                                bucket_name=self.bucket_name,
+                                                                                prefix=self.prefix,
+                                                                                blob_name=blob.name,
+                                                                                creation_time=blob.time_created))
+    processed_files = list()
+
     def check_permissions(self):
         """Check if the Service Account has access to the bucket."""
         try:
@@ -164,39 +197,7 @@ class WazuhGCloudBucket(WazuhGCloudIntegration):
                 pass
             return creation_time
 
-        def get_last_processed_files():
-            """Get the names of the blobs processed during the last execution."""
-            processed_files = self.db_connector.execute(
-                self.sql_find_processed_files.format(table_name=self.db_table_name,
-                                                     project_id=self.project_id,
-                                                     bucket_name=self.bucket_name,
-                                                     prefix=self.prefix))
-            try:
-                return [p[0] for p in processed_files.fetchall()]
-            except (TypeError, IndexError):
-                return list()
-
-        def update_last_processed_files():
-            """Remove the records for the previous execution and store the new values from the current one."""
-            if processed_files:
-                self.logger.info('Updating previously processed files.')
-                try:
-                    self.db_connector.execute(self.sql_delete_processed_files.format(table_name=self.db_table_name,
-                                                                                     project_id=self.project_id,
-                                                                                     bucket_name=self.bucket_name,
-                                                                                     prefix=self.prefix))
-                except sqlite3.IntegrityError:
-                    pass
-
-                for blob_name in processed_files:
-                    self.db_connector.execute(self.sql_insert_processed_file.format(table_name=self.db_table_name,
-                                                                                    project_id=self.project_id,
-                                                                                    bucket_name=self.bucket_name,
-                                                                                    prefix=self.prefix,
-                                                                                    blob_name=blob_name,
-                                                                                    creation_time=new_creation_time))
-
-        processed_files = list()
+        processed_files = []
         try:
             bucket_contents = self.bucket.list_blobs(prefix=self.prefix)
 
@@ -205,7 +206,7 @@ class WazuhGCloudBucket(WazuhGCloudIntegration):
 
             self.init_db()
             last_creation_time = get_last_creation_time()
-            previous_processed_files = get_last_processed_files()
+            previous_processed_files = self._get_last_processed_files()
 
             for blob in bucket_contents:
                 # Skip folders
@@ -224,7 +225,7 @@ class WazuhGCloudBucket(WazuhGCloudIntegration):
                             processed_files.clear()
                             new_creation_time = current_creation_time
 
-                        processed_files.append(blob.name)
+                        processed_files.append(blob)
                     else:
                         self.logger.info(f'Skipping previously processed file: {blob.name}')
                 else:
@@ -233,7 +234,7 @@ class WazuhGCloudBucket(WazuhGCloudIntegration):
         finally:
             # Ensure the changes are committed to the database even if an exception was raised
             if self.db_connector:
-                update_last_processed_files()
+                self._update_last_processed_files(processed_files)
                 self.db_connector.commit()
                 self.db_connector.close()
         return processed_messages


### PR DESCRIPTION
|Related issue|
|---|
|Closes #10756 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

In this PR we fix the bug that made the Google Cloud Storage module save an incorrect `creation_time`. Now the dates stored in the database are the same as the ones in the bucket, as can be seen below:

```
sqlite> select * FROM  access_logs ;
wazuh-dev-258815|framework-test-bucket||test_0.txt|2021-11-05 17:22:07.982000+00:00
wazuh-dev-258815|framework-test-bucket||test_1.txt|2021-11-04 21:40:03.567000+00:00
wazuh-dev-258815|framework-test-bucket||test_22.txt|2021-11-05 12:31:05.589000+00:00
```
![image](https://user-images.githubusercontent.com/72474806/140560069-7d95cf2f-5410-4332-b20c-79b038922ce8.png)  

I made the `_get_last_processed_files` and `_update_last_processed_files` private instead of nested functions to avoid them messing up the parent method's namespace like the `get_last_processed_files` function was doing, since it was setting the `processed_files` variable, which was also shared by the parent method. This can avoid unexpected errors.

## Tests performed
### Execution with an empty database specifying an old `only_logs_after` value
It fetchs all files, as it should.
```
root@7ca944c0391d:/var/ossec/wodles/gcloud# /var/ossec/wodles/gcloud/gcloud -c  /var/ossec/wodles/gcloud/credentials.json -l 1 -T access_logs -b framework-test-bucket -o 2021-oct-31
gcloud_wodle - INFO - Processing test_0.txt
gcloud_wodle - INFO - Skipping previously processed file: test_1.txt
gcloud_wodle - INFO - Skipping previously processed file: test_22.txt
gcloud_wodle - INFO - Updating previously processed files.
gcloud_wodle - INFO - Received 0 messages
```  

### Fetching logs from an empty bucket
It works normally.
```
root@7ca944c0391d:/var/ossec/wodles/gcloud# /var/ossec/wodles/gcloud/gcloud -c  /var/ossec/wodles/gcloud/credentials.json -l 1 -T access_logs -b framework-empty-bucket -o 2021-oct-31
gcloud_wodle - INFO - Received 0 messages
```  

### Fetching logs in a bucket with logs older than the one processed
It should only process the newer ones.
```
root@7ca944c0391d:/var/ossec/wodles/gcloud# /var/ossec/wodles/gcloud/gcloud -c  /var/ossec/wodles/gcloud/credentials.json -l 1 -T access_logs -b framework-test-bucket
gcloud_wodle - INFO - Processing test_0.txt
gcloud_wodle - INFO - The creation time of test_1.txt is older than 2021-11-05 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - Processing test_22.txt
gcloud_wodle - INFO - Updating previously processed files.
gcloud_wodle - INFO - Received 0 messages
```  

### Executing the module when there are new logs that hasn't been processed yet
It only fetchs the `test_0.txt` file, which is newer than the ones already processed.
```
root@7ca944c0391d:/var/ossec/wodles/gcloud# /var/ossec/wodles/gcloud/gcloud -c  /var/ossec/wodles/gcloud/credentials.json -l 1 -T access_logs -b framework-test-bucket -o 2021-oct-31
gcloud_wodle - INFO - Processing test_0.txt
gcloud_wodle - INFO - Skipping previously processed file: test_1.txt
gcloud_wodle - INFO - Skipping previously processed file: test_22.txt
gcloud_wodle - INFO - Updating previously processed files.
gcloud_wodle - INFO - Received 0 messages
```  

### Executing the module with an empty database and without specifying an `only_logs_after`
It only collects the logs with the same `creation_date` as the execution date and skips the rest as expected.
```
root@7ca944c0391d:/var/ossec/wodles/gcloud# /var/ossec/wodles/gcloud/gcloud -c  /var/ossec/wodles/gcloud/credentials.json -l 1 -T access_logs -b framework-test-bucket  
gcloud_wodle - INFO - Processing test_0.txt
gcloud_wodle - INFO - The creation time of test_1.txt is older than 2021-11-05 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - Processing test_22.txt
gcloud_wodle - INFO - Updating previously processed files.
gcloud_wodle - INFO - Received 0 messages
```