### PR TITLE
Fix a segmentation fault in Analysisd by a wrong Active Response configuration

### DIFF
--- a/src/analysisd/alerts/exec.c
+++ b/src/analysisd/alerts/exec.c
@@ -111,7 +111,11 @@ void OS_Exec(int *execq, int *arq, int *sock, const Eventinfo *lf, const active_
                     json_agt_info = wdb_get_agent_info(id_array[i], sock);
                     if (!json_agt_info) {
                         merror("Failed to get agent '%d' information from Wazuh DB.", id_array[i]);
-                        labels_free(agt_labels);
+
+                        if (agt_labels != Config.labels) {
+                            labels_free(agt_labels);
+                        }
+
                         continue;
                     }
 
@@ -121,7 +125,11 @@ void OS_Exec(int *execq, int *arq, int *sock, const Eventinfo *lf, const active_
                         agt_version = json_agt_version->valuestring;
                     } else {
                         mdebug2("Failed to get agent '%d' version.", id_array[i]);
-                        labels_free(agt_labels);
+
+                        if (agt_labels != Config.labels) {
+                            labels_free(agt_labels);
+                        }
+
                         cJSON_Delete(json_agt_info);
                         continue;
                     }
@@ -135,7 +143,11 @@ void OS_Exec(int *execq, int *arq, int *sock, const Eventinfo *lf, const active_
                 char *patch = strtok_r(NULL, ".", &save_ptr);
                 if (!major || !minor || !patch) {
                     merror("Unable to read agent version.");
-                    labels_free(agt_labels);
+
+                    if (agt_labels != Config.labels) {
+                        labels_free(agt_labels);
+                    }
+
                     cJSON_Delete(json_agt_info);
                     continue;
                 } else {
@@ -147,7 +159,10 @@ void OS_Exec(int *execq, int *arq, int *sock, const Eventinfo *lf, const active_
                     }
                 }
 
-                labels_free(agt_labels);
+                if (agt_labels != Config.labels) {
+                    labels_free(agt_labels);
+                }
+
                 cJSON_Delete(json_agt_info);
 
                 get_exec_msg(ar, c_agent_id, msg, exec_msg);
@@ -186,7 +201,11 @@ void OS_Exec(int *execq, int *arq, int *sock, const Eventinfo *lf, const active_
                 json_agt_info = wdb_get_agent_info(agt_id, sock);
                 if (!json_agt_info) {
                     merror("Failed to get agent '%d' information from Wazuh DB.", agt_id);
-                    labels_free(agt_labels);
+
+                    if (agt_labels != Config.labels) {
+                        labels_free(agt_labels);
+                    }
+
                     goto cleanup;
                 }
 
@@ -196,7 +215,11 @@ void OS_Exec(int *execq, int *arq, int *sock, const Eventinfo *lf, const active_
                     agt_version = json_agt_version->valuestring;
                 } else {
                     mdebug2("Failed to get agent '%d' version.", agt_id);
-                    labels_free(agt_labels);
+
+                    if (agt_labels != Config.labels) {
+                        labels_free(agt_labels);
+                    }
+
                     cJSON_Delete(json_agt_info);
                     goto cleanup;
                 }
@@ -210,7 +233,11 @@ void OS_Exec(int *execq, int *arq, int *sock, const Eventinfo *lf, const active_
             char *patch = strtok_r(NULL, ".", &save_ptr);
             if (!major || !minor || !patch) {
                 merror("Unable to read agent version.");
-                labels_free(agt_labels);
+
+                if (agt_labels != Config.labels) {
+                    labels_free(agt_labels);
+                }
+
                 cJSON_Delete(json_agt_info);
                 goto cleanup;
             } else {
@@ -222,7 +249,10 @@ void OS_Exec(int *execq, int *arq, int *sock, const Eventinfo *lf, const active_
                 }
             }
 
-            labels_free(agt_labels);
+            if (agt_labels != Config.labels) {
+                labels_free(agt_labels);
+            }
+
             cJSON_Delete(json_agt_info);
 
             get_exec_msg(ar, c_agent_id, msg, exec_msg);

--- a/src/config/active-response.c
+++ b/src/config/active-response.c
@@ -209,6 +209,15 @@ int ReadActiveResponses(XML_NODE node, void *d1, void *d2)
             return (-1);
         }
 
+        if (atoi(tmp_ar->agent_id) == 0) {
+            mdebug1("'defined-agent' is 0");
+            mwarn(AR_SERVER_AGENT);
+            fclose(fp);
+            free(tmp_ar);
+            free(tmp_location);
+            return 0;
+        }
+
         tmp_ar->location |= SPECIFIC_AGENT;
 
     }

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -11,6 +11,9 @@
 #ifndef WARN_MESSAGES_H
 #define WARN_MESSAGES_H
 
+/* Active Response */
+#define AR_SERVER_AGENT "(1306): Invalid agent ID. Use location=server to run AR on the manager."
+
 /* File integrity monitoring warning messages*/
 #define FIM_WARN_ACCESS                         "(6900): Accessing  '%s': [(%d) - (%s)]"
 #define FIM_WARN_DELETE                         "(6901): Could not delete from filesystem '%s'"


### PR DESCRIPTION
## Related issue

This PR closes #10911.

## Rationale

An Active Response stanza with this configuration will produce a read-after-free access and a subsequent segment violation:

```xml
<location>defined-agent</location>
<agent_id>000</agent_id>
```

This happens because Analysisd reads the agents' labels to get their version. They are stored in a cache to save up database access. However, the manager's labels are not cached and they are constant.

Currently, the setting _location = defined-agent_ assumes that _agent_id > 0_. When _agent_id > 0_, AR gets the manager's labels as agent labels, and then it deletes them. This causes invalid access in the subsequent read to the manager's labels.

## Proposed change

1. Do not allow the configuration above. Print a warning in the log and skip the stanza.
```
wazuh-analysisd: WARNING: (1306): Invalid agent ID. Use location=server to run AR on the manager.
```

2. Prevent Analysisd from freeing the manager's labels. This is merely a secondary protection as Analysisd should not query the manager version.

## Affected components

- wazuh-analysisd

## Tests

- [X] The configuration above prints the mentioned warning.
- [X] The configuration above is skipped: Remoted prints no errors.
- [x] _location = server_ works.
- [x] _defined_agent = 001_ (other than 000) works.
- [X] Valgrind reports no memory errors.
- [x] Run Coverity.