### PR TITLE
Fixed warnings when compiling windows agent.

### DIFF
--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -1903,9 +1903,9 @@ const char *getuname()
                             snprintf(__wp, 63, " [Ver: %d.%d.%s]", (unsigned int)winMajor, (unsigned int)winMinor, wincomp);
 
                             char *endptr = NULL, *osVersion = NULL;
-                            const int buildNumber = (int) strtol(wincomp, endptr, 10);
+                            const int buildNumber = (int) strtol(wincomp, &endptr, 10);
 
-                            if ('\0' == endptr && buildNumber >= FIRST_BUILD_WINDOWS_11) {
+                            if ('\0' == *endptr && buildNumber >= FIRST_BUILD_WINDOWS_11) {
                                 if (osVersion = strstr(ret, "Microsoft Windows 10"), osVersion != NULL) {
                                     memcpy(osVersion, "Microsoft Windows 11", strlen("Microsoft Windows 11"));
                                 }


### PR DESCRIPTION
|Related issue|
|---|
|#10941|

## Description

This PR aims to fix some warnings on file_op.c file when the agent is compiled for Windows. After a little changed the compiler didn't throw Warning for this file. The warning detected were:

![image](https://user-images.githubusercontent.com/58960358/143089142-5bd7dbf1-e68d-4073-8d0e-59aeebee18ca.png)

After the change the output compiler was:

<details>
<summary>Output</summary>

```
~/wazuh/wazuh/src (10941-warning-compiling-windows-agent) $ make -j2 TARGET=winagent
grep: /etc/redhat-release: No existe el archivo o el directorio
cp /usr/i686-w64-mingw32/lib/libwinpthread-1.dll win32/libwinpthread-1.dll
make win32/wazuh-agent.exe win32/wazuh-agent-eventchannel.exe win32/manage_agents.exe win32/setup-windows.exe win32/setup-syscheck.exe win32/setup-iis.exe win32/os_win32ui.exe win32/agent-auth.exe win32/syscollector CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32"
make[1]: se entra en el directorio '/home/hanes/wazuh/wazuh/src'
grep: /etc/redhat-release: No existe el archivo o el directorio
    CC win32/icon.o
    CC win32/win_agent.o
    CC win32/win_service.o
    CC win32/win_utils.o
    CC syscheckd/db/schema_fim_db.o
    CC syscheckd/run_realtime.o
In file included from ./headers/shared.h:229,
                 from win32/win_utils.c:12:
win32/win_utils.c: In function ‘local_start’:
win32/win_utils.c:198:26: warning: cast between incompatible function types from ‘void * (*)(void *)’ to ‘DWORD (__attribute__((stdcall)) *)(void *)’ [-Wcast-function-type]
  198 |                          (LPTHREAD_START_ROUTINE)dispatch_buffer,
      |                          ^
./headers/pthreads_op.h:17:84: note: in definition of macro ‘w_create_thread’
   17 | #define w_create_thread(x, y, z, a, b, c) ({HANDLE hd; if (!(hd = CreateThread(x,y,z,a,b,c))) merror_exit(THREAD_ERROR); hd;})
      |                                                                                    ^
win32/win_utils.c:210:22: warning: cast between incompatible function types from ‘void * (*)(void *)’ to ‘DWORD (__attribute__((stdcall)) *)(void *)’ [-Wcast-function-type]
  210 |                      (LPTHREAD_START_ROUTINE)state_main,
      |                      ^
./headers/pthreads_op.h:17:84: note: in definition of macro ‘w_create_thread’
   17 | #define w_create_thread(x, y, z, a, b, c) ({HANDLE hd; if (!(hd = CreateThread(x,y,z,a,b,c))) merror_exit(THREAD_ERROR); hd;})
      |                                                                                    ^
win32/win_utils.c:227:22: warning: cast between incompatible function types from ‘void * (*)()’ to ‘DWORD (__attribute__((stdcall)) *)(void *)’ [-Wcast-function-type]
  227 |                      (LPTHREAD_START_ROUTINE)skthread,
      |                      ^
./headers/pthreads_op.h:17:84: note: in definition of macro ‘w_create_thread’
   17 | #define w_create_thread(x, y, z, a, b, c) ({HANDLE hd; if (!(hd = CreateThread(x,y,z,a,b,c))) merror_exit(THREAD_ERROR); hd;})
      |                                                                                    ^
win32/win_utils.c:237:25: warning: cast between incompatible function types from ‘void * (*)(void *)’ to ‘DWORD (__attribute__((stdcall)) *)(void *)’ [-Wcast-function-type]
  237 |                         (LPTHREAD_START_ROUTINE)w_rotate_log_thread,
      |                         ^
./headers/pthreads_op.h:17:84: note: in definition of macro ‘w_create_thread’
   17 | #define w_create_thread(x, y, z, a, b, c) ({HANDLE hd; if (!(hd = CreateThread(x,y,z,a,b,c))) merror_exit(THREAD_ERROR); hd;})
      |                                                                                    ^
win32/win_utils.c:254:22: warning: cast between incompatible function types from ‘void * (*)(void *)’ to ‘DWORD (__attribute__((stdcall)) *)(void *)’ [-Wcast-function-type]
  254 |                      (LPTHREAD_START_ROUTINE)receiver_thread,
      |                      ^
./headers/pthreads_op.h:17:84: note: in definition of macro ‘w_create_thread’
   17 | #define w_create_thread(x, y, z, a, b, c) ({HANDLE hd; if (!(hd = CreateThread(x,y,z,a,b,c))) merror_exit(THREAD_ERROR); hd;})
      |                                                                                    ^
win32/win_utils.c:262:22: warning: cast between incompatible function types from ‘void * (*)(void *)’ to ‘DWORD (__attribute__((stdcall)) *)(void *)’ [-Wcast-function-type]
  262 |                      (LPTHREAD_START_ROUTINE)req_receiver,
      |                      ^
./headers/pthreads_op.h:17:84: note: in definition of macro ‘w_create_thread’
   17 | #define w_create_thread(x, y, z, a, b, c) ({HANDLE hd; if (!(hd = CreateThread(x,y,z,a,b,c))) merror_exit(THREAD_ERROR); hd;})
      |                                                                                    ^
win32/win_utils.c:275:29: warning: cast between incompatible function types from ‘wm_routine’ {aka ‘void * (* const)(void *)’} to ‘DWORD (__attribute__((stdcall)) *)(void *)’ [-Wcast-function-type]
  275 |                             (LPTHREAD_START_ROUTINE)cur_module->context->start,
      |                             ^
./headers/pthreads_op.h:17:84: note: in definition of macro ‘w_create_thread’
   17 | #define w_create_thread(x, y, z, a, b, c) ({HANDLE hd; if (!(hd = CreateThread(x,y,z,a,b,c))) merror_exit(THREAD_ERROR); hd;})
      |                                                                                    ^
    CC syscheckd/config.o
    CC syscheckd/create_db.o
    CC syscheckd/run_check.o
syscheckd/create_db.c: In function ‘fim_directory’:
syscheckd/create_db.c:397:9: warning: ‘strncpy’ output may be truncated copying between 0 and 258 bytes from a string of length 259 [-Wstringop-truncation]
  397 |         strncpy(s_name, entry->d_name, PATH_MAX - path_size - 2);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC syscheckd/syscheck.o
    CC syscheckd/fim_diff_changes.o
    CC syscheckd/fim_sync.o
    CC syscheckd/syscom.o
    CC syscheckd/main.o
    CC syscheckd/db/fim_db.o
    CC syscheckd/db/fim_db_files.o
    CC syscheckd/db/fim_db_registries.o
    CC syscheckd/whodata/audit_healthcheck.o
    CC syscheckd/whodata/audit_rule_handling.o
    CC syscheckd/whodata/syscheck_audit.o
    CC syscheckd/whodata/audit_parse.o
    CC syscheckd/whodata/win_whodata.o
    CC syscheckd/registry/registry.o
    CC syscheckd/registry/events.o
    CC rootcheck/unix-process.o
    CC rootcheck/rootcheck-config.o
    CC rootcheck/config.o
    CC rootcheck/check_rc_files.o
    CC rootcheck/check_rc_ports.o
    CC rootcheck/common_rcl.o
    CC rootcheck/win-process.o
    CC rootcheck/common.o
    CC rootcheck/rootcheck.o
In file included from ./headers/shared.h:220,
                 from rootcheck/common.c:11:
In function ‘is_file’,
    inlined from ‘is_file’ at rootcheck/common.c:446:5:
./headers/debug_op.h:46:32: warning: argument 6 null where non-null expected [-Wnonnull]
   46 | #define mterror(tag, msg, ...) _mterror(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./headers/debug_op.h:46:32: note: in definition of macro ‘mterror’
   46 | #define mterror(tag, msg, ...) _mterror(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
      |                                ^~~~~~~~
In file included from ./headers/shared.h:220,
                 from rootcheck/common.c:11:
rootcheck/common.c: In function ‘is_file’:
./headers/debug_op.h:61:6: note: in a call to function ‘_mterror’ declared here
   61 | void _mterror(const char *tag, const char * file, int line, const char * func, const char *msg, ...) __attribute__((format(_PRINTF_FORMAT, 5, 6))) __attribute__((nonnull));
      |      ^~~~~~~~
    CC rootcheck/check_rc_if.o
    CC rootcheck/check_rc_sys.o
    CC rootcheck/check_open_ports.o
    CC rootcheck/os_string.o
    CC rootcheck/win-common.o
    CC rootcheck/check_rc_readproc.o
    CC rootcheck/check_rc_dev.o
    CC rootcheck/run_rk_check.o
rootcheck/win-common.c: In function ‘__os_winreg_querykey’:
rootcheck/win-common.c:265:29: warning: ‘strncat’ output may be truncated copying between 3 and 16381 bytes from a string of length 16383 [-Wstringop-truncation]
  265 |                             strncat(var_storage, mt_data, size_available);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC rootcheck/check_rc_policy.o
    CC rootcheck/check_rc_pids.o
    CC rootcheck/check_rc_trojans.o
    CC client-agent/state.o
    CC client-agent/sendmsg.o
    CC client-agent/restart_agent.o
    CC client-agent/request.o
    CC client-agent/config.o
    CC client-agent/rotate_log.o
    CC client-agent/receiver-win.o
    CC client-agent/receiver.o
    CC client-agent/buffer.o
    CC client-agent/start_agent.o
    CC client-agent/agcom.o
    CC client-agent/notify.o
    CC logcollector/read_ossecalert.o
    CC logcollector/read_command.o
    CC logcollector/state.o
    CC logcollector/read_djb_multilog.o
    CC logcollector/read_postgresql_log.o
    CC logcollector/read_ucs2_le.o
logcollector/read_postgresql_log.c: In function ‘read_postgresql_log’:
logcollector/read_postgresql_log.c:114:17: warning: ‘strncpy’ output may be truncated copying between 35 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  114 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_postgresql_log.c:106:17: warning: ‘strncpy’ output may be truncated copying between 35 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  106 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/config.o
    CC logcollector/read_win_el.o
    CC logcollector/lccom.o
    CC logcollector/read_macos.o
    CC logcollector/read_mssql_log.o
    CC logcollector/read_json.o
logcollector/read_mssql_log.c: In function ‘read_mssql_log’:
logcollector/read_mssql_log.c:117:17: warning: ‘strncpy’ output may be truncated copying between 22 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  117 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_mssql_log.c:108:17: warning: ‘strncpy’ output may be truncated copying between 22 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  108 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_win_event_channel.o
    CC logcollector/read_syslog.o
    CC logcollector/read_audit.o
    CC logcollector/read_multiline_regex.o
logcollector/read_audit.c: In function ‘audit_send_msg’:
logcollector/read_audit.c:31:13: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
   31 |             strncpy(message + n, cache[i], z);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_audit.c:25:13: note: length computed here
   25 |         z = strlen(cache[i]);
      |             ^~~~~~~~~~~~~~~~
    CC logcollector/read_nmapg.o
    CC logcollector/logcollector.o
logcollector/read_nmapg.c: In function ‘read_nmapg’:
logcollector/read_nmapg.c:246:13: warning: ‘strncat’ output may be truncated copying between 27 and 65533 bytes from a string of length 65536 [-Wstringop-truncation]
  246 |             strncat(final_msg, buffer, final_msg_s);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_mysql_log.o
    CC logcollector/read_ucs2_be.o
    CC logcollector/read_multiline.o
    CC logcollector/macos_log.o
    CC logcollector/read_fullcommand.o
logcollector/read_multiline.c: In function ‘read_multiline’:
logcollector/read_multiline.c:96:9: warning: ‘strncpy’ output may be truncated copying between 0 and 65534 bytes from a string of length 65536 [-Wstringop-truncation]
   96 |         strncpy(buffer + buffer_size, str, OS_MAXSTR - buffer_size - 2);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_snortfull.o
    CC os_execd/exec.o
logcollector/read_snortfull.c: In function ‘read_snortfull’:
logcollector/read_snortfull.c:54:17: warning: ‘strncpy’ output may be truncated copying 65536 bytes from a string of length 65536 [-Wstringop-truncation]
   54 |                 strncpy(f_msg, str, OS_MAXSTR);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC os_execd/config.o
os_execd/exec.c: In function ‘ReadExecConfig’:
os_execd/exec.c:72:9: warning: ‘strncpy’ output may be truncated copying 256 bytes from a string of length 65536 [-Wstringop-truncation]
   72 |         strncpy(exec_names[exec_size], str_pt, OS_FLSIZE);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
os_execd/exec.c:125:21: warning: ‘strncpy’ accessing 256 bytes at offsets [0, 16705] and [0, 16705] may overlap up to 256 bytes at offset 255 [-Wrestrict]
  125 |                     strncpy(exec_cmd[j], exec_cmd[exec_size], OS_FLSIZE);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC os_execd/execd.o
    CC os_execd/win_execd.o
    CC os_execd/wcom.o
    CC active-response/active_responses.o
    CC monitord/rotate_log.o
    CC monitord/compress_log.o
    CC config/wmodules-aws.o
    CC config/wmodules-office365.o
    CC config/localfile-config.o
    CC config/wmodules-docker.o
    CC config/rootcheck-config.o
    CC config/config.o
    CC config/socket-config.o
    CC config/remote-config.o
    CC config/active-response.o
    CC config/wmodules-osquery-monitor.o
    CC config/integrator-config.o
    CC config/wmodules-fluent.o
    CC config/reports-config.o
    CC config/dbd-config.o
    CC config/wmodules_syscollector.o
    CC config/wmodules-task-manager.o
    CC config/wmodules-config.o
    CC config/wmodules-github.o
    CC config/buffer-config.o
    CC config/email-alerts-config.o
    CC config/global-config.o
    CC config/labels-config.o
    CC config/wmodules-sca.o
    CC config/authd-config.o
    CC config/wmodules-agent-upgrade.o
    CC config/cluster-config.o
    CC config/wmodules-key-request.o
    CC config/rules-config.o
    CC config/wmodules-oscap.o
    CC config/wmodules-vuln-detector.o
    CC config/wmodules-azure.o
    CC config/syscheck-config.o
    CC config/agentlessd-config.o
config/syscheck-config.c: In function ‘read_data_unit’:
config/syscheck-config.c:1261:13: warning: ‘strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
 1261 |             strncpy(value_str, content, len_value_str - 2);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
config/syscheck-config.c:1251:28: note: length computed here
 1251 |     size_t len_value_str = strlen(content);
      |                            ^~~~~~~~~~~~~~~
    CC config/alerts-config.o
    CC config/wmodules-command.o
    CC config/csyslogd-config.o
    CC config/client-config.o
    CC config/wmodules-ciscat.o
    CC config/wmodules-gcp.o
    CC config/logtest-config.o
    CC wazuh_modules/wm_control.o
    CC wazuh_modules/wm_oscap.o
    CC wazuh_modules/wm_gcp.o
    CC wazuh_modules/wmodules.o
    CC wazuh_modules/wm_azure.o
    CC wazuh_modules/wm_office365.o
    CC wazuh_modules/wm_exec.o
wazuh_modules/wm_office365.c: In function ‘wm_office365_execute_scan’:
wazuh_modules/wm_office365.c:432:33: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  432 |                                 strncpy(url, next_page, strlen(next_page));
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC wazuh_modules/wm_osquery_monitor.o
    CC wazuh_modules/wm_task_general.o
    CC wazuh_modules/wm_aws.o
    CC wazuh_modules/wm_syscollector.o
    CC wazuh_modules/wmcom.o
    CC wazuh_modules/wm_keyrequest.o
    CC wazuh_modules/wm_github.o
    CC wazuh_modules/wm_database.o
wazuh_modules/wm_github.c: In function ‘wm_github_execute_scan’:
wazuh_modules/wm_github.c:308:33: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  308 |                                 strncpy(url, next_page, strlen(next_page));
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC wazuh_modules/wm_download.o
    CC wazuh_modules/wm_docker.o
    CC wazuh_modules/wm_sca.o
    CC wazuh_modules/wm_fluent.o
    CC wazuh_modules/wm_command.o
wazuh_modules/wm_sca.c: In function ‘wm_sca_winreg_querykey’:
wazuh_modules/wm_sca.c:2325:29: warning: ‘strncat’ output may be truncated copying between 3 and 16381 bytes from a string of length 16383 [-Wstringop-truncation]
 2325 |                             strncat(var_storage, mt_data, size_available);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC wazuh_modules/wm_ciscat.o
    CC wazuh_modules/agent_upgrade/wm_agent_upgrade.o
wazuh_modules/wm_ciscat.c: In function ‘wm_ciscat_main’:
wazuh_modules/wm_ciscat.c:119:14: warning: unused variable ‘pwd’ [-Wunused-variable]
  119 |         char pwd[PATH_MAX];
      |              ^~~
    CC wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_agent.o
    CC wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.o
    CC wazuh_db/wdb_metadata.o
wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c: In function ‘wm_agent_upgrade_com_open’:
wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c:233:9: warning: ‘strncpy’ output may be truncated copying 260 bytes from a string of length 260 [-Wstringop-truncation]
  233 |         strncpy(file.path, final_path, PATH_MAX);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC wazuh_db/wdb_agents.o
    CC wazuh_db/wdb_integrity.o
    CC wazuh_db/wdb.o
    CC wazuh_db/wdb_scan_info.o
    CC wazuh_db/wdb_syscollector.o
    CC wazuh_db/wdb_task.o
    CC wazuh_db/wdb_upgrade.o
    CC wazuh_db/wdb_sca.o
    CC wazuh_db/wdb_global.o
    CC wazuh_db/wdb_parser.o
wazuh_db/wdb_parser.c: In function ‘wdb_parse_syscheck’:
wazuh_db/wdb_parser.c:1266:13: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
 1266 |             strncpy(unsc_checksum + unsc_size, mark, mark_size);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
wazuh_db/wdb_parser.c:1264:32: note: length computed here
 1264 |             size_t mark_size = strlen(mark);
      |                                ^~~~~~~~~~~~
    CC wazuh_db/wdb_fim.o
    CC wazuh_db/wdb_rootcheck.o
    CC wazuh_db/wdb_ciscat.o
    CC wazuh_db/helpers/wdb_global_helpers.o
    CC wazuh_db/helpers/wdb_agents_helpers.o
    CC wazuh_db/schema_global_upgrade_v2.o
    CC wazuh_db/schema_upgrade_v3.o
    CC wazuh_db/schema_global_upgrade_v1.o
    CC wazuh_db/schema_upgrade_v6.o
    CC wazuh_db/schema_agents.o
    CC wazuh_db/schema_task_manager.o
    CC wazuh_db/schema_upgrade_v1.o
    CC wazuh_db/schema_upgrade_v8.o
    CC wazuh_db/schema_upgrade_v4.o
    CC wazuh_db/schema_global.o
    CC wazuh_db/schema_upgrade_v7.o
    CC wazuh_db/schema_upgrade_v2.o
    CC wazuh_db/schema_upgrade_v5.o
    CC wazuh_db/schema_global_upgrade_v3.o
    CC wazuh_db/schema_vuln_detector.o
    CC os_crypto/blowfish/bf_op.o
    CC os_crypto/md5/md5_op.o
    CC os_crypto/sha1/sha1_op.o
    CC os_crypto/shared/keys.o
    CC os_crypto/shared/msgs.o
os_crypto/shared/keys.c: In function ‘OS_ReadKeys’:
os_crypto/shared/keys.c:251:13: warning: ‘strncpy’ output may be truncated copying 127 bytes from a string of length 2048 [-Wstringop-truncation]
  251 |             strncpy(id, valid_str, KEYSIZE - 1);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC os_crypto/md5_sha1/md5_sha1_op.o
    CC os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.o
    CC os_crypto/sha256/sha256_op.o
    CC os_crypto/sha512/sha512_op.o
    CC os_crypto/aes/aes_op.o
    CC os_crypto/hmac/hmac.o
    CC os_crypto/signature/signature.o
    CC shared/json-queue.o
    CC shared/read-alert.o
    CC shared/rootcheck_op.o
    CC shared/read-agents.o
    CC shared/fs_op.o
    CC shared/store_op.o
    CC shared/sig_op.o
    CC shared/exec_op.o
    CC shared/mem_op.o
    CC shared/json_op.o
shared/mem_op.c: In function ‘os_LoadString’:
shared/mem_op.c:112:9: warning: ‘strncat’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  112 |         strncat(at, str, strsize);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~
shared/mem_op.c:101:26: note: length computed here
  101 |         size_t strsize = strlen(str);
      |                          ^~~~~~~~~~~
    CC shared/request_op.o
    CC shared/log_builder.o
    CC shared/regex_op.o
    CC shared/file_op.o
    CC shared/labels_op.o
    CC shared/debug_op.o
    CC shared/rbtree_op.o
    CC shared/audit_op.o
    CC shared/bzip2_op.o
    CC shared/enrollment_op.o
    CC shared/atomic.o
shared/enrollment_op.c: In function ‘w_enrollment_concat_src_ip’:
shared/enrollment_op.c:547:13: warning: ‘strncat’ output may be truncated copying 254 bytes from a string of length 255 [-Wstringop-truncation]
  547 |             strncat(buff,opt_buf,254);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~
    CC shared/cluster_utils.o
    CC shared/integrity_op.o
    CC shared/time_op.o
    CC shared/syscheck_op.o
    CC shared/queue_linked_op.o
    CC shared/yaml2json.o
    CC shared/buffer_op.o
    CC shared/report_op.o
    CC shared/queue_op.o
    CC shared/sym_load.o
    CC shared/wait_op.o
    CC shared/help.o
    CC shared/pthreads_op.o
    CC shared/auth_client.o
    CC shared/list_op.o
    CC shared/privsep_op.o
    CC shared/b64.o
    CC shared/custom_output_search_replace.o
    CC shared/file-queue.o
shared/custom_output_search_replace.c: In function ‘searchAndReplace’:
shared/custom_output_search_replace.c:51:9: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
   51 |         strncpy(tmp + tmp_offset, value, value_len);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
shared/custom_output_search_replace.c:19:30: note: length computed here
   19 |     const size_t value_len = strlen(value);
      |                              ^~~~~~~~~~~~~
    CC shared/math_op.o
    CC shared/sysinfo_utils.o
    CC shared/rules_op.o
    CC shared/string_op.o
shared/string_op.c: In function ‘wstr_split’:
shared/string_op.c:612:17: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  612 |                 strncpy(new_term_it, acc_strs[count], strlen(acc_strs[count]));
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
shared/string_op.c:609:21: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  609 |                     strncpy(new_term_it, new_delim, new_delim_size);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
shared/string_op.c:569:29: note: length computed here
  569 |     size_t new_delim_size = strlen(replace_delim ? replace_delim : delim);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC shared/url.o
    CC shared/version_op.o
    CC shared/remoted_op.o
    CC shared/mq_op.o
    CC shared/hash_op.o
    CC shared/notify_op.o
    CC shared/vector_op.o
    CC shared/validate_op.o
    CC shared/utf8_op.o
    CC shared/schedule_scan.o
    CC shared/expression.o
    CC shared/bqueue_op.o
    CC shared/randombytes.o
    CC shared/agent_op.o
    CC shared/os_utils.o
    CC shared/wazuhdb_op.o
    CC os_net/os_net.o
    CC os_regex/os_regex_match.o
    CC os_regex/os_regex.o
    CC os_regex/os_regex_str.o
    CC os_regex/os_match.o
    CC os_regex/os_regex_compile.o
    CC os_regex/os_regex_startswith.o
    CC os_regex/os_regex_free_pattern.o
    CC os_regex/os_match_compile.o
    CC os_regex/os_regex_strbreak.o
    CC os_regex/os_match_free_pattern.o
    CC os_regex/os_regex_maps.o
    CC os_regex/os_regex_execute.o
    CC os_regex/os_match_execute.o
    CC os_xml/os_xml_variables.o
    CC os_xml/os_xml_writer.o
    CC os_xml/os_xml_access.o
    CC os_xml/os_xml.o
    CC os_xml/os_xml_node_access.o
    CC os_zlib/os_zlib.o
    CC os_auth/ssl.o
    CC os_auth/check_cert.o
    CC addagent/validate.o
    CC analysisd/logmsg.o
    CC libwazuhext.dll
    CC syscheckd/run_realtime-event.o
    CC syscheckd/config-event.o
    CC syscheckd/create_db-event.o
    CC syscheckd/run_check-event.o
    CC syscheckd/syscheck-event.o
syscheckd/create_db.c: In function ‘fim_directory’:
syscheckd/create_db.c:397:9: warning: ‘strncpy’ output may be truncated copying between 0 and 258 bytes from a string of length 259 [-Wstringop-truncation]
  397 |         strncpy(s_name, entry->d_name, PATH_MAX - path_size - 2);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC syscheckd/fim_diff_changes-event.o
    CC syscheckd/fim_sync-event.o
    CC syscheckd/syscom-event.o
    CC syscheckd/db/fim_db-event.o
    CC syscheckd/db/fim_db_files-event.o
    CC syscheckd/db/fim_db_registries-event.o
    CC syscheckd/whodata/audit_healthcheck-event.o
    CC syscheckd/whodata/audit_rule_handling-event.o
    CC syscheckd/whodata/syscheck_audit-event.o
    CC syscheckd/whodata/audit_parse-event.o
    CC syscheckd/whodata/win_whodata-event.o
    CC syscheckd/registry/registry-event.o
    CC syscheckd/registry/events-event.o
    CC logcollector/read_ossecalert-event.o
    CC logcollector/read_command-event.o
    CC logcollector/state-event.o
    CC logcollector/read_djb_multilog-event.o
    CC logcollector/read_postgresql_log-event.o
    CC logcollector/read_ucs2_le-event.o
logcollector/read_postgresql_log.c: In function ‘read_postgresql_log’:
logcollector/read_postgresql_log.c:114:17: warning: ‘strncpy’ output may be truncated copying between 35 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  114 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_postgresql_log.c:106:17: warning: ‘strncpy’ output may be truncated copying between 35 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  106 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/config-event.o
    CC logcollector/read_win_el-event.o
    CC logcollector/lccom-event.o
    CC logcollector/read_macos-event.o
    CC logcollector/read_mssql_log-event.o
    CC logcollector/read_json-event.o
logcollector/read_mssql_log.c: In function ‘read_mssql_log’:
logcollector/read_mssql_log.c:117:17: warning: ‘strncpy’ output may be truncated copying between 22 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  117 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_mssql_log.c:108:17: warning: ‘strncpy’ output may be truncated copying between 22 and 65536 bytes from a string of length 65536 [-Wstringop-truncation]
  108 |                 strncpy(buffer, str, str_len + 2);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_win_event_channel-event.o
    CC logcollector/read_syslog-event.o
    CC logcollector/read_audit-event.o
    CC logcollector/read_multiline_regex-event.o
logcollector/read_audit.c: In function ‘audit_send_msg’:
logcollector/read_audit.c:31:13: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
   31 |             strncpy(message + n, cache[i], z);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
logcollector/read_audit.c:25:13: note: length computed here
   25 |         z = strlen(cache[i]);
      |             ^~~~~~~~~~~~~~~~
    CC logcollector/read_nmapg-event.o
    CC logcollector/logcollector-event.o
logcollector/read_nmapg.c: In function ‘read_nmapg’:
logcollector/read_nmapg.c:246:13: warning: ‘strncat’ output may be truncated copying between 27 and 65533 bytes from a string of length 65536 [-Wstringop-truncation]
  246 |             strncat(final_msg, buffer, final_msg_s);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_mysql_log-event.o
    CC logcollector/read_ucs2_be-event.o
    CC logcollector/read_multiline-event.o
    CC logcollector/macos_log-event.o
    CC logcollector/read_fullcommand-event.o
logcollector/read_multiline.c: In function ‘read_multiline’:
logcollector/read_multiline.c:96:9: warning: ‘strncpy’ output may be truncated copying between 0 and 65534 bytes from a string of length 65536 [-Wstringop-truncation]
   96 |         strncpy(buffer + buffer_size, str, OS_MAXSTR - buffer_size - 2);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC logcollector/read_snortfull-event.o
    CC win32/win_service_rk.o
logcollector/read_snortfull.c: In function ‘read_snortfull’:
logcollector/read_snortfull.c:54:17: warning: ‘strncpy’ output may be truncated copying 65536 bytes from a string of length 65536 [-Wstringop-truncation]
   54 |                 strncpy(f_msg, str, OS_MAXSTR);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC addagent/read_from_user.o
    CC addagent/main.o
    CC addagent/manage_keys.o
    CC addagent/manage_agents.o
    CC win32/setup-win.o
    CC win32/setup-shared.o
    CC win32/setup-syscheck.o
    CC win32/setup-iis.o
    CC win32/ui/common.o
    CC win32/ui/os_win32ui.o
    CC os_auth/main-client.o
cd shared_modules/dbsync/ && mkdir -p build && cd build && cmake -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++-posix   .. && make
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc - works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
cd data_provider/ && mkdir -p build && cd build && cmake -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++-posix    .. && make
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix
-- The C compiler identification is GNU 9.3.0
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix - works
-- Detecting CXX compiler ABI info
-- The CXX compiler identification is GNU 9.3.0
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build
make[2]: se entra en el directorio '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[3]: se entra en el directorio '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[4]: se entra en el directorio '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc - works
-- Detecting C compiler ABI info
Scanning dependencies of target dbsync
make[4]: se sale del directorio '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[4]: se entra en el directorio '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[ 10%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync.cpp.obj
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix - works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/wazuh/src/data_provider/build
make[2]: se entra en el directorio '/home/hanes/wazuh/wazuh/src/data_provider/build'
make[3]: se entra en el directorio '/home/hanes/wazuh/wazuh/src/data_provider/build'
make[4]: se entra en el directorio '/home/hanes/wazuh/wazuh/src/data_provider/build'
Scanning dependencies of target sysinfo
make[4]: se sale del directorio '/home/hanes/wazuh/wazuh/src/data_provider/build'
make[4]: se entra en el directorio '/home/hanes/wazuh/wazuh/src/data_provider/build'
[ 14%] Building CXX object CMakeFiles/sysinfo.dir/src/network/networkInterfaceWindows.cpp.obj
[ 28%] Building CXX object CMakeFiles/sysinfo.dir/src/osinfo/sysOsInfoWin.cpp.obj
[ 20%] Building CXX object CMakeFiles/dbsync.dir/src/dbsyncPipelineFactory.cpp.obj
[ 42%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfoWin.cpp.obj
/home/hanes/wazuh/wazuh/src/data_provider/src/sysInfoWin.cpp:447:56: warning: multi-character character constant [-Wmultichar]
  447 |             const auto size {pfnGetSystemFirmwareTable('RSMB', 0, nullptr, 0)};
      |                                                        ^~~~~~
/home/hanes/wazuh/wazuh/src/data_provider/src/sysInfoWin.cpp:456:51: warning: multi-character character constant [-Wmultichar]
  456 |                     if (pfnGetSystemFirmwareTable('RSMB', 0, spBuff.get(), size) == size)
      |                                                   ^~~~~~
[ 30%] Building CXX object CMakeFiles/dbsync.dir/src/dbsync_implementation.cpp.obj
[ 40%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_dbengine.cpp.obj
[ 57%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfo.cpp.obj
[ 50%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_wrapper.cpp.obj
[ 60%] Linking CXX shared library bin/dbsync.dll
make[4]: se sale del directorio '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[ 60%] Built target dbsync
make[4]: se entra en el directorio '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync_example
make[4]: se sale del directorio '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[4]: se entra en el directorio '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[ 70%] Building CXX object example/CMakeFiles/dbsync_example.dir/main.cpp.obj
[ 71%] Linking CXX shared library bin/sysinfo.dll
make[4]: se sale del directorio '/home/hanes/wazuh/wazuh/src/data_provider/build'
[ 80%] Linking CXX executable ../bin/dbsync_example.exe
[ 71%] Built target sysinfo
make[4]: se entra en el directorio '/home/hanes/wazuh/wazuh/src/data_provider/build'
Scanning dependencies of target sysinfo_test_tool
make[4]: se sale del directorio '/home/hanes/wazuh/wazuh/src/data_provider/build'
make[4]: se entra en el directorio '/home/hanes/wazuh/wazuh/src/data_provider/build'
[ 85%] Building CXX object testtool/CMakeFiles/sysinfo_test_tool.dir/main.cpp.obj
make[4]: se sale del directorio '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[ 80%] Built target dbsync_example
make[4]: se entra en el directorio '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
Scanning dependencies of target dbsync_test_tool
make[4]: se sale del directorio '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[4]: se entra en el directorio '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[ 90%] Building CXX object testtool/CMakeFiles/dbsync_test_tool.dir/main.cpp.obj
[100%] Linking CXX executable ../bin/sysinfo_test_tool.exe
make[4]: se sale del directorio '/home/hanes/wazuh/wazuh/src/data_provider/build'
[100%] Built target sysinfo_test_tool
make[3]: se sale del directorio '/home/hanes/wazuh/wazuh/src/data_provider/build'
make[2]: se sale del directorio '/home/hanes/wazuh/wazuh/src/data_provider/build'
    LINK libwazuh.a
i686-w64-mingw32-ar: `u' modifier ignored since `D' is the default (see `U')
    RANLIB libwazuh.a
    CC win32/wazuh-agent.exe
    CC win32/wazuh-agent-eventchannel.exe
    CC win32/manage_agents.exe
    CC win32/setup-windows.exe
    CC win32/setup-syscheck.exe
    CC win32/setup-iis.exe
    CC win32/os_win32ui.exe
    CC win32/agent-auth.exe
[100%] Linking CXX executable ../bin/dbsync_test_tool.exe
make[4]: se sale del directorio '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
[100%] Built target dbsync_test_tool
make[3]: se sale del directorio '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
make[2]: se sale del directorio '/home/hanes/wazuh/wazuh/src/shared_modules/dbsync/build'
cd shared_modules/rsync/ &&  mkdir -p build && cd build && cmake -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++-posix   .. && make
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc - works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix - works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/wazuh/src/shared_modules/rsync/build
make[2]: se entra en el directorio '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
make[3]: se entra en el directorio '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
make[4]: se entra en el directorio '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
Scanning dependencies of target rsync
make[4]: se sale del directorio '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
make[4]: se entra en el directorio '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
[ 12%] Building CXX object CMakeFiles/rsync.dir/src/rsync.cpp.obj
[ 25%] Building CXX object CMakeFiles/rsync.dir/src/rsyncImplementation.cpp.obj
[ 37%] Linking CXX shared library bin/rsync.dll
make[4]: se sale del directorio '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
[ 37%] Built target rsync
make[4]: se entra en el directorio '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
Scanning dependencies of target rsync_test_tool
make[4]: se sale del directorio '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
make[4]: se entra en el directorio '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
[ 62%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/main.cpp.obj
[ 62%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/agentEmulator.cpp.obj
[ 75%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/oneTimeSync.cpp.obj
[ 87%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/managerEmulator.cpp.obj
[100%] Linking CXX executable ../bin/rsync_test_tool.exe
make[4]: se sale del directorio '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
[100%] Built target rsync_test_tool
make[3]: se sale del directorio '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
make[2]: se sale del directorio '/home/hanes/wazuh/wazuh/src/shared_modules/rsync/build'
cd wazuh_modules/syscollector/ && mkdir -p build && cd build && cmake -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++-posix   .. && make
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc - works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++-posix - works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build
make[2]: se entra en el directorio '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[3]: se entra en el directorio '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[4]: se entra en el directorio '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
Scanning dependencies of target syscollector
make[4]: se sale del directorio '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[4]: se entra en el directorio '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
[ 33%] Building CXX object CMakeFiles/syscollector.dir/src/syscollectorImp.cpp.obj
[ 33%] Building CXX object CMakeFiles/syscollector.dir/src/syscollector.cpp.obj
[ 50%] Building CXX object CMakeFiles/syscollector.dir/src/syscollectorNormalizer.cpp.obj
[ 66%] Linking CXX shared library bin/syscollector.dll
make[4]: se sale del directorio '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
[ 66%] Built target syscollector
make[4]: se entra en el directorio '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
Scanning dependencies of target syscollector_test_tool
make[4]: se sale del directorio '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[4]: se entra en el directorio '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
[ 83%] Building CXX object testtool/CMakeFiles/syscollector_test_tool.dir/main.cpp.obj
[100%] Linking CXX executable ../bin/syscollector_test_tool.exe
make[4]: se sale del directorio '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
[100%] Built target syscollector_test_tool
make[3]: se sale del directorio '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[2]: se sale del directorio '/home/hanes/wazuh/wazuh/src/wazuh_modules/syscollector/build'
make[1]: se sale del directorio '/home/hanes/wazuh/wazuh/src'
make win32/restart-wazuh.exe win32/route-null.exe win32/netsh.exe CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32"
make[1]: se entra en el directorio '/home/hanes/wazuh/wazuh/src'
grep: /etc/redhat-release: No existe el archivo o el directorio
    CC shared/debug_op_proc.o
    CC shared/file_op_proc.o
    CC active-response/restart-wazuh.o
    CC active-response/route-null.o
    CC active-response/netsh.o
active-response/route-null.c: In function ‘main’:
active-response/route-null.c:130:21: warning: ‘strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
  130 |                     strncpy(gateway, ptr+2, strlen(ptr+2)-1);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
active-response/route-null.c:130:45: note: length computed here
  130 |                     strncpy(gateway, ptr+2, strlen(ptr+2)-1);
      |                                             ^~~~~~~~~~~~~
    CC libwazuhshared.dll
    CC win32/restart-wazuh.exe
    CC win32/route-null.exe
    CC win32/netsh.exe
make[1]: se sale del directorio '/home/hanes/wazuh/wazuh/src'
cd win32/ && ./unix2dos.pl ossec.conf > default-ossec.conf
cd win32/ && ./unix2dos.pl help.txt > help_win.txt
cd win32/ && ./unix2dos.pl ../../etc/internal_options.conf > internal_options.conf
cd win32/ && ./unix2dos.pl ../../etc/local_internal_options-win.conf > default-local_internal_options.conf
cd win32/ && ./unix2dos.pl ../../LICENSE > LICENSE.txt
cd win32/ && ./unix2dos.pl ../VERSION > VERSION
cd win32/ && ./unix2dos.pl ../REVISION > REVISION
cd win32/ && makensis wazuh-installer.nsi
Processing config: /etc/nsisconf.nsh
Processing script file: "wazuh-installer.nsi" (UTF8)

Processed 1 file, writing output (x86-ansi):
warning 7998: ANSI targets are deprecated

Output: "wazuh-agent-4.3.0.exe"
Install: 6 pages (384 bytes), 3 sections (12360 bytes), 1152 instructions (32256 bytes), 402 strings (33238 bytes), 1 language table (346 bytes).
Uninstall: 4 pages (320 bytes), 1 section (4120 bytes), 401 instructions (11228 bytes), 207 strings (3699 bytes), 1 language table (290 bytes).

Using zlib compression.

EXE header size:              112128 / 78336 bytes
Install code:                  16762 / 69832 bytes
Install data:                8098213 / 22825748 bytes
Uninstall code+data:           48194 / 70349 bytes
CRC (0x1A035AA8):                  4 / 4 bytes

Total size:                  8275301 / 23044269 bytes (35.9%)

1 warning:
  7998: ANSI targets are deprecated
make settings
make[1]: se entra en el directorio '/home/hanes/wazuh/wazuh/src'
grep: /etc/redhat-release: No existe el archivo o el directorio

General settings:
    TARGET:             winagent
    V:                  
    DEBUG:              
    DEBUGAD             
    INSTALLDIR:         
    DATABASE:           
    ONEWAY:             no
    CLEANFULL:          no
    RESOURCES_URL:      https://packages.wazuh.com/deps/15
    EXTERNAL_SRC_ONLY:  
User settings:
    WAZUH_GROUP:        wazuh
    WAZUH_USER:         wazuh
USE settings:
    USE_ZEROMQ:         no
    USE_GEOIP:          no
    USE_PRELUDE:        no
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        yes
    USE_AUDIT:          no
    DISABLE_SYSC:       no
    DISABLE_CISCAT:     no
Mysql settings:
    includes:           
    libs:               
Pgsql settings:
    includes:           
    libs:               
Defines:
    -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DENABLE_SYSC -DENABLE_CISCAT
Compiler:
    CFLAGS            -pthread -DNDEBUG -O2 -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DENABLE_SYSC -DENABLE_CISCAT -pipe -Wall -Wextra -std=gnu99 -I./ -I./headers/ -Iexternal/openssl/include -Iexternal/cJSON/ -Iexternal/libyaml/include -Iexternal/curl/include -Iexternal/msgpack/include -Iexternal/bzip2/ -Ishared_modules/common -Ishared_modules/dbsync/include -Ishared_modules/rsync/include -Iwazuh_modules/syscollector/include  -Idata_provider/include  -Iexternal/libpcre2/include 
    LDFLAGS           -pthread -O2 -Lshared_modules/dbsync/build/bin -Lshared_modules/rsync/build/bin  -Lwazuh_modules/syscollector/build/bin -Ldata_provider/build/bin
    LIBS              
    CC                gcc
    MAKE              make
make[1]: se sale del directorio '/home/hanes/wazuh/wazuh/src'

Done building winagent

```
</details> 

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors