### PR TITLE
Change referenced issue in upgrade API test case `xfail` mark

### DIFF
--- a/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
@@ -846,7 +846,7 @@ stages:
 test_name: PUT /agents/upgrade
 
 marks:
-  - xfail # Review agents upgrade API integration tests - https://github.com/wazuh/wazuh/issues/10791
+  - xfail # Agents stay with "pending" status for too long - https://github.com/wazuh/wazuh/issues/10162
 
 stages:
 


### PR DESCRIPTION
|Related issue|
|---|
| close #10791 |

This PR closes #10791. 

As it was commented in the related issue, the `agent_PUT` API integration test is randomly failing due to the `PUT /agents/upgrade` test case.

The test case is failing because we expect an **1822** status code and **1707** is returned. The 1822 code indicates that we are trying to upgrade an agent to a version greater or equal to the actual version. On the other hand, the 1707 code means that the agent is not active. In this case, as we see in the session summary:

```
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/{agent_id}/restart PASSED [ 70%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/node/{node_id}/restart XFAIL [ 80%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/upgrade FAILED         [ 90%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/{agent_id}/upgrade_custom XFAIL [100%]
```

when this test fails, the previous one also fails (but it is marked as `xfail`). This failure is due to the same error, we expect something and the agent is not active (1707 code) because it is `pending`. 

An `xfail` mark has been added to the test case to indicate that the issue #10162 reports this problem. We should remove the `xfail` marks when solving the issue.

### Test result

```
test_agent_PUT_endpoints.tavern.yaml 
	 6 passed, 4 xpassed, 12 warnings
```