### PR TITLE
New fim sync options for fim/dbsync implementation

### DIFF
--- a/ruleset/rules/0016-wazuh_rules.xml
+++ b/ruleset/rules/0016-wazuh_rules.xml
@@ -154,28 +154,28 @@
   <rule id="231" level="7">
     <if_sid>230</if_sid>
     <field name="alert_type">80_percentage</field>
-    <description>The file limit set for this agent is $(file_limit). Now, $(file_count) files are being monitored and all files that come after the limit will not be monitored. Change this setting in centralized configuration or locally on the agent.</description>
+    <description>The file limit set for this agent is $(db_entry_file_limit). Now, $(file_count) files are being monitored and all files that come after the limit will not be monitored. Change this setting in centralized configuration or locally on the agent.</description>
     <group>syscheck,fim_db_state,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="232" level="9">
     <if_sid>230</if_sid>
     <field name="alert_type">90_percentage</field>
-    <description>The file limit set for this agent is $(file_limit). Now, $(file_count) files are being monitored and all files that come after the limit will not be monitored. Change this setting in centralized configuration or locally on the agent.</description>
+    <description>The file limit set for this agent is $(db_entry_file_limit). Now, $(file_count) files are being monitored and all files that come after the limit will not be monitored. Change this setting in centralized configuration or locally on the agent.</description>
     <group>syscheck,fim_db_state,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="233" level="12">
     <if_sid>230</if_sid>
     <field name="alert_type">full</field>
-    <description>The file limit set for this agent is $(file_limit). Now, $(file_count) files are being monitored and no more files will be monitored. Change this setting in centralized configuration or locally on the agent.</description>
+    <description>The file limit set for this agent is $(db_entry_file_limit). Now, $(file_count) files are being monitored and no more files will be monitored. Change this setting in centralized configuration or locally on the agent.</description>
     <group>syscheck,fim_db_state,gdpr_IV_35.7.d,</group>
   </rule>
 
   <rule id="234" level="3">
     <if_sid>230</if_sid>
     <field name="alert_type">normal</field>
-    <description>The file limit set for this agent is $(file_limit). Now, $(file_count) files are being monitored.</description>
+    <description>The file limit set for this agent is $(db_entry_file_limit). Now, $(file_count) files are being monitored.</description>
     <group>syscheck,fim_db_state,</group>
   </rule>
 

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -79,7 +79,7 @@ int initialize_syscheck_configuration(syscheck_config *syscheck) {
     syscheck->nodiff_regex                    = NULL;
     syscheck->scan_day                        = NULL;
     syscheck->scan_time                       = NULL;
-    syscheck->db_entry_limit_enabled              = true;
+    syscheck->db_entry_limit_enabled          = true;
     syscheck->db_entry_file_limit             = 100000;
     syscheck->directories                     = OSList_Create();
 

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -79,8 +79,8 @@ int initialize_syscheck_configuration(syscheck_config *syscheck) {
     syscheck->nodiff_regex                    = NULL;
     syscheck->scan_day                        = NULL;
     syscheck->scan_time                       = NULL;
-    syscheck->file_limit_enabled              = true;
-    syscheck->file_limit                      = 100000;
+    syscheck->db_entry_limit_enabled              = true;
+    syscheck->db_entry_file_limit             = 100000;
     syscheck->directories                     = OSList_Create();
 
     if (syscheck->directories == NULL) {
@@ -100,7 +100,7 @@ int initialize_syscheck_configuration(syscheck_config *syscheck) {
     syscheck->wdata.fd                        = NULL;
 #endif
 #ifdef WIN32
-    syscheck->reg_entry_limit                 = 100000;
+    syscheck->db_entry_registry_limit         = 100000;
     syscheck->realtime_change                 = 0;
     syscheck->registry                        = NULL;
     syscheck->key_ignore                      = NULL;
@@ -1584,17 +1584,17 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
     const char *xml_scanday = "scan_day";
     const char *xml_database = "database";
     const char *xml_scantime = "scan_time";
-    const char *xml_file_limit = "file_limit";
-    const char *xml_file_limit_enabled = "enabled";
-    const char *xml_file_limit_entries = "entries";
+    const char *xml_file_limit = "file_limit"; // Deprecated
+    const char *xml_file_limit_enabled = "enabled"; // Deprecated
+    const char *xml_file_limit_entries = "entries"; // Deprecated
     const char *xml_db_entry = "db_entry_limit";
     const char *xml_db_entry_enabled = "enabled";
     const char *xml_db_entry_file_limit = "files";
-    const char *xml_db_entry_registry_limit = "registries";
     const char *xml_ignore = "ignore";
     const char *xml_registry_ignore = "registry_ignore";
 #ifdef WIN32
     const char *xml_registry_ignore_value = "registry_ignore_value";
+    const char *xml_db_entry_registry_limit = "registries";
 #endif
     const char *xml_auto_ignore = "auto_ignore"; // TODO: Deprecated since 3.11.0
     const char *xml_alert_new_files = "alert_new_files"; // TODO: Deprecated since 3.11.0
@@ -1732,10 +1732,10 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
             for(j = 0; children[j]; j++) {
                 if (strcmp(children[j]->element, xml_file_limit_enabled) == 0) {
                     if (strcmp(children[j]->content, "yes") == 0) {
-                        syscheck->file_limit_enabled = true;
+                        syscheck->db_entry_limit_enabled = true;
                     }
                     else if (strcmp(children[j]->content, "no") == 0) {
-                        syscheck->file_limit_enabled = false;
+                        syscheck->db_entry_limit_enabled = false;
                     }
                     else {
                         merror(XML_VALUEERR, children[j]->element, children[j]->content);
@@ -1750,17 +1750,17 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                         return (OS_INVALID);
                     }
 
-                    syscheck->file_limit = atoi(children[j]->content);
+                    syscheck->db_entry_file_limit = atoi(children[j]->content);
 
-                    if (syscheck->file_limit < 0) {
+                    if (syscheck->db_entry_file_limit < 0) {
                         mdebug2("Maximum value allowed for file_limit is '%d'", MAX_FILE_LIMIT);
-                        syscheck->file_limit = MAX_FILE_LIMIT;
+                        syscheck->db_entry_file_limit = MAX_FILE_LIMIT;
                     }
                 }
             }
 
-            if (!syscheck->file_limit_enabled) {
-                syscheck->file_limit = 0;
+            if (!syscheck->db_entry_limit_enabled) {
+                syscheck->db_entry_file_limit = 0;
             }
 
             OS_ClearNode(children);
@@ -1800,6 +1800,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                         syscheck->db_entry_file_limit = MAX_FILE_LIMIT;
                     }
                 }
+#ifdef WIN32
                 else if (strcmp(children[j]->element, xml_db_entry_registry_limit) == 0) {
                     if (!OS_StrIsNum(children[j]->content)) {
                         merror(XML_VALUEERR, children[j]->element, children[j]->content);
@@ -1814,11 +1815,14 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                         syscheck->db_entry_registry_limit = MAX_FILE_LIMIT;
                     }
                 }
+#endif
             }
 
             if (!syscheck->db_entry_limit_enabled) {
                 syscheck->db_entry_file_limit = 0;
+#ifdef WIN32
                 syscheck->db_entry_registry_limit = 0;
+#endif
             }
 
             OS_ClearNode(children);

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -383,7 +383,7 @@ typedef struct _config {
     char *scan_time;                                   /* run syscheck at this time */
 
     unsigned int db_entry_limit_enabled;               /* Enable FIM entry max limits */
-    int db_entry_file_limit;                           /* maximun number of files to monitor */
+    int db_entry_file_limit;                           /* maximum number of files to monitor */
 
     char **ignore;                                     /* list of files/dirs to ignore */
     OSMatch **ignore_regex;                            /* regex of files/dirs to ignore */
@@ -410,7 +410,7 @@ typedef struct _config {
 
     /* Windows only registry checking */
 #ifdef WIN32
-    int db_entry_registry_limit;                       /* maximun number of registries to monitor */
+    int db_entry_registry_limit;                       /* maximum number of registries to monitor */
     registry_ignore *key_ignore;                       /* List of registry keys to ignore */
     registry_ignore_regex *key_ignore_regex;           /* Regex of registry keys to ignore */
     registry_ignore *value_ignore;                     /* List of registry values to ignore*/

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -382,12 +382,8 @@ typedef struct _config {
     char *scan_day;                                    /* run syscheck on this day */
     char *scan_time;                                   /* run syscheck at this time */
 
-    int file_limit;                                    /* maximum number of files to monitor */
-    unsigned int file_limit_enabled;                   /* Enable file_limit option */
-
-    int db_entry_file_limit;             /* maximun number of files to monitor */
-    int db_entry_registry_limit;         /* maximun number of registries to monitor */
-    unsigned int db_entry_limit_enabled; /* Enable FIM entry max limits */
+    unsigned int db_entry_limit_enabled;               /* Enable FIM entry max limits */
+    int db_entry_file_limit;                           /* maximun number of files to monitor */
 
     char **ignore;                                     /* list of files/dirs to ignore */
     OSMatch **ignore_regex;                            /* regex of files/dirs to ignore */
@@ -414,7 +410,7 @@ typedef struct _config {
 
     /* Windows only registry checking */
 #ifdef WIN32
-    int reg_entry_limit;                               /* maximum number of registry values to monitor */
+    int db_entry_registry_limit;                       /* maximun number of registries to monitor */
     registry_ignore *key_ignore;                       /* List of registry keys to ignore */
     registry_ignore_regex *key_ignore_regex;           /* Regex of registry keys to ignore */
     registry_ignore *value_ignore;                     /* List of registry values to ignore*/

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -385,6 +385,10 @@ typedef struct _config {
     int file_limit;                                    /* maximum number of files to monitor */
     unsigned int file_limit_enabled;                   /* Enable file_limit option */
 
+    int db_entry_file_limit;             /* maximun number of files to monitor */
+    int db_entry_registry_limit;         /* maximun number of registries to monitor */
+    unsigned int db_entry_limit_enabled; /* Enable FIM entry max limits */
+
     char **ignore;                                     /* list of files/dirs to ignore */
     OSMatch **ignore_regex;                            /* regex of files/dirs to ignore */
 

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -145,10 +145,13 @@ cJSON *getSyscheckConfig(void) {
     if (syscheck.scan_time) cJSON_AddStringToObject(syscfg,"scan_time",syscheck.scan_time);
     cJSON_AddNumberToObject(syscfg, "max_files_per_second", syscheck.max_files_per_second);
 
-    cJSON * file_limit = cJSON_CreateObject();
-    cJSON_AddStringToObject(file_limit, "enabled", syscheck.file_limit_enabled ? "yes" : "no");
-    cJSON_AddNumberToObject(file_limit, "entries", syscheck.file_limit);
-    cJSON_AddItemToObject(syscfg, "file_limit", file_limit);
+    cJSON * db_entry_limit = cJSON_CreateObject();
+    cJSON_AddStringToObject(db_entry_limit, "enabled", syscheck.db_entry_limit_enabled ? "yes" : "no");
+    cJSON_AddNumberToObject(db_entry_limit, "files", syscheck.db_entry_file_limit);
+#ifdef WIN32
+    cJSON_AddNumberToObject(db_entry_limit, "registries", syscheck.db_entry_registry_limit);
+#endif
+    cJSON_AddItemToObject(syscfg, "db_entry_limit", db_entry_limit);
 
     cJSON *diff = cJSON_CreateObject();
 

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -272,13 +272,13 @@ time_t fim_scan() {
 #ifdef WIN32
     fim_registry_scan();
 #endif
-    if (syscheck.file_limit_enabled) {
+    if (syscheck.db_entry_limit_enabled) {
         /* DEPRECATED CODE
         nodes_count = fim_db_get_count_entries(syscheck.database);
         */
     }
 
-    if (syscheck.file_limit_enabled && (nodes_count >= syscheck.file_limit)) {
+    if (syscheck.db_entry_limit_enabled && (nodes_count >= syscheck.db_entry_file_limit)) {
         w_mutex_lock(&syscheck.fim_scan_mutex);
 
         db_transaction_handle = fim_db_transaction_start(FIMDB_FILE_TXN_TABLE, transaction_callback, &txn_ctx);
@@ -326,7 +326,7 @@ time_t fim_scan() {
     gettime(&end);
     end_of_scan = time(NULL);
 
-    if (syscheck.file_limit_enabled) {
+    if (syscheck.db_entry_limit_enabled) {
         fim_check_db_state();
     }
 
@@ -748,17 +748,17 @@ void fim_check_db_state() {
 
     switch (_db_state) {
     case FIM_STATE_DB_FULL:
-        if (nodes_count >= syscheck.file_limit) {
+        if (nodes_count >= syscheck.db_entry_file_limit) {
             return;
         }
         break;
     case FIM_STATE_DB_90_PERCENTAGE:
-        if ((nodes_count < syscheck.file_limit) && (nodes_count >= syscheck.file_limit * 0.9)) {
+        if ((nodes_count < syscheck.db_entry_file_limit) && (nodes_count >= syscheck.db_entry_file_limit * 0.9)) {
             return;
         }
         break;
     case FIM_STATE_DB_80_PERCENTAGE:
-        if ((nodes_count < syscheck.file_limit * 0.9) && (nodes_count >= syscheck.file_limit * 0.8)) {
+        if ((nodes_count < syscheck.db_entry_file_limit * 0.9) && (nodes_count >= syscheck.db_entry_file_limit * 0.8)) {
             return;
         }
         break;
@@ -767,7 +767,7 @@ void fim_check_db_state() {
             _db_state = FIM_STATE_DB_EMPTY;
             return;
         }
-        else if (nodes_count < syscheck.file_limit * 0.8) {
+        else if (nodes_count < syscheck.db_entry_file_limit * 0.8) {
             return;
         }
         break;
@@ -775,7 +775,7 @@ void fim_check_db_state() {
         if (nodes_count == 0) {
             return;
         }
-        else if (nodes_count < syscheck.file_limit * 0.8) {
+        else if (nodes_count < syscheck.db_entry_file_limit * 0.8) {
             _db_state = FIM_STATE_DB_NORMAL;
             return;
         }
@@ -785,20 +785,20 @@ void fim_check_db_state() {
     }
 
     json_event = cJSON_CreateObject();
-    cJSON_AddNumberToObject(json_event, "file_limit", syscheck.file_limit);
+    cJSON_AddNumberToObject(json_event, "db_entry_file_limit", syscheck.db_entry_file_limit);
     cJSON_AddNumberToObject(json_event, "file_count", nodes_count);
 
-    if (nodes_count >= syscheck.file_limit) {
+    if (nodes_count >= syscheck.db_entry_file_limit) {
         _db_state = FIM_STATE_DB_FULL;
         mwarn(FIM_DB_FULL_ALERT);
         cJSON_AddStringToObject(json_event, "alert_type", "full");
     }
-    else if (nodes_count >= syscheck.file_limit * 0.9) {
+    else if (nodes_count >= syscheck.db_entry_file_limit * 0.9) {
         _db_state = FIM_STATE_DB_90_PERCENTAGE;
         minfo(FIM_DB_90_PERCENTAGE_ALERT);
         cJSON_AddStringToObject(json_event, "alert_type", "90_percentage");
     }
-    else if (nodes_count >= syscheck.file_limit * 0.8) {
+    else if (nodes_count >= syscheck.db_entry_file_limit * 0.8) {
         _db_state = FIM_STATE_DB_80_PERCENTAGE;
         minfo(FIM_DB_80_PERCENTAGE_ALERT);
         cJSON_AddStringToObject(json_event, "alert_type", "80_percentage");

--- a/src/syscheckd/main.c
+++ b/src/syscheckd/main.c
@@ -215,8 +215,8 @@ int main(int argc, char **argv)
             minfo(FIM_DISK_QUOTA_LIMIT_DISABLED);
         }
 
-        if (syscheck.file_limit_enabled) {
-            mdebug2(FIM_FILE_LIMIT_VALUE, syscheck.file_limit);
+        if (syscheck.db_entry_limit_enabled) {
+            mdebug2(FIM_FILE_LIMIT_VALUE, syscheck.db_entry_file_limit);
         } else {
             mdebug2(FIM_FILE_LIMIT_UNLIMITED);
         }

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -82,7 +82,7 @@ void fim_initialize() {
                 syscheck.sync_interval,
                 fim_send_sync_state,
                 loggingFunction,
-                syscheck.file_limit,
+                syscheck.db_entry_file_limit,
                 0,
                 false);
 #else
@@ -90,8 +90,8 @@ void fim_initialize() {
                 syscheck.sync_interval,
                 fim_send_sync_state,
                 loggingFunction,
-                syscheck.file_limit,
-                syscheck.reg_entry_limit,
+                syscheck.db_entry_file_limit,
+                syscheck.db_entry_registry_limit,
                 true);
 #endif
 

--- a/src/unit_tests/syscheckd/db/test_fim_db_files.c
+++ b/src/unit_tests/syscheckd/db/test_fim_db_files.c
@@ -794,7 +794,7 @@ static void test_fim_db_file_update_new_entry(void **state) {
 
     expect_function_call(__wrap_pthread_mutex_unlock);
 
-    syscheck.file_limit = 50000;
+    syscheck.db_entry_file_limit = 50000;
 
     expect_fim_db_clean_stmt();
 

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -429,15 +429,15 @@ static int teardown_struct_dirent(void **state) {
 }
 
 static int setup_file_limit(void **state) {
-    syscheck.file_limit_enabled = false;
-    syscheck.file_limit = 0;
+    syscheck.db_entry_limit_enabled = false;
+    syscheck.db_entry_file_limit = 0;
 
     return 0;
 }
 
 static int teardown_file_limit(void **state) {
-    syscheck.file_limit_enabled = true;
-    syscheck.file_limit = 50000;
+    syscheck.db_entry_limit_enabled = true;
+    syscheck.db_entry_file_limit = 50000;
 
     return 0;
 }
@@ -2012,7 +2012,7 @@ static void test_fim_scan_db_full_double_scan(void **state) {
     // fim_check_db_state
     expect_wrapper_fim_db_get_count_entries(syscheck.database, 50000);
     expect_string(__wrap__mwarn, formatted_msg, "(6927): Sending DB 100% full alert.");
-    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":50000,\"alert_type\":\"full\"}");
+    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"db_entry_file_limit\":50000,\"file_count\":50000,\"alert_type\":\"full\"}");
     will_return(__wrap_send_log_msg, 1);
 
     // fim_send_scan_info
@@ -2162,7 +2162,7 @@ static void test_fim_scan_realtime_enabled(void **state) {
     expect_string(__wrap__mdebug2, formatted_msg, debug_buffer);
 
     expect_string(__wrap__mwarn, formatted_msg, "(6927): Sending DB 100% full alert.");
-    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":50000,\"alert_type\":\"full\"}");
+    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"db_entry_file_limit\":50000,\"file_count\":50000,\"alert_type\":\"full\"}");
     will_return(__wrap_send_log_msg, 1);
 
     expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_ENDED);
@@ -2231,7 +2231,7 @@ static void test_fim_scan_db_free(void **state) {
     will_return(__wrap_fim_db_set_all_unscanned, 0);
 
     expect_string(__wrap__minfo, formatted_msg, "(6038): Sending DB back to normal alert.");
-    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":1000,\"alert_type\":\"normal\"}");
+    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"db_entry_file_limit\":50000,\"file_count\":1000,\"alert_type\":\"normal\"}");
     will_return(__wrap_send_log_msg, 1);
 
     expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_ENDED);
@@ -2838,7 +2838,7 @@ static void test_fim_scan_db_full_double_scan(void **state) {
     expect_wrapper_fim_db_get_count_entries(syscheck.database, 50000);
 
     expect_string(__wrap__mwarn, formatted_msg, "(6927): Sending DB 100% full alert.");
-    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":50000,\"alert_type\":\"full\"}");
+    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"db_entry_file_limit\":50000,\"file_count\":50000,\"alert_type\":\"full\"}");
     will_return(__wrap_send_log_msg, 1);
 
     expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_ENDED);
@@ -2982,7 +2982,7 @@ static void test_fim_scan_db_free(void **state) {
     will_return(__wrap_fim_db_set_all_unscanned, 0);
 
     expect_string(__wrap__minfo, formatted_msg, "(6038): Sending DB back to normal alert.");
-    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":1000,\"alert_type\":\"normal\"}");
+    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"db_entry_file_limit\":50000,\"file_count\":1000,\"alert_type\":\"normal\"}");
     will_return(__wrap_send_log_msg, 1);
 
     expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_ENDED);
@@ -3343,7 +3343,7 @@ static void test_fim_check_db_state_empty_to_empty(void **state) {
 static void test_fim_check_db_state_empty_to_full(void **state) {
     expect_wrapper_fim_db_get_count_entries(syscheck.database, 50000);
     expect_string(__wrap__mwarn, formatted_msg, "(6927): Sending DB 100% full alert.");
-    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":50000,\"alert_type\":\"full\"}");
+    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"db_entry_file_limit\":50000,\"file_count\":50000,\"alert_type\":\"full\"}");
     will_return(__wrap_send_log_msg, 1);
 
     assert_int_equal(_db_state, FIM_STATE_DB_EMPTY);
@@ -3356,7 +3356,7 @@ static void test_fim_check_db_state_empty_to_full(void **state) {
 static void test_fim_check_db_state_full_to_empty(void **state) {
     expect_wrapper_fim_db_get_count_entries(syscheck.database, 0);
     expect_string(__wrap__minfo, formatted_msg, "(6038): Sending DB back to normal alert.");
-    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":0,\"alert_type\":\"normal\"}");
+    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"db_entry_file_limit\":50000,\"file_count\":0,\"alert_type\":\"normal\"}");
     will_return(__wrap_send_log_msg, 1);
 
     assert_int_equal(_db_state, FIM_STATE_DB_FULL);
@@ -3369,7 +3369,7 @@ static void test_fim_check_db_state_full_to_empty(void **state) {
 static void test_fim_check_db_state_empty_to_90_percentage(void **state) {
     expect_wrapper_fim_db_get_count_entries(syscheck.database, 46000);
     expect_string(__wrap__minfo, formatted_msg, "(6039): Sending DB 90% full alert.");
-    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":46000,\"alert_type\":\"90_percentage\"}");
+    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"db_entry_file_limit\":50000,\"file_count\":46000,\"alert_type\":\"90_percentage\"}");
     will_return(__wrap_send_log_msg, 1);
 
     assert_int_equal(_db_state, FIM_STATE_DB_EMPTY);
@@ -3382,7 +3382,7 @@ static void test_fim_check_db_state_empty_to_90_percentage(void **state) {
 static void test_fim_check_db_state_90_percentage_to_empty(void **state) {
     expect_wrapper_fim_db_get_count_entries(syscheck.database, 0);
     expect_string(__wrap__minfo, formatted_msg, "(6038): Sending DB back to normal alert.");
-    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":0,\"alert_type\":\"normal\"}");
+    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"db_entry_file_limit\":50000,\"file_count\":0,\"alert_type\":\"normal\"}");
     will_return(__wrap_send_log_msg, 1);
 
     assert_int_equal(_db_state, FIM_STATE_DB_90_PERCENTAGE);
@@ -3395,7 +3395,7 @@ static void test_fim_check_db_state_90_percentage_to_empty(void **state) {
 static void test_fim_check_db_state_empty_to_80_percentage(void **state) {
     expect_wrapper_fim_db_get_count_entries(syscheck.database, 41000);
     expect_string(__wrap__minfo, formatted_msg, "(6039): Sending DB 80% full alert.");
-    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":41000,\"alert_type\":\"80_percentage\"}");
+    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"db_entry_file_limit\":50000,\"file_count\":41000,\"alert_type\":\"80_percentage\"}");
     will_return(__wrap_send_log_msg, 1);
 
     assert_int_equal(_db_state, FIM_STATE_DB_EMPTY);
@@ -3408,7 +3408,7 @@ static void test_fim_check_db_state_empty_to_80_percentage(void **state) {
 static void test_fim_check_db_state_80_percentage_to_empty(void **state) {
     expect_wrapper_fim_db_get_count_entries(syscheck.database, 0);
     expect_string(__wrap__minfo, formatted_msg, "(6038): Sending DB back to normal alert.");
-    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":0,\"alert_type\":\"normal\"}");
+    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"db_entry_file_limit\":50000,\"file_count\":0,\"alert_type\":\"normal\"}");
     will_return(__wrap_send_log_msg, 1);
 
     assert_int_equal(_db_state, FIM_STATE_DB_80_PERCENTAGE);
@@ -3439,7 +3439,7 @@ static void test_fim_check_db_state_normal_to_normal(void **state) {
 static void test_fim_check_db_state_normal_to_full(void **state) {
     expect_wrapper_fim_db_get_count_entries(syscheck.database, 50000);
     expect_string(__wrap__mwarn, formatted_msg, "(6927): Sending DB 100% full alert.");
-    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":50000,\"alert_type\":\"full\"}");
+    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"db_entry_file_limit\":50000,\"file_count\":50000,\"alert_type\":\"full\"}");
     will_return(__wrap_send_log_msg, 1);
 
     assert_int_equal(_db_state, FIM_STATE_DB_NORMAL);
@@ -3453,7 +3453,7 @@ static void test_fim_check_db_state_full_to_normal(void **state) {
     expect_wrapper_fim_db_get_count_entries(syscheck.database, 10000);
 
     expect_string(__wrap__minfo, formatted_msg, "(6038): Sending DB back to normal alert.");
-    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":10000,\"alert_type\":\"normal\"}");
+    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"db_entry_file_limit\":50000,\"file_count\":10000,\"alert_type\":\"normal\"}");
     will_return(__wrap_send_log_msg, 1);
 
     assert_int_equal(_db_state, FIM_STATE_DB_FULL);
@@ -3467,7 +3467,7 @@ static void test_fim_check_db_state_normal_to_90_percentage(void **state) {
     expect_wrapper_fim_db_get_count_entries(syscheck.database, 46000);
 
     expect_string(__wrap__minfo, formatted_msg, "(6039): Sending DB 90% full alert.");
-    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":46000,\"alert_type\":\"90_percentage\"}");
+    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"db_entry_file_limit\":50000,\"file_count\":46000,\"alert_type\":\"90_percentage\"}");
     will_return(__wrap_send_log_msg, 1);
 
     assert_int_equal(_db_state, FIM_STATE_DB_NORMAL);
@@ -3481,7 +3481,7 @@ static void test_fim_check_db_state_90_percentage_to_normal(void **state) {
     expect_wrapper_fim_db_get_count_entries(syscheck.database, 10000);
 
     expect_string(__wrap__minfo, formatted_msg, "(6038): Sending DB back to normal alert.");
-    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":10000,\"alert_type\":\"normal\"}");
+    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"db_entry_file_limit\":50000,\"file_count\":10000,\"alert_type\":\"normal\"}");
     will_return(__wrap_send_log_msg, 1);
 
     assert_int_equal(_db_state, FIM_STATE_DB_90_PERCENTAGE);
@@ -3494,7 +3494,7 @@ static void test_fim_check_db_state_90_percentage_to_normal(void **state) {
 static void test_fim_check_db_state_normal_to_80_percentage(void **state) {
     expect_wrapper_fim_db_get_count_entries(syscheck.database, 41000);
     expect_string(__wrap__minfo, formatted_msg, "(6039): Sending DB 80% full alert.");
-    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":41000,\"alert_type\":\"80_percentage\"}");
+    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"db_entry_file_limit\":50000,\"file_count\":41000,\"alert_type\":\"80_percentage\"}");
     will_return(__wrap_send_log_msg, 1);
 
     assert_int_equal(_db_state, FIM_STATE_DB_NORMAL);
@@ -3517,7 +3517,7 @@ static void test_fim_check_db_state_80_percentage_to_80_percentage(void **state)
 static void test_fim_check_db_state_80_percentage_to_full(void **state) {
     expect_wrapper_fim_db_get_count_entries(syscheck.database, 50000);
     expect_string(__wrap__mwarn, formatted_msg, "(6927): Sending DB 100% full alert.");
-    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":50000,\"alert_type\":\"full\"}");
+    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"db_entry_file_limit\":50000,\"file_count\":50000,\"alert_type\":\"full\"}");
     will_return(__wrap_send_log_msg, 1);
 
     assert_int_equal(_db_state, FIM_STATE_DB_80_PERCENTAGE);
@@ -3531,7 +3531,7 @@ static void test_fim_check_db_state_full_to_80_percentage(void **state) {
     expect_wrapper_fim_db_get_count_entries(syscheck.database, 41000);
 
     expect_string(__wrap__minfo, formatted_msg, "(6039): Sending DB 80% full alert.");
-    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":41000,\"alert_type\":\"80_percentage\"}");
+    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"db_entry_file_limit\":50000,\"file_count\":41000,\"alert_type\":\"80_percentage\"}");
     will_return(__wrap_send_log_msg, 1);
 
     assert_int_equal(_db_state, FIM_STATE_DB_FULL);
@@ -3544,7 +3544,7 @@ static void test_fim_check_db_state_full_to_80_percentage(void **state) {
 static void test_fim_check_db_state_80_percentage_to_90_percentage(void **state) {
     expect_wrapper_fim_db_get_count_entries(syscheck.database, 46000);
     expect_string(__wrap__minfo, formatted_msg, "(6039): Sending DB 90% full alert.");
-    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":46000,\"alert_type\":\"90_percentage\"}");
+    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"db_entry_file_limit\":50000,\"file_count\":46000,\"alert_type\":\"90_percentage\"}");
     will_return(__wrap_send_log_msg, 1);
 
     assert_int_equal(_db_state, FIM_STATE_DB_80_PERCENTAGE);
@@ -3567,7 +3567,7 @@ static void test_fim_check_db_state_90_percentage_to_90_percentage(void **state)
 static void test_fim_check_db_state_90_percentage_to_full(void **state) {
     expect_wrapper_fim_db_get_count_entries(syscheck.database, 50000);
     expect_string(__wrap__mwarn, formatted_msg, "(6927): Sending DB 100% full alert.");
-    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":50000,\"alert_type\":\"full\"}");
+    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"db_entry_file_limit\":50000,\"file_count\":50000,\"alert_type\":\"full\"}");
     will_return(__wrap_send_log_msg, 1);
 
     assert_int_equal(_db_state, FIM_STATE_DB_90_PERCENTAGE);
@@ -3591,7 +3591,7 @@ static void test_fim_check_db_state_full_to_90_percentage(void **state) {
     expect_wrapper_fim_db_get_count_entries(syscheck.database, 46000);
 
     expect_string(__wrap__minfo, formatted_msg, "(6039): Sending DB 90% full alert.");
-    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":46000,\"alert_type\":\"90_percentage\"}");
+    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"db_entry_file_limit\":50000,\"file_count\":46000,\"alert_type\":\"90_percentage\"}");
     will_return(__wrap_send_log_msg, 1);
 
     assert_int_equal(_db_state, FIM_STATE_DB_FULL);
@@ -3604,7 +3604,7 @@ static void test_fim_check_db_state_full_to_90_percentage(void **state) {
 static void test_fim_check_db_state_90_percentage_to_80_percentage(void **state) {
     expect_wrapper_fim_db_get_count_entries(syscheck.database, 41000);
     expect_string(__wrap__minfo, formatted_msg, "(6039): Sending DB 80% full alert.");
-    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":41000,\"alert_type\":\"80_percentage\"}");
+    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"db_entry_file_limit\":50000,\"file_count\":41000,\"alert_type\":\"80_percentage\"}");
     will_return(__wrap_send_log_msg, 1);
 
     assert_int_equal(_db_state, FIM_STATE_DB_90_PERCENTAGE);
@@ -3617,7 +3617,7 @@ static void test_fim_check_db_state_90_percentage_to_80_percentage(void **state)
 static void test_fim_check_db_state_80_percentage_to_normal(void **state) {
     expect_wrapper_fim_db_get_count_entries(syscheck.database, 10000);
     expect_string(__wrap__minfo, formatted_msg, "(6038): Sending DB back to normal alert.");
-    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":10000,\"alert_type\":\"normal\"}");
+    expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"db_entry_file_limit\":50000,\"file_count\":10000,\"alert_type\":\"normal\"}");
     will_return(__wrap_send_log_msg, 1);
 
     assert_int_equal(_db_state, FIM_STATE_DB_80_PERCENTAGE);


### PR DESCRIPTION
… for the old ones

|Related issue|
|---|
|#10224|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Added new db_entry_limit block to replace the old file_limit from ossec.conf and warn about the deprecated option.
<!--
Add a clear description of how the problem has been solved.
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Valgrind (memcheck and descriptor leaks check)