### PR TITLE
Fix syscollector deltas handling for new CVEs alerts inventory

### DIFF
--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -196,6 +196,8 @@ static struct deltas_fields_match_list const OS_FIELDS[] = {
     { .current = { "version", "os.version" }, .next = &OS_FIELDS[14]},
     { .current = { "os_release", "os.os_release" }, .next = &OS_FIELDS[15]},
     { .current = { "os_display_version", "os.display_version" }, .next = &OS_FIELDS[16]},
+    { .current = { "triaged", "" }, .next = &OS_FIELDS[17]},
+    { .current = { "reference", "" }, .next = &OS_FIELDS[18]},
     { .current = { "checksum", "" }, .next = NULL},
 };
 

--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -195,10 +195,10 @@ static struct deltas_fields_match_list const OS_FIELDS[] = {
     { .current = { "release", "os.release" }, .next = &OS_FIELDS[13]},
     { .current = { "version", "os.version" }, .next = &OS_FIELDS[14]},
     { .current = { "os_release", "os.os_release" }, .next = &OS_FIELDS[15]},
-    { .current = { "os_display_version", "os.display_version" }, .next = &OS_FIELDS[16]},
-    { .current = { "triaged", "" }, .next = &OS_FIELDS[17]},
-    { .current = { "reference", "" }, .next = &OS_FIELDS[18]},
-    { .current = { "checksum", "" }, .next = NULL},
+    { .current = { "checksum", "" }, .next = &OS_FIELDS[16]},
+    { .current = { "os_display_version", "os.display_version" }, .next = &OS_FIELDS[17]},
+    { .current = { "triaged", "" }, .next = &OS_FIELDS[18]},
+    { .current = { "reference", "" }, .next = NULL},
 };
 
 void SyscollectorInit(){

--- a/src/unit_tests/analysisd/test_decoder_syscollector.c
+++ b/src/unit_tests/analysisd/test_decoder_syscollector.c
@@ -442,7 +442,9 @@ int test_setup_os_valid_msg(void **state)
             \"version\" : \"105\",\
             \"os_release\" : \"106\",\
             \"os_display_version\" : \"107\",\
-            \"checksum\" : \"108\"\
+            \"triaged\" : \"108\",\
+            \"reference\" : \"109\",\
+            \"checksum\" : \"110\"\
     }}"), lf->log == NULL)
         return -1;
     os_strdup("(>syscollector", lf->location);
@@ -730,7 +732,9 @@ int test_setup_os_valid_msg_inserted(void **state)
             \"version\" : \"105\",\
             \"os_release\" : \"106\",\
             \"os_display_version\" : \"107\",\
-            \"checksum\" : \"108\"\
+            \"triaged\" : \"108\",\
+            \"reference\" : \"109\",\
+            \"checksum\" : \"110\"\
     }}"), lf->log == NULL)
         return -1;
     os_strdup("(>syscollector", lf->location);
@@ -767,7 +771,9 @@ int test_setup_os_valid_msg_with_number_pk(void **state)
             \"version\" : \"105\",\
             \"os_release\" : \"106\",\
             \"os_display_version\" : \"107\",\
-            \"checksum\" : \"108\"\
+            \"triaged\" : \"108\",\
+            \"reference\" : \"109\",\
+            \"checksum\" : \"110\"\
     }}"), lf->log == NULL)
         return -1;
     os_strdup("(>syscollector", lf->location);
@@ -1283,8 +1289,8 @@ void test_syscollector_dbsync_os_valid_msg(void **state)
 {
     Eventinfo *lf = *state;
 
-    const char *query = "agent 001 dbsync osinfo MODIFIED 2021/10/29 14:26:24|93|94|95|96|97|98|99|100|101|102|103|104|105|106|107|108|";
-    const char *result = "ok 2021/10/29 14:26:24|93|94|95|96|97|98|99|100|101|102|103|104|105|106|107|108|";
+    const char *query = "agent 001 dbsync osinfo MODIFIED 2021/10/29 14:26:24|93|94|95|96|97|98|99|100|101|102|103|104|105|106|107|108|109|110|";
+    const char *result = "ok 2021/10/29 14:26:24|93|94|95|96|97|98|99|100|101|102|103|104|105|106|107|108|109|110|";
     int sock = 1;
 
     expect_any(__wrap_wdbc_query_ex, *sock);
@@ -1444,8 +1450,8 @@ void test_syscollector_dbsync_os_valid_msg_inserted(void **state)
 {
     Eventinfo *lf = *state;
 
-    const char *query = "agent 001 dbsync osinfo INSERTED 2021/10/29 14:26:24|93|94|95|96|97|98|99|100|101|102|103|104|105|106|107|108|";
-    const char *result = "ok 2021/10/29 14:26:24|93|94|95|96|97|98|99|100|101|102|103|104|105|106|107|108|";
+    const char *query = "agent 001 dbsync osinfo INSERTED 2021/10/29 14:26:24|93|94|95|96|97|98|99|100|101|102|103|104|105|106|107|108|109|110|";
+    const char *result = "ok 2021/10/29 14:26:24|93|94|95|96|97|98|99|100|101|102|103|104|105|106|107|108|109|110|";
     int sock = 1;
 
     expect_any(__wrap_wdbc_query_ex, *sock);
@@ -1463,8 +1469,8 @@ void test_syscollector_dbsync_os_valid_msg_with_number_pk(void **state)
 {
     Eventinfo *lf = *state;
 
-    const char *query = "agent 001 dbsync osinfo MODIFIED 2021/10/29 14:26:24|93|94|95|96|97|98|99|100|101|102|103|104|105|106|107|108|";
-    const char *result = "ok 2021/10/29 14:26:24|93|94|95|96|97|98|99|100|101|102|103|104|105|106|107|108|";
+    const char *query = "agent 001 dbsync osinfo MODIFIED 2021/10/29 14:26:24|93|94|95|96|97|98|99|100|101|102|103|104|105|106|107|108|109|110|";
+    const char *result = "ok 2021/10/29 14:26:24|93|94|95|96|97|98|99|100|101|102|103|104|105|106|107|108|109|110|";
     int sock = 1;
 
     expect_any(__wrap_wdbc_query_ex, *sock);
@@ -1518,7 +1524,7 @@ void test_syscollector_dbsync_os_valid_msg_no_result_payload(void **state)
 {
     Eventinfo *lf = *state;
 
-    const char *query = "agent 001 dbsync osinfo MODIFIED 2021/10/29 14:26:24|93|94|95|96|97|98|99|100|101|102|103|104|105|106|107|108|";
+    const char *query = "agent 001 dbsync osinfo MODIFIED 2021/10/29 14:26:24|93|94|95|96|97|98|99|100|101|102|103|104|105|106|107|108|109|110|";
     const char *result = "ok";
     int sock = 1;
 

--- a/src/unit_tests/analysisd/test_decoder_syscollector.c
+++ b/src/unit_tests/analysisd/test_decoder_syscollector.c
@@ -441,10 +441,10 @@ int test_setup_os_valid_msg(void **state)
             \"release\" : \"104\",\
             \"version\" : \"105\",\
             \"os_release\" : \"106\",\
-            \"os_display_version\" : \"107\",\
-            \"triaged\" : \"108\",\
-            \"reference\" : \"109\",\
-            \"checksum\" : \"110\"\
+            \"checksum\" : \"107\",\
+            \"os_display_version\" : \"108\",\
+            \"triaged\" : \"109\",\
+            \"reference\" : \"110\"\
     }}"), lf->log == NULL)
         return -1;
     os_strdup("(>syscollector", lf->location);
@@ -731,10 +731,10 @@ int test_setup_os_valid_msg_inserted(void **state)
             \"release\" : \"104\",\
             \"version\" : \"105\",\
             \"os_release\" : \"106\",\
-            \"os_display_version\" : \"107\",\
-            \"triaged\" : \"108\",\
-            \"reference\" : \"109\",\
-            \"checksum\" : \"110\"\
+            \"checksum\" : \"107\",\
+            \"os_display_version\" : \"108\",\
+            \"triaged\" : \"109\",\
+            \"reference\" : \"110\"\
     }}"), lf->log == NULL)
         return -1;
     os_strdup("(>syscollector", lf->location);
@@ -770,10 +770,10 @@ int test_setup_os_valid_msg_with_number_pk(void **state)
             \"release\" : \"104\",\
             \"version\" : \"105\",\
             \"os_release\" : \"106\",\
-            \"os_display_version\" : \"107\",\
-            \"triaged\" : \"108\",\
-            \"reference\" : \"109\",\
-            \"checksum\" : \"110\"\
+            \"checksum\" : \"107\",\
+            \"os_display_version\" : \"108\",\
+            \"triaged\" : \"109\",\
+            \"reference\" : \"110\"\
     }}"), lf->log == NULL)
         return -1;
     os_strdup("(>syscollector", lf->location);

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -123,9 +123,10 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_stmt_cache -Wl,--wrap,sqlite3_bind_t
 list(APPEND wdb_tests_names "test_wdb_syscollector")
 list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_begin2 -Wl,--wrap,_mdebug1 -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,sqlite3_bind_text \
                              -Wl,--wrap,sqlite3_bind_int -Wl,--wrap,sqlite3_bind_int64 -Wl,--wrap,sqlite3_step -Wl,--wrap,sqlite3_errmsg \
-                             -Wl,--wrap,_merror -Wl,--wrap,sqlite3_column_text -Wl,--wrap,sqlite3_column_int -Wl,--wrap,sqlite3_bind_double \
+                             -Wl,--wrap,sqlite3_column_text -Wl,--wrap,sqlite3_column_int -Wl,--wrap,sqlite3_bind_double \
                              -Wl,--wrap,sqlite3_bind_null -Wl,--wrap,cJSON_GetStringValue -Wl,--wrap,cJSON_GetObjectItem -Wl,--wrap,cJSON_Parse \
-                             -Wl,--wrap,cJSON_Delete")
+                             -Wl,--wrap,cJSON_Delete -Wl,--wrap,cJSON_IsNumber -Wl,--wrap,cJSON_IsString -Wl,--wrap,wdb_agents_get_sys_osinfo \
+                             ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_task")
 list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_begin2 -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,sqlite3_bind_int \

--- a/src/unit_tests/wazuh_db/test_wdb_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_parser.c
@@ -2968,7 +2968,7 @@ void test_dbsync_delete_type_exists_data_bind_error(void **state) {
 
     sprintf(error_message, DB_AGENT_SQL_ERROR, "000", error_value);
 
-    os_strdup("osinfo DELETED NULL|NULL|NULL|data5|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|", query);
+    os_strdup("osinfo DELETED NULL|NULL|NULL|data5|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|", query);
 
     will_return(__wrap_wdb_get_cache_stmt, 1);
     will_return_always(__wrap_sqlite3_errmsg, error_value);

--- a/src/unit_tests/wazuh_db/test_wdb_syscollector.c
+++ b/src/unit_tests/wazuh_db/test_wdb_syscollector.c
@@ -13,6 +13,7 @@
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../wrappers/externals/sqlite/sqlite3_wrappers.h"
 #include "../wrappers/externals/cJSON/cJSON_wrappers.h"
+#include "../wrappers/wazuh/wazuh_db/wdb_agents_wrappers.h"
 
 static int test_setup(void **state) {
     wdb_t *data = NULL;
@@ -811,92 +812,6 @@ static void wdb_syscollector_osinfo_save2_fail(void) {
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "at wdb_osinfo_save(): cannot begin transaction");
 }
-
-static void wdb_syscollector_osinfo_save2_success(void) {
-    int i = 0;
-
-    for (i = 0; i < 17; i++) {
-        will_return(__wrap_cJSON_GetObjectItem, NULL);
-    }
-
-    will_return(__wrap_cJSON_GetStringValue, "scan_time");
-    will_return(__wrap_cJSON_GetStringValue, "hostname");
-    will_return(__wrap_cJSON_GetStringValue, "architecture");
-    will_return(__wrap_cJSON_GetStringValue, "os_name");
-    will_return(__wrap_cJSON_GetStringValue, "os_version");
-    will_return(__wrap_cJSON_GetStringValue, "os_codename");
-    will_return(__wrap_cJSON_GetStringValue, "os_major");
-    will_return(__wrap_cJSON_GetStringValue, "os_minor");
-    will_return(__wrap_cJSON_GetStringValue, "os_patch");
-    will_return(__wrap_cJSON_GetStringValue, "os_build");
-    will_return(__wrap_cJSON_GetStringValue, "os_platform");
-    will_return(__wrap_cJSON_GetStringValue, "sysname");
-    will_return(__wrap_cJSON_GetStringValue, "release");
-    will_return(__wrap_cJSON_GetStringValue, "version");
-    will_return(__wrap_cJSON_GetStringValue, "os_release");
-    will_return(__wrap_cJSON_GetStringValue, "os_display_version");
-    will_return(__wrap_cJSON_GetStringValue, "checksum");
-
-    will_return(__wrap_wdb_stmt_cache, 0);
-    expect_sqlite3_step_call(SQLITE_DONE);
-    will_return(__wrap_wdb_stmt_cache, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 1);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "0");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 2);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "scan_time");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 3);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "hostname");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 4);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "architecture");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 5);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "os_name");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 6);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "os_version");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 7);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "os_codename");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 8);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "os_major");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 9);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "os_minor");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 10);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "os_patch");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 11);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "os_build");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 12);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "os_platform");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 13);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "sysname");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 14);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "release");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 15);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "version");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 16);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "os_release");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 17);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "os_display_version");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 18);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "checksum");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_sqlite3_step_call(SQLITE_DONE);
-}
-
 
 /* Tests wdb_netinfo_save */
 void test_wdb_netinfo_save_transaction_fail(void **state) {
@@ -1910,63 +1825,6 @@ void test_wdb_hotfix_delete_success(void **state) {
     assert_int_equal(output, 0);
 }
 
-/* Test wdb_set_hotfix_metadata */
-void test_wdb_set_hotfix_metadata_transaction_fail(void **state) {
-    int output = 0;
-    wdb_t *data = (wdb_t *)*state;
-
-    data->transaction = 0;
-    will_return(__wrap_wdb_begin2, -1);
-    expect_string(__wrap__mdebug1, formatted_msg, "at wdb_set_hotfix_metadata(): cannot begin transaction");
-
-    output = wdb_set_hotfix_metadata(data, "scan_id");
-    assert_int_equal(output, -1);
-}
-
-void test_wdb_set_hotfix_metadata_cache_fail(void **state) {
-    int output = 0;
-    wdb_t *data = (wdb_t *)*state;
-
-    data->transaction = 1;
-    will_return(__wrap_wdb_stmt_cache, -1);
-    expect_string(__wrap__mdebug1, formatted_msg, "at wdb_set_hotfix_metadata(): cannot cache statement");
-
-    output = wdb_set_hotfix_metadata(data, "scan_id");
-    assert_int_equal(output, -1);
-}
-
-void test_wdb_set_hotfix_metadata_sql_fail(void **state) {
-    int output = 0;
-    wdb_t *data = (wdb_t *)*state;
-
-    will_return(__wrap_wdb_begin2, 0);
-    will_return(__wrap_wdb_stmt_cache, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 1);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "scan_id");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_sqlite3_step_call(1);
-    will_return(__wrap_sqlite3_errmsg, "ERROR");
-    expect_string(__wrap__merror, formatted_msg, "Could not set the hotfix metadata: ERROR");
-
-    output = wdb_set_hotfix_metadata(data, "scan_id");
-    assert_int_equal(output, -1);
-}
-
-void test_wdb_set_hotfix_metadata_success(void **state) {
-    int output = 0;
-    wdb_t *data = (wdb_t *)*state;
-
-    will_return(__wrap_wdb_begin2, 0);
-    will_return(__wrap_wdb_stmt_cache, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 1);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "scan_id");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_sqlite3_step_call(SQLITE_DONE);
-
-    output = wdb_set_hotfix_metadata(data, "scan_id");
-    assert_int_equal(output, 0);
-}
-
 /* Test wdb_osinfo_save */
 void test_wdb_osinfo_save_transaction_fail(void **state) {
     int output = 0;
@@ -1980,131 +1838,377 @@ void test_wdb_osinfo_save_transaction_fail(void **state) {
     assert_int_equal(output, -1);
 }
 
-void test_wdb_osinfo_save_cache_fail(void **state) {
+void test_wdb_osinfo_save_retrieve_osinfo_fail(void **state) {
     int output = 0;
     wdb_t *data = (wdb_t *)*state;
 
     will_return(__wrap_wdb_begin2, 0);
-    will_return(__wrap_wdb_stmt_cache, -1);
-    expect_string(__wrap__mdebug1, formatted_msg, "at wdb_osinfo_save(): cannot cache statement");
+    will_return(__wrap_wdb_agents_get_sys_osinfo, NULL);
+    will_return(__wrap_sqlite3_errmsg, "ERROR");
+    expect_string(__wrap__merror, formatted_msg, "Retrieving old information from 'sys_osinfo' table: ERROR");
 
     output = wdb_osinfo_save(data, "scan_id", "scan_time", "hostname", "architecture", "os_name", "os_version", "os_codename", "os_major", "os_minor", "os_patch", "os_build", "os_platform", "sysname", "release", "version", "os_release", "os_display_version", "checksum", false);
     assert_int_equal(output, -1);
 }
 
-void test_wdb_osinfo_save_sql_fail(void **state) {
+void test_wdb_osinfo_save_retrieve_osinfo_type_triaged_fail(void ** state) {
     int output = 0;
-    wdb_t *data = (wdb_t *)*state;
+    wdb_t * data = (wdb_t *) *state;
+    cJSON * osinfo_retrieved_info =
+        __real_cJSON_Parse("[{\"triaged\":\"string_value\", \"reference\":\"string_value\"}]");
+    will_return(__wrap_wdb_begin2, 0);
+    will_return(__wrap_wdb_agents_get_sys_osinfo, osinfo_retrieved_info);
+    will_return(__wrap_cJSON_GetObjectItem, NULL);
+    will_return(__wrap_cJSON_GetObjectItem, 1);
+    will_return(__wrap_cJSON_IsNumber, false);
+    expect_string(__wrap__mdebug2, formatted_msg,
+                  "No previous data related to the triaged status and reference of the OS");
+    expect_function_call(__wrap_cJSON_Delete);
+
+    will_return(__wrap_wdb_stmt_cache, 0);
+    expect_sqlite3_step_call(SQLITE_DONE);
+
+    will_return(__wrap_wdb_stmt_cache, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "scan_id");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "scan_time");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 3);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "hostname");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 4);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "architecture");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 5);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_name");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 6);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_version");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 7);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_codename");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 8);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_major");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 9);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_minor");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 10);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_patch");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 11);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_build");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 12);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_platform");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 13);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "sysname");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 14);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "release");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 15);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "version");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 16);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_release");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 17);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_display_version");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 18);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "checksum");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 19);
+    expect_any(__wrap_sqlite3_bind_text, buffer);
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_int, index, 20);
+    expect_any(__wrap_sqlite3_bind_int, value);
+    will_return(__wrap_sqlite3_bind_int, 0);
+
+    expect_sqlite3_step_call(SQLITE_DONE);
+
+    output = wdb_osinfo_save(data, "scan_id", "scan_time", "hostname", "architecture", "os_name", "os_version",
+                             "os_codename", "os_major", "os_minor", "os_patch", "os_build", "os_platform", "sysname",
+                             "release", "version", "os_release", "os_display_version", "checksum", false);
+    assert_int_equal(output, 0);
+    __real_cJSON_Delete(osinfo_retrieved_info);
+}
+
+void test_wdb_osinfo_save_retrieve_osinfo_type_reference_fail(void ** state) {
+    int output = 0;
+    wdb_t * data = (wdb_t *) *state;
+    cJSON * osinfo_retrieved_info = __real_cJSON_Parse("[{\"triaged\":1, \"reference\":1234}]");
 
     will_return(__wrap_wdb_begin2, 0);
+    will_return(__wrap_wdb_agents_get_sys_osinfo, osinfo_retrieved_info);
+    will_return(__wrap_cJSON_GetObjectItem, 1);
+    will_return(__wrap_cJSON_GetObjectItem, NULL);
+    will_return(__wrap_cJSON_IsNumber, true);
+    will_return(__wrap_cJSON_IsString, false);
+    expect_string(__wrap__mdebug2, formatted_msg,
+                  "No previous data related to the triaged status and reference of the OS");
+    expect_function_call(__wrap_cJSON_Delete);
+
     will_return(__wrap_wdb_stmt_cache, 0);
-    expect_sqlite3_step_call(1);
+    expect_sqlite3_step_call(SQLITE_DONE);
+
+    will_return(__wrap_wdb_stmt_cache, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "scan_id");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "scan_time");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 3);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "hostname");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 4);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "architecture");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 5);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_name");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 6);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_version");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 7);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_codename");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 8);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_major");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 9);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_minor");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 10);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_patch");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 11);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_build");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 12);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_platform");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 13);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "sysname");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 14);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "release");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 15);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "version");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 16);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_release");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 17);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_display_version");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 18);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "checksum");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 19);
+    expect_any(__wrap_sqlite3_bind_text, buffer);
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_int, index, 20);
+    expect_any(__wrap_sqlite3_bind_int, value);
+    will_return(__wrap_sqlite3_bind_int, 0);
+
+    expect_sqlite3_step_call(SQLITE_DONE);
+
+    output = wdb_osinfo_save(data, "scan_id", "scan_time", "hostname", "architecture", "os_name", "os_version",
+                             "os_codename", "os_major", "os_minor", "os_patch", "os_build", "os_platform", "sysname",
+                             "release", "version", "os_release", "os_display_version", "checksum", false);
+    assert_int_equal(output, 0);
+    __real_cJSON_Delete(osinfo_retrieved_info);
+}
+
+void test_wdb_osinfo_save_retrieve_osinfo_ok(void ** state) {
+    int output = 0;
+    wdb_t * data = (wdb_t *) *state;
+    cJSON * osinfo_retrieved_info = __real_cJSON_Parse("[{\"triaged\":1, \"reference\":\"1234\"}]");
+
+    will_return(__wrap_wdb_begin2, 0);
+    will_return(__wrap_wdb_agents_get_sys_osinfo, osinfo_retrieved_info);
+    will_return(__wrap_cJSON_GetObjectItem, __real_cJSON_GetObjectItem(osinfo_retrieved_info->child, "triaged"));
+    will_return(__wrap_cJSON_GetObjectItem, __real_cJSON_GetObjectItem(osinfo_retrieved_info->child, "reference"));
+    will_return(__wrap_cJSON_IsNumber, true);
+    will_return(__wrap_cJSON_IsString, true);
+
+    expect_function_call(__wrap_cJSON_Delete);
+
+    will_return(__wrap_wdb_stmt_cache, 0);
+    expect_sqlite3_step_call(SQLITE_DONE);
+
+    will_return(__wrap_wdb_stmt_cache, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "scan_id");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "scan_time");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 3);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "hostname");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 4);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "architecture");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 5);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_name");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 6);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_version");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 7);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_codename");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 8);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_major");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 9);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_minor");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 10);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_patch");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 11);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_build");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 12);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_platform");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 13);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "sysname");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 14);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "release");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 15);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "version");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 16);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_release");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 17);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_display_version");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 18);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "checksum");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 19);
+    expect_any(__wrap_sqlite3_bind_text, buffer);
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_int, index, 20);
+    expect_any(__wrap_sqlite3_bind_int, value);
+    will_return(__wrap_sqlite3_bind_int, 0);
+
+    expect_sqlite3_step_call(SQLITE_DONE);
+
+    output = wdb_osinfo_save(data, "scan_id", "scan_time", "hostname", "architecture", "os_name", "os_version",
+                             "os_codename", "os_major", "os_minor", "os_patch", "os_build", "os_platform", "sysname",
+                             "release", "version", "os_release", "os_display_version", "checksum", false);
+    assert_int_equal(output, 0);
+    __real_cJSON_Delete(osinfo_retrieved_info);
+}
+
+void test_wdb_osinfo_save_cache_fail(void ** state) {
+    int output = 0;
+    wdb_t * data = (wdb_t *) *state;
+    cJSON * osinfo_retrieved_info = __real_cJSON_Parse("[{\"triaged\":1, \"reference\":\"1234\"}]");
+
+    will_return(__wrap_wdb_begin2, 0);
+    will_return(__wrap_wdb_agents_get_sys_osinfo, osinfo_retrieved_info);
+    will_return(__wrap_cJSON_GetObjectItem, __real_cJSON_GetObjectItem(osinfo_retrieved_info->child, "triaged"));
+    will_return(__wrap_cJSON_GetObjectItem, __real_cJSON_GetObjectItem(osinfo_retrieved_info->child, "reference"));
+    will_return(__wrap_cJSON_IsNumber, true);
+    will_return(__wrap_cJSON_IsString, true);
+
+    expect_function_call(__wrap_cJSON_Delete);
+    will_return(__wrap_wdb_stmt_cache, -1);
+    expect_string(__wrap__mdebug1, formatted_msg, "at wdb_osinfo_save(): cannot cache statement (12)");
+
+    output = wdb_osinfo_save(data, "scan_id", "scan_time", "hostname", "architecture", "os_name", "os_version",
+                             "os_codename", "os_major", "os_minor", "os_patch", "os_build", "os_platform", "sysname",
+                             "release", "version", "os_release", "os_display_version", "checksum", false);
+    assert_int_equal(output, -1);
+    __real_cJSON_Delete(osinfo_retrieved_info);
+}
+
+void test_wdb_osinfo_save_sql_fail(void ** state) {
+    int output = 0;
+    wdb_t * data = (wdb_t *) *state;
+    cJSON * osinfo_retrieved_info = __real_cJSON_Parse("[{\"triaged\":1, \"reference\":\"1234\"}]");
+
+    will_return(__wrap_wdb_begin2, 0);
+    will_return(__wrap_wdb_agents_get_sys_osinfo, osinfo_retrieved_info);
+    will_return(__wrap_cJSON_GetObjectItem, __real_cJSON_GetObjectItem(osinfo_retrieved_info->child, "triaged"));
+    will_return(__wrap_cJSON_GetObjectItem, __real_cJSON_GetObjectItem(osinfo_retrieved_info->child, "reference"));
+    will_return(__wrap_cJSON_IsNumber, true);
+    will_return(__wrap_cJSON_IsString, true);
+
+    expect_function_call(__wrap_cJSON_Delete);
+    will_return(__wrap_wdb_stmt_cache, 0);
+    expect_sqlite3_step_call(SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR");
     expect_string(__wrap__merror, formatted_msg, "Deleting old information from 'sys_osinfo' table: ERROR");
 
-    output = wdb_osinfo_save(data, "scan_id", "scan_time", "hostname", "architecture", "os_name", "os_version", "os_codename", "os_major", "os_minor", "os_patch", "os_build", "os_platform", "sysname", "release", "version", "os_release", "os_display_version", "checksum", false);
+    output = wdb_osinfo_save(data, "scan_id", "scan_time", "hostname", "architecture", "os_name", "os_version",
+                             "os_codename", "os_major", "os_minor", "os_patch", "os_build", "os_platform", "sysname",
+                             "release", "version", "os_release", "os_display_version", "checksum", false);
     assert_int_equal(output, -1);
+    __real_cJSON_Delete(osinfo_retrieved_info);
 }
 
-void test_wdb_osinfo_save_insert_fail(void **state) {
+void test_wdb_osinfo_save_insert_fail(void ** state) {
     int output = 0;
-    wdb_t *data = (wdb_t *)*state;
+    wdb_t * data = (wdb_t *) *state;
+    cJSON * osinfo_retrieved_info = __real_cJSON_Parse("[{\"triaged\":1, \"reference\":\"1234\"}]");
 
     will_return(__wrap_wdb_begin2, 0);
+    will_return(__wrap_wdb_agents_get_sys_osinfo, osinfo_retrieved_info);
+    will_return(__wrap_cJSON_GetObjectItem, __real_cJSON_GetObjectItem(osinfo_retrieved_info->child, "triaged"));
+    will_return(__wrap_cJSON_GetObjectItem, __real_cJSON_GetObjectItem(osinfo_retrieved_info->child, "reference"));
+    will_return(__wrap_cJSON_IsNumber, true);
+    will_return(__wrap_cJSON_IsString, true);
+
+    expect_function_call(__wrap_cJSON_Delete);
+
     will_return(__wrap_wdb_stmt_cache, 0);
     expect_sqlite3_step_call(SQLITE_DONE);
 
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "at wdb_osinfo_insert(): cannot cache statement");
 
-    output = wdb_osinfo_save(data, "scan_id", "scan_time", "hostname", "architecture", "os_name", "os_version", "os_codename", "os_major", "os_minor", "os_patch", "os_build", "os_platform", "sysname", "release", "version", "os_release", "os_display_version", "checksum", false);
+    output = wdb_osinfo_save(data, "scan_id", "scan_time", "hostname", "architecture", "os_name", "os_version",
+                             "os_codename", "os_major", "os_minor", "os_patch", "os_build", "os_platform", "sysname",
+                             "release", "version", "os_release", "os_display_version", "checksum", false);
     assert_int_equal(output, -1);
-}
-
-void test_wdb_osinfo_save_success(void **state) {
-    int output = 0;
-    wdb_t *data = (wdb_t *)*state;
-
-    will_return(__wrap_wdb_begin2, 0);
-    will_return(__wrap_wdb_stmt_cache, 0);
-    expect_sqlite3_step_call(SQLITE_DONE);
-
-    will_return(__wrap_wdb_stmt_cache, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 1);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "scan_id");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 2);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "scan_time");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 3);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "hostname");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 4);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "architecture");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 5);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "os_name");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 6);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "os_version");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 7);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "os_codename");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 8);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "os_major");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 9);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "os_minor");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 10);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "os_patch");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 11);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "os_build");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 12);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "os_platform");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 13);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "sysname");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 14);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "release");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 15);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "version");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 16);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "os_release");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 17);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "os_display_version");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_value(__wrap_sqlite3_bind_text, pos, 18);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "checksum");
-    will_return(__wrap_sqlite3_bind_text, 0);
-    expect_sqlite3_step_call(SQLITE_DONE);
-
-    output = wdb_osinfo_save(data, "scan_id", "scan_time", "hostname", "architecture", "os_name", "os_version", "os_codename", "os_major", "os_minor", "os_patch", "os_build", "os_platform", "sysname", "release", "version", "os_release", "os_display_version", "checksum", false);
-    assert_int_equal(output, 0);
+    __real_cJSON_Delete(osinfo_retrieved_info);
 }
 
 /* Test wdb_osinfo_insert */
-void test_wdb_osinfo_insert_cache_fail(void **state) {
+void test_wdb_osinfo_insert_cache_fail(void ** state) {
     int output = 0;
-    wdb_t *data = (wdb_t *)*state;
+    wdb_t * data = (wdb_t *) *state;
 
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "at wdb_osinfo_insert(): cannot cache statement");
 
-    output = wdb_osinfo_insert(data, "scan_id", "scan_time", "hostname", "architecture", "os_name", "os_version", "os_codename", "os_major", "os_minor", "os_patch", "os_build", "os_platform", "sysname", "release", "version", "os_release", "os_display_version", "checksum", false);
+    output =
+        wdb_osinfo_insert(data, "scan_id", "scan_time", "hostname", "architecture", "os_name", "os_version",
+                          "os_codename", "os_major", "os_minor", "os_patch", "os_build", "os_platform", "sysname",
+                          "release", "version", "os_release", "os_display_version", "checksum", false, "hexdigest", 1);
     assert_int_equal(output, -1);
 }
 
-void test_wdb_osinfo_insert_sql_fail(void **state) {
+void test_wdb_osinfo_insert_sql_fail(void ** state) {
     int output = 0;
-    wdb_t *data = (wdb_t *)*state;
+    wdb_t * data = (wdb_t *) *state;
 
     will_return(__wrap_wdb_stmt_cache, 0);
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
@@ -2161,18 +2265,27 @@ void test_wdb_osinfo_insert_sql_fail(void **state) {
     expect_value(__wrap_sqlite3_bind_text, pos, 18);
     expect_string(__wrap_sqlite3_bind_text, buffer, "checksum");
     will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 19);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "hexdigest");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_int, index, 20);
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
+    will_return(__wrap_sqlite3_bind_int, 0);
 
     expect_sqlite3_step_call(1);
     will_return(__wrap_sqlite3_errmsg, "ERROR");
     expect_string(__wrap__merror, formatted_msg, "at wdb_osinfo_insert(): sqlite3_step(): ERROR");
 
-    output = wdb_osinfo_insert(data, "scan_id", "scan_time", "hostname", "architecture", "os_name", "os_version", "os_codename", "os_major", "os_minor", "os_patch", "os_build", "os_platform", "sysname", "release", "version", "os_release", "os_display_version", "checksum", false);
+    output =
+        wdb_osinfo_insert(data, "scan_id", "scan_time", "hostname", "architecture", "os_name", "os_version",
+                          "os_codename", "os_major", "os_minor", "os_patch", "os_build", "os_platform", "sysname",
+                          "release", "version", "os_release", "os_display_version", "checksum", false, "hexdigest", 1);
     assert_int_equal(output, -1);
 }
 
-void test_wdb_osinfo_insert_success(void **state) {
+void test_wdb_osinfo_insert_success(void ** state) {
     int output = 0;
-    wdb_t *data = (wdb_t *)*state;
+    wdb_t * data = (wdb_t *) *state;
 
     will_return(__wrap_wdb_stmt_cache, 0);
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
@@ -2229,9 +2342,18 @@ void test_wdb_osinfo_insert_success(void **state) {
     expect_value(__wrap_sqlite3_bind_text, pos, 18);
     expect_string(__wrap_sqlite3_bind_text, buffer, "checksum");
     will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 19);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "hexdigest");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_int, index, 20);
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
+    will_return(__wrap_sqlite3_bind_int, 0);
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    output = wdb_osinfo_insert(data, "scan_id", "scan_time", "hostname", "architecture", "os_name", "os_version", "os_codename", "os_major", "os_minor", "os_patch", "os_build", "os_platform", "sysname", "release", "version", "os_release", "os_display_version", "checksum", false);
+    output =
+        wdb_osinfo_insert(data, "scan_id", "scan_time", "hostname", "architecture", "os_name", "os_version",
+                          "os_codename", "os_major", "os_minor", "os_patch", "os_build", "os_platform", "sysname",
+                          "release", "version", "os_release", "os_display_version", "checksum", false, "hexdigest", 1);
     assert_int_equal(output, 0);
 }
 
@@ -4195,19 +4317,121 @@ void test_wdb_syscollector_save2_osinfo_fail(void **state) {
     assert_int_equal(output, -1);
 }
 
-void test_wdb_syscollector_save2_osinfo_success(void **state) {
+void test_wdb_syscollector_save2_osinfo_success(void ** state) {
     int output = 0;
-    wdb_t *data = (wdb_t *)*state;
+    wdb_t * data = (wdb_t *) *state;
+
+    data->transaction = 0;
 
     will_return(__wrap_cJSON_Parse, 1);
     will_return(__wrap_cJSON_GetObjectItem, 1);
 
-    data->transaction = 1;
-    wdb_syscollector_osinfo_save2_success();
+    for (int i = 0; i < 17; i++) {
+        will_return(__wrap_cJSON_GetObjectItem, NULL);
+    }
+
+    will_return(__wrap_cJSON_GetStringValue, "scan_time");
+    will_return(__wrap_cJSON_GetStringValue, "hostname");
+    will_return(__wrap_cJSON_GetStringValue, "architecture");
+    will_return(__wrap_cJSON_GetStringValue, "os_name");
+    will_return(__wrap_cJSON_GetStringValue, "os_version");
+    will_return(__wrap_cJSON_GetStringValue, "os_codename");
+    will_return(__wrap_cJSON_GetStringValue, "os_major");
+    will_return(__wrap_cJSON_GetStringValue, "os_minor");
+    will_return(__wrap_cJSON_GetStringValue, "os_patch");
+    will_return(__wrap_cJSON_GetStringValue, "os_build");
+    will_return(__wrap_cJSON_GetStringValue, "os_platform");
+    will_return(__wrap_cJSON_GetStringValue, "sysname");
+    will_return(__wrap_cJSON_GetStringValue, "release");
+    will_return(__wrap_cJSON_GetStringValue, "version");
+    will_return(__wrap_cJSON_GetStringValue, "os_release");
+    will_return(__wrap_cJSON_GetStringValue, "os_display_version");
+    will_return(__wrap_cJSON_GetStringValue, "checksum");
+
+    cJSON * osinfo_retrieved_info =
+        __real_cJSON_Parse("[{\"triaged\":\"string_value\", \"reference\":\"string_value\"}]");
+
+    will_return(__wrap_wdb_begin2, 0);
+    will_return(__wrap_wdb_agents_get_sys_osinfo, osinfo_retrieved_info);
+    will_return(__wrap_cJSON_GetObjectItem, NULL);
+    will_return(__wrap_cJSON_GetObjectItem, 1);
+    will_return(__wrap_cJSON_IsNumber, false);
+    expect_string(__wrap__mdebug2, formatted_msg,
+                  "No previous data related to the triaged status and reference of the OS");
+    expect_function_call(__wrap_cJSON_Delete);
+
+    will_return(__wrap_wdb_stmt_cache, 0);
+    expect_sqlite3_step_call(SQLITE_DONE);
+
+    will_return(__wrap_wdb_stmt_cache, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "0");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "scan_time");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 3);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "hostname");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 4);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "architecture");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 5);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_name");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 6);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_version");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 7);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_codename");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 8);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_major");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 9);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_minor");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 10);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_patch");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 11);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_build");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 12);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_platform");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 13);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "sysname");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 14);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "release");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 15);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "version");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 16);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_release");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 17);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "os_display_version");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 18);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "checksum");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 19);
+    expect_any(__wrap_sqlite3_bind_text, buffer);
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_int, index, 20);
+    expect_any(__wrap_sqlite3_bind_int, value);
+    will_return(__wrap_sqlite3_bind_int, 0);
+
+    expect_sqlite3_step_call(SQLITE_DONE);
+
     expect_function_call(__wrap_cJSON_Delete);
 
     output = wdb_syscollector_save2(data, WDB_SYSCOLLECTOR_OSINFO, NULL);
     assert_int_equal(output, 0);
+    __real_cJSON_Delete(osinfo_retrieved_info);
 }
 
 int main() {
@@ -4255,17 +4479,15 @@ int main() {
         cmocka_unit_test_setup_teardown(test_wdb_hotfix_delete_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_hotfix_delete_sql_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_hotfix_delete_success, test_setup, test_teardown),
-        /* Test wdb_set_hotfix_metadata */
-        cmocka_unit_test_setup_teardown(test_wdb_set_hotfix_metadata_transaction_fail, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_set_hotfix_metadata_cache_fail, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_set_hotfix_metadata_sql_fail, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_set_hotfix_metadata_success, test_setup, test_teardown),
         /* Test wdb_osinfo_save */
         cmocka_unit_test_setup_teardown(test_wdb_osinfo_save_transaction_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_osinfo_save_retrieve_osinfo_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_osinfo_save_retrieve_osinfo_type_triaged_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_osinfo_save_retrieve_osinfo_type_reference_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_osinfo_save_retrieve_osinfo_ok, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_osinfo_save_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_osinfo_save_sql_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_osinfo_save_insert_fail, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_osinfo_save_success, test_setup, test_teardown),
         /* Test wdb_osinfo_insert */
         cmocka_unit_test_setup_teardown(test_wdb_osinfo_insert_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_osinfo_insert_sql_fail, test_setup, test_teardown),

--- a/src/unit_tests/wrappers/externals/cJSON/cJSON_wrappers.c
+++ b/src/unit_tests/wrappers/externals/cJSON/cJSON_wrappers.c
@@ -101,6 +101,10 @@ cJSON_bool __wrap_cJSON_IsNumber(__attribute__ ((__unused__)) cJSON * item) {
     return mock_type(cJSON_bool);
 }
 
+cJSON_bool __wrap_cJSON_IsString(const cJSON * const item) {
+    return mock_type(cJSON_bool);
+}
+
 cJSON_bool __wrap_cJSON_IsObject(__attribute__ ((__unused__)) cJSON * item) {
     return mock_type(cJSON_bool);
 }

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -165,10 +165,10 @@ static struct column_list const TABLE_OS[] = {
     { .value = { FIELD_TEXT, 14, false, false, "release" }, .next = &TABLE_OS[14] },
     { .value = { FIELD_TEXT, 15, false, false, "version" }, .next = &TABLE_OS[15] },
     { .value = { FIELD_TEXT, 16, false, false, "os_release" }, .next = &TABLE_OS[16] },
-    { .value = { FIELD_TEXT, 17, false, false, "os_display_version" }, .next = &TABLE_OS[17] },
-    { .value = { FIELD_INTEGER, 18, false, false, "triaged" }, .next = &TABLE_OS[18] },
-    { .value = { FIELD_TEXT, 19, false, false, "reference" }, .next = &TABLE_OS[19] },
-    { .value = { FIELD_TEXT, 20, false, false, "checksum" }, .next = NULL }
+    { .value = { FIELD_TEXT, 17, false, false, "checksum" }, .next = &TABLE_OS[17] },
+    { .value = { FIELD_TEXT, 18, false, false, "os_display_version" }, .next = &TABLE_OS[18] },
+    { .value = { FIELD_INTEGER, 19, false, false, "triaged" }, .next = &TABLE_OS[19] },
+    { .value = { FIELD_TEXT, 20, false, false, "reference" }, .next = NULL },
 };
 #define OS_FIELD_COUNT 19
 

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -166,9 +166,11 @@ static struct column_list const TABLE_OS[] = {
     { .value = { FIELD_TEXT, 15, false, false, "version" }, .next = &TABLE_OS[15] },
     { .value = { FIELD_TEXT, 16, false, false, "os_release" }, .next = &TABLE_OS[16] },
     { .value = { FIELD_TEXT, 17, false, false, "os_display_version" }, .next = &TABLE_OS[17] },
-    { .value = { FIELD_TEXT, 18, false, false, "checksum" }, .next = NULL }
+    { .value = { FIELD_INTEGER, 18, false, false, "triaged" }, .next = &TABLE_OS[18] },
+    { .value = { FIELD_TEXT, 19, false, false, "reference" }, .next = &TABLE_OS[19] },
+    { .value = { FIELD_TEXT, 20, false, false, "checksum" }, .next = NULL }
 };
-#define OS_FIELD_COUNT 17
+#define OS_FIELD_COUNT 19
 
 static struct column_list const TABLE_HARDWARE[] = {
     { .value = { FIELD_INTEGER, 1, true, false, "scan_id" }, .next = &TABLE_HARDWARE[1] },


### PR DESCRIPTION
|Related issue|
|---|
|#10853|

## Description

Hi team!

This PR aims to fix syscollector deltas handling after adding the CVEs alerts inventory feature.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors