### PR TITLE
Fix Google Cloud Storage folder filtering

### DIFF
--- a/wodles/gcloud/buckets/bucket.py
+++ b/wodles/gcloud/buckets/bucket.py
@@ -53,7 +53,7 @@ class WazuhGCloudBucket(WazuhGCloudIntegration):
         self.bucket = None
         self.client = storage.client.Client.from_service_account_json(credentials_file)
         self.project_id = self.client.project
-        self.prefix = prefix if not prefix or prefix[-1] == '/' else prefix + '/'
+        self.prefix = prefix if not prefix or prefix[-1] == '/' else f'{prefix}/'
         self.delete_file = delete_file
         self.only_logs_after = only_logs_after
 

--- a/wodles/gcloud/buckets/bucket.py
+++ b/wodles/gcloud/buckets/bucket.py
@@ -53,7 +53,7 @@ class WazuhGCloudBucket(WazuhGCloudIntegration):
         self.bucket = None
         self.client = storage.client.Client.from_service_account_json(credentials_file)
         self.project_id = self.client.project
-        self.prefix = prefix
+        self.prefix = prefix if not prefix or prefix[-1] == '/' else prefix + '/'
         self.delete_file = delete_file
         self.only_logs_after = only_logs_after
 
@@ -211,8 +211,7 @@ class WazuhGCloudBucket(WazuhGCloudIntegration):
 
         processed_files = []
         try:
-            bucket_contents = self.bucket.list_blobs(prefix=self.prefix)
-
+            bucket_contents = self.bucket.list_blobs(prefix=self.prefix, delimiter='/')
             processed_messages = 0
             new_creation_time = datetime.min.replace(tzinfo=pytz.UTC)
 

--- a/wodles/gcloud/pubsub/subscriber.py
+++ b/wodles/gcloud/pubsub/subscriber.py
@@ -17,7 +17,7 @@ from integration import WazuhGCloudIntegration
 try:
     from google.cloud import pubsub_v1 as pubsub
 except ImportError:
-    raise Exception('ERROR: google-cloud-storage module is required.')
+    raise Exception('ERROR: google-cloud-pubsub module is required.')
 
 
 class WazuhGCloudSubscriber(WazuhGCloudIntegration):


### PR DESCRIPTION
|Related issue|
|---|
|Closes #11149|

## Description
In this PR we fix the problem with the GCP Buckets module, which was processing every file under every folder when making a request. This would generate duplicate alerts when any of those subfolders were requested using the `-P/--prefix` parameter.  

To fix this problem we only had to add a delimiter to the request to GCP to point that we just need the files under that folder, and not the files on its subfolders. The delimiter added can be seen in following code snippet:

https://github.com/wazuh/wazuh/blob/919f3f9ef5861f99a330dc5bed4f555cfacea535/wodles/gcloud/buckets/bucket.py#L214

We also fix an incorrect exception message in the pubsub module that could confuse the users.

## Tests
### Unit tests
```
==================================== test session starts ====================================
platform linux -- Python 3.9.9, pytest-6.0.1, py-1.10.0, pluggy-0.13.1
rootdir: /home/gonzz/git/wazuh/wodles/gcloud
collected 6 items                                                                           

tests/test_access_logs.py .                                                           [ 16%]
tests/test_bucket.py .                                                                [ 33%]
tests/test_integration.py ...                                                         [ 83%]
tests/test_subscriber.py .                                                            [100%]

===================================== 6 passed in 0.27s =====================================
```  

### Test in a manager
The module works as expected.

#### Process files under /
Only the files under the `/` folder were processed, as expected.
<details><summary>Command output</summary>

	root@a5f045757149:/var/ossec/wodles/gcloud# /var/ossec/wodles/gcloud/gcloud -c  /var/ossec/wodles/gcloud/credentials.json -l 1 -T access_logs -b framework-test-bucket -o 2021-jan-01
	gcloud_wodle - INFO - Processing test_22.txt
	gcloud_wodle - INFO - Processing test_3.txt
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 3", "source": "gcp_bucket"}}'"
	gcloud_wodle - INFO - Processing test_4.txt
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 4", "source": "gcp_bucket"}}'"
	gcloud_wodle - INFO - Processing test_5.txt
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 5", "source": "gcp_bucket"}}'"
	gcloud_wodle - INFO - Processing test_6.txt
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 6", "source": "gcp_bucket"}}'"
	gcloud_wodle - INFO - Processing test_7.txt
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 7", "source": "gcp_bucket"}}'"
	gcloud_wodle - INFO - Processing test_8.txt
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 8", "source": "gcp_bucket"}}'"
	gcloud_wodle - INFO - Processing test_9.txt
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 9", "source": "gcp_bucket"}}'"
	gcloud_wodle - INFO - Updating previously processed files.
	gcloud_wodle - INFO - Received 7 messages

</details>


#### Process files under test_prefix
Only the files under the `/test_prefix/` folder were processed, as expected.
<details><summary>Command output</summary>

	root@a5f045757149:/var/ossec/wodles/gcloud# /var/ossec/wodles/gcloud/gcloud -c  /var/ossec/wodles/gcloud/credentials.json -l 1 -T access_logs -b framework-test-bucket -o 2021-jan-01 -P test_prefix
	gcloud_wodle - INFO - Processing test_prefix/test_1.txt
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 1", "source": "gcp_bucket"}}'"
	gcloud_wodle - INFO - Updating previously processed files.
	gcloud_wodle - INFO - Received 1 message

</details>

#### Process files under test_prefix/
Only the files under the `/test_prefix/` folder were processed, as expected.
<details><summary>Command output</summary>

	root@a5f045757149:/var/ossec/wodles/gcloud# /var/ossec/wodles/gcloud/gcloud -c  /var/ossec/wodles/gcloud/credentials.json -l 1 -T access_logs -b framework-test-bucket -o 2021-jan-01 -P test_prefix/
	gcloud_wodle - INFO - Processing test_prefix/test_1.txt
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 1", "source": "gcp_bucket"}}'"
	gcloud_wodle - INFO - Updating previously processed files.
	gcloud_wodle - INFO - Received 1 message

</details>

#### Process files under test_prefix/test_subprefix
Only the files under the `/test_prefix/test_subprefix/` folder were processed, as expected.
<details><summary>Command output</summary>

	root@a5f045757149:/var/ossec/wodles/gcloud# /var/ossec/wodles/gcloud/gcloud -c  /var/ossec/wodles/gcloud/credentials.json -l 1 -T access_logs -b framework-test-bucket -o 2021-jan-01 -P test_prefix/test_subprefix
	gcloud_wodle - INFO - Processing test_prefix/test_subprefix/test_1.txt
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 1", "source": "gcp_bucket"}}'"
	gcloud_wodle - INFO - Updating previously processed files.
	gcloud_wodle - INFO - Received 1 message

</details>

### Test in an agent
The module works as expected.

#### Process files under /
Only the files under the `/` folder were processed, as expected.
<details><summary>Command output</summary>

	root@5b361f82146f:/var/ossec/wodles/gcloud# python3.9 /var/ossec/wodles/gcloud/gcloud -c  /var/ossec/wodles/gcloud/credentials.json -l 1 -T access_logs -b framework-test-bucket -o 2021-jan-01
	gcloud_wodle - INFO - Processing test_22.txt
	gcloud_wodle - INFO - Processing test_3.txt
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 3", "source": "gcp_bucket"}}'"
	gcloud_wodle - INFO - Processing test_4.txt
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 4", "source": "gcp_bucket"}}'"
	gcloud_wodle - INFO - Processing test_5.txt
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 5", "source": "gcp_bucket"}}'"
	gcloud_wodle - INFO - Processing test_6.txt
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 6", "source": "gcp_bucket"}}'"
	gcloud_wodle - INFO - Processing test_7.txt
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 7", "source": "gcp_bucket"}}'"
	gcloud_wodle - INFO - Processing test_8.txt
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 8", "source": "gcp_bucket"}}'"
	gcloud_wodle - INFO - Processing test_9.txt
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 9", "source": "gcp_bucket"}}'"
	gcloud_wodle - INFO - Updating previously processed files.
	gcloud_wodle - INFO - Received 7 messages

</details>


#### Process files under test_prefix
Only the files under the `/test_prefix/` folder were processed, as expected.

<details><summary>Command output</summary>

	root@5b361f82146f:/var/ossec/wodles/gcloud# python3.9 /var/ossec/wodles/gcloud/gcloud -c  /var/ossec/wodles/gcloud/credentials.json -l 1 -T access_logs -b framework-test-bucket -o 2021-jan-01 -P test_prefix
	gcloud_wodle - INFO - Processing test_prefix/test_1.txt
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 1", "source": "gcp_bucket"}}'"
	gcloud_wodle - INFO - Updating previously processed files.
	gcloud_wodle - INFO - Received 1 message

</details>

#### Process files under test_prefix/
Only the files under the `/test_prefix/` folder were processed, as expected.

<details><summary>Command output</summary>

	root@5b361f82146f:/var/ossec/wodles/gcloud# python3.9 /var/ossec/wodles/gcloud/gcloud -c  /var/ossec/wodles/gcloud/credentials.json -l 1 -T access_logs -b framework-test-bucket -o 2021-jan-01 -P test_prefix/
	gcloud_wodle - INFO - Processing test_prefix/test_1.txt
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 1", "source": "gcp_bucket"}}'"
	gcloud_wodle - INFO - Updating previously processed files.
	gcloud_wodle - INFO - Received 1 message

</details>

#### Process files under test_prefix/test_subprefix
Only the files under the `/test_prefix/test_subprefix/` folder were processed, as expected.
<details><summary>Command output</summary>

	root@5b361f82146f:/var/ossec/wodles/gcloud# python3.9 /var/ossec/wodles/gcloud/gcloud -c  /var/ossec/wodles/gcloud/credentials.json -l 1 -T access_logs -b framework-test-bucket -o 2021-jan-01 -P test_prefix/test_subprefix
	gcloud_wodle - INFO - Processing test_prefix/test_subprefix/test_1.txt
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"GOOGLE CLOUD STORAGE TEST": "Log 1", "source": "gcp_bucket"}}'"
	gcloud_wodle - INFO - Updating previously processed files.
	gcloud_wodle - INFO - Received 1 message

</details>

