### PR TITLE
Rework of PR 9037 - Added glpi decoders and .ini file

### DIFF
--- a/ruleset/testing/tests/glpi.ini
+++ b/ruleset/testing/tests/glpi.ini
@@ -1,3 +1,11 @@
+;  Copyright (C) 2015-2021, Wazuh Inc.
+;
+;  Tests for products: 
+;    Apache GLPI.
+;
+;  Sample logs source: 
+;    Apache GLPI: Community https://github.com/wazuh/wazuh-operations/issues/1947#issuecomment-518331845.
+
 [apache glpi error-log]
 log 1 pass = [Wed Jul 31 16:44:52.906254 2019] [suexec:notice] [pid 8575] AH01232: suEXEC mechanism enabled (wrapper: /usr/sbin/suexec)
 rule = 30303


### PR DESCRIPTION
|Related issue|
|---|
| #11236 |

## Description

This PR aims to resolve issues detected under #9037 PR. Closes #11236.
The issues resolved are:
- Copyright headers.
- Fixed indentation issues.
- Added a blank line at the EOF.
- Added line breaks in between rules and decoder blocks.

## Checks and changes 

### Syntax

- [x] 1.a Rule tags order must be compliant.
- [x] 1.b Decoder tags order must be compliant.
- [x] 1.c XML blocks must as compact as possible.
- [X] 1.d Only one empty line between rule/decoder and the next rule/decoder.
- [X] 1.e Decoder extracted fields names must use '_' whether a space is needed.
- [X] 1.f Decoder name must use '-' whether a space is needed.
 
### Grammar

- [X] 2.a Grammar quality.
- [X] 2.b Similar phrases must keep tenses and expressions.
- [X] 2.c Grammar basic rules like capitalization, punctuation marks, sentence construction, and others.


### Semantic

- [x] 3.a New decoder, rule, or test are written in the correct file and grouped correctly inside the file.
- [x] 3.b Group similar rules under same ID's group.
- [x] 3.c: 
     - [x] 3.c1 Find and reuse group name before creating a new one.
     - [x] 3.c2 Include a new group definition in a PR comment.
     - [x] 3.c3 Any group name must use '_' whether it does need a space char.
     - [x] 3.c4 The groups inside a tag must be sorted in alphabetical order.
- [x] 3.d Rule level should be compliant with the [documentation](https://documentation.wazuh.com/current/user-manual/ruleset/rules-classification.html).

### Unit testing

- [X] 4.a A metadata block at the beginning of the .ini file describing software, version, and logs source.
- [X] 4.b Each new rule must have at least one test entry in the correct .ini file.
- [x] 4.c Runtest.py must pass and must include the results in raw format here.

<details><summary>FreePBX.ini tests.</summary>
<p>

```

```
</p>
</details>

<details><summary>All rules and decoders test.</summary>
<p>

```

```
</p>
</details>

- [X] 4.d New CDB lists must include the proper test entry in the correct .ini file.

### E2E testing

- [x] 5.a Logs for new or modified decoder/rules sent to a manager running with this PR ruleset appear in Kibana.


- [x] 5.b There are no affected or broken visualizations on Kibana.


- [x] 5.c New or modified items can be seen correctly using APP ruleset navigation.



### Elasticsearch Template

- [X] 6.a Known fields with output format managed and usually used for searching are included in template array index.query.default_field. 
- [X] 6.b The new field with the correct date format is stored as a "date" type field in the template.
- [X] 6.c The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 
- [X] 6.d Known fields with output format managed and usually used for searching are included in the template.

### Stoppers

- [x] 7.a No previous rule ID changes without triple check.
- [x] 7.b No previous decoder name changes without triple check.
- [x] 7.c No previous file name changes without triple check.
- [x] 7.d No previous test changes its 'rule' field value without triple check.

### Others

- [x] 8.a Each file has the correct copyright block.
- [x] 8.b The copyright block doesn't have "Author" only "Created by Wazuh". To include an "Author" request triple check.
- [x] 8.c The copyright block doesn't use "-". 
- [x] 8.d The rule files don't have any sample log.
- [x] 8.e The decoder file has sample logs next to the decoder that matches that log.
- [x] 8.f The decoder and rule files have information about software, version, and any helpful information.
- [x] 8.g The PR has a single commit with CHANGELOG changes in the correct format.
- [x] 8.h The new rule ID is not in use.
- [x] 8.i The new rule ID must be in the defined IDs range. 
- [x] 8.j New rules ID range must be verified with a triple check and noted in the rules ID document.
- [x] 8.k The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 