### PR TITLE
Editing

### DIFF
--- a/ruleset/decoders/0060-cisco-estreamer_decoders.xml
+++ b/ruleset/decoders/0060-cisco-estreamer_decoders.xml
@@ -14,7 +14,7 @@ Sep  4 11:33:17 opsdcossec01 ossec-admin: AlertPriority 3 SourceIp 10.xx.xx.xx D
 -->
 <decoder name="cisco-estreamer">
 	<program_name></program_name>
-    <prematch>AlertPriority \d+ SourceIp \.+ DestinationIP \.+</prematch>
+    <prematch>AlertPriority \d+ SourceIp \.+ DestinationIp \.+</prematch>
 </decoder>
 
 <decoder name="cisco-estreamer-fields">


### PR DESCRIPTION
The regex is not run because of  DestinationIP

|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] Dr. Memory
  - [x] AddressSanitizer
- Memory tests for Windows
  - [x] Scan-build report
  - [x] Coverity
  - [x] Dr. Memory
- Memory tests for macOS
  - [x] Scan-build report
  - [x] Leaks
  - [x] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] Working on cluster environments
- [x] Configuration on demand reports new parameters
- [x] The data flow works as expected (agent-manager-api-app)
- [x] Added unit tests (for new features)
- [x] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [x] Added unit testing files ".ini"
  - [x] runtests.py executed without errors