### PR TITLE
Fix a typo in an error log about enrollment SSL certificate

### DIFF
--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -210,7 +210,7 @@ static int w_enrollment_connect(w_enrollment_ctx *cfg, const char * server_addre
     SSL_CTX *ctx = os_ssl_keys(0, NULL, cfg->cert_cfg->ciphers,
         cfg->cert_cfg->agent_cert, cfg->cert_cfg->agent_key, cfg->cert_cfg->ca_cert, cfg->cert_cfg->auto_method);
     if (!ctx) {
-        merror("Could not set up SSL connection! Check ceritification configuration.");
+        merror("Could not set up SSL connection! Check certification configuration.");
         os_free(ip_address);
         return ENROLLMENT_WRONG_CONFIGURATION;
     }
@@ -467,7 +467,7 @@ static int w_enrollment_process_agent_key(char *buffer) {
 /**
  * Verifies the manager's ca certificate. Displays a warning message if it does not match
  * @param ssl SSL connection established with the manager
- * @param ca_cert cerificate to verify
+ * @param ca_cert certificate to verify
  * @param hostname
  * */
 static void w_enrollment_verify_ca_certificate(const SSL *ssl, const char *ca_cert, const char *hostname) {

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -478,7 +478,7 @@ void test_w_enrollment_connect_could_not_setup(void **state) {
     expect_value(__wrap_os_ssl_keys, auto_method, 0);
     will_return(__wrap_os_ssl_keys, NULL);
 
-    expect_string(__wrap__merror, formatted_msg, "Could not set up SSL connection! Check ceritification configuration.");
+    expect_string(__wrap__merror, formatted_msg, "Could not set up SSL connection! Check certification configuration.");
     int ret = w_enrollment_connect(cfg, cfg->target_cfg->manager_name);
     assert_int_equal(ret, ENROLLMENT_WRONG_CONFIGURATION);
 }


### PR DESCRIPTION
|Related issue|
|---|
|#11110|

This PR aims to fix a typo found during the analysis of issue #11110:

We're replacing this log:
```
ERROR: Could not set up SSL connection! Check ceritification configuration.
```
With:
```
ERROR: Could not set up SSL connection! Check certification configuration.
```

## Affected artifacts

- wazuh-agentd
- wazuh-agent.exe
- agent-auth (Windows and UNIX)