### PR TITLE
Implement FimDBHelpers Interface and Mock class for unit testing

### DIFF
--- a/src/syscheckd/db/include/fimDBHelpersUTInterface.hpp
+++ b/src/syscheckd/db/include/fimDBHelpersUTInterface.hpp
@@ -1,0 +1,72 @@
+/*
+ * Wazuh Syscheckd
+ * Copyright (C) 2015-2021, Wazuh Inc.
+ * September 23, 2021.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "FDBHMockInterface.hpp"
+#include "dbItem.hpp"
+
+#ifndef _FIMDB_HELPERS_UT_INTERFACE_
+#define _FIMDB_HELPERS_UT_INTERFACE_
+
+namespace FIMDBHelper
+{
+    template<typename T>
+#ifndef WIN32
+
+    void initDB(unsigned int sync_interval, unsigned int file_limit,
+                            fim_sync_callback_t sync_callback, logging_callback_t logCallback,
+                            std::shared_ptr<DBSync>handler_DBSync, std::shared_ptr<RemoteSync>handler_RSync)
+    {
+        FIMDBHelpersUTInterface::initDB(sync_interval, file_limit, sync_callback, logCallback, handler_DBSync, handler_RSync);
+    }
+#else
+
+    void initDB(unsigned int sync_interval, unsigned int file_limit, unsigned int registry_limit,
+                             fim_sync_callback_t sync_callback, logging_callback_t logCallback,
+                             std::shared_ptr<DBSync>handler_DBSync, std::shared_ptr<RemoteSync>handler_RSync)
+    {
+        FIMDBHelpersUTInterface::initDB(sync_interval, file_limit, registry_limit, sync_callback, logCallback, handler_DBSync,
+                              handler_RSync);
+    }
+#endif
+
+    template<typename T>
+    int removeFromDB(const std::string& tableName, const nlohmann::json& filter)
+    {
+        return FIMDBHelpersUTInterface::removeFromDB(tableName, filter);
+    }
+
+    template<typename T>
+    int getCount(const std::string & tableName, int & count)
+    {
+
+        return FIMDBHelpersUTInterface::getCount(tableName, count);
+    }
+
+    template<typename T>
+    int insertItem(const std::string & tableName, const nlohmann::json & item)
+    {
+        return FIMDBHelpersUTInterface::insertItem(tableName, item);
+    }
+
+    template<typename T>
+    int updateItem(const std::string & tableName, const nlohmann::json & item)
+    {
+        return FIMDBHelpersUTInterface::updateItem(tableName, item);
+    }
+
+    template<typename T>
+    int getDBItem(nlohmann::json & item, const nlohmann::json & query)
+    {
+        return FIMDBHelpersUTInterface::getDBItem(item, query);
+    }
+}
+
+#endif

--- a/src/syscheckd/db/include/fimDBHelpersUTInterface.hpp
+++ b/src/syscheckd/db/include/fimDBHelpersUTInterface.hpp
@@ -38,34 +38,34 @@ namespace FIMDBHelper
 #endif
 
     template<typename T>
-    int removeFromDB(const std::string& tableName, const nlohmann::json& filter)
+    void removeFromDB(const std::string& tableName, const nlohmann::json& filter)
     {
-        return FIMDBHelpersUTInterface::removeFromDB(tableName, filter);
+        FIMDBHelpersUTInterface::removeFromDB(tableName, filter);
     }
 
     template<typename T>
-    int getCount(const std::string & tableName, int & count)
+    void getCount(const std::string & tableName, int & count)
     {
 
-        return FIMDBHelpersUTInterface::getCount(tableName, count);
+        FIMDBHelpersUTInterface::getCount(tableName, count);
     }
 
     template<typename T>
-    int insertItem(const std::string & tableName, const nlohmann::json & item)
+    void insertItem(const std::string & tableName, const nlohmann::json & item)
     {
-        return FIMDBHelpersUTInterface::insertItem(tableName, item);
+        FIMDBHelpersUTInterface::insertItem(tableName, item);
     }
 
     template<typename T>
-    int updateItem(const std::string & tableName, const nlohmann::json & item)
+    void updateItem(const std::string & tableName, const nlohmann::json & item)
     {
-        return FIMDBHelpersUTInterface::updateItem(tableName, item);
+        FIMDBHelpersUTInterface::updateItem(tableName, item);
     }
 
     template<typename T>
-    int getDBItem(nlohmann::json & item, const nlohmann::json & query)
+    void getDBItem(nlohmann::json & item, const nlohmann::json & query)
     {
-        return FIMDBHelpersUTInterface::getDBItem(item, query);
+        FIMDBHelpersUTInterface::getDBItem(item, query);
     }
 }
 

--- a/src/syscheckd/db/tests/FDBHMockClass.hpp
+++ b/src/syscheckd/db/tests/FDBHMockClass.hpp
@@ -13,18 +13,18 @@ class FIMDBHelpersMock {
             return mock;
         }
 
-        MOCK_METHOD(void, initDBMock, (unsigned int, unsigned int,
+        MOCK_METHOD(void, initDB, (unsigned int, unsigned int,
                                 fim_sync_callback_t, logging_callback_t,
                                 std::shared_ptr<DBSync>, std::shared_ptr<RemoteSync>), ());
-        MOCK_METHOD(void, initDBMock, (unsigned int, unsigned int, unsigned int, fim_sync_callback_t, logging_callback_t,
+        MOCK_METHOD(void, initDB, (unsigned int, unsigned int, unsigned int, fim_sync_callback_t, logging_callback_t,
                                 std::shared_ptr<DBSync>, std::shared_ptr<RemoteSync>), ());
-        MOCK_METHOD(int, removeFromDBMock, (const std::string&, const nlohmann::json&), ());
-        MOCK_METHOD(int, getCountMock, (const std::string&, int&), ());
-        MOCK_METHOD(int, insertItemMock, (const std::string&, const nlohmann::json&), ());
-        MOCK_METHOD(int, updateItemMock, (const std::string&, const nlohmann::json&), ());
-        MOCK_METHOD(int, getDBItemMock, (nlohmann::json&, const nlohmann::json&), ());
-        MOCK_METHOD(int, removeItemMock, (const std::string&, const nlohmann::json&), ());
-        MOCK_METHOD(int, executeQueryMock, (nlohmann::json&, const nlohmann::json&), ());
+        MOCK_METHOD(void, removeFromDB, (const std::string&, const nlohmann::json&), ());
+        MOCK_METHOD(void, getCount, (const std::string&, int&), ());
+        MOCK_METHOD(void, insertItem, (const std::string&, const nlohmann::json&), ());
+        MOCK_METHOD(void, updateItem, (const std::string&, const nlohmann::json&), ());
+        MOCK_METHOD(void, getDBItem, (nlohmann::json&, const nlohmann::json&), ());
+        MOCK_METHOD(void, removeItem, (const std::string&, const nlohmann::json&), ());
+        MOCK_METHOD(void, executeQuery, (nlohmann::json&, const nlohmann::json&), ());
 };
 
 #endif

--- a/src/syscheckd/db/tests/FDBHMockClass.hpp
+++ b/src/syscheckd/db/tests/FDBHMockClass.hpp
@@ -1,0 +1,30 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "fimDB.hpp"
+
+#ifndef _FIM_DB_HELPERS_MOCK_CLASS_
+#define _FIM_DB_HELPERS_MOCK_CLASS_
+
+class FIMDBHelpersMock {
+    public:
+        static FIMDBHelpersMock& getInstance(){
+            static FIMDBHelpersMock mock;
+            return mock;
+        }
+
+        MOCK_METHOD(void, initDBMock, (unsigned int, unsigned int,
+                                fim_sync_callback_t, logging_callback_t,
+                                std::shared_ptr<DBSync>, std::shared_ptr<RemoteSync>), ());
+        MOCK_METHOD(void, initDBMock, (unsigned int, unsigned int, unsigned int, fim_sync_callback_t, logging_callback_t,
+                                std::shared_ptr<DBSync>, std::shared_ptr<RemoteSync>), ());
+        MOCK_METHOD(int, removeFromDBMock, (const std::string&, const nlohmann::json&), ());
+        MOCK_METHOD(int, getCountMock, (const std::string&, int&), ());
+        MOCK_METHOD(int, insertItemMock, (const std::string&, const nlohmann::json&), ());
+        MOCK_METHOD(int, updateItemMock, (const std::string&, const nlohmann::json&), ());
+        MOCK_METHOD(int, getDBItemMock, (nlohmann::json&, const nlohmann::json&), ());
+        MOCK_METHOD(int, removeItemMock, (const std::string&, const nlohmann::json&), ());
+        MOCK_METHOD(int, executeQueryMock, (nlohmann::json&, const nlohmann::json&), ());
+};
+
+#endif

--- a/src/syscheckd/db/tests/FDBHMockInterface.hpp
+++ b/src/syscheckd/db/tests/FDBHMockInterface.hpp
@@ -12,7 +12,7 @@ namespace FIMDBHelpersUTInterface {
                             fim_sync_callback_t sync_callback, logging_callback_t logCallback,
                             std::shared_ptr<DBSync>handler_DBSync, std::shared_ptr<RemoteSync>handler_RSync)
     {
-        FIMDBHelpersMock::getInstance().initDBMock(sync_interval, file_limit, sync_callback, logCallback, handler_DBSync, handler_RSync);
+        FIMDBHelpersMock::getInstance().initDB(sync_interval, file_limit, sync_callback, logCallback, handler_DBSync, handler_RSync);
     }
 #else
 
@@ -20,36 +20,36 @@ namespace FIMDBHelpersUTInterface {
                              fim_sync_callback_t sync_callback, logging_callback_t logCallback,
                              std::shared_ptr<DBSync>handler_DBSync, std::shared_ptr<RemoteSync>handler_RSync)
     {
-        FIMDBHelpersMock::getInstance().initDBMock(sync_interval, file_limit, registry_limit, sync_callback, logCallback, handler_DBSync,
+        FIMDBHelpersMock::getInstance().initDB(sync_interval, file_limit, registry_limit, sync_callback, logCallback, handler_DBSync,
                               handler_RSync);
     }
 #endif
 
 
-    int removeFromDB(const std::string& tableName, const nlohmann::json& filter)
+    void removeFromDB(const std::string& tableName, const nlohmann::json& filter)
     {
-        return FIMDBHelpersMock::getInstance().removeFromDBMock(tableName, filter);
+        FIMDBHelpersMock::getInstance().removeFromDB(tableName, filter);
     }
 
-    int getCount(const std::string & tableName, int & count)
+    void getCount(const std::string & tableName, int & count)
     {
-        return FIMDBHelpersMock::getInstance().getCountMock(tableName, count);
+        FIMDBHelpersMock::getInstance().getCount(tableName, count);
     }
 
-    int insertItem(const std::string & tableName, const nlohmann::json & item)
+    void insertItem(const std::string & tableName, const nlohmann::json & item)
     {
-        return FIMDBHelpersMock::getInstance().insertItemMock(tableName, item);
+        FIMDBHelpersMock::getInstance().insertItem(tableName, item);
     }
 
-    int updateItem(const std::string & tableName, const nlohmann::json & item)
+    void updateItem(const std::string & tableName, const nlohmann::json & item)
     {
 
-        return FIMDBHelpersMock::getInstance().updateItemMock(tableName, item);
+        FIMDBHelpersMock::getInstance().updateItem(tableName, item);
     }
 
-    int getDBItem(nlohmann::json & item, const nlohmann::json & query)
+    void getDBItem(nlohmann::json & item, const nlohmann::json & query)
     {
-        return FIMDBHelpersMock::getInstance().executeQueryMock(item, query);
+        FIMDBHelpersMock::getInstance().executeQuery(item, query);
     }
 }
 

--- a/src/syscheckd/db/tests/FDBHMockInterface.hpp
+++ b/src/syscheckd/db/tests/FDBHMockInterface.hpp
@@ -1,0 +1,56 @@
+#include "fimDB.hpp"
+#include "FDBHMockClass.hpp"
+
+#ifndef _FIMDB_HELPERS_MOCK_INTERFACE_
+#define _FIMDB_HELPERS_MOCK_INTERFACE_
+
+namespace FIMDBHelpersUTInterface {
+
+#ifndef WIN32
+
+    void initDB(unsigned int sync_interval, unsigned int file_limit,
+                            fim_sync_callback_t sync_callback, logging_callback_t logCallback,
+                            std::shared_ptr<DBSync>handler_DBSync, std::shared_ptr<RemoteSync>handler_RSync)
+    {
+        FIMDBHelpersMock::getInstance().initDBMock(sync_interval, file_limit, sync_callback, logCallback, handler_DBSync, handler_RSync);
+    }
+#else
+
+    void initDB(unsigned int sync_interval, unsigned int file_limit, unsigned int registry_limit,
+                             fim_sync_callback_t sync_callback, logging_callback_t logCallback,
+                             std::shared_ptr<DBSync>handler_DBSync, std::shared_ptr<RemoteSync>handler_RSync)
+    {
+        FIMDBHelpersMock::getInstance().initDBMock(sync_interval, file_limit, registry_limit, sync_callback, logCallback, handler_DBSync,
+                              handler_RSync);
+    }
+#endif
+
+
+    int removeFromDB(const std::string& tableName, const nlohmann::json& filter)
+    {
+        return FIMDBHelpersMock::getInstance().removeFromDBMock(tableName, filter);
+    }
+
+    int getCount(const std::string & tableName, int & count)
+    {
+        return FIMDBHelpersMock::getInstance().getCountMock(tableName, count);
+    }
+
+    int insertItem(const std::string & tableName, const nlohmann::json & item)
+    {
+        return FIMDBHelpersMock::getInstance().insertItemMock(tableName, item);
+    }
+
+    int updateItem(const std::string & tableName, const nlohmann::json & item)
+    {
+
+        return FIMDBHelpersMock::getInstance().updateItemMock(tableName, item);
+    }
+
+    int getDBItem(nlohmann::json & item, const nlohmann::json & query)
+    {
+        return FIMDBHelpersMock::getInstance().executeQueryMock(item, query);
+    }
+}
+
+#endif


### PR DESCRIPTION
|Related issue|
|---|
|#9108|

## Description

Added a interface for FIMDBHelpers that make use of another namespace wrapping calls to our mock class covering FIMDBHelpers methods.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
  - [X] Source installation
