### PR TITLE
Fix duplicate values from hotfixes provider

### DIFF
--- a/src/data_provider/cppcheckSuppress.txt
+++ b/src/data_provider/cppcheckSuppress.txt
@@ -1,5 +1,5 @@
 *:*src/sysInfoLinux.cpp:259
 *:*src/packages/pkgWrapper.h:105
-*:*src/packages/packagesWindowsParserHelper.h:55
+*:*src/packages/packagesWindowsParserHelper.h:54
 *:*src/packages/packagesWindowsParserHelper.h:182
 *:*src/packages/packagesWindowsParserHelper.h:197

--- a/src/data_provider/src/packages/packagesWindowsParserHelper.h
+++ b/src/data_provider/src/packages/packagesWindowsParserHelper.h
@@ -42,11 +42,10 @@ namespace PackageWindowsHelper
         return ret;
     }
 
-    static void getHotFixFromReg(const HKEY key, const std::string& subKey, nlohmann::json& data)
+    static void getHotFixFromReg(const HKEY key, const std::string& subKey, std::set<std::string>& hotfixes)
     {
         try
         {
-            std::set<std::string> hotfixes;
             Utils::Registry root{key, subKey, KEY_WOW64_64KEY | KEY_ENUMERATE_SUB_KEYS | KEY_READ};
             const auto callback
             {
@@ -79,24 +78,16 @@ namespace PackageWindowsHelper
                 }
             };
             root.enumerate(callback);
-
-            for (auto& hotfix : hotfixes)
-            {
-                nlohmann::json hotfixValue;
-                hotfixValue["hotfix"] = std::move(hotfix);
-                data.push_back(std::move(hotfixValue));
-            }
         }
         catch (...)
         {
         }
     }
 
-    static void getHotFixFromRegNT(const HKEY key, const std::string& subKey, nlohmann::json& data)
+    static void getHotFixFromRegNT(const HKEY key, const std::string& subKey, std::set<std::string>& hotfixes)
     {
         try
         {
-            std::set<std::string> hotfixes;
             const auto callback
             {
                 [&key, &subKey, &hotfixes](const std::string & package)
@@ -112,23 +103,16 @@ namespace PackageWindowsHelper
             Utils::Registry root{key, subKey, KEY_WOW64_64KEY | KEY_ENUMERATE_SUB_KEYS | KEY_READ};
             root.enumerate(callback);
 
-            for (auto& hotfix : hotfixes)
-            {
-                nlohmann::json hotfixValue;
-                hotfixValue["hotfix"] = std::move(hotfix);
-                data.push_back(std::move(hotfixValue));
-            }
         }
         catch (...)
         {
         }
     }
 
-    static void getHotFixFromRegWOW(const HKEY key, const std::string& subKey, nlohmann::json& data)
+    static void getHotFixFromRegWOW(const HKEY key, const std::string& subKey, std::set<std::string>& hotfixes)
     {
         try
         {
-            std::set<std::string> hotfixes;
             const auto callback
             {
                 [&key, &subKey, &hotfixes](const std::string & packageKey)
@@ -151,13 +135,6 @@ namespace PackageWindowsHelper
             };
             Utils::Registry root{key, subKey, KEY_WOW64_64KEY | KEY_ENUMERATE_SUB_KEYS | KEY_READ};
             root.enumerate(callback);
-
-            for (auto& hotfix : hotfixes)
-            {
-                nlohmann::json hotfixValue;
-                hotfixValue["hotfix"] = std::move(hotfix);
-                data.push_back(std::move(hotfixValue));
-            }
         }
         catch (...)
         {
@@ -165,11 +142,10 @@ namespace PackageWindowsHelper
 
     }
 
-    static void getHotFixFromRegProduct(const HKEY key, const std::string& subKey, nlohmann::json& data)
+    static void getHotFixFromRegProduct(const HKEY key, const std::string& subKey, std::set<std::string>& hotfixes)
     {
         try
         {
-            std::set<std::string> hotfixes;
             const auto callback
             {
                 [&key, &subKey, &hotfixes](const std::string & packageKey)
@@ -229,12 +205,6 @@ namespace PackageWindowsHelper
             Utils::Registry root{key, subKey, KEY_WOW64_64KEY | KEY_ENUMERATE_SUB_KEYS | KEY_READ};
             root.enumerate(callback);
 
-            for (auto& hotfix : hotfixes)
-            {
-                nlohmann::json hotfixValue;
-                hotfixValue["hotfix"] = std::move(hotfix);
-                data.push_back(std::move(hotfixValue));
-            }
         }
         catch (...)
         {

--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -774,10 +774,20 @@ void SysInfo::getPackages(std::function<void(nlohmann::json&)> callback) const
 
 nlohmann::json SysInfo::getHotfixes() const
 {
+    std::set<std::string> hotfixes;
+    PackageWindowsHelper::getHotFixFromReg(HKEY_LOCAL_MACHINE, PackageWindowsHelper::WIN_REG_HOTFIX, hotfixes);
+    PackageWindowsHelper::getHotFixFromRegNT(HKEY_LOCAL_MACHINE, PackageWindowsHelper::VISTA_REG_HOTFIX, hotfixes);
+    PackageWindowsHelper::getHotFixFromRegWOW(HKEY_LOCAL_MACHINE, PackageWindowsHelper::WIN_REG_WOW_HOTFIX, hotfixes);
+    PackageWindowsHelper::getHotFixFromRegProduct(HKEY_LOCAL_MACHINE, PackageWindowsHelper::WIN_REG_PRODUCT_HOTFIX, hotfixes);
+
     nlohmann::json ret;
-    PackageWindowsHelper::getHotFixFromReg(HKEY_LOCAL_MACHINE, PackageWindowsHelper::WIN_REG_HOTFIX, ret);
-    PackageWindowsHelper::getHotFixFromRegNT(HKEY_LOCAL_MACHINE, PackageWindowsHelper::VISTA_REG_HOTFIX, ret);
-    PackageWindowsHelper::getHotFixFromRegWOW(HKEY_LOCAL_MACHINE, PackageWindowsHelper::WIN_REG_WOW_HOTFIX, ret);
-    PackageWindowsHelper::getHotFixFromRegProduct(HKEY_LOCAL_MACHINE, PackageWindowsHelper::WIN_REG_PRODUCT_HOTFIX, ret);
+
+    for (auto& hotfix : hotfixes)
+    {
+        nlohmann::json hotfixValue;
+        hotfixValue["hotfix"] = std::move(hotfix);
+        ret.push_back(std::move(hotfixValue));
+    }
+
     return ret;
 }

--- a/src/data_provider/tests/sysInfoWin/sysInfoWin_test.cpp
+++ b/src/data_provider/tests/sysInfoWin/sysInfoWin_test.cpp
@@ -33,7 +33,7 @@ TEST_F(SysInfoWinTest, test_extract_HFValue_7618)
 
 TEST_F(SysInfoWinTest, testHF_Valids_Format)
 {
-    nlohmann::json ret;
+    std::set<std::string> ret;
     constexpr auto KB_FORMAT_REGEX_OK { "(KB+[0-9]{6,})"};
     constexpr auto KB_ONLY_FORMAT_REGEX { "(KB)"};
     constexpr auto KB_NO_NUMBERS_FORMAT_REGEX { "(KB+[a-z])"};
@@ -42,17 +42,16 @@ TEST_F(SysInfoWinTest, testHF_Valids_Format)
 
     for (const auto& hf : ret)
     {
-        auto hfValue { hf.at("hotfix").get_ref<const std::string&>() };
-        EXPECT_TRUE(std::regex_match(hfValue, std::regex(KB_FORMAT_REGEX_OK)));
-        EXPECT_FALSE(std::regex_match(hfValue, std::regex(KB_ONLY_FORMAT_REGEX)));
-        EXPECT_FALSE(std::regex_match(hfValue, std::regex(KB_NO_NUMBERS_FORMAT_REGEX)));
-        EXPECT_FALSE(std::regex_match(hfValue, std::regex(KB_WITH_NUMBERS_AND_LETTERS_FORMAT_REGEX)));
+        EXPECT_TRUE(std::regex_match(hf, std::regex(KB_FORMAT_REGEX_OK)));
+        EXPECT_FALSE(std::regex_match(hf, std::regex(KB_ONLY_FORMAT_REGEX)));
+        EXPECT_FALSE(std::regex_match(hf, std::regex(KB_NO_NUMBERS_FORMAT_REGEX)));
+        EXPECT_FALSE(std::regex_match(hf, std::regex(KB_WITH_NUMBERS_AND_LETTERS_FORMAT_REGEX)));
     }
 }
 
 TEST_F(SysInfoWinTest, testHF_NT_Valids_Format)
 {
-    nlohmann::json ret;
+    std::set<std::string> ret;
     constexpr auto KB_FORMAT_REGEX_OK { "(KB+[0-9]{6,})"};
     constexpr auto KB_ONLY_FORMAT_REGEX { "(KB)"};
     constexpr auto KB_NO_NUMBERS_FORMAT_REGEX { "(KB+[a-z])"};
@@ -61,17 +60,16 @@ TEST_F(SysInfoWinTest, testHF_NT_Valids_Format)
 
     for (const auto& hf : ret)
     {
-        auto hfValue { hf.at("hotfix").get_ref<const std::string&>() };
-        EXPECT_TRUE(std::regex_match(hfValue, std::regex(KB_FORMAT_REGEX_OK)));
-        EXPECT_FALSE(std::regex_match(hfValue, std::regex(KB_ONLY_FORMAT_REGEX)));
-        EXPECT_FALSE(std::regex_match(hfValue, std::regex(KB_NO_NUMBERS_FORMAT_REGEX)));
-        EXPECT_FALSE(std::regex_match(hfValue, std::regex(KB_WITH_NUMBERS_AND_LETTERS_FORMAT_REGEX)));
+        EXPECT_TRUE(std::regex_match(hf, std::regex(KB_FORMAT_REGEX_OK)));
+        EXPECT_FALSE(std::regex_match(hf, std::regex(KB_ONLY_FORMAT_REGEX)));
+        EXPECT_FALSE(std::regex_match(hf, std::regex(KB_NO_NUMBERS_FORMAT_REGEX)));
+        EXPECT_FALSE(std::regex_match(hf, std::regex(KB_WITH_NUMBERS_AND_LETTERS_FORMAT_REGEX)));
     }
 }
 
 TEST_F(SysInfoWinTest, testHF_WOW_Valids_Format)
 {
-    nlohmann::json ret;
+    std::set<std::string> ret;
     constexpr auto KB_FORMAT_REGEX_OK { "(KB+[0-9]{6,})"};
     constexpr auto KB_ONLY_FORMAT_REGEX { "(KB)"};
     constexpr auto KB_NO_NUMBERS_FORMAT_REGEX { "(KB+[a-z])"};
@@ -80,17 +78,16 @@ TEST_F(SysInfoWinTest, testHF_WOW_Valids_Format)
 
     for (const auto& hf : ret)
     {
-        auto hfValue { hf.at("hotfix").get_ref<const std::string&>() };
-        EXPECT_TRUE(std::regex_match(hfValue, std::regex(KB_FORMAT_REGEX_OK)));
-        EXPECT_FALSE(std::regex_match(hfValue, std::regex(KB_ONLY_FORMAT_REGEX)));
-        EXPECT_FALSE(std::regex_match(hfValue, std::regex(KB_NO_NUMBERS_FORMAT_REGEX)));
-        EXPECT_FALSE(std::regex_match(hfValue, std::regex(KB_WITH_NUMBERS_AND_LETTERS_FORMAT_REGEX)));
+        EXPECT_TRUE(std::regex_match(hf, std::regex(KB_FORMAT_REGEX_OK)));
+        EXPECT_FALSE(std::regex_match(hf, std::regex(KB_ONLY_FORMAT_REGEX)));
+        EXPECT_FALSE(std::regex_match(hf, std::regex(KB_NO_NUMBERS_FORMAT_REGEX)));
+        EXPECT_FALSE(std::regex_match(hf, std::regex(KB_WITH_NUMBERS_AND_LETTERS_FORMAT_REGEX)));
     }
 }
 
 TEST_F(SysInfoWinTest, testHF_PRODUCT_Valids_Format)
 {
-    nlohmann::json ret;
+    std::set<std::string> ret;
     constexpr auto KB_FORMAT_REGEX_OK { "(KB+[0-9]{6,})"};
     constexpr auto KB_ONLY_FORMAT_REGEX { "(KB)"};
     constexpr auto KB_NO_NUMBERS_FORMAT_REGEX { "(KB+[a-z])"};
@@ -99,10 +96,9 @@ TEST_F(SysInfoWinTest, testHF_PRODUCT_Valids_Format)
 
     for (const auto& hf : ret)
     {
-        auto hfValue { hf.at("hotfix").get_ref<const std::string&>() };
-        EXPECT_TRUE(std::regex_match(hfValue, std::regex(KB_FORMAT_REGEX_OK)));
-        EXPECT_FALSE(std::regex_match(hfValue, std::regex(KB_ONLY_FORMAT_REGEX)));
-        EXPECT_FALSE(std::regex_match(hfValue, std::regex(KB_NO_NUMBERS_FORMAT_REGEX)));
-        EXPECT_FALSE(std::regex_match(hfValue, std::regex(KB_WITH_NUMBERS_AND_LETTERS_FORMAT_REGEX)));
+        EXPECT_TRUE(std::regex_match(hf, std::regex(KB_FORMAT_REGEX_OK)));
+        EXPECT_FALSE(std::regex_match(hf, std::regex(KB_ONLY_FORMAT_REGEX)));
+        EXPECT_FALSE(std::regex_match(hf, std::regex(KB_NO_NUMBERS_FORMAT_REGEX)));
+        EXPECT_FALSE(std::regex_match(hf, std::regex(KB_WITH_NUMBERS_AND_LETTERS_FORMAT_REGEX)));
     }
 }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #11105 |

## Description
Duplicate data is returned from the data provider for hotfixes.

This issue is introduced in https://github.com/wazuh/wazuh/pull/10259

### RCA: 
Basically different key paths are being traversed and everything is appended without evaluating whether what is inserted already had an occurrence in the JSON.


### Actual: 
DBSYNC Unique constraint exception, hotfixes table empty.
Log 

`2021/11/29 21:03:08 wazuh-modulesd:syscollector: ERROR: {"data":[{"checksum":"2a8a3fe2b4ee332f5c5786555e077a7b7a7d9f8b","hotfix":"KB4601554"},{"checksum":"668f68e501900d6b25e070caa0239e302e29a8b5","hotfix":"KB5000736"},{"checksum":"0ac906284183061e56f0d883fdb6fd46647c3bd0","hotfix":"KB5001405"},{"checksum":"9b1d8e0f90436d583371d27f46d9bf69c459f897","hotfix":"KB5003742"},{"checksum":"222f14c3216c9ba03c0d986818bec6edad64d16a","hotfix":"KB5004331"},{"checksum":"93494b3e0283ab397c1a582628a321bd948cb41f","hotfix":"KB5005033"},{"checksum":"d9fbc6a677f5fcbfd1bcf017d93f73c3cf991533","hotfix":"KB5005260"},{"checksum":"8f99821b9e79bc2258cb56cd14cfcaf9bbeda8e5","hotfix":"KB2468871"},{"checksum":"8511235ae3ab3b642d8ba429599092634fdde3a8","hotfix":"KB2478063"},{"checksum":"2878a010b14cc0f1c864a846bee59eea0ec61ba6","hotfix":"KB2504637"},{"checksum":"b8c4cb9a2aeb6a64269e88f6116765420a65cd80","hotfix":"KB2533523"},{"checksum":"8e468309f00c0f31b8a0f12a6a79d2658652e9e9","hotfix":"KB2544514"},{"checksum":"cb13c01ba11045aabbb074fc3e61b0a3b2d88dd4","hotfix":"KB2600211"},{"checksum":"8253af775746f8545784d27edb852281c9a06955","hotfix":"KB2600217"},{"checksum":"2878a010b14cc0f1c864a846bee59eea0ec61ba6","hotfix":"KB2504637"}],"exception":"sqlite: UNIQUE constraint failed: dbsync_hotfixes.hotfix","table":"dbsync_hotfixes"}`

### Expected: 
No exception.