### PR TITLE
Limit zip size in cluster sync

### DIFF
--- a/framework/wazuh/core/cluster/cluster.json
+++ b/framework/wazuh/core/cluster/cluster.json
@@ -113,7 +113,8 @@
         "communication":{
             "timeout_cluster_request": 20,
             "timeout_dapi_request": 200,
-            "timeout_receiving_file": 120
+            "timeout_receiving_file": 120,
+            "max_zip_size": 524288000
         }
     },
 

--- a/framework/wazuh/core/cluster/cluster.json
+++ b/framework/wazuh/core/cluster/cluster.json
@@ -107,14 +107,14 @@
             "timeout_agent_info": 40,
             "check_worker_lastkeepalive": 60,
             "max_allowed_time_without_keepalive": 120,
-            "max_locked_integrity_time": 1000,
-            "max_zip_size": 524288000
+            "max_locked_integrity_time": 1000
         },
 
         "communication":{
             "timeout_cluster_request": 20,
             "timeout_dapi_request": 200,
-            "timeout_receiving_file": 120
+            "timeout_receiving_file": 120,
+            "max_zip_size": 524288000
         }
     },
 

--- a/framework/wazuh/core/cluster/cluster.json
+++ b/framework/wazuh/core/cluster/cluster.json
@@ -107,14 +107,14 @@
             "timeout_agent_info": 40,
             "check_worker_lastkeepalive": 60,
             "max_allowed_time_without_keepalive": 120,
-            "max_locked_integrity_time": 1000
+            "max_locked_integrity_time": 1000,
+            "max_zip_size": 524288000
         },
 
         "communication":{
             "timeout_cluster_request": 20,
             "timeout_dapi_request": 200,
-            "timeout_receiving_file": 120,
-            "max_zip_size": 524288000
+            "timeout_receiving_file": 120
         }
     },
 

--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -268,6 +268,7 @@ def compress_files(name, list_path, cluster_control_json=None):
     failed_files = []
     exceeded_size = False
     max_zip_size = get_cluster_items()['intervals']['communication']['max_zip_size']
+    # max_zip_size = 5000000
     zip_file_path = path.join(common.wazuh_path, 'queue', 'cluster', name,
                               f'{name}-{datetime.utcnow().timestamp()}-{str(random())[2:]}.zip')
 

--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -268,7 +268,6 @@ def compress_files(name, list_path, cluster_control_json=None):
     failed_files = []
     exceeded_size = False
     max_zip_size = get_cluster_items()['intervals']['communication']['max_zip_size']
-    # max_zip_size = 5000000
     zip_file_path = path.join(common.wazuh_path, 'queue', 'cluster', name,
                               f'{name}-{datetime.utcnow().timestamp()}-{str(random())[2:]}.zip')
 

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -953,7 +953,6 @@ class Master(server.AbstractServer):
 
     def __init__(self, **kwargs):
         """Class constructor.
-
         Parameters
         ----------
         kwargs

--- a/framework/wazuh/core/cluster/tests/test_utils.py
+++ b/framework/wazuh/core/cluster/tests/test_utils.py
@@ -156,7 +156,7 @@ def test_get_cluster_items():
                                               'max_allowed_time_without_keepalive': 120, 'process_pool_size': 2,
                                               'timeout_agent_info': 40, 'max_locked_integrity_time': 1000},
                                    'communication': {'timeout_cluster_request': 20, 'timeout_dapi_request': 200,
-                                                     'timeout_receiving_file': 120}},
+                                                     'timeout_receiving_file': 120, 'max_zip_size': 524288000}},
                      'distributed_api': {'enabled': True}}
 
 

--- a/framework/wazuh/core/cluster/tests/test_utils.py
+++ b/framework/wazuh/core/cluster/tests/test_utils.py
@@ -154,9 +154,10 @@ def test_get_cluster_items():
                                    'master': {'timeout_extra_valid': 40, 'recalculate_integrity': 8,
                                               'check_worker_lastkeepalive': 60,
                                               'max_allowed_time_without_keepalive': 120, 'process_pool_size': 2,
-                                              'timeout_agent_info': 40, 'max_locked_integrity_time': 1000},
+                                              'timeout_agent_info': 40, 'max_locked_integrity_time': 1000,
+                                              'max_zip_size': 524288000},
                                    'communication': {'timeout_cluster_request': 20, 'timeout_dapi_request': 200,
-                                                     'timeout_receiving_file': 120, 'max_zip_size': 524288000}},
+                                                     'timeout_receiving_file': 120}},
                      'distributed_api': {'enabled': True}}
 
 

--- a/framework/wazuh/core/cluster/tests/test_utils.py
+++ b/framework/wazuh/core/cluster/tests/test_utils.py
@@ -154,10 +154,9 @@ def test_get_cluster_items():
                                    'master': {'timeout_extra_valid': 40, 'recalculate_integrity': 8,
                                               'check_worker_lastkeepalive': 60,
                                               'max_allowed_time_without_keepalive': 120, 'process_pool_size': 2,
-                                              'timeout_agent_info': 40, 'max_locked_integrity_time': 1000,
-                                              'max_zip_size': 524288000},
+                                              'timeout_agent_info': 40, 'max_locked_integrity_time': 1000},
                                    'communication': {'timeout_cluster_request': 20, 'timeout_dapi_request': 200,
-                                                     'timeout_receiving_file': 120}},
+                                                     'timeout_receiving_file': 120, 'max_zip_size': 524288000}},
                      'distributed_api': {'enabled': True}}
 
 

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -124,6 +124,7 @@ async def test_SyncTask(create_log, caplog):
 
 
 @pytest.mark.asyncio
+@patch('wazuh.core.cluster.cluster.get_cluster_items', return_value={'intervals': {'communication': {'max_zip_size': 9}}})
 async def test_SyncWorker(create_log, caplog):
     worker_handler = get_worker_handler()
     sync_worker = worker.SyncFiles(cmd=b'testing', logger=logger, worker=worker_handler)


### PR DESCRIPTION
|Related issue|
|---|
| Closes #10980 |

## Description

This PR adds a new mechanism to prevent the creation of very big zips during the cluster synchronization process. 

Until now, if many files needed to be synchronized at once (for instance when a new node is added to a cluster with many groups, custom rules/decoders/lists, etc.) a big zip containing all those files would be created. If the zip was too big, a timeout could be raised (actually, it still can) in the worker while waiting for said zip. In addition, right now the worker can't send any keep alive or do any other action while processing the received files. 

Now, while creating the zip, the master won't compress more files (except the JSON with metadata) after reaching the size specified in the cluster.json (500 MB):
https://github.com/wazuh/wazuh/blob/30ee7f47cbc4ede8e842ce655b1e80561e0f77b2/framework/wazuh/core/cluster/cluster.json#L111

There are a few points to keep in mind:
- When creating the zip, once it is closed, its size is larger than before being closed. This causes the final size not to fit exactly what is specified in the `cluster.json`.
- The size of the zip is checked after adding each file. Therefore, regardless of the size, a file will always be added. For example, if the cluster wants to sync 5 files of 1GB each, it will sync one at a time even if the maximum is set to 500MB.
- Compression size is only limited when synchronizing from master to worker. It doesn't make sense when syncing from worker to master since all agent-groups (extra-valid) are merged into a single file.
- This does not ensure that no timeouts are raised in the worker. If the master is busy with many tasks, it may take longer than expected to send the zip, even if it is smaller than before.

## Performance
In cases where all the files fit in the zip, the time it takes to create the zip is almost the same as it was until now. This is the time it takes for 50000 agent groups:

**Before changes:**
```
3,849754
3,897619
3,722419
4,006115
3,643002
```
Average: 3,8237818

**After changes:**
```
3,577236
4,389307
3,934570
3,597606
3,790379
```
Average: 3,8578196

If not all files fit in the zip, they will be synced over subsequent iterations of Integrity sync. 

## Logs
The following warning log is shown in the master's cluster.log if the zip size is exceeded:
```
2021/11/30 14:11:42 WARNING: [Worker worker1] [Main] Maximum allowed zip size was exceeded so no more files will be compressed during this iteration.
```

This is be the behaviour when files need to be synced in multiple iterations. Master node:
```
2021/11/30 14:11:42 INFO: [Worker worker1] [Integrity check] Starting.
2021/11/30 14:11:42 INFO: [Worker worker1] [Integrity check] Finished in 0.035s. Received metadata of 64 files. Sync required.
2021/11/30 14:11:42 INFO: [Worker worker1] [Integrity sync] Starting.
2021/11/30 14:11:42 INFO: [Worker worker1] [Integrity sync] Files to create in worker: 49999 | Files to update in worker: 0 | Files to delete in worker: 0 | Files to receive: 0
2021/11/30 14:11:42 WARNING: [Worker worker1] [Main] Maximum allowed zip size was exceeded so no more files will be compressed during this iteration.
2021/11/30 14:11:42 INFO: [Worker worker1] [Integrity sync] Finished in 0.120s.
2021/11/30 14:11:47 INFO: [Master] [Local integrity] Starting.
2021/11/30 14:11:49 INFO: [Master] [Local integrity] Finished in 1.408s. Calculated metadata of 50063 files.
2021/11/30 14:11:51 INFO: [Worker worker1] [Integrity check] Starting.
2021/11/30 14:11:51 INFO: [Worker worker1] [Integrity check] Finished in 0.033s. Received metadata of 887 files. Sync required.
2021/11/30 14:11:51 INFO: [Worker worker1] [Integrity sync] Starting.
2021/11/30 14:11:51 INFO: [Worker worker1] [Integrity sync] Files to create in worker: 49176 | Files to update in worker: 0 | Files to delete in worker: 0 | Files to receive: 0
2021/11/30 14:11:51 WARNING: [Worker worker1] [Main] Maximum allowed zip size was exceeded so no more files will be compressed during this iteration.
2021/11/30 14:11:51 INFO: [Worker worker1] [Integrity sync] Finished in 0.117s.
2021/11/30 14:11:57 INFO: [Master] [Local integrity] Starting.
2021/11/30 14:11:58 INFO: [Master] [Local integrity] Finished in 1.383s. Calculated metadata of 50063 files.
2021/11/30 14:12:00 INFO: [Worker worker1] [Integrity check] Starting.
2021/11/30 14:12:00 INFO: [Worker worker1] [Integrity check] Finished in 0.061s. Received metadata of 1710 files. Sync required.
2021/11/30 14:12:00 INFO: [Worker worker1] [Integrity sync] Starting.
2021/11/30 14:12:00 INFO: [Worker worker1] [Integrity sync] Files to create in worker: 48353 | Files to update in worker: 0 | Files to delete in worker: 0 | Files to receive: 0
2021/11/30 14:12:00 WARNING: [Worker worker1] [Main] Maximum allowed zip size was exceeded so no more files will be compressed during this iteration.
2021/11/30 14:12:00 INFO: [Worker worker1] [Integrity sync] Finished in 0.147s.
2021/11/30 14:12:06 INFO: [Master] [Local integrity] Starting.
2021/11/30 14:12:07 INFO: [Master] [Local integrity] Finished in 1.439s. Calculated metadata of 50063 files.
2021/11/30 14:12:09 INFO: [Worker worker1] [Integrity check] Starting.
2021/11/30 14:12:09 INFO: [Worker worker1] [Integrity check] Finished in 0.079s. Received metadata of 2533 files. Sync required.
2021/11/30 14:12:09 INFO: [Worker worker1] [Integrity sync] Starting.
2021/11/30 14:12:09 INFO: [Worker worker1] [Integrity sync] Files to create in worker: 47530 | Files to update in worker: 0 | Files to delete in worker: 0 | Files to receive: 0
2021/11/30 14:12:09 WARNING: [Worker worker1] [Main] Maximum allowed zip size was exceeded so no more files will be compressed during this iteration.
2021/11/30 14:12:09 INFO: [Worker worker1] [Integrity sync] Finished in 0.167s.
```

And this is what happens in the worker, who is agnostic:
```
2021/11/30 14:11:42 INFO: [Worker worker1] [Integrity sync] Starting.
2021/11/30 14:11:42 INFO: [Worker worker1] [Integrity sync] Files to create: 823 | Files to update: 0 | Files to delete: 0 | Files to send: 0
2021/11/30 14:11:42 INFO: [Worker worker1] [Integrity sync] Finished in 0.161s.
2021/11/30 14:11:51 INFO: [Worker worker1] [Integrity check] Starting.
2021/11/30 14:11:51 INFO: [Worker worker1] [Integrity check] Finished in 0.195s. Sync required.
2021/11/30 14:11:51 INFO: [Worker worker1] [Integrity sync] Starting.
2021/11/30 14:11:51 INFO: [Worker worker1] [Integrity sync] Files to create: 823 | Files to update: 0 | Files to delete: 0 | Files to send: 0
2021/11/30 14:11:51 INFO: [Worker worker1] [Integrity sync] Finished in 0.175s.
2021/11/30 14:11:52 INFO: [Worker worker1] [Agent-info sync] Starting.
2021/11/30 14:11:52 INFO: [Worker worker1] [Agent-info sync] Finished in 0.033s (0 chunks sent).
2021/11/30 14:12:00 INFO: [Worker worker1] [Integrity check] Starting.
2021/11/30 14:12:00 INFO: [Worker worker1] [Integrity check] Finished in 0.256s. Sync required.
2021/11/30 14:12:00 INFO: [Worker worker1] [Integrity sync] Starting.
2021/11/30 14:12:00 INFO: [Worker worker1] [Integrity sync] Files to create: 823 | Files to update: 0 | Files to delete: 0 | Files to send: 0
2021/11/30 14:12:00 INFO: [Worker worker1] [Integrity sync] Finished in 0.209s.
2021/11/30 14:12:02 INFO: [Worker worker1] [Agent-info sync] Starting.
2021/11/30 14:12:02 INFO: [Worker worker1] [Agent-info sync] Finished in 0.039s (0 chunks sent).
2021/11/30 14:12:09 INFO: [Worker worker1] [Integrity check] Starting.
2021/11/30 14:12:09 INFO: [Worker worker1] [Integrity check] Finished in 0.318s. Sync required.
2021/11/30 14:12:09 INFO: [Worker worker1] [Integrity sync] Starting.
2021/11/30 14:12:09 INFO: [Worker worker1] [Integrity sync] Files to create: 823 | Files to update: 0 | Files to delete: 0 | Files to send: 0
2021/11/30 14:12:10 INFO: [Worker worker1] [Integrity sync] Finished in 0.212s.
```