### PR TITLE
Add xfail marks to known failing API integration test cases

### DIFF
--- a/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
@@ -391,6 +391,9 @@ stages:
 ---
 test_name: PUT /agents/reconnect
 
+marks:
+  - xfail # Review and fix RBAC black agent API integration test - https://github.com/wazuh/wazuh/issues/10914
+
 stages:
 
   # PUT /agents/reconnect?agents_list=wrong_id
@@ -841,6 +844,9 @@ stages:
 
 ---
 test_name: PUT /agents/upgrade
+
+marks:
+  - xfail # Review agents upgrade API integration tests - https://github.com/wazuh/wazuh/issues/10791
 
 stages:
 

--- a/api/test/integration/test_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_experimental_endpoints.tavern.yaml
@@ -211,6 +211,9 @@ stages:
 ---
 test_name: GET /experimental/syscollector/netaddr
 
+marks:
+  - xfail # Investigate and fix error in experimental API integration tests - https://github.com/wazuh/wazuh/issues/10654
+
 stages:
 
   - name: Request
@@ -275,6 +278,9 @@ stages:
 
 ---
 test_name: GET /experimental/syscollector/netiface
+
+marks:
+  - xfail # Investigate and fix error in experimental API integration tests - https://github.com/wazuh/wazuh/issues/10654
 
 stages:
 
@@ -352,6 +358,9 @@ stages:
 ---
 test_name: GET /experimental/syscollector/netproto
 
+marks:
+  - xfail # Investigate and fix error in experimental API integration tests - https://github.com/wazuh/wazuh/issues/10654
+
 stages:
 
   - name: Request
@@ -415,6 +424,9 @@ stages:
 
 ---
 test_name: GET /experimental/syscollector/os
+
+marks:
+  - xfail # Investigate and fix error in experimental API integration tests - https://github.com/wazuh/wazuh/issues/10654
 
 stages:
 
@@ -529,6 +541,9 @@ stages:
 
 ---
 test_name: GET /experimental/syscollector/ports
+
+marks:
+  - xfail # Investigate and fix error in experimental API integration tests - https://github.com/wazuh/wazuh/issues/10654
 
 stages:
 

--- a/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
@@ -1352,6 +1352,9 @@ stages:
 ---
 test_name: PUT /agents/reconnect
 
+marks:
+  - xfail # Review and fix RBAC black agent API integration test - https://github.com/wazuh/wazuh/issues/10914
+
 stages:
 
   - name: Try to reconnect agent 001 (Denied)

--- a/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
@@ -191,6 +191,9 @@ stages:
 ---
 test_name: GET /experimental/syscollector/hardware
 
+marks:
+  - xfail # Investigate and fix error in experimental API integration tests - https://github.com/wazuh/wazuh/issues/10654
+
 stages:
 
   - name: Request all agents (Partially allowed, user agnostic)
@@ -244,6 +247,9 @@ stages:
 ---
 test_name: GET /experimental/syscollector/netaddr
 
+marks:
+  - xfail # Investigate and fix error in experimental API integration tests - https://github.com/wazuh/wazuh/issues/10654
+
 stages:
 
   - name: Request all agents (Partially allowed, user agnostic)
@@ -288,6 +294,9 @@ stages:
 
 ---
 test_name: GET /experimental/syscollector/netiface
+
+marks:
+  - xfail # Investigate and fix error in experimental API integration tests - https://github.com/wazuh/wazuh/issues/10654
 
 stages:
 
@@ -334,6 +343,9 @@ stages:
 ---
 test_name: GET /experimental/syscollector/netproto
 
+marks:
+  - xfail # Investigate and fix error in experimental API integration tests - https://github.com/wazuh/wazuh/issues/10654
+
 stages:
 
   - name: Request all agents (Partially allowed, user agnostic)
@@ -378,6 +390,9 @@ stages:
 
 ---
 test_name: GET /experimental/syscollector/os
+
+marks:
+  - xfail # Investigate and fix error in experimental API integration tests - https://github.com/wazuh/wazuh/issues/10654
 
 stages:
 
@@ -457,6 +472,9 @@ stages:
 
 ---
 test_name: GET /experimental/syscollector/ports
+
+marks:
+  - xfail # Investigate and fix error in experimental API integration tests - https://github.com/wazuh/wazuh/issues/10654
 
 stages:
 

--- a/api/test/integration/test_rbac_black_syscollector_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_syscollector_endpoints.tavern.yaml
@@ -2,6 +2,7 @@
 test_name: GET OS SYSCOLLECTOR RBAC
 
 marks:
+  - xfail # Review and fix syscollector endpoints API integration tests - https://github.com/wazuh/wazuh/issues/10923
   - base_tests
 
 stages:
@@ -53,6 +54,9 @@ stages:
 ---
 test_name: GET HARDWARE SYSCOLLECTOR RBAC
 
+marks:
+  - xfail # Review and fix syscollector endpoints API integration tests - https://github.com/wazuh/wazuh/issues/10923
+
 stages:
 
   - name: Get hardware from an agent (Allow)
@@ -96,6 +100,9 @@ stages:
 ---
 test_name: GET NETADDR SYSCOLLECTOR RBAC
 
+marks:
+  - xfail # Review and fix syscollector endpoints API integration tests - https://github.com/wazuh/wazuh/issues/10923
+
 stages:
 
   - name: Get netaddr from an agent (Allow)
@@ -132,6 +139,9 @@ stages:
 
 ---
 test_name: GET NETIFACE SYSCOLLECTOR RBAC
+
+marks:
+  - xfail # Review and fix syscollector endpoints API integration tests - https://github.com/wazuh/wazuh/issues/10923
 
 stages:
 

--- a/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
@@ -1400,6 +1400,9 @@ stages:
 ---
 test_name: PUT /agents/reconnect
 
+marks:
+  - xfail # Review and fix RBAC black agent API integration test - https://github.com/wazuh/wazuh/issues/10914
+
 stages:
 
   - name: Try to reconnect non existing agent (Allowed)

--- a/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
@@ -191,6 +191,9 @@ stages:
 ---
 test_name: GET /experimental/syscollector/hardware
 
+marks:
+  - xfail # Investigate and fix error in experimental API integration tests - https://github.com/wazuh/wazuh/issues/10654
+
 stages:
 
   - name: Request all agents (Partially allowed, user agnostic)
@@ -242,6 +245,9 @@ stages:
 
 ---
 test_name: GET /experimental/syscollector/netaddr
+
+marks:
+  - xfail # Investigate and fix error in experimental API integration tests - https://github.com/wazuh/wazuh/issues/10654
 
 stages:
 
@@ -295,6 +301,9 @@ stages:
 ---
 test_name: GET /experimental/syscollector/netiface
 
+marks:
+  - xfail # Investigate and fix error in experimental API integration tests - https://github.com/wazuh/wazuh/issues/10654
+
 stages:
 
   - name: Request all agents (Partially allowed, user agnostic)
@@ -347,6 +356,9 @@ stages:
 ---
 test_name: GET /experimental/syscollector/netproto
 
+marks:
+  - xfail # Investigate and fix error in experimental API integration tests - https://github.com/wazuh/wazuh/issues/10654
+
 stages:
 
   - name: Request all agents (Partially allowed, user agnostic)
@@ -398,6 +410,9 @@ stages:
 
 ---
 test_name: GET /experimental/syscollector/os
+
+marks:
+  - xfail # Investigate and fix error in experimental API integration tests - https://github.com/wazuh/wazuh/issues/10654
 
 stages:
 
@@ -488,6 +503,9 @@ stages:
 
 ---
 test_name: GET /experimental/syscollector/ports
+
+marks:
+  - xfail # Investigate and fix error in experimental API integration tests - https://github.com/wazuh/wazuh/issues/10654
 
 stages:
 

--- a/api/test/integration/test_rbac_white_syscollector_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_syscollector_endpoints.tavern.yaml
@@ -2,6 +2,7 @@
 test_name: GET OS SYSCOLLECTOR RBAC
 
 marks:
+  - xfail # Review and fix syscollector endpoints API integration tests - https://github.com/wazuh/wazuh/issues/10923
   - rbac_tests
 
 stages:
@@ -56,6 +57,9 @@ stages:
 ---
 test_name: GET HARDWARE SYSCOLLECTOR RBAC
 
+marks:
+  - xfail # Review and fix syscollector endpoints API integration tests - https://github.com/wazuh/wazuh/issues/10923
+
 stages:
 
   - name: Get hardware from an agent (Allow)
@@ -99,6 +103,9 @@ stages:
 ---
 test_name: GET NETADDR SYSCOLLECTOR RBAC
 
+marks:
+  - xfail # Review and fix syscollector endpoints API integration tests - https://github.com/wazuh/wazuh/issues/10923
+
 stages:
 
   - name: Get netaddr from an agent (Allow)
@@ -135,6 +142,9 @@ stages:
 
 ---
 test_name: GET NETIFACE SYSCOLLECTOR RBAC
+
+marks:
+  - xfail # Review and fix syscollector endpoints API integration tests - https://github.com/wazuh/wazuh/issues/10923
 
 stages:
 

--- a/api/test/integration/test_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_syscheck_endpoints.tavern.yaml
@@ -490,6 +490,9 @@ stages:
 ---
 test_name: PUT /syscheck
 
+marks:
+  - xfail # Review and fix syscheck API integration test - https://github.com/wazuh/wazuh/issues/10913
+
 stages:
 
   - name: Try to run a syscheck scan in agent 000

--- a/api/test/integration/test_syscollector_endpoints.tavern.yaml
+++ b/api/test/integration/test_syscollector_endpoints.tavern.yaml
@@ -3,6 +3,7 @@ test_name: GET /syscollector/{agent_id}/os
 
 marks:
   - base_tests
+  - xfail # Review and fix syscollector endpoints API integration tests - https://github.com/wazuh/wazuh/issues/10923
 
 stages:
 
@@ -59,6 +60,7 @@ stages:
 test_name: GET /syscollector/{agent_id}/os?{select}
 
 marks:
+  - xfail # Review and fix syscollector endpoints API integration tests - https://github.com/wazuh/wazuh/issues/10923
   - parametrize:
       key: field
       vals:
@@ -94,6 +96,9 @@ stages:
 
 ---
 test_name: GET /syscollector/{agent_id}/hardware
+
+marks:
+  - xfail # Review and fix syscollector endpoints API integration tests - https://github.com/wazuh/wazuh/issues/10923
 
 stages:
 
@@ -143,6 +148,7 @@ stages:
 test_name: GET /syscollector/{agent_id}/hardware?{select}
 
 marks:
+  - xfail # Review and fix syscollector endpoints API integration tests - https://github.com/wazuh/wazuh/issues/10923
   - parametrize:
       key: field
       vals:
@@ -1317,6 +1323,9 @@ stages:
 ---
 test_name: GET /syscollector/{agent_id}/netaddr
 
+marks:
+  - xfail # Review and fix syscollector endpoints API integration tests - https://github.com/wazuh/wazuh/issues/10923
+
 stages:
 
   - name: Netaddress of an agent
@@ -1658,6 +1667,7 @@ stages:
 test_name: GET /syscollector/{agent_id}/netaddr?{sort,select}
 
 marks:
+  - xfail # Review and fix syscollector endpoints API integration tests - https://github.com/wazuh/wazuh/issues/10923
   - parametrize:
       key: field
       vals:
@@ -2033,6 +2043,9 @@ stages:
 
 ---
 test_name: GET /syscollector/{agent_id}/netiface
+
+marks:
+  - xfail # Review and fix syscollector endpoints API integration tests - https://github.com/wazuh/wazuh/issues/10923
 
 stages:
 
@@ -2643,6 +2656,7 @@ stages:
 test_name: GET /syscollector/{agent_id}/netiface?{sort,select}
 
 marks:
+  - xfail # Review and fix syscollector endpoints API integration tests - https://github.com/wazuh/wazuh/issues/10923
   - parametrize:
       key: field
       vals:
@@ -2699,6 +2713,9 @@ stages:
 ---
 test_name: GET /syscollector/{agent_id}/os
 
+marks:
+  - xfail # Review and fix syscollector endpoints API integration tests - https://github.com/wazuh/wazuh/issues/10923
+
 stages:
 
   - name: Get the OS of an agent
@@ -2748,6 +2765,7 @@ stages:
 test_name: GET /syscollector/{agent_id}/os?{select}
 
 marks:
+  - xfail # Review and fix syscollector endpoints API integration tests - https://github.com/wazuh/wazuh/issues/10923
   - parametrize:
       key: field
       vals:
@@ -2785,6 +2803,9 @@ stages:
 
 ---
 test_name: GET /syscollector/{agent_id}/hardware
+
+marks:
+  - xfail # Review and fix syscollector endpoints API integration tests - https://github.com/wazuh/wazuh/issues/10923
 
 stages:
 
@@ -2830,6 +2851,7 @@ stages:
 test_name: GET /syscollector/{agent_id}/hardware?{select}
 
 marks:
+  - xfail # Review and fix syscollector endpoints API integration tests - https://github.com/wazuh/wazuh/issues/10923
   - parametrize:
       key: field
       vals:
@@ -2860,6 +2882,9 @@ stages:
 
 ---
 test_name: GET /syscollector/{agent_id}/netaddr
+
+marks:
+  - xfail # Review and fix syscollector endpoints API integration tests - https://github.com/wazuh/wazuh/issues/10923
 
 stages:
 
@@ -3160,6 +3185,7 @@ stages:
 test_name: GET /syscollector/{agent_id}/netaddr?{sort,select}
 
 marks:
+  - xfail # Review and fix syscollector endpoints API integration tests - https://github.com/wazuh/wazuh/issues/10923
   - parametrize:
       key: field
       vals:
@@ -3535,6 +3561,9 @@ stages:
 
 ---
 test_name: GET /syscollector/{agent_id}/netiface
+
+marks:
+  - xfail # Review and fix syscollector endpoints API integration tests - https://github.com/wazuh/wazuh/issues/10923
 
 stages:
 
@@ -4130,6 +4159,7 @@ stages:
 test_name: GET /syscollector/{agent_id}/netiface?{sort,select}
 
 marks:
+  - xfail # Review and fix syscollector endpoints API integration tests - https://github.com/wazuh/wazuh/issues/10923
   - parametrize:
       key: field
       vals:

--- a/api/test/integration/test_vulnerability_endpoints.tavern.yaml
+++ b/api/test/integration/test_vulnerability_endpoints.tavern.yaml
@@ -3,6 +3,7 @@ test_name: GET /vulnerability/{agent_id}
 
 marks:
   - base_tests
+  - xfail # Review and fix vulnerability endpoints API integration test - https://github.com/wazuh/wazuh/issues/10917
 
 stages:
 


### PR DESCRIPTION
This pull request is related to the epic issue #10918.

In this PR, I have added **`xfail`** marks to API integration tests failing that we have already reported in issues:

- test_syscheck_endpoints: https://github.com/wazuh/wazuh/issues/10913
- test_agent_PUT_endpoints: https://github.com/wazuh/wazuh/issues/10791 y https://github.com/wazuh/wazuh/issues/10914
- test_rbac_black_agent_endpoints: https://github.com/wazuh/wazuh/issues/10914
- test_rbac_white_agent_endpoints: https://github.com/wazuh/wazuh/issues/10914
- test_experimental_endpoints: https://github.com/wazuh/wazuh/issues/10654
- test_rbac_black_experimental_endpoints: https://github.com/wazuh/wazuh/issues/10654
- test_rbac_white_experimental_endpoints: https://github.com/wazuh/wazuh/issues/10654
- test_vulnerability_endpoints: https://github.com/wazuh/wazuh/issues/10917
- test_rbac_black_syscollector_endpoints: https://github.com/wazuh/wazuh/issues/10923
- test_rbac_white_syscollector_endpoints: https://github.com/wazuh/wazuh/issues/10923
- test_syscollector_endpoints: https://github.com/wazuh/wazuh/issues/10923

### Test results

```
test_syscheck_endpoints.tavern.yaml 
	 34 passed, 1 xpassed, 37 warnings

test_agent_PUT_endpoints.tavern.yaml 
	 6 passed, 4 xpassed, 12 warnings

test_rbac_black_agent_endpoints.tavern.yaml 
	 39 passed, 2 xpassed, 43 warnings

test_rbac_white_agent_endpoints.tavern.yaml 
	 40 passed, 1 xpassed, 43 warnings

test_experimental_endpoints.tavern.yaml 
	 6 passed, 6 xpassed, 14 warnings

test_rbac_black_experimental_endpoints.tavern.yaml 
	 6 passed, 6 xpassed, 14 warnings

test_rbac_white_experimental_endpoints.tavern.yaml 
	 6 passed, 6 xpassed, 14 warnings

test_vulnerability_endpoints.tavern.yaml 
	 1 passed, 1 xpassed, 4 warnings

test_rbac_black_syscollector_endpoints.tavern.yaml 
	 5 passed, 4 xpassed, 11 warnings

test_rbac_white_syscollector_endpoints.tavern.yaml 
	 5 passed, 4 xpassed, 11 warnings
	 
test_syscollector_endpoints.tavern.yaml 
	 67 passed, 92 xpassed, 161 warnings
```
