### PR TITLE
Change some `cluster_control` binary functionalities

### DIFF
--- a/framework/scripts/cluster_control.py
+++ b/framework/scripts/cluster_control.py
@@ -11,6 +11,7 @@ import logging
 import operator
 import sys
 from datetime import datetime
+from os import path
 
 import wazuh.core.cluster.cluster
 import wazuh.core.cluster.utils
@@ -167,6 +168,34 @@ async def print_health(config, more, filter_node):
     more and print(msg2)
 
 
+def usage():
+    """Show the usage of the parameters."""
+    msg = """
+    {0} [-h] [-d] [-fn [FILTER_NODE ...]] [-fs [FILTER_STATUS ...]][-a | -l | -i [HEALTH]]
+    Usage:
+    \t-l                                    # List all nodes present in a cluster
+    \t-l -fn <node_name>                    # List certain nodes that belong to the cluster
+    \t-a                                    # List all agents connected to the cluster
+    \t-a -fn <node_name>                    # Check which agents are reporting to certain nodes
+    \t-a -fs <agent_status>                 # List agents with certain status
+    \t-a -fn <node_name> <agent_status>     # List agents reporting to certain node and with certain status
+    \t-i                                    # Check cluster health
+    \t-i -fn <node_name>                    # Check certain node's health
+    
+
+    Params:
+    \t-l, --list
+    \t-d, --debug
+    \t-h, --help
+    \t-fn, --filter-node
+    \t-fs, --filter-agent-status
+    \t-a, --list-agents
+    \t-i, --health
+    
+    """.format(path.basename(sys.argv[0]))
+    print(msg)
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('-d', '--debug', action='store_true', dest='debug', help="Enable debug mode")
@@ -177,6 +206,7 @@ if __name__ == '__main__':
     exclusive.add_argument('-a', '--list-agents', action='store_const', const='list_agents', help='List agents')
     exclusive.add_argument('-l', '--list-nodes', action='store_const', const='list_nodes', help='List nodes')
     exclusive.add_argument('-i', '--health', action='store', nargs='?', const='health', help='Show cluster health')
+    exclusive.add_argument('-u', '--usage', action='store_true', help='Show usage')
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.DEBUG if args.debug else logging.ERROR, format='%(levelname)s: %(message)s')
@@ -188,11 +218,10 @@ if __name__ == '__main__':
 
     cluster_config = wazuh.core.cluster.utils.read_config()
     wazuh.core.cluster.cluster.check_cluster_config(config=cluster_config)
-
     try:
         if args.filter_status and not args.list_agents:
             logging.error("Wrong arguments.")
-            parser.print_help()
+            usage()
             sys.exit(1)
         elif args.list_agents:
             my_function, my_args = print_agents, (args.filter_status, args.filter_node,)
@@ -201,6 +230,9 @@ if __name__ == '__main__':
         elif args.health:
             more = args.health.lower() == 'more'
             my_function, my_args = print_health, (cluster_config, more, args.filter_node,)
+        elif args.usage:
+            usage()
+            sys.exit(0)
         else:
             parser.print_help()
             sys.exit(0)


### PR DESCRIPTION
|Related issue|
|---|
|#10823|

## Description

This closes #10823. The first aim of this PR was to modify the description of the `cluster_control` binary help message. This was thought in order to not modify the already allowed parameters. However, as the code allows it, it was possible to leave the old option (`cluster_control -fn <node_name> -l` and `cluster_control -fs <agent_status> -a`) alongside the new one (`cluster_control -fn <node_name>` and `cluster_control -fs <agent_status>`)
