### PR TITLE
Make `local_integrity` task stand-alone

### DIFF
--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -10,6 +10,8 @@ import os
 import sys
 from signal import signal, Signals, SIGTERM, SIG_DFL
 
+from psutil import Process
+
 from wazuh.core.utils import check_pid
 
 
@@ -30,11 +32,20 @@ def print_version():
     print("\n{} {} - {}\n\n{}".format(__wazuh_name__, __version__, __author__, __licence__))
 
 
+def terminate_child_processes(parent_pid):
+    for child in Process(parent_pid).children(recursive=True):
+        child.kill()
+
+
 def exit_handler(signum, frame):
+    cluster_pid = os.getpid()
     main_logger.info(f'SIGNAL [({signum})-({Signals(signum).name})] received. Exit...')
 
+    # Terminate cluster's child processes
+    terminate_child_processes(cluster_pid)
+
     # Remove cluster's pidfile
-    pyDaemonModule.delete_pid('wazuh-clusterd', os.getpid())
+    pyDaemonModule.delete_pid('wazuh-clusterd', cluster_pid)
 
     if callable(original_sig_handler):
         original_sig_handler(signum, frame)
@@ -184,4 +195,5 @@ if __name__ == '__main__':
     except Exception as e:
         main_logger.error(f"Unhandled exception: {e}")
     finally:
+        terminate_child_processes(pid)
         pyDaemonModule.delete_pid('wazuh-clusterd', pid)

--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -33,8 +33,18 @@ def print_version():
 
 
 def terminate_child_processes(parent_pid):
+    """Stop the execution of all cluster child processes.
+
+    Parameters
+    ----------
+    parent_pid : int
+        Parent process ID.
+    """
     for child in Process(parent_pid).children(recursive=True):
-        child.kill()
+        try:
+            child.kill()
+        except Exception:
+            pass
 
 
 def exit_handler(signum, frame):

--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -14,7 +14,7 @@ from shutil import rmtree
 from subprocess import check_output
 from time import time
 
-from wazuh import WazuhError, WazuhException
+from wazuh import WazuhError, WazuhException, WazuhInternalError
 from wazuh.core import common
 from wazuh.core.cluster.utils import get_cluster_items, read_config
 from wazuh.core.InputValidator import InputValidator

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -952,6 +952,7 @@ class Master(server.AbstractServer):
                          'version': metadata.__version__, 'ip': self.configuration['nodes'][0]}}
 
     async def start(self):
+        """Starts all cluster child processes."""
         for process in self.processes:
             process.start()
 

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -432,7 +432,14 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         bytes
             Response message.
         """
-        if sync_type == b'syn_i_w_m_p':
+        # Check if an integrity_check has already been performed
+        # for the worker in the current iteration of local_integrity
+        if sync_type == b'syn_i_w_m_p' and self.name not in self.server.integrity_already_executed:
+            # Add the variable self.name to keep track of the number
+            # of integrity_checks of the worker in one local_integrity
+            if self.server.calculating_local_integrity:
+                self.server.integrity_already_executed.append(self.name)
+
             permission = self.sync_integrity_free
         elif sync_type == b'syn_a_w_m_p':
             permission = self.sync_agent_info_free
@@ -933,6 +940,8 @@ class Master(server.AbstractServer):
         self.integrity_control = {}
         self.handler_class = MasterHandler
         self.task_pool = ProcessPoolExecutor(max_workers=2)
+        self.integrity_already_executed = []
+        self.calculating_local_integrity = False
         self.dapi = dapi.APIRequestQueue(server=self)
         self.sendsync = dapi.SendSyncRequestQueue(server=self)
         self.tasks.extend([self.dapi.run, self.sendsync.run, self.file_status_update])
@@ -964,7 +973,11 @@ class Master(server.AbstractServer):
             file_integrity_logger.info("Starting.")
             try:
                 task = self.loop.run_in_executor(self.task_pool, wazuh.core.cluster.cluster.get_files_status)
+                # With this we avoid that each worker starts integrity_check more than once per local_integrity
+                self.calculating_local_integrity = True
                 self.integrity_control = await asyncio.wait_for(task, timeout=None)
+                self.calculating_local_integrity = False
+                self.integrity_already_executed.clear()
             except Exception as e:
                 file_integrity_logger.error(f"Error calculating local file integrity: {e}")
             file_integrity_logger.info(f"Finished in {(datetime.now() - before).total_seconds():.3f}s. Calculated "


### PR DESCRIPTION
|Related issue|
|---|
|#10765|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR closes #10765. In this PR we have isolated the `local_integrity` task from the main process of the cluster. This way we reduce the load on the main process.

### Cluster unittests
```
============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.9.5, pytest-6.2.5, py-1.10.0, pluggy-1.0.0 -- /home/adriiiprodri/.venvs/wazuh/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.9.5', 'Platform': 'Linux-5.10.60.1-microsoft-standard-WSL2-x86_64-with-glibc2.31', 'Packages': {'pytest': '6.2.5', 'py': '1.10.0', 'pluggy': '1.0.0'}, 'Plugins': {'trio': '0.7.0', 'asyncio': '0.16.0', 'metadata': '1.11.0', 'testinfra': '6.4.0', 'html': '3.1.1', 'aiohttp': '0.3.0'}}
rootdir: /mnt/c/Users/adr_i/git/wazuh/framework
plugins: trio-0.7.0, asyncio-0.16.0, metadata-1.11.0, testinfra-6.0.0, testinfra-6.4.0, html-3.1.1, aiohttp-0.3.0
collected 71 items

framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI[kwargs0] PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI[kwargs1] PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_distribute_function[get_agents_summary_status-local_master-master-local-True] PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_distribute_function[restart_agents-distributed_master-master-forward-True] PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_distribute_function[get_node_wrapper-local_any-worker-local-True] PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_distribute_function[get_ciscat_results-distributed_master-worker-remote-True] PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_distribute_function[status-local_master-worker-local-False] PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_distribute_function_mock_solver[restart_agents-distributed_master-master-local] PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_distribute_function_exception PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_invalid_json PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_local_request_errors PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_local_request PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_remote_request_errors PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_remote_request PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_forward_request_errors PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_logger PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_tmp_file PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_tmp_file_cluster_error PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_get_solver_node PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_check_wazuh_status[get_agents_summary_status] PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_check_wazuh_status[status] PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_check_wazuh_status_exception[failed] PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_check_wazuh_status_exception[restarting] PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_check_wazuh_status_exception[stopped] PASSED
framework/wazuh/core/cluster/dapi/tests/test_dapi.py::test_APIRequestQueue PASSED
framework/wazuh/core/cluster/tests/test_cluster.py::test_read_empty_configuration PASSED
framework/wazuh/core/cluster/tests/test_cluster.py::test_read_configuration[read_config0] PASSED
framework/wazuh/core/cluster/tests/test_cluster.py::test_read_configuration[read_config1] PASSED
framework/wazuh/core/cluster/tests/test_cluster.py::test_read_configuration[read_config2] PASSED
framework/wazuh/core/cluster/tests/test_cluster.py::test_checking_configuration[read_config0] PASSED
framework/wazuh/core/cluster/tests/test_cluster.py::test_checking_configuration[read_config1] PASSED
framework/wazuh/core/cluster/tests/test_cluster.py::test_checking_configuration[read_config2] PASSED
framework/wazuh/core/cluster/tests/test_cluster.py::test_checking_configuration[read_config3] PASSED
framework/wazuh/core/cluster/tests/test_cluster.py::test_checking_configuration[read_config4] PASSED
framework/wazuh/core/cluster/tests/test_cluster.py::test_checking_configuration[read_config5] PASSED
framework/wazuh/core/cluster/tests/test_cluster.py::test_checking_configuration[read_config6] PASSED
framework/wazuh/core/cluster/tests/test_cluster.py::test_checking_configuration[read_config7] PASSED
framework/wazuh/core/cluster/tests/test_cluster.py::test_checking_configuration[read_config8] PASSED
framework/wazuh/core/cluster/tests/test_cluster.py::test_checking_configuration[read_config9] PASSED
framework/wazuh/core/cluster/tests/test_cluster.py::test_checking_configuration[read_config10] PASSED
framework/wazuh/core/cluster/tests/test_cluster.py::test_merge_info PASSED
framework/wazuh/core/cluster/tests/test_cluster.py::test_unmerge_info[23 005 2019-03-29 14:57:29.610934\nb'default,windows-servers'-None] PASSED
framework/wazuh/core/cluster/tests/test_cluster.py::test_unmerge_info[2i58 006 2019-03-29 14:57:29.610934\nb'default,windows-servers'-ValueError] PASSED
framework/wazuh/core/cluster/tests/test_cluster.py::test_update_cluster_control_with_failed PASSED
framework/wazuh/core/cluster/tests/test_common.py::test_encoder_decoder[obj0] PASSED
framework/wazuh/core/cluster/tests/test_common.py::test_encoder_decoder[obj1] PASSED
framework/wazuh/core/cluster/tests/test_common.py::test_encoder_decoder[obj2] PASSED
framework/wazuh/core/cluster/tests/test_common.py::test_encoder_decoder[obj3] PASSED
framework/wazuh/core/cluster/tests/test_common.py::test_encoder_decoder[obj4] PASSED
framework/wazuh/core/cluster/tests/test_common.py::test_encoder_decoder[obj5] PASSED
framework/wazuh/core/cluster/tests/test_common.py::test_encoder_decoder[obj6] PASSED
framework/wazuh/core/cluster/tests/test_control.py::test_get_nodes PASSED
framework/wazuh/core/cluster/tests/test_control.py::test_get_node PASSED
framework/wazuh/core/cluster/tests/test_control.py::test_get_health PASSED
framework/wazuh/core/cluster/tests/test_control.py::test_get_agents PASSED
framework/wazuh/core/cluster/tests/test_control.py::test_get_system_nodes PASSED
framework/wazuh/core/cluster/tests/test_local_client.py::test_crypto PASSED
framework/wazuh/core/cluster/tests/test_utils.py::test_read_cluster_config wazuh-apid: There is an error in the ossec.conf file: 'type' object is not iterable
PASSED
framework/wazuh/core/cluster/tests/test_utils.py::test_get_manager_status PASSED
framework/wazuh/core/cluster/tests/test_utils.py::test_get_cluster_status PASSED
framework/wazuh/core/cluster/tests/test_utils.py::test_manager_restart PASSED
framework/wazuh/core/cluster/tests/test_utils.py::test_get_cluster_items PASSED
framework/wazuh/core/cluster/tests/test_utils.py::test_ClusterFilter PASSED
framework/wazuh/core/cluster/tests/test_utils.py::test_ClusterLogger PASSED
framework/wazuh/core/cluster/tests/test_worker.py::test_ReceiveIntegrityTask PASSED
framework/wazuh/core/cluster/tests/test_worker.py::test_SyncTask PASSED
framework/wazuh/core/cluster/tests/test_worker.py::test_SyncWorker PASSED
framework/wazuh/core/cluster/tests/test_worker.py::test_SyncWazuhdb PASSED
framework/wazuh/core/cluster/tests/test_worker.py::test_RetrieveAndSendToMaster PASSED
framework/wazuh/core/cluster/tests/test_worker.py::test_WorkerHandler PASSED
framework/wazuh/core/cluster/tests/test_worker.py::test_WorkerHandler_sync_integrity PASSED

======================================================================================== 71 passed, 11 warnings in 4.67s =========================================================================================
```