### PR TITLE
Fix non sorted ids in API response

### DIFF
--- a/framework/wazuh/active_response.py
+++ b/framework/wazuh/active_response.py
@@ -52,6 +52,7 @@ def run_command(agent_list: list = None, command: str = '', arguments: list = No
                 result.total_affected_items += 1
             except WazuhException as e:
                 result.add_failed_item(id_=agent_id, error=e)
+        result.affected_items.sort(key=int)
         wq.close()
 
     return result

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -377,6 +377,7 @@ def get_agents_keys(agent_list=None):
         except WazuhException as e:
             result.add_failed_item(id_=agent_id, error=e)
     result.total_affected_items = len(result.affected_items)
+    result.affected_items.sort(key=lambda i: i['id'])
 
     return result
 
@@ -1137,6 +1138,7 @@ def get_agents_sync_group(agent_list=None):
             result.add_failed_item(id_=agent_id, error=e)
 
     result.total_affected_items = len(result.affected_items)
+    result.affected_items.sort(key=lambda i: i['id'])
 
     return result
 

--- a/framework/wazuh/security.py
+++ b/framework/wazuh/security.py
@@ -760,10 +760,19 @@ def set_user_role(user_id, role_ids, position=None):
 @expose_resources(actions=['security:delete'], resources=['role:id:{role_ids}'],
                   post_proc_kwargs={'exclude_codes': [4002, 4016, 4008]})
 def remove_user_role(user_id, role_ids):
-    """Create a relationship between a user and a role
-    :param user_id: User id
-    :param role_ids: List of role ids
-    :return User-Roles information
+    """Remove a relationship between a user and a role.
+
+    Parameters
+    ----------
+    user_id : list
+        User ID
+    role_ids : list of int
+        List of role ids
+
+    Returns
+    -------
+    Dict
+        User-Roles information
     """
     username = get_username(user_id=user_id)
     if username == 'unknown':


### PR DESCRIPTION
|Related issue|
|---|
|This PR closes #10733 |

## Description
After reviewing this situation in more depth I noticed there are a few options to pick between. For example, doing this default sort at `expose_resources` in `decorators.py`.

https://github.com/wazuh/wazuh/blob/a8122d460d3eb8165a4cd90c58ae28fd9e39bc11/framework/wazuh/rbac/decorators.py#L399-L404

More precisely, It could be sorted at `kwargs[target_param] = list(allow[res_id])`. [_This is well-explained at the related issue._](https://github.com/wazuh/wazuh/issues/10593#issuecomment-960624241)


As we discussed with the team, sorting a list is not the expected behaviour of this decorator. Instead, it should be done inside the SDK corresponding method.

I added a fix just for `affected_items` since I checked that `failed_items` are already sorted.

Finally, if the Cluster is enabled or `affected_items` are already sorted, this will be a little bit redundant but practically no overhead will be added since `sort()` uses `Timsort` which runs in linear time for those cases.

Regards,
Alexis

## Related Integration Tests:
```s
test_active_response_endpoints.tavern.yaml:
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.9.5, pytest-5.0.0, py-1.10.0, pluggy-0.13.1 -- /home/kondent/pythonEnv/inttest-env/bin/python3.9
cachedir: .pytest_cache
metadata: {'Python': '3.9.5', 'Platform': 'Linux-5.11.0-40-generic-x86_64-with-glibc2.31', 'Packages': {'pytest': '5.0.0', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'metadata': '1.11.0', 'tavern': '1.2.2'}}
rootdir: /home/kondent/git/wazuh/api/test/integration, inifile: pytest.ini
plugins: html-3.1.1, metadata-1.11.0, tavern-1.2.2
collected 2 items                                                                                                                                                                            

test_active_response_endpoints.tavern.yaml::PUT /active-response/{:agent_id} PASSED                                                                                                    [ 50%]
test_active_response_endpoints.tavern.yaml::PUT /active-response PASSED                                                                                                                [100%]

=========================================================================== 2 passed, 1 warnings in 111.43 seconds ===========================================================================


test_rbac_black_active_response_endpoints.tavern.yaml:
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.9.5, pytest-5.0.0, py-1.10.0, pluggy-0.13.1 -- /home/kondent/pythonEnv/inttest-env/bin/python3.9
cachedir: .pytest_cache
metadata: {'Python': '3.9.5', 'Platform': 'Linux-5.11.0-40-generic-x86_64-with-glibc2.31', 'Packages': {'pytest': '5.0.0', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'metadata': '1.11.0', 'tavern': '1.2.2'}}
rootdir: /home/kondent/git/wazuh/api/test/integration, inifile: pytest.ini
plugins: html-3.1.1, metadata-1.11.0, tavern-1.2.2
collected 2 items                                                                                                                                                                            

test_rbac_black_active_response_endpoints.tavern.yaml::PUT ACTIVE-RESPONSE OVER A LIST OF AGENTS PASSED                                                                                [ 50%]
test_rbac_black_active_response_endpoints.tavern.yaml::PUT /active-response PASSED                                                                                                     [100%]

=========================================================================== 2 passed, 1 warnings in 111.61 seconds ===========================================================================


test_rbac_white_active_response_endpoints.tavern.yaml:
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.9.5, pytest-5.0.0, py-1.10.0, pluggy-0.13.1 -- /home/kondent/pythonEnv/inttest-env/bin/python3.9
cachedir: .pytest_cache
metadata: {'Python': '3.9.5', 'Platform': 'Linux-5.11.0-40-generic-x86_64-with-glibc2.31', 'Packages': {'pytest': '5.0.0', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'metadata': '1.11.0', 'tavern': '1.2.2'}}
rootdir: /home/kondent/git/wazuh/api/test/integration, inifile: pytest.ini
plugins: html-3.1.1, metadata-1.11.0, tavern-1.2.2
collected 2 items                                                                                                                                                                            

test_rbac_white_active_response_endpoints.tavern.yaml::PUT ACTIVE-RESPONSE OVER A LIST OF AGENTS PASSED                                                                                [ 50%]
test_rbac_white_active_response_endpoints.tavern.yaml::PUT /active-response PASSED                                                                                                     [100%]

=========================================================================== 2 passed, 1 warnings in 110.57 seconds ===========================================================================
```