### PR TITLE
Rename commonDefs to fimCommonDefs

### DIFF
--- a/src/syscheckd/db/include/db.hpp
+++ b/src/syscheckd/db/include/db.hpp
@@ -8,7 +8,7 @@
 
 #ifndef FIMDB_H
 #define FIMDB_H
-#include "commonDefs.h"
+#include "fimCommonDefs.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/syscheckd/db/include/fimCommonDefs.h
+++ b/src/syscheckd/db/include/fimCommonDefs.h
@@ -1,5 +1,5 @@
 /**
- * @file commonDefs.h
+ * @file fimCommonDefs.h
  * @brief Common definitions for FIM
  * @date 2021-09-06
  *

--- a/src/syscheckd/db/include/fimDB.hpp
+++ b/src/syscheckd/db/include/fimDB.hpp
@@ -13,7 +13,7 @@
 #define _FIMDB_HPP
 #include "dbsync.hpp"
 #include "rsync.hpp"
-#include "commonDefs.h"
+#include "fimCommonDefs.h"
 #include <condition_variable>
 #include <mutex>
 

--- a/src/syscheckd/db/src/db.cpp
+++ b/src/syscheckd/db/src/db.cpp
@@ -8,7 +8,7 @@
 
 #include "dbsync.hpp"
 #include "db.hpp"
-#include "commonDefs.h"
+#include "fimCommonDefs.h"
 #include "fimDB.hpp"
 #include "fimDBHelper.hpp"
 

--- a/src/syscheckd/db/tests/fimDBHelper/fimDBHelperTest.h
+++ b/src/syscheckd/db/tests/fimDBHelper/fimDBHelperTest.h
@@ -13,7 +13,7 @@
 #define _FIMHELPER_TEST_H
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
-#include "commonDefs.h"
+#include "fimCommonDefs.h"
 
 class FIMDBMOCK final
 {

--- a/src/syscheckd/db/tests/fimDBTests/fimDBImpTests.hpp
+++ b/src/syscheckd/db/tests/fimDBTests/fimDBImpTests.hpp
@@ -6,7 +6,7 @@
 #include "fimDB.hpp"
 #include "dbItem.hpp"
 #include "syscheck-config.h"
-#include "commonDefs.h"
+#include "fimCommonDefs.h"
 
 class MockDBSyncHandler: public DBSync
 {

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -16,7 +16,7 @@
 #include "syscheck.h"
 #include "rootcheck/rootcheck.h"
 #include "db/include/db.hpp"
-#include "db/include/commonDefs.h"
+#include "db/include/fimCommonDefs.h"
 // Global variables
 syscheck_config syscheck;
 


### PR DESCRIPTION
|Related issue|
|---|
|#9108|

## Description

Renamed commonDefs.h to avoid collisions with others files named equal.