### PR TITLE
Check that files collected by the AWS module aren't folders before processing them

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -903,6 +903,10 @@ class AWSBucket(WazuhIntegration):
                     if not bucket_file['Key']:
                         continue
 
+                    if bucket_file['Key'][-1] == '/':
+                        # The file is a folder
+                        continue
+
                     if self.check_prefix:
                         date_match = self.date_regex.search(bucket_file['Key'])
                         match_start = date_match.span()[0] if date_match else None
@@ -1194,6 +1198,10 @@ class AWSConfigBucket(AWSLogsBucket):
                 if not bucket_file['Key']:
                     continue
 
+                if bucket_file['Key'][-1] == '/':
+                    # The file is a folder
+                    continue
+
                 if self.already_processed(bucket_file['Key'], aws_account_id, aws_region):
                     if self.reparse:
                         debug("++ File previously processed, but reparse flag set: {file}".format(
@@ -1227,6 +1235,11 @@ class AWSConfigBucket(AWSLogsBucket):
                 for bucket_file in bucket_files['Contents']:
                     if not bucket_file['Key']:
                         continue
+
+                    if bucket_file['Key'][-1] == '/':
+                        # The file is a folder
+                        continue
+
                     if self.already_processed(bucket_file['Key'], aws_account_id, aws_region):
                         if self.reparse:
                             debug("++ File previously processed, but reparse flag set: {file}".format(
@@ -1663,6 +1676,10 @@ class AWSVPCFlowBucket(AWSLogsBucket):
                 if not bucket_file['Key']:
                     continue
 
+                if bucket_file['Key'][-1] == '/':
+                    # The file is a folder
+                    continue
+
                 if self.already_processed(bucket_file['Key'], aws_account_id, aws_region, flow_log_id):
                     if self.reparse:
                         debug("++ File previously processed, but reparse flag set: {file}".format(
@@ -1699,6 +1716,11 @@ class AWSVPCFlowBucket(AWSLogsBucket):
                 for bucket_file in bucket_files['Contents']:
                     if not bucket_file['Key']:
                         continue
+
+                    if bucket_file['Key'][-1] == '/':
+                        # The file is a folder
+                        continue
+
                     if self.already_processed(bucket_file['Key'], aws_account_id, aws_region, flow_log_id):
                         if self.reparse:
                             debug("++ File previously processed, but reparse flag set: {file}".format(
@@ -2291,6 +2313,10 @@ class AWSServerAccess(AWSCustomBucket):
                 if not bucket_file['Key']:
                     continue
 
+                if bucket_file['Key'][-1] == '/':
+                    # The file is a folder
+                    continue
+
                 try:
                     date_match = self.date_regex.search(bucket_file['Key'])
                     file_date = datetime.strptime(date_match.group(), '%Y-%m-%d-%H-%M-%S') if date_match else None
@@ -2341,6 +2367,10 @@ class AWSServerAccess(AWSCustomBucket):
 
                 for bucket_file in bucket_files['Contents']:
                     if not bucket_file['Key']:
+                        continue
+
+                    if bucket_file['Key'][-1] == '/':
+                        # The file is a folder
                         continue
 
                     try:


### PR DESCRIPTION
|Related issue|
|--|
|Closes #10664|

## Description
In this PR we fix that sometimes the module would process manually created bucket folders as if they were files.

<details><summary>Execution before fix</summary>

<p>

```
root@4d6e620e43c1:/var/ossec/wodles/aws# ./aws-s3 -d2 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -s 2021-nov-01  
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/01
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/01/XXXXXXXXXXXX_CloudTrail_us-west-1_20211101T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/02/XXXXXXXXXXXX_CloudTrail_us-west-1_20211102T0000Z_qJRrDloAWNoOMRAy.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/03/XXXXXXXXXXXX_CloudTrail_us-west-1_20211103T0000Z_OtoPYJqXyVMnScng.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/08/XXXXXXXXXXXX_CloudTrail_us-west-1_20211108T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/11/XXXXXXXXXXXX_CloudTrail_us-west-1_20211111T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/15/XXXXXXXXXXXX_CloudTrail_us-west-1_20211115T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/21/
DEBUG: ++ Failed to parse file AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/21/: Expecting value: line 1 column 1 (char 0); skipping...
DEBUG: +++ Error marking log AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/21/ as completed: list index out of range
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/21/XXXXXXXXXXXX_CloudTrail_us-west-1_20211121T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/22/XXXXXXXXXXXX_CloudTrail_us-west-1_20211122T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_empty - us-west-1
DEBUG: +++ Marker: AWSLogs/test_empty/CloudTrail/us-west-1/2021/11/01
DEBUG: +++ No logs to process in bucket: test_empty/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_suffix - us-west-1
DEBUG: +++ Marker: AWSLogs/test_suffix/CloudTrail/us-west-1/2021/11/01
DEBUG: +++ No logs to process in bucket: test_suffix/us-west-1
DEBUG: +++ DB Maintenance
```

</p>

</details>

<details><summary>Execution after fix</summary>

<p>

```
root@4d6e620e43c1:/var/ossec/wodles/aws# ./aws-s3 -d2 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -s 2021-nov-01  
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/01
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/01/XXXXXXXXXXXX_CloudTrail_us-west-1_20211101T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/02/XXXXXXXXXXXX_CloudTrail_us-west-1_20211102T0000Z_qJRrDloAWNoOMRAy.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/03/XXXXXXXXXXXX_CloudTrail_us-west-1_20211103T0000Z_OtoPYJqXyVMnScng.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/08/XXXXXXXXXXXX_CloudTrail_us-west-1_20211108T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/11/XXXXXXXXXXXX_CloudTrail_us-west-1_20211111T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/15/XXXXXXXXXXXX_CloudTrail_us-west-1_20211115T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/21/XXXXXXXXXXXX_CloudTrail_us-west-1_20211121T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/22/XXXXXXXXXXXX_CloudTrail_us-west-1_20211122T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_empty - us-west-1
DEBUG: +++ Marker: AWSLogs/test_empty/CloudTrail/us-west-1/2021/11/01
DEBUG: +++ No logs to process in bucket: test_empty/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_suffix - us-west-1
DEBUG: +++ Marker: AWSLogs/test_suffix/CloudTrail/us-west-1/2021/11/01
DEBUG: +++ No logs to process in bucket: test_suffix/us-west-1
DEBUG: +++ DB Maintenance
```


</p>

</details>

## Tests performed
The following execution examples -one for every affected bucket- show that the aforementioned `Failed to parse...` error doesn't appears anymore after the changes introduced in this PR.

<details><summary>Execution with Cloudtrail</summary>

<p>

```
root@4d6e620e43c1:/var/ossec/wodles/aws# ./aws-s3 -d2 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -s 2021-nov-01  
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/01
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/01/XXXXXXXXXXXX_CloudTrail_us-west-1_20211101T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/02/XXXXXXXXXXXX_CloudTrail_us-west-1_20211102T0000Z_qJRrDloAWNoOMRAy.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/03/XXXXXXXXXXXX_CloudTrail_us-west-1_20211103T0000Z_OtoPYJqXyVMnScng.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/08/XXXXXXXXXXXX_CloudTrail_us-west-1_20211108T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/11/XXXXXXXXXXXX_CloudTrail_us-west-1_20211111T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/15/XXXXXXXXXXXX_CloudTrail_us-west-1_20211115T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/21/XXXXXXXXXXXX_CloudTrail_us-west-1_20211121T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/22/XXXXXXXXXXXX_CloudTrail_us-west-1_20211122T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_empty - us-west-1
DEBUG: +++ Marker: AWSLogs/test_empty/CloudTrail/us-west-1/2021/11/01
DEBUG: +++ No logs to process in bucket: test_empty/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_suffix - us-west-1
DEBUG: +++ Marker: AWSLogs/test_suffix/CloudTrail/us-west-1/2021/11/01
DEBUG: +++ No logs to process in bucket: test_suffix/us-west-1
DEBUG: +++ DB Maintenance
```

</p>

</details>


<details><summary>Execution with AWSConfigBucket</summary>

<p>

```
root@4d6e620e43c1:/var/ossec/wodles/aws# rm *.db; ./aws-s3 -d2 -b wazuh-aws-wodle-config -t config -s 2021-nov-10 -r us-east-1 
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/10
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/11
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/12
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/13
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/14
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/15
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/16
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/17
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/18
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/19
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/20
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/21
DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/22
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/22/22/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211122T004303Z_20211109T025123Z_1.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
```

</p>

</details>

<details><summary>Execution with AWSVPCFlow</summary>

<p>

```
root@4d6e620e43c1:/var/ossec/wodles/aws# rm *.db; ./aws-s3 -d2 -b wazuh-aws-wodle-vpcflow -t vpcflow -s 2021-nov-10 -r us-east-1
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/10
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/11
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/12
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/13
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/14
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/15
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/16
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/17
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/18
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/19
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/20
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/21
DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/22
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/22/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211122T0000Z_ce6176d8.log.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
```

</p>

</details>

<details><summary>Execution with AWSConfigBucket</summary>

<p>

```
root@4d6e620e43c1:/var/ossec/wodles/aws# rm *.db; ./aws-s3 -d2 -b wazuh-aws-wodle-access -t server_access -s 2021-nov-10 -r us-east-1 -l test_process_folder
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Marker: test_process_folder/2021-11-10
DEBUG: ++ Found new log: test_process_folder/2021-11-15-09-12-25-F92E1554CC549BEE
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
```

</p>

</details>

<details><summary>Execution with an agent</summary>

<p>

```
root@83295ec3b046:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -d2 
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Table does not exist; create
DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/22
DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/22/XXXXXXXXXXXX_CloudTrail_us-west-1_20211122T0000Z_rUQtGNUqmrPZMCnu.json.gz
DEBUG: +++ DB Maintenance
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_empty - us-west-1
DEBUG: +++ Marker: AWSLogs/test_empty/CloudTrail/us-west-1/2021/11/22
DEBUG: +++ No logs to process in bucket: test_empty/us-west-1
DEBUG: +++ DB Maintenance
DEBUG: +++ Working on test_suffix - us-west-1
DEBUG: +++ Marker: AWSLogs/test_suffix/CloudTrail/us-west-1/2021/11/22
DEBUG: +++ No logs to process in bucket: test_suffix/us-west-1
DEBUG: +++ DB Maintenance
```

</p>

</details>
