### PR TITLE
Fix memory leak to avoid crash on winagent

### DIFF
--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -850,18 +850,24 @@ static int process_ace_info(void *ace, cJSON *acl_json) {
     }
 
     if (error = w_get_account_info(sid, &account_name, &domain_name), error) {
+        os_free(account_name);
+        os_free(domain_name);
         mdebug2("No information could be extracted from the account linked to the SID. Error: %d.", error);
+        return 1;
     }
 
     if (!ConvertSidToStringSid(sid, &sid_str)) {
         mdebug2("Could not extract the SID.");
-        free(account_name);
-        free(domain_name);
+        os_free(account_name);
+        os_free(domain_name);
         return 1;
     }
 
     add_ace_to_json(acl_json, sid_str, account_name, ace_type ? "denied" : "allowed", mask);
+
     LocalFree(sid_str);
+    os_free(account_name);
+    os_free(domain_name);
 
     return 0;
 }
@@ -995,8 +1001,6 @@ int w_get_account_info(SID *sid, char **account_name, char **account_domain) {
     os_calloc(a_domain_size, sizeof(char), *account_domain);
 
     if (error = LookupAccountSid(0, sid, *account_name, &a_name_size, *account_domain, &a_domain_size, &snu), !error) {
-        os_free(*account_name);
-        os_free(*account_domain);
         return GetLastError();
     }
 

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -850,10 +850,7 @@ static int process_ace_info(void *ace, cJSON *acl_json) {
     }
 
     if (error = w_get_account_info(sid, &account_name, &domain_name), error) {
-        os_free(account_name);
-        os_free(domain_name);
         mdebug2("No information could be extracted from the account linked to the SID. Error: %d.", error);
-        return 1;
     }
 
     if (!ConvertSidToStringSid(sid, &sid_str)) {


### PR DESCRIPTION
|Related issue|
|---|
|#11084|

## Description
Hi team,

This PR aims to fix the first error described in https://github.com/wazuh/wazuh/issues/11019#issuecomment-980453570, which caused Windows agent's service to stop during the latest [footprint metrics for 4.3](https://github.com/wazuh/wazuh/issues/11019).

The cause of this error seems to be a memory leak introduced in https://github.com/wazuh/wazuh/pull/9765, which ended up filling the agent's virtual memory until the process crashed:

```
wazuh-agent: CRITICAL: (1102): Could not acquire memory due to [(12)-(Not enough space)].
```

## Tests
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

- Memory tests for Windows
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Dr. Memory