### PR TITLE
Rework PR 8977 - SLES12 & SLES15 - Add new sca files for MS IIS, Oracle Database 19c, MongoDB 3.6, Nginx, SQL Server and SLES

### DIFF
--- a/ruleset/sca/sles/12/cis_sles12_linux.yml
+++ b/ruleset/sca/sles/12/cis_sles12_linux.yml
@@ -1,6 +1,6 @@
 # Security Configuration Assessment
 # CIS Checks for SUSE SLES 12
-# Copyright (C) 2015-2020, Wazuh Inc.
+# Copyright (C) 2015-2021, Wazuh Inc.
 #
 # This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public

--- a/ruleset/sca/sles/12/cis_sles12_linux.yml
+++ b/ruleset/sca/sles/12/cis_sles12_linux.yml
@@ -230,7 +230,6 @@ checks:
       - 'c:grep -Rh ^kernel\.randomize_va_space /etc/sysctl.conf /etc/sysctl.d -> r:^\s*kernel.randomize_va_space\s*=\s*2$'
       - 'c:sysctl kernel.randomize_va_space -> r:\s2$|\t2$'
 
-
 ###############################################
 # 2 OS Services
 ###############################################
@@ -1352,7 +1351,6 @@ checks:
     condition: all
     rules:
       - 'c:rpm -q talk -> r:not installed'
-
 
   - id: 7578
     title: Ensure telnet client is not installed
@@ -3321,17 +3319,3 @@ checks:
       - 'f:/etc/dconf/profile/gdm -> r:^\s*file-db:/usr/share/gdm/greeter-dconf-defaults'
       - 'c:grep -Rh "banner-message-enable=true" /etc/dconf/db/gdm.d -> r:^\s*banner-message-enable=true'
       - 'c:grep -Rh "banner-message-text=" /etc/dconf/db/gdm.d -> r:^\s*banner-message-text=\S+'
-
-#  - id:
-#    title:
-#    description:
-#    rationale:
-#    remediation:
-#    compliance:
-#      - cis: [""]
-#      - cis_csc: [""]
-#    references:
-#      -
-#    condition:
-#    rules:
-#      - ''

--- a/ruleset/sca/sles/12/cis_sles12_linux.yml
+++ b/ruleset/sca/sles/12/cis_sles12_linux.yml
@@ -1,6 +1,6 @@
 # Security Configuration Assessment
 # CIS Checks for SUSE SLES 12
-# Copyright (C) 2015-2021, Wazuh Inc.
+# Copyright (C) 2015-2020, Wazuh Inc.
 #
 # This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
@@ -30,7 +30,7 @@ variables:
 
 checks:
 # Section 1.1 - Filesystem Configuration
-  - id: 7500
+  - id: 7500 
     title: "Ensure separate partition exists for /tmp"
     description: "The /tmp directory is a world-writable directory used for temporary storage by all users and some applications."
     rationale: "Since the /tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. In addition, making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw."
@@ -43,7 +43,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/tmp\s'
 
-  - id: 7501
+  - id: 7501 
     title: "Ensure nodev option set on /tmp partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /tmp."
@@ -56,7 +56,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/tmp\s && r:nodev'
 
-  - id: 7502
+  - id: 7502 
     title: "Ensure nosuid option set on /tmp partition"
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /tmp."
@@ -70,7 +70,7 @@ checks:
       - 'c:mount -> r:\s/tmp\s && r:nosuid'
 
 # 1.1.5 /tmp: noexec
-  - id: 7503
+  - id: 7503 
     title: "Ensure noexec option set on /tmp partition"
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /tmp."
@@ -85,7 +85,7 @@ checks:
       - 'c:mount -> r:\s/tmp\s && r:noexec'
 
 # 1.1.6 Build considerations - Partition scheme.
-  - id: 7504
+  - id: 7504 
     title: "Ensure separate partition exists for /var"
     description: "The /var directory is used by daemons and other system services to temporarily store dynamic data. Some directories created by these processes may be world-writable."
     rationale: "Since the /var directory may contain world-writable files and directories, there is a risk of resource exhaustion if it is not bound to a separate partition."
@@ -98,7 +98,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/var\s'
 
-  - id: 7505
+  - id: 7505 
     title: "Ensure separate partition exists for /var/log"
     description: "The /var/log directory is used by system services to store log data."
     rationale: "There are two important reasons to ensure that system logs are stored on a separate partition: protection against resource exhaustion (since logs can grow quite large) and protection of audit data."
@@ -113,7 +113,7 @@ checks:
       - 'c:mount -> r:\s/var/log\s'
 
 # 1.1.12 /var/log/audit: partition
-  - id: 7506
+  - id: 7506 
     title: "Ensure separate partition exists for /var/log/audit"
     description: "The auditing daemon, auditd , stores log data in the /var/log/audit directory."
     rationale: "There are two important reasons to ensure that data gathered by auditd is stored on a separate partition: protection against resource exhaustion (since the audit.log file can grow quite large) and protection of audit data. The audit daemon calculates how much free space is left and performs actions based on the results. If other processes (such as syslog ) consume space in the same partition as auditd, it may not perform as desired."
@@ -128,7 +128,7 @@ checks:
       - 'c:mount -> r:\s/var/log/audit\s'
 
 # 1.1.13 /home: partition
-  - id: 7507
+  - id: 7507 
     title: "Ensure separate partition exists for /home"
     description: "The /home directory is used to support disk storage needs of local users."
     rationale: "If the system is intended to support local users, create a separate partition for the /home directory to protect against resource exhaustion and restrict the type of files that can be stored under /home."
@@ -142,7 +142,7 @@ checks:
       - 'c:mount -> r:\s/home\s'
 
 # 1.1.14 /home: nodev
-  - id: 7508
+  - id: 7508 
     title: "Ensure nodev option set on /home partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the user partitions are not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices."
@@ -156,7 +156,7 @@ checks:
       - 'c:mount -> r:\s/home\s && r:nodev'
 
 # 1.1.15 /dev/shm: nodev
-  - id: 7509
+  - id: 7509 
     title: "Ensure nodev option set on /dev/shm partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /dev/shm filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create special devices in /dev/shm partitions."
@@ -170,7 +170,7 @@ checks:
       - 'c:mount -> r:\s/dev/shm\s && r:nodev'
 
 # 1.1.16 /dev/shm: nosuid
-  - id: 7510
+  - id: 7510 
     title: "Ensure nosuid option set on /dev/shm partition"
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Setting this option on a file system prevents users from introducing privileged programs onto the system and allowing non-root users to execute them."
@@ -184,7 +184,7 @@ checks:
       - 'c:mount -> r:\s/dev/shm\s && r:nosuid'
 
 # 1.1.17 /dev/shm: noexec
-  - id: 7511
+  - id: 7511 
     title: "Ensure noexec option set on /dev/shm partition"
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Setting this option on a file system prevents users from executing programs from shared memory. This deters users from introducing potentially malicious software on the system."
@@ -202,7 +202,7 @@ checks:
 # 1.5  Additional Process Hardening
 ###############################################
 # 1.5.1 Restrict Core Dumps (Scored)
-  - id: 7512
+  - id: 7512 
     title: "Ensure core dumps are restricted"
     description: "A core dump is the memory of an executable program. It is generally used to determine why a program aborted. It can also be used to glean confidential information from a core file. The system provides the ability to set a soft limit for core dumps, but this can be overridden by the user."
     rationale: "Setting a hard limit on core dumps prevents users from overriding the soft variable. If core dumps are required, consider setting limits for user groups (see limits.conf(5) ). In addition, setting the fs.suid_dumpable variable to 0 will prevent setuid programs from dumping core."
@@ -217,7 +217,7 @@ checks:
       - 'c:grep -Rh fs\.suid_dumpable /etc/sysctl.conf /etc/sysctl.d -> r:^\s*fs.suid_dumpable\s*=\s*0\s*$'
 
 # 1.5.3 Enable Randomized Virtual Memory Region Placement (Scored)
-  - id: 7513
+  - id: 7513 
     title: "Ensure address space layout randomization (ASLR) is enabled"
     description: "Address space layout randomization (ASLR) is an exploit mitigation technique which randomly arranges the address space of key data areas of a process."
     rationale: "Randomly placing virtual memory regions will make it difficult to write memory page exploits as the memory placement will be consistently shifting."
@@ -230,6 +230,7 @@ checks:
       - 'c:grep -Rh ^kernel\.randomize_va_space /etc/sysctl.conf /etc/sysctl.d -> r:^\s*kernel.randomize_va_space\s*=\s*2$'
       - 'c:sysctl kernel.randomize_va_space -> r:\s2$|\t2$'
 
+
 ###############################################
 # 2 OS Services
 ###############################################
@@ -237,7 +238,7 @@ checks:
 # 2.1 Remove Legacy Services
 ###############################################
 # Section 2.1 - inetd Services
-  - id: 7514
+  - id: 7514 
     title: "Ensure chargen services are not enabled"
     description: "chargen is a network service that responds with 0 to 512 ASCII characters for each connection it receives. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
     rationale: "Disabling this service will reduce the remote attack surface of the system."
@@ -249,7 +250,7 @@ checks:
     rules:
       - 'c:chkconfig --list -> r:chargen:|chargen-udp: && r::on'
 
-  - id: 7515
+  - id: 7515 
     title: "Ensure daytime services are not enabled"
     description: "daytime is a network service that responds with the server's current date and time. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
     rationale: "Disabling this service will reduce the remote attack surface of the system."
@@ -261,7 +262,7 @@ checks:
     rules:
       - 'c:chkconfig --list -> r:daytime:|daytime-udp && r::on'
 
-  - id: 7516
+  - id: 7516 
     title: "Ensure discard services are not enabled"
     description: "discard is a network service that simply discards all data it receives. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
     rationale: "Disabling this service will reduce the remote attack surface of the system."
@@ -273,7 +274,7 @@ checks:
     rules:
       - 'c:chkconfig --list -> r:discard:|discard-udp: && r::on'
 
-  - id: 7517
+  - id: 7517 
     title: "Ensure echo services are not enabled"
     description: "echo is a network service that responds to clients with the data sent to it by the client. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
     rationale: "Disabling this service will reduce the remote attack surface of the system."
@@ -285,7 +286,7 @@ checks:
     rules:
       - 'c:chkconfig --list -> r:echo:|echo-udp: && r::on'
 
-  - id: 7518
+  - id: 7518 
     title: "Ensure time services are not enabled"
     description: "timeis a network service that responds with the server's current date and time as a 32 bit integer. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
     rationale: "Disabling this service will reduce the remote attack surface of the system."
@@ -297,7 +298,7 @@ checks:
     rules:
       - 'c:chkconfig --list -> r:time:|time-udp && r::on'
 
-  - id: 7519
+  - id: 7519 
     title: "Ensure rsh server is not enabled"
     description: "The Berkeley rsh-server (rsh, rlogin, rexec) package contains legacy services that exchange credentials in clear-text."
     rationale: "These legacy services contain numerous security exposures and have been replaced with the more secure SSH package."
@@ -311,7 +312,7 @@ checks:
     rules:
       - 'c:chkconfig --list -> r:rexec:|rlogin:|rsh: && r::on'
 
-  - id: 7520
+  - id: 7520 
     title: "Ensure talk server is not enabled"
     description: "The talk software makes it possible for users to send and receive messages across systems through a terminal session. The talk client (allows initiate of talk sessions) is installed by default."
     rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
@@ -325,7 +326,7 @@ checks:
     rules:
       - 'c:chkconfig --list -> r:talk: && r::on'
 
-  - id: 7521
+  - id: 7521 
     title: "Ensure telnet server is not enabled"
     description: "The telnet-server package contains the telnet daemon, which accepts connections from users from other systems via the telnet protocol."
     rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow a user with access to sniff network traffic the ability to steal credentials. The ssh package provides an encrypted session and stronger security."
@@ -339,7 +340,7 @@ checks:
     rules:
       - 'c:chkconfig --list -> r:telnet: && r::on'
 
-  - id: 7522
+  - id: 7522 
     title: "Ensure tftp server is not enabled"
     description: "Trivial File Transfer Protocol (TFTP) is a simple file transfer protocol, typically used to automatically transfer configuration or boot machines from a boot server. The package atftp is used to define and support a TFTP server."
     rationale: "TFTP does not support authentication nor does it ensure the confidentiality or integrity of data. It is recommended that TFTP be removed, unless there is a specific need for TFTP. In that case, extreme caution must be used when configuring the services."
@@ -353,7 +354,7 @@ checks:
     rules:
       - 'c:chkconfig --list -> r:tftp: && r::on'
 
-  - id: 7523
+  - id: 7523 
     title: "Ensure rsync service is not enabled"
     description: "The rsyncd service can be used to synchronize files between systems over network links."
     rationale: "The rsyncd service presents a security risk as it uses unencrypted protocols for communication."
@@ -366,7 +367,7 @@ checks:
     rules:
       - 'c:chkconfig --list -> r:rsync: && r::on'
 
-  - id: 7524
+  - id: 7524 
     title: "Ensure xinetd is not enabled"
     description: "The eXtended InterNET Daemon ( xinetd ) is an open source super daemon that replaced the original inetd daemon. The xinetd daemon listens for well known services and dispatches the appropriate daemon to properly respond to service requests."
     rationale: "If there are no xinetd services required, it is recommended that the daemon be disabled."
@@ -381,7 +382,7 @@ checks:
 ###############################################
 # 2 Special Purpose Services
 ###############################################
-  - id: 7525
+  - id: 7525 
     title: "Ensure ntp is configured"
     description: "ntp is a daemon which implements the Network Time Protocol (NTP). It is designed to synchronize system clocks across a variety of systems and use a source that is highly accurate. More information on NTP can be found at https://tools.ietf.org/html/rfc958. ntp can be configured to be a client and/or a server.  This recommendation only applies if ntp is in use on the system."
     rationale: "If ntp is in use on the system proper configuration is vital to ensuring time synchronization is working properly."
@@ -399,7 +400,7 @@ checks:
       - 'f:/etc/sysconfig/ntp -> r:NTPD_OPTIONS= && r:-u && r:ntp:ntp'
 
 # 2.2.2 Remove X Windows (Scored)
-  - id: 7526
+  - id: 7526 
     title: "Ensure X Window System is not installed"
     description: "The X Window System provides a Graphical User Interface (GUI) where users can have multiple windows in which to run programs and various add on. The X Windows system is typically used on workstations where users login, but not on servers where users typically do not login."
     rationale: "Unless your organization specifically requires graphical login access via X Windows, remove it to reduce the potential attack surface."
@@ -414,7 +415,7 @@ checks:
       - 'c:rpm -qa xorg-x11* -> r:^xorg-x11'
 
 # 2.2.3 Disable Avahi Server (Scored)
-  - id: 7527
+  - id: 7527 
     title: "Ensure Avahi Server is not enabled"
     description: "Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD service discovery. Avahi allows programs to publish and discover services and hosts running on a local network with no specific configuration. For example, a user can plug a computer into a network and Avahi automatically finds printers to print to, files to look at and people to talk to, as well as network services running on the machine."
     rationale: "Automatic discovery of network services is not normally required for system functionality.  It is recommended to disable the service to reduce the potential attack surface."
@@ -428,7 +429,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled avahi-daemon -> r:enabled'
 
-  - id: 7528
+  - id: 7528 
     title: "Ensure DHCP Server is not enabled"
     description: "The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be dynamically assigned IP addresses."
     rationale: "Unless a system is specifically set up to act as a DHCP server, it is recommended that this service be disabled to reduce the potential attack surface."
@@ -441,7 +442,7 @@ checks:
       - 'c:systemctl is-enabled dhcpd -> r:enabled'
 
 # 2.2.7 Disable NFS and RPC (Not Scored)
-  - id: 7529
+  - id: 7529 
     title: "Ensure NFS and RPC are not enabled"
     description: "The Network File System (NFS) is one of the first and most widely distributed file systems in the UNIX environment. It provides the ability for systems to mount file systems of other servers through the network."
     rationale: "If the system does not export NFS shares or act as an NFS client, it is recommended that these services be disabled to reduce remote attack surface."
@@ -456,7 +457,7 @@ checks:
       - 'c:systemctl is-enabled nfs -> r:enabled'
       - 'c:systemctl is-enabled rpcbind -> r:enabled'
 
-  - id: 7530
+  - id: 7530 
     title: "Ensure DNS Server is not enabled"
     description: "The Domain Name System (DNS) is a hierarchical naming system that maps names to IP addresses for computers, services and other resources connected to a network."
     rationale: "Unless a system is specifically designated to act as a DNS server, it is recommended that the service be disabled to reduce the potential attack surface."
@@ -470,7 +471,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled named -> r:enabled'
 
-  - id: 7531
+  - id: 7531 
     title: "Ensure FTP Server is not enabled"
     description: "The File Transfer Protocol (FTP) provides networked computers with the ability to transfer files."
     rationale: "FTP does not protect the confidentiality of data or authentication credentials. It is recommended sftp be used if file transfer is required. Unless there is a need to run the system as a FTP server (for example, to allow anonymous downloads), it is recommended that the service be disabled to reduce the potential attack surface."
@@ -485,7 +486,7 @@ checks:
       - 'c:systemctl is-enabled vsftpd -> r:enabled'
 
 # 2.2.10 Remove HTTP Server (Not Scored)
-  - id: 7532
+  - id: 7532 
     title: "Ensure HTTP server is not enabled"
     description: "HTTP or web servers provide the ability to host web site content."
     rationale: "Unless there is a need to run the system as a web server, it is recommended that the service be disabled to reduce the potential attack surface."
@@ -497,7 +498,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled apache2 -> r:enabled'
 
-  - id: 7533
+  - id: 7533 
     title: "Ensure IMAP and POP3 server is not enabled"
     description: "dovecot is an open source IMAP and POP3 server for Linux based systems."
     rationale: "Unless POP3 and/or IMAP servers are to be provided by this system, it is recommended that the service be disabled to reduce the potential attack surface."
@@ -512,7 +513,7 @@ checks:
       - 'c:systemctl is-enabled dovecot -> r:enabled'
 
 # 2.2.12 Remove Samba (Not Scored)
-  - id: 7534
+  - id: 7534 
     title: "Ensure Samba is not enabled"
     description: "The Samba daemon allows system administrators to configure their Linux systems to share file systems and directories with Windows desktops. Samba will advertise the file systems and directories via the Small Message Block (SMB) protocol. Windows desktop users will be able to mount these directories and file systems as letter drives on their systems."
     rationale: "If there is no need to mount directories and file systems to Windows systems, then this service can be disabled to reduce the potential attack surface."
@@ -526,7 +527,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled smb -> r:enabled'
 
-  - id: 7535
+  - id: 7535 
     title: "Ensure HTTP Proxy Server is not enabled"
     description: "Squid is a standard proxy server used in many distributions and environments."
     rationale: "If there is no need for a proxy server, it is recommended that the squid proxy be disabled to reduce the potential attack surface."
@@ -540,7 +541,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled squid -> r:enabled'
 
-  - id: 7536
+  - id: 7536 
     title: "Ensure SNMP Server is not enabled"
     description: "The Simple Network Management Protocol (SNMP) server is used to listen for SNMP commands from an SNMP management system, execute the commands or collect the information and then send results back to the requesting system."
     rationale: "The SNMP server can communicate using SNMP v1, which transmits data in the clear and does not require authentication to execute commands. Unless absolutely necessary, it is recommended that the SNMP service not be used. If SNMP is required the server should be configured to disallow SNMP v1."
@@ -554,7 +555,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled snmpd -> r:enabled'
 
-  - id: 7537
+  - id: 7537 
     title: "Ensure NIS Server is not enabled"
     description: "The Network Information Service (NIS) (formally known as Yellow Pages) is a client-server directory service protocol for distributing system configuration files. The NIS server is a collection of programs that allow for the distribution of configuration files."
     rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be disabled and other, more secure services be used"
@@ -569,7 +570,7 @@ checks:
       - 'c:systemctl is-enabled ypserv -> r:enabled'
 
 # Section 2.3 - Service Clients
-  - id: 7538
+  - id: 7538 
     title: "Ensure NIS Client is not installed"
     description: "The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server directory service protocol used to distribute system configuration files. The NIS client ( ypbind ) was used to bind a machine to an NIS server and receive the distributed configuration files."
     rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed."
@@ -590,7 +591,7 @@ checks:
 # 3.1 Modify Network Parameters (Host Only)
 ###############################################
 # 3.1.1 Disable IP Forwarding (Scored)
-  - id: 7539
+  - id: 7539 
     title: "Ensure IP forwarding is disabled"
     description: "The net.ipv4.ip_forward flag is used to tell the system whether it can forward packets or not."
     rationale: "Setting the flag to 0 ensures that a system with multiple interfaces (for example, a hard proxy), will never be able to forward packets, and therefore, never serve as a router."
@@ -606,7 +607,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.ip_forward /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.ip_forward\s*=\s*0$'
 
 # 3.1.2 Disable Send Packet Redirects (Scored)
-  - id: 7540
+  - id: 7540 
     title: "Ensure packet redirect sending is disabled"
     description: "ICMP Redirects are used to send routing information to other hosts. As a host itself does not act as a router (in a host only configuration), there is no need to send redirects."
     rationale: "An attacker could use a compromised host to send invalid ICMP redirects to other router devices in an attempt to corrupt routing and have users access a system set up by the attacker as opposed to a valid system."
@@ -627,7 +628,7 @@ checks:
 # 3.2 Modify Network Parameters (Host and Router)
 ###############################################
 # 3.2.1 Disable Source Routed Packet Acceptance (Scored)
-  - id: 7541
+  - id: 7541 
     title: "Ensure source routed packets are not accepted"
     description: "In networking, source routing allows a sender to partially or fully specify the route packets take through a network. In contrast, non-source routed packets travel a path determined by routers in the network. In some cases, systems may not be routable or reachable from some locations (e.g. private addresses vs. Internet routable), and so source routed packets would need to be used."
     rationale: "Setting net.ipv4.conf.all.accept_source_route and net.ipv4.conf.default.accept_source_route to 0 disables the system from accepting source routed packets. Assume this system was capable of routing packets to Internet routable addresses on one interface and private addresses on another interface. Assume that the private addresses were not routable to the Internet routable addresses and vice versa. Under normal routing circumstances, an attacker from the Internet routable addresses could not use the system as a way to reach the private address systems. If, however, source routed packets were allowed, they could be used to gain access to the private address systems as the route could be specified, rather than rely on routing protocols that did not allow this routing."
@@ -645,7 +646,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.default\.accept_source_route /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.accept_source_route\s*=\s*0$'
 
 # 3.2.2 Disable ICMP Redirect Acceptance (Scored)
-  - id: 7542
+  - id: 7542 
     title: "Ensure ICMP redirects are not accepted"
     description: "ICMP redirect messages are packets that convey routing information and tell your host (acting as a router) to send packets via an alternate path. It is a way of allowing an outside routing device to update your system routing tables. By setting net.ipv4.conf.all.accept_redirects to 0, the system will not accept any ICMP redirect messages, and therefore, won't allow outsiders to update the system's routing tables."
     rationale: "Attackers could use bogus ICMP redirect messages to maliciously alter the system routing tables and get them to send packets to incorrect networks and allow your system packets to be captured."
@@ -663,7 +664,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.default\.accept_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.accept_redirects\s*=\s*0$'
 
 # 3.2.3 Disable Secure ICMP Redirect Acceptance (Scored)
-  - id: 7543
+  - id: 7543 
     title: "Ensure secure ICMP redirects are not accepted"
     description: "Secure ICMP redirects are the same as ICMP redirects, except they come from gateways listed on the default gateway list. It is assumed that these gateways are known to your system, and that they are likely to be secure."
     rationale: "It is still possible for even known gateways to be compromised. Setting net.ipv4.conf.all.secure_redirects to 0 protects the system from routing table updates by possibly compromised known gateways."
@@ -680,7 +681,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.all\.secure_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.secure_redirects\s*=\s*0$'
       - 'c:grep -Rh net\.ipv4\.conf\.default\.secure_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.secure_redirects\s*=\s*0$'
 
-  - id: 7544
+  - id: 7544 
     title: "Ensure suspicious packets are logged"
     description: "When enabled, this feature logs packets with un-routable source addresses to the kernel log."
     rationale: "Enabling this feature and logging these packets allows an administrator to investigate the possibility that an attacker is sending spoofed packets to their system."
@@ -698,7 +699,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.default\.log_martians /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.log_martians\s*=\s*1$'
 
 # 3.2.5 Enable Ignore Broadcast Requests (Scored)
-  - id: 7545
+  - id: 7545 
     title: "Ensure broadcast ICMP requests are ignored"
     description: "Setting net.ipv4.icmp_echo_ignore_broadcasts to 1 will cause the system to ignore all ICMP echo and timestamp requests to broadcast and multicast addresses."
     rationale: "Accepting ICMP echo and timestamp requests with broadcast or multicast destinations for your network could be used to trick your host into starting (or participating) in a Smurf attack. A Smurf attack relies on an attacker sending large amounts of ICMP broadcast messages with a spoofed source address. All hosts receiving this message and responding would send echo-reply messages back to the spoofed address, which is probably not routable. If many hosts respond to the packets, the amount of traffic on the network could be significantly multiplied."
@@ -714,7 +715,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.icmp_ignore_bogus_error_responses /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
 
 # 3.2.6 Enable Bad Error Message Protection (Scored)
-  - id: 7546
+  - id: 7546 
     title: "Ensure bogus ICMP responses are ignored"
     description: "Setting icmp_ignore_bogus_error_responses to 1 prevents the kernel from logging bogus responses (RFC-1122 non-compliant) from broadcast reframes, keeping file systems from filling up with useless log messages."
     rationale: "Some routers (and some attackers) will send responses that violate RFC-1122 and attempt to fill up a log file system with many useless error messages."
@@ -730,7 +731,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.icmp_ignore_bogus_error_responses /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
 
 # 3.2.7 Ensure Reverse Path Filtering is enabled (Scored)
-  - id: 7547
+  - id: 7547 
     title: "Ensure Reverse Path Filtering is enabled"
     description: "Setting net.ipv4.conf.all.rp_filter and net.ipv4.conf.default.rp_filter to 1 forces the Linux kernel to utilize reverse path filtering on a received packet to determine if the packet was valid. Essentially, with reverse path filtering, if the return packet does not go out the same interface that the corresponding source packet came from, the packet is dropped (and logged if log_martians is set)."
     rationale: "Setting these flags is a good way to deter attackers from sending your system bogus packets that cannot be responded to. One instance where this feature breaks down is if asymmetrical routing is employed. This would occur when using dynamic routing protocols (bgp, ospf, etc) on your system. If you are using asymmetrical routing on your system, you will not be able to enable this feature without breaking the routing."
@@ -748,7 +749,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.default\.rp_filter /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.rp_filter\s*=\s*1$'
 
 # 3.2.8 Enable TCP SYN Cookies (Scored)
-  - id: 7548
+  - id: 7548 
     title: "Ensure TCP SYN Cookies is enabled"
     description: "When tcp_syncookies is set, the kernel will handle TCP SYN packets normally until the half-open connection queue is full, at which time, the SYN cookie functionality kicks in. SYN cookies work by not using the SYN queue at all. Instead, the kernel simply replies to the SYN with a SYN|ACK, but will include a specially crafted TCP sequence number that encodes the source and destination IP address and port number and the time the packet was sent. A legitimate connection would send the ACK packet of the three way handshake with the specially crafted sequence number. This allows the system to verify that it has received a valid response to a SYN cookie and allow the connection, even though there is no corresponding SYN in the queue."
     rationale: "Attackers use SYN flood attacks to perform a denial of service attacked on a system by sending many SYN packets without completing the three way handshake. This will quickly use up slots in the kernel's half-open connection queue and prevent legitimate connections from succeeding. SYN cookies allow the system to keep accepting valid connections, even if under a denial of service attack."
@@ -770,7 +771,7 @@ checks:
 # 5.2 Configure SSH
 ###############################################
 # 5.2.2 Set SSH Protocol to 2 (Scored)
-  - id: 7549
+  - id: 7549 
     title: "Ensure SSH Protocol is set to 2"
     description: "SSH supports two different and incompatible protocols: SSH1 and SSH2. SSH1 was the original protocol and was subject to security issues. SSH2 is more advanced and secure."
     rationale: "SSH v1 suffers from insecurities that do not affect SSH v2."
@@ -787,7 +788,7 @@ checks:
       - 'f:$sshd_file -> !r:^\s*\t*# && r:Protocol\s*\t*2$'
 
 # 5.2.3 Set LogLevel to INFO (Scored)
-  - id: 7550
+  - id: 7550 
     title: "Ensure SSH LogLevel is set to INFO"
     description: "The INFO parameter specifies that login and logout activity will be logged."
     rationale: "SSH provides several logging levels with varying amounts of verbosity. DEBUG is specifically not recommended other than strictly for debugging SSH communications since it provides so much data that it is difficult to identify important security information. INFO level is the basic level that only records login activity of SSH users. In many situations, such as Incident Response, it is important to determine when a particular user was active on a system. The logout record can eliminate those users who disconnected, which helps narrow the field."
@@ -804,7 +805,7 @@ checks:
       - 'f:$sshd_file -> !r:^\s*\t*# && r:LogLevel\s*\t*INFO'
 
 # 5.2.5 Set SSH MaxAuthTries to 4 or Less (Scored)
-  - id: 7551
+  - id: 7551 
     title: "Ensure SSH MaxAuthTries is set to 4 or less"
     description: "The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection. When the login failure count reaches half the number, error messages will be written to the syslog file detailing the login failure."
     rationale: "Setting the MaxAuthTries parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. While the recommended setting is 4, set the number based on site policy."
@@ -819,7 +820,7 @@ checks:
       - 'f:$sshd_file -> !r:^\s*\t*# && n:^MaxAuthTries\s*\t*(\d+) compare <= 4'
 
 # 5.2.6 Set SSH IgnoreRhosts to Yes (Scored)
-  - id: 7552
+  - id: 7552 
     title: "Ensure SSH IgnoreRhosts is enabled"
     description: "The IgnoreRhosts parameter specifies that .rhosts and .shosts files will not be used in RhostsRSAAuthentication or HostbasedAuthentication."
     rationale: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: IgnoreRhosts yes"
@@ -836,7 +837,7 @@ checks:
       - 'f:$sshd_file -> !r:^\s*\t*# && r:IgnoreRhosts\s*\t*yes'
 
 # 5.2.7 Set SSH HostbasedAuthentication to No (Scored)
-  - id: 7553
+  - id: 7553 
     title: "Ensure SSH HostbasedAuthentication is disabled"
     description: "The HostbasedAuthentication parameter specifies if authentication is allowed through trusted hosts via the user of .rhosts , or /etc/hosts.equiv , along with successful public key client host authentication. This option only applies to SSH Protocol Version 2."
     rationale: "Even though the .rhosts files are ineffective if support is disabled in /etc/pam.conf, disabling the ability to use .rhosts files in SSH provides an additional layer of protection."
@@ -853,7 +854,7 @@ checks:
       - 'f:$sshd_file -> !r:^\s*\t*# && r:HostbasedAuthentication\s*\t*no'
 
 # 5.2.8 Disable SSH Root Login (Scored)
-  - id: 7554
+  - id: 7554 
     title: "Ensure SSH root login is disabled"
     description: "The PermitRootLogin parameter specifies if the root user can log in using ssh(1). The default is no."
     rationale: "Disallowing root logins over SSH requires system admins to authenticate using their own individual account, then escalating to root via sudo or su. This in turn limits opportunity for non-repudiation and provides a clear audit trail in the event of a security incident"
@@ -870,7 +871,7 @@ checks:
       - 'f:$sshd_file -> !r:^\s*\t*# && r:PermitRootLogin\s*\t*no'
 
 # 5.2.9 Set SSH PermitEmptyPasswords to No (Scored)
-  - id: 7555
+  - id: 7555 
     title: "Ensure SSH PermitEmptyPasswords is disabled"
     description: "The PermitEmptyPasswords parameter specifies if the SSH server allows login to accounts with empty password strings."
     rationale: "Disallowing remote shell access to accounts that have an empty password reduces the probability of unauthorized access to the system"
@@ -893,7 +894,7 @@ checks:
 # 6.2 Review User and Group Settings
 ###############################################
 # 6.2.5 Verify No UID 0 Accounts Exist Other Than root (Scored)
-  - id: 7556
+  - id: 7556 
     title: "Ensure root is the only UID 0 account"
     description: "Any account with UID 0 has superuser privileges on the system."
     rationale: "This access must be limited to only the default root account and only from the system console. Administrative access must be through an unprivileged account using an approved mechanism as noted in Item 5.6 Ensure access to the su command is restricted."
@@ -909,7 +910,7 @@ checks:
     rules:
       - 'f:/etc/passwd -> !r:^\s*\t*# && !r:^\s*\t*root: && r:^\w+:\w+:0:'
 
-  - id: 7557
+  - id: 7557 
     title: "Ensure password fields are not empty"
     description: "An account with an empty password field means that anybody may log in as that user without providing a password."
     rationale: "All accounts must have passwords or be locked to prevent the account from being used by an unauthorized user."
@@ -924,2398 +925,3 @@ checks:
     condition: none
     rules:
       - 'f:/etc/shadow -> r:^\w+::'
-
-  - id: 7558
-    title: Ensure mounting of cramfs filesystems is disabled
-    description: >
-      The cramfs filesystem type is a compressed read-only Linux filesystem embedded in small
-      footprint systems. A cramfs image can be used without having to first decompress the
-      image.
-    rationale: >
-      Removing support for unneeded filesystem types reduces the local attack surface of the
-      server. If this filesystem type is not needed, disable it.
-    remediation: >
-      Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
-      install cramfs /bin/true
-
-      Run the following command to unload the cramfs module:
-      # rmmod cramfs
-    compliance:
-      - cis: ["1.1.1.1"]
-      - cis_csc: ["13"]
-    condition: any
-    rules:
-      - 'c:modprobe -n -v cramfs -> r:install'
-      - 'c:modprobe -n -v cramfs -> r:cramfs'
-
-  - id: 7559
-    title: Ensure mounting of freevxfs filesystems is disabled
-    description: >
-      The freevxfs filesystem type is a free version of the Veritas type filesystem. This is the
-      primary filesystem type for HP-UX operating systems.
-    rationale: >
-      Removing support for unneeded filesystem types reduces the local attack surface of the
-      system. If this filesystem type is not needed, disable it.
-    remediation: >
-      Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
-      install freevxfs /bin/true
-
-      Run the following command to unload the freevxfs module:
-      # rmmod freevxfs
-    compliance:
-      - cis: ["1.1.1.2"]
-      - cis_csc: ["13"]
-    condition: any
-    rules:
-      - 'c:modprobe -n -v freevxfs -> r:install'
-      - 'c:modprobe -n -v freevxfs -> r:freevxfs'
-
-  - id: 7560
-    title: Ensure mounting of jffs2 filesystems is disabled
-    description: >
-      The jffs2 (journaling flash filesystem 2) filesystem type is a log-structured filesystem used
-      in flash memory devices.
-    rationale: >
-      Removing support for unneeded filesystem types reduces the local attack surface of the
-      system. If this filesystem type is not needed, disable it.
-    remediation: >
-      Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
-      install jffs2 /bin/true
-
-      Run the following command to unload the jffs2 module:
-      # rmmod jffs2
-    compliance:
-      - cis: ["1.1.1.3"]
-      - cis_csc: ["13"]
-    condition: any
-    rules:
-      - 'c:modprobe -n -v jffs2 -> r:install'
-      - 'c:modprobe -n -v jffs2 -> r:jffs2'
-
-  - id: 7561
-    title: Ensure mounting of hfs filesystems is disabled
-    description: >
-      The hfs filesystem type is a hierarchical filesystem that allows you to mount Mac OS
-      filesystems.
-    rationale: >
-      Removing support for unneeded filesystem types reduces the local attack surface of the
-      system. If this filesystem type is not needed, disable it.
-    remediation: >
-      Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
-      install hfs /bin/true
-
-      Run the following command to unload the hfs module:
-      # rmmod hfs
-    compliance:
-      - cis: ["1.1.1.4"]
-      - cis_csc: ["13"]
-    condition: any
-    rules:
-      - 'c:modprobe -n -v hfs -> r:install'
-      - 'c:modprobe -n -v hfs -> r:hfs'
-
-  - id: 7562
-    title: Ensure mounting of hfsplus filesystems is disabled
-    description: >
-      The hfsplus filesystem type is a hierarchical filesystem designed to replace hfs that allows
-      you to mount Mac OS filesystems.
-    rationale: >
-      Removing support for unneeded filesystem types reduces the local attack surface of the
-      system. If this filesystem type is not needed, disable it.
-    remediation: >
-      Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
-      install hfsplus /bin/true
-
-      Run the following command to unload the hfsplus module:
-      # rmmod hfsplus
-    compliance:
-      - cis: ["1.1.1.5"]
-      - cis_csc: ["13"]
-    condition: any
-    rules:
-      - 'c:modprobe -n -v hfsplus -> r:install'
-      - 'c:modprobe -n -v hfsplus -> r:hfsplus'
-
-  - id: 7563
-    title: Ensure mounting of squashfs filesystems is disabled
-    description: >
-      The squashfs filesystem type is a compressed read-only Linux filesystem embedded in
-      small footprint systems (similar to cramfs ). A squashfs image can be used without having
-      to first decompress the image.
-    rationale: >
-      Removing support for unneeded filesystem types reduces the local attack surface of the
-      system. If this filesystem type is not needed, disable it.
-    remediation: >
-      Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
-      install squashfs /bin/true
-
-      Run the following command to unload the squashfs module:
-      # rmmod squashfs
-    compliance:
-      - cis: ["1.1.1.6"]
-      - cis_csc: ["13"]
-    condition: any
-    rules:
-      - 'c:modprobe -n -v squashfs -> r:install'
-      - 'c:modprobe -n -v squashfs -> r:squashfs'
-
-  - id: 7564
-    title: Ensure mounting of udf filesystems is disabled
-    description: >
-      The udf filesystem type is the universal disk format used to implement ISO/IEC 13346 and
-      ECMA-167 specifications. This is an open vendor filesystem type for data storage on a
-      broad range of media. This filesystem type is necessary to support writing DVDs and newer
-      optical disc formats.
-    rationale: >
-      Removing support for unneeded filesystem types reduces the local attack surface of the
-      system. If this filesystem type is not needed, disable it.
-    remediation: >
-      Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
-      install udf /bin/true
-
-      Run the following command to unload the udf module:
-      # rmmod udf
-    compliance:
-      - cis: ["1.1.1.7"]
-      - cis_csc: ["13"]
-    condition: any
-    rules:
-      - 'c:modprobe -n -v udf -> r:install'
-      - 'c:modprobe -n -v udf -> r:udf'
-
-  - id: 7565
-    title: Ensure mounting of FAT filesystems is disabled
-    description: >
-      The FAT filesystem format is primarily used on older windows systems and portable USB
-      drives or flash modules. It comes in three types FAT12 , FAT16 , and FAT32 all of which are
-      supported by the vfat kernel module.
-    rationale: >
-      Removing support for unneeded filesystem types reduces the local attack surface of the
-      system. If this filesystem type is not needed, disable it.
-    remediation: >
-      Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
-      install vfat /bin/true
-
-      Run the following command to unload the vfat module:
-      # rmmod vfat
-    compliance:
-      - cis: ["1.1.1.8"]
-      - cis_csc: ["13"]
-    condition: any
-    rules:
-      - 'c:modprobe -n -v vfat -> r:install'
-      - 'c:modprobe -n -v vfat -> r:vfat'
-
-  - id: 7566
-    title: Ensure separate partition exists for /var/tmp
-    description: >
-      The /var/tmp directory is a world-writable directory used for temporary storage by all
-      users and some applications.
-    rationale: >
-      Since the /var/tmp directory is intended to be world-writable, there is a risk of resource
-      exhaustion if it is not bound to a separate partition. In addition, making /var/tmp its own
-      file system allows an administrator to set the noexec option on the mount, making
-      /var/tmp useless for an attacker to install executable code. It would also prevent an
-      attacker from establishing a hardlink to a system setuid program and wait for it to be
-      updated. Once the program was updated, the hardlink would be broken and the attacker
-      would have his own copy of the program. If the program happened to have a security
-      vulnerability, the attacker could continue to exploit the known flaw.
-    remediation: >
-      For new installations, during installation create a custom partition setup and specify a
-      separate partition for /var/tmp .
-      For systems that were previously installed, create a new partition and configure
-      /etc/fstab as appropriate.
-    compliance:
-      - cis: ["1.1.7"]
-    condition: all
-    rules:
-      - 'c:mount -> r:\s/var/tmp\s'
-
-  - id: 7567
-    title: Ensure nodev option set on /var/tmp partition
-    description: The nodev mount option specifies that the filesystem cannot contain special devices.
-    rationale: >
-      Since the /var/tmp filesystem is not intended to support devices, set this option to ensure
-      that users cannot attempt to create block or character special devices in /var/tmp .
-    remediation: >
-      Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the
-      /var/tmp partition. See the fstab(5) manual page for more information.
-
-      Run the following command to remount /var/tmp :
-      # mount -o remount,nodev /var/tmp
-    compliance:
-      - cis: ["1.1.8"]
-    condition: all
-    rules:
-      - 'c:mount -> r:\s+/var/tmp\s+ && r:nodev'
-
-  - id: 7568
-    title: Ensure nosuid option set on /var/tmp partition
-    description: The nosuid mount option specifies that the filesystem cannot contain setuid files.
-    rationale: >
-      Since the /var/tmp filesystem is only intended for temporary file storage, set this option to
-      ensure that users cannot create setuid files in /var/tmp .
-    remediation: >
-      Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the
-      /var/tmp partition. See the fstab(5) manual page for more information.
-
-      Run the following command to remount /var/tmp :
-      # mount -o remount,nosuid /var/tmp
-    compliance:
-      - cis: ["1.1.9"]
-    condition: all
-    rules:
-      - 'c:mount -> r:\s+/var/tmp\s+ && r:nosuid'
-
-  - id: 7569
-    title: Ensure noexec option set on /var/tmp partition
-    description: The noexec mount option specifies that the filesystem cannot contain executable binaries.
-    rationale: >
-      Since the /var/tmp filesystem is only intended for temporary file storage, set this option to
-      ensure that users cannot run executable binaries from /var/tmp .
-    remediation: >
-      Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the
-      /var/tmp partition. See the fstab(5) manual page for more information.
-
-      Run the following command to remount /var/tmp :
-      # mount -o remount,noexec /var/tmp
-    compliance:
-      - cis: ["1.1.10"]
-      - cis_csc: ["2"]
-    condition: all
-    rules:
-      - 'c:mount -> r:\s/var/tmp\s && r:noexec'
-
-  - id: 7570
-    title: Ensure AIDE is installed
-    description: >
-      AIDE takes a snapshot of filesystem state including modification times, permissions, and
-      file hashes which can then be used to compare against the current state of the filesystem to
-      detect modifications to the system.
-    rationale: >
-      By monitoring the filesystem state compromised files can be detected to prevent or limit
-      the exposure of accidental or malicious misconfigurations or modified binaries.
-    remediation: >
-      Run the following command to install aide :
-      # zypper install aide
-
-      Configure AIDE as appropriate for your environment. Consult the AIDE documentation for
-      options.
-
-      Initialize AIDE:
-        # aide --init
-      # mv /var/lib/aide/aide.db.new /var/lib/aide/aide.db
-      The name of the aide.db.new database may be different on your system.
-    compliance:
-      - cis: ["1.3.1"]
-      - cis_csc: ["3.5"]
-    references:
-      - AIDE stable manual http://aide.sourceforge.net/stable/manual.html
-    condition: none
-    rules:
-      - 'c:rpm -q aide -> r:not installed'
-
-  - id: 7571
-    title: Ensure TCP Wrappers is installed
-    description: >
-      TCP Wrappers provides a simple access list and standardized logging method for services
-      capable of supporting it. In the past, services that were called from inetd and xinetd
-      supported the use of tcp wrappers. As inetd and xinetd have been falling in disuse, any
-      service that can support tcp wrappers will have the libwrap.so library attached to it.
-    rationale: >
-      TCP Wrappers provide a good simple access list mechanism to services that may not have
-      that support built in. It is recommended that all services that can support TCP Wrappers,
-      use it.
-    remediation: >
-      Run the following command to install tcpd :
-      # zypper install tcpd
-
-      Notes:
-      To verify if a service supports TCP Wrappers, run the following command:
-
-        # ldd <path-to-daemon> | grep libwrap.so
-      If there is any output, then the service supports TCP Wrappers.
-    compliance:
-      - cis: ["3.4.1"]
-      - cis_csc: ["9.2"]
-    condition: none
-    rules:
-      - 'c:rpm -q tcpd -> r:not installed'
-
-  - id: 7572
-    title: Ensure iptables is installed
-    description: >
-      iptables allows configuration of the IPv4 tables in the linux kernel and the rules stored
-      within them. Most firewall configuration utilities operate as a front end to iptables.
-    rationale: >
-      iptables is required for firewall management and configuration.
-    remediation: >
-      Run the following command to install iptables :
-      # zypper install iptables
-    compliance:
-      - cis: ["3.6.1"]
-      - cis_csc: ["9.2"]
-    condition: none
-    rules:
-      - 'c:rpm -q iptables -> r:not installed'
-
-  - id: 7573
-    title: Ensure rsyslog or syslog-ng is installed
-    description: >
-      The rsyslog and syslog-ng software are recommended replacements to the original
-      syslogd daemon which provide improvements over syslogd , such as connection-oriented
-      (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of
-      log data en route to a central logging server.
-    rationale: >
-      The security enhancements of rsyslog and syslog-ng such as connection-oriented (i.e.
-      TCP) transmission of logs, the option to log to database formats, and the encryption of log
-      data en route to a central logging server) justify installing and configuring the package.
-    remediation: >
-      Install rsyslog or syslog-ng using one of the following commands:
-      # zypper install rsyslog
-      # zypper install syslog-ng
-    compliance:
-      - cis: ["4.2.3"]
-      - cis_csc: ["6.2"]
-    condition: any
-    rules:
-      - 'not c:rpm -q rsyslog -> r:not installed'
-      - 'not c:rpm -q syslog-ng -> r:not installed'
-
-  - id: 7574
-    title: Ensure SETroubleshoot is not installed
-    description: >
-      The SETroubleshoot service notifies desktop users of SELinux denials through a userfriendly interface. The service provides important information around configuration errors,
-      unauthorized intrusions, and other potential errors.
-    rationale: >
-      The SETroubleshoot service is an unnecessary daemon to have running on a server,
-      especially if X Windows is disabled.
-    remediation: >
-      Run the following command to uninstall s etroubleshoot :
-      # zypper remove setroubleshoot
-    compliance:
-      - cis: ["1.6.1.4"]
-    condition: all
-    rules:
-      - 'c:rpm -q setroubleshoot -> r:not installed'
-
-  - id: 7575
-    title: Ensure the MCS Translation Service (mcstrans) is not installed
-    description: >
-      The mcstransd daemon provides category label information to client processes requesting
-      information. The label translations are defined in /etc/selinux/targeted/setrans.conf
-    rationale: >
-      Since this service is not used very often, remove it to reduce the amount of potentially
-      vulnerable code running on the system.
-    remediation: >
-      Run the following command to uninstall mcstrans:
-      # zypper remove mcstrans
-    compliance:
-      - cis: ["1.6.1.5"]
-    condition: all
-    rules:
-      - 'c:rpm -q mcstrans -> r:not installed'
-
-  - id: 7576
-    title: Ensure rsh client is not installed
-    description: The rsh package contains the client commands for the rsh services.
-    rationale: >
-      These legacy clients contain numerous security exposures and have been replaced with the
-      more secure SSH package. Even if the server is removed, it is best to ensure the clients are
-      also removed to prevent users from inadvertently attempting to use these commands and
-      therefore exposing their credentials. Note that removing the rsh package removes the
-      clients for rsh , rcp and rlogin .
-    remediation: >
-      Run the following command to uninstall rsh :
-      # zypper remove rsh
-    compliance:
-      - cis: ["2.3.2"]
-      - cis_csc: ["3.4"]
-    condition: all
-    rules:
-      - 'c:rpm -q rsh -> r:not installed'
-
-  - id: 7577
-    title: Ensure talk client is not installed
-    description: >
-      The talk software makes it possible for users to send and receive messages across systems
-      through a terminal session. The talk client, which allows initialization of talk sessions, is
-      installed by default.
-    rationale: The software presents a security risk as it uses unencrypted protocols for communication.
-    remediation: >
-      Run the following command to uninstall talk :
-      # zypper remove talk
-    compliance:
-      - cis: ["2.3.3"]
-      - cis_csc: ["2"]
-    condition: all
-    rules:
-      - 'c:rpm -q talk -> r:not installed'
-
-  - id: 7578
-    title: Ensure telnet client is not installed
-    description: >
-      The telnet package contains the telnet client, which allows users to start connections to
-      other systems via the telnet protocol.
-    rationale: >
-      The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission
-      medium could allow an unauthorized user to steal credentials. The ssh package provides
-      an encrypted session and stronger security and is included in most Linux distributions.
-    remediation: >
-      Run the following command to uninstall telnet :
-      # zypper remove telnet
-    compliance:
-      - cis: ["2.3.4"]
-      - cis_csc: ["3.4"]
-    condition: all
-    rules:
-      - 'c:rpm -q telnet -> r:not installed'
-
-  - id: 7579
-    title: Ensure LDAP client is not installed
-    description: >
-      The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for
-      NIS/YP. It is a service that provides a method for looking up information from a central
-      database.
-    rationale: >
-      If the system will not need to act as an LDAP client, it is recommended that the software be
-      removed to reduce the potential attack surface.
-    remediation: >
-      Run the following command to uninstall openldap2-client :
-      # zypper remove openldap2-client
-    compliance:
-      - cis: ["2.3.5"]
-      - cis_csc: ["2"]
-    condition: all
-    rules:
-      - 'c:rpm -q openldap2-client -> r:not installed'
-
-  - id: 7580
-    title: Ensure prelink is disabled
-    description: >
-      prelinkis a program that modifies ELF shared libraries and ELF dynamically linked
-      binaries in such a way that the time needed for the dynamic linker to perform relocations
-      at startup significantly decreases.
-    rationale: >
-      The prelinking feature can interfere with the operation of AIDE, because it changes
-      binaries. Prelinking can also increase the vulnerability of the system if a malicious user is
-      able to compromise a common library such as libc.
-    remediation: >
-      Run the following commands to restore binaries to normal and uninstall prelink :
-      # prelink -ua
-      # zypper remove prelink
-    compliance:
-      - cis: ["1.5.4"]
-      - cis_csc: ["3.5"]
-    condition: all
-    rules:
-      - 'c:rpm -q prelink -> r:not installed'
-
-  - id: 7581
-    title: Ensure DCCP is disabled
-    description: >
-      The Datagram Congestion Control Protocol (DCCP) is a transport layer protocol that
-      supports streaming media and telephony. DCCP provides a way to gain access to
-      congestion control, without having to do it at the application layer, but does not provide insequence delivery.
-    rationale: >
-      If the protocol is not required, it is recommended that the drivers not be installed to reduce
-      the potential attack surface.
-    remediation: >
-      Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
-      install dccp /bin/true
-    compliance:
-      - cis: ["3.5.1"]
-      - cis_csc: ["9.1"]
-    condition: any
-    rules:
-      - 'c:modprobe -n -v dccp -> r:install'
-      - 'c:modprobe -n -v dccp -> r:dccp'
-
-  - id: 7582
-    title: Ensure SCTP is disabled
-    description: >
-      The Stream Control Transmission Protocol (SCTP) is a transport layer protocol used to
-      support message oriented communication, with several streams of messages in one
-      connection. It serves a similar function as TCP and UDP, incorporating features of both. It is
-      message-oriented like UDP, and ensures reliable in-sequence transport of messages with
-      congestion control like TCP.
-    rationale: >
-      If the protocol is not being used, it is recommended that kernel module not be loaded,
-      disabling the service to reduce the potential attack surface.
-    remediation: >
-      Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
-      install sctp /bin/true
-    compliance:
-      - cis: ["3.5.2"]
-      - cis_csc: ["9.1"]
-    condition: any
-    rules:
-      - 'c:modprobe -n -v sctp -> r:install'
-      - 'c:modprobe -n -v sctp -> r:sctp'
-
-  - id: 7583
-    title: Ensure RDS is disabled
-    description: >
-      The Reliable Datagram Sockets (RDS) protocol is a transport layer protocol designed to
-      provide low-latency, high-bandwidth communications between cluster nodes. It was
-      developed by the Oracle Corporation.
-    rationale: >
-      If the protocol is not being used, it is recommended that kernel module not be loaded,
-      disabling the service to reduce the potential attack surface.
-    remediation: >
-      Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
-      install rds /bin/true
-    compliance:
-      - cis: ["3.5.3"]
-      - cis_csc: ["9.1"]
-    condition: any
-    rules:
-      - 'c:modprobe -n -v rds -> r:install'
-      - 'c:modprobe -n -v rds -> r:rds'
-
-  - id: 7584
-    title: Ensure TIPC is disabled
-    description: >
-      The Transparent Inter-Process Communication (TIPC) protocol is designed to provide
-      communication between cluster nodes.
-    rationale: >
-      If the protocol is not being used, it is recommended that kernel module not be loaded,
-      disabling the service to reduce the potential attack surface.
-    remediation: >
-      Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
-      install tipc /bin/true
-    compliance:
-      - cis: ["3.5.4"]
-      - cis_csc: ["9.1"]
-    condition: any
-    rules:
-      - 'c:modprobe -n -v tipc -> r:install'
-      - 'c:modprobe -n -v tipc -> r:tipc'
-
-  - id: 7585
-    title: Ensure SSH X11 forwarding is disabled
-    description: >
-      The X11Forwarding parameter provides the ability to tunnel X11 traffic through the
-      connection to enable remote graphic connections.
-    rationale: >
-      Disable X11 forwarding unless there is an operational requirement to use X11 applications
-      directly. There is a small risk that the remote X11 servers of users who are logged in via
-      SSH with X11 forwarding could be compromised by other users on the X11 server. Note
-      that even if X11 forwarding is disabled, users can always install their own forwarders.
-    remediation: >
-      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
-      X11Forwarding no
-    compliance:
-      - cis: ["5.2.4"]
-    condition: all
-    rules:
-      - 'f:/etc/ssh/sshd_config -> r:^\s*X11Forwarding\s+no'
-
-  - id: 7586
-    title: Ensure SSH PermitUserEnvironment is disabled
-    description: >
-      The PermitUserEnvironment option allows users to present environment options to the
-      ssh daemon.
-    rationale: >
-      Permitting users the ability to set environment variables through the SSH daemon could
-      potentially allow users to bypass security controls (e.g. setting an execution path that has
-      ssh executing trojan'd programs)
-    remediation: >
-      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
-      PermitUserEnvironment no
-    compliance:
-      - cis: ["5.2.10"]
-      - cis_csc: ["16"]
-    condition: all
-    rules:
-      - 'f:/etc/ssh/sshd_config -> r:^\s*PermitUserEnvironment\s+no'
-
-  - id: 7587
-    title: Ensure permissions on bootloader config are configured
-    description: >
-      The grub configuration file contains information on boot settings and passwords for
-      unlocking boot options. The grub configuration is usually located at
-      /boot/grub2/grub.cfg.
-    rationale: >
-      Setting the permissions to read and write for root only prevents non-root users from
-      seeing the boot parameters or changing them. Non-root users who read the boot
-      parameters may be able to identify weaknesses in security upon boot and be able to exploit
-      them.
-    remediation: >
-      Run the following commands to set permissions on your grub configuration:
-      # chown root:root /boot/grub2/grub.cfg
-      # chmod og-rwx /boot/grub2/grub.cfg
-    compliance:
-      - cis: ["1.4.1"]
-      - cis_csc: ["5.1"]
-    condition: all
-    rules:
-      - 'c:stat -L /boot/grub2/grub.cfg -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
-
-  - id: 7588
-    title: Ensure permissions on /etc/motd are configured
-    description: >
-      The contents of the /etc/motd file are displayed to users after login and function as a
-      message of the day for authenticated users.
-    rationale: >
-      If the /etc/motd file does not have the correct ownership it could be modified by
-      unauthorized users with incorrect or misleading information.
-    remediation: >
-      Run the following commands to set permissions on /etc/motd :
-      # chown root:root /etc/motd
-      # chmod 644 /etc/motd
-    compliance:
-      - cis: ["1.7.1.4"]
-      - cis_csc: ["5.1"]
-    condition: all
-    rules:
-      - 'c:stat -L /etc/motd -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
-
-  - id: 7589
-    title: Ensure permissions on /etc/issue are configured
-    description: The contents of the /etc/issue file are displayed to users prior to login for local terminals.
-    rationale: >
-      If the /etc/issue file does not have the correct ownership it could be modified by
-      unauthorized users with incorrect or misleading information.
-    remediation: >
-      Run the following commands to set permissions on /etc/issue :
-      # chown root:root /etc/issue
-      # chmod 644 /etc/issue
-    compliance:
-      - cis: ["1.7.1.5"]
-      - cis_csc: ["5.1"]
-    condition: all
-    rules:
-      - 'c:stat -L /etc/issue -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
-
-  - id: 7590
-    title: Ensure permissions on /etc/issue.net are configured
-    description: >
-      The contents of the /etc/issue.net file are displayed to users prior to login for remote
-      connections from configured services.
-    rationale: >
-      If the /etc/issue.net file does not have the correct ownership it could be modified by
-      unauthorized users with incorrect or misleading information.
-    remediation: >
-      Run the following commands to set permissions on /etc/issue.net :
-      # chown root:root /etc/issue.net
-      # chmod 644 /etc/issue.net
-    compliance:
-      - cis: ["1.7.1.6"]
-      - cis_csc: ["5.1"]
-    condition: all
-    rules:
-      - 'c:stat -L /etc/issue.net -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
-
-  - id: 7591
-    title: Ensure permissions on /etc/hosts.allow are configured
-    description: >
-      The /etc/hosts.allow file contains networking information that is used by many
-      applications and therefore must be readable for these applications to operate.
-    rationale: >
-      It is critical to ensure that the /etc/hosts.allow file is protected from unauthorized write
-      access. Although it is protected by default, the file permissions could be changed either
-      inadvertently or through malicious actions.
-    remediation: >
-      Run the following commands to set permissions on /etc/hosts.allow :
-      # chown root:root /etc/hosts.allow
-      # chmod 644 /etc/hosts.allow
-    compliance:
-      - cis: ["3.4.4"]
-      - cis_csc: ["5.1"]
-    condition: all
-    rules:
-      - 'c:stat -L /etc/hosts.allow -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
-
-  - id: 7592
-    title: Ensure permissions on /etc/hosts.deny are configured
-    description: >
-      The /etc/hosts.deny file contains network information that is used by many system
-      applications and therefore must be readable for these applications to operate.
-    rationale: >
-      It is critical to ensure that the /etc/hosts.deny file is protected from unauthorized write
-      access. Although it is protected by default, the file permissions could be changed either
-      inadvertently or through malicious actions.
-    remediation: >
-      Run the following commands to set permissions on /etc/hosts.deny :
-      # chown root:root /etc/hosts.deny
-      # chmod 644 /etc/hosts.deny
-    compliance:
-      - cis: ["3.4.5"]
-      - cis_csc: ["5.1"]
-    condition: all
-    rules:
-      - 'c:stat -L /etc/hosts.deny -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
-
-  - id: 7593
-    title: Ensure permissions on /etc/crontab are configured
-    description: >
-      The /etc/crontab file is used by cron to control its own jobs. The commands in this item
-      make sure that root is the user and group owner of the file and that only the owner can
-      access the file.
-    rationale: >
-      This file contains information on what system jobs are run by cron. Write access to these
-      files could provide unprivileged users with the ability to elevate their privileges. Read
-      access to these files could provide users with the ability to gain insight on system jobs that
-      run on the system and could provide them a way to gain unauthorized privileged access.
-    remediation: >
-      Run the following commands to set ownership and permissions on /etc/crontab :
-      # chown root:root /etc/crontab
-      # chmod og-rwx /etc/crontab
-    compliance:
-      - cis: ["5.1.2"]
-      - cis_csc: ["5.1"]
-    condition: all
-    rules:
-      - 'c:stat -L /etc/crontab -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
-
-  - id: 7594
-    title: Ensure permissions on /etc/cron.hourly are configured
-    description: >
-      This directory contains system cron jobs that need to run on an hourly basis. The files in
-      this directory cannot be manipulated by the crontab command, but are instead edited by
-      system administrators using a text editor. The commands below restrict read/write and
-      search access to user and group root, preventing regular users from accessing this
-      directory.
-    rationale: >
-      Granting write access to this directory for non-privileged users could provide them the
-      means for gaining unauthorized elevated privileges. Granting read access to this directory
-      could give an unprivileged user insight in how to gain elevated privileges or circumvent
-      auditing controls.
-    remediation: >
-      Run the following commands to set ownership and permissions on /etc/cron.hourly :
-      # chown root:root /etc/cron.hourly
-      # chmod og-rwx /etc/cron.hourly
-    compliance:
-      - cis: ["5.1.3"]
-      - cis_csc: ["5.1"]
-    condition: all
-    rules:
-      - 'c:stat -L /etc/cron.hourly -> r:^Access:\s*\(0700/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
-
-  - id: 7595
-    title: Ensure permissions on /etc/cron.daily are configured
-    description: >
-      The /etc/cron.daily directory contains system cron jobs that need to run on a daily basis.
-      The files in this directory cannot be manipulated by the crontab command, but are instead
-      edited by system administrators using a text editor. The commands below restrict
-      read/write and search access to user and group root, preventing regular users from
-      accessing this directory.
-    rationale: >
-      Granting write access to this directory for non-privileged users could provide them the
-      means for gaining unauthorized elevated privileges. Granting read access to this directory
-      could give an unprivileged user insight in how to gain elevated privileges or circumvent
-      auditing controls.
-    remediation: >
-      Run the following commands to set ownership and permissions on /etc/cron.daily :
-      # chown root:root /etc/cron.daily
-      # chmod og-rwx /etc/cron.daily
-    compliance:
-      - cis: ["5.1.4"]
-      - cis_csc: ["5.1"]
-    condition: all
-    rules:
-      - 'c:stat -L /etc/cron.daily -> r:^Access:\s*\(0700/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
-
-  - id: 7596
-    title: Ensure permissions on /etc/cron.weekly are configured
-    description: >
-      The /etc/cron.weekly directory contains system cron jobs that need to run on a weekly
-      basis. The files in this directory cannot be manipulated by the crontab command, but are
-      instead edited by system administrators using a text editor. The commands below restrict
-      read/write and search access to user and group root, preventing regular users from
-      accessing this directory.
-    rationale: >
-      Granting write access to this directory for non-privileged users could provide them the
-      means for gaining unauthorized elevated privileges. Granting read access to this directory
-      could give an unprivileged user insight in how to gain elevated privileges or circumvent
-      auditing controls.
-    remediation: >
-      Run the following commands to set ownership and permissions on /etc/cron.weekly :
-      # chown root:root /etc/cron.weekly
-      # chmod og-rwx /etc/cron.weekly
-    compliance:
-      - cis: ["5.1.5"]
-      - cis_csc: ["5.1"]
-    condition: all
-    rules:
-      - 'c:stat -L /etc/cron.weekly -> r:^Access:\s*\(0700/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
-
-  - id: 7597
-    title: Ensure permissions on /etc/cron.monthly are configured
-    description: >
-      The /etc/cron.monthly directory contains system cron jobs that need to run on a monthly
-      basis. The files in this directory cannot be manipulated by the crontab command, but are
-      instead edited by system administrators using a text editor. The commands below restrict
-      read/write and search access to user and group root, preventing regular users from
-      accessing this directory.
-    rationale: >
-      Granting write access to this directory for non-privileged users could provide them the
-      means for gaining unauthorized elevated privileges. Granting read access to this directory
-      could give an unprivileged user insight in how to gain elevated privileges or circumvent
-      auditing controls.
-    remediation: >
-      Run the following commands to set ownership and permissions on /etc/cron.monthly :
-      # chown root:root /etc/cron.monthly
-      # chmod og-rwx /etc/cron.monthly
-    compliance:
-      - cis: ["5.1.6"]
-      - cis_csc: ["5.1"]
-    condition: all
-    rules:
-      - 'c:stat -L /etc/cron.monthly -> r:^Access:\s*\(0700/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
-
-  - id: 7598
-    title: Ensure permissions on /etc/cron.d are configured
-    description: >
-      The /etc/cron.d directory contains system cron jobs that need to run in a similar manner
-      to the hourly, daily weekly and monthly jobs from /etc/crontab , but require more
-      granular control as to when they run. The files in this directory cannot be manipulated by
-      the crontab command, but are instead edited by system administrators using a text editor.
-      The commands below restrict read/write and search access to user and group root,
-      preventing regular users from accessing this directory.
-    rationale: >
-      Granting write access to this directory for non-privileged users could provide them the
-      means for gaining unauthorized elevated privileges. Granting read access to this directory
-      could give an unprivileged user insight in how to gain elevated privileges or circumvent
-      auditing controls.
-    remediation: >
-      Run the following commands to set ownership and permissions on /etc/cron.d :
-      # chown root:root /etc/cron.d
-      # chmod og-rwx /etc/cron.d
-    compliance:
-      - cis: ["5.1.7"]
-      - cis_csc: ["5.1"]
-    condition: all
-    rules:
-      - 'c:stat -L /etc/cron.d -> r:^Access:\s*\(0700/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
-
-  - id: 7599
-    title: Ensure permissions on /etc/ssh/sshd_config are configured
-    description: >
-      The /etc/ssh/sshd_config file contains configuration specifications for sshd. The
-      command below sets the owner and group of the file to root.
-    rationale: >
-      The /etc/ssh/sshd_config file needs to be protected from unauthorized changes by nonprivileged users.
-    remediation: >
-      Run the following commands to set ownership and permissions on /etc/ssh/sshd_config:
-      # chown root:root /etc/ssh/sshd_config
-      # chmod og-rwx /etc/ssh/sshd_config
-    compliance:
-      - cis: ["5.2.1"]
-      - cis_csc: ["5.1"]
-    condition: all
-    rules:
-      - 'c:stat -L /etc/ssh/sshd_config -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
-
-  - id: 7600
-    title: Ensure permissions on /etc/passwd are configured
-    description: >
-      The /etc/passwd file contains user account information that is used by many system
-      utilities and therefore must be readable for these utilities to operate.
-    rationale: >
-      It is critical to ensure that the /etc/passwd file is protected from unauthorized write
-      access. Although it is protected by default, the file permissions could be changed either
-      inadvertently or through malicious actions.
-    remediation: >
-      Run the following command to set permissions on /etc/passwd :
-      # chown root:root /etc/passwd
-      # chmod 644 /etc/passwd
-    compliance:
-      - cis: ["6.1.2"]
-      - cis_csc: ["16.14"]
-    condition: all
-    rules:
-      - 'c:stat -L /etc/passwd -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
-
-  - id: 7601
-    title: Ensure permissions on /etc/shadow are configured
-    description: >
-      The /etc/shadow file is used to store the information about user accounts that is critical to
-      the security of those accounts, such as the hashed password and other security
-      information.
-    rationale: >
-      If attackers can gain read access to the /etc/shadow file, they can easily run a password
-      cracking program against the hashed password to break it. Other security information that
-      is stored in the /etc/shadow file (such as expiration) could also be useful to subvert the
-      user accounts.
-    remediation: >
-      Run the following commands to set permissions on /etc/shadow:
-      # chown root:shadow /etc/shadow
-      # chmod o-rwx,g-wx /etc/shadow
-    compliance:
-      - cis: ["6.1.3"]
-      - cis_csc: ["16.14"]
-    condition: all
-    rules:
-      - 'c:stat -L /etc/shadow -> r:^Access:\s*\(0640/-rw-r-----\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*15/\s*shadow\)'
-
-  - id: 7602
-    title: Ensure permissions on /etc/group are configured
-    description: >
-      The /etc/group file contains a list of all the valid groups defined in the system. The
-      command below allows read/write access for root and read access for everyone else.
-    rationale: >
-      The /etc/group file needs to be protected from unauthorized changes by non-privileged
-      users, but needs to be readable as this information is used with many non-privileged
-      programs.
-    remediation: >
-      Run the following command to set permissions on /etc/group :
-      # chown root:root /etc/group
-      # chmod 644 /etc/group
-    compliance:
-      - cis: ["6.1.4"]
-      - cis_csc: ["16.14"]
-    condition: all
-    rules:
-      - 'c:stat -L /etc/group -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
-
-  - id: 7603
-    title: Ensure permissions on /etc/gshadow are configured
-    description: >
-      The /etc/gshadow file is used to store the information about groups that is critical to the
-      security of those accounts, such as the hashed password and other security information.
-    rationale: >
-      If attackers can gain read access to the /etc/gshadow file, they can easily run a password
-      cracking program against the hashed password to break it. Other security information that
-      is stored in the /etc/gshadow file (such as group administrators) could also be useful to
-      subvert the group.
-    remediation: >
-      Run the one of the following chown commands as appropriate and the chmod to set
-      permissions on /etc/gshadow:
-
-      # chown root:root /etc/gshadow
-      # chown root:shadow /etc/gshadow
-      # chmod o-rwx,g-rw /etc/gshadow
-    compliance:
-      - cis: ["6.1.5"]
-      - cis_csc: ["16.14"]
-    condition: all
-    rules:
-      - 'c:stat -L /etc/gshadow -> r:^Access:\s*\(0640/-rw-r-----\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
-
-  - id: 7604
-    title: Ensure permissions on /etc/passwd- are configured
-    description: The /etc/passwd- file contains backup user account information.
-    rationale: >
-      It is critical to ensure that the /etc/passwd- file is protected from unauthorized access.
-      Although it is protected by default, the file permissions could be changed either
-      inadvertently or through malicious actions.
-    remediation: >
-      Run the following command to set permissions on /etc/passwd- :
-
-      # chown root:root /etc/passwd-
-      # chmod u-x,go-wx /etc/passwd-
-    compliance:
-      - cis: ["6.1.6"]
-      - cis_csc: ["16.14"]
-    condition: all
-    rules:
-      - 'c:stat -L /etc/passwd- -> r:^Access:\s*\(0644/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
-
-  - id: 7605
-    title: Ensure permissions on /etc/shadow- are configured
-    description: >
-      The /etc/shadow- file is used to store backup information about user accounts that is
-      critical to the security of those accounts, such as the hashed password and other security
-      information.
-    rationale: >
-      It is critical to ensure that the /etc/shadow- file is protected from unauthorized access.
-      Although it is protected by default, the file permissions could be changed either
-      inadvertently or through malicious actions.
-    remediation: >
-      Run the one of the following chown commands as appropriate and the chmod to set
-      permissions on /etc/shadow- :
-
-      # chown root:root /etc/shadow-
-      # chown root:shadow /etc/shadow-
-      # chmod o-rwx,g-rw /etc/shadow-
-    compliance:
-      - cis: ["6.1.7"]
-      - cis_csc: ["16.14"]
-    condition: all
-    rules:
-      - 'c:stat -L /etc/shadow- -> r:^Access:\s*\(0640/-rw-r-----\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*15/\s*shadow\)'
-
-  - id: 7606
-    title: Ensure permissions on /etc/group- are configured
-    description: The /etc/group- file contains a backup list of all the valid groups defined in the system.
-    rationale: >
-      It is critical to ensure that the /etc/group- file is protected from unauthorized access.
-      Although it is protected by default, the file permissions could be changed either
-      inadvertently or through malicious actions.
-    remediation: >
-      Run the following command to set permissions on /etc/group- :
-
-      # chown root:root /etc/group-
-      # chmod u-x,go-wx /etc/group-
-    compliance:
-      - cis: ["6.1.8"]
-      - cis_csc: ["16.14"]
-    condition: all
-    rules:
-      - 'c:stat -L /etc/group -> r:^Access:\s*\(0644/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
-
-  - id: 7607
-    title: Ensure permissions on /etc/gshadow- are configured
-    description: >
-      The /etc/gshadow- file is used to store backup information about groups that is critical to
-      the security of those accounts, such as the hashed password and other security
-      information.
-    rationale: >
-      It is critical to ensure that the /etc/gshadow- file is protected from unauthorized access.
-      Although it is protected by default, the file permissions could be changed either
-      inadvertently or through malicious actions.
-    remediation: >
-      Run the one of the following chown commands as appropriate and the chmod to set
-      permissions on /etc/gshadow- :
-
-      # chown root:root /etc/gshadow-
-      # chown root:shadow /etc/gshadow-
-      # chmod o-rwx,g-rw /etc/gshadow-
-    compliance:
-      - cis: ["6.1.9"]
-      - cis_csc: ["16.14"]
-    condition: all
-    rules:
-      - 'c:stat -L /etc/gshadow- -> r:^Access:\s*\(0640/-rw-r-----\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
-
-  - id: 7608
-    title: Ensure no legacy "+" entries exist in /etc/passwd
-    description: >
-      The character + in various files used to be markers for systems to insert data from NIS
-      maps at a certain point in a system configuration file. These entries are no longer required
-      on most systems, but may exist in files that have been imported from other platforms.
-    rationale: These entries may provide an avenue for attackers to gain privileged access on the system.
-    remediation: Remove any legacy '+' entries from /etc/passwd if they exist.
-    compliance:
-      - cis: ["6.2.2"]
-      - cis_csc: ["16.9"]
-    condition: none
-    rules:
-      - 'f:/etc/passwd -> r:^+:'
-
-  - id: 7609
-    title: Ensure no legacy "+" entries exist in /etc/shadow
-    description: >
-      The character + in various files used to be markers for systems to insert data from NIS
-      maps at a certain point in a system configuration file. These entries are no longer required
-      on most systems, but may exist in files that have been imported from other platforms.
-    rationale: These entries may provide an avenue for attackers to gain privileged access on the system.
-    remediation: Remove any legacy '+' entries from /etc/shadow if they exist.
-    compliance:
-      - cis: ["6.2.3"]
-      - cis_csc: ["16.9"]
-    condition: none
-    rules:
-      - 'f:/etc/shadow -> r:^+:'
-
-  - id: 7610
-    title: Ensure no legacy "+" entries exist in /etc/group
-    description: >
-      The character + in various files used to be markers for systems to insert data from NIS
-      maps at a certain point in a system configuration file. These entries are no longer required
-      on most systems, but may exist in files that have been imported from other platforms.
-    rationale: These entries may provide an avenue for attackers to gain privileged access on the system.
-    remediation: Remove any legacy '+' entries from /etc/group if they exist.
-    compliance:
-      - cis: ["6.2.4"]
-      - cis_csc: ["16.9"]
-    condition: none
-    rules:
-      - 'f:/etc/group -> r:^+:'
-
-  - id: 7611
-    title: Disable Automounting
-    description: autofs allows automatic mounting of devices, typically including CD/DVDs and USB drives.
-    rationale: >
-      With automounting enabled anyone with physical access could attach a USB drive or disc
-      and have its contents available in system even if they lacked permissions to mount it
-      themselves.
-    remediation: >
-      Run the following command to disable autofs:
-      # systemctl disable autofs
-    compliance:
-      - cis: ["1.1.22"]
-      - cis_csc: ["8.3"]
-    condition: none
-    rules:
-      - 'c:systemctl is-enabled autofs -> r:enabled'
-
-  - id: 7612
-    title: Ensure bootloader password is set
-    description: >
-      Setting the boot loader password will require that anyone rebooting the system must enter
-      a password before being able to set command line boot parameters
-    rationale: >
-      Requiring a boot password upon execution of the boot loader will prevent an unauthorized
-      user from entering boot parameters or changing the boot partition. This prevents users
-      from weakening security (e.g. turning off SELinux at boot time).
-    remediation: >
-      Create an encrypted password with grub-mkpasswd-pbkdf2:
-      # grub2-mkpasswd-pbkdf2
-      Enter password: <password>
-      Reenter password: <password>
-      Your PBKDF2 is <encrypted-password>
-
-      Add the following into /etc/grub.d/01_users or a custom /etc/grub.d configuration file:
-      cat <<EOF
-      set superusers="<username>"
-      password_pbkdf2 <username> <encrypted-password>
-      EOF
-
-      Run the following command to update the grub2 configuration:
-      # grub2-mkconfig > /boot/grub2/grub.cfg
-    compliance:
-      - cis: ["1.4.2"]
-      - cis_csc: ["5.1"]
-    condition: all
-    rules:
-      - 'f:/boot/grub2/grub.cfg -> r:^\s*set superusers'
-      - 'f:/boot/grub2/grub.cfg -> r:^\s*password_pbkdf2\s+\S+\s+\S+'
-
-  - id: 7613
-    title: Ensure authentication required for single user mode
-    description: >
-      Single user mode (rescue mode) is used for recovery when the system detects an issue
-      during boot or by manual selection from the bootloader.
-    rationale: >
-      Requiring authentication in single user mode (rescue mode) prevents an unauthorized user
-      from rebooting the system into single user to gain root privileges without credentials.
-    remediation: >
-      Edit /usr/lib/systemd/system/rescue.service and
-      /usr/lib/systemd/system/emergency.service and set ExecStart to use
-      '/usr/sbin/sulogin':
-      ExecStart=-/bin/sh -c "/usr/sbin/sulogin; /usr/bin/systemctl --job-mode=fail
-      --no-block default"
-
-      Notes:
-      The systemctl option --fail is synonymous with --job-mode=fail. Using either is
-      acceptable.
-    compliance:
-      - cis: ["1.4.3"]
-      - cis_csc: ["5.1"]
-    condition: all
-    rules:
-      - 'f:/usr/lib/systemd/system/rescue.service -> r:^ExecStart=-/bin/sh -c "/usr/sbin/sulogin; /usr/bin/systemctl --job-mode=fail --no-block default"'
-      - 'f:/usr/lib/systemd/system/emergency.service -> r:^ExecStart=-/bin/sh -c "/usr/sbin/sulogin; /usr/bin/systemctl --job-mode=fail --no-block default"'
-
-  - id: 7614
-    title: Ensure XD/NX support is enabled
-    description: >
-      Recent processors in the x86 family support the ability to prevent code execution on a per
-      memory page basis. Generically and on AMD processors, this ability is called No Execute
-      (NX), while on Intel processors it is called Execute Disable (XD). This ability can help
-      prevent exploitation of buffer overflow vulnerabilities and should be activated whenever
-      possible. Extra steps must be taken to ensure that this protection is enabled, particularly on
-      32-bit x86 systems. Other processors, such as Itanium and POWER, have included such
-      support since inception and the standard kernel for those platforms supports the feature.
-    rationale: >
-      Enabling any feature that can protect against buffer overflow attacks enhances the security
-      of the system.
-    remediation: >
-      On 32 bit systems install a kernel with PAE support, no installation is required on 64 bit
-      systems:
-      If necessary configure your bootloader to load the new kernel and reboot the system.
-      You may need to enable NX or XD support in your bios.
-
-      Notes:
-      Ensure your system supports the XD or NX bit and has PAE support before implementing
-      this recommendation as this may prevent it from booting if these are not supported by
-      your hardware.
-    compliance:
-      - cis: ["1.5.2"]
-      - cis_csc: ["8.4"]
-    condition: all
-    rules:
-      - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
-
-  - id: 7615
-    title: Ensure AppArmor is not disabled in bootloader configuration
-    description: >
-      Configure AppArmor to be enabled at boot time and verify that it has not been overwritten
-      by the bootloader boot parameters.
-    rationale: >
-      AppArmor must be enabled at boot time in your bootloader configuration to ensure that
-      the controls it provides are not overridden.
-    remediation: >
-      Edit /etc/default/grub and remove all instances of apparmor =0 from all CMDLINE_LINUX
-      parameters:
-      GRUB_CMDLINE_LINUX_DEFAULT="quiet"
-      GRUB_CMDLINE_LINUX=""
-
-      Run the following command to update the grub2 configuration:
-      # grub2-mkconfig > /boot/grub2/grub.cfg
-    compliance:
-      - cis: ["1.6.2.1"]
-      - cis_csc: ["14.4"]
-    condition: none
-    rules:
-      - 'f:/boot/grub2/grub.cfg -> r:^\s*linux && r:apparmor=0'
-
-  - id: 7616
-    title: Ensure message of the day is configured properly
-    description: >
-      The contents of the /etc/motd file are displayed to users after login and function as a
-      message of the day for authenticated users.
-
-      Unix-based systems have typically displayed information about the OS release and patch
-      level upon logging in to the system. This information can be useful to developers who are
-      developing software for a particular OS platform. If mingetty(8) supports the following
-      options, they display operating system information: \m - machine architecture \r -
-      operating system release \s - operating system name \v - operating system version
-    rationale: >
-      Warning messages inform users who are attempting to login to the system of their legal
-      status regarding the system and must include the name of the organization that owns the
-      system and any monitoring policies that are in place. Displaying OS and patch level
-      information in login banners also has the side effect of providing detailed system
-      information to attackers attempting to target specific exploits of a system. Authorized users
-      can easily get this information by running the " uname -a " command once they have logged
-      in.
-    remediation: >
-      Edit the /etc/motd file with the appropriate contents according to your site policy, remove
-      any instances of \m , \r , \s , or \v.
-    compliance:
-      - cis: ["1.7.1.1"]
-    condition: none
-    rules:
-      - 'f:/etc/motd -> r:\\m'
-      - 'f:/etc/motd -> r:\\r'
-      - 'f:/etc/motd -> r:\\s'
-      - 'f:/etc/motd -> r:\\v'
-
-  - id: 7617
-    title: Ensure local login warning banner is configured properly
-    description: >
-      The contents of the /etc/issue file are displayed to users prior to login for local terminals.
-
-      Unix-based systems have typically displayed information about the OS release and patch
-      level upon logging in to the system. This information can be useful to developers who are
-      developing software for a particular OS platform. If mingetty(8) supports the following
-      options, they display operating system information: \m - machine architecture \r -
-      operating system release \s - operating system name \v - operating system version
-    rationale: >
-      Warning messages inform users who are attempting to login to the system of their legal
-      status regarding the system and must include the name of the organization that owns the
-      system and any monitoring policies that are in place. Displaying OS and patch level
-      information in login banners also has the side effect of providing detailed system
-      information to attackers attempting to target specific exploits of a system. Authorized users
-      can easily get this information by running the " uname -a " command once they have logged
-      in.
-    remediation: >
-      Edit the /etc/issue file with the appropriate contents according to your site policy,
-      remove any instances of \m , \r , \s , or \v :
-      # echo "Authorized uses only. All activity may be monitored and reported." >
-      /etc/issue
-    compliance:
-      - cis: ["1.7.1.2"]
-    condition: none
-    rules:
-      - 'f:/etc/issue -> r:\\m'
-      - 'f:/etc/issue -> r:\\r'
-      - 'f:/etc/issue -> r:\\s'
-      - 'f:/etc/issue -> r:\\v'
-
-  - id: 7618
-    title: Ensure remote login warning banner is configured properly
-    description: >
-      The contents of the /etc/issue.net file are displayed to users prior to login for remote
-      connections from configured services.
-
-      Unix-based systems have typically displayed information about the OS release and patch
-      level upon logging in to the system. This information can be useful to developers who are
-      developing software for a particular OS platform. If mingetty(8) supports the following
-      options, they display operating system information: \m - machine architecture \r -
-      operating system release \s - operating system name \v - operating system version
-    rationale: >
-      Warning messages inform users who are attempting to login to the system of their legal
-      status regarding the system and must include the name of the organization that owns the
-      system and any monitoring policies that are in place. Displaying OS and patch level
-      information in login banners also has the side effect of providing detailed system
-      information to attackers attempting to target specific exploits of a system. Authorized users
-      can easily get this information by running the " uname -a " command once they have logged
-      in.
-    remediation: >
-      Edit the /etc/issue.net file with the appropriate contents according to your site policy,
-      remove any instances of \m , \r , \s , or \v :
-
-      # echo "Authorized uses only. All activity may be monitored and reported." >
-      /etc/issue.net
-    compliance:
-      - cis: ["1.7.1.3"]
-    condition: none
-    rules:
-      - 'f:/etc/issue.net -> r:\\m'
-      - 'f:/etc/issue.net -> r:\\r'
-      - 'f:/etc/issue.net -> r:\\s'
-      - 'f:/etc/issue.net -> r:\\v'
-
-  - id: 7619
-    title: Ensure updates, patches, and additional security software are installed
-    description: >
-      Periodically patches are released for included software either due to security flaws or to
-      include additional functionality.
-    rationale: >
-      Newer patches may contain security enhancements that would not be available through the
-      latest full update. As a result, it is recommended that the latest software patches be used to
-      take advantage of the latest functionality. As with any software installation, organizations
-      need to determine if a given update meets their requirements and verify the compatibility
-      and supportability of any additional software against the update revision that is selected.
-    remediation: >
-      Use your package manager to update all packages on the system according to site policy.
-      The following command will install all available updates:
-      # zypper update
-
-      Notes:
-      Site policy may mandate a testing period before install onto production systems for
-      available updates.
-    compliance:
-      - cis: ["1.8"]
-      - cis_csc: ["4.5"]
-    condition: all
-    rules:
-      - 'c:zypper list-updates -> r:^No updates found'
-
-  - id: 7620
-    title: Ensure time synchronization is in use
-    description: >
-      System time should be synchronized between all systems in an environment. This is
-      typically done by establishing an authoritative time server or set of servers and having all
-      systems synchronize their clocks to them.
-
-      Notes:
-        - On systems where host based time synchronization is not available, verify that chrony
-          is installed or systemd-timesyncd is enabled.
-        - On systems where host based time synchronization is available consult your
-          documentation and verify that host based synchronization is in use.
-        - If another method for time synchronization is being used, this section may be skipped.
-    rationale: >
-        Time synchronization is important to support time sensitive security mechanisms like
-        Kerberos and also ensures log files have consistent time records across the enterprise,
-        which aids in forensic investigations.
-    remediation: >
-        On systems where host based time synchronization is not available, install chrony OR
-        enable systemd-timesyncd:
-
-          Run the following command to install chrony:
-        # zypper install chrony
-
-        OR
-
-        Run the following command to enable systemd-timesyncd
-        # systemctl enable systemd-timesyncd
-
-        Note: On systems where host based time synchronization is available consult your
-        virtualization software documentation and setup host based synchronization.
-    compliance:
-      - cis: ["2.2.1.1"]
-      - cis_csc: ["6.1"]
-    condition: any
-    rules:
-      - 'c:rpm -q chrony -> r:^chrony-\S+'
-      - 'c:rpm -q ntp -> r:^ntp-\S+'
-
-  - id: 7621
-    title: Ensure chrony is configured
-    description: >
-      chrony is a daemon which implements the Network Time Protocol (NTP) is designed to
-      synchronize system clocks across a variety of systems and use a source that is highly
-      accurate. More information on chrony can be found at http://chrony.tuxfamily.org/. chrony
-      can be configured to be a client and/or a server.
-    rationale: >
-      If chrony is in use on the system proper configuration is vital to ensuring time
-      synchronization is working properly.
-
-      This recommendation only applies if chrony is in use on the system.
-    remediation: >
-      Add or edit server or pool lines to /etc/chrony.conf as appropriate:
-      server <remote-server>
-
-      Add or edit the OPTIONS in /etc/sysconfig/chronyd to include '-u chrony':
-      OPTIONS="-u chrony"
-    compliance:
-      - cis: ["2.2.1.3"]
-      - cis_csc: ["6.1"]
-    condition: all
-    rules:
-      - 'f:/etc/chrony.conf -> r:^\s*server\s+\.+'
-      - 'f:/etc/sysconfig/chronyd -> r:^\s*OPTIONS\s*=\s*"-u\s*chrony"'
-
-  - id: 7622
-    title: Ensure CUPS is not enabled
-    description: >
-      The Common Unix Print System (CUPS) provides the ability to print to both local and
-      network printers. A system running CUPS can also accept print jobs from remote systems
-      and print them to local printers. It also provides a web based remote administration
-      capability.
-    rationale: >
-      If the system does not need to print jobs or accept print jobs from other systems, it is
-      recommended that CUPS be disabled to reduce the potential attack surface.
-    remediation: >
-      Run the following command to disable cups :
-      # systemctl disable cups
-    compliance:
-      - cis: ["2.2.4"]
-      - cis_csc: ["9.1"]
-    references:
-      - http://www.cups.org
-    condition: none
-    rules:
-      - 'c:systemctl is-enabled cups -> r:^enabled'
-
-  - id: 7623
-    title: Ensure LDAP server is not enabled
-    description: >
-      The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for
-      NIS/YP. It is a service that provides a method for looking up information from a central
-      database.
-    rationale: >
-      If the system will not need to act as an LDAP server, it is recommended that the software be
-      disabled to reduce the potential attack surface.
-    remediation: >
-      Run the following command to disable slapd :
-      # systemctl disable slapd
-    compliance:
-      - cis: ["2.2.6"]
-      - cis_csc: ["9.1"]
-    references:
-      - http://www.openldap.org
-    condition: none
-    rules:
-      - 'c:systemctl is-enabled slapd -> r:^enabled'
-
-  - id: 7624
-    title: Ensure default deny firewall policy
-    description: >
-      A default deny all policy on connections ensures that any unconfigured network usage will
-      be rejected.
-    rationale: >
-      With a default accept policy the firewall will accept any packet that is not configured to be
-      denied. It is easier to white list acceptable usage than to black list unacceptable usage.
-    remediation: >
-      Run the following commands to implement a default DROP policy:
-      # iptables -P INPUT DROP
-      # iptables -P OUTPUT DROP
-      # iptables -P FORWARD DROP
-      Notes:
-      Changing firewall settings while connected over network can result in being locked out of
-      the system.
-
-      Remediation will only affect the active system firewall, be sure to configure the default
-      policy in your firewall management to apply on boot as well.
-    compliance:
-      - cis: ["3.6.2"]
-      - cis_csc: ["9.2"]
-    condition: all
-    rules:
-      - 'c:iptables -L -> r:^Chain\s+INPUT\s+\(policy\s+DROP\)'
-      - 'c:iptables -L -> r:^Chain\s+FORWARD\s+\(policy\s+DROP\)'
-      - 'c:iptables -L -> r:^Chain\s+OUTPUT\s+\(policy\s+DROP\)'
-
-  - id: 7625
-    title: Ensure loopback traffic is configured
-    description: >
-      Configure the loopback interface to accept traffic. Configure all other interfaces to deny
-      traffic to the loopback network (127.0.0.0/8).
-    rationale: >
-      Loopback traffic is generated between processes on machine and is typically critical to
-      operation of the system. The loopback interface is the only place that loopback network
-      (127.0.0.0/8) traffic should be seen, all other interfaces should ignore traffic on this
-      network as an anti-spoofing measure.
-    remediation: >
-      Run the following commands to implement the loopback rules:
-      # iptables -A INPUT -i lo -j ACCEPT
-      # iptables -A OUTPUT -o lo -j ACCEPT
-      # iptables -A INPUT -s 127.0.0.0/8 -j DROP195 | P a g e
-
-      Notes:
-      Changing firewall settings while connected over network can result in being locked out of
-      the system.
-
-      Remediation will only affect the active system firewall, be sure to configure the default
-      policy in your firewall management to apply on boot as well.
-    compliance:
-      - cis: ["3.6.3"]
-      - cis_csc: ["9.2"]
-    condition: all
-    rules:
-      - 'c:iptables -L INPUT -v -n -> r:^\s*\d+\s+\d+\s+ACCEPT\s+all\s+--\s+lo\s+*\s+0.0.0.0/0\s+0.0.0.0/0'
-      - 'c:iptables -L INPUT -v -n -> r:^\s*\d+\s+\d+\s+DROP\s+all\s+--\s+*\s+*\s+127.0.0.0/8\s+0.0.0.0/0'
-      - 'c:iptables -L OUTPUT -v -n -> r:^\s*\d+\s+\d+\s+ACCEPT\s+all\s+--\s+*\s+lo\s+0.0.0.0/0\s+0.0.0.0/0'
-
-  - id: 7626
-    title: Ensure audit log storage size is configured
-    description: >
-      Configure the maximum size of the audit log file. Once the log reaches the maximum size, it
-      will be rotated and a new log file will be started.
-    rationale: >
-      It is important that an appropriate size is determined for log files so that they do not impact
-      the system and audit data is not lost.
-    remediation: >
-      Set the following parameter in /etc/audit/auditd.conf in accordance with site policy:
-      max_log_file = <MB>
-
-      Notes:
-      The max_log_file parameter is measured in megabytes.
-    compliance:
-      - cis: ["4.1.1.1"]
-      - cis_csc: ["6.3"]
-    condition: all
-    rules:
-      - 'f:/etc/audit/auditd.conf -> r:^\s*max_log_file\s*=\s*\d+'
-
-  - id: 7627
-    title: Ensure system is disabled when audit logs are full
-    description: >
-      The auditd daemon can be configured to halt the system when the audit logs are full.
-    rationale: >
-      In high security contexts, the risk of detecting unauthorized access or nonrepudiation
-      exceeds the benefit of the system's availability.
-    remediation: >
-      Set the following parameters in /etc/audit/auditd.conf:
-      space_left_action = email
-      action_mail_acct = root
-      admin_space_left_action = halt
-    compliance:
-      - cis: ["4.1.1.2"]
-      - cis_csc: ["6.3"]
-    condition: all
-    rules:
-      - 'f:/etc/audit/auditd.conf -> r:^\s*space_left_action\s*=\s*email'
-      - 'f:/etc/audit/auditd.conf -> r:^\s*action_mail_acct\s*=\s*root'
-      - 'f:/etc/audit/auditd.conf -> r:^\s*admin_space_left_action\s*=\s*halt'
-
-  - id: 7628
-    title: Ensure audit logs are not automatically deleted
-    description: >
-      The max_log_file_action setting determines how to handle the audit log file reaching the
-      max file size. A value of keep_logs will rotate the logs but never delete old logs.
-    rationale: >
-      In high security contexts, the benefits of maintaining a long audit history exceed the cost of
-      storing the audit history.
-    remediation: >
-      Set the following parameter in /etc/audit/auditd.conf:
-      max_log_file_action = keep_logs
-    compliance:
-      - cis: ["4.1.1.3"]
-      - cis_csc: ["6.3"]
-    condition: all
-    rules:
-      - 'f:/etc/audit/auditd.conf -> r:^\s*max_log_file_action\s*=\s*keep_logs'
-
-  - id: 7629
-    title: Ensure auditd service is enabled
-    description: Turn on the auditd daemon to record system events.
-    rationale: >
-      The capturing of system events provides system administrators with information to allow
-      them to determine if unauthorized access to their system is occurring.
-    remediation: >
-      Run the following command to enable auditd :
-      # systemctl enable auditd
-    compliance:
-      - cis: ["4.1.2"]
-      - cis_csc: ["6.2"]
-    condition: all
-    rules:
-      - 'c:systemctl is-enabled auditd -> r:^enabled'
-
-  - id: 7630
-    title: Ensure events that modify user/group information are collected
-    description: >
-      Record events affecting the group , passwd (user IDs), shadow and gshadow (passwords) or
-      /etc/security/opasswd (old passwords, based on remember parameter in the PAM
-      configuration) files. The parameters in this section will watch the files to see if they have
-      been opened for write or have had attribute changes (e.g. permissions) and tag them with
-      the identifier "identity" in the audit log file.
-    rationale: >
-      Unexpected changes to these files could be an indication that the system has been
-      compromised and that an unauthorized user is attempting to hide their activities or
-      compromise additional accounts.
-    remediation: >
-      Add the following lines to the /etc/audit/audit.rules file:
-      -w /etc/group -p wa -k identity
-      -w /etc/passwd -p wa -k identity
-      -w /etc/gshadow -p wa -k identity
-      -w /etc/shadow -p wa -k identity
-      -w /etc/security/opasswd -p wa -k identity
-
-      Notes:
-      Reloading the auditd config to set active settings may require a system reboot.
-    compliance:
-      - cis: ["4.1.5"]
-      - cis_csc: ["5.4"]
-    condition: all
-    rules:
-      - 'c:grep identity /etc/audit/audit.rules -> r:^\s*-w\s+/etc/group\s+-p\s+wa\s+-k\s+identity'
-      - 'c:grep identity /etc/audit/audit.rules -> r:^\s*-w\s+/etc/passwd\s+-p\s+wa\s+-k\s+identity'
-      - 'c:grep identity /etc/audit/audit.rules -> r:^\s*-w\s+/etc/gshadow\s+-p\s+wa\s+-k\s+identity'
-      - 'c:grep identity /etc/audit/audit.rules -> r:^\s*-w\s+/etc/shadow\s+-p\s+wa\s+-k\s+identity'
-      - 'c:grep identity /etc/audit/audit.rules -> r:^\s*-w\s+/etc/security/opasswd\s+-p\s+wa\s+-k\s+identity'
-      - 'c:auditctl -l | grep identity -> r:^\s*-w\s+/etc/group\s+-p\s+wa\s+-k\s+identity'
-      - 'c:auditctl -l | grep identity -> r:^\s*-w\s+/etc/passwd\s+-p\s+wa\s+-k\s+identity'
-      - 'c:auditctl -l | grep identity -> r:^\s*-w\s+/etc/gshadow\s+-p\s+wa\s+-k\s+identity'
-      - 'c:auditctl -l | grep identity -> r:^\s*-w\s+/etc/shadow\s+-p\s+wa\s+-k\s+identity'
-      - 'c:auditctl -l | grep identity -> r:^\s*-w\s+/etc/security/opasswd\s+-p\s+wa\s+-k\s+identity'
-
-  - id: 7631
-    title: Ensure events that modify the system's Mandatory Access Controls are collected
-    description: >
-      Monitor SELinux/AppArmor mandatory access controls. The parameters below monitor
-      any write access (potential additional, deletion or modification of files in the directory) or
-      attribute changes to the /etc/selinux or /etc/apparmor and /etc/apparmor.d directories.
-    rationale: >
-      Changes to files in these directories could indicate that an unauthorized user is attempting
-      to modify access controls and change security contexts, leading to a compromise of the
-      system.
-    remediation: >
-      On systems using SELinux add the following line to the /etc/audit/audit.rules file:
-      -w /etc/selinux/ -p wa -k MAC-policy
-      -w /usr/share/selinux/ -p wa -k MAC-policy
-
-      On systems using AppArmor add the following line to the /etc/audit/audit.rules file:
-      -w /etc/apparmor/ -p wa -k MAC-policy
-      -w /etc/apparmor.d/ -p wa -k MAC-policy
-
-      Notes:
-      Reloading the auditd config to set active settings may require a system reboot.
-    compliance:
-      - cis: ["4.1.7"]
-      - cis_csc: ["3.6"]
-    condition: all
-    rules:
-      - 'c:grep MAC-policy /etc/audit/audit.rules -> r:^\s*-w\s+/etc/selinux/\s+-p\s+wa\s+-k\s+MAC-policy'
-      - 'c:grep MAC-policy /etc/audit/audit.rules -> r:^\s*-w\s+/usr/share/selinux/\s+-p\s+wa\s+-k\s+MAC-policy'
-      - 'c:auditctl -l | grep MAC-policy -> r:^\s*-w\s+/etc/selinux/\s+-p\s+wa\s+-k\s+MAC-policy'
-      - 'c:auditctl -l | grep MAC-policy -> r:^\s*-w\s+/usr/share/selinux/\s+-p\s+wa\s+-k\s+MAC-policy'
-
-  - id: 7632
-    title: Ensure login and logout events are collected
-    description: >
-      Monitor login and logout events. The parameters below track changes to files associated
-      with login/logout events. The file /var/log/faillog tracks failed events from login. The
-      file /var/log/lastlog maintain records of the last time a user successfully logged in. The
-      file /var/log/tallylog maintains records of failures via the pam_tally2 module
-    rationale: >
-      Monitoring login/logout events could provide a system administrator with information
-      associated with brute force attacks against user logins.
-    remediation: >
-      Add the following lines to the /etc/audit/audit.rules file:
-      -w /var/log/faillog -p wa -k logins
-      -w /var/log/lastlog -p wa -k logins
-      -w /var/log/tallylog -p wa -k logins
-
-      Notes:
-      Reloading the auditd config to set active settings may require a system reboot.
-    compliance:
-      - cis: ["4.1.8"]
-      - cis_csc: ["5.5","16.10","16.4"]
-    condition: all
-    rules:
-      - 'c:grep logins /etc/audit/audit.rules -> r:^\s*-w\s+/var/log/faillog\s+-p\s+wa\s+-k\s+logins'
-      - 'c:grep logins /etc/audit/audit.rules -> r:^\s*-w\s+/var/log/lastlog\s+-p\s+wa\s+-k\s+logins'
-      - 'c:grep logins /etc/audit/audit.rules -> r:^\s*-w\s+/var/log/tallylog\s+-p\s+wa\s+-k\s+logins'
-      - 'c:auditctl -l | grep logins -> r:^\s*-w\s+/var/log/faillog\s+-p\s+wa\s+-k\s+logins'
-      - 'c:auditctl -l | grep logins -> r:^\s*-w\s+/var/log/lastlog\s+-p\s+wa\s+-k\s+logins'
-      - 'c:auditctl -l | grep logins -> r:^\s*-w\s+/var/log/tallylog\s+-p\s+wa\s+-k\s+logins'
-
-  - id: 7633
-    title: Ensure session initiation information is collected
-    description: >
-      Monitor session initiation events. The parameters in this section track changes to the files
-      associated with session events. The file /var/run/utmp file tracks all currently logged in
-      users. All audit records will be tagged with the identifier "session." The /var/log/wtmp file
-      tracks logins, logouts, shutdown, and reboot events. The file /var/log/btmp keeps track of
-      failed login attempts and can be read by entering the command /usr/bin/last -f
-      /var/log/btmp . All audit records will be tagged with the identifier "logins."
-    rationale: >
-      Monitoring these files for changes could alert a system administrator to logins occurring at
-      unusual hours, which could indicate intruder activity (i.e. a user logging in at a time when
-      they do not normally log in).
-    remediation: >
-      Add the following lines to the /etc/audit/audit.rules file:
-      -w /var/run/utmp -p wa -k session
-      -w /var/log/wtmp -p wa -k logins
-      -w /var/log/btmp -p wa -k logins
-
-      Notes:
-      The last command can be used to read /var/log/wtmp (last with no parameters) and
-      /var/run/utmp (last -f /var/run/utmp)
-      Reloading the auditd config to set active settings may require a system reboot.
-    compliance:
-      - cis: ["4.1.9"]
-      - cis_csc: ["5.5","16.10","16.4"]
-    condition: all
-    rules:
-      - 'c:grep -E "(session|logins)" /etc/audit/audit.rules -> r:^\s*-w\s+/var/run/utmp\s+-p\s+wa\s+-k\s+session'
-      - 'c:grep -E "(session|logins)" /etc/audit/audit.rules -> r:^\s*-w\s+/var/log/wtmp\s+-p\s+wa\s+-k\s+logins'
-      - 'c:grep -E "(session|logins)" /etc/audit/audit.rules -> r:^\s*-w\s+/var/log/btmp\s+-p\s+wa\s+-k\s+logins'
-      - 'c:auditctl -l | grep -E "(session|logins)" -> r:^\s*-w\s+/var/run/utmp\s+-p\s+wa\s+-k\s+session'
-      - 'c:auditctl -l | grep -E "(session|logins)" -> r:^\s*-w\s+/var/log/wtmp\s+-p\s+wa\s+-k\s+logins'
-      - 'c:auditctl -l | grep -E "(session|logins)" -> r:^\s*-w\s+/var/log/btmp\s+-p\s+wa\s+-k\s+logins'
-
-  - id: 7634
-    title: Ensure changes to system administration scope (sudoers) is collected
-    description: >
-      Monitor scope changes for system administrations. If the system has been properly
-      configured to force system administrators to log in as themselves first and then use the
-      sudo command to execute privileged commands, it is possible to monitor changes in scope.
-      The file /etc/sudoers will be written to when the file or its attributes have changed. The
-      audit records will be tagged with the identifier "scope."
-    rationale: >
-      Changes in the /etc/sudoers file can indicate that an unauthorized change has been made
-      to scope of system administrator activity.
-    remediation: >
-      Add the following line to the /etc/audit/audit.rules file:
-      -w /etc/sudoers -p wa -k scope
-      -w /etc/sudoers.d/ -p wa -k scope
-
-      Notes:
-      Reloading the auditd config to set active settings may require a system reboot.
-    compliance:
-      - cis: ["4.1.15"]
-      - cis_csc: ["5.4"]
-    condition: all
-    rules:
-      - 'c:grep scope /etc/audit/audit.rules -> r:^\s*-w\s+/etc/sudoers\s+-p\s+wa\s+-k\s+scope'
-      - 'c:grep scope /etc/audit/audit.rules -> r:^\s*-w\s+/etc/sudoers.d/\s+-p\s+wa\s+-k\s+scope'
-      - 'c:auditctl -l | grep scope -> r:^\s*-w\s+/etc/sudoers\s+-p\s+wa\s+-k\s+scope'
-      - 'c:auditctl -l | grep scope -> r:^\s*-w\s+/etc/sudoers.d/\s+-p\s+wa\s+-k\s+scope'
-
-  - id: 7635
-    title: Ensure system administrator actions (sudolog) are collected
-    description: >
-      Monitor the sudo log file. If the system has been properly configured to disable the use of
-      the su command and force all administrators to have to log in first and then use sudo to
-      execute privileged commands, then all administrator commands will be logged to
-      /var/log/sudo.log . Any time a command is executed, an audit event will be triggered as
-      the /var/log/sudo.log file will be opened for write and the executed administration
-      command will be written to the log.
-    rationale: >
-      Changes in /var/log/sudo.log indicate that an administrator has executed a command or
-      the log file itself has been tampered with. Administrators will want to correlate the events
-      written to the audit trail with the records written to /var/log/sudo.log to verify if
-      unauthorized commands have been executed.
-    remediation: >
-      Add the following lines to the /etc/audit/audit.rules file:
-      -w /var/log/sudo.log -p wa -k actions
-    compliance:
-      - cis: ["4.1.16"]
-      - cis_csc: ["5.1","5.5"]
-    condition: all
-    rules:
-      - 'c:grep actions /etc/audit/audit.rules -> r:^\s*-w\s+/var/log/sudo.log\s+-p\s+wa\s+-k\s+actions'
-      - 'c:auditctl -l | grep actions -> r:^\s*-w\s+/var/log/sudo.log\s+-p\s+wa\s+-k\s+actions'
-
-  - id: 7636
-    title: Ensure the audit configuration is immutable
-    description: >
-      Set system audit so that audit rules cannot be modified with auditctl . Setting the flag "-e
-      2" forces audit to be put in immutable mode. Audit changes can only be made on system
-      reboot.
-    rationale: >
-      In immutable mode, unauthorized users cannot execute changes to the audit system to
-      potentially hide malicious activity and then put the audit rules back. Users would most
-      likely notice a system reboot and that could alert administrators of an attempt to make
-      unauthorized audit changes.
-    remediation: >
-      Add the following line to the end of the /etc/audit/audit.rules file.
-      -e 2
-
-      Notes:
-      This setting will ensure reloading the auditd config to set active settings requires a system
-      reboot.
-    compliance:
-      - cis: ["4.1.18"]
-      - cis_csc: ["3","6"]
-    condition: all
-    rules:
-      - 'c:grep "^\s*[^#]" /etc/audit/audit.rules | tail -1 -> r:^\s*-e\s+2\s*$'
-
-  - id: 7637
-    title: Ensure tftp server is not enabled
-    description: >
-      Trivial File Transfer Protocol (TFTP) is a simple file transfer protocol, typically used to
-      automatically transfer configuration or boot machines from a boot server. The package
-      atftp is used to define and support a TFTP server.
-    rationale: >
-      TFTP does not support authentication nor does it ensure the confidentiality or integrity of
-      data. It is recommended that TFTP be removed, unless there is a specific need for TFTP. In
-      that case, extreme caution must be used when configuring the services.
-    remediation: >
-      Run the following command to disable tftp:
-      # systemctl disable atftpd
-    compliance:
-      - cis: ["2.2.17"]
-    condition: none
-    rules:
-      - 'c:systemctl is-enabled atftpd -> r:enabled'
-
-  - id: 7638
-    title: Ensure rsync service is not enabled
-    description: The rsyncd service can be used to synchronize files between systems over network links.
-    rationale: >
-      The rsyncd service presents a security risk as it uses unencrypted protocols for
-      communication.
-    remediation: >
-      Run the following command to disable rsyncd:
-      # systemctl disable rsyncd
-    compliance:
-      - cis: ["2.2.18"]
-    condition: none
-    rules:
-      - 'c:systemctl is-enabled rsyncd -> r:enabled'
-
-  - id: 7639
-    title: Ensure IPv6 router advertisements are not accepted
-    description: This setting disables the system's ability to accept IPv6 router advertisements.
-    rationale: >
-      It is recommended that systems not accept router advertisements as they could be tricked
-      into routing traffic to compromised machines. Setting hard routes within the system
-      (usually a single default route to a trusted router) protects the system from bad routes.
-    remediation: >
-      Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file:
-      net.ipv6.conf.all.accept_ra = 0
-      net.ipv6.conf.default.accept_ra = 0
-
-      Run the following commands to set the active kernel parameters:
-      # sysctl -w net.ipv6.conf.all.accept_ra=0
-      # sysctl -w net.ipv6.conf.default.accept_ra=0
-      # sysctl -w net.ipv6.route.flush=1
-    compliance:
-      - cis: ["3.3.1"]
-      - cis_csc: ["3","11"]
-    condition: all
-    rules:
-      - 'c:sysctl net.ipv6.conf.all.accept_ra -> r:\s*0$'
-      - 'c:sysctl net.ipv6.conf.default.accept_ra -> r:\s*0$'
-      - 'c:grep -Rh "net\.ipv6\.conf\.all\.accept_ra" /etc/sysctl.conf /etc/sysctl.d -> r:^\s*net.ipv6.conf.all.accept_ra\s*=\s*0'
-      - 'c:grep -Rh "net\.ipv6\.conf\.default\.accept_ra" /etc/sysctl.conf /etc/sysctl.d -> r:^\s*net.ipv6.conf.default.accept_ra\s*=\s*0'
-
-  - id: 7640
-    title: Ensure IPv6 redirects are not accepted
-    description: >
-      This setting prevents the system from accepting ICMP redirects. ICMP redirects tell the
-      system about alternate routes for sending traffic.
-    rationale: >
-      It is recommended that systems not accept ICMP redirects as they could be tricked into
-      routing traffic to compromised machines. Setting hard routes within the system (usually a
-      single default route to a trusted router) protects the system from bad routes.
-    remediation: >
-      Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file:
-      net.ipv6.conf.all.accept_redirects = 0
-      net.ipv6.conf.default.accept_redirects = 0
-
-      Run the following commands to set the active kernel parameters:
-      # sysctl -w net.ipv6.conf.all.accept_redirects=0
-      # sysctl -w net.ipv6.conf.default.accept_redirects=0
-      # sysctl -w net.ipv6.route.flush=1
-    compliance:
-      - cis: ["3.3.2"]
-      - cis_csc: ["3","11"]
-    condition: all
-    rules:
-      - 'c:sysctl net.ipv6.conf.all.accept_redirects -> r:\s*0$'
-      - 'c:sysctl net.ipv6.conf.default.accept_redirects -> r:\s*0$'
-      - 'c:grep -Rh "net\.ipv6\.conf\.all\.accept_redirect" /etc/sysctl.conf /etc/sysctl.d -> r:^\s*net.ipv6.conf.all.accept_redirect\s*=\s*0'
-      - 'c:grep -Rh "net\.ipv6\.conf\.default\.accept_redirect" /etc/sysctl.conf /etc/sysctl.d -> r:^\s*net.ipv6.conf.default.accept_redirect\s*=\s*0'
-
-  - id: 7641
-    title: Ensure /etc/hosts.allow is configured
-    description: >
-      The /etc/hosts.allow file specifies which IP addresses are permitted to connect to the
-      host. It is intended to be used in conjunction with the /etc/hosts.deny file.
-    rationale: >
-      The /etc/hosts.allow file supports access control by IP and helps ensure that only
-      authorized systems can connect to the system.
-    remediation: >
-      Run the following command to create /etc/hosts.allow :
-      # echo "ALL: <net>/<mask>, <net>/<mask>, ..." >/etc/hosts.allow
-
-      where each <net>/<mask> combination (for example, "192.168.1.0/255.255.255.0")
-      represents one network block in use by your organization that requires access to this
-      system.
-
-      Notes:
-      Contents of the /etc/hosts.allow file will vary depending on your network configuration.
-    compliance:
-      - cis: ["3.4.2"]
-      - cis_csc: ["9.2"]
-    condition: all
-    rules:
-      - 'f:/etc/hosts.allow -> r:^\s*ALL:\s+\S+'
-
-  - id: 7642
-    title: Ensure /etc/hosts.deny is configured
-    description: >
-      The /etc/hosts.deny file specifies which IP addresses are not permitted to connect to the
-      host. It is intended to be used in conjunction with the /etc/hosts.allow file.
-    rationale: >
-      The /etc/hosts.deny file serves as a failsafe so that any host not specified in
-      /etc/hosts.allow is denied access to the system.
-    remediation: >
-      Run the following command to create /etc/hosts.deny :
-      # echo "ALL: ALL" >> /etc/hosts.deny
-
-      Notes:
-      Contents of the /etc/hosts.deny file may include additional options depending on your
-      network configuration.
-    compliance:
-      - cis: ["3.4.3"]
-      - cis_csc: ["9.2"]
-    condition: all
-    rules:
-      - 'f:/etc/hosts.deny -> r:^\s*ALL:\s+ALL'
-
-  - id: 7643
-    title: Ensure rsyslog Service is enabled
-    description: Once the rsyslog package is installed it needs to be activated.
-    rationale: >
-      If the rsyslog service is not activated the system may default to the syslogd service or lack
-      logging instead.
-    remediation: >
-      Run the following command to enable rsyslog :
-      # systemctl enable rsyslog
-    compliance:
-      - cis: ["4.2.1.1"]
-      - cis_csc: ["6.2"]
-    condition: all
-    rules:
-      - 'c:systemctl is-enabled rsyslog -> r:enabled'
-
-  - id: 7644
-    title: Ensure syslog-ng service is enabled
-    description: >
-      Once the syslog-ng package is installed it needs to be activated.
-    rationale: >
-      If the syslog-ng service is not activated the system may default to the syslogd service or
-      lack logging instead.
-    remediation: >
-      Run the following command to enable syslog-ng :
-      # systemctl enable syslog-ng
-    compliance:
-      - cis: ["4.2.2.1"]
-      - cis_csc: ["6.2"]
-    condition: all
-    rules:
-      - 'c:systemctl is-enabled syslog-ng -> r:enabled'
-
-  - id: 7645
-    title: Ensure cron daemon is enabled
-    description: The cron daemon is used to execute batch jobs on the system.
-    rationale: >
-      While there may not be user jobs that need to be run on the system, the system does have
-      maintenance jobs that may include security monitoring that have to run, and cron is used
-      to execute them.
-    remediation: >
-      Run the following command to enable cron :
-      # systemctl enable cron
-    compliance:
-      - cis: ["5.1.1"]
-      - cis_csc: ["6"]
-    condition: all
-    rules:
-      - 'c:systemctl is-enabled cron -> r:enabled'
-
-  - id: 7646
-    title: Ensure at/cron is restricted to authorized users
-    description: >
-      Configure /etc/cron.allow and /etc/at.allow to allow specific users to use these
-      services. If /etc/cron.allow or /etc/at.allow do not exist, then /etc/at.deny and
-      /etc/cron.deny are checked. Any user not specifically defined in those files is allowed to
-      use at and cron. By removing the files, only users in /etc/cron.allow and /etc/at.allow
-      are allowed to use at and cron. Note that even though a given user is not listed in
-      cron.allow , cron jobs can still be run as that user. The cron.allow file only controls
-      administrative access to the crontab command for scheduling and modifying cron jobs.
-    rationale: >
-      On many systems, only the system administrator is authorized to schedule cron jobs. Using
-      the cron.allow file to control who can run cron jobs enforces this policy. It is easier to
-      manage an allow list than a deny list. In a deny list, you could potentially add a user ID to
-      the system and forget to add it to the deny files.
-    remediation: >
-      Run the following commands to remove /etc/cron.deny and /etc/at.deny and create and
-      set permissions and ownership for /etc/cron.allow and /etc/at.allow :
-
-      # rm /etc/cron.deny
-      # rm /etc/at.deny
-      # touch /etc/cron.allow
-      # touch /etc/at.allow
-      # chmod og-rwx /etc/cron.allow
-      # chmod og-rwx /etc/at.allow
-      # chown root:root /etc/cron.allow
-      # chown root:root /etc/at.allow
-    compliance:
-      - cis: ["5.1.8"]
-      - cis_csc: ["16"]
-    condition: all
-    rules:
-      - 'not f:/etc/cron.deny'
-      - 'not f:/etc/at.deny'
-      - 'c:stat -L /etc/cron.allow -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
-      - 'c:stat -L /etc/at.allow -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
-
-  - id: 7647
-    title: Ensure only approved MAC algorithms are used
-    description: This variable limits the types of MAC algorithms that SSH can use during communication.
-    rationale: >
-      MD5 and 96-bit MAC algorithms are considered weak and have been shown to increase
-      exploitability in SSH downgrade attacks. Weak algorithms continue to have a great deal of
-      attention as a weak spot that can be exploited with expanded computing power. An
-      attacker that breaks the algorithm could take advantage of a MiTM position to decrypt the
-      SSH tunnel and capture credentials and information
-    remediation: >
-      Edit the /etc/ssh/sshd_config file to set the parameter in accordance with site policy. The
-      following includes all supported and accepted MACs:
-
-      MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-
-      etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com
-    compliance:
-      - cis: ["5.2.11"]
-      - cis_csc: ["3.4"]
-    references:
-      - http://www.mitls.org/pages/attacks/SLOTH
-    condition: none
-    rules:
-      - 'c:sshd -T -> r:^macs\s+ && r:hmac-md5\s*'
-      - 'c:sshd -T -> r:^macs\s+ && r:hmac-md5-96\s*'
-      - 'c:sshd -T -> r:^macs\s+ && r:hmac-ripemd160\s*'
-      - 'c:sshd -T -> r:^macs\s+ && r:hmac-sha1\s*'
-      - 'c:sshd -T -> r:^macs\s+ && r:hmac-sha1-96\s*'
-      - 'c:sshd -T -> r:^macs\s+ && r:umac-64@openssh.com\s*'
-      - 'c:sshd -T -> r:^macs\s+ && r:hmac-md5-etm@openssh.com\s*'
-      - 'c:sshd -T -> r:^macs\s+ && r:hmac-md5-96-etm@openssh.com\s*'
-      - 'c:sshd -T -> r:^macs\s+ && r:hmac-ripemd160-etm@openssh.com\s*'
-      - 'c:sshd -T -> r:^macs\s+ && r:hmac-sha1-etm@openssh.com\s*'
-      - 'c:sshd -T -> r:^macs\s+ && r:hmac-sha1-96-etm@openssh.com\s*'
-      - 'c:sshd -T -> r:^macs\s+ && r:umac-64-etm@openssh.com\s*'
-
-  - id: 7648
-    title: Ensure SSH Idle Timeout Interval is configured
-    description: >
-      The two options ClientAliveInterval and ClientAliveCountMax control the timeout of
-      ssh sessions. When the ClientAliveInterval variable is set, ssh sessions that have no
-      activity for the specified length of time are terminated. When the ClientAliveCountMax
-      variable is set, sshd will send client alive messages at every ClientAliveInterval interval.
-      When the number of consecutive client alive messages are sent with no response from the
-      client, the ssh session is terminated. For example, if the ClientAliveInterval is set to 15
-      seconds and the ClientAliveCountMax is set to 3, the client ssh session will be terminated
-      after 45 seconds of idle time.
-    rationale: >
-      Having no timeout value associated with a connection could allow an unauthorized user
-      access to another user's ssh session (e.g. user walks away from their computer and doesn't
-      lock the screen). Setting a timeout value at least reduces the risk of this happening..
-
-      While the recommended setting is 300 seconds (5 minutes), set this timeout value based on
-      site policy. The recommended setting for ClientAliveCountMax is 0. In this case, the client
-      session will be terminated after 5 minutes of idle time and no keepalive messages will be
-      sent.
-    remediation: >
-      Edit the /etc/ssh/sshd_config file to set the parameters according to site policy:
-      ClientAliveInterval 300
-      ClientAliveCountMax 0
-    compliance:
-      - cis: ["5.2.12"]
-      - cis_csc: ["16.4"]
-    condition: all
-    rules:
-      - 'c:sshd -T -> n:^clientaliveinterval\s+(\d+) compare >= 1'
-      - 'c:sshd -T -> n:^clientaliveinterval\s+(\d+) compare <= 300'
-      - 'c:sshd -T -> n:^ClientAliveCountMax\s+(\d+) compare == 0'
-
-  - id: 7649
-    title: Ensure SSH LoginGraceTime is set to one minute or less
-    description: >
-      The LoginGraceTime parameter specifies the time allowed for successful authentication to
-      the SSH server. The longer the Grace period is the more open unauthenticated connections
-      can exist. Like other session controls in this session the Grace Period should be limited to
-      appropriate organizational limits to ensure the service is available for needed access.
-    rationale: >
-      Setting the LoginGraceTime parameter to a low number will minimize the risk of successful
-      brute force attacks to the SSH server. It will also limit the number of concurrent
-      unauthenticated connections While the recommended setting is 60 seconds (1 Minute), set
-      the number based on site policy.
-    remediation: >
-      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
-      LoginGraceTime 60
-    compliance:
-      - cis: ["5.2.13"]
-    condition: all
-    rules:
-      - 'c:sshd -T -> n:^logingracetime\s+(\d+) compare >= 1'
-      - 'c:sshd -T -> n:^logingracetime\s+(\d+) compare <= 60'
-
-  - id: 7650
-    title: Ensure SSH access is limited
-    description: >
-      There are several options available to limit which users and group can access the system
-      via SSH. It is recommended that at least one of the following options be leveraged:
-      AllowUsers
-
-      The AllowUsers variable gives the system administrator the option of allowing specific
-      users to ssh into the system. The list consists of space separated user names. Numeric user
-      IDs are not recognized with this variable. If a system administrator wants to restrict user
-      access further by only allowing the allowed users to log in from a particular host, the entry
-      can be specified in the form of user@host. AllowGroups
-
-      The AllowGroups variable gives the system administrator the option of allowing specific
-      groups of users to ssh into the system. The list consists of space separated group names.
-      Numeric group IDs are not recognized with this variable. DenyUsers
-
-      The DenyUsers variable gives the system administrator the option of denying specific users
-      to ssh into the system. The list consists of space separated user names. Numeric user IDs
-      are not recognized with this variable. If a system administrator wants to restrict user
-      access further by specifically denying a user's access from a particular host, the entry can
-      be specified in the form of user@host. DenyGroups
-
-      The DenyGroups variable gives the system administrator the option of denying specific
-      groups of users to ssh into the system. The list consists of space separated group names.
-      Numeric group IDs are not recognized with this variable.
-    rationale: >
-      Restricting which users can remotely access the system via SSH will help ensure that only
-      authorized users access the system.
-    remediation: >
-      Edit the /etc/ssh/sshd_config file to set one or more of the parameter as follows:
-
-      AllowUsers <userlist>
-      AllowGroups <grouplist>
-      DenyUsers <userlist>
-      DenyGroups <grouplist>
-    compliance:
-      - cis: ["5.2.14"]
-      - cis_csc: ["5.1","5.8"]
-    condition: any
-    rules:
-      - 'c:sshd -T -> r:^\s*allowusers\s+\S+'
-      - 'c:sshd -T -> r:^\s*allowgroups\s+\S+'
-      - 'c:sshd -T -> r:^\s*denyusers\s+\S+'
-      - 'c:sshd -T -> r:^\s*denygroups\s+\S+'
-
-  - id: 7651
-    title: Ensure SSH warning banner is configured
-    description: >
-      The Banner parameter specifies a file whose contents must be sent to the remote user
-      before authentication is permitted. By default, no banner is displayed.
-    rationale: >
-      Banners are used to warn connecting users of the particular site's policy regarding
-      connection. Presenting a warning message prior to the normal user login may assist the
-      prosecution of trespassers on the computer system.
-    remediation: >
-      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
-
-      Banner /etc/issue.net
-    compliance:
-      - cis: ["5.2.15"]
-    condition: all
-    rules:
-      - 'c:sshd -T -> r:^banner\s+/etc/issue.net'
-
-  - id: 7652
-    title: Ensure lockout for failed password attempts is configured
-    description: >
-      Lock out users after n unsuccessful consecutive login attempts. The first sets of changes are
-      made to the PAM configuration files. The second set of changes are applied to the program
-      specific PAM configuration file. The second set of changes must be applied to each program
-      that will lock out users. Check the documentation for each secondary program for
-      instructions on how to configure them to work with PAM.
-
-      Set the lockout number to the policy in effect at your site.
-    rationale: >
-      Locking out user IDs after n unsuccessful consecutive login attempts mitigates brute force
-      password attacks against your systems.
-    remediation: >
-      Edit the /etc/pam.d/common-auth file and add the following pam_tally2.so line:
-      auth required pam_tally2.so onerr=fail audit silent deny=5 unlock_time=900
-
-      Edit the /etc/pam.d/common-account file and add the following pam_tally2.so line:
-      account required pam_tally2.so
-
-      Notes:
-      Additional module options may be set, recommendation only covers those listed here.
-
-      If a user has been locked out because they have reached the maximum consecutive failure
-      count defined by deny= in the pam_tally2.so module, the user can be unlocked by issuing
-      the command pam_tally2 -u --reset. This command sets the failed count to 0, effectively
-      unlocking the user.
-
-      Use of the "audit" keyword may log credentials in the case of user error during
-      authentication. This risk should be evaluated in the context of the site policies of your
-      organization.
-    compliance:
-      - cis: ["5.3.2"]
-      - cis_csc: ["16.7"]
-    condition: all
-    rules:
-      - 'c:grep pam_tally2\.so /etc/pam.d/common-auth -> r:^\t*auth\t*required\t*pam_tally2.so\t*\.*'
-      - 'c:grep pam_tally2\.so /etc/pam.d/common-account -> r:^\t*account\t*required\t*pam_tally2.so'
-
-  - id: 7653
-    title: Ensure password reuse is limited
-    description: >
-      The /etc/security/opasswd file stores the users' old passwords and can be checked to
-      ensure that users are not recycling recent passwords.
-    rationale: >
-      Forcing users not to reuse their past 5 passwords make it less likely that an attacker will be
-      able to guess the password.
-      Note that these change only apply to accounts configured on the local system.
-    remediation: >
-      Edit the /etc/pam.d/common-password file to include the remember option and conform to
-      site policy as shown:
-      password required pam_pwhistory.so remember=5
-
-      Notes:
-      Additional module options may be set, recommendation only covers those listed here.
-    compliance:
-      - cis: ["5.3.3"]
-      - cis_csc: ["16"]
-    condition: all
-    rules:
-      - 'f:/etc/pam.d/common-password -> n:^\s*password\t+required\t+pam_pwhistory\.so\t+remember\s*=\s*(\d+) compare >= 5'
-
-  - id: 7654
-    title: Ensure password hashing algorithm is SHA-512
-    description: >
-      The commands below change password encryption from md5 to sha512 (a much stronger
-      hashing algorithm). All existing accounts will need to perform a password change to
-      upgrade the stored hashes to the new algorithm.
-    rationale: >
-      The SHA-512 algorithm provides much stronger hashing than MD5, thus providing
-      additional protection to the system by increasing the level of effort for an attacker to
-      successfully determine passwords.
-
-      Note that these change only apply to accounts configured on the local system.
-    remediation: >
-      Edit the /etc/pam.d/common-password file to include the sha512 option for pam_unix.so as
-      shown:
-      password required pam_unix.so sha512
-    compliance:
-      - cis: ["5.3.4"]
-      - cis_csc: ["16.14"]
-    condition: all
-    rules:
-      - 'f:/etc/pam.d/common-password -> r:^\s*password\t+required\t+pam_unix.so\t+sha512'
-
-  - id: 7655
-    title: Ensure default group for the root account is GID 0
-    description: >
-      The usermod command can be used to specify which group the root user belongs to. This
-      affects permissions of files that are created by the root user.
-    rationale: >
-      Using GID 0 for the _root_ account helps prevent _root_ -owned files from accidentally
-      becoming accessible to non-privileged users.
-    remediation: >
-      Run the following command to set the root user default group to GID 0 :
-      # usermod -g 0 root
-    compliance:
-      - cis: ["5.4.3"]
-      - cis_csc: ["5"]
-    condition: all
-    rules:
-      - 'f:/etc/passwd -> r:^root:\S+:\S+:0:'
-
-  - id: 7656
-    title: Ensure default user shell timeout is 900 seconds or less
-    description: >
-      The default TMOUT determines the shell timeout for users. The TMOUT value is measured in
-      seconds.
-    rationale: >
-      Having no timeout value associated with a shell could allow an unauthorized user access to
-      another user's shell session (e.g. user walks away from their computer and doesn't lock the
-      screen). Setting a timeout value at least reduces the risk of this happening.
-    remediation: >
-      Edit the /etc/bashrc and /etc/profile files (and the appropriate files for any other shell
-      supported on your system) and add or edit any umask parameters as follows:
-      TMOUT=600
-
-      Notes:
-      The audit and remediation in this recommendation apply to bash and shell. If other shells
-      are supported on the system, it is recommended that their configuration files also are
-      checked. Other methods of setting a timeout exist for other shells not covered here.
-    compliance:
-      - cis: ["5.4.5"]
-      - cis_csc: ["13"]
-    condition: all
-    rules:
-      - 'f:/etc/bashrc -> r:^TMOUT'
-      - 'f:/etc/profile -> r:^TMOUT'
-      - 'not f:/etc/bashrc -> n:^TMOUT=(\d+) compare > 900'
-      - 'not f:/etc/profile -> n:^TMOUT=(\d+) compare > 900'
-
-  - id: 7657
-    title: Ensure the SELinux state is enforcing
-    description: Set SELinux to enable when the system is booted.
-    rationale: >
-      SELinux must be enabled at boot time in to ensure that the controls it provides are in effect
-      at all times.
-    remediation: >
-      Edit the /etc/selinux/config file to set the SELINUX parameter:
-      SELINUX=enforcing
-    compliance:
-      - cis: ["1.6.1.2"]
-      - cis_csc: ["14.4"]
-    condition: all
-    rules:
-      - 'f:/etc/selinux/config -> r:^\s*SELINUX=enforcing'
-      - 'c:sestatus -> r:^\s*SELinux status:\t*enabled'
-      - 'c:sestatus -> r:^\s*Current mode:\t*enforcing'
-      - 'c:sestatus -> r:^\s*Mode from config file:\t*enforcing'
-
-  - id: 7658
-    title: Ensure SELinux policy is configured
-    description: >
-      Configure SELinux to meet or exceed the default targeted policy, which constrains daemons
-      and system software only.
-    rationale: >
-      Security configuration requirements vary from site to site. Some sites may mandate a
-      policy that is stricter than the default policy, which is perfectly acceptable. This item is
-      intended to ensure that at least the default recommendations are met.
-    remediation: >
-      Edit the /etc/selinux/config file to set the SELINUXTYPE parameter:
-      SELINUXTYPE=targeted
-
-      Notes:
-      If your organization requires stricter policies, ensure that they are set in the
-      /etc/selinux/configfile.
-    compliance:
-      - cis: ["1.6.1.3"]
-    condition: all
-    rules:
-      - 'f:/etc/selinux/config -> r:^\s*SELINUXTYPE=targeted'
-      - 'not c:sestatus -> r:^\s*Loaded policy name:\t*minimum'
-
-  - id: 7659
-    title: Ensure GDM login banner is configured
-    description: >
-      GDM is the GNOME Display Manager which handles graphical login for GNOME based
-      systems.
-    rationale: >
-      Warning messages inform users who are attempting to login to the system of their legal
-      status regarding the system and must include the name of the organization that owns the
-      system and any monitoring policies that are in place.
-    remediation: >
-      Create the /etc/dconf/profile/gdm file with the following contents:
-      user-db:user
-      system-db:gdm
-      file-db:/usr/share/gdm/greeter-dconf-defaults
-
-      Create or edit the banner-message-enable and banner-message-text options in
-      /etc/dconf/db/gdm.d/01-banner-message:
-      [org/gnome/login-screen]
-      banner-message-enable=true
-      banner-message-text='Authorized uses only. All activity may be monitored and
-      reported.'
-
-      Run the following command to update the system databases:
-      # dconf update
-
-      Notes:
-      Additional options and sections may appear in the /etc/dconf/db/gdm.d/01-bannermessage file.
-      If a different GUI login service is in use, consult your documentation and apply an
-      equivalent banner.
-    compliance:
-      - cis: ["1.7.2"]
-    condition: all
-    rules:
-      - 'f:/etc/dconf/profile/gdm -> r:^\s*user-db:user'
-      - 'f:/etc/dconf/profile/gdm -> r:^\s*system-db:gdm'
-      - 'f:/etc/dconf/profile/gdm -> r:^\s*file-db:/usr/share/gdm/greeter-dconf-defaults'
-      - 'c:grep -Rh "banner-message-enable=true" /etc/dconf/db/gdm.d -> r:^\s*banner-message-enable=true'
-      - 'c:grep -Rh "banner-message-text=" /etc/dconf/db/gdm.d -> r:^\s*banner-message-text=\S+'

--- a/ruleset/sca/sles/15/cis_sles15_linux.yml
+++ b/ruleset/sca/sles/15/cis_sles15_linux.yml
@@ -8,7 +8,7 @@
 # Foundation
 #
 # Based on:
-# CIS Benchmark for SUSE Linux Enterprise 15 v1.0.0 - 06-30-2020
+# CIS Benchmark for SUSE Linux Enterprise 15 v1.1.0 - 09-17-2021
 
 policy:
   id: "cis_sles15_linux"
@@ -31,71 +31,66 @@ variables:
 checks:
 
 # Section 1.1 - Filesystem Configuration
+
+# 1.1.1.1 Ensure mounting of squashfs filesystems is disabled
   - id: 7500
-    title: Ensure nodev option set on /tmp partition
-    description: The nodev mount option specifies that the filesystem cannot contain special devices.
+    title: Ensure mounting of squashfs filesystems is disabled.
+    description: >
+      The squashfs filesystem type is a compressed read-only Linux filesystem embedded in
+      small footprint systems (similar to cramfs ). A squashfs image can be used without having
+      to first decompress the image.
     rationale: >
-      Since the /tmp filesystem is not intended to support devices, set this option to ensure that
-      users cannot attempt to create block or character special devices in /tmp .
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
     remediation: >
-      Edit the /etc/fstab file OR the /etc/systemd/system/localfs.target.wants/tmp.mount file:
-      IF /etc/fstab is used to mount /tmp:
-      Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /tmp
-      partition. See the fstab(5) manual page for more information.
-      Run the following command to remount /tmp :
-      # mount -o remount,nodev /tmp
-      OR
-      IF systemd is used to mount /tmp:
-      Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to add nodev to the /tmp
-      mount options:
-      [Mount]
-      Options=mode=1777,strictatime,noexec,nodev,nosuid
-      Run the following command to restart the systemd daemon:
-      # systemctl daemon-reload
+      Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
+      Example: vi /etc/modprobe.d/squashfs.conf
+      and add the following line:
+      install squashfs /bin/true
 
-      Run the following command to restart tmp.mount
-      # systemctl restart tmp.mount
+      Run the following command to unload the squashfs module:
+      # modprobe -r squashfs
     compliance:
-      - cis: ["1.1.4"]
+      - cis: ["1.1.1.1"]
       - cis_csc: ["5.1"]
-    condition: all
+    condition: any
     rules:
-      - 'c:mount -> r:\s/tmp\s && r:nodev'
+      - 'c:modprobe -n -v squashfs -> r:install'
+      - 'c:modprobe -n -v squashfs -> r:squashfs'
 
+# 1.1.1.2 Ensure mounting of udf filesystems is disabled
   - id: 7501
-    title: Ensure nosuid option set on /tmp partition
-    description: The nosuid mount option specifies that the filesystem cannot contain setuid files.
+    title: Ensure mounting of udf filesystems is disabled.
+    description: >
+      The udf filesystem type is the universal disk format used to implement ISO/IEC 13346 and
+      ECMA-167 specifications. This is an open vendor filesystem type for data storage on a
+      broad range of media. This filesystem type is necessary to support writing DVDs and newer
+      optical disc formats.
     rationale: >
-      Since the /tmp filesystem is only intended for temporary file storage, set this option to
-      ensure that users cannot create setuid files in /tmp.
+      Removing support for unneeded filesystem types reduces the local attack surface of the
+      system. If this filesystem type is not needed, disable it.
     remediation: >
-      IF /etc/fstab is used to mount /tmp
-      Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /tmp
-      partition. See the fstab(5) manual page for more information.
-      Run the following command to remount /tmp :
-      # mount -o remount,nosuid /tmp
+      Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
+      Example: vi /etc/modprobe.d/udf.conf
+      and add the following line:
+      install udf /bin/true
 
-      OR
-      IF systemd is used to mount /tmp:
-      Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to add nosuid to the /tmp
-      mount options:
-      [Mount]
-      Options=mode=1777,strictatime,noexec,nodev,nosuid
-
-      Run the following command to restart the systemd daemon:
-      # systemctl daemon-reload
-
-      Run the following command to restart tmp.mount:
-      # systemctl restart tmp.mount
+      Run the following command to unload the udf module:
+      # modprobe -r udf
     compliance:
-      - cis: ["1.1.5"]
-      - cis_csc: ["5.1","13"]
-    condition: all
+      - cis: ["1.1.1.2"]
+      - cis_csc: ["5.1"]
+    condition: any
     rules:
-      - 'c:mount -> r:\s/tmp\s && r:nosuid'
+      - 'c:modprobe -n -v udf -> r:install'
+      - 'c:modprobe -n -v udf -> r:udf'
 
+# 1.1.1.3 Ensure mounting of FAT filesystems is limited - Not implemented
+# 1.1.2 Ensure /tmp is configured - Not implemented  
+
+# 1.1.3 Ensure noexec option set on /tmp partition - Not implemented
   - id: 7502
-    title: Ensure noexec option set on /tmp partition
+    title: Ensure noexec option set on /tmp partition.
     description: The noexec mount option specifies that the filesystem cannot contain executable binaries.
     rationale: >
       Since the /tmp filesystem is only intended for temporary file storage, set this option to
@@ -130,8 +125,159 @@ checks:
     rules:
       - 'c:mount -> r:\s/tmp\s && r:noexec'
 
+# 1.1.4 Ensure nodev option set on /tmp partition
   - id: 7503
-    title: Ensure separate partition exists for /var
+    title: Ensure nodev option set on /tmp partition.
+    description: The nodev mount option specifies that the filesystem cannot contain special devices.
+    rationale: >
+      Since the /tmp filesystem is not intended to support devices, set this option to ensure that
+      users cannot attempt to create block or character special devices in /tmp .
+    remediation: >
+      Edit the /etc/fstab file OR the /etc/systemd/system/localfs.target.wants/tmp.mount file:
+      IF /etc/fstab is used to mount /tmp:
+      Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /tmp
+      partition. See the fstab(5) manual page for more information.
+      Run the following command to remount /tmp :
+      # mount -o remount,nodev /tmp
+      OR
+      IF systemd is used to mount /tmp:
+      Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to add nodev to the /tmp
+      mount options:
+      [Mount]
+      Options=mode=1777,strictatime,noexec,nodev,nosuid
+      Run the following command to restart the systemd daemon:
+      # systemctl daemon-reload
+
+      Run the following command to restart tmp.mount
+      # systemctl restart tmp.mount
+    compliance:
+      - cis: ["1.1.4"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:mount -> r:\s/tmp\s && r:nodev'
+
+# 1.1.5 Ensure nosuid option set on /tmp partition
+  - id: 7504
+    title: Ensure nosuid option set on /tmp partition.
+    description: The nosuid mount option specifies that the filesystem cannot contain setuid files.
+    rationale: >
+      Since the /tmp filesystem is only intended for temporary file storage, set this option to
+      ensure that users cannot create setuid files in /tmp.
+    remediation: >
+      IF /etc/fstab is used to mount /tmp
+      Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /tmp
+      partition. See the fstab(5) manual page for more information.
+      Run the following command to remount /tmp :
+      # mount -o remount,nosuid /tmp
+
+      OR
+      IF systemd is used to mount /tmp:
+      Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to add nosuid to the /tmp
+      mount options:
+      [Mount]
+      Options=mode=1777,strictatime,noexec,nodev,nosuid
+
+      Run the following command to restart the systemd daemon:
+      # systemctl daemon-reload
+
+      Run the following command to restart tmp.mount:
+      # systemctl restart tmp.mount
+    compliance:
+      - cis: ["1.1.5"]
+      - cis_csc: ["5.1","13"]
+    condition: all
+    rules:
+      - 'c:mount -> r:\s/tmp\s && r:nosuid'
+
+# 1.1.6 Ensure /dev/shm is configured
+  - id: 7505
+    title: Ensure /dev/shm is configured.
+    description: >
+      /dev/shm is a traditional shared memory concept. One program will create a memory
+      portion, which other processes (if permitted) can access. If /dev/shm is not configured,
+      tmpfs will be mounted to /dev/shm by systemd.
+
+      Notes:
+        - An entry for /dev/shm in /etc/fstab will take precedence.
+        - tmpfs can be resized using the size={size} parameter in /etc/fstab. If we don't specify
+          the size, it will be half the RAM.
+
+      Resize tmpfs example:
+      tmpfs /dev/shm tmpfs defaults,noexec,nodev,nosuid,size=2G 0 0
+    rationale: >
+      Any user can upload and execute files inside the /dev/shm similar to the /tmp partition.
+      Configuring /dev/shm allows an administrator to set the noexec option on the mount,
+      making /dev/shm useless for an attacker to install executable code. It would also prevent an
+      attacker from establishing a hardlink to a system setuid program and wait for it to be
+      updated. Once the program was updated, the hardlink would be broken and the attacker
+      would have his own copy of the program. If the program happened to have a security
+      vulnerability, the attacker could continue to exploit the known flaw.
+    remediation: >
+      Edit /etc/fstab and add or edit the following line:
+      tmpfs /dev/shm tmpfs defaults,noexec,nodev,nosuid 0 0
+
+      Run the following command to remount /dev/shm:
+      # mount -o remount,noexec,nodev,nosuid /dev/shm
+    compliance:
+      - cis: ["1.1.6"]
+      - cis_csc: ["5.1","13"]
+    condition: all
+    rules:
+      - 'c:mount -> r:\.+\s+/dev/shm\s+'
+      - 'f:/etc/fstab -> r:\.+\s+/dev/shm\s+'
+
+# 1.1.7 Ensure noexec option set on /dev/shm partition
+  - id: 7506
+    title: Ensure noexec option set on /dev/shm partition.
+    description: >
+      The noexec mount option specifies that the filesystem cannot contain executable binaries.
+      Note: /dev/shm is mounted automatically by systemd. /dev/shm needs to be added to
+      /etc/fstab to add mount options even though it is already being mounted on boot.
+    rationale: >
+      Setting this option on a file system prevents users from executing programs from shared
+      memory. This deters users from introducing potentially malicious software on the system.
+    remediation: >
+      Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the
+      /dev/shm partition. See the fstab(5) manual page for more information.
+
+      Run the following command to remount /dev/shm:
+      # mount -o remount,noexec,nodev,nosuid /dev/shm
+    compliance:
+      - cis: ["1.1.7"]
+      - cis_csc: ["2.6","13"]
+    condition: all
+    rules:
+      - 'c:mount -> r:\s/dev/shm\s && r:noexec'
+
+# 1.1.8 Ensure nodev option set on /dev/shm partition - Not implemented
+
+# 1.1.9 Ensure nosuid option set on /dev/shm partition
+  - id: 7507
+    title: Ensure nosuid option set on /dev/shm partition.
+    description: >
+      The nosuid mount option specifies that the filesystem cannot contain setuid files.
+      Note: /dev/shm is mounted automatically by systemd. /dev/shm needs to be added to
+      /etc/fstab to add mount options even though it is already being mounted on boot.
+    rationale: >
+      Setting this option on a file system prevents users from introducing privileged programs
+      onto the system and allowing non-root users to execute them.
+    remediation: >
+      Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the
+      /dev/shm partition. See the fstab(5) manual page for more information.
+
+      Run the following command to remount /dev/shm:
+      # mount -o remount,noexec,nodev,nosuid /dev/shm
+    compliance:
+      - cis: ["1.1.9"]
+      - cis_csc: ["5.1","13"]
+    condition: all
+    rules:
+      - 'c:mount -> r:\s/dev/shm\s && r:nosuid'
+
+# 1.1.10 Ensure separate partition exists for /var
+  - id: 7508
+    title: Ensure separate partition exists for /var.
     description: >
       The /var directory is used by daemons and other system services to temporarily store
       dynamic data. Some directories created by these processes may be world-writable.
@@ -156,8 +302,100 @@ checks:
     rules:
       - 'c:mount -> r:\s/var\s'
 
-  - id: 7504
-    title: Ensure separate partition exists for /var/log
+# 1.1.11 Ensure separate partition exists for /var/tmp 
+  - id: 7509
+    title: Ensure separate partition exists for /var/tmp.
+    description: >
+      The /var/tmp directory is a world-writable directory used for temporary storage by all
+      users and some applications and is intended for temporary files that are preserved across
+      reboots.
+
+      Note: tmpfs should not be used for /var/tmp/. tmpfs is a temporary filesystem that resides in
+      memory and/or swap partition(s). Files in tmpfs are automatically cleared at each bootup.
+    rationale: >
+      Since the /var/tmp directory is intended to be world-writable, there is a risk of resource
+      exhaustion if it is not bound to a separate partition. In addition, making /var/tmp its own
+      file system allows an administrator to set the noexec option on the mount, making
+      /var/tmp useless for an attacker to install executable code. It would also prevent an
+      attacker from establishing a hardlink to a system setuid program and wait for it to be
+      updated. Once the program was updated, the hardlink would be broken and the attacker
+      would have his own copy of the program. If the program happened to have a security
+      vulnerability, the attacker could continue to exploit the known flaw.
+    remediation: >
+      For new installations, during installation create a custom partition setup and specify a
+      separate partition for /var/tmp .
+      For systems that were previously installed, create a new partition and configure
+      /etc/fstab as appropriate.
+    compliance:
+      - cis: ["1.1.11"]
+      - cis_csc: ["5.1","13"]
+    condition: all
+    rules:
+      - 'c:mount -> r:\s/var/tmp\s'
+
+# 1.1.12 Ensure noexec option set on /var/tmp partition 
+  - id: 7510
+    title: Ensure noexec option set on /var/tmp partition.
+    description: The noexec mount option specifies that the filesystem cannot contain executable binaries.
+    rationale: >
+      Since the /var/tmp filesystem is only intended for temporary file storage, set this option to
+      ensure that users cannot run executable binaries from /var/tmp .
+    remediation: >
+      Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the
+      /var/tmp partition. See the fstab(5) manual page for more information.
+
+      Run the following command to remount /var/tmp :
+      # mount -o remount,noexec /var/tmp
+    compliance:
+      - cis: ["1.1.12"]
+      - cis_csc: ["2.6"]
+    condition: all
+    rules:
+      - 'c:mount -> r:\s/var/tmp\s && r:noexec'
+
+# 1.1.13 Ensure nodev option set on /var/tmp partition 
+  - id: 7511
+    title: Ensure nodev option set on /var/tmp partition.
+    description: The nodev mount option specifies that the filesystem cannot contain special devices.
+    rationale: >
+      Since the /var/tmp filesystem is not intended to support devices, set this option to ensure
+      that users cannot attempt to create block or character special devices in /var/tmp .
+    remediation: >
+      Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the
+      /var/tmp partition. See the fstab(5) manual page for more information.
+
+      Run the following command to remount /var/tmp :
+      # mount -o remount,nodev /var/tmp
+    compliance:
+      - cis: ["1.1.13"]
+      - cis_csc: ["5.1","13"]
+    condition: all
+    rules:
+      - 'c:mount -> r:\s+/var/tmp\s+ && r:nodev'
+
+# 1.1.14 Ensure nosuid option set on /var/tmp partition
+  - id: 7512
+    title: Ensure nosuid option set on /var/tmp partition.
+    description: The nosuid mount option specifies that the filesystem cannot contain setuid files.
+    rationale: >
+      Since the /var/tmp filesystem is only intended for temporary file storage, set this option to
+      ensure that users cannot create setuid files in /var/tmp
+    remediation: >
+      Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the
+      /var/tmp partition. See the fstab(5) manual page for more information.
+
+      Run the following command to remount /var/tmp :
+      # mount -o remount,nosuid /var/tmp
+    compliance:
+      - cis: ["1.1.14"]
+      - cis_csc: ["5.1","13"]
+    condition: all
+    rules:
+      - 'c:mount -> r:\s+/var/tmp\s+ && r:nosuid'
+
+# 1.1.15 Ensure separate partition exists for /var/log
+  - id: 7513
+    title: Ensure separate partition exists for /var/log.
     description: The /var/log directory is used by system services to store log data.
     rationale: >
       There are two important reasons to ensure that system logs are stored on a separate
@@ -181,8 +419,9 @@ checks:
     rules:
       - 'c:mount -> r:\s/var/log\s'
 
-  - id: 7505
-    title: Ensure separate partition exists for /var/log/audit
+# 1.1.16 Ensure separate partition exists for /var/log/audit
+  - id: 7514
+    title: Ensure separate partition exists for /var/log/audit.
     description: >
       The auditing daemon, auditd , stores log data in the /var/log/audit directory.
 
@@ -209,8 +448,9 @@ checks:
     rules:
       - 'c:mount -> r:\s/var/log/audit\s'
 
-  - id: 7506
-    title: Ensure separate partition exists for /home
+# 1.1.17 Ensure separate partition exists for /home
+  - id: 7515
+    title: Ensure separate partition exists for /home.
     description: The /home directory is used to support disk storage needs of local users.
     rationale: >
       If the system is intended to support local users, create a separate partition for the /home
@@ -230,8 +470,9 @@ checks:
     rules:
       - 'c:mount -> r:\s/home\s'
 
-  - id: 7507
-    title: Ensure nodev option set on /home partition
+# 1.1.18 Ensure nodev option set on /home partition 
+  - id: 7516
+    title: Ensure nodev option set on /home partition.
     description: >
       The nodev mount option specifies that the filesystem cannot contain special devices.
       Note: The actions in this recommendation refer to the /home partition, which is the default
@@ -253,52 +494,266 @@ checks:
     rules:
       - 'c:mount -> r:\s/home\s && r:nodev'
 
-  - id: 7508
-    title: Ensure nosuid option set on /dev/shm partition
-    description: >
-      The nosuid mount option specifies that the filesystem cannot contain setuid files.
-      Note: /dev/shm is mounted automatically by systemd. /dev/shm needs to be added to
-      /etc/fstab to add mount options even though it is already being mounted on boot.
-    rationale: >
-      Setting this option on a file system prevents users from introducing privileged programs
-      onto the system and allowing non-root users to execute them.
-    remediation: >
-      Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the
-      /dev/shm partition. See the fstab(5) manual page for more information.
+# 1.1.19 Ensure noexec option set on removable media partitions - Not implemented
+# 1.1.20 Ensure nodev option set on removable media partitions - Not implemented
+# 1.1.21 Ensure nosuid option set on removable media partitions - Not implemented
+# 1.1.22 Ensure sticky bit is set on all world-writable directories - Not implemented
 
-      Run the following command to remount /dev/shm:
-      # mount -o remount,noexec,nodev,nosuid /dev/shm
+# 1.1.23 Disable Automounting 
+  - id: 7517
+    title: Disable Automounting.
+    description: >
+      autofs allows automatic mounting of devices, typically including CD/DVDs and USB drives.
+      Notes:
+        - Additional methods of disabling a service exist. Consult your distribution
+          documentation for appropriate methods.
+        - This control should align with the tolerance of the use of portable drives and optical
+          media in the organization.
+          - On a server requiring an admin to manually mount media can be part of
+            defense-in-depth to reduce the risk of unapproved software or information
+            being introduced or proprietary software or information being exfiltrated.
+          - If admins commonly use flash drives and Server access has sufficient physical
+            controls, requiring manual mounting may not increase security.
+    rationale: >
+      With automounting enabled anyone with physical access could attach a USB drive or disc
+      and have its contents available in system even if they lacked permissions to mount it
+      themselves.
+    remediation: >
+      Run the following command to mask autofs:
+      # systemctl --now mask autofs
     compliance:
-      - cis: ["1.1.9"]
-      - cis_csc: ["5.1","13"]
+      - cis: ["1.1.23"]
+      - cis_csc: ["8.4","8.5"]
+    condition: none
+    rules:
+      - 'c:systemctl is-enabled autofs -> r:enabled'
+
+# 1.2.1 Ensure GPG keys are configured - Not implemented
+# 1.2.2 Ensure package manager repositories are configured - Not implemented
+# 1.2.3 Ensure gpgcheck is globally activated - Not implemented
+
+# 1.3.1 Ensure sudo is installed
+  - id: 7518
+    title: Ensure sudo is installed.
+    description: >
+      sudo allows a permitted user to execute a command as the superuser or another user, as
+      specified by the security policy. The invoking user's real (not effective) user ID is used to
+      determine the user name with which to query the security policy.
+    rationale: >
+      sudo supports a plugin architecture for security policies and input/output logging. Third
+      parties can develop and distribute their own policy and I/O logging plugins to work
+      seamlessly with the sudo front end. The default security policy is sudoers, which is
+      configured via the file /etc/sudoers.
+
+      The security policy determines what privileges, if any, a user has to run sudo. The policy
+      may require that users authenticate themselves with a password or another authentication
+      mechanism. If authentication is required, sudo will exit if the user's password is not
+      entered within a configurable time limit. This limit is policy-specific.
+    remediation: >
+      Run the following command to install sudo.
+      # zypper install sudo
+    compliance:
+      - cis: ["1.3.1"]
+      - cis_csc: ["4"]
+    references:
+      - SUDO(8)
+    condition: none
+    rules:
+      - 'c:rpm -q sudo -> r:not installed'
+
+# 1.3.2 Ensure sudo commands use pty
+  - id: 7519
+    title: Ensure sudo commands use pty.
+    description: >
+      sudo can be configured to run only from a pseudo-pty
+
+      Note: visudo edits the sudoers file in a safe fashion, analogous to vipw(8). visudo locks the
+      sudoers file against multiple simultaneous edits, provides basic sanity checks, and checks for
+      parse errors. If the sudoers file is currently being edited you will receive a message to try
+      again later. The -f option allows you to tell visudo which file to edit.
+    rationale: >
+      Attackers can run a malicious program using sudo, which would again fork a background
+      process that remains even when the main program has finished executing.
+      This can be mitigated by configuring sudo to run other commands only from a pseudo-pty,
+      whether I/O logging is turned on or not.
+    remediation: >
+      Edit the file /etc/sudoers or a file in /etc/sudoers.d/ with visudo or visudo -f <PATH
+      TO FILE> and add the following line:
+
+      Defaults use_pty
+    compliance:
+      - cis: ["1.3.2"]
+      - cis_csc: ["4"]
+    references:
+      - SUDO(8)
     condition: all
     rules:
-      - 'c:mount -> r:\s/dev/shm\s && r:nosuid'
+      - 'c:grep -REsih "^Defaults" /etc/sudoers /etc/sudoers.d -> r:^\wefaults\s+use_pty'
 
-  - id: 7509
-    title: Ensure noexec option set on /dev/shm partition
+# 1.3.3 Ensure sudo log file exists
+  - id: 7520
+    title: Ensure sudo log file exists.
     description: >
-      The noexec mount option specifies that the filesystem cannot contain executable binaries.
-      Note: /dev/shm is mounted automatically by systemd. /dev/shm needs to be added to
-      /etc/fstab to add mount options even though it is already being mounted on boot.
-    rationale: >
-      Setting this option on a file system prevents users from executing programs from shared
-      memory. This deters users from introducing potentially malicious software on the system.
-    remediation: >
-      Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the
-      /dev/shm partition. See the fstab(5) manual page for more information.
+      sudo can use a custom log file
 
-      Run the following command to remount /dev/shm:
-      # mount -o remount,noexec,nodev,nosuid /dev/shm
+      Note: visudo edits the sudoers file in a safe fashion, analogous to vipw(8). visudo locks the
+      sudoers file against multiple simultaneous edits, provides basic sanity checks, and checks
+      for parse errors. If the sudoers file is currently being edited you will receive a message to
+      try again later. The -f option allows you to tell visudo which file to edit.
+    rationale: A sudo log file simplifies auditing of sudo commands
+    remediation: >
+      edit the file /etc/sudoers or a file in /etc/sudoers.d/ with visudo or visudo -f <PATH
+      TO FILE> and add the following line:
+      Defaults logfile="<PATH TO CUSTOM LOG FILE>"
+
+      Example
+      Defaults logfile="/var/log/sudo.log"
     compliance:
-      - cis: ["1.1.7"]
-      - cis_csc: ["2.6","13"]
+      - cis: ["1.3.3"]
+      - cis_csc: ["6.3"]
+    references:
+      - SUDO(8)
+      - VISUDO(8)
     condition: all
     rules:
-      - 'c:mount -> r:\s/dev/shm\s && r:noexec'
+      - 'c:grep -REsih "^Defaults" /etc/sudoers /etc/sudoers.d -> r:^\wefaults\s+logfile="\.+"'
 
-  - id: 7510
-    title: Ensure core dumps are restricted
+# 1.4.1 Ensure AIDE is installed
+  - id: 7521
+    title: Ensure AIDE is installed.
+    description: >
+      AIDE takes a snapshot of filesystem state including modification times, permissions, and
+      file hashes which can then be used to compare against the current state of the filesystem to
+      detect modifications to the system.
+
+      Note: The prelinking feature can interfere with AIDE because it alters binaries to speed up
+      their start up times. Run prelink -ua to restore the binaries to their prelinked state, thus
+      avoiding false positives from AIDE.
+    rationale: >
+      By monitoring the filesystem state compromised files can be detected to prevent or limit
+      the exposure of accidental or malicious misconfigurations or modified binaries.
+    remediation: >
+      Configure AIDE as appropriate for your environment. Consult the AIDE documentation for
+      options.
+      Run the following command to install AIDE:
+      # zypper install aide
+
+      Run the following commands to initialize AIDE:
+      # aide --init
+      # mv /var/lib/aide/aide.db.new /var/lib/aide/aide.db
+    compliance:
+      - cis: ["1.4.1"]
+      - cis_csc: ["14.9"]
+    references:
+      - AIDE stable manual: http://aide.sourceforge.net/stable/manual.html
+    condition: none
+    rules:
+      - 'c:rpm -q aide -> r:not installed'
+
+# 1.4.2 Ensure filesystem integrity is regularly checked - Not implemented
+
+# 1.5.1 Ensure bootloader password is set
+  - id: 7522
+    title: Ensure bootloader password is set.
+    description: >
+      Setting the boot loader password will require that anyone rebooting the system must enter
+      a password before being able to set command line boot parameters
+
+      Notes:
+        - This recommendation is designed around the grub2 bootloader, if LILO or another
+          bootloader is in use in your environment enact equivalent settings. Replace
+          `/boot/grub2/grub.cfg with the appropriate grub configuration file for your
+          environment
+        - The information can be placed in any /etc/grub.d file as long as that file is
+          incorporated into grub.cfg
+          - The superuser/user information and password should not be contained in the
+            /etc/grub.d/00_header file.
+          - A custom file, such as /etc/grub.d/40_custom should be used so it is not
+            overwritten should the Grub package be updated.
+    rationale: >
+      Requiring a boot password upon execution of the boot loader will prevent an unauthorized
+      user from entering boot parameters or changing the boot partition. This prevents users
+      from weakening security (e.g. turning off SELinux at boot time).
+    remediation: >
+      Create an encrypted password with grub2-mkpasswd-pbkdf2:
+        # grub2-mkpasswd-pbkdf2
+        Enter password: <password>
+        Reenter password: <password>
+        Your PBKDF2 is <encrypted-password>
+
+      Add the following into /etc/grub.d/40_custom
+        set superusers="<username>"
+        password_pbkdf2 <username> <encrypted-password>
+
+      Run the following command to update the grub2 configuration:
+        # grub2-mkconfig -o /boot/grub2/grub.cfg
+    compliance:
+      - cis: ["1.5.1"]
+      - cis_csc: ["5.1"]
+    references:
+      - https://documentation.suse.com/sles/15-SP1/html/SLES-all/cha-grub2.html
+    condition: all
+    rules:
+      - 'f:/boot/grub2/grub.cfg -> r:^\s*set superusers'
+      - 'f:/boot/grub2/grub.cfg -> r:^\s*password'
+
+# 1.5.2 Ensure permissions on bootloader config are configured
+  - id: 7523
+    title: Ensure permissions on bootloader config are configured.
+    description: >
+      The grub configuration file contains information on boot settings and passwords for
+      unlocking boot options. The grub2 configuration is usually grub.cfg stored in
+      /boot/grub2/.
+
+      Notes:
+        - This recommendation is designed around the grub2 bootloader.
+        - If LILO or another bootloader is in use in your environment:
+          - Enact equivalent settings
+          - Replace /boot/grub2/grub.cfg and /boot/grub2/user.cfg with the
+            appropriate boot configuration files for your environment
+    rationale: >
+      Setting the permissions to read and write for root only prevents non-root users from
+      seeing the boot parameters or changing them. Non-root users who read the boot
+      parameters may be able to identify weaknesses in security upon boot and be able to exploit
+      them.
+    remediation: >
+      Run the following commands to set ownership and permissions on your grub
+      configuration:
+      # chown root:root /boot/grub2/grub.cfg
+      # chmod og-rwx /boot/grub2/grub.cfg
+    compliance:
+      - cis: ["1.5.2"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'c:stat -L /boot/grub2/grub.cfg -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+# 1.5.3 Ensure authentication required for single user mode
+  - id: 7524
+    title: Ensure authentication required for single user mode.
+    description: >
+      Single user mode (rescue mode) is used for recovery when the system detects an issue
+      during boot or by manual selection from the bootloader.
+    rationale: >
+      Requiring authentication in single user mode (rescue mode) prevents an unauthorized user
+      from rebooting the system into single user to gain root privileges without credentials.
+    remediation: >
+      Edit /usr/lib/systemd/system/rescue.service and add/modify the following line:
+      ExecStart=-/usr/lib/systemd/systemd-sulogin-shell rescue
+
+      Edit /usr/lib/systemd/system/emergency.service and add/modify the following line:
+      ExecStart=-/usr/lib/systemd/systemd-sulogin-shell emergency
+    compliance:
+      - cis: ["1.5.3"]
+      - cis_csc: ["5.1"]
+    condition: all
+    rules:
+      - 'f:/usr/lib/systemd/system/rescue.service -> r:^ExecStart=\.*/systemd/systemd-sulogin-shell\s+rescue'
+      - 'f:/usr/lib/systemd/system/emergency.service -> r:^ExecStart=\.*/systemd/systemd-sulogin-shell\s+emergency'
+
+# 1.6.1 Ensure core dumps are restricted
+  - id: 7525
+    title: Ensure core dumps are restricted.
     description: >
       A core dump is the memory of an executable program. It is generally used to determine
       why a program aborted. It can also be used to glean confidential information from a core
@@ -336,8 +791,39 @@ checks:
       - 'c:sysctl fs.suid_dumpable -> r:\s0$'
       - 'c:grep -Rh fs\.suid_dumpable /etc/sysctl.conf /etc/sysctl.d -> r:^\s*fs.suid_dumpable\s*=\s*0\s*$'
 
-  - id: 7511
-    title: Ensure address space layout randomization (ASLR) is enabled
+# 1.6.2 Ensure XD/NX support is enabled 
+  - id: 7526
+    title: Ensure XD/NX support is enabled.
+    description: >
+      Recent processors in the x86 family support the ability to prevent code execution on a per
+      memory page basis. Generically and on AMD processors, this ability is called No Execute
+      (NX), while on Intel processors it is called Execute Disable (XD). This ability can help
+      prevent exploitation of buffer overflow vulnerabilities and should be activated whenever
+      possible. Extra steps must be taken to ensure that this protection is enabled, particularly on
+      32-bit x86 systems. Other processors, such as Itanium and POWER, have included such
+      support since inception and the standard kernel for those platforms supports the feature.
+    rationale: >
+      Enabling any feature that can protect against buffer overflow attacks enhances the security
+      of the system.
+
+      Note: Ensure your system supports the XD or NX bit and has PAE support before implementing
+      this recommendation as this may prevent it from booting if these are not supported by your
+      hardware.
+    remediation: >
+      On 32 bit systems install a kernel with PAE support, no installation is required on 64 bit
+      systems:
+      If necessary configure your bootloader to load the new kernel and reboot the system.
+      You may need to enable NX or XD support in your bios.
+    compliance:
+      - cis: ["1.6.2"]
+      - cis_csc: ["8.3"]
+    condition: all
+    rules:
+      - 'c:journalctl -> r:\.*kernel: NX \(Execute Disable\) protection:\s*active'
+
+# 1.6.3 Ensure address space layout randomization (ASLR) is enabled
+  - id: 7527
+    title: Ensure address space layout randomization (ASLR) is enabled.
     description: >
       Address space layout randomization (ASLR) is an exploit mitigation technique which
       randomly arranges the address space of key data areas of a process.
@@ -357,6 +843,256 @@ checks:
     rules:
       - 'c:grep -Rh ^kernel\.randomize_va_space /etc/sysctl.conf /etc/sysctl.d -> r:^\s*kernel.randomize_va_space\s*=\s*2$'
       - 'c:sysctl kernel.randomize_va_space -> r:\s2$|\t2$'
+
+# 1.6.4 Ensure prelink is disabled
+  - id: 7528
+    title: Ensure prelink is disabled.
+    description: >
+      prelinkis a program that modifies ELF shared libraries and ELF dynamically linked
+      binaries in such a way that the time needed for the dynamic linker to perform relocations
+      at startup significantly decreases.
+    rationale: >
+      The prelinking feature can interfere with the operation of AIDE, because it changes
+      binaries. Prelinking can also increase the vulnerability of the system if a malicious user is
+      able to compromise a common library such as libc.
+    remediation: >
+      Run the following command to restore binaries to normal:
+      # prelink -ua
+
+      Run the following command to uninstall prelink:
+      # zypper remove prelink
+    compliance:
+      - cis: ["1.6.4"]
+      - cis_csc: ["14.9"]
+    condition: all
+    rules:
+      - 'c:rpm -q prelink -> r:not installed'
+
+# 1.7.1.1 Ensure AppArmor is installed
+  - id: 7529
+    title: Ensure AppArmor is installed.
+    description: AppArmor provides Mandatory Access Controls.
+    rationale: >
+      Without a Mandatory Access Control system installed only the default Discretionary Access
+      Control system will be available.
+    remediation: >
+      Run the following command to install AppArmor:
+      # zypper install -t pattern apparmor
+    compliance:
+      - cis: ["1.7.1.1"]
+      - cis_csc: ["14.6"]
+    condition: none
+    rules:
+      - 'c:rpm -q apparmor-docs -> r:not installed'
+      - 'c:rpm -q apparmor-parser -> r:not installed'
+      - 'c:rpm -q apparmor-profiles -> r:not installed'
+      - 'c:rpm -q apparmor-utils -> r:not installed'
+      - 'c:rpm -q libapparmor1 -> r:not installed'
+
+# 1.7.1.2 Ensure AppArmor is enabled in the bootloader configuration - Not implemented
+# 1.7.1.3 Ensure all AppArmor Profiles are in enforce or complain mode - Not implemented
+# 1.7.1.4 Ensure all AppArmor Profiles are enforcing - Not implemented
+
+# 1.8.1.1 Ensure message of the day is configured properly
+  - id: 7530
+    title: Ensure message of the day is configured properly.
+    description: >
+      The contents of the /etc/motd file are displayed to users after login and function as a
+      message of the day for authenticated users.
+
+      Unix-based systems have typically displayed information about the OS release and patch
+      level upon logging in to the system. This information can be useful to developers who are
+      developing software for a particular OS platform. If mingetty(8) supports the following
+      options, they display operating system information: \m - machine architecture \r -
+      operating system release \s - operating system name \v - operating system version
+    rationale: >
+      Warning messages inform users who are attempting to login to the system of their legal
+      status regarding the system and must include the name of the organization that owns the
+      system and any monitoring policies that are in place. Displaying OS and patch level
+      information in login banners also has the side effect of providing detailed system
+      information to attackers attempting to target specific exploits of a system. Authorized users
+      can easily get this information by running the " uname -a " command once they have logged
+      in.
+    remediation: >
+      Edit the /etc/motd file with the appropriate contents according to your site policy, remove
+      any instances of \m , \r , \s , \v or references to the OS platform
+
+      OR
+
+      If the motd is not used, this file can be removed.
+      Run the following command to remove the motd file:
+      # rm /etc/motd
+    compliance:
+      - cis: ["1.8.1.1"]
+      - cis_csc: ["5.1"]
+    condition: none
+    rules:
+      - 'f:/etc/motd -> r:\\m'
+      - 'f:/etc/motd -> r:\\r'
+      - 'f:/etc/motd -> r:\\s'
+      - 'f:/etc/motd -> r:\\v'
+
+# 1.8.1.2 Ensure local login warning banner is configured properly
+  - id: 7531
+    title: Ensure local login warning banner is configured properly.
+    description: >
+      The contents of the /etc/issue file are displayed to users prior to login for local terminals.
+      Unix-based systems have typically displayed information about the OS release and patch
+      level upon logging in to the system. This information can be useful to developers who are
+      developing software for a particular OS platform. If mingetty(8) supports the following
+      options, they display operating system information: \m - machine architecture \r -
+      operating system release \s - operating system name \v - operating system version - or the
+      operating system's name
+    rationale: >
+      Warning messages inform users who are attempting to login to the system of their legal
+      status regarding the system and must include the name of the organization that owns the
+      system and any monitoring policies that are in place. Displaying OS and patch level
+      information in login banners also has the side effect of providing detailed system
+      information to attackers attempting to target specific exploits of a system. Authorized users
+      can easily get this information by running the " uname -a " command once they have logged
+      in.
+    remediation: >
+      Edit the /etc/issue file with the appropriate contents according to your site policy,
+      remove any instances of \m , \r , \s , \v or references to the OS platform
+      # echo "Authorized uses only. All activity may be monitored and reported." >
+      /etc/issue
+    compliance:
+      - cis: ["1.8.1.2"]
+      - cis_csc: ["5.1"]
+    condition: none
+    rules:
+      - 'f:/etc/issue -> r:\\m'
+      - 'f:/etc/issue -> r:\\r'
+      - 'f:/etc/issue -> r:\\s'
+      - 'f:/etc/issue -> r:\\v'
+
+# 1.8.1.3 Ensure remote login warning banner is configured properly
+  - id: 7532
+    title: Ensure remote login warning banner is configured properly.
+    description: >
+      The contents of the /etc/issue.net file are displayed to users prior to login for remote
+      connections from configured services.
+      Unix-based systems have typically displayed information about the OS release and patch
+      level upon logging in to the system. This information can be useful to developers who are
+      developing software for a particular OS platform. If mingetty(8) supports the following
+      options, they display operating system information: \m - machine architecture \r -
+      operating system release \s - operating system name \v - operating system version
+    rationale: >
+      Warning messages inform users who are attempting to login to the system of their legal
+      status regarding the system and must include the name of the organization that owns the
+      system and any monitoring policies that are in place. Displaying OS and patch level
+      information in login banners also has the side effect of providing detailed system
+      information to attackers attempting to target specific exploits of a system. Authorized users
+      can easily get this information by running the " uname -a " command once they have logged
+      in.
+    remediation: >
+      Edit the /etc/issue.net file with the appropriate contents according to your site policy,
+      remove any instances of \m , \r , \s , \v or references to the OS platform
+      # echo "Authorized uses only. All activity may be monitored and reported." >
+      /etc/issue.net
+    compliance:
+      - cis: ["1.8.1.3"]
+      - cis_csc: ["5.1"]
+    condition: none
+    rules:
+      - 'f:/etc/issue.net -> r:\\m'
+      - 'f:/etc/issue.net -> r:\\r'
+      - 'f:/etc/issue.net -> r:\\s'
+      - 'f:/etc/issue.net -> r:\\v'
+
+# 1.8.1.4 Ensure permissions on /etc/motd are configured
+  - id: 7533
+    title: Ensure permissions on /etc/motd are configured.
+    description: >
+      The contents of the /etc/motd file are displayed to users after login and function as a
+      message of the day for authenticated users.
+    rationale: >
+      If the /etc/motd file does not have the correct ownership it could be modified by
+      unauthorized users with incorrect or misleading information.
+    remediation: >
+      Run the following commands to set permissions on /etc/motd :
+      # chown root:root /etc/motd
+      # chmod u-x,go-wx /etc/motd
+    compliance:
+      - cis: ["1.8.1.4"]
+      - cis_csc: ["14.6"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/motd -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+# 1.8.1.5 Ensure permissions on /etc/issue are configured
+  - id: 7534
+    title: Ensure permissions on /etc/issue are configured.
+    description: >
+      The contents of the /etc/issue file are displayed to users prior to login for local terminals.
+    rationale: >
+      If the /etc/issue file does not have the correct ownership it could be modified by
+      unauthorized users with incorrect or misleading information.
+    remediation: >
+      Run the following commands to set permissions on /etc/issue:
+      # chown root:root /etc/issue
+      # chmod u-x,go-wx /etc/issue
+    compliance:
+      - cis: ["1.8.1.5"]
+      - cis_csc: ["14.6"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/issue -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+# 1.8.1.6 Ensure permissions on /etc/issue.net are configured
+  - id: 7535
+    title: Ensure permissions on /etc/issue.net are configured.
+    description: >
+      The contents of the /etc/issue.net file are displayed to users prior to login for remote
+      connections from configured services.
+    rationale: >
+      If the /etc/issue.net file does not have the correct ownership it could be modified by
+      unauthorized users with incorrect or misleading information.
+    remediation: >
+      Run the following commands to set permissions on /etc/issue.net:
+      # chown root:root /etc/issue.net
+      # chmod u-x,go-wx /etc/issue.net
+    compliance:
+      - cis: ["1.8.1.6"]
+      - cis_csc: ["14.6"]
+    condition: all
+    rules:
+      - 'c:stat -L /etc/issue.net -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+
+# 1.9 Ensure updates, patches, and additional security software are installed - Not implemented
+# 1.10 Ensure GDM is removed or login is configured - Not implemented
+
+# 2.1.1 Ensure xinetd is not installed
+  - id: 7536
+    title: Ensure xinetd is not installed.
+    description: >
+      The eXtended InterNET Daemon ( xinetd ) is an open source super daemon that replaced
+      the original inetd daemon. The xinetd daemon listens for well known services and
+      dispatches the appropriate daemon to properly respond to service requests.
+    rationale: >
+      If there are no xinetd services required, it is recommended that the package be removed to
+      reduce the attack surface are of the system.
+
+      Note: If an xinetd service or services are required, ensure that any xinetd service not required
+      is stopped and disabled
+    remediation: >
+      Run the following command to remove xinetd:
+      # zypper remove xinetd
+    compliance:
+      - cis: ["2.1.1"]
+      - cis_csc: ["2.6","9.2"]
+    condition: all
+    rules:
+      - 'c:rpm -q xinetd -> r:not installed'
+
+# 2.2.1.1 Ensure time synchronization is in use - Not implemented
+# 2.2.1.2 Ensure systemd-timesyncd is configured - Not implemented
+
+
+
+
+
+
 
   - id: 7512
     title: Ensure rsh client is not installed
@@ -465,27 +1201,7 @@ checks:
       - 'c:rpm -q rsync -> r:not installed'
       - 'c:systemctl is-enabled rsyncd -> r:^masked'
 
-  - id: 7517
-    title: Ensure xinetd is not installed
-    description: >
-      The eXtended InterNET Daemon ( xinetd ) is an open source super daemon that replaced
-      the original inetd daemon. The xinetd daemon listens for well known services and
-      dispatches the appropriate daemon to properly respond to service requests.
-    rationale: >
-      If there are no xinetd services required, it is recommended that the package be removed to
-      reduce the attack surface are of the system.
 
-      Note: If an xinetd service or services are required, ensure that any xinetd service not required
-      is stopped and disabled
-    remediation: >
-      Run the following command to remove xinetd:
-      # zypper remove xinetd
-    compliance:
-      - cis: ["2.1.1"]
-      - cis_csc: ["2.6","9.2"]
-    condition: all
-    rules:
-      - 'c:rpm -q xinetd -> r:not installed'
 
   - id: 7518
     title: Ensure X11 Server components are not installed
@@ -1090,649 +1806,30 @@ checks:
     rules:
       - 'f:/etc/passwd -> !r:^\s*\t*# && !r:^\s*\t*root: && r:^\w+:\w+:0:'
 
-  - id: 7544
-    title: Ensure mounting of squashfs filesystems is disabled
-    description: >
-      The squashfs filesystem type is a compressed read-only Linux filesystem embedded in
-      small footprint systems (similar to cramfs ). A squashfs image can be used without having
-      to first decompress the image.
-    rationale: >
-      Removing support for unneeded filesystem types reduces the local attack surface of the
-      system. If this filesystem type is not needed, disable it.
-    remediation: >
-      Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
-      Example: vi /etc/modprobe.d/squashfs.conf
-      and add the following line:
-      install squashfs /bin/true
 
-      Run the following command to unload the squashfs module:
-      # modprobe -r squashfs
-    compliance:
-      - cis: ["1.1.1.1"]
-      - cis_csc: ["5.1"]
-    condition: any
-    rules:
-      - 'c:modprobe -n -v squashfs -> r:install'
-      - 'c:modprobe -n -v squashfs -> r:squashfs'
 
-  - id: 7545
-    title: Ensure mounting of udf filesystems is disabled
-    description: >
-      The udf filesystem type is the universal disk format used to implement ISO/IEC 13346 and
-      ECMA-167 specifications. This is an open vendor filesystem type for data storage on a
-      broad range of media. This filesystem type is necessary to support writing DVDs and newer
-      optical disc formats.
-    rationale: >
-      Removing support for unneeded filesystem types reduces the local attack surface of the
-      system. If this filesystem type is not needed, disable it.
-    remediation: >
-      Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
-      Example: vi /etc/modprobe.d/udf.conf
-      and add the following line:
-      install udf /bin/true
 
-      Run the following command to unload the udf module:
-      # modprobe -r udf
-    compliance:
-      - cis: ["1.1.1.2"]
-      - cis_csc: ["5.1"]
-    condition: any
-    rules:
-      - 'c:modprobe -n -v udf -> r:install'
-      - 'c:modprobe -n -v udf -> r:udf'
 
-  - id: 7546
-    title: Ensure /dev/shm is configured
-    description: >
-      /dev/shm is a traditional shared memory concept. One program will create a memory
-      portion, which other processes (if permitted) can access. If /dev/shm is not configured,
-      tmpfs will be mounted to /dev/shm by systemd.
 
-      Notes:
-        - An entry for /dev/shm in /etc/fstab will take precedence.
-        - tmpfs can be resized using the size={size} parameter in /etc/fstab. If we don't specify
-          the size, it will be half the RAM.
 
-      Resize tmpfs example:
-      tmpfs /dev/shm tmpfs defaults,noexec,nodev,nosuid,size=2G 0 0
-    rationale: >
-      Any user can upload and execute files inside the /dev/shm similar to the /tmp partition.
-      Configuring /dev/shm allows an administrator to set the noexec option on the mount,
-      making /dev/shm useless for an attacker to install executable code. It would also prevent an
-      attacker from establishing a hardlink to a system setuid program and wait for it to be
-      updated. Once the program was updated, the hardlink would be broken and the attacker
-      would have his own copy of the program. If the program happened to have a security
-      vulnerability, the attacker could continue to exploit the known flaw.
-    remediation: >
-      Edit /etc/fstab and add or edit the following line:
-      tmpfs /dev/shm tmpfs defaults,noexec,nodev,nosuid 0 0
 
-      Run the following command to remount /dev/shm:
-      # mount -o remount,noexec,nodev,nosuid /dev/shm
-    compliance:
-      - cis: ["1.1.6"]
-      - cis_csc: ["5.1","13"]
-    condition: all
-    rules:
-      - 'c:mount -> r:\.+\s+/dev/shm\s+'
-      - 'f:/etc/fstab -> r:\.+\s+/dev/shm\s+'
 
-  - id: 7547
-    title: Ensure separate partition exists for /var/tmp
-    description: >
-      The /var/tmp directory is a world-writable directory used for temporary storage by all
-      users and some applications and is intended for temporary files that are preserved across
-      reboots.
+ 
 
-      Note: tmpfs should not be used for /var/tmp/. tmpfs is a temporary filesystem that resides in
-      memory and/or swap partition(s). Files in tmpfs are automatically cleared at each bootup.
-    rationale: >
-      Since the /var/tmp directory is intended to be world-writable, there is a risk of resource
-      exhaustion if it is not bound to a separate partition. In addition, making /var/tmp its own
-      file system allows an administrator to set the noexec option on the mount, making
-      /var/tmp useless for an attacker to install executable code. It would also prevent an
-      attacker from establishing a hardlink to a system setuid program and wait for it to be
-      updated. Once the program was updated, the hardlink would be broken and the attacker
-      would have his own copy of the program. If the program happened to have a security
-      vulnerability, the attacker could continue to exploit the known flaw.
-    remediation: >
-      For new installations, during installation create a custom partition setup and specify a
-      separate partition for /var/tmp .
-      For systems that were previously installed, create a new partition and configure
-      /etc/fstab as appropriate.
-    compliance:
-      - cis: ["1.1.11"]
-      - cis_csc: ["5.1","13"]
-    condition: all
-    rules:
-      - 'c:mount -> r:\s/var/tmp\s'
 
-  - id: 7548
-    title: Ensure noexec option set on /var/tmp partition
-    description: The noexec mount option specifies that the filesystem cannot contain executable binaries.
-    rationale: >
-      Since the /var/tmp filesystem is only intended for temporary file storage, set this option to
-      ensure that users cannot run executable binaries from /var/tmp .
-    remediation: >
-      Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the
-      /var/tmp partition. See the fstab(5) manual page for more information.
 
-      Run the following command to remount /var/tmp :
-      # mount -o remount,noexec /var/tmp
-    compliance:
-      - cis: ["1.1.12"]
-      - cis_csc: ["2.6"]
-    condition: all
-    rules:
-      - 'c:mount -> r:\s/var/tmp\s && r:noexec'
 
-  - id: 7549
-    title: Ensure nodev option set on /var/tmp partition
-    description: The nodev mount option specifies that the filesystem cannot contain special devices.
-    rationale: >
-      Since the /var/tmp filesystem is not intended to support devices, set this option to ensure
-      that users cannot attempt to create block or character special devices in /var/tmp .
-    remediation: >
-      Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the
-      /var/tmp partition. See the fstab(5) manual page for more information.
 
-      Run the following command to remount /var/tmp :
-      # mount -o remount,nodev /var/tmp
-    compliance:
-      - cis: ["1.1.13"]
-      - cis_csc: ["5.1","13"]
-    condition: all
-    rules:
-      - 'c:mount -> r:\s+/var/tmp\s+ && r:nodev'
 
-  - id: 7550
-    title: Ensure nosuid option set on /var/tmp partition
-    description: The nosuid mount option specifies that the filesystem cannot contain setuid files.
-    rationale: >
-      Since the /var/tmp filesystem is only intended for temporary file storage, set this option to
-      ensure that users cannot create setuid files in /var/tmp
-    remediation: >
-      Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the
-      /var/tmp partition. See the fstab(5) manual page for more information.
 
-      Run the following command to remount /var/tmp :
-      # mount -o remount,nosuid /var/tmp
-    compliance:
-      - cis: ["1.1.14"]
-      - cis_csc: ["5.1","13"]
-    condition: all
-    rules:
-      - 'c:mount -> r:\s+/var/tmp\s+ && r:nosuid'
 
-  - id: 7551
-    title: Disable Automounting
-    description: >
-      autofs allows automatic mounting of devices, typically including CD/DVDs and USB drives.
-      Notes:
-        - Additional methods of disabling a service exist. Consult your distribution
-          documentation for appropriate methods.
-        - This control should align with the tolerance of the use of portable drives and optical
-          media in the organization.
-          - On a server requiring an admin to manually mount media can be part of
-            defense-in-depth to reduce the risk of unapproved software or information
-            being introduced or proprietary software or information being exfiltrated.
-          - If admins commonly use flash drives and Server access has sufficient physical
-            controls, requiring manual mounting may not increase security.
-    rationale: >
-      With automounting enabled anyone with physical access could attach a USB drive or disc
-      and have its contents available in system even if they lacked permissions to mount it
-      themselves.
-    remediation: >
-      Run the following command to mask autofs:
-      # systemctl --now mask autofs
-    compliance:
-      - cis: ["1.1.23"]
-      - cis_csc: ["8.4","8.5"]
-    condition: none
-    rules:
-      - 'c:systemctl is-enabled autofs -> r:enabled'
 
-  - id: 7552
-    title: Ensure sudo is installed
-    description: >
-      sudo allows a permitted user to execute a command as the superuser or another user, as
-      specified by the security policy. The invoking user's real (not effective) user ID is used to
-      determine the user name with which to query the security policy.
-    rationale: >
-      sudo supports a plugin architecture for security policies and input/output logging. Third
-      parties can develop and distribute their own policy and I/O logging plugins to work
-      seamlessly with the sudo front end. The default security policy is sudoers, which is
-      configured via the file /etc/sudoers.
 
-      The security policy determines what privileges, if any, a user has to run sudo. The policy
-      may require that users authenticate themselves with a password or another authentication
-      mechanism. If authentication is required, sudo will exit if the user's password is not
-      entered within a configurable time limit. This limit is policy-specific.
-    remediation: >
-      Run the following command to install sudo.
-      # zypper install sudo
-    compliance:
-      - cis: ["1.3.1"]
-      - cis_csc: ["4"]
-    references:
-      - SUDO(8)
-    condition: none
-    rules:
-      - 'c:rpm -q sudo -> r:not installed'
 
-  - id: 7553
-    title: Ensure sudo commands use pty
-    description: >
-      sudo can be configured to run only from a pseudo-pty
 
-      Note: visudo edits the sudoers file in a safe fashion, analogous to vipw(8). visudo locks the
-      sudoers file against multiple simultaneous edits, provides basic sanity checks, and checks for
-      parse errors. If the sudoers file is currently being edited you will receive a message to try
-      again later. The -f option allows you to tell visudo which file to edit.
-    rationale: >
-      Attackers can run a malicious program using sudo, which would again fork a background
-      process that remains even when the main program has finished executing.
-      This can be mitigated by configuring sudo to run other commands only from a pseudo-pty,
-      whether I/O logging is turned on or not.
-    remediation: >
-      Edit the file /etc/sudoers or a file in /etc/sudoers.d/ with visudo or visudo -f <PATH
-      TO FILE> and add the following line:
 
-      Defaults use_pty
-    compliance:
-      - cis: ["1.3.2"]
-      - cis_csc: ["4"]
-    references:
-      - SUDO(8)
-    condition: all
-    rules:
-      - 'c:grep -REsih "^Defaults" /etc/sudoers /etc/sudoers.d -> r:^\wefaults\s+use_pty'
 
-  - id: 7554
-    title: Ensure sudo log file exists
-    description: >
-      sudo can use a custom log file
-
-      Note: visudo edits the sudoers file in a safe fashion, analogous to vipw(8). visudo locks the
-      sudoers file against multiple simultaneous edits, provides basic sanity checks, and checks
-      for parse errors. If the sudoers file is currently being edited you will receive a message to
-      try again later. The -f option allows you to tell visudo which file to edit.
-    rationale: A sudo log file simplifies auditing of sudo commands
-    remediation: >
-      edit the file /etc/sudoers or a file in /etc/sudoers.d/ with visudo or visudo -f <PATH
-      TO FILE> and add the following line:
-      Defaults logfile="<PATH TO CUSTOM LOG FILE>"
-
-      Example
-      Defaults logfile="/var/log/sudo.log"
-    compliance:
-      - cis: ["1.3.3"]
-      - cis_csc: ["6.3"]
-    references:
-      - SUDO(8)
-      - VISUDO(8)
-    condition: all
-    rules:
-      - 'c:grep -REsih "^Defaults" /etc/sudoers /etc/sudoers.d -> r:^\wefaults\s+logfile="\.+"'
-
-  - id: 7555
-    title: Ensure AIDE is installed
-    description: >
-      AIDE takes a snapshot of filesystem state including modification times, permissions, and
-      file hashes which can then be used to compare against the current state of the filesystem to
-      detect modifications to the system.
-
-      Note: The prelinking feature can interfere with AIDE because it alters binaries to speed up
-      their start up times. Run prelink -ua to restore the binaries to their prelinked state, thus
-      avoiding false positives from AIDE.
-    rationale: >
-      By monitoring the filesystem state compromised files can be detected to prevent or limit
-      the exposure of accidental or malicious misconfigurations or modified binaries.
-    remediation: >
-      Configure AIDE as appropriate for your environment. Consult the AIDE documentation for
-      options.
-      Run the following command to install AIDE:
-      # zypper install aide
-
-      Run the following commands to initialize AIDE:
-      # aide --init
-      # mv /var/lib/aide/aide.db.new /var/lib/aide/aide.db
-    compliance:
-      - cis: ["1.4.1"]
-      - cis_csc: ["14.9"]
-    references:
-      - AIDE stable manual: http://aide.sourceforge.net/stable/manual.html
-    condition: none
-    rules:
-      - 'c:rpm -q aide -> r:not installed'
-
-  - id: 7556
-    title: Ensure bootloader password is set
-    description: >
-      Setting the boot loader password will require that anyone rebooting the system must enter
-      a password before being able to set command line boot parameters
-
-      Notes:
-        - This recommendation is designed around the grub2 bootloader, if LILO or another
-          bootloader is in use in your environment enact equivalent settings. Replace
-          `/boot/grub2/grub.cfg with the appropriate grub configuration file for your
-          environment
-        - The information can be placed in any /etc/grub.d file as long as that file is
-          incorporated into grub.cfg
-          - The superuser/user information and password should not be contained in the
-            /etc/grub.d/00_header file.
-          - A custom file, such as /etc/grub.d/40_custom should be used so it is not
-            overwritten should the Grub package be updated.
-    rationale: >
-      Requiring a boot password upon execution of the boot loader will prevent an unauthorized
-      user from entering boot parameters or changing the boot partition. This prevents users
-      from weakening security (e.g. turning off SELinux at boot time).
-    remediation: >
-      Create an encrypted password with grub2-mkpasswd-pbkdf2:
-        # grub2-mkpasswd-pbkdf2
-        Enter password: <password>
-        Reenter password: <password>
-        Your PBKDF2 is <encrypted-password>
-
-      Add the following into /etc/grub.d/40_custom
-        set superusers="<username>"
-        password_pbkdf2 <username> <encrypted-password>
-
-      Run the following command to update the grub2 configuration:
-        # grub2-mkconfig -o /boot/grub2/grub.cfg
-    compliance:
-      - cis: ["1.5.1"]
-      - cis_csc: ["5.1"]
-    references:
-      - https://documentation.suse.com/sles/15-SP1/html/SLES-all/cha-grub2.html
-    condition: all
-    rules:
-      - 'f:/boot/grub2/grub.cfg -> r:^\s*set superusers'
-      - 'f:/boot/grub2/grub.cfg -> r:^\s*password'
-
-  - id: 7557
-    title: Ensure permissions on bootloader config are configured
-    description: >
-      The grub configuration file contains information on boot settings and passwords for
-      unlocking boot options. The grub2 configuration is usually grub.cfg stored in
-      /boot/grub2/.
-
-      Notes:
-        - This recommendation is designed around the grub2 bootloader.
-        - If LILO or another bootloader is in use in your environment:
-          - Enact equivalent settings
-          - Replace /boot/grub2/grub.cfg and /boot/grub2/user.cfg with the
-            appropriate boot configuration files for your environment
-    rationale: >
-      Setting the permissions to read and write for root only prevents non-root users from
-      seeing the boot parameters or changing them. Non-root users who read the boot
-      parameters may be able to identify weaknesses in security upon boot and be able to exploit
-      them.
-    remediation: >
-      Run the following commands to set ownership and permissions on your grub
-      configuration:
-      # chown root:root /boot/grub2/grub.cfg
-      # chmod og-rwx /boot/grub2/grub.cfg
-    compliance:
-      - cis: ["1.5.2"]
-      - cis_csc: ["5.1"]
-    condition: all
-    rules:
-      - 'c:stat -L /boot/grub2/grub.cfg -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
-
-  - id: 7558
-    title: Ensure authentication required for single user mode
-    description: >
-      Single user mode (rescue mode) is used for recovery when the system detects an issue
-      during boot or by manual selection from the bootloader.
-    rationale: >
-      Requiring authentication in single user mode (rescue mode) prevents an unauthorized user
-      from rebooting the system into single user to gain root privileges without credentials.
-    remediation: >
-      Edit /usr/lib/systemd/system/rescue.service and add/modify the following line:
-      ExecStart=-/usr/lib/systemd/systemd-sulogin-shell rescue
-
-      Edit /usr/lib/systemd/system/emergency.service and add/modify the following line:
-      ExecStart=-/usr/lib/systemd/systemd-sulogin-shell emergency
-    compliance:
-      - cis: ["1.5.3"]
-      - cis_csc: ["5.1"]
-    condition: all
-    rules:
-      - 'f:/usr/lib/systemd/system/rescue.service -> r:^ExecStart=\.*/systemd/systemd-sulogin-shell\s+rescue'
-      - 'f:/usr/lib/systemd/system/emergency.service -> r:^ExecStart=\.*/systemd/systemd-sulogin-shell\s+emergency'
-
-  - id: 7559
-    title: Ensure XD/NX support is enabled
-    description: >
-      Recent processors in the x86 family support the ability to prevent code execution on a per
-      memory page basis. Generically and on AMD processors, this ability is called No Execute
-      (NX), while on Intel processors it is called Execute Disable (XD). This ability can help
-      prevent exploitation of buffer overflow vulnerabilities and should be activated whenever
-      possible. Extra steps must be taken to ensure that this protection is enabled, particularly on
-      32-bit x86 systems. Other processors, such as Itanium and POWER, have included such
-      support since inception and the standard kernel for those platforms supports the feature.
-    rationale: >
-      Enabling any feature that can protect against buffer overflow attacks enhances the security
-      of the system.
-
-      Note: Ensure your system supports the XD or NX bit and has PAE support before implementing
-      this recommendation as this may prevent it from booting if these are not supported by your
-      hardware.
-    remediation: >
-      On 32 bit systems install a kernel with PAE support, no installation is required on 64 bit
-      systems:
-      If necessary configure your bootloader to load the new kernel and reboot the system.
-      You may need to enable NX or XD support in your bios.
-    compliance:
-      - cis: ["1.6.2"]
-      - cis_csc: ["8.3"]
-    condition: all
-    rules:
-      - 'c:journalctl -> r:\.*kernel: NX \(Execute Disable\) protection:\s*active'
-
-  - id: 7560
-    title: Ensure prelink is disabled
-    description: >
-      prelinkis a program that modifies ELF shared libraries and ELF dynamically linked
-      binaries in such a way that the time needed for the dynamic linker to perform relocations
-      at startup significantly decreases.
-    rationale: >
-      The prelinking feature can interfere with the operation of AIDE, because it changes
-      binaries. Prelinking can also increase the vulnerability of the system if a malicious user is
-      able to compromise a common library such as libc.
-    remediation: >
-      Run the following command to restore binaries to normal:
-      # prelink -ua
-
-      Run the following command to uninstall prelink:
-      # zypper remove prelink
-    compliance:
-      - cis: ["1.6.4"]
-      - cis_csc: ["14.9"]
-    condition: all
-    rules:
-      - 'c:rpm -q prelink -> r:not installed'
-
-  - id: 7561
-    title: Ensure AppArmor is installed
-    description: AppArmor provides Mandatory Access Controls.
-    rationale: >
-      Without a Mandatory Access Control system installed only the default Discretionary Access
-      Control system will be available.
-    remediation: >
-      Run the following command to install AppArmor:
-      # zypper install -t pattern apparmor
-    compliance:
-      - cis: ["1.7.1.1"]
-      - cis_csc: ["14.6"]
-    condition: none
-    rules:
-      - 'c:rpm -q apparmor-docs -> r:not installed'
-      - 'c:rpm -q apparmor-parser -> r:not installed'
-      - 'c:rpm -q apparmor-profiles -> r:not installed'
-      - 'c:rpm -q apparmor-utils -> r:not installed'
-      - 'c:rpm -q libapparmor1 -> r:not installed'
-
-  - id: 7562
-    title: Ensure message of the day is configured properly
-    description: >
-      The contents of the /etc/motd file are displayed to users after login and function as a
-      message of the day for authenticated users.
-
-      Unix-based systems have typically displayed information about the OS release and patch
-      level upon logging in to the system. This information can be useful to developers who are
-      developing software for a particular OS platform. If mingetty(8) supports the following
-      options, they display operating system information: \m - machine architecture \r -
-      operating system release \s - operating system name \v - operating system version
-    rationale: >
-      Warning messages inform users who are attempting to login to the system of their legal
-      status regarding the system and must include the name of the organization that owns the
-      system and any monitoring policies that are in place. Displaying OS and patch level
-      information in login banners also has the side effect of providing detailed system
-      information to attackers attempting to target specific exploits of a system. Authorized users
-      can easily get this information by running the " uname -a " command once they have logged
-      in.
-    remediation: >
-      Edit the /etc/motd file with the appropriate contents according to your site policy, remove
-      any instances of \m , \r , \s , \v or references to the OS platform
-
-      OR
-
-      If the motd is not used, this file can be removed.
-      Run the following command to remove the motd file:
-      # rm /etc/motd
-    compliance:
-      - cis: ["1.8.1.1"]
-      - cis_csc: ["5.1"]
-    condition: none
-    rules:
-      - 'f:/etc/motd -> r:\\m'
-      - 'f:/etc/motd -> r:\\r'
-      - 'f:/etc/motd -> r:\\s'
-      - 'f:/etc/motd -> r:\\v'
-
-  - id: 7563
-    title: Ensure local login warning banner is configured properly
-    description: >
-      The contents of the /etc/issue file are displayed to users prior to login for local terminals.
-      Unix-based systems have typically displayed information about the OS release and patch
-      level upon logging in to the system. This information can be useful to developers who are
-      developing software for a particular OS platform. If mingetty(8) supports the following
-      options, they display operating system information: \m - machine architecture \r -
-      operating system release \s - operating system name \v - operating system version - or the
-      operating system's name
-    rationale: >
-      Warning messages inform users who are attempting to login to the system of their legal
-      status regarding the system and must include the name of the organization that owns the
-      system and any monitoring policies that are in place. Displaying OS and patch level
-      information in login banners also has the side effect of providing detailed system
-      information to attackers attempting to target specific exploits of a system. Authorized users
-      can easily get this information by running the " uname -a " command once they have logged
-      in.
-    remediation: >
-      Edit the /etc/issue file with the appropriate contents according to your site policy,
-      remove any instances of \m , \r , \s , \v or references to the OS platform
-      # echo "Authorized uses only. All activity may be monitored and reported." >
-      /etc/issue
-    compliance:
-      - cis: ["1.8.1.2"]
-      - cis_csc: ["5.1"]
-    condition: none
-    rules:
-      - 'f:/etc/issue -> r:\\m'
-      - 'f:/etc/issue -> r:\\r'
-      - 'f:/etc/issue -> r:\\s'
-      - 'f:/etc/issue -> r:\\v'
-
-  - id: 7564
-    title: Ensure remote login warning banner is configured properly
-    description: >
-      The contents of the /etc/issue.net file are displayed to users prior to login for remote
-      connections from configured services.
-      Unix-based systems have typically displayed information about the OS release and patch
-      level upon logging in to the system. This information can be useful to developers who are
-      developing software for a particular OS platform. If mingetty(8) supports the following
-      options, they display operating system information: \m - machine architecture \r -
-      operating system release \s - operating system name \v - operating system version
-    rationale: >
-      Warning messages inform users who are attempting to login to the system of their legal
-      status regarding the system and must include the name of the organization that owns the
-      system and any monitoring policies that are in place. Displaying OS and patch level
-      information in login banners also has the side effect of providing detailed system
-      information to attackers attempting to target specific exploits of a system. Authorized users
-      can easily get this information by running the " uname -a " command once they have logged
-      in.
-    remediation: >
-      Edit the /etc/issue.net file with the appropriate contents according to your site policy,
-      remove any instances of \m , \r , \s , \v or references to the OS platform
-      # echo "Authorized uses only. All activity may be monitored and reported." >
-      /etc/issue.net
-    compliance:
-      - cis: ["1.8.1.3"]
-      - cis_csc: ["5.1"]
-    condition: none
-    rules:
-      - 'f:/etc/issue.net -> r:\\m'
-      - 'f:/etc/issue.net -> r:\\r'
-      - 'f:/etc/issue.net -> r:\\s'
-      - 'f:/etc/issue.net -> r:\\v'
-
-  - id: 7565
-    title: Ensure permissions on /etc/motd are configured
-    description: >
-      The contents of the /etc/motd file are displayed to users after login and function as a
-      message of the day for authenticated users.
-    rationale: >
-      If the /etc/motd file does not have the correct ownership it could be modified by
-      unauthorized users with incorrect or misleading information.
-    remediation: >
-      Run the following commands to set permissions on /etc/motd :
-      # chown root:root /etc/motd
-      # chmod u-x,go-wx /etc/motd
-    compliance:
-      - cis: ["1.8.1.4"]
-      - cis_csc: ["14.6"]
-    condition: all
-    rules:
-      - 'c:stat -L /etc/motd -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
-
-  - id: 7566
-    title: Ensure permissions on /etc/issue are configured
-    description: >
-      The contents of the /etc/issue file are displayed to users prior to login for local terminals.
-    rationale: >
-      If the /etc/issue file does not have the correct ownership it could be modified by
-      unauthorized users with incorrect or misleading information.
-    remediation: >
-      Run the following commands to set permissions on /etc/issue:
-      # chown root:root /etc/issue
-      # chmod u-x,go-wx /etc/issue
-    compliance:
-      - cis: ["1.8.1.5"]
-      - cis_csc: ["14.6"]
-    condition: all
-    rules:
-      - 'c:stat -L /etc/issue -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
-
-  - id: 7567
-    title: Ensure permissions on /etc/issue.net are configured
-    description: >
-      The contents of the /etc/issue.net file are displayed to users prior to login for remote
-      connections from configured services.
-    rationale: >
-      If the /etc/issue.net file does not have the correct ownership it could be modified by
-      unauthorized users with incorrect or misleading information.
-    remediation: >
-      Run the following commands to set permissions on /etc/issue.net:
-      # chown root:root /etc/issue.net
-      # chmod u-x,go-wx /etc/issue.net
-    compliance:
-      - cis: ["1.8.1.6"]
-      - cis_csc: ["14.6"]
-    condition: all
-    rules:
-      - 'c:stat -L /etc/issue.net -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+  
 
   - id: 7568
     title: Ensure chrony is configured

--- a/ruleset/sca/sles/15/cis_sles15_linux.yml
+++ b/ruleset/sca/sles/15/cis_sles15_linux.yml
@@ -1088,123 +1088,37 @@ checks:
 # 2.2.1.1 Ensure time synchronization is in use - Not implemented
 # 2.2.1.2 Ensure systemd-timesyncd is configured - Not implemented
 
-
-
-
-
-
-
-  - id: 7512
-    title: Ensure rsh client is not installed
-    description: The rsh package contains the client commands for the rsh services.
-    rationale: >
-      These legacy clients contain numerous security exposures and have been replaced with the
-      more secure SSH package. Even if the server is removed, it is best to ensure the clients are
-      also removed to prevent users from inadvertently attempting to use these commands and
-      therefore exposing their credentials. Note that removing the rsh package removes the
-      clients for rsh , rcp and rlogin.
-    remediation: >
-      Run the following command to remove the rsh package:
-      # zypper remove rsh
-    compliance:
-      - cis: ["2.3.2"]
-      - cis_csc: ["2.6"]
-    condition: all
-    rules:
-      - 'c:rpm -q rsh -> r:not installed'
-
-  - id: 7513
-    title: Ensure talk client is not installed
+# 2.2.1.3 Ensure chrony is configured
+  - id: 7537
+    title: Ensure chrony is configured.
     description: >
-      The talk software makes it possible for users to send and receive messages across systems
-      through a terminal session. The talk client, which allows initialization of talk sessions, is
-      installed by default.
+      chrony is a daemon which implements the Network Time Protocol (NTP) and is designed to
+      synchronize system clocks across a variety of systems and use a source that is highly
+      accurate. More information on chrony can be found at: http://chrony.tuxfamily.org/.
+      chrony can be configured to be a client and/or a server.
     rationale: >
-      The software presents a security risk as it uses unencrypted protocols for communication.
+      If chrony is in use on the system proper configuration is vital to ensuring time
+      synchronization is working properly.
+
+      Note: This recommendation only applies if chrony is in use on the system. If another method of
+      time synchronization is in use on the system, this recommendation can be skipped.
     remediation: >
-      Run the following command to remove the talk package:
-      # zypper remove talk
+      Add or edit server or pool lines to /etc/chrony.conf as appropriate:
+      server <remote-server>
+
+      Add or edit the OPTIONS in /etc/sysconfig/chronyd to include '-u chrony':
+      OPTIONS="-u chrony"
     compliance:
-      - cis: ["2.3.3"]
-      - cis_csc: ["2.6"]
+      - cis: ["2.2.1.3"]
+      - cis_csc: ["6.1"]
     condition: all
     rules:
-      - 'c:rpm -q talk -> r:not installed'
+      - 'f:/etc/chrony.conf -> r:^\s*server\s+\.+'
+      - 'f:/etc/sysconfig/chronyd -> r:^\s*OPTIONS\s*=\s*"-u\s*chrony"'
 
-  - id: 7514
-    title: Ensure telnet-server is not installed
-    description: >
-      The telnet package contains the telnet daemon, which accepts connections from users
-      from other systems via the telnet protocol.
-    rationale: >
-      The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission
-      medium could allow a user with access to sniff network traffic the ability to steal
-      credentials. The ssh package provides an encrypted session and stronger security.
-    remediation: >
-      Run the following command to remove the telnet-server package:
-      # zypper remove telnet
-    compliance:
-      - cis: ["2.2.19"]
-      - cis_csc: ["2.6","9.2"]
-    condition: all
-    rules:
-      - 'c:rpm -q telnet -> r:not installed'
-
-  - id: 7515
-    title: Ensure FTP Server is not installed
-    description: >
-      FTP (File Transfer Protocol) is a traditional and widely used standard tool for transferring
-      files between a server and clients over a network, especially where no authentication is
-      necessary (permits anonymous users to connect to a server).
-    rationale: >
-      FTP does not protect the confidentiality of data or authentication credentials. It is
-      recommended SFTP be used if file transfer is required. Unless there is a need to run the
-      system as a FTP server (for example, to allow anonymous downloads), it is recommended
-      that the package be removed to reduce the potential attack surface.
-
-      Note: Additional FTP servers also exist and should be removed if not required.
-    remediation: >
-      Run the following command to remove vsftpd:
-      # zypper remove vsftpd
-    compliance:
-      - cis: ["2.2.10"]
-      - cis_csc: ["9.2"]
-    condition: all
-    rules:
-      - 'c:rpm -q vsftpd -> r:not installed'
-
-  - id: 7516
-    title: Ensure rsync is not installed or the rsyncd service is masked
-    description: The rsyncd service can be used to synchronize files between systems over network links.
-    rationale: >
-      Unless required, the rsync package should be removed to reduce the attack surface area of
-      the system.
-
-      The rsyncd service presents a security risk as it uses unencrypted protocols for
-      communication.
-
-      Note: If a required dependency exists for the rsync package, but the rsyncd service is not
-      required, the service should be masked.
-    remediation: >
-      Run the following command to remove the rsync package:
-      # zypper remove rsync
-
-      OR
-
-      Run the following command to mask the rsyncd service:
-      # systemctl --now mask rsyncd
-    compliance:
-      - cis: ["2.2.17"]
-      - cis_csc: ["9.2"]
-    condition: any
-    rules:
-      - 'c:rpm -q rsync -> r:not installed'
-      - 'c:systemctl is-enabled rsyncd -> r:^masked'
-
-
-
-  - id: 7518
-    title: Ensure X11 Server components are not installed
+# 2.2.2 Ensure X11 Server components are not installed
+  - id: 7538
+    title: Ensure X11 Server components are not installed.
     description: >
       The X Window System provides a Graphical User Interface (GUI) where users can have
       multiple windows in which to run programs and various add on. The X Windows system is
@@ -1223,8 +1137,9 @@ checks:
     rules:
       - 'c:rpm -qa -> r:^xorg-x11'
 
-  - id: 7519
-    title: Ensure Avahi Server is not installed
+# 2.2.3 Ensure Avahi Server is not installed
+  - id: 7539
+    title: Ensure Avahi Server is not installed.
     description: >
       Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD
       service discovery. Avahi allows programs to publish and discover services and hosts
@@ -1245,8 +1160,34 @@ checks:
     rules:
       - 'c:rpm -qa -> r:^avahi'
 
-  - id: 7520
-    title: Ensure DHCP Server is not installed
+# 2.2.4 Ensure CUPS is not installed
+  - id: 7540
+    title: Ensure CUPS is not installed.
+    description: >
+      The Common Unix Print System (CUPS) provides the ability to print to both local and
+      network printers. A system running CUPS can also accept print jobs from remote systems
+      and print them to local printers. It also provides a web based remote administration
+      capability.
+    rationale: >
+      If the system does not need to print jobs or accept print jobs from other systems, it is
+      recommended that CUPS be removed to reduce the potential attack surface.
+
+      Note: Removing CUPS will prevent printing from the system
+    remediation: >
+      Run the following command to remove cups:
+      # zypper remove cups
+    compliance:
+      - cis: ["2.2.4"]
+      - cis_csc: ["9.2"]
+    references:
+      - http://www.cups.org
+    condition: all
+    rules:
+      - 'c:rpm -q cups -> r:not installed'
+
+# 2.2.5 Ensure DHCP Server is not installed 
+  - id: 7541
+    title: Ensure DHCP Server is not installed.
     description: >
       The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be
       dynamically assigned IP addresses.
@@ -1265,8 +1206,34 @@ checks:
     rules:
       - 'c:rpm -q dhcp -> r:not installed'
 
-  - id: 7521
-    title: Ensure DNS Server is not installed
+# 2.2.6 Ensure LDAP server is not installed
+  - id: 7542
+    title: Ensure LDAP server is not installed
+    description: >
+      The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for
+      NIS/YP. It is a service that provides a method for looking up information from a central
+      database.
+    rationale: >
+      If the system will not need to act as an LDAP server, it is recommended that the software be
+      removed to reduce the potential attack surface.
+    remediation: >
+      Run the following command to remove openldap-servers:
+      # zypper remove openldap2
+    compliance:
+      - cis: ["2.2.6"]
+      - cis_csc: ["9.2"]
+    references:
+      - http://www.openldap.org
+    condition: all
+    rules:
+      - 'c:rpm -q openldap2 -> r:not installed'
+
+# 2.2.7 Ensure nfs-utils is not installed or the nfs-server service is masked - Not implemented
+# 2.2.8 Ensure rpcbind is not installed or the rpcbind services are masked - Not implemented
+
+# 2.2.9 Ensure DNS Server is not installed
+  - id: 7543
+    title: Ensure DNS Server is not installed.
     description: >
       The Domain Name System (DNS) is a hierarchical naming system that maps names to IP
       addresses for computers, services and other resources connected to a network.
@@ -1283,8 +1250,9 @@ checks:
     rules:
       - 'c:rpm -q bind -> r:not installed'
 
-  - id: 7522
-    title: Ensure FTP Server is not installed
+# 2.2.10 Ensure FTP Server is not installed
+  - id: 7544
+    title: Ensure FTP Server is not installed.
     description: >
       FTP (File Transfer Protocol) is a traditional and widely used standard tool for transferring
       files between a server and clients over a network, especially where no authentication is
@@ -1306,8 +1274,9 @@ checks:
     rules:
       - 'c:rpm -q vsftpd -> r:not installed'
 
-  - id: 7523
-    title: Ensure HTTP server is not installed
+# 2.2.11 Ensure HTTP server is not installed
+  - id: 7545
+    title: Ensure HTTP server is not installed.
     description: HTTP or web servers provide the ability to host web site content.
     rationale: >
       Unless there is a need to run the system as a web server, it is recommended that the
@@ -1327,8 +1296,9 @@ checks:
     rules:
       - 'c:rpm -q apache2 -> r:not installed'
 
-  - id: 7524
-    title: Ensure IMAP and POP3 server is not installed
+# 2.2.12 Ensure IMAP and POP3 server is not installed 
+  - id: 7546
+    title: Ensure IMAP and POP3 server is not installed.
     description: dovecot is an open source IMAP and POP3 server for Linux based systems.
     rationale: >
       Unless POP3 and/or IMAP servers are to be provided by this system, it is recommended
@@ -1349,8 +1319,9 @@ checks:
     rules:
       - 'c:rpm -q dovecot -> r:not installed'
 
-  - id: 7525
-    title: Ensure Samba is not installed
+# 2.2.13 Ensure Samba is not installed
+  - id: 7547
+    title: Ensure Samba is not installed.
     description: >
       The Samba daemon allows system administrators to configure their Linux systems to share
       file systems and directories with Windows desktops. Samba will advertise the file systems
@@ -1369,8 +1340,9 @@ checks:
     rules:
       - 'c:rpm -q samba -> r:not installed'
 
-  - id: 7526
-    title: Ensure HTTP Proxy Server is not installed
+# 2.2.14 Ensure HTTP Proxy Server is not installed
+  - id: 7548
+    title: Ensure HTTP Proxy Server is not installed.
     description: Squid is a standard proxy server used in many distributions and environments.
     rationale: >
       Unless a system is specifically set up to act as a proxy server, it is recommended that the
@@ -1387,8 +1359,9 @@ checks:
     rules:
       - 'c:rpm -q squid -> r:not installed'
 
-  - id: 7527
-    title: Ensure net-snmp is not installed
+# 2.2.15 Ensure net-snmp is not installed
+  - id: 7549
+    title: Ensure net-snmp is not installed.
     description: >
       Simple Network Management Protocol (SNMP) is a widely used protocol for monitoring the
       health and welfare of network equipment, computer equipment and devices like UPSs.
@@ -1421,8 +1394,70 @@ checks:
     rules:
       - 'c:rpm -q net-snmp -> r:not installed'
 
-  - id: 7528
-    title: Ensure NIS server is not installed
+# 2.2.16 Ensure mail transfer agent is configured for local-only mode
+  - id: 7550
+    title: Ensure mail transfer agent is configured for local-only mode.
+    description: >
+      Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming
+      mail and transfer the messages to the appropriate user or mail server. If the system is not
+      intended to be a mail server, it is recommended that the MTA be configured to only process
+      local mail.
+    rationale: >
+      The software for all Mail Transfer Agents is complex and most have a long history of
+      security issues. While it is important to ensure that the system can process local mail
+      messages, it is not necessary to have the MTA's daemon listening on a port unless the
+      server is intended to be a mail server that receives and processes mail from other systems.
+      Notes:
+        - This recommendation is designed around the postfix mail server.
+        - Depending on your environment you may have an alternative MTA installed such as
+          sendmail. If this is the case consult the documentation for your installed MTA to
+          configure the recommended state.
+    remediation: >
+      Edit /etc/postfix/main.cf and add the following line to the RECEIVING MAIL section. If
+      the line already exists, change it to look like the line below:
+      inet_interfaces = loopback-only
+
+      Run the folloing command to restart postfix:
+      # systemctl restart postfix
+    compliance:
+      - cis: ["2.2.16"]
+      - cis_csc: ["9.2"]
+    condition: all
+    rules:
+      - 'f:/etc/postfix/main.cf -> r:^\s*inet_interfaces\s*=\s*loopback-only'
+
+# 2.2.17 Ensure rsync is not installed or the rsyncd service is masked
+  - id: 7551
+    title: Ensure rsync is not installed or the rsyncd service is masked.
+    description: The rsyncd service can be used to synchronize files between systems over network links.
+    rationale: >
+      Unless required, the rsync package should be removed to reduce the attack surface area of
+      the system.
+
+      The rsyncd service presents a security risk as it uses unencrypted protocols for
+      communication.
+
+      Note: If a required dependency exists for the rsync package, but the rsyncd service is not
+      required, the service should be masked.
+    remediation: >
+      Run the following command to remove the rsync package:
+      # zypper remove rsync
+
+      OR
+
+      Run the following command to mask the rsyncd service:
+      # systemctl --now mask rsyncd
+    compliance:
+      - cis: ["2.2.17"]
+      - cis_csc: ["9.2"]
+    condition: any
+    rules:
+      - 'c:rpm -q rsync -> r:not installed'
+      - 'c:systemctl is-enabled rsyncd -> r:^masked'
+
+# 2.2.18 Ensure NIS server is not installed
+  - id: 7552
+    title: Ensure NIS server is not installed.
     description: >
       The ypserv package provides the Network Information Service (NIS). This service, formally
       known as Yellow Pages, is a client-server directory service protocol for distributing system
@@ -1444,8 +1479,29 @@ checks:
     rules:
       - 'c:rpm -q ypserv -> r:not installed'
 
-  - id: 7529
-    title: Ensure NIS Client is not installed
+# 2.2.19 Ensure telnet-server is not installed
+  - id: 7553
+    title: Ensure telnet-server is not installed.
+    description: >
+      The telnet package contains the telnet daemon, which accepts connections from users
+      from other systems via the telnet protocol.
+    rationale: >
+      The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission
+      medium could allow a user with access to sniff network traffic the ability to steal
+      credentials. The ssh package provides an encrypted session and stronger security.
+    remediation: >
+      Run the following command to remove the telnet-server package:
+      # zypper remove telnet
+    compliance:
+      - cis: ["2.2.19"]
+      - cis_csc: ["2.6","9.2"]
+    condition: all
+    rules:
+      - 'c:rpm -q telnet -> r:not installed'
+
+# 2.3.1 Ensure NIS Client is not installed
+  - id: 7554
+    title: Ensure NIS Client is not installed.
     description: >
       The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server
       directory service protocol used to distribute system configuration files. The NIS client (
@@ -1466,7 +1522,92 @@ checks:
     rules:
       - 'c:rpm -q ypbind -> r:not installed'
 
-  - id: 7530
+# 2.3.2 Ensure rsh client is not installed
+  - id: 7555
+    title: Ensure rsh client is not installed.
+    description: The rsh package contains the client commands for the rsh services.
+    rationale: >
+      These legacy clients contain numerous security exposures and have been replaced with the
+      more secure SSH package. Even if the server is removed, it is best to ensure the clients are
+      also removed to prevent users from inadvertently attempting to use these commands and
+      therefore exposing their credentials. Note that removing the rsh package removes the
+      clients for rsh , rcp and rlogin.
+    remediation: >
+      Run the following command to remove the rsh package:
+      # zypper remove rsh
+    compliance:
+      - cis: ["2.3.2"]
+      - cis_csc: ["2.6"]
+    condition: all
+    rules:
+      - 'c:rpm -q rsh -> r:not installed'
+
+# 2.3.3 Ensure talk client is not installed
+  - id: 7556
+    title: Ensure talk client is not installed.
+    description: >
+      The talk software makes it possible for users to send and receive messages across systems
+      through a terminal session. The talk client, which allows initialization of talk sessions, is
+      installed by default.
+    rationale: >
+      The software presents a security risk as it uses unencrypted protocols for communication.
+    remediation: >
+      Run the following command to remove the talk package:
+      # zypper remove talk
+    compliance:
+      - cis: ["2.3.3"]
+      - cis_csc: ["2.6"]
+    condition: all
+    rules:
+      - 'c:rpm -q talk -> r:not installed'
+
+# 2.3.4 Ensure telnet client is not installed
+  - id: 7557
+    title: Ensure telnet client is not installed.
+    description: >
+      The telnet package contains the telnet client, which allows users to start connections to
+      other systems via the telnet protocol.
+    rationale: >
+      The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission
+      medium could allow an unauthorized user to steal credentials. The ssh package provides
+      an encrypted session and stronger security and is included in most Linux distributions.
+    remediation: >
+      Run the following command to remove the telnet package:
+      # zypper remove telnet
+    compliance:
+      - cis: ["2.3.4"]
+      - cis_csc: ["2.6"]
+    condition: all
+    rules:
+      - 'c:rpm -q telnet -> r:not installed'
+
+# 2.3.5 Ensure LDAP client is not installed
+  - id: 7558
+    title: Ensure LDAP client is not installed.
+    description: >
+      The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for
+      NIS/YP. It is a service that provides a method for looking up information from a central
+      database.
+    rationale: >
+      If the system will not need to act as an LDAP client, it is recommended that the software be
+      removed to reduce the potential attack surface.
+    remediation: >
+      Run the following command to remove the openldap-clients package:
+      # zypper remove openldap2-clients
+    compliance:
+      - cis: ["2.3.5"]
+      - cis_csc: ["2.6"]
+    condition: all
+    rules:
+      - 'c:rpm -q openldap2-clients -> r:not installed'
+
+# 2.4 Ensure nonessential services are removed or masked - Not implemented
+# 3.1.1 Disable IPv6 - Not implemented
+# 3.1.2 Ensure wireless interfaces are disabled - Not implemented
+# 3.2.1 Ensure IP forwarding is disabled - Not implemented
+
+# 3.2.2 Ensure packet redirect sending is disabled
+  - id: 7559
     title: Ensure packet redirect sending is disabled
     description: >
       ICMP Redirects are used to send routing information to other hosts. As a host itself does
@@ -1494,8 +1635,12 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.all\.send_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.send_redirects\s*=\s*0$'
       - 'c:grep -Rh net\.ipv4\.conf\.default\.send_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.send_redirects\s*=\s*0$'
 
-  - id: 7531
-    title: Ensure secure ICMP redirects are not accepted
+# 3.3.1 Ensure source routed packets are not accepted - Not implemented
+# 3.3.2 Ensure ICMP redirects are not accepted - Not implemented
+
+#3.3.3 Ensure secure ICMP redirects are not accepted
+  - id: 7560
+    title: Ensure secure ICMP redirects are not accepted.
     description: >
       Secure ICMP redirects are the same as ICMP redirects, except they come from gateways
       listed on the default gateway list. It is assumed that these gateways are known to your
@@ -1523,8 +1668,9 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.all\.secure_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.secure_redirects\s*=\s*0$'
       - 'c:grep -Rh net\.ipv4\.conf\.default\.secure_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.secure_redirects\s*=\s*0$'
 
-  - id: 7532
-    title: Ensure suspicious packets are logged
+# 3.3.4 Ensure suspicious packets are logged
+  - id: 7561
+    title: Ensure suspicious packets are logged.
     description: >
       When enabled, this feature logs packets with un-routable source addresses to the kernel
       log.
@@ -1550,7 +1696,8 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.all\.log_martians /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.log_martians\s*=\s*1$'
       - 'c:grep -Rh net\.ipv4\.conf\.default\.log_martians /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.log_martians\s*=\s*1$'
 
-  - id: 7533
+# 3.3.5 Ensure broadcast ICMP requests are ignored
+  - id: 7562
     title: Ensure broadcast ICMP requests are ignored
     description: >
       Setting net.ipv4.icmp_echo_ignore_broadcasts to 1 will cause the system to ignore all
@@ -1578,8 +1725,9 @@ checks:
       - 'c:sysctl net.ipv4.icmp_echo_ignore_broadcasts -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
       - 'c:grep -Rh net\.ipv4\.icmp_echo_ignore_broadcasts /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
 
-  - id: 7534
-    title: Ensure bogus ICMP responses are ignored
+# 3.3.6 Ensure bogus ICMP responses are ignored
+  - id: 7563
+    title: Ensure bogus ICMP responses are ignored.
     description: >
       Setting icmp_ignore_bogus_error_responses to 1 prevents the kernel from logging bogus
       responses (RFC-1122 non-compliant) from broadcast reframes, keeping file systems from
@@ -1602,8 +1750,9 @@ checks:
       - 'c:sysctl net.ipv4.icmp_ignore_bogus_error_responses -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
       - 'c:grep -Rh net\.ipv4\.icmp_ignore_bogus_error_responses /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
 
-  - id: 7535
-    title: Ensure Reverse Path Filtering is enabled
+# 3.3.7 Ensure Reverse Path Filtering is enabled
+  - id: 7564
+    title: Ensure Reverse Path Filtering is enabled.
     description: >
       Setting net.ipv4.conf.all.rp_filter and net.ipv4.conf.default.rp_filter to 1 forces
       the Linux kernel to utilize reverse path filtering on a received packet to determine if the
@@ -1635,7 +1784,8 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.all\.rp_filter /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.rp_filter\s*=\s*1$'
       - 'c:grep -Rh net\.ipv4\.conf\.default\.rp_filter /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.rp_filter\s*=\s*1$'
 
-  - id: 7536
+# 3.3.8 Ensure TCP SYN Cookies is enabled 
+  - id: 7565
     title: Ensure TCP SYN Cookies is enabled
     description: >
       When tcp_syncookies is set, the kernel will handle TCP SYN packets normally until the
@@ -1668,311 +1818,8 @@ checks:
       - 'c:grep -Rh net\.ipv4\.tcp_syncookies /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.tcp_syncookies\s*=\s*1$'
       - 'c:/sbin/sysctl net.ipv4.tcp_syncookies -> r:^net.ipv4.tcp_syncookies\s*=\s*1$'
 
-  - id: 7537
-    title: Ensure SSH MaxAuthTries is set to 4 or less
-    description: >
-      The MaxAuthTries parameter specifies the maximum number of authentication attempts
-      permitted per connection. When the login failure count reaches half the number, error
-      messages will be written to the syslog file detailing the login failure.
-    rationale: >
-      Setting the MaxAuthTries parameter to a low number will minimize the risk of successful
-      brute force attacks to the SSH server. While the recommended setting is 4, set the number
-      based on site policy.
-    remediation: >
-      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
-      MaxAuthTries 4
-    compliance:
-      - cis: ["5.2.7"]
-      - cis_csc: ["16.13"]
-    condition: all
-    rules:
-      - 'f:$sshd_file -> !r:^\s*\t*# && n:^MaxAuthTries\s*\t*(\d+) compare <= 4'
-
-  - id: 7538
-    title: Ensure SSH IgnoreRhosts is enabled
-    description: >
-      The IgnoreRhosts parameter specifies that .rhosts and .shosts files will not be used in
-      RhostsRSAAuthentication or HostbasedAuthentication.
-    rationale: Setting this parameter forces users to enter a password when authenticating with ssh.
-    remediation: >
-      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
-      IgnoreRhosts yes
-    compliance:
-      - cis: ["5.2.8"]
-      - cis_csc: ["9.2"]
-    condition: all
-    rules:
-      - 'f:$sshd_file -> !r:^\s*\t*# && r:IgnoreRhosts\s*\t*yes'
-
-  - id: 7539
-    title: Ensure SSH HostbasedAuthentication is disabled
-    description: >
-      The HostbasedAuthentication parameter specifies if authentication is allowed through
-      trusted hosts via the user of .rhosts, or /etc/hosts.equiv, along with successful public
-      key client host authentication. This option only applies to SSH Protocol Version 2.
-    rationale: >
-      Even though the .rhosts files are ineffective if support is disabled in /etc/pam.conf,
-      disabling the ability to use .rhosts files in SSH provides an additional layer of protection.
-    remediation: >
-      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
-      HostbasedAuthentication no
-    compliance:
-      - cis: ["5.2.9"]
-      - cis_csc: ["16.3"]
-    condition: all
-    rules:
-      - 'f:$sshd_file -> !r:^\s*\t*# && r:HostbasedAuthentication\s*\t*no'
-
-  - id: 7540
-    title: Ensure SSH root login is disabled
-    description: >
-      The PermitRootLogin parameter specifies if the root user can log in using ssh. The default
-      is no.
-    rationale: >
-      Disallowing root logins over SSH requires system admins to authenticate using their own
-      individual account, then escalating to root via sudo or su. This in turn limits opportunity for
-      non-repudiation and provides a clear audit trail in the event of a security incident.
-    remediation: >
-      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
-      PermitRootLogin no
-    compliance:
-      - cis: ["5.2.10"]
-      - cis_csc: ["4.3"]
-    condition: all
-    rules:
-      - 'f:$sshd_file -> !r:^\s*\t*# && r:PermitRootLogin\s*\t*no'
-
-  - id: 7541
-    title: Ensure SSH PermitEmptyPasswords is disabled
-    description: >
-      The PermitEmptyPasswords parameter specifies if the SSH server allows login to accounts
-      with empty password strings.
-    rationale: >
-      Disallowing remote shell access to accounts that have an empty password reduces the
-      probability of unauthorized access to the system
-    remediation: >
-      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
-      PermitEmptyPasswords no
-    compliance:
-      - cis: ["5.2.11"]
-      - cis_csc: ["16.3"]
-    condition: all
-    rules:
-      - 'f:$sshd_file -> !r:^\s*\t*# && r:PermitEmptyPasswords\s*\t*no'
-
-  - id: 7542
-    title: Ensure SSH LogLevel is appropriate
-    description: >
-      INFO level is the basic level that only records login activity of SSH users. In many situations,
-      such as Incident Response, it is important to determine when a particular user was active
-      on a system. The logout record can eliminate those users who disconnected, which helps
-      narrow the field.
-
-      VERBOSE level specifies that login and logout activity as well as the key fingerprint for any
-      SSH key used for login will be logged. This information is important for SSH key
-      management, especially in legacy environments.
-    rationale: >
-      SSH provides several logging levels with varying amounts of verbosity. DEBUG is specifically
-      not recommended other than strictly for debugging SSH communications since it provides
-      so much data that it is difficult to identify important security information.
-    remediation: >
-      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
-      LogLevel VERBOSE
-      OR
-      LogLevel INFO
-    compliance:
-      - cis: ["5.2.5"]
-      - cis_csc: ["6.2","6.3"]
-    references:
-      - https://www.ssh.com/ssh/sshd_config/
-    condition: any
-    rules:
-      - 'f:$sshd_file -> !r:^\s*\t*# && r:LogLevel\s*\t*VERBOSE'
-      - 'f:$sshd_file -> !r:^\s*\t*# && r:LogLevel\s*\t*INFO'
-
-  - id: 7543
-    title: Ensure root is the only UID 0 account
-    description: Any account with UID 0 has superuser privileges on the system.
-    rationale: >
-      This access must be limited to only the default root account and only from the system
-      console. Administrative access must be through an unprivileged account using an approved
-      mechanism as noted in Item 5.6 Ensure access to the su command is restricted.
-    remediation: >
-      Remove any users other than root with UID 0 or assign them a new UID if appropriate.
-    compliance:
-      - cis: ["6.2.3"]
-      - cis_csc: ["5.1"]
-    condition: none
-    rules:
-      - 'f:/etc/passwd -> !r:^\s*\t*# && !r:^\s*\t*root: && r:^\w+:\w+:0:'
-
-
-
-
-
-
-
-
-
- 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-  
-
-  - id: 7568
-    title: Ensure chrony is configured
-    description: >
-      chrony is a daemon which implements the Network Time Protocol (NTP) and is designed to
-      synchronize system clocks across a variety of systems and use a source that is highly
-      accurate. More information on chrony can be found at: http://chrony.tuxfamily.org/.
-      chrony can be configured to be a client and/or a server.
-    rationale: >
-      If chrony is in use on the system proper configuration is vital to ensuring time
-      synchronization is working properly.
-
-      Note: This recommendation only applies if chrony is in use on the system. If another method of
-      time synchronization is in use on the system, this recommendation can be skipped.
-    remediation: >
-      Add or edit server or pool lines to /etc/chrony.conf as appropriate:
-      server <remote-server>
-
-      Add or edit the OPTIONS in /etc/sysconfig/chronyd to include '-u chrony':
-      OPTIONS="-u chrony"
-    compliance:
-      - cis: ["2.2.1.3"]
-      - cis_csc: ["6.1"]
-    condition: all
-    rules:
-      - 'f:/etc/chrony.conf -> r:^\s*server\s+\.+'
-      - 'f:/etc/sysconfig/chronyd -> r:^\s*OPTIONS\s*=\s*"-u\s*chrony"'
-
-  - id: 7569
-    title: Ensure CUPS is not installed
-    description: >
-      The Common Unix Print System (CUPS) provides the ability to print to both local and
-      network printers. A system running CUPS can also accept print jobs from remote systems
-      and print them to local printers. It also provides a web based remote administration
-      capability.
-    rationale: >
-      If the system does not need to print jobs or accept print jobs from other systems, it is
-      recommended that CUPS be removed to reduce the potential attack surface.
-
-      Note: Removing CUPS will prevent printing from the system
-    remediation: >
-      Run the following command to remove cups:
-      # zypper remove cups
-    compliance:
-      - cis: ["2.2.4"]
-      - cis_csc: ["9.2"]
-    references:
-      - http://www.cups.org
-    condition: all
-    rules:
-      - 'c:rpm -q cups -> r:not installed'
-
-  - id: 7570
-    title: Ensure LDAP server is not installed
-    description: >
-      The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for
-      NIS/YP. It is a service that provides a method for looking up information from a central
-      database.
-    rationale: >
-      If the system will not need to act as an LDAP server, it is recommended that the software be
-      removed to reduce the potential attack surface.
-    remediation: >
-      Run the following command to remove openldap-servers:
-      # zypper remove openldap2
-    compliance:
-      - cis: ["2.2.6"]
-      - cis_csc: ["9.2"]
-    references:
-      - http://www.openldap.org
-    condition: all
-    rules:
-      - 'c:rpm -q openldap2 -> r:not installed'
-
-  - id: 7571
-    title: Ensure mail transfer agent is configured for local-only mode
-    description: >
-      Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming
-      mail and transfer the messages to the appropriate user or mail server. If the system is not
-      intended to be a mail server, it is recommended that the MTA be configured to only process
-      local mail.
-    rationale: >
-      The software for all Mail Transfer Agents is complex and most have a long history of
-      security issues. While it is important to ensure that the system can process local mail
-      messages, it is not necessary to have the MTA's daemon listening on a port unless the
-      server is intended to be a mail server that receives and processes mail from other systems.
-      Notes:
-        - This recommendation is designed around the postfix mail server.
-        - Depending on your environment you may have an alternative MTA installed such as
-          sendmail. If this is the case consult the documentation for your installed MTA to
-          configure the recommended state.
-    remediation: >
-      Edit /etc/postfix/main.cf and add the following line to the RECEIVING MAIL section. If
-      the line already exists, change it to look like the line below:
-      inet_interfaces = loopback-only
-
-      Run the folloing command to restart postfix:
-      # systemctl restart postfix
-    compliance:
-      - cis: ["2.2.16"]
-      - cis_csc: ["9.2"]
-    condition: all
-    rules:
-      - 'f:/etc/postfix/main.cf -> r:^\s*inet_interfaces\s*=\s*loopback-only'
-
-  - id: 7572
-    title: Ensure telnet client is not installed
-    description: >
-      The telnet package contains the telnet client, which allows users to start connections to
-      other systems via the telnet protocol.
-    rationale: >
-      The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission
-      medium could allow an unauthorized user to steal credentials. The ssh package provides
-      an encrypted session and stronger security and is included in most Linux distributions.
-    remediation: >
-      Run the following command to remove the telnet package:
-      # zypper remove telnet
-    compliance:
-      - cis: ["2.3.4"]
-      - cis_csc: ["2.6"]
-    condition: all
-    rules:
-      - 'c:rpm -q telnet -> r:not installed'
-
-  - id: 7573
-    title: Ensure LDAP client is not installed
-    description: >
-      The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for
-      NIS/YP. It is a service that provides a method for looking up information from a central
-      database.
-    rationale: >
-      If the system will not need to act as an LDAP client, it is recommended that the software be
-      removed to reduce the potential attack surface.
-    remediation: >
-      Run the following command to remove the openldap-clients package:
-      # zypper remove openldap2-clients
-    compliance:
-      - cis: ["2.3.5"]
-      - cis_csc: ["2.6"]
-    condition: all
-    rules:
-      - 'c:rpm -q openldap2-clients -> r:not installed'
-
-  - id: 7574
+# 3.3.9 Ensure IPv6 router advertisements are not accepted
+  - id: 7566
     title: Ensure IPv6 router advertisements are not accepted
     description: This setting disables the system's ability to accept IPv6 router advertisements.
     rationale: >
@@ -2001,7 +1848,8 @@ checks:
       - 'c:grep -Rh "net\.ipv6\.conf\.all\.accept_ra" /etc/sysctl.conf /etc/sysctl.d -> r:^\s*net.ipv6.conf.all.accept_ra\s*=\s*0'
       - 'c:grep -Rh "net\.ipv6\.conf\.default\.accept_ra" /etc/sysctl.conf /etc/sysctl.d -> r:^\s*net.ipv6.conf.default.accept_ra\s*=\s*0'
 
-  - id: 7575
+# 3.4.1 Ensure DCCP is disabled
+  - id: 7567
     title: Ensure DCCP is disabled
     description: >
       The Datagram Congestion Control Protocol (DCCP) is a transport layer protocol that
@@ -2024,7 +1872,8 @@ checks:
     rules:
       - 'c:grep -R dccp /etc/modprobe.d -> r:^/etc/modprobe.d/\.+.conf:\s*install\s+dccp\s+/bin/true'
 
-  - id: 7576
+# 3.4.2 Ensure SCTP is disabled 
+  - id: 7568
     title: Ensure SCTP is disabled
     description: >
       The Stream Control Transmission Protocol (SCTP) is a transport layer protocol used to
@@ -2048,7 +1897,8 @@ checks:
     rules:
       - 'c:grep -R sctp /etc/modprobe.d -> r:^/etc/modprobe.d/\.+.conf:\s*install\s+sctp\s+/bin/true'
 
-  - id: 7577
+# 3.5.1.1 Ensure FirewallD is installed
+  - id: 7569
     title: Ensure FirewallD is installed
     description: >
       firewalld is a firewall management tool for Linux operating systems. It provides firewall
@@ -2085,7 +1935,10 @@ checks:
       - 'c:rpm -q firewalld -> r:not installed'
       - 'c:rpm -q iptables -> r:not installed'
 
-  - id: 7578
+# 3.5.1.2 Ensure nftables is not installed or stopped and masked - Not implemented
+
+# 3.5.1.3 Ensure firewalld service is enabled and running
+  - id: 7570
     title: Ensure firewalld service is enabled and running
     description: >
       firewalld.service enables the enforcement of firewall rules configured through
@@ -2107,7 +1960,12 @@ checks:
       - 'c:systemctl is-enabled firewalld -> r:^enabled'
       - 'c:firewall-cmd --state -> r:^running'
 
-  - id: 7579
+# 3.5.1.4 Ensure default zone is set - Not implemented
+# 3.5.1.5 Ensure network interfaces are assigned to appropriate zone - Not implemented
+# 3.5.1.6 Ensure unnecessary services and ports are not accepted - Not implemented
+
+# 3.5.2.1 Ensure nftables is installed 
+  - id: 7571
     title: Ensure nftables is installed
     description: >
       nftables provides a new in-kernel packet classification framework that is based on a
@@ -2131,8 +1989,12 @@ checks:
     rules:
       - 'c:rpm -q nftables -> r:not installed'
 
-  - id: 7580
-    title: Ensure a table exists
+# 3.5.2.2 Ensure firewalld is not installed or stopped and masked - Not implemented
+# 3.5.2.3 Ensure iptables are flushed - Not implemented
+
+# 3.5.2.4 Ensure a table exists 
+  - id: 7572
+    title: Ensure a table exists.
     description: >
       Tables hold chains. Each table only has one address family and only applies to packets of
       this family. Tables can have one of five families.
@@ -2149,8 +2011,9 @@ checks:
     rules:
       - 'c:nft list tables -> r:^table inet\s+\.+'
 
-  - id: 7581
-    title: Ensure base chains exist
+# 3.5.2.5 Ensure base chains exist 
+  - id: 7573
+    title: Ensure base chains exist.
     description: >
       Chains are containers for rules. They exist in two kinds, base chains and regular chains. A
       base chain is an entry point for packets from the networking stack, a regular chain may be
@@ -2171,8 +2034,12 @@ checks:
       - 'c:nft list ruleset -> !r:^# && r:type hook forward\s+\.+'
       - 'c:nft list ruleset -> !r:^# && r:type hook output\s+\.+'
 
-  - id: 7582
-    title: Ensure default deny firewall policy
+# 3.5.2.6 Ensure loopback traffic is configured
+# 3.5.2.7 Ensure outbound and established connections are configured
+
+# 3.5.2.8 Ensure default deny firewall policy 
+  - id: 7574
+    title: Ensure default deny firewall policy.
     description: >
       Base chain policy is the default verdict that will be applied to packets reaching the end of
       the chain.
@@ -2204,7 +2071,8 @@ checks:
       - 'c:nft list ruleset -> !r:^# && r:type hook forward\s+\.+policy\s+drop'
       - 'c:nft list ruleset -> !r:^# && r:type hook output\s+\.+policy\s+drop'
 
-  - id: 7583
+# 3.5.2.9 Ensure nftables service is enabled 
+  - id: 7575
     title: Ensure nftables service is enabled
     description: >
       The nftables service allows for the loading of nftables rulesets during boot, or starting on
@@ -2222,28 +2090,11 @@ checks:
     rules:
       - 'c:systemctl is-enabled nftables -> r:^enabled'
 
-  - id: 7584
-    title: Ensure iptables package is installed
-    description: >
-      iptables is a utility program that allows a system administrator to configure the tables
-      provided by the Linux kernel firewall, implemented as different Netfilter modules, and the
-      chains and rules it stores. Different kernel modules and programs are used for different
-      protocols; iptables applies to IPv4, ip6tables to IPv6, arptables to ARP, and ebtables to
-      Ethernet frames.
-    rationale: >
-      A method of configuring and maintaining firewall rules is necessary to configure a Host
-      Based Firewall.
-    remediation: >
-      Run the following command to install iptables
-      # zypper install iptables
-    compliance:
-      - cis: ["3.5.1.1"]
-      - cis_csc: ["9.4"]
-    condition: none
-    rules:
-      - 'c:rpm -q iptables -> r:not installed'
+# 3.5.2.10 Ensure nftables rules are permanent - Not implemented
+# 3.5.3.1.1 Ensure iptables package is installed - Not implemented
 
-  - id: 7585
+# 3.5.3.1.2 Ensure nftables is not installed - Not implemented
+  - id: 7576
     title: Ensure nftables is not installed
     description: >
       nftables is a subsystem of the Linux kernel providing filtering and classification of network
@@ -2260,7 +2111,10 @@ checks:
     rules:
       - 'c:rpm -q nftables -> r:not installed'
 
-  - id: 7586
+# 3.5.3.1.3 Ensure firewalld is not installed or stopped and masked - Not implemented
+
+# 3.5.3.2.1 Ensure default deny firewall policy
+  - id: 7577
     title: Ensure default deny firewall policy
     description: >
       A default deny all policy on connections ensures that any unconfigured network usage will
@@ -2285,7 +2139,8 @@ checks:
       - 'c:iptables -L -> r:^Chain FORWARD \(policy DROP\)'
       - 'c:iptables -L -> r:^Chain OUTPUT \(policy DROP\)'
 
-  - id: 7587
+# 3.5.3.2.2 Ensure loopback traffic is configured
+  - id: 7578
     title: Ensure loopback traffic is configured
     description: >
       Configure the loopback interface to accept traffic. Configure all other interfaces to deny
@@ -2312,7 +2167,15 @@ checks:
       - 'c:iptables -L INPUT -v -n -> r:^\s*\d+\s+\d+\s+DROP\s+all\s+--\s+*\s+*\s+127.0.0.0/8\s+0.0.0.0/0'
       - 'c:iptables -L OUTPUT -v -n -> r:^\s*\d+\s+\d+\s+ACCEPT\s+all\s+--\s+*\s+lo\s+0.0.0.0/0\s+0.0.0.0/0'
 
-  - id: 7588
+# 3.5.3.2.3 Ensure outbound and established connections are configured - Not implemented
+# 3.5.3.2.4 Ensure firewall rules exist for all open ports - Not implemented
+# 3.5.3.3.1 Ensure IPv6 default deny firewall policy - Not implemented
+# 3.5.3.3.2 Ensure IPv6 loopback traffic is configured - Not implemented
+# 3.5.3.3.3 Ensure IPv6 outbound and established connections are configured - Not implemented
+# 3.5.3.3.4 Ensure IPv6 firewall rules exist for all open ports - Not implemented
+
+# 4.1.1.1 Ensure auditd is installed
+  - id: 7579
     title: Ensure auditd is installed
     description: >
       auditd is the userspace component to the Linux Auditing System. It's responsible for
@@ -2330,7 +2193,8 @@ checks:
     rules:
       - 'c:rpm -q audit -> r:not installed'
 
-  - id: 7589
+# 4.1.1.2 Ensure auditd service is enabled and running
+  - id: 7580
     title: Ensure auditd service is enabled and running
     description: Turn on the auditd daemon to record system events.
     rationale: >
@@ -2347,8 +2211,11 @@ checks:
       - 'c:systemctl is-enabled auditd -> r:^enabled'
       - 'c:systemctl status auditd -> r:^\s*Active: active \(running\) since \.+'
 
-  - id: 7590
-    title: Ensure audit log storage size is configured
+# 4.1.1.3 Ensure auditing for processes that start prior to auditd is enabled - Not implemented
+
+# 4.1.2.1 Ensure audit log storage size is configured 
+  - id: 7581
+    title: Ensure audit log storage size is configured.
     description: >
       Configure the maximum size of the audit log file. Once the log reaches the maximum size, it
       will be rotated and a new log file will be started.
@@ -2372,8 +2239,9 @@ checks:
     rules:
       - 'f:/etc/audit/auditd.conf -> r:^\s*max_log_file\s*=\s*\d+'
 
-  - id: 7591
-    title: Ensure audit logs are not automatically deleted
+# 4.1.2.2 Ensure audit logs are not automatically deleted
+  - id: 7582
+    title: Ensure audit logs are not automatically deleted.
     description: >
       The max_log_file_action setting determines how to handle the audit log file reaching the
       max file size. A value of keep_logs will rotate the logs but never delete old logs.
@@ -2390,8 +2258,9 @@ checks:
     rules:
       - 'f:/etc/audit/auditd.conf -> r:^\s*max_log_file_action\s*=\s*keep_logs'
 
-  - id: 7592
-    title: Ensure system is disabled when audit logs are full
+# 4.1.2.3 Ensure system is disabled when audit logs are full
+  - id: 7583
+    title: Ensure system is disabled when audit logs are full.
     description: The auditd daemon can be configured to halt the system when the audit logs are full.
     rationale: >
       In high security contexts, the risk of detecting unauthorized access or nonrepudiation
@@ -2410,8 +2279,12 @@ checks:
       - 'f:/etc/audit/auditd.conf -> r:^\s*action_mail_acct\s*=\s*root'
       - 'f:/etc/audit/auditd.conf -> r:^\s*admin_space_left_action\s*=\s*halt'
 
-  - id: 7593
-    title: Ensure events that modify user/group information are collected
+# 4.1.2.4 Ensure audit_backlog_limit is sufficient - Not implemented
+# 4.1.3 Ensure events that modify date and time information are collected - Not implemented
+
+# 4.1.4 Ensure events that modify user/group information are collected
+  - id: 7584
+    title: Ensure events that modify user/group information are collected.
     description: >
       Record events affecting the group , passwd (user IDs), shadow and gshadow (passwords) or
       /etc/security/opasswd (old passwords, based on remember parameter in the PAM
@@ -2450,8 +2323,11 @@ checks:
       - 'c:auditctl -l | grep identity -> r:^\s*-w\s+/etc/shadow\s+-p\s+wa\s+-k\s+identity'
       - 'c:auditctl -l | grep identity -> r:^\s*-w\s+/etc/security/opasswd\s+-p\s+wa\s+-k\s+identity'
 
-  - id: 7594
-    title: Ensure events that modify the system's Mandatory Access Controls are collected
+# 4.1.5 Ensure events that modify the system's network environment are collected - Not implemented
+
+# 4.1.6 Ensure events that modify the system's Mandatory Access Controls are collected
+  - id: 7585
+    title: Ensure events that modify the system's Mandatory Access Controls are collected.
     description: >
       Monitor SELinux mandatory access controls. The parameters below monitor any write
       access (potential additional, deletion or modification of files in the directory) or attribute
@@ -2483,8 +2359,9 @@ checks:
       - 'c:auditctl -l | grep MAC-policy -> r:^\s*-w\s+/etc/selinux/\s+-p\s+wa\s+-k\s+MAC-policy'
       - 'c:auditctl -l | grep MAC-policy -> r:^\s*-w\s+/usr/share/selinux/\s+-p\s+wa\s+-k\s+MAC-policy'
 
-  - id: 7595
-    title: Ensure login and logout events are collected
+# 4.1.7 Ensure login and logout events are collected 
+  - id: 7586
+    title: Ensure login and logout events are collected.
     description: >
       Monitor login and logout events. The parameters below track changes to files associated
       with login/logout events.
@@ -2518,8 +2395,9 @@ checks:
       - 'c:auditctl -l | grep logins -> r:^\s*-w\s+/var/log/lastlog\s+-p\s+wa\s+-k\s+logins'
       - 'c:auditctl -l | grep logins -> r:^\s*-w\s+/var/log/tallylog\s+-p\s+wa\s+-k\s+logins'
 
-  - id: 7596
-    title: Ensure session initiation information is collected
+# 4.1.8 Ensure session initiation information is collected
+  - id: 7587
+    title: Ensure session initiation information is collected.
     description: >
       Monitor session initiation events. The parameters in this section track changes to the files
       associated with session events. The file /var/run/utmp tracks all currently logged in users.
@@ -2557,7 +2435,14 @@ checks:
       - 'c:auditctl -l | grep -E "(session|logins)" -> r:^\s*-w\s+/var/log/wtmp\s+-p\s+wa\s+-k\s+logins'
       - 'c:auditctl -l | grep -E "(session|logins)" -> r:^\s*-w\s+/var/log/btmp\s+-p\s+wa\s+-k\s+logins'
 
-  - id: 7597
+# 4.1.9 Ensure discretionary access control permission modification events are collected - Not implemented
+# 4.1.10 Ensure unsuccessful unauthorized file access attempts are collected - Not implemented
+# 4.1.11 Ensure use of privileged commands is collected - Not implemented
+# 4.1.12 Ensure successful file system mounts are collected - Not implemented
+# 4.1.13 Ensure file deletion events by users are collected - Not implemented
+
+# 4.1.14 Ensure changes to system administration scope (sudoers) is collected
+  - id: 7588
     title: Ensure changes to system administration scope (sudoers) is collected
     description: >
       Monitor scope changes for system administrators. If the system has been properly
@@ -2587,8 +2472,12 @@ checks:
       - 'c:auditctl -l | grep scope -> r:^\s*-w\s+/etc/sudoers\s+-p\s+wa\s+-k\s+scope'
       - 'c:auditctl -l | grep scope -> r:^\s*-w\s+/etc/sudoers.d/\s+-p\s+wa\s+-k\s+scope'
 
-  - id: 7598
-    title: Ensure the audit configuration is immutable
+# 4.1.15 Ensure system administrator actions (sudolog) are collected - Not implemented
+# 4.1.16 Ensure kernel module loading and unloading is collected - Not implemented
+
+# 4.1.17 Ensure the audit configuration is immutable
+  - id: 7589
+    title: Ensure the audit configuration is immutable.
     description: >
       Set system audit so that audit rules cannot be modified with auditctl . Setting the flag "-e
       2" forces audit to be put in immutable mode. Audit changes can only be made on system
@@ -2613,8 +2502,9 @@ checks:
     rules:
       - 'c:grep -R "^\s*[^#]" /etc/audit/rules.d/ | tail -1 -> r:^/etc/audit/rules.d/\.+.rules:\s*-e\s+2\s*$'
 
-  - id: 7599
-    title: Ensure rsyslog is installed
+# 4.2.1.1 Ensure rsyslog is installed
+  - id: 7590
+    title: Ensure rsyslog is installed.
     description: >
       The rsyslog software is a recommended replacement to the original syslogd daemon.
       rsyslog provides improvements over syslogd, including:
@@ -2635,8 +2525,9 @@ checks:
     rules:
       - 'c:rpm -q rsyslog -> r:not installed'
 
-  - id: 7600
-    title: Ensure rsyslog Service is enabled and running
+# 4.2.1.2 Ensure rsyslog Service is enabled and running
+  - id: 7591
+    title: Ensure rsyslog Service is enabled and running.
     description: rsyslog needs to be enabled and running to perform logging
     rationale: >
       If the rsyslog service is not activated the system may default to the syslogd service or lack
@@ -2652,8 +2543,9 @@ checks:
       - 'c:systemctl is-enabled rsyslog -> r:^enabled'
       - 'c:systemctl status rsyslog -> r:^\s*Active: active \(running\) since \.+'
 
-  - id: 7601
-    title: Ensure rsyslog default file permissions configured
+# 4.2.1.3 Ensure rsyslog default file permissions configured 
+  - id: 7592
+    title: Ensure rsyslog default file permissions configured.
     description: >
       rsyslog will create logfiles that do not already exist on the system. This setting controls
       what permissions will be applied to these newly created files.
@@ -2681,8 +2573,13 @@ checks:
     rules:
       - 'c:grep -Rh ^\$FileCreateMode /etc/rsyslog.conf /etc/rsyslog.d/ -> r:^\$FileCreateMode\s+0640'
 
-  - id: 7602
-    title: Ensure journald is configured to send logs to rsyslog
+# 4.2.1.4 Ensure logging is configured - Not implemented
+# 4.2.1.5 Ensure rsyslog is configured to send logs to a remote log host - Not implemented
+# 4.2.1.6 Ensure remote rsyslog messages are only accepted on designated log hosts - Not implemented
+
+# 4.2.2.1 Ensure journald is configured to send logs to rsyslog
+  - id: 7593
+    title: Ensure journald is configured to send logs to rsyslog.
     description: >
       Data from journald may be stored in volatile memory or persisted locally on the server.
       Utilities exist to accept remote export of journald logs, however, use of the rsyslog service
@@ -2718,8 +2615,9 @@ checks:
     rules:
       - 'f:/etc/systemd/journald.conf -> r:^ForwardToSyslog=yes'
 
-  - id: 7603
-    title: Ensure journald is configured to compress large log files
+# 4.2.2.2 Ensure journald is configured to compress large log files
+  - id: 7594
+    title: Ensure journald is configured to compress large log files.
     description: >
       The journald system includes the capability of compressing overly large files to avoid filling
       up the system with logs or making the log's size unmanageable.
@@ -2743,8 +2641,9 @@ checks:
     rules:
       - 'f:/etc/systemd/journald.conf -> r:^Compress=yes'
 
-  - id: 7604
-    title: Ensure journald is configured to write logfiles to persistent disk
+# 4.2.2.3 Ensure journald is configured to write logfiles to persistent disk
+  - id: 7595
+    title: Ensure journald is configured to write logfiles to persistent disk.
     description: >
       Data from journald may be stored in volatile memory or persisted locally on the server.
       Logs in memory will be lost upon a system reboot. By persisting logs to local disk on the
@@ -2769,7 +2668,11 @@ checks:
     rules:
       - 'f:/etc/systemd/journald.conf -> r:^Storage=persistent'
 
-  - id: 7605
+# 4.2.3 Ensure permissions on all logfiles are configured - Not implemented
+# 4.2.4 Ensure logrotate is configured - Not implemented
+
+# 5.1.1 Ensure cron daemon is enabled and running 
+  - id: 7596
     title: Ensure cron daemon is enabled and running
     description: The cron daemon is used to execute batch jobs on the system.
     rationale: >
@@ -2793,8 +2696,9 @@ checks:
       - 'c:systemctl is-enabled cron -> r:^enabled'
       - 'c:systemctl status cron -> r:^\s*Active: active \(running\) since \.+'
 
-  - id: 7606
-    title: Ensure permissions on /etc/crontab are configured
+# 5.1.2 Ensure permissions on /etc/crontab are configured
+  - id: 7597
+    title: Ensure permissions on /etc/crontab are configured.
     description: >
       The /etc/crontab file is used by cron to control its own jobs. The commands in this item
       make sure that root is the user and group owner of the file and that only the owner can
@@ -2820,8 +2724,9 @@ checks:
     rules:
       - 'c:stat -L /etc/crontab -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
-  - id: 7607
-    title: Ensure permissions on /etc/cron.hourly are configured
+# 5.1.3 Ensure permissions on /etc/cron.hourly are configured
+  - id: 7598
+    title: Ensure permissions on /etc/cron.hourly are configured.
     description: >
       This directory contains system cron jobs that need to run on an hourly basis. The files in
       this directory cannot be manipulated by the crontab command, but are instead edited by
@@ -2850,8 +2755,9 @@ checks:
     rules:
       - 'c:stat -L /etc/cron.hourly/ -> r:^Access:\s*\(0700/drwx------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
-  - id: 7608
-    title: Ensure permissions on /etc/cron.daily are configured
+# 5.1.4 Ensure permissions on /etc/cron.daily are configured
+  - id: 7599
+    title: Ensure permissions on /etc/cron.daily are configured.
     description: >
       The /etc/cron.daily directory contains system cron jobs that need to run on a daily basis.
       The files in this directory cannot be manipulated by the crontab command, but are instead
@@ -2880,8 +2786,9 @@ checks:
     rules:
       - 'c:stat -L /etc/cron.daily/ -> r:^Access:\s*\(0700/drwx------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
-  - id: 7609
-    title: Ensure permissions on /etc/cron.weekly are configured
+# 5.1.5 Ensure permissions on /etc/cron.weekly are configured
+  - id: 7600
+    title: Ensure permissions on /etc/cron.weekly are configured.
     description: >
       The /etc/cron.weekly directory contains system cron jobs that need to run on a weekly
       basis. The files in this directory cannot be manipulated by the crontab command, but are
@@ -2905,8 +2812,9 @@ checks:
     rules:
       - 'c:stat -L /etc/cron.weekly -> r:^Access:\s*\(0700/drwx------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
-  - id: 7610
-    title: Ensure permissions on /etc/cron.monthly are configured
+# 5.1.6 Ensure permissions on /etc/cron.monthly are configured
+  - id: 7601
+    title: Ensure permissions on /etc/cron.monthly are configured.
     description: >
       The /etc/cron.monthly directory contains system cron jobs that need to run on a monthly
       basis. The files in this directory cannot be manipulated by the crontab command, but are
@@ -2935,8 +2843,9 @@ checks:
     rules:
       - 'c:stat -L /etc/cron.monthly/ -> r:^Access:\s*\(0700/drwx------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
-  - id: 7611
-    title: Ensure permissions on /etc/cron.d are configured
+# 5.1.7 Ensure permissions on /etc/cron.d are configured 
+  - id: 7602
+    title: Ensure permissions on /etc/cron.d are configured.
     description: >
       The /etc/cron.d/ directory contains system cron jobs that need to run in a similar manner
       to the hourly, daily weekly and monthly jobs from /etc/crontab , but require more
@@ -2965,8 +2874,9 @@ checks:
     rules:
       - 'c:stat -L /etc/cron.d -> r:^Access:\s*\(0700/drwx------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
-  - id: 7612
-    title: Ensure cron is restricted to authorized users
+# 5.1.8 Ensure cron is restricted to authorized users
+  - id: 7603
+    title: Ensure cron is restricted to authorized users.
     description: >
       If cron is installed in the system, configure /etc/cron.allow to allow specific users to use
       these services. If /etc/cron.allow does not exist, then /etc/cron.deny is checked. Any
@@ -3004,8 +2914,9 @@ checks:
       - 'not f:/etc/cron.deny'
       - 'c:stat -L /etc/cron.allow -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
-  - id: 7613
-    title: Ensure at is restricted to authorized users
+# 5.1.9 Ensure at is restricted to authorized users
+  - id: 7604
+    title: Ensure at is restricted to authorized users.
     description: >
       If at is installed in the system, configure /etc/at.allow to allow specific users to use these
       services. If /etc/at.allow does not exist, then /etc/at.deny is checked. Any user not
@@ -3043,6 +2954,7 @@ checks:
       - 'not f:/etc/at.deny'
       - 'c:stat -L /etc/at.allow -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
+# 5.2.1 Ensure permissions on /etc/ssh/sshd_config are configured
   - id: 7614
     title: Ensure permissions on /etc/ssh/sshd_config are configured
     description: >
@@ -3062,8 +2974,12 @@ checks:
     rules:
       - 'c:stat -L /etc/ssh/sshd_config -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
+# 5.2.2 Ensure permissions on SSH private host key files are configured - Not implemented
+# 5.2.3 Ensure permissions on SSH public host key files are configured - Not implemented
+
+# 5.2.4 Ensure SSH access is limited
   - id: 7615
-    title: Ensure SSH access is limited
+    title: Ensure SSH access is limited.
     description: >
       There are several options available to limit which users and group can access the system
       via SSH. It is recommended that at least one of the following options be leveraged:
@@ -3116,8 +3032,40 @@ checks:
       - 'c:sshd -T -> r:^\s*denyusers\s+\S+'
       - 'c:sshd -T -> r:^\s*denygroups\s+\S+'
 
+# 5.2.5 Ensure SSH LogLevel is appropriate
   - id: 7616
-    title: Ensure SSH X11 forwarding is disabled
+    title: Ensure SSH LogLevel is appropriate.
+    description: >
+      INFO level is the basic level that only records login activity of SSH users. In many situations,
+      such as Incident Response, it is important to determine when a particular user was active
+      on a system. The logout record can eliminate those users who disconnected, which helps
+      narrow the field.
+
+      VERBOSE level specifies that login and logout activity as well as the key fingerprint for any
+      SSH key used for login will be logged. This information is important for SSH key
+      management, especially in legacy environments.
+    rationale: >
+      SSH provides several logging levels with varying amounts of verbosity. DEBUG is specifically
+      not recommended other than strictly for debugging SSH communications since it provides
+      so much data that it is difficult to identify important security information.
+    remediation: >
+      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+      LogLevel VERBOSE
+      OR
+      LogLevel INFO
+    compliance:
+      - cis: ["5.2.5"]
+      - cis_csc: ["6.2","6.3"]
+    references:
+      - https://www.ssh.com/ssh/sshd_config/
+    condition: any
+    rules:
+      - 'f:$sshd_file -> !r:^\s*\t*# && r:LogLevel\s*\t*VERBOSE'
+      - 'f:$sshd_file -> !r:^\s*\t*# && r:LogLevel\s*\t*INFO'
+
+# 5.2.6 Ensure SSH X11 forwarding is disabled 
+  - id: 7617
+    title: Ensure SSH X11 forwarding is disabled.
     description: >
       The X11Forwarding parameter provides the ability to tunnel X11 traffic through the
       connection to enable remote graphic connections.
@@ -3136,8 +3084,106 @@ checks:
     rules:
       - 'c:sshd -T -> r:^\s*x11forwarding\s+no'
 
-  - id: 7617
-    title: Ensure SSH PermitUserEnvironment is disabled
+# 5.2.7 Ensure SSH MaxAuthTries is set to 4 or less 
+  - id: 7618
+    title: Ensure SSH MaxAuthTries is set to 4 or less.
+    description: >
+      The MaxAuthTries parameter specifies the maximum number of authentication attempts
+      permitted per connection. When the login failure count reaches half the number, error
+      messages will be written to the syslog file detailing the login failure.
+    rationale: >
+      Setting the MaxAuthTries parameter to a low number will minimize the risk of successful
+      brute force attacks to the SSH server. While the recommended setting is 4, set the number
+      based on site policy.
+    remediation: >
+      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+      MaxAuthTries 4
+    compliance:
+      - cis: ["5.2.7"]
+      - cis_csc: ["16.13"]
+    condition: all
+    rules:
+      - 'f:$sshd_file -> !r:^\s*\t*# && n:^MaxAuthTries\s*\t*(\d+) compare <= 4'
+
+# 5.2.8 Ensure SSH IgnoreRhosts is enabled 
+  - id: 7619
+    title: Ensure SSH IgnoreRhosts is enabled.
+    description: >
+      The IgnoreRhosts parameter specifies that .rhosts and .shosts files will not be used in
+      RhostsRSAAuthentication or HostbasedAuthentication.
+    rationale: Setting this parameter forces users to enter a password when authenticating with ssh.
+    remediation: >
+      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+      IgnoreRhosts yes
+    compliance:
+      - cis: ["5.2.8"]
+      - cis_csc: ["9.2"]
+    condition: all
+    rules:
+      - 'f:$sshd_file -> !r:^\s*\t*# && r:IgnoreRhosts\s*\t*yes'
+
+# 5.2.9 Ensure SSH HostbasedAuthentication is disabled
+  - id: 7620
+    title: Ensure SSH HostbasedAuthentication is disabled.
+    description: >
+      The HostbasedAuthentication parameter specifies if authentication is allowed through
+      trusted hosts via the user of .rhosts, or /etc/hosts.equiv, along with successful public
+      key client host authentication. This option only applies to SSH Protocol Version 2.
+    rationale: >
+      Even though the .rhosts files are ineffective if support is disabled in /etc/pam.conf,
+      disabling the ability to use .rhosts files in SSH provides an additional layer of protection.
+    remediation: >
+      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+      HostbasedAuthentication no
+    compliance:
+      - cis: ["5.2.9"]
+      - cis_csc: ["16.3"]
+    condition: all
+    rules:
+      - 'f:$sshd_file -> !r:^\s*\t*# && r:HostbasedAuthentication\s*\t*no'
+
+# 5.2.10 Ensure SSH root login is disabled
+  - id: 7521
+    title: Ensure SSH root login is disabled.
+    description: >
+      The PermitRootLogin parameter specifies if the root user can log in using ssh. The default
+      is no.
+    rationale: >
+      Disallowing root logins over SSH requires system admins to authenticate using their own
+      individual account, then escalating to root via sudo or su. This in turn limits opportunity for
+      non-repudiation and provides a clear audit trail in the event of a security incident.
+    remediation: >
+      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+      PermitRootLogin no
+    compliance:
+      - cis: ["5.2.10"]
+      - cis_csc: ["4.3"]
+    condition: all
+    rules:
+      - 'f:$sshd_file -> !r:^\s*\t*# && r:PermitRootLogin\s*\t*no'
+
+# 5.2.11 Ensure SSH PermitEmptyPasswords is disabled 
+  - id: 7522
+    title: Ensure SSH PermitEmptyPasswords is disabled.
+    description: >
+      The PermitEmptyPasswords parameter specifies if the SSH server allows login to accounts
+      with empty password strings.
+    rationale: >
+      Disallowing remote shell access to accounts that have an empty password reduces the
+      probability of unauthorized access to the system
+    remediation: >
+      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+      PermitEmptyPasswords no
+    compliance:
+      - cis: ["5.2.11"]
+      - cis_csc: ["16.3"]
+    condition: all
+    rules:
+      - 'f:$sshd_file -> !r:^\s*\t*# && r:PermitEmptyPasswords\s*\t*no'
+
+# 5.2.12 Ensure SSH PermitUserEnvironment is disabled 
+  - id: 7623
+    title: Ensure SSH PermitUserEnvironment is disabled.
     description: >
       The PermitUserEnvironment option allows users to present environment options to the
       ssh daemon.
@@ -3155,8 +3201,9 @@ checks:
     rules:
       - 'c:sshd -T -> r:^\s*permituserenvironment\s+no'
 
-  - id: 7618
-    title: Ensure only strong Ciphers are used
+# 5.2.13 Ensure only strong Ciphers are used
+  - id: 7624
+    title: Ensure only strong Ciphers are used.
     description: >
       This variable limits the ciphers that SSH can use during communication.
       Notes:
@@ -3228,8 +3275,9 @@ checks:
       - 'c:sshd -T -> r:^ciphers\s+ && r:aes192-cbc'
       - 'c:sshd -T -> r:^ciphers\s+ && r:aes256-cbc'
 
-  - id: 7619
-    title: Ensure only strong MAC algorithms are used
+# 5.2.14 Ensure only strong MAC algorithms are used
+  - id: 7625
+    title: Ensure only strong MAC algorithms are used.
     description: >
       This variable limits the types of MAC algorithms that SSH can use during communication.
       Notes:
@@ -3290,8 +3338,9 @@ checks:
       - 'c:sshd -T -> r:^macs\s+ && r:umac-64-etm@openssh.com'
       - 'c:sshd -T -> r:^macs\s+ && r:umac-128-etm@openssh.com'
 
-  - id: 7620
-    title: Ensure only strong Key Exchange algorithms are used
+# 5.2.15 Ensure only strong Key Exchange algorithms are used
+  - id: 7626
+    title: Ensure only strong Key Exchange algorithms are used.
     description: >
       Key exchange is any method in cryptography by which cryptographic keys are exchanged
       between two parties, allowing use of a cryptographic algorithm. If the sender and receiver
@@ -3339,7 +3388,8 @@ checks:
       - 'c:sshd -T -> r:^kexalgorithms\s+ && r:diffie-hellman-group14-sha1'
       - 'c:sshd -T -> r:^kexalgorithms\s+ && r:diffie-hellman-group-exchange-sha1'
 
-  - id: 7621
+# 5.2.16 Ensure SSH Idle Timeout Interval is configured
+  - id: 7627
     title: Ensure SSH Idle Timeout Interval is configured
     description: >
       The two options ClientAliveInterval and ClientAliveCountMax control the timeout of
@@ -3386,8 +3436,9 @@ checks:
       - 'c:sshd -T -> n:^clientaliveinterval\s+(\d+) compare <= 300'
       - 'c:sshd -T -> n:^ClientAliveCountMax\s+(\d+) compare <= 3'
 
-  - id: 7622
-    title: Ensure SSH LoginGraceTime is set to one minute or less
+# 5.2.17 Ensure SSH LoginGraceTime is set to one minute or less
+  - id: 7628
+    title: Ensure SSH LoginGraceTime is set to one minute or less.
     description: >
       The LoginGraceTime parameter specifies the time allowed for successful authentication to
       the SSH server. The longer the Grace period is the more open unauthenticated connections
@@ -3409,8 +3460,9 @@ checks:
       - 'c:sshd -T -> n:^logingracetime\s+(\d+) compare >= 1'
       - 'c:sshd -T -> n:^logingracetime\s+(\d+) compare <= 60'
 
-  - id: 7623
-    title: Ensure SSH warning banner is configured
+# 5.2.18 Ensure SSH warning banner is configured
+  - id: 7629
+    title: Ensure SSH warning banner is configured.
     description: >
       The Banner parameter specifies a file whose contents must be sent to the remote user
       before authentication is permitted. By default, no banner is displayed.
@@ -3429,8 +3481,9 @@ checks:
     rules:
       - 'c:sshd -T -> r:^banner\s+/etc/issue.net'
 
-  - id: 7624
-    title: Ensure SSH PAM is enabled
+# 5.2.19 Ensure SSH PAM is enabled
+  - id: 7630
+    title: Ensure SSH PAM is enabled.
     description: >
       UsePAM Enables the Pluggable Authentication Module interface. If set to “yes” this will
       enable PAM authentication using ChallengeResponseAuthentication and
@@ -3452,8 +3505,9 @@ checks:
     rules:
       - 'c:sshd -T -> r:^usepam\s+yes'
 
-  - id: 7625
-    title: Ensure SSH AllowTcpForwarding is disabled
+# 5.2.20 Ensure SSH AllowTcpForwarding is disabled
+  - id: 7631
+    title: Ensure SSH AllowTcpForwarding is disabled.
     description: >
       SSH port forwarding is a mechanism in SSH for tunneling application ports from the client
       to the server, or servers to clients. It can be used for adding encryption to legacy
@@ -3480,8 +3534,9 @@ checks:
     rules:
       - 'c:sshd -T -> r:^allowtcpforwarding\s+no'
 
-  - id: 7626
-    title: Ensure SSH MaxStartups is configured
+# 5.2.21 Ensure SSH MaxStartups is configured
+  - id: 7632
+    title: Ensure SSH MaxStartups is configured.
     description: >
       The MaxStartups parameter specifies the maximum number of concurrent unauthenticated
       connections to the SSH daemon.
@@ -3500,8 +3555,9 @@ checks:
     rules:
       - 'c:sshd -T -> r:^maxstartups\s+10:30:60\s*$'
 
-  - id: 7627
-    title: Ensure SSH MaxSessions is limited
+# 5.2.22 Ensure SSH MaxSessions is limited
+  - id: 7633
+    title: Ensure SSH MaxSessions is limited.
     description: >
       The MaxSessions parameter specifies the maximum number of open sessions permitted
       from a given connection.
@@ -3520,8 +3576,12 @@ checks:
     rules:
       - 'c:sshd -T -> n:^maxsessions\s+(\d+) compare <= 10'
 
-  - id: 7628
-    title: Ensure password reuse is limited
+# 5.3.1 Ensure password creation requirements are configured - Not implemented
+# 5.3.2 Ensure lockout for failed password attempts is configured - Not implemented
+
+# 5.3.3 Ensure password reuse is limited
+  - id: 7634
+    title: Ensure password reuse is limited.
     description: >
       The /etc/security/opasswd file stores the users' old passwords and can be checked to
       ensure that users are not recycling recent passwords.
@@ -3550,8 +3610,9 @@ checks:
       - 'f:/etc/pam.d/common-password -> n:^\s*password\t+requisite\t+pam_pwhistory\.so\t+remember\s*=\s*(\d+) compare >= 5'
       - 'f:/etc/pam.d/common-password -> n:^\s*password\t+required\t+pam_pwhistory\.so\t+remember\s*=\s*(\d+) compare >= 5'
 
-  - id: 7629
-    title: Ensure password hashing algorithm is SHA-512
+# 5.4.1.1 Ensure password hashing algorithm is SHA-512 
+  - id: 7635
+    title: Ensure password hashing algorithm is SHA-512.
     description: >
       Login passwords are hashed and stored in the /etc/shadow file.
 
@@ -3580,7 +3641,15 @@ checks:
     rules:
       - 'f:/etc/login.defs -> r:^\s*ENCRYPT_METHOD\s+SHA512'
 
-  - id: 7630
+# 5.4.1.2 Ensure password expiration is 365 days or less - Not implemented
+# 5.4.1.3 Ensure minimum days between password changes is configured - Not implemented
+# 5.4.1.4 Ensure password expiration warning days is 7 or more - Not implemented
+# 5.4.1.5 Ensure inactive password lock is 30 days or less - Not implemented
+# 5.4.1.6 Ensure all users last password change date is in the past - Not implemented
+# 5.4.2 Ensure system accounts are secured - Not implemented
+
+# 5.4.3 Ensure default group for the root account is GID 0
+  - id: 7636
     title: Ensure default group for the root account is GID 0
     description: >
       The usermod command can be used to specify which group the root user belongs to. This
@@ -3598,8 +3667,15 @@ checks:
     rules:
       - 'f:/etc/passwd -> r:^root:\S+:\S+:0:'
 
-  - id: 7631
-    title: Ensure permissions on /etc/passwd are configured
+# 5.4.4 Ensure default user shell timeout is configured - Not implemented
+# 5.4.5 Ensure default user umask is configured - Not implemented
+# 5.5 Ensure root login is restricted to system console - Not implemented
+# 5.6 Ensure access to the su command is restricted - Not implemented
+# 6.1.1 Audit system file permissions 
+
+# 6.1.2 Ensure permissions on /etc/passwd are configured
+  - id: 7637
+    title: Ensure permissions on /etc/passwd are configured.
     description: >
       The /etc/passwd file contains user account information that is used by many system
       utilities and therefore must be readable for these utilities to operate.
@@ -3619,8 +3695,9 @@ checks:
     rules:
       - 'c:stat -L /etc/passwd -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
-  - id: 7632
-    title: Ensure permissions on /etc/shadow are configured
+# 6.1.3 Ensure permissions on /etc/shadow are configured
+  - id: 7638
+    title: Ensure permissions on /etc/shadow are configured.
     description: >
       The /etc/shadow file is used to store the information about user accounts that is critical to
       the security of those accounts, such as the hashed password and other security
@@ -3642,8 +3719,9 @@ checks:
     rules:
       - 'c:stat -L /etc/shadow -> r:^Access:\s*\(0640/-rw-r-----\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*15/\s*shadow\)'
 
-  - id: 7633
-    title: Ensure permissions on /etc/group are configured
+# 6.1.4 Ensure permissions on /etc/group are configured 
+  - id: 7639
+    title: Ensure permissions on /etc/group are configured.
     description: >
       The /etc/group file contains a list of all the valid groups defined in the system. The
       command below allows read/write access for root and read access for everyone else.
@@ -3663,8 +3741,9 @@ checks:
     rules:
       - 'c:stat -L /etc/group -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
-  - id: 7634
-    title: Ensure permissions on /etc/passwd- are configured
+# 6.1.5 Ensure permissions on /etc/passwd- are configured
+  - id: 7640
+    title: Ensure permissions on /etc/passwd- are configured.
     description: The /etc/passwd- file contains backup user account information.
     rationale: >
       It is critical to ensure that the /etc/passwd- file is protected from unauthorized access.
@@ -3682,7 +3761,8 @@ checks:
     rules:
       - 'c:stat -L /etc/passwd -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
-  - id: 7635
+# 6.1.6 Ensure permissions on /etc/shadow- are configured
+  - id: 7641
     title: Ensure permissions on /etc/shadow- are configured
     description: >
       The /etc/shadow- file is used to store backup information about user accounts that is
@@ -3704,8 +3784,9 @@ checks:
     rules:
       - 'c:stat -L /etc/shadow- -> r:^Access:\s*\(0640/-rw-r-----\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*15/\s*shadow\)'
 
-  - id: 7636
-    title: Ensure permissions on /etc/group- are configured
+# 6.1.7 Ensure permissions on /etc/group- are configured 
+  - id: 7642
+    title: Ensure permissions on /etc/group- are configured.
     description: The /etc/group- file contains a backup list of all the valid groups defined in the system.
     rationale: >
       It is critical to ensure that the /etc/group- file is protected from unauthorized access.
@@ -3723,8 +3804,15 @@ checks:
     rules:
       - 'c:stat -L /etc/group- -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
-  - id: 7637
-    title: Ensure accounts in /etc/passwd use shadowed passwords
+# 6.1.8 Ensure no world writable files exist - Not implemented
+# 6.1.9 Ensure no unowned files or directories exist - Not implemented
+# 6.1.10 Ensure no ungrouped files or directories exist - Not implemented
+# 6.1.11 Audit SUID executables - Not implemented
+# 6.1.12 Audit SGID executables - Not implemented
+
+# 6.2.1 Ensure accounts in /etc/passwd use shadowed passwords
+  - id: 7643
+    title: Ensure accounts in /etc/passwd use shadowed passwords.
     description: >
       Local accounts can uses shadowed passwords. With shadowed passwords, The passwords
       are saved in shadow password file, /etc/shadow, encrypted by a salted one-way hash.
@@ -3759,8 +3847,9 @@ checks:
     rules:
       - 'f:/etc/passwd -> !r:^\.+:x:'
 
-  - id: 7638
-    title: Ensure /etc/shadow password fields are not empty
+# 6.2.2 Ensure /etc/shadow password fields are not empty
+  - id: 7644
+    title: Ensure /etc/shadow password fields are not empty.
     description: >
       An account with an empty password field means that anybody may log in as that user
       without providing a password.
@@ -3781,3 +3870,37 @@ checks:
     condition: none
     rules:
       - 'c:grep -E ^[^:]+:: /etc/shadow -> r:::'
+
+# 6.2.3 Ensure root is the only UID 0 account
+  - id: 7645
+    title: Ensure root is the only UID 0 account.
+    description: Any account with UID 0 has superuser privileges on the system.
+    rationale: >
+      This access must be limited to only the default root account and only from the system
+      console. Administrative access must be through an unprivileged account using an approved
+      mechanism as noted in Item 5.6 Ensure access to the su command is restricted.
+    remediation: >
+      Remove any users other than root with UID 0 or assign them a new UID if appropriate.
+    compliance:
+      - cis: ["6.2.3"]
+      - cis_csc: ["5.1"]
+    condition: none
+    rules:
+      - 'f:/etc/passwd -> !r:^\s*\t*# && !r:^\s*\t*root: && r:^\w+:\w+:0:'
+
+# 6.2.4 Ensure root PATH Integrity - Not implemented
+# 6.2.5 Ensure all users' home directories exist - Not implemented
+# 6.2.6 Ensure users' home directories permissions are 750 or more restrictive - Not implemented
+# 6.2.7 Ensure users own their home directories - Not implemented
+# 6.2.8 Ensure users' dot files are not group or world writable - Not implemented
+# 6.2.9 6.2.9 Ensure no users have .forward files - Not implemented
+# 6.2.10 Ensure no users have .netrc files - Not implemented
+# 6.2.11 Ensure users' .netrc Files are not group or world accessible - Not implemented
+# 6.2.12 Ensure no users have .rhosts files - Not implemented
+# 6.2.13 Ensure all groups in /etc/passwd exist in /etc/group - Not implemented
+# 6.2.14 Ensure no duplicate UIDs exist - Not implemented
+# 6.2.15 Ensure no duplicate GIDs exist - Not implemented
+# 6.2.16 Ensure no duplicate user names exist - Not implemented
+# 6.2.17 Ensure no duplicate group names exist - Not implemented
+# 6.2.18 Ensure shadow group is empty - Not implemented
+

--- a/ruleset/sca/sles/15/cis_sles15_linux.yml
+++ b/ruleset/sca/sles/15/cis_sles15_linux.yml
@@ -31,7 +31,6 @@ variables:
 checks:
 
 # Section 1.1 - Filesystem Configuration
-
   - id: 7500
     title: Ensure nodev option set on /tmp partition
     description: The nodev mount option specifies that the filesystem cannot contain special devices.
@@ -550,7 +549,7 @@ checks:
     rules:
       - 'c:rpm -q dhcp -> r:not installed'
 
-  - id: 7522
+  - id: 7521
     title: Ensure DNS Server is not installed
     description: >
       The Domain Name System (DNS) is a hierarchical naming system that maps names to IP
@@ -568,7 +567,7 @@ checks:
     rules:
       - 'c:rpm -q bind -> r:not installed'
 
-  - id: 7523
+  - id: 7522
     title: Ensure FTP Server is not installed
     description: >
       FTP (File Transfer Protocol) is a traditional and widely used standard tool for transferring
@@ -591,7 +590,7 @@ checks:
     rules:
       - 'c:rpm -q vsftpd -> r:not installed'
 
-  - id: 7524
+  - id: 7523
     title: Ensure HTTP server is not installed
     description: HTTP or web servers provide the ability to host web site content.
     rationale: >
@@ -612,7 +611,7 @@ checks:
     rules:
       - 'c:rpm -q apache2 -> r:not installed'
 
-  - id: 7525
+  - id: 7524
     title: Ensure IMAP and POP3 server is not installed
     description: dovecot is an open source IMAP and POP3 server for Linux based systems.
     rationale: >
@@ -634,7 +633,7 @@ checks:
     rules:
       - 'c:rpm -q dovecot -> r:not installed'
 
-  - id: 7526
+  - id: 7525
     title: Ensure Samba is not installed
     description: >
       The Samba daemon allows system administrators to configure their Linux systems to share
@@ -654,7 +653,7 @@ checks:
     rules:
       - 'c:rpm -q samba -> r:not installed'
 
-  - id: 7527
+  - id: 7526
     title: Ensure HTTP Proxy Server is not installed
     description: Squid is a standard proxy server used in many distributions and environments.
     rationale: >
@@ -672,7 +671,7 @@ checks:
     rules:
       - 'c:rpm -q squid -> r:not installed'
 
-  - id: 7528
+  - id: 7527
     title: Ensure net-snmp is not installed
     description: >
       Simple Network Management Protocol (SNMP) is a widely used protocol for monitoring the
@@ -706,7 +705,7 @@ checks:
     rules:
       - 'c:rpm -q net-snmp -> r:not installed'
 
-  - id: 7529
+  - id: 7528
     title: Ensure NIS server is not installed
     description: >
       The ypserv package provides the Network Information Service (NIS). This service, formally
@@ -729,7 +728,7 @@ checks:
     rules:
       - 'c:rpm -q ypserv -> r:not installed'
 
-  - id: 7530
+  - id: 7529
     title: Ensure NIS Client is not installed
     description: >
       The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server
@@ -751,7 +750,7 @@ checks:
     rules:
       - 'c:rpm -q ypbind -> r:not installed'
 
-  - id: 7532
+  - id: 7530
     title: Ensure packet redirect sending is disabled
     description: >
       ICMP Redirects are used to send routing information to other hosts. As a host itself does
@@ -779,7 +778,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.all\.send_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.send_redirects\s*=\s*0$'
       - 'c:grep -Rh net\.ipv4\.conf\.default\.send_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.send_redirects\s*=\s*0$'
 
-  - id: 7534
+  - id: 7531
     title: Ensure secure ICMP redirects are not accepted
     description: >
       Secure ICMP redirects are the same as ICMP redirects, except they come from gateways
@@ -808,7 +807,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.all\.secure_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.secure_redirects\s*=\s*0$'
       - 'c:grep -Rh net\.ipv4\.conf\.default\.secure_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.secure_redirects\s*=\s*0$'
 
-  - id: 7535
+  - id: 7532
     title: Ensure suspicious packets are logged
     description: >
       When enabled, this feature logs packets with un-routable source addresses to the kernel
@@ -835,7 +834,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.all\.log_martians /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.log_martians\s*=\s*1$'
       - 'c:grep -Rh net\.ipv4\.conf\.default\.log_martians /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.log_martians\s*=\s*1$'
 
-  - id: 7536
+  - id: 7533
     title: Ensure broadcast ICMP requests are ignored
     description: >
       Setting net.ipv4.icmp_echo_ignore_broadcasts to 1 will cause the system to ignore all
@@ -863,7 +862,7 @@ checks:
       - 'c:sysctl net.ipv4.icmp_echo_ignore_broadcasts -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
       - 'c:grep -Rh net\.ipv4\.icmp_echo_ignore_broadcasts /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
 
-  - id: 7537
+  - id: 7534
     title: Ensure bogus ICMP responses are ignored
     description: >
       Setting icmp_ignore_bogus_error_responses to 1 prevents the kernel from logging bogus
@@ -887,7 +886,7 @@ checks:
       - 'c:sysctl net.ipv4.icmp_ignore_bogus_error_responses -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
       - 'c:grep -Rh net\.ipv4\.icmp_ignore_bogus_error_responses /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
 
-  - id: 7538
+  - id: 7535
     title: Ensure Reverse Path Filtering is enabled
     description: >
       Setting net.ipv4.conf.all.rp_filter and net.ipv4.conf.default.rp_filter to 1 forces
@@ -920,7 +919,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.all\.rp_filter /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.rp_filter\s*=\s*1$'
       - 'c:grep -Rh net\.ipv4\.conf\.default\.rp_filter /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.rp_filter\s*=\s*1$'
 
-  - id: 7539
+  - id: 7536
     title: Ensure TCP SYN Cookies is enabled
     description: >
       When tcp_syncookies is set, the kernel will handle TCP SYN packets normally until the
@@ -953,7 +952,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.tcp_syncookies /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.tcp_syncookies\s*=\s*1$'
       - 'c:/sbin/sysctl net.ipv4.tcp_syncookies -> r:^net.ipv4.tcp_syncookies\s*=\s*1$'
 
-  - id: 7540
+  - id: 7537
     title: Ensure SSH MaxAuthTries is set to 4 or less
     description: >
       The MaxAuthTries parameter specifies the maximum number of authentication attempts
@@ -973,7 +972,7 @@ checks:
     rules:
       - 'f:$sshd_file -> !r:^\s*\t*# && n:^MaxAuthTries\s*\t*(\d+) compare <= 4'
 
-  - id: 7541
+  - id: 7538
     title: Ensure SSH IgnoreRhosts is enabled
     description: >
       The IgnoreRhosts parameter specifies that .rhosts and .shosts files will not be used in
@@ -989,7 +988,7 @@ checks:
     rules:
       - 'f:$sshd_file -> !r:^\s*\t*# && r:IgnoreRhosts\s*\t*yes'
 
-  - id: 7542
+  - id: 7539
     title: Ensure SSH HostbasedAuthentication is disabled
     description: >
       The HostbasedAuthentication parameter specifies if authentication is allowed through
@@ -1008,7 +1007,7 @@ checks:
     rules:
       - 'f:$sshd_file -> !r:^\s*\t*# && r:HostbasedAuthentication\s*\t*no'
 
-  - id: 7543
+  - id: 7540
     title: Ensure SSH root login is disabled
     description: >
       The PermitRootLogin parameter specifies if the root user can log in using ssh. The default
@@ -1027,7 +1026,7 @@ checks:
     rules:
       - 'f:$sshd_file -> !r:^\s*\t*# && r:PermitRootLogin\s*\t*no'
 
-  - id: 7544
+  - id: 7541
     title: Ensure SSH PermitEmptyPasswords is disabled
     description: >
       The PermitEmptyPasswords parameter specifies if the SSH server allows login to accounts
@@ -1045,7 +1044,7 @@ checks:
     rules:
       - 'f:$sshd_file -> !r:^\s*\t*# && r:PermitEmptyPasswords\s*\t*no'
 
-  - id: 7545
+  - id: 7542
     title: Ensure SSH LogLevel is appropriate
     description: >
       INFO level is the basic level that only records login activity of SSH users. In many situations,
@@ -1075,7 +1074,7 @@ checks:
       - 'f:$sshd_file -> !r:^\s*\t*# && r:LogLevel\s*\t*VERBOSE'
       - 'f:$sshd_file -> !r:^\s*\t*# && r:LogLevel\s*\t*INFO'
 
-  - id: 7546
+  - id: 7543
     title: Ensure root is the only UID 0 account
     description: Any account with UID 0 has superuser privileges on the system.
     rationale: >
@@ -1091,7 +1090,7 @@ checks:
     rules:
       - 'f:/etc/passwd -> !r:^\s*\t*# && !r:^\s*\t*root: && r:^\w+:\w+:0:'
 
-  - id: 7547
+  - id: 7544
     title: Ensure mounting of squashfs filesystems is disabled
     description: >
       The squashfs filesystem type is a compressed read-only Linux filesystem embedded in
@@ -1116,7 +1115,7 @@ checks:
       - 'c:modprobe -n -v squashfs -> r:install'
       - 'c:modprobe -n -v squashfs -> r:squashfs'
 
-  - id: 7548
+  - id: 7545
     title: Ensure mounting of udf filesystems is disabled
     description: >
       The udf filesystem type is the universal disk format used to implement ISO/IEC 13346 and
@@ -1142,7 +1141,7 @@ checks:
       - 'c:modprobe -n -v udf -> r:install'
       - 'c:modprobe -n -v udf -> r:udf'
 
-  - id: 7549
+  - id: 7546
     title: Ensure /dev/shm is configured
     description: >
       /dev/shm is a traditional shared memory concept. One program will create a memory
@@ -1178,7 +1177,7 @@ checks:
       - 'c:mount -> r:\.+\s+/dev/shm\s+'
       - 'f:/etc/fstab -> r:\.+\s+/dev/shm\s+'
 
-  - id: 7550
+  - id: 7547
     title: Ensure separate partition exists for /var/tmp
     description: >
       The /var/tmp directory is a world-writable directory used for temporary storage by all
@@ -1208,7 +1207,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/var/tmp\s'
 
-  - id: 7551
+  - id: 7548
     title: Ensure noexec option set on /var/tmp partition
     description: The noexec mount option specifies that the filesystem cannot contain executable binaries.
     rationale: >
@@ -1227,7 +1226,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/var/tmp\s && r:noexec'
 
-  - id: 7552
+  - id: 7549
     title: Ensure nodev option set on /var/tmp partition
     description: The nodev mount option specifies that the filesystem cannot contain special devices.
     rationale: >
@@ -1246,7 +1245,7 @@ checks:
     rules:
       - 'c:mount -> r:\s+/var/tmp\s+ && r:nodev'
 
-  - id: 7553
+  - id: 7550
     title: Ensure nosuid option set on /var/tmp partition
     description: The nosuid mount option specifies that the filesystem cannot contain setuid files.
     rationale: >
@@ -1265,7 +1264,7 @@ checks:
     rules:
       - 'c:mount -> r:\s+/var/tmp\s+ && r:nosuid'
 
-  - id: 7554
+  - id: 7551
     title: Disable Automounting
     description: >
       autofs allows automatic mounting of devices, typically including CD/DVDs and USB drives.
@@ -1293,7 +1292,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled autofs -> r:enabled'
 
-  - id: 7556
+  - id: 7552
     title: Ensure sudo is installed
     description: >
       sudo allows a permitted user to execute a command as the superuser or another user, as
@@ -1321,7 +1320,7 @@ checks:
     rules:
       - 'c:rpm -q sudo -> r:not installed'
 
-  - id: 7557
+  - id: 7553
     title: Ensure sudo commands use pty
     description: >
       sudo can be configured to run only from a pseudo-pty
@@ -1349,7 +1348,7 @@ checks:
     rules:
       - 'c:grep -REsih "^Defaults" /etc/sudoers /etc/sudoers.d -> r:^\wefaults\s+use_pty'
 
-  - id: 7558
+  - id: 7554
     title: Ensure sudo log file exists
     description: >
       sudo can use a custom log file
@@ -1376,7 +1375,7 @@ checks:
     rules:
       - 'c:grep -REsih "^Defaults" /etc/sudoers /etc/sudoers.d -> r:^\wefaults\s+logfile="\.+"'
 
-  - id: 7559
+  - id: 7555
     title: Ensure AIDE is installed
     description: >
       AIDE takes a snapshot of filesystem state including modification times, permissions, and
@@ -1407,7 +1406,7 @@ checks:
     rules:
       - 'c:rpm -q aide -> r:not installed'
 
-  - id: 7560
+  - id: 7556
     title: Ensure bootloader password is set
     description: >
       Setting the boot loader password will require that anyone rebooting the system must enter
@@ -1451,7 +1450,7 @@ checks:
       - 'f:/boot/grub2/grub.cfg -> r:^\s*set superusers'
       - 'f:/boot/grub2/grub.cfg -> r:^\s*password'
 
-  - id: 7561
+  - id: 7557
     title: Ensure permissions on bootloader config are configured
     description: >
       The grub configuration file contains information on boot settings and passwords for
@@ -1481,7 +1480,7 @@ checks:
     rules:
       - 'c:stat -L /boot/grub2/grub.cfg -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
-  - id: 7562
+  - id: 7558
     title: Ensure authentication required for single user mode
     description: >
       Single user mode (rescue mode) is used for recovery when the system detects an issue
@@ -1503,7 +1502,7 @@ checks:
       - 'f:/usr/lib/systemd/system/rescue.service -> r:^ExecStart=\.*/systemd/systemd-sulogin-shell\s+rescue'
       - 'f:/usr/lib/systemd/system/emergency.service -> r:^ExecStart=\.*/systemd/systemd-sulogin-shell\s+emergency'
 
-  - id: 7563
+  - id: 7559
     title: Ensure XD/NX support is enabled
     description: >
       Recent processors in the x86 family support the ability to prevent code execution on a per
@@ -1532,7 +1531,7 @@ checks:
     rules:
       - 'c:journalctl -> r:\.*kernel: NX \(Execute Disable\) protection:\s*active'
 
-  - id: 7564
+  - id: 7560
     title: Ensure prelink is disabled
     description: >
       prelinkis a program that modifies ELF shared libraries and ELF dynamically linked
@@ -1555,7 +1554,7 @@ checks:
     rules:
       - 'c:rpm -q prelink -> r:not installed'
 
-  - id: 7565
+  - id: 7561
     title: Ensure AppArmor is installed
     description: AppArmor provides Mandatory Access Controls.
     rationale: >
@@ -1575,7 +1574,7 @@ checks:
       - 'c:rpm -q apparmor-utils -> r:not installed'
       - 'c:rpm -q libapparmor1 -> r:not installed'
 
-  - id: 7567
+  - id: 7562
     title: Ensure message of the day is configured properly
     description: >
       The contents of the /etc/motd file are displayed to users after login and function as a
@@ -1613,7 +1612,7 @@ checks:
       - 'f:/etc/motd -> r:\\s'
       - 'f:/etc/motd -> r:\\v'
 
-  - id: 7568
+  - id: 7563
     title: Ensure local login warning banner is configured properly
     description: >
       The contents of the /etc/issue file are displayed to users prior to login for local terminals.
@@ -1646,7 +1645,7 @@ checks:
       - 'f:/etc/issue -> r:\\s'
       - 'f:/etc/issue -> r:\\v'
 
-  - id: 7569
+  - id: 7564
     title: Ensure remote login warning banner is configured properly
     description: >
       The contents of the /etc/issue.net file are displayed to users prior to login for remote
@@ -1679,7 +1678,7 @@ checks:
       - 'f:/etc/issue.net -> r:\\s'
       - 'f:/etc/issue.net -> r:\\v'
 
-  - id: 7570
+  - id: 7565
     title: Ensure permissions on /etc/motd are configured
     description: >
       The contents of the /etc/motd file are displayed to users after login and function as a
@@ -1698,7 +1697,7 @@ checks:
     rules:
       - 'c:stat -L /etc/motd -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
-  - id: 7571
+  - id: 7566
     title: Ensure permissions on /etc/issue are configured
     description: >
       The contents of the /etc/issue file are displayed to users prior to login for local terminals.
@@ -1716,7 +1715,7 @@ checks:
     rules:
       - 'c:stat -L /etc/issue -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
-  - id: 7572
+  - id: 7567
     title: Ensure permissions on /etc/issue.net are configured
     description: >
       The contents of the /etc/issue.net file are displayed to users prior to login for remote
@@ -1735,7 +1734,7 @@ checks:
     rules:
       - 'c:stat -L /etc/issue.net -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
-  - id: 7573
+  - id: 7568
     title: Ensure chrony is configured
     description: >
       chrony is a daemon which implements the Network Time Protocol (NTP) and is designed to
@@ -1762,7 +1761,7 @@ checks:
       - 'f:/etc/chrony.conf -> r:^\s*server\s+\.+'
       - 'f:/etc/sysconfig/chronyd -> r:^\s*OPTIONS\s*=\s*"-u\s*chrony"'
 
-  - id: 7574
+  - id: 7569
     title: Ensure CUPS is not installed
     description: >
       The Common Unix Print System (CUPS) provides the ability to print to both local and
@@ -1786,7 +1785,7 @@ checks:
     rules:
       - 'c:rpm -q cups -> r:not installed'
 
-  - id: 7575
+  - id: 7570
     title: Ensure LDAP server is not installed
     description: >
       The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for
@@ -1807,7 +1806,7 @@ checks:
     rules:
       - 'c:rpm -q openldap2 -> r:not installed'
 
-  - id: 7576
+  - id: 7571
     title: Ensure mail transfer agent is configured for local-only mode
     description: >
       Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming
@@ -1838,7 +1837,7 @@ checks:
     rules:
       - 'f:/etc/postfix/main.cf -> r:^\s*inet_interfaces\s*=\s*loopback-only'
 
-  - id: 7577
+  - id: 7572
     title: Ensure telnet client is not installed
     description: >
       The telnet package contains the telnet client, which allows users to start connections to
@@ -1857,7 +1856,7 @@ checks:
     rules:
       - 'c:rpm -q telnet -> r:not installed'
 
-  - id: 7578
+  - id: 7573
     title: Ensure LDAP client is not installed
     description: >
       The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for
@@ -1876,7 +1875,7 @@ checks:
     rules:
       - 'c:rpm -q openldap2-clients -> r:not installed'
 
-  - id: 7579
+  - id: 7574
     title: Ensure IPv6 router advertisements are not accepted
     description: This setting disables the system's ability to accept IPv6 router advertisements.
     rationale: >
@@ -1905,7 +1904,7 @@ checks:
       - 'c:grep -Rh "net\.ipv6\.conf\.all\.accept_ra" /etc/sysctl.conf /etc/sysctl.d -> r:^\s*net.ipv6.conf.all.accept_ra\s*=\s*0'
       - 'c:grep -Rh "net\.ipv6\.conf\.default\.accept_ra" /etc/sysctl.conf /etc/sysctl.d -> r:^\s*net.ipv6.conf.default.accept_ra\s*=\s*0'
 
-  - id: 7580
+  - id: 7575
     title: Ensure DCCP is disabled
     description: >
       The Datagram Congestion Control Protocol (DCCP) is a transport layer protocol that
@@ -1928,7 +1927,7 @@ checks:
     rules:
       - 'c:grep -R dccp /etc/modprobe.d -> r:^/etc/modprobe.d/\.+.conf:\s*install\s+dccp\s+/bin/true'
 
-  - id: 7581
+  - id: 7576
     title: Ensure SCTP is disabled
     description: >
       The Stream Control Transmission Protocol (SCTP) is a transport layer protocol used to
@@ -1952,7 +1951,7 @@ checks:
     rules:
       - 'c:grep -R sctp /etc/modprobe.d -> r:^/etc/modprobe.d/\.+.conf:\s*install\s+sctp\s+/bin/true'
 
-  - id: 7582
+  - id: 7577
     title: Ensure FirewallD is installed
     description: >
       firewalld is a firewall management tool for Linux operating systems. It provides firewall
@@ -1989,7 +1988,7 @@ checks:
       - 'c:rpm -q firewalld -> r:not installed'
       - 'c:rpm -q iptables -> r:not installed'
 
-  - id: 7583
+  - id: 7578
     title: Ensure firewalld service is enabled and running
     description: >
       firewalld.service enables the enforcement of firewall rules configured through
@@ -2011,7 +2010,7 @@ checks:
       - 'c:systemctl is-enabled firewalld -> r:^enabled'
       - 'c:firewall-cmd --state -> r:^running'
 
-  - id: 7584
+  - id: 7579
     title: Ensure nftables is installed
     description: >
       nftables provides a new in-kernel packet classification framework that is based on a
@@ -2035,7 +2034,7 @@ checks:
     rules:
       - 'c:rpm -q nftables -> r:not installed'
 
-  - id: 7585
+  - id: 7580
     title: Ensure a table exists
     description: >
       Tables hold chains. Each table only has one address family and only applies to packets of
@@ -2053,7 +2052,7 @@ checks:
     rules:
       - 'c:nft list tables -> r:^table inet\s+\.+'
 
-  - id: 7586
+  - id: 7581
     title: Ensure base chains exist
     description: >
       Chains are containers for rules. They exist in two kinds, base chains and regular chains. A
@@ -2075,7 +2074,7 @@ checks:
       - 'c:nft list ruleset -> !r:^# && r:type hook forward\s+\.+'
       - 'c:nft list ruleset -> !r:^# && r:type hook output\s+\.+'
 
-  - id: 7587
+  - id: 7582
     title: Ensure default deny firewall policy
     description: >
       Base chain policy is the default verdict that will be applied to packets reaching the end of
@@ -2108,7 +2107,7 @@ checks:
       - 'c:nft list ruleset -> !r:^# && r:type hook forward\s+\.+policy\s+drop'
       - 'c:nft list ruleset -> !r:^# && r:type hook output\s+\.+policy\s+drop'
 
-  - id: 7588
+  - id: 7583
     title: Ensure nftables service is enabled
     description: >
       The nftables service allows for the loading of nftables rulesets during boot, or starting on
@@ -2126,7 +2125,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled nftables -> r:^enabled'
 
-  - id: 7589
+  - id: 7584
     title: Ensure iptables package is installed
     description: >
       iptables is a utility program that allows a system administrator to configure the tables
@@ -2147,7 +2146,7 @@ checks:
     rules:
       - 'c:rpm -q iptables -> r:not installed'
 
-  - id: 7590
+  - id: 7585
     title: Ensure nftables is not installed
     description: >
       nftables is a subsystem of the Linux kernel providing filtering and classification of network
@@ -2164,7 +2163,7 @@ checks:
     rules:
       - 'c:rpm -q nftables -> r:not installed'
 
-  - id: 7591
+  - id: 7586
     title: Ensure default deny firewall policy
     description: >
       A default deny all policy on connections ensures that any unconfigured network usage will
@@ -2189,7 +2188,7 @@ checks:
       - 'c:iptables -L -> r:^Chain FORWARD \(policy DROP\)'
       - 'c:iptables -L -> r:^Chain OUTPUT \(policy DROP\)'
 
-  - id: 7592
+  - id: 7587
     title: Ensure loopback traffic is configured
     description: >
       Configure the loopback interface to accept traffic. Configure all other interfaces to deny
@@ -2216,7 +2215,7 @@ checks:
       - 'c:iptables -L INPUT -v -n -> r:^\s*\d+\s+\d+\s+DROP\s+all\s+--\s+*\s+*\s+127.0.0.0/8\s+0.0.0.0/0'
       - 'c:iptables -L OUTPUT -v -n -> r:^\s*\d+\s+\d+\s+ACCEPT\s+all\s+--\s+*\s+lo\s+0.0.0.0/0\s+0.0.0.0/0'
 
-  - id: 7593
+  - id: 7588
     title: Ensure auditd is installed
     description: >
       auditd is the userspace component to the Linux Auditing System. It's responsible for
@@ -2234,7 +2233,7 @@ checks:
     rules:
       - 'c:rpm -q audit -> r:not installed'
 
-  - id: 7594
+  - id: 7589
     title: Ensure auditd service is enabled and running
     description: Turn on the auditd daemon to record system events.
     rationale: >
@@ -2251,7 +2250,7 @@ checks:
       - 'c:systemctl is-enabled auditd -> r:^enabled'
       - 'c:systemctl status auditd -> r:^\s*Active: active \(running\) since \.+'
 
-  - id: 7596
+  - id: 7590
     title: Ensure audit log storage size is configured
     description: >
       Configure the maximum size of the audit log file. Once the log reaches the maximum size, it
@@ -2276,7 +2275,7 @@ checks:
     rules:
       - 'f:/etc/audit/auditd.conf -> r:^\s*max_log_file\s*=\s*\d+'
 
-  - id: 7597
+  - id: 7591
     title: Ensure audit logs are not automatically deleted
     description: >
       The max_log_file_action setting determines how to handle the audit log file reaching the
@@ -2294,7 +2293,7 @@ checks:
     rules:
       - 'f:/etc/audit/auditd.conf -> r:^\s*max_log_file_action\s*=\s*keep_logs'
 
-  - id: 7598
+  - id: 7592
     title: Ensure system is disabled when audit logs are full
     description: The auditd daemon can be configured to halt the system when the audit logs are full.
     rationale: >
@@ -2314,7 +2313,7 @@ checks:
       - 'f:/etc/audit/auditd.conf -> r:^\s*action_mail_acct\s*=\s*root'
       - 'f:/etc/audit/auditd.conf -> r:^\s*admin_space_left_action\s*=\s*halt'
 
-  - id: 7599
+  - id: 7593
     title: Ensure events that modify user/group information are collected
     description: >
       Record events affecting the group , passwd (user IDs), shadow and gshadow (passwords) or
@@ -2354,7 +2353,7 @@ checks:
       - 'c:auditctl -l | grep identity -> r:^\s*-w\s+/etc/shadow\s+-p\s+wa\s+-k\s+identity'
       - 'c:auditctl -l | grep identity -> r:^\s*-w\s+/etc/security/opasswd\s+-p\s+wa\s+-k\s+identity'
 
-  - id: 7600
+  - id: 7594
     title: Ensure events that modify the system's Mandatory Access Controls are collected
     description: >
       Monitor SELinux mandatory access controls. The parameters below monitor any write
@@ -2387,7 +2386,7 @@ checks:
       - 'c:auditctl -l | grep MAC-policy -> r:^\s*-w\s+/etc/selinux/\s+-p\s+wa\s+-k\s+MAC-policy'
       - 'c:auditctl -l | grep MAC-policy -> r:^\s*-w\s+/usr/share/selinux/\s+-p\s+wa\s+-k\s+MAC-policy'
 
-  - id: 7601
+  - id: 7595
     title: Ensure login and logout events are collected
     description: >
       Monitor login and logout events. The parameters below track changes to files associated
@@ -2422,7 +2421,7 @@ checks:
       - 'c:auditctl -l | grep logins -> r:^\s*-w\s+/var/log/lastlog\s+-p\s+wa\s+-k\s+logins'
       - 'c:auditctl -l | grep logins -> r:^\s*-w\s+/var/log/tallylog\s+-p\s+wa\s+-k\s+logins'
 
-  - id: 7602
+  - id: 7596
     title: Ensure session initiation information is collected
     description: >
       Monitor session initiation events. The parameters in this section track changes to the files
@@ -2461,7 +2460,7 @@ checks:
       - 'c:auditctl -l | grep -E "(session|logins)" -> r:^\s*-w\s+/var/log/wtmp\s+-p\s+wa\s+-k\s+logins'
       - 'c:auditctl -l | grep -E "(session|logins)" -> r:^\s*-w\s+/var/log/btmp\s+-p\s+wa\s+-k\s+logins'
 
-  - id: 7603
+  - id: 7597
     title: Ensure changes to system administration scope (sudoers) is collected
     description: >
       Monitor scope changes for system administrators. If the system has been properly
@@ -2491,7 +2490,7 @@ checks:
       - 'c:auditctl -l | grep scope -> r:^\s*-w\s+/etc/sudoers\s+-p\s+wa\s+-k\s+scope'
       - 'c:auditctl -l | grep scope -> r:^\s*-w\s+/etc/sudoers.d/\s+-p\s+wa\s+-k\s+scope'
 
-  - id: 7604
+  - id: 7598
     title: Ensure the audit configuration is immutable
     description: >
       Set system audit so that audit rules cannot be modified with auditctl . Setting the flag "-e
@@ -2517,7 +2516,7 @@ checks:
     rules:
       - 'c:grep -R "^\s*[^#]" /etc/audit/rules.d/ | tail -1 -> r:^/etc/audit/rules.d/\.+.rules:\s*-e\s+2\s*$'
 
-  - id: 7605
+  - id: 7599
     title: Ensure rsyslog is installed
     description: >
       The rsyslog software is a recommended replacement to the original syslogd daemon.
@@ -2539,7 +2538,7 @@ checks:
     rules:
       - 'c:rpm -q rsyslog -> r:not installed'
 
-  - id: 7606
+  - id: 7600
     title: Ensure rsyslog Service is enabled and running
     description: rsyslog needs to be enabled and running to perform logging
     rationale: >
@@ -2556,7 +2555,7 @@ checks:
       - 'c:systemctl is-enabled rsyslog -> r:^enabled'
       - 'c:systemctl status rsyslog -> r:^\s*Active: active \(running\) since \.+'
 
-  - id: 7607
+  - id: 7601
     title: Ensure rsyslog default file permissions configured
     description: >
       rsyslog will create logfiles that do not already exist on the system. This setting controls
@@ -2585,7 +2584,7 @@ checks:
     rules:
       - 'c:grep -Rh ^\$FileCreateMode /etc/rsyslog.conf /etc/rsyslog.d/ -> r:^\$FileCreateMode\s+0640'
 
-  - id: 7608
+  - id: 7602
     title: Ensure journald is configured to send logs to rsyslog
     description: >
       Data from journald may be stored in volatile memory or persisted locally on the server.
@@ -2622,7 +2621,7 @@ checks:
     rules:
       - 'f:/etc/systemd/journald.conf -> r:^ForwardToSyslog=yes'
 
-  - id: 7609
+  - id: 7603
     title: Ensure journald is configured to compress large log files
     description: >
       The journald system includes the capability of compressing overly large files to avoid filling
@@ -2647,7 +2646,7 @@ checks:
     rules:
       - 'f:/etc/systemd/journald.conf -> r:^Compress=yes'
 
-  - id: 7610
+  - id: 7604
     title: Ensure journald is configured to write logfiles to persistent disk
     description: >
       Data from journald may be stored in volatile memory or persisted locally on the server.
@@ -2673,7 +2672,7 @@ checks:
     rules:
       - 'f:/etc/systemd/journald.conf -> r:^Storage=persistent'
 
-  - id: 7611
+  - id: 7605
     title: Ensure cron daemon is enabled and running
     description: The cron daemon is used to execute batch jobs on the system.
     rationale: >
@@ -2697,7 +2696,7 @@ checks:
       - 'c:systemctl is-enabled cron -> r:^enabled'
       - 'c:systemctl status cron -> r:^\s*Active: active \(running\) since \.+'
 
-  - id: 7612
+  - id: 7606
     title: Ensure permissions on /etc/crontab are configured
     description: >
       The /etc/crontab file is used by cron to control its own jobs. The commands in this item
@@ -2724,7 +2723,7 @@ checks:
     rules:
       - 'c:stat -L /etc/crontab -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
-  - id: 7613
+  - id: 7607
     title: Ensure permissions on /etc/cron.hourly are configured
     description: >
       This directory contains system cron jobs that need to run on an hourly basis. The files in
@@ -2754,7 +2753,7 @@ checks:
     rules:
       - 'c:stat -L /etc/cron.hourly/ -> r:^Access:\s*\(0700/drwx------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
-  - id: 7614
+  - id: 7608
     title: Ensure permissions on /etc/cron.daily are configured
     description: >
       The /etc/cron.daily directory contains system cron jobs that need to run on a daily basis.
@@ -2784,7 +2783,7 @@ checks:
     rules:
       - 'c:stat -L /etc/cron.daily/ -> r:^Access:\s*\(0700/drwx------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
-  - id: 7615
+  - id: 7609
     title: Ensure permissions on /etc/cron.weekly are configured
     description: >
       The /etc/cron.weekly directory contains system cron jobs that need to run on a weekly
@@ -2809,7 +2808,7 @@ checks:
     rules:
       - 'c:stat -L /etc/cron.weekly -> r:^Access:\s*\(0700/drwx------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
-  - id: 7616
+  - id: 7610
     title: Ensure permissions on /etc/cron.monthly are configured
     description: >
       The /etc/cron.monthly directory contains system cron jobs that need to run on a monthly
@@ -2839,7 +2838,7 @@ checks:
     rules:
       - 'c:stat -L /etc/cron.monthly/ -> r:^Access:\s*\(0700/drwx------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
-  - id: 7617
+  - id: 7611
     title: Ensure permissions on /etc/cron.d are configured
     description: >
       The /etc/cron.d/ directory contains system cron jobs that need to run in a similar manner
@@ -2869,7 +2868,7 @@ checks:
     rules:
       - 'c:stat -L /etc/cron.d -> r:^Access:\s*\(0700/drwx------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
-  - id: 7618
+  - id: 7612
     title: Ensure cron is restricted to authorized users
     description: >
       If cron is installed in the system, configure /etc/cron.allow to allow specific users to use
@@ -2908,7 +2907,7 @@ checks:
       - 'not f:/etc/cron.deny'
       - 'c:stat -L /etc/cron.allow -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
-  - id: 7619
+  - id: 7613
     title: Ensure at is restricted to authorized users
     description: >
       If at is installed in the system, configure /etc/at.allow to allow specific users to use these
@@ -2947,7 +2946,7 @@ checks:
       - 'not f:/etc/at.deny'
       - 'c:stat -L /etc/at.allow -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
-  - id: 7620
+  - id: 7614
     title: Ensure permissions on /etc/ssh/sshd_config are configured
     description: >
       The /etc/ssh/sshd_config file contains configuration specifications for sshd. The
@@ -2966,7 +2965,7 @@ checks:
     rules:
       - 'c:stat -L /etc/ssh/sshd_config -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
-  - id: 7621
+  - id: 7615
     title: Ensure SSH access is limited
     description: >
       There are several options available to limit which users and group can access the system
@@ -3020,7 +3019,7 @@ checks:
       - 'c:sshd -T -> r:^\s*denyusers\s+\S+'
       - 'c:sshd -T -> r:^\s*denygroups\s+\S+'
 
-  - id: 7622
+  - id: 7616
     title: Ensure SSH X11 forwarding is disabled
     description: >
       The X11Forwarding parameter provides the ability to tunnel X11 traffic through the
@@ -3040,7 +3039,7 @@ checks:
     rules:
       - 'c:sshd -T -> r:^\s*x11forwarding\s+no'
 
-  - id: 7623
+  - id: 7617
     title: Ensure SSH PermitUserEnvironment is disabled
     description: >
       The PermitUserEnvironment option allows users to present environment options to the
@@ -3059,7 +3058,7 @@ checks:
     rules:
       - 'c:sshd -T -> r:^\s*permituserenvironment\s+no'
 
-  - id: 7624
+  - id: 7618
     title: Ensure only strong Ciphers are used
     description: >
       This variable limits the ciphers that SSH can use during communication.
@@ -3132,7 +3131,7 @@ checks:
       - 'c:sshd -T -> r:^ciphers\s+ && r:aes192-cbc'
       - 'c:sshd -T -> r:^ciphers\s+ && r:aes256-cbc'
 
-  - id: 7625
+  - id: 7619
     title: Ensure only strong MAC algorithms are used
     description: >
       This variable limits the types of MAC algorithms that SSH can use during communication.
@@ -3194,7 +3193,7 @@ checks:
       - 'c:sshd -T -> r:^macs\s+ && r:umac-64-etm@openssh.com'
       - 'c:sshd -T -> r:^macs\s+ && r:umac-128-etm@openssh.com'
 
-  - id: 7626
+  - id: 7620
     title: Ensure only strong Key Exchange algorithms are used
     description: >
       Key exchange is any method in cryptography by which cryptographic keys are exchanged
@@ -3243,7 +3242,7 @@ checks:
       - 'c:sshd -T -> r:^kexalgorithms\s+ && r:diffie-hellman-group14-sha1'
       - 'c:sshd -T -> r:^kexalgorithms\s+ && r:diffie-hellman-group-exchange-sha1'
 
-  - id: 7627
+  - id: 7621
     title: Ensure SSH Idle Timeout Interval is configured
     description: >
       The two options ClientAliveInterval and ClientAliveCountMax control the timeout of
@@ -3290,7 +3289,7 @@ checks:
       - 'c:sshd -T -> n:^clientaliveinterval\s+(\d+) compare <= 300'
       - 'c:sshd -T -> n:^ClientAliveCountMax\s+(\d+) compare <= 3'
 
-  - id: 7628
+  - id: 7622
     title: Ensure SSH LoginGraceTime is set to one minute or less
     description: >
       The LoginGraceTime parameter specifies the time allowed for successful authentication to
@@ -3313,7 +3312,7 @@ checks:
       - 'c:sshd -T -> n:^logingracetime\s+(\d+) compare >= 1'
       - 'c:sshd -T -> n:^logingracetime\s+(\d+) compare <= 60'
 
-  - id: 7629
+  - id: 7623
     title: Ensure SSH warning banner is configured
     description: >
       The Banner parameter specifies a file whose contents must be sent to the remote user
@@ -3333,7 +3332,7 @@ checks:
     rules:
       - 'c:sshd -T -> r:^banner\s+/etc/issue.net'
 
-  - id: 7630
+  - id: 7624
     title: Ensure SSH PAM is enabled
     description: >
       UsePAM Enables the Pluggable Authentication Module interface. If set to “yes” this will
@@ -3356,7 +3355,7 @@ checks:
     rules:
       - 'c:sshd -T -> r:^usepam\s+yes'
 
-  - id: 7631
+  - id: 7625
     title: Ensure SSH AllowTcpForwarding is disabled
     description: >
       SSH port forwarding is a mechanism in SSH for tunneling application ports from the client
@@ -3384,7 +3383,7 @@ checks:
     rules:
       - 'c:sshd -T -> r:^allowtcpforwarding\s+no'
 
-  - id: 7632
+  - id: 7626
     title: Ensure SSH MaxStartups is configured
     description: >
       The MaxStartups parameter specifies the maximum number of concurrent unauthenticated
@@ -3404,7 +3403,7 @@ checks:
     rules:
       - 'c:sshd -T -> r:^maxstartups\s+10:30:60\s*$'
 
-  - id: 7633
+  - id: 7627
     title: Ensure SSH MaxSessions is limited
     description: >
       The MaxSessions parameter specifies the maximum number of open sessions permitted
@@ -3424,7 +3423,7 @@ checks:
     rules:
       - 'c:sshd -T -> n:^maxsessions\s+(\d+) compare <= 10'
 
-  - id: 7634
+  - id: 7628
     title: Ensure password reuse is limited
     description: >
       The /etc/security/opasswd file stores the users' old passwords and can be checked to
@@ -3454,7 +3453,7 @@ checks:
       - 'f:/etc/pam.d/common-password -> n:^\s*password\t+requisite\t+pam_pwhistory\.so\t+remember\s*=\s*(\d+) compare >= 5'
       - 'f:/etc/pam.d/common-password -> n:^\s*password\t+required\t+pam_pwhistory\.so\t+remember\s*=\s*(\d+) compare >= 5'
 
-  - id: 7635
+  - id: 7629
     title: Ensure password hashing algorithm is SHA-512
     description: >
       Login passwords are hashed and stored in the /etc/shadow file.
@@ -3484,7 +3483,7 @@ checks:
     rules:
       - 'f:/etc/login.defs -> r:^\s*ENCRYPT_METHOD\s+SHA512'
 
-  - id: 7636
+  - id: 7630
     title: Ensure default group for the root account is GID 0
     description: >
       The usermod command can be used to specify which group the root user belongs to. This
@@ -3502,7 +3501,7 @@ checks:
     rules:
       - 'f:/etc/passwd -> r:^root:\S+:\S+:0:'
 
-  - id: 7637
+  - id: 7631
     title: Ensure permissions on /etc/passwd are configured
     description: >
       The /etc/passwd file contains user account information that is used by many system
@@ -3523,7 +3522,7 @@ checks:
     rules:
       - 'c:stat -L /etc/passwd -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
-  - id: 7638
+  - id: 7632
     title: Ensure permissions on /etc/shadow are configured
     description: >
       The /etc/shadow file is used to store the information about user accounts that is critical to
@@ -3546,7 +3545,7 @@ checks:
     rules:
       - 'c:stat -L /etc/shadow -> r:^Access:\s*\(0640/-rw-r-----\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*15/\s*shadow\)'
 
-  - id: 7639
+  - id: 7633
     title: Ensure permissions on /etc/group are configured
     description: >
       The /etc/group file contains a list of all the valid groups defined in the system. The
@@ -3567,7 +3566,7 @@ checks:
     rules:
       - 'c:stat -L /etc/group -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
-  - id: 7640
+  - id: 7634
     title: Ensure permissions on /etc/passwd- are configured
     description: The /etc/passwd- file contains backup user account information.
     rationale: >
@@ -3586,7 +3585,7 @@ checks:
     rules:
       - 'c:stat -L /etc/passwd -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
-  - id: 7641
+  - id: 7635
     title: Ensure permissions on /etc/shadow- are configured
     description: >
       The /etc/shadow- file is used to store backup information about user accounts that is
@@ -3608,7 +3607,7 @@ checks:
     rules:
       - 'c:stat -L /etc/shadow- -> r:^Access:\s*\(0640/-rw-r-----\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*15/\s*shadow\)'
 
-  - id: 7642
+  - id: 7636
     title: Ensure permissions on /etc/group- are configured
     description: The /etc/group- file contains a backup list of all the valid groups defined in the system.
     rationale: >
@@ -3627,7 +3626,7 @@ checks:
     rules:
       - 'c:stat -L /etc/group- -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
 
-  - id: 7643
+  - id: 7637
     title: Ensure accounts in /etc/passwd use shadowed passwords
     description: >
       Local accounts can uses shadowed passwords. With shadowed passwords, The passwords
@@ -3663,7 +3662,7 @@ checks:
     rules:
       - 'f:/etc/passwd -> !r:^\.+:x:'
 
-  - id: 7644
+  - id: 7638
     title: Ensure /etc/shadow password fields are not empty
     description: >
       An account with an empty password field means that anybody may log in as that user
@@ -3685,17 +3684,3 @@ checks:
     condition: none
     rules:
       - 'c:grep -E ^[^:]+:: /etc/shadow -> r:::'
-
-#  - id:
-#    title:
-#    description:
-#    rationale:
-#    remediation:
-#    compliance:
-#      - cis: [""]
-#      - cis_csc: [""]
-#    references:
-#      -
-#    condition:
-#    rules:
-#      - ''

--- a/ruleset/sca/sles/15/cis_sles15_linux.yml
+++ b/ruleset/sca/sles/15/cis_sles15_linux.yml
@@ -1156,7 +1156,7 @@ checks:
     compliance:
       - cis: ["2.2.3"]
       - cis_csc: ["9.2"]
-    condition: none
+    condition: all
     rules:
       - 'c:rpm -q avahi -> r:not installed'
       - 'c:rpm -q avahi-autoipd -> r:not installed'

--- a/ruleset/sca/sles/15/cis_sles15_linux.yml
+++ b/ruleset/sca/sles/15/cis_sles15_linux.yml
@@ -819,7 +819,7 @@ checks:
       - cis_csc: ["8.3"]
     condition: all
     rules:
-      - 'c:journalctl -> r:\.*kernel: NX \(Execute Disable\) protection:\s*active'
+      - 'c:sh -c "journalctl | grep \"protection: active\"" -> r:\.*kernel: NX \(Execute Disable\) protection:\s*active'
 
 # 1.6.3 Ensure address space layout randomization (ASLR) is enabled
   - id: 7527
@@ -1158,7 +1158,8 @@ checks:
       - cis_csc: ["9.2"]
     condition: none
     rules:
-      - 'c:rpm -qa -> r:^avahi'
+      - 'c:rpm -q avahi -> r:not installed'
+      - 'c:rpm -q avahi-autoipd -> r:not installed'
 
 # 2.2.4 Ensure CUPS is not installed
   - id: 7540
@@ -2317,11 +2318,11 @@ checks:
       - 'c:grep -R identity /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/etc/gshadow\s+-p\s+wa\s+-k\s+identity'
       - 'c:grep -R identity /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/etc/shadow\s+-p\s+wa\s+-k\s+identity'
       - 'c:grep -R identity /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/etc/security/opasswd\s+-p\s+wa\s+-k\s+identity'
-      - 'c:auditctl -l | grep identity -> r:^\s*-w\s+/etc/group\s+-p\s+wa\s+-k\s+identity'
-      - 'c:auditctl -l | grep identity -> r:^\s*-w\s+/etc/passwd\s+-p\s+wa\s+-k\s+identity'
-      - 'c:auditctl -l | grep identity -> r:^\s*-w\s+/etc/gshadow\s+-p\s+wa\s+-k\s+identity'
-      - 'c:auditctl -l | grep identity -> r:^\s*-w\s+/etc/shadow\s+-p\s+wa\s+-k\s+identity'
-      - 'c:auditctl -l | grep identity -> r:^\s*-w\s+/etc/security/opasswd\s+-p\s+wa\s+-k\s+identity'
+      - 'c:sh -c "auditctl -l | grep identity" -> r:^\s*-w\s+/etc/group\s+-p\s+wa\s+-k\s+identity'
+      - 'c:sh -c "auditctl -l | grep identity" -> r:^\s*-w\s+/etc/passwd\s+-p\s+wa\s+-k\s+identity'
+      - 'c:sh -c "auditctl -l | grep identity" -> r:^\s*-w\s+/etc/gshadow\s+-p\s+wa\s+-k\s+identity'
+      - 'c:sh -c "auditctl -l | grep identity" -> r:^\s*-w\s+/etc/shadow\s+-p\s+wa\s+-k\s+identity'
+      - 'c:sh -c "auditctl -l | grep identity" -> r:^\s*-w\s+/etc/security/opasswd\s+-p\s+wa\s+-k\s+identity'
 
 # 4.1.5 Ensure events that modify the system's network environment are collected - Not implemented
 
@@ -2356,8 +2357,8 @@ checks:
     rules:
       - 'c:grep -R MAC-policy /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/etc/selinux/\s+-p\s+wa\s+-k\s+MAC-policy'
       - 'c:grep -R MAC-policy /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/usr/share/selinux/\s+-p\s+wa\s+-k\s+MAC-policy'
-      - 'c:auditctl -l | grep MAC-policy -> r:^\s*-w\s+/etc/selinux/\s+-p\s+wa\s+-k\s+MAC-policy'
-      - 'c:auditctl -l | grep MAC-policy -> r:^\s*-w\s+/usr/share/selinux/\s+-p\s+wa\s+-k\s+MAC-policy'
+      - 'c:sh -c "auditctl -l | grep MAC-policy" -> r:^\s*-w\s+/etc/selinux/\s+-p\s+wa\s+-k\s+MAC-policy'
+      - 'c:sh -c "auditctl -l | grep MAC-policy" -> r:^\s*-w\s+/usr/share/selinux/\s+-p\s+wa\s+-k\s+MAC-policy'
 
 # 4.1.7 Ensure login and logout events are collected 
   - id: 7586
@@ -2391,9 +2392,9 @@ checks:
       - 'c:grep -R logins /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/var/log/faillog\s+-p\s+wa\s+-k\s+logins'
       - 'c:grep -R logins /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/var/log/lastlog\s+-p\s+wa\s+-k\s+logins'
       - 'c:grep -R logins /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/var/log/tallylog\s+-p\s+wa\s+-k\s+logins'
-      - 'c:auditctl -l | grep logins -> r:^\s*-w\s+/var/log/faillog\s+-p\s+wa\s+-k\s+logins'
-      - 'c:auditctl -l | grep logins -> r:^\s*-w\s+/var/log/lastlog\s+-p\s+wa\s+-k\s+logins'
-      - 'c:auditctl -l | grep logins -> r:^\s*-w\s+/var/log/tallylog\s+-p\s+wa\s+-k\s+logins'
+      - 'c:sh -c "auditctl -l | grep logins" -> r:^\s*-w\s+/var/log/faillog\s+-p\s+wa\s+-k\s+logins'
+      - 'c:sh -c "auditctl -l | grep logins" -> r:^\s*-w\s+/var/log/lastlog\s+-p\s+wa\s+-k\s+logins'
+      - 'c:sh -c "auditctl -l | grep logins" -> r:^\s*-w\s+/var/log/tallylog\s+-p\s+wa\s+-k\s+logins'
 
 # 4.1.8 Ensure session initiation information is collected
   - id: 7587
@@ -2431,9 +2432,9 @@ checks:
       - 'c:grep -RE "(session|logins)" /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/var/run/utmp\s+-p\s+wa\s+-k\s+session'
       - 'c:grep -RE "(session|logins)" /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/var/log/wtmp\s+-p\s+wa\s+-k\s+logins'
       - 'c:grep -RE "(session|logins)" /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/var/log/btmp\s+-p\s+wa\s+-k\s+logins'
-      - 'c:auditctl -l | grep -E "(session|logins)" -> r:^\s*-w\s+/var/run/utmp\s+-p\s+wa\s+-k\s+session'
-      - 'c:auditctl -l | grep -E "(session|logins)" -> r:^\s*-w\s+/var/log/wtmp\s+-p\s+wa\s+-k\s+logins'
-      - 'c:auditctl -l | grep -E "(session|logins)" -> r:^\s*-w\s+/var/log/btmp\s+-p\s+wa\s+-k\s+logins'
+      - 'c:sh -c "auditctl -l | grep -E \"(session|logins)\"" -> r:^\s*-w\s+/var/run/utmp\s+-p\s+wa\s+-k\s+session'
+      - 'c:sh -c "auditctl -l | grep -E \"(session|logins)\"" -> r:^\s*-w\s+/var/log/wtmp\s+-p\s+wa\s+-k\s+logins'
+      - 'c:sh -c "auditctl -l | grep -E \"(session|logins)\"" -> r:^\s*-w\s+/var/log/btmp\s+-p\s+wa\s+-k\s+logins'
 
 # 4.1.9 Ensure discretionary access control permission modification events are collected - Not implemented
 # 4.1.10 Ensure unsuccessful unauthorized file access attempts are collected - Not implemented
@@ -2469,8 +2470,8 @@ checks:
     rules:
       - 'c:grep -R scope /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/etc/sudoers\s+-p\s+wa\s+-k\s+scope'
       - 'c:grep -R scope /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/etc/sudoers.d/\s+-p\s+wa\s+-k\s+scope'
-      - 'c:auditctl -l | grep scope -> r:^\s*-w\s+/etc/sudoers\s+-p\s+wa\s+-k\s+scope'
-      - 'c:auditctl -l | grep scope -> r:^\s*-w\s+/etc/sudoers.d/\s+-p\s+wa\s+-k\s+scope'
+      - 'c:sh -c "auditctl -l | grep scope" -> r:^\s*-w\s+/etc/sudoers\s+-p\s+wa\s+-k\s+scope'
+      - 'c:sh -c "auditctl -l | grep scope" -> r:^\s*-w\s+/etc/sudoers.d/\s+-p\s+wa\s+-k\s+scope'
 
 # 4.1.15 Ensure system administrator actions (sudolog) are collected - Not implemented
 # 4.1.16 Ensure kernel module loading and unloading is collected - Not implemented
@@ -2500,7 +2501,7 @@ checks:
       - cis_csc: ["6.2","6.3"]
     condition: all
     rules:
-      - 'c:grep -R "^\s*[^#]" /etc/audit/rules.d/ | tail -1 -> r:^/etc/audit/rules.d/\.+.rules:\s*-e\s+2\s*$'
+      - 'c:sh -c "grep -R \"^\s*[^#]\" /etc/audit/rules.d/ | tail -1" -> r:^/etc/audit/rules.d/\.+.rules:\s*-e\s+2\s*$'
 
 # 4.2.1.1 Ensure rsyslog is installed
   - id: 7590


### PR DESCRIPTION
|Related PR|
|---|
|https://github.com/wazuh/wazuh/issues/8977|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR reworks the changes added in the previous https://github.com/wazuh/wazuh/pull/8977

The effected changes were:
- Reordered the ID of the checks to make them continuous.
- Fixed wrongly implemented checks.
- Added consistency to indexation.
- Fixed YML format.

After these changes, another iteration will be needed to add the missing checks.

## SCA Checks
### Syntax and semantic

- [x] a) ID of each policy must be contiguous.
- [x] b) The order and format set in [Documentation](https://documentation.wazuh.com/current/user-manual/capabilities/sec-config-assessment/creating-custom-policies.html) must be respected.
- [x] c) YML must be valid to avoid errors.

### Content

- [x] a) Compare each check with its analogue from CIS Benchmark.
- [x] b) Try to maintain each rule as similar as possible with the `Audit` section from the CIS check.
- [x] c) Check that the commands provide the expected output.
- [x] d) When a failure is discovered, check similar policies to avoid repetition of the issue.

### Unit testing

- [x] a) Output from `agent.log` after the SCA scan and a raw output of the result of the checks.
<details><summary>Tests results</summary>
<p>

#### Analysisd (server or local)
analysisd.debug=2

#### Auth daemon debug (server)
authd.debug=0

#### Exec daemon debug (server, local, or Unix agent)
execd.debug=0

#### Monitor daemon debug (server, local, or Unix agent)
monitord.debug=0

#### Log collector (server, local or Unix agent)
logcollector.debug=0

#### Integrator daemon debug (server, local or Unix agent)
integrator.debug=0

#### Unix agentd
agent.debug=2

2021/12/06 18:08:14 sca: INFO: Module started.
2021/12/06 18:08:14 sca: INFO: Loaded policy '/var/ossec/ruleset/sca/sles/12/cis_sles12_linux.yml'
2021/12/06 18:08:14 sca: INFO: Starting Security Configuration Assessment scan.
2021/12/06 18:08:14 sca: INFO: Starting evaluation of policy: '/var/ossec/ruleset/sca/sles/12/cis_sles12_linux.yml'
2021/12/06 18:08:19 sca: INFO: Evaluation finished for policy '/var/ossec/ruleset/sca/sles/12/cis_sles12_linux.yml'
2021/12/06 18:08:19 sca: INFO: Security Configuration Assessment scan finished. Duration: 5 seconds.

2021/12/06 18:08:14 sca: INFO: Module started.
2021/12/06 18:08:14 sca: INFO: Loaded policy '/var/ossec/ruleset/sca/sles/15/cis_sles15_linux.yml'
2021/12/06 18:08:14 sca: INFO: Starting Security Configuration Assessment scan.
2021/12/06 18:08:14 sca: INFO: Starting evaluation of policy: '/var/ossec/ruleset/sca/sles/15/cis_sles15_linux.yml'
2021/12/06 18:08:19 sca: INFO: Evaluation finished for policy '/var/ossec/ruleset/sca/sles/15/cis_sles15_linux.yml'
2021/12/06 18:08:19 sca: INFO: Security Configuration Assessment scan finished. Duration: 5 seconds.
</p>
</details>

### Deployment

- [x] a) If the policy it's new, it must be added to the `sca.files` templates.
- [x] b) If the OS has many supported SCA policies, a policy must be set as default policy. ([as example](https://github.com/wazuh/wazuh/blob/master/etc/templates/config/centos/sca.files))

