### PR TITLE
Add issue template for the external integrations

### DIFF
--- a/.github/ISSUE_TEMPLATE/external-integrations.md
+++ b/.github/ISSUE_TEMPLATE/external-integrations.md
@@ -2,7 +2,7 @@
 name: External integrations issue. 
 about: Report a bug or make a feature request.
 title: ''
-labels: 'external_integrations, framework'
+labels: 'external_integrations'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/external-integrations.md
+++ b/.github/ISSUE_TEMPLATE/external-integrations.md
@@ -13,11 +13,11 @@ assignees: ''
 
 <!--
 Whenever possible, issues should be created for bug reporting and feature requests.
-For questions related to the user experience, please refer:
+For questions related to the user experience, please refer to:
 - Wazuh mailing list: https://groups.google.com/forum/#!forum/wazuh
 - Join Wazuh on Slack: https://wazuh.com/community/join-us-on-slack
 
-Please fill the table above. Feel free to extend it at your convenience.
+Please fill in the table above. Feel free to extend it at your convenience.
 -->
 
 
@@ -27,7 +27,7 @@ In case of a feature request of a new service please provide example logs of tha
 
 In case of a bug report:
 - Indicate the Wazuh version.
-- Tell if it has failed on a manager, an agent or both.
+- Tell if it has failed on a manager, an agent, or both.
 - Attach logs that illustrate the bug inside the <detail> tag below -you may want to set debug options `wazuh_modules.debug=2` and restart Wazuh (see https://documentation.wazuh.com/current/user-manual/reference/internal-options.html) to get verbose logs. This may help investigate the issue-.
 
 <details><summary><SERVICE> logs</summary>

--- a/.github/ISSUE_TEMPLATE/external-integrations.md
+++ b/.github/ISSUE_TEMPLATE/external-integrations.md
@@ -1,0 +1,49 @@
+---
+name: External integrations issue. 
+about: Report a bug or make a feature request.
+title: ''
+labels: 'external_integrations, framework'
+assignees: ''
+
+---
+
+| Affected integration |
+|---|
+| AWS, GCloud, Azure...|
+
+<!--
+Whenever possible, issues should be created for bug reporting and feature requests.
+For questions related to the user experience, please refer:
+- Wazuh mailing list: https://groups.google.com/forum/#!forum/wazuh
+- Join Wazuh on Slack: https://wazuh.com/community/join-us-on-slack
+
+Please fill the table above. Feel free to extend it at your convenience.
+-->
+
+
+## Description
+<!--
+In case of a feature request of a new service please provide example logs of that service copying them inside the <details> tag below.
+
+In case of a bug report:
+- Indicate the Wazuh version.
+- Tell if it has failed on a manager, an agent or both.
+- Attach logs that illustrate the bug inside the <detail> tag below -you may want to set debug options `wazuh_modules.debug=2` and restart Wazuh (see https://documentation.wazuh.com/current/user-manual/reference/internal-options.html) to get verbose logs. This may help investigate the issue-.
+
+<details><summary><SERVICE> logs</summary>
+
+<p>
+
+```
+<COPY LOGS HERE>
+```
+</p>
+
+</details>
+-->
+
+## Tasks
+- [ ] Test in a manager
+- [ ] Test in an agent
+- [ ] Update the documentation if necessary
+- [ ] Add entry to the changelog if necessary

--- a/.github/ISSUE_TEMPLATE/external-integrations.md
+++ b/.github/ISSUE_TEMPLATE/external-integrations.md
@@ -43,7 +43,9 @@ In case of a bug report:
 -->
 
 ## Tasks
-- [ ] Test in a manager
-- [ ] Test in an agent
-- [ ] Update the documentation if necessary
-- [ ] Add entry to the changelog if necessary
+- [ ] Test in a manager.
+- [ ] Test in an agent.
+- [ ] Unit tests without failures. Updated if there are any relevant changes.
+- [ ] API integration tests without failures. Updated if there are any relevant changes.
+- [ ] Update the documentation if necessary.
+- [ ] Add entry to the changelog if necessary.


### PR DESCRIPTION
| Related issue |
|--|
|Closes #10878 |

## Description
In this PR we add a new issue template for the external integrations to the repository. This will ease the task of reporting bugs or requesting new features related to the AWS, Azure and GCloud integrations.