### PR TITLE
Fix AWS VPCFlow reparse option

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -1753,7 +1753,7 @@ class AWSVPCFlowBucket(AWSLogsBucket):
 
     def mark_complete(self, aws_account_id, aws_region, log_file, flow_log_id):
         if self.reparse:
-            if self.already_processed(log_file['Key'], aws_account_id, aws_region):
+            if self.already_processed(log_file['Key'], aws_account_id, aws_region, flow_log_id):
                 debug(
                     '+++ File already marked complete, but reparse flag set: {log_key}'.format(log_key=log_file['Key']),
                     2)


### PR DESCRIPTION
|Related issue|
|---|
|Closes #11113|

## Description
In this PR we fix the problem with the AWS VPCFlow module which, if executed using the `--reparse` flag, would show the following error:

```
DEBUG: +++ Unexpected error: already_processed() missing 1 required positional argument: 'flow_log_id'
ERROR: Unexpected error querying/working with objects in S3: already_processed() missing 1 required positional argument: 'flow_log_id'
```

## Tests
### Test in a manager
The module works as expected.

<details><summary>Command output</summary>

	root@9d332fd92d0b:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -s 2021-NOV-21 --reparse  -d2    
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Working on 166157441623 - us-east-1
	DEBUG: +++ Marker: AWSLogs/166157441623/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: 166157441623/us-east-1
	DEBUG: +++ Marker: AWSLogs/166157441623/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: ++ Found new log: AWSLogs/166157441623/vpcflowlogs/us-east-1/2021/11/22/166157441623_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211122T0000Z_ce6176d8.log.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Marker: AWSLogs/166157441623/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: 166157441623/us-east-1
	DEBUG: +++ Marker: AWSLogs/166157441623/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: 166157441623/us-east-1
	DEBUG: +++ Marker: AWSLogs/166157441623/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: 166157441623/us-east-1
	DEBUG: +++ Marker: AWSLogs/166157441623/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: 166157441623/us-east-1
	DEBUG: +++ Marker: AWSLogs/166157441623/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: 166157441623/us-east-1
	DEBUG: +++ Marker: AWSLogs/166157441623/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: 166157441623/us-east-1
	DEBUG: +++ Marker: AWSLogs/166157441623/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: 166157441623/us-east-1
	DEBUG: +++ Marker: AWSLogs/166157441623/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: 166157441623/us-east-1
	DEBUG: +++ Marker: AWSLogs/166157441623/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: 166157441623/us-east-1
	DEBUG: +++ Marker: AWSLogs/166157441623/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: 166157441623/us-east-1
	DEBUG: +++ Marker: AWSLogs/166157441623/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: 166157441623/us-east-1
	DEBUG: +++ Working on 166157441623 - us-west-1
	DEBUG: +++ Working on test_empty - us-east-1
	DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
	DEBUG: +++ Working on test_empty - us-west-1
	DEBUG: +++ Working on test_suffix - us-east-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
	DEBUG: +++ Working on test_suffix - us-west-1

</details>

### Test in an agent
The module works as expected.

<details><summary>Command output</summary>

	root@91e4558d4008:/var/ossec/wodles/aws# python3.9 /var/ossec/wodles/aws/aws-s3.py -b wazuh-aws-wodle-vpcflow -t vpcflow -s 2021-NOV-21 --reparse -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on 166157441623 - us-east-1
	DEBUG: +++ Marker: AWSLogs/166157441623/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: 166157441623/us-east-1
	DEBUG: +++ Marker: AWSLogs/166157441623/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: ++ Found new log: AWSLogs/166157441623/vpcflowlogs/us-east-1/2021/11/22/166157441623_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211122T0000Z_ce6176d8.log.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Marker: AWSLogs/166157441623/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: 166157441623/us-east-1
	DEBUG: +++ Marker: AWSLogs/166157441623/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: 166157441623/us-east-1
	DEBUG: +++ Marker: AWSLogs/166157441623/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: 166157441623/us-east-1
	DEBUG: +++ Marker: AWSLogs/166157441623/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: 166157441623/us-east-1
	DEBUG: +++ Marker: AWSLogs/166157441623/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: 166157441623/us-east-1
	DEBUG: +++ Marker: AWSLogs/166157441623/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: 166157441623/us-east-1
	DEBUG: +++ Marker: AWSLogs/166157441623/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: 166157441623/us-east-1
	DEBUG: +++ Marker: AWSLogs/166157441623/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: 166157441623/us-east-1
	DEBUG: +++ Marker: AWSLogs/166157441623/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: 166157441623/us-east-1
	DEBUG: +++ Marker: AWSLogs/166157441623/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: 166157441623/us-east-1
	DEBUG: +++ Marker: AWSLogs/166157441623/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: 166157441623/us-east-1
	DEBUG: +++ Working on 166157441623 - us-west-1
	DEBUG: +++ Working on test_empty - us-east-1
	DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_empty/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_empty/us-east-1
	DEBUG: +++ Working on test_empty - us-west-1
	DEBUG: +++ Working on test_suffix - us-east-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
	DEBUG: +++ Marker: AWSLogs/test_suffix/vpcflowlogs/us-east-1/2021/11/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: test_suffix/us-east-1
	DEBUG: +++ Working on test_suffix - us-west-1

</details>
