### PR TITLE
Rework of #9018 - Updated proftd decoder and added more sample logs

### DIFF
--- a/ruleset/decoders/0230-proftpd_decoders.xml
+++ b/ruleset/decoders/0230-proftpd_decoders.xml
@@ -1,29 +1,24 @@
 <!--
-  -  ProFTPD decoders
-  -  Author: Daniel Cid.
-  -  Updated by Wazuh, Inc.
-  -  Copyright (C) 2015-2021, Wazuh Inc.
-  -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  ProFTPD decoders
 -->
 
-
 <!--
-  - Will extract the username/srcip
-  - Examples:
-  - proftpd[26916]: hayaletgemi (85.101.218.135[85.101.218.135]) - ANON anonymous: Login successful.
-  - proftpd[12564]: juf01 (pD9EE35B1.dip.t-dialin.net[217.238.53.177]) - USER jufu: Login successful
-  - proftpd[30362] xx.yy.zz (aa.bb.cc[aa.bb.vv.dd]): USER backup: Login successful.
-  - proftpd[2344]: refused connect from 192.168.1.2 (192.168.1.2)
-  - proftpd[15181]: valhalla (crawl-66-249-66-80.googlebot.com[66.249.66.80]) - Connection from crawl-66-249-66-80.googlebot.com [66.249.66.80] denied.
-  - proftpd[26169] server.example.net: Fatal: unable to open incoming connection: Der Socket ist nicht verbunden
+  Will extract the username/srcip
+  Examples:
+  proftpd[26916]: hayaletgemi (85.101.218.135[85.101.218.135]) - ANON anonymous: Login successful.
+  proftpd[12564]: juf01 (pD9EE35B1.dip.t-dialin.net[217.238.53.177]) - USER jufu: Login successful
+  proftpd[30362] xx.yy.zz (aa.bb.cc[aa.bb.vv.dd]): USER backup: Login successful.
+  proftpd[2344]: refused connect from 192.168.1.2 (192.168.1.2)
+  proftpd[15181]: valhalla (crawl-66-249-66-80.googlebot.com[66.249.66.80]) - Connection from crawl-66-249-66-80.googlebot.com [66.249.66.80] denied.
+  proftpd[26169] server.example.net: Fatal: unable to open incoming connection: Der Socket ist nicht verbunden
 
-  - More different logs examples:
-  - Oct 24 09:30:30 devXXX proftpd[119259]: [authpriv.notice]: 0.0.0.0 (54.86.105.198[54.86.105.198]) - USER 24-0-proc (Login failed): No such user found
-  - Oct 24 09:31:08 devXXX proftpd[39209]: [authpriv.info]: 0.0.0.0 (54.86.105.198[54.86.105.198]) - USER 24-0-proc: Login successful.
-  - Oct 24 09:29:57 devXXX proftpd[1150]: [authpriv.notice]: 0.0.0.0 (181.49.117.130[181.49.117.130]) - USER root (Login failed): Incorrect password
-  - Oct 22 23:23:34 devXXX proftpd[13512]: [authpriv.notice]: 0.0.0.0 (211.177.150.14[211.177.150.14]) - Maximum login attempts (6) exceeded, connection refused
+  More different logs examples:
+  Oct 24 09:30:30 devXXX proftpd[119259]: [authpriv.notice]: 0.0.0.0 (54.86.105.198[54.86.105.198]) - USER 24-0-proc (Login failed): No such user found
+  Oct 24 09:31:08 devXXX proftpd[39209]: [authpriv.info]: 0.0.0.0 (54.86.105.198[54.86.105.198]) - USER 24-0-proc: Login successful.
+  Oct 24 09:29:57 devXXX proftpd[1150]: [authpriv.notice]: 0.0.0.0 (181.49.117.130[181.49.117.130]) - USER root (Login failed): Incorrect password
+  Oct 22 23:23:34 devXXX proftpd[13512]: [authpriv.notice]: 0.0.0.0 (211.177.150.14[211.177.150.14]) - Maximum login attempts (6) exceeded, connection refused
   -->
+
 <decoder name="proftpd">
   <program_name>^proftpd</program_name>
 </decoder>

--- a/ruleset/decoders/0230-proftpd_decoders.xml
+++ b/ruleset/decoders/0230-proftpd_decoders.xml
@@ -25,17 +25,17 @@
 
 <decoder name="proftpd-success">
   <parent>proftpd</parent>
-  <prematch>: Login successful</prematch>
   <regex>^\S+ \(\S+[(\S+)]\)\s*\S \w+ (\S+): </regex>
   <regex>Login successful</regex>
+  <prematch>: Login successful</prematch>
   <order>srcip, user</order>
   <fts>name, user, srcip, location</fts>
 </decoder>
 
 <decoder name="proftpd-login failed">
   <parent>proftpd</parent>
-  <prematch>Login failed</prematch>
   <regex>^[\.+]: \S+ \(\S+[(\S+)]\) \w+ USER (\S*)</regex>
+  <prematch>Login failed</prematch>
   <order>srcip, user</order>
 </decoder>
 

--- a/ruleset/decoders/0230-proftpd_decoders.xml
+++ b/ruleset/decoders/0230-proftpd_decoders.xml
@@ -1,22 +1,26 @@
 <!--
+  Copyright (C) 2015-2021, Wazuh Inc.
+-->
+
+<!--
   ProFTPD decoders
 -->
 
 <!--
   Will extract the username/srcip
   Examples:
-  proftpd[26916]: hayaletgemi (85.101.218.135[85.101.218.135]) - ANON anonymous: Login successful.
-  proftpd[12564]: juf01 (pD9EE35B1.dip.t-dialin.net[217.238.53.177]) - USER jufu: Login successful
-  proftpd[30362] xx.yy.zz (aa.bb.cc[aa.bb.vv.dd]): USER backup: Login successful.
-  proftpd[2344]: refused connect from 192.168.1.2 (192.168.1.2)
-  proftpd[15181]: valhalla (crawl-66-249-66-80.googlebot.com[66.249.66.80]) - Connection from crawl-66-249-66-80.googlebot.com [66.249.66.80] denied.
-  proftpd[26169] server.example.net: Fatal: unable to open incoming connection: Der Socket ist nicht verbunden
+    proftpd[26916]: hayaletgemi (85.101.218.135[85.101.218.135]) - ANON anonymous: Login successful.
+    proftpd[12564]: juf01 (pD9EE35B1.dip.t-dialin.net[217.238.53.177]) - USER jufu: Login successful
+    proftpd[30362] xx.yy.zz (aa.bb.cc[aa.bb.vv.dd]): USER backup: Login successful.
+    proftpd[2344]: refused connect from 192.168.1.2 (192.168.1.2)
+    proftpd[15181]: valhalla (crawl-66-249-66-80.googlebot.com[66.249.66.80]) - Connection from crawl-66-249-66-80.googlebot.com [66.249.66.80] denied.
+    proftpd[26169] server.example.net: Fatal: unable to open incoming connection: Der Socket ist nicht verbunden
 
-  More different logs examples:
-  Oct 24 09:30:30 devXXX proftpd[119259]: [authpriv.notice]: 0.0.0.0 (54.86.105.198[54.86.105.198]) - USER 24-0-proc (Login failed): No such user found
-  Oct 24 09:31:08 devXXX proftpd[39209]: [authpriv.info]: 0.0.0.0 (54.86.105.198[54.86.105.198]) - USER 24-0-proc: Login successful.
-  Oct 24 09:29:57 devXXX proftpd[1150]: [authpriv.notice]: 0.0.0.0 (181.49.117.130[181.49.117.130]) - USER root (Login failed): Incorrect password
-  Oct 22 23:23:34 devXXX proftpd[13512]: [authpriv.notice]: 0.0.0.0 (211.177.150.14[211.177.150.14]) - Maximum login attempts (6) exceeded, connection refused
+    More different logs examples:
+    Oct 24 09:30:30 devXXX proftpd[119259]: [authpriv.notice]: 0.0.0.0 (54.86.105.198[54.86.105.198]) - USER 24-0-proc (Login failed): No such user found
+    Oct 24 09:31:08 devXXX proftpd[39209]: [authpriv.info]: 0.0.0.0 (54.86.105.198[54.86.105.198]) - USER 24-0-proc: Login successful.
+    Oct 24 09:29:57 devXXX proftpd[1150]: [authpriv.notice]: 0.0.0.0 (181.49.117.130[181.49.117.130]) - USER root (Login failed): Incorrect password
+    Oct 22 23:23:34 devXXX proftpd[13512]: [authpriv.notice]: 0.0.0.0 (211.177.150.14[211.177.150.14]) - Maximum login attempts (6) exceeded, connection refused
   -->
 
 <decoder name="proftpd">
@@ -25,17 +29,17 @@
 
 <decoder name="proftpd-success">
   <parent>proftpd</parent>
+  <prematch>: Login successful</prematch>
   <regex>^\S+ \(\S+[(\S+)]\)\s*\S \w+ (\S+): </regex>
   <regex>Login successful</regex>
-  <prematch>: Login successful</prematch>
   <order>srcip, user</order>
   <fts>name, user, srcip, location</fts>
 </decoder>
 
 <decoder name="proftpd-login failed">
   <parent>proftpd</parent>
-  <regex>^[\.+]: \S+ \(\S+[(\S+)]\) \w+ USER (\S*)</regex>
   <prematch>Login failed</prematch>
+  <regex>^[\.+]: \S+ \(\S+[(\S+)]\) \w+ USER (\S*)</regex>
   <order>srcip, user</order>
 </decoder>
 

--- a/ruleset/rules/0175-proftpd_rules.xml
+++ b/ruleset/rules/0175-proftpd_rules.xml
@@ -15,34 +15,34 @@
   <rule id="11201" level="3">
     <if_sid>11200</if_sid>
     <match>FTP session opened.$</match>
-    <description>Proftpd: FTP session opened.</description>
+    <description>ProFTPD: FTP session opened.</description>
     <group>connection_attempt,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,pci_dss_10.2.5,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="11202" level="0">
     <if_sid>11200</if_sid>
     <match>FTP session closed.$</match>
-    <description>Proftpd: FTP session closed.</description>
+    <description>ProFTPD: FTP session closed.</description>
   </rule>
 
   <rule id="11203" level="5">
     <if_sid>11200</if_sid>
     <match> no such user </match>
-    <description>Proftpd: Attempt to login using a non-existent user.</description>
+    <description>ProFTPD: Attempt to login using a non-existent user.</description>
     <group>gdpr_IV_32.2,gdpr_IV_35.7.d,gpg13_7.1,hipaa_164.312.b,invalid_login,nist_800_53_AC.7,nist_800_53_AU.14,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="11204" level="5">
     <if_sid>11200</if_sid>
     <match>Incorrect password.$|Login failed</match>
-    <description>Proftpd: Login failed accessing the FTP server.</description>
+    <description>ProFTPD: Login failed accessing the FTP server.</description>
     <group>authentication_failed,gdpr_IV_32.2,gdpr_IV_35.7.d,gpg13_7.1,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="11205" level="3">
     <if_sid>11200</if_sid>
     <match>Login successful</match>
-    <description>Proftpd: FTP Authentication success.</description>
+    <description>ProFTPD: FTP Authentication success.</description>
     <mitre>
       <id>T1078</id>
     </mitre>
@@ -52,14 +52,14 @@
   <rule id="11206" level="5">
     <if_sid>11200</if_sid>
     <regex>Connection from \S+ [\S+] denied</regex>
-    <description>Proftpd: Connection denied by ProFTPD configuration.</description>
+    <description>ProFTPD: Connection denied by ProFTPD configuration.</description>
     <group>access_denied,gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="11207" level="5">
     <if_sid>11200</if_sid>
     <match>refused connect from</match>
-    <description>Proftpd: Connection refused by TCP Wrappers.</description>
+    <description>ProFTPD: Connection refused by TCP Wrappers.</description>
     <mitre>
       <id>T1095</id>
     </mitre>
@@ -69,15 +69,15 @@
   <rule id="11208" level="4">
     <if_sid>11200</if_sid>
     <match>unable to find open port in PassivePorts range</match>
-    <description>Proftpd: Small PassivePorts range in config file. Server misconfiguration.</description>
+    <description>ProFTPD: Small PassivePorts range in config file. Server misconfiguration.</description>
   </rule>
 
   <rule id="11209" level="14">
     <if_sid>11200</if_sid>
     <match>Refused PORT </match>
-    <description>Proftpd: Attempt to bypass firewall that can't adequately keep state of FTP traffic.</description>
     <info type="link">http://www.kb.cert.org/vuls/id/328867</info>
     <info type="text">US-Cert Note VU#328867: Multiple vendors' firewalls do not adequately keep state of FTP traffic</info>
+    <description>ProFTPD: Attempt to bypass firewall that can't adequately keep state of FTP traffic.</description>
     <mitre>
       <id>T1071</id>
     </mitre>
@@ -87,7 +87,7 @@
   <rule id="11210" level="10">
     <if_sid>11200</if_sid>
     <match>Maximum login attempts </match>
-    <description>Proftpd: Multiple failed login attempts.</description>
+    <description>ProFTPD: Multiple failed login attempts.</description>
     <mitre>
       <id>T1110</id>
     </mitre>
@@ -97,53 +97,53 @@
   <rule id="11211" level="4">
     <if_sid>11200</if_sid>
     <match>host name/name mismatch|host name/address mismatch</match>
-    <description>Proftpd: Mismatch in server's hostname.</description>
+    <description>ProFTPD: Mismatch in server's hostname.</description>
   </rule>
 
   <rule id="11212" level="5">
     <if_sid>11200</if_sid>
     <match>warning: can't verify hostname: </match>
-    <description>Proftpd: Reverse lookup error (bad ISP config).</description>
+    <description>ProFTPD: Reverse lookup error (bad ISP config).</description>
   </rule>
 
   <rule id="11213" level="3">
     <if_sid>11200</if_sid>
     <match>connect from </match>
-    <description>Proftpd: Remote host connected to FTP server.</description>
+    <description>ProFTPD: Remote host connected to FTP server.</description>
     <group>connection_attempt,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,pci_dss_10.6.1,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="11214" level="3">
     <if_sid>11200</if_sid>
     <match>FTP no transfer timeout, disconnected</match>
-    <description>Proftpd: Remote host disconnected due to inactivity.</description>
+    <description>ProFTPD: Remote host disconnected due to inactivity.</description>
     <group>gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_AC.2,pci_dss_8.1.5,tsc_CC6.1,</group>
   </rule>
 
   <rule id="11215" level="3">
     <if_sid>11200</if_sid>
     <match>FTP login timed out, disconnected</match>
-    <description>Proftpd: Remote host disconnected due to login time out.</description>
+    <description>ProFTPD: Remote host disconnected due to login time out.</description>
     <group>gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_AC.2,pci_dss_8.1.5,tsc_CC6.1,</group>
   </rule>
 
   <rule id="11216" level="3">
     <if_sid>11200</if_sid>
     <match>FTP session idle timeout, disconnected</match>
-    <description>Proftpd: Remote host disconnected due to time out.</description>
+    <description>ProFTPD: Remote host disconnected due to time out.</description>
     <group>gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_AC.2,pci_dss_8.1.5,tsc_CC6.1,</group>
   </rule>
 
   <rule id="11217" level="3">
     <if_sid>11200</if_sid>
     <match>Data transfer stall timeout:</match>
-    <description>Proftpd: Data transfer stalled.</description>
+    <description>ProFTPD: Data transfer stalled.</description>
   </rule>
 
   <rule id="11218" level="12">
     <if_sid>11200</if_sid>
     <match>ProFTPD terminating (signal 11)</match>
-    <description>Proftpd: FTP process crashed.</description>
+    <description>ProFTPD: FTP process crashed.</description>
     <mitre>
       <id>T1210</id>
     </mitre>
@@ -153,7 +153,7 @@
   <rule id="11219" level="12">
     <if_sid>11200</if_sid>
     <match>Reallocating sreaddir buffer</match>
-    <description>Proftpd: FTP server Buffer overflow attempt.</description>
+    <description>ProFTPD: FTP server Buffer overflow attempt.</description>
     <mitre>
       <id>T1499</id>
     </mitre>
@@ -163,7 +163,7 @@
   <rule id="11220" level="4">
     <if_sid>11200</if_sid>
     <match>listen() failed in</match>
-    <description>Proftpd: Unable to bind to adress.</description>
+    <description>ProFTPD: Unable to bind to adress.</description>
   </rule>
 
   <rule id="11221" level="0">
@@ -171,19 +171,19 @@
     <match>error setting IPV6_V6ONLY: Protocol not available|</match>
     <match> - mod_delay/|PAM(setcred): System error|</match>
     <match>PAM(close_session): System error|cap_set_proc failed|reverting to normal operation|error retrieving information about user</match>
-    <description>Proftpd: IPv6 error and mod-delay info (ignored).</description>
+    <description>ProFTPD: IPv6 error and mod-delay info (ignored).</description>
   </rule>
 
   <rule id="11222" level="4">
     <if_sid>11200</if_sid>
     <match>unable to open incoming connection</match>
-    <description>Proftpd: Couldn't open the incoming connection. Check log message for reason.</description>
+    <description>ProFTPD: Couldn't open the incoming connection. Check log message for reason.</description>
   </rule>
 
   <rule id="11251" level="10" frequency="8" timeframe="120">
     <if_matched_sid>11204</if_matched_sid>
     <same_source_ip />
-    <description>Proftpd: FTP brute force (multiple failed logins).</description>
+    <description>ProFTPD: FTP brute force (multiple failed logins).</description>
     <mitre>
       <id>T1110</id>
     </mitre>
@@ -193,7 +193,7 @@
   <rule id="11252" level="10" frequency="12" timeframe="60">
     <if_matched_sid>11201</if_matched_sid>
     <same_source_ip />
-    <description>Proftpd: Multiple connection attempts from same source.</description>
+    <description>ProFTPD: Multiple connection attempts from same source.</description>
     <mitre>
       <id>T1110</id>
     </mitre>
@@ -203,7 +203,7 @@
   <rule id="11253" level="10" frequency="12" timeframe="120">
     <if_matched_sid>11215</if_matched_sid>
     <same_source_ip />
-    <description>Proftpd: Multiple timed out logins from same source.</description>
+    <description>ProFTPD: Multiple timed out logins from same source.</description>
     <mitre>
       <id>T1110</id>
     </mitre>

--- a/ruleset/rules/0175-proftpd_rules.xml
+++ b/ruleset/rules/0175-proftpd_rules.xml
@@ -1,10 +1,9 @@
 <!--
-  -  Proftpd rules
-  -  Author: Daniel Cid.
-  -  Updated by Wazuh, Inc.
-  -  Copyright (C) 2015-2021, Wazuh Inc.
-  -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  Copyright (C) 2015-2021, Wazuh Inc.
+-->
+
+<!-- 
+  Proftpd rules ID:           11200 - 11300
 -->
 
 <group name="syslog,proftpd,">
@@ -17,7 +16,7 @@
     <if_sid>11200</if_sid>
     <match>FTP session opened.$</match>
     <description>proftpd: FTP session opened.</description>
-    <group>connection_attempt,pci_dss_10.2.5,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>connection_attempt,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,pci_dss_10.2.5,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="11202" level="0">
@@ -30,14 +29,14 @@
     <if_sid>11200</if_sid>
     <match> no such user </match>
     <description>proftpd: Attempt to login using a non-existent user.</description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_32.2,gdpr_IV_35.7.d,gpg13_7.1,hipaa_164.312.b,invalid_login,nist_800_53_AC.7,nist_800_53_AU.14,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="11204" level="5">
     <if_sid>11200</if_sid>
     <match>Incorrect password.$|Login failed</match>
-    <description>proftpd: Login failed accessing the FTP server</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <description>proftpd: Login failed accessing the FTP server.</description>
+    <group>authentication_failed,gdpr_IV_32.2,gdpr_IV_35.7.d,gpg13_7.1,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="11205" level="3">
@@ -47,14 +46,14 @@
     <mitre>
       <id>T1078</id>
     </mitre>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_success,gdpr_IV_32.2,gpg13_7.1,gpg13_7.2,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,pci_dss_10.2.5,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="11206" level="5">
     <if_sid>11200</if_sid>
     <regex>Connection from \S+ [\S+] denied</regex>
     <description>proftpd: Connection denied by ProFTPD configuration.</description>
-    <group>access_denied,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>access_denied,gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="11207" level="5">
@@ -64,27 +63,25 @@
     <mitre>
       <id>T1095</id>
     </mitre>
-    <group>access_denied,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>access_denied,gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="11208" level="4">
     <if_sid>11200</if_sid>
     <match>unable to find open port in PassivePorts range</match>
-    <description>proftpd: Small PassivePorts range in config file. </description>
-    <description>Server misconfiguration.</description>
+    <description>proftpd: Small PassivePorts range in config file. Server misconfiguration.</description>
   </rule>
 
   <rule id="11209" level="14">
     <if_sid>11200</if_sid>
     <match>Refused PORT </match>
-    <description>proftpd: Attempt to bypass firewall that can't adequately</description>
-    <description> keep state of FTP traffic.</description>
+    <description>proftpd: Attempt to bypass firewall that can't adequately keep state of FTP traffic.</description>
     <info type="link">http://www.kb.cert.org/vuls/id/328867</info>
     <info type="text">US-Cert Note VU#328867: Multiple vendors' firewalls do not adequately keep state of FTP traffic</info>
     <mitre>
       <id>T1071</id>
     </mitre>
-    <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SI.4,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,</group>
+    <group>gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SI.4,pci_dss_10.6.1,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="11210" level="10">
@@ -94,7 +91,7 @@
     <mitre>
       <id>T1110</id>
     </mitre>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_failures,gdpr_IV_32.2,gdpr_IV_35.7.d,gpg13_7.1,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,nist_800_53_SI.4,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="11211" level="4">
@@ -113,28 +110,28 @@
     <if_sid>11200</if_sid>
     <match>connect from </match>
     <description>proftpd: Remote host connected to FTP server.</description>
-    <group>connection_attempt,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>connection_attempt,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,pci_dss_10.6.1,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="11214" level="3">
     <if_sid>11200</if_sid>
     <match>FTP no transfer timeout, disconnected</match>
     <description>proftpd: Remote host disconnected due to inactivity.</description>
-    <group>pci_dss_8.1.5,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_AC.2,tsc_CC6.1,</group>
+    <group>gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_AC.2,pci_dss_8.1.5,tsc_CC6.1,</group>
   </rule>
 
   <rule id="11215" level="3">
     <if_sid>11200</if_sid>
     <match>FTP login timed out, disconnected</match>
     <description>proftpd: Remote host disconnected due to login time out.</description>
-    <group>pci_dss_8.1.5,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_AC.2,tsc_CC6.1,</group>
+    <group>gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_AC.2,pci_dss_8.1.5,tsc_CC6.1,</group>
   </rule>
 
   <rule id="11216" level="3">
     <if_sid>11200</if_sid>
     <match>FTP session idle timeout, disconnected</match>
     <description>proftpd: Remote host disconnected due to time out.</description>
-    <group>pci_dss_8.1.5,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_AC.2,tsc_CC6.1,</group>
+    <group>gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_AC.2,pci_dss_8.1.5,tsc_CC6.1,</group>
   </rule>
 
   <rule id="11217" level="3">
@@ -150,7 +147,7 @@
     <mitre>
       <id>T1210</id>
     </mitre>
-    <group>service_availability,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,pci_dss_10.6.1,service_availability,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="11219" level="12">
@@ -160,7 +157,7 @@
     <mitre>
       <id>T1499</id>
     </mitre>
-    <group>pci_dss_6.5.2,pci_dss_11.4,pci_dss_6.2,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SI.4,nist_800_53_SI.2,tsc_CC6.6,tsc_CC7.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SI.2,nist_800_53_SI.4,pci_dss_11.4,pci_dss_6.2,pci_dss_6.5.2,tsc_CC6.1,tsc_CC6.6,tsc_CC6.8,tsc_CC7.1,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="11220" level="4">
@@ -180,8 +177,7 @@
   <rule id="11222" level="4">
     <if_sid>11200</if_sid>
     <match>unable to open incoming connection</match>
-    <description>proftpd: Couldn't open the incoming connection. </description>
-    <description>Check log message for reason.</description>
+    <description>proftpd: Couldn't open the incoming connection. Check log message for reason.</description>
   </rule>
 
   <rule id="11251" level="10" frequency="8" timeframe="120">
@@ -191,7 +187,7 @@
     <mitre>
       <id>T1110</id>
     </mitre>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_failures,gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,nist_800_53_SI.4,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="11252" level="10" frequency="12" timeframe="60">
@@ -201,7 +197,7 @@
     <mitre>
       <id>T1110</id>
     </mitre>
-    <group>recon,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,nist_800_53_SI.4,pci_dss_11.4,recon,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="11253" level="10" frequency="12" timeframe="120">
@@ -211,7 +207,7 @@
     <mitre>
       <id>T1110</id>
     </mitre>
-    <group>pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,pci_dss_10.6.1,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
 </group>

--- a/ruleset/rules/0175-proftpd_rules.xml
+++ b/ruleset/rules/0175-proftpd_rules.xml
@@ -3,7 +3,7 @@
 -->
 
 <!-- 
-  Proftpd rules ID:           11200 - 11300
+  ProFTPD rules ID:           11200 - 11300
 -->
 
 <group name="syslog,proftpd,">

--- a/ruleset/rules/0175-proftpd_rules.xml
+++ b/ruleset/rules/0175-proftpd_rules.xml
@@ -15,34 +15,34 @@
   <rule id="11201" level="3">
     <if_sid>11200</if_sid>
     <match>FTP session opened.$</match>
-    <description>proftpd: FTP session opened.</description>
+    <description>Proftpd: FTP session opened.</description>
     <group>connection_attempt,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,pci_dss_10.2.5,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="11202" level="0">
     <if_sid>11200</if_sid>
     <match>FTP session closed.$</match>
-    <description>proftpd: FTP session closed.</description>
+    <description>Proftpd: FTP session closed.</description>
   </rule>
 
   <rule id="11203" level="5">
     <if_sid>11200</if_sid>
     <match> no such user </match>
-    <description>proftpd: Attempt to login using a non-existent user.</description>
+    <description>Proftpd: Attempt to login using a non-existent user.</description>
     <group>gdpr_IV_32.2,gdpr_IV_35.7.d,gpg13_7.1,hipaa_164.312.b,invalid_login,nist_800_53_AC.7,nist_800_53_AU.14,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="11204" level="5">
     <if_sid>11200</if_sid>
     <match>Incorrect password.$|Login failed</match>
-    <description>proftpd: Login failed accessing the FTP server.</description>
+    <description>Proftpd: Login failed accessing the FTP server.</description>
     <group>authentication_failed,gdpr_IV_32.2,gdpr_IV_35.7.d,gpg13_7.1,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="11205" level="3">
     <if_sid>11200</if_sid>
     <match>Login successful</match>
