### PR TITLE
PR: Fix cdb lists not being added to ossec.conf

### DIFF
--- a/etc/templates/config/generic/rules.template
+++ b/etc/templates/config/generic/rules.template
@@ -6,6 +6,8 @@
     <list>etc/lists/audit-keys</list>
     <list>etc/lists/amazon/aws-eventnames</list>
     <list>etc/lists/security-eventchannel</list>
+    <list>etc/lists/ip_reputation</list>
+    <list>etc/lists/uncommon-cmd-opened-process</list>
 
     <!-- User-defined ruleset -->
     <decoder_dir>etc/decoders</decoder_dir>

--- a/etc/templates/config/generic/rules.template
+++ b/etc/templates/config/generic/rules.template
@@ -4,10 +4,10 @@
     <rule_dir>ruleset/rules</rule_dir>
     <rule_exclude>0215-policy_rules.xml</rule_exclude>
     <list>etc/lists/audit-keys</list>
-    <list>etc/lists/amazon/aws-eventnames</list>
-    <list>etc/lists/security-eventchannel</list>
     <list>etc/lists/ip_reputation</list>
     <list>etc/lists/uncommon-cmd-opened-process</list>
+    <list>etc/lists/amazon/aws-eventnames</list>
+    <list>etc/lists/security-eventchannel</list>
 
     <!-- User-defined ruleset -->
     <decoder_dir>etc/decoders</decoder_dir>


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR fixes the issue of the CDB lists of `ip_reputation` and `uncommon-cmd-opened-process` not being added to `ossec.conf` file. This is caused because it wasn't added by us (me) to the file `rules.template`.

By adding this PR both files should be loaded in the manager making the rules relying on these cdbs usable as intended.
Thank you @juliancnn y @nmkoremblum for noticing and reporting this.