### PR TITLE
Show agent-info permissions flag and other minor improvements

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1718,7 +1718,7 @@ components:
                         shared:
                           type: integer
                           format: int32
-                sync_agentinfo_free:
+                sync_agent_info_free:
                   type: boolean
                 sync_integrity_free:
                   type: boolean
@@ -7914,6 +7914,7 @@ paths:
                             extra: 0
                             extra_valid: 0
                             shared: 0
+                        sync_agent_info_free: true
                         last_sync_agentinfo:
                           date_start_master: 2021-05-27T10:50:49.174463Z
                           date_end_master: 2021-05-27T10:50:49.175921Z
@@ -7940,6 +7941,7 @@ paths:
                             extra: 0
                             extra_valid: 0
                             shared: 0
+                        sync_agent_info_free: true
                         last_sync_agentinfo:
                           date_start_master: 2021-05-27T10:50:48.832800Z
                           date_end_master: 2021-05-27T10:50:48.833854Z

--- a/framework/scripts/cluster_control.py
+++ b/framework/scripts/cluster_control.py
@@ -71,6 +71,7 @@ async def print_health(config, more, filter_node):
     filter_node : str, list
         Node to return.
     """
+
     def calculate_seconds(start_time, end_time):
         """Calculate the time difference between two dates.
 
@@ -159,6 +160,8 @@ async def print_health(config, more, filter_node):
                     f"{node_info['status']['last_sync_agentinfo']['date_end_master']}).\n"
             msg2 += f"                Number of synchronized chunks: " \
                     f"{node_info['status']['last_sync_agentinfo']['n_synced_chunks']}.\n"
+            msg2 += f"                Permission to synchronize agent-info: " \
+                    f"{node_info['status']['sync_agent_info_free']}.\n"
 
     print(msg1)
     more and print(msg2)

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -188,6 +188,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                                                     not key.startswith('tmp')},
                            'last_sync_integrity': {key: value for key, value in self.integrity_sync_status.items() if
                                                    not key.startswith('tmp')},
+                           'sync_agent_info_free': self.sync_agent_info_free,
                            'last_sync_agentinfo': self.sync_agent_info_status,
                            'last_keep_alive': self.last_keepalive}
                 }
@@ -1001,9 +1002,11 @@ class Master(server.AbstractServer):
                 task = self.loop.run_in_executor(self.task_pool, wazuh.core.cluster.cluster.get_files_status)
                 # With this we avoid that each worker starts integrity_check more than once per local_integrity
                 self.integrity_control = await asyncio.wait_for(task, timeout=None)
-                self.integrity_already_executed.clear()
             except Exception as e:
                 file_integrity_logger.error(f"Error calculating local file integrity: {e}")
+            finally:
+                self.integrity_already_executed.clear()
+
             file_integrity_logger.info(f"Finished in {(datetime.now() - before).total_seconds():.3f}s. Calculated "
                                        f"metadata of {len(self.integrity_control)} files.")
 

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -72,8 +72,7 @@ class SyncTask:
             self.logger.debug("Permission to synchronize granted.")
             return True
         else:
-            self.logger.debug("Master didn't grant permission to start a new synchronization because there is one "
-                              "still in progress.")
+            self.logger.debug(f"Master didn't grant permission to start a new synchronization: {result}")
 
         return False
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes #10946 |

## Description

This PR adds the 3 fixes/improvements mentioned at #10946:
- Enclose the cleaning of the `integrity_already_executed` variable inside a Finally clause.
- Show status of agent-info permission flag in `cluster_control -i more` and API.
- Show response got when not getting sync permission on worker nodes.
