### PR TITLE
Handle both IPv4 and IPv6 connections

### DIFF
--- a/src/config/authd-config.c
+++ b/src/config/authd-config.c
@@ -25,6 +25,7 @@ int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
     /* XML Definitions */
     static const char *xml_disabled = "disabled";
     static const char *xml_port = "port";
+    static const char *xml_ipv6 = "ipv6";
     static const char *xml_use_source_ip = "use_source_ip";
     static const char *xml_force_insert = "force_insert";       // Deprecated since 4.3.0
     static const char *xml_force_time = "force_time";           // Deprecated since 4.3.0
@@ -93,6 +94,15 @@ int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
             config->port = (unsigned short)atoi(node[i]->content);
 
             if (!config->port) {
+                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                return OS_INVALID;
+            }
+        } else if (!strcmp(node[i]->element, xml_ipv6)) {
+            if (strcasecmp(node[i]->content, "yes") == 0) {
+                config->ipv6 = true;
+            } else if (strcasecmp(node[i]->content, "no") == 0) {
+                config->ipv6 = false;
+            } else {
                 merror(XML_VALUEERR, node[i]->element, node[i]->content);
                 return OS_INVALID;
             }

--- a/src/config/authd-config.h
+++ b/src/config/authd-config.h
@@ -49,6 +49,7 @@ typedef struct authd_config_t {
     long timeout_sec;
     long timeout_usec;
     bool worker_node;
+    bool ipv6;
 } authd_config_t;
 
 /**

--- a/src/config/remote-config.c
+++ b/src/config/remote-config.c
@@ -22,7 +22,7 @@
 /**
  * @brief gets the remoted protocol configuration from a configuration string
  * @param content configuration string
- * @return returns the TCP/UDP protocol configuration 
+ * @return returns the TCP/UDP protocol configuration
  */
 STATIC int w_remoted_get_net_protocol(const char * content);
 
@@ -158,7 +158,7 @@ int Read_Remote(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
                 return (OS_INVALID);
             }
         } else if (strcasecmp(node[i]->element, xml_remote_proto) == 0) {
-            
+
             logr->proto[pl] = w_remoted_get_net_protocol(node[i]->content);
 
         } else if (strcasecmp(node[i]->element, xml_remote_ipv6) == 0) {
@@ -265,12 +265,6 @@ int Read_Remote(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
     else if (logr->conn[pl] != SECURE_CONN && (logr->proto[pl] == REMOTED_NET_PROTOCOL_TCP_UDP)) {
         mwarn(REMOTED_NET_PROTOCOL_ONLY_SECURE, REMOTED_NET_PROTOCOL_DEFAULT_STR);
         logr->proto[pl] = REMOTED_NET_PROTOCOL_DEFAULT;
-    }
-
-    /*  Secure does not support IPv6. */
-    if (logr->conn[pl] == SECURE_CONN && logr->ipv6[pl]) {
-        mwarn(REMOTED_INET6_SECURE_CONNNECTION);
-        logr->ipv6[pl] = 0;
     }
 
     /* Queue_size is only for secure connections */

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -113,8 +113,6 @@
 #define REMOTED_INV_VALUE_IGNORE                "(9001): Ignored invalid value '%s' for '%s'."
 #define REMOTED_NET_PROTOCOL_ONLY_SECURE        "(9002): Only secure connection supports TCP and UDP at the same time."\
                                                 " Default value (%s) will be used."
-#define REMOTED_INET6_SECURE_CONNNECTION        "(9003): Secure connection does not support IPv6. "\
-                                                "IPv4 will be used instead."
 #define REMOTED_INV_VALUE_DEFAULT               "(9004): Invalid value '%s' in '%s' option. " \
                                                 "Default value will be used."
 #endif /* WARN_MESSAGES_H */

--- a/src/headers/sec.h
+++ b/src/headers/sec.h
@@ -52,7 +52,7 @@ typedef struct _keyentry {
     int net_protocol;                   ///< Client current protocol
     time_t time_added;
     pthread_mutex_t mutex;
-    struct sockaddr_in peer_info;
+    struct sockaddr_storage peer_info;
     FILE *fp;
     crypt_method crypto_method;
 

--- a/src/os_auth/auth.h
+++ b/src/os_auth/auth.h
@@ -55,7 +55,11 @@ extern BIO *bio_err;
 
 struct client {
     int socket;
-    struct in_addr addr;
+    union {
+        struct in_addr *addr4;
+        struct in6_addr *addr6;
+    };
+    bool is_ipv6;
 };
 
 struct keynode {

--- a/src/os_auth/config.c
+++ b/src/os_auth/config.c
@@ -53,6 +53,7 @@ cJSON *getAuthdConfig(void) {
     cJSON_AddNumberToObject(auth,"port",config.port);
     if (config.flags.disabled) cJSON_AddStringToObject(auth,"disabled","yes"); else cJSON_AddStringToObject(auth,"disabled","no");
     if (config.flags.remote_enrollment) cJSON_AddStringToObject(auth,"remote_enrollment","yes"); else cJSON_AddStringToObject(auth,"remote_enrollment","no");
+    if (config.ipv6) cJSON_AddStringToObject(auth,"ipv6","yes"); else cJSON_AddStringToObject(auth,"ipv6","no");
     if (config.flags.use_source_ip) cJSON_AddStringToObject(auth,"use_source_ip","yes"); else cJSON_AddStringToObject(auth,"use_source_ip","no");
     if (config.flags.clear_removed) cJSON_AddStringToObject(auth,"purge","yes"); else cJSON_AddStringToObject(auth,"purge","no");
     if (config.flags.use_password) cJSON_AddStringToObject(auth,"use_password","yes"); else cJSON_AddStringToObject(auth,"use_password","no");

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -787,7 +787,7 @@ void* run_remote_server(__attribute__((unused)) void *arg) {
             case AF_INET:
                 new_client->is_ipv6 = FALSE;
                 os_calloc(1, sizeof(struct in_addr), new_client->addr4);
-                new_client->addr4 = &((struct sockaddr_in *)&_nc)->sin_addr;
+                memcpy(new_client->addr4, &((struct sockaddr_in *)&_nc)->sin_addr, sizeof(struct in_addr));
                 break;
             case AF_INET6:
                 new_client->is_ipv6 = TRUE;

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -572,7 +572,11 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
             continue;
         }
 
-        get_ipv4_string(client->addr, ip, IPSIZE - 1);
+        if (client->is_ipv6) {
+            get_ipv6_string(*client->addr6, ip, IPSIZE - 1);
+        } else {
+            get_ipv4_string(*client->addr4, ip, IPSIZE - 1);
+        }
         ssl = SSL_new(ctx);
         SSL_set_fd(ssl, client->socket);
         ret = SSL_accept(ssl);
@@ -581,6 +585,11 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
             mdebug1("SSL Error (%d)", ret);
             SSL_free(ssl);
             close(client->socket);
+            if (client->is_ipv6) {
+                os_free(client->addr6);
+            } else {
+                os_free(client->addr4);
+            }
             os_free(client);
             continue;
         }
@@ -594,6 +603,11 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
                 merror("Unable to verify client certificate.");
                 SSL_free(ssl);
                 close(client->socket);
+                if (client->is_ipv6) {
+                    os_free(client->addr6);
+                } else {
+                    os_free(client->addr4);
+                }
                 os_free(client);
                 continue;
             }
@@ -612,6 +626,11 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
             }
             SSL_free(ssl);
             close(client->socket);
+            if (client->is_ipv6) {
+                os_free(client->addr6);
+            } else {
+                os_free(client->addr4);
+            }
             os_free(client);
             free(buf);
             continue;
@@ -690,6 +709,11 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
 
         SSL_free(ssl);
         close(client->socket);
+        if (client->is_ipv6) {
+            os_free(client->addr6);
+        } else {
+            os_free(client->addr4);
+        }
         os_free(client);
         os_free(buf);
         os_free(agentname);
@@ -708,7 +732,7 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
 /* Thread for remote server */
 void* run_remote_server(__attribute__((unused)) void *arg) {
     int client_sock = 0;
-    struct sockaddr_in _nc;
+    struct sockaddr_storage _nc;
     socklen_t _ncl;
     fd_set fdset;
     struct timeval timeout;
@@ -758,14 +782,32 @@ void* run_remote_server(__attribute__((unused)) void *arg) {
             struct client *new_client;
             os_malloc(sizeof(struct client), new_client);
             new_client->socket = client_sock;
-            new_client->addr = _nc.sin_addr;
+
+            switch (_nc.ss_family) {
+            case AF_INET:
+                new_client->is_ipv6 = FALSE;
+                os_calloc(1, sizeof(struct in_addr), new_client->addr4);
+                new_client->addr4 = &((struct sockaddr_in *)&_nc)->sin_addr;
+                break;
+            case AF_INET6:
+                new_client->is_ipv6 = TRUE;
+                os_calloc(1, sizeof(struct in6_addr), new_client->addr6);
+                memcpy(new_client->addr6, &((struct sockaddr_in6 *)&_nc)->sin6_addr, sizeof(struct in6_addr));
+                break;
+            default:
+                merror("Unknown IP protocol from new connection. Rejecting.");
+                os_free(new_client);
+                close(client_sock);
+            }
 
             if (queue_push_ex(client_queue, new_client) == -1) {
                 merror("Too many connections. Rejecting.");
+                os_free(new_client);
                 close(client_sock);
             }
-        } else if ((errno == EBADF && running) || (errno != EBADF && errno != EINTR))
+        } else if ((errno == EBADF && running) || (errno != EBADF && errno != EINTR)) {
             merror("at main(): accept(): %s", strerror(errno));
+        }
     }
 
     mdebug1("Remote server thread finished");

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -795,7 +795,7 @@ void* run_remote_server(__attribute__((unused)) void *arg) {
                 memcpy(new_client->addr6, &((struct sockaddr_in6 *)&_nc)->sin6_addr, sizeof(struct in6_addr));
                 break;
             default:
-                merror("Unknown IP protocol from new connection. Rejecting.");
+                merror("IP address family not supported. Rejecting.");
                 os_free(new_client);
                 close(client_sock);
             }

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -433,7 +433,7 @@ int main(int argc, char **argv)
         }
 
         /* Connect via TCP */
-        if (remote_sock = OS_Bindporttcp(config.port, NULL, 0), remote_sock <= 0) {
+        if (remote_sock = OS_Bindporttcp(config.port, NULL, config.ipv6), remote_sock <= 0) {
             merror(BIND_ERROR, config.port, errno, strerror(errno));
             exit(1);
         }

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -39,7 +39,7 @@ static void move_netdata(keystore *keys, const keystore *old_keys)
         if (keyid >= 0 && !strcmp(keys->keyentries[keyid]->ip->ip, old_keys->keyentries[i]->ip->ip)) {
             keys->keyentries[keyid]->rcvd = old_keys->keyentries[i]->rcvd;
             keys->keyentries[keyid]->sock = old_keys->keyentries[i]->sock;
-            memcpy(&keys->keyentries[keyid]->peer_info, &old_keys->keyentries[i]->peer_info, sizeof(struct sockaddr_in));
+            memcpy(&keys->keyentries[keyid]->peer_info, &old_keys->keyentries[i]->peer_info, sizeof(struct sockaddr_storage));
 
             snprintf(strsock, sizeof(strsock), "%d", keys->keyentries[keyid]->sock);
             rbtree_insert(keys->keytree_sock, strsock, keys->keyentries[keyid]);

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -366,7 +366,7 @@ int OS_SendUDPbySize(int socket, int size, const char *msg)
 int OS_AcceptTCP(int socket, char *srcip, size_t addrsize)
 {
     int clientsocket;
-    struct sockaddr_in _nc;
+    struct sockaddr_storage _nc;
     socklen_t _ncl;
 
     memset(&_nc, 0, sizeof(_nc));
@@ -377,7 +377,16 @@ int OS_AcceptTCP(int socket, char *srcip, size_t addrsize)
         return (-1);
     }
 
-    get_ipv4_string(_nc.sin_addr, srcip, addrsize - 1);
+    switch (_nc.ss_family) {
+    case AF_INET:
+        get_ipv4_string(((struct sockaddr_in *)&_nc)->sin_addr, srcip, addrsize - 1);
+        break;
+    case AF_INET6:
+        get_ipv6_string(((struct sockaddr_in6 *)&_nc)->sin6_addr, srcip, addrsize - 1);
+        break;
+    default:
+        return (-1);
+    }
 
     return (clientsocket);
 }

--- a/src/remoted/netbuffer.c
+++ b/src/remoted/netbuffer.c
@@ -18,7 +18,7 @@ extern wnotify_t * notify;
 
 static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 
-void nb_open(netbuffer_t * buffer, int sock, const struct sockaddr_in * peer_info) {
+void nb_open(netbuffer_t * buffer, int sock, const struct sockaddr_storage * peer_info) {
     w_mutex_lock(&mutex);
 
     if (sock >= buffer->max_fd) {
@@ -27,7 +27,7 @@ void nb_open(netbuffer_t * buffer, int sock, const struct sockaddr_in * peer_inf
     }
 
     memset(buffer->buffers + sock, 0, sizeof(sockbuffer_t));
-    memcpy(&buffer->buffers[sock].peer_info, peer_info, sizeof(struct sockaddr_in));
+    memcpy(&buffer->buffers[sock].peer_info, peer_info, sizeof(struct sockaddr_storage));
 
     buffer->buffers[sock].bqueue = bqueue_init(send_buffer_size, BQUEUE_SHRINK);
 

--- a/src/remoted/queue.c
+++ b/src/remoted/queue.c
@@ -22,7 +22,7 @@ void rem_msginit(size_t size) {
 }
 
 // Push message into queue
-int rem_msgpush(const char * buffer, unsigned long size, struct sockaddr_in * addr, int sock) {
+int rem_msgpush(const char * buffer, unsigned long size, struct sockaddr_storage * addr, int sock) {
     message_t * message;
     int result;
     static int reported = 0;
@@ -31,7 +31,7 @@ int rem_msgpush(const char * buffer, unsigned long size, struct sockaddr_in * ad
     os_malloc(size, message->buffer);
     memcpy(message->buffer, buffer, size);
     message->size = size;
-    memcpy(&message->addr, addr, sizeof(struct sockaddr_in));
+    memcpy(&message->addr, addr, sizeof(struct sockaddr_storage));
     message->sock = sock;
 
     w_mutex_lock(&mutex);

--- a/src/remoted/remoted.h
+++ b/src/remoted/remoted.h
@@ -35,7 +35,7 @@ typedef struct pending_data_t {
 typedef struct message_t {
     char * buffer;
     unsigned int size;
-    struct sockaddr_in addr;
+    struct sockaddr_storage addr;
     int sock;
     size_t counter;
 } message_t;
@@ -56,7 +56,7 @@ typedef struct remoted_state_t {
 /* Network buffer structure */
 
 typedef struct sockbuffer_t {
-    struct sockaddr_in peer_info;
+    struct sockaddr_storage peer_info;
     char * data;
     unsigned long data_size;
     unsigned long data_len;
@@ -130,7 +130,7 @@ void key_unlock(void);
 void rem_msginit(size_t size);
 
 // Push message into queue
-int rem_msgpush(const char * buffer, unsigned long size, struct sockaddr_in * addr, int sock);
+int rem_msgpush(const char * buffer, unsigned long size, struct sockaddr_storage * addr, int sock);
 
 // Pop message from queue
 message_t * rem_msgpop();
@@ -164,7 +164,7 @@ cJSON *getRemoteGlobalConfig(void);
 
 /* Network buffer */
 
-void nb_open(netbuffer_t * buffer, int sock, const struct sockaddr_in * peer_info);
+void nb_open(netbuffer_t * buffer, int sock, const struct sockaddr_storage * peer_info);
 void nb_close(netbuffer_t * buffer, int sock);
 int nb_recv(netbuffer_t * buffer, int sock);
 

--- a/src/remoted/syslog.c
+++ b/src/remoted/syslog.c
@@ -41,15 +41,15 @@ void HandleSyslog()
     char srcip[IPSIZE + 1];
     char *buffer_pt = NULL;
     ssize_t recv_b;
-    struct sockaddr_in peer_info;
-    socklen_t peer_size;
+    struct sockaddr_storage _nc;
+    socklen_t _ncl;
 
     /* Set peer size */
-    peer_size = sizeof(peer_info);
+    _ncl = sizeof(_nc);
 
     /* Initialize some variables */
     memset(buffer, '\0', OS_MAXSTR + 2);
-    memset(&peer_info, 0, sizeof(struct sockaddr_in));
+    memset(&_nc, 0, sizeof(_nc));
 
     /* Connect to the message queue infinitely */
     if ((logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
@@ -59,7 +59,7 @@ void HandleSyslog()
     /* Infinite loop */
     while (1) {
         /* Receive message */
-        recv_b = recvfrom(logr.udp_sock, buffer, OS_MAXSTR, 0, (struct sockaddr *)&peer_info, &peer_size);
+        recv_b = recvfrom(logr.udp_sock, buffer, OS_MAXSTR, 0, (struct sockaddr *)&_nc, &_ncl);
 
         /* Nothing received */
         if (recv_b <= 0) {
@@ -75,7 +75,16 @@ void HandleSyslog()
         }
 
         /* Set the source IP */
-        get_ipv4_string(peer_info.sin_addr, srcip, IPSIZE - 1);
+        switch (_nc.ss_family) {
+        case AF_INET:
+            get_ipv4_string(((struct sockaddr_in *)&_nc)->sin_addr, srcip, IPSIZE - 1);
+            break;
+        case AF_INET6:
+            get_ipv6_string(((struct sockaddr_in6 *)&_nc)->sin6_addr, srcip, IPSIZE - 1);
+            break;
+        default:
+            continue;
+        }
 
         /* Remove syslog header */
         if (buffer[0] == '<') {

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -216,7 +216,7 @@ static int w_enrollment_connect(w_enrollment_ctx *cfg, const char * server_addre
     }
 
     /* Connect via TCP */
-    int sock = OS_ConnectTCP((u_int16_t) cfg->target_cfg->port, ip_address, 0);
+    int sock = OS_ConnectTCP((u_int16_t) cfg->target_cfg->port, ip_address, strchr(ip_address, ':') != NULL);
     if (sock < 0) {
         merror("Unable to connect to %s:%d", ip_address, cfg->target_cfg->port);
         os_free(ip_address);

--- a/src/unit_tests/os_net/test_os_net.c
+++ b/src/unit_tests/os_net/test_os_net.c
@@ -144,6 +144,7 @@ void test_accept_TCP(void **state) {
     char ipbuffer[BUFFERSIZE];
 
     data->server_root_socket = 0;
+    will_return(__wrap_accept, AF_INET);
     will_return(__wrap_accept, 0);
 
     data->server_client_socket = OS_AcceptTCP(data->server_root_socket, ipbuffer, BUFFERSIZE);
@@ -155,6 +156,7 @@ void test_accept_TCP(void **state) {
 void test_invalid_accept_TCP(void **state) {
     char buffer[BUFFERSIZE];
 
+    will_return(__wrap_accept, AF_INET);
     will_return(__wrap_accept, -1);
 
     assert_int_equal(OS_AcceptTCP(-1, buffer, BUFFERSIZE), -1);
@@ -249,6 +251,7 @@ void test_recv_secure_TCP(void **state) {
 
 void test_tcp_invalid_sockets(void **state) {
     char buffer[BUFFERSIZE];
+    will_return(__wrap_accept, AF_INET);
     will_return(__wrap_accept, -1);
 
     assert_int_equal(OS_AcceptTCP(-1, buffer, BUFFERSIZE), -1);

--- a/src/unit_tests/remoted/test_netbuffer.c
+++ b/src/unit_tests/remoted/test_netbuffer.c
@@ -37,9 +37,9 @@ static int test_setup(void ** state) {
     send_buffer_size = 100;
 
     netbuffer_t *netbuffer;
-    struct sockaddr_in peer_info;
+    struct sockaddr_storage peer_info;
 
-    memset(&peer_info, 0, sizeof(struct sockaddr_in));
+    memset(&peer_info, 0, sizeof(struct sockaddr_storage));
 
     os_calloc(1, sizeof(netbuffer_t), netbuffer);
 

--- a/src/unit_tests/wrappers/linux/netbuffer_wrappers.c
+++ b/src/unit_tests/wrappers/linux/netbuffer_wrappers.c
@@ -24,7 +24,7 @@ void __wrap_nb_close(__attribute__((unused)) netbuffer_t * buffer, int sock) {
     check_expected(sock);
 }
 
-void __wrap_nb_open(__attribute__((unused)) netbuffer_t * buffer, int sock, const struct sockaddr_in * peer_info) {
+void __wrap_nb_open(__attribute__((unused)) netbuffer_t * buffer, int sock, const struct sockaddr_storage * peer_info) {
     check_expected(sock);
     check_expected_ptr(peer_info);
 }

--- a/src/unit_tests/wrappers/linux/netbuffer_wrappers.h
+++ b/src/unit_tests/wrappers/linux/netbuffer_wrappers.h
@@ -12,7 +12,7 @@
 
 void __wrap_nb_close(__attribute__((unused)) netbuffer_t * buffer, int sock);
 
-void __wrap_nb_open(__attribute__((unused)) netbuffer_t * buffer, int sock, const struct sockaddr_in * peer_info);
+void __wrap_nb_open(__attribute__((unused)) netbuffer_t * buffer, int sock, const struct sockaddr_storage * peer_info);
 
 int __wrap_nb_queue(__attribute__((unused)) netbuffer_t * buffer, int socket, char * crypt_msg, ssize_t msg_size);
 

--- a/src/unit_tests/wrappers/linux/queue.c
+++ b/src/unit_tests/wrappers/linux/queue.c
@@ -19,7 +19,7 @@
 #include "remoted/remoted.h"
 #include "queue.h"
 
-int __wrap_rem_msgpush(__attribute__((unused)) const char * buffer, unsigned long size, struct sockaddr_in * addr, int sock) {
+int __wrap_rem_msgpush(__attribute__((unused)) const char * buffer, unsigned long size, struct sockaddr_storage * addr, int sock) {
     check_expected(sock);
     check_expected_ptr(addr);
     check_expected(size);

--- a/src/unit_tests/wrappers/linux/queue.h
+++ b/src/unit_tests/wrappers/linux/queue.h
@@ -10,6 +10,6 @@
 #ifndef QUEUE_WRAPPERS_H
 #define QUEUE_WRAPPERS_H
 
-int __wrap_rem_msgpush(const char * buffer, unsigned long size, struct sockaddr_in * addr, int sock);
+int __wrap_rem_msgpush(const char * buffer, unsigned long size, struct sockaddr_storage * addr, int sock);
 
 #endif

--- a/src/unit_tests/wrappers/linux/socket_wrappers.c
+++ b/src/unit_tests/wrappers/linux/socket_wrappers.c
@@ -48,7 +48,8 @@ int __wrap_connect(__attribute__((unused))int __fd, __attribute__((unused))__CON
     return mock();
 }
 
-int __wrap_accept(__attribute__((unused))int __fd, __attribute__((unused))__SOCKADDR_ARG __addr, __attribute__((unused))socklen_t *__restrict __addr_len) {
+int __wrap_accept(__attribute__((unused))int __fd, struct sockaddr * __addr, __attribute__((unused))socklen_t *__restrict __addr_len) {
+    __addr->sa_family = mock();
     return mock();
 }
 

--- a/src/unit_tests/wrappers/linux/socket_wrappers.h
+++ b/src/unit_tests/wrappers/linux/socket_wrappers.h
@@ -26,7 +26,7 @@ int __wrap_listen(__attribute__((unused))int __fd, __attribute__((unused))int __
 
 int __wrap_connect(__attribute__((unused))int __fd, __attribute__((unused))__CONST_SOCKADDR_ARG __addr, __attribute__((unused))socklen_t __len);
 
-int __wrap_accept(__attribute__((unused))int __fd, __attribute__((unused))__SOCKADDR_ARG __addr, __attribute__((unused))socklen_t *__restrict __addr_len);
+int __wrap_accept(__attribute__((unused))int __fd, struct sockaddr * __addr, __attribute__((unused))socklen_t *__restrict __addr_len);
 
 ssize_t __wrap_send(__attribute__((unused))int __fd, __attribute__((unused))const void *__buf, __attribute__((unused))size_t __n, __attribute__((unused))int __flags);
 

--- a/src/win32/agent_auth.c
+++ b/src/win32/agent_auth.c
@@ -77,7 +77,7 @@ void CreateSecureConnection(char *manager, int port, int *socket, CtxtHandle *co
         merror_exit("Could not resolve manager's hostname");
 
     // Connect via TCP
-    *socket = OS_ConnectTCP(port, manager, 0);
+    *socket = OS_ConnectTCP(port, manager, strchr(manager, ':') != NULL);
     if (*socket < 0)
         merror_exit("Unable to connect to %s:%d", manager, port);
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/11052|

## Description

This PR adds support to IPv6 connections in both `wazuh-authd` and `wazuh-remoted` daemons.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Source upgrade