### PR TITLE
Fixed 22 typos in rule descriptions

### DIFF
--- a/ruleset/rules/0017-wazuh-api_rules.xml
+++ b/ruleset/rules/0017-wazuh-api_rules.xml
@@ -33,7 +33,7 @@
 <rule id="404" level="12">
  <if_sid>400</if_sid>
  <field name="type">CRITICAL</field>
- <description>API: critical error event, requires inmediate atention</description>
+ <description>API: critical error event, requires immediate attention</description>
  <group>pci_dss_10.6.1,gpg13_4.1,gpg13_4.3,gpg13_4.12</group>
 </rule>
 
@@ -61,7 +61,7 @@
 <rule id="424" level="12">
  <if_sid>420</if_sid>
  <field name="type">CRITICAL</field>
- <description>API critical error event, requires inmediate atention</description>
+ <description>API critical error event, requires immediate attention</description>
  <group>pci_dss_1.3.2,pci_dss_6.5.10,pci_dss_7.1,pci_dss_8.1,tsc_cc6.1,hipaa_164.312.a.1,gpg13_3.3,gpg13_7.1,nist_800_53_AC.7,nist_800_53_SC.5,gpg13_4.12,gpg13_4.3,pci_dss_10.6.1,gpg13_4.1</group>
 </rule>
 

--- a/ruleset/rules/0035-spamd_rules.xml
+++ b/ruleset/rules/0035-spamd_rules.xml
@@ -17,7 +17,7 @@
   <rule id="3501" level="0">
     <if_sid>3500</if_sid>
     <match>: result:</match>
-    <description>SPAMD result message (not very usefull here).</description>
+    <description>SPAMD result message (not very useful here).</description>
   </rule>
 
   <rule id="3502" level="0">

--- a/ruleset/rules/0070-netscreenfw_rules.xml
+++ b/ruleset/rules/0070-netscreenfw_rules.xml
@@ -58,7 +58,7 @@
   <rule id="4506" level="8">
     <if_sid>4501</if_sid>
     <id>^00002</id>
-    <description>Netscreen firewall: Successfull admin login</description>
+    <description>Netscreen firewall: Successful admin login</description>
     <group>authentication_success,pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.8,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_AC.6,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
     <mitre>
       <id>T1078</id>
@@ -68,7 +68,7 @@
   <rule id="4507" level="8">
     <if_sid>4502</if_sid>
     <id>^00515</id>
-    <description>Netscreen firewall: Successfull admin login</description>
+    <description>Netscreen firewall: Successful admin login</description>
     <group>authentication_success,pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.8,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_AC.6,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
     <mitre>
       <id>T1078</id>

--- a/ruleset/rules/0095-sshd_rules.xml
+++ b/ruleset/rules/0095-sshd_rules.xml
@@ -35,7 +35,7 @@
   <rule id="5703" level="10" frequency="6" timeframe="360">
     <if_matched_sid>5702</if_matched_sid>
     <same_source_ip />
-    <description>sshd: Possible breakin attempt </description>
+    <description>sshd: Possible break-in attempt </description>
     <description>(high number of reverse lookup errors).</description>
     <group>pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
     <mitre>
@@ -51,7 +51,7 @@
 
   <rule id="5705" level="10" frequency="6" timeframe="360">
     <if_matched_sid>5704</if_matched_sid>
-    <description>sshd: Possible scan or breakin attempt </description>
+    <description>sshd: Possible scan or break-in attempt </description>
     <description>(high number of login timeouts).</description>
     <group>pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
     <mitre>

--- a/ruleset/rules/0175-proftpd_rules.xml
+++ b/ruleset/rules/0175-proftpd_rules.xml
@@ -166,7 +166,7 @@
   <rule id="11220" level="4">
     <if_sid>11200</if_sid>
     <match>listen() failed in</match>
-    <description>proftpd: Unable to bind to adress.</description>
+    <description>proftpd: Unable to bind to address.</description>
   </rule>
 
   <rule id="11221" level="0">

--- a/ruleset/rules/0195-named_rules.xml
+++ b/ruleset/rules/0195-named_rules.xml
@@ -34,7 +34,7 @@
     <if_sid>12100</if_sid>
     <match>denied update from|unapproved update from</match>
     <description>DNS update denied. </description>
-    <description>Generally mis-configuration.</description>
+    <description>Generally a misconfiguration.</description>
     <info type="link">http://seclists.org/incidents/2000/May/217</info>
     <group>client_misconfig,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>

--- a/ruleset/rules/0390-fortiddos_rules.xml
+++ b/ruleset/rules/0390-fortiddos_rules.xml
@@ -308,7 +308,7 @@
       <field name="evesubcode">^28$</field>
       <group>layer4,header_anomaly,</group>
       <options>no_full_log</options>
-      <description>Drops due to predefined Layer 4 header rules: Data offset is less than 5 for a TCP packet; EOP (End of packet) is detected before the 20 bytes of TCP header; EOP before the data offset indicated data offset; Length field in TCP window scale option is a value other than 3; Length field in TCP window scale option is a value other than 3; Missing UDP payload; Missing ICMP payload ; TCP Option Anamoly based on Option Type</description>
+      <description>Drops due to predefined Layer 4 header rules: Data offset is less than 5 for a TCP packet; EOP (End of packet) is detected before the 20 bytes of TCP header; EOP before the data offset indicated data offset; Length field in TCP window scale option is a value other than 3; Length field in TCP window scale option is a value other than 3; Missing UDP payload; Missing ICMP payload ; TCP Option Anomaly based on Option Type</description>
   </rule>
 
   <rule id="44439" level="5">
@@ -428,7 +428,7 @@
       <field name="evesubcode">^8$</field>
       <group>layer7,rate_flood,</group>
       <options>no_full_log</options>
-      <description>Effective rate limit for a particular Referer header threshold has been reached.</description>
+      <description>Effective rate limit for a particular Referrer header threshold has been reached.</description>
   </rule>
 
   <rule id="44454" level="5">

--- a/ruleset/rules/0405-rsa-auth-manager_rules.xml
+++ b/ruleset/rules/0405-rsa-auth-manager_rules.xml
@@ -17,7 +17,7 @@
     <rule id="81901" level="2">
         <if_sid>81900</if_sid>
         <id>AUTHN_LOGIN_EVENT</id>
-        <description>RSA Authentication Manager: Loging event</description>
+        <description>RSA Authentication Manager: Login event</description>
     </rule>
 
     <rule id="81902" level="4">

--- a/ruleset/rules/0585-win-application_rules.xml
+++ b/ruleset/rules/0585-win-application_rules.xml
@@ -1256,7 +1256,7 @@
     <if_sid>60749</if_sid>
     <field name="win.system.eventID">^4625$</field>
     <field name="win.eventdata.param1">\.+</field>
-    <description>EventSystem supressed duplicate log entries for $(win.eventdata.param1) seconds</description>
+    <description>EventSystem suppressed duplicate log entries for $(win.eventdata.param1) seconds</description>
     <options>no_full_log</options>
   </rule>
 
@@ -1899,7 +1899,7 @@
   <rule id="60839" level="5">
     <if_sid>60838</if_sid>
     <field name="win.system.eventID">^4098$</field>
-    <description>Unable to translate the MS DTC error code to the appropiate MS DTC error message</description>
+    <description>Unable to translate the MS DTC error code to the appropriate MS DTC error message</description>
     <options>no_full_log</options>
   </rule>
 
@@ -2196,7 +2196,7 @@
   <rule id="60881" level="5">
     <if_sid>60838</if_sid>
     <field name="win.system.eventID">^4166$</field>
-    <description>Exceeded maximum number of active transactions that the MS DTC log file can accomodate</description>
+    <description>Exceeded maximum number of active transactions that the MS DTC log file can accommodate</description>
     <options>no_full_log</options>
   </rule>
 

--- a/ruleset/rules/0590-win-system_rules.xml
+++ b/ruleset/rules/0590-win-system_rules.xml
@@ -316,7 +316,7 @@
   <rule id="61137" level="10">
     <if_sid>61113</if_sid>
     <field name="win.system.eventID">^10051$</field>
-    <description>Some errors occur aproximately every three seconds</description>
+    <description>Some errors occur approximately every three seconds</description>
     <options>no_full_log</options>
   </rule>
 

--- a/ruleset/rules/0601-win-vipre_rules.xml
+++ b/ruleset/rules/0601-win-vipre_rules.xml
@@ -64,7 +64,7 @@
 <rule id="90506" level="5">
     <if_sid>60600</if_sid>
     <field name="win.system.eventID">^4103$</field>
-    <description>Transfer occured</description>
+    <description>Transfer occurred</description>
     <options>no_full_log</options>
 </rule>
 

--- a/ruleset/rules/0715-icinga_rules.xml
+++ b/ruleset/rules/0715-icinga_rules.xml
@@ -49,7 +49,7 @@
 <rule id="70107" level="1">
    <if_sid>70100</if_sid>
    <field name="msg_type">debug</field>
-   <description>Debugging in proccess</description>
+   <description>Debugging in process</description>
    <group>icingainfo</group>
 </rule>
 </group>

--- a/ruleset/rules/0770-gitlab_rules.xml
+++ b/ruleset/rules/0770-gitlab_rules.xml
@@ -30,7 +30,7 @@ api_json
         <regex>"method":"\w+","path":"/gitlab/gitlab-ce/\w+/\.+","format":"\w+","controller":"\.+","action":"\w+"</regex>
         <match>"status":200</match>
         <options>no_full_log</options>
-        <description>(Gitlab)$(method) request Completed Succesfully</description>
+        <description>(Gitlab)$(method) request Completed Successfully</description>
     </rule>
     <rule id="65602" level="5">
         <decoded_as>json</decoded_as>
@@ -53,7 +53,7 @@ api_json
     <regex>"method":"\w+","path":"/api/\w+/\.+","params":\.+</regex>
     <match>"status":200</match>
     <options>no_full_log</options>
-    <description>(Gitlab)$(method) request Completed Succesfully</description>
+    <description>(Gitlab)$(method) request Completed Successfully</description>
 </rule>
 <rule id="65624" level="5">
     <decoded_as>json</decoded_as>

--- a/ruleset/rules/0800-sysmon_id_1.xml
+++ b/ruleset/rules/0800-sysmon_id_1.xml
@@ -57,7 +57,7 @@
         <if_group>sysmon_event1</if_group>
         <field name="win.eventdata.commandLine" type="pcre2">(?i)\\(c|w)script\.exe.+[c-z]:\\(Windows\\Temp)|Users\\.+\.(bat|cmd|lnk|pif|vbs|vbe|js|wsh|ps1)</field>
         <field name="win.eventdata.parentCommandLine" type="pcre2">(?i)cmd\.exe.+/(c|k)</field>
-        <description>Command shell started script with /c modifier. Script itnerpreter is $(win.eventdata.originalFileName)</description>
+        <description>Command shell started script with /c modifier. Script interpreter is $(win.eventdata.originalFileName)</description>
         <mitre>
             <id>T1059</id>
         </mitre>

--- a/ruleset/rules/0945-sysmon_id_10.xml
+++ b/ruleset/rules/0945-sysmon_id_10.xml
@@ -29,7 +29,7 @@
   <rule id="92920" level="14">
     <if_group>sysmon_event_10</if_group>
     <field name="win.eventdata.targetImage" type="pcre2">(?i)mstsc\.exe</field>
-    <description>Windows Remote Dektop utility process was accessed by $(win.eventdata.sourceImage), possible process injection</description>
+    <description>Windows Remote Desktop utility process was accessed by $(win.eventdata.sourceImage), possible process injection</description>
     <mitre>
       <id>T1055</id>
     </mitre>


### PR DESCRIPTION
## Description
I've looked at the descriptions of all rules currently in the `master` branch and run spellcheck.
Visually verifying the results I've found 22 typos and corrected them in this PR.

This PR does not change any matching criteria and is limited only to descriptions so the result does not affect any of the analysis logic.