### PR TITLE
Update AWS integration unit tests

### DIFF
--- a/wodles/aws/tests/test_aws.py
+++ b/wodles/aws/tests/test_aws.py
@@ -55,7 +55,8 @@ def test_metadata_version_buckets(mocked_db, class_):
                         'only_logs_after': '19700101', 'skip_on_error': True,
                         'account_alias': None, 'prefix': 'test',
                         'delete_file': False, 'aws_organization_id': None,
-                        'region': None})
+                        'region': None, 'suffix': '', 'discard_field': None,
+                        'discard_regex': None, 'sts_endpoint': None, 'service_endpoint': None})
 
         query_version = ins.db_connector.execute(ins.sql_get_metadata_version)
         metadata_version = query_version.fetchone()[0]
@@ -106,7 +107,8 @@ def test_db_maintenance(class_, sql_file, db_name):
                         'only_logs_after': '19700101', 'skip_on_error': True,
                         'account_alias': None, 'prefix': '',
                         'delete_file': False, 'aws_organization_id': None,
-                        'region': None})
+                        'region': None, 'suffix': '', 'discard_field': None,
+                        'discard_regex': None, 'sts_endpoint': None, 'service_endpoint': None})
 
         account_id = '123456789'
         ins.aws_account_id = account_id  # set 'aws_account_id' for custom buckets


### PR DESCRIPTION
| Related issue | 
|--|
| Closes #10973 |

## Description
In this PR we update the AWS integration unit tests, which weren't considering the latest changes made to the module and therefore where failing.

## Test results
```
==================================== test session starts ====================================
platform linux -- Python 3.9.7, pytest-6.0.1, py-1.10.0, pluggy-0.13.1
rootdir: /home/gonzz/git/wazuh/wodles/aws
collected 11 items                                                                          

tests/test_aws.py ...........                                                         [100%]

==================================== 11 passed in 0.07s =====================================
```
### Note
The integration tests that failed are due to a known issue and will be fixed soon via https://github.com/wazuh/wazuh-jenkins/pull/3091.