### PR TITLE
Stop resetting the Wazuh manager when testing a custom ruleset with runtest.py

### DIFF
--- a/ruleset/testing/runtests.py
+++ b/ruleset/testing/runtests.py
@@ -74,10 +74,6 @@ def cleanDR():
         if os.path.isfile(file_fullpath) and re.match(r'^test_(.*?)_decoders.xml$',file):
             os.remove(file_fullpath)
 
-def restart_analysisd():
-    print("Restarting wazuh-manager...")
-    ret = os.system('systemctl restart wazuh-manager')
-
 class OssecTester(object):
     def __init__(self, bdir):
         self._error = False
@@ -166,7 +162,7 @@ if __name__ == "__main__":
     parser.add_argument('--testfile', '-t', action='store', type=str, dest='testfile',
                         help='Use -t or --testfile to pass the ini file to test')
     parser.add_argument('--custom-ruleset', '-c', action='store_true', dest='custom',
-                        help='Use -c or --custom-ruleset to test custom rules and decoders. WARNING: This will cause wazuh-manager restart')
+                        help='Use -c or --custom-ruleset to test custom rules and decoders.')
     args = parser.parse_args()
     selective_test = False
     if args.testfile:
@@ -182,11 +178,9 @@ if __name__ == "__main__":
         signal.signal(sig, cleanup)
     if args.custom:
         provisionDR()
-        restart_analysisd()
     OT = OssecTester(args.wazuh_home)
     error = OT.run(selective_test, args.geoip, args.custom)
     if args.custom:
         cleanDR()
-        restart_analysisd()
     if error:
         sys.exit(1)


### PR DESCRIPTION
|Related issue|
|---|
|Closes #10721|

## Description

This PR aims to close #10721, which requires testing the custom ruleset without restarting the Wazuh manager, as this is not necessary anymore given the feature implemented on the PR #8892.

## Configuration options

``` bash
# python2 runtests.py -c
```

## Logs/Alerts example

There should be no `"Failed"` messages.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] ~Windows~
  - [ ] ~MAC OS X~
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
- [ ] ~QA templates contemplate the added capabilities~

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [x] Added unit testing files ".ini"
  - [x] runtests.py executed without errors

Best Regards,

Mariano Koremblum