### PR TITLE
Rework of PR #8609 - 8395 wmi discovery rules

### DIFF
--- a/ruleset/rules/0575-win-base_rules.xml
+++ b/ruleset/rules/0575-win-base_rules.xml
@@ -1,8 +1,5 @@
 <!--
-  -  Windows Event Channel ruleset
-  -  Created by Wazuh, Inc.
-  -  Copyright (C) 2015-2021, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  Copyright (C) 2015-2021, Wazuh Inc.
 -->
 
 <!-- Group of parent rules for the Windows eventchannel -->
@@ -17,7 +14,7 @@
     <decoded_as>windows_eventchannel</decoded_as>
     <field name="win.system.providerName">\.+</field>
     <options>no_full_log</options>
-    <description>Group of windows rules</description>
+    <description>Group of windows rules.</description>
   </rule>
 
   <!-- Classification by channel -->
@@ -25,129 +22,130 @@
     <if_sid>60000</if_sid>
     <field name="win.system.channel">^Security$</field>
     <options>no_full_log</options>
-    <description>Group of Windows rules for the Security channel</description>
+    <description>Group of Windows rules for the security channel.</description>
   </rule>
 
   <rule id="60002" level="0">
     <if_sid>60000</if_sid>
     <field name="win.system.channel">^System$</field>
     <options>no_full_log</options>
-    <description>Group of Windows rules for the System channel</description>
+    <description>Group of Windows rules for the system channel.</description>
   </rule>
 
   <rule id="60003" level="0">
     <if_sid>60000</if_sid>
     <field name="win.system.channel">^Application$</field>
     <options>no_full_log</options>
-    <description>Group of Windows rules for the Application channel</description>
+    <description>Group of Windows rules for the application channel.</description>
   </rule>
 
   <rule id="60004" level="0">
     <if_sid>60000</if_sid>
     <field name="win.system.channel">^Microsoft-Windows-Sysmon/Operational$</field>
     <options>no_full_log</options>
-    <description>Group of Windows rules for the Sysmon channel</description>
+    <description>Group of Windows rules for the sysmon channel.</description>
   </rule>
 
   <rule id="60005" level="0">
     <if_sid>60000</if_sid>
     <field name="win.system.channel">^Microsoft-Windows-Windows Defender/Operational$</field>
     <options>no_full_log</options>
-    <description>Group of Windows rules for the System channel</description>
+    <description>Group of Windows rules for the system channel.</description>
   </rule>
 
   <rule id="60016" level="0">
     <if_sid>60000</if_sid>
     <field name="win.system.channel">^Microsoft-Windows-Windows Firewall With Advanced Security/Firewall$</field>
     <options>no_full_log</options>
-    <description>Group of Microsoft Windows Firewall With Advanced Security rules</description>
+    <description>Group of Microsoft Windows firewall with advanced security rules.</description>
   </rule>
 
   <rule id="60006" level="0">
     <if_sid>60003</if_sid>
     <field name="win.system.providerName">^McLogEvent$</field>
     <options>no_full_log</options>
-    <description>Group of Windows rules for the McAfee channel</description>
+    <description>Group of Windows rules for the McAfee channel.</description>
   </rule>
 
   <rule id="60017" level="0">
     <if_sid>60001</if_sid>
     <field name="win.system.providerName">^Microsoft-Windows-Eventlog$</field>
     <options>no_full_log</options>
-    <description>Group of rules for Windows Eventlog from Security channel</description>
+    <description>Group of rules for Windows eventlog from security channel.</description>
   </rule>
 
   <rule id="60007" level="0">
     <if_sid>60002</if_sid>
     <field name="win.system.providerName">^Eventlog$|^Microsoft-Windows-Eventlog$</field>
     <options>no_full_log</options>
-    <description>Group of rules for Windows Eventlog from System channel</description>
+    <description>Group of rules for Windows eventlog from system channel.</description>
   </rule>
 
   <rule id="60008" level="0">
     <if_sid>60002</if_sid>
     <field name="win.system.providerName">^Microsoft Antimalware$</field>
     <options>no_full_log</options>
-    <description>Group of Microsoft Security Essentials rules</description>
+    <description>Group of Microsoft security essentials rules.</description>
   </rule>
 
   <rule id="60018" level="0">
     <if_sid>60000</if_sid>
     <field name="win.system.providerName">^Microsoft-Windows-WMI-Activity$</field>
     <options>no_full_log</options>
-    <description>Group of Microsoft Windows Management Instrumentation (WMI) rules</description>
+    <description>Group of Microsoft Windows Management Instrumentation (WMI) rules.</description>
   </rule>
+
   <!-- Rules to classify events by level (for rules with no defined channel) -->
 
   <rule id="60009" level="0">
     <if_sid>60000</if_sid>
     <field name="win.system.severityValue">^INFORMATION$</field>
-    <description>Windows informational event</description>
     <options>no_full_log</options>
+    <description>Windows informational event.</description>
   </rule>
 
   <rule id="60010" level="0">
     <if_sid>60000</if_sid>
     <field name="win.system.severityValue">^WARNING$</field>
-    <description>Windows warning event</description>
     <options>no_full_log</options>
+    <description>Windows warning event.</description>
     <group>gpg13_4.12,</group>
   </rule>
   
   <rule id="60011" level="5">
     <if_sid>60000</if_sid>
     <field name="win.system.severityValue">^ERROR$</field>
-    <description>Windows error event</description>
     <options>no_full_log</options>
-    <group>system_error,gpg13_4.3,gdpr_IV_35.7.d,</group>
+    <description>Windows error event.</description>
+    <group>gdpr_IV_35.7.d,gpg13_4.3,system_error,</group>
   </rule>
 
   <rule id="60012" level="10">
     <if_sid>60000</if_sid>
     <field name="win.system.severityValue">^CRITICAL$</field>
-    <description>Windows critical event</description>
     <options>no_full_log</options>
-    <group>system_error,gpg13_4.3,gdpr_IV_35.7.d,</group>
+    <description>Windows critical event.</description>
+    <group>gdpr_IV_35.7.d,gpg13_4.3,system_error,</group>
   </rule>
 
   <!-- Rules about multiple events -->
 
   <rule id="60013" level="8" frequency="$MS_FREQ" timeframe="120">
     <if_matched_sid>60010</if_matched_sid>
-    <description>Multiple Windows warning events</description>
     <options>no_full_log</options>
+    <description>Multiple Windows warning events.</description>
   </rule>
 
   <rule id="60014" level="10" frequency="$MS_FREQ" timeframe="240">
     <if_matched_sid>60011</if_matched_sid>
-    <description>Multiple Windows error events</description>
     <options>no_full_log</options>
+    <description>Multiple Windows error events.</description>
   </rule>
 
   <rule id="60015" level="12" frequency="$CRITICAL_FREQ" timeframe="240">
     <if_matched_sid>60012</if_matched_sid>
-    <description>Multiple Windows critical events</description>
     <options>no_full_log</options>
+    <description>Multiple Windows critical events.</description>
   </rule>
 
 </group>

--- a/ruleset/rules/0575-win-base_rules.xml
+++ b/ruleset/rules/0575-win-base_rules.xml
@@ -6,7 +6,7 @@
   Powershell Rules 60000 - 60099
 -->
 
-<!-- Group of parent rules for the Windows eventchannel -->
+<!-- Windows event channel rules. -->
 
 <group name="windows,">
 

--- a/ruleset/rules/0575-win-base_rules.xml
+++ b/ruleset/rules/0575-win-base_rules.xml
@@ -3,7 +3,7 @@
 -->
 
 <!--
-  Powershell Rules 60000 - 60099
+  Windows event channel rules 60000 - 60099
 -->
 
 <!-- Windows event channel rules. -->

--- a/ruleset/rules/0575-win-base_rules.xml
+++ b/ruleset/rules/0575-win-base_rules.xml
@@ -2,6 +2,10 @@
   Copyright (C) 2015-2021, Wazuh Inc.
 -->
 
+<!--
+  Powershell Rules 60000 - 60099
+-->
+
 <!-- Group of parent rules for the Windows eventchannel -->
 
 <group name="windows,">

--- a/ruleset/rules/0575-win-base_rules.xml
+++ b/ruleset/rules/0575-win-base_rules.xml
@@ -4,9 +4,6 @@
 
 <!-- Group of parent rules for the Windows eventchannel -->
 
-<var name="MS_FREQ">8</var>
-<var name="CRITICAL_FREQ">4</var>
-
 <group name="windows,">
 
   <rule id="60000" level="0">
@@ -130,19 +127,19 @@
 
   <!-- Rules about multiple events -->
 
-  <rule id="60013" level="8" frequency="$MS_FREQ" timeframe="120">
+  <rule id="60013" level="8" frequency="8" timeframe="120">
     <if_matched_sid>60010</if_matched_sid>
     <options>no_full_log</options>
     <description>Multiple Windows warning events.</description>
   </rule>
 
-  <rule id="60014" level="10" frequency="$MS_FREQ" timeframe="240">
+  <rule id="60014" level="10" frequency="8" timeframe="240">
     <if_matched_sid>60011</if_matched_sid>
     <options>no_full_log</options>
     <description>Multiple Windows error events.</description>
   </rule>
 
-  <rule id="60015" level="12" frequency="$CRITICAL_FREQ" timeframe="240">
+  <rule id="60015" level="12" frequency="4" timeframe="240">
     <if_matched_sid>60012</if_matched_sid>
     <options>no_full_log</options>
     <description>Multiple Windows critical events.</description>


### PR DESCRIPTION
|Related issue|
|---|
|#11209 |

## Description

This PR aims to resolve issues detected under #8609 PR. Closes #11209 .
The issues resolved are:
- Copyright headers.
- Fixed indentation issues.
- Added a blank line at the EOF.
- ruleset/rules/0807-attack-TA0007.xml in the initial PR has been replaced as such, it has not been reworked.

## Checks and changes 

### Syntax

- [x] 1.a Rule tags order must be compliant.
- [x] 1.b Decoder tags order must be compliant.
- [x] 1.c XML blocks must as compact as possible.
- [X] 1.d Only one empty line between rule/decoder and the next rule/decoder.
- [X] 1.e Decoder extracted fields names must use '_' whether a space is needed.
- [X] 1.f Decoder name must use '-' whether a space is needed.
 
### Grammar

- [X] 2.a Grammar quality.
- [X] 2.b Similar phrases must keep tenses and expressions.
- [X] 2.c Grammar basic rules like capitalization, punctuation marks, sentence construction, and others.


### Semantic

- [x] 3.a New decoder, rule, or test are written in the correct file and grouped correctly inside the file.
- [x] 3.b Group similar rules under same ID's group.
- [x] 3.c: 
     - [x] 3.c1 Find and reuse group name before creating a new one.
     - [x] 3.c2 Include a new group definition in a PR comment.
     - [x] 3.c3 Any group name must use '_' whether it does need a space char.
     - [x] 3.c4 The groups inside a tag must be sorted in alphabetical order.
- [x] 3.d Rule level should be compliant with the [documentation](https://documentation.wazuh.com/current/user-manual/ruleset/rules-classification.html).

### Unit testing

- [X] 4.a A metadata block at the beginning of the .ini file describing software, version, and logs source.
- [X] 4.b Each new rule must have at least one test entry in the correct .ini file.
- [x] 4.c Runtest.py must pass and must include the results in raw format here.


<details><summary>All rules and decoders test.</summary>
<p>

```
root@ubuntu-focal:/var/ossec/ruleset/feed/testing# python3 runtests.py 
Restarting wazuh-manager...
- [ File = ./tests/samba.ini ] ---------
....

- [ File = ./tests/fortigate.ini ] ---------
........................................

- [ File = ./tests/apparmor.ini ] ---------
.....

- [ File = ./tests/pam.ini ] ---------
.....

- [ File = ./tests/audit_lateral.ini ] ---------
......

- [ File = ./tests/systemd.ini ] ---------
..

- [ File = ./tests/arbor.ini ] ---------
..

- [ File = ./tests/dovecot.ini ] ---------
...............

- [ File = ./tests/mailscanner.ini ] ---------
.

- [ File = ./tests/ossec.ini ] ---------
.....

- [ File = ./tests/vuln_detector.ini ] ---------
..

- [ File = ./tests/squid_rules.ini ] ---------
..

- [ File = ./tests/pix.ini ] ---------
......................

- [ File = ./tests/huawei_usg.ini ] ---------
...

- [ File = ./tests/checkpoint_smart1.ini ] ---------
..................

- [ File = ./tests/junos.ini ] ---------
...

- [ File = ./tests/web_appsec.ini ] ---------
...............................

- [ File = ./tests/cimserver.ini ] ---------
..

- [ File = ./tests/cisco_ftd.ini ] ---------
..........................................

- [ File = ./tests/firewalld.ini ] ---------
..

- [ File = ./tests/audit_recon.ini ] ---------
..

- [ File = ./tests/openldap.ini ] ---------
.........

- [ File = ./tests/sophos_fw.ini ] ---------
..........

- [ File = ./tests/owlh.ini ] ---------
....

- [ File = ./tests/freepbx.ini ] ---------
......

- [ File = ./tests/syslog.ini ] ---------
......

- [ File = ./tests/openvpn_ldap.ini ] ---------
..

- [ File = ./tests/sophos.ini ] ---------
........

- [ File = ./tests/unbound.ini ] ---------


- [ File = ./tests/github.ini ] ---------
....................................................................................................................................................................................................................................................................................................................................

- [ File = ./tests/cpanel.ini ] ---------
.......

- [ File = ./tests/fireeye.ini ] ---------
...

- [ File = ./tests/fortiauth.ini ] ---------
....

- [ File = ./tests/iptables.ini ] ---------
........

- [ File = ./tests/named.ini ] ---------
.....

- [ File = ./tests/sophos-utm-firewall.ini ] ---------
......

- [ File = ./tests/nginx.ini ] ---------
............

- [ File = ./tests/exim.ini ] ---------
.......

- [ File = ./tests/opensmtpd.ini ] ---------
.......

- [ File = ./tests/oscap.ini ] ---------
................................

- [ File = ./tests/gitlab.ini ] ---------
.........................

- [ File = ./tests/paloalto.ini ] ---------
................

- [ File = ./tests/api.ini ] ---------
............................

- [ File = ./tests/aws_s3_access.ini ] ---------
.......

- [ File = ./tests/exchange.ini ] ---------
..

- [ File = ./tests/f5_big_ip.ini ] ---------
...........................................

- [ File = ./tests/cisco_asa.ini ] ---------
........................................................................................

- [ File = ./tests/nextcloud.ini ] ---------
.......

- [ File = ./tests/trendmicro-cloud-one.ini ] ---------
.................

- [ File = ./tests/pfsense.ini ] ---------
..

- [ File = ./tests/vsftpd.ini ] ---------
....

- [ File = ./tests/web_rules.ini ] ---------
..........

- [ File = ./tests/apache.ini ] ---------
..................

- [ File = ./tests/eset.ini ] ---------
........

- [ File = ./tests/doas.ini ] ---------
....

- [ File = ./tests/sysmon.ini ] ---------
...

- [ File = ./tests/gcp.ini ] ---------
...........

- [ File = ./tests/icinga.ini ] ---------
....

- [ File = ./tests/postfix.ini ] ---------
..

- [ File = ./tests/audit_scp.ini ] ---------
.

- [ File = ./tests/dropbear.ini ] ---------
...

- [ File = ./tests/rsh.ini ] ---------
..

- [ File = ./tests/kernel_usb.ini ] ---------
......

- [ File = ./tests/mcafee_epo.ini ] ---------
.

- [ File = ./tests/netscreen.ini ] ---------
....

- [ File = ./tests/panda_paps.ini ] ---------
........

- [ File = ./tests/auditd.ini ] ---------
...

- [ File = ./tests/cylance.ini ] ---------
.......

- [ File = ./tests/modsecurity.ini ] ---------
......

- [ File = ./tests/cloudlfare-waf.ini ] ---------
.............

- [ File = ./tests/office365.ini ] ---------
................................................................................................................................

- [ File = ./tests/sshd.ini ] ---------
...........................................

- [ File = ./tests/cisco_ios.ini ] ---------
.................

- [ File = ./tests/glpi.ini ] ---------
...

- [ File = ./tests/sudo.ini ] ---------
........

- [ File = ./tests/su.ini ] ---------
.....

- [ File = ./tests/proftpd.ini ] ---------
.......

- [ File = ./tests/SonicWall.ini ] ---------
........

|Component |  Tested  |  Total   | Coverage |
| -------- | -------- | -------- | -------- |
|  Rules   |   982    |   4174   |  23.53%  |
| Decoders |    76    |   172    |  44.19%  |

|          File           |  Passed  |  Failed  |  Status  |
|        --------         | -------- | -------- | -------- |
|./tests/samba.ini        |    4     |    0     |    ✅     |
|./tests/fortigate.ini    |    40    |    0     |    ✅     |
|./tests/apparmor.ini     |    5     |    0     |    ✅     |
|./tests/pam.ini          |    5     |    0     |    ✅     |
|./tests/audit_lateral.ini|    6     |    0     |    ✅     |
|./tests/systemd.ini      |    2     |    0     |    ✅     |
|./tests/arbor.ini        |    2     |    0     |    ✅     |
|./tests/dovecot.ini      |    15    |    0     |    ✅     |
|./tests/mailscanner.ini  |    1     |    0     |    ✅     |
|./tests/ossec.ini        |    5     |    0     |    ✅     |
|./tests/vuln_detector.ini|    2     |    0     |    ✅     |
|./tests/squid_rules.ini  |    2     |    0     |    ✅     |
|./tests/pix.ini          |    22    |    0     |    ✅     |
|./tests/huawei_usg.ini   |    3     |    0     |    ✅     |
|./tests/checkpoint_smart1.ini|    18    |    0     |    ✅     |
|./tests/junos.ini        |    3     |    0     |    ✅     |
|./tests/web_appsec.ini   |    31    |    0     |    ✅     |
|./tests/cimserver.ini    |    2     |    0     |    ✅     |
|./tests/cisco_ftd.ini    |    42    |    0     |    ✅     |
|./tests/firewalld.ini    |    2     |    0     |    ✅     |
|./tests/audit_recon.ini  |    2     |    0     |    ✅     |
|./tests/openldap.ini     |    9     |    0     |    ✅     |
|./tests/sophos_fw.ini    |    10    |    0     |    ✅     |
|./tests/owlh.ini         |    4     |    0     |    ✅     |
|./tests/freepbx.ini      |    6     |    0     |    ✅     |
|./tests/syslog.ini       |    6     |    0     |    ✅     |
|./tests/openvpn_ldap.ini |    2     |    0     |    ✅     |
|./tests/sophos.ini       |    8     |    0     |    ✅     |
|./tests/unbound.ini      |    0     |    0     |    ✅     |
|./tests/github.ini       |   324    |    0     |    ✅     |
|./tests/cpanel.ini       |    7     |    0     |    ✅     |
|./tests/fireeye.ini      |    3     |    0     |    ✅     |
|./tests/fortiauth.ini    |    4     |    0     |    ✅     |
|./tests/iptables.ini     |    8     |    0     |    ✅     |
|./tests/named.ini        |    5     |    0     |    ✅     |
|./tests/sophos-utm-firewall.ini|    6     |    0     |    ✅     |
|./tests/nginx.ini        |    12    |    0     |    ✅     |
|./tests/exim.ini         |    7     |    0     |    ✅     |
|./tests/opensmtpd.ini    |    7     |    0     |    ✅     |
|./tests/oscap.ini        |    32    |    0     |    ✅     |
|./tests/gitlab.ini       |    25    |    0     |    ✅     |
|./tests/paloalto.ini     |    16    |    0     |    ✅     |
|./tests/api.ini          |    28    |    0     |    ✅     |
|./tests/aws_s3_access.ini|    7     |    0     |    ✅     |
|./tests/exchange.ini     |    2     |    0     |    ✅     |
|./tests/f5_big_ip.ini    |    43    |    0     |    ✅     |
|./tests/cisco_asa.ini    |    88    |    0     |    ✅     |
|./tests/nextcloud.ini    |    7     |    0     |    ✅     |
|./tests/trendmicro-cloud-one.ini|    17    |    0     |    ✅     |
|./tests/pfsense.ini      |    2     |    0     |    ✅     |
|./tests/vsftpd.ini       |    4     |    0     |    ✅     |
|./tests/web_rules.ini    |    10    |    0     |    ✅     |
|./tests/apache.ini       |    18    |    0     |    ✅     |
|./tests/eset.ini         |    8     |    0     |    ✅     |
|./tests/doas.ini         |    4     |    0     |    ✅     |
|./tests/sysmon.ini       |    3     |    0     |    ✅     |
|./tests/gcp.ini          |    11    |    0     |    ✅     |
|./tests/icinga.ini       |    4     |    0     |    ✅     |
|./tests/postfix.ini      |    2     |    0     |    ✅     |
|./tests/audit_scp.ini    |    1     |    0     |    ✅     |
|./tests/dropbear.ini     |    3     |    0     |    ✅     |
|./tests/rsh.ini          |    2     |    0     |    ✅     |
|./tests/kernel_usb.ini   |    6     |    0     |    ✅     |
|./tests/mcafee_epo.ini   |    1     |    0     |    ✅     |
|./tests/netscreen.ini    |    4     |    0     |    ✅     |
|./tests/panda_paps.ini   |    8     |    0     |    ✅     |
|./tests/auditd.ini       |    3     |    0     |    ✅     |
|./tests/cylance.ini      |    7     |    0     |    ✅     |
|./tests/modsecurity.ini  |    6     |    0     |    ✅     |
|./tests/cloudlfare-waf.ini|    13    |    0     |    ✅     |
|./tests/office365.ini    |   128    |    0     |    ✅     |
|./tests/sshd.ini         |    43    |    0     |    ✅     |
|./tests/cisco_ios.ini    |    17    |    0     |    ✅     |
|./tests/glpi.ini         |    3     |    0     |    ✅     |
|./tests/sudo.ini         |    8     |    0     |    ✅     |
|./tests/su.ini           |    5     |    0     |    ✅     |
|./tests/proftpd.ini      |    7     |    0     |    ✅     |
|./tests/SonicWall.ini    |    8     |    0     |    ✅     |
Restarting wazuh-manager...
root@ubuntu-focal:/var/ossec/ruleset/feed/testing# 
```
</p>
</details>

- [X] 4.d New CDB lists must include the proper test entry in the correct .ini file.

### E2E testing

- [x] 5.a Logs for new or modified decoder/rules sent to a manager running with this PR ruleset appear in Kibana.

- [x] 5.b There are not affected or broken visualizations on Kibana.
![image](https://user-images.githubusercontent.com/25141115/144846706-71363b87-51d5-4733-85f6-6107bb360879.png)

- [x] 5.c New or modified items can be seen correctly using APP ruleset navigation.

![image](https://user-images.githubusercontent.com/25141115/144844944-d587fb64-3f16-48b8-8b6e-259b85ffca50.png)

### Elasticsearch Template

- [X] 6.a Known fields with output format managed and usually used for searching are included in template array index.query.default_field. 
- [X] 6.b The new field with the correct date format is stored as a "date" type field in the template.
- [X] 6.c The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 
- [X] 6.d Known fields with output format managed and usually used for searching are included in the template.

### Stoppers

- [x] 7.a No previous rule ID changes without triple check.
- [x] 7.b No previous decoder name changes without triple check.
- [x] 7.c No previous file name changes without triple check.
- [x] 7.d No previous test changes its 'rule' field value without triple check.

### Others

- [x] 8.a Each file has the correct copyright block.
- [x] 8.b The copyright block doesn't have "Author" only "Created by Wazuh". To include an "Author" request triple check.
- [x] 8.c The copyright block doesn't use "-". 
- [x] 8.d The rule files don't have any sample log.
- [x] 8.e The decoder file has sample logs next to the decoder that matches that log.
- [x] 8.f The decoder and rule files have information about software, version, and any helpful information.
- [x] 8.g The PR has a single commit with CHANGELOG changes in the correct format.
- [x] 8.h The new rule ID is not in use.
- [x] 8.i The new rule ID must be in the defined IDs range. 
- [x] 8.j New rules ID range must be verified with a triple check and noted in the rules ID document.
- [x] 8.k The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 