### PR TITLE
Standardize the use of the `only_logs_after` parameter in the external integration modules

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2899,10 +2899,7 @@ class AWSCloudWatchLogs(AWSService):
                                                                          end_time=db_values['start_time'])
 
                         if db_values['end_time']:
-                            if self.only_logs_after_millis is not None and \
-                                    db_values['end_time'] < self.only_logs_after_millis:
-                                start_time = self.only_logs_after_millis
-                            else:
+                            if not self.only_logs_after_millis or db_values['end_time'] > self.only_logs_after_millis:
                                 start_time = db_values['end_time'] + 1
                                 token = db_values['token']
 

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2917,7 +2917,7 @@ class AWSCloudWatchLogs(AWSService):
         self.remove_log_streams = remove_log_streams
         self.only_logs_after_millis = int(datetime.strptime(only_logs_after, '%Y%m%d').replace(
             tzinfo=timezone.utc).timestamp() * 1000) if only_logs_after else None
-        self.default_date_millis = int(self.default_date.timestamp()) * 1000
+        self.default_date_millis = int(self.default_date.timestamp() * 1000)
         debug("only logs: {}".format(self.only_logs_after_millis), 1)
 
     def get_alerts(self):

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -660,7 +660,7 @@ class AWSBucket(WazuhIntegration):
 
     def marker_custom_date(self, aws_region: str, aws_account_id: str, date: datetime) -> str:
         """
-        Returns a AWS bucket marker using a custom date.
+        Return a AWS bucket marker using a custom date.
 
         Parameters
         ----------
@@ -1199,7 +1199,7 @@ class AWSConfigBucket(AWSLogsBucket):
         return datetime.strftime(aux, '%Y%m%d')
 
     def _remove_padding_zeros_from_marker(self, marker: str) -> str:
-        """Removes the leading zeros from the month and day of a given marker.
+        """Remove the leading zeros from the month and day of a given marker.
 
         For example, 'AWSLogs/123456789012/Config/us-east-1/2020/01/06' would become
         'AWSLogs/123456789012/Config/us-east-1/2020/1/6'.
@@ -1224,7 +1224,7 @@ class AWSConfigBucket(AWSLogsBucket):
             sys.exit(16)
 
     def marker_only_logs_after(self, aws_region: str, aws_account_id: str) -> str:
-        """Returns a marker using the only_logs_after date to pass it as a filter to the list_objects_v2 method.
+        """Return a marker using the only_logs_after date to pass it as a filter to the list_objects_v2 method.
 
         This method removes the leading zeroes for the month and the day to comply with the config buckets folder
         structure.
@@ -1245,7 +1245,7 @@ class AWSConfigBucket(AWSLogsBucket):
                                                                                        aws_account_id))
 
     def marker_custom_date(self, aws_region: str, aws_account_id: str, date: datetime) -> str:
-        """Returns a marker using the specified date to pass it as a filter to the list_objects_v2 method.
+        """Return a marker using the specified date to pass it as a filter to the list_objects_v2 method.
 
         This method removes the leading zeroes for the month and the day to comply with the config buckets folder
         structure.

--- a/wodles/gcloud/tools.py
+++ b/wodles/gcloud/tools.py
@@ -10,7 +10,7 @@
 
 import argparse
 import logging
-from sys import path, stdout
+from sys import stdout
 from datetime import datetime
 from logging.handlers import TimedRotatingFileHandler
 from pytz import UTC
@@ -70,7 +70,7 @@ def get_script_arguments():
 
     parser.add_argument('-o', '--only_logs_after', dest='only_logs_after',
                         help='Only parse logs after this date - format YYYY-MMM-DD',
-                        default=datetime.strftime(datetime.utcnow(), '%Y-%b-%d'), type=arg_valid_date)
+                        default=None, type=arg_valid_date)
 
     parser.add_argument('-t', '--num_threads', dest='n_threads', type=int,
                         help='Number of threads', required=False, default=min_num_threads)


### PR DESCRIPTION
|Related issue|
|---|
|Closes #9993 |

## Description
In this PR we standardize the use of the `only_logs_after` parameter for all the external integration modules to comply with the following cases:

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">
<tr>
<th scope="col" class="org-left">Behavior</th>
<th scope="col" class="org-left">Last key = None, only logs = None</th>
<th scope="col" class="org-left">Last key = None, only logs set</th>
<th scope="col" class="org-left">Last key earlier in the past than only logs</th>
<th scope="col" class="org-left">Last key set, only logs = None</th>
<th scope="col" class="org-left">Last key later in time than only logs</th>

</tr>
</thead>
<tbody>

<tr>
<td class="org-left"><b><b>Desired</b></b></td>
<td class="org-left"><b><b>Process todays logs.</b></b></td>
<td class="org-left"><b><b>Process from the date set by only logs until today.</b></b></td>
<td class="org-left"><b><b>Starts from only logs' date.</b></b></td>
<td class="org-left"><b><b>Starts from last key's date.</b></b></td>
<td class="org-left"><b><b>Either starts from last key's date or process every log that had not been processed yet after only logs and skip the rest.</b></b></td>
</tr>
</tbody>
</table>  

## Tests performed
Since we had to change almost the whole AWS module to add the requested functionallity, we will have to test the whole module.

### AWS Buckets

#### Cloudtrail
##### Without specifying a prefix
<details><summary>Last key = None, only logs = None</summary>
<p>
It only process todays logs, as expected.

```
root@0afd4fba62e1:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -d 2
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/08
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/08/XXXXXXXXXXXX_CloudTrail_us-west-1_20211108T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_empty - us-west-1
DEBUG: +++ Marker: AWSLogs/test_empty/CloudTrail/us-west-1/2021/11/08
DEBUG: +++ No logs to process in bucket: test_empty/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_suffix - us-west-1
DEBUG: +++ Marker: AWSLogs/test_suffix/CloudTrail/us-west-1/2021/11/08
DEBUG: +++ No logs to process in bucket: test_suffix/us-west-1
DEBUG: +++ DB Maintenance
```
</p>

</details>


<details><summary>Last key = None, only logs set</summary>
<p>
It process all logs between the specified date and today.

```
root@0afd4fba62e1:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -d 2 -s 2021-nov-01
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/01
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/01/XXXXXXXXXXXX_CloudTrail_us-west-1_20211101T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/02/XXXXXXXXXXXX_CloudTrail_us-west-1_20211102T0000Z_qJRrDloAWNoOMRAy.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/03/XXXXXXXXXXXX_CloudTrail_us-west-1_20211103T0000Z_OtoPYJqXyVMnScng.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/08/XXXXXXXXXXXX_CloudTrail_us-west-1_20211108T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_empty - us-west-1
DEBUG: +++ Marker: AWSLogs/test_empty/CloudTrail/us-west-1/2021/11/01
DEBUG: +++ No logs to process in bucket: test_empty/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_suffix - us-west-1
DEBUG: +++ Marker: AWSLogs/test_suffix/CloudTrail/us-west-1/2021/11/01
DEBUG: +++ No logs to process in bucket: test_suffix/us-west-1
DEBUG: +++ DB Maintenance
```
</p>

</details>

<details><summary>Last key earlier in the past than only logs</summary>
<p>
It uses the date passed as only logs as marker instead of the last key, as expected.

```
root@32fcc439e3a3:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -d 2 -s 2021-nov-08
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/08
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/08/XXXXXXXXXXXX_CloudTrail_us-west-1_20211108T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_empty - us-west-1
DEBUG: +++ Marker: AWSLogs/test_empty/CloudTrail/us-west-1/2021/11/08
DEBUG: +++ No logs to process in bucket: test_empty/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_suffix - us-west-1
DEBUG: +++ Marker: AWSLogs/test_suffix/CloudTrail/us-west-1/2021/11/08
DEBUG: +++ No logs to process in bucket: test_suffix/us-west-1
DEBUG: +++ DB Maintenance
```
</p>

</details>

<details><summary>Last key set, only logs = None</summary>
<p>
It collects all logs starting from the last key's date, as expected.

```
root@32fcc439e3a3:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -d 2  
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/02/XXXXXXXXXXXX_CloudTrail_us-west-1_20211102T0000Z_qJRrDloAWNoOMRAy.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/03/XXXXXXXXXXXX_CloudTrail_us-west-1_20211103T0000Z_OtoPYJqXyVMnScng.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/08/XXXXXXXXXXXX_CloudTrail_us-west-1_20211108T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_empty - us-west-1
DEBUG: +++ Marker: AWSLogs/test_empty/CloudTrail/us-west-1/2021/11/08
DEBUG: +++ No logs to process in bucket: test_empty/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_suffix - us-west-1
DEBUG: +++ Marker: AWSLogs/test_suffix/CloudTrail/us-west-1/2021/11/08
DEBUG: +++ No logs to process in bucket: test_suffix/us-west-1
DEBUG: +++ DB Maintenance

```
</p>

</details>

<details><summary>Last key later in time than only logs</summary>
<p>
As expected, it starts from the last keys' date.

```
root@32fcc439e3a3:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -d 2 -s 2021-oct-31
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/03/XXXXXXXXXXXX_CloudTrail_us-west-1_20211103T0000Z_OtoPYJqXyVMnScng.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/08/XXXXXXXXXXXX_CloudTrail_us-west-1_20211108T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_empty - us-west-1
DEBUG: +++ Marker: AWSLogs/test_empty/CloudTrail/us-west-1/2021/10/31
DEBUG: +++ No logs to process in bucket: test_empty/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_suffix - us-west-1
DEBUG: +++ Marker: AWSLogs/test_suffix/CloudTrail/us-west-1/2021/10/31
DEBUG: +++ No logs to process in bucket: test_suffix/us-west-1
DEBUG: +++ DB Maintenance
```
</p>

</details>

##### Specifying a prefix
<details><summary>Last key = None, only logs = None</summary>
<p>
It only process todays logs, as expected.  

```
root@309c9a134fea:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-cloudtrail -d2 -l test_prefix 
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: test_prefix/AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/15
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/15/XXXXXXXXXXXX_CloudTrail_us-west-1_20211115T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_empty - us-west-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_empty/CloudTrail/us-west-1/2021/11/15
DEBUG: +++ No logs to process in bucket: test_empty/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_suffix - us-west-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_suffix/CloudTrail/us-west-1/2021/11/15
DEBUG: +++ No logs to process in bucket: test_suffix/us-west-1
DEBUG: +++ DB Maintenance

```
</p>

</details>


<details><summary>Last key = None, only logs set</summary>
<p>
It process all logs between the specified date and today. The message 'Failed to parse file...' is due to a known issue (#10664) that will be addressed in the future.  

```
root@309c9a134fea:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-cloudtrail -d2 -l test_prefix -s 2021-nov-01
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: test_prefix/AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/01
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/01/
DEBUG: ++ Failed to parse file test_prefix/AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/01/: Expecting value: line 1 column 1 (char 0); skipping...
DEBUG: +++ Error marking log test_prefix/AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/01/ as completed: list index out of range
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/01/XXXXXXXXXXXX_CloudTrail_us-west-1_20211101T0000Z_KkVGkGAKPWjHiSzV.json.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/03/XXXXXXXXXXXX_CloudTrail_us-west-1_20211103T0000Z_OtoPYJqXyVMnScng.json.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/15/XXXXXXXXXXXX_CloudTrail_us-west-1_20211115T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_empty - us-west-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_empty/CloudTrail/us-west-1/2021/11/01
DEBUG: +++ No logs to process in bucket: test_empty/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_suffix - us-west-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_suffix/CloudTrail/us-west-1/2021/11/01
DEBUG: +++ No logs to process in bucket: test_suffix/us-west-1
DEBUG: +++ DB Maintenance

```
</p>

</details>

<details><summary>Last key earlier in the past than only logs</summary>
<p>
It uses the date passed as only logs as marker instead of the last key, as expected.  

```
root@309c9a134fea:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-cloudtrail -d2 -l test_prefix -s 2021-nov-15
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: test_prefix/AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/15
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/15/XXXXXXXXXXXX_CloudTrail_us-west-1_20211115T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_empty - us-west-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_empty/CloudTrail/us-west-1/2021/11/15
DEBUG: +++ No logs to process in bucket: test_empty/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_suffix - us-west-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_suffix/CloudTrail/us-west-1/2021/11/15
DEBUG: +++ No logs to process in bucket: test_suffix/us-west-1
DEBUG: +++ DB Maintenance
```
</p>

</details>

<details><summary>Last key set, only logs = None</summary>
<p>
It collects all logs starting from the last key's date, as expected.  

```
root@309c9a134fea:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-cloudtrail -d2 -l test_prefix  
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: test_prefix/AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/01/XXXXXXXXXXXX_CloudTrail_us-west-1_20211101T0000Z_KkVGkGAKPWjHiSzV.json.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/03/XXXXXXXXXXXX_CloudTrail_us-west-1_20211103T0000Z_OtoPYJqXyVMnScng.json.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/15/XXXXXXXXXXXX_CloudTrail_us-west-1_20211115T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_empty - us-west-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_empty/CloudTrail/us-west-1/2021/11/15
DEBUG: +++ No logs to process in bucket: test_empty/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_suffix - us-west-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_suffix/CloudTrail/us-west-1/2021/11/15
DEBUG: +++ No logs to process in bucket: test_suffix/us-west-1
DEBUG: +++ DB Maintenance
```
</p>

</details>

<details><summary>Last key later in time than only logs</summary>
<p>
It uses the last key's value as marker and collects all logs after that one, as expected.

```
root@309c9a134fea:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-cloudtrail -d2 -l test_prefix -s 2021-jan-01 
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: test_prefix/AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/01/XXXXXXXXXXXX_CloudTrail_us-west-1_20211101T0000Z_KkVGkGAKPWjHiSzV.json.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/03/XXXXXXXXXXXX_CloudTrail_us-west-1_20211103T0000Z_OtoPYJqXyVMnScng.json.gz
DEBUG: ++ Found new log: test_prefix/AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/15/XXXXXXXXXXXX_CloudTrail_us-west-1_20211115T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_empty - us-west-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_empty/CloudTrail/us-west-1/2021/01/01
DEBUG: +++ No logs to process in bucket: test_empty/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_suffix - us-west-1
DEBUG: +++ Marker: test_prefix/AWSLogs/test_suffix/CloudTrail/us-west-1/2021/01/01
DEBUG: +++ No logs to process in bucket: test_suffix/us-west-1
DEBUG: +++ DB Maintenance
```
</p>

</details>

##### In an agent
<details><summary>Last key = None, only logs = None</summary>
<p>
It only process todays logs, as expected.  

```
root@feed7978d7eb:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -d 2 
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/15
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/15/XXXXXXXXXXXX_CloudTrail_us-west-1_20211115T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_empty - us-west-1
DEBUG: +++ Marker: AWSLogs/test_empty/CloudTrail/us-west-1/2021/11/15
DEBUG: +++ No logs to process in bucket: test_empty/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_suffix - us-west-1
DEBUG: +++ Marker: AWSLogs/test_suffix/CloudTrail/us-west-1/2021/11/15
DEBUG: +++ No logs to process in bucket: test_suffix/us-west-1
DEBUG: +++ DB Maintenance
```
</p>

</details>

<details><summary>Last key = None, only logs set</summary>
<p>
It process all logs between the specified date and today.  

```
root@feed7978d7eb:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -d 2 -s 2021-nov-01
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/01
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/01/XXXXXXXXXXXX_CloudTrail_us-west-1_20211101T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/02/XXXXXXXXXXXX_CloudTrail_us-west-1_20211102T0000Z_qJRrDloAWNoOMRAy.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/03/XXXXXXXXXXXX_CloudTrail_us-west-1_20211103T0000Z_OtoPYJqXyVMnScng.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/08/XXXXXXXXXXXX_CloudTrail_us-west-1_20211108T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/11/XXXXXXXXXXXX_CloudTrail_us-west-1_20211111T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/15/XXXXXXXXXXXX_CloudTrail_us-west-1_20211115T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_empty - us-west-1
DEBUG: +++ Marker: AWSLogs/test_empty/CloudTrail/us-west-1/2021/11/01
DEBUG: +++ No logs to process in bucket: test_empty/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_suffix - us-west-1
DEBUG: +++ Marker: AWSLogs/test_suffix/CloudTrail/us-west-1/2021/11/01
DEBUG: +++ No logs to process in bucket: test_suffix/us-west-1
DEBUG: +++ DB Maintenance
```
</p>

</details>

<details><summary>Last key earlier in the past than only logs</summary>
<p>
It uses the date passed as only logs as marker instead of the last key, as expected.  

```
root@feed7978d7eb:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -d 2 -s 2021-nov-11
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/11
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/11/XXXXXXXXXXXX_CloudTrail_us-west-1_20211111T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/15/XXXXXXXXXXXX_CloudTrail_us-west-1_20211115T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_empty - us-west-1
DEBUG: +++ Marker: AWSLogs/test_empty/CloudTrail/us-west-1/2021/11/11
DEBUG: +++ No logs to process in bucket: test_empty/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_suffix - us-west-1
DEBUG: +++ Marker: AWSLogs/test_suffix/CloudTrail/us-west-1/2021/11/11
DEBUG: +++ No logs to process in bucket: test_suffix/us-west-1
DEBUG: +++ DB Maintenance
```
</p>

</details>

<details><summary>Last key set, only logs = None</summary>
<p>
It collects all logs starting from the last key's date, as expected.  

```
root@feed7978d7eb:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -d 2  
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/01/XXXXXXXXXXXX_CloudTrail_us-west-1_20211101T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/02/XXXXXXXXXXXX_CloudTrail_us-west-1_20211102T0000Z_qJRrDloAWNoOMRAy.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/03/XXXXXXXXXXXX_CloudTrail_us-west-1_20211103T0000Z_OtoPYJqXyVMnScng.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/08/XXXXXXXXXXXX_CloudTrail_us-west-1_20211108T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/11/XXXXXXXXXXXX_CloudTrail_us-west-1_20211111T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/15/XXXXXXXXXXXX_CloudTrail_us-west-1_20211115T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_empty - us-west-1
DEBUG: +++ Marker: AWSLogs/test_empty/CloudTrail/us-west-1/2021/11/15
DEBUG: +++ No logs to process in bucket: test_empty/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_suffix - us-west-1
DEBUG: +++ Marker: AWSLogs/test_suffix/CloudTrail/us-west-1/2021/11/15
DEBUG: +++ No logs to process in bucket: test_suffix/us-west-1
DEBUG: +++ DB Maintenance

```
</p>

</details>

<details><summary>Last key later in time than only logs</summary>
<p>
It uses the last key's value as marker and collects all logs after that one, as expected.

```
root@feed7978d7eb:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -d 2  -s 2021-jan-01
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/01/XXXXXXXXXXXX_CloudTrail_us-west-1_20211101T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/02/XXXXXXXXXXXX_CloudTrail_us-west-1_20211102T0000Z_qJRrDloAWNoOMRAy.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/03/XXXXXXXXXXXX_CloudTrail_us-west-1_20211103T0000Z_OtoPYJqXyVMnScng.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/08/XXXXXXXXXXXX_CloudTrail_us-west-1_20211108T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/11/XXXXXXXXXXXX_CloudTrail_us-west-1_20211111T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/15/XXXXXXXXXXXX_CloudTrail_us-west-1_20211115T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_empty - us-west-1
DEBUG: +++ Marker: AWSLogs/test_empty/CloudTrail/us-west-1/2021/01/01
DEBUG: +++ No logs to process in bucket: test_empty/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_suffix - us-west-1
DEBUG: +++ Marker: AWSLogs/test_suffix/CloudTrail/us-west-1/2021/01/01
DEBUG: +++ No logs to process in bucket: test_suffix/us-west-1
DEBUG: +++ DB Maintenance
```
</p>

</details>


#### Config
<details><summary>Last key = None, only logs = None</summary>
<p>
It only process todays logs, as expected.

```
root@cdb62b01287a:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-config -t config -d 2 
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/9
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/9/09/ConfigHistory/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211109T004303Z_20211109T025123Z_1.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_empty - us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/11/9
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_suffix - us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/11/9
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ DB Maintenance
```
</p>

</details>


<details><summary>Last key = None, only logs set</summary>
<p>
It process all logs between the specified date and today.

```
root@cdb62b01287a:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-config -t config -d 2  -s 2021-nov-05
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/5
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/5/05/ConfigHistory/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20200601T004303Z_20211105T025123Z_1.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/6
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/6/06/ConfigHistory/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211106T004303Z_20211106T025123Z_1.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/7
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/7/07/ConfigHistory/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211107T004303Z_20211107T025123Z_1.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/8
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/8/08/ConfigHistory/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20200601T004303Z_20211108T025123Z_1.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/9
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/9/09/ConfigHistory/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211109T004303Z_20211109T025123Z_1.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_empty - us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/11/5
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/11/6
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/11/7
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/11/8
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/11/9
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_suffix - us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/11/5
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/11/6
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/11/7
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/11/8
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/11/9
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ DB Maintenance
```
</p>

</details>

<details><summary>Last key earlier in the past than only logs</summary>
<p>
It uses the date passed as only logs as marker instead of the last key, and therefore it skips the `2021-11-07` log.

```
root@cdb62b01287a:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-config -t config -d 2  -s 2021-nov-08
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/8
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/8
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/8
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/8/08/ConfigHistory/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20200601T004303Z_20211108T025123Z_1.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/9
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/9/09/ConfigHistory/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211109T004303Z_20211109T025123Z_1.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_empty - us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/11/8
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/11/9
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_suffix - us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/11/8
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/11/9
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ DB Maintenance
```
</p>

</details>

<details><summary>Last key set, only logs = None</summary>
<p>
It collects all logs starting from the last key's date, as expected.

```
root@cdb62b01287a:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-config -t config -d 2
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/6/06/ConfigHistory/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211106T004303Z_20211106T025123Z_1.json.gz
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/7
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/7/07/ConfigHistory/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211107T004303Z_20211107T025123Z_1.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/8
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/8/08/ConfigHistory/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20200601T004303Z_20211108T025123Z_1.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/9
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/9/09/ConfigHistory/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211109T004303Z_20211109T025123Z_1.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_empty - us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/11/9
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_suffix - us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/11/9
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ DB Maintenance
```
</p>

</details>

<details><summary>Last key later in time than only logs</summary>
<p>
It uses the last key's value as marker and collects all logs after that one, as expected.

```
root@cdb62b01287a:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-config -t config -d 2 -s 2021-nov-05
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/6/06/ConfigHistory/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211106T004303Z_20211106T025123Z_1.json.gz
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/7
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/7/07/ConfigHistory/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211107T004303Z_20211107T025123Z_1.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/8
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/8/08/ConfigHistory/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20200601T004303Z_20211108T025123Z_1.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/9
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/9/09/ConfigHistory/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211109T004303Z_20211109T025123Z_1.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_empty - us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/11/5
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/11/6
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/11/7
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/11/8
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/11/9
DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_suffix - us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/11/5
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/11/6
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/11/7
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/11/8
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/11/9
DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
DEBUG: +++ DB Maintenance
```
</p>

</details>

#### VPCFlow
To test this bucket we will use the `-r us-east-1` parameter, since this module is specially slow and verbose if no region is specified.

<details><summary>Last key = None, only logs = None</summary>
<p>
It only process todays logs, as expected.

```
root@cdb62b01287a:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -d 2 -r us-east-1
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/09
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/09/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211109T0000Z_ce6176d8.log.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/09
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Working on test_empty - us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/09
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Working on test_suffix - us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/09
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
```
</p>

</details>


<details><summary>Last key = None, only logs set</summary>
<p>
It process all logs between the specified date and today.

```
root@cdb62b01287a:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -d 2 -r us-east-1 -s 2021-nov-01
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/01
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/01/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211101T0000Z_ce6176d8.log.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/02
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/03
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/04
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/04/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211104T0000Z_ce6176d8.log.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/05
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/05/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211105T0000Z_ce6176d8.log.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/06
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/07
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/08
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/09
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/09/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211109T0000Z_ce6176d8.log.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/01
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/02
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/03
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/04
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/05
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/06
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/07
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/08
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/09
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Working on test_empty - us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/01
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/02
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/03
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/04
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/05
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/06
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/07
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/08
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/09
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Working on test_suffix - us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/01
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/02
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/03
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/04
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/05
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/06
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/07
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/08
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/09
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
```
</p>

</details>

<details><summary>Last key earlier in the past than only logs</summary>
<p>
It uses the date passed as only logs as marker instead of the last key and only collects that day's logs, as expected.

```
root@cdb62b01287a:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -d 2 -r us-east-1 -s 2021-nov-09
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/09
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/09
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/09
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/09
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/09
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/09
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/09
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/09
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/09
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/09/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211109T0000Z_ce6176d8.log.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/09
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Working on test_empty - us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/09
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Working on test_suffix - us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/09
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
```
</p>

</details>

<details><summary>Last key set, only logs = None</summary>
<p>
It collects all logs starting from the last key's date, as expected.

```
root@cdb62b01287a:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -d 2 -r us-east-1    
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/01/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211101T0000Z_ce6176d8.log.gz
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/02
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/03
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/04
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/04/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211104T0000Z_ce6176d8.log.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/05
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/05/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211105T0000Z_ce6176d8.log.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/06
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/07
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/08
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/09
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/09/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211109T0000Z_ce6176d8.log.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/09
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Working on test_empty - us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/09
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Working on test_suffix - us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/09
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
```
</p>

</details>

<details><summary>Last key later in time than only logs</summary>
<p>
It uses the last key's value as marker and collects all logs after that one, as expected.

```
root@cdb62b01287a:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -d 2 -r us-east-1 -s 2021-nov-01
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/04/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211104T0000Z_ce6176d8.log.gz
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/05
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/05/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211105T0000Z_ce6176d8.log.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/06
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/07
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/08
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/09
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/09/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211109T0000Z_ce6176d8.log.gz
root@cdb62b01287a:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -d 2 -r us-east-1 -s 2021-nov-01
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/04/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211104T0000Z_ce6176d8.log.gz
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/05
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/05/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211105T0000Z_ce6176d8.log.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/06
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/07
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/08
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/09
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/09/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211109T0000Z_ce6176d8.log.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/01
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/02
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/03
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/04
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/05
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/06
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/07
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/08
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/09
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Working on test_empty - us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/01
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/02
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/03
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/04
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/05
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/06
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/07
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/08
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/09
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Working on test_suffix - us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/01
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/02
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/03
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/04
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/05
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/06
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/07
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/08
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/09
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/01
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/02
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/03
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/04
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/05
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/06
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/07
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/08
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/09
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Working on test_empty - us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/01
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/02
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/03
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/04
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/05
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/06
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/07
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/08
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/09
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
DEBUG: +++ Working on test_suffix - us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/01
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/02
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/03
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/04
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/05
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/06
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/07
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/08
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/09
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
```
</p>

</details>


#### Custom Bucket (Macie)
<details><summary>Last key = None, only logs = None</summary>
<p>
It only process todays logs, as expected.

```
root@660d5191aa3a:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-macie -d 2 -t custom
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Marker: 2021/11/11
DEBUG: ++ Found new log: 2021/11/11/00/firehose_macie-1-2021-11-11-00-20-42-eb1f80bc-5d9d-426b-a0a1-e0ad8d3ef656
DEBUG: ++ Skipping file with another prefix: test_empty/
DEBUG: ++ Skipping file with another prefix: test_prefix/
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/01/00/firehose_macie-1-2021-01-01-00-20-42-eb1f80bc-5d9d-426b-a0a1-e0ad8d3ef656
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/01/00/firehose_macie-1-2021-01-01-00-40-35-0f4dd6e8-e374-4295-a0e6-23a6a6da4729
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/02/00/firehose_macie-1-2021-01-02-00-21-04-e29c7d70-a931-47d0-a74c-f2a187fd1035
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/02/00/firehose_macie-1-2021-01-02-00-41-11-2fd1297a-e57e-449f-8434-b48ea04c3f35
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/03/00/firehose_macie-1-2021-01-03-00-20-43-97c9b612-b9e2-419d-b91f-2a664e18ef7c
...
...
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/05/04/00/firehose_macie-1-2021-12-01-00-40-40-e269348f-0b8e-4f61-a4e9-995424ftest1
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/05/04/00/firehose_macie-1-2021-12-01-00-40-40-e269348f-0b8e-4f61-a4e9-995424ftest2
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance

```
</p>

</details>


<details><summary>Last key = None, only logs set</summary>
<p>
It process all logs between the specified date and today.

```
root@660d5191aa3a:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-macie -d 2 -t custom -s 2021-nov-01
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Marker: 2021/11/01
DEBUG: ++ Found new log: 2021/11/09/00/firehose_macie-1-2021-11-09-00-20-42-eb1f80bc-5d9d-426b-a0a1-e0ad8d3ef656
DEBUG: ++ Found new log: 2021/11/10/00/firehose_macie-1-2021-11-10-00-20-42-eb1f80bc-5d9d-426b-a0a1-e0ad8d3ef656
DEBUG: ++ Found new log: 2021/11/11/00/firehose_macie-1-2021-11-11-00-20-42-eb1f80bc-5d9d-426b-a0a1-e0ad8d3ef656
DEBUG: ++ Skipping file with another prefix: test_empty/
DEBUG: ++ Skipping file with another prefix: test_prefix/
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/01/00/firehose_macie-1-2021-01-01-00-20-42-eb1f80bc-5d9d-426b-a0a1-e0ad8d3ef656
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/01/00/firehose_macie-1-2021-01-01-00-40-35-0f4dd6e8-e374-4295-a0e6-23a6a6da4729
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/02/00/firehose_macie-1-2021-01-02-00-21-04-e29c7d70-a931-47d0-a74c-f2a187fd1035
...
...
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/03/10/00/firehose_macie-1-2021-03-10-00-40-41-f0ed4042-15cb-47bd-afe4-248729ca5ad3
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/05/04/00/firehose_macie-1-2021-12-01-00-40-40-e269348f-0b8e-4f61-a4e9-995424ftest1
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/05/04/00/firehose_macie-1-2021-12-01-00-40-40-e269348f-0b8e-4f61-a4e9-995424ftest2
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
```
</p>

</details>

<details><summary>Last key earlier in the past than only logs</summary>
<p>
It uses the date passed as only logs as marker instead of the last key, as expected.

```
root@660d5191aa3a:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-macie -d 2 -t custom -s 2021-nov-11
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Marker: 2021/11/11
DEBUG: ++ Found new log: 2021/11/11/00/firehose_macie-1-2021-11-11-00-20-42-eb1f80bc-5d9d-426b-a0a1-e0ad8d3ef656
DEBUG: ++ Skipping file with another prefix: test_empty/
DEBUG: ++ Skipping file with another prefix: test_prefix/
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/01/00/firehose_macie-1-2021-01-01-00-20-42-eb1f80bc-5d9d-426b-a0a1-e0ad8d3ef656
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/01/00/firehose_macie-1-2021-01-01-00-40-35-0f4dd6e8-e374-4295-a0e6-23a6a6da4729
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/02/00/firehose_macie-1-2021-01-02-00-21-04-e29c7d70-a931-47d0-a74c-f2a187fd1035
...
...
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/03/10/00/firehose_macie-1-2021-03-10-00-20-42-467e0793-238c-460c-b3c8-30b90b5982a6
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/03/10/00/firehose_macie-1-2021-03-10-00-40-41-f0ed4042-15cb-47bd-afe4-248729ca5ad3
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/05/04/00/firehose_macie-1-2021-12-01-00-40-40-e269348f-0b8e-4f61-a4e9-995424ftest1
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/05/04/00/firehose_macie-1-2021-12-01-00-40-40-e269348f-0b8e-4f61-a4e9-995424ftest2
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
```
</p>

</details>

<details><summary>Last key set, only logs = None</summary>
<p>
It collects all logs starting from the last key's date, as expected.

```
root@660d5191aa3a:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-macie -d 2 -t custom  
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Marker: 2021/11/09/00/firehose_macie-1-2021-11-09-00-20-42-eb1f80bc-5d9d-426b-a0a1-e0ad8d3ef656
DEBUG: ++ Found new log: 2021/11/10/00/firehose_macie-1-2021-11-10-00-20-42-eb1f80bc-5d9d-426b-a0a1-e0ad8d3ef656
DEBUG: ++ Found new log: 2021/11/11/00/firehose_macie-1-2021-11-11-00-20-42-eb1f80bc-5d9d-426b-a0a1-e0ad8d3ef656
DEBUG: ++ Skipping file with another prefix: test_empty/
DEBUG: ++ Skipping file with another prefix: test_prefix/
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/01/00/firehose_macie-1-2021-01-01-00-20-42-eb1f80bc-5d9d-426b-a0a1-e0ad8d3ef656
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/01/00/firehose_macie-1-2021-01-01-00-40-35-0f4dd6e8-e374-4295-a0e6-23a6a6da4729
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/02/00/firehose_macie-1-2021-01-02-00-21-04-e29c7d70-a931-47d0-a74c-f2a187fd1035
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/02/00/firehose_macie-1-2021-01-02-00-41-11-2fd1297a-e57e-449f-8434-b48ea04c3f35
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/03/00/firehose_macie-1-2021-01-03-00-20-43-97c9b612-b9e2-419d-b91f-2a664e18ef7c
...
...
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/03/09/00/firehose_macie-1-2021-03-09-00-41-01-b35a0b87-c4ee-4250-a512-e1907ab8309f
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/03/10/00/firehose_macie-1-2021-03-10-00-20-42-467e0793-238c-460c-b3c8-30b90b5982a6
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/03/10/00/firehose_macie-1-2021-03-10-00-40-41-f0ed4042-15cb-47bd-afe4-248729ca5ad3
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/05/04/00/firehose_macie-1-2021-12-01-00-40-40-e269348f-0b8e-4f61-a4e9-995424ftest1
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/05/04/00/firehose_macie-1-2021-12-01-00-40-40-e269348f-0b8e-4f61-a4e9-995424ftest2
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
```
</p>

</details>

<details><summary>Last key later in time than only logs</summary>
<p>
It uses the last key's value as marker and collects all logs after that one, as expected.

```
root@660d5191aa3a:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-macie -d 2 -t custom -s 2021-nov-01
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Marker: 2021/11/10/00/firehose_macie-1-2021-11-10-00-20-42-eb1f80bc-5d9d-426b-a0a1-e0ad8d3ef656
DEBUG: ++ Found new log: 2021/11/11/00/firehose_macie-1-2021-11-11-00-20-42-eb1f80bc-5d9d-426b-a0a1-e0ad8d3ef656
DEBUG: ++ Skipping file with another prefix: test_empty/
DEBUG: ++ Skipping file with another prefix: test_prefix/
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/01/00/firehose_macie-1-2021-01-01-00-20-42-eb1f80bc-5d9d-426b-a0a1-e0ad8d3ef656
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/01/01/00/firehose_macie-1-2021-01-01-00-40-35-0f4dd6e8-e374-4295-a0e6-23a6a6da4729
...
...
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/03/10/00/firehose_macie-1-2021-03-10-00-20-42-467e0793-238c-460c-b3c8-30b90b5982a6
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/03/10/00/firehose_macie-1-2021-03-10-00-40-41-f0ed4042-15cb-47bd-afe4-248729ca5ad3
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/05/04/00/firehose_macie-1-2021-12-01-00-40-40-e269348f-0b8e-4f61-a4e9-995424ftest1
DEBUG: ++ Skipping file with another prefix: test_prefix/2021/05/04/00/firehose_macie-1-2021-12-01-00-40-40-e269348f-0b8e-4f61-a4e9-995424ftest2
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
```
</p>

</details>


#### Server Access
##### Without specifying a prefix

<details><summary>Last key = None, only logs = None</summary>
<p>
It only process todays logs, as expected.  

```
root@b720b31a3a04:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-access -d 2 -t server_access    
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Marker: 2021-11-15
DEBUG: ++ Found new log: 2021-11-15-09-12-25-F92E1554CC549BEE
DEBUG: ++ Skipping file with another prefix: test_empty/
DEBUG: ++ Skipping file with another prefix: test_prefix/
DEBUG: ++ Skipping file with another prefix: test_prefix/2021-04-29-09-11-26-B9F9F891E8D0EB13
DEBUG: ++ Skipping file with another prefix: test_prefix/2021-04-29-09-12-25-F92E1554CC549BEE
DEBUG: ++ Skipping file with another prefix: test_prefix/2021-04-29-09-13-06-338835093EADA3C1
...
...
DEBUG: ++ Skipping file with another prefix: test_prefix/2021-11-12-09-11-26-B9F9F891E8D0EB13
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-11-26-B9F9F891E8D0EB13
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-12-25-F92E1554CC549BEE
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-13-06-338835093EADA3C1
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-14-05-B61AAAC9147C7F9F
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
```
</p>

</details>


<details><summary>Last key = None, only logs set</summary>
<p>
It process all logs between the specified date and today.  

```
root@b720b31a3a04:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-access -d 2 -t server_access -s 2021-nov-01
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Marker: 2021-11-01
DEBUG: ++ Found new log: 2021-11-09-09-11-26-B9F9F891E8D0EB13
DEBUG: ++ Found new log: 2021-11-11-09-11-26-B9F9F891E8D0EB13
DEBUG: ++ Found new log: 2021-11-12-09-11-26-B9F9F891E8D0EB13
DEBUG: ++ Found new log: 2021-11-12-13-11-26-B9F9F891E8D0EB13
DEBUG: ++ Found new log: 2021-11-15-09-12-25-F92E1554CC549BEE
DEBUG: ++ Skipping file with another prefix: test_empty/
DEBUG: ++ Skipping file with another prefix: test_prefix/
DEBUG: ++ Skipping file with another prefix: test_prefix/2021-04-29-09-11-26-B9F9F891E8D0EB13
DEBUG: ++ Skipping file with another prefix: test_prefix/2021-04-29-09-12-25-F92E1554CC549BEE
...
...
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-11-26-B9F9F891E8D0EB13
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-12-25-F92E1554CC549BEE
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-13-06-338835093EADA3C1
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-14-05-B61AAAC9147C7F9F
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
```
</p>

</details>

<details><summary>Last key earlier in the past than only logs</summary>
<p>
It uses the date passed as only logs as marker instead of the last key, as expected.  

```
root@b720b31a3a04:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-access -d 2 -t server_access -s 2021-nov-12
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Marker: 2021-11-12
DEBUG: ++ Found new log: 2021-11-12-09-11-26-B9F9F891E8D0EB13
DEBUG: ++ Found new log: 2021-11-12-13-11-26-B9F9F891E8D0EB13
DEBUG: ++ Found new log: 2021-11-15-09-12-25-F92E1554CC549BEE
DEBUG: ++ Skipping file with another prefix: test_empty/
DEBUG: ++ Skipping file with another prefix: test_prefix/
DEBUG: ++ Skipping file with another prefix: test_prefix/2021-04-29-09-11-26-B9F9F891E8D0EB13
DEBUG: ++ Skipping file with another prefix: test_prefix/2021-04-29-09-12-25-F92E1554CC549BEE
DEBUG: ++ Skipping file with another prefix: test_prefix/2021-04-29-09-13-06-338835093EADA3C1
DEBUG: ++ Skipping file with another prefix: test_prefix/2021-04-29-09-14-05-B61AAAC9147C7F9F
...
...
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-12-25-F92E1554CC549BEE
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-13-06-338835093EADA3C1
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-14-05-B61AAAC9147C7F9F
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
```
</p>

</details>

<details><summary>Last key set, only logs = None</summary>
<p>
It collects all logs starting from the last key's date, as expected.  

```
root@b720b31a3a04:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-access -d 2 -t server_access    
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Marker: 2021-11-09-09-11-26-B9F9F891E8D0EB13
DEBUG: ++ Found new log: 2021-11-11-09-11-26-B9F9F891E8D0EB13
DEBUG: ++ Found new log: 2021-11-12-09-11-26-B9F9F891E8D0EB13
DEBUG: ++ Found new log: 2021-11-12-13-11-26-B9F9F891E8D0EB13
DEBUG: ++ Found new log: 2021-11-15-09-12-25-F92E1554CC549BEE
DEBUG: ++ Skipping file with another prefix: test_empty/
DEBUG: ++ Skipping file with another prefix: test_prefix/
DEBUG: ++ Skipping file with another prefix: test_prefix/2021-04-29-09-11-26-B9F9F891E8D0EB13
DEBUG: ++ Skipping file with another prefix: test_prefix/2021-04-29-09-12-25-F92E1554CC549BEE
...
...
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-12-25-F92E1554CC549BEE
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-13-06-338835093EADA3C1
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-14-05-B61AAAC9147C7F9F
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
```
</p>

</details>

<details><summary>Last key later in time than only logs</summary>
<p>
It uses the last key's value as marker and collects all logs after that one, as expected.

```
root@b720b31a3a04:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-access -d 2 -t server_access -s 2021-oct-01
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Marker: 2021-11-09-09-11-26-B9F9F891E8D0EB13
DEBUG: ++ Found new log: 2021-11-11-09-11-26-B9F9F891E8D0EB13
DEBUG: ++ Found new log: 2021-11-12-09-11-26-B9F9F891E8D0EB13
DEBUG: ++ Found new log: 2021-11-12-13-11-26-B9F9F891E8D0EB13
DEBUG: ++ Found new log: 2021-11-15-09-12-25-F92E1554CC549BEE
DEBUG: ++ Skipping file with another prefix: test_empty/
DEBUG: ++ Skipping file with another prefix: test_prefix/
DEBUG: ++ Skipping file with another prefix: test_prefix/2021-04-29-09-11-26-B9F9F891E8D0EB13
DEBUG: ++ Skipping file with another prefix: test_prefix/2021-04-29-09-12-25-F92E1554CC549BEE
...
...
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-13-06-338835093EADA3C1
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-14-05-B61AAAC9147C7F9F
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
```
</p>

</details>

##### Specifying a prefix
<details><summary>Last key = None, only logs = None</summary>
<p>
It only process todays logs, as expected.  

```
root@b720b31a3a04:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-access -d 2 -t server_access -l test_prefix
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Marker: test_prefix/2021-11-15
DEBUG: ++ Found new log: test_prefix/2021-11-15-09-12-25-F92E1554CC549BEE
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-11-26-B9F9F891E8D0EB13
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-12-25-F92E1554CC549BEE
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-13-06-338835093EADA3C1
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-14-05-B61AAAC9147C7F9F
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
```
</p>

</details>


<details><summary>Last key = None, only logs set</summary>
<p>
It process all logs between the specified date and today.  

```
root@b720b31a3a04:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-access -d 2 -t server_access -l test_prefix -s 2021-nov-01
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Marker: test_prefix/2021-11-01
DEBUG: ++ Found new log: test_prefix/2021-11-09-09-11-26-B9F9F891E8D0EB13
DEBUG: ++ Found new log: test_prefix/2021-11-11-09-11-26-B9F9F891E8D0EB13
DEBUG: ++ Found new log: test_prefix/2021-11-12-09-11-26-B9F9F891E8D0EB13
DEBUG: ++ Found new log: test_prefix/2021-11-15-09-12-25-F92E1554CC549BEE
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-11-26-B9F9F891E8D0EB13
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-12-25-F92E1554CC549BEE
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-13-06-338835093EADA3C1
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-14-05-B61AAAC9147C7F9F
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
```
</p>

</details>

<details><summary>Last key earlier in the past than only logs</summary>
<p>
It uses the date passed as only logs as marker instead of the last key, as expected.  

```
root@b720b31a3a04:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-access -d 2 -t server_access -l test_prefix -s 2021-nov-15
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Marker: test_prefix/2021-11-15
DEBUG: ++ Found new log: test_prefix/2021-11-15-09-12-25-F92E1554CC549BEE
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-11-26-B9F9F891E8D0EB13
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-12-25-F92E1554CC549BEE
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-13-06-338835093EADA3C1
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-14-05-B61AAAC9147C7F9F
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
```
</p>

</details>

<details><summary>Last key set, only logs = None</summary>
<p>
It collects all logs starting from the last key's date, as expected.  

```
root@b720b31a3a04:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-access -d 2 -t server_access -l test_prefix
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Marker: test_prefix/2021-11-12-09-11-26-B9F9F891E8D0EB13
DEBUG: ++ Found new log: test_prefix/2021-11-15-09-12-25-F92E1554CC549BEE
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-11-26-B9F9F891E8D0EB13
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-12-25-F92E1554CC549BEE
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-13-06-338835093EADA3C1
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-14-05-B61AAAC9147C7F9F
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
```
</p>

</details>

<details><summary>Last key later in time than only logs</summary>
<p>
It uses the last key's value as marker and collects all logs after that one, as expected.

```
root@b720b31a3a04:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-access -d 2 -t server_access -l test_prefix -s 2021-jan-01
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Marker: test_prefix/2021-11-12-09-11-26-B9F9F891E8D0EB13
DEBUG: ++ Found new log: test_prefix/2021-11-15-09-12-25-F92E1554CC549BEE
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-11-26-B9F9F891E8D0EB13
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-12-25-F92E1554CC549BEE
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-13-06-338835093EADA3C1
DEBUG: ++ Skipping file with another prefix: test_prefix/test_subfolder/2021-04-29-09-14-05-B61AAAC9147C7F9F
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
```
</p>

</details>

#### CLB
<details><summary>Last key = None, only logs = None</summary>
<p>
It only process todays logs, as expected.  

```
root@dc5de24f9d43:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-clb -d 2  -t clb
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
1DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2021/11/12
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2021/11/12/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211112T1735Z_18.144.142.112_2helnha7.log
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
```
</p>

</details>


<details><summary>Last key = None, only logs set</summary>
<p>
It process all logs between the specified date and today.  

```
root@dc5de24f9d43:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-clb -d 2  -t clb -s 2021-nov-06
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2021/11/06
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2021/11/09/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211109T1735Z_18.144.142.112_2helnha7.log
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2021/11/10/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211110T1735Z_18.144.142.112_2helnha7.log
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2021/11/11/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211111T1735Z_18.144.142.112_2helnha7.log
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2021/11/12/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211112T1735Z_18.144.142.112_2helnha7.log
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
```
</p>

</details>

<details><summary>Last key earlier in the past than only logs</summary>
<p>
It uses the date passed as only logs as marker instead of the last key, as expected.  

```
root@dc5de24f9d43:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-clb -d 2  -t clb -s 2021-nov-12
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2021/11/12
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2021/11/12/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211112T1735Z_18.144.142.112_2helnha7.log
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
```
</p>

</details>

<details><summary>Last key set, only logs = None</summary>
<p>
It collects all logs starting from the last key's date, as expected.  

```
root@dc5de24f9d43:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-clb -d 2  -t clb  
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2021/11/09/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211109T1735Z_18.144.142.112_2helnha7.log
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2021/11/10/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211110T1735Z_18.144.142.112_2helnha7.log
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2021/11/11/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211111T1735Z_18.144.142.112_2helnha7.log
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2021/11/12/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211112T1735Z_18.144.142.112_2helnha7.log
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
```
</p>

</details>

<details><summary>Last key later in time than only logs</summary>
<p>
It uses the last key's value as marker and collects all logs after that one, as expected.  

```
root@dc5de24f9d43:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-clb -d 2  -t clb  -s 2021-jan-01
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2021/11/09/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211109T1735Z_18.144.142.112_2helnha7.log
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2021/11/10/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211110T1735Z_18.144.142.112_2helnha7.log
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2021/11/11/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211111T1735Z_18.144.142.112_2helnha7.log
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2021/11/12/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_fram-dev-APIClassi-TCDBB3LRKY97_20211112T1735Z_18.144.142.112_2helnha7.log
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
```
</p>

</details>


#### CloudWatch Logs
<details><summary>Last key = None, only logs = None</summary>
<p>
It only process todays logs, as expected.

```
root@b9875d019c7e:/var/ossec/wodles/aws# ./aws-s3 -sr cloudwatchlogs -r us-east-2 -g /test/9993 -d3 
DEBUG: +++ Debug mode on - Level: 3
DEBUG: +++ Getting alerts from "us-east-2" region.
DEBUG: only logs: None
DEBUG: +++ Table does not exist; create
DEBUG: Getting log streams for "/test/9993" log group
DEBUG: Found "test_stream" log stream in /test/9993
DEBUG: Getting data from DB for log stream "test_stream" in log group "/test/9993"
DEBUG: Token: "None", start_time: "None", end_time: "None"
DEBUG: Getting CloudWatch logs from log stream "test_stream" in log group "/test/9993" using token "None", start_time "1636412400000" and end_time "None"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 18 - 2021-11-9 - 1636416000000"
DEBUG: The message's timestamp is 1636416000000
DEBUG: "Test log 18 - 2021-11-9 - 1636416000000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 19 - 2021-11-9 - 1636430400000"
DEBUG: The message's timestamp is 1636430400000
DEBUG: "Test log 19 - 2021-11-9 - 1636430400000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 20 - 2021-11-9 - 1636444800000"
DEBUG: The message's timestamp is 1636444800000
DEBUG: "Test log 20 - 2021-11-9 - 1636444800000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 21 - 2021-11-9 - 1636459200000"
DEBUG: The message's timestamp is 1636459200000
DEBUG: "Test log 21 - 2021-11-9 - 1636459200000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 22 - 2021-11-9 - 1636473600000"
DEBUG: The message's timestamp is 1636473600000
DEBUG: "Test log 22 - 2021-11-9 - 1636473600000"
DEBUG: Getting CloudWatch logs from log stream "test_stream" in log group "/test/9993" using token "f/36494580777722123564650636731199524216524412965459263488", start_time "1636412400000" and end_time "None"
DEBUG: Saving data for log group "/test/9993" and log stream "test_stream".
DEBUG: The saved values are "{'token': 'f/36494580777722123564650636731199524216524412965459263488', 'start_time': 1636412400000, 'end_time': 1636473600000}"
DEBUG: Purging the BD
DEBUG: Getting log streams for "/test/9993" log group
DEBUG: Found "test_stream" log stream in /test/9993
DEBUG: committing changes and closing the DB
```
</p>

</details>


<details><summary>Last key = None, only logs set</summary>
<p>
It process all logs between the specified date and today.

```
root@b9875d019c7e:/var/ossec/wodles/aws# ./aws-s3 -sr cloudwatchlogs -r us-east-2 -g /test/9993 -d3 -s 2021-nov-01
DEBUG: +++ Debug mode on - Level: 3
DEBUG: +++ Getting alerts from "us-east-2" region.
DEBUG: only logs: 1635724800000
DEBUG: +++ Table does not exist; create
DEBUG: Getting log streams for "/test/9993" log group
DEBUG: Found "test_stream" log stream in /test/9993
DEBUG: Getting data from DB for log stream "test_stream" in log group "/test/9993"
DEBUG: Token: "None", start_time: "None", end_time: "None"
DEBUG: Getting CloudWatch logs from log stream "test_stream" in log group "/test/9993" using token "None", start_time "1635724800000" and end_time "None"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 0 - 2021-11-6 - 1636156800000"
DEBUG: The message's timestamp is 1636156800000
DEBUG: "Test log 0 - 2021-11-6 - 1636156800000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 1 - 2021-11-6 - 1636171200000"
DEBUG: The message's timestamp is 1636171200000
DEBUG: "Test log 1 - 2021-11-6 - 1636171200000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 2 - 2021-11-6 - 1636185600000"
DEBUG: The message's timestamp is 1636185600000
DEBUG: "Test log 2 - 2021-11-6 - 1636185600000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 3 - 2021-11-6 - 1636200000000"
DEBUG: The message's timestamp is 1636200000000
DEBUG: "Test log 3 - 2021-11-6 - 1636200000000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 4 - 2021-11-6 - 1636214400000"
DEBUG: The message's timestamp is 1636214400000
DEBUG: "Test log 4 - 2021-11-6 - 1636214400000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 5 - 2021-11-6 - 1636228800000"
DEBUG: The message's timestamp is 1636228800000
DEBUG: "Test log 5 - 2021-11-6 - 1636228800000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 6 - 2021-11-7 - 1636243200000"
DEBUG: The message's timestamp is 1636243200000
DEBUG: "Test log 6 - 2021-11-7 - 1636243200000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 7 - 2021-11-7 - 1636257600000"
DEBUG: The message's timestamp is 1636257600000
DEBUG: "Test log 7 - 2021-11-7 - 1636257600000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 8 - 2021-11-7 - 1636272000000"
DEBUG: The message's timestamp is 1636272000000
DEBUG: "Test log 8 - 2021-11-7 - 1636272000000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 9 - 2021-11-7 - 1636286400000"
DEBUG: The message's timestamp is 1636286400000
DEBUG: "Test log 9 - 2021-11-7 - 1636286400000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 10 - 2021-11-7 - 1636300800000"
DEBUG: The message's timestamp is 1636300800000
DEBUG: "Test log 10 - 2021-11-7 - 1636300800000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 11 - 2021-11-7 - 1636315200000"
DEBUG: The message's timestamp is 1636315200000
DEBUG: "Test log 11 - 2021-11-7 - 1636315200000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 12 - 2021-11-8 - 1636329600000"
DEBUG: The message's timestamp is 1636329600000
DEBUG: "Test log 12 - 2021-11-8 - 1636329600000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 13 - 2021-11-8 - 1636344000000"
DEBUG: The message's timestamp is 1636344000000
DEBUG: "Test log 13 - 2021-11-8 - 1636344000000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 14 - 2021-11-8 - 1636358400000"
DEBUG: The message's timestamp is 1636358400000
DEBUG: "Test log 14 - 2021-11-8 - 1636358400000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 15 - 2021-11-8 - 1636372800000"
DEBUG: The message's timestamp is 1636372800000
DEBUG: "Test log 15 - 2021-11-8 - 1636372800000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 16 - 2021-11-8 - 1636387200000"
DEBUG: The message's timestamp is 1636387200000
DEBUG: "Test log 16 - 2021-11-8 - 1636387200000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 17 - 2021-11-8 - 1636401600000"
DEBUG: The message's timestamp is 1636401600000
DEBUG: "Test log 17 - 2021-11-8 - 1636401600000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 18 - 2021-11-9 - 1636416000000"
DEBUG: The message's timestamp is 1636416000000
DEBUG: "Test log 18 - 2021-11-9 - 1636416000000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 19 - 2021-11-9 - 1636430400000"
DEBUG: The message's timestamp is 1636430400000
DEBUG: "Test log 19 - 2021-11-9 - 1636430400000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 20 - 2021-11-9 - 1636444800000"
DEBUG: The message's timestamp is 1636444800000
DEBUG: "Test log 20 - 2021-11-9 - 1636444800000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 21 - 2021-11-9 - 1636459200000"
DEBUG: The message's timestamp is 1636459200000
DEBUG: "Test log 21 - 2021-11-9 - 1636459200000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 22 - 2021-11-9 - 1636473600000"
DEBUG: The message's timestamp is 1636473600000
DEBUG: "Test log 22 - 2021-11-9 - 1636473600000"
DEBUG: Getting CloudWatch logs from log stream "test_stream" in log group "/test/9993" using token "f/36494580777722123564650636731199524216524412965459263488", start_time "1635724800000" and end_time "None"
DEBUG: Saving data for log group "/test/9993" and log stream "test_stream".
DEBUG: The saved values are "{'token': 'f/36494580777722123564650636731199524216524412965459263488', 'start_time': 1635724800000, 'end_time': 1636473600000}"
DEBUG: Purging the BD
DEBUG: Getting log streams for "/test/9993" log group
DEBUG: Found "test_stream" log stream in /test/9993
DEBUG: committing changes and closing the DB
```
</p>

</details>

<details><summary>Last key earlier in the past than only logs</summary>
<p>
It uses the date passed as only logs as timestamps instead of the last key, as expected.

```
root@b9875d019c7e:/var/ossec/wodles/aws# ./aws-s3 -sr cloudwatchlogs -r us-east-2 -g /test/9993 -d3 -s 2021-nov-09
DEBUG: +++ Debug mode on - Level: 3
DEBUG: +++ Getting alerts from "us-east-2" region.
DEBUG: only logs: 1636416000000
DEBUG: Getting log streams for "/test/9993" log group
DEBUG: Found "test_stream" log stream in /test/9993
DEBUG: Getting data from DB for log stream "test_stream" in log group "/test/9993"
DEBUG: Token: "f/36494580777722123564650636731199524216524412965459263488", start_time: "1635724800000", end_time: "1636257600000"
DEBUG: Getting CloudWatch logs from log stream "test_stream" in log group "/test/9993" using token "None", start_time "1636416000000" and end_time "None"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 18 - 2021-11-9 - 1636416000000"
DEBUG: The message's timestamp is 1636416000000
DEBUG: "Test log 18 - 2021-11-9 - 1636416000000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 19 - 2021-11-9 - 1636430400000"
DEBUG: The message's timestamp is 1636430400000
DEBUG: "Test log 19 - 2021-11-9 - 1636430400000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 20 - 2021-11-9 - 1636444800000"
DEBUG: The message's timestamp is 1636444800000
DEBUG: "Test log 20 - 2021-11-9 - 1636444800000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 21 - 2021-11-9 - 1636459200000"
DEBUG: The message's timestamp is 1636459200000
DEBUG: "Test log 21 - 2021-11-9 - 1636459200000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 22 - 2021-11-9 - 1636473600000"
DEBUG: The message's timestamp is 1636473600000
DEBUG: "Test log 22 - 2021-11-9 - 1636473600000"
DEBUG: Getting CloudWatch logs from log stream "test_stream" in log group "/test/9993" using token "f/36494580777722123564650636731199524216524412965459263488", start_time "1636416000000" and end_time "None"
DEBUG: Saving data for log group "/test/9993" and log stream "test_stream".
DEBUG: The saved values are "{'token': 'f/36494580777722123564650636731199524216524412965459263488', 'start_time': 1635724800000, 'end_time': 1636473600000}"
DEBUG: Some data already exists on DB for that key. Updating their values...
DEBUG: Purging the BD
DEBUG: Getting log streams for "/test/9993" log group
DEBUG: Found "test_stream" log stream in /test/9993
DEBUG: committing changes and closing the DB
```
</p>

</details>

<details><summary>Last key set, only logs = None</summary>
<p>
It collects all logs starting from the last key's timestamp, as expected.

```
root@b9875d019c7e:/var/ossec/wodles/aws# ./aws-s3 -sr cloudwatchlogs -r us-east-2 -g /test/9993 -d3 
DEBUG: +++ Debug mode on - Level: 3
DEBUG: +++ Getting alerts from "us-east-2" region.
DEBUG: only logs: None
DEBUG: Getting log streams for "/test/9993" log group
DEBUG: Found "test_stream" log stream in /test/9993
DEBUG: Getting data from DB for log stream "test_stream" in log group "/test/9993"
DEBUG: Token: "f/36488800424566664427132351844460564304336656264064729088", start_time: "1635724800000", end_time: "1636214400000"
DEBUG: Getting CloudWatch logs from log stream "test_stream" in log group "/test/9993" using token "f/36488800424566664427132351844460564304336656264064729088", start_time "1636214400001" and end_time "None"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 5 - 2021-11-7 - 1636243200000"
DEBUG: The message's timestamp is 1636243200000
DEBUG: "Test log 5 - 2021-11-7 - 1636243200000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 6 - 2021-11-7 - 1636257600000"
DEBUG: The message's timestamp is 1636257600000
DEBUG: "Test log 6 - 2021-11-7 - 1636257600000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 7 - 2021-11-7 - 1636272000000"
DEBUG: The message's timestamp is 1636272000000
DEBUG: "Test log 7 - 2021-11-7 - 1636272000000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 8 - 2021-11-7 - 1636286400000"
DEBUG: The message's timestamp is 1636286400000
DEBUG: "Test log 8 - 2021-11-7 - 1636286400000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 9 - 2021-11-7 - 1636300800000"
DEBUG: The message's timestamp is 1636300800000
DEBUG: "Test log 9 - 2021-11-7 - 1636300800000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 10 - 2021-11-7 - 1636315200000"
DEBUG: The message's timestamp is 1636315200000
DEBUG: "Test log 10 - 2021-11-7 - 1636315200000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 11 - 2021-11-8 - 1636329600000"
DEBUG: The message's timestamp is 1636329600000
DEBUG: "Test log 11 - 2021-11-8 - 1636329600000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 12 - 2021-11-8 - 1636344000000"
DEBUG: The message's timestamp is 1636344000000
DEBUG: "Test log 12 - 2021-11-8 - 1636344000000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 13 - 2021-11-8 - 1636358400000"
DEBUG: The message's timestamp is 1636358400000
DEBUG: "Test log 13 - 2021-11-8 - 1636358400000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 14 - 2021-11-8 - 1636372800000"
DEBUG: The message's timestamp is 1636372800000
DEBUG: "Test log 14 - 2021-11-8 - 1636372800000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 15 - 2021-11-8 - 1636387200000"
DEBUG: The message's timestamp is 1636387200000
DEBUG: "Test log 15 - 2021-11-8 - 1636387200000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 16 - 2021-11-8 - 1636401600000"
DEBUG: The message's timestamp is 1636401600000
DEBUG: "Test log 16 - 2021-11-8 - 1636401600000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 17 - 2021-11-9 - 1636416000000"
DEBUG: The message's timestamp is 1636416000000
DEBUG: "Test log 17 - 2021-11-9 - 1636416000000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 18 - 2021-11-9 - 1636430400000"
DEBUG: The message's timestamp is 1636430400000
DEBUG: "Test log 18 - 2021-11-9 - 1636430400000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 19 - 2021-11-9 - 1636444800000"
DEBUG: The message's timestamp is 1636444800000
DEBUG: "Test log 19 - 2021-11-9 - 1636444800000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 20 - 2021-11-9 - 1636459200000"
DEBUG: The message's timestamp is 1636459200000
DEBUG: "Test log 20 - 2021-11-9 - 1636459200000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 21 - 2021-11-9 - 1636473600000"
DEBUG: The message's timestamp is 1636473600000
DEBUG: "Test log 21 - 2021-11-9 - 1636473600000"
DEBUG: Getting CloudWatch logs from log stream "test_stream" in log group "/test/9993" using token "f/36494580777722123564650637958010295200521831575693623296", start_time "1636214400001" and end_time "None"
DEBUG: Saving data for log group "/test/9993" and log stream "test_stream".
DEBUG: The saved values are "{'token': 'f/36494580777722123564650637958010295200521831575693623296', 'start_time': 1635724800000, 'end_time': 1636473600000}"
DEBUG: Some data already exists on DB for that key. Updating their values...
DEBUG: Purging the BD
DEBUG: Getting log streams for "/test/9993" log group
DEBUG: Found "test_stream" log stream in /test/9993
DEBUG: committing changes and closing the DB
```
</p>

</details>

<details><summary>Last key later in time than only logs</summary>
<p>
It uses the last key timestamp and collects all logs after that one, as expected.

```
root@b9875d019c7e:/var/ossec/wodles/aws# ./aws-s3 -sr cloudwatchlogs -r us-east-2 -g /test/9993 -d3  -s 2021-nov-01
DEBUG: +++ Debug mode on - Level: 3
DEBUG: +++ Getting alerts from "us-east-2" region.
DEBUG: only logs: 1635724800000
DEBUG: Getting log streams for "/test/9993" log group
DEBUG: Found "test_stream" log stream in /test/9993
DEBUG: Getting data from DB for log stream "test_stream" in log group "/test/9993"
DEBUG: Token: "f/36488800424566664427132352666862505676847853858820587520", start_time: "1635724800000", end_time: "1636214400000"
DEBUG: Getting CloudWatch logs from log stream "test_stream" in log group "/test/9993" using token "f/36488800424566664427132352666862505676847853858820587520", start_time "1636214400001" and end_time "None"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 5 - 2021-11-7 - 1636243200000"
DEBUG: The message's timestamp is 1636243200000
DEBUG: "Test log 5 - 2021-11-7 - 1636243200000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 6 - 2021-11-7 - 1636257600000"
DEBUG: The message's timestamp is 1636257600000
DEBUG: "Test log 6 - 2021-11-7 - 1636257600000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 7 - 2021-11-7 - 1636272000000"
DEBUG: The message's timestamp is 1636272000000
DEBUG: "Test log 7 - 2021-11-7 - 1636272000000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 8 - 2021-11-7 - 1636286400000"
DEBUG: The message's timestamp is 1636286400000
DEBUG: "Test log 8 - 2021-11-7 - 1636286400000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 9 - 2021-11-7 - 1636300800000"
DEBUG: The message's timestamp is 1636300800000
DEBUG: "Test log 9 - 2021-11-7 - 1636300800000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 10 - 2021-11-7 - 1636315200000"
DEBUG: The message's timestamp is 1636315200000
DEBUG: "Test log 10 - 2021-11-7 - 1636315200000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 11 - 2021-11-8 - 1636329600000"
DEBUG: The message's timestamp is 1636329600000
DEBUG: "Test log 11 - 2021-11-8 - 1636329600000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 12 - 2021-11-8 - 1636344000000"
DEBUG: The message's timestamp is 1636344000000
DEBUG: "Test log 12 - 2021-11-8 - 1636344000000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 13 - 2021-11-8 - 1636358400000"
DEBUG: The message's timestamp is 1636358400000
DEBUG: "Test log 13 - 2021-11-8 - 1636358400000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 14 - 2021-11-8 - 1636372800000"
DEBUG: The message's timestamp is 1636372800000
DEBUG: "Test log 14 - 2021-11-8 - 1636372800000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 15 - 2021-11-8 - 1636387200000"
DEBUG: The message's timestamp is 1636387200000
DEBUG: "Test log 15 - 2021-11-8 - 1636387200000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 16 - 2021-11-8 - 1636401600000"
DEBUG: The message's timestamp is 1636401600000
DEBUG: "Test log 16 - 2021-11-8 - 1636401600000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 17 - 2021-11-9 - 1636416000000"
DEBUG: The message's timestamp is 1636416000000
DEBUG: "Test log 17 - 2021-11-9 - 1636416000000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 18 - 2021-11-9 - 1636430400000"
DEBUG: The message's timestamp is 1636430400000
DEBUG: "Test log 18 - 2021-11-9 - 1636430400000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 19 - 2021-11-9 - 1636444800000"
DEBUG: The message's timestamp is 1636444800000
DEBUG: "Test log 19 - 2021-11-9 - 1636444800000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 20 - 2021-11-9 - 1636459200000"
DEBUG: The message's timestamp is 1636459200000
DEBUG: "Test log 20 - 2021-11-9 - 1636459200000"
DEBUG: +++ Sending events to Analysd...
DEBUG: The message is "Test log 21 - 2021-11-9 - 1636473600000"
DEBUG: The message's timestamp is 1636473600000
DEBUG: "Test log 21 - 2021-11-9 - 1636473600000"
DEBUG: Getting CloudWatch logs from log stream "test_stream" in log group "/test/9993" using token "f/36494580777722123564650638746338689123763756697186598912", start_time "1636214400001" and end_time "None"
DEBUG: Saving data for log group "/test/9993" and log stream "test_stream".
DEBUG: The saved values are "{'token': 'f/36494580777722123564650638746338689123763756697186598912', 'start_time': 1635724800000, 'end_time': 1636473600000}"
DEBUG: Some data already exists on DB for that key. Updating their values...
DEBUG: Purging the BD
DEBUG: Getting log streams for "/test/9993" log group
DEBUG: Found "test_stream" log stream in /test/9993
DEBUG: committing changes and closing the DB
```
</p>

</details>  


### Google Cloud
### Buckets
As a note, some of the collected files are empty, and that's why the number of messages processed could look like it is wrong. The module will fetch the logs and it will try to process them, but since there's no content, it won't add anything to the total number of messages.

<details><summary>Last key = None, only logs = None</summary>
<p>
It only process todays logs, as expected.

```
root@eb653066c51e:/# /var/ossec/wodles/gcloud/gcloud -c  /var/ossec/wodles/gcloud/credentials.json -l 1 -T access_logs -b framework-test-bucket
gcloud_wodle - INFO - The creation time of test_0.txt is older than 2021-11-10 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - The creation time of test_1.txt is older than 2021-11-10 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - The creation time of test_22.txt is older than 2021-11-10 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - The creation time of test_3.txt is older than 2021-11-10 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - Processing test_4.txt
gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 4", "source": "gcp_bucket"}}'"
gcloud_wodle - INFO - Updating previously processed files.
gcloud_wodle - INFO - Received 1 message
```
</p>

</details>


<details><summary>Last key = None, only logs set</summary>
<p>
It process all logs between the specified date and today.

```
root@eb653066c51e:/# /var/ossec/wodles/gcloud/gcloud -c  /var/ossec/wodles/gcloud/credentials.json -l 1 -T access_logs -b framework-test-bucket -o 2021-nov-01
gcloud_wodle - INFO - Processing test_0.txt
gcloud_wodle - INFO - Processing test_1.txt
gcloud_wodle - INFO - Processing test_22.txt
gcloud_wodle - INFO - Processing test_3.txt
gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 3", "source": "gcp_bucket"}}'"
gcloud_wodle - INFO - Processing test_4.txt
gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 4", "source": "gcp_bucket"}}'"
gcloud_wodle - INFO - Updating previously processed files.
gcloud_wodle - INFO - Received 2 messages
```
</p>

</details>

<details><summary>Last key earlier in the past than only logs</summary>
<p>
It uses the date passed as only logs as marker instead of the last key, as expected.

```
root@eb653066c51e:/# /var/ossec/wodles/gcloud/gcloud -c  /var/ossec/wodles/gcloud/credentials.json -l 1 -T access_logs -b framework-test-bucket -o 2021-nov-10
gcloud_wodle - INFO - The creation time of test_0.txt is older than 2021-11-10 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - The creation time of test_1.txt is older than 2021-11-10 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - The creation time of test_22.txt is older than 2021-11-10 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - The creation time of test_3.txt is older than 2021-11-10 00:00:00+00:00. Skipping it...
gcloud_wodle - INFO - Processing test_4.txt
gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 4", "source": "gcp_bucket"}}'"
gcloud_wodle - INFO - Updating previously processed files.
gcloud_wodle - INFO - Received 1 message
```
</p>

</details>

<details><summary>Last key set, only logs = None</summary>
<p>
It collects all logs starting from the last key's date, as expected.

```
root@eb653066c51e:/# /var/ossec/wodles/gcloud/gcloud -c  /var/ossec/wodles/gcloud/credentials.json -l 1 -T access_logs -b framework-test-bucket 
gcloud_wodle - INFO - Processing test_3.txt
gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 3", "source": "gcp_bucket"}}'"
gcloud_wodle - INFO - Processing test_4.txt
gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 4", "source": "gcp_bucket"}}'"
gcloud_wodle - INFO - Updating previously processed files.
gcloud_wodle - INFO - Received 2 messages
```
</p>

</details>

<details><summary>Last key later in time than only logs</summary>
<p>
It uses the last key's value as marker and collects all logs after that one, as expected.

```
root@eb653066c51e:/# /var/ossec/wodles/gcloud/gcloud -c  /var/ossec/wodles/gcloud/credentials.json -l 1 -T access_logs -b framework-test-bucket  -o 2020-jan-01
gcloud_wodle - INFO - Processing test_3.txt
gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 3", "source": "gcp_bucket"}}'"
gcloud_wodle - INFO - Processing test_4.txt
gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 4", "source": "gcp_bucket"}}'"
gcloud_wodle - INFO - Updating previously processed files.
gcloud_wodle - INFO - Received 2 messages
```
</p>

</details>
