### PR TITLE
Release cluster integrity permission flag if locked more than n seconds

### DIFF
--- a/framework/wazuh/core/cluster/cluster.json
+++ b/framework/wazuh/core/cluster/cluster.json
@@ -107,7 +107,8 @@
             "timeout_agent_info": 40,
             "check_worker_lastkeepalive": 60,
             "max_allowed_time_without_keepalive": 120,
-            "process_pool_debug": false
+            "process_pool_debug": false,
+            "max_locked_integrity_time": 1000
         },
 
         "communication":{

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -444,7 +444,11 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             # Reset integrity permissions if False for more than "max_locked_integrity_time" seconds
             if not self.sync_integrity_free[0] and (datetime.utcnow() - self.sync_integrity_free[1]).total_seconds() > \
                     self.cluster_items['intervals']['master']['max_locked_integrity_time']:
+                self.logger.warning(f'Automatically releasing Integrity check permissions flag ({sync_type}) after '
+                                    f'being locked out for more than '
+                                    f'{self.cluster_items["intervals"]["master"]["max_locked_integrity_time"]}s.')
                 self.sync_integrity_free = (True, datetime.utcnow())
+
             permission = self.sync_integrity_free[0]
         elif sync_type == b'syn_a_w_m_p':
             permission = self.sync_agent_info_free

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -61,7 +61,7 @@ class ReceiveIntegrityTask(c_common.ReceiveFileTask):
         super().done_callback(future)
         # Integrity task is only freed if master is not waiting for Extra valid files.
         if not self.wazuh_common.extra_valid_requested:
-            self.wazuh_common.sync_integrity_free = (True, datetime.utcnow())
+            self.wazuh_common.sync_integrity_free[0] = True
 
 
 class ReceiveExtraValidTask(c_common.ReceiveFileTask):
@@ -98,7 +98,7 @@ class ReceiveExtraValidTask(c_common.ReceiveFileTask):
         """
         super().done_callback(future)
         self.wazuh_common.extra_valid_requested = False
-        self.wazuh_common.sync_integrity_free = (True, datetime.utcnow())
+        self.wazuh_common.sync_integrity_free[0] = True
 
 
 class ReceiveAgentInfoTask(c_common.ReceiveStringTask):
@@ -153,7 +153,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         super().__init__(**kwargs, tag="Worker")
         # Sync availability variables. Used to prevent sync process from overlapping.
         self.sync_agent_info_free = True
-        self.sync_integrity_free = (True, datetime.utcnow())
+        self.sync_integrity_free = [True, datetime.utcnow()]
 
         # Variable used to check whether integrity sync process includes extra_valid files.
         self.extra_valid_requested = False
@@ -447,7 +447,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                 self.logger.warning(f'Automatically releasing Integrity check permissions flag ({sync_type}) after '
                                     f'being locked out for more than '
                                     f'{self.cluster_items["intervals"]["master"]["max_locked_integrity_time"]}s.')
-                self.sync_integrity_free = (True, datetime.utcnow())
+                self.sync_integrity_free[0] = True
 
             permission = self.sync_integrity_free[0]
         elif sync_type == b'syn_a_w_m_p':
@@ -473,7 +473,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             Response message.
         """
         if sync_type == b'syn_i_w_m':
-            self.sync_integrity_free, sync_function = (False, datetime.utcnow()), ReceiveIntegrityTask
+            self.sync_integrity_free, sync_function = [False, datetime.utcnow()], ReceiveIntegrityTask
         elif sync_type == b'syn_e_w_m':
             sync_function = ReceiveExtraValidTask
         elif sync_type == b'syn_a_w_m':
@@ -500,7 +500,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         bytes
             Response message.
         """
-        self.sync_integrity_free = (True, datetime.utcnow())
+        self.sync_integrity_free[0] = True
         return super().error_receiving_file(error_msg.decode())
 
     def end_receiving_integrity_checksums(self, task_and_file_names: str) -> Tuple[bytes, bytes]:
@@ -774,7 +774,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         self.integrity_sync_status['date_end_master'] = \
             self.integrity_sync_status['date_end_master'].strftime(decimals_date_format)
         self.extra_valid_requested = False
-        self.sync_integrity_free = (True, datetime.utcnow())
+        self.sync_integrity_free[0] = True
 
     async def sync_worker_files(self, task_id: str, received_file: asyncio.Event, logger):
         """Wait until extra valid files are received from the worker and create a child process for them.

--- a/framework/wazuh/core/cluster/tests/test_utils.py
+++ b/framework/wazuh/core/cluster/tests/test_utils.py
@@ -154,7 +154,8 @@ def test_get_cluster_items():
                                    'master': {'timeout_extra_valid': 40, 'recalculate_integrity': 8,
                                               'check_worker_lastkeepalive': 60,
                                               'max_allowed_time_without_keepalive': 120, 'process_pool_size': 2,
-                                              'timeout_agent_info': 40, 'process_pool_debug': False},
+                                              'timeout_agent_info': 40, 'process_pool_debug': False,
+                                              'max_locked_integrity_time': 1000},
                                    'communication': {'timeout_cluster_request': 20, 'timeout_dapi_request': 200,
                                                      'timeout_receiving_file': 120}},
                      'distributed_api': {'enabled': True}}

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -717,9 +717,8 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         except Exception:
             await self.send_request(
                 command=b'syn_i_w_m_r',
-                data=b'None ' + json.dumps(timeout_exc := WazuhClusterError(3039, extra_message=self.name),
-                                           cls=c_common.WazuhJSONEncoder).encode()
-            )
+                data=b'None ' + json.dumps(timeout_exc := WazuhClusterError(
+                    3039, extra_message=f'Integrity sync at {self.name}'), cls=c_common.WazuhJSONEncoder).encode())
             raise timeout_exc
 
         if isinstance(self.sync_tasks[name].filename, Exception):

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -467,6 +467,7 @@ class WazuhException(Exception):
         3036: "JSON couldn't be loaded",
         3037: 'Error while processing Agent-info chunks',
         3038: "Error while processing extra-valid files",
+        3039: "Timeout while waiting to receive a file",
 
         # RBAC exceptions
         # The messages of these exceptions are provisional until the RBAC documentation is published.


### PR DESCRIPTION
|Related issue|
|---|
| Closes #10979 |

## Description

This PR adds a new mechanism to release the `sync_integrity_free` flag which is used to prevent that a worker starts a new Integrity check/sync iteration if the last one is not finished yet.

The flag is still used for the same purpose. The difference now is that, if more than `max_locked_integrity_time` seconds have passed since the flag was set to `False` (it means, no permission to start new Integrity checks), it will be set to `True` again:
https://github.com/wazuh/wazuh/blob/4185ab9e8a3e70db7a3146b98f7b045e23cb16ec/framework/wazuh/core/cluster/cluster.json#L110

This is done to make sure that, if any error prevented the correct update of said flag during an Integrity iteration, the flag will eventually be released again and the synchronization will not be blocked forever.

This PR also manages those cases in which the worker raises a timeout while waiting for a file from the master. Now, if such a timeout occurs, the worker will notify the master node to release its permission flag.

A log like the one below will be printed when that happens:
```
2021/11/29 07:54:18 WARNING: [Worker worker1] [Main] Automatically releasing Integrity check permissions flag (b'syn_i_w_m_p') after being locked out for more than 1000s.
```