### PR TITLE
Rework of PR #10064 - Decoders and Rules update for Apache

### DIFF
--- a/ruleset/decoders/0025-apache_decoders.xml
+++ b/ruleset/decoders/0025-apache_decoders.xml
@@ -7,80 +7,78 @@
   -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
-
 <!--
-  - Will extract the srcip
   - Examples:
-  - Without ID: Will extract the srcip and srcport (when it is available)
+    - Without ID: Will extract the srcip and srcport (when it is available)
       - [error] [client 80.230.208.105] Directory index forbidden by rule: /home/
       - [error] [client 64.94.163.159] Client sent malformed Host header
       - [error] [client 66.31.142.16] File does not exist: /var/www/html/default.ida
       - [Sun Nov 23 18:49:01.713508 2014] [:error] [pid 15816] [client 141.8.147.9:51507] PHP Notice:  A non well formed numeric value encountered in /path/to/file.php on line 123
       - Feb 17 18:00:00 myhost httpd[18660]: [error] [client 12.34.56.78] File does not exist: /usr/local/htdocs/cache
       - Feb 17 18:00:00 myhost httpd[23745]: [error] [client 12.34.56.78] PHP Notice:
-  - With IP + ID: Will extract the srcip, id, and srcport (when it is available)
+    - With IP + ID: Will extract the srcip, id, and srcport (when it is available)
       - [Tue Sep 30 11:30:13.262255 2014] [core:error] [pid 20101] [client 99.47.227.95:34567] AH00037: Symbolic link not allowed or link target not accessible: /usr/share/awstats/icon/mime/document.png
       - [Tue Sep 30 12:24:22.891366 2014] [proxy:warn] [pid 2331] [client 77.127.180.111:54082] AH01136: Unescaped URL path matched ProxyPass; ignoring unsafe nocanon, referer: http://www.easylinker.co.il/he/links.aspx?user=bguyb
       - [Tue Sep 30 14:25:44.895897 2014] [authz_core:error] [pid 31858] [client 99.47.227.95:38870] AH01630: client denied by server configuration: /var/www/example.com/docroot/
       - [Thu Oct 23 15:17:55.926067 2014] [ssl:info] [pid 18838] [client 36.226.119.49:2359] AH02008: SSL library error 1 in handshake (server www.example.com:443)
-      - ModSecurity
-        - [Tue Feb 16 04:02:21.018764 2016] [:error] [pid 3223] [client 10.10.10.10] ModSecurity: Access denied with code 403 (phase 2). Text...
-        - [Tue Feb 16 04:02:21.018764 2016] [:error] [pid 3223] [client 10.10.10.10:5555] ModSecurity: Access denied with code 403 (phase 2). Text...
-  - Others
+    - ModSecurity
+      - [Tue Feb 16 04:02:21.018764 2016] [:error] [pid 3223] [client 10.10.10.10] ModSecurity: Access denied with code 403 (phase 2). Text...
+      - [Tue Feb 16 04:02:21.018764 2016] [:error] [pid 3223] [client 10.10.10.10:5555] ModSecurity: Access denied with code 403 (phase 2). Text...
+    - Others
       - [notice] Apache configured
-      - [Thu Oct 23 15:17:55.926123 2014] [ssl:info] [pid 18838] SSL Library Error: error:1407609B:SSL routines:SSL23_GET_CLIENT_HELLO:https proxy request -- speaking HTTP to HTTPS port!?
+      - [Thu Oct 23 15:17:55.926123 2014] [ssl:info] [pid 18838] SSL Library Error: error:1407609B:SSL routines:SSL23_GET_CLIENT_HELLO:https proxy request - - speaking HTTP to HTTPS port!?
       - [Tue Sep 30 12:11:21.258612 2014] [ssl:error] [pid 30473] AH02032: Hostname www.example.com provided via SNI and hostname ssl://www.example.com provided via HTTP are different
       - [Wed Jul 31 16:44:52.967837 2019] [core:notice] [pid 8575] AH00094: Command line: '/usr/sbin/httpd -D FOREGROUND'
-
+      - [Tue Mar 07 12:05:15 2006] [error] [client 200.206.165.91] Invalid URI in request %3Bi%3A3%3Bi%3A0%3B%7D; usercookie[password]=d6ed9e1750d0b2aba6b3311cbec087d8; 45befd35f8a0f47b89ed8831f892b8dc=167c4e46a940cd2570b952eea527b27a; PHPSESSID=616hjdg7kj9bln37efsv7vt7g3 - [client 65.204.137.200] script '/var/www/html/xmlrpc.php' not found or unable to stat
 -->
 
 <!-- Parent decoders -->
 <decoder name="apache-errorlog">
-    <program_name>^apache2|^httpd</program_name>
+  <program_name>^apache2|^httpd</program_name>
 </decoder>
 
 <decoder name="apache-errorlog">
-    <prematch type="pcre2">^\[\w+\]\s</prematch>
+  <prematch type="pcre2">^\[\w+\]\s</prematch>
 </decoder>
 
 <decoder name="apache-errorlog">
-    <prematch type="pcre2">^\[\w{3}\s\w{3}\s\d{1,2}+\s\d{2}:\d{2}:\d{2}(?:\.\d+)?\s\d{4}\]\s</prematch>
+  <prematch type="pcre2">^\[\w{3}\s\w{3}\s\d{1,2}+\s\d{2}:\d{2}:\d{2}(?:\.\d+)?\s\d{4}\]\s</prematch>
 </decoder>
 
 <!-- Siblings decoders -->
 <decoder name="apache-errorlog-fields">
-    <parent>apache-errorlog</parent>
-    <regex type="pcre2">\[(?:(\w+):)?:?(\w+)\]</regex>
-    <order>apache.module, severity</order>
+  <parent>apache-errorlog</parent>
+  <regex type="pcre2">\[(?:(\w+):)?:?(\w+)\]</regex>
+  <order>apache.module, severity</order>
 </decoder>
 
 <decoder name="apache-errorlog-fields">
-    <parent>apache-errorlog</parent>
-    <regex offset="after_parent" type="pcre2">\[pid\s(\d+)(?::tid\s(\d+))?\]</regex>
-    <order>pid, tid</order>
+  <parent>apache-errorlog</parent>
+  <regex offset="after_parent" type="pcre2">\[pid\s(\d+)(?::tid\s(\d+))?\]</regex>
+  <order>pid, tid</order>
 </decoder>
 
 <decoder name="apache-errorlog-fields">
-    <parent>apache-errorlog</parent>
-    <regex offset="after_parent" type="pcre2">\s([\w\-_]+\.\w+)\((\d+)\):\s</regex>
-    <order>apache.log_file, apache.log_line</order>
+  <parent>apache-errorlog</parent>
+  <regex offset="after_parent" type="pcre2">\s([\w\-_]+\.\w+)\((\d+)\):\s</regex>
+  <order>apache.log_file, apache.log_line</order>
 </decoder>
 
 <decoder name="apache-errorlog-fields">
