### PR TITLE
Add multiprocessing to Agent-info task

### DIFF
--- a/framework/wazuh/core/cluster/cluster.json
+++ b/framework/wazuh/core/cluster/cluster.json
@@ -101,7 +101,9 @@
         },
 
         "master": {
+            "process_pool_size": 2,
             "recalculate_integrity": 8,
+            "timeout_agent_info": 40,
             "check_worker_lastkeepalive": 60,
             "max_allowed_time_without_keepalive": 120
         },

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -437,7 +437,6 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         if sync_type == b'syn_i_w_m_p' and self.name not in self.server.integrity_already_executed:
             # Add the variable self.name to keep track of the number of integrity_checks per cycle
             self.server.integrity_already_executed.append(self.name)
-
             permission = self.sync_integrity_free
         elif sync_type == b'syn_a_w_m_p':
             permission = self.sync_agent_info_free

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -979,7 +979,8 @@ class Master(server.AbstractServer):
         self.manager = Manager()
         self.integrity_control = {}
         self.handler_class = MasterHandler
-        self.task_pool = ProcessPoolExecutor(max_workers=self.cluster_items['intervals']['master']['process_pool_size'])
+        self.task_pool = ProcessPoolExecutor(
+            max_workers=min(os.cpu_count(), self.cluster_items['intervals']['master']['process_pool_size']))
         self.integrity_already_executed = []
         self.dapi = dapi.APIRequestQueue(server=self)
         self.sendsync = dapi.SendSyncRequestQueue(server=self)

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -669,8 +669,10 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         logger.info(f"Starting. Received metadata of {len(files_metadata)} files.")
 
         # Classify files in shared, missing, extra and extra valid.
+        self.server.local_integrity_lock.acquire()
         worker_files_ko, counts = wazuh.core.cluster.cluster.compare_files(self.server.integrity_control,
                                                                            files_metadata, self.name)
+        self.server.local_integrity_lock.release()
 
         total_time = (datetime.now() - date_start_master).total_seconds()
         self.extra_valid_requested = bool(worker_files_ko['extra_valid'])

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -979,9 +979,8 @@ class Master(server.AbstractServer):
         self.manager = Manager()
         self.integrity_control = {}
         self.handler_class = MasterHandler
-        self.task_pool = ProcessPoolExecutor(max_workers=1)
-        self.integrity_already_executed = []
         self.task_pool = ProcessPoolExecutor(max_workers=self.cluster_items['intervals']['master']['process_pool_size'])
+        self.integrity_already_executed = []
         self.dapi = dapi.APIRequestQueue(server=self)
         self.sendsync = dapi.SendSyncRequestQueue(server=self)
         self.tasks.extend([self.dapi.run, self.sendsync.run, self.file_status_update])

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -536,7 +536,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                         wdb_conn.send(f"{data['set_data_command']} {chunk}", raw=True)
                         result['updated_chunks'] += 1
                     except TimeoutError:
-                        raise TimeoutError
+                        raise e
                     except Exception as e:
                         result['error_messages']['chunks'].append((i, str(e)))
         except TimeoutError:

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -652,7 +652,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         """
         logger = self.task_loggers['Integrity sync']
         await self.sync_worker_files(task_id, received_file, logger)
-        self.integrity_sync_status['date_end_master'] = datetime.utcnow()
+        self.integrity_sync_status['date_end_master'] = datetime.now()
         logger.info("Finished in {:.3f}s.".format(
             (self.integrity_sync_status['date_end_master'] -
              self.integrity_sync_status['tmp_date_start_master']).total_seconds()))

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -562,7 +562,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             Worker's response after finishing the synchronization.
         """
         logger = self.task_loggers['Agent-info sync']
-        logger.info(f"Starting")
+        logger.info('Starting')
         date_start_master = datetime.now()
 
         try:
@@ -570,12 +570,12 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             received_string = self.in_str[task_id].payload
             data = json.loads(received_string.decode())
         except KeyError as e:
-            await self.send_request(command=b"syn_m_a_err",
-                                    data=f"error while trying to access string under task_id {str(e)}.".encode())
+            await self.send_request(command=b'syn_m_a_err',
+                                    data=f'error while trying to access string under task_id {str(e)}.'.encode())
             raise exception.WazuhClusterError(3035,
                                               extra_message=f"it should be under task_id {str(e)}, but it's empty.")
         except ValueError as e:
-            await self.send_request(command=b"syn_m_a_err", data=f"error while trying to load JSON: {str(e)}".encode())
+            await self.send_request(command=b'syn_m_a_err', data=f'error while trying to load JSON: {str(e)}'.encode())
             raise exception.WazuhClusterError(3036, extra_message=str(e))
 
         # Update chunks in local wazuh-db
@@ -595,20 +595,20 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             logger.error(error)
 
         for error in result['error_messages']['chunks']:
-            logger.debug2(f"Chunk {error[0]}/{len(data['chunks'])}: {data['chunks'][error[0]]}")
-            logger.error(f"Wazuh-db response for chunk {error[0]}/{len(data['chunks'])} was not 'ok': {error[1]}")
+            logger.debug2(f'Chunk {error[0]+1}/{len(data["chunks"])}: {data["chunks"][error[0]]}')
+            logger.error(f'Wazuh-db response for chunk {error[0]+1}/{len(data["chunks"])} was not "ok": {error[1]}')
 
-        logger.debug(f"{result['updated_chunks']}/{len(data['chunks'])} chunks updated in wazuh-db "
-                     f"in {result['time_spent']:3f}s.")
+        logger.debug(f'{result["updated_chunks"]}/{len(data["chunks"])} chunks updated in wazuh-db '
+                     f'in {result["time_spent"]:3f}s.')
 
         # Send result to worker
-        result["error_messages"] = [error[1] for error in result["error_messages"]]
+        result['error_messages'] = [error[1] for error in result['error_messages']['chunks']]
         response = await self.send_request(command=b'syn_m_a_e', data=json.dumps(result).encode())
         date_end_master = datetime.now()
         self.sync_agent_info_status.update({'date_start_master': date_start_master.strftime(decimals_date_format),
                                             'date_end_master': date_end_master.strftime(decimals_date_format),
                                             'n_synced_chunks': result['updated_chunks']})
-        logger.info("Finished in {:.3f}s ({} chunks updated).".format((date_end_master - date_start_master
+        logger.info('Finished in {:.3f}s ({} chunks updated).'.format((date_end_master - date_start_master
                                                                        ).total_seconds(), result['updated_chunks']))
 
         return response

--- a/framework/wazuh/core/cluster/tests/test_utils.py
+++ b/framework/wazuh/core/cluster/tests/test_utils.py
@@ -152,7 +152,8 @@ def test_get_cluster_items():
                                               'keep_alive': 60, 'connection_retry': 10,
                                               'max_failed_keepalive_attempts': 2},
                                    'master': {'recalculate_integrity': 8, 'check_worker_lastkeepalive': 60,
-                                              'max_allowed_time_without_keepalive': 120},
+                                              'max_allowed_time_without_keepalive': 120, 'process_pool_size': 2,
+                                              'timeout_agent_info': 40},
                                    'communication': {'timeout_cluster_request': 20, 'timeout_dapi_request': 200,
                                                      'timeout_receiving_file': 120}},
                      'distributed_api': {'enabled': True}}

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -421,7 +421,6 @@ class WazuhException(Exception):
         3009: {'message': 'Error executing distributed API request',
                'remediation': ''},
         3010: 'Received the status/group of a non-existent agent',
-        3011: 'Agent info file received in a worker node',
         3012: 'Cluster is not running',
         3013: {'message': 'Cluster is not running, it might be disabled in `WAZUH_HOME/etc/ossec.conf`',
                'remediation': f'Please, visit the official documentation (https://documentation.wazuh.com/{WAZUH_VERSION}/user-manual/configuring-cluster/index.html)'
@@ -463,6 +462,8 @@ class WazuhException(Exception):
         3034: "Error sending file. File not found.",
         3035: "String couldn't be found",
         3036: "JSON couldn't be loaded",
+        3037: 'Timeout while waiting for response of Agent-info update in the process pool.',
+        3038: 'Error while processing Agent-info chunks',
 
         # RBAC exceptions
         # The messages of these exceptions are provisional until the RBAC documentation is published.

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -462,8 +462,7 @@ class WazuhException(Exception):
         3034: "Error sending file. File not found.",
         3035: "String couldn't be found",
         3036: "JSON couldn't be loaded",
-        3037: 'Timeout while waiting for response of Agent-info update in the process pool.',
-        3038: 'Error while processing Agent-info chunks',
+        3037: 'Error while processing Agent-info chunks',
 
         # RBAC exceptions
         # The messages of these exceptions are provisional until the RBAC documentation is published.

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -21,6 +21,7 @@ from os import chmod, chown, path, listdir, mkdir, curdir, rename, utime, remove
 from os.path import join, basename, relpath
 from pyexpat import ExpatError
 from shutil import Error, copyfile, move
+from signal import signal, alarm, SIGALRM
 from subprocess import CalledProcessError, check_output
 from xml.etree.ElementTree import ElementTree
 
@@ -1856,3 +1857,23 @@ def temporary_cache():
             return func(*args, **kwargs)
         return wrapper
     return decorator
+
+
+class Timeout:
+    """
+    Raise TimeoutError after n seconds.
+    """
+
+    def __init__(self, seconds, error_message=''):
+        self.seconds = seconds
+        self.error_message = error_message
+
+    def handle_timeout(self, signum, frame):
+        raise TimeoutError(self.error_message)
+
+    def __enter__(self):
+        signal(SIGALRM, self.handle_timeout)
+        alarm(self.seconds)
+
+    def __exit__(self, type, value, traceback):
+        alarm(0)


### PR DESCRIPTION
|Related issue|
|---|
| Closes #10770 |

## Description

This PR refactors the way that `Agent-info` cluster task is performed in the master node. Until now, although asynchronous tasks were used, there was no parallelism. This meant that in places like the one shown below, the cluster process couldn't handle any other tasks while processing and sending all chunks of data to wazuh-db:
https://github.com/wazuh/wazuh/blob/a642fd531c67876671260477e4226c63af4e7f07/framework/wazuh/core/cluster/master.py#L539-L551

If for example, a distributed API call came in while the CPU was busy sending these chunks, the cluster process could not respond. In large, loaded environments, this can lead to API timeouts and poorer cluster performance. 

To improve the situation, a pool of processes has been implemented which are responsible for executing the above code snippet in a different process. This means that while the communication with wazuh-db is carried out (sequentially in the child process), the parent process can take care of other tasks.


## Configuration options

The `cluster.json` file is not intended for modification by users, but the `process_pool_size` variable allows setting the number of processes in the pool available to process the information of the agents:
https://github.com/wazuh/wazuh/blob/93baec413c29b19e5bccda18023c7668dbefb89f/framework/wazuh/core/cluster/cluster.json#L103-L104

In addition, the variable `timeout_agent_info` the establishes how long an agent-info task can be queued or running in the child process before generating a timeout and being canceled.
https://github.com/wazuh/wazuh/blob/93baec413c29b19e5bccda18023c7668dbefb89f/framework/wazuh/core/cluster/cluster.json#L106

