### PR TITLE
Fix UT error reported by address sanitizer

### DIFF
--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -1999,10 +1999,11 @@ static void fill_event_alert(Eventinfo * lf, const struct deltas_fields_match_li
                       char * response) {
     const bool have_a_escaped_pipe = strstr(response, FIELD_SEPARATOR_DBSYNC_ESCAPE);
 
-    const size_t separator_count = sizeof(char *) * (os_strcnt(response, *FIELD_SEPARATOR_DBSYNC));
+    const size_t separator_count = os_strcnt(response, *FIELD_SEPARATOR_DBSYNC);
+    const size_t field_values_size = sizeof(char *) * (separator_count > 0 ? separator_count : 1);
 
     char ** field_values = NULL;
-    os_calloc(1, separator_count + 1, field_values);
+    os_calloc(1, field_values_size + 1, field_values);
 
     char ** field_values_iterator = field_values;
 

--- a/src/wazuh_db/wdb_delta_event.c
+++ b/src/wazuh_db/wdb_delta_event.c
@@ -93,17 +93,18 @@ bool wdb_modify_dbsync(wdb_t * wdb, struct kv const *kv_value, const char *data)
         strcat(query, kv_value->value);
         strcat(query, " SET ");
 
-        const size_t size = sizeof(char*) * (os_strcnt(data, *FIELD_SEPARATOR_DBSYNC));
+        const size_t separator_count = os_strcnt(data, *FIELD_SEPARATOR_DBSYNC);
+        const size_t field_values_size = sizeof(char*) * (separator_count > 0 ? separator_count : 1);
         // field_values vector will be used to point to the beginning of each field.
         char ** field_values = NULL;
-        os_calloc(1, size + 1, field_values);
+        os_calloc(1, field_values_size + 1, field_values);
         char **curr = field_values;
 
         char * data_temp = NULL;
         os_strdup(data, data_temp);
+        *curr = data_temp;
 
         char *curr_data = data_temp;
-        *curr = curr_data;
         char *next = strchr(curr_data, *FIELD_SEPARATOR_DBSYNC);
         // This loop replace '|' with '\0' and assign the beggining of each string to field_values vector.
         while (NULL != next) {
@@ -114,8 +115,6 @@ bool wdb_modify_dbsync(wdb_t * wdb, struct kv const *kv_value, const char *data)
             next = strchr(curr_data, *FIELD_SEPARATOR_DBSYNC);
             ++curr;
         }
-
-        *curr = NULL;
 
         bool first_condition_element = true;
         curr = field_values;


### PR DESCRIPTION
|Related issue|
|---|
| Closes #10795 |

## Description

During rebase of master branch after #9099 merge, it was found multiple error messages from AddressSanitizer
```
99% tests passed, 2 tests failed out of 138

Total Test time (real) =   4.74 sec

The following tests FAILED:
         27 - test_wdb_parser (Failed)
         40 - test_wdb_delta_event (Failed)
```

```
[ RUN      ] test_wdb_modify_dbsync_bad_cache
=================================================================
==274842==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x602000000a90 at pc 0x559fc03a0c6e bp 0x7ffe3e33d320 sp 0x7ffe3e33d310
WRITE of size 8 at 0x602000000a90 thread T0
    #0 0x559fc03a0c6d in wdb_modify_dbsync wazuh_db/wdb_delta_event.c:106
    #1 0x559fc039c2b6 in test_wdb_modify_dbsync_bad_cache /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_delta_event.c:251
    #2 0x7f61d3e02322 in cmocka_run_one_test_or_fixture (/usr/local/lib/libcmocka.so.0+0x6322)
    #3 0x7f61d3e03366 in _cmocka_run_group_tests (/usr/local/lib/libcmocka.so.0+0x7366)
    #4 0x559fc039e813 in main /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_delta_event.c:557
    #5 0x7f61d32c40b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
    #6 0x559fc03988fd in _start (/root/repos/wazuh/src/unit_tests/build/wazuh_db/test_wdb_delta_event+0x958fd)

0x602000000a91 is located 0 bytes to the right of 1-byte region [0x602000000a90,0x602000000a91)
allocated by thread T0 here:
    #0 0x7f61d4791dc6 in calloc (/lib/x86_64-linux-gnu/libasan.so.5+0x10ddc6)
    #1 0x559fc03a0920 in wdb_modify_dbsync wazuh_db/wdb_delta_event.c:99
    #2 0x559fc039c2b6 in test_wdb_modify_dbsync_bad_cache /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_delta_event.c:251
    #3 0x7f61d3e02322 in cmocka_run_one_test_or_fixture (/usr/local/lib/libcmocka.so.0+0x6322)

SUMMARY: AddressSanitizer: heap-buffer-overflow wazuh_db/wdb_delta_event.c:106 in wdb_modify_dbsync
Shadow bytes around the buggy address:
  0x0c047fff8100: fa fa fd fa fa fa fd fa fa fa fd fa fa fa fd fa
  0x0c047fff8110: fa fa fd fa fa fa fd fa fa fa fd fd fa fa fd fa
  0x0c047fff8120: fa fa fd fa fa fa fd fa fa fa fd fa fa fa fd fa
  0x0c047fff8130: fa fa fd fa fa fa fd fa fa fa fd fd fa fa fd fa
  0x0c047fff8140: fa fa fd fa fa fa 00 00 fa fa 07 fa fa fa 00 fa
=>0x0c047fff8150: fa fa[01]fa fa fa 00 02 fa fa fa fa fa fa fa fa
  0x0c047fff8160: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff8170: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff8180: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff8190: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff81a0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==274842==ABORTING
```
```
[ RUN      ] test_dbsync_modify_type_exists_data_1
=================================================================
==274885==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6030000062f8 at pc 0x55fa8ea50e4e bp 0x7fff8fb4be30 sp 0x7fff8fb4be20
WRITE of size 8 at 0x6030000062f8 thread T0
    #0 0x55fa8ea50e4d in wdb_modify_dbsync wazuh_db/wdb_delta_event.c:118
    #1 0x55fa8e9f9dc3 in process_dbsync_data wazuh_db/wdb_parser.c:5713
    #2 0x55fa8e9fa67a in wdb_parse_dbsync wazuh_db/wdb_parser.c:5762
    #3 0x55fa8e9b8e30 in test_dbsync_modify_type_exists_data_1 /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_parser.c:1101
    #4 0x7f2c72fe2322 in cmocka_run_one_test_or_fixture (/usr/local/lib/libcmocka.so.0+0x6322)
    #5 0x7f2c72fe3366 in _cmocka_run_group_tests (/usr/local/lib/libcmocka.so.0+0x7366)
    #6 0x55fa8e9c9141 in main /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_parser.c:2304
    #7 0x7f2c724a40b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
    #8 0x55fa8e9a907d in _start (/root/repos/wazuh/src/unit_tests/build/wazuh_db/test_wdb_parser+0x1c207d)

0x6030000062f9 is located 0 bytes to the right of 25-byte region [0x6030000062e0,0x6030000062f9)
allocated by thread T0 here:
    #0 0x7f2c73971dc6 in calloc (/lib/x86_64-linux-gnu/libasan.so.5+0x10ddc6)
    #1 0x55fa8ea508ba in wdb_modify_dbsync wazuh_db/wdb_delta_event.c:99
    #2 0x55fa8e9f9dc3 in process_dbsync_data wazuh_db/wdb_parser.c:5713
    #3 0x55fa8e9fa67a in wdb_parse_dbsync wazuh_db/wdb_parser.c:5762
    #4 0x55fa8e9b8e30 in test_dbsync_modify_type_exists_data_1 /root/repos/wazuh/src/unit_tests/wazuh_db/test_wdb_parser.c:1101
    #5 0x7f2c72fe2322 in cmocka_run_one_test_or_fixture (/usr/local/lib/libcmocka.so.0+0x6322)

SUMMARY: AddressSanitizer: heap-buffer-overflow wazuh_db/wdb_delta_event.c:118 in wdb_modify_dbsync
Shadow bytes around the buggy address:
  0x0c067fff8c00: fa fa 00 00 00 00 fa fa 00 00 00 00 fa fa 00 00
  0x0c067fff8c10: 00 fa fa fa 00 00 00 00 fa fa 00 00 00 00 fa fa
  0x0c067fff8c20: 00 00 00 fa fa fa 00 00 00 00 fa fa 00 00 00 00
  0x0c067fff8c30: fa fa 00 00 00 fa fa fa 00 00 00 00 fa fa 00 00
  0x0c067fff8c40: 00 00 fa fa 00 00 00 00 fa fa 00 00 00 00 fa fa
=>0x0c067fff8c50: 00 00 00 fa fa fa 00 00 00 00 fa fa 00 00 00[01]
  0x0c067fff8c60: fa fa 00 00 03 fa fa fa fa fa fa fa fa fa fa fa
  0x0c067fff8c70: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c067fff8c80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c067fff8c90: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c067fff8ca0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==274885==ABORTING
```