### PR TITLE
Fix cdb list integration tests and related API spec examples

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -8573,6 +8573,8 @@ paths:
                           - 0215-policy_rules.xml
                         list:
                           - etc/lists/audit-keys
+                          - etc/lists/ip_reputation
+                          - etc/lists/uncommon-cmd-opened-process
                           - etc/lists/amazon/aws-eventnames
                           - etc/lists/security-eventchannel
                       auth:
@@ -9729,8 +9731,12 @@ paths:
                     - relative_dirname: etc/lists
                       filename: audit-keys
                     - relative_dirname: etc/lists
+                      filename: ip_reputation
+                    - relative_dirname: etc/lists
                       filename: security-eventchannel
-                  total_affected_items: 4
+                    - relative_dirname: etc/lists
+                      filename: uncommon-cmd-opened-process
+                  total_affected_items: 6
                   total_failed_items: 0
                   failed_items: []
                 message: 'All specified paths were returned'

--- a/api/test/integration/test_cdb_list_endpoints.tavern.yaml
+++ b/api/test/integration/test_cdb_list_endpoints.tavern.yaml
@@ -16,13 +16,6 @@ stages:
         Authorization: "Bearer {test_login_token}"
     response:
       status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: !anything
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
 
     # GET /lists?limit=0
   - name: Try to get lists using wrong limit parameter
@@ -60,14 +53,14 @@ stages:
           returned_filename: data.affected_items[0].filename
 
     # We implement a dual stage to check offset parameter behaviour
-    # GET /lists?limit=2&offset=0
+    # GET /lists?limit=2&offset=2
   - name: Try to get lists using limit and offset parameter
     request:
       verify: False
       <<: *get_lists
       params:
         limit: 2
-        offset: 0
+        offset: 2
     response:
       status_code: 200
       json:
@@ -89,14 +82,14 @@ stages:
           offset_item_relative_dirname: data.affected_items[1].relative_dirname
           offset_item_filename: data.affected_items[1].filename
 
-    # GET /lists?limit=1&offset=1
+    # GET /lists?limit=1&offset=3
   - name: Try to get lists using limit and offset parameter
     request:
       verify: False
       <<: *get_lists
       params:
         limit: 1
-        offset: 1
+        offset: 3
     response:
       status_code: 200
       json:

--- a/api/test/integration/test_cdb_list_endpoints.tavern.yaml
+++ b/api/test/integration/test_cdb_list_endpoints.tavern.yaml
@@ -51,7 +51,7 @@ stages:
               relative_dirname: !anystr
               filename: !anystr
           failed_items: []
-          total_affected_items: 4 # Number of cdb_lists by default in Wazuh, this number may change anytime, update accordingly
+          total_affected_items: 6 # Number of cdb_lists by default in Wazuh, this number may change anytime, update accordingly
           total_failed_items: 0
       # Save some data for future use in the test
       save:
@@ -243,7 +243,7 @@ stages:
             - items: !anything
               relative_dirname: "{tavern.request_vars.params.relative_dirname}"
           failed_items: []
-          total_affected_items: 2 # Number of cdb_lists by default in Wazuh with this relative_dirname, this number may change anytime, update accordingly
+          total_affected_items: 4 # Number of cdb_lists by default in Wazuh with this relative_dirname, this number may change anytime, update accordingly
           total_failed_items: 0
 
     # GET /lists?limit=1&relative_dirname=wrong_dirname

--- a/api/test/integration/test_rbac_black_cdb_list_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_cdb_list_endpoints.tavern.yaml
@@ -20,13 +20,19 @@ stages:
         data:
           affected_items:
             - items: !anything
+              filename: ip_reputation
+              relative_dirname: etc/lists
+            - items: !anything
               filename: security-eventchannel
+              relative_dirname: etc/lists
+            - items: !anything
+              filename: uncommon-cmd-opened-process
               relative_dirname: etc/lists
             - items: !anything
               filename: aws-sources
               relative_dirname: etc/lists/amazon
           failed_items: []
-          total_affected_items: 2
+          total_affected_items: 4
           total_failed_items: 0
 
   - name: Show an specified filename (Allow)
@@ -84,12 +90,16 @@ stages:
         error: 0
         data:
           affected_items:
+            - filename: ip_reputation
+              relative_dirname: etc/lists
             - filename: security-eventchannel
+              relative_dirname: etc/lists
+            - filename: uncommon-cmd-opened-process
               relative_dirname: etc/lists
             - filename: aws-sources
               relative_dirname: etc/lists/amazon
           failed_items: []
-          total_affected_items: 2
+          total_affected_items: 4
           total_failed_items: 0
 
 ---


### PR DESCRIPTION
|Related issue|
|---|
| This PR closes #10817 |

Under this PR I evaluated the problem and possible solution related with cdb list (`PUT /lists/files/{filename}` and `DELETE /lists/files/{filename}` endpoints) to avoid the modification or deletion of the product cdb lists (as `audit-key`). 
After reviewed and discussed this situation with @davidjiglesias, we decided to stick with the current behavior:
* Product cdb lists can be modified if the `overwrite` parameter is set as `True`.
* `DELETE /lists/files/{filename}` can delete any cdb list.

Finally, and since two new default cdb lists were added, I made a few fixes at related integration tests and examples at API spec file.

Regards,
Alexis