### PR TITLE
Investigate and fix API integration tests failing in a standalone environment

### DIFF
--- a/api/test/integration/env/configurations/experimental/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/experimental/manager/healthcheck/healthcheck.py
@@ -8,4 +8,4 @@ from healthcheck_utils import get_manager_health_base
 if __name__ == "__main__":
     # Workers are not needed in this test, so the exit code is set to 0 (healthy).
     exit(os.system("grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
-         or get_manager_health_base()) if socket.gethostname() == 'wazuh-master' else exit(0)
+         or get_manager_health_base(env_mode=sys.argv[1] if len(sys.argv) > 1 else None)) if socket.gethostname() == 'wazuh-master' else exit(0)

--- a/api/test/integration/env/configurations/syscheck/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/syscheck/manager/healthcheck/healthcheck.py
@@ -9,4 +9,4 @@ if __name__ == "__main__":
     # Workers are not needed in this test, so the exit code is set to 0 (healthy).
     exit(os.system(
         "grep -q 'wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.' /var/ossec/logs/ossec.log")
-         or get_manager_health_base()) if socket.gethostname() == 'wazuh-master' else exit(0)
+         or get_manager_health_base(env_mode=sys.argv[1] if len(sys.argv) > 1 else None)) if socket.gethostname() == 'wazuh-master' else exit(0)

--- a/api/test/integration/env/configurations/syscollector/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/syscollector/manager/healthcheck/healthcheck.py
@@ -9,4 +9,4 @@ if __name__ == "__main__":
     # Workers are not needed in this test, so the exit code is set to 0 (healthy).
     exit(os.system(
         "grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
-         or get_manager_health_base()) if socket.gethostname() == 'wazuh-master' else exit(0)
+         or get_manager_health_base(env_mode=sys.argv[1] if len(sys.argv) > 1 else None)) if socket.gethostname() == 'wazuh-master' else exit(0)

--- a/api/test/integration/env/configurations/vulnerability/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/vulnerability/manager/healthcheck/healthcheck.py
@@ -65,7 +65,7 @@ if __name__ == '__main__':
         agents_node = get_healthcheck_state()
 
     # Create a checks list with the manager health base at first
-    checks_list = [get_manager_health_base()]
+    checks_list = [get_manager_health_base(env_mode=sys.argv[1] if len(sys.argv) > 1 else None)]
 
     expected_log = "grep -q 'wazuh-modulesd:vulnerability-detector: INFO: (5471): Finished vulnerability assessment " \
                    "for agent '\\''{}'\\''' /var/ossec/logs/ossec.log"

--- a/api/test/integration/env/docker-compose.yml
+++ b/api/test/integration/env/docker-compose.yml
@@ -92,6 +92,7 @@ services:
       - nginx-lb
       - wazuh-agent2
     depends_on:
+      - wazuh-agent1
       - nginx-lb
 
   wazuh-agent3:
@@ -111,6 +112,7 @@ services:
       - nginx-lb
       - wazuh-agent3
     depends_on:
+      - wazuh-agent2
       - nginx-lb
 
   wazuh-agent4:
@@ -130,6 +132,7 @@ services:
       - nginx-lb
       - wazuh-agent4
     depends_on:
+      - wazuh-agent3
       - nginx-lb
 
   wazuh-agent5:
@@ -150,6 +153,7 @@ services:
       - wazuh-agent5
       - agent_old
     depends_on:
+      - wazuh-agent4
       - nginx-lb
 
   wazuh-agent6:
@@ -170,6 +174,7 @@ services:
       - wazuh-agent6
       - agent_old
     depends_on:
+      - wazuh-agent5
       - nginx-lb
 
   wazuh-agent7:
@@ -190,6 +195,7 @@ services:
       - wazuh-agent7
       - agent_old
     depends_on:
+      - wazuh-agent6
       - nginx-lb
 
   wazuh-agent8:
@@ -210,6 +216,7 @@ services:
       - wazuh-agent8
       - agent_old
     depends_on:
+      - wazuh-agent7
       - nginx-lb
 
   nginx-lb:

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -1489,28 +1489,6 @@ stages:
               request_timeout: !anyint
               max_restart_lock: !anyint
 
-  - name: Request-Com-Cluster (Manager)
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/com/cluster"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          bind_addr: !anystr
-          disabled: !anybool
-          hidden: !anystr
-          key: !anystr
-          name: !anystr
-          node_name: !anystr
-          node_type: !anystr
-          nodes: !anything
-          port: !anyint
-
   - name: Request-Logcollector-Localfile (Manager)
     request:
       verify: False
@@ -1929,6 +1907,36 @@ stages:
       status_code: 400
       json:
         <<: *error_spec
+
+---
+test_name: GET /agents/{agent_id}/config/{component}/{configuration} (only cluster configuration)
+
+marks:
+  - cluster
+
+stages:
+
+- name: Request-Com-Cluster (Manager)
+  request:
+    verify: False
+    url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/com/cluster"
+    method: GET
+    headers:
+      Authorization: "Bearer {test_login_token}"
+  response:
+    status_code: 200
+    json:
+      error: !anyint
+      data:
+        bind_addr: !anystr
+        disabled: !anybool
+        hidden: !anystr
+        key: !anystr
+        name: !anystr
+        node_name: !anystr
+        node_type: !anystr
+        nodes: !anything
+        port: !anyint
 
 ---
 test_name: GET /agents/{agent_id}/group/is_sync


### PR DESCRIPTION
|Related issue|
|---|
| #10593 |

This PR closes #10593.

All the investigation done to solve the issue can be found in the related issue.

The API integration tests failing in a Wazuh environment with cluster disabled have been reviewed. The PR includes fixes related to healthchecks, Docker services dependencies, and others fixes.

