### PR TITLE
Fix INSERTED delta alerts by removing dbsync header

### DIFF
--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -2078,7 +2078,7 @@ static int decode_dbsync( Eventinfo * lf, char *msg_type, cJSON *logJSON, int *s
                             mdebug1(A_QUERY_ERROR);
                         } else {
                             if (is_inserted_operation) {
-                                fill_event_alert(lf, field_list, operation, msg->data);
+                                fill_event_alert(lf, field_list, operation, msg->data + header_size);
                             } else {
                                 char *response_data = NULL;
                                 strtok_r(response, " ", &response_data);


### PR DESCRIPTION
|Related issue|
|---|
|Closes #10695|

## Description

Hi team!

This PR aims to fix #10695 issue by removing dbsync header before filling event information structure with the proper dynamic fields and their values while dealing with INSERTED deltas.
### Delta input
```
echo 'd:[000] (myhostname) any->syscollector:{"data":{"checksum":"3d8855caa85501d22b40fa6616c0670f206b2c4e","gateway":" ","dhcp":"enabled","iface":"dummy0","item_id":"7ca46dd4c59f73c36a44ee5ebb0d0a37db4187a9","scan_time":"2021/10/13 18:32:06","type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_protocol"}' | nc -w 0 -Uu /var/ossec/queue/sockets/queue
```
## Before Fix (see iface field)
```json
{
   "timestamp":"2021-11-09T22:18:03.204+0000",
   "rule":{
      "level":3,
      "description":"Syscollector network protocol creation event.",
      "id":"100361",
      "firedtimes":1,
      "mail":false,
      "groups":[
         "syscollector"
      ]
   },
   "agent":{
      "id":"005",
      "name":"myhostname"
   },
   "manager":{
      "name":"wazuh-dev"
   },
   "id":"1636496283.1587800",
   "full_log":"{\"data\":{\"checksum\":\"3d8855caa85501d22b40fa6616c0670f206b2c4e\",\"gateway\":\" \",\"dhcp\":\"enabled\",\"iface\":\"dummy0\",\"item_id\":\"7ca46dd4c59f73c36a44ee5ebb0d0a37db4187a9\",\"scan_time\":\"2021/10/13 18:32:06\",\"type\":\"ethernet\"},\"operation\":\"INSERTED\",\"type\":\"dbsync_network_protocol\"}",
   "decoder":{
      "name":"syscollector"
   },
   "data":{
      "type":"dbsync_network_protocol",
      "netinfo":{
         "proto":{
            "iface":"agent 005 dbsync network_protocol INSERTED dummy0",
            "type":"ethernet",
            "gateway":" ",
            "dhcp":"enabled"
         }
      },
      "operation_type":"INSERTED"
   },
   "location":"syscollector"
}
```
## After Fix
```json
{
   "timestamp":"2021-11-09T23:08:31.017+0000",
   "rule":{
      "level":3,
      "description":"Syscollector network protocol creation event.",
      "id":"100361",
      "firedtimes":1,
      "mail":false,
      "groups":[
         "syscollector"
      ]
   },
   "agent":{
      "id":"005",
      "name":"myhostname"
   },
   "manager":{
      "name":"wazuh-dev"
   },
   "id":"1636499311.2342978",
   "full_log":"{\"data\":{\"checksum\":\"3d8855caa85501d22b40fa6616c0670f206b2c4e\",\"gateway\":\" \",\"dhcp\":\"enabled\",\"iface\":\"dummy0\",\"item_id\":\"7ca46dd4c59f73c36a44ee5ebb0d0a37db4187a9\",\"scan_time\":\"2021/10/13 18:32:06\",\"type\":\"ethernet\"},\"operation\":\"INSERTED\",\"type\":\"dbsync_network_protocol\"}",
   "decoder":{
      "name":"syscollector"
   },
   "data":{
      "type":"dbsync_network_protocol",
      "netinfo":{
         "proto":{
            "iface":"dummy0",
            "type":"ethernet",
            "gateway":" ",
            "dhcp":"enabled"
         }
      },
      "operation_type":"INSERTED"
   },
   "location":"syscollector"
}
```

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors