### PR TITLE
Fix undefined reference to pthread_yield() by libdb on gcc 11

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1004,7 +1004,7 @@ ${DB_LIB}: $(EXTERNAL_LIBDB)Makefile
 	 ${MAKE} -C $(EXTERNAL_LIBDB) libdb.a
 
 $(EXTERNAL_LIBDB)Makefile:
-	cd ${EXTERNAL_LIBDB} && CPPFLAGS=-fPIC ../dist/configure --with-cryptography=no --disable-queue --disable-heap --disable-partition --disable-mutexsupport --disable-replication --disable-verify --disable-statistics
+	cd ${EXTERNAL_LIBDB} && CPPFLAGS=-fPIC ../dist/configure --with-cryptography=no --disable-queue --disable-heap --disable-partition --disable-mutexsupport --disable-replication --disable-verify --disable-statistics ac_cv_func_pthread_yield=no
 endif
 
 #### libarchive ######


### PR DESCRIPTION
|Related issue|
|---|
|Closes #10897|

This PR aims to fix this build error that happens on Ubuntu 21.10 (GCC 11):
```
/usr/bin/ld: src/libwazuhext.so: undefined reference to `pthread_yield'
```

`pthread_yield` is now deprecated. On GNU, it's replaced by `sched_yield()`, but we need to define `_GNU_SOURCE` on build time.

**Note:** This PR cannot be merged until the precompiled library repo gets updated.