### PR TITLE
Fixing ids of ip reputation rules

### DIFF
--- a/ruleset/rules/0095-sshd_rules.xml
+++ b/ruleset/rules/0095-sshd_rules.xml
@@ -112,17 +112,6 @@
     <description>sshd: Useless/Duplicated SSHD message without a user/ip.</description>
   </rule>
 
-  <rule id="5712" level="10" frequency="8" timeframe="120" ignore="60">
-    <if_matched_sid>5710</if_matched_sid>
-    <description>sshd: brute force trying to get access to </description>
-    <description>the system.</description>
-    <same_source_ip />
-    <group>authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SI.4,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-    <mitre>
-      <id>T1110</id>
-    </mitre>
-  </rule>
-
   <rule id="5713" level="6">
     <if_sid>5700</if_sid>
     <match>Corrupted check bytes on</match>
@@ -518,4 +507,14 @@ T1048.001 </id>
     <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
+  <rule id="5765" level="10" frequency="8" timeframe="120" ignore="60">
+    <if_matched_sid>5760</if_matched_sid>
+    <description>sshd: brute force trying to get access to </description>
+    <description>the system.</description>
+    <same_source_ip />
+    <group>authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SI.4,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <mitre>
+      <id>T1110</id>
+    </mitre>
+  </rule>
 </group>

--- a/ruleset/rules/0095-sshd_rules.xml
+++ b/ruleset/rules/0095-sshd_rules.xml
@@ -112,6 +112,17 @@
     <description>sshd: Useless/Duplicated SSHD message without a user/ip.</description>
   </rule>
 
+  <rule id="5712" level="10" frequency="8" timeframe="120" ignore="60">
+    <if_matched_sid>5710</if_matched_sid>
+    <description>sshd: brute force trying to get access to </description>
+    <description>the system.</description>
+    <same_source_ip />
+    <group>authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SI.4,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <mitre>
+      <id>T1110</id>
+    </mitre>
+  </rule>
+
   <rule id="5713" level="6">
     <if_sid>5700</if_sid>
     <match>Corrupted check bytes on</match>

--- a/ruleset/rules/0940-ip_reputation_rules.xml
+++ b/ruleset/rules/0940-ip_reputation_rules.xml
@@ -7,23 +7,23 @@
 
 <group name="malicious_ip,">
 
-    <rule id="99901" level="12">
-      <if_group>web|attack|attacks</if_group>
-      <list field="srcip" lookup="address_match_key">etc/lists/ip_reputation</list>
-      <description>Source IP address has been found in the IP reputation database</description>
-      <group>attack,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.7,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SI.4,</group>
-    </rule>
+  <rule id="40001" level="12">
+    <if_group>web|attack|attacks</if_group>
+    <list field="srcip" lookup="address_match_key">etc/lists/ip_reputation</list>
+    <description>Source IP address has been found in the IP reputation database</description>
+    <group>attack,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.7,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SI.4,</group>
+  </rule>
 
-    <rule id="99902" level="12">
-      <if_group>authentication_success</if_group>
-      <list field="srcip" lookup="address_match_key">etc/lists/ip_reputation</list>
-      <description>Authentication success from IP found on reputation database</description>
-    </rule>
+  <rule id="40002" level="12">
+    <if_group>authentication_success</if_group>
+    <list field="srcip" lookup="address_match_key">etc/lists/ip_reputation</list>
+    <description>Authentication success from IP found on reputation database</description>
+  </rule>
 
-    <rule id="99903" level="7">
-      <if_group>authentication_failure</if_group>
-      <list field="srcip" lookup="address_match_key">etc/lists/ip_reputation</list>
-      <description>Authentication attempt from IP found on reputation database</description>
-    </rule>
+  <rule id="40003" level="7">
+    <if_group>authentication_failure</if_group>
+    <list field="srcip" lookup="address_match_key">etc/lists/ip_reputation</list>
+    <description>Authentication attempt from IP found on reputation database</description>
+  </rule>
 
 </group>

