### PR TITLE
fix linux process start_time(#11114)

### DIFF
--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -70,6 +70,39 @@ static bool getSystemInfo(const std::string& fileName, const std::string& separa
     return ret;
 }
 
+static uint64_t getBootTime(void)
+{
+    static uint64_t btime = 0UL;
+
+    if (0UL == btime)
+    {
+        auto file { Utils::getFileContent("/proc/stat") };
+        auto offset { file.rfind("btime ") };
+        sscanf(file.c_str() + offset, "btime %lu", &btime);
+    }
+
+    return btime;
+}
+
+static uint64_t getClockTick(void)
+{
+   static uint64_t tick = 0UL;
+
+   if (0UL == tick)
+   {
+       tick = (uint64_t)sysconf(_SC_CLK_TCK);
+   }
+
+   return tick;
+}
+
+static uint64_t timeTick2unixTime(uint64_t startTime)
+{
+    auto btime { getBootTime()  };
+    auto tick  { getClockTick() };
+    return (startTime / tick) + btime;
+}
+
 static nlohmann::json getProcessInfo(const SysInfoProcess& process)
 {
     nlohmann::json jsProcessInfo{};
@@ -115,7 +148,7 @@ static nlohmann::json getProcessInfo(const SysInfoProcess& process)
     jsProcessInfo["vm_size"]    = process->vm_size;
     jsProcessInfo["resident"]   = process->resident;
     jsProcessInfo["share"]      = process->share;
-    jsProcessInfo["start_time"] = process->start_time;
+    jsProcessInfo["start_time"] = timeTick2unixTime(process->start_time);
     jsProcessInfo["pgrp"]       = process->pgrp;
     jsProcessInfo["session"]    = process->session;
     jsProcessInfo["tgid"]       = process->tgid;

--- a/src/shared_modules/utils/linuxProcessHelper.h
+++ b/src/shared_modules/utils/linuxProcessHelper.h
@@ -1,0 +1,64 @@
+/*
+ * Wazuh shared modules utils
+ * Copyright (C) 2015-2021, Wazuh Inc.
+ * December 10, 2021.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _LINUXPROCESS_HELPER_H
+#define _LINUXPROCESS_HELPER_H
+
+#include <cstdint>   //uint64_t
+#include <string>    //std::stoul
+
+#include <unistd.h>  //sysconf
+
+#include <vector>
+#include "filesystemHelper.h" //getFileContent
+
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+
+namespace Utils
+{
+    static uint64_t getBootTime(void)
+    {
+        static uint64_t btime;
+
+        try
+        {
+            if (0UL == btime)
+            {
+                const std::string key {"btime "};
+                const auto file { Utils::getFileContent("/proc/stat") };
+
+                btime = std::stoul(file.substr(file.find(key) + key.length()));
+            }
+         }
+         catch(...)
+         {
+         }
+
+         return btime;
+    }
+
+    static uint64_t getClockTick(void)
+    {
+       static uint64_t tick = static_cast<uint64_t>(sysconf(_SC_CLK_TCK));
+
+       return tick;
+    }
+
+    static uint64_t timeTick2unixTime(const uint64_t startTime)
+    {
+        return (startTime / getClockTick()) + getBootTime();
+    }
+}
+
+
+#endif // _LINUXPROCESS_HELPER_H

--- a/src/shared_modules/utils/tests/linuxProcessHelper_test.cpp
+++ b/src/shared_modules/utils/tests/linuxProcessHelper_test.cpp
@@ -1,0 +1,44 @@
+/*
+ * Wazuh shared modules utils
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ * December 10, 2021.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "linuxProcessHelper_test.h"
+#include "linuxProcessHelper.h"
+#include "cmdHelper.h"
+
+
+void LinuxProcessHelperTest::SetUp() {};
+
+void LinuxProcessHelperTest::TearDown() {};
+
+#ifndef WIN32
+TEST_F(LinuxProcessHelperTest, getBootTime)
+{
+    const auto btimeNumFromFunc{Utils::getBootTime()};
+
+    const auto btimeStr{Utils::exec("grep 'btime' /proc/stat | awk '{print $2}'")};
+    const auto btimeNumFromProc{std::stoul(btimeStr)};
+
+    EXPECT_FALSE(btimeNumFromFunc != btimeNumFromProc);
+}
+
+TEST_F(LinuxProcessHelperTest, timeTick2unixTime)
+{
+    const auto startTimeStr{Utils::exec("awk '{print $22}' /proc/1/stat")};
+    const auto startTimeNum{std::stoul(startTimeStr)};
+    const auto startTimeUnixFunc{Utils::timeTick2unixTime(startTimeNum)};
+
+    const auto startTimeUnixCmd{std::stoul(Utils::exec("date -d \"`ps -o lstart -p 1|tail -n 1`\" +%s"))};
+
+    EXPECT_FALSE(startTimeUnixFunc != startTimeUnixCmd);
+}
+
+
+#endif

--- a/src/shared_modules/utils/tests/linuxProcessHelper_test.h
+++ b/src/shared_modules/utils/tests/linuxProcessHelper_test.h
@@ -1,0 +1,26 @@
+/*
+ * Wazuh shared modules utils
+ * Copyright (C) 2015-2021, Wazuh Inc.
+ * December 10, 2021.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef LINUXPROCESS_HELPER_TESTS_H
+#define LINUXPROCESS_HELPER_TESTS_H
+#include "gtest/gtest.h"
+
+class LinuxProcessHelperTest : public ::testing::Test
+{
+protected:
+
+    LinuxProcessHelperTest() = default;
+    virtual ~LinuxProcessHelperTest() = default;
+
+    void SetUp() override;
+    void TearDown() override;
+};
+#endif //LINUXPROCESS_HELPER_TESTS_H


### PR DESCRIPTION
|Related issue|
|-|
|#11114|


## Description

Fix the startup time of linux process.

<!--
Add a clear description of how the problem has been solved.
-->


## Test Logs

```bash
./sysinfo_test_tool | grep -Eo '"start_time": [0-9]+' | awk '{print "TimeStamp: "$2 ;system("date -d @"$2)}'
TimeStamp: 1638866508
Tue Dec  7 08:41:48 UTC 2021
TimeStamp: 1638866961
Tue Dec  7 08:49:21 UTC 2021
TimeStamp: 1638866961
Tue Dec  7 08:49:21 UTC 2021
TimeStamp: 1638866961
Tue Dec  7 08:49:21 UTC 2021

```

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors