### PR TITLE
Refactor cluster files comparison

### DIFF
--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -9,7 +9,6 @@ import shutil
 import zipfile
 from datetime import datetime
 from operator import eq
-from operator import itemgetter
 from os import listdir, path, remove, stat, walk
 from random import random
 from shutil import rmtree
@@ -430,7 +429,7 @@ def compare_files(good_files, check_files, node_name):
         try:
             agent_groups = [os.path.basename(file) for file in extra_valid_files if file.startswith(agent_groups_path)]
             db_agents = Agent.get_agents_overview(select=['id'], limit=None, filters={'id': agent_groups})['items']
-            db_agents = set(map(itemgetter('id'), db_agents))
+            db_agents = {agent['id'] for agent in db_agents}
             for leftover in set(agent_groups) - db_agents:
                 extra_valid_files.pop(os.path.join(agent_groups_path, leftover), None)
         except Exception as e:

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -794,16 +794,6 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                                                          os.path.basename(file_path))
 
                         try:
-                            agent_id = os.path.basename(file_path)
-                            # If the agent does not exist on the master, do not copy its file from the worker.
-                            if agent_id not in agent_ids:
-                                n_errors['warnings'][data['cluster_item_key']] = 1 \
-                                    if n_errors['warnings'].get(data['cluster_item_key']) is None \
-                                    else n_errors['warnings'][data['cluster_item_key']] + 1
-
-                                self.logger.debug2(f"Received group of an non-existent agent '{agent_id}'")
-                                continue
-
                             # Format the file_data specified inside the merged file.
                             try:
                                 mtime = datetime.strptime(file_time, '%Y-%m-%d %H:%M:%S.%f')
@@ -861,15 +851,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
 
         n_errors = {'errors': {}, 'warnings': {}}
 
-        # Get ID of all agents.
-        try:
-            agents = Agent.get_agents_overview(select=['name'], limit=None)['items']
-            agent_ids = set(map(operator.itemgetter('id'), agents))
-        except Exception as e:
-            logger.debug2(f"Error getting agent ids: {e}")
-            agent_ids = {}
-
-        # Iterate and update each file specified in 'files_metadata' if conditions are meets.
+        # Iterate and update each file specified in 'files_metadata' if conditions are met.
         try:
             for filename, data in files_metadata.items():
                 await update_file(data=data, name=filename)

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -1531,7 +1531,7 @@ class WazuhDBQuery(object):
             return self.general_run()
 
         rbac_ids = set(self.legacy_filters.get('rbac_ids', set()))
-        return self.general_run() if len(str(rbac_ids)) < common.MAX_QUERY_FILTERS_RESERVED_SIZE else \
+        return self.general_run() if len(','.join(rbac_ids)) < common.MAX_QUERY_FILTERS_RESERVED_SIZE else \
             self.oversized_run()
 
     def reset(self):


### PR DESCRIPTION
|Related issue|
|---|
| Closes #10816 |

## Description

This PR refactors the way that cluster files are compared. 

The master compares all the files of the worker with his own files. Then, if the worker had any extra-valid file that the master needed, it was requested. The problem is that, sometimes, the workers are sending files (agent-groups) that were requested by the master but whose corresponding agents aren't in the master's `global.db` yet. Therefore, the files are discarded as soon as they are processed by the `wazuh-clusterd` of the master. 

This is not very efficient, so we have moved the code that checks if extra-valid files (agent-groups) correspond to agents that do exist in the master's global database. Until now, this task was done while processing the received extra-valid files. After this PR, it is checked before the master requests extra-valid files to workers. It is:
1. Workers send MD5 of their files to the master.
2. Master compares his own files with the MD5 of the received ones. **In addition**, if `agent-group` files are required, it is checked if those files correspond to agents existing in the master's `global.db`. Now the master no longer requests files that do not correspond to any agent.
