### PR TITLE
Fix Window agent unit tests on MinGW 10

### DIFF
--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -20,6 +20,7 @@
 #include <external/cJSON/cJSON.h>
 
 #ifdef WIN32
+#include <winsock2.h>
 #include <windows.h>
 #endif
 

--- a/src/headers/sym_load.h
+++ b/src/headers/sym_load.h
@@ -14,6 +14,7 @@
 #ifndef WIN32
 #include <dlfcn.h>
 #else
+#include <winsock2.h>
 #include <windows.h>
 #endif
 

--- a/src/unit_tests/client-agent/CMakeLists.txt
+++ b/src/unit_tests/client-agent/CMakeLists.txt
@@ -51,7 +51,7 @@ if(${TARGET} STREQUAL "winagent")
                                 -Wl,--wrap,cJSON_AddItemToObject@12 -Wl,--wrap,cJSON_AddStringToObject@12 \
                                 -Wl,--wrap,cJSON_Delete@4 -Wl,--wrap,strftime \
                                 -Wl,--wrap,cJSON_PrintUnformatted@4 -Wl,--wrap,w_agentd_get_buffer_lenght \
-                                -Wl,--wrap,cJSON_AddBoolToObject@12 ${DEBUG_OP_WRAPPERS}")
+                                -Wl,--wrap,cJSON_AddBoolToObject@12 -Wl,--enable-stdcall-fixup ${DEBUG_OP_WRAPPERS}")
 else()
     list(APPEND client-agent_flags "-Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_mutex_unlock \
                                 -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_AddNumberToObject -Wl,--wrap,strftime \

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -26,13 +26,13 @@ list(APPEND shared_tests_names "test_integrity_op")
 list(APPEND shared_tests_flags " ")
 
 list(APPEND shared_tests_names "test_rbtree_op")
-list(APPEND shared_tests_flags "-Wl,--wrap,getpid")
+list(APPEND shared_tests_flags " ")
 
 list(APPEND shared_tests_names "test_validate_op")
 list(APPEND shared_tests_flags " ")
 
 list(APPEND shared_tests_names "test_string_op")
-list(APPEND shared_tests_flags "-Wl,--wrap,getpid ${DEBUG_OP_WRAPPERS}")
+list(APPEND shared_tests_flags "${DEBUG_OP_WRAPPERS}")
 
 list(APPEND shared_tests_names "test_expression")
 list(APPEND shared_tests_flags "-Wl,--wrap,OS_IsValidIP -Wl,--wrap,OSMatch_Execute -Wl,--wrap,OSRegex_Compile \
@@ -46,14 +46,14 @@ list(APPEND shared_tests_flags "${VERSION_OP_BASE_FLAGS}")
 
 list(APPEND shared_tests_names "test_queue_op")
 list(APPEND shared_tests_flags "-Wl,--wrap=pthread_mutex_lock,--wrap=pthread_mutex_unlock,--wrap=pthread_cond_wait \
-                                -Wl,--wrap=pthread_cond_signal,--wrap=pthread_cond_timedwait -Wl,--wrap,getpid")
+                                -Wl,--wrap=pthread_cond_signal,--wrap=pthread_cond_timedwait")
 
 list(APPEND shared_tests_names "test_queue_linked_op")
 list(APPEND shared_tests_flags "-Wl,--wrap=pthread_mutex_lock,--wrap=pthread_mutex_unlock,--wrap=pthread_cond_wait \
                                 -Wl,--wrap=pthread_cond_signal")
 
 list(APPEND shared_tests_names "test_agent_op")
-list(APPEND shared_tests_flags "-Wl,--wrap,getpid ${DEBUG_OP_WRAPPERS}")
+list(APPEND shared_tests_flags "${DEBUG_OP_WRAPPERS}")
 
 if(${TARGET} STREQUAL "server")
 list(APPEND shared_tests_names "test_set_agent_group")
@@ -70,16 +70,16 @@ set(ENROLLMENT_OP_BASE_FLAGS "-Wl,--wrap=OS_IsValidIP,--wrap=_merror,--wrap=_mwa
                                 -Wl,--wrap=SSL_new,--wrap=SSL_connect,--wrap=SSL_get_error,--wrap=SSL_set_bio \
                                 -Wl,--wrap=SSL_write,--wrap=fopen,--wrap=fclose,--wrap=SSL_read \
                                 -Wl,--wrap=BIO_new_socket,--wrap=_merror_exit,--wrap=TempFile,--wrap=OS_MoveFile \
-                                -Wl,--wrap=fgets -Wl,--wrap,getpid -Wl,--wrap,OS_CloseSocket")
+                                -Wl,--wrap=fgets -Wl,--wrap,OS_CloseSocket")
 if(${TARGET} STREQUAL "winagent")
     list(APPEND shared_tests_flags "${ENROLLMENT_OP_BASE_FLAGS}")
 else()
-    list(APPEND shared_tests_flags "${ENROLLMENT_OP_BASE_FLAGS} -Wl,--wrap=fprintf,--wrap=gethostname,--wrap=getpid \
-                                -Wl,--wrap=fgets,--wrap=chmod,--wrap=stat")
+    list(APPEND shared_tests_flags "${ENROLLMENT_OP_BASE_FLAGS} -Wl,--wrap=fprintf,--wrap=gethostname \
+                                -Wl,--wrap=fgets,--wrap=chmod,--wrap=stat,--wrap=getpid")
 endif()
 
 list(APPEND shared_tests_names "test_time_op")
-list(APPEND shared_tests_flags "-Wl,--wrap,getpid")
+list(APPEND shared_tests_flags " ")
 
 list(APPEND shared_tests_names "test_buffer_op")
 list(APPEND shared_tests_flags " ")
@@ -107,7 +107,12 @@ list(APPEND shared_tests_flags "-Wl,--wrap=OS_StrIsNum,--wrap=_merror,--wrap=w_t
                                 -Wl,--wrap,OSRegex_Execute_ex")
 
 list(APPEND shared_tests_names "test_rootcheck_op")
-list(APPEND shared_tests_flags "-Wl,--wrap=wdbc_query_ex -Wl,--wrap=_merror,--wrap=close,--wrap=getpid")
+set(ROOTCHECK_OP_BASE_FLAGS "-Wl,--wrap=wdbc_query_ex -Wl,--wrap=_merror,--wrap=close")
+if(${TARGET} STREQUAL "winagent")
+list(APPEND shared_tests_flags "${ROOTCHECK_OP_BASE_FLAGS}")
+else()
+list(APPEND shared_tests_flags "${ROOTCHECK_OP_BASE_FLAGS} -Wl,--wrap=getpid")
+endif()
 
 list(APPEND shared_tests_names "test_fs_op")
 list(APPEND shared_tests_flags " ")
@@ -119,14 +124,14 @@ endif()
 list(APPEND shared_tests_names "test_syscheck_op")
 set(SYSCHECK_OP_BASE_FLAGS "-Wl,--wrap,rmdir_ex -Wl,--wrap,wreaddir -Wl,--wrap,getpwuid_r -Wl,--wrap,w_getgrgid \
                             -Wl,--wrap,wstr_split -Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,OS_SendSecureTCP \
-                            -Wl,--wrap,sysconf -Wl,--wrap,getpid ${DEBUG_OP_WRAPPERS}")
+                            -Wl,--wrap,sysconf ${DEBUG_OP_WRAPPERS}")
 if(${TARGET} STREQUAL "winagent")
     # cJSON_CreateArray@0 instead of cJSON_CreateArray since linker will be looking for cdecl forma
     # More info at: (https://devblogs.microsoft.com/oldnewthing/20040108-00/?p=41163)
     list(APPEND shared_tests_flags "${SYSCHECK_OP_BASE_FLAGS} -Wl,--wrap=syscom_dispatch \
                                     -Wl,--wrap,cJSON_CreateArray@0 -Wl,--wrap,cJSON_CreateObject@0")
 else()
-    list(APPEND shared_tests_flags "${SYSCHECK_OP_BASE_FLAGS} -Wl,--wrap=cJSON_CreateArray,--wrap=cJSON_CreateObject")
+    list(APPEND shared_tests_flags "${SYSCHECK_OP_BASE_FLAGS} -Wl,--wrap=cJSON_CreateArray,--wrap=cJSON_CreateObject -Wl,--wrap,getpid")
 endif()
 
 if(NOT ${TARGET} STREQUAL "winagent")

--- a/src/unit_tests/shared/test_list_op.c
+++ b/src/unit_tests/shared/test_list_op.c
@@ -18,12 +18,12 @@
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../../headers/shared.h"
 
-syscheck_config syscheck;
+syscheck_config config;
 
 static int setup_syscheck_dir_links(void **state) {
 
-    syscheck.directories = OSList_Create();
-    if (syscheck.directories == NULL) {
+    config.directories = OSList_Create();
+    if (config.directories == NULL) {
         return (1);
     }
 
@@ -39,13 +39,13 @@ static int teardown_syscheck_dir_links(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
 
-    if (syscheck.directories) {
-        OSList_foreach(node_it, syscheck.directories) {
+    if (config.directories) {
+        OSList_foreach(node_it, config.directories) {
             free_directory(node_it->data);
             node_it->data = NULL;
         }
-        OSList_Destroy(syscheck.directories);
-        syscheck.directories = NULL;
+        OSList_Destroy(config.directories);
+        config.directories = NULL;
     }
 
     return 0;
@@ -74,7 +74,7 @@ void test_OSList_GetNext_null_return(void **state) {
 
 void test_OSList_GetNext_node_return(void **state) {
 
-    OSList *list = syscheck.directories;
+    OSList *list = config.directories;
     OSListNode *node;
     OSListNode *node_returned;
 
@@ -100,7 +100,7 @@ void test_OSList_GetNext_node_return(void **state) {
 
 void test_OSList_GetDataFromIndex_null_return(void **state) {
 
-    OSList *list = syscheck.directories;
+    OSList *list = config.directories;
     int data_index = 0;
     void* data_return;
 
@@ -119,7 +119,7 @@ void test_OSList_GetDataFromIndex_null_return(void **state) {
 
 void test_OSList_GetDataFromIndex_data_return(void **state) {
 
-    OSList *list = syscheck.directories;
+    OSList *list = config.directories;
     int data_index = 0;
     void* data_return;
     char* data = malloc(sizeof(char)*5);
@@ -147,7 +147,7 @@ void test_OSList_GetDataFromIndex_data_return(void **state) {
 
 void test_OSList_InsertData_insert_at_first_position(void **state) {
 
-    OSList *list = syscheck.directories;
+    OSList *list = config.directories;
     OSListNode *node = NULL;
     void *data = NULL;
     int return_code;
@@ -175,7 +175,7 @@ void test_OSList_InsertData_insert_at_first_position(void **state) {
 
 void test_OSList_InsertData_insert_at_last_position(void **state) {
 
-    OSList *list = syscheck.directories;
+    OSList *list = config.directories;
     OSListNode *node = NULL;
     char *data = malloc(sizeof(char)*5);
     int return_code;
@@ -206,7 +206,7 @@ void test_OSList_InsertData_insert_at_last_position(void **state) {
 
 void test_OSList_InsertData_insert_at_first_position_before_node(void **state) {
 
-    OSList *list = syscheck.directories;
+    OSList *list = config.directories;
     OSListNode *node;
     char *data = malloc(sizeof(char)*5);
     int return_code;
@@ -238,7 +238,7 @@ void test_OSList_InsertData_insert_at_first_position_before_node(void **state) {
 
 void test_OSList_InsertData_insert_at_n_position_before_node(void **state) {
 
-    OSList *list = syscheck.directories;
+    OSList *list = config.directories;
     OSListNode *node;
     char *data = malloc(sizeof(char)*5);
     int return_code;

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -211,7 +211,7 @@ if(${TARGET} STREQUAL "winagent")
                                     -Wl,--wrap=rootcheck_init \
                                     -Wl,--wrap=start_daemon \
                                     -Wl,--wrap=File_DateofChange \
-                                    -Wl,--wrap,getpid, -Wl,--wrap,realtime_start \
+                                    -Wl,--wrap,getpid,--wrap,realtime_start \
                                     -Wl,--wrap,pthread_rwlock_rdlock -Wl,--wrap,pthread_rwlock_unlock \
                                     -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_rwlock_wrlock \
                                     -Wl,--wrap,pthread_mutex_unlock")

--- a/src/unit_tests/syscheckd/db/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/db/CMakeLists.txt
@@ -41,7 +41,7 @@ set(FIM_DB_FILES_LINUX_FLAGS "-Wl,--wrap=usleep,--wrap=time,--wrap=sqlite3_bind_
                               -Wl,--wrap=sqlite3_last_insert_rowid,--wrap=SendMSG,--wrap=rmdir_ex,--wrap=opendir \
                               -Wl,--wrap=readdir,--wrap=closedir")
 
-set(FIM_DB_FILES_WINDOWS_FLAG "-Wl,--wrap=sqlite3_last_insert_rowid,--wrap=SendMSG,,--wrap=rmdir_ex,--wrap=opendir \
+set(FIM_DB_FILES_WINDOWS_FLAG "-Wl,--wrap=sqlite3_last_insert_rowid,--wrap=SendMSG,--wrap=rmdir_ex,--wrap=opendir \
                                -Wl,--wrap=readdir,--wrap=closedir,--wrap=sqlite3_bind_null")
 
 if(${TARGET} STREQUAL "winagent")

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -3110,8 +3110,6 @@ void test_fim_delete_file_event_remove_success(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
 
-    char buffer[OS_SIZE_128] = {0};
-
     if(!ExpandEnvironmentStrings(path, expanded_path, OS_MAXSTR))
         fail();
 
@@ -3192,7 +3190,6 @@ void test_fim_delete_file_event_different_mode_scheduled(void **state) {
     fim_data_t *fim_data = *state;
     char *path = "%WINDIR%\\System32\\drivers\\etc\\test.exe";
     char expanded_path[OS_MAXSTR];
-    char buffer[OS_SIZE_128] = {0};
     event_data_t evt_data = { .mode = FIM_SCHEDULED, .report_event = true };
 
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);


### PR DESCRIPTION
## Related issue

This PR closes #11026.

## Description

This PR aims to fix three problems:

1. There were two linker flags with a spurious trailing comma, which made the building fail with this error:
```
/usr/bin/i686-w64-mingw32-ld: cannot find : No such file or directory
```
2. The `syscheck` configuration structure in the _syscheck_op_ test suite collided with the global Syscheck configuration:
```
/usr/bin/i686-w64-mingw32-ld: ../syscheckd/libSYSCHECK_O.a(syscheck.o):syscheck.c:(.bss+0x0): multiple definition of `syscheck'; CMakeFiles/test_list_op.dir/objects.a(test_list_op.c.obj):test_list_op.c:(.bss+0x0): first defined here
```
3. There were multiple wrong flags to wrap `getpid()` on the Windows tests:
```
/usr/bin/i686-w64-mingw32-ld: /usr/lib/gcc/i686-w64-mingw32/10-win32/libgcov.a(_gcov.o):(.text+0xc36): undefined reference to `__wrap_getpid'
```
4. Fix these warnings:
   - Unused variable `buffer` [-Wunused-variable]
   - Please include `winsock2.h` before `windows.h` [-Wcpp]
   - Resolving `___wrap_cJSON_AddNumberToObject@16` by linking to `___wrap_cJSON_AddNumberToObject`
   - Resolving `___wrap_cJSON_AddItemToObject@12` by linking to `___wrap_cJSON_AddItemToObject`
   - Resolving `___wrap_cJSON_AddStringToObject@12` by linking to `___wrap_cJSON_AddStringToObject`
   - Resolving `___wrap_cJSON_AddBoolToObject@12` by linking to `___wrap_cJSON_AddBoolToObject`
   - Resolving `___wrap_cJSON_PrintUnformatted@4` by linking to `___wrap_cJSON_PrintUnformatted`
   - Resolving `___wrap_cJSON_Delete@4` by linking to `___wrap_cJSON_Delete`