### PR TITLE
Removing duplicated os_free for cpe_data structure and setting to NULL the freed structure

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5035,7 +5035,7 @@ int wm_vuldet_collect_agent_software(scan_agent *agent, sqlite3 *db, scan_ctx_t*
                 }
 
                 if (s_cpe) {
-                    wm_vuldet_free_cpe(s_cpe);
+                    wm_vuldet_free_cpe(&s_cpe);
                 }
 
                 if (!success) {
@@ -6141,7 +6141,7 @@ void wm_vuldet_free_scan_agent(scan_agent *agent) {
         free(agent->kernel_release);
         int i;
         for (i = 0; agent->agent_os_cpe && agent->agent_os_cpe[i]; i++) {
-            wm_vuldet_free_cpe(agent->agent_os_cpe[i]);
+            wm_vuldet_free_cpe(&agent->agent_os_cpe[i]);
         }
         free(agent->agent_os_cpe);
         free(agent->os_name);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -1091,7 +1091,7 @@ int wm_vuldet_has_offline_update(sqlite3 *db);
 int wm_vuldet_clean_nvd_year(sqlite3 *db, int year);
 int wm_vuldet_remove_sequence(sqlite3 *db, char *table);
 char *wm_vuldet_cpe_str(cpe *cpe_s);
-void wm_vuldet_free_cpe(cpe *node);
+void wm_vuldet_free_cpe(cpe **node);
 void wm_vuldet_free_multi_cpe(cpe *node);
 int wm_vuldet_read(const OS_XML *xml, xml_node **nodes, wmodule *module);
 void wm_vuldet_free_update_node(update_node *update);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -422,53 +422,51 @@ cpe *wm_vuldet_decode_cpe(char *raw_cpe) {
 end:
     if (!success) {
         os_free(cpeuri);
-        wm_vuldet_free_cpe(decoded_cpe);
+        wm_vuldet_free_cpe(&decoded_cpe);
         return NULL;
     }
     return decoded_cpe;
 }
 
-void wm_vuldet_free_cpe(cpe *node) {
-    int i;
+void wm_vuldet_free_cpe(cpe **node) {
+    int i = 0;
 
-    if(node != NULL){
+    if(*node != NULL){
+        cpe* node_ptr = *node;
         // CPE fields
-        os_free(node->part);
-        os_free(node->vendor);
-        os_free(node->product);
-        os_free(node->version);
-        os_free(node->update);
-        os_free(node->edition);
-        os_free(node->language);
-        os_free(node->sw_edition);
-        os_free(node->target_sw);
-        os_free(node->target_hw);
-        os_free(node->other);
+        os_free(node_ptr->part);
+        os_free(node_ptr->vendor);
+        os_free(node_ptr->product);
+        os_free(node_ptr->version);
+        os_free(node_ptr->update);
+        os_free(node_ptr->edition);
+        os_free(node_ptr->language);
+        os_free(node_ptr->sw_edition);
+        os_free(node_ptr->target_sw);
+        os_free(node_ptr->target_hw);
+        os_free(node_ptr->other);
         // Extra fields
-        os_free(node->msu_name);
-        os_free(node->raw);
+        os_free(node_ptr->msu_name);
+        os_free(node_ptr->raw);
         // Multi-fields
-        if (node->cm_product) {
-            for (i = 0; (node->cm_product + i)->translation; i++) {
-                free((void *) (node->cm_product + i)->translation);
-                free((void *) (node->cm_product + i)->field);
-                free((void *) (node->cm_product + i)->condition);
+        if (node_ptr->cm_product) {
+            for (i = 0; (node_ptr->cm_product + i)->translation; i++) {
+                free((void *) (node_ptr->cm_product + i)->translation);
+                free((void *) (node_ptr->cm_product + i)->field);
+                free((void *) (node_ptr->cm_product + i)->condition);
             }
 
-            os_free(node->cm_product);
+            os_free(node_ptr->cm_product);
         }
 
-        os_free(node);
+        os_free(*node);
     }
-
-
-    os_free(node);
 }
 
 void wm_vuldet_free_multi_cpe(cpe *node) {
     while (node) {
         cpe *next = node->next;
-        wm_vuldet_free_cpe(node);
+        wm_vuldet_free_cpe(&node);
         node = next;
     }
 }
@@ -1668,7 +1666,7 @@ void wm_vuldet_free_nvd_conf_cpe_match_node(nvd_conf_cpe_match *data) {
         os_free(data->version_start_excluding);
         os_free(data->version_end_including);
         os_free(data->version_end_excluding);
-        wm_vuldet_free_cpe(data->cpe_node);
+        wm_vuldet_free_cpe(&data->cpe_node);
         os_free(data);
 }
 
@@ -1891,10 +1889,10 @@ int wm_vuldet_find_nvd_vulnerabilities(sqlite3 *db, scan_agent *agent, wm_vuldet
                                            raw_reference, raw_type, nvd_report_list)) {
                 mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_FIND_NVD_VULN_ERR, raw_product, raw_version);
                 wdb_finalize(stmt);
-                wm_vuldet_free_cpe(stored_cpe);
+                wm_vuldet_free_cpe(&stored_cpe);
                 return OS_INVALID;
             }
-            wm_vuldet_free_cpe(stored_cpe);
+            wm_vuldet_free_cpe(&stored_cpe);
             break;
         default:
             return wm_vuldet_sql_error(db, stmt);
@@ -2039,7 +2037,7 @@ int wm_vuldet_get_vuln_nvd_cpe(sqlite3 *db,
                                     free(nvd_report_node);
                                 }
                             }
-                            wm_vuldet_free_cpe(cpe_node);
+                            wm_vuldet_free_cpe(&cpe_node);
                         } else {
                             goto end;
                         }
@@ -2342,7 +2340,7 @@ int wm_vuldet_process_agent_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd
 
         wm_vuldet_free_nvd_report(f_report_node);
         os_free(f_report_node);
-        wm_vuldet_free_cpe(cpe_data);
+        wm_vuldet_free_cpe(&cpe_data);
     }
 
     retval = 0;
@@ -4059,7 +4057,7 @@ void wm_vuldet_free_cpe_list(cpe_list *node_list) {
     cpe_node *node_it = node_list ? node_list->first : NULL;
 
     while (node_it) {
-        wm_vuldet_free_cpe(node_it->node);
+        wm_vuldet_free_cpe(&node_it->node);
         r_node = node_it->next;
         os_free(node_it);
         node_it = r_node;


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/10903 |

## Description

The next pull request fixes the next issues reported by Coverity:

- There was an unnecessary `os_free` call within the `wm_vuldet_free_cpe` function.
- After freeing the memory of a structure, it wasn't set to `NULL` causing a double free and use after free.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

- Memory tests for Linux
  - [x] Coverity
![image](https://user-images.githubusercontent.com/5703274/142466581-94748cd5-bdea-4ed9-9b88-9ff479b731ab.png)
