### PR TITLE
Remove xfail mark at test_rbac_black_agent_endpoints

### DIFF
--- a/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
@@ -1622,9 +1622,6 @@ stages:
 ---
 test_name: PUT /agents/node/{node_id}/restart
 
-marks:
-  - xfail  # https://github.com/wazuh/wazuh/issues/10105
-
 stages:
 
   - name: Restart all agents belonging to master-node (Allow node_id - Could deny agent_id)


### PR DESCRIPTION
## Description

At this PR the [xfail mark](https://github.com/wazuh/wazuh/pull/9158/commits/d108169356122a88300b8d7d62a4233aa2ea7a7b) from one of our AIT test is removed since the related problem with this mark is currently fixed.

## Integration Test Result:
```s
pytest -vv -x --disable-warnings test_rbac_black_agent_endpoints.tavern.yaml
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.9.5, pytest-5.0.0, py-1.10.0, pluggy-0.13.1 -- /home/kondent/pythonEnv/inttest-env/bin/python3.9
cachedir: .pytest_cache
metadata: {'Python': '3.9.5', 'Platform': 'Linux-5.11.0-40-generic-x86_64-with-glibc2.31', 'Packages': {'pytest': '5.0.0', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'metadata': '1.11.0', 'tavern': '1.2.2'}}
rootdir: /home/kondent/git/wazuh/api/test/integration, inifile: pytest.ini
plugins: html-3.1.1, metadata-1.11.0, tavern-1.2.2
collected 41 items                                                                                                                                                                           

test_rbac_black_agent_endpoints.tavern.yaml::GET /agents PASSED                                                                                                                        [  2%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents?agents_list=agent_id PASSED                                                                                                   [  4%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} PASSED                                                                          [  7%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/group/is_sync PASSED                                                                                               [  9%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/key PASSED                                                                                                         [ 12%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/stats/{component} PASSED                                                                                           [ 14%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups PASSED                                                                                                                        [ 17%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups/{group_id}/agents PASSED                                                                                                      [ 19%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups/{group_id}/configuration PASSED                                                                                               [ 21%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files PASSED                                                                                                       [ 24%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/json PASSED                                                                                       [ 26%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/xml PASSED                                                                                        [ 29%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents?name=agent_name PASSED                                                                                                        [ 31%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/no_group PASSED                                                                                                               [ 34%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/outdated PASSED                                                                                                               [ 36%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED                                                                                                         [ 39%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/summary/status PASSED                                                                                                         [ 41%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/summary/os PASSED                                                                                                             [ 43%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/upgrade_result PASSED                                                                                                         [ 46%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group/{group_id} PASSED                                                                                         [ 48%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group PASSED                                                                                                    [ 51%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents/group?group_id=group_id PASSED                                                                                             [ 53%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE groups?groups_list=group_id PASSED                                                                                                 [ 56%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /groups PASSED                                                                                                                     [ 58%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents?agents_list=agent_id PASSED                                                                                                [ 60%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents PASSED                                                                                                                     [ 63%]
test_rbac_black_agent_endpoints.tavern.yaml::POST /agents PASSED                                                                                                                       [ 65%]
test_rbac_black_agent_endpoints.tavern.yaml::POST /agents/insert PASSED                                                                                                                [ 68%]
test_rbac_black_agent_endpoints.tavern.yaml::POST /agents/insert/quick PASSED                                                                                                          [ 70%]
test_rbac_black_agent_endpoints.tavern.yaml::POST /groups PASSED                                                                                                                       [ 73%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/group?group_id={group_id} PASSED                                                                                              [ 75%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /groups/{group_id}/configuration PASSED                                                                                               [ 78%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/group/{group_id}/restart PASSED                                                                                               [ 80%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/reconnect XPASS                                                                                                               [ 82%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/restart PASSED                                                                                                                [ 85%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/{agent_id}/group/{group_id} PASSED                                                                                            [ 87%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/{agent_id}/restart PASSED                                                                                                     [ 90%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/upgrade PASSED                                                                                                                [ 92%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/upgrade_custom PASSED                                                                                                         [ 95%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents (allow cluster:read) PASSED                                                                                                   [ 97%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/node/{node_id}/restart PASSED                                                                                                 [100%]

===================================================================== 40 passed, 1 xpassed, 1 warnings in 849.34 seconds =====================================================================
```