-    <description>proftpd: FTP Authentication success.</description>
+    <description>Proftpd: FTP Authentication success.</description>
     <mitre>
       <id>T1078</id>
     </mitre>
@@ -52,14 +52,14 @@
   <rule id="11206" level="5">
     <if_sid>11200</if_sid>
     <regex>Connection from \S+ [\S+] denied</regex>
-    <description>proftpd: Connection denied by ProFTPD configuration.</description>
+    <description>Proftpd: Connection denied by ProFTPD configuration.</description>
     <group>access_denied,gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="11207" level="5">
     <if_sid>11200</if_sid>
     <match>refused connect from</match>
-    <description>proftpd: Connection refused by TCP Wrappers.</description>
+    <description>Proftpd: Connection refused by TCP Wrappers.</description>
     <mitre>
       <id>T1095</id>
     </mitre>
@@ -69,13 +69,13 @@
   <rule id="11208" level="4">
     <if_sid>11200</if_sid>
     <match>unable to find open port in PassivePorts range</match>
-    <description>proftpd: Small PassivePorts range in config file. Server misconfiguration.</description>
+    <description>Proftpd: Small PassivePorts range in config file. Server misconfiguration.</description>
   </rule>
 
   <rule id="11209" level="14">
     <if_sid>11200</if_sid>
     <match>Refused PORT </match>
-    <description>proftpd: Attempt to bypass firewall that can't adequately keep state of FTP traffic.</description>
+    <description>Proftpd: Attempt to bypass firewall that can't adequately keep state of FTP traffic.</description>
     <info type="link">http://www.kb.cert.org/vuls/id/328867</info>
     <info type="text">US-Cert Note VU#328867: Multiple vendors' firewalls do not adequately keep state of FTP traffic</info>
     <mitre>
@@ -87,7 +87,7 @@
   <rule id="11210" level="10">
     <if_sid>11200</if_sid>
     <match>Maximum login attempts </match>
-    <description>proftpd: Multiple failed login attempts.</description>
+    <description>Proftpd: Multiple failed login attempts.</description>
     <mitre>
       <id>T1110</id>
     </mitre>
@@ -97,53 +97,53 @@
   <rule id="11211" level="4">
     <if_sid>11200</if_sid>
     <match>host name/name mismatch|host name/address mismatch</match>
-    <description>proftpd: Mismatch in server's hostname.</description>
+    <description>Proftpd: Mismatch in server's hostname.</description>
   </rule>
 
   <rule id="11212" level="5">
     <if_sid>11200</if_sid>
     <match>warning: can't verify hostname: </match>
-    <description>proftpd: Reverse lookup error (bad ISP config).</description>
+    <description>Proftpd: Reverse lookup error (bad ISP config).</description>
   </rule>
 
   <rule id="11213" level="3">
     <if_sid>11200</if_sid>
     <match>connect from </match>
-    <description>proftpd: Remote host connected to FTP server.</description>
+    <description>Proftpd: Remote host connected to FTP server.</description>
     <group>connection_attempt,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,pci_dss_10.6.1,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="11214" level="3">
     <if_sid>11200</if_sid>
     <match>FTP no transfer timeout, disconnected</match>
-    <description>proftpd: Remote host disconnected due to inactivity.</description>
+    <description>Proftpd: Remote host disconnected due to inactivity.</description>
     <group>gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_AC.2,pci_dss_8.1.5,tsc_CC6.1,</group>
   </rule>
 
   <rule id="11215" level="3">
     <if_sid>11200</if_sid>
     <match>FTP login timed out, disconnected</match>
-    <description>proftpd: Remote host disconnected due to login time out.</description>
+    <description>Proftpd: Remote host disconnected due to login time out.</description>
     <group>gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_AC.2,pci_dss_8.1.5,tsc_CC6.1,</group>
   </rule>
 
   <rule id="11216" level="3">
     <if_sid>11200</if_sid>
     <match>FTP session idle timeout, disconnected</match>
-    <description>proftpd: Remote host disconnected due to time out.</description>
+    <description>Proftpd: Remote host disconnected due to time out.</description>
     <group>gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_AC.2,pci_dss_8.1.5,tsc_CC6.1,</group>
   </rule>
 
   <rule id="11217" level="3">
     <if_sid>11200</if_sid>
     <match>Data transfer stall timeout:</match>
-    <description>proftpd: Data transfer stalled.</description>
+    <description>Proftpd: Data transfer stalled.</description>
   </rule>
 
   <rule id="11218" level="12">
     <if_sid>11200</if_sid>
     <match>ProFTPD terminating (signal 11)</match>
-    <description>proftpd: FTP process crashed.</description>
+    <description>Proftpd: FTP process crashed.</description>
     <mitre>
       <id>T1210</id>
     </mitre>
@@ -153,7 +153,7 @@
   <rule id="11219" level="12">
     <if_sid>11200</if_sid>
     <match>Reallocating sreaddir buffer</match>
-    <description>proftpd: FTP server Buffer overflow attempt.</description>
+    <description>Proftpd: FTP server Buffer overflow attempt.</description>
     <mitre>
       <id>T1499</id>
     </mitre>
@@ -163,7 +163,7 @@
   <rule id="11220" level="4">
     <if_sid>11200</if_sid>
     <match>listen() failed in</match>
-    <description>proftpd: Unable to bind to adress.</description>
+    <description>Proftpd: Unable to bind to adress.</description>
   </rule>
 
   <rule id="11221" level="0">
@@ -171,19 +171,19 @@
     <match>error setting IPV6_V6ONLY: Protocol not available|</match>
     <match> - mod_delay/|PAM(setcred): System error|</match>
     <match>PAM(close_session): System error|cap_set_proc failed|reverting to normal operation|error retrieving information about user</match>
-    <description>proftpd: IPv6 error and mod-delay info (ignored).</description>
+    <description>Proftpd: IPv6 error and mod-delay info (ignored).</description>
   </rule>
 
   <rule id="11222" level="4">
     <if_sid>11200</if_sid>
     <match>unable to open incoming connection</match>
-    <description>proftpd: Couldn't open the incoming connection. Check log message for reason.</description>
+    <description>Proftpd: Couldn't open the incoming connection. Check log message for reason.</description>
   </rule>
 
   <rule id="11251" level="10" frequency="8" timeframe="120">
     <if_matched_sid>11204</if_matched_sid>
     <same_source_ip />
-    <description>proftpd: FTP brute force (multiple failed logins).</description>
+    <description>Proftpd: FTP brute force (multiple failed logins).</description>
     <mitre>
       <id>T1110</id>
     </mitre>
@@ -193,7 +193,7 @@
   <rule id="11252" level="10" frequency="12" timeframe="60">
     <if_matched_sid>11201</if_matched_sid>
     <same_source_ip />
-    <description>proftpd: Multiple connection attempts from same source.</description>
+    <description>Proftpd: Multiple connection attempts from same source.</description>
     <mitre>
       <id>T1110</id>
     </mitre>
@@ -203,7 +203,7 @@
   <rule id="11253" level="10" frequency="12" timeframe="120">
     <if_matched_sid>11215</if_matched_sid>
     <same_source_ip />
-    <description>proftpd: Multiple timed out logins from same source.</description>
+    <description>Proftpd: Multiple timed out logins from same source.</description>
     <mitre>
       <id>T1110</id>
     </mitre>

--- a/ruleset/testing/tests/proftpd.ini
+++ b/ruleset/testing/tests/proftpd.ini
@@ -6,13 +6,13 @@
 ;  Sample logs source: 
 ;    Proftpd Logs
 
-[unable to open incoming connection (reason may vary)]
+[Unable to open incoming connection (reason may vary).]
 log 1 pass = Jan 04 22:51:57 server proftpd[26169] server.example.net: Fatal: unable to open incoming connection: Der Socket ist nicht verbunden
 rule = 11222
 alert = 4
 decoder = proftpd
 
-[FTP Authentication success]
+[FTP Authentication success.]
 log 1 pass = Jan 04 22:51:57 hayaletgemi proftpd[26916]: hayaletgemi (85.101.218.135[85.101.218.135]) - ANON anonymous: Login successful.
 log 2 pass = Jan 04 22:51:57 juf01 proftpd[12564]: juf01 (pD9EE35B1.dip.t-dialin.net[217.238.53.177]) - USER jufu: Login successful
 log 3 pass = Jan 04 22:51:57 xx.yy.zz proftpd[30362] xx.yy.zz (aa.bb.cc[aa.bb.vv.dd]): USER backup: Login successful.
@@ -20,19 +20,19 @@ rule = 11205
 alert = 3
 decoder = proftpd
 
-[Connection refused by TCP Wrappers]
+[Connection refused by TCP Wrappers.]
 log 1 pass = Jan 04 22:51:57 server proftpd[2344]: refused connect from 192.168.1.2 (192.168.1.2)
 rule = 11207
 alert = 5
 decoder = proftpd
 
-[Connection denied by ProFTPD configuration]
+[Connection denied by ProFTPD configuration.]
 log 1 pass = Jan 04 22:51:57 valhalla proftpd[15181]: valhalla (crawl-66-249-66-80.googlebot.com[66.249.66.80]) - Connection from crawl-66-249-66-80.googlebot.com [66.249.66.80] denied.
 rule = 11206
 alert = 5
 decoder = proftpd
 
-[Login failed accessing the FTP server]
+[Login failed accessing the FTP server.]
 log 1 pass = 2015-04-16 21:51:02,805 zuse proftpd[26189] zuse.domain.com (182.100.67.115[182.100.67.115]): USER root (Login failed): Incorrect password
 rule = 11204
 alert = 5

--- a/ruleset/testing/tests/proftpd.ini
+++ b/ruleset/testing/tests/proftpd.ini
@@ -1,3 +1,11 @@
+;  Copyright (C) 2015-2021, Wazuh Inc.
+;
+;  Tests for products: 
+;    Proftpd 
+;
+;  Sample logs source: 
+;    Proftpd Logs
+
 [unable to open incoming connection (reason may vary)]
 log 1 pass = Jan 04 22:51:57 server proftpd[26169] server.example.net: Fatal: unable to open incoming connection: Der Socket ist nicht verbunden
 rule = 11222

--- a/ruleset/testing/tests/proftpd.ini
+++ b/ruleset/testing/tests/proftpd.ini
@@ -1,10 +1,10 @@
 ;  Copyright (C) 2015-2021, Wazuh Inc.
 ;
 ;  Tests for products: 
-;    Proftpd 
+;    ProFTPD 
 ;
 ;  Sample logs source: 
-;    Proftpd Logs
+;    ProFTPD Logs
 
 [Unable to open incoming connection (reason may vary).]
 log 1 pass = Jan 04 22:51:57 server proftpd[26169] server.example.net: Fatal: unable to open incoming connection: Der Socket ist nicht verbunden

--- a/ruleset/testing/tests/proftpd.ini
+++ b/ruleset/testing/tests/proftpd.ini
@@ -37,4 +37,3 @@ log 1 pass = 2015-04-16 21:51:02,805 zuse proftpd[26189] zuse.domain.com (182.10
 rule = 11204
 alert = 5
 decoder = proftpd
-


### PR DESCRIPTION
## Description
|Related PR|Related PR|Closes Issue|
|---|---|---|
| [#9018](https://github.com/wazuh/wazuh/pull/9018) | [#512](https://github.com/wazuh/wazuh-ruleset/pull/512)   |[#11229 ](https://github.com/wazuh/wazuh/issues/11229)|

## Changes & Comments
The aim of this PR is:

Add copyright headers
Fix tag ordering and alphabetical order in group tag
To ensure the rules and decoders from issue [#9018](https://github.com/wazuh/wazuh/pull/9018) work correctly.
To fix issues regarding indentation, syntax, rule granularity, spellings and ensure the ruleset quality is standard

### Ruleset

## Checks 

### Syntax

- [x] 1.a Rule tags order must be compliant.
- [x] 1.b Decoder tags order must be compliant.
- [x] 1.c XML blocks must as compact as possible.
- [x] 1.d Only one empty line between rule/decoder and the next rule/decoder.
- [x] 1.e Decoder extracted fields names must use '_' whether a space is needed.
- [x] 1.f Decoder name must use '-' whether a space is needed.
- [x] 2.d XML and ini files must use correct indentation
 
### Grammar

- [x] 2.a Grammar quality.
- [x] 2.b Similar phrases must keep tenses and expressions.
- [x] 2.c Grammar basic rules like capitalization, punctuation marks, sentence construction, and others.


### Semantic

- [x] 3.a New decoder, rule, or test are written in the correct file and grouped correctly inside the file.
- [x] 3.b Group similar rules under same ID's group.
- [x] 3.c: 
   - [x] 3.c1 Find and reuse group name before creating a new one.
   - [x] 3.c2 Include a new group definition in a PR comment.
   - [x] 3.c3 Any group name must use '_' whether it does need a space char.
   - [x] 3.c4 The groups inside a tag must be sorted in alphabetical order.
   - [x] 3.d Rule level should be compliant with the [documentation](https://documentation.wazuh.com/current/user-manual/ruleset/rules-classification.html).

### Unit testing

- [x] 4.a A metadata block at the beginning of the .ini file describing software, version, and logs source.
- [x] 4.b Each new rule must have at least one test entry in the correct .ini file.
- [x] 4.c Runtest.py must pass and must include the results in raw format here.
<details>
  <statement>Unit Tests</statement>

  ```
Restarting wazuh-manager...
- [ File = ./tests/samba.ini ] ---------
....

- [ File = ./tests/fortigate.ini ] ---------
........................................

- [ File = ./tests/apparmor.ini ] ---------
.....

- [ File = ./tests/pam.ini ] ---------
.....

- [ File = ./tests/audit_lateral.ini ] ---------
......

- [ File = ./tests/systemd.ini ] ---------
..

- [ File = ./tests/arbor.ini ] ---------
..

- [ File = ./tests/dovecot.ini ] ---------
...............

- [ File = ./tests/mailscanner.ini ] ---------
.

- [ File = ./tests/ossec.ini ] ---------
.....

- [ File = ./tests/vuln_detector.ini ] ---------
..

- [ File = ./tests/squid_rules.ini ] ---------
..

- [ File = ./tests/pix.ini ] ---------
......................

- [ File = ./tests/huawei_usg.ini ] ---------
...

- [ File = ./tests/checkpoint_smart1.ini ] ---------
..................

- [ File = ./tests/junos.ini ] ---------
...

- [ File = ./tests/web_appsec.ini ] ---------
...............................

- [ File = ./tests/cimserver.ini ] ---------
..

- [ File = ./tests/cisco_ftd.ini ] ---------
..........................................

- [ File = ./tests/firewalld.ini ] ---------
..

- [ File = ./tests/audit_recon.ini ] ---------
..

- [ File = ./tests/openldap.ini ] ---------
.........

- [ File = ./tests/sophos_fw.ini ] ---------
..........

- [ File = ./tests/owlh.ini ] ---------
....

- [ File = ./tests/freepbx.ini ] ---------
......

- [ File = ./tests/syslog.ini ] ---------
......

- [ File = ./tests/openvpn_ldap.ini ] ---------
..

- [ File = ./tests/sophos.ini ] ---------
........

- [ File = ./tests/unbound.ini ] ---------


- [ File = ./tests/github.ini ] ---------
....................................................................................................................................................................................................................................................................................................................................

- [ File = ./tests/cpanel.ini ] ---------
.......

- [ File = ./tests/fireeye.ini ] ---------
...

- [ File = ./tests/fortiauth.ini ] ---------
....

- [ File = ./tests/iptables.ini ] ---------
........

- [ File = ./tests/named.ini ] ---------
.....

- [ File = ./tests/sophos-utm-firewall.ini ] ---------
......

- [ File = ./tests/nginx.ini ] ---------
............

- [ File = ./tests/exim.ini ] ---------
.......

- [ File = ./tests/opensmtpd.ini ] ---------
.......

- [ File = ./tests/oscap.ini ] ---------
................................

- [ File = ./tests/gitlab.ini ] ---------
.........................

- [ File = ./tests/paloalto.ini ] ---------
................

- [ File = ./tests/api.ini ] ---------
............................

- [ File = ./tests/aws_s3_access.ini ] ---------
.......

- [ File = ./tests/exchange.ini ] ---------
..

- [ File = ./tests/f5_big_ip.ini ] ---------
...........................................

- [ File = ./tests/cisco_asa.ini ] ---------
........................................................................................

- [ File = ./tests/nextcloud.ini ] ---------
.......

- [ File = ./tests/trendmicro-cloud-one.ini ] ---------
.................

- [ File = ./tests/pfsense.ini ] ---------
..

- [ File = ./tests/vsftpd.ini ] ---------
....

- [ File = ./tests/web_rules.ini ] ---------
..........

- [ File = ./tests/apache.ini ] ---------
..................

- [ File = ./tests/eset.ini ] ---------
........

- [ File = ./tests/doas.ini ] ---------
....

- [ File = ./tests/sysmon.ini ] ---------
...

- [ File = ./tests/gcp.ini ] ---------
...........

- [ File = ./tests/icinga.ini ] ---------
....

- [ File = ./tests/postfix.ini ] ---------
..

- [ File = ./tests/audit_scp.ini ] ---------
.

- [ File = ./tests/dropbear.ini ] ---------
...

- [ File = ./tests/rsh.ini ] ---------
..

- [ File = ./tests/kernel_usb.ini ] ---------
......

- [ File = ./tests/mcafee_epo.ini ] ---------
.

- [ File = ./tests/netscreen.ini ] ---------
....

- [ File = ./tests/panda_paps.ini ] ---------
........

- [ File = ./tests/powershell.ini ] ---------
...

- [ File = ./tests/auditd.ini ] ---------
...

- [ File = ./tests/cylance.ini ] ---------
.......

- [ File = ./tests/modsecurity.ini ] ---------
......

- [ File = ./tests/cloudlfare-waf.ini ] ---------
.............

- [ File = ./tests/office365.ini ] ---------
................................................................................................................................

- [ File = ./tests/sshd.ini ] ---------
...........................................

- [ File = ./tests/cisco_ios.ini ] ---------
.................

- [ File = ./tests/glpi.ini ] ---------
...

- [ File = ./tests/sudo.ini ] ---------
........

- [ File = ./tests/su.ini ] ---------
.....

- [ File = ./tests/proftpd.ini ] ---------
.......

- [ File = ./tests/SonicWall.ini ] ---------
........

|Component |  Tested  |  Total   | Coverage |
| -------- | -------- | -------- | -------- |
|  Rules   |   985    |   4174   |  23.60%  |
| Decoders |    76    |   172    |  44.19%  |

|          File           |  Passed  |  Failed  |  Status  |
|        --------         | -------- | -------- | -------- |
|./tests/samba.ini        |    4     |    0     |    ✅     |
|./tests/fortigate.ini    |    40    |    0     |    ✅     |
|./tests/apparmor.ini     |    5     |    0     |    ✅     |
|./tests/pam.ini          |    5     |    0     |    ✅     |
|./tests/audit_lateral.ini|    6     |    0     |    ✅     |
|./tests/systemd.ini      |    2     |    0     |    ✅     |
|./tests/arbor.ini        |    2     |    0     |    ✅     |
|./tests/dovecot.ini      |    15    |    0     |    ✅     |
|./tests/mailscanner.ini  |    1     |    0     |    ✅     |
|./tests/ossec.ini        |    5     |    0     |    ✅     |
|./tests/vuln_detector.ini|    2     |    0     |    ✅     |
|./tests/squid_rules.ini  |    2     |    0     |    ✅     |
|./tests/pix.ini          |    22    |    0     |    ✅     |
|./tests/huawei_usg.ini   |    3     |    0     |    ✅     |
|./tests/checkpoint_smart1.ini|    18    |    0     |    ✅     |
|./tests/junos.ini        |    3     |    0     |    ✅     |
|./tests/web_appsec.ini   |    31    |    0     |    ✅     |
|./tests/cimserver.ini    |    2     |    0     |    ✅     |
|./tests/cisco_ftd.ini    |    42    |    0     |    ✅     |
|./tests/firewalld.ini    |    2     |    0     |    ✅     |
|./tests/audit_recon.ini  |    2     |    0     |    ✅     |
|./tests/openldap.ini     |    9     |    0     |    ✅     |
|./tests/sophos_fw.ini    |    10    |    0     |    ✅     |
|./tests/owlh.ini         |    4     |    0     |    ✅     |
|./tests/freepbx.ini      |    6     |    0     |    ✅     |
|./tests/syslog.ini       |    6     |    0     |    ✅     |
|./tests/openvpn_ldap.ini |    2     |    0     |    ✅     |
|./tests/sophos.ini       |    8     |    0     |    ✅     |
|./tests/unbound.ini      |    0     |    0     |    ✅     |
|./tests/github.ini       |   324    |    0     |    ✅     |
|./tests/cpanel.ini       |    7     |    0     |    ✅     |
|./tests/fireeye.ini      |    3     |    0     |    ✅     |
|./tests/fortiauth.ini    |    4     |    0     |    ✅     |
|./tests/iptables.ini     |    8     |    0     |    ✅     |
|./tests/named.ini        |    5     |    0     |    ✅     |
|./tests/sophos-utm-firewall.ini|    6     |    0     |    ✅     |
|./tests/nginx.ini        |    12    |    0     |    ✅     |
|./tests/exim.ini         |    7     |    0     |    ✅     |
|./tests/opensmtpd.ini    |    7     |    0     |    ✅     |
|./tests/oscap.ini        |    32    |    0     |    ✅     |
|./tests/gitlab.ini       |    25    |    0     |    ✅     |
|./tests/paloalto.ini     |    16    |    0     |    ✅     |
|./tests/api.ini          |    28    |    0     |    ✅     |
|./tests/aws_s3_access.ini|    7     |    0     |    ✅     |
|./tests/exchange.ini     |    2     |    0     |    ✅     |
|./tests/f5_big_ip.ini    |    43    |    0     |    ✅     |
|./tests/cisco_asa.ini    |    88    |    0     |    ✅     |
|./tests/nextcloud.ini    |    7     |    0     |    ✅     |
|./tests/trendmicro-cloud-one.ini|    17    |    0     |    ✅     |
|./tests/pfsense.ini      |    2     |    0     |    ✅     |
|./tests/vsftpd.ini       |    4     |    0     |    ✅     |
|./tests/web_rules.ini    |    10    |    0     |    ✅     |
|./tests/apache.ini       |    18    |    0     |    ✅     |
|./tests/eset.ini         |    8     |    0     |    ✅     |
|./tests/doas.ini         |    4     |    0     |    ✅     |
|./tests/sysmon.ini       |    3     |    0     |    ✅     |
|./tests/gcp.ini          |    11    |    0     |    ✅     |
|./tests/icinga.ini       |    4     |    0     |    ✅     |
|./tests/postfix.ini      |    2     |    0     |    ✅     |
|./tests/audit_scp.ini    |    1     |    0     |    ✅     |
|./tests/dropbear.ini     |    3     |    0     |    ✅     |
|./tests/rsh.ini          |    2     |    0     |    ✅     |
|./tests/kernel_usb.ini   |    6     |    0     |    ✅     |
|./tests/mcafee_epo.ini   |    1     |    0     |    ✅     |
|./tests/netscreen.ini    |    4     |    0     |    ✅     |
|./tests/panda_paps.ini   |    8     |    0     |    ✅     |
|./tests/powershell.ini   |    3     |    0     |    ✅     |
|./tests/auditd.ini       |    3     |    0     |    ✅     |
|./tests/cylance.ini      |    7     |    0     |    ✅     |
|./tests/modsecurity.ini  |    6     |    0     |    ✅     |
|./tests/cloudlfare-waf.ini|    13    |    0     |    ✅     |
|./tests/office365.ini    |   128    |    0     |    ✅     |
|./tests/sshd.ini         |    43    |    0     |    ✅     |
|./tests/cisco_ios.ini    |    17    |    0     |    ✅     |
|./tests/glpi.ini         |    3     |    0     |    ✅     |
|./tests/sudo.ini         |    8     |    0     |    ✅     |
|./tests/su.ini           |    5     |    0     |    ✅     |
|./tests/proftpd.ini      |    7     |    0     |    ✅     |
|./tests/SonicWall.ini    |    8     |    0     |    ✅     |
Restarting wazuh-manager...

Restarting wazuh-manager...
- [ File = ./tests/proftpd.ini ] ---------
.......

|Component |  Tested  |  Total   | Coverage |
| -------- | -------- | -------- | -------- |
|  Rules   |    5     |   4174   |  0.12%   |
| Decoders |    1     |   172    |  0.58%   |

|          File           |  Passed  |  Failed  |  Status  |
|        --------         | -------- | -------- | -------- |
|./tests/proftpd.ini      |    7     |    0     |    ✅     |
Restarting wazuh-manager...
  ```
</details>

- [x] 4.d New CDB lists must include the proper test entry in the correct .ini file.

### E2E testing

- [x] 5.a Logs for new or modified decoder/rules sent to a manager running with this PR ruleset appear in Kibana. 

![image](https://user-images.githubusercontent.com/20155990/145029221-84ab8ef4-91ef-4c18-9162-229db674d35e.png)

- [x] 5.b There are not affected or broken visualizations on Kibana.

![image](https://user-images.githubusercontent.com/20155990/145029372-ed580362-612b-4dee-a653-28e71c4fc47a.png)

- [x] 5.c New or modified items can be seen correctly using APP ruleset navigation.

![image](https://user-images.githubusercontent.com/20155990/145029835-bd6b2d85-e3a5-43cd-a125-6ddb43dd0802.png)

### Elasticsearch Template

- [x] 6.a Known fields with output format managed and usually used for searching are included in template array index.query.default_field. 
- [x] 6.b The new field with the correct date format is stored as a "date" type field in the template.
- [x] 6.c The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 
- [x] 6.d Known fields with output format managed and usually used for searching are included in the template.

### Stoppers

- [x] 7.a No previous rule ID changes without triple check.
- [x] 7.b No previous decoder name changes without triple check.
- [x] 7.c No previous file name changes without triple check.
- [x] 7.d No previous test changes its 'rule' field value without triple check.

### Others

- [x] 8.a Each file has the correct copyright block.
- [x] 8.b The copyright block doesn't have "Author" only "Created by Wazuh". To include an "Author" request triple check.
- [x] 8.c The copyright block doesn't use "-". 
- [x] 8.d The rule files don't have any sample log.
- [x] 8.e The decoder file has sample logs next to the decoder that matches that log.
- [x] 8.f The decoder and rule files have information about software, version, and any helpful information.
- [x] 8.g The PR has a single commit with CHANGELOG changes in the correct format.
- [x] 8.h The new rule ID is not in use.
- [x] 8.i The new rule ID must be in the defined IDs range. 
- [x] 8.j New rules ID range must be verified with a triple check and noted in the rules ID document.
- [x] 8.k The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 