### PR TITLE
Initialize Blowfish encryption structure

### DIFF
--- a/src/os_crypto/blowfish/bf_op.c
+++ b/src/os_crypto/blowfish/bf_op.c
@@ -25,7 +25,7 @@ typedef unsigned char uchar;
 int OS_BF_Str(const char *input, char *output, const char *charkey,
               long size, short int action)
 {
-    BF_KEY key;
+    BF_KEY key = { };
     static unsigned char cbc_iv [8] = {0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10};
     unsigned char iv[8];
 


### PR DESCRIPTION
This should fix a defect reported by Coverity.

|Related issue|
|---|
|#11022|

This change proposal aims to initialize the Blowfish structure `key` at the crypto library, before calling the initializer `BF_set_key()`.

This will fix the defect 1503035 reported by Coverity, though I'm sure it has no effect.

## Tests

PoC without warnings:

- [X] Ubuntu 16.04.
- [X] Ubuntu 18.04.
- [X] Ubuntu 20.04.
- [X] CentOS 7.
- [X] CentOS 8.
- [X] Solaris 10.