### PR TITLE
Creating new groups_hash column in the `agent` table of global.db 

### DIFF
--- a/src/wazuh_db/schema_global.sql
+++ b/src/wazuh_db/schema_global.sql
@@ -35,11 +35,13 @@ CREATE TABLE IF NOT EXISTS agent (
     `group` TEXT DEFAULT 'default',
     sync_status TEXT NOT NULL CHECK (sync_status IN ('synced', 'syncreq')) DEFAULT 'synced',
     connection_status TEXT NOT NULL CHECK (connection_status IN ('pending', 'never_connected', 'active', 'disconnected')) DEFAULT 'never_connected',
-    disconnection_time INTEGER DEFAULT 0
+    disconnection_time INTEGER DEFAULT 0,
+    groups_hash TEXT default NULL
 );
 
 CREATE INDEX IF NOT EXISTS agent_name ON agent (name);
 CREATE INDEX IF NOT EXISTS agent_ip ON agent (ip);
+CREATE INDEX IF NOT EXISTS agent_groups_hash ON agent (groups_hash);
 
 INSERT INTO agent (id, ip, register_ip, name, date_add, last_keepalive, `group`, connection_status) VALUES (0, '127.0.0.1', '127.0.0.1', 'localhost', strftime('%s','now'), 253402300799, NULL, 'active');
 
