### PR TITLE
Fix API integration tests failing in `master` branch

### DIFF
--- a/api/test/integration/env/configurations/rbac/task/white_config.txt
+++ b/api/test/integration/env/configurations/rbac/task/white_config.txt
@@ -1,4 +1,4 @@
 | Actions                  | Resources | Allow                                   | Deny                         |
 |--------------------------|-----------|-----------------------------------------|------------------------------|
-| agent:upgrade            | agent:id  | 001                                     |                              |
+| agent:upgrade            | agent:id  | 005                                     |                              |
 | task:status              | *:*       | *                                       |                              |

--- a/api/test/integration/env/configurations/rbac/task/white_config.yaml
+++ b/api/test/integration/env/configurations/rbac/task/white_config.yaml
@@ -3,6 +3,6 @@
   - agent:upgrade
   - task:status
   resources:
-  - "agent:id:001"
+  - "agent:id:005"
   - "*:*:*"
   effect: allow

--- a/api/test/integration/test_rbac_black_decoder_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_decoder_endpoints.tavern.yaml
@@ -29,13 +29,13 @@ stages:
               position: !anyint
               status: !anystr
             - <<: *full_item_decoders
-              filename: 0010-active-response_decoders.xml
+              filename: 0007-wazuh-api_decoders.xml
             - <<: *full_item_decoders
-              filename: 0010-active-response_decoders.xml
+              filename: 0007-wazuh-api_decoders.xml
             - <<: *full_item_decoders
-              filename: 0010-active-response_decoders.xml
+              filename: 0007-wazuh-api_decoders.xml
             - <<: *full_item_decoders
-              filename: 0010-active-response_decoders.xml
+              filename: 0007-wazuh-api_decoders.xml
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
@@ -109,6 +109,9 @@ stages:
             - filename: 0006-json_decoders.xml
               relative_dirname: ruleset/decoders
               status: enabled
+            - filename: 0007-wazuh-api_decoders.xml
+              relative_dirname: ruleset/decoders
+              status: enabled
             - filename: 0010-active-response_decoders.xml
               relative_dirname: ruleset/decoders
               status: enabled
@@ -116,9 +119,6 @@ stages:
               relative_dirname: ruleset/decoders
               status: enabled
             - filename: 0025-apache_decoders.xml
-              relative_dirname: ruleset/decoders
-              status: enabled
-            - filename: 0030-arpwatch_decoders.xml
               relative_dirname: ruleset/decoders
               status: enabled
           failed_items: []
@@ -262,13 +262,13 @@ stages:
               position: !anyint
               status: !anystr
             - <<: *full_item_decoders_parent
-              filename: 0010-active-response_decoders.xml
+              filename: 0007-wazuh-api_decoders.xml
+            - <<: *full_item_decoders_parent
+              filename: 0007-wazuh-api_decoders.xml
             - <<: *full_item_decoders_parent
               filename: 0010-active-response_decoders.xml
             - <<: *full_item_decoders_parent
-              filename: 0015-aix-ipsec_decoders.xml
-            - <<: *full_item_decoders_parent
-              filename: 0025-apache_decoders.xml
+              filename: 0010-active-response_decoders.xml
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0

--- a/api/test/integration/test_rbac_black_rule_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_rule_endpoints.tavern.yaml
@@ -118,13 +118,13 @@ stages:
               relative_dirname: ruleset/rules
               status: enabled
             - <<: *full_item_rules_files
+              filename: 0017-wazuh-api_rules.xml
+            - <<: *full_item_rules_files
               filename: 0020-syslog_rules.xml
             - <<: *full_item_rules_files
               filename: 0025-sendmail_rules.xml
             - <<: *full_item_rules_files
               filename: 0030-postfix_rules.xml
-            - <<: *full_item_rules_files
-              filename: 0035-spamd_rules.xml
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0

--- a/api/test/integration/test_rbac_white_task_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_task_endpoints.tavern.yaml
@@ -32,8 +32,8 @@ stages:
         Authorization: "Bearer {test_login_token}"
       params:
         force: True
-        agents_list: '001'
-        version: '4.0.1'
+        agents_list: '005'
+        upgrade_version: '4.2.4'
     response:
       status_code: 200
 
@@ -47,7 +47,7 @@ stages:
         error: 0
         data:
           affected_items:
-            - agent_id: "001"
+            - agent_id: "005"
               create_time: !anystr
               node: !anystr
               status: !anystr

--- a/api/test/integration/test_task_endpoints.tavern.yaml
+++ b/api/test/integration/test_task_endpoints.tavern.yaml
@@ -23,7 +23,7 @@ stages:
           total_affected_items: 0
           total_failed_items: 0
 
-  - name: Upgrade agents to create tasks
+  - name: Upgrade old agents to create tasks
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade"
@@ -32,22 +32,18 @@ stages:
         Authorization: "Bearer {test_login_token}"
       params:
         force: True
-        agents_list: '003,004,005,006'
-        version: '4.0.1'
+        agents_list: '005,006'
+        upgrade_version: '4.2.4'
     response:
       status_code: 200
       json:
         data:
           affected_items:
-            - agent: '003'
-              task_id: !anyint
-            - agent: '004'
-              task_id: !anyint
             - agent: '005'
               task_id: !anyint
             - agent: '006'
               task_id: !anyint
-          total_affected_items: 4
+          total_affected_items: 2
           total_failed_items: 0
           failed_items: []
         message: !anystr
@@ -62,14 +58,14 @@ stages:
       params:
         force: True
         agents_list: '007'
-        version: '2.0.0'
+        upgrade_version: '2.0.0'
     response:
       status_code: 200
       json:
         data:
           affected_items:
             - agent: '007'
-              task_id: 5
+              task_id: 3
           total_affected_items: 1
           total_failed_items: 0
           failed_items: []
@@ -97,7 +93,7 @@ stages:
               module: "upgrade_module"
               task_id: 2
           failed_items: []
-          total_affected_items: 5
+          total_affected_items: 3
           total_failed_items: 0
 
   - name: Get all existent tasks (Limit 2)
@@ -122,7 +118,7 @@ stages:
               task_id: 1
             - <<: *task
           failed_items: []
-          total_affected_items: 5
+          total_affected_items: 3
           total_failed_items: 0
 
   - name: Try to get tasks using select parameter
@@ -189,14 +185,14 @@ stages:
       verify: False
       <<: *get_tasks
       params:
-        q: "agent_id=004"
+        q: "agent_id=005"
     response:
       status_code: 200
       verify_response_with:
         - function: tavern_utils:test_expected_value
           extra_kwargs:
             key: "agent_id"
-            expected_values: "004"
+            expected_values: "005"
 
   - name: Verify that query parameter works as expected
     request:
@@ -210,7 +206,7 @@ stages:
         error: 0
         data:
           failed_items: [ ]
-          total_affected_items: 5
+          total_affected_items: 3
           total_failed_items: 0
 
   - name: Verify that query parameter works as expected
@@ -248,14 +244,14 @@ stages:
       verify: False
       <<: *get_tasks
       params:
-        q: "agent_id=004;module=upgrade_module;command=upgrade"
+        q: "agent_id=005;module=upgrade_module;command=upgrade"
     response:
       status_code: 200
       verify_response_with:
         - function: tavern_utils:test_expected_value
           extra_kwargs:
             key: "agent_id"
-            expected_values: "004"
+            expected_values: "005"
         - function: tavern_utils:test_expected_value
           extra_kwargs:
             key: "module"
@@ -287,7 +283,7 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
-        tasks_list: 4,3
+        tasks_list: 3,2
     response:
       status_code: 200
       json:
@@ -298,17 +294,17 @@ stages:
               status: !anystr
               last_update_time: !anystr
               agent_id: !anystr
-              task_id: 3
+              task_id: 2
             - <<: *task
               status: !anystr
               last_update_time: !anystr
               agent_id: !anystr
-              task_id: 4
+              task_id: 3
           failed_items: []
           total_affected_items: 2
           total_failed_items: 0
 
-  - name: Get specified tasks, agent_id (003)
+  - name: Get specified tasks, agent_id (005)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/tasks/status"
@@ -316,7 +312,7 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
-        agents_list: ["003","000"]
+        agents_list: ["005","000"]
     response:
       status_code: 200
       json:
@@ -326,7 +322,7 @@ stages:
             - <<: *task
               status: !anystr
               last_update_time: !anystr
-              agent_id: "003"
+              agent_id: "005"
               task_id: !anyint
           failed_items: []
           total_affected_items: 1
@@ -378,16 +374,8 @@ stages:
               status: !anystr
               last_update_time: !anystr
               task_id: 3
-            - <<: *task
-              status: !anystr
-              last_update_time: !anystr
-              task_id: 4
-            - <<: *task
-              status: !anystr
-              last_update_time: !anystr
-              task_id: 5
           failed_items: []
-          total_affected_items: 5
+          total_affected_items: 3
           total_failed_items: 0
 
   - name: Get all existent tasks with command=upgrade


### PR DESCRIPTION
|Related issue|
|---|
| #10818 |

This PR closes #10818.

In this pull request, some API integration tests have been fixed. These errors are explained in the related issue comments.

### Test results

```
test_rbac_black_decoder_endpoints.tavern.yaml 
	 6 passed, 8 warnings
	 
test_rbac_black_rule_endpoints.tavern.yaml 
	 8 passed, 10 warnings

test_task_endpoints.tavern.yaml 
	 2 passed, 4 warnings

test_rbac_white_task_endpoints.tavern.yaml 
	 1 passed, 3 warnings
```


