### PR TITLE
Support the use of the Azure integration module in Linux agents

### DIFF
--- a/src/config/wmodules-azure.c
+++ b/src/config/wmodules-azure.c
@@ -9,7 +9,6 @@
  * Foundation.
  */
 
-#ifndef CLIENT
 #ifndef WIN32
 #include "wazuh_modules/wmodules.h"
 
@@ -679,5 +678,4 @@ void wm_clean_container(wm_azure_container_t * container) {
     free(container);
 }
 
-#endif
 #endif

--- a/src/config/wmodules-config.c
+++ b/src/config/wmodules-config.c
@@ -134,12 +134,16 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
         mwarn("A deprecated Vulnerability Detector configuration block was found. It will be ignored.");
         OS_ClearNode(children);
         return 0;
-    } else if (!strcmp(node->values[0], WM_AZURE_CONTEXT.name)) {
+    }
+#endif
+else if (!strcmp(node->values[0], WM_AZURE_CONTEXT.name)) {
         if (wm_azure_read(xml, children, cur_wmodule) < 0) {
             OS_ClearNode(children);
             return OS_INVALID;
         }
-    } else if (!strcmp(node->values[0], WM_KEY_REQUEST_CONTEXT.name)) {
+    }
+#ifndef CLIENT
+    else if (!strcmp(node->values[0], WM_KEY_REQUEST_CONTEXT.name)) {
         if (wm_key_request_read(children, cur_wmodule) < 0) {
             OS_ClearNode(children);
             return OS_INVALID;

--- a/src/config/wmodules-config.c
+++ b/src/config/wmodules-config.c
@@ -135,14 +135,6 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
         OS_ClearNode(children);
         return 0;
     }
-#endif
-else if (!strcmp(node->values[0], WM_AZURE_CONTEXT.name)) {
-        if (wm_azure_read(xml, children, cur_wmodule) < 0) {
-            OS_ClearNode(children);
-            return OS_INVALID;
-        }
-    }
-#ifndef CLIENT
     else if (!strcmp(node->values[0], WM_KEY_REQUEST_CONTEXT.name)) {
         if (wm_key_request_read(children, cur_wmodule) < 0) {
             OS_ClearNode(children);
@@ -150,6 +142,12 @@ else if (!strcmp(node->values[0], WM_AZURE_CONTEXT.name)) {
         }
     }
 #endif
+else if (!strcmp(node->values[0], WM_AZURE_CONTEXT.name)) {
+        if (wm_azure_read(xml, children, cur_wmodule) < 0) {
+            OS_ClearNode(children);
+            return OS_INVALID;
+        }
+    }
 #endif
     else {
         if(!strcmp(node->values[0], VU_WM_NAME) || !strcmp(node->values[0], AZ_WM_NAME) ||

--- a/src/config/wmodules-config.c
+++ b/src/config/wmodules-config.c
@@ -142,7 +142,7 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
         }
     }
 #endif
-else if (!strcmp(node->values[0], WM_AZURE_CONTEXT.name)) {
+    else if (!strcmp(node->values[0], WM_AZURE_CONTEXT.name)) {
         if (wm_azure_read(xml, children, cur_wmodule) < 0) {
             OS_ClearNode(children);
             return OS_INVALID;

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -1140,6 +1140,8 @@ InstallAgent()
     ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/wodles/docker
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/docker-listener/DockerListener.py ${INSTALLDIR}/wodles/docker/DockerListener
 
+    ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/wodles/azure
+    ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/azure/azure-logs.py ${INSTALLDIR}/wodles/azure/azure-logs
 }
 
 InstallWazuh()

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -1089,7 +1089,6 @@ InstallServer()
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/docker-listener/DockerListener.py ${INSTALLDIR}/wodles/docker/DockerListener.py
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../framework/wrappers/generic_wrapper.sh ${INSTALLDIR}/wodles/docker/DockerListener
 
-    # Add Azure script (for manager only)
     ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/wodles/azure
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/azure/azure-logs.py ${INSTALLDIR}/wodles/azure/azure-logs.py
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../framework/wrappers/generic_wrapper.sh ${INSTALLDIR}/wodles/azure/azure-logs

--- a/src/wazuh_modules/wm_azure.c
+++ b/src/wazuh_modules/wm_azure.c
@@ -10,7 +10,6 @@
  */
 
 #ifndef WIN32
-#ifndef CLIENT
 
 #include "wmodules.h"
 #include "wm_azure.h"
@@ -535,5 +534,4 @@ cJSON *wm_azure_dump(const wm_azure_t * azure) {
     return root;
 }
 
-#endif
 #endif

--- a/src/wazuh_modules/wm_azure.h
+++ b/src/wazuh_modules/wm_azure.h
@@ -9,7 +9,6 @@
  * Foundation.
  */
 
-#ifndef CLIENT
 #ifndef WM_AZURE
 #define WM_AZURE
 
@@ -81,5 +80,4 @@ extern const wm_context WM_AZURE_CONTEXT;   // Context
 // Parse XML configuration
 int wm_azure_read(const OS_XML *xml, xml_node **nodes, wmodule *module);
 
-#endif
 #endif


### PR DESCRIPTION
|Related issue|
|---|
|Closes #10662 |

## Description
In this PR we add support to the use of the Azure external integration module to Linux agents.

## Tests
### Setup an agent and configure Azure module
After installing pip in the agent using `apt install python3-pip` and installing the dependencies using `pip3 install azure-common==1.1.25 azure-storage-blob==2.1.0 azure-storage-common==2.1.0 pytz==2020.1 requests==2.25.1`, we configure the Azure module adding the following code block to the `ossec.conf` file:
```
<wodle name="azure-logs">
  <disabled>no</disabled>
  <interval>1d</interval>
  <run_on_start>yes</run_on_start>
    <storage>
          <auth_path>/var/ossec/wodles/azure/credentials-storage</auth_path>
          <tag>azure-activity</tag>
          <container name="frameworktestcontainer">
              <blobs>.json</blobs>
              <content_type>json_inline</content_type>
              <time_offset>10d</time_offset>
          </container>
     </storage>

     <graph>
        <auth_path>/var/ossec/wodles/azure/credentials</auth_path>
        <tenantdomain>wazuh.onmicrosoft.com</tenantdomain>
        <request>
            <tag>azure-active_directory</tag>
            <query>auditLogs/directoryAudits</query>
            <time_offset>10d</time_offset>
        </request>
     </graph>

      <log_analytics>
       <auth_path>/var/ossec/wodles/azure/credentials-analytics</auth_path>
       <tenantdomain>wazuh.onmicrosoft.com</tenantdomain>
       <request>
          <tag>AzureActivity</tag>
          <query>AzureActivity</query>
          <workspace>bc8d21bd-b966-4a4f-8eed-9e0328720cbe</workspace>
          <time_offset>10d</time_offset>
       </request>
     </log_analytics>
</wodle>
```

We also set the modulesd daemon in debug mode to properly check that the Azure daemon is working as expected.

After that, we executed `service wazuh-agent restart` and checked the output of `grep -i azure /var/ossec/logs/ossec.log`.  

```
2021/11/16 16:17:20 wazuh-modulesd:azure-logs[683] wm_azure.c:397 at wm_azure_cleanup(): INFO: Module finished.
2021/11/16 16:17:24 wazuh-modulesd[2653] main.c:94 at main(): DEBUG: Created new thread for the 'azure-logs' module.
2021/11/16 16:17:24 wazuh-modulesd:azure-logs[2653] wm_azure.c:53 at wm_azure_main(): INFO: Module started.
2021/11/16 16:17:24 wazuh-modulesd:azure-logs[2653] wm_azure.c:73 at wm_azure_main(): INFO: Starting fetching of logs.
2021/11/16 16:17:24 wazuh-modulesd:azure-logs[2653] wm_azure.c:84 at wm_azure_main(): INFO: Starting Graphs log collection for the domain 'wazuh.onmicrosoft.com'.
2021/11/16 16:17:24 wazuh-modulesd:azure-logs[2653] wm_azure.c:198 at wm_azure_graphs(): DEBUG: Creating argument list.
2021/11/16 16:17:24 wazuh-modulesd:azure-logs[2653] wm_azure.c:237 at wm_azure_graphs(): DEBUG: Launching command: wodles/azure/azure-logs --graph --graph_auth_path /var/ossec/wodles/azure/credentials --graph_tenant_domain wazuh.onmicrosoft.com --graph_tag azure-active_directory --graph_query 'auditLogs/directoryAudits' --graph_time_offset 10d
2021/11/16 16:17:25 wazuh-modulesd:azure-logs[2653] wm_azure.c:254 at wm_azure_graphs(): INFO: Finished Graphs log collection for request 'azure-active_directory'.
2021/11/16 16:17:25 wazuh-modulesd:azure-logs[2653] wm_azure.c:86 at wm_azure_main(): INFO: Finished Graphs log collection for the domain 'wazuh.onmicrosoft.com'.
2021/11/16 16:17:25 wazuh-modulesd:azure-logs[2653] wm_azure.c:80 at wm_azure_main(): INFO: Starting Log Analytics collection for the domain 'wazuh.onmicrosoft.com'.
2021/11/16 16:17:25 wazuh-modulesd:azure-logs[2653] wm_azure.c:119 at wm_azure_log_analytics(): DEBUG: Creating argument list.
2021/11/16 16:17:25 wazuh-modulesd:azure-logs[2653] wm_azure.c:161 at wm_azure_log_analytics(): DEBUG: Launching command: wodles/azure/azure-logs --log_analytics --la_auth_path /var/ossec/wodles/azure/credentials-analytics --la_tenant_domain wazuh.onmicrosoft.com --la_tag AzureActivity --la_query "AzureActivity" --workspace bc8d21bd-b966-4a4f-8eed-9e0328720cbe --la_time_offset 10d
2021/11/16 16:17:26 wazuh-modulesd:syscollector[2653] wm_syscollector.c:98 at wm_sys_log(): DEBUG: Sync sent: {"component":"syscollector_processes","data":{"attributes":{"argvs":"wodles/azure/azure-logs --graph --graph_auth_path /var/ossec/wodles/azure/credentials --graph_tenant_domain wazuh.onmicrosoft.com --graph_tag azure-active_directory --graph_query 'auditLogs/directoryAudits' --graph_time_offset 10d","checksum":"87b94ec4068d283f591427d1a977d7d1681a05a3","cmd":"python3","egroup":"wazuh","euser":"root","fgroup":"wazuh","name":"python3","nice":10,"nlwp":1,"pgrp":2669,"pid":"2669","ppid":2655,"priority":30,"processor":12,"resident":3918,"rgroup":"wazuh","ruser":"root","scan_time":"2021/11/16 16:17:26","session":2669,"sgroup":"wazuh","share":2062,"size":4933,"start_time":363701,"state":"R","stime":1,"suser":"root","tgid":2669,"tty":0,"utime":4,"vm_size":19732},"index":"2669","timestamp":""},"type":"state"}
2021/11/16 16:17:27 wazuh-modulesd:azure-logs[2653] wm_azure.c:178 at wm_azure_log_analytics(): INFO: Finished Log Analytics collection for request 'AzureActivity'.
2021/11/16 16:17:27 wazuh-modulesd:azure-logs[2653] wm_azure.c:82 at wm_azure_main(): INFO: Finished Log Analytics collection for the domain 'wazuh.onmicrosoft.com'.
2021/11/16 16:17:27 wazuh-modulesd:azure-logs[2653] wm_azure.c:91 at wm_azure_main(): INFO: Starting Storage log collection for 'azure-activity'.
2021/11/16 16:17:27 wazuh-modulesd:azure-logs[2653] wm_azure.c:275 at wm_azure_storage(): DEBUG: Creating argument list.
2021/11/16 16:17:27 wazuh-modulesd:azure-logs[2653] wm_azure.c:321 at wm_azure_storage(): DEBUG: Launching command: wodles/azure/azure-logs --storage --storage_auth_path /var/ossec/wodles/azure/credentials-storage --container "frameworktestcontainer" --blobs ".json" --storage_tag azure-activity --json_inline --storage_time_offset 10d
2021/11/16 16:17:28 wazuh-modulesd:azure-logs[2653] wm_azure.c:338 at wm_azure_storage(): INFO: Finished Storage log collection for container 'frameworktestcontainer'.
2021/11/16 16:17:28 wazuh-modulesd:azure-logs[2653] wm_azure.c:93 at wm_azure_main(): INFO: Finished Storage log collection for 'azure-activity'.
2021/11/16 16:17:28 wazuh-modulesd:azure-logs[2653] wm_azure.c:99 at wm_azure_main(): DEBUG: Fetching logs finished.
2021/11/16 16:17:28 wazuh-modulesd:azure-logs[2653] wm_azure.c:69 at wm_azure_main(): DEBUG: Sleeping until: 2021/11/17 16:17:24
```

As can be seen in the output, the three services, that is, Graph, Storage and Log Analytics have worked as expected.

### Upgrade an agent without Azure support to the new branch using WPK package
The state of the `wodles` folder of an agent with version `v4.2.5` before upgrading Wazuh with the custom WPK was this:
![before upgrade](https://user-images.githubusercontent.com/72474806/141989093-e009bba1-b58b-4652-b22e-73878131d2de.png)  

The state of the `wodles` folder after upgrading Wazuh with the custom WPK was this:
![after upgrade](https://user-images.githubusercontent.com/72474806/141989108-824ac4ec-d89b-490c-85b3-ceb091a4b203.png)  
