### PR TITLE
Change from `datetime.fromtimestamp` to `datetime.utcfromtimestamp`

### DIFF
--- a/framework/wazuh/__init__.py
+++ b/framework/wazuh/__init__.py
@@ -69,7 +69,7 @@ class Wazuh:
         try:
             compilation_date = datetime.strptime(self.installation_date, date_format)
         except ValueError:
-            compilation_date = datetime.now()
+            compilation_date = datetime.utcnow()
         return {'path': self.path,
                 'version': self.version,
                 'compilation_date': compilation_date,

--- a/framework/wazuh/core/cluster/local_server.py
+++ b/framework/wazuh/core/cluster/local_server.py
@@ -290,7 +290,8 @@ class LocalServerHandlerMaster(LocalServerHandler):
 
         """
         return b'ok', json.dumps(self.server.node.get_health(json.loads(filter_nodes)),
-                                 default=lambda o: "n/a" if isinstance(o, datetime) and o == datetime.fromtimestamp(0)
+                                 default=lambda o: "n/a" if isinstance(o, datetime) and o ==
+                                 datetime.utcfromtimestamp(0)
                                  else (o.__str__() if isinstance(o, datetime) else None)).encode()
 
     def send_file_request(self, path, node_name):
@@ -456,8 +457,9 @@ class LocalServerHandlerWorker(LocalServerHandler):
         future : asyncio.Future object
             Request result.
         """
-        send_res = asyncio.create_task(self.send_request(command=b'dapi_res' if in_command == b'dapi' else b'control_res',
-                                                         data=future.result()))
+        send_res = asyncio.create_task(
+            self.send_request(command=b'dapi_res' if in_command == b'dapi' else b'control_res',
+                              data=future.result()))
         send_res.add_done_callback(self.send_res_callback)
 
     def send_file_request(self, path, node_name):

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -519,7 +519,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         """
         logger = self.task_loggers['Agent-info sync']
         logger.info(f"Starting")
-        date_start_master = datetime.now()
+        date_start_master = datetime.utcnow()
         wdb_conn = WazuhDBConnection()
         result = {'updated_chunks': 0, 'error_messages': list()}
 
@@ -553,7 +553,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
 
         # Send result to worker
         response = await self.send_request(command=b'syn_m_a_e', data=json.dumps(result).encode())
-        date_end_master = datetime.now()
+        date_end_master = datetime.utcnow()
         self.sync_agent_info_status.update({'date_start_master': date_start_master.strftime(decimals_date_format),
                                             'date_end_master': date_end_master.strftime(decimals_date_format),
                                             'n_synced_chunks': result['updated_chunks']})
@@ -606,7 +606,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         """
         logger = self.task_loggers['Integrity sync']
         await self.sync_worker_files(task_id, received_file, logger)
-        self.integrity_sync_status['date_end_master'] = datetime.now()
+        self.integrity_sync_status['date_end_master'] = datetime.utcnow()
         logger.info("Finished in {:.3f}s.".format((self.integrity_sync_status['date_end_master'] -
                                                    self.integrity_sync_status[
                                                        'tmp_date_start_master']).total_seconds()))
@@ -645,7 +645,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             Response message.
         """
         logger = self.task_loggers['Integrity check']
-        date_start_master = datetime.now()
+        date_start_master = datetime.utcnow()
 
         logger.debug("Waiting to receive zip file from worker.")
         await asyncio.wait_for(received_file.wait(),
@@ -668,10 +668,10 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         worker_files_ko, counts = wazuh.core.cluster.cluster.compare_files(self.server.integrity_control,
                                                                            files_metadata, self.name)
 
-        total_time = (datetime.now() - date_start_master).total_seconds()
+        total_time = (datetime.utcnow() - date_start_master).total_seconds()
         self.extra_valid_requested = bool(worker_files_ko['extra_valid'])
         self.integrity_check_status.update({'date_start_master': date_start_master.strftime(decimals_date_format),
-                                            'date_end_master': datetime.now().strftime(decimals_date_format)})
+                                            'date_end_master': datetime.utcnow().strftime(decimals_date_format)})
 
         # Get the total number of files that require some change.
         if not functools.reduce(operator.add, map(len, worker_files_ko.values())):
@@ -682,7 +682,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
 
             logger = self.task_loggers['Integrity sync']
             logger.info("Starting.")
-            self.integrity_sync_status.update({'tmp_date_start_master': datetime.now(), 'total_files': counts,
+            self.integrity_sync_status.update({'tmp_date_start_master': datetime.utcnow(), 'total_files': counts,
                                                'total_extra_valid': 0})
             logger.info("Files to create in worker: {} | Files to update in worker: {} | Files to delete in worker: {} "
                         "| Files to receive: {}".format(len(worker_files_ko['missing']), len(worker_files_ko['shared']),
@@ -733,7 +733,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                 logger.debug("Finished sending files to worker.")
                 # Log 'Finished in' message only if there are no extra_valid files to sync.
                 if not self.extra_valid_requested:
-                    self.integrity_sync_status['date_end_master'] = datetime.now()
+                    self.integrity_sync_status['date_end_master'] = datetime.utcnow()
                     logger.info("Finished in {:.3f}s.".format((self.integrity_sync_status['date_end_master'] -
                                                                self.integrity_sync_status['tmp_date_start_master'])
                                                               .total_seconds()))
@@ -961,13 +961,13 @@ class Master(server.AbstractServer):
         """
         file_integrity_logger = self.setup_task_logger("Local integrity")
         while True:
-            before = datetime.now()
+            before = datetime.utcnow()
             file_integrity_logger.info("Starting.")
             try:
                 self.integrity_control = wazuh.core.cluster.cluster.get_files_status()
             except Exception as e:
                 file_integrity_logger.error(f"Error calculating local file integrity: {e}")
-            file_integrity_logger.info(f"Finished in {(datetime.now() - before).total_seconds():.3f}s. Calculated "
+            file_integrity_logger.info(f"Finished in {(datetime.utcnow() - before).total_seconds():.3f}s. Calculated "
                                        f"metadata of {len(self.integrity_control)} files.")
 
             await asyncio.sleep(self.cluster_items['intervals']['master']['recalculate_integrity'])
@@ -997,7 +997,7 @@ class Master(server.AbstractServer):
                 Agent.get_agents_overview(filters={'status': 'active', 'node_name': node_name})['totalItems']
             if workers_info[node_name]['info']['type'] != 'master':
                 workers_info[node_name]['status']['last_keep_alive'] = str(
-                    datetime.fromtimestamp(workers_info[node_name]['status']['last_keep_alive']
+                    datetime.utcfromtimestamp(workers_info[node_name]['status']['last_keep_alive']
                                            ).strftime(decimals_date_format))
 
         return {"n_connected_nodes": n_connected_nodes, "nodes": workers_info}

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -156,7 +156,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         self.extra_valid_requested = False
 
         # Sync status variables. Used in cluster_control -i and GET/cluster/healthcheck.
-        default_date = datetime.fromtimestamp(0)
+        default_date = datetime.utcfromtimestamp(0)
         self.integrity_check_status = {'date_start_master': default_date, 'date_end_master': default_date}
         self.integrity_sync_status = {'date_start_master': default_date, 'tmp_date_start_master': default_date,
                                       'date_end_master': default_date, 'total_extra_valid': 0,
@@ -231,7 +231,8 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         elif command == b'get_health':
             cmd, res = self.get_health(json.loads(data))
             return cmd, json.dumps(res,
-                                   default=lambda o: "n/a" if isinstance(o, datetime) and o == datetime.fromtimestamp(0)
+                                   default=lambda o: "n/a" if isinstance(o,
+                                                                         datetime) and o == datetime.utcfromtimestamp(0)
                                    else (o.__str__() if isinstance(o, datetime) else None)
                                    ).encode()
         elif command == b'sendsync':
@@ -607,7 +608,8 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         await self.sync_worker_files(task_id, received_file, logger)
         self.integrity_sync_status['date_end_master'] = datetime.now()
         logger.info("Finished in {:.3f}s.".format((self.integrity_sync_status['date_end_master'] -
-                                                   self.integrity_sync_status['tmp_date_start_master']).total_seconds()))
+                                                   self.integrity_sync_status[
+                                                       'tmp_date_start_master']).total_seconds()))
         self.integrity_sync_status['date_start_master'] = \
             self.integrity_sync_status['tmp_date_start_master'].strftime(decimals_date_format)
         self.integrity_sync_status['date_end_master'] = \
@@ -992,7 +994,7 @@ class Master(server.AbstractServer):
         # Get active agents by node and format last keep alive date format
         for node_name in workers_info.keys():
             workers_info[node_name]["info"]["n_active_agents"] = \
-            Agent.get_agents_overview(filters={'status': 'active', 'node_name': node_name})['totalItems']
+                Agent.get_agents_overview(filters={'status': 'active', 'node_name': node_name})['totalItems']
             if workers_info[node_name]['info']['type'] != 'master':
                 workers_info[node_name]['status']['last_keep_alive'] = str(
                     datetime.fromtimestamp(workers_info[node_name]['status']['last_keep_alive']

--- a/framework/wazuh/core/stats.py
+++ b/framework/wazuh/core/stats.py
@@ -71,7 +71,7 @@ def weekly_():
     return weekly_results
 
 
-def totals_(date=datetime.now()):
+def totals_(date=datetime.utcnow()):
     """Compute statistical information for the current or specified date.
 
     Parameters


### PR DESCRIPTION
|Related issue|
|---|
|#10749|

## Description

Hi team, 

In some fragments within the cluster code, we were using `datetime.fromtimestamp` meanwhile in others, we were applying `datetime.utcfromtimestamp`. The main goal of this PR is to set everything to `datetime.utcfromtimestamp`

Regards.