### PR TITLE
Update the wodles code in agents when upgrading Wazuh

### DIFF
--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -1123,27 +1123,22 @@ InstallAgent()
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/__init__.py ${INSTALLDIR}/wodles/__init__.py
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/utils.py ${INSTALLDIR}/wodles/utils.py
 
-    if [ ! -d ${INSTALLDIR}/wodles/aws ]; then
-        ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/wodles/aws
-        ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/aws/aws_s3.py ${INSTALLDIR}/wodles/aws/aws-s3
-    fi
+    ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/wodles/aws
+    ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/aws/aws_s3.py ${INSTALLDIR}/wodles/aws/aws-s3
 
-    if [ ! -d ${INSTALLDIR}/wodles/gcloud ]; then
-        ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/wodles/gcloud
-        ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/wodles/gcloud/pubsub
-        ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/wodles/gcloud/buckets
-        ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/gcloud/gcloud.py ${INSTALLDIR}/wodles/gcloud/gcloud
-        ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/gcloud/integration.py ${INSTALLDIR}/wodles/gcloud/integration.py
-        ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/gcloud/tools.py ${INSTALLDIR}/wodles/gcloud/tools.py
-        ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/gcloud/buckets/bucket.py ${INSTALLDIR}/wodles/gcloud/buckets/bucket.py
-        ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/gcloud/buckets/access_logs.py ${INSTALLDIR}/wodles/gcloud/buckets/access_logs.py
-        ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/gcloud/pubsub/subscriber.py ${INSTALLDIR}/wodles/gcloud/pubsub/subscriber.py
-    fi
 
-    if [ ! -d ${INSTALLDIR}/wodles/docker ]; then
-        ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/wodles/docker
-        ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/docker-listener/DockerListener.py ${INSTALLDIR}/wodles/docker/DockerListener
-    fi
+    ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/wodles/gcloud
+    ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/wodles/gcloud/pubsub
+    ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/wodles/gcloud/buckets
+    ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/gcloud/gcloud.py ${INSTALLDIR}/wodles/gcloud/gcloud
+    ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/gcloud/integration.py ${INSTALLDIR}/wodles/gcloud/integration.py
+    ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/gcloud/tools.py ${INSTALLDIR}/wodles/gcloud/tools.py
+    ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/gcloud/buckets/bucket.py ${INSTALLDIR}/wodles/gcloud/buckets/bucket.py
+    ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/gcloud/buckets/access_logs.py ${INSTALLDIR}/wodles/gcloud/buckets/access_logs.py
+    ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/gcloud/pubsub/subscriber.py ${INSTALLDIR}/wodles/gcloud/pubsub/subscriber.py
+
+    ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/wodles/docker
+    ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../wodles/docker-listener/DockerListener.py ${INSTALLDIR}/wodles/docker/DockerListener
 
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #10499 |

## Description
In this PR, we add support for updating the external integration code in agents when upgrading, either via sources or using a package.  

## Tests
To test it, we deployed the following initial environment:
A manager with version v4.3 (master).
An agent with version v4.2.5, with the following wodles folder structure:

```
root@d0376075a902:/var/ossec/wodles# tree
.
|-- __init__.py
|-- aws
|-- docker
|-- gcloud
`-- utils.py
```

The `aws`, `docker` and `gcloud` folders will be empty to illustrate two things:
- That upgrading an agent to a branch without the changes introduced in this PR will leave those folders empty.
- That upgrading an agent to this branch will successfully update the code in those directories.  

<details><summary>Upgrading to master doesn't update the external integrations</summary>
<p>
Folder structure and version before upgrade:  

```
root@281ecaadebf7:/var/ossec/wodles# tree
.
|-- __init__.py
|-- aws
|-- docker
|-- gcloud
`-- utils.py

3 directories, 2 files
root@281ecaadebf7:/var/ossec/wodles# ../bin/wazuh-control info
WAZUH_VERSION="v4.2.5"
WAZUH_REVISION="40220"
WAZUH_TYPE="agent"
```

Folder structure and version after the upgrade:

```
root@281ecaadebf7:/var/ossec/wodles# tree
.
|-- __init__.py
|-- aws
|-- docker
|-- gcloud
`-- utils.py

3 directories, 2 files
root@281ecaadebf7:/var/ossec/wodles# ../bin/wazuh-control info
WAZUH_VERSION="v4.3.0"
WAZUH_REVISION="40302"
WAZUH_TYPE="agent"
```  

The external integrations weren't updated, as expected.

</p>
</details>



<details><summary>Upgrading to this branch via sources updates the external integrations</summary>
<p>
Folder structure and version before upgrade:  

```
root@1a70eb406d86:/var/ossec/wodles# ../bin/wazuh-control info
WAZUH_VERSION="v4.2.5"
WAZUH_REVISION="40220"
WAZUH_TYPE="agent"
root@1a70eb406d86:/var/ossec/wodles# tree
.
|-- __init__.py
|-- aws
|-- docker
|-- gcloud
`-- utils.py

3 directories, 2 files
```

Folder structure and version after the upgrade:

```
root@1a70eb406d86:/var/ossec/wodles# ../bin/wazuh-control info
WAZUH_VERSION="v4.3.0"
WAZUH_REVISION="40302"
WAZUH_TYPE="agent"
root@1a70eb406d86:/var/ossec/wodles# tree
.
|-- __init__.py
|-- aws
|   `-- aws-s3
|-- docker
|   `-- DockerListener
|-- gcloud
|   |-- buckets
|   |   |-- access_logs.py
|   |   `-- bucket.py
|   |-- gcloud
|   |-- integration.py
|   |-- pubsub
|   |   `-- subscriber.py
|   `-- tools.py
`-- utils.py

5 directories, 10 files
```  

The external integrations were updated, as expected.

</p>
</details>  

<details><summary>Upgrading to this branch via a WPK package updates the external integrations</summary>
<p>
Folder structure and version before upgrade:  

```
root@99e01e712a4c:/var/ossec/wodles# ../bin/wazuh-control info
WAZUH_VERSION="v4.2.5"
WAZUH_REVISION="40220"
WAZUH_TYPE="agent"
root@99e01e712a4c:/var/ossec/wodles# tree
.
|-- __init__.py
|-- aws
|-- docker
|-- gcloud
`-- utils.py

3 directories, 2 files
```

Folder structure and version after the upgrade:

```
root@99e01e712a4c:/var/ossec/wodles# ../bin/wazuh-control info
WAZUH_VERSION="v4.3.0"
WAZUH_REVISION="40302"
WAZUH_TYPE="agent"
root@99e01e712a4c:/var/ossec/wodles# tree
.
|-- __init__.py
|-- aws
|   `-- aws-s3
|-- docker
|   `-- DockerListener
|-- gcloud
|   |-- buckets
|   |   |-- access_logs.py
|   |   `-- bucket.py
|   |-- gcloud
|   |-- integration.py
|   |-- pubsub
|   |   `-- subscriber.py
|   `-- tools.py
`-- utils.py

5 directories, 10 files
```  

The external integrations were updated, as expected.

</p>
</details>