-    <parent>apache-errorlog</parent>
-    <regex offset="after_parent" type="pcre2">\[client\s(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|::1)(?::(\d+))?\]</regex>
-    <order>srcip, srcport</order>
+  <parent>apache-errorlog</parent>
+  <regex offset="after_parent" type="pcre2">\[client\s(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|::1)(?::(\d+))?\]</regex>
+  <order>srcip, srcport</order>
 </decoder>
 
 <decoder name="apache-errorlog-fields">
-    <parent>apache-errorlog</parent>
-    <regex offset="after_parent" type="pcre2">\]\s((?:([^\[:]+):\s)?[^\[](?:.+referer:\s(.+)|.+)$)</regex>
-    <order>message, id, referer</order>
+  <parent>apache-errorlog</parent>
+  <regex offset="after_parent" type="pcre2">\]\s((?:([^\[:]+):\s)?[^\[](?:.+referer:\s(.+)|.+)$)</regex>
+  <order>message, id, referer</order>
 </decoder>
 
 <!-- Specific decoders -->
 <decoder name="apache-errorlog-fields">
-    <parent>apache-errorlog</parent>
-    <regex offset="after_parent" type="pcre2">\s\w+:\s([^"]+)"([^"]+)":\s([^\[]+)\[RemoteIP:\s([^\]]+)]</regex>
-    <order>apache.error_message, user, apache.error_reason, apache.remote_ip</order>
+  <parent>apache-errorlog</parent>
+  <regex offset="after_parent" type="pcre2">\s\w+:\s([^"]+)"([^"]+)":\s([^\[]+)\[RemoteIP:\s([^\]]+)]</regex>
+  <order>apache.error_message, user, apache.error_reason, apache.remote_ip</order>
 </decoder>

--- a/ruleset/decoders/0025-apache_decoders.xml
+++ b/ruleset/decoders/0025-apache_decoders.xml
@@ -1,35 +1,39 @@
 <!--
-  -  Apache decoders
-  -  Author: Daniel Cid.
-  -  Updated by Wazuh, Inc.
-  -  Copyright (C) 2015-2021, Wazuh Inc.
-  -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  Author: Daniel Cid.
+  Updated by Wazuh, Inc.
+  Copyright (C) 2015-2021, Wazuh Inc.
+  Copyright (C) 2009 Trend Micro Inc.
+  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <!--
-  - Examples:
-    - Without ID: Will extract the srcip and srcport (when it is available)
-      - [error] [client 80.230.208.105] Directory index forbidden by rule: /home/
-      - [error] [client 64.94.163.159] Client sent malformed Host header
-      - [error] [client 66.31.142.16] File does not exist: /var/www/html/default.ida
-      - [Sun Nov 23 18:49:01.713508 2014] [:error] [pid 15816] [client 141.8.147.9:51507] PHP Notice:  A non well formed numeric value encountered in /path/to/file.php on line 123
-      - Feb 17 18:00:00 myhost httpd[18660]: [error] [client 12.34.56.78] File does not exist: /usr/local/htdocs/cache
-      - Feb 17 18:00:00 myhost httpd[23745]: [error] [client 12.34.56.78] PHP Notice:
-    - With IP + ID: Will extract the srcip, id, and srcport (when it is available)
-      - [Tue Sep 30 11:30:13.262255 2014] [core:error] [pid 20101] [client 99.47.227.95:34567] AH00037: Symbolic link not allowed or link target not accessible: /usr/share/awstats/icon/mime/document.png
-      - [Tue Sep 30 12:24:22.891366 2014] [proxy:warn] [pid 2331] [client 77.127.180.111:54082] AH01136: Unescaped URL path matched ProxyPass; ignoring unsafe nocanon, referer: http://www.easylinker.co.il/he/links.aspx?user=bguyb
-      - [Tue Sep 30 14:25:44.895897 2014] [authz_core:error] [pid 31858] [client 99.47.227.95:38870] AH01630: client denied by server configuration: /var/www/example.com/docroot/
-      - [Thu Oct 23 15:17:55.926067 2014] [ssl:info] [pid 18838] [client 36.226.119.49:2359] AH02008: SSL library error 1 in handshake (server www.example.com:443)
-    - ModSecurity
-      - [Tue Feb 16 04:02:21.018764 2016] [:error] [pid 3223] [client 10.10.10.10] ModSecurity: Access denied with code 403 (phase 2). Text...
-      - [Tue Feb 16 04:02:21.018764 2016] [:error] [pid 3223] [client 10.10.10.10:5555] ModSecurity: Access denied with code 403 (phase 2). Text...
-    - Others
-      - [notice] Apache configured
-      - [Thu Oct 23 15:17:55.926123 2014] [ssl:info] [pid 18838] SSL Library Error: error:1407609B:SSL routines:SSL23_GET_CLIENT_HELLO:https proxy request - - speaking HTTP to HTTPS port!?
-      - [Tue Sep 30 12:11:21.258612 2014] [ssl:error] [pid 30473] AH02032: Hostname www.example.com provided via SNI and hostname ssl://www.example.com provided via HTTP are different
-      - [Wed Jul 31 16:44:52.967837 2019] [core:notice] [pid 8575] AH00094: Command line: '/usr/sbin/httpd -D FOREGROUND'
-      - [Tue Mar 07 12:05:15 2006] [error] [client 200.206.165.91] Invalid URI in request %3Bi%3A3%3Bi%3A0%3B%7D; usercookie[password]=d6ed9e1750d0b2aba6b3311cbec087d8; 45befd35f8a0f47b89ed8831f892b8dc=167c4e46a940cd2570b952eea527b27a; PHPSESSID=616hjdg7kj9bln37efsv7vt7g3 - [client 65.204.137.200] script '/var/www/html/xmlrpc.php' not found or unable to stat
+  Decoders for: 
+    Apache HTTP Server 2.4
+-->
+
+<!--
+  Examples:
+    Without ID: Will extract the srcip and srcport (when it is available)
+      [error] [client 80.230.208.105] Directory index forbidden by rule: /home/
+      [error] [client 64.94.163.159] Client sent malformed Host header
+      [error] [client 66.31.142.16] File does not exist: /var/www/html/default.ida
+      [Sun Nov 23 18:49:01.713508 2014] [:error] [pid 15816] [client 141.8.147.9:51507] PHP Notice:  A non well formed numeric value encountered in /path/to/file.php on line 123
+      Feb 17 18:00:00 myhost httpd[18660]: [error] [client 12.34.56.78] File does not exist: /usr/local/htdocs/cache
+      Feb 17 18:00:00 myhost httpd[23745]: [error] [client 12.34.56.78] PHP Notice:
+    With IP + ID: Will extract the srcip, id, and srcport (when it is available)
+      [Tue Sep 30 11:30:13.262255 2014] [core:error] [pid 20101] [client 99.47.227.95:34567] AH00037: Symbolic link not allowed or link target not accessible: /usr/share/awstats/icon/mime/document.png
+      [Tue Sep 30 12:24:22.891366 2014] [proxy:warn] [pid 2331] [client 77.127.180.111:54082] AH01136: Unescaped URL path matched ProxyPass; ignoring unsafe nocanon, referer: http://www.easylinker.co.il/he/links.aspx?user=bguyb
+      [Tue Sep 30 14:25:44.895897 2014] [authz_core:error] [pid 31858] [client 99.47.227.95:38870] AH01630: client denied by server configuration: /var/www/example.com/docroot/
+      [Thu Oct 23 15:17:55.926067 2014] [ssl:info] [pid 18838] [client 36.226.119.49:2359] AH02008: SSL library error 1 in handshake (server www.example.com:443)
+    ModSecurity
+      [Tue Feb 16 04:02:21.018764 2016] [:error] [pid 3223] [client 10.10.10.10] ModSecurity: Access denied with code 403 (phase 2). Text...
+      [Tue Feb 16 04:02:21.018764 2016] [:error] [pid 3223] [client 10.10.10.10:5555] ModSecurity: Access denied with code 403 (phase 2). Text...
+    Others
+      [notice] Apache configured
+      [Thu Oct 23 15:17:55.926123 2014] [ssl:info] [pid 18838] SSL Library Error: error:1407609B:SSL routines:SSL23_GET_CLIENT_HELLO:https proxy request - - speaking HTTP to HTTPS port!?
+      [Tue Sep 30 12:11:21.258612 2014] [ssl:error] [pid 30473] AH02032: Hostname www.example.com provided via SNI and hostname ssl://www.example.com provided via HTTP are different
+      [Wed Jul 31 16:44:52.967837 2019] [core:notice] [pid 8575] AH00094: Command line: '/usr/sbin/httpd -D FOREGROUND'
+      [Tue Mar 07 12:05:15 2006] [error] [client 200.206.165.91] Invalid URI in request %3Bi%3A3%3Bi%3A0%3B%7D; usercookie[password]=d6ed9e1750d0b2aba6b3311cbec087d8; 45befd35f8a0f47b89ed8831f892b8dc=167c4e46a940cd2570b952eea527b27a; PHPSESSID=616hjdg7kj9bln37efsv7vt7g3 - [client 65.204.137.200] script '/var/www/html/xmlrpc.php' not found or unable to stat
 -->
 
 <!-- Parent decoders -->

--- a/ruleset/rules/0250-apache_rules.xml
+++ b/ruleset/rules/0250-apache_rules.xml
@@ -299,7 +299,7 @@
     <description>Apache: PHP notice in apache log.</description>
   </rule>
 
-  <rule id="30113" level="5">
+  <rule id="30319" level="5">
     <if_sid>30302</if_sid>
     <id>AUDIT</id>
     <field name="apache.error_message">authentication failure for principal</field>

--- a/ruleset/rules/0250-apache_rules.xml
+++ b/ruleset/rules/0250-apache_rules.xml
@@ -42,7 +42,7 @@
     <if_sid>30103</if_sid>
     <match>exit signal Segmentation Fault</match>
     <info type="link">http://www.securityfocus.com/infocus/1633</info>
-    <description>Apache: segmentation fault.</description>
+    <description>Apache: Segmentation fault.</description>
     <group>service_availability,pci_dss_6.5.2,pci_dss_6.6,gpg13_4.14,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.5,nist_800_53_SI.3,tsc_CC6.6,tsc_CC7.1,tsc_CC8.1,</group>
   </rule>
 
@@ -83,7 +83,7 @@
   <rule id="30109" level="9">
     <if_sid>30101</if_sid>
     <regex>user \S+ not found|user \S+ in realm \.* not found</regex>
-    <description>Apache: Attempt to login using a non-existent user.</description>
+    <description>Apache: Attempt to log in using a non-existent user.</description>
     <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
@@ -99,7 +99,7 @@
     <match>File does not exist: |</match>
     <match>failed to open stream: No such file or directory|</match>
     <match>Failed opening </match>
-    <description>Apache: Attempt to access an non-existent file (those are reported on the access.log).</description>
+    <description>Apache: Attempt to access a non-existent file (those are reported on the access.log).</description>
     <group>unknown_resource,pci_dss_10.2.1,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
@@ -123,7 +123,7 @@
   <rule id="30117" level="10">
     <if_sid>30101</if_sid>
     <match>File name too long|request failed: URI too long</match>
-    <description>Apache: Invalid URI, file name too long.</description>
+    <description>Apache: Invalid URI, filename too long.</description>
     <group>invalid_request,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
@@ -147,7 +147,7 @@
   <rule id="30120" level="12">
     <if_sid>30101</if_sid>
     <match>Resource temporarily unavailable:</match>
-    <description>Apache: without resources to run.</description>
+    <description>Apache: Without resources to run.</description>
     <group>service_availability,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
@@ -160,7 +160,7 @@
   <rule id="30201" level="6">
     <if_sid>30200</if_sid>
     <match>^mod_security-message: Access denied </match>
-    <description>ModSecurity: access denied.</description>
+    <description>ModSecurity: Access denied.</description>
     <group>modsecurity,access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
@@ -196,7 +196,7 @@
     <if_sid>30303</if_sid>
     <match>exit signal Segmentation Fault</match>
     <info type="link">http://www.securityfocus.com/infocus/1633</info>
-    <description>Apache: segmentation fault.</description>
+    <description>Apache: Segmentation fault.</description>
     <group>service_availability,pci_dss_6.5.2,pci_dss_6.6,gpg13_4.14,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.5,nist_800_53_SI.3,tsc_CC6.6,tsc_CC7.1,tsc_CC8.1,</group>
   </rule>
 
@@ -259,7 +259,7 @@
     <match>File does not exist: |</match>
     <match>failed to open stream: No such file or directory|</match>
     <match>Failed opening </match>
-    <description>Apache: Attempt to access an non-existent file (those are reported on the access.log).</description>
+    <description>Apache: Attempt to access a non-existent file (those are reported on the access.log).</description>
     <group>unknown_resource,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
@@ -273,7 +273,7 @@
   <rule id="30316" level="10" frequency="10" timeframe="120">
     <if_matched_sid>30315</if_matched_sid>
     <same_source_ip />
-    <description>Apache: Multiple Invalid URI requests from same source.</description>
+    <description>Apache: Multiple invalid URI requests from same source.</description>
     <mitre>
       <id>T1499</id>
     </mitre>
@@ -290,7 +290,7 @@
   <rule id="30318" level="5">
     <if_sid>30301</if_sid>
     <match>PHP Notice:</match>
-    <description>Apache: PHP Notice in Apache log.</description>
+    <description>Apache: PHP notice in apache log.</description>
   </rule>
 
   <rule id="30113" level="5">

--- a/ruleset/rules/0250-apache_rules.xml
+++ b/ruleset/rules/0250-apache_rules.xml
@@ -98,9 +98,6 @@
     <group>unknown_resource,pci_dss_10.2.1,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
-  <!-- [Tue Mar 07 12:05:15 2006] [error] [client 200.206.165.91] Invalid URI in request %3Bi%3A3%3Bi%3A0%3B%7D; usercookie[password]=d6ed9e1750d0b2aba6b3311cbec087d8; 45befd35f8a0f47b89ed8831f892b8dc=167c4e46a940cd2570b952eea527b27a; PHPSESSID=616hjdg7kj9bln37efsv7vt7g3
-  - [client 65.204.137.200] script '/var/www/html/xmlrpc.php' not found or unable to stat
-  -->
   <rule id="30115" level="5">
     <if_sid>30101</if_sid>
     <match>Invalid URI in request</match>
@@ -125,7 +122,6 @@
     <group>invalid_request,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
-  <!-- Mod security rules by <ossec ( at ) sioban.net -->
   <rule id="30118" level="6">
     <if_sid>30101</if_sid>
     <match>mod_security: Access denied|ModSecurity: Access denied</match>

--- a/ruleset/rules/0250-apache_rules.xml
+++ b/ruleset/rules/0250-apache_rules.xml
@@ -1,12 +1,17 @@
 <!--
-  -  Apache rules
-  -  Author: Daniel Cid.
-  -  Contributed by: Ahmet Ozturk
-  -                  Ben Chavet <ben.chavet@lullabot.com>
-  -  Updated by Wazuh, Inc.
-  -  Copyright (C) 2015-2021, Wazuh Inc.
-  -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  Author: Daniel Cid.
+  Contributed by: Ahmet Ozturk
+                  Ben Chavet <ben.chavet@lullabot.com>
+  Updated by Wazuh, Inc.
+  Copyright (C) 2015-2021, Wazuh Inc.
+  Copyright (C) 2009 Trend Micro Inc.
+  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+
+<!-- 
+  Rules for:
+    Apache HTTP Server 2.2 ID:    30100 - 30299
+    Apache HTTP Server 2.4 ID:    30300 - 30499 
 -->
 
 <group name="apache,web,">
@@ -36,8 +41,8 @@
   <rule id="30104" level="12">
     <if_sid>30103</if_sid>
     <match>exit signal Segmentation Fault</match>
-    <description>Apache: segmentation fault.</description>
     <info type="link">http://www.securityfocus.com/infocus/1633</info>
+    <description>Apache: segmentation fault.</description>
     <group>service_availability,pci_dss_6.5.2,pci_dss_6.6,gpg13_4.14,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.5,nist_800_53_SI.3,tsc_CC6.6,tsc_CC7.1,tsc_CC8.1,</group>
   </rule>
 
@@ -58,9 +63,9 @@
   <rule id="30107" level="6">
     <if_sid>30101</if_sid>
     <match>Client sent malformed Host header</match>
-    <description>Apache: Code Red attack.</description>
     <info type="link">http://www.cert.org/advisories/CA-2001-19.html</info>
     <info type="text">CERT: Advisory CA-2001-19 "Code Red" Worm Exploiting Buffer Overflow In IIS Indexing Service DLL</info>
+    <description>Apache: Code Red attack.</description>
     <mitre>
       <id>T1190</id>
       <id>T107.001</id>
@@ -190,8 +195,8 @@
   <rule id="30304" level="12">
     <if_sid>30303</if_sid>
     <match>exit signal Segmentation Fault</match>
-    <description>Apache: segmentation fault.</description>
     <info type="link">http://www.securityfocus.com/infocus/1633</info>
+    <description>Apache: segmentation fault.</description>
     <group>service_availability,pci_dss_6.5.2,pci_dss_6.6,gpg13_4.14,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.5,nist_800_53_SI.3,tsc_CC6.6,tsc_CC7.1,tsc_CC8.1,</group>
   </rule>
 
@@ -215,9 +220,9 @@
   <rule id="30307" level="6">
     <if_sid>30301</if_sid>
     <id>AH00550</id>
-    <description>Apache: Client sent malformed Host header. Possible Code Red attack.</description>
     <info type="link">http://www.cert.org/advisories/CA-2001-19.html</info>
     <info type="text">CERT: Advisory CA-2001-19 "Code Red" Worm Exploiting Buffer Overflow In IIS Indexing Service DLL</info>
+    <description>Apache: Client sent malformed Host header. Possible Code Red attack.</description>
     <mitre>
       <id>T1190</id>
       <id>T107.001</id>
@@ -285,14 +290,14 @@
   <rule id="30318" level="5">
     <if_sid>30301</if_sid>
     <match>PHP Notice:</match>
-    <description>Apache: PHP Notice in Apache log</description>
+    <description>Apache: PHP Notice in Apache log.</description>
   </rule>
 
   <rule id="30113" level="5">
     <if_sid>30302</if_sid>
     <id>AUDIT</id>
     <field name="apache.error_message">authentication failure for principal</field>
-    <description>Apache: $(apache.error_message) $(apache.remote_ip) due to $(apache.error_reason)</description>
+    <description>Apache: $(apache.error_message) $(apache.remote_ip) due to $(apache.error_reason).</description>
     <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
@@ -300,28 +305,28 @@
   <rule id="30401" level="0">
     <if_sid>30301</if_sid>
     <match>ModSecurity: Warning</match>
-    <description>ModSecurity Warning messages grouped</description>
+    <description>ModSecurity Warning messages grouped.</description>
     <group>modsecurity,</group>
   </rule>
 
   <rule id="30402" level="0">
     <if_sid>30301</if_sid>
     <match>ModSecurity: Access denied</match>
-    <description>ModSecurity Access denied messages grouped</description>
+    <description>ModSecurity Access denied messages grouped.</description>
     <group>modsecurity,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="30403" level="0">
     <if_sid>30301</if_sid>
     <match>ModSecurity: Audit log:</match>
-    <description>ModSecurity Audit log messages grouped</description>
+    <description>ModSecurity Audit log messages grouped.</description>
     <group>modsecurity,gpg13_10.1,</group>
   </rule>
 
   <rule id="30411" level="7">
     <if_sid>30402</if_sid>
     <match>with code 403</match>
-    <description>ModSecurity rejected a query</description>
+    <description>ModSecurity rejected a query.</description>
     <mitre>
       <id>T1083</id>
     </mitre>

--- a/ruleset/rules/0250-apache_rules.xml
+++ b/ruleset/rules/0250-apache_rules.xml
@@ -43,21 +43,21 @@
     <match>exit signal Segmentation Fault</match>
     <info type="link">http://www.securityfocus.com/infocus/1633</info>
     <description>Apache: Segmentation fault.</description>
-    <group>service_availability,pci_dss_6.5.2,pci_dss_6.6,gpg13_4.14,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.5,nist_800_53_SI.3,tsc_CC6.6,tsc_CC7.1,tsc_CC8.1,</group>
+    <group>gdpr_IV_35.7.d,gpg13_4.14,nist_800_53_SA.11,nist_800_53_SC.5,nist_800_53_SI.3,pci_dss_6.5.2,pci_dss_6.6,service_availability,tsc_CC6.6,tsc_CC7.1,tsc_CC8.1,</group>
   </rule>
 
   <rule id="30105" level="5">
     <if_sid>30101</if_sid>
     <match>denied by server configuration</match>
     <description>Apache: Attempt to access forbidden file or directory.</description>
-    <group>access_denied,pci_dss_6.5.8,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.6,tsc_CC7.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>access_denied,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_6.5.8,pci_dss_10.2.4,tsc_CC6.6,tsc_CC7.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="30106" level="5">
     <if_sid>30101</if_sid>
     <match>Directory index forbidden by rule</match>
     <description>Apache: Attempt to access forbidden directory index.</description>
-    <group>access_denied,pci_dss_6.5.8,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.6,tsc_CC7.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>access_denied,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_6.5.8,pci_dss_10.2.4,tsc_CC6.6,tsc_CC7.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="30107" level="6">
@@ -70,28 +70,28 @@
       <id>T1190</id>
       <id>T107.001</id>
     </mitre>
-    <group>automatic_attack,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SI.2,nist_800_53_SA.11,nist_800_53_SI.4,tsc_CC6.8,tsc_CC6.6,tsc_CC7.1,tsc_CC6.1,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>automatic_attack,nist_800_53_SI.2,nist_800_53_SA.11,nist_800_53_SI.4,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,gdpr_IV_35.7.d,tsc_CC6.8,tsc_CC6.6,tsc_CC7.1,tsc_CC6.1,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="30108" level="5">
     <if_sid>30102</if_sid>
     <match>authentication failed</match>
     <description>Apache: User authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_failed,gdpr_IV_35.7.d,gdpr_IV_32.2,gpg13_7.1,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="30109" level="9">
     <if_sid>30101</if_sid>
     <regex>user \S+ not found|user \S+ in realm \.* not found</regex>
     <description>Apache: Attempt to log in using a non-existent user.</description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,gpg13_7.1,hipaa_164.312.b,invalid_login,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="30110" level="5">
     <if_sid>30101</if_sid>
     <match>authentication failure</match>
     <description>Apache: User authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_failed,gdpr_IV_35.7.d,gdpr_IV_32.2,gpg13_7.1,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="30112" level="0">
@@ -100,7 +100,13 @@
     <match>failed to open stream: No such file or directory|</match>
     <match>Failed opening </match>
     <description>Apache: Attempt to access a non-existent file (those are reported on the access.log).</description>
-    <group>unknown_resource,pci_dss_10.2.1,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+
+  <rule id="30113" level="10" frequency="10" timeframe="120">
+    <if_matched_sid>30112</if_matched_sid>
+    <same_source_ip />
+    <description>Apache: Multiple attempts to access a non-existent file (those are reported on the access.log).</description>
+    <group>gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.1,pci_dss_10.2.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,unknown_resource,</group>
   </rule>
 
   <rule id="30115" level="5">
@@ -113,25 +119,25 @@
   <rule id="30116" level="10" frequency="10" timeframe="120">
     <if_matched_sid>30115</if_matched_sid>
     <same_source_ip />
-    <description>Apache: Multiple Invalid URI requests from same source.</description>
+    <description>Apache: Multiple invalid URI requests from same source.</description>
     <mitre>
       <id>T1499</id>
     </mitre>
-    <group>invalid_request,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,hipaa_164.312.b,invalid_request,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,pci_dss_10.2.4,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="30117" level="10">
     <if_sid>30101</if_sid>
     <match>File name too long|request failed: URI too long</match>
     <description>Apache: Invalid URI, filename too long.</description>
-    <group>invalid_request,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,hipaa_164.312.b,invalid_request,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="30118" level="6">
     <if_sid>30101</if_sid>
     <match>mod_security: Access denied|ModSecurity: Access denied</match>
     <description>ModSecurity: Access attempt blocked.</description>
-    <group>modsecurity,access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>access_denied,gdpr_IV_35.7.d,hipaa_164.312.b,modsecurity,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="30119" level="12" frequency="8" timeframe="120">
@@ -141,14 +147,14 @@
     <mitre>
       <id>T1110</id>
     </mitre>
-    <group>modsecurity,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>access_denied,gdpr_IV_35.7.d,hipaa_164.312.b,modsecurity,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,pci_dss_10.2.4,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="30120" level="12">
     <if_sid>30101</if_sid>
     <match>Resource temporarily unavailable:</match>
     <description>Apache: Without resources to run.</description>
-    <group>service_availability,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,pci_dss_10.6.1,service_availability,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="30200" level="6" noalert="1">
@@ -161,7 +167,7 @@
     <if_sid>30200</if_sid>
     <match>^mod_security-message: Access denied </match>
     <description>ModSecurity: Access denied.</description>
-    <group>modsecurity,access_denied,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>access_denied,gdpr_IV_35.7.d,hipaa_164.312.b,modsecurity,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="30202" level="10" frequency="10" timeframe="120">
@@ -170,7 +176,7 @@
     <mitre>
       <id>T1110</id>
     </mitre>
-    <group>modsecurity,access_denied,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>access_denied,gdpr_IV_35.7.d,hipaa_164.312.b,modsecurity,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,pci_dss_10.2.4,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <!-- Apache 2.4 Rules -->
@@ -197,14 +203,14 @@
     <match>exit signal Segmentation Fault</match>
     <info type="link">http://www.securityfocus.com/infocus/1633</info>
     <description>Apache: Segmentation fault.</description>
-    <group>service_availability,pci_dss_6.5.2,pci_dss_6.6,gpg13_4.14,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.5,nist_800_53_SI.3,tsc_CC6.6,tsc_CC7.1,tsc_CC8.1,</group>
+    <group>gpg13_4.14,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SC.5,nist_800_53_SI.3,pci_dss_6.5.2,pci_dss_6.6,service_availability,tsc_CC6.6,tsc_CC7.1,tsc_CC8.1,</group>
   </rule>
 
   <rule id="30305" level="5">
     <if_sid>30301</if_sid>
     <id>AH01630</id>
     <description>Apache: Attempt to access forbidden file or directory.</description>
-    <group>access_denied,pci_dss_6.5.8,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.6,tsc_CC7.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>access_denied,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_6.5.8,pci_dss_10.2.4,tsc_CC6.6,tsc_CC7.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="30306" level="5">
@@ -214,7 +220,7 @@
     <mitre>
       <id>T1190</id>
     </mitre>
-    <group>access_denied,pci_dss_6.5.8,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.6,tsc_CC7.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>access_denied,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_6.5.8,pci_dss_10.2.4,tsc_CC6.6,tsc_CC7.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="30307" level="6">
@@ -227,21 +233,21 @@
       <id>T1190</id>
       <id>T107.001</id>
     </mitre>
-    <group>automatic_attack,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SI.2,nist_800_53_SA.11,nist_800_53_SI.4,tsc_CC6.8,tsc_CC6.6,tsc_CC7.1,tsc_CC6.1,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>automatic_attack,gdpr_IV_35.7.d,nist_800_53_SI.2,nist_800_53_SA.11,nist_800_53_SI.4,tsc_CC6.8,pci_dss_6.2,pci_dss_6.5.2,pci_dss_11.4,tsc_CC6.6,tsc_CC7.1,tsc_CC6.1,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="30308" level="5">
     <if_sid>30302</if_sid>
     <id>AH01617|AH01807|AH01694|AH01695|AH02009|AH02010</id>
     <description>Apache: User authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_failed,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="30309" level="5">
     <if_sid>30301</if_sid>
     <id>AH01618|AH01808|AH01790</id>
     <description>Apache: Attempt to login using a non-existent user.</description>
-    <group>invalid_login,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SI.4,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,invalid_login,nist_800_53_SI.4,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="30310" level="10" frequency="12" timeframe="160">
@@ -251,7 +257,7 @@
     <mitre>
       <id>T1110</id>
     </mitre>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_failures,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="30312" level="0">
@@ -260,14 +266,14 @@
     <match>failed to open stream: No such file or directory|</match>
     <match>Failed opening </match>
     <description>Apache: Attempt to access a non-existent file (those are reported on the access.log).</description>
-    <group>unknown_resource,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,unknown_resource,</group>
   </rule>
 
   <rule id="30315" level="5">
     <if_sid>30301</if_sid>
     <id>AH00126</id>
     <description>Apache: Invalid URI (bad client request).</description>
-    <group>invalid_request,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,hipaa_164.312.b,invalid_request,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="30316" level="10" frequency="10" timeframe="120">
@@ -277,14 +283,14 @@
     <mitre>
       <id>T1499</id>
     </mitre>
-    <group>invalid_request,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,hipaa_164.312.b,invalid_request,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,pci_dss_10.2.4,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="30317" level="10">
     <if_sid>30301</if_sid>
     <id>AH00565</id>
     <description>Apache: Invalid URI, file name too long.</description>
-    <group>invalid_request,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,hipaa_164.312.b,invalid_request,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="30318" level="5">
@@ -298,29 +304,29 @@
     <id>AUDIT</id>
     <field name="apache.error_message">authentication failure for principal</field>
     <description>Apache: $(apache.error_message) $(apache.remote_ip) due to $(apache.error_reason).</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_failed,gdpr_IV_35.7.d,gdpr_IV_32.2,gpg13_7.1,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <!-- Apache 2.4 ModSecurity Rules -->
   <rule id="30401" level="0">
     <if_sid>30301</if_sid>
     <match>ModSecurity: Warning</match>
-    <description>ModSecurity Warning messages grouped.</description>
+    <description>ModSecurity: Warning messages grouped.</description>
     <group>modsecurity,</group>
   </rule>
 
   <rule id="30402" level="0">
     <if_sid>30301</if_sid>
     <match>ModSecurity: Access denied</match>
-    <description>ModSecurity Access denied messages grouped.</description>
-    <group>modsecurity,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <description>ModSecurity: Access denied messages grouped.</description>
+    <group>gdpr_IV_35.7.d,hipaa_164.312.b,modsecurity,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="30403" level="0">
     <if_sid>30301</if_sid>
     <match>ModSecurity: Audit log:</match>
-    <description>ModSecurity Audit log messages grouped.</description>
-    <group>modsecurity,gpg13_10.1,</group>
+    <description>ModSecurity: Audit log messages grouped.</description>
+    <group>gpg13_10.1,modsecurity,</group>
   </rule>
 
   <rule id="30411" level="7">
@@ -330,7 +336,7 @@
     <mitre>
       <id>T1083</id>
     </mitre>
-    <group>modsecurity,gpg13_10.1,</group>
+    <group>gpg13_10.1,modsecurity,</group>
   </rule>
 
 </group>

--- a/ruleset/testing/tests/apache.ini
+++ b/ruleset/testing/tests/apache.ini
@@ -20,7 +20,7 @@ decoder = apache-errorlog
 
 [AUDIT authentication failure for principal.]
 log 1 pass = [Tue Aug 31 17:36:20.864110 2021] [authnz_e2proxy:warn] [pid 1234225:tid 140373607307008] [client XXX.XXX.XXX.XX:7212] AUDIT: authentication failure for principal "yyyy.zzzz@xxxx.com": password mismatch [RemoteIP: XXX.XXX.XXX.XX], referer: https://infoseckibana2.ZZZZ.com/pages/login?destination=%2f&source=redirect
-rule = 30113
+rule = 30319
 alert = 5
 decoder = apache-errorlog
 

--- a/ruleset/testing/tests/apache.ini
+++ b/ruleset/testing/tests/apache.ini
@@ -1,4 +1,14 @@
-[Errorlog parent]
+;  Copyright (C) 2015-2021, Wazuh Inc.
+;
+;  Tests for products: 
+;    Apache HTTP Server 2.2
+;    Apache HTTP Server 2.4
+;
+;  Sample logs source: 
+;    Apache HTTP Server 2.2: community
+;    Apache HTTP Server 2.4: community
+
+[Errorlog parent.]
 log 1 pass = Feb 17 18:00:00 myhost httpd[18660]: ...
 log 2 pass = Feb 17 18:00:00 myhost apache2[18660]:
 log 3 pass = [Tue Sep 30 11:30:13.262255 2014] [core:error]
@@ -8,7 +18,7 @@ rule = 30100
 alert = 0
 decoder = apache-errorlog
 
-[AUDIT authentication failure for principal]
+[AUDIT authentication failure for principal.]
 log 1 pass = [Tue Aug 31 17:36:20.864110 2021] [authnz_e2proxy:warn] [pid 1234225:tid 140373607307008] [client XXX.XXX.XXX.XX:7212] AUDIT: authentication failure for principal "yyyy.zzzz@xxxx.com": password mismatch [RemoteIP: XXX.XXX.XXX.XX], referer: https://infoseckibana2.ZZZZ.com/pages/login?destination=%2f&source=redirect
 rule = 30113
 alert = 5
@@ -20,57 +30,57 @@ rule = 30106
 alert = 5
 decoder = apache-errorlog
 
-[Code Red attack]
+[Code Red attack.]
 log 1 pass = [error] [client 64.94.163.159] Client sent malformed Host header
 rule = 30107
 alert = 6
 decoder = apache-errorlog
 
-[Attempt to access an non-existent file]
+[Attempt to access an non-existent file.]
 log 1 pass = [error] [client 66.31.142.16] File does not exist: /var/www/html/default.ida
 rule = 30112
 alert = 0
 decoder = apache-errorlog
 
-[Apache notice messages grouped]
+[Apache notice messages grouped.]
 log 1 pass = [notice] Apache configured
 rule = 30103
 alert = 0
 decoder = apache-errorlog
 
-[Apache 2.2 error messages grouped]
+[Apache 2.2 error messages grouped.]
 log 1 pass = [Fri Dec 13 06:59:54 2013] [error] [client 12.34.65.78] PHP Notice:
 rule = 30101
 alert = 0
 decoder = apache-errorlog
 
-[Apache 2.4 error messages grouped]
+[Apache 2.4 error messages grouped.]
 log 1 pass = [Tue Sep 30 11:30:13.262255 2014] [core:error] [pid 20101] [client 99.47.227.95:34567] AH00037: Symbolic link not allowed or link target not accessible: /usr/share/awstats/icon/mime/document.png
 log 2 pass = [Tue Sep 30 12:11:21.258612 2014] [ssl:error] [pid 30473] AH02032: Hostname www.example.com provided via SNI and hostname ssl://www.example.com provided via HTTP are different
 rule = 30301
 alert = 0
 decoder = apache-errorlog
 
-[Apache 2.4 warn messages grouped]
+[Apache 2.4 warn messages grouped.]
 log 1 pass = [Tue Sep 30 12:24:22.891366 2014] [proxy:warn] [pid 2331] [client 77.127.180.111:54082] AH01136: Unescaped URL path matched ProxyPass; ignoring unsafe nocanon, referer: http://www.easylinker.co.il/he/links.aspx?user=bguyb
 rule = 30302
 alert = 0
 decoder = apache-errorlog
 
-[Attempt to access forbidden file or directory]
+[Attempt to access forbidden file or directory.]
 log 1 pass = [Tue Sep 30 14:25:44.895897 2014] [authz_core:error] [pid 31858] [client 99.47.227.95:38870] AH01630: client denied by server configuration: /var/www/example.com/docroot/
 rule = 30305
 alert = 5
 decoder = apache-errorlog
 
-[Apache messages grouped]
+[Apache messages grouped.]
 log 1 pass = [Thu Oct 23 15:17:55.926067 2014] [ssl:info] [pid 18838] [client 36.226.119.49:2359] AH02008: SSL library error 1 in handshake (server www.example.com:443)
 log 2 pass = [Thu Oct 23 15:17:55.926123 2014] [ssl:info] [pid 18838] SSL Library Error: error:1407609B:SSL routines:SSL23_GET_CLIENT_HELLO:https proxy request -- speaking HTTP to HTTPS port!?
 rule = 30100
 alert = 0
 decoder = apache-errorlog
 
-[PHP Notices in Apache 2.4 errorlog]
+[PHP Notices in Apache 2.4 errorlog.]
 log 1 pass = [Sun Nov 23 18:49:01.713508 2014] [:error] [pid 15816] [client 141.8.147.9:51507] PHP Notice:  A non well formed numeric value encountered in /path/to/file.php on line 123
 rule = 30318
 alert = 5

--- a/ruleset/testing/tests/apache.ini
+++ b/ruleset/testing/tests/apache.ini
@@ -4,14 +4,12 @@ log 2 pass = Feb 17 18:00:00 myhost apache2[18660]:
 log 3 pass = [Tue Sep 30 11:30:13.262255 2014] [core:error]
 log 4 pass = [Tue Sep 30 11:30:13.262255 2014] [:warn]
 log 5 pass = [Tue Sep 30 11:30:13.262255 2014] [info]
-
 rule = 30100
 alert = 0
 decoder = apache-errorlog
 
 [AUDIT authentication failure for principal]
 log 1 pass = [Tue Aug 31 17:36:20.864110 2021] [authnz_e2proxy:warn] [pid 1234225:tid 140373607307008] [client XXX.XXX.XXX.XX:7212] AUDIT: authentication failure for principal "yyyy.zzzz@xxxx.com": password mismatch [RemoteIP: XXX.XXX.XXX.XX], referer: https://infoseckibana2.ZZZZ.com/pages/login?destination=%2f&source=redirect
-
 rule = 30113
 alert = 5
 decoder = apache-errorlog


### PR DESCRIPTION
|Related issues|
|---|
| #10976 | 

## Description

This PR aims to resolve issues related to and detected under #10064 PR 

- Fixed and missing copyright headers.
- Missing software details.
- Fixed indentation issues.
- Fixed the rule descriptions.
- Added the rule ID range.
- Added rule ID 30113.
- [ ] Triple check - Modified current rule 30113 to 30319.
- Fixed group tag elements order.
- Fixed XML tag order.
- Removed sample logs from rule file.

## Checks 

### Syntax

- [x] 1.a Rule tags order must be compliant.
- [x] 1.b Decoder tags order must be compliant.
- [x] 1.c XML blocks must as compact as possible.
- [X] 1.d Only one empty line between rule/decoder and the next rule/decoder.
- [X] 1.e Decoder extracted fields names must use '_' whether a space is needed.
- [X] 1.f Decoder name must use '-' whether a space is needed.
- [X] 2.d XML and ini files must use correct indentation
 
### Grammar

- [X] 2.a Grammar quality.
- [X] 2.b Similar phrases must keep tenses and expressions.
- [X] 2.c Grammar basic rules like capitalization, punctuation marks, sentence construction, and others.


### Semantic

- [x] 3.a New decoder, rule, or test are written in the correct file and grouped correctly inside the file.
- [x] 3.b Group similar rules under same ID's group.
- [x] 3.c: 
     - [x] 3.c1 Find and reuse group name before creating a new one.
     - [x] 3.c2 Include a new group definition in a PR comment.
     - [x] 3.c3 Any group name must use '_' whether it does need a space char.
     - [x] 3.c4 The groups inside a tag must be sorted in alphabetical order.
- [x] 3.d Rule level should be compliant with the [documentation](https://documentation.wazuh.com/current/user-manual/ruleset/rules-classification.html).

### Unit testing

- [X] 4.a A metadata block at the beginning of the .ini file describing software, version, and logs source.
- [X] 4.b Each new rule must have at least one test entry in the correct .ini file.
- [x] 4.c Runtest.py must pass and must include the results in raw format here.

<details><summary>runtest.py results</summary>
<p>

```
python runtests.py
- [ File = ./tests/opensmtpd.ini ] ---------
.......

- [ File = ./tests/arbor.ini ] ---------
..

- [ File = ./tests/aws_s3_access.ini ] ---------
.......

- [ File = ./tests/panda_paps.ini ] ---------
........

- [ File = ./tests/fortigate.ini ] ---------
........................................

- [ File = ./tests/iptables.ini ] ---------
........

- [ File = ./tests/vuln_detector.ini ] ---------
..

- [ File = ./tests/syslog.ini ] ---------
......

- [ File = ./tests/fortiauth.ini ] ---------
....

- [ File = ./tests/postfix.ini ] ---------
..

- [ File = ./tests/pam.ini ] ---------
.....

- [ File = ./tests/vsftpd.ini ] ---------
....

- [ File = ./tests/audit_recon.ini ] ---------
..

- [ File = ./tests/kernel_usb.ini ] ---------
......

- [ File = ./tests/sudo.ini ] ---------
........

- [ File = ./tests/systemd.ini ] ---------
..

- [ File = ./tests/audit_lateral.ini ] ---------
......

- [ File = ./tests/fireeye.ini ] ---------
...

- [ File = ./tests/freepbx.ini ] ---------
......

- [ File = ./tests/f5_big_ip.ini ] ---------
...........................................

- [ File = ./tests/cylance.ini ] ---------
.......

- [ File = ./tests/netscreen.ini ] ---------
....

- [ File = ./tests/huawei_usg.ini ] ---------
...

- [ File = ./tests/junos.ini ] ---------
...

- [ File = ./tests/cpanel.ini ] ---------
.......

- [ File = ./tests/mcafee_epo.ini ] ---------
.

- [ File = ./tests/glpi.ini ] ---------
...

- [ File = ./tests/api.ini ] ---------
............................

- [ File = ./tests/rsh.ini ] ---------
..

- [ File = ./tests/nginx.ini ] ---------
............

- [ File = ./tests/audit_scp.ini ] ---------
.

- [ File = ./tests/cloudlfare-waf.ini ] ---------
.............

- [ File = ./tests/sophos-utm-firewall.ini ] ---------
......

- [ File = ./tests/icinga.ini ] ---------
....

- [ File = ./tests/checkpoint_smart1.ini ] ---------
..................

- [ File = ./tests/doas.ini ] ---------
....

- [ File = ./tests/sophos.ini ] ---------
........

- [ File = ./tests/web_rules.ini ] ---------
..........

- [ File = ./tests/ossec.ini ] ---------
.....

- [ File = ./tests/sophos_fw.ini ] ---------
..........

- [ File = ./tests/openldap.ini ] ---------
.........

- [ File = ./tests/nextcloud.ini ] ---------
.......

- [ File = ./tests/cimserver.ini ] ---------
..

- [ File = ./tests/paloalto.ini ] ---------
................

- [ File = ./tests/unbound.ini ] ---------


- [ File = ./tests/cisco_ios.ini ] ---------
.................

- [ File = ./tests/su.ini ] ---------
.....

- [ File = ./tests/oscap.ini ] ---------
................................

- [ File = ./tests/gitlab.ini ] ---------
.........................

- [ File = ./tests/gcp.ini ] ---------
...........

- [ File = ./tests/github.ini ] ---------
....................................................................................................................................................................................................................................................................................................................................

- [ File = ./tests/exim.ini ] ---------
.......

- [ File = ./tests/named.ini ] ---------
.....

- [ File = ./tests/samba.ini ] ---------
....

- [ File = ./tests/owlh.ini ] ---------
....

- [ File = ./tests/pix.ini ] ---------
......................

- [ File = ./tests/modsecurity.ini ] ---------
......

- [ File = ./tests/apparmor.ini ] ---------
.....

- [ File = ./tests/proftpd.ini ] ---------
.......

- [ File = ./tests/eset.ini ] ---------
........

- [ File = ./tests/firewalld.ini ] ---------
..

- [ File = ./tests/SonicWall.ini ] ---------
........

- [ File = ./tests/cisco_ftd.ini ] ---------
..........................................

- [ File = ./tests/trendmicro-cloud-one.ini ] ---------
.................

- [ File = ./tests/dovecot.ini ] ---------
...............

- [ File = ./tests/sysmon.ini ] ---------
...

- [ File = ./tests/auditd.ini ] ---------
...

- [ File = ./tests/mailscanner.ini ] ---------
.

- [ File = ./tests/openvpn_ldap.ini ] ---------
..

- [ File = ./tests/sshd.ini ] ---------
...........................................

- [ File = ./tests/pfsense.ini ] ---------
..

- [ File = ./tests/squid_rules.ini ] ---------
..

- [ File = ./tests/office365.ini ] ---------
................................................................................................................................

- [ File = ./tests/exchange.ini ] ---------
..

- [ File = ./tests/cisco_asa.ini ] ---------
........................................................................................

- [ File = ./tests/web_appsec.ini ] ---------
...............................

- [ File = ./tests/dropbear.ini ] ---------
...

- [ File = ./tests/apache.ini ] ---------
..................
```
</p>
</details>

- [X] 4.d New CDB lists must include the proper test entry in the correct .ini file.

### E2E testing

- ~~5.a Logs for new or modified decoder/rules sent to a manager running with this PR ruleset appear in Kibana.~~ 
- ~~5.b There are not affected or broken visualizations on Kibana.~~
- ~~5.c New or modified items can be seen correctly using APP ruleset navigation.~~

### Elasticsearch Template

- [X] 6.a Known fields with output format managed and usually used for searching are included in template array index.query.default_field. 
- [X] 6.b The new field with the correct date format is stored as a "date" type field in the template.
- [X] 6.c The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 
- [X] 6.d Known fields with output format managed and usually used for searching are included in the template.

### Stoppers

- [x] 7.a No previous rule ID changes without triple check.
- [x] 7.b No previous decoder name changes without triple check.

<details><summary>No rule is using old decoder name</summary>
<p>

```
# grep -inH 'apache24-errorlog-ip' /var/ossec/ruleset/rules/*.xml
# grep -inH 'apache24-errorlog-ip-port' /var/ossec/ruleset/rules/*.xml
# grep -inH 'apache24-errorlog-glpi' /var/ossec/ruleset/rules/*.xml
#
```
</p>
</details>

<details><summary>No decoder is using old decoder name</summary>
<p>

```
# grep -inH 'apache24-errorlog-ip' /var/ossec/ruleset/decoders/*.xml
# grep -inH 'apache24-errorlog-ip-port' /var/ossec/ruleset/decoders/*.xml
# grep -inH 'apache24-errorlog-glpi' /var/ossec/ruleset/decoders/*.xml
#
```
</p>
</details>


- [x] 7.c No previous file name changes without triple check.
- [x] 7.d No previous test changes its 'rule' field value without triple check.

### Others

- [x] 8.a Each file has the correct copyright block.
- [x] 8.b The copyright block doesn't have "Author" only "Created by Wazuh". To include an "Author" request triple check.
- [x] 8.c The copyright block doesn't use "-". 
- [x] 8.d The rule files don't have any sample log.
- [x] 8.e The decoder file has sample logs next to the decoder that matches that log.
- [x] 8.f The decoder and rule files have information about software, version, and any helpful information.
- [x] 8.g The PR has a single commit with CHANGELOG changes in the correct format.
- [x] 8.h The new rule ID is not in use.
- [x] 8.i The new rule ID must be in the defined IDs range. 
- [x] 8.j New rules ID range must be verified with a triple check and noted in the rules ID document.
- [x] 8.k The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 