### PR TITLE
Revert of #8842 - 8301 improve ms dhcp ipv4 decoder

### DIFF
--- a/ruleset/decoders/0380-windows_decoders.xml
+++ b/ruleset/decoders/0380-windows_decoders.xml
@@ -3,14 +3,13 @@
   Copyright (C) 2015-2021, Wazuh Inc.
 
   Products:
-  MS IIS
-  MS Firewall
-  MS Exchange
-  Sysmon
-  Defender
-  Terminal Services
+    MS IIS
+    MS Firewall
+    MS Exchange
+    Sysmon
+    Defender
+    Terminal Services
 -->
-
 
 <!--
   Windows date format.
@@ -22,8 +21,6 @@
 <decoder name="windows-date-format">
   <prematch>^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d </prematch>
 </decoder>
-
-
 
 <!--
   Windows firewall decoder.
@@ -44,7 +41,6 @@
   <order>action, protocol, srcip, dstip, srcport, dstport</order>
 </decoder>
 
-
 <!--
   IIS 5 WWW W3C log format.
   #Fields: date time c-ip cs-username s-sitename s-computername s-ip s-port cs-method cs-uri-stem cs-uri-query sc-status cs-host cs(User-Agent) cs(Referer)
@@ -60,7 +56,6 @@
   <regex>\d+ \S+ (\S+ \S+) (\d+) </regex>
   <order>srcip,url,id</order>
 </decoder>
-
 
 <!--
   IIS6 WWW W3C log format.
@@ -80,7 +75,6 @@
   <regex>\S+ \S+ \S+ \S+ \S+ (\d+) </regex>
   <order>url, srcip, id</order>
 </decoder>
-
 
 <!--
   Windows IIS decoder for default settings
@@ -103,7 +97,6 @@
   <order>action, url, srcport, srcip, user_agent, id</order>
 </decoder>
 
-
 <!--
   IIS 5 W3C FTP log format.
   Examples:
@@ -119,7 +112,6 @@
   <regex>\d+ [\d+](\S+) \S+ \S+ (\d+) </regex>
   <order>srcip,user,action,id</order>
 </decoder>
-
 
 <!--
   IIS 5 W3C SMTP log format (Exchange).
@@ -354,7 +346,6 @@
     <order>sysmon.image, sysmon.imageLoaded, sysmon.hashes, sysmon.signed, sysmon.signature</order>
 </decoder>
 
-
 <!--
   Event ID 8: CreateRemoteThread
 
@@ -465,7 +456,6 @@
 	<order>defender.processname, defender.action</order>
 </decoder>
 
-
 <!--
   Terminal Services
 
@@ -529,9 +519,6 @@
     <regex offset="after_regex">error occurred: "(\.*)"</regex>
 	<order>error_code</order>
 </decoder>
-
-
-
 
 <!--
   Windows generic
@@ -645,7 +632,6 @@
   <regex>^(\w+)[(\w+)] (\d+) </regex>
   <order>extra_data, status, id</order>
 </decoder>
-
 
 <!--
   Windows decoder - Snare format.

--- a/ruleset/decoders/0380-windows_decoders.xml
+++ b/ruleset/decoders/0380-windows_decoders.xml
@@ -1,10 +1,6 @@
 <!--
-  -  Windows decoders
-  -  Author: Daniel Cid.
-  -  Updated by Wazuh, Inc.
-  -  Copyright (C) 2015-2021, Wazuh Inc.
-  -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  Windows decoders
+  Copyright (C) 2015-2021, Wazuh Inc.
 -->
 
 
@@ -139,9 +135,10 @@
 -->
 
 <decoder name="ms-dhcp-ipv4">
-  <prematch type="pcre2">^\d{2},\d{2}\/\d{2}\/\d{2,4},\d{2}:\d{2}:\d+,</prematch>
-  <regex type="pcre2">^(\d{2}),(\d{2}\/\d{2}\/\d{2,4},\d{2}:\d{2}:\d+),([^,]+),([^,]+),([^,]+)</regex>
-  <order>id,timestamp,action,srcip,hostname</order>
+  <prematch>^\d\d,\d+/\d+/\d\d\d\d,\d+:\d+:\d+,|</prematch>
+  <prematch>^\d\d,\d+/\d+/\d\d,\d+:\d+:\d+,</prematch>
+  <regex>^(\d\d),\d+/\d+/\d\d\d*,\d+:\d+:\d+,(\w+),(\S+)</regex>
+  <order>id,extra_data,srcip</order>
 </decoder>
 
 <!--

--- a/ruleset/decoders/0380-windows_decoders.xml
+++ b/ruleset/decoders/0380-windows_decoders.xml
@@ -1,29 +1,39 @@
 <!--
   Windows decoders
   Copyright (C) 2015-2021, Wazuh Inc.
+
+  Products:
+  MS IIS
+  MS Firewall
+  MS Exchange
+  Sysmon
+  Defender
+  Terminal Services
 -->
 
 
-<!-- Windows date format.
-  -  Pre match for windows date format. Used on Windows firewall,
-  -  IIS, etc.
-  -  Examples:
-  -  2006-07-23 04:40:02 xxx
-  -->
+<!--
+  Windows date format.
+  Pre match for windows date format. Used on Windows firewall,
+  IIS, etc.
+  Examples:
+  2006-07-23 04:40:02 xxx
+-->
 <decoder name="windows-date-format">
   <prematch>^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d </prematch>
 </decoder>
 
 
 
-<!-- Windows firewall decoder.
-  - Will extract action, protocol, srcip, dstip, srcport and dstport.
-  - Examples:
-  - 2006-09-18 22:25:30 OPEN TCP 11.12.72.10 12.252.71.6 3311 445 - - - - - - - - -
-  - 2006-09-18 22:26:23 DROP UDP 11.152.183.14 239.255.255.250 65299 1900 310 - - - - - - - RECEIVE
-  - 2006-09-18 22:26:23 DROP UDP 11.152.183.14 239.255.255.250 65299 1900 310 - - - - - - - RECEIVE
-  - 2006-09-18 22:26:23 DROP UDP 11.152.183.14 239.255.255.250 65298 1900 319 - - - - - - - RECEIVE
-  -->
+<!--
+  Windows firewall decoder.
+  Will extract action, protocol, srcip, dstip, srcport and dstport.
+  Examples:
+  2006-09-18 22:25:30 OPEN TCP 11.12.72.10 12.252.71.6 3311 445 - - - - - - - - -
+  2006-09-18 22:26:23 DROP UDP 11.152.183.14 239.255.255.250 65299 1900 310 - - - - - - - RECEIVE
+  2006-09-18 22:26:23 DROP UDP 11.152.183.14 239.255.255.250 65299 1900 310 - - - - - - - RECEIVE
+  2006-09-18 22:26:23 DROP UDP 11.152.183.14 239.255.255.250 65298 1900 319 - - - - - - - RECEIVE
+ -->
 <decoder name="windows-firewall">
   <parent>windows-date-format</parent>
   <type>firewall</type>
@@ -35,11 +45,12 @@
 </decoder>
 
 
-<!-- IIS 5 WWW W3C log format.
-  - #Fields: date time c-ip cs-username s-sitename s-computername s-ip s-port cs-method cs-uri-stem cs-uri-query sc-status cs-host cs(User-Agent) cs(Referer)
-  - Examples:
-  - 2006-07-23 04:40:02 1.2.3.4 - W3SVC3 CIN1WEB03 1.2.3.4 443 GET /Default.asp - 200 hiden.com Mozilla/4.0+(compatible;+MSIE+6.0;+Windows+NT+5.1;+Avant+Browser;+Avant+Browser;+.NET+CLR+1.1.4322;+.NET+CLR+2.0.50727) -
-  -->
+<!--
+  IIS 5 WWW W3C log format.
+  #Fields: date time c-ip cs-username s-sitename s-computername s-ip s-port cs-method cs-uri-stem cs-uri-query sc-status cs-host cs(User-Agent) cs(Referer)
+  Examples:
+  2006-07-23 04:40:02 1.2.3.4 - W3SVC3 CIN1WEB03 1.2.3.4 443 GET /Default.asp - 200 hiden.com Mozilla/4.0+(compatible;+MSIE+6.0;+Windows+NT+5.1;+Avant+Browser;+Avant+Browser;+.NET+CLR+1.1.4322;+.NET+CLR+2.0.50727) -
+-->
 <decoder name="web-accesslog-iis5">
   <parent>windows-date-format</parent>
   <type>web-log</type>
@@ -51,14 +62,15 @@
 </decoder>
 
 
-<!-- IIS6 WWW W3C log format.
-  - #Fields: date time s-sitename s-computername s-ip cs-method cs-uri-stem
+<!--
+  IIS6 WWW W3C log format.
+  #Fields: date time s-sitename s-computername s-ip cs-method cs-uri-stem
   cs-uri-query s-port cs-username c-ip cs-version cs(User-Agent)
   cs(Cookie) cs(Referer) cs-host sc-status sc-substatus sc-win32-status
   sc-bytes cs-bytes time-taken
-  - Examples:
-  - 2007-01-22 05:00:11 W3SVC1 HOSTNAME 1.1.1.1 POST /SimpleAuthWebService/SimpleAuth.asmx - 80 - 2.2.2.2 HTTP/1.1 Windows-Update-Agent - - hostname 200 0 0 1467 841 31
-  -->
+  Examples:
+  2007-01-22 05:00:11 W3SVC1 HOSTNAME 1.1.1.1 POST /SimpleAuthWebService/SimpleAuth.asmx - 80 - 2.2.2.2 HTTP/1.1 Windows-Update-Agent - - hostname 200 0 0 1467 841 31
+-->
 <decoder name="web-accesslog-iis6">
   <parent>windows-date-format</parent>
   <type>web-log</type>
@@ -70,18 +82,18 @@
 </decoder>
 
 
-<!-- Windows IIS decoder for default settings
-  -  Tested with IIS 7.5 and IIS 8.5 (Windows 2008R2 and Windows 2012R2)
-  -  Will extract URL, Source IP, and HTTP response code
-  -  Examples:
-  -  IIS 7.5
-  -  2015-07-28 15:07:26 1.2.3.4 GET /QOsa/Browser/Default.aspx UISessionId=SN1234123&DeviceId=SN12312232SHARP+MX-4111N 80 - 31.3.3.7 OpenSystems/1.0;+product-family="85";+product-version="123ER123" 302 0 0 624
-  -  IIS 8.5
-  -  2015-03-11 20:28:21 1.2.3.4 GET /certsrv/Default.asp - 80 - 31.3.3.7 Mozilla/5.0+(compatible;+MSIE+9.0;+Windows+NT+6.1;+WOW64;+Trident/7.0) - 401 2 5 0
-  -  2015-03-11 21:59:09 1.2.3.4 GET /console/faces/com_sun_web_ui/jsp/version/version_30.jsp - 80 - 31.3.3.7 Sun+Web+Console+Fingerprinter/7.15 - 404 0 2 0
-  -  2015-03-11 22:01:58 1.2.3.4 GET /IISADMPWD/aexp.htr - 80 - 31.3.3.7 - - 404 0 2 0
+<!--
+  Windows IIS decoder for default settings
+  Tested with IIS 7.5 and IIS 8.5 (Windows 2008R2 and Windows 2012R2)
+  Will extract URL, Source IP, and HTTP response code
+  Examples:
+  IIS 7.5
+  2015-07-28 15:07:26 1.2.3.4 GET /QOsa/Browser/Default.aspx UISessionId=SN1234123&DeviceId=SN12312232SHARP+MX-4111N 80 - 31.3.3.7 OpenSystems/1.0;+product-family="85";+product-version="123ER123" 302 0 0 624
+  IIS 8.5
+  2015-03-11 20:28:21 1.2.3.4 GET /certsrv/Default.asp - 80 - 31.3.3.7 Mozilla/5.0+(compatible;+MSIE+9.0;+Windows+NT+6.1;+WOW64;+Trident/7.0) - 401 2 5 0
+  2015-03-11 21:59:09 1.2.3.4 GET /console/faces/com_sun_web_ui/jsp/version/version_30.jsp - 80 - 31.3.3.7 Sun+Web+Console+Fingerprinter/7.15 - 404 0 2 0
+  2015-03-11 22:01:58 1.2.3.4 GET /IISADMPWD/aexp.htr - 80 - 31.3.3.7 - - 404 0 2 0
 -->
-
 <decoder name="web-accesslog-iis-default">
   <parent>windows-date-format</parent>
   <type>web-log</type>
@@ -92,12 +104,13 @@
 </decoder>
 
 
-<!-- IIS 5 W3C FTP log format.
-  - Examples:
-  - #Fields: date time c-ip cs-username s-sitename s-computername s-ip s-port cs-method cs-uri-stem cs-uri-query sc-status sc-win32-status sc-bytes cs-bytes time-taken cs-version cs-host cs(User-Agent) cs(Cookie) cs(Referer)
-  - 2006-07-23 17:57:59 192.168.3.64 Administrator MSFTPSVC1 HAIJO2 192.168.1.12 21 [144]USER Administrator - 331 0 0 0 0 FTP - - - -
-  - 2006-07-23 17:57:59 192.168.3.64 Administrator MSFTPSVC1 HAIJO2 192.168.1.12 21 [144]PASS - - 230 0 0 0 16 FTP - - - -
-  -->
+<!--
+  IIS 5 W3C FTP log format.
+  Examples:
+  #Fields: date time c-ip cs-username s-sitename s-computername s-ip s-port cs-method cs-uri-stem cs-uri-query sc-status sc-win32-status sc-bytes cs-bytes time-taken cs-version cs-host cs(User-Agent) cs(Cookie) cs(Referer)
+  2006-07-23 17:57:59 192.168.3.64 Administrator MSFTPSVC1 HAIJO2 192.168.1.12 21 [144]USER Administrator - 331 0 0 0 0 FTP - - - -
+  2006-07-23 17:57:59 192.168.3.64 Administrator MSFTPSVC1 HAIJO2 192.168.1.12 21 [144]PASS - - 230 0 0 0 16 FTP - - - -
+-->
 <decoder name="msftp">
   <parent>windows-date-format</parent>
   <use_own_name>true</use_own_name>
@@ -108,12 +121,13 @@
 </decoder>
 
 
-<!-- IIS 5 W3C SMTP log format (Exchange).
-  - Examples:
-  - #Fields: date time c-ip cs-username s-sitename s-computername s-ip s-port cs-method cs-uri-stem cs-uri-query sc-status sc-win32-status sc-bytes cs-bytes time-taken cs-version cs-host cs(User-Agent) cs(Cookie) cs(Referer)
-  - 2006-10-09 14:04:46 69.217.186.117 - SMTPSVC1 MEE-PDC 192.168.X.X 0 xxxx -
-  > +hupylaw.hupy.local 500 0 32 23 0 SMTP - - - -
-  -->
+<!--
+  IIS 5 W3C SMTP log format (Exchange).
+  Examples:
+  #Fields: date time c-ip cs-username s-sitename s-computername s-ip s-port cs-method cs-uri-stem cs-uri-query sc-status sc-win32-status sc-bytes cs-bytes time-taken cs-version cs-host cs(User-Agent) cs(Cookie) cs(Referer)
+  2006-10-09 14:04:46 69.217.186.117 - SMTPSVC1 MEE-PDC 192.168.X.X 0 xxxx -
+  +hupylaw.hupy.local 500 0 32 23 0 SMTP - - - -
+-->
 <decoder name="msexchange">
   <parent>windows-date-format</parent>
   <use_own_name>true</use_own_name>
@@ -123,17 +137,12 @@
   <order>srcip, action, id</order>
 </decoder>
 
-<!-- Microsoft Windows 2003 ipv4, 2008 ipv4/ipv6 DHCP decoder for OSSEC
-  -  Author: phishphreek@gmail.com
-  -->
-
 <!--
-  -  Server 2008 DHCP IPv4 Decoder (must go first)
-  -  ID,Date,Time,Description,IP Address,Host Name,MAC Address,User Name, TransactionID, QResult,Probationtime, CorrelationID.
-  -  24,3/10/2009,0:00:46,Database Cleanup Begin,,,,
-  -  0,3/10/2009,0:00:46,DNS Update Request,201.10.168.192,OPS03W034.,,
+  Server 2008 DHCP IPv4 Decoder (must go first)
+  ID,Date,Time,Description,IP Address,Host Name,MAC Address,User Name, TransactionID, QResult,Probationtime, CorrelationID.
+  24,3/10/2009,0:00:46,Database Cleanup Begin,,,,
+  0,3/10/2009,0:00:46,DNS Update Request,201.10.168.192,OPS03W034.,,
 -->
-
 <decoder name="ms-dhcp-ipv4">
   <prematch>^\d\d,\d+/\d+/\d\d\d\d,\d+:\d+:\d+,|</prematch>
   <prematch>^\d\d,\d+/\d+/\d\d,\d+:\d+:\d+,</prematch>
@@ -142,8 +151,8 @@
 </decoder>
 
 <!--
-  -  Server 2008 DHCP IPv6 Decoder (must go second)
-  -  ID,Date,Time,Description,IPV6 Address,Host Name,Error Code, Duid Length, Duid Bytes(Hex),User Name.
+  Server 2008 DHCP IPv6 Decoder (must go second)
+  ID,Date,Time,Description,IPV6 Address,Host Name,Error Code, Duid Length, Duid Bytes(Hex),User Name.
 -->
 <decoder name="ms-dhcp-ipv6">
   <prematch>^\d\d\d\d\d,\d\d/\d\d/\d\d,\d\d:\d\d:\d\d,</prematch>
@@ -151,50 +160,43 @@
   <order>id</order>
 </decoder>
 
-<!-- Windows decoder
-  - Will extract extra_data (as win source),action (as win category), id,
-  - username and computer name (as system_name).
-  - Examples:
-  - WinEvtLog: Application: INFORMATION(0x00000064): ESENT:
-    (no user)(no domain):
-  - WinEvtLog: Security: AUDIT_FAILURE(0x000002A9): Security:
-    SYSTEM: NT AUTHORITY: The logon to account: xyz    by:
-    MICROSOFT_AUTHENTICATION_PACKAGE_V1_0    from workstation: la    failed.
-    The error code was: 3221225572
-  - WinEvtLog: Security: AUDIT_FAILURE(0x00000211): Security:
-    SYSTEM: NT AUTHORITY: Logon Failure:      Reason:     Unknown user
-    name or bad password       User Name:  ab      Domain:     cd
-    Logon Type: 2       Logon Process:  User32          Authentication
-    Package: Negotiate       Workstation Name:   ad
-  - WinEvtLog: Security: AUDIT_SUCCESS(538): Security: lac: OSSEC-HM: OSSEC-HM: User Logoff:        User Name:      lac     Domain:         OSSEC-HM        Logon ID:               (0x0,0x7C966E)          Logon Type:     2
-  - 2013 Oct 09 17:09:04 WinEvtLog: Application: INFORMATION(1): My Script: (no user): no domain: demo1.foo.example.com: test
-  - 2016 Sep 27 10:48:30 WinEvtLog: Security: AUDIT_SUCCESS(4624): Microsoft-Windows-Security-Auditing: AAAABCC: KKKKK: 01.KKKKK.com: An account was successfully logged on. Subject:  Security ID:  S-1-0-0  Account Name:  -  Account Domain:  -  Logon ID:  0x0  Logon Type:   3  New Logon:  Security ID:  S-1-5-21-1119803419-263072742-1537874043-22758  Account Name:  AAAABCC  Account Domain:  KKKKK  Logon ID:  0x2b111bcc  Logon GUID:  {C609F1DB-667E-654F-AC26-48E1A2C6FA5F}  Process Information:  Process ID:  0x0  Process Name:  -  Network Information:  Workstation Name:   Source Network Address: 192.168.12.123  Source Port:  54200  Detailed Authentication Information:  Logon Process:  Kerberos  Authentication Package: Kerberos  Transited Services: -  Package Name (NTLM only): -  Key Length:  0  This event is generated when a logon session is created. It is generated on the computer that was accessed.
-  - 2016 Sep 27 07:51:56 WinEvtLog: Application: AUDIT_FAILURE(18456): MSSQLSERVER: (no user): no domain: BBBB.AAAA.com: Login failed for user ''. Reason: An attempt to login using SQL authentication failed. Server is configured for Windows authentication only. [CLIENT: 10.1.4.21]
+<!--
+  Windows decoder
+  Will extract extra_data (as win source),action (as win category), id,
+  username and computer name (as system_name).
+  Examples:
+  WinEvtLog: Application: INFORMATION(0x00000064): ESENT:
+  (no user)(no domain):
+  WinEvtLog: Security: AUDIT_FAILURE(0x000002A9): Security:
+  SYSTEM: NT AUTHORITY: The logon to account: xyz    by:
+  MICROSOFT_AUTHENTICATION_PACKAGE_V1_0    from workstation: la    failed.
+  The error code was: 3221225572
+  WinEvtLog: Security: AUDIT_FAILURE(0x00000211): Security:
+  SYSTEM: NT AUTHORITY: Logon Failure:      Reason:     Unknown user
+  name or bad password       User Name:  ab      Domain:     cd
+  Logon Type: 2       Logon Process:  User32          Authentication
+  Package: Negotiate       Workstation Name:   ad
+  WinEvtLog: Security: AUDIT_SUCCESS(538): Security: lac: OSSEC-HM: OSSEC-HM: User Logoff:        User Name:      lac     Domain:         OSSEC-HM        Logon ID:               (0x0,0x7C966E)          Logon Type:     2
+  2013 Oct 09 17:09:04 WinEvtLog: Application: INFORMATION(1): My Script: (no user): no domain: demo1.foo.example.com: test
+  2016 Sep 27 10:48:30 WinEvtLog: Security: AUDIT_SUCCESS(4624): Microsoft-Windows-Security-Auditing: AAAABCC: KKKKK: 01.KKKKK.com: An account was successfully logged on. Subject:  Security ID:  S-1-0-0  Account Name:  -  Account Domain:  -  Logon ID:  0x0  Logon Type:   3  New Logon:  Security ID:  S-1-5-21-1119803419-263072742-1537874043-22758  Account Name:  AAAABCC  Account Domain:  KKKKK  Logon ID:  0x2b111bcc  Logon GUID:  {C609F1DB-667E-654F-AC26-48E1A2C6FA5F}  Process Information:  Process ID:  0x0  Process Name:  -  Network Information:  Workstation Name:   Source Network Address: 192.168.12.123  Source Port:  54200  Detailed Authentication Information:  Logon Process:  Kerberos  Authentication Package: Kerberos  Transited Services: -  Package Name (NTLM only): -  Key Length:  0  This event is generated when a logon session is created. It is generated on the computer that was accessed.
+  2016 Sep 27 07:51:56 WinEvtLog: Application: AUDIT_FAILURE(18456): MSSQLSERVER: (no user): no domain: BBBB.AAAA.com: Login failed for user ''. Reason: An attempt to login using SQL authentication failed. Server is configured for Windows authentication only. [CLIENT: 10.1.4.21]
   -->
 <decoder name="windows">
   <type>windows</type>
   <program_name>^WinEvtLog</program_name>
 </decoder>
 
-<!-- WinEvtLog: sysmon decoder
-
-    - Created by Wazuh, Inc. <ossec@wazuh.com>.
-        - Sysmon-EventID#1 Originally created by Josh Brower, Josh@DefensiveDepth.com
-    -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
--->
-
 <!--
-Event ID 1: Process Created
+  WinEvtLog: sysmon decoder
+  Event ID 1: Process Created
 
-  - Examples Old version:
-  - 2014 Dec 20 09:29:47 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(1): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-U93G48C7BOP: Process Create:  UtcTime: 12/20/2014 2:29 PM  ProcessGuid: {00000000-87DB-5495-0000-001045F25A00}  ProcessId: 3048  Image: C:\Windows\system32\svchost.exe  CommandLine: "C:\Windows\system32\NOTEPAD.EXE" C:\Users\Administrator\Desktop\ossec.log  User: WIN-U93G48C7BOP\Administrator  LogonGuid: {00000000-84B8-5494-0000-0020CB330200}  LogonId: 0x233CB  TerminalSessionId: 1  IntegrityLevel: High  HashType: SHA1  Hash: 9FEF303BEDF8430403915951564E0D9888F6F365  ParentProcessGuid: {00000000-84B9-5494-0000-0010BE4A0200}  ParentProcessId: 848  ParentImage: C:\Windows\Explorer.EXE  ParentCommandLine: C:\Windows\Explorer.EXE
+ Examples Old version:
+ 2014 Dec 20 09:29:47 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(1): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-U93G48C7BOP: Process Create:  UtcTime: 12/20/2014 2:29 PM  ProcessGuid: {00000000-87DB-5495-0000-001045F25A00}  ProcessId: 3048  Image: C:\Windows\system32\svchost.exe  CommandLine: "C:\Windows\system32\NOTEPAD.EXE" C:\Users\Administrator\Desktop\ossec.log  User: WIN-U93G48C7BOP\Administrator  LogonGuid: {00000000-84B8-5494-0000-0020CB330200}  LogonId: 0x233CB  TerminalSessionId: 1  IntegrityLevel: High  HashType: SHA1  Hash: 9FEF303BEDF8430403915951564E0D9888F6F365  ParentProcessGuid: {00000000-84B9-5494-0000-0010BE4A0200}  ParentProcessId: 848  ParentImage: C:\Windows\Explorer.EXE  ParentCommandLine: C:\Windows\Explorer.EXE
 
-  - Examples New version*:
-  - 2015 Nov 19 18:32:31 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(1): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-K3UD9R5LCEL: Process Create:  UtcTime: 2015-11-19 17:32:31.562  ProcessGuid: {0B364D7C-07AF-564E-0000-001098C90800}  ProcessId: 2188  Image: C:\Windows\System32\rundll32.exe  CommandLine: C:\Windows\system32\rundll32.exe C:\Windows\system32\inetcpl.cpl,ClearMyTracksByProcess Flags:65800 WinX:0 WinY:0 IEFrame:0000000000000000  CurrentDirectory: C:\Users\Administrator.WIN-K3UD9R5LCEL\Desktop\  User: WIN-K3UD9R5LCEL\Administrator  LogonGuid: {0B364D7C-FDDB-564D-0000-00209CA10100}  LogonId: 0x1a19c  TerminalSessionId: 1  IntegrityLevel: High  Hashes: SHA1=963B55ACC8C566876364716D5AAFA353995812A8  ParentProcessGuid: {0B364D7C-FE43-564D-0000-0010F1720200}  ParentProcessId: 576  ParentImage: C:\Program Files\Internet Explorer\iexplore.exe  ParentCommandLine: "C:\Program Files\Internet Explorer\iexplore.exe"
-
-  2017 Mar 29 13:36:36 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(1): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-P57C9KN929H: Process Create:  UtcTime: 2017-03-29 11:36:36.964  ProcessGuid: {DB577E3B-9C44-58DB-0000-0010B0983A00}  ProcessId: 3784  Image: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe  CommandLine: "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" "-file" "C:\Users\Alberto\Desktop\test.ps1"  CurrentDirectory: C:\Users\Alberto\Desktop\  User: WIN-P57C9KN929H\Alberto  LogonGuid: {DB577E3B-89E5-58DB-0000-0020CB290500}  LogonId: 0x529cb  TerminalSessionId: 1  IntegrityLevel: Medium  Hashes: MD5=92F44E405DB16AC55D97E3BFE3B132FA,SHA256=6C05E11399B7E3C8ED31BAE72014CF249C144A8F4A2C54A758EB2E6FAD47AEC7  ParentProcessGuid: {DB577E3B-89E6-58DB-0000-0010FA3B0500}  ParentProcessId: 2308  ParentImage: C:\Windows\explorer.exe  ParentCommandLine: C:\Windows\Explorer.EXE
+ Examples New version*:
+ 2015 Nov 19 18:32:31 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(1): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-K3UD9R5LCEL: Process Create:  UtcTime: 2015-11-19 17:32:31.562  ProcessGuid: {0B364D7C-07AF-564E-0000-001098C90800}  ProcessId: 2188  Image: C:\Windows\System32\rundll32.exe  CommandLine: C:\Windows\system32\rundll32.exe C:\Windows\system32\inetcpl.cpl,ClearMyTracksByProcess Flags:65800 WinX:0 WinY:0 IEFrame:0000000000000000  CurrentDirectory: C:\Users\Administrator.WIN-K3UD9R5LCEL\Desktop\  User: WIN-K3UD9R5LCEL\Administrator  LogonGuid: {0B364D7C-FDDB-564D-0000-00209CA10100}  LogonId: 0x1a19c  TerminalSessionId: 1  IntegrityLevel: High  Hashes: SHA1=963B55ACC8C566876364716D5AAFA353995812A8  ParentProcessGuid: {0B364D7C-FE43-564D-0000-0010F1720200}  ParentProcessId: 576  ParentImage: C:\Program Files\Internet Explorer\iexplore.exe  ParentCommandLine: "C:\Program Files\Internet Explorer\iexplore.exe"
+ 2017 Mar 29 13:36:36 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(1): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-P57C9KN929H: Process Create:  UtcTime: 2017-03-29 11:36:36.964  ProcessGuid: {DB577E3B-9C44-58DB-0000-0010B0983A00}  ProcessId: 3784  Image: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe  CommandLine: "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" "-file" "C:\Users\Alberto\Desktop\test.ps1"  CurrentDirectory: C:\Users\Alberto\Desktop\  User: WIN-P57C9KN929H\Alberto  LogonGuid: {DB577E3B-89E5-58DB-0000-0020CB290500}  LogonId: 0x529cb  TerminalSessionId: 1  IntegrityLevel: Medium  Hashes: MD5=92F44E405DB16AC55D97E3BFE3B132FA,SHA256=6C05E11399B7E3C8ED31BAE72014CF249C144A8F4A2C54A758EB2E6FAD47AEC7  ParentProcessGuid: {DB577E3B-89E6-58DB-0000-0010FA3B0500}  ParentProcessId: 2308  ParentImage: C:\Windows\explorer.exe  ParentCommandLine: C:\Windows\Explorer.EXE
 -->
-
 <decoder name="Sysmon-EventID#1">
     <parent>windows</parent>
     <type>windows</type>
@@ -233,9 +235,8 @@ Event ID 1: Process Created
 </decoder>
 
 <!--
-Event ID 2: A process changed a file creation time
-
-2015 Nov 19 18:32:16 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(2): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-K3UD9R5LCEL: File creation time changed:  UtcTime: 2015-11-19 17:32:16.578  ProcessGuid: {0B364D7C-FE43-564D-0000-0010F1720200}  ProcessId: 576  Image: C:\Program Files\Internet Explorer\iexplore.exe  TargetFilename: C:\Users\Administrator.WIN-K3UD9R5LCEL\AppData\Roaming\Microsoft\Windows\Recent\CustomDestinations\QK9FKZ7I2DSU0MTCD160.temp  CreationUtcTime: 2015-11-19 03:28:08.281  PreviousCreationUtcTime: 2015-11-19 17:32:16.578
+  Event ID 2: A process changed a file creation time
+  2015 Nov 19 18:32:16 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(2): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-K3UD9R5LCEL: File creation time changed:  UtcTime: 2015-11-19 17:32:16.578  ProcessGuid: {0B364D7C-FE43-564D-0000-0010F1720200}  ProcessId: 576  Image: C:\Program Files\Internet Explorer\iexplore.exe  TargetFilename: C:\Users\Administrator.WIN-K3UD9R5LCEL\AppData\Roaming\Microsoft\Windows\Recent\CustomDestinations\QK9FKZ7I2DSU0MTCD160.temp  CreationUtcTime: 2015-11-19 03:28:08.281  PreviousCreationUtcTime: 2015-11-19 17:32:16.578
 -->
 <decoder name="Sysmon-EventID#2">
     <parent>windows</parent>
@@ -253,13 +254,11 @@ Event ID 2: A process changed a file creation time
 </decoder>
 
 <!--
-Event ID 3: Network connection
+  Event ID 3: Network connection
 
-2015 Nov 19 20:33:25 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(3): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-K3UD9R5LCEL: Network connection detected:  UtcTime: 2015-11-19 19:33:23.824  ProcessGuid: {0B364D7C-23F6-564E-0000-00100D5A1100}  ProcessId: 2028  Image: C:\Program Files (x86)\Internet Explorer\iexplore.exe  User: WIN-K3UD9R5LCEL\Administrator  Protocol: tcp  Initiated: true  SourceIsIpv6: false  SourceIp: 192.168.2.201  SourceHostname: WIN-K3UD9R5LCEL.LinDomain  SourcePort: 49192  SourcePortName:   DestinationIsIpv6: false  DestinationIp: XXX.58.XXX.206  DestinationHostname: webdest  DestinationPort: 443  DestinationPortName: https
-2018 Nov 03 14:41:15 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(3): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: HOST2.abcusa.local: Network connection detected:  RuleName:   UtcTime: 2018-11-03 18:41:12.049  ProcessGuid: {1DCE106C-1FD9-5BD9-0000-001089032E01}  ProcessId: 12836  Image: C:\Windows\System32\mmc.exe  User: ABCUSA\admin.smith  Protocol: tcp  Initiated: true  SourceIsIpv6: false  SourceIp: 10.150.133.7  SourceHostname: HOST2.abcusa.local  SourcePort: 54709  SourcePortName:   DestinationIsIpv6: false  DestinationIp: 10.150.133.6  DestinationHostname: HOST1.abcusa.local  DestinationPort: 49161  DestinationPortName:
-
+  2015 Nov 19 20:33:25 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(3): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-K3UD9R5LCEL: Network connection detected:  UtcTime: 2015-11-19 19:33:23.824  ProcessGuid: {0B364D7C-23F6-564E-0000-00100D5A1100}  ProcessId: 2028  Image: C:\Program Files (x86)\Internet Explorer\iexplore.exe  User: WIN-K3UD9R5LCEL\Administrator  Protocol: tcp  Initiated: true  SourceIsIpv6: false  SourceIp: 192.168.2.201  SourceHostname: WIN-K3UD9R5LCEL.LinDomain  SourcePort: 49192  SourcePortName:   DestinationIsIpv6: false  DestinationIp: XXX.58.XXX.206  DestinationHostname: webdest  DestinationPort: 443  DestinationPortName: https
+  2018 Nov 03 14:41:15 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(3): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: HOST2.abcusa.local: Network connection detected:  RuleName:   UtcTime: 2018-11-03 18:41:12.049  ProcessGuid: {1DCE106C-1FD9-5BD9-0000-001089032E01}  ProcessId: 12836  Image: C:\Windows\System32\mmc.exe  User: ABCUSA\admin.smith  Protocol: tcp  Initiated: true  SourceIsIpv6: false  SourceIp: 10.150.133.7  SourceHostname: HOST2.abcusa.local  SourcePort: 54709  SourcePortName:   DestinationIsIpv6: false  DestinationIp: 10.150.133.6  DestinationHostname: HOST1.abcusa.local  DestinationPort: 49161  DestinationPortName:
 -->
-
 <decoder name="Sysmon-EventID#3">
     <parent>windows</parent>
     <type>windows</type>
@@ -276,11 +275,10 @@ Event ID 3: Network connection
 </decoder>
 
 <!--
-Event ID 4: Sysmon service state changed
+  Event ID 4: Sysmon service state changed
 
-2015 Nov 19 20:27:42 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(4): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-K3UD9R5LCEL: Sysmon service state changed:  UtcTime: 2015-11-19 19:27:42.796  State: Started
+  2015 Nov 19 20:27:42 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(4): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-K3UD9R5LCEL: Sysmon service state changed:  UtcTime: 2015-11-19 19:27:42.796  State: Started
 -->
-
 <decoder name="Sysmon-EventID#4">
     <parent>windows</parent>
     <type>windows</type>
@@ -297,9 +295,9 @@ Event ID 4: Sysmon service state changed
 </decoder>
 
 <!--
-Event ID 5: Process terminated
+  Event ID 5: Process terminated
 
-2015 Nov 19 20:41:57 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(5): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-K3UD9R5LCEL: Process terminated:  UtcTime: 2015-11-19 19:41:57.648  ProcessGuid: {0B364D7C-2353-564E-0000-001025511000}  ProcessId: 2196  Image: C:\Windows\System32\wbem\WmiPrvSE.exe
+  2015 Nov 19 20:41:57 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(5): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-K3UD9R5LCEL: Process terminated:  UtcTime: 2015-11-19 19:41:57.648  ProcessGuid: {0B364D7C-2353-564E-0000-001025511000}  ProcessId: 2196  Image: C:\Windows\System32\wbem\WmiPrvSE.exe
 -->
 <decoder name="Sysmon-EventID#5">
     <parent>windows</parent>
@@ -317,9 +315,9 @@ Event ID 5: Process terminated
 </decoder>
 
 <!--
-Event ID 6: Driver loaded
+  Event ID 6: Driver loaded
 
-2015 Nov 20 11:01:41 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(6): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-K3UD9R5LCEL: Driver loaded:  UtcTime: 2015-11-20 10:01:41.765  ImageLoaded: C:\Windows\System32\drivers\cdrom.sys  Hashes: SHA1=89204964B695862C31B10AB7129EC96B66C78F89  Signed: true  Signature: Microsoft Windows
+  2015 Nov 20 11:01:41 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(6): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-K3UD9R5LCEL: Driver loaded:  UtcTime: 2015-11-20 10:01:41.765  ImageLoaded: C:\Windows\System32\drivers\cdrom.sys  Hashes: SHA1=89204964B695862C31B10AB7129EC96B66C78F89  Signed: true  Signature: Microsoft Windows
 -->
 <decoder name="Sysmon-EventID#6">
     <parent>windows</parent>
@@ -337,9 +335,9 @@ Event ID 6: Driver loaded
 </decoder>
 
 <!--
-Event ID 7: Image loaded
+  Event ID 7: Image loaded
 
-2015 Nov 20 11:26:13 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(7): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-K3UD9R5LCEL: Image loaded:  UtcTime: 2015-11-20 10:26:13.672  ProcessGuid: {0B364D7C-F545-564E-0000-001085D69400}  ProcessId: 2216  Image: C:\Windows\System32\cmd.exe  ImageLoaded: C:\Windows\System32\msctf.dll  Hashes: SHA1=E425577CCFC9B92EFBBCB760D21FCAA478D3E51A  Signed: true  Signature: Microsoft Windows
+  2015 Nov 20 11:26:13 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(7): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-K3UD9R5LCEL: Image loaded:  UtcTime: 2015-11-20 10:26:13.672  ProcessGuid: {0B364D7C-F545-564E-0000-001085D69400}  ProcessId: 2216  Image: C:\Windows\System32\cmd.exe  ImageLoaded: C:\Windows\System32\msctf.dll  Hashes: SHA1=E425577CCFC9B92EFBBCB760D21FCAA478D3E51A  Signed: true  Signature: Microsoft Windows
 -->
 <decoder name="Sysmon-EventID#7">
     <parent>windows</parent>
@@ -358,9 +356,9 @@ Event ID 7: Image loaded
 
 
 <!--
-Event ID 8: CreateRemoteThread
+  Event ID 8: CreateRemoteThread
 
-2015 Nov 20 11:25:44 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(8): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-K3UD9R5LCEL: CreateRemoteThread detected:  UtcTime: 2015-11-20 10:25:44.562  SourceProcessGuid: {0B364D7C-E952-564E-0000-00104C3B0000}  SourceProcessId: 388  SourceImage: C:\Windows\System32\csrss.exe  TargetProcessGuid: {0B364D7C-EF10-564E-0000-001010EA0700}  TargetProcessId: 1152  TargetImage: C:\Windows\System32\cmd.exe  NewThreadId: 2128  StartAddress: 0x00000000777F4910  StartModule: C:\Windows\system32\kernel32.dll  StartFunction: CtrlRoutine
+  2015 Nov 20 11:25:44 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(8): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-K3UD9R5LCEL: CreateRemoteThread detected:  UtcTime: 2015-11-20 10:25:44.562  SourceProcessGuid: {0B364D7C-E952-564E-0000-00104C3B0000}  SourceProcessId: 388  SourceImage: C:\Windows\System32\csrss.exe  TargetProcessGuid: {0B364D7C-EF10-564E-0000-001010EA0700}  TargetProcessId: 1152  TargetImage: C:\Windows\System32\cmd.exe  NewThreadId: 2128  StartAddress: 0x00000000777F4910  StartModule: C:\Windows\system32\kernel32.dll  StartFunction: CtrlRoutine
 -->
 <decoder name="Sysmon-EventID#8">
     <parent>windows</parent>
@@ -377,23 +375,10 @@ Event ID 8: CreateRemoteThread
     <order>sysmon.sourceImage, sysmon.targetImage, sysmon.startModule, sysmon.startFunction</order>
 </decoder>
 
-
 <!--
-Event ID 9
--->
+  Event ID 11:
 
-
-<!--
-Event ID 10: ProcessAccess
-
-2017 Mar 29 13:26:05 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(10): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-P57C9KN929H: Process accessed:  UtcTime: 2017-03-29 11:26:05.493  SourceProcessGUID: {DB577E3B-99C4-58DB-0000-0010E0A83700}  SourceProcessId: 3048  SourceThreadId: 980  SourceImage: C:\Windows\System32\cmd.exe  TargetProcessGUID: {DB577E3B-99CD-58DB-0000-001006AF3700}  TargetProcessId: 3044  TargetImage: C:\Windows\System32\PING.EXE  GrantedAccess: 0x1fffff  CallTrace: C:\Windows\SYSTEM32\ntdll.dll+44bcc|C:\Windows\system32\kernel32.dll+54a0b|C:\Windows\system32\kernel32.dll+2059|C:\Windows\System32\cmd.exe+4090|C:\Windows\System32\cmd.exe+3e5c|C:\Windows\System32\cmd.exe+3ef0|C:\Windows\System32\cmd.exe+15ae|C:\Windows\System32\cmd.exe+23c0|C:\Windows\System32\cmd.exe+178d3|C:\Windows\System32\cmd.exe+61a0|C:\Windows\system32\kernel32.dll+51174|C:\Windows\SYSTEM32\ntdll.dll+5b3f5|C:\Windows\SYSTEM32\ntdll.dll+5b3c8
--->
-
-
-<!--
-Event ID 11:
-
-2017 Mar 30 15:09:02 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(11): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-KND6QGDH48O: File created:  UtcTime: 2017-03-30 15:09:02.934  ProcessGuid: {FE5A418C-1C6B-58DD-0000-001023A40B00}  ProcessId: 3064  Image: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe  TargetFilename: C:\Windows\System32\drivers\malware.txt  CreationUtcTime: 2017-03-30 15:09:02.934
+  2017 Mar 30 15:09:02 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(11): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-KND6QGDH48O: File created:  UtcTime: 2017-03-30 15:09:02.934  ProcessGuid: {FE5A418C-1C6B-58DD-0000-001023A40B00}  ProcessId: 3064  Image: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe  TargetFilename: C:\Windows\System32\drivers\malware.txt  CreationUtcTime: 2017-03-30 15:09:02.934
 -->
 <decoder name="Sysmon-EventID#11">
     <parent>windows</parent>
@@ -411,31 +396,9 @@ Event ID 11:
 </decoder>
 
 <!--
+  Event ID 15: FileCreateStreamHash
 
-Event ID 12: RegistryEvent (Object create and delete)
-
-2017 Mar 27 10:38:48 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(12): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-P57C9KN929H: Registry object added or deleted:  EventType: CreateKey  UtcTime: 2017-03-27 08:38:48.108  ProcessGuid: {DB577E3B-C979-58D8-0000-001049540100}  ProcessId: 1288  Image: C:\Windows\Explorer.EXE  TargetObject: HKU\S-1-5-21-2895701376-138392475-4243184240-1000\Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\.com
--->
-
-
-<!--
-Event ID 13: RegistryEvent (Value Set)
-
-2017 Mar 27 10:57:57 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(13): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-P57C9KN929H: Registry value set:  EventType: SetValue  UtcTime: 2017-03-27 08:57:57.885  ProcessGuid: {DB577E3B-D415-58D8-0000-00108ED53500}  ProcessId: 2040  Image: C:\Windows\system32\winsat.exe  TargetObject: HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce\WinSATRestorePower  Details: powercfg -setactive 8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c
--->
-
-
-<!--
-Event ID 14: RegistryEvent (Key and Value Rename)
-
-2017 Mar 29 13:20:37 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(14): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-P57C9KN929H: Registry object renamed:  EventType: RenameKey  UtcTime: 2017-03-29 11:20:37.159  ProcessGuid: {DB577E3B-97E1-58DB-0000-0010272E3300}  ProcessId: 2684  Image: C:\Windows\regedit.exe  TargetObject: HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WINEVT\Channels\Microsoft-Windows-Sysmon/Operational  NewName: \REGISTRY\MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\WINEVT\Channels\Microsoft-Windows-Sysmon/Operational2
--->
-
-
-<!--
-Event ID 15: FileCreateStreamHash
-
-2017 Mar 22 20:58:52 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(15): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-M0OTMBFUNGN: File stream created:  UtcTime: 2017-03-22 19:58:52.021  ProcessGuid: {514DFA4C-D745-58D2-0000-00107ECE2501}  ProcessId: 2476  Image: C:\Program Files\Internet Explorer\iexplore.exe  TargetFilename: C:\Users\Alberto\Desktop\setupssh381-20040709.zip  CreationUtcTime: 2017-03-22 19:58:42.380  Hash: MD5=9F82020D0494ED2E38B201C1948DD146
+  2017 Mar 22 20:58:52 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(15): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-M0OTMBFUNGN: File stream created:  UtcTime: 2017-03-22 19:58:52.021  ProcessGuid: {514DFA4C-D745-58D2-0000-00107ECE2501}  ProcessId: 2476  Image: C:\Program Files\Internet Explorer\iexplore.exe  TargetFilename: C:\Users\Alberto\Desktop\setupssh381-20040709.zip  CreationUtcTime: 2017-03-22 19:58:42.380  Hash: MD5=9F82020D0494ED2E38B201C1948DD146
 -->
 <decoder name="Sysmon-EventID#15">
     <parent>windows</parent>
@@ -452,12 +415,9 @@ Event ID 15: FileCreateStreamHash
     <order>sysmon.processId, sysmon.image, sysmon.targetfilename, sysmon.creationUtcTime, sysmon.hash</order>
 </decoder>
 
-<!-- sysmon decoder END -->
-
-<!-- Windows Defender -->
-
 <!--
-2017 Apr 06 06:25:54 WinEvtLog: Microsoft-Windows-Windows Defender/Operational: WARNING(1116): Microsoft-Windows-Windows Defender: SYSTEM: NT AUTHORITY: DESKTOP-6UOEPO5: Windows Defender has detected malware or other potentially unwanted software.   For more information please see the following:  http://go.microsoft.com/fwlink/?linkid=37020&name=Virus:DOS/EICAR_Test_File&threatid=2147519003&enterprise=0     Name: Virus:DOS/EICAR_Test_File          ID: 2147519003          Severity: Severe        Category: Virus         Path: file:_C:\Users\spiderman\Downloads\eicar.com.txt          Detection Origin: Local machine         Detection Type: Concrete     Detection Source: Real-Time Protection          User: NT AUTHORITY\SYSTEM       Process Name: C:\Windows\System32\SearchProtocolHost.exe        Signature Version: AV: 1.239.892.0, AS: 1.239.892.0, NIS: 116.88.0.0    Engine Version: AM: 1.1.13601.0, NIS: 2.1.12706.0
+  Windows Defender
+  2017 Apr 06 06:25:54 WinEvtLog: Microsoft-Windows-Windows Defender/Operational: WARNING(1116): Microsoft-Windows-Windows Defender: SYSTEM: NT AUTHORITY: DESKTOP-6UOEPO5: Windows Defender has detected malware or other potentially unwanted software.   For more information please see the following:  http://go.microsoft.com/fwlink/?linkid=37020&name=Virus:DOS/EICAR_Test_File&threatid=2147519003&enterprise=0     Name: Virus:DOS/EICAR_Test_File          ID: 2147519003          Severity: Severe        Category: Virus         Path: file:_C:\Users\spiderman\Downloads\eicar.com.txt          Detection Origin: Local machine         Detection Type: Concrete     Detection Source: Real-Time Protection          User: NT AUTHORITY\SYSTEM       Process Name: C:\Windows\System32\SearchProtocolHost.exe        Signature Version: AV: 1.239.892.0, AS: 1.239.892.0, NIS: 116.88.0.0    Engine Version: AM: 1.1.13601.0, NIS: 2.1.12706.0
 -->
 <decoder name="Windows-defender">
     <parent>windows</parent>
@@ -482,7 +442,7 @@ Event ID 15: FileCreateStreamHash
 </decoder>
 
 <!--
-2017 Apr 06 06:26:01 WinEvtLog: Microsoft-Windows-Windows Defender/Operational: INFORMATION(1117): Microsoft-Windows-Windows Defender: SYSTEM: NT AUTHORITY: DESKTOP-6UOEPO5: Windows Defender has taken action to protect this machine from malware or other potentially unwanted software.   For more information please see the following:  http://go.microsoft.com/fwlink/?linkid=37020&name=Virus:DOS/EICAR_Test_File&threatid=2147519003&enterprise=0         Name: Virus:DOS/EICAR_Test_File         ID: 2147519003          Severity: Severe        Category: Virus         Path: file:_C:\Users\spiderman\Downloads\eicar.com.txt;webfile:_C:\Users\spiderman\Downloads\eicar.com.txt|http://www.eicar.org/download/eicar.com.txt|chrome.exe    Detection Origin: Internet      Detection Type: Concrete        Detection Source: Real-Time Protection          User: NT AUTHORITY\SYSTEM       Process Name: C:\Windows\System32\SearchProtocolHost.exe     Action: Quarantine      Action Status:  No additional actions required          Error Code: 0x80508023          Error description: The program could not find the malware and other potentially unwanted software on this computer.          Signature Version: AV: 1.239.892.0, AS: 1.239.892.0, NIS: 116.88.0.0    Engine Version: AM: 1.1.13601.0, NIS: 2.1.12706.0
+  2017 Apr 06 06:26:01 WinEvtLog: Microsoft-Windows-Windows Defender/Operational: INFORMATION(1117): Microsoft-Windows-Windows Defender: SYSTEM: NT AUTHORITY: DESKTOP-6UOEPO5: Windows Defender has taken action to protect this machine from malware or other potentially unwanted software.   For more information please see the following:  http://go.microsoft.com/fwlink/?linkid=37020&name=Virus:DOS/EICAR_Test_File&threatid=2147519003&enterprise=0         Name: Virus:DOS/EICAR_Test_File         ID: 2147519003          Severity: Severe        Category: Virus         Path: file:_C:\Users\spiderman\Downloads\eicar.com.txt;webfile:_C:\Users\spiderman\Downloads\eicar.com.txt|http://www.eicar.org/download/eicar.com.txt|chrome.exe    Detection Origin: Internet      Detection Type: Concrete        Detection Source: Real-Time Protection          User: NT AUTHORITY\SYSTEM       Process Name: C:\Windows\System32\SearchProtocolHost.exe     Action: Quarantine      Action Status:  No additional actions required          Error Code: 0x80508023          Error description: The program could not find the malware and other potentially unwanted software on this computer.          Signature Version: AV: 1.239.892.0, AS: 1.239.892.0, NIS: 116.88.0.0    Engine Version: AM: 1.1.13601.0, NIS: 2.1.12706.0
 -->
 <decoder name="Windows-defender">
     <parent>windows</parent>
@@ -505,30 +465,19 @@ Event ID 15: FileCreateStreamHash
 	<order>defender.processname, defender.action</order>
 </decoder>
 
-<!-- Windows Defender END -->
 
+<!--
+  Terminal Services
 
-<!-- Terminal Services
-
-  - 2018 Aug 20 10:09:53 WinEvtLog: Microsoft-Windows-TerminalServices-Gateway/Operational: INFORMATION(200): Microsoft-Windows-TerminalServices-Gateway: NETWORK SERVICE: NT AUTHORITY: some-host-name: The user "someuser\somedomain", on client computer "1.2.3.4", met connection authorization policy requirements and was therefore authorized to access the RD Gateway server. The authentication method used was: "NTLM" and connection protocol used: "HTTP".
-
-  - 2018 Aug 20 07:41:27 WinEvtLog: Microsoft-Windows-TerminalServices-Gateway/Operational: ERROR(201): Microsoft-Windows-TerminalServices-Gateway: NETWORK SERVICE: NT AUTHORITY: some-host-name: The user "someuser\somedomain", on client computer "1.2.3.4", did not meet connection authorization policy requirements and was therefore not authorized to access the RD Gateway server. The authentication method used was: "NTLM" and connection protocol used: "HTTP". The following error occurred: "23003".
-
-  - 2018 Aug 20 07:32:33 WinEvtLog: Microsoft-Windows-TerminalServices-Gateway/Operational: INFORMATION(202): Microsoft-Windows-TerminalServices-Gateway: NETWORK SERVICE: NT AUTHORITY: some-host-name: The administrator disconnected the user "someuser\somedomain", on client computer "1.2.3.4", from the following network resource: "resourceName". Before the user was disconnected, the client transferred 149218 bytes and received 196031 bytes using HTTP connection protocol. The client session duration was 85 seconds.
-
-  - 2018 Aug 20 10:09:53 WinEvtLog: Microsoft-Windows-TerminalServices-Gateway/Operational: INFORMATION(300): Microsoft-Windows-TerminalServices-Gateway: NETWORK SERVICE: NT AUTHORITY: some-host-name: The user "someuser\somedomain", on client computer "1.2.3.4", met resource authorization policy requirements and was therefore authorized to connect to resource "resourceName".
-
-  - 2018 Aug 20 07:55:34 WinEvtLog: Microsoft-Windows-TerminalServices-Gateway/Operational: ERROR(301): Microsoft-Windows-TerminalServices-Gateway: NETWORK SERVICE: NT AUTHORITY: some-host-name: The user "someuser\somedomain", on client computer "1.2.3.4", did not meet resource authorization policy requirements and was therefore not authorized to resource "resourceName". The following error occurred: "23002".
-
-  - 2018 Aug 20 10:09:53 WinEvtLog: Microsoft-Windows-TerminalServices-Gateway/Operational: INFORMATION(302): Microsoft-Windows-TerminalServices-Gateway: NETWORK SERVICE: NT AUTHORITY: some-host-name: The user "someuser\somedomain", on client computer "1.2.3.4", connected to resource "resourceName". Connection protocol used: "HTTP".
-
-  - 2018 Aug 20 10:10:36 WinEvtLog: Microsoft-Windows-TerminalServices-Gateway/Operational: INFORMATION(303): Microsoft-Windows-TerminalServices-Gateway: NETWORK SERVICE: NT AUTHORITY: some-host-name: The user "someuser\somedomain", on client computer "1.2.3.4", disconnected from the following network resource: "resourceName". Before the user disconnected, the client transferred 1285 bytes and received 3122 bytes. The client session duration was 43 seconds. Connection protocol used: "HTTP".
-
-  - 2018 Aug 21 09:49:54 WinEvtLog: Microsoft-Windows-TerminalServices-Gateway/Operational: WARNING(304): Microsoft-Windows-TerminalServices-Gateway: NETWORK SERVICE: NT AUTHORITY: some-host-name: The user "someuser\somedomain", on client computer "195.160.232.242", met connection authorization policy and resource authorization policy requirements, but could not connect to resource "resourceName". Connection protocol used: "HTTP". The following error occurred: "23005".
-
+  2018 Aug 20 10:09:53 WinEvtLog: Microsoft-Windows-TerminalServices-Gateway/Operational: INFORMATION(200): Microsoft-Windows-TerminalServices-Gateway: NETWORK SERVICE: NT AUTHORITY: some-host-name: The user "someuser\somedomain", on client computer "1.2.3.4", met connection authorization policy requirements and was therefore authorized to access the RD Gateway server. The authentication method used was: "NTLM" and connection protocol used: "HTTP".
+  2018 Aug 20 07:41:27 WinEvtLog: Microsoft-Windows-TerminalServices-Gateway/Operational: ERROR(201): Microsoft-Windows-TerminalServices-Gateway: NETWORK SERVICE: NT AUTHORITY: some-host-name: The user "someuser\somedomain", on client computer "1.2.3.4", did not meet connection authorization policy requirements and was therefore not authorized to access the RD Gateway server. The authentication method used was: "NTLM" and connection protocol used: "HTTP". The following error occurred: "23003".
+  2018 Aug 20 07:32:33 WinEvtLog: Microsoft-Windows-TerminalServices-Gateway/Operational: INFORMATION(202): Microsoft-Windows-TerminalServices-Gateway: NETWORK SERVICE: NT AUTHORITY: some-host-name: The administrator disconnected the user "someuser\somedomain", on client computer "1.2.3.4", from the following network resource: "resourceName". Before the user was disconnected, the client transferred 149218 bytes and received 196031 bytes using HTTP connection protocol. The client session duration was 85 seconds.
+  2018 Aug 20 10:09:53 WinEvtLog: Microsoft-Windows-TerminalServices-Gateway/Operational: INFORMATION(300): Microsoft-Windows-TerminalServices-Gateway: NETWORK SERVICE: NT AUTHORITY: some-host-name: The user "someuser\somedomain", on client computer "1.2.3.4", met resource authorization policy requirements and was therefore authorized to connect to resource "resourceName".
+  2018 Aug 20 07:55:34 WinEvtLog: Microsoft-Windows-TerminalServices-Gateway/Operational: ERROR(301): Microsoft-Windows-TerminalServices-Gateway: NETWORK SERVICE: NT AUTHORITY: some-host-name: The user "someuser\somedomain", on client computer "1.2.3.4", did not meet resource authorization policy requirements and was therefore not authorized to resource "resourceName". The following error occurred: "23002".
+  2018 Aug 20 10:09:53 WinEvtLog: Microsoft-Windows-TerminalServices-Gateway/Operational: INFORMATION(302): Microsoft-Windows-TerminalServices-Gateway: NETWORK SERVICE: NT AUTHORITY: some-host-name: The user "someuser\somedomain", on client computer "1.2.3.4", connected to resource "resourceName". Connection protocol used: "HTTP".
+  2018 Aug 20 10:10:36 WinEvtLog: Microsoft-Windows-TerminalServices-Gateway/Operational: INFORMATION(303): Microsoft-Windows-TerminalServices-Gateway: NETWORK SERVICE: NT AUTHORITY: some-host-name: The user "someuser\somedomain", on client computer "1.2.3.4", disconnected from the following network resource: "resourceName". Before the user disconnected, the client transferred 1285 bytes and received 3122 bytes. The client session duration was 43 seconds. Connection protocol used: "HTTP".
+  2018 Aug 21 09:49:54 WinEvtLog: Microsoft-Windows-TerminalServices-Gateway/Operational: WARNING(304): Microsoft-Windows-TerminalServices-Gateway: NETWORK SERVICE: NT AUTHORITY: some-host-name: The user "someuser\somedomain", on client computer "195.160.232.242", met connection authorization policy and resource authorization policy requirements, but could not connect to resource "resourceName". Connection protocol used: "HTTP". The following error occurred: "23005".
 -->
-
-
 <decoder name="TerminalServices-Gateway">
   <type>windows</type>
   <parent>windows</parent>
@@ -582,16 +531,14 @@ Event ID 15: FileCreateStreamHash
 </decoder>
 
 
-<!-- Terminal Services END -->
 
-
-<!-- Windows generic -->
 
 <!--
-2013 Oct 09 17:09:04 WinEvtLog: Application: INFORMATION(1): My Script: (no user): no domain: demo1.foo.example.com: test
-fts:
-2016 Oct 14 11:44:25 WinEvtLog: Security: AUDIT_SUCCESS(528): Microsoft-Windows-Security-Auditing: homer: no domain: my.domain.com: A handle
-2016 Oct 14 11:44:25 WinEvtLog: Security: AUDIT_SUCCESS(528): Microsoft-Windows-Security-Auditing: bart: no domain: my.domain.com: A handle
+  Windows generic
+  2013 Oct 09 17:09:04 WinEvtLog: Application: INFORMATION(1): My Script: (no user): no domain: demo1.foo.example.com: test
+  fts:
+  2016 Oct 14 11:44:25 WinEvtLog: Security: AUDIT_SUCCESS(528): Microsoft-Windows-Security-Auditing: homer: no domain: my.domain.com: A handle
+  2016 Oct 14 11:44:25 WinEvtLog: Security: AUDIT_SUCCESS(528): Microsoft-Windows-Security-Auditing: bart: no domain: my.domain.com: A handle
 -->
 <decoder name="windows_fields">
   <type>windows</type>
@@ -604,21 +551,19 @@ fts:
 </decoder>
 
 <!--
-General:
-2016 Oct 14 11:44:25 WinEvtLog: Security: AUDIT_SUCCESS(4656): Microsoft-Windows-Security-Auditing: (no user): no domain: my.domain.com: A handle to an object was requested. Subject:  Security ID:  S-1-5-21-4109284664-1754905691-1510191782-1615  Account Name:  snaowpc  Account Domain:  DEV  Logon ID:  0x2054e3a2  Object:  Object Server:  Security  Object Type:  File  Object Name:  C:\ossec_test\test_file.txt  Handle ID:  0x15d4  Process Information: Process ID:  0  Process Name:  0xbd0  Access Request Information:  Transaction ID:  {00000000-0000-0000-0000-000000000000}  Accesses:  %%1541      %%4423       Access Mask:  %%1541: %%1801     D:(A;ID;FA;;;S-1-5-21-4109284664-1754905691-1510191782-1615)      %%4423: %%1801 D:(A;ID;FA;;;S-1-5-21-4109284664-1754905691-1510191782-1615)       Privileges Used for Access Check: 0x100080  Restricted SID Count: -
+  General:
+  2016 Oct 14 11:44:25 WinEvtLog: Security: AUDIT_SUCCESS(4656): Microsoft-Windows-Security-Auditing: (no user): no domain: my.domain.com: A handle to an object was requested. Subject:  Security ID:  S-1-5-21-4109284664-1754905691-1510191782-1615  Account Name:  snaowpc  Account Domain:  DEV  Logon ID:  0x2054e3a2  Object:  Object Server:  Security  Object Type:  File  Object Name:  C:\ossec_test\test_file.txt  Handle ID:  0x15d4  Process Information: Process ID:  0  Process Name:  0xbd0  Access Request Information:  Transaction ID:  {00000000-0000-0000-0000-000000000000}  Accesses:  %%1541      %%4423       Access Mask:  %%1541: %%1801     D:(A;ID;FA;;;S-1-5-21-4109284664-1754905691-1510191782-1615)      %%4423: %%1801 D:(A;ID;FA;;;S-1-5-21-4109284664-1754905691-1510191782-1615)       Privileges Used for Access Check: 0x100080  Restricted SID Count: -
 
-General with '-':
-2016 Oct 14 11:44:25 WinEvtLog: Security: AUDIT_SUCCESS(4656): Microsoft-Windows-Security-Auditing: (no user): no domain: my.domain.com: A handle to an object was requested. Subject:  Security ID:  S-1-5-21-4109284664-1754905691-1510191782-1615  Account Name:  -  Account Domain:  -  Logon ID:  0x2054e3a2  Object:  Object Server:  Security  Object Type:  File  Object Name:  C:\ossec_test\test_file.txt  Handle ID:  0x15d4  Process Information: Process ID:  0  Process Name:  0xbd0  Access Request Information:  Transaction ID:  {00000000-0000-0000-0000-000000000000}  Accesses:  %%1541      %%4423       Access Mask:  %%1541: %%1801     D:(A;ID;FA;;;S-1-5-21-4109284664-1754905691-1510191782-1615)      %%4423: %%1801 D:(A;ID;FA;;;S-1-5-21-4109284664-1754905691-1510191782-1615)       Privileges Used for Access Check: 0x100080  Restricted SID Count: -
+  General with '-':
+  2016 Oct 14 11:44:25 WinEvtLog: Security: AUDIT_SUCCESS(4656): Microsoft-Windows-Security-Auditing: (no user): no domain: my.domain.com: A handle to an object was requested. Subject:  Security ID:  S-1-5-21-4109284664-1754905691-1510191782-1615  Account Name:  -  Account Domain:  -  Logon ID:  0x2054e3a2  Object:  Object Server:  Security  Object Type:  File  Object Name:  C:\ossec_test\test_file.txt  Handle ID:  0x15d4  Process Information: Process ID:  0  Process Name:  0xbd0  Access Request Information:  Transaction ID:  {00000000-0000-0000-0000-000000000000}  Accesses:  %%1541      %%4423       Access Mask:  %%1541: %%1801     D:(A;ID;FA;;;S-1-5-21-4109284664-1754905691-1510191782-1615)      %%4423: %%1801 D:(A;ID;FA;;;S-1-5-21-4109284664-1754905691-1510191782-1615)       Privileges Used for Access Check: 0x100080  Restricted SID Count: -
 
-Tabs:
-2016 Oct 14 11:44:25 WinEvtLog: Security: AUDIT_SUCCESS(4656): Microsoft-Windows-Security-Auditing: (no user): no domain: my.domain.com: A handle to an object was requested. Subject:	Security ID:	S-1-5-21-4109284664-1754905691-1510191782-1615	Account Name:	snaowpc	Account Domain:	DEV	Logon ID:	0x2054e3a2	Object:	Object Server:	Security	Object Type:	File	Object Name:	C:\ossec_test\test_file.txt	Handle ID:	0x15d4	Process Information: Process ID:	0	Process Name:	0xbd0	Access Request Information:	Transaction ID:	{00000000-0000-0000-0000-000000000000}	Accesses:	%%1541			%%4423			 Access Mask:	%%1541: %%1801		 D:(A;ID;FA;;;S-1-5-21-4109284664-1754905691-1510191782-1615)			%%4423: %%1801 D:(A;ID;FA;;;S-1-5-21-4109284664-1754905691-1510191782-1615)			 Privileges Used for Access Check: 0x100080	Restricted SID Count: -
+  Tabs:
+  2016 Oct 14 11:44:25 WinEvtLog: Security: AUDIT_SUCCESS(4656): Microsoft-Windows-Security-Auditing: (no user): no domain: my.domain.com: A handle to an object was requested. Subject:	Security ID:	S-1-5-21-4109284664-1754905691-1510191782-1615	Account Name:	snaowpc	Account Domain:	DEV	Logon ID:	0x2054e3a2	Object:	Object Server:	Security	Object Type:	File	Object Name:	C:\ossec_test\test_file.txt	Handle ID:	0x15d4	Process Information: Process ID:	0	Process Name:	0xbd0	Access Request Information:	Transaction ID:	{00000000-0000-0000-0000-000000000000}	Accesses:	%%1541			%%4423			 Access Mask:	%%1541: %%1801		 D:(A;ID;FA;;;S-1-5-21-4109284664-1754905691-1510191782-1615)			%%4423: %%1801 D:(A;ID;FA;;;S-1-5-21-4109284664-1754905691-1510191782-1615)			 Privileges Used for Access Check: 0x100080	Restricted SID Count: -
 
-Subject:
-2017 Apr 18 17:30:52 WinEvtLog: Security: AUDIT_FAILURE(4625): Microsoft-Windows-Security-Auditing: (no user): no domain: WIN-1: An account failed to log on. Subject: Security ID: S-1-5-10 Account Name: WIN-1$ Account Domain: WORKGROUP Logon ID: 0x3E7 Logon Type: 10 Account For Which Logon Failed: Security ID: S-1-0-0 Account Name: Santiago Account Domain: test2 Failure Information: Failure Reason: Unknown user name or bad password. Status: 0xC000006D Sub Status: 0xC0000064 Process Information: Caller Process ID: 0xb50 Caller Process Name: C:\Windows\System32\winlogon.exe Network Information: Workstation Name: WIN-1 Source Network Address: 17.217.25.247 Source Port: 0 Detailed Authentication Information: Logon Process: User32 Authentication Package: Negotiate Transited Services: - Package Name (NTLM only): - Key Length: 0 This event is generated when a logon request fails. It.
-
-2017 Jun 10 12:34:01 WinEvtLog: Security: AUDIT_SUCCESS(4740): Microsoft-Windows-Security-Auditing: (no user): no domain: SERVER.mydomain.local: 0x8000000000000000    message: A user account was locked out.  Subject:  Security ID:  S-1-5-18  Account Name:  SERVER$  Account Domain:  MYDOMAIN  Logon ID:  0x3e7  Account That Was Locked Out:  Security ID:  S-1-5-21-1634102539-605432415-635521153-12345  Account Name:  user_account_name  Additional Information:  Caller Computer Name: OTHERSERVER
+  Subject:
+  2017 Apr 18 17:30:52 WinEvtLog: Security: AUDIT_FAILURE(4625): Microsoft-Windows-Security-Auditing: (no user): no domain: WIN-1: An account failed to log on. Subject: Security ID: S-1-5-10 Account Name: WIN-1$ Account Domain: WORKGROUP Logon ID: 0x3E7 Logon Type: 10 Account For Which Logon Failed: Security ID: S-1-0-0 Account Name: Santiago Account Domain: test2 Failure Information: Failure Reason: Unknown user name or bad password. Status: 0xC000006D Sub Status: 0xC0000064 Process Information: Caller Process ID: 0xb50 Caller Process Name: C:\Windows\System32\winlogon.exe Network Information: Workstation Name: WIN-1 Source Network Address: 17.217.25.247 Source Port: 0 Detailed Authentication Information: Logon Process: User32 Authentication Package: Negotiate Transited Services: - Package Name (NTLM only): - Key Length: 0 This event is generated when a logon request fails. It.
+  2017 Jun 10 12:34:01 WinEvtLog: Security: AUDIT_SUCCESS(4740): Microsoft-Windows-Security-Auditing: (no user): no domain: SERVER.mydomain.local: 0x8000000000000000    message: A user account was locked out.  Subject:  Security ID:  S-1-5-18  Account Name:  SERVER$  Account Domain:  MYDOMAIN  Logon ID:  0x3e7  Account That Was Locked Out:  Security ID:  S-1-5-21-1634102539-605432415-635521153-12345  Account Name:  user_account_name  Additional Information:  Caller Computer Name: OTHERSERVER
 -->
-
 <decoder name="windows_fields">
   <type>windows</type>
   <parent>windows</parent>
@@ -676,9 +621,8 @@ Subject:
 </decoder>
 
 <!--
-2016 Oct 20 09:42:00 WinEvtLog: Security: AUDIT_SUCCESS(4656): Microsoft-Windows-Security-Auditing: (no user): no domain: snaowpc: A handle to an object was requested.    Subject:   Security ID:  S-1-5-21-466511811-1859800458-3340017162-1001   Account Name:  Pedro   Account Domain:  snaowpc   Logon ID:  0x1274A0BE    Object:   Source Network Address: 10.0.0.4 Object Server:  Security   Object Type:  File   Object Name:  C:\ossec_test\perro1 - copia (2).txt   Handle ID:  0x1dd0 Resource Attributes: -    Process Information:   Process ID:  0x1024   Process Name:  C:\Windows\explorer.exe    Access Request Information:   Transaction ID:  {00000000-0000-0000-0000-000000000000}   Accesses:  DELETE      READ_CONTROL      WRITE_DAC      SYNCHRONIZE      ReadData (or ListDirectory)      WriteData (or AddFile)      AppendData (or AddSubdirectory or CreatePipeInstance)      ReadEA      WriteEA      ReadAttributes      Write Attributes         Access Reasons:  -   Access Mask:  0x17019F   Privileges Used for Access Check: -   Restricted SID Count: 0
-
-2016 Oct 20 09:42:00 WinEvtLog: Security: AUDIT_SUCCESS(4656): Microsoft-Windows-Security-Auditing: (no user): no domain: snaowpc: A handle to an object was requested.    Subject:   Security ID:  S-1-5-21-466511811-1859800458-3340017162-1001   Account Name:  Pedro   Account Domain:  snaowpc   Logon ID:  0x1274A0BE    Object:   Source Network Address: - Object Server:  Security   Object Type:  File   Object Name:  C:\ossec_test\perro1 - copia (2).txt   Handle ID:  0x1dd0 Resource Attributes: -    Process Information:   Process ID:  0x1024   Process Name:  C:\Windows\explorer.exe    Access Request Information:   Transaction ID:  {00000000-0000-0000-0000-000000000000}   Accesses:  DELETE      READ_CONTROL      WRITE_DAC      SYNCHRONIZE      ReadData (or ListDirectory)      WriteData (or AddFile)      AppendData (or AddSubdirectory or CreatePipeInstance)      ReadEA      WriteEA      ReadAttributes      Write Attributes         Access Reasons:  -   Access Mask:  0x17019F   Privileges Used for Access Check: -   Restricted SID Count: 0
+  2016 Oct 20 09:42:00 WinEvtLog: Security: AUDIT_SUCCESS(4656): Microsoft-Windows-Security-Auditing: (no user): no domain: snaowpc: A handle to an object was requested.    Subject:   Security ID:  S-1-5-21-466511811-1859800458-3340017162-1001   Account Name:  Pedro   Account Domain:  snaowpc   Logon ID:  0x1274A0BE    Object:   Source Network Address: 10.0.0.4 Object Server:  Security   Object Type:  File   Object Name:  C:\ossec_test\perro1 - copia (2).txt   Handle ID:  0x1dd0 Resource Attributes: -    Process Information:   Process ID:  0x1024   Process Name:  C:\Windows\explorer.exe    Access Request Information:   Transaction ID:  {00000000-0000-0000-0000-000000000000}   Accesses:  DELETE      READ_CONTROL      WRITE_DAC      SYNCHRONIZE      ReadData (or ListDirectory)      WriteData (or AddFile)      AppendData (or AddSubdirectory or CreatePipeInstance)      ReadEA      WriteEA      ReadAttributes      Write Attributes         Access Reasons:  -   Access Mask:  0x17019F   Privileges Used for Access Check: -   Restricted SID Count: 0
+  2016 Oct 20 09:42:00 WinEvtLog: Security: AUDIT_SUCCESS(4656): Microsoft-Windows-Security-Auditing: (no user): no domain: snaowpc: A handle to an object was requested.    Subject:   Security ID:  S-1-5-21-466511811-1859800458-3340017162-1001   Account Name:  Pedro   Account Domain:  snaowpc   Logon ID:  0x1274A0BE    Object:   Source Network Address: - Object Server:  Security   Object Type:  File   Object Name:  C:\ossec_test\perro1 - copia (2).txt   Handle ID:  0x1dd0 Resource Attributes: -    Process Information:   Process ID:  0x1024   Process Name:  C:\Windows\explorer.exe    Access Request Information:   Transaction ID:  {00000000-0000-0000-0000-000000000000}   Accesses:  DELETE      READ_CONTROL      WRITE_DAC      SYNCHRONIZE      ReadData (or ListDirectory)      WriteData (or AddFile)      AppendData (or AddSubdirectory or CreatePipeInstance)      ReadEA      WriteEA      ReadAttributes      Write Attributes         Access Reasons:  -   Access Mask:  0x17019F   Privileges Used for Access Check: -   Restricted SID Count: 0
 -->
 <decoder name="windows_fields">
   <type>windows</type>
@@ -687,15 +631,14 @@ Subject:
   <order>srcip</order>
 </decoder>
 
-<!-- Windows generic END -->
-
-<!-- Windows decoder -NTsyslog format
-  - Will extract extra_data (as win source),action (as win category), id,
-  - username and computer name (as url).
-  - Examples:
-  - security[failure] 577 IBM17M\Jeremy Lee  Privileged Service Called:  Server:Security  Service:-  Primary User Name:IBM17M$  Primary Domain:LEETHERNET  Primary Logon ID:(0x0,0x3E7)  Client User Name:Jeremy Lee  Client Domain:IBM17M  Client Logon ID:(0x0,0x1447F)  Privileges:SeSecurityPrivilege
-  - security[success] 528 IBM17M\Jeremy Lee  Successful Logon:  User Name:Jeremy Lee  Domain:IBM17M  Logon ID:(0x0,0x3A2E471)  Logon Type:2  Logon Process:User32    Authentication Package:Negotiate  Workstation Name:IBM17M  Logon GUID: {00000000-0000-0000-0000-000000000000}
-  -->
+<!--
+  Windows decoder -NTsyslog format
+  Will extract extra_data (as win source),action (as win category), id,
+  username and computer name (as url).
+  Examples:
+  security[failure] 577 IBM17M\Jeremy Lee  Privileged Service Called:  Server:Security  Service:-  Primary User Name:IBM17M$  Primary Domain:LEETHERNET  Primary Logon ID:(0x0,0x3E7)  Client User Name:Jeremy Lee  Client Domain:IBM17M  Client Logon ID:(0x0,0x1447F)  Privileges:SeSecurityPrivilege
+  security[success] 528 IBM17M\Jeremy Lee  Successful Logon:  User Name:Jeremy Lee  Domain:IBM17M  Logon ID:(0x0,0x3A2E471)  Logon Type:2  Logon Process:User32    Authentication Package:Negotiate  Workstation Name:IBM17M  Logon GUID: {00000000-0000-0000-0000-000000000000}
+-->
 <decoder name="windows-ntsyslog">
   <type>windows</type>
   <prematch>^security[\w+] \d+ </prematch>
@@ -704,31 +647,32 @@ Subject:
 </decoder>
 
 
-<!-- Windows decoder - Snare format.
-  - Will extract extra_data (as win source), action (as category), id,
-  - username and computer name (as system_name).
-  -
-  - These logs must be tab-separated (as specified in the Snare format)
-  -
-  - Examples:
-  - Aug 11 11:11:11 xx.org MSWinEventLog  1       System 59221    Thu Aug 11 01:11:11 2006        17      Windows Update Agent    Unknown User
-  - Jan 16 05:52:15 hostname.xx.org MSWinEventLog 1
+<!--
+  Windows decoder - Snare format.
+  Will extract extra_data (as win source), action (as category), id,
+  username and computer name (as system_name).
+
+  These logs must be tab-separated (as specified in the Snare format)
+
+  Examples:
+  Aug 11 11:11:11 xx.org MSWinEventLog  1       System 59221    Thu Aug 11 01:11:11 2006        17      Windows Update Agent    Unknown User
+  Jan 16 05:52:15 hostname.xx.org MSWinEventLog 1
   Security        13049   Tue Jan 16 05:52:15 2007        680     Security
   SYSTEM  User    Success Audit   ACTUATE Account Logon
   Account Used for Logon by: MICROSOFT_AUTHENTICATION_PACKAGE_V1_0
   Account Name:     IUSR_HOSTNAME    Workstation:      ACTUATE
   12653
-  - Jan 16 13:02:24 hostname.yy.org MSWinEventLog 1
+  Jan 16 13:02:24 hostname.yy.org MSWinEventLog 1
   Application     14539   Tue Jan 16 13:02:24 2007        1704    SceCli
   Unknown User    N/A     Information     ACTUATE None      Security
   policy in the Group policy objects are applied successfully.    67
-  - Jan 16 15:41:37 hostname.zz.org MSWinEventLog 1       System
+  Jan 16 15:41:37 hostname.zz.org MSWinEventLog 1       System
   15059   Tue Jan 16 15:41:37 2007        10      Print   username User
   Information     HOSTNAME None            Document 76,
   /directory/directory/directory/directory/directory/date/Afilename owned
   by username was printed on hostname_duplex via port hostname_duplex.
   Size in bytes: 19543296; pages printed: 162        361
-  -->
+-->
 <decoder name="windows-snare">
   <type>windows</type>
   <prematch>^MSWinEventLog\t\d\t\.+\t\d+\t\w\w\S+ \w\w\w \d\d \d\d</prematch>


### PR DESCRIPTION
|Related issue|
|---|
|#8301|

## Description

This PR aims to revert PR #8842

The issues resolved are:
- Source logs should be analyzed in deeper detail.
- No impact in detection rules

## Checks and changes 

### Syntax

- ~~1.a Rule tags order must be compliant.~~
- ~~1.b Decoder tags order must be compliant.~~
- ~~1.c XML blocks must as compact as possible.~~
- ~~1.d Only one empty line between rule/decoder and the next rule/decoder.~~
- ~~1.e Decoder extracted fields names must use '_' whether a space is needed.~~
- ~~1.f Decoder name must use '-' whether a space is needed.~~
 
### Grammar

- ~~2.a Grammar quality.~~
- ~~2.b Similar phrases must keep tenses and expressions.~~
- ~~2.c Grammar basic rules like capitalization, punctuation marks, sentence construction, and others.~~


### Semantic

- ~~3.a New decoder, rule, or test are written in the correct file and grouped correctly inside the file.~~
- ~~3.b Group similar rules under same ID's group.~~
- ~~3.c:~~
     - ~~3.c1 Find and reuse group name before creating a new one.~~
     - ~~3.c2 Include a new group definition in a PR comment.~~
     - ~~3.c3 Any group name must use '_' whether it does need a space char.~~
     - ~~3.c4 The groups inside a tag must be sorted in alphabetical order.~~
- ~~3.d Rule level should be compliant with the [documentation](https://documentation.wazuh.com/current/user-manual/ruleset/rules-classification.html).~~

### Unit testing

- ~~4.a A metadata block at the beginning of the .ini file describing software, version, and logs source.~~
- ~~4.b Each new rule must have at least one test entry in the correct .ini file.~~
- [x] 4.c Runtest.py must pass and must include the results in raw format here.

<details><summary>All rules and decoders test.</summary>
<p>

```
- [ File = ./tests/sophos_fw.ini ] ---------
..........

- [ File = ./tests/dropbear.ini ] ---------
...

- [ File = ./tests/squid_rules.ini ] ---------
..

- [ File = ./tests/sudo.ini ] ---------
........

- [ File = ./tests/gitlab.ini ] ---------
.........................

- [ File = ./tests/glpi.ini ] ---------
...

- [ File = ./tests/unbound.ini ] ---------


- [ File = ./tests/mailscanner.ini ] ---------
.

- [ File = ./tests/samba.ini ] ---------
....

- [ File = ./tests/cisco_ios.ini ] ---------
.................

- [ File = ./tests/cimserver.ini ] ---------
..

- [ File = ./tests/audit_recon.ini ] ---------
..

- [ File = ./tests/fortigate.ini ] ---------
........................................

- [ File = ./tests/cisco_asa.ini ] ---------
........................................................................................

- [ File = ./tests/systemd.ini ] ---------
..

- [ File = ./tests/openldap.ini ] ---------
.........

- [ File = ./tests/oscap.ini ] ---------
................................

- [ File = ./tests/github.ini ] ---------
....................................................................................................................................................................................................................................................................................................................................

- [ File = ./tests/pfsense.ini ] ---------
..

- [ File = ./tests/apache.ini ] ---------
..................

- [ File = ./tests/api.ini ] ---------
............................

- [ File = ./tests/SonicWall.ini ] ---------
........

- [ File = ./tests/rsh.ini ] ---------
..

- [ File = ./tests/auditd.ini ] ---------
...

- [ File = ./tests/junos.ini ] ---------
...

- [ File = ./tests/owlh.ini ] ---------
....

- [ File = ./tests/pam.ini ] ---------
.....

- [ File = ./tests/sophos.ini ] ---------
........

- [ File = ./tests/modsecurity.ini ] ---------
......

- [ File = ./tests/paloalto.ini ] ---------
................

- [ File = ./tests/cylance.ini ] ---------
.......

- [ File = ./tests/pix.ini ] ---------
......................

- [ File = ./tests/sophos-utm-firewall.ini ] ---------
......

- [ File = ./tests/exim.ini ] ---------
.......

- [ File = ./tests/freepbx.ini ] ---------
......

- [ File = ./tests/trendmicro-cloud-one.ini ] ---------
.................

- [ File = ./tests/kernel_usb.ini ] ---------
......

- [ File = ./tests/netscreen.ini ] ---------
....

- [ File = ./tests/panda_paps.ini ] ---------
........

- [ File = ./tests/nextcloud.ini ] ---------
........

- [ File = ./tests/aws_s3_access.ini ] ---------
.......

- [ File = ./tests/doas.ini ] ---------
....

- [ File = ./tests/icinga.ini ] ---------
....

- [ File = ./tests/apparmor.ini ] ---------
.....

- [ File = ./tests/sshd.ini ] ---------
...........................................

- [ File = ./tests/opensmtpd.ini ] ---------
.......

- [ File = ./tests/proftpd.ini ] ---------
.......

- [ File = ./tests/named.ini ] ---------
.....

- [ File = ./tests/syslog.ini ] ---------
......

- [ File = ./tests/checkpoint_smart1.ini ] ---------
..................

- [ File = ./tests/fireeye.ini ] ---------
...

- [ File = ./tests/office365.ini ] ---------
................................................................................................................................

- [ File = ./tests/vsftpd.ini ] ---------
....

- [ File = ./tests/openvpn_ldap.ini ] ---------
..

- [ File = ./tests/cpanel.ini ] ---------
.......

- [ File = ./tests/audit_scp.ini ] ---------
.

- [ File = ./tests/cloudlfare-waf.ini ] ---------
.............

- [ File = ./tests/web_appsec.ini ] ---------
...............................

- [ File = ./tests/fortiauth.ini ] ---------
....

- [ File = ./tests/cisco_ftd.ini ] ---------
..........................................

- [ File = ./tests/ossec.ini ] ---------
.....

- [ File = ./tests/arbor.ini ] ---------
..

- [ File = ./tests/huawei_usg.ini ] ---------
...

- [ File = ./tests/exchange.ini ] ---------
..

- [ File = ./tests/postfix.ini ] ---------
..

- [ File = ./tests/su.ini ] ---------
.....

- [ File = ./tests/vuln_detector.ini ] ---------
..

- [ File = ./tests/f5_big_ip.ini ] ---------
...........................................

- [ File = ./tests/mcafee_epo.ini ] ---------
.

- [ File = ./tests/audit_lateral.ini ] ---------
......

- [ File = ./tests/sysmon.ini ] ---------
...

- [ File = ./tests/web_rules.ini ] ---------
..........

- [ File = ./tests/iptables.ini ] ---------
........

- [ File = ./tests/eset.ini ] ---------
........

- [ File = ./tests/gcp.ini ] ---------
...........

- [ File = ./tests/firewalld.ini ] ---------
..

- [ File = ./tests/dovecot.ini ] ---------
...............

- [ File = ./tests/nginx.ini ] ---------
............


|Component |  Tested  |  Total   | Coverage |
| -------- | -------- | -------- | -------- |
|  Rules   |   983    |   4171   |  23.57%  |
| Decoders |    77    |   172    |  44.77%  |

|          File           |  Passed  |  Failed  |  Status  |
|        --------         | -------- | -------- | -------- |
|./tests/sysmon.ini       |    3     |    0     |   ✅    |
|./tests/proftpd.ini      |    7     |    0     |   ✅    |
|./tests/glpi.ini         |    3     |    0     |   ✅    |
|./tests/dovecot.ini      |    15    |    0     |   ✅    |
|./tests/exim.ini         |    7     |    0     |   ✅    |
|./tests/huawei_usg.ini   |    3     |    0     |   ✅    |
|./tests/squid_rules.ini  |    2     |    0     |   ✅    |
|./tests/pix.ini          |    22    |    0     |   ✅    |
|./tests/samba.ini        |    4     |    0     |   ✅    |
|./tests/mcafee_epo.ini   |    1     |    0     |   ✅    |
|./tests/checkpoint_smart1.ini|    18    |    0     |   ✅    |
|./tests/pfsense.ini      |    2     |    0     |   ✅    |
|./tests/iptables.ini     |    8     |    0     |   ✅    |
|./tests/cisco_asa.ini    |    88    |    0     |   ✅    |
|./tests/dropbear.ini     |    3     |    0     |   ✅    |
|./tests/systemd.ini      |    2     |    0     |   ✅    |
|./tests/SonicWall.ini    |    8     |    0     |   ✅    |
|./tests/panda_paps.ini   |    8     |    0     |   ✅    |
|./tests/mailscanner.ini  |    1     |    0     |   ✅    |
|./tests/owlh.ini         |    4     |    0     |   ✅    |
|./tests/fortiauth.ini    |    4     |    0     |   ✅    |
|./tests/cisco_ios.ini    |    17    |    0     |   ✅    |
|./tests/vuln_detector.ini|    2     |    0     |   ✅    |
|./tests/cloudlfare-waf.ini|    13    |    0     |   ✅    |
|./tests/gcp.ini          |    11    |    0     |   ✅    |
|./tests/openldap.ini     |    9     |    0     |   ✅    |
|./tests/unbound.ini      |    0     |    0     |   ✅    |
|./tests/oscap.ini        |    32    |    0     |   ✅    |
|./tests/f5_big_ip.ini    |    43    |    0     |   ✅    |
|./tests/sophos.ini       |    8     |    0     |   ✅    |
|./tests/opensmtpd.ini    |    7     |    0     |   ✅    |
|./tests/exchange.ini     |    2     |    0     |   ✅    |
|./tests/icinga.ini       |    4     |    0     |   ✅    |
|./tests/netscreen.ini    |    4     |    0     |   ✅    |
|./tests/doas.ini         |    4     |    0     |   ✅    |
|./tests/rsh.ini          |    2     |    0     |   ✅    |
|./tests/arbor.ini        |    2     |    0     |   ✅    |
|./tests/office365.ini    |   128    |    0     |   ✅    |
|./tests/paloalto.ini     |    16    |    0     |   ✅    |
|./tests/cylance.ini      |    7     |    0     |   ✅    |
|./tests/fortigate.ini    |    40    |    0     |   ✅    |
|./tests/ossec.ini        |    5     |    0     |   ✅    |
|./tests/web_rules.ini    |    10    |    0     |   ✅    |
|./tests/sudo.ini         |    8     |    0     |   ✅    |
|./tests/audit_lateral.ini|    6     |    0     |   ✅    |
|./tests/cisco_ftd.ini    |    42    |    0     |   ✅    |
|./tests/github.ini       |   324    |    0     |   ✅    |
|./tests/postfix.ini      |    2     |    0     |   ✅    |
|./tests/syslog.ini       |    6     |    0     |   ✅    |
|./tests/kernel_usb.ini   |    6     |    0     |   ✅    |
|./tests/api.ini          |    28    |    0     |   ✅    |
|./tests/sophos-utm-firewall.ini|    6     |    0     |   ✅    |
|./tests/apparmor.ini     |    5     |    0     |   ✅    |
|./tests/audit_scp.ini    |    1     |    0     |   ✅    |
|./tests/nginx.ini        |    12    |    0     |   ✅    |
|./tests/named.ini        |    5     |    0     |   ✅    |
|./tests/sophos_fw.ini    |    10    |    0     |   ✅    |
|./tests/openvpn_ldap.ini |    2     |    0     |   ✅    |
|./tests/cimserver.ini    |    2     |    0     |   ✅    |
|./tests/vsftpd.ini       |    4     |    0     |   ✅    |
|./tests/freepbx.ini      |    6     |    0     |   ✅    |
|./tests/sshd.ini         |    43    |    0     |   ✅    |
|./tests/junos.ini        |    3     |    0     |   ✅    |
|./tests/modsecurity.ini  |    6     |    0     |   ✅    |
|./tests/nextcloud.ini    |    8     |    0     |   ✅    |
|./tests/fireeye.ini      |    3     |    0     |   ✅    |
|./tests/cpanel.ini       |    7     |    0     |   ✅    |
|./tests/trendmicro-cloud-one.ini|    17    |    0     |   ✅    |
|./tests/pam.ini          |    5     |    0     |   ✅    |
|./tests/su.ini           |    5     |    0     |   ✅    |
|./tests/apache.ini       |    18    |    0     |   ✅    |
|./tests/gitlab.ini       |    25    |    0     |   ✅    |
|./tests/aws_s3_access.ini|    7     |    0     |   ✅    |
|./tests/firewalld.ini    |    2     |    0     |   ✅    |
|./tests/eset.ini         |    8     |    0     |   ✅    |
|./tests/auditd.ini       |    3     |    0     |   ✅    |
|./tests/web_appsec.ini   |    31    |    0     |   ✅    |
|./tests/audit_recon.ini  |    2     |    0     |   ✅    |


```
</p>
</details>

- ~~4.d New CDB lists must include the proper test entry in the correct .ini file.~~

### E2E testing

- ~~5.a Logs for new or modified decoder/rules sent to a manager running with this PR ruleset appear in Kibana.~~ 
- ~~5.b There are not affected or broken visualizations on Kibana.~~
- ~~5.c New or modified items can be seen correctly using APP ruleset navigation.~~

### Elasticsearch Template

- ~~6.a Known fields with output format managed and usually used for searching are included in template array index.query.default_field.~~
- ~~6.b The new field with the correct date format is stored as a "date" type field in the template.~~
- ~~6.c The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template.~~
- ~~6.d Known fields with output format managed and usually used for searching are included in the template.~~

### Stoppers

- ~~7.a No previous rule ID changes without triple check.~~
- ~~7.b No previous decoder name changes without triple check.~~
- ~~7.c No previous file name changes without triple check.~~
- ~~7.d No previous test changes its 'rule' field value without triple check.~~

### Others

- ~~8.a Each file has the correct copyright block.~~
- ~~8.b The copyright block doesn't have "Author" only "Created by Wazuh". To include an "Author" request triple check.~~
- ~~8.c The copyright block doesn't use "-".~~
- ~~8.d The rule files don't have any sample log.~~
- ~~8.e The decoder file has sample logs next to the decoder that matches that log.~~
- ~~8.f The decoder and rule files have information about software, version, and any helpful information.~~
- ~~8.g The PR has a single commit with CHANGELOG changes in the correct format.~~
- ~~8.h The new rule ID is not in use.~~
- ~~8.i The new rule ID must be in the defined IDs range.~~
- ~~8.j New rules ID range must be verified with a triple check and noted in the rules ID document.~~
- ~~8.k The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template.~~