### PR TITLE
Fix find_account_ids function in AWS module

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -687,10 +687,9 @@ class AWSBucket(WazuhIntegration):
 
     def find_account_ids(self):
         try:
-            common_prefixes = self.client.list_objects_v2(Bucket=self.bucket, Prefix=self.get_base_prefix(),
-                                                          Delimiter='/')['CommonPrefixes']
-            return [prefix['Prefix'].split('/')[-2] for prefix in common_prefixes if
-                    self.prefix_regex.match(prefix['Prefix'].split('/')[-2])]
+            prefixes = self.client.list_objects_v2(Bucket=self.bucket, Prefix=self.get_base_prefix(),
+                                                   Delimiter='/')['CommonPrefixes']
+            return [account_id for p in prefixes if self.prefix_regex.match(account_id := p['Prefix'].split('/')[-2])]
         except KeyError:
             bucket_types = {'cloudtrail', 'config', 'vpcflow', 'guardduty', 'waf', 'custom'}
             print(f"ERROR: Invalid type of bucket. The bucket was set up as '{get_script_arguments().type.lower()}' "

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -501,6 +501,7 @@ class AWSBucket(WazuhIntegration):
         self.bucket_path = self.bucket + '/' + self.prefix
         self.aws_organization_id = aws_organization_id
         self.date_regex = re.compile(r'(\d{4}/\d{2}/\d{2})')
+        self.prefix_regex= re.compile("^\d{12}$")
         self.check_prefix = False
 
     def _same_prefix(self, match_start: int or None, aws_account_id: str, aws_region: str) -> bool:
@@ -686,11 +687,10 @@ class AWSBucket(WazuhIntegration):
 
     def find_account_ids(self):
         try:
-            return [common_prefix['Prefix'].split('/')[-2] for common_prefix in
-                    self.client.list_objects_v2(Bucket=self.bucket,
-                                                Prefix=self.get_base_prefix(),
-                                                Delimiter='/')['CommonPrefixes']
-                    ]
+            common_prefixes = self.client.list_objects_v2(Bucket=self.bucket, Prefix=self.get_base_prefix(),
+                                                          Delimiter='/')['CommonPrefixes']
+            return [prefix['Prefix'].split('/')[-2] for prefix in common_prefixes if
+                    self.prefix_regex.match(prefix['Prefix'].split('/')[-2])]
         except KeyError:
             bucket_types = {'cloudtrail', 'config', 'vpcflow', 'guardduty', 'waf', 'custom'}
             print(f"ERROR: Invalid type of bucket. The bucket was set up as '{get_script_arguments().type.lower()}' "


### PR DESCRIPTION
|Related issue|
|---|
|#10840|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The fin`d_account_ids` function present in our AWS module is used to get the different account IDs with data available for a given bucket. This is needed because the bucket itself may contain logs from different account IDs and if that's the case these logs will be stored using a path that starts with a folder named as the Account ID the data belongs to. Here is an example:

```
bucketA/AWSLogs/111111111111/CloudTrail/us-east-1/2021/11/24/filename
bucketA/AWSLogs/22222222222/CloudTrail/us-east-1/2021/11/24/filename
bucketA/AWSLogs/33333333333/CloudTrail/us-east-1/2021/11/24/filename
```

This PR updates the `fix_account_ids` function to ignore any folder present with a name that is not composed of 12 digits only. The module will not try to explore these paths as if they were Account IDs, avoiding unnecesary AWS API calls.

## Tests


The module has been tested after applying this change to ensure its correct operation. Here are the results:




<details>
  <summary>AWS Config before the fix</summary>

  ```
 	/var/ossec/wodles/aws/aws-s3 -p dev -b wazuh-aws-wodle-config -t config --region us-east-1 --debug 2 -s 2021-NOV-22
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Working on 123456789000 - us-east-1
	DEBUG: +++ Marker: AWSLogs/123456789000/Config/us-east-1/2021/11/22
	DEBUG: ++ Found new log: AWSLogs/123456789000/Config/us-east-1/2021/11/22/123456789000_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211122T004303Z_20211122T025123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Marker: AWSLogs/123456789000/Config/us-east-1/2021/11/23
	DEBUG: +++ No logs to process in bucket: 123456789000/us-east-1
	DEBUG: +++ Marker: AWSLogs/123456789000/Config/us-east-1/2021/11/24
	DEBUG: ++ Found new log: AWSLogs/123456789000/Config/us-east-1/2021/11/24/123456789000_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211124T004303Z_20211124T025123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Working on test_empty - us-east-1
	DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/11/22
	DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/11/23
	DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_empty/Config/us-east-1/2021/11/24
	DEBUG: +++ No logs to process in bucket: test_empty/us-east-1
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Working on test_suffix - us-east-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/11/22
	DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/11/23
	DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/Config/us-east-1/2021/11/24
	DEBUG: +++ No logs to process in bucket: test_suffix/us-east-1
	DEBUG: +++ DB Maintenance
  ```
</details>

The module assume the `test_empty` and `test_suffix` represent different account IDs, which is not true.

<details>
  <summary>AWS Config after the fix</summary>
  
  ```
	/var/ossec/wodles/aws/aws-s3 -p dev -b wazuh-aws-wodle-config -t config --region us-east-1 --debug 2 -s 2021-NOV-22
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Working on 123456789000 - us-east-1
	DEBUG: +++ Marker: AWSLogs/123456789000/Config/us-east-1/2021/11/22
	DEBUG: ++ Found new log: AWSLogs/123456789000/Config/us-east-1/2021/11/22/123456789000_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211122T004303Z_20211122T025123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Marker: AWSLogs/123456789000/Config/us-east-1/2021/11/23
	DEBUG: +++ No logs to process in bucket: 123456789000/us-east-1
	DEBUG: +++ Marker: AWSLogs/123456789000/Config/us-east-1/2021/11/24
	DEBUG: ++ Found new log: AWSLogs/123456789000/Config/us-east-1/2021/11/24/123456789000_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211124T004303Z_20211124T025123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance
  ```
</details>

The module try to obtain logs from the only account ID available in the bucket. The other folders are being ignored.

<details>
  <summary>AWS Cloudtrail before the fix</summary>
  
  ```
	/var/ossec/wodles/aws/aws-s3 -p dev -b wazuh-aws-wodle-cloudtrail -t cloudtrail --region us-west-1 --debug 2 -s 2021-NOV-22
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on 123456789000 - us-west-1
	DEBUG: +++ Marker: AWSLogs/123456789000/CloudTrail/us-west-1/2021/11/22
	DEBUG: ++ Found new log: AWSLogs/123456789000/CloudTrail/us-west-1/2021/11/22/123456789000_CloudTrail_us-west-1_20211122T0000Z_rUQtGNUqmrPZMCnu.json.gz
	DEBUG: ++ Found new log: AWSLogs/123456789000/CloudTrail/us-west-1/2021/11/23/123456789000_CloudTrail_us-west-1_20211123T0000Z_rUQtGNUqmrPZMCnu.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Working on test_empty - us-west-1
	DEBUG: +++ Marker: AWSLogs/test_empty/CloudTrail/us-west-1/2021/11/22
	DEBUG: +++ No logs to process in bucket: test_empty/us-west-1
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Working on test_suffix - us-west-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/CloudTrail/us-west-1/2021/11/22
	DEBUG: +++ No logs to process in bucket: test_suffix/us-west-1
	DEBUG: +++ DB Maintenance
  ```
</details>

The module assume the `test_empty` and `test_suffix` represent different account IDs, which is not true.

<details>
  <summary>AWS Cloudtrail after the fix</summary>
  
  ```
	/var/ossec/wodles/aws/aws-s3 -p dev -b wazuh-aws-wodle-cloudtrail -t cloudtrail --debug 2 -s 2021-NOV-22       
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Working on 123456789000 - us-west-1
	DEBUG: +++ Marker: AWSLogs/123456789000/CloudTrail/us-west-1/2021/11/22
	DEBUG: ++ Found new log: AWSLogs/123456789000/CloudTrail/us-west-1/2021/11/22/123456789000_CloudTrail_us-west-1_20211122T0000Z_rUQtGNUqmrPZMCnu.json.gz
	DEBUG: ++ Found new log: AWSLogs/123456789000/CloudTrail/us-west-1/2021/11/23/123456789000_CloudTrail_us-west-1_20211123T0000Z_rUQtGNUqmrPZMCnu.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance
  ```
</details>

The module try to obtain logs from the only account ID available in the bucket. The other folders are being ignored.

<details>
  <summary>AWS Cloudtrailg before the fix using a suffix</summary>

  ```
	/var/ossec/wodles/aws/aws-s3 -p dev -b wazuh-aws-wodle-cloudtrail -t cloudtrail --debug 2 -s 2021-NOV-22 -L test_suffix/
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Working on 123456789000 - us-west-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/123456789000/CloudTrail/us-west-1/2021/11/22
	DEBUG: ++ Found new log: AWSLogs/test_suffix/123456789000/CloudTrail/us-west-1/2021/11/22/123456789000_CloudTrail_us-west-1_20211122T0000Z_rUQtGNUqmrPZMCnu.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Working on invalid - us-west-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/invalid/CloudTrail/us-west-1/2021/11/22
	DEBUG: +++ No logs to process in bucket: invalid/us-west-1
	DEBUG: +++ DB Maintenance
  ```
</details>

The module assume the `invalid` folder represent a different account ID, which is not true.

<details>
  <summary>AWS Cloudtrail after the fix using a suffix</summary>

  ```
	/var/ossec/wodles/aws/aws-s3 -p dev -b wazuh-aws-wodle-cloudtrail -t cloudtrail --debug 2 -s 2021-NOV-22 -L test_suffix/
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Working on 123456789000 - us-west-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/123456789000/CloudTrail/us-west-1/2021/11/22
	DEBUG: ++ Found new log: AWSLogs/test_suffix/123456789000/CloudTrail/us-west-1/2021/11/22/123456789000_CloudTrail_us-west-1_20211122T0000Z_rUQtGNUqmrPZMCnu.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance
  ```
</details>

The module try to obtain logs from the only account ID available in the bucket. The other folders are being ignored. The suffix is applied as intended.

Everything works as expected.
