### PR TITLE
Improving Doxygen in force options related functions and structures of authd

### DIFF
--- a/src/config/authd-config.h
+++ b/src/config/authd-config.h
@@ -55,6 +55,7 @@ typedef struct authd_config_t {
  * @brief It converts a time string with the format <time><unit>, where the unit could be
  *        d (days), h (hours), m (minutes), or s (seconds), to a representation in seconds saved
  *        in a `time_t` variable.
+ *        The time unit is optional. If not provided, it is asumed as seconds.
  *
  * @param syscheck String with the format <time><unit>.
  * @param interval The variable to save the time conversion.

--- a/src/config/authd-config.h
+++ b/src/config/authd-config.h
@@ -21,11 +21,11 @@
  * @brief Structure that defines the force options for agent replacement.
  **/
 typedef struct authd_force_options_t {
-    bool enabled;
-    bool key_mismatch;
-    bool disconnected_time_enabled;
-    time_t disconnected_time;
-    time_t after_registration_time;
+    bool enabled;                    ///< Sets to enabled or disabled the force options for agent replacement
+    bool key_mismatch;               ///< Sets to enabled or disabled the key_mismatch auth setting
+    bool disconnected_time_enabled;  ///< Sets to enabled or disabled the disconnected_time auth setting
+    time_t disconnected_time;        ///< Sets the time to be used by the disconnected_time auth setting if enabled
+    time_t after_registration_time;  ///< Sets the time to be used by the after_registration_time auth setting
 } authd_force_options_t;
 
 typedef struct authd_flags_t {
@@ -51,6 +51,15 @@ typedef struct authd_config_t {
     bool worker_node;
 } authd_config_t;
 
+/**
+ * @brief It converts a time string with the format <time><unit>, where the unit could be
+ *        d (days), h (hours), m (minutes), or s (seconds), to a representation in seconds saved
+ *        in a `time_t` variable.
+ *
+ * @param syscheck String with the format <time><unit>.
+ * @param interval The variable to save the time conversion.
+ * @retval OS_INVALID in case of error. OS_SUCCES otherways.
+ */
 int get_time_interval(char *source, time_t *interval);
 
 #endif

--- a/src/headers/agent_op.h
+++ b/src/headers/agent_op.h
@@ -93,7 +93,7 @@ int auth_close(int sock);
  * @param ip IP of the agent to request the new key.
  * @param groups Groups list of the agent to request the new key.
  * @param key KEY of the newly generated key.
- * @param force Force option to be used during the registration. -1 means disabled. 0 or a positive value means enabled.
+ * @param force_options Force options to be used during the registration.
  * @param json_format Flag to identify if the response should be printed in JSON format.
  * @param agent_id ID of the agent when requesting a new key for a specific ID.
  * @param exit_on_error Flag to identify if the application should exit on any error.


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/10762 |

## Description

This pull request improves some Doxygen descriptions for functions and structures related to the new force options in the authd daemon. The improvements are:

- The function `get_time_interval` now has a Doxygen description.
- The function `w_request_agent_add_local` had a wrong `force` parameter in the Doxygen description.
- The structure `authd_force_options_t` now has a Doxygen description for all its members. 

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation