### PR TITLE
Saving registration time for agents in UTC format for both agent-timestamps and DB

### DIFF
--- a/src/headers/time_op.h
+++ b/src/headers/time_op.h
@@ -88,4 +88,13 @@ long long int get_windows_file_time_epoch(FILETIME ft);
  */
 bool is_leap_year(int year);
 
+/**
+ * @brief Method to obtain the UNIX timestamp from a time structure in UTC format.
+ *        It internally uses mktime() and TZ environemnt variable, to mimic the non-standard timegm() function.
+ *
+ * @param t Time structure to obtain timestamp from.
+ * @return time_t UNIX timestamp in UTC format.
+ */
+time_t w_mktime_utc (struct tm* t);
+
 #endif // TIME_OP_H

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -803,7 +803,7 @@ int OS_WriteTimestamps(keystore * keys) {
         char cidr[20];
         struct tm tm_result = { .tm_sec = 0 };
 
-        strftime(timestamp, 40, "%Y-%m-%d %H:%M:%S", localtime_r(&entry->time_added, &tm_result));
+        strftime(timestamp, 40, "%Y-%m-%d %H:%M:%S", gmtime_r(&entry->time_added, &tm_result));
 
         if (fprintf(file.fp, "%s %s %s %s\n", entry->id, entry->name, OS_CIDRtoStr(entry->ip, cidr, 20) ? entry->ip->ip : cidr, timestamp) < 0) {
             merror(FWRITE_ERROR, file.name, errno, strerror(errno));

--- a/src/shared/time_op.c
+++ b/src/shared/time_op.c
@@ -139,3 +139,25 @@ bool is_leap_year(int year) {
 
     return result;
 }
+
+time_t w_mktime_utc (struct tm* t) {
+    char *tz = NULL;
+    time_t result = {0};
+
+#ifndef WIN32
+    // The environment variable is needed to avoid the non-standard method timegm()
+    tz = getenv("TZ");
+    setenv("TZ", "", 1);
+    tzset();
+
+    result = mktime(t);
+
+    if (tz)
+        setenv("TZ", tz, 1);
+    else
+        unsetenv("TZ");
+    tzset();
+#endif
+
+    return result;
+}

--- a/src/wazuh_db/helpers/wdb_global_helpers.c
+++ b/src/wazuh_db/helpers/wdb_global_helpers.c
@@ -12,6 +12,7 @@
 #include "wdb_global_helpers.h"
 #include "defs.h"
 #include "wazuhdb_op.h"
+#include "headers/time_op.h"
 
 #ifdef WIN32
 #define chown(x, y, z) 0
@@ -1421,10 +1422,11 @@ time_t get_agent_date_added(int agent_id) {
                 fclose(fp);
                 return 0;
             }
+
             t.tm_year -= 1900;
             t.tm_mon -= 1;
             t.tm_isdst = -1;
-            t_of_sec = mktime(&t);
+            t_of_sec = w_mktime_utc(&t);
 
             free(date);
             fclose(fp);


### PR DESCRIPTION
|Related issue|
|---|
|#8502|

## Description

This PR changes the registration date format for agents in both **global.db** and `agent-timetamps` file to UTC.
Currently, it's saved in local time in the file but the conversion for the DB results in a wrong UNIX timestamp:
- Both values are not the same, leading to a data inconsistency
- Even if the conversion would be successful, not using UTC format could lead to confusions, due to DTS for example

Also, the API expects the time values in UTC as we can see in https://github.com/wazuh/wazuh/issues/3784.
The only consideration related to this fix is that, in case of an upgrade, the new registered agents would have a different time format than previous ones.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Added unit tests (for new features)
