### PR TITLE
Print ruleset warning messages in wazuh-logtest

### DIFF
--- a/framework/scripts/wazuh-logtest.py
+++ b/framework/scripts/wazuh-logtest.py
@@ -97,6 +97,7 @@ def main():
 
     # Main processing loop
     session_token = str()
+
     while True:
         # Get user input
         try:
@@ -132,6 +133,16 @@ def main():
         # Check and alert to user if new session was created
         if session_token and session_token != output['token']:
             logging.warning('New session was created with token "%s"', output['token'])
+
+        # Show the warning messages
+        if 'messages' in output.keys():
+            do_print_newline = False
+            for message in output['messages']:
+                if message.startswith("WARNING"):
+                    logging.warning('** Wazuh-Logtest: %s', message)
+                    do_print_newline = True
+            if do_print_newline:
+                    logging.warning('')
 
         # Continue using last available session
         session_token = output['token']


### PR DESCRIPTION
|Related issue|
|---|
|Closes #10785|


## Description

This PR print rules warning messages (if they exist) in wazuh-logtest.

### Example:

Custom rules that generate warnings
```xml
<rule id="100001" level="5" overwrite="yes">
  <match>basic test</match>
  <description>basic test</description>
</rule>
<rule id="100001" level="5" overwrite="yes">
  <if_sid>123</if_sid>
  <match>basic test</match>
  <description>basic test</description>
</rule>
<rule id="100005" level="5">
  <if_sid>123</if_sid>
  <match>basic test</match>
  <description>basic test</description>
</rule>
```

Wazuh-Logtest Output

```console
╰─#  /var/ossec/framework/python/bin/python3 /root/repos/wazuh/framework/scripts/wazuh-logtest.py 
Starting wazuh-logtest v4.3.0
Type one log per line

Oct 15 21:06:59 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928

** Wazuh-Logtest: WARNING: (7613): Rule ID '100001' does not exist but 'overwrite' is set to 'yes'. Still, the rule will be loaded.
** Wazuh-Logtest: WARNING: (7605): Invalid use of 'overwrite' option, it is not compatible with 'if_sid', 'if_group' nor 'if_level' attributes. Could not overwrite rule '100001'.
** Wazuh-Logtest: WARNING: (7606): Signature ID '123' was not found. Invalid 'if_sid'. Rule '100005' will be ignored.

**Phase 1: Completed pre-decoding.
        full event: 'Oct 15 21:06:59 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928'
        timestamp: 'Oct 15 21:06:59'
        hostname: 'linux-agent'
        program_name: 'sshd'

**Phase 2: Completed decoding.
        name: 'sshd'
        parent: 'sshd'
        srcip: '18.18.18.18'
        srcport: '48928'
        srcuser: 'blimey'

**Phase 3: Completed filtering (rules).
        id: '5710'
        level: '5'
        description: 'sshd: Attempt to login using a non-existent user'
        groups: '['syslog', 'sshd', 'invalid_login', 'authentication_failed']'
        firedtimes: '1'
        gdpr: '['IV_35.7.d', 'IV_32.2']'
        gpg13: '['7.1']'
        hipaa: '['164.312.b']'
        mail: 'False'
        mitre.id: '['T1110']'
        mitre.tactic: '['Credential Access']'
        mitre.technique: '['Brute Force']'
        nist_800_53: '['AU.14', 'AC.7', 'AU.6']'
        pci_dss: '['10.2.4', '10.2.5', '10.6.1']'
        tsc: '['CC6.1', 'CC6.8', 'CC7.2', 'CC7.3']'
**Alert to be generated.

```

## Tests
- [x] pep8 style
- [x] runtest.py