### PR TITLE
Fix netproto table issues.

### DIFF
--- a/src/unit_tests/wazuh_db/test_wdb_syscollector.c
+++ b/src/unit_tests/wazuh_db/test_wdb_syscollector.c
@@ -480,6 +480,7 @@ static void wdb_syscollector_netproto_save2_fail(void) {
 
     will_return(__wrap_cJSON_GetStringValue, "iface");
     will_return(__wrap_cJSON_GetStringValue, "gateway");
+    will_return(__wrap_cJSON_GetStringValue, "type");
     will_return(__wrap_cJSON_GetStringValue, "dhcp");
     will_return(__wrap_cJSON_GetStringValue, "checksum");
     will_return(__wrap_cJSON_GetStringValue, "item_id");
@@ -491,7 +492,6 @@ static void wdb_syscollector_netproto_save2_fail(void) {
 static void wdb_syscollector_netproto_save2_success(cJSON *attribute) {
     will_return(__wrap_cJSON_GetObjectItem, NULL);
     will_return(__wrap_cJSON_GetObjectItem, 1);
-    will_return(__wrap_cJSON_GetObjectItem, attribute);
     will_return(__wrap_cJSON_GetObjectItem, NULL);
     will_return(__wrap_cJSON_GetObjectItem, NULL);
     will_return(__wrap_cJSON_GetObjectItem, 1);
@@ -500,6 +500,7 @@ static void wdb_syscollector_netproto_save2_success(cJSON *attribute) {
     will_return(__wrap_cJSON_GetObjectItem, NULL);
 
     will_return(__wrap_cJSON_GetStringValue, "iface");
+    will_return(__wrap_cJSON_GetStringValue, "ipv6");
     will_return(__wrap_cJSON_GetStringValue, "gateway");
     will_return(__wrap_cJSON_GetStringValue, "dhcp");
     will_return(__wrap_cJSON_GetStringValue, "checksum");

--- a/src/wazuh_db/wdb_syscollector.c
+++ b/src/wazuh_db/wdb_syscollector.c
@@ -1168,7 +1168,8 @@ int wdb_syscollector_netproto_save2(wdb_t * wdb, const cJSON * attributes)
 {
     const char * scan_id = "0";
     const char * iface = cJSON_GetStringValue(cJSON_GetObjectItem(attributes, "iface"));
-    const int type = cJSON_GetObjectItem(attributes, "type") ? cJSON_GetObjectItem(attributes, "type")->valueint : 0;
+    const char * type_string = cJSON_GetStringValue(cJSON_GetObjectItem(attributes, "type"));
+    const int type = type_string ? (strcmp(type_string, "ipv6") == 0 ? 1 : 0) : 0;
     const char * gateway = cJSON_GetStringValue(cJSON_GetObjectItem(attributes, "gateway"));
     const char * dhcp = cJSON_GetStringValue(cJSON_GetObjectItem(attributes, "dhcp"));
     const int metric = cJSON_GetObjectItem(attributes, "metric") ? cJSON_GetObjectItem(attributes, "metric")->valueint : 0;

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -131,7 +131,7 @@ TEST_F(SyscollectorImpTest, defaultCtor)
     };
     const auto expectedResult4
     {
-        R"({"data":{"checksum":"2ab0e1d3980d80e11fd5262236a662b9726151a8","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"338a8e51ab095707973bb34d85a22208c7284490","metric":" ","type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
+        R"({"data":{"checksum":"ff63981c231f110a0877ac6acd8862ac09877b5d","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"d633b040008ea38303d778431ee2fd0b4ee5a37a","metric":" ","type":"ipv4"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
     };
     const auto expectedResult5
     {
@@ -163,7 +163,7 @@ TEST_F(SyscollectorImpTest, defaultCtor)
     };
     const auto expectedResult12
     {
-        R"({"component":"syscollector_network_protocol","data":{"begin":"338a8e51ab095707973bb34d85a22208c7284490","end":"338a8e51ab095707973bb34d85a22208c7284490"},"type":"integrity_check_global"})"
+        R"({"component":"syscollector_network_protocol","data":{"begin":"9dff246584835755137820c975f034d089e90b6f","end":"d633b040008ea38303d778431ee2fd0b4ee5a37a"},"type":"integrity_check_global"})"
     };
     const auto expectedResult13
     {
@@ -193,6 +193,12 @@ TEST_F(SyscollectorImpTest, defaultCtor)
     {
         R"({"component":"syscollector_hotfixes","data":{"begin":"KB12345678","end":"KB12345678"},"type":"integrity_check_global"})"
     };
+    const auto expectedResult20
+    {
+        R"({"data":{"checksum":"ea17673e7422c0ab04c4f1f111a5828be8cd366a","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"9dff246584835755137820c975f034d089e90b6f","metric":" ","type":"ipv6"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
+    };
+
+
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult2)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult3)).Times(1);
@@ -212,6 +218,7 @@ TEST_F(SyscollectorImpTest, defaultCtor)
     EXPECT_CALL(wrapper, callbackMock(expectedResult17)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult18)).Times(1);
     EXPECT_CALL(wrapper, callbackMock(expectedResult19)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult20)).Times(1);
 
     std::thread t
     {
@@ -380,7 +387,7 @@ TEST_F(SyscollectorImpTest, noHardware)
     };
     const auto expectedResult4
     {
-        R"({"data":{"checksum":"2ab0e1d3980d80e11fd5262236a662b9726151a8","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"338a8e51ab095707973bb34d85a22208c7284490","metric":" ","type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
+        R"({"data":{"checksum":"ff63981c231f110a0877ac6acd8862ac09877b5d","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"d633b040008ea38303d778431ee2fd0b4ee5a37a","metric":" ","type":"ipv4"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
     };
     const auto expectedResult5
     {
@@ -412,7 +419,7 @@ TEST_F(SyscollectorImpTest, noHardware)
     };
     const auto expectedResult12
     {
-        R"({"component":"syscollector_network_protocol","data":{"begin":"338a8e51ab095707973bb34d85a22208c7284490","end":"338a8e51ab095707973bb34d85a22208c7284490"},"type":"integrity_check_global"})"
+        R"({"component":"syscollector_network_protocol","data":{"begin":"9dff246584835755137820c975f034d089e90b6f","end":"d633b040008ea38303d778431ee2fd0b4ee5a37a"},"type":"integrity_check_global"})"
     };
     const auto expectedResult13
     {
@@ -438,6 +445,11 @@ TEST_F(SyscollectorImpTest, noHardware)
     {
         R"({"component":"syscollector_hotfixes","data":{"begin":"KB12345678","end":"KB12345678"},"type":"integrity_check_global"})"
     };
+    const auto expectedResult20
+    {
+        R"({"data":{"checksum":"ea17673e7422c0ab04c4f1f111a5828be8cd366a","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"9dff246584835755137820c975f034d089e90b6f","metric":" ","type":"ipv6"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
+    };
+
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult2)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult3)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult4)).Times(1);
@@ -455,6 +467,7 @@ TEST_F(SyscollectorImpTest, noHardware)
     EXPECT_CALL(wrapper, callbackMock(expectedResult17)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult18)).Times(1);
     EXPECT_CALL(wrapper, callbackMock(expectedResult19)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult20)).Times(1);
 
     std::thread t
     {
@@ -542,7 +555,7 @@ TEST_F(SyscollectorImpTest, noOs)
     };
     const auto expectedResult4
     {
-        R"({"data":{"checksum":"2ab0e1d3980d80e11fd5262236a662b9726151a8","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"338a8e51ab095707973bb34d85a22208c7284490","metric":" ","type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
+        R"({"data":{"checksum":"ff63981c231f110a0877ac6acd8862ac09877b5d","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"d633b040008ea38303d778431ee2fd0b4ee5a37a","metric":" ","type":"ipv4"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
     };
     const auto expectedResult5
     {
@@ -570,7 +583,7 @@ TEST_F(SyscollectorImpTest, noOs)
     };
     const auto expectedResult12
     {
-        R"({"component":"syscollector_network_protocol","data":{"begin":"338a8e51ab095707973bb34d85a22208c7284490","end":"338a8e51ab095707973bb34d85a22208c7284490"},"type":"integrity_check_global"})"
+        R"({"component":"syscollector_network_protocol","data":{"begin":"9dff246584835755137820c975f034d089e90b6f","end":"d633b040008ea38303d778431ee2fd0b4ee5a37a"},"type":"integrity_check_global"})"
     };
     const auto expectedResult13
     {
@@ -600,6 +613,11 @@ TEST_F(SyscollectorImpTest, noOs)
     {
         R"({"component":"syscollector_hotfixes","data":{"begin":"KB12345678","end":"KB12345678"},"type":"integrity_check_global"})"
     };
+    const auto expectedResult20
+    {
+        R"({"data":{"checksum":"ea17673e7422c0ab04c4f1f111a5828be8cd366a","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"9dff246584835755137820c975f034d089e90b6f","metric":" ","type":"ipv6"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
+    };
+
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult3)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult4)).Times(1);
@@ -617,6 +635,7 @@ TEST_F(SyscollectorImpTest, noOs)
     EXPECT_CALL(wrapper, callbackMock(expectedResult17)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult18)).Times(1);
     EXPECT_CALL(wrapper, callbackMock(expectedResult19)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult20)).Times(1);
 
     std::thread t
     {
@@ -842,7 +861,7 @@ TEST_F(SyscollectorImpTest, noPackages)
     };
     const auto expectedResult4
     {
-        R"({"data":{"checksum":"2ab0e1d3980d80e11fd5262236a662b9726151a8","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"338a8e51ab095707973bb34d85a22208c7284490","metric":" ","type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
+        R"({"data":{"checksum":"ff63981c231f110a0877ac6acd8862ac09877b5d","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"d633b040008ea38303d778431ee2fd0b4ee5a37a","metric":" ","type":"ipv4"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
     };
     const auto expectedResult5
     {
@@ -870,7 +889,7 @@ TEST_F(SyscollectorImpTest, noPackages)
     };
     const auto expectedResult12
     {
-        R"({"component":"syscollector_network_protocol","data":{"begin":"338a8e51ab095707973bb34d85a22208c7284490","end":"338a8e51ab095707973bb34d85a22208c7284490"},"type":"integrity_check_global"})"
+        R"({"component":"syscollector_network_protocol","data":{"begin":"9dff246584835755137820c975f034d089e90b6f","end":"d633b040008ea38303d778431ee2fd0b4ee5a37a"},"type":"integrity_check_global"})"
     };
     const auto expectedResult13
     {
@@ -896,7 +915,10 @@ TEST_F(SyscollectorImpTest, noPackages)
     {
         R"({"component":"syscollector_hotfixes","data":{"begin":"KB12345678","end":"KB12345678"},"type":"integrity_check_global"})"
     };
-
+    const auto expectedResult20
+    {
+        R"({"data":{"checksum":"ea17673e7422c0ab04c4f1f111a5828be8cd366a","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"9dff246584835755137820c975f034d089e90b6f","metric":" ","type":"ipv6"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
+    };
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult2)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult3)).Times(1);
@@ -914,6 +936,7 @@ TEST_F(SyscollectorImpTest, noPackages)
     EXPECT_CALL(wrapper, callbackMock(expectedResult16)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult18)).Times(1);
     EXPECT_CALL(wrapper, callbackMock(expectedResult19)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult20)).Times(1);
 
     std::thread t
     {
@@ -1004,7 +1027,7 @@ TEST_F(SyscollectorImpTest, noPorts)
     };
     const auto expectedResult4
     {
-        R"({"data":{"checksum":"2ab0e1d3980d80e11fd5262236a662b9726151a8","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"338a8e51ab095707973bb34d85a22208c7284490","metric":" ","type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
+        R"({"data":{"checksum":"ff63981c231f110a0877ac6acd8862ac09877b5d","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"d633b040008ea38303d778431ee2fd0b4ee5a37a","metric":" ","type":"ipv4"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
     };
     const auto expectedResult5
     {
@@ -1032,7 +1055,7 @@ TEST_F(SyscollectorImpTest, noPorts)
     };
     const auto expectedResult12
     {
-        R"({"component":"syscollector_network_protocol","data":{"begin":"338a8e51ab095707973bb34d85a22208c7284490","end":"338a8e51ab095707973bb34d85a22208c7284490"},"type":"integrity_check_global"})"
+        R"({"component":"syscollector_network_protocol","data":{"begin":"9dff246584835755137820c975f034d089e90b6f","end":"d633b040008ea38303d778431ee2fd0b4ee5a37a"},"type":"integrity_check_global"})"
     };
     const auto expectedResult13
     {
@@ -1058,6 +1081,11 @@ TEST_F(SyscollectorImpTest, noPorts)
     {
         R"({"component":"syscollector_hotfixes","data":{"begin":"KB12345678","end":"KB12345678"},"type":"integrity_check_global"})"
     };
+    const auto expectedResult20
+    {
+        R"({"data":{"checksum":"ea17673e7422c0ab04c4f1f111a5828be8cd366a","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"9dff246584835755137820c975f034d089e90b6f","metric":" ","type":"ipv6"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
+    };
+
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult2)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult3)).Times(1);
@@ -1075,6 +1103,7 @@ TEST_F(SyscollectorImpTest, noPorts)
     EXPECT_CALL(wrapper, callbackMock(expectedResult17)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult18)).Times(1);
     EXPECT_CALL(wrapper, callbackMock(expectedResult19)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult20)).Times(1);
 
 
     std::thread t
@@ -1167,7 +1196,7 @@ TEST_F(SyscollectorImpTest, noPortsAll)
     };
     const auto expectedResult4
     {
-        R"({"data":{"checksum":"2ab0e1d3980d80e11fd5262236a662b9726151a8","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"338a8e51ab095707973bb34d85a22208c7284490","metric":" ","type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
+        R"({"data":{"checksum":"ff63981c231f110a0877ac6acd8862ac09877b5d","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"d633b040008ea38303d778431ee2fd0b4ee5a37a","metric":" ","type":"ipv4"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
     };
     const auto expectedResult5
     {
@@ -1199,7 +1228,7 @@ TEST_F(SyscollectorImpTest, noPortsAll)
     };
     const auto expectedResult12
     {
-        R"({"component":"syscollector_network_protocol","data":{"begin":"338a8e51ab095707973bb34d85a22208c7284490","end":"338a8e51ab095707973bb34d85a22208c7284490"},"type":"integrity_check_global"})"
+        R"({"component":"syscollector_network_protocol","data":{"begin":"9dff246584835755137820c975f034d089e90b6f","end":"d633b040008ea38303d778431ee2fd0b4ee5a37a"},"type":"integrity_check_global"})"
     };
     const auto expectedResult13
     {
@@ -1233,6 +1262,10 @@ TEST_F(SyscollectorImpTest, noPortsAll)
     {
         R"({"data":{"checksum":"09d591fb0ed092c387f77b24af5bada43b5d519d","inode":0,"item_id":"7046b3f9cda975eb6567259c2469748e634dde49","local_ip":"127.0.0.1","local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"udp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":null,"tx_queue":0},"operation":"INSERTED","type":"dbsync_ports"})"
     };
+    const auto expectedResult21
+    {
+        R"({"data":{"checksum":"ea17673e7422c0ab04c4f1f111a5828be8cd366a","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"9dff246584835755137820c975f034d089e90b6f","metric":" ","type":"ipv6"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
+    };
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult2)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult3)).Times(1);
@@ -1253,6 +1286,7 @@ TEST_F(SyscollectorImpTest, noPortsAll)
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult18)).Times(1);
     EXPECT_CALL(wrapper, callbackMock(expectedResult19)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult20)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult21)).Times(1);
 
     std::thread t
     {
@@ -1341,7 +1375,7 @@ TEST_F(SyscollectorImpTest, noProcesses)
     };
     const auto expectedResult4
     {
-        R"({"data":{"checksum":"2ab0e1d3980d80e11fd5262236a662b9726151a8","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"338a8e51ab095707973bb34d85a22208c7284490","metric":" ","type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
+        R"({"data":{"checksum":"ff63981c231f110a0877ac6acd8862ac09877b5d","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"d633b040008ea38303d778431ee2fd0b4ee5a37a","metric":" ","type":"ipv4"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
     };
     const auto expectedResult5
     {
@@ -1369,7 +1403,7 @@ TEST_F(SyscollectorImpTest, noProcesses)
     };
     const auto expectedResult12
     {
-        R"({"component":"syscollector_network_protocol","data":{"begin":"338a8e51ab095707973bb34d85a22208c7284490","end":"338a8e51ab095707973bb34d85a22208c7284490"},"type":"integrity_check_global"})"
+        R"({"component":"syscollector_network_protocol","data":{"begin":"9dff246584835755137820c975f034d089e90b6f","end":"d633b040008ea38303d778431ee2fd0b4ee5a37a"},"type":"integrity_check_global"})"
     };
     const auto expectedResult13
     {
@@ -1395,6 +1429,10 @@ TEST_F(SyscollectorImpTest, noProcesses)
     {
         R"({"component":"syscollector_hotfixes","data":{"begin":"KB12345678","end":"KB12345678"},"type":"integrity_check_global"})"
     };
+    const auto expectedResult20
+    {
+        R"({"data":{"checksum":"ea17673e7422c0ab04c4f1f111a5828be8cd366a","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"9dff246584835755137820c975f034d089e90b6f","metric":" ","type":"ipv6"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
+    };
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult2)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult3)).Times(1);
@@ -1412,6 +1450,7 @@ TEST_F(SyscollectorImpTest, noProcesses)
     EXPECT_CALL(wrapper, callbackMock(expectedResult17)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult18)).Times(1);
     EXPECT_CALL(wrapper, callbackMock(expectedResult19)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult20)).Times(1);
 
 
     std::thread t
@@ -1504,7 +1543,7 @@ TEST_F(SyscollectorImpTest, noHotfixes)
     };
     const auto expectedResult4
     {
-        R"({"data":{"checksum":"2ab0e1d3980d80e11fd5262236a662b9726151a8","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"338a8e51ab095707973bb34d85a22208c7284490","metric":" ","type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
+        R"({"data":{"checksum":"ff63981c231f110a0877ac6acd8862ac09877b5d","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"d633b040008ea38303d778431ee2fd0b4ee5a37a","metric":" ","type":"ipv4"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
     };
     const auto expectedResult5
     {
@@ -1536,7 +1575,7 @@ TEST_F(SyscollectorImpTest, noHotfixes)
     };
     const auto expectedResult12
     {
-        R"({"component":"syscollector_network_protocol","data":{"begin":"338a8e51ab095707973bb34d85a22208c7284490","end":"338a8e51ab095707973bb34d85a22208c7284490"},"type":"integrity_check_global"})"
+        R"({"component":"syscollector_network_protocol","data":{"begin":"9dff246584835755137820c975f034d089e90b6f","end":"d633b040008ea38303d778431ee2fd0b4ee5a37a"},"type":"integrity_check_global"})"
     };
     const auto expectedResult13
     {
@@ -1558,6 +1597,10 @@ TEST_F(SyscollectorImpTest, noHotfixes)
     {
         R"({"component":"syscollector_packages","data":{"begin":"7a119de04989606ebae116083afc1ec2579b0631","end":"7a119de04989606ebae116083afc1ec2579b0631"},"type":"integrity_check_global"})"
     };
+    const auto expectedResult18
+    {
+        R"({"data":{"checksum":"ea17673e7422c0ab04c4f1f111a5828be8cd366a","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"9dff246584835755137820c975f034d089e90b6f","metric":" ","type":"ipv6"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
+    };
 
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult2)).Times(1);
@@ -1576,7 +1619,7 @@ TEST_F(SyscollectorImpTest, noHotfixes)
     EXPECT_CALL(wrapper, callbackMock(expectedResult15)).Times(1);
     EXPECT_CALL(wrapper, callbackMock(expectedResult16)).Times(1);
     EXPECT_CALL(wrapper, callbackMock(expectedResult17)).Times(1);
-
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult18)).Times(1);
 
     std::thread t
     {
@@ -1715,7 +1758,7 @@ TEST_F(SyscollectorImpTest, pushMessageOk1)
     };
     const auto expectedResult4
     {
-        R"({"component":"syscollector_network_protocol","data":{"begin":"338a8e51ab095707973bb34d85a22208c7284490","end":"338a8e51ab095707973bb34d85a22208c7284490"},"type":"integrity_check_global"})"
+        R"({"component":"syscollector_network_protocol","data":{"begin":"9dff246584835755137820c975f034d089e90b6f","end":"d633b040008ea38303d778431ee2fd0b4ee5a37a"},"type":"integrity_check_global"})"
     };
     const auto expectedResult5
     {
@@ -1755,7 +1798,7 @@ TEST_F(SyscollectorImpTest, pushMessageOk1)
     };
     const auto expectedResult14
     {
-        R"({"data":{"checksum":"2ab0e1d3980d80e11fd5262236a662b9726151a8","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"338a8e51ab095707973bb34d85a22208c7284490","metric":" ","type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
+        R"({"data":{"checksum":"ff63981c231f110a0877ac6acd8862ac09877b5d","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"d633b040008ea38303d778431ee2fd0b4ee5a37a","metric":" ","type":"ipv4"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
     };
     const auto expectedResult15
     {
@@ -1781,6 +1824,10 @@ TEST_F(SyscollectorImpTest, pushMessageOk1)
     {
         R"({"data":{"checksum":"af3801fac517cf9ae30f746092ce3e4058574454","egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":"45","ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0},"operation":"INSERTED","type":"dbsync_processes"})"
     };
+    const auto expectedResult21
+    {
+        R"({"data":{"checksum":"ea17673e7422c0ab04c4f1f111a5828be8cd366a","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"9dff246584835755137820c975f034d089e90b6f","metric":" ","type":"ipv6"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
+    };
 
     EXPECT_CALL(wrapper, callbackMock(expectedResult1)).Times(1);
     EXPECT_CALL(wrapper, callbackMock(expectedResult2)).Times(1);
@@ -1802,6 +1849,7 @@ TEST_F(SyscollectorImpTest, pushMessageOk1)
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult18)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult19)).Times(1);
     EXPECT_CALL(wrapperDelta, callbackMock(expectedResult20)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult21)).Times(1);
 
     std::thread t
     {


### PR DESCRIPTION
|Related issue|
|---|
| Closes #10584 |
| Closes #10701 |

## Description

Issue 1:
An incorrect value is being sent under the netproto table, as well as something invalid is being stored in the local database, this is an issue in the agent.

Expected

    Save in netproto table a correct "type" field value(ipv4, ipv6)

Actual

    Syscollector Save the interface type on netproto.type field.


Issue 2:
Currently we are facing a problem during INSERTED deltas by wazuh-db, leading to not inserting them in the agent database
Steps to reproduce

The next scenario was reproduced using network_protocol as an example
1- Enable syscollector with a short interval time i.e 20s
2- Start the agent, wait until first scan was completed (this could be done by following ossec.log)
3- Create a dummy interface using the next command ip link add dummy0 type dummy
4- Wait until the next scan
Expected output

    Insertion network_protocol delta was properly stored in the agent database. This could be verified using the next command

sqlite3 /var/ossec/queue/db/001.db "SELECT * FROM sys_netproto;" 

Current output

    Insertion delta was not stored in the agent database. This could be verified using the next command

sqlite3 /var/ossec/queue/db/001.db "SELECT * FROM sys_netproto;" 