@@ -62,13 +64,16 @@ CREATE TABLE IF NOT EXISTS `group` (
 
 CREATE TABLE IF NOT EXISTS belongs (
     id_agent INTEGER REFERENCES agent (id) ON DELETE CASCADE,
-    id_group INTEGER,
+    id_group INTEGER REFERENCES `group`(id),
     PRIMARY KEY (id_agent, id_group)
 );
+
+CREATE INDEX IF NOT EXISTS belongs_id_agent ON belongs (id_agent);
+CREATE INDEX IF NOT EXISTS belongs_id_group ON belongs (id_group);
 
 CREATE TABLE IF NOT EXISTS metadata (
     key TEXT PRIMARY KEY,
     value TEXT
 );
 
-INSERT INTO metadata (key, value) VALUES ('db_version', '3');
+INSERT INTO metadata (key, value) VALUES ('db_version', '4');

--- a/src/wazuh_db/schema_global.sql
+++ b/src/wazuh_db/schema_global.sql
@@ -64,7 +64,7 @@ CREATE TABLE IF NOT EXISTS `group` (
 
 CREATE TABLE IF NOT EXISTS belongs (
     id_agent INTEGER REFERENCES agent (id) ON DELETE CASCADE,
-    id_group INTEGER REFERENCES `group`(id),
+    id_group INTEGER REFERENCES `group`(id) ON DELETE CASCADE,
     PRIMARY KEY (id_agent, id_group)
 );
 

--- a/src/wazuh_db/schema_global_upgrade_v4.sql
+++ b/src/wazuh_db/schema_global_upgrade_v4.sql
@@ -10,7 +10,7 @@
 
 CREATE TABLE IF NOT EXISTS _belongs (
     id_agent INTEGER REFERENCES agent (id) ON DELETE CASCADE,
-    id_group INTEGER REFERENCES `group`(id),
+    id_group INTEGER REFERENCES `group`(id) ON DELETE CASCADE,
     PRIMARY KEY (id_agent, id_group)
 );
 

--- a/src/wazuh_db/schema_global_upgrade_v4.sql
+++ b/src/wazuh_db/schema_global_upgrade_v4.sql
@@ -1,0 +1,34 @@
+/*
+ * SQL Schema for upgrading databases
+ * Copyright (C) 2015-2021, Wazuh Inc.
+ *
+ * November, 2021.
+ *
+ * This program is a free software, you can redistribute it
+ * and/or modify it under the terms of GPLv2.
+*/
+
+CREATE TABLE IF NOT EXISTS _belongs (
+    id_agent INTEGER REFERENCES agent (id) ON DELETE CASCADE,
+    id_group INTEGER REFERENCES `group`(id),
+    PRIMARY KEY (id_agent, id_group)
+);
+
+CREATE INDEX IF NOT EXISTS belongs_id_agent ON belongs (id_agent);
+CREATE INDEX IF NOT EXISTS belongs_id_group ON belongs (id_group);
+
+BEGIN;
+
+INSERT INTO _belongs (id_agent, id_group) SELECT id_agent, id_group FROM belongs WHERE id_agent IN (SELECT id FROM agent) AND id_group IN (SELECT id FROM `group`);
+
+END;
+
+DROP TABLE IF EXISTS belongs;
+ALTER TABLE _belongs RENAME TO belongs;
+
+ALTER TABLE agent ADD COLUMN groups_hash TEXT default NULL;
+CREATE INDEX IF NOT EXISTS agent_name ON agent (name);
+CREATE INDEX IF NOT EXISTS agent_ip ON agent (ip);
+CREATE INDEX IF NOT EXISTS agent_groups_hash ON agent (groups_hash);
+
+UPDATE metadata SET value = '4' where key = 'db_version';

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -153,6 +153,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_FIND_AGENT] = "SELECT id FROM agent WHERE name = ? AND (register_ip = ? OR register_ip LIKE ? || '/_%');",
     [WDB_STMT_GLOBAL_FIND_GROUP] = "SELECT id FROM `group` WHERE name = ?;",
     [WDB_STMT_GLOBAL_UPDATE_AGENT_GROUP] = "UPDATE agent SET `group` = ? WHERE id = ?;",
+    [WDB_STMT_GLOBAL_UPDATE_AGENT_GROUPS_HASH] = "UPDATE agent SET groups_hash = ? WHERE id = ?;",
     [WDB_STMT_GLOBAL_INSERT_AGENT_GROUP] = "INSERT INTO `group` (name) VALUES(?);",
     [WDB_STMT_GLOBAL_INSERT_AGENT_BELONG] = "INSERT INTO belongs (id_group, id_agent) VALUES(?,?);",
     [WDB_STMT_GLOBAL_DELETE_AGENT_BELONG] = "DELETE FROM belongs WHERE id_agent = ?;",

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -1620,9 +1620,11 @@ int wdb_global_update_agent_group(wdb_t *wdb, int id, char *group);
  *
  * @param [in] wdb The Global struct database.
  * @param [in] id The agent ID
+ * @param [in] groups_string The comma separated groups string to hash and store in groups_hash column. If not set,
+ *                           it will be read from 'group' column.
  * @return Returns 0 on success or -1 on error.
  */
-int wdb_global_update_agent_groups_hash(wdb_t* wdb, int agent_id);
+int wdb_global_update_agent_groups_hash(wdb_t* wdb, int agent_id, char* groups_string);
 
 /**
  * @brief Function to update the agent's groups_hash column for all agents. It gets all agents and calls

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -180,6 +180,7 @@ typedef enum wdb_stmt {
     WDB_STMT_GLOBAL_FIND_AGENT,
     WDB_STMT_GLOBAL_FIND_GROUP,
     WDB_STMT_GLOBAL_UPDATE_AGENT_GROUP,
+    WDB_STMT_GLOBAL_UPDATE_AGENT_GROUPS_HASH,
     WDB_STMT_GLOBAL_INSERT_AGENT_GROUP,
     WDB_STMT_GLOBAL_INSERT_AGENT_BELONG,
     WDB_STMT_GLOBAL_DELETE_AGENT_BELONG,
@@ -1612,6 +1613,25 @@ cJSON* wdb_global_find_agent(wdb_t *wdb, const char *name, const char *ip);
  * @return Returns 0 on success or -1 on error.
  */
 int wdb_global_update_agent_group(wdb_t *wdb, int id, char *group);
+
+/**
+ * @brief Function to update the agent's groups_hash column. It reads the group column, calculates and stores its hash
+ *        but if the group column is NULL, the method returns without modifying groups_hash.
+ *
+ * @param [in] wdb The Global struct database.
+ * @param [in] id The agent ID
+ * @return Returns 0 on success or -1 on error.
+ */
+int wdb_global_update_agent_groups_hash(wdb_t* wdb, int agent_id);
+
+/**
+ * @brief Function to update the agent's groups_hash column for all agents. It gets all agents and calls
+ *        wdb_global_update_agent_groups_hash() for each one.
+ *
+ * @param [in] wdb The Global struct database.
+ * @return Returns 0 on success or -1 on error.
+ */
+int wdb_global_update_all_agents_groups_hash(wdb_t* wdb);
 
 /**
  * @brief Function to get a group id using the group name.

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -329,6 +329,7 @@ extern char *schema_upgrade_v8_sql;
 extern char *schema_global_upgrade_v1_sql;
 extern char *schema_global_upgrade_v2_sql;
 extern char *schema_global_upgrade_v3_sql;
+extern char *schema_global_upgrade_v4_sql;
 
 extern wdb_config wconfig;
 extern pthread_mutex_t pool_mutex;

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -599,6 +599,108 @@ int wdb_global_update_agent_group(wdb_t *wdb, int id, char *group) {
     }
 }
 
+int wdb_global_update_agent_groups_hash(wdb_t* wdb, int agent_id) {
+    cJSON* j_agent_info = NULL;
+    char* agent_groups = NULL;
+    char truncated_groups_hash[9] = {0};
+    os_sha256 groups_hash;
+    int result = OS_INVALID;
+
+    j_agent_info = wdb_global_get_agent_info(wdb, agent_id);
+    if(!j_agent_info) {
+        mdebug1("Unable to get the agent's '%d' info to update the groups_hash column", agent_id);
+        return OS_INVALID;
+    }
+
+    agent_groups = cJSON_GetStringValue(cJSON_GetObjectItem(j_agent_info->child, "group"));
+    if(!agent_groups) {
+        mdebug2("Empty group column for agent '%d', groups_hash column won't be updated", agent_id);
+        cJSON_Delete(j_agent_info);
+        return OS_SUCCESS;
+    }
+
+    OS_SHA256_String(agent_groups, groups_hash);
+    /* We'll use only the first 8 bytes to keep the same legacy format */
+    groups_hash[8] = '\0';
+    strncpy(truncated_groups_hash, groups_hash, 8);
+
+    cJSON_Delete(j_agent_info);
+
+    if (!wdb->transaction && wdb_begin2(wdb) < 0) {
+        mdebug1("Cannot begin transaction");
+        return OS_INVALID;
+    }
+
+    if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_UPDATE_AGENT_GROUPS_HASH) < 0) {
+        mdebug1("Cannot cache statement");
+        return OS_INVALID;
+    }
+
+    sqlite3_stmt* stmt = wdb->stmt[WDB_STMT_GLOBAL_UPDATE_AGENT_GROUPS_HASH];
+    if (sqlite3_bind_text(stmt, 1, truncated_groups_hash, -1, NULL) != SQLITE_OK) {
+        merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+        return OS_INVALID;
+    }
+
+    if (sqlite3_bind_int(stmt, 2, agent_id) != SQLITE_OK) {
+        merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+        return OS_INVALID;
+    }
+
+    switch (wdb_step(stmt)) {
+    case SQLITE_DONE:
+        result = OS_SUCCESS;
+        break;
+    default:
+        mdebug1("SQLite: %s", sqlite3_errmsg(wdb->db));
+        result = OS_INVALID;
+    }
+
+    return result;
+}
+
+int wdb_global_update_all_agents_groups_hash(wdb_t* wdb) {
+    int step_result = -1;
+    int update_result = OS_SUCCESS;
+    int result = OS_INVALID;
+    int agent_id = -1;
+
+    if (!wdb->transaction && wdb_begin2(wdb) < 0) {
+        mdebug1("Cannot begin transaction");
+        return OS_INVALID;
+    }
+
+    if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_GET_AGENTS) < 0) {
+        mdebug1("Cannot cache statement");
+        return OS_INVALID;
+    }
+
+    sqlite3_stmt* stmt = wdb->stmt[WDB_STMT_GLOBAL_GET_AGENTS];
+
+    if (sqlite3_bind_int(stmt, 1, 0) != SQLITE_OK) {
+        merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+        return OS_INVALID;
+    }
+
+    do {
+        step_result = wdb_step(stmt);
+        switch (step_result) {
+        case SQLITE_ROW:
+            agent_id = sqlite3_column_int(stmt, 0);
+            update_result = wdb_global_update_agent_groups_hash(wdb, agent_id);
+            break;
+        case SQLITE_DONE:
+            result = OS_SUCCESS;
+            break;
+        default:
+            mdebug1("SQLite: %s", sqlite3_errmsg(wdb->db));
+            result = OS_INVALID;
+        }
+    } while(step_result == SQLITE_ROW && update_result == OS_SUCCESS);
+
+    return result;
+}
+
 cJSON* wdb_global_find_group(wdb_t *wdb, char* group_name) {
     sqlite3_stmt *stmt = NULL;
     cJSON * result = NULL;

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -616,7 +616,7 @@ int wdb_global_update_agent_groups_hash(wdb_t* wdb, int agent_id, char* groups_s
 
         agent_groups = cJSON_GetStringValue(cJSON_GetObjectItem(j_agent_info->child, "group"));
         if(!agent_groups) {
-            mdebug2("Empty group column for agent '%d', groups_hash column won't be updated", agent_id);
+            mdebug2("Empty group column for agent '%d'. The groups_hash column won't be updated", agent_id);
             cJSON_Delete(j_agent_info);
             return OS_SUCCESS;
         }

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5115,6 +5115,13 @@ int wdb_parse_global_update_agent_group(wdb_t * wdb, char * input, char * output
                 cJSON_Delete(agent_data);
                 return OS_INVALID;
             }
+
+            if (OS_SUCCESS != wdb_global_update_agent_groups_hash(wdb, id, group)) {
+                mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db: %s", WDB2_DIR, WDB_GLOB_NAME, sqlite3_errmsg(wdb->db));
+                snprintf(output, OS_MAXSTR + 1, "err Cannot execute Global database query; %s", sqlite3_errmsg(wdb->db));
+                cJSON_Delete(agent_data);
+                return OS_INVALID;
+            }
         } else {
             mdebug1("Global DB Invalid JSON data when updating agent group.");
             snprintf(output, OS_MAXSTR + 1, "err Invalid JSON data, near '%.32s'", input);

--- a/src/wazuh_db/wdb_upgrade.c
+++ b/src/wazuh_db/wdb_upgrade.c
@@ -76,7 +76,8 @@ wdb_t * wdb_upgrade_global(wdb_t *wdb) {
     const char * UPDATES[] = {
         schema_global_upgrade_v1_sql,
         schema_global_upgrade_v2_sql,
-        schema_global_upgrade_v3_sql
+        schema_global_upgrade_v3_sql,
+        schema_global_upgrade_v4_sql
     };
 
     char db_version[OS_SIZE_256 + 2];


### PR DESCRIPTION
|Related issue|
|---|
|#10951|

## Description

This PR adds a new column to the `agent` table to store the hash of the comma separated groups string in **global.db**.
An upgrade mechanism was considered to set the initial value of the column and every modification of the `group` column also updates `groups_hash`.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