--- a/ruleset/testing/tests/sshd.ini
+++ b/ruleset/testing/tests/sshd.ini
@@ -214,3 +214,31 @@ log 1 pass = 2020-03-25 06:37:50.176931-0700  localhost sshd[852]: Bad protocol 
 rule = 5701
 alert = 8
 decoder = sshd
+
+[sshd brute force rule 1]
+log 1 pass = May 29 11:31:00 vagrant sshd[30016]: Invalid user user from 212.64.151.233
+log 1 pass = May 29 11:31:00 vagrant sshd[30016]: Invalid user user from 212.64.151.233
+log 1 pass = May 29 11:31:00 vagrant sshd[30016]: Invalid user user from 212.64.151.233
+log 1 pass = May 29 11:31:00 vagrant sshd[30016]: Invalid user user from 212.64.151.233
+log 1 pass = May 29 11:31:00 vagrant sshd[30016]: Invalid user user from 212.64.151.233
+log 1 pass = May 29 11:31:00 vagrant sshd[30016]: Invalid user user from 212.64.151.233
+log 1 pass = May 29 11:31:00 vagrant sshd[30016]: Invalid user user from 212.64.151.233
+log 1 pass = May 29 11:31:00 vagrant sshd[30016]: Invalid user user from 212.64.151.233
+
+rule = 5712
+alert = 10
+decoder = sshd
+
+[sshd brute force rule 2]
+log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
+log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
+log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
+log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
+log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
+log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
+log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
+log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
+
+rule = 5765
+alert = 10
+decoder = sshd

--- a/ruleset/testing/tests/test_features.ini
+++ b/ruleset/testing/tests/test_features.ini
@@ -29,17 +29,3 @@ log 1 pass = Dec 25 20:45:02 MyHost test_same_fields[12345]: User 'admin' logged
 rule = 999208
 alert = 7
 decoder = test_same
-
-[sshd brute force rule]
-log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
-log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
-log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
-log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
-log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
-log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
-log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
-log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
-
-rule = 5765
-alert = 10
-decoder = sshd

--- a/ruleset/testing/tests/test_features.ini
+++ b/ruleset/testing/tests/test_features.ini
@@ -40,6 +40,6 @@ log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid us
 log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
 log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
 
-rule = 5712
+rule = 5765
 alert = 10
 decoder = sshd


### PR DESCRIPTION
|Related issue|
|---|
| #10824 |


## Description
Closes #10824
Rule 99901 - Source IP address has been found in the IP reputation database - is conflicting with ids used in custom rule tests (ruleset runtest.py with -c parameters).
This error prevents some CI checks to be completed.
While testing an issue was found on rule 5712, reworked it into 5765



## Tests
runtests.py -c results:

```
- [ File = ./tests/sophos_fw.ini ] ---------
..........

- [ File = ./tests/dropbear.ini ] ---------
...

- [ File = ./tests/squid_rules.ini ] ---------
..

- [ File = ./tests/sudo.ini ] ---------
........

- [ File = ./tests/gitlab.ini ] ---------
.........................

- [ File = ./tests/glpi.ini ] ---------
...

- [ File = ./tests/unbound.ini ] ---------


- [ File = ./tests/mailscanner.ini ] ---------
.

- [ File = ./tests/samba.ini ] ---------
....

- [ File = ./tests/cisco_ios.ini ] ---------
.................

- [ File = ./tests/cimserver.ini ] ---------
..

- [ File = ./tests/audit_recon.ini ] ---------
..

- [ File = ./tests/fortigate.ini ] ---------
........................................

- [ File = ./tests/cisco_asa.ini ] ---------
........................................................................................

- [ File = ./tests/test_pcre2_regex.ini ] ---------
.................................

- [ File = ./tests/systemd.ini ] ---------
..

- [ File = ./tests/openldap.ini ] ---------
.........

- [ File = ./tests/oscap.ini ] ---------
................................

- [ File = ./tests/github.ini ] ---------
....................................................................................................................................................................................................................................................................................................................................

- [ File = ./tests/test_static_filters.ini ] ---------
............................

- [ File = ./tests/pfsense.ini ] ---------
..

- [ File = ./tests/apache.ini ] ---------
..................

- [ File = ./tests/api.ini ] ---------
............................

- [ File = ./tests/SonicWall.ini ] ---------
........

- [ File = ./tests/rsh.ini ] ---------
..

- [ File = ./tests/auditd.ini ] ---------
...

- [ File = ./tests/junos.ini ] ---------
...

- [ File = ./tests/owlh.ini ] ---------
....

- [ File = ./tests/pam.ini ] ---------
.....

- [ File = ./tests/sophos.ini ] ---------
........

- [ File = ./tests/modsecurity.ini ] ---------
......

- [ File = ./tests/paloalto.ini ] ---------
................

- [ File = ./tests/cylance.ini ] ---------
.......

- [ File = ./tests/pix.ini ] ---------
......................

- [ File = ./tests/sophos-utm-firewall.ini ] ---------
......

- [ File = ./tests/exim.ini ] ---------
.......

- [ File = ./tests/freepbx.ini ] ---------
......

- [ File = ./tests/trendmicro-cloud-one.ini ] ---------
.................

- [ File = ./tests/kernel_usb.ini ] ---------
......

- [ File = ./tests/netscreen.ini ] ---------
....

- [ File = ./tests/panda_paps.ini ] ---------
........

- [ File = ./tests/nextcloud.ini ] ---------
.......

- [ File = ./tests/test_osmatch_regex.ini ] ---------
......

- [ File = ./tests/aws_s3_access.ini ] ---------
.......

- [ File = ./tests/doas.ini ] ---------
....

- [ File = ./tests/test_features.ini ] ---------
.....

- [ File = ./tests/icinga.ini ] ---------
....

- [ File = ./tests/apparmor.ini ] ---------
.....

- [ File = ./tests/sshd.ini ] ---------
...........................................

- [ File = ./tests/opensmtpd.ini ] ---------
.......

- [ File = ./tests/proftpd.ini ] ---------
.......

- [ File = ./tests/named.ini ] ---------
.....

- [ File = ./tests/syslog.ini ] ---------
......

- [ File = ./tests/checkpoint_smart1.ini ] ---------
..................

- [ File = ./tests/fireeye.ini ] ---------
...

- [ File = ./tests/office365.ini ] ---------
................................................................................................................................

- [ File = ./tests/vsftpd.ini ] ---------
....

- [ File = ./tests/forti.ini ] ---------
...

- [ File = ./tests/openvpn_ldap.ini ] ---------
..

- [ File = ./tests/test_osregex_regex.ini ] ---------
...........................

- [ File = ./tests/cpanel.ini ] ---------
.......

- [ File = ./tests/aws_cloudtrail.ini ] ---------
.........

- [ File = ./tests/audit_scp.ini ] ---------
.

- [ File = ./tests/cloudlfare-waf.ini ] ---------
.............

- [ File = ./tests/web_appsec.ini ] ---------
...............................

- [ File = ./tests/fortiauth.ini ] ---------
....

- [ File = ./tests/cisco_ftd.ini ] ---------
..........................................

- [ File = ./tests/ossec.ini ] ---------
.....

- [ File = ./tests/arbor.ini ] ---------
..

- [ File = ./tests/huawei_usg.ini ] ---------
...

- [ File = ./tests/exchange.ini ] ---------
..

- [ File = ./tests/postfix.ini ] ---------
..

- [ File = ./tests/su.ini ] ---------
.....

- [ File = ./tests/test_expr_negation.ini ] ---------
........................................................

- [ File = ./tests/f5_big_ip.ini ] ---------
...........................................

- [ File = ./tests/mcafee_epo.ini ] ---------
.

- [ File = ./tests/audit_lateral.ini ] ---------
......

- [ File = ./tests/web_rules.ini ] ---------
..........

- [ File = ./tests/iptables.ini ] ---------
........

- [ File = ./tests/eset.ini ] ---------
........

- [ File = ./tests/gcp.ini ] ---------
...........

- [ File = ./tests/firewalld.ini ] ---------
..

- [ File = ./tests/dovecot.ini ] ---------
...............

- [ File = ./tests/nginx.ini ] ---------
............

```
<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors