### PR TITLE
Add process debugging option to the Wazuh cluster

### DIFF
--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -78,6 +78,10 @@ async def master_main(args, cluster_config, cluster_items, logger):
                                                      concurrency_test=args.concurrency_test, node=my_server,
                                                      configuration=cluster_config, enable_ssl=args.ssl,
                                                      cluster_items=cluster_items)
+    # Spawn pool processes if needed
+    if cluster_items['intervals']['master']['process_pool_debug']:
+        my_server.task_pool.map(cluster_utils.process_spawn_sleep,
+                                range(my_server.task_pool._max_workers))
     await asyncio.gather(my_server.start(), my_local_server.start())
 
 

--- a/framework/wazuh/core/cluster/cluster.json
+++ b/framework/wazuh/core/cluster/cluster.json
@@ -106,7 +106,8 @@
             "recalculate_integrity": 8,
             "timeout_agent_info": 40,
             "check_worker_lastkeepalive": 60,
-            "max_allowed_time_without_keepalive": 120
+            "max_allowed_time_without_keepalive": 120,
+            "process_pool_debug": false
         },
 
         "communication":{

--- a/framework/wazuh/core/cluster/tests/test_utils.py
+++ b/framework/wazuh/core/cluster/tests/test_utils.py
@@ -154,7 +154,7 @@ def test_get_cluster_items():
                                    'master': {'timeout_extra_valid': 40, 'recalculate_integrity': 8,
                                               'check_worker_lastkeepalive': 60,
                                               'max_allowed_time_without_keepalive': 120, 'process_pool_size': 2,
-                                              'timeout_agent_info': 40},
+                                              'timeout_agent_info': 40, 'process_pool_debug': False},
                                    'communication': {'timeout_cluster_request': 20, 'timeout_dapi_request': 200,
                                                      'timeout_receiving_file': 120}},
                      'distributed_api': {'enabled': True}}

--- a/framework/wazuh/core/cluster/utils.py
+++ b/framework/wazuh/core/cluster/utils.py
@@ -287,3 +287,8 @@ class ClusterLogger(WazuhLogger):
             logging.DEBUG if self.debug_level == 1 else logging.INFO
 
         self.logger.setLevel(debug_level)
+
+
+def process_spawn_sleep():
+    """Simple task to force the cluster pool spawn all its children."""
+    return


### PR DESCRIPTION
|Related issue|
|---|
| closes #11027 |

A new option has been added to the `cluster.json` file:

```json
    "intervals":{

    [...]

        "master": {
        
            [...]

            "process_pool_debug": false
        },
```

Depending on the value of this option, the cluster process pool will spawn all its processes on start or on demand. This option is intended to be used only under development/debugging purposes.

## Tests performed
### Manual testing
- Setting a pool size of 5 with the debug option **disabled**
```shellsession
root@wazuh-master:/# ps -edf ww | grep wazuh-clusterd
wazuh      47444       1  2 11:23 ?        Sl     0:01 /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/wazuh-clusterd.py
wazuh      47752   47444  0 11:23 ?        S      0:00 /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/wazuh-clusterd.py
root       48026    1211  0 11:24 pts/1    S+     0:00 grep --color=auto wazuh-clusterd
```

- Setting a pool size of 5 with the debug option **enabled**
```shellsession
root@wazuh-master:/# ps -edf ww | grep wazuh-clusterd
wazuh      48672       1  6 11:24 ?        Sl     0:02 /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/wazuh-clusterd.py
wazuh      48962   48672  0 11:24 ?        S      0:00 /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/wazuh-clusterd.py
wazuh      48965   48672  0 11:24 ?        S      0:00 /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/wazuh-clusterd.py
wazuh      48966   48672  0 11:24 ?        S      0:00 /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/wazuh-clusterd.py
wazuh      48967   48672  0 11:24 ?        S      0:00 /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/wazuh-clusterd.py
wazuh      48968   48672  0 11:24 ?        S      0:00 /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/wazuh-clusterd.py
root       48984    1211  0 11:25 pts/1    S+     0:00 grep --color=auto wazuh-clusterd
```

> **NOTE:** these outputs were obtained right away after restarting the service.

### Unit tests
```
================================================================================================================================== test session starts ===================================================================================================================================
platform linux -- Python 3.9.7, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: cov-2.12.0, asyncio-0.15.1
collected 71 items                                                                                                                                                                                                                                                                       

wazuh/core/cluster/dapi/tests/test_dapi.py .........................                                                                                                                                                                                                               [ 35%]
wazuh/core/cluster/tests/test_cluster.py ...................                                                                                                                                                                                                                       [ 61%]
wazuh/core/cluster/tests/test_common.py .......                                                                                                                                                                                                                                    [ 71%]
wazuh/core/cluster/tests/test_control.py .....                                                                                                                                                                                                                                     [ 78%]
wazuh/core/cluster/tests/test_local_client.py .                                                                                                                                                                                                                                    [ 80%]
wazuh/core/cluster/tests/test_utils.py .......                                                                                                                                                                                                                                     [ 90%]
wazuh/core/cluster/tests/test_worker.py .......                                                                                                                                                                                                                                    [100%]

============================================================================================================================ 71 passed, 11 warnings in 0.74s =============================================================================================================================
```

Regards,
Víctor