### PR TITLE
Prevent Wazuh DB from preparing statements multiple times

### DIFF
--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -1240,17 +1240,9 @@ int wdb_stmt_cache(wdb_t * wdb, int index) {
             merror("DB(%s) sqlite3_prepare_v2() stmt(%d): %s", wdb->id, index, sqlite3_errmsg(wdb->db));
             return -1;
         }
-    } else if (sqlite3_reset(wdb->stmt[index]) != SQLITE_OK || sqlite3_clear_bindings(wdb->stmt[index]) != SQLITE_OK) {
-        mdebug1("DB(%s) sqlite3_reset() stmt(%d): %s", wdb->id, index, sqlite3_errmsg(wdb->db));
-
-        // Retry to prepare
-
-        sqlite3_finalize(wdb->stmt[index]);
-
-        if (sqlite3_prepare_v2(wdb->db, SQL_STMT[index], -1, wdb->stmt + index, NULL) != SQLITE_OK) {
-            merror("DB(%s) sqlite3_prepare_v2() stmt(%d): %s", wdb->id, index, sqlite3_errmsg(wdb->db));
-            return -1;
-        }
+    } else {
+        sqlite3_reset(wdb->stmt[index]);
+        sqlite3_clear_bindings(wdb->stmt[index]);
     }
 
     return 0;


### PR DESCRIPTION
This PR aims to prevent Wazuh DB from unnecessarily recompiling SQL statements.

## Rationale

Wazuh DB produced this log during a test:

```
2021/11/15 16:01:55 wazuh-modulesd:database[21279] wm_database.c:279 at wm_sync_agents(): DEBUG: Synchronizing agent 22488 '1-62aP5XF9rbwZA4hu-debian10'.
2021/11/15 16:01:55 wazuh-db[21102] wdb_parser.c:643 at wdb_parse(): DEBUG: Global query: insert-agent {"id":22488,"name":"1-62aP5XF9rbwZA4hu-debian10","register_ip":"any","internal_key":"abafcf0600b04be021dbb81ca2bf3f2051c64a3f6c4d7c6fecec2bf06238074a","group":"default","date_add":1636991641}
2021/11/15 16:01:55 wazuh-db[21102] wdb.c:1244 at wdb_stmt_cache(): DEBUG: DB(global) sqlite3_reset() stmt(103): UNIQUE constraint failed: agent.id
2021/11/15 16:01:55 wazuh-db[21102] wdb_global.c:90 at wdb_global_insert_agent(): DEBUG: SQLite: UNIQUE constraint failed: agent.id
2021/11/15 16:01:55 wazuh-db[21102] wdb_parser.c:4640 at wdb_parse_global_insert_agent(): DEBUG: Global DB Cannot execute SQL query; err database queue/db/global.db: UNIQUE constraint failed: agent.id
2021/11/15 16:01:55 wazuh-modulesd[21279] wdb_global_helpers.c:103 at wdb_insert_agent(): DEBUG: Global DB Error reported in the result of the query
2021/11/15 16:01:55 wazuh-db[21102] wdb_parser.c:643 at wdb_parse(): DEBUG: Global query: update-agent-group {"id":22488,"group":"default"}
2021/11/15 16:01:55 wazuh-db[21102] wdb_parser.c:643 at wdb_parse(): DEBUG: Global query: delete-agent-belong 22488
2021/11/15 16:01:55 wazuh-db[21102] wdb_parser.c:643 at wdb_parse(): DEBUG: Global query: find-group default
2021/11/15 16:01:55 wazuh-db[21102] wdb_parser.c:643 at wdb_parse(): DEBUG: Global query: insert-agent-belong {"id_group":1,"id_agent":22488}
2021/11/15 16:01:55 wazuh-modulesd:database[21279] wm_database.c:473 at wm_sync_agent_group(): DEBUG: wm_sync_agent_group(22488): 0.074 ms.
```

These logs correspond to a normal agent synchronization. The sync module tries to insert every agent in the database, and Wazuh DB returns that the agent is already in the database.

However, we don't expect this line to appear:
```
2021/11/15 16:01:55 wazuh-db[21102] wdb.c:1244 at wdb_stmt_cache(): DEBUG: DB(global) sqlite3_reset() stmt(103): UNIQUE constraint failed: agent.id
```

This is because **the sqlite's statement reset function returns the latest statement's result** ([Reset A Prepared Statement Object](https://www.sqlite.org/c3ref/reset.html)):

> If the most recent call to `sqlite3_step(S)` for the prepared statement S indicated an error, then `sqlite3_reset(S)` returns an appropriate error code.

Due to this, Wazuh DB wrongly interprets that the reset operation failed, and it recompiles the statement.

On the other hand, the documentation of `sqlite3_clear_bindings` ([Reset All Bindings On A Prepared Statement](https://www.sqlite.org/c3ref/clear_bindings.html)) provides no data about its return value. Based on a PoC, I suspect that the function always returns `0`.

## Proposed change

Ignore the return value of `sqlite3_reset()` and `sqlite3_clear_bindings()`.

## Tests

- [X] Wazuh DB no longer produces such logs.
- [X] Agent synchronization works properly.