### PR TITLE
Rework PR 8977 -  Oracle Database 19c - Add new sca files for MS IIS, MongoDB 3.6, Nginx, SQL Server and SLES

### DIFF
--- a/ruleset/sca/oracledb/cis_oracle_database_19c.yml
+++ b/ruleset/sca/oracledb/cis_oracle_database_19c.yml
@@ -251,21 +251,9 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT DISTINCT UPPER(V.VALUE), DECODE (V.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE V.CON_ID = B.CON_ID)) FROM V\\"\$SYSTEM_PARAMETER" V WHERE UPPER(NAME) = ''SQL92_SECURITY'';\" | sqlplus / as sysdba | grep -A 1 ^- | grep -v ^-" -> r:TRUE'
 
 # 2.2.15 Ensure '_trace_files_public' Is Set to 'FALSE' - EXCLUDED: this check requires database presets based on SCA appendix instructions
-  # - id: 24516
-  #   title: "Ensure '_trace_files_public' Is Set to 'FALSE'"
-  #   description: "The	_trace_files_public setting	determines	whether	or	not	the	system's	trace	file	is world	readable.	This	setting	should	have	a	value	of	FALSE	to	restrict	trace	file	access."
-  #   rationale: "Making	the	file	world	readable	means	anyone	can	read	the	instance's	trace	file,	which	could contain	sensitive	information	about	instance	operations."
-  #   remediation: "ALTER SYSTEM SET "_trace_files_public" = FALSE SCOPE = SPFILE;"
-  #   compliance:
-  #     - cis: ["2.2.15"]
-  #     - cis_csc: ["14.4","14.6"]
-  #   condition: any
-  #   rules:
-  #     - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT A.KSPPINM, B.KSPPSTVL FROM SYS.X \\"\$KSPPI" a, SYS.X \\"\$KSPPCV" b WHERE A.INDX=B.INDX AND A.KSPPINM LIKE '\_%trace_files_public' escape '\';\" | sqlplus / as sysdba | grep -A 1 ^- | grep -v ^-" -> FALSE'
-  #     - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT A.KSPPINM, B.KSPPSTVL FROM SYS.X \\"\$KSPPI" a, SYS.X \\"\$KSPPCV" b WHERE A.INDX=B.INDX AND A.KSPPINM LIKE '\_%trace_files_public' escape '\';\" | sqlplus / as sysdba | grep -A 1 ^- | grep -v ^-" -> .' #revisar: el resultado deberia ser nada
 
 # 2.2.16 Ensure 'RESOURCE_LIMIT' Is Set to 'TRUE'
-  - id: 24517
+  - id: 24516
     title: "Ensure 'RESOURCE_LIMIT' Is Set to 'TRUE'"
     description: "RESOURCE_LIMIT determines	whether	resource	limits	are	enforced	in	database	profiles. This	setting	should	have	a	value	of	TRUE."
     rationale: "If	RESOURCE_LIMIT is	set	to	FALSE,	none	of	the	system	resource	limits	that	are	set	in	any database	profiles	are	enforced.	If	RESOURCE_LIMIT is	set	to	TRUE,	the	limits	set	in	database profiles	are	enforced."
@@ -282,7 +270,7 @@ checks:
 # 3 Oracle Connection and Login Restrictions
 ###############################################
 # 3.1 Ensure 'FAILED_LOGIN_ATTEMPTS' Is Less than or Equal to '5'
-  - id: 24518
+  - id: 24517
     title: "Ensure 'FAILED_LOGIN_ATTEMPTS' Is Less than or Equal to '5'"
     description: "The	FAILED_LOGIN_ATTEMPTS setting	determines	how	many	failed	login	attempts	are permitted	before	the	system	locks	the	user's	account.	While	different	profiles	can	have different	and	more	restrictive	settings,	such	as	USERS and	APPS,	the	minimum(s) recommended	here	should	be	set	on	the	DEFAULT profile."
     rationale: "Repeated	failed	login	attempts	can	indicate	the	initiation	of	a	brute-force	login	attack,	this value	should	be	set	according	to	the	needs	of	the	organization.	(See	the	Notes for	a	warning on	a	known	bug	that	can	make	this	security	measure	backfire.)"
@@ -296,7 +284,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT P.PROFILE, P.RESOURCE_NAME, P.LIMIT, DECODE (P.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE P.CON_ID = B.CON_ID)) DATABASE FROM CDB_PROFILES P WHERE TO_NUMBER(DECODE(P.LIMIT, ''DEFAULT'',(SELECT DECODE(LIMIT,''UNLIMITED'',9999,LIMIT) FROM CDB_PROFILES WHERE PROFILE=''DEFAULT'' AND RESOURCE_NAME=''FAILED_LOGIN_ATTEMPTS'' AND CON_ID = P.CON_ID), ''UNLIMITED'',''9999'',P.LIMIT)) > 5 AND P.RESOURCE_NAME = ''FAILED_LOGIN_ATTEMPTS'' AND EXISTS ( SELECT ''X'' FROM CDB_USERS U WHERE U.PROFILE = P.PROFILE ) ORDER BY CON_ID, PROFILE, RESOURCE_NAME;\" | sqlplus / as sysdba | grep -A 1 FAILED_LOGIN_ATTEMPTS | grep -v FAILED_LOGIN_ATTEMPTS | head -n 1" -> n:(\d+) compare <= 5'
 
 # 3.2 Ensure 'PASSWORD_LOCK_TIME' Is Greater than or Equal to '1'
-  - id: 24519
+  - id: 24518
     title: "Ensure 'PASSWORD_LOCK_TIME' Is Greater than or Equal to '1'"
     description: "The	PASSWORD_LOCK_TIME setting	determines	how	many	days	must	pass	for	the	user's account	to	be	unlocked	after	the	set	number	of	failed	login	attempts	has	occurred.	The suggested	value	for	this	is	one	day	or	greater."
     rationale: "Locking	the	user	account	after	repeated	failed	login	attempts	can	block	further	brute-force login	attacks,	but	can	create	administrative	headaches	as	this	account	unlocking	process always	requires	DBA	intervention."
@@ -312,7 +300,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT P.PROFILE, P.RESOURCE_NAME, P.LIMIT, DECODE (P.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE P.CON_ID = B.CON_ID)) DATABASE FROM CDB_PROFILES P WHERE TO_NUMBER(DECODE(P.LIMIT, ''DEFAULT'',(SELECT DECODE(LIMIT,''UNLIMITED'',9999,LIMIT) FROM CDB_PROFILES WHERE PROFILE=''DEFAULT'' AND RESOURCE_NAME=''PASSWORD_LOCK_TIME'' AND CON_ID = P.CON_ID), ''UNLIMITED'',''9999'',P.LIMIT)) < 1 AND P.RESOURCE_NAME = ''PASSWORD_LOCK_TIME'' AND EXISTS ( SELECT ''X'' FROM CDB_USERS U WHERE U.PROFILE = P.PROFILE ) ORDER BY CON_ID, PROFILE, RESOURCE_NAME;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> r:no rows selected'
 
 # 3.3 Ensure 'PASSWORD_LIFE_TIME' Is Less than or Equal to '90'
-  - id: 24520
+  - id: 24519
     title: "Ensure 'PASSWORD_LIFE_TIME' Is Less than or Equal to '90'"
     description: "The	PASSWORD_LIFE_TIME setting	determines	how	long	a	password	may	be	used	before	the user	is	required	to	be	change	it.	The	suggested	value	for	this	is	90	days	or	less."
     rationale: "Allowing	passwords	to	remain	unchanged	for	long	periods	makes	the	success	of	bruteforce	login	attacks	more	likely."
@@ -328,7 +316,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT P.PROFILE, P.RESOURCE_NAME, P.LIMIT, DECODE (P.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE P.CON_ID = B.CON_ID)) DATABASE FROM CDB_PROFILES P WHERE TO_NUMBER(DECODE(P.LIMIT, ''DEFAULT'',(SELECT DECODE(LIMIT,''UNLIMITED'',9999,LIMIT) FROM CDB_PROFILES WHERE PROFILE=''DEFAULT'' AND RESOURCE_NAME=''PASSWORD_LIFE_TIME'' AND CON_ID = P.CON_ID), ''UNLIMITED'',''9999'', P.LIMIT)) > 90 AND P.RESOURCE_NAME = ''PASSWORD_LIFE_TIME'' AND EXISTS ( SELECT ''X'' FROM CDB_USERS U WHERE U.PROFILE = P.PROFILE ) ORDER BY CON_ID, PROFILE, RESOURCE_NAME;\" | sqlplus / as sysdba | grep -A 1 \"PASSWORD_LIFE_TIME\" | grep \"no rows selected\"" -> r:no rows selected'
 
 # 3.4 Ensure 'PASSWORD_REUSE_MAX' Is Greater than or Equal to '20'
-  - id: 24521
+  - id: 24520
     title: "Ensure 'PASSWORD_REUSE_MAX' Is Greater than or Equal to '20'"
     description: "The	PASSWORD_REUSE_MAX setting	determines	how	many	different	passwords	must	be	used before	the	user	is	allowed	to	reuse	a	prior	password.	The	suggested	value	for	this	is	20 passwords	or	greater."
     rationale: "Allowing	reuse	of	a	password	within	a	short	period	of	time	after	the	password's	initial	use can	make	the	success	of	both	social-engineering	and	brute-force	password-based	attacks more	likely."
@@ -344,7 +332,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT P.PROFILE, P.RESOURCE_NAME, P.LIMIT, DECODE (P.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE P.CON_ID = B.CON_ID)) DATABASE FROM CDB_PROFILES P WHERE TO_NUMBER(DECODE(P.LIMIT, ''DEFAULT'',(SELECT DECODE(LIMIT,''UNLIMITED'',9999,LIMIT) FROM CDB_PROFILES WHERE PROFILE=''DEFAULT'' AND RESOURCE_NAME=''PASSWORD_REUSE_MAX'' AND CON_ID = P.CON_ID), ''UNLIMITED'',''9999'',P.LIMIT)) < 20 AND P.RESOURCE_NAME = ''PASSWORD_REUSE_MAX'' AND EXISTS ( SELECT ''X'' FROM CDB_USERS U WHERE U.PROFILE = P.PROFILE ) ORDER BY CON_ID, PROFILE, RESOURCE_NAME;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> r:no rows selected'
 
 # 3.5 Ensure 'PASSWORD_REUSE_TIME' Is Greater than or Equal to '365'
-  - id: 24522
+  - id: 24521
     title: "Ensure 'PASSWORD_REUSE_TIME' Is Greater than or Equal to '365'"
     description: "The	PASSWORD_REUSE_TIME setting	determines	the	amount	of	time	in	days	that	must	pass before	the	same	password	may	be	reused.	The	suggested	value	for	this	is 365	days	or greater."
     rationale: "Reusing	the	same	password	after	only	a	short	period	of	time	has	passed	makes	the	success of	brute-force	login	attacks	more	likely."
@@ -359,9 +347,8 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT P.PROFILE, P.RESOURCE_NAME, P.LIMIT, DECODE (P.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE P.CON_ID = B.CON_ID)) DATABASE FROM CDB_PROFILES P WHERE TO_NUMBER(DECODE(P.LIMIT, ''DEFAULT'',(SELECT DECODE(LIMIT,''UNLIMITED'',9999,LIMIT) FROM CDB_PROFILES WHERE PROFILE=''DEFAULT'' AND RESOURCE_NAME=''PASSWORD_REUSE_TIME'' AND CON_ID = P.CON_ID), ''UNLIMITED'',''9999'',P.LIMIT)) < 365 AND P.RESOURCE_NAME = ''PASSWORD_REUSE_TIME'' AND EXISTS ( SELECT ''X'' FROM CDB_USERS U WHERE U.PROFILE = P.PROFILE ) ORDER BY CON_ID, PROFILE, RESOURCE_NAME;\" | sqlplus / as sysdba | grep -A 1 ^- | grep -v ^-" -> n:(\d+) compare >= 365'
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT P.PROFILE, P.RESOURCE_NAME, P.LIMIT, DECODE (P.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE P.CON_ID = B.CON_ID)) DATABASE FROM CDB_PROFILES P WHERE TO_NUMBER(DECODE(P.LIMIT, ''DEFAULT'',(SELECT DECODE(LIMIT,''UNLIMITED'',9999,LIMIT) FROM CDB_PROFILES WHERE PROFILE=''DEFAULT'' AND RESOURCE_NAME=''PASSWORD_REUSE_TIME'' AND CON_ID = P.CON_ID), ''UNLIMITED'',''9999'',P.LIMIT)) < 365 AND P.RESOURCE_NAME = ''PASSWORD_REUSE_TIME'' AND EXISTS ( SELECT ''X'' FROM CDB_USERS U WHERE U.PROFILE = P.PROFILE ) ORDER BY CON_ID, PROFILE, RESOURCE_NAME;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> r:no rows selected'
 
-
 # 3.6 Ensure 'PASSWORD_GRACE_TIME' Is Less than or Equal to '5'
-  - id: 24523
+  - id: 24522
     title: "Ensure 'PASSWORD_GRACE_TIME' Is Less than or Equal to '5'"
     description: "The	PASSWORD_GRACE_TIME setting	determines	how	many	days	can	pass	after	the	user's password	expires	before	the	user's	login	capability	is	automatically locked	out.	The suggested	value	for	this	is	five	days	or	less."
     rationale: "Locking	the	user	account	after	the	expiration	of	the	password	change	requirement's	grace period	can	help	prevent	password-based	attacks	against	any	forgotten	or	disused	accounts, while	still	allowing	the	account	and	its	information	to	be	accessible	by	DBA	intervention."
@@ -376,9 +363,8 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT P.PROFILE, P.RESOURCE_NAME, P.LIMIT, DECODE (P.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE P.CON_ID = B.CON_ID)) DATABASE FROM CDB_PROFILES P WHERE TO_NUMBER(DECODE(P.LIMIT, ''DEFAULT'',(SELECT DECODE(LIMIT,''UNLIMITED'',9999,LIMIT) FROM CDB_PROFILES WHERE PROFILE=''DEFAULT'' AND RESOURCE_NAME=''PASSWORD_GRACE_TIME'' AND CON_ID = P.CON_ID), ''UNLIMITED'',''9999'',P.LIMIT)) > 5 AND P.RESOURCE_NAME = ''PASSWORD_GRACE_TIME'' AND EXISTS ( SELECT ''X'' FROM CDB_USERS U WHERE U.PROFILE = P.PROFILE ) ORDER BY CON_ID, PROFILE, RESOURCE_NAME;\" | sqlplus / as sysdba | grep -A 1 ^PASSWORD_GRACE_TIME | grep -v ^PASSWORD_GRACE_TIME" -> n:(\d+) compare <= 5'
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT P.PROFILE, P.RESOURCE_NAME, P.LIMIT, DECODE (P.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE P.CON_ID = B.CON_ID)) DATABASE FROM CDB_PROFILES P WHERE TO_NUMBER(DECODE(P.LIMIT, ''DEFAULT'',(SELECT DECODE(LIMIT,''UNLIMITED'',9999,LIMIT) FROM CDB_PROFILES WHERE PROFILE=''DEFAULT'' AND RESOURCE_NAME=''PASSWORD_GRACE_TIME'' AND CON_ID = P.CON_ID), ''UNLIMITED'',''9999'',P.LIMIT)) > 5 AND P.RESOURCE_NAME = ''PASSWORD_GRACE_TIME'' AND EXISTS ( SELECT ''X'' FROM CDB_USERS U WHERE U.PROFILE = P.PROFILE ) ORDER BY CON_ID, PROFILE, RESOURCE_NAME;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> r:no rows selected'
 
-
 # 3.7 Ensure 'PASSWORD_VERIFY_FUNCTION' Is Set for All Profiles
-  - id: 24524
+  - id: 24523
     title: "Ensure 'PASSWORD_VERIFY_FUNCTION' Is Set for All Profiles"
     description: "The	PASSWORD_VERIFY_FUNCTION determines	password	settings	requirements	when	a	user password	is	changed	at	the	SQL	command	prompt.	It	should	be	set	for	all	profiles.	Note	that this	setting	does	not	apply	for	users	managed	by	the	Oracle	password	file."
     rationale: "Through Oracle	database	profiles,	password	complexity	rules	(mixed	cases	with	digits	and special	characters),	blocking	of	simple	combinations,	and	enforcing	change/history	settings can	potentially	thwart	unauthorized	logins	by	an	unauthorized	user."
@@ -391,10 +377,8 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT P.PROFILE, P.RESOURCE_NAME, P.LIMIT FROM DBA_PROFILES P WHERE DECODE(P.LIMIT, ''DEFAULT'',(SELECT LIMIT FROM DBA_PROFILES WHERE PROFILE=''DEFAULT'' AND RESOURCE_NAME = P.RESOURCE_NAME), LIMIT) = ''NULL'' AND P.RESOURCE_NAME = ''PASSWORD_VERIFY_FUNCTION'' AND EXISTS ( SELECT ''X'' FROM DBA_USERS U WHERE U.PROFILE = P.PROFILE );\" | sqlplus / as sysdba | grep -A 1 ^PASSWORD_VERIFY_FUNCTION | grep -v ^PASSWORD_VERIFY_FUNCTION" -> NULL'
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT P.PROFILE, P.RESOURCE_NAME, P.LIMIT, DECODE (P.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE P.CON_ID = B.CON_ID)) DATABASE FROM CDB_PROFILES P WHERE DECODE(P.LIMIT, ''DEFAULT'',(SELECT LIMIT FROM CDB_PROFILES WHERE PROFILE=''DEFAULT'' AND RESOURCE_NAME = P.RESOURCE_NAME AND CON_ID = P.CON_ID), LIMIT) = ''NULL'' AND P.RESOURCE_NAME = ''PASSWORD_VERIFY_FUNCTION'' AND EXISTS ( SELECT ''X'' FROM CDB_USERS U WHERE U.PROFILE = P.PROFILE ) ORDER BY CON_ID, PROFILE, RESOURCE_NAME;\" | sqlplus / as sysdba | grep -A 1 ^PASSWORD_VERIFY_FUNCTION | grep -v ^PASSWORD_VERIFY_FUNCTION" -> NULL'
 
-
-
 # 3.8 Ensure 'SESSIONS_PER_USER' Is Less than or Equal to '10'
-  - id: 24525
+  - id: 24524
     title: "Ensure 'SESSIONS_PER_USER' Is Less than or Equal to '10'"
     description: "The	SESSIONS_PER_USER setting	determines	the	maximum	number	of	user	sessions	that	are allowed	to	be	open	concurrently.	The	suggested	value	for	this	is	10	or	less."
     rationale: "Limiting	the	number	of	the	SESSIONS_PER_USER can	help	prevent	memory	resource exhaustion	by	poorly	formed	requests	or	intentional	denial-of-service	attacks."
@@ -409,9 +393,8 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT P.PROFILE, P.RESOURCE_NAME, P.LIMIT FROM DBA_PROFILES P WHERE TO_NUMBER(DECODE(P.LIMIT, ''DEFAULT'',(SELECT DISTINCT DECODE(LIMIT,''UNLIMITED'',9999,LIMIT) FROM DBA_PROFILES WHERE PROFILE=''DEFAULT'' AND RESOURCE_NAME=''SESSIONS_PER_USER''), ''UNLIMITED'',''9999'',P.LIMIT)) > 10 AND P.RESOURCE_NAME = ''SESSIONS_PER_USER'' AND EXISTS ( SELECT ''X'' FROM DBA_USERS U WHERE U.PROFILE = P.PROFILE );\" | sqlplus / as sysdba | grep -A 1 ^SESSIONS_PER_USER | grep -v ^SESSIONS_PER_USER" -> n:(\d+) compare <= 10'
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT P.PROFILE, P.RESOURCE_NAME, P.LIMIT FROM DBA_PROFILES P WHERE TO_NUMBER(DECODE(P.LIMIT, ''DEFAULT'',(SELECT DISTINCT DECODE(LIMIT,''UNLIMITED'',9999,LIMIT) FROM DBA_PROFILES WHERE PROFILE=''DEFAULT'' AND RESOURCE_NAME=''SESSIONS_PER_USER''), ''UNLIMITED'',''9999'',P.LIMIT)) > 10 AND P.RESOURCE_NAME = ''SESSIONS_PER_USER'' AND EXISTS ( SELECT ''X'' FROM DBA_USERS U WHERE U.PROFILE = P.PROFILE );\" | sqlplus / as sysdba | grep \"no rows selected\"" -> r:no rows selected'
 
-
 # 3.9 Ensure 'INACTIVE_ACCOUNT_TIME' Is Less than or Equal to '120
-  - id: 24526
+  - id: 24525
     title: "Ensure 'INACTIVE_ACCOUNT_TIME' Is Less than or Equal to '120"
     description: "The	'INACTIVE_ACCOUNT_TIME'	setting	determines	the	maximum	number	of	days	of inactivity	(no	logins	at	all)	after	which	the	account	will	be	locked.	The	suggested	value	for this	is	120	or	less."
     rationale: "Setting	'INACTIVE_ACCOUNT_TIME'	can	help	with	deactivation	of	inactive	or	unused accounts."
@@ -430,7 +413,7 @@ checks:
 # 4 Users
 ###############################################
 # 4.1 Ensure All Default Passwords Are Changed
-  - id: 24527
+  - id: 24526
     title: "Ensure All Default Passwords Are Changed"
     description: "Default	passwords	should	not	be	used	by	Oracle	database	users."
     rationale: "Default	passwords	should	be	considered	well	known	to	attackers.	Consequently,	if	default passwords	remain	in	place,	any	attacker	with	access	to	the	database	can	authenticate	as	the	user	with	that	default	password."
@@ -444,7 +427,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT DISTINCT A.USERNAME, DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_USERS_WITH_DEFPWD A, CDB_USERS C WHERE A.USERNAME = C.USERNAME AND C.ACCOUNT_STATUS = ''OPEN'';\" | sqlplus / as sysdba | grep \"no rows selected\"" -> r:no rows selected'
 
 # 4.2 Ensure All Sample Data And Users Have Been Removed
-  - id: 24528
+  - id: 24527
     title: "Ensure All Sample Data And Users Have Been Removed"
     description: "Oracle	sample	schemas	can	be	used	to	create	sample	users	(BI,HR,IX,OE,PM,SCOTT,SH),	with well-known	default	passwords,	particular	views,	and	procedures/functions,	in	addition	to tables	and	fictitious	data.	The	sample	schemas	should	be	removed."
     rationale: "The	sample	schemas	are	typically	not	required	for	production	operations	of	the	database. The	default	users,	views,	and/or	procedures/functions	created	by	sample	schemas	could be	used	to	launch	exploits	against	production	environments."
@@ -458,7 +441,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT DISTINCT A.USERNAME, DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_USERS A WHERE A.USERNAME IN (''BI'',''HR'',''IX'',''OE'',''PM'',''SCOTT'',''SH'');\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 4.3 Ensure 'DBA_USERS.AUTHENTICATION_TYPE' Is Not Set to 'EXTERNAL' for Any User
-  - id: 24529
+  - id: 24528
     title: "Ensure 'DBA_USERS.AUTHENTICATION_TYPE' Is Not Set to 'EXTERNAL' for Any User"
     description: "The	authentication_type=''EXTERNAL'' setting	determines	whether	or	not	a	user	can	be authenticated	by	a	remote	OS	to	allow	access	to	the	database	with	full	authorization.	This setting	should	not	be	used."
     rationale: "Allowing	remote	OS	authentication	of	a	user	to	the	database	can	potentially	allow	supposed privileged	users	to	connect	as	authenticated,	even	when	the	remote	system	is compromised."
@@ -472,7 +455,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT A.USERNAME, DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_USERS A WHERE AUTHENTICATION_TYPE = ''EXTERNAL'';\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 4.4 Ensure No Users Are Assigned the 'DEFAULT' Profile
-  - id: 24530
+  - id: 24529
     title: "Ensure No Users Are Assigned the 'DEFAULT' Profile"
     description: "Upon	creation	database	users	are	assigned	to	the	DEFAULT profile	unless	otherwise specified.	No	users	should	be	assigned	to	that	profile."
     rationale: "Users	should	be	created	with	function-appropriate	profiles.	The	DEFAULT profile,	being defined	by	Oracle,	is	subject	to	change	at	any	time	(e.g.	by	patch	or	version	update).	The DEFAULT profile	has	unlimited	settings	that	are	often	required	by	the	SYS user	when patching;	such	unlimited	settings	should	be	tightly	reserved	and	not	applied	to unnecessary	users."
@@ -486,7 +469,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT A.USERNAME, DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_USERS A WHERE A.PROFILE=''DEFAULT'' AND A.ACCOUNT_STATUS=''OPEN'' AND A.ORACLE_MAINTAINED = ''N'';\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 4.5 Ensure 'SYS.USER$MIG' Has Been Dropped
-  - id: 24531
+  - id: 24530
     title: "Ensure 'SYS.USER$MIG' Has Been Dropped"
     description: "The	table	sys.user$mig is	created	during	migration	and	contains	the	Oracle	password hashes	before	the	migration	starts.	This	table	should	be	dropped."
     rationale: "The	table	sys.user$mig is	not	deleted	after	the	migration.	An	attacker	could	access	the table	containing	the	Oracle	password	hashes."
@@ -500,7 +483,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT OWNER, TABLE_NAME, DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_TABLES A WHERE TABLE_NAME=''USER\$MIG'' AND OWNER=''SYS'';\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 4.6 Ensure No Public Database Links Exist
-  - id: 24532
+  - id: 24531
     title: "Ensure No Public Database Links Exist"
     description: "Public	Database	links	are	used	to	allow	connections	between	databases."
     rationale: "Using	public	database	links	in	the	database	can	allow	anyone	with	a	connection	to	the database	to	query,	update,	insert,	delete	data	on	a	remote	database	depending	on	the userid	that	is	part	of	the	link."
@@ -522,7 +505,7 @@ checks:
 # 5.1.1 Public Privileges
 ###############################################
 # 5.1.1.1 Ensure 'EXECUTE' is revoked from 'PUBLIC' on "Network" Packages
-  - id: 24533
+  - id: 24532
     title: "Ensure 'EXECUTE' is revoked from 'PUBLIC' on Network Packages"
     description: "As	described	below,	Oracle	Database	PL/SQL	Network	packages	- DBMS_LDAP,	UTL_INADDR, UTL_TCP,	UTL_MAIL,	UTL_SMTP,	UTL_DBWS,	UTL_ORAMTS,	UTL_HTTP and	type	HTTPURITYPE – provide	PL/SQL	APIs	to	interact	or	access	remote	servers.	The	PUBLIC	should	not	be	able to	execute	these	packages. • The	Oracle	database	DBMS_LDAP package	contains	functions	and	procedures	that enable	programmers	to	access	data	from	LDAP	servers. • The	Oracle	database	UTL_INADDR package	provides	an	API	to	retrieve	host	names and	IP	addresses	of	local	and	remote	hosts. • The	Oracle	database	UTL_TCP package	can	be	used	to	read/write	file	to	TCP	sockets on	the	server	where	the	Oracle	instance	is	installed. • The	Oracle	database	UTL_MAIL package	can	be	used	to	send	email	from	the	server where	the	Oracle	instance	is	installed. • The	Oracle	database	UTL_SMTP package	can	be	used	to	send	email	from	the	server where	the	Oracle	instance	is	installed.	The	user	PUBLIC should	not	be	able	to	execute UTL_SMTP. • The	Oracle	database	UTL_DBWS package	can	be	used	to	read/write	file	to	web-based applications	on	the	server	where	the	Oracle	instance	is	installed.	This	package	is	not automatically	installed	for	security	reasons. • The	Oracle	database	UTL_ORAMTS package	can	be	used	to	perform	HTTP	requests. This	could	be	used	to	send	information	to	the	outside.85 |	P a g e • The	Oracle	database	UTL_HTTP package	can	be	used	to	perform	HTTP	requests.	This could	be	used	to	send	information	to	the	outside. • The	Oracle	database	HTTPURITYPE object	type	can	be	used	to	perform	HTTP requests."
     rationale: "As	described	below,	Oracle	Database	PL/SQL	packages	- DBMS_LDAP,	UTL_INADDR,	UTL_TCP, UTL_MAIL,	UTL_SMTP,	UTL_DBWS,	UTL_ORAMTS,	UTL_HTTP and	type	HTTPURITYPE can	be	used	by unauthorized	users	to	create	specially	crafted	error	messages	or	send	information	to external	servers.	The	PUBLIC should	not	be	able	to	execute	these	packages. • The	use	of	the	DBMS_LDAP package	can	be	used	to	create	specially	crafted	error messages	or	send	information	via	DNS	to	the	outside. • The	UTL_INADDR package	can	be	used	to	create	specially	crafted	error	messages	or send	information	via	DNS	to the	outside. • The	UTL_TCP package	could	allow	an	unauthorized	user	to	corrupt	the	TCP	stream used	to	carry	the	protocols	that	communicate	with	the	instance's	external communications. • The	UTL_MAIL package	could	allow	an	unauthorized	user	to	corrupt	the	SMTP function	to	accept	or	generate	junk	mail	that	can	result	in	a	denial-of-service condition	due	to	network	saturation. • The	UTL_SMTP package	could	allow	an	unauthorized	user	to	corrupt	the	SMTP function	to	accept	or	generate	junk	mail	that	can	result	in	a	denial-of-service condition	due	to	network	saturation. • The	UTL_DBWS package	could	allow	an	unauthorized	user	to	corrupt	the	HTTP stream	used	to	carry	the	protocols	that	communicate	for	the	instance's	web-based external	communications. • The	UTL_ORAMTS package	could	be	used	to	send	(sensitive)	information	to	external websites.	The	use	of	this	package	should	be	restricted	according	to	the	needs	of	the organization. • The	UTL_HTTP package	could	be	used	to	send	(sensitive)	information	to	external websites. • The	use	of this	package	should	be	restricted	according	to	the	needs	of	the organization. • The	ability	to	perform	HTTP	requests	could	be	used	to	leak	information	from	the database	to	an	external	destination."
@@ -536,7 +519,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT TABLE_NAME, PRIVILEGE, GRANTEE,DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_TAB_PRIVS A WHERE GRANTEE=''PUBLIC'' AND PRIVILEGE=''EXECUTE'' AND TABLE_NAME IN (''DBMS_LDAP'',''UTL_INADDR'',''UTL_TCP'',''UTL_MAIL'',''UTL_SMTP'',''UTL_DBWS'',''UTL_ORA MTS'',''UTL_HTTP'',''HTTPURITYPE'') ORDER BY CON_ID, TABLE_NAME;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 5.1.1.2 Ensure 'EXECUTE' is revoked from 'PUBLIC' on "File System" Packages
-  - id: 24534
+  - id: 24533
     title: "Ensure 'EXECUTE' is revoked from 'PUBLIC' on File System Packages"
     description: "As	described	below,	Oracle	Database	PL/SQL	File	System	packages	- DBMS_ADVISOR, DBMS_LOB and	UTL_FILE – provide	PL/SQL	APIs	to	access	files	on	the	servers.	The	user PUBLIC should	not	be	able	to	execute	these	packages. • The	Oracle	database	DBMS_ADVISOR package	can	be	used	to	write	files	located	on	the server	where	the	Oracle	instance	is	installed.	The	user	PUBLIC	should	not	be	able	to execute	DBMS_ADVISOR. • The	Oracle	database	DBMS_LOB package	provides	subprograms	that	can	manipulate and	read/write	on	BLOB's,	CLOB's,	NCLOB's,	BFILE's,	and	temporary	LOB's.	The	user PUBLIC should	not	be	able	to	execute	DBMS_LOB. • The	Oracle	database	UTL_FILE package	can	be	used	to	read/write	files	located	on the	server	where	the	Oracle	instance	is	installed.	The	user	PUBLIC should	not	be	able to	execute	UTL_FILE."
     rationale: "As	described	below,	Oracle	Database	PL/SQL	File	System	packages	- DBMS_ADVISOR, DBMS_LOB and	UTL_FILE – should	not	be	granted	to	PUBLIC. • Use	of	the	DBMS_ADVISOR package	could	allow	an	unauthorized	user	to	corrupt operating	system	files	on	the	instance's	host. • Use	of	the	DBMS_LOB package	could	allow	an	unauthorized	user	to	manipulate	BLOB's, CLOB's,	NCLOB's,	BFILE's,	and	temporary	LOBs	on	the	instance,	either	destroying	data or	causing	a	denial-of-service	condition	due	to	corruption	of	disk	space. • Use	of	the	UTL_FILE package	could	allow	a	user	to	read	OS	files.	These	files	could contain	sensitive	information	(e.g.	passwords	in	.bash_history)"
@@ -550,7 +533,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT TABLE_NAME, PRIVILEGE, GRANTEE,DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_TAB_PRIVS A WHERE GRANTEE=''PUBLIC'' AND PRIVILEGE=''EXECUTE'' AND TABLE_NAME IN (''DBMS_ADVISOR'',''DBMS_LOB'',''UTL_FILE'') ORDER BY CON_ID, TABLE_NAME;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 5.1.1.3 Ensure 'EXECUTE' is revoked from 'PUBLIC' on "Encryption" Packages
-  - id: 24535
+  - id: 24534
     title: "Ensure 'EXECUTE' is revoked from 'PUBLIC' on Encryption Packages"
     description: "As	described	below,	Oracle	Database	PL/SQL	Encryption	packages	- DBMS_CRYPTO, DBMS_OBFUSCATION_TOOLKIT and	DBMS_RANDOM – provide	PL/SQL	APIs	to	perform	functions related	to	cryptography.	The	PUBLIC should	not	be	able	to	execute	these	packages. • The	DBMS_CRYPTO settings	provide	a	toolset	that	determines	the	strength	of	the encryption	algorithm	used	to	encrypt	application	data	and	is	part	of	the	SYS schema. The	DES (56-bit	key),	3DES (168-bit	key),	3DES-2KEY (112-bit	key),	AES (128/192/256-bit	keys),	and	RC4 are	available. • The	DBMS_OBFUSCATION_TOOLKIT provides	one	of	the	tools	that	determine	the strength	of	the	encryption	algorithm	used	to	encrypt	application	data	and	is	part	of the	SYS	schema.	The	DES (56-bit	key)	and	3DES (168-bit	key)	are	the	only	two	types available. • The	Oracle	database	DBMS_RANDOM package	is	used	for	generating	random	numbers but	should	not	be	used	for	cryptographic	purposes."
     rationale: "As	described	below,	Oracle	Database	PL/SQL	Encryption	packages	- DBMS_CRYPTO, DBMS_OBFUSCATION_TOOLKIT and	DBMS_RANDOM – should	not	be	granted	to	PUBLIC. • Execution	of	the	DBMS_CRYPTO procedures	by	the	PUBLIC can	potentially	endanger portions	of	or	all	of	the	data	storage. • Allowing	the	PUBLIC privileges	to	access	this	capability	can	be	potentially	harm	data storage. • Use	of	the	DBMS_RANDOM package	can	allow	the	unauthorized	application	of	the random	number-generating	function."
@@ -564,7 +547,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT TABLE_NAME, PRIVILEGE, GRANTEE,DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_TAB_PRIVS A WHERE GRANTEE=''PUBLIC'' AND PRIVILEGE=''EXECUTE'' AND TABLE_NAME IN (''DBMS_CRYPTO'',''DBMS_OBFUSCATION_TOOLKIT'', ''DBMS_RANDOM'') ORDER BY CON_ID, TABLE_NAME;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 5.1.1.4 Ensure 'EXECUTE' is revoked from 'PUBLIC' on "Java" Packages
-  - id: 24536
+  - id: 24535
     title: "Ensure 'EXECUTE' is revoked from 'PUBLIC' on Java Packages"
     description: "As	described	below,	Oracle	Database	PL/SQL	Java	packages	- DBMS_JAVA and DBMS_JAVA_TEST – provide	APIs	to	run	Java	classes	or	grant	Java	packages.	The	user	PUBLIC should	not	be	able	to	execute	these	packages. • The	Oracle	database	DBMS_JAVA package	can	run	Java	classes	(e.g.	OS	commands)	or grant	Java	privileges.	The	user	PUBLIC should	not	be	able	to	execute	DBMS_JAVA. • The	Oracle	database	DBMS_JAVA_TEST package	can	run	Java	classes	(e.g.	OS commands)	or	grant	Java	privileges.	The	user	PUBLIC should	not	be	able	to	execute DBMS_JAVA_TEST."
     rationale: "As	described	below,	Oracle	Database	PL/SQL	Java	packages	- DBMS_JAVA and DBMS_JAVA_TEST – should	not	be	granted	to	PUBLIC. • The	DBMS_JAVA package	could	allow	an	attacker	to	run	OS	commands	from	the database. • The	DBMS_JAVA_TEST package	could	allow	an	attacker	to	run	operating	system commands	from	the	database."
@@ -578,7 +561,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT TABLE_NAME, PRIVILEGE, GRANTEE,DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_TAB_PRIVS A WHERE GRANTEE=''PUBLIC'' AND PRIVILEGE=''EXECUTE'' AND TABLE_NAME IN (''DBMS_JAVA'',''DBMS_JAVA_TEST'') ORDER BY CON_ID, TABLE_NAME;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 5.1.1.5 Ensure 'EXECUTE' is revoked from 'PUBLIC' on "Job Scheduler" Packages
-  - id: 24537
+  - id: 24536
     title: "Ensure 'EXECUTE' is revoked from 'PUBLIC' on Job Scheduler Packages"
     description: "As	described	below,	Oracle	Database	PL/SQL	Job	Scheduler	packages	- DBMS_SCHEDULER and	DBMS_JOB – provide	APIs	to	schedule	jobs.	The	user	PUBLIC should	not	be	able	to execute	these	packages. • The	Oracle	database	DBMS_SCHEDULER package	schedules	and	manages	the	database and	operating	system	jobs.	The	user	PUBLIC should	not	be	able	to	execute DBMS_SCHEDULER. • The	Oracle	database	DBMS_JOB package	schedules	and	manages	the	jobs	sent	to	the job	queue	and	has	been	superseded	by	the	DBMS_SCHEDULER package,	even	though DBMS_JOB has	been	retained	for	backwards	compatibility.	The	user	PUBLIC should not	be	able	to	execute	DBMS_JOB."
     rationale: "As	described	below,	Oracle	Database	PL/SQL	Job	Scheduler	packages	- DBMS_SCHEDULER and	DBMS_JOB – should	not	be	granted	to	the user	PUBLIC. • Use	of	the	DBMS_SCHEDULER package	could	allow	an	unauthorized	user	to	run database	or	operating	system	jobs. • Use	of	the	DBMS_JOB package	could	allow	an	unauthorized	user	to	disable	or overload	the	job	queue.	It	has	been	superseded	by	the	DBMS_SCHEDULER package"
@@ -592,7 +575,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT TABLE_NAME, PRIVILEGE, GRANTEE,DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_TAB_PRIVS A WHERE GRANTEE=''PUBLIC'' AND PRIVILEGE=''EXECUTE'' AND TABLE_NAME IN (''DBMS_SCHEDULER'',''DBMS_JOB'') ORDER BY CON_ID, TABLE_NAME;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 5.1.1.6 Ensure 'EXECUTE' is revoked from 'PUBLIC' on "SQL Injection Helper" Packages
-  - id: 24538
+  - id: 24537
     title: "Ensure 'EXECUTE' is revoked from 'PUBLIC' on SQL Injection Helper Packages"
     description: "As	described	below,	Oracle	Database	PL/SQL	SQL	Injection	Helper	Packages	packages	- DBMS_SQL,	DBMS_XMLGEN,	DBMS_XMLQUERY,	DBMS_XLMSTORE,	DBMS_XLMSAVE and	DBMS_REDACT – provide	APIs	to	schedule	jobs.	The	user	PUBLIC should	not	be	able	to	execute	these packages. • The	Oracle	database	DBMS_SQL package	is	used	for	running	dynamic	SQL	statements. • The	DBMS_XMLGEN package	takes	an	arbitrary	SQL	query	as	input,	converts	it	to	XML format,	and	returns	the	result	as	a	CLOB. • The	Oracle	package	DBMS_XMLQUERY takes	an	arbitrary	SQL	query,	converts	it	to	XML format,	and	returns	the	result.	This	package	is	similar	to	DBMS_XMLGEN. • The	DBMS_XLMSTORE package	provides	XML	functionality.	It	accepts	a	table	name	and XML	as	input	to	perform	DML operations	against	the	table. • The	DBMS_XLMSAVE package	provides	XML	functionality.	It	accepts	a	table	name	and XML	as	input	and	then	inserts	into	or	updates	that	table. • The	DBMS_REDACT	package provides	an	interface	to	Oracle	Data	Redaction,	which enables	you	to	mask	(redact)	data	that	is	returned	from	queries	issued	by	lowprivileged	users	or	an	application."
     rationale: "As	described	below,	Oracle	Database	PL/SQL	SQL	Injection	Helper	Packages	packages	- DBMS_SQL,	DBMS_XMLGEN,	DBMS_XMLQUERY,	DBMS_XLMSTORE,	DBMS_XLMSAVE and 'DBMS_REDACT'	– should	not	be	granted	to	PUBLIC. • The	DBMS_SQL package	could	allow	privilege	escalation	if	input	validation	is	not	done properly. • The	package	DBMS_XMLGEN can	be	used	to	search	the	entire	database	for	sensitive information	like	credit	card	numbers • The	package	DBMS_XMLQUERY can	be	used	to	search	the	entire	database	for	sensitive information	like	credit	card	numbers.	Malicious	users	may	be	able	to	exploit	this package	as	an	auxiliary	inject	function	in	a	SQL	injection	attack. • Malicious	users	may	be	able	to	exploit	the	DBMS_XLMSTORE package	as	an	auxiliary inject	function	in	a	SQL	injection	attack. • Malicious	users	may	be	able	to	exploit	the	DBMS_XLMSAVE package	as	an	auxiliary inject	function	in	a	SQL	injection	attack. • Malicious	users	may	be	able	to	exploit	DBMS_REDACT	as	an	auxiliary	inject	function in	a	SQL	injection	attack."
@@ -609,7 +592,7 @@ checks:
 # 5.1.2 Non-Default Privileges
 ###############################################
 # 5.1.2.1 Ensure 'EXECUTE' is not granted to 'PUBLIC' on "Non-default" Packages
-  - id: 24539
+  - id: 24538
     title: "Ensure 'EXECUTE' is not granted to 'PUBLIC' on Non-default Packages"
     description: "The	packages	described	in	this	control	are	not	granted	to	PUBLIC by	default	(Non-default packages).	These	packages	should	not	be	granted	to	PUBLIC. • The	Oracle	database	DBMS_BACKUP_RESTORE package	is	used	for	applying	PL/SQL commands	to	the	native	RMAN sequences. • The	Oracle	database	DBMS_FILE_TRANSFER package	allows	a	user	to	transfer	files from	one	database	server	to	another. • The	Oracle	database	DBMS_SYS_SQL,DBMS_REPCAT_SQL_UTL,	INITJVMAUX, DBMS_AQADM_SYS,	DBMS_STREAMS_RPC,	DBMS_PRVTAQIM,	LTADM and DBMS_IJOB packages are	shipped	as	undocumented."
     rationale: "As	described	below,	these	non-default	group	of	PL/SQL	packages,	which	are	not	granted to	PUBLIC by	default,	packages	should	not	be	granted	to	PUBLIC. • The	DBMS_BACKUP_RESTORE package	can	allow	access	to	OS	files. • The	DBMS_FILE_TRANSFER package	could	allow	to	transfer	files	from	one	database server	to	another	without	authorization	to	do	so. • The	DBMS_SYS_SQL package	could	allow	a	user	to	run	code	as	a	different	user without	entering	valid	credentials. • The	DBMS_REPCAT_SQL_UTL package	could	allow	an	unauthorized	user	to	run	SQL commands	as	user	SYS. • The	INITJVMAUX package	could	allow	an	unauthorized	user	to	run	SQL	commands	as user	SYS. • The	DBMS_AQADM_SYS package	could	allow	an	unauthorized	user	to	run SQL commands	as	user	SYS. • The	DBMS_STREAMS_RPC package	could	allow	an	unauthorized	user	to	run	SQL commands	as	user	SYS.102 |	P a g e • The	DBMS_PRVTAQIM package	could	allow	an	unauthorized	user	to	escalate	privileges because	any	SQL	statements	could	be	executed	as	user SYS. • The	LTADM package	could	allow	an	unauthorized	user	to	run	any	SQL	command	as user	SYS.	It	allows	privilege	escalation	if	granted	to	unprivileged	users. • The	DBMS_IJOB package	could	allow	an	attacker	to	change	identities	by	using	a different	username	to	execute	a	database	job.	It	allows	a	user	to	run	database	jobs	in the	context	of	another	user."
@@ -626,7 +609,7 @@ checks:
 # 5.1.3 Other Privileges
 ###############################################
 # 5.1.3.1 Ensure 'ALL' Is Revoked from Unauthorized 'GRANTEE' on 'AUD$'
-  - id: 24540
+  - id: 24539
     title: "Ensure 'ALL' Is Revoked from Unauthorized 'GRANTEE' on 'AUD$'"
     description: "The	Oracle	database	SYS.AUD$ table	contains	all	the	audit	records	for	the	database	of	the non-Data	Manipulation	Language	(DML)	events,	such	as	ALTER,	DROP,	and	CREATE,	and	so forth.	(DML	changes	need	trigger-based	audit	events	to	record	data	alterations.) Unauthorized	grantees	should not	have	full	access	to	that	table."
     rationale: "Permitting	non-privileged	users	the	authorization	to	manipulate	the	SYS.AUD$ table	can allow	distortion	of	the	audit	records,	hiding	unauthorized	activities."
@@ -640,7 +623,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT GRANTEE, PRIVILEGE, DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_TAB_PRIVS A WHERE TABLE_NAME=''AUD\$'' AND OWNER = ''SYS'';\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 5.1.3.2 Ensure 'ALL' Is Revoked from Unauthorized 'GRANTEE' on 'DBA_%'
-  - id: 24541
+  - id: 24540
     title: "Ensure 'ALL' Is Revoked from Unauthorized 'GRANTEE' on 'DBA_%'"
     description: "The	Oracle	database	DBA_ views	show	all	information	which	is	relevant	to	administrative accounts.	Unauthorized	grantees	should	not	have	full	access	to	those	views."
     rationale: "Permitting	users	the	authorization	to	manipulate	the	DBA_ views	can	expose	sensitive	data."
@@ -654,7 +637,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT GRANTEE,TABLE_NAME, DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_TAB_PRIVS A WHERE TABLE_NAME LIKE ''DBA_%'' AND OWNER = ''SYS'' AND GRANTEE NOT IN (SELECT USERNAME FROM CDB_USERS WHERE ORACLE_MAINTAINED=''Y'') AND GRANTEE NOT IN (SELECT ROLE FROM CDB_ROLES WHERE ORACLE_MAINTAINED=''Y'');\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 5.1.3.3 Ensure 'ALL' Is Revoked on 'Sensitive' Tables
-  - id: 24542
+  - id: 24541
     title: "Ensure 'ALL' Is Revoked on 'Sensitive' Tables "
     description: "The	Oracle	database	tables	listed	below	may	contain	sensitive	information,	and	should	not be	accessible	to	unauthorized	users. • USER$,	USER_HISTORY$,	XS$VERIFIERS and	DEFAULT_PWD$ may	contain	password hashes. • CDB_LOCAL_ADMINAUTH$ and	PDB_SYNC$ may	contain	DDLs. • LINK$ and	SCHEDULER$_CREDENTIAL may	contain	encrypted	passwords. • ENC$ may	contains	encryption	keys. • HISTGRM$ and	HIST_HEAD$ may	contain	sensitive	data."
     rationale: "Access	to	sensitive	information	such	as	hashed	passwords	may	allow	unauthorized	users	to decrypt	the	passwords	hashes	which	could	potentially	result	in	complete	compromise	of the	database."
@@ -667,12 +650,11 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT GRANTEE, PRIVILEGE, TABLE_NAME FROM DBA_TAB_PRIVS WHERE TABLE_NAME in (''CDB_LOCAL_ADMINAUTH\$'',''DEFAULT_PWD\$'',''ENC\$'',''HISTGRM\$'',''HIST_HEAD\$'',''LINK\$'' ,''PDB_SYNC\$'',''SCHEDULER\$_CREDENTIAL'',''USER\$'',''USER_HISTORY\$'',''XS\$VERIFIERS'') AND OWNER = ''SYS'' AND GRANTEE NOT IN (SELECT USERNAME FROM DBA_USERS WHERE ORACLE_MAINTAINED=''Y'') AND GRANTEE NOT IN (SELECT ROLE FROM DBA_ROLES WHERE ORACLE_MAINTAINED=''Y'');\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT TABLE_NAME, PRIVILEGE, GRANTEE,DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) DATABASE FROM CDB_TAB_PRIVS A WHERE TABLE_NAME in (''CDB_LOCAL_ADMINAUTH\$'',''DEFAULT_PWD\$'',''ENC\$'',''HISTGRM\$'',''HIST_HEAD\$'',''LINK\$'' ,''PDB_SYNC\$'',''SCHEDULER\$_CREDENTIAL'',''USER\$'',''USER_HISTORY\$'',''XS\$VERIFIERS'') AND OWNER = ''SYS'' AND GRANTEE NOT IN (SELECT USERNAME FROM DBA_USERS WHERE ORACLE_MAINTAINED=''Y'') AND GRANTEE NOT IN (SELECT ROLE FROM DBA_ROLES WHERE ORACLE_MAINTAINED=''Y'') ORDER BY CON_ID, TABLE_NAME;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
-
 ###############################################
 # 5.2 Excessive System Privileges
 ###############################################
 # 5.2.1 Ensure '%ANY%' Is Revoked from Unauthorized 'GRANTEE'
-  - id: 24543
+  - id: 24542
     title: "Ensure '%ANY%' Is Revoked from Unauthorized 'GRANTEE'"
     description: "The	Oracle	database	ANY keyword	provides	the	user	the	capability	to	alter	any	item	in	the catalog	of	the	database.	Unauthorized	grantees	should	not	have	that	keyword	assigned	to them"
     rationale: "Authorization	to	use	the	ANY expansion	of	a	privilege	can	allow	an	unauthorized	user to potentially	change	confidential	data	or	damage	the	data	catalog."
@@ -686,7 +668,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT GRANTEE, PRIVILEGE, DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_SYS_PRIVS A WHERE PRIVILEGE LIKE ''%ANY%'' AND GRANTEE NOT IN (SELECT USERNAME FROM CDB_USERS WHERE ORACLE_MAINTAINED=''Y'') AND GRANTEE NOT IN (SELECT ROLE FROM CDB_ROLES WHERE ORACLE_MAINTAINED=''Y'');\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 5.2.2 Ensure 'DBA_SYS_PRIVS.%' Is Revoked from Unauthorized 'GRANTEE' with 'ADMIN_OPTION' Set to 'YES'
-  - id: 24544
+  - id: 24543
     title: "Ensure 'DBA_SYS_PRIVS.%' Is Revoked from Unauthorized 'GRANTEE' with 'ADMIN_OPTION' Set to 'YES'"
     description: "The	Oracle	database	WITH_ADMIN privilege	allows	the	designated	user	to	grant	another	user the	same	privileges.	Unauthorized	grantees	should	not	have	that	privilege."
     rationale: "Assignment	of	the	WITH_ADMIN privilege	can	allow	the	granting	of	a	restricted	privilege	to an	unauthorized	user."
@@ -700,7 +682,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT GRANTEE, PRIVILEGE, DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_SYS_PRIVS A WHERE ADMIN_OPTION=''YES'' AND GRANTEE NOT IN (SELECT USERNAME FROM CDB_USERS WHERE ORACLE_MAINTAINED=''Y'') AND GRANTEE NOT IN (SELECT ROLE FROM CDB_ROLES WHERE ORACLE_MAINTAINED=''Y'');\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 5.2.3 Ensure 'EXECUTE ANY PROCEDURE' Is Revoked from 'OUTLN'
-  - id: 24545
+  - id: 24544
     title: "Ensure 'EXECUTE ANY PROCEDURE' Is Revoked from 'OUTLN'"
     description: "Remove	unneeded	EXECUTE ANY PROCEDURE privileges	from	OUTLN."
     rationale: "Migrated	OUTLN users	have	more	privileges	than	required."
@@ -714,7 +696,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT GRANTEE, PRIVILEGE, DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_SYS_PRIVS A WHERE PRIVILEGE=''EXECUTE ANY PROCEDURE'' AND GRANTEE=''OUTLN'';\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 5.2.4 Ensure 'EXECUTE ANY PROCEDURE' Is Revoked from 'DBSNMP'
-  - id: 24546
+  - id: 24545
     title: "Ensure 'EXECUTE ANY PROCEDURE' Is Revoked from 'DBSNMP'"
     description: "Remove	unneeded	EXECUTE ANY PROCEDURE privileges	from	DBSNMP."
     rationale: "Migrated	DBSNMP users	have	more	privileges	than	required."
@@ -728,7 +710,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT GRANTEE, PRIVILEGE, DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_SYS_PRIVS A WHERE PRIVILEGE=''EXECUTE ANY PROCEDURE'' AND GRANTEE=''DBSNMP'';\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 5.2.5 Ensure 'SELECT ANY DICTIONARY' Is Revoked from Unauthorized 'GRANTEE'
-  - id: 24547
+  - id: 24546
     title: "Ensure 'SELECT ANY DICTIONARY' Is Revoked from Unauthorized 'GRANTEE'"
     description: "The	Oracle	database	SELECT ANY DICTIONARY privilege	allows	the	designated	user	to	access SYS schema	objects.	Unauthorized	grantees	should	not	have	that	privilege."
     rationale: "SELECT ANY DICTIONARY is	a	powerful	system	privilege	which	would	allow	an unauthorized	user	to	gather	information	about	the database	through	data	dictionary objects.	Information	collected	could	potentially	be	used	to	exploit	the	database."
@@ -742,7 +724,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT GRANTEE, PRIVILEGE, DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_SYS_PRIVS A WHERE PRIVILEGE=''SELECT ANY DICTIONARY'' AND GRANTEE NOT IN (SELECT USERNAME FROM CDB_USERS WHERE ORACLE_MAINTAINED=''Y'') AND GRANTEE NOT IN (SELECT ROLE FROM CDB_ROLES WHERE ORACLE_MAINTAINED=''Y'');\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 5.2.6 Ensure 'SELECT ANY TABLE' Is Revoked from Unauthorized 'GRANTEE'
-  - id: 24548
+  - id: 24547
     title: "Ensure 'SELECT ANY TABLE' Is Revoked from Unauthorized 'GRANTEE'"
     description: "The	Oracle	database	SELECT ANY TABLE privilege	allows	the	designated	user	to	open	any table,	except	SYS,	to	view	it.	Unauthorized	grantees	should	not	have	that	privilege."
     rationale: "Assignment	of	the	SELECT ANY TABLE privilege	can	allow	the	unauthorized	viewing	of sensitive	data."
@@ -756,7 +738,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT GRANTEE, PRIVILEGE, DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_SYS_PRIVS A WHERE PRIVILEGE=''SELECT ANY TABLE'' AND GRANTEE NOT IN (SELECT USERNAME FROM CDB_USERS WHERE ORACLE_MAINTAINED=''Y'') AND GRANTEE NOT IN (SELECT ROLE FROM CDB_ROLES WHERE ORACLE_MAINTAINED=''Y'');\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 5.2.7 Ensure 'AUDIT SYSTEM' Is Revoked from Unauthorized 'GRANTEE'
-  - id: 24549
+  - id: 24548
     title: "Ensure 'AUDIT SYSTEM' Is Revoked from Unauthorized 'GRANTEE'"
     description: "The	Oracle	database	AUDIT SYSTEM privilege	allows	changes	to	auditing	activities	on	the system.	Unauthorized	grantees	should	not	have	that	privilege."
     rationale: "The	AUDIT SYSTEM privilege	can	allow	the	unauthorized	alteration	of	system	audit activities,	such	as	disabling	the	creation	of	audit	trails."
@@ -770,7 +752,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT GRANTEE, PRIVILEGE, DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_SYS_PRIVS A WHERE PRIVILEGE=''AUDIT SYSTEM'' AND GRANTEE NOT IN (SELECT USERNAME FROM CDB_USERS WHERE ORACLE_MAINTAINED=''Y'') AND GRANTEE NOT IN (SELECT ROLE FROM CDB_ROLES WHERE ORACLE_MAINTAINED=''Y'');\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 5.2.8 Ensure 'EXEMPT ACCESS POLICY' Is Revoked from Unauthorized 'GRANTEE'
-  - id: 24550
+  - id: 24549
     title: "Ensure 'EXEMPT ACCESS POLICY' Is Revoked from Unauthorized 'GRANTEE'"
     description: "The	Oracle	database	EXEMPT ACCESS POLICY keyword	provides	the	user	the	capability	to access	all	the	table	rows	regardless	of	row-level	security	lockouts.	Unauthorized	grantees should	not	have	that	keyword	assigned	to	them."
     rationale: "The	EXEMPT ACCESS POLICY privilege	can	allow	an	unauthorized	user	to	potentially	access and	change	data."
@@ -784,7 +766,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT GRANTEE, PRIVILEGE, DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_SYS_PRIVS A WHERE PRIVILEGE=''EXEMPT ACCESS POLICY'' AND GRANTEE NOT IN (SELECT USERNAME FROM CDB_USERS WHERE ORACLE_MAINTAINED=''Y'') AND GRANTEE NOT IN (SELECT ROLE FROM CDB_ROLES WHERE ORACLE_MAINTAINED=''Y'');\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 5.2.9 Ensure 'BECOME USER' Is Revoked from Unauthorized 'GRANTEE'
-  - id: 24551
+  - id: 24550
     title: "Ensure 'BECOME USER' Is Revoked from Unauthorized 'GRANTEE'"
     description: "The	Oracle	database	BECOME USER privilege	allows	the	designated	user	to	inherit	the	rights of	another	user.	Unauthorized	grantees	should	not	have	that	privilege."
     rationale: "The	BECOME USER privilege	can	allow	the	unauthorized	use	of	another	user's	privileges,	this capability	should	be	restricted	according	to	the	needs	of	the	organization."
@@ -798,7 +780,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT GRANTEE, PRIVILEGE, DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_SYS_PRIVS A WHERE PRIVILEGE=''BECOME USER'' AND GRANTEE NOT IN (SELECT USERNAME FROM CDB_USERS WHERE ORACLE_MAINTAINED=''Y'') AND GRANTEE NOT IN (SELECT ROLE FROM CDB_ROLES WHERE ORACLE_MAINTAINED=''Y'');\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 5.2.10 Ensure 'CREATE PROCEDURE' Is Revoked from Unauthorized 'GRANTEE'
-  - id: 24552
+  - id: 24551
     title: "Ensure 'CREATE PROCEDURE' Is Revoked from Unauthorized 'GRANTEE'"
     description: "The	Oracle	database	CREATE PROCEDURE privilege	allows	the	designated	user	to	create	a stored	procedure	that	will	fire	when	given	the	correct	command	sequence.	Unauthorized grantees	should	not	have	that	privilege."
     rationale: "The	CREATE PROCEDURE privilege	can	lead	to	severe	problems	in	unauthorized	hands,	such as	rogue	procedures	facilitating	data	theft	or	denial-of-service	by	corrupting	data	tables."
@@ -812,7 +794,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT GRANTEE, PRIVILEGE, DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_SYS_PRIVS A WHERE PRIVILEGE=''CREATE PROCEDURE'' AND GRANTEE NOT IN (SELECT USERNAME FROM CDB_USERS WHERE ORACLE_MAINTAINED=''Y'') AND GRANTEE NOT IN (SELECT ROLE FROM CDB_ROLES WHERE ORACLE_MAINTAINED=''Y'');\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 5.2.11 Ensure 'ALTER SYSTEM' Is Revoked from Unauthorized 'GRANTEE'
-  - id: 24553
+  - id: 24552
     title: "Ensure 'ALTER SYSTEM' Is Revoked from Unauthorized 'GRANTEE'"
     description: "The	Oracle	database	ALTER SYSTEM privilege	allows	the	designated	user	to	dynamically alter	the	instance's	running	operations.	Unauthorized	grantees	should	not	have	that privilege."
     rationale: "The	ALTER SYSTEM privilege	can	lead	to	severe	problems,	such	as	the	instance's	session being	killed	or	the	stopping	of	redo	log	recording,	which	would	make	transactions unrecoverable."
@@ -826,7 +808,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT GRANTEE, PRIVILEGE, DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_SYS_PRIVS A WHERE PRIVILEGE=''ALTER SYSTEM'' AND GRANTEE NOT IN (SELECT USERNAME FROM CDB_USERS WHERE ORACLE_MAINTAINED=''Y'') AND GRANTEE NOT IN (SELECT ROLE FROM CDB_ROLES WHERE ORACLE_MAINTAINED=''Y'');\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 5.2.12 Ensure 'CREATE ANY LIBRARY' Is Revoked from Unauthorized 'GRANTEE'
-  - id: 24554
+  - id: 24553
     title: "Ensure 'CREATE ANY LIBRARY' Is Revoked from Unauthorized 'GRANTEE'"
     description: "The	Oracle	database	CREATE ANY LIBRARY privilege	allows	the	designated	user	to	create objects	that	are	associated	to	the	shared	libraries.	Unauthorized	grantees	should	not	have that	privilege."
     rationale: "The	CREATE ANY LIBRARY privilege	can	allow	the	creation	of	numerous	library-associated objects	and	potentially	corrupt	the	libraries'	integrity."
@@ -840,7 +822,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT GRANTEE, PRIVILEGE, DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_SYS_PRIVS A WHERE PRIVILEGE=''CREATE ANY LIBRARY'' AND GRANTEE NOT IN (SELECT USERNAME FROM CDB_USERS WHERE ORACLE_MAINTAINED=''Y'') AND GRANTEE NOT IN (SELECT ROLE FROM CDB_ROLES WHERE ORACLE_MAINTAINED=''Y'');\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 5.2.13 Ensure 'CREATE LIBRARY' Is Revoked from Unauthorized 'GRANTEE'
-  - id: 24555
+  - id: 24554
     title: "Ensure 'CREATE LIBRARY' Is Revoked from Unauthorized 'GRANTEE'"
     description: "The	Oracle	database	CREATE LIBRARY privilege	allows	the	designated	user	to	create	objects that	are	associated	to	the	shared	libraries.	Unauthorized	grantees	should	not	have	that privilege."
     rationale: "The	CREATE LIBRARY privilege	can	allow	the	creation	of	numerous	library-associated objects	and	potentially	corrupt	the	libraries'	integrity"
@@ -854,7 +836,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT GRANTEE, PRIVILEGE, DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_SYS_PRIVS A WHERE PRIVILEGE=''CREATE LIBRARY'' AND GRANTEE NOT IN (SELECT USERNAME FROM CDB_USERS WHERE ORACLE_MAINTAINED=''Y'') AND GRANTEE NOT IN (SELECT ROLE FROM CDB_ROLES WHERE ORACLE_MAINTAINED=''Y'');\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 5.2.14 Ensure 'GRANT ANY OBJECT PRIVILEGE' Is Revoked from Unauthorized 'GRANTEE'
-  - id: 24556
+  - id: 24555
     title: "Ensure 'GRANT ANY OBJECT PRIVILEGE' Is Revoked from Unauthorized 'GRANTEE'"
     description: "The	Oracle	database	GRANT ANY OBJECT PRIVILEGE keyword	provides	the	grantee	the capability	to	grant	access	to	any	single	or	multiple	combinations	of	objects	to	any	grantee in	the	catalog	of	the	database.	Unauthorized	grantees	should	not	have	that	keyword assigned	to	them."
     rationale: "The	GRANT ANY OBJECT PRIVILEGE capability	can	allow	an	unauthorized	user	to	potentially access	or	change	confidential	data,	or	damage	the	data	catalog	due	to	potential	complete instance	access."
@@ -868,7 +850,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT GRANTEE, PRIVILEGE, DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_SYS_PRIVS A WHERE PRIVILEGE=''GRANT ANY OBJECT PRIVILEGE'' AND GRANTEE NOT IN (SELECT USERNAME FROM CDB_USERS WHERE ORACLE_MAINTAINED=''Y'') AND GRANTEE NOT IN (SELECT ROLE FROM CDB_ROLES WHERE ORACLE_MAINTAINED=''Y'');\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 5.2.15 Ensure 'GRANT ANY ROLE' Is Revoked from Unauthorized 'GRANTEE'
-  - id: 24557
+  - id: 24556
     title: "Ensure 'GRANT ANY ROLE' Is Revoked from Unauthorized 'GRANTEE'"
     description: "The	Oracle	database	GRANT ANY ROLE keyword	provides	the	grantee	the	capability	to	grant any	single	role	to	any	grantee	in	the	catalog	of	the	database.	Unauthorized	grantees	should not	have	that	keyword	assigned	to	them."
     rationale: "The	GRANT ANY ROLE capability	can	allow	an	unauthorized	user	to	potentially	access	or change	confidential	data	or	damage	the	data	catalog	due	to	potential	complete	instance access."
@@ -882,7 +864,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT GRANTEE, PRIVILEGE, DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_SYS_PRIVS A WHERE PRIVILEGE=''GRANT ANY ROLE'' AND GRANTEE NOT IN (SELECT USERNAME FROM CDB_USERS WHERE ORACLE_MAINTAINED=''Y'') AND GRANTEE NOT IN (SELECT ROLE FROM CDB_ROLES WHERE ORACLE_MAINTAINED=''Y'');\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 5.2.16 Ensure 'GRANT ANY PRIVILEGE' Is Revoked from Unauthorized 'GRANTEE'
-  - id: 24558
+  - id: 24557
     title: "Ensure 'GRANT ANY PRIVILEGE' Is Revoked from Unauthorized 'GRANTEE'"
     description: "The	Oracle	database	GRANT ANY PRIVILEGE keyword	provides	the	grantee	the	capability	to grant	any	single	privilege	to	any	item	in	the	catalog	of	the	database.	Unauthorized	grantees should	not	have	that	privilege."
     rationale: "The	GRANT ANY PRIVILEGE capability	can	allow	an	unauthorized	user	to	potentially	access or	change	confidential	data	or	damage	the	data	catalog	due	to	potential	complete	instance access."
@@ -895,12 +877,11 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT GRANTEE, PRIVILEGE FROM DBA_SYS_PRIVS WHERE PRIVILEGE=''GRANT ANY PRIVILEGE'' AND GRANTEE NOT IN (SELECT USERNAME FROM DBA_USERS WHERE ORACLE_MAINTAINED=''Y'') AND GRANTEE NOT IN (SELECT ROLE FROM DBA_ROLES WHERE ORACLE_MAINTAINED=''Y'');\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT GRANTEE, PRIVILEGE, DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_SYS_PRIVS A WHERE PRIVILEGE=''GRANT ANY PRIVILEGE'' AND GRANTEE NOT IN (SELECT USERNAME FROM CDB_USERS WHERE ORACLE_MAINTAINED=''Y'') AND GRANTEE NOT IN (SELECT ROLE FROM CDB_ROLES WHERE ORACLE_MAINTAINED=''Y'');\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
-
 ###############################################
 # 5.3 Excessive Role Privileges
 ###############################################
 # 5.3.1 Ensure 'SELECT_CATALOG_ROLE' Is Revoked from Unauthorized 'GRANTEE'
-  - id: 24559
+  - id: 24558
     title: "Ensure 'SELECT_CATALOG_ROLE' Is Revoked from Unauthorized 'GRANTEE'"
     description: "The	Oracle	database	SELECT_CATALOG_ROLE provides	SELECT privileges	on	all	data dictionary	views	held	in	the	SYS schema.	Unauthorized	grantees	should	not	have	that	role."
     rationale: "Permitting	unauthorized	access	to	the	SELECT_CATALOG_ROLE can	allow	the	disclosure	of	all dictionary	data."
@@ -914,7 +895,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT GRANTEE, GRANTED_ROLE, DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_ROLE_PRIVS A WHERE GRANTED_ROLE=''SELECT_CATALOG_ROLE'' AND GRANTEE NOT IN (SELECT USERNAME FROM CDB_USERS WHERE ORACLE_MAINTAINED=''Y'') AND GRANTEE NOT IN (SELECT ROLE FROM CDB_ROLES WHERE ORACLE_MAINTAINED=''Y'');\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 5.3.2 Ensure 'EXECUTE_CATALOG_ROLE' Is Revoked from Unauthorized 'GRANTEE'
-  - id: 24560
+  - id: 24559
     title: "Ensure 'EXECUTE_CATALOG_ROLE' Is Revoked from Unauthorized 'GRANTEE'"
     description: "The	Oracle	database	EXECUTE_CATALOG_ROLE provides	EXECUTE privileges	for	a	number	of packages	and	procedures	in	the	data	dictionary	in	the	SYS schema.	Unauthorized	grantees should	not	have	that	role."
     rationale: "Permitting	unauthorized	access	to	the	EXECUTE_CATALOG_ROLE can	allow	the	disruption	of operations	by	initialization	of	rogue	procedures,	this	capability	should	be	restricted according	to	the	needs	of	the	organization."
@@ -928,7 +909,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT GRANTEE, GRANTED_ROLE, DECODE (A.CON_ID,0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_ROLE_PRIVS A WHERE GRANTED_ROLE=''EXECUTE_CATALOG_ROLE'' AND GRANTEE NOT IN (SELECT USERNAME FROM CDB_USERS WHERE ORACLE_MAINTAINED=''Y'') AND GRANTEE NOT IN (SELECT ROLE FROM CDB_ROLES WHERE ORACLE_MAINTAINED=''Y'');\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 5.3.3 Ensure 'DBA' Is Revoked from Unauthorized 'GRANTEE'
-  - id: 24561
+  - id: 24560
     title: "Ensure 'DBA' Is Revoked from Unauthorized 'GRANTEE'"
     description: "The	Oracle	database	DBA role	is	the	default	database	administrator role	provided	for	the allocation	of	administrative	privileges.	Unauthorized	grantees	should	not	have	that	role."
     rationale: "Assignment	of	the	DBA role	to	an	ordinary	user	can	provide	a	great	number	of	unnecessary privileges	to	that	user	and	open	the	door	to	data	breaches,	integrity	violations,	and	denialof-service	conditions."
@@ -948,7 +929,7 @@ checks:
 # 6.1 Traditional Auditing
 ###############################################
 # 6.1.1 Ensure the 'USER' Audit Option Is Enabled
-  - id: 24562
+  - id: 24561
     title: "Ensure the 'USER' Audit Option Is Enabled"
     description: "The	USER object	allows	for	creating	accounts	that	can	interact	with	the	database	according to	the	roles	and	privileges	allotted	to	the	account.	It	may	also	own	database	objects. Enabling	the	audit option	causes	auditing	of	all	activities	and	requests	to	create,	drop	or alter	a	user,	including	a	user	changing	their	own	password.	(The	latter	is	not	audited	by audit ALTER USER.)"
     rationale: "Any	unauthorized	attempts	to	create,	drop	or	alter	a	user	should	cause	concern,	whether successful	or	not.	Auditing	can	also	be	useful	in	forensics	if	an	account	is	compromised,	and auditing	is	mandated	by	many	common	security	initiatives.	An	abnormally	high	number	of these	activities	in	a	given	period	might	be	worth	investigation.	Any	failed	attempt	to	drop	a user	or	create	a	user	may	be	worth	further	review."
@@ -962,7 +943,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT AUDIT_OPTION,SUCCESS,FAILURE, DECODE (A.CON_ID, 0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_STMT_AUDIT_OPTS A WHERE USER_NAME IS NULL AND PROXY_NAME IS NULL AND SUCCESS = ''BY ACCESS'' AND FAILURE = ''BY ACCESS'' AND AUDIT_OPTION=''USER'';\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.1.2 Ensure the 'ROLE' Audit Option Is Enabled
-  - id: 24563
+  - id: 24562
     title: "Ensure the 'ROLE' Audit Option Is Enabled"
     description: "The	ROLE object	allows	for	the	creation	of	a	set	of	privileges	that	can	be	granted	to	users	or other	roles.	Enabling	the	audit	option	causes	auditing	of	all	attempts,	successful	or	not,	to create,	drop,	alter	or	set	roles."
     rationale: "Roles	are a	key	database	security	infrastructure	component.	Any	attempt	to	create,	drop	or alter	a	role	should	be	audited.	This	statement	auditing	option	also	audits	attempts, successful	or	not,	to	set	a	role	in	a	session.	Any	unauthorized	attempts	to	create,	drop	or alter	a	role	may	be	worthy	of	investigation.	Attempts	to	set	a	role	by	users	without	the	role privilege	may	warrant	investigation."
@@ -976,7 +957,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT AUDIT_OPTION,SUCCESS,FAILURE, DECODE (A.CON_ID, 0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_STMT_AUDIT_OPTS A WHERE USER_NAME IS NULL AND PROXY_NAME IS NULL AND SUCCESS = ''BY ACCESS'' AND FAILURE = ''BY ACCESS'' AND AUDIT_OPTION=''ROLE'';\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.1.3 Ensure the 'SYSTEM GRANT' Audit Option Is Enabled
-  - id: 24564
+  - id: 24563
     title: "Ensure the 'SYSTEM GRANT' Audit Option Is Enabled"
     description: "Enabling	the	audit	option	for	the	SYSTEM GRANT object	causes	auditing	of	any	attempt, successful	or	not,	to	grant	or	revoke	any	system	privilege	or	role,	regardless	of	privilege held	by	the	user	attempting	the	operation."
     rationale: "Logging	of	all	grant	and	revokes	(roles	and	system	privileges)	can	provide	forensic evidence	about	a	pattern	of	suspect/unauthorized	activities.	Any	unauthorized	attempt may	be	cause	for	further	investigation."
@@ -990,7 +971,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT AUDIT_OPTION,SUCCESS,FAILURE, DECODE (A.CON_ID, 0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_STMT_AUDIT_OPTS A WHERE USER_NAME IS NULL AND PROXY_NAME IS NULL AND SUCCESS = ''BY ACCESS'' AND FAILURE = ''BY ACCESS'' AND AUDIT_OPTION=''SYSTEM GRANT'';\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.1.4 Ensure the 'PROFILE' Audit Option Is Enabled
-  - id: 24565
+  - id: 24564
     title: "Ensure the 'PROFILE' Audit Option Is Enabled"
     description: "The	PROFILE object	allows	for	the	creation	of	a	set	of	database	resource	limits	that	can	be assigned	to	a	user,	so	that	that	user	cannot	exceed	those	resource	limitations.	Enabling	the audit	option	causes	auditing	of	all	attempts,	successful	or	not,	to	create,	drop	or	alter	any profile."
     rationale: "As	profiles	are	part	of	the	database	security	infrastructure,	auditing	the	creation, modification,	and	deletion	of	profiles	is	recommended."
@@ -1004,7 +985,7 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT AUDIT_OPTION,SUCCESS,FAILURE, DECODE (A.CON_ID, 0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_STMT_AUDIT_OPTS A WHERE USER_NAME IS NULL AND PROXY_NAME IS NULL AND SUCCESS = ''BY ACCESS'' AND FAILURE = ''BY ACCESS'' AND AUDIT_OPTION=''PROFILE'';\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.1.5 Ensure the 'DATABASE LINK' Audit Option Is Enabled
-  - id: 24566
+  - id: 24565
     title: "Ensure the 'DATABASE LINK' Audit Option Is Enabled"
     description: "Enabling	the	audit	option	for	the	DATABASE	LINK	object	causes	all	activities	on	database links	to	be	audited."
     rationale: "As	the	logging	of	user	activities	involving	the	creation	or	dropping	of	a	DATABASE LINK can provide	forensic	evidence	about	a	pattern	of	unauthorized	activities,	the	audit	capability should	be	enabled."
@@ -1018,11 +999,9 @@ checks:
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT AUDIT_OPTION,SUCCESS,FAILURE, DECODE (A.CON_ID, 0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_STMT_AUDIT_OPTS A WHERE USER_NAME IS NULL AND PROXY_NAME IS NULL AND SUCCESS = ''BY ACCESS'' AND FAILURE = ''BY ACCESS'' AND AUDIT_OPTION=''DATABASE LINK'';\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.1.6 Ensure the 'PUBLIC DATABASE LINK' Audit Option Is Enabled
-  - id: 24567
+  - id: 24566
     title: "Ensure the 'PUBLIC DATABASE LINK' Audit Option Is Enabled"
-    description: "The	PUBLIC DATABASE LINK object	allows	for	the	creation	of	a	public	link	for	an application-based	user	to	access	the	database	for	connections/session	creation.	Enabling
-the	audit	option	causes	all	user	activities	involving	the	creation,	alteration,	or	dropping	of
-public	links	to	be	audited."
+    description: "The	PUBLIC DATABASE LINK object	allows	for	the	creation	of	a	public	link	for	an application-based	user	to	access	the	database	for	connections/session	creation.	Enabling the	audit	option	causes	all	user	activities	involving	the	creation,	alteration,	or	dropping	of public	links	to	be	audited."
     rationale: "As	the	logging	of	user	activities	involving	the	creation,	alteration,	or	dropping	of	a	PUBLIC DATABASE LINK can	provide	forensic	evidence	about	a	pattern	of	unauthorized	activities, the	audit	capability	should	be	enabled."
     remediation: "AUDIT PUBLIC DATABASE LINK;"
     compliance:
@@ -1034,7 +1013,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT AUDIT_OPTION,SUCCESS,FAILURE, DECODE (A.CON_ID, 0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_STMT_AUDIT_OPTS A WHERE USER_NAME IS NULL AND PROXY_NAME IS NULL AND SUCCESS = ''BY ACCESS'' AND FAILURE = ''BY ACCESS'' AND AUDIT_OPTION=''PUBLIC DATABASE LINK'';\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.1.7 Ensure the 'PUBLIC SYNONYM' Audit Option Is Enabled
-  - id: 24568
+  - id: 24567
     title: "Ensure the 'PUBLIC SYNONYM' Audit Option Is Enabled"
     description: "The	PUBLIC SYNONYM object	allows	for	the	creation	of	an	alternate	description	of	an	object. Public	synonyms	are	accessible	by	all	users	that	have	the	appropriate	privileges	to	the underlying	object.	Enabling	the	audit	option	causes	all	user	activities	involving	the	creation or	dropping	of	public	synonyms	to	be	audited."
     rationale: "As	the	logging	of	user	activities	involving	the	creation	or	dropping	of	a	PUBLIC SYNONYM can provide	forensic	evidence	about	a	pattern	of	unauthorized	activities,	the	audit	capability should	be	enabled."
@@ -1048,7 +1027,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT AUDIT_OPTION,SUCCESS,FAILURE, DECODE (A.CON_ID, 0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_STMT_AUDIT_OPTS A WHERE USER_NAME IS NULL AND PROXY_NAME IS NULL AND SUCCESS = ''BY ACCESS'' AND FAILURE = ''BY ACCESS'' AND AUDIT_OPTION=''PUBLIC SYNONYM'';\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.1.8 Ensure the 'SYNONYM' Audit Option Is Enabled
-  - id: 24569
+  - id: 24568
     title: "Ensure the 'SYNONYM' Audit Option Is Enabled"
     description: "The	SYNONYM operation	allows	for	the	creation	of	an	alternative	name	for	a	database	object such	as	a	Java	class	schema	object,	materialized	view,	operator,	package,	procedure, sequence,	stored	function,	table,	view,	user-defined	object	type,	or	even	another	synonym. This	synonym	puts	a	dependency	on	its	target	and	is	rendered	invalid	if	the	target	object	is changed/dropped.	Enabling	the	audit	option	causes	all	user	activities	involving	the	creation or	dropping	of	synonyms	to	be	audited."
     rationale: "As	the	logging	of	user	activities	involving	the	creation	or	dropping	of	a	SYNONYM can	provide forensic	evidence	about	a	pattern	of	suspect/unauthorized	activities,	the	audit	capability should	be	enabled."
@@ -1062,7 +1041,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT AUDIT_OPTION,SUCCESS,FAILURE, DECODE (A.CON_ID, 0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_STMT_AUDIT_OPTS A WHERE USER_NAME IS NULL AND PROXY_NAME IS NULL AND SUCCESS = ''BY ACCESS'' AND FAILURE = ''BY ACCESS'' AND AUDIT_OPTION=''SYNONYM'';\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.1.9 Ensure the 'DIRECTORY' Audit Option Is Enabled
-  - id: 24570
+  - id: 24569
     title: "Ensure the 'DIRECTORY' Audit Option Is Enabled"
     description: "The	DIRECTORY object	allows	for	the	creation	of	a	directory	object	that	specifies	an	alias	for a	directory	on	the	server	file	system,	where	the	external	binary	file	LOBs (BFILEs)/	table data	are	located.	Enabling	this	audit	option	causes	all	user	activities	involving	the	creation or	dropping	of	a	directory	alias	to	be	audited."
     rationale: "As	the	logging	of	user	activities	involving	the	creation	or	dropping	of	a	DIRECTORY can provide	forensic	evidence	about	a	pattern	of	unauthorized	activities,	the	audit	capability should	be	enabled."
@@ -1076,7 +1055,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT AUDIT_OPTION,SUCCESS,FAILURE, DECODE (A.CON_ID, 0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_STMT_AUDIT_OPTS A WHERE USER_NAME IS NULL AND PROXY_NAME IS NULL AND SUCCESS = ''BY ACCESS'' AND FAILURE = ''BY ACCESS'' AND AUDIT_OPTION=''DIRECTORY'';\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.1.10 Ensure the 'SELECT ANY DICTIONARY' Audit Option Is Enabled
-  - id: 24571
+  - id: 24570
     title: "Ensure the 'SELECT ANY DICTIONARY' Audit Option Is Enabled"
     description: "The	SELECT ANY DICTIONARY capability	allows	the	user	to	view	the	definitions	of	all	schema objects	in	the	database.	Enabling	the	audit	option	causes	all	user	activities	involving	this capability	to	be	audited."
     rationale: "As	the	logging	of	user	activities	involving	the	capability	to	access	the	description	of	all schema	objects	in	the	database	can	provide	forensic	evidence	about	a	pattern	of unauthorized	activities,	the	audit	capability	should	be	enabled."
@@ -1090,7 +1069,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT AUDIT_OPTION,SUCCESS,FAILURE, DECODE (A.CON_ID, 0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_STMT_AUDIT_OPTS A WHERE USER_NAME IS NULL AND PROXY_NAME IS NULL AND SUCCESS = ''BY ACCESS'' AND FAILURE = ''BY ACCESS'' AND AUDIT_OPTION=''SELECT ANY DICTIONARY'';\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.1.11 Ensure the 'GRANT ANY OBJECT PRIVILEGE' Audit Option Is Enabled
-  - id: 24572
+  - id: 24571
     title: "Ensure the 'GRANT ANY OBJECT PRIVILEGE' Audit Option Is Enabled"
     description: "GRANT ANY OBJECT PRIVILEGE allows	the	user	to	grant	or	revoke	any	object	privilege, which	includes	privileges	on	tables,	directories,	mining	models,	etc.	Enabling	this	audit option	causes	auditing	of	all	uses	of	that	privilege."
     rationale: "Logging	of	privilege	grants	that	can	lead	to	the	creation,	alteration,	or	deletion	of	critical data,	the	modification	of	objects,	object	privilege	propagation	and	other	such	activities	can be	critical	to	forensic	investigations."
@@ -1104,7 +1083,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT AUDIT_OPTION,SUCCESS,FAILURE, DECODE (A.CON_ID, 0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_STMT_AUDIT_OPTS A WHERE USER_NAME IS NULL AND PROXY_NAME IS NULL AND SUCCESS = ''BY ACCESS'' AND FAILURE = ''BY ACCESS'' AND AUDIT_OPTION=''GRANT ANY OBJECT PRIVILEGE'';\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.1.12 Ensure the 'GRANT ANY PRIVILEGE' Audit Option Is Enabled
-  - id: 24573
+  - id: 24572
     title: "Ensure the 'GRANT ANY PRIVILEGE' Audit Option Is Enabled"
     description: "GRANT ANY PRIVILEGE allows	a	user	to	grant	any	system	privilege,	including	the	most powerful	privileges	typically	available	only	to	administrators	- to	change	the	security infrastructure,	to	drop/add/modify	users	and	more."
     rationale: "Auditing	the	use	of	this	privilege	is	part	of	a	comprehensive	auditing	policy	that	can	help	in detecting	issues	and	can	be	useful	in	forensics."
@@ -1118,7 +1097,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT AUDIT_OPTION,SUCCESS,FAILURE, DECODE (A.CON_ID, 0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_STMT_AUDIT_OPTS A WHERE USER_NAME IS NULL AND PROXY_NAME IS NULL AND SUCCESS = ''BY ACCESS'' AND FAILURE = ''BY ACCESS'' AND AUDIT_OPTION=''GRANT ANY PRIVILEGE'';\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.1.13 Ensure the 'DROP ANY PROCEDURE' Audit Option Is Enabled
-  - id: 24574
+  - id: 24573
     title: "Ensure the 'DROP ANY PROCEDURE' Audit Option Is Enabled"
     description: "The	AUDIT DROP ANY PROCEDURE command	is	auditing	the	dropping	of	procedures. Enabling	the	option	causes	auditing	of	all	such	activities."
     rationale: "Dropping	procedures	of	another	user	could	be	part	of	a	privilege	escalation	exploit	and should	be	audited."
@@ -1132,7 +1111,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT AUDIT_OPTION,SUCCESS,FAILURE, DECODE (A.CON_ID, 0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_STMT_AUDIT_OPTS A WHERE USER_NAME IS NULL AND PROXY_NAME IS NULL AND SUCCESS = ''BY ACCESS'' AND FAILURE = ''BY ACCESS'' AND AUDIT_OPTION=''DROP ANY PROCEDURE'';\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.1.14 Ensure the 'ALL' Audit Option on 'SYS.AUD$' Is Enabled
-  - id: 24575
+  - id: 24574
     title: "Ensure the 'ALL' Audit Option on 'SYS.AUD$' Is Enabled"
     description: "The	logging	of	attempts	to	alter	the	audit	trail	in	the	SYS.AUD$ table	(open	for read/update/delete/view)	will	provide	a	record	of	any	activities	that	may	indicate unauthorized	attempts	to	access	the	audit	trail.	Enabling	the	audit	option	will	cause	these activities	to	be	audited."
     rationale: "As	the	logging	of	attempts	to	alter	the	SYS.AUD$ table	can	provide	forensic	evidence	of	the initiation	of	a	pattern	of	unauthorized	activities,	this	logging	capability	should	be	enabled."
@@ -1145,7 +1124,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT * FROM CDB_OBJ_AUDIT_OPTS WHERE OBJECT_NAME=''AUD$'' AND ALT=''A/A'' AND AUD=''A/A'' AND COM=''A/A'' AND DEL=''A/A'' AND GRA=''A/A'' AND IND=''A/A'' AND INS=''A/A'' AND LOC=''A/A'' AND REN=''A/A'' AND SEL=''A/A'' AND UPD=''A/A'' AND FBK=''A/A'';\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.1.15 Ensure the 'PROCEDURE' Audit Option Is Enabled
-  - id: 24576
+  - id: 24575
     title: "Ensure the 'PROCEDURE' Audit Option Is Enabled"
     description: "In	this	statement	audit,	PROCEDURE means	any	procedure,	function,	package	or	library. Enabling	this	audit	option	causes	any	attempt,	successful	or	not,	to	create	or	drop	any	of these	types	of	objects	to	be	audited,	regardless	of	privilege	or	lack	thereof.	Java	schema objects	(sources,	classes,	and	resources)	are	considered	the	same	as	procedures	for	the purposes	of	auditing	SQL	statements."
     rationale: "Any	unauthorized	attempts	to	create	or	drop	a	procedure	in	another's	schema	should	cause concern,	whether	successful	or	not.	Changes	to	critical	stored	code	can	dramatically	change the	behavior	of	the	application	and	produce	serious	security	consequences,	including enabling	privilege	escalation	and	introducing	SQL	injection	vulnerabilities.	Audit	records	of such	changes	can	be	helpful	in	forensics."
@@ -1159,7 +1138,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT AUDIT_OPTION,SUCCESS,FAILURE, DECODE (A.CON_ID, 0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_STMT_AUDIT_OPTS A WHERE USER_NAME IS NULL AND PROXY_NAME IS NULL AND SUCCESS = ''BY ACCESS'' AND FAILURE = ''BY ACCESS'' AND AUDIT_OPTION=''PROCEDURE'';\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.1.16 Ensure the 'ALTER SYSTEM' Audit Option Is Enabled
-  - id: 24577
+  - id: 24576
     title: "Ensure the 'ALTER SYSTEM' Audit Option Is Enabled"
     description: "ALTER SYSTEM allows	one	to	change	instance	settings,	including	security	settings	and auditing	options.	Additionally,	ALTER SYSTEM can	be	used	to	run	operating	system commands	using	undocumented	Oracle	functionality.	Enabling	the	audit	option	will	audit all	attempts	to	perform	ALTER SYSTEM,	whether	successful	or	not	and	regardless	of	whether or	not	the	ALTER SYSTEM privilege	is	held	by	the	user	attempting	the	action."
     rationale: "Any	unauthorized	attempt	to	alter	the	system	should	be	cause	for	concern.	Alterations outside	of	some	specified	maintenance	window	may	be	of	concern.	In	forensics,	these	audit records	could	be	quite	useful."
@@ -1173,7 +1152,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT AUDIT_OPTION,SUCCESS,FAILURE, DECODE (A.CON_ID, 0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_STMT_AUDIT_OPTS A WHERE USER_NAME IS NULL AND PROXY_NAME IS NULL AND SUCCESS = ''BY ACCESS'' AND FAILURE = ''BY ACCESS'' AND AUDIT_OPTION=''ALTER SYSTEM'';\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.1.17 Ensure the 'TRIGGER' Audit Option Is Enabled
-  - id: 24578
+  - id: 24577
     title: "Ensure the 'TRIGGER' Audit Option Is Enabled"
     description: "A	TRIGGER may	be	used	to	modify	DML actions	or	invoke	other	(recursive)	actions	when some	types	of	user-initiated	actions	occur.	Enabling	this	audit	option	will	cause	auditing	of any	attempt,	successful	or	not,	to	create,	drop,	enable	or	disable	any	schema	trigger	in	any schema	regardless	of	privilege	or	lack	thereof.	For	enabling	and	disabling	a	trigger,	it covers	both	ALTER TRIGGER and	ALTER TABLE."
     rationale: "Triggers	are	often	part	of	schema	security,	data	validation	and	other	critical	constraints upon	actions	and	data.	A	trigger	in	another	schema	may	be	used	to	escalate	privileges, redirect	operations,	transform	data	and	perform	other	sorts	of	perhaps	undesired	actions. Any	unauthorized	attempt	to	create,	drop	or	alter	a	trigger	in	another	schema	may	be	cause for	investigation."
@@ -1187,7 +1166,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"SELECT AUDIT_OPTION,SUCCESS,FAILURE, DECODE (A.CON_ID, 0,(SELECT NAME FROM V\\"\$DATABASE"), 1,(SELECT NAME FROM V\\"\$DATABASE"), (SELECT NAME FROM V\\"\$PDBS" B WHERE A.CON_ID = B.CON_ID)) FROM CDB_STMT_AUDIT_OPTS A WHERE USER_NAME IS NULL AND PROXY_NAME IS NULL AND SUCCESS = ''BY ACCESS'' AND FAILURE = ''BY ACCESS'' AND AUDIT_OPTION=''TRIGGER'';\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.1.18 Ensure the 'CREATE SESSION' Audit Option Is Enabled
-  - id: 24579
+  - id: 24578
     title: "Ensure the 'CREATE SESSION' Audit Option Is Enabled"
     description: "Enabling	this	audit	option	will	cause	auditing	of	all	attempts	to	connect	to	the	database, whether	successful	or	not,	as	well	as	audit	session	disconnects/logoffs.	The	commands	to audit	SESSION,	CONNECT or	CREATE SESSION all	accomplish	the	same	thing	- they	initiate statement	auditing	of	the	connect	statement	used	to	create	a	database	session."
     rationale: "Auditing	attempts	to	connect	to	the	database	is	basic	and	mandated	by	most	security initiatives.	Any	attempt	to	logon	to	a	locked	account,	failed	attempts	to	logon	to	default accounts	or	an	unusually	high	number	of	failed	logon	attempts	of	any	sort,	for	any	user,	in	a particular	time	period	may	indicate	an	intrusion	attempt.	In	forensics,	the	logon	record may	be	first	in	a	chain	of	evidence	and	contain	information	found	in	no	other	type	of	audit record	for	the	session.	Logon	and	logoff	in	the	audit	trail	define	the	period	and	duration	of the	session."
@@ -1204,7 +1183,7 @@ public	links	to	be	audited."
 # 6.2 Unified Auditing
 ###############################################
 # 6.2.1 Ensure the 'CREATE USER' Action Audit Is Enabled
-  - id: 24580
+  - id: 24579
     title: "Ensure the 'CREATE USER' Action Audit Is Enabled"
     description: "The	CREATE USER statement	is	used	to create	Oracle	database	accounts	and	assign	database properties	to	them.	Enabling	this	unified	action	audit	causes	logging	of	all	CREATE USER statements,	whether	successful	or	unsuccessful,	issued	by	the	users	regardless	of	the privileges	held	by	the	users to	issue	such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	create	user	accounts,	whether	successful	or unsuccessful,	may	provide	clues	and	forensic	evidences	about	potential suspicious/unauthorized	activities.	Any	such	activities	may	be	a	cause	for	further investigation.	In	addition,	organization	security	policies	and	industry/government regulations	may	require	logging	of	all	activities	involving	CREATE USER."
@@ -1217,7 +1196,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"WITH CIS_AUDIT(AUDIT_OPTION) AS ( SELECT * FROM TABLE( DBMSOUTPUT_LINESARRAY(''CREATE USER'' ) ) ), AUDIT_ENABLED AS ( SELECT DISTINCT AUDIT_OPTION FROM AUDIT_UNIFIED_POLICIES AUD WHERE AUD.AUDIT_OPTION IN (''CREATE USER'' ) AND AUD.AUDIT_OPTION_TYPE = ''STANDARD ACTION'' AND EXISTS (SELECT * FROM AUDIT_UNIFIED_ENABLED_POLICIES ENABLED WHERE ENABLED.SUCCESS = ''YES'' AND ENABLED.FAILURE = ''YES'' AND ENABLED.ENABLED_OPTION = ''BY USER'' AND ENABLED.ENTITY_NAME = ''ALL USERS'' AND ENABLED.POLICY_NAME = AUD.POLICY_NAME) ) SELECT C.AUDIT_OPTION FROM CIS_AUDIT C LEFT JOIN AUDIT_ENABLED E ON C.AUDIT_OPTION = E.AUDIT_OPTION WHERE E.AUDIT_OPTION IS NULL ;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.2.2 Ensure the 'ALTER USER' Action Audit Is Enabled
-  - id: 24581
+  - id: 24580
     title: "Ensure the 'ALTER USER' Action Audit Is Enabled"
     description: "The	ALTER USER statement	is	used	to	change	database	users’	password,	lock	accounts,	and expire	passwords.	In	addition,	this	statement	is	used	to	change	database	properties	of	user accounts	such	as	database	profiles,	default	and	temporary	tablespaces,	and	tablespace quotas.	This	unified	audit	action	enables	logging	of	all	ALTER USER statements,	whether successful	or	unsuccessful,	issued	by	the	users	regardless	of	the	privileges	held	by	the	users to	issue	such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	alter	user	accounts,	whether	successful	or unsuccessful,	may	provide	clues	and	forensic	evidences	about	potential suspicious/unauthorized	activities.	Any	such	activities	may	be	a	cause	for	further investigation.	In	addition,	organization	security	policies	and	industry/government regulations	may	require	logging	of	all	activities	involving	ALTER USER."
@@ -1230,7 +1209,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"WITH CIS_AUDIT(AUDIT_OPTION) AS ( SELECT * FROM TABLE( DBMSOUTPUT_LINESARRAY(''ALTER USER'' ) ) ), AUDIT_ENABLED AS ( SELECT DISTINCT AUDIT_OPTION FROM AUDIT_UNIFIED_POLICIES AUD WHERE AUD.AUDIT_OPTION IN (''ALTER USER'' ) AND AUD.AUDIT_OPTION_TYPE = ''STANDARD ACTION'' AND EXISTS (SELECT * FROM AUDIT_UNIFIED_ENABLED_POLICIES ENABLED WHERE ENABLED.SUCCESS = ''YES'' AND ENABLED.FAILURE = ''YES'' AND ENABLED.ENABLED_OPTION = ''BY USER'' AND ENABLED.ENTITY_NAME = ''ALL USERS'' AND ENABLED.POLICY_NAME = AUD.POLICY_NAME) ) SELECT C.AUDIT_OPTION FROM CIS_AUDIT C LEFT JOIN AUDIT_ENABLED E ON C.AUDIT_OPTION = E.AUDIT_OPTION WHERE E.AUDIT_OPTION IS NULL;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.2.3 Ensure the 'DROP USER' Audit Option Is Enabled
-  - id: 24582
+  - id: 24581
     title: "Ensure the 'DROP USER' Audit Option Is Enabled"
     description: "The	DROP USER statement	is	used	to	drop	Oracle	database	accounts	and	schemas	associated with	them.	Enabling	this	unified	action	audit	enables	logging	of	all	DROP USER statements, whether	successful	or	unsuccessful,	issued	by	the	users	regardless	of	the	privileges	held	by the	users	to	issue	such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	drop	user,	whether	successful	or	unsuccessful, may	provide	clues	and	forensic	evidence	about	potential	suspicious/unauthorized activities.	Any	such	activities	may	be	a	cause	for	further	investigation.	In	addition, organization	security	policies	and	industry/government	regulations	may	require	logging	of all	activities	involving	DROP USER."
@@ -1243,7 +1222,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"WITH CIS_AUDIT(AUDIT_OPTION) AS ( SELECT * FROM TABLE( DBMSOUTPUT_LINESARRAY(''DROP USER'' ) ) ), AUDIT_ENABLED AS ( SELECT DISTINCT AUDIT_OPTION FROM AUDIT_UNIFIED_POLICIES AUD WHERE AUD.AUDIT_OPTION IN (''DROP USER'' ) AND AUD.AUDIT_OPTION_TYPE = ''STANDARD ACTION'' AND EXISTS (SELECT * FROM AUDIT_UNIFIED_ENABLED_POLICIES ENABLED WHERE ENABLED.SUCCESS = ''YES'' AND ENABLED.FAILURE = ''YES'' AND ENABLED.ENABLED_OPTION = ''BY USER'' AND ENABLED.ENTITY_NAME = ''ALL USERS'' AND ENABLED.POLICY_NAME = AUD.POLICY_NAME) ) SELECT C.AUDIT_OPTION FROM CIS_AUDIT C LEFT JOIN AUDIT_ENABLED E ON C.AUDIT_OPTION = E.AUDIT_OPTION WHERE E.AUDIT_OPTION IS NULL;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.2.4 Ensure the 'CREATE ROLE' Action Audit Is Enabled
-  - id: 24583
+  - id: 24582
     title: "Ensure the 'CREATE ROLE' Action Audit Is Enabled"
     description: "An	Oracle	database	role	is	a	collection	or	set	of	privileges	that	can	be	granted	to	users	or other	roles.	Roles	may	include	system	privileges,	object	privileges	or	other	roles.	Enabling this	unified	audit	action	enables	logging	of	all	CREATE ROLE statements,	whether	successful or	unsuccessful,	issued	by	the	users	regardless	of	the	privileges	held	by	the	users	to	issue such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	create	roles,	whether	successful	or	unsuccessful, may	provide	clues	and	forensic	evidence	about	potential	suspicious/unauthorized activities.	Any	such	activities	may	be	a	cause	for	further	investigation.	In	addition, organization	security	policies	and	industry/government	regulations	may	require	logging	of all	user	activities	involving	CREATE ROLE."
@@ -1256,7 +1235,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"WITH CIS_AUDIT(AUDIT_OPTION) AS ( SELECT * FROM TABLE( DBMSOUTPUT_LINESARRAY(''CREATE ROLE'' ) ) ), AUDIT_ENABLED AS ( SELECT DISTINCT AUDIT_OPTION FROM AUDIT_UNIFIED_POLICIES AUD WHERE AUD.AUDIT_OPTION IN (''CREATE ROLE'' ) AND AUD.AUDIT_OPTION_TYPE = ''STANDARD ACTION'' AND EXISTS (SELECT * FROM AUDIT_UNIFIED_ENABLED_POLICIES ENABLED WHERE ENABLED.SUCCESS = ''YES'' AND ENABLED.FAILURE = ''YES'' AND ENABLED.ENABLED_OPTION = ''BY USER'' AND ENABLED.ENTITY_NAME = ''ALL USERS'' AND ENABLED.POLICY_NAME = AUD.POLICY_NAME) ) SELECT C.AUDIT_OPTION FROM CIS_AUDIT C LEFT JOIN AUDIT_ENABLED E ON C.AUDIT_OPTION = E.AUDIT_OPTION WHERE E.AUDIT_OPTION IS NULL;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.2.5 Ensure the 'ALTER ROLE' Action Audit Is Enabled
-  - id: 24584
+  - id: 24583
     title: "Ensure the 'ALTER ROLE' Action Audit Is Enabled"
     description: "An	Oracle	database	role	is	a	collection	or	set	of	privileges	that	can	be	granted	to	users	or other	roles.	Roles	may	include	system	privileges,	object	privileges	or	other	roles.	The	ALTER ROLE statement	is	used	to	change	the	authorization	needed	to	enable	a	role.	Enabling	this unified	action	audit	causes	logging	of	all	ALTER ROLE statements,	whether	successful	or unsuccessful,	issued	by	the	users	regardless	of	the	privileges	held	by	the	users	to	issue	such statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	alter	roles,	whether	successful	or	unsuccessful, may	provide	clues	and	forensic	evidence	about	potential	suspicious/unauthorized activities.	Any	such	activities	may	be	a	cause	for	further	investigation.	In	addition, organization	security	policies	and	industry/government	regulations	may	require	logging	of all	user	activities	involving	alteration	of	roles."
@@ -1269,7 +1248,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"WITH CIS_AUDIT(AUDIT_OPTION) AS ( SELECT * FROM TABLE( DBMSOUTPUT_LINESARRAY(''ALTER ROLE'' ) ) ), AUDIT_ENABLED AS ( SELECT DISTINCT AUDIT_OPTION FROM AUDIT_UNIFIED_POLICIES AUD WHERE AUD.AUDIT_OPTION IN (''ALTER ROLE'' ) AND AUD.AUDIT_OPTION_TYPE = ''STANDARD ACTION'' AND EXISTS (SELECT * FROM AUDIT_UNIFIED_ENABLED_POLICIES ENABLED WHERE ENABLED.SUCCESS = ''YES'' AND ENABLED.FAILURE = ''YES'' AND ENABLED.ENABLED_OPTION = ''BY USER'' AND ENABLED.ENTITY_NAME = ''ALL USERS'' AND ENABLED.POLICY_NAME = AUD.POLICY_NAME) ) SELECT C.AUDIT_OPTION FROM CIS_AUDIT C LEFT JOIN AUDIT_ENABLED E ON C.AUDIT_OPTION = E.AUDIT_OPTION WHERE E.AUDIT_OPTION IS NULL;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.2.6 Ensure the 'DROP ROLE' Action Audit Is Enabled
-  - id: 24585
+  - id: 24584
     title: "Ensure the 'DROP ROLE' Action Audit Is Enabled"
     description: "An	Oracle	database	role	is	a	collection	or	set	of	privileges	that	can	be	granted	to	users	or other	roles.	Roles	may	include	system	privileges,	object	privileges	or	other	roles.	Enabling this	unified	audit	action	enables	logging	of	all	DROP ROLE statements,	successful	or unsuccessful,	issued	by	the	users	regardless	of	the	privileges	held	by	the	users	to	issue	such statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	drop	roles,	whether	successful	or	unsuccessful, may	provide	clues	and	forensic	evidence	about	potential	suspicious/unauthorized activities.	Any	such	activities	may	be	a	cause	for	further	investigation.	In	addition, organization	security	policies	and	industry/government	regulations	may	require	logging	of all	user	activities	involving	DROP ROLE."
@@ -1282,7 +1261,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"WITH CIS_AUDIT(AUDIT_OPTION) AS ( SELECT * FROM TABLE( DBMSOUTPUT_LINESARRAY(''DROP ROLE'' ) ) ), AUDIT_ENABLED AS ( SELECT DISTINCT AUDIT_OPTION FROM AUDIT_UNIFIED_POLICIES AUD WHERE AUD.AUDIT_OPTION IN (''DROP ROLE'' ) AND AUD.AUDIT_OPTION_TYPE = ''STANDARD ACTION'' AND EXISTS (SELECT * FROM AUDIT_UNIFIED_ENABLED_POLICIES ENABLED WHERE ENABLED.SUCCESS = ''YES'' AND ENABLED.FAILURE = ''YES'' AND ENABLED.ENABLED_OPTION = ''BY USER'' AND ENABLED.ENTITY_NAME = ''ALL USERS'' AND ENABLED.POLICY_NAME = AUD.POLICY_NAME) ) SELECT C.AUDIT_OPTION FROM CIS_AUDIT C LEFT JOIN AUDIT_ENABLED E ON C.AUDIT_OPTION = E.AUDIT_OPTION WHERE E.AUDIT_OPTION IS NULL;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.2.7 Ensure the 'GRANT' Action Audit Is Enabled
-  - id: 24586
+  - id: 24585
     title: "Ensure the 'GRANT' Action Audit Is Enabled"
     description: "GRANT statements	are	used	to	grant	privileges	to	Oracle	database	users	and	roles,	including the	most	powerful	privileges	and	roles	typically	available	to	the	database	administrators. Enabling	this	unified	action	audit	enables	logging	of	all	GRANT statements,	whether successful	or	unsuccessful,	issued	by	the	users	regardless	of	the	privileges	held	by	the	users to	issue	such	statements."
     rationale: "With	unauthorized	grants	and	permissions,	a	malicious	user	may	be	able	to	change	the security	of	the	database,	access/update	confidential	data,	or	compromise	the	integrity	of the	database.	Logging	and	monitoring	of	all	attempts	to	grant	system	privileges,	object privileges	or	roles,	whether	successful	or	unsuccessful,	may	provide	forensic	evidence about	potential	suspicious/unauthorized	activities	as	well	as	privilege	escalation	activities. Any	such	activities	may	be	a	cause	for	further	investigation.	In	addition,	organization security	policies	and	industry/government	regulations	may	require	logging	of	all	user activities	involving	GRANT."
@@ -1295,7 +1274,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"WITH CIS_AUDIT(AUDIT_OPTION) AS ( SELECT * FROM TABLE( DBMSOUTPUT_LINESARRAY(''GRANT'' ) ) ), AUDIT_ENABLED AS ( SELECT DISTINCT AUDIT_OPTION FROM AUDIT_UNIFIED_POLICIES AUD WHERE AUD.AUDIT_OPTION IN (''GRANT'' ) AND AUD.AUDIT_OPTION_TYPE = ''STANDARD ACTION'' AND EXISTS (SELECT * FROM AUDIT_UNIFIED_ENABLED_POLICIES ENABLED WHERE ENABLED.SUCCESS = ''YES'' AND ENABLED.FAILURE = ''YES'' AND ENABLED.ENABLED_OPTION = ''BY USER'' AND ENABLED.ENTITY_NAME = ''ALL USERS'' AND ENABLED.POLICY_NAME = AUD.POLICY_NAME) ) SELECT C.AUDIT_OPTION FROM CIS_AUDIT C LEFT JOIN AUDIT_ENABLED E ON C.AUDIT_OPTION = E.AUDIT_OPTION WHERE E.AUDIT_OPTION IS NULL;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.2.8 Ensure the 'REVOKE' Action Audit Is Enabled
-  - id: 24587
+  - id: 24586
     title: "Ensure the 'REVOKE' Action Audit Is Enabled"
     description: "REVOKE statements	are	used	to	revoke	privileges	from	Oracle	database	users	and	roles. Enabling	this	unified	action	audit	enables	logging	of	all	REVOKE statements,	successful	or unsuccessful,	issued	by	the	users	regardless	of	the	privileges	held	by	the	users	to	issue	such statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	revoke	system	privileges,	object	privileges	or roles,	whether	successful	or	unsuccessful,	may	provide	clues	and	forensic	evidence	about potential	suspicious/unauthorized	activities.	Any	such	activities	may	be	a	cause	for	further investigation.	In	addition,	organization	security	policies	and	industry/government regulations	may	require	logging	of	all	user	activities	involving	REVOKE."
@@ -1308,7 +1287,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"WITH CIS_AUDIT(AUDIT_OPTION) AS ( SELECT * FROM TABLE( DBMSOUTPUT_LINESARRAY(''REVOKE'' ) ) ), AUDIT_ENABLED AS ( SELECT DISTINCT AUDIT_OPTION FROM AUDIT_UNIFIED_POLICIES AUD WHERE AUD.AUDIT_OPTION IN (''REVOKE'' ) AND AUD.AUDIT_OPTION_TYPE = ''STANDARD ACTION'' AND EXISTS (SELECT * FROM AUDIT_UNIFIED_ENABLED_POLICIES ENABLED WHERE ENABLED.SUCCESS = ''YES'' AND ENABLED.FAILURE = ''YES'' AND ENABLED.ENABLED_OPTION = ''BY USER'' AND ENABLED.ENTITY_NAME = ''ALL USERS'' AND ENABLED.POLICY_NAME = AUD.POLICY_NAME) ) SELECT C.AUDIT_OPTION FROM CIS_AUDIT C LEFT JOIN AUDIT_ENABLED E ON C.AUDIT_OPTION = E.AUDIT_OPTION WHERE E.AUDIT_OPTION IS NULL;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.2.9 Ensure the 'CREATE PROFILE' Action Audit Is Enabled
-  - id: 24588
+  - id: 24587
     title: "Ensure the 'CREATE PROFILE' Action Audit Is Enabled"
     description: "Oracle	database	profiles	are	used	to	enforce	resource	usage	limits	and	implement password	policies	such	as	password	complexity	rules	and	reuse	restrictions.	Enabling	this unified	action	audit	enables	logging	of	all	CREATE PROFILE statements,	whether	successful or	unsuccessful,	issued	by	the	users	regardless	of	the	privileges	held	by	the	users	to	issue such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	create	profiles,	whether	successful	or unsuccessful,	may	provide	clues	and	forensic	evidence	about	potential suspicious/unauthorized	activities.	Any	such	activities	may	be	a	cause	for	further investigation.	In	addition,	organization	security	policies	and	industry/government regulations	may	require	logging	of	all	user	activities	involving	creation	of	database	profiles."
@@ -1321,7 +1300,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"WITH CIS_AUDIT(AUDIT_OPTION) AS ( SELECT * FROM TABLE( DBMSOUTPUT_LINESARRAY(''CREATE PROFILE'' ) ) ), AUDIT_ENABLED AS ( SELECT DISTINCT AUDIT_OPTION FROM AUDIT_UNIFIED_POLICIES AUD WHERE AUD.AUDIT_OPTION IN (''CREATE PROFILE'') AND AUD.AUDIT_OPTION_TYPE = ''STANDARD ACTION'' AND EXISTS (SELECT * FROM AUDIT_UNIFIED_ENABLED_POLICIES ENABLED WHERE ENABLED.SUCCESS = ''YES'' AND ENABLED.FAILURE = ''YES'' AND ENABLED.ENABLED_OPTION = ''BY USER'' AND ENABLED.ENTITY_NAME = ''ALL USERS'' AND ENABLED.POLICY_NAME = AUD.POLICY_NAME) ) SELECT C.AUDIT_OPTION FROM CIS_AUDIT C LEFT JOIN AUDIT_ENABLED E ON C.AUDIT_OPTION = E.AUDIT_OPTION WHERE E.AUDIT_OPTION IS NULL;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.2.10 Ensure the 'ALTER PROFILE' Action Audit Is Enabled
-  - id: 24589
+  - id: 24588
     title: "Ensure the 'ALTER PROFILE' Action Audit Is Enabled"
     description: "Oracle	database	profiles	are	used	to	enforce	resource	usage	limits	and	implement password	policies	such	as	password	complexity	rules	and	reuse	restrictions.	Enabling	this unified	action	audit	enables	logging	of	all	ALTER PROFILE statements,	whether	successful	or unsuccessful,	issued	by	the	users	regardless	of	the	privileges	held	by	the	users	to	issue	such statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	alter	profiles,	whether	successful	or	unsuccessful, may	provide	forensic	evidence	about	potential	suspicious/unauthorized	activities.	Any such	activities	may	be	a	cause	for	further	investigation.	In	addition,	organization	security policies	and	industry/government	regulations	may	require	logging	of	all	user	activities involving	alteration	of	database	profiles."
@@ -1334,7 +1313,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"WITH CIS_AUDIT(AUDIT_OPTION) AS ( SELECT * FROM TABLE( DBMSOUTPUT_LINESARRAY(''ALTER PROFILE'' ) ) ), AUDIT_ENABLED AS ( SELECT DISTINCT AUDIT_OPTION FROM AUDIT_UNIFIED_POLICIES AUD WHERE AUD.AUDIT_OPTION IN (''ALTER PROFILE'' ) AND AUD.AUDIT_OPTION_TYPE = ''STANDARD ACTION'' AND EXISTS (SELECT * FROM AUDIT_UNIFIED_ENABLED_POLICIES ENABLED WHERE ENABLED.SUCCESS = ''YES'' AND ENABLED.FAILURE = ''YES'' AND ENABLED.ENABLED_OPTION = ''BY USER'' AND ENABLED.ENTITY_NAME = ''ALL USERS'' AND ENABLED.POLICY_NAME = AUD.POLICY_NAME) ) SELECT C.AUDIT_OPTION FROM CIS_AUDIT C LEFT JOIN AUDIT_ENABLED E ON C.AUDIT_OPTION = E.AUDIT_OPTION WHERE E.AUDIT_OPTION IS NULL;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.2.11 Ensure the 'DROP PROFILE' Action Audit Is Enabled
-  - id: 24590
+  - id: 24589
     title: "Ensure the 'DROP PROFILE' Action Audit Is Enabled "
     description: "Oracle	database	profiles	are	used	to	enforce	resource	usage	limits	and	implement password	policies	such	as	password	complexity	rules	and	reuse	restrictions.	Enabling	this unified	action	audit	enables	logging	of	all	DROP PROFILE statements,	whether	successful	or unsuccessful,	issued	by	the	users	regardless	of	the	privileges	held	by	the	users	to	issue	such statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	drop	profiles,	whether	successful	or unsuccessful,	may	provide	clues	and	forensic	evidence	about	potential suspicious/unauthorized	activities.	Any	such	activities	may	be	a	cause	for	further investigation.	In	addition,	organization	security	policies	and	industry/government regulations	may	require	logging	of	all	user	activities	involving	dropping	database	profiles."
@@ -1347,7 +1326,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"WITH CIS_AUDIT(AUDIT_OPTION) AS ( SELECT * FROM TABLE( DBMSOUTPUT_LINESARRAY(''DROP PROFILE'' ) ) ), AUDIT_ENABLED AS ( SELECT DISTINCT AUDIT_OPTION FROM AUDIT_UNIFIED_POLICIES AUD WHERE AUD.AUDIT_OPTION IN (''DROP PROFILE'' ) AND AUD.AUDIT_OPTION_TYPE = ''STANDARD ACTION'' AND EXISTS (SELECT * FROM AUDIT_UNIFIED_ENABLED_POLICIES ENABLED WHERE ENABLED.SUCCESS = ''YES'' AND ENABLED.FAILURE = ''YES'' AND ENABLED.ENABLED_OPTION = ''BY USER'' AND ENABLED.ENTITY_NAME = ''ALL USERS'' AND ENABLED.POLICY_NAME = AUD.POLICY_NAME) ) SELECT C.AUDIT_OPTION FROM CIS_AUDIT C LEFT JOIN AUDIT_ENABLED E ON C.AUDIT_OPTION = E.AUDIT_OPTION WHERE E.AUDIT_OPTION IS NULL;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.2.12 Ensure the 'CREATE DATABASE LINK' Action Audit Is Enabled
-  - id: 24591
+  - id: 24590
     title: "Ensure the 'CREATE DATABASE LINK' Action Audit Is Enabled"
     description: "Oracle	database	links	are	used	to	establish	database-to-database	connections	to	other databases.	These	connections	are	available	without	further	authentication	once	the	link	is established.	Enabling	this	unified	action	audit	causes	logging	of	all	CREATE DATABASE and CREATE PUBLIC DATABASE statements,	whether	successful	or	unsuccessful,	issued	by	the users	regardless	of	the	privileges	held	by	the	users	to	issue	such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	create	database	links,	whether	successful	or unsuccessful,	may	provide	forensic	evidence	about	potential	suspicious/unauthorized activities.	Any	such	activities	may	be	a	cause	for	further	investigation.	In	addition, organization	security	policies	and	industry/government	regulations	may	require	logging	of all	user	activities	involving	creation	of	database	links."
@@ -1360,7 +1339,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"WITH CIS_AUDIT(AUDIT_OPTION) AS ( SELECT * FROM TABLE( DBMSOUTPUT_LINESARRAY(''CREATE DATABASE LINK'' ) ) ), AUDIT_ENABLED AS ( SELECT DISTINCT AUDIT_OPTION FROM AUDIT_UNIFIED_POLICIES AUD WHERE AUD.AUDIT_OPTION IN (''CREATE DATABASE LINK'' ) AND AUD.AUDIT_OPTION_TYPE = ''STANDARD ACTION'' AND EXISTS (SELECT * FROM AUDIT_UNIFIED_ENABLED_POLICIES ENABLED WHERE ENABLED.SUCCESS = ''YES'' AND ENABLED.FAILURE = ''YES'' AND ENABLED.ENABLED_OPTION = ''BY USER'' AND ENABLED.ENTITY_NAME = ''ALL USERS'' AND ENABLED.POLICY_NAME = AUD.POLICY_NAME) ) SELECT C.AUDIT_OPTION FROM CIS_AUDIT C LEFT JOIN AUDIT_ENABLED E ON C.AUDIT_OPTION = E.AUDIT_OPTION WHERE E.AUDIT_OPTION IS NULL;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.2.13 Ensure the 'ALTER DATABASE LINK' Action Audit Is Enabled
-  - id: 24592
+  - id: 24591
     title: "Ensure the 'ALTER DATABASE LINK' Action Audit Is Enabled"
     description: "Oracle	database	links	are	used	to	establish	database-to-database	connections	to	other databases.	These	connections	are	always	available	without	further	authentication	once	the link	is	established.	Enabling	this	unified	action	audit	causes	logging	of	all	ALTER DATABASE and	ALTER PUBLIC DATABASE statements,	whether	successful	or	unsuccessful,	issued	by	the users	regardless	of	the	privileges	held	by	the	users	to	issue	such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	alter	database	links,	whether	successful	or unsuccessful,	may	provide	forensic	evidence	about	potential	suspicious/unauthorized activities.	Any	such	activities	may	be	a	cause	for	further	investigation.	In	addition, organization	security	policies	and	industry/government	regulations	may	require	logging	of all	user	activities	involving	alteration	of	database	links."
@@ -1373,7 +1352,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"WITH CIS_AUDIT(AUDIT_OPTION) AS ( SELECT * FROM TABLE( DBMSOUTPUT_LINESARRAY(''ALTER DATABASE LINK'' ) ) ), AUDIT_ENABLED AS ( SELECT DISTINCT AUDIT_OPTION FROM AUDIT_UNIFIED_POLICIES AUD WHERE AUD.AUDIT_OPTION IN (''ALTER DATABASE LINK'' ) AND AUD.AUDIT_OPTION_TYPE = ''STANDARD ACTION'' AND EXISTS (SELECT * FROM AUDIT_UNIFIED_ENABLED_POLICIES ENABLED WHERE ENABLED.SUCCESS = ''YES'' AND ENABLED.FAILURE = ''YES'' AND ENABLED.ENABLED_OPTION = ''BY USER'' AND ENABLED.ENTITY_NAME = ''ALL USERS'' AND ENABLED.POLICY_NAME = AUD.POLICY_NAME) ) SELECT C.AUDIT_OPTION FROM CIS_AUDIT C LEFT JOIN AUDIT_ENABLED E ON C.AUDIT_OPTION = E.AUDIT_OPTION WHERE E.AUDIT_OPTION IS NULL;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.2.14 Ensure the 'DROP DATABASE LINK' Action Audit Is Enabled
-  - id: 24593
+  - id: 24592
     title: "Ensure the 'DROP DATABASE LINK' Action Audit Is Enabled"
     description: "Oracle	database	links	are	used	to	establish	database-to-database	connections	to	other databases.	These	connections	are	always	available	without	further	authentication	once	the link	is	established.	Enabling	this	unified	action	audit	causes	logging	of	all	DROP DATABASE and	DROP PUBLIC DATABASE,	whether	successful	or	unsuccessful,	statements	issued	by	the users	regardless	of	the	privileges	held	by	the	users	to	issue	such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	drop	database	links,	whether	successful	or unsuccessful,	may	provide	forensic	evidence	about	potential	suspicious/unauthorized activities.	Any	such	activities	may	be	a	cause	for	further	investigation.	In	addition, organization	security	policies	and	industry/government	regulations	may	require	logging	of all	user	activities	involving	dropping	database	links."
@@ -1386,7 +1365,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"WITH CIS_AUDIT(AUDIT_OPTION) AS (SELECT * FROM TABLE( DBMSOUTPUT_LINESARRAY(''DROP DATABASE LINK'' ) ) ), AUDIT_ENABLED AS ( SELECT DISTINCT AUDIT_OPTION FROM AUDIT_UNIFIED_POLICIES AUD WHERE AUD.AUDIT_OPTION IN (''DROP DATABASE LINK'' ) AND AUD.AUDIT_OPTION_TYPE = ''STANDARD ACTION'' AND EXISTS (SELECT * FROM AUDIT_UNIFIED_ENABLED_POLICIES ENABLED WHERE ENABLED.SUCCESS = ''YES'' AND ENABLED.FAILURE = ''YES'' AND ENABLED.ENABLED_OPTION = ''BY USER'' AND ENABLED.ENTITY_NAME = ''ALL USERS'' AND ENABLED.POLICY_NAME = AUD.POLICY_NAME) ) SELECT C.AUDIT_OPTION FROM CIS_AUDIT C LEFT JOIN AUDIT_ENABLED E ON C.AUDIT_OPTION = E.AUDIT_OPTION WHERE E.AUDIT_OPTION IS NULL;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.2.15 Ensure the 'CREATE SYNONYM' Action Audit Is Enabled
-  - id: 24594
+  - id: 24593
     title: "Ensure the 'CREATE SYNONYM' Action Audit Is Enabled"
     description: "An	Oracle	database	synonym	is	used	to	create	an	alternative	name	for	a	database	object such	as	table,	view,	procedure,	java	object	or	even	another	synonym,	etc.	Enabling	this unified	action	audit	causes	logging	of	all	CREATE SYNONYM and	CREATE PUBLIC SYNONYM statements,	whether	successful	or	unsuccessful,	issued	by	the	users	regardless	of	the privileges	held	by	the	users	to	issue	such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	create	synonyms,	whether	successful	or unsuccessful,	may	provide	clues	and	forensic	evidence	about	potential suspicious/unauthorized	activities.	Any	such	activities	may	be	a	cause	for	further investigation.	In	addition,	organization	security	policies	and	industry/government regulations	may	require	logging	of	all	user	activities	involving	creation	of	synonyms	or public	synonyms."
@@ -1399,7 +1378,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"WITH CIS_AUDIT(AUDIT_OPTION) AS ( SELECT * FROM TABLE( DBMSOUTPUT_LINESARRAY( ''CREATE SYNONYM'' ) ) ), AUDIT_ENABLED AS ( SELECT DISTINCT AUDIT_OPTION FROM AUDIT_UNIFIED_POLICIES AUD WHERE AUD.AUDIT_OPTION IN (''CREATE SYNONYM'' ) AND AUD.AUDIT_OPTION_TYPE = ''STANDARD ACTION'' AND EXISTS (SELECT * FROM AUDIT_UNIFIED_ENABLED_POLICIES ENABLED WHERE ENABLED.SUCCESS = ''YES'' AND ENABLED.FAILURE = ''YES'' AND ENABLED.ENABLED_OPTION = ''BY USER'' AND ENABLED.ENTITY_NAME = ''ALL USERS'' AND ENABLED.POLICY_NAME = AUD.POLICY_NAME) ) SELECT C.AUDIT_OPTION FROM CIS_AUDIT C LEFT JOIN AUDIT_ENABLED E ON C.AUDIT_OPTION = E.AUDIT_OPTION WHERE E.AUDIT_OPTION IS NULL;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.2.16 Ensure the 'ALTER SYNONYM' Action Audit Is Enabled
-  - id: 24595
+  - id: 24594
     title: "Ensure the 'ALTER SYNONYM' Action Audit Is Enabled"
     description: "An	Oracle	database	synonym	is	used	to	create	an	alternative	name	for	a	database	object such	as	table,	view,	procedure,	or	java	object,	or	even	another	synonym.	Enabling	this unified	action	audit	causes	logging	of	all	ALTER SYNONYM and	ALTER PUBLIC SYNONYM statements,	whether	successful	or	unsuccessful,	issued	by	the	users	regardless	of	the privileges	held	by	the	users	to	issue	such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	alter	synonyms,	whether	successful	or unsuccessful,	may	provide	clues	and	forensic	evidence	about	potential suspicious/unauthorized	activities.	Any	such	activities	may	be	a	cause	for	further investigation.	In	addition,	organization	security	policies	and	industry/government regulations	may	require	logging	of	all	user	activities	involving	alteration	of	synonyms	or public	synonyms."
@@ -1412,7 +1391,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"WITH CIS_AUDIT(AUDIT_OPTION) AS ( SELECT * FROM TABLE( DBMSOUTPUT_LINESARRAY(''ALTER SYNONYM'' ) ) ), AUDIT_ENABLED AS ( SELECT DISTINCT AUDIT_OPTION FROM AUDIT_UNIFIED_POLICIES AUD WHERE AUD.AUDIT_OPTION IN (''ALTER SYNONYM'' ) AND AUD.AUDIT_OPTION_TYPE = ''STANDARD ACTION'' AND EXISTS (SELECT * FROM AUDIT_UNIFIED_ENABLED_POLICIES ENABLED WHERE ENABLED.SUCCESS = ''YES'' AND ENABLED.FAILURE = ''YES'' AND ENABLED.ENABLED_OPTION = ''BY USER'' AND ENABLED.ENTITY_NAME = ''ALL USERS'' AND ENABLED.POLICY_NAME = AUD.POLICY_NAME) ) SELECT C.AUDIT_OPTION FROM CIS_AUDIT C LEFT JOIN AUDIT_ENABLED E ON C.AUDIT_OPTION = E.AUDIT_OPTION WHERE E.AUDIT_OPTION IS NULL;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.2.17 Ensure the 'DROP SYNONYM' Action Audit Is Enabled
-  - id: 24596
+  - id: 24595
     title: "Ensure the 'DROP SYNONYM' Action Audit Is Enabled"
     description: "An	Oracle	database	synonym	is	used	to	create	an	alternative	name	for	a	database	object such	as	table,	view,	procedure,	or	java	object,	or	even	another	synonym.	Enabling	his unified	action	audit	causes	logging	of	all	DROP SYNONYM and	DROP PUBLIC SYNONYM statements,	whether	successful	or	unsuccessful,	issued	by	the	users	regardless	of	the privileges	held	by	the	users	to	issue	such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	drop	synonyms,	whether	successful	or unsuccessful,	may	provide	forensic	evidence	about	potential	suspicious/unauthorized activities.	Any	such	activities	may	be	a	cause	for	further	investigation.	In	addition, organization	security	policies	and	industry/government	regulations	may	require	logging	of all	user	activities involving	dropping	of	synonyms	or	public	synonyms."
@@ -1425,7 +1404,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"WITH CIS_AUDIT(AUDIT_OPTION) AS ( SELECT * FROM TABLE( DBMSOUTPUT_LINESARRAY( ''DROP SYNONYM'' ) ) ), AUDIT_ENABLED AS ( SELECT DISTINCT AUDIT_OPTION FROM AUDIT_UNIFIED_POLICIES AUD WHERE AUD.AUDIT_OPTION IN (''DROP SYNONYM'' ) AND AUD.AUDIT_OPTION_TYPE = ''STANDARD ACTION'' AND EXISTS (SELECT * FROM AUDIT_UNIFIED_ENABLED_POLICIES ENABLED WHERE ENABLED.SUCCESS = ''YES'' AND ENABLED.FAILURE = ''YES'' AND ENABLED.ENABLED_OPTION = ''BY USER'' AND ENABLED.ENTITY_NAME = ''ALL USERS'' AND ENABLED.POLICY_NAME = AUD.POLICY_NAME) ) SELECT C.AUDIT_OPTION FROM CIS_AUDIT C LEFT JOIN AUDIT_ENABLED E ON C.AUDIT_OPTION = E.AUDIT_OPTION WHERE E.AUDIT_OPTION IS NULL;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.2.18 Ensure the 'SELECT ANY DICTIONARY' Privilege Audit Is Enabled
-  - id: 24597
+  - id: 24596
     title: "Ensure the 'SELECT ANY DICTIONARY' Privilege Audit Is Enabled"
     description: "The	SELECT ANY DICTIONARY system	privilege	allows	the	user	to	view	the	definition	of	all schema	objects	in	the	database.	It	grants	SELECT privileges	on	the	data	dictionary	objects	to the	grantees,	including	SELECT on	DBA_ views,	V$ views,	X$ views	and	underlying	SYS tables such	as	TAB$ and	OBJ$.	This	privilege	also	allows	grantees	to	create	stored	objects	such	as procedures,	packages	and	views	on	the	underlying	data	dictionary	objects.	Please	note	that this	privilege	does	not	grant	SELECT on	tables	with	password	hashes	such	as	USER$, DEFAULT_PWD$,	LINK$,	and	USER_HISTORY$.	Enabling	this	audit	causes	logging	of	activities that	exercise	this	privilege."
     rationale: "Logging	and	monitoring	of	all	attempts	to	access	a	data	dictionary,	whether	successful	or unsuccessful,	may	provide	clues	and	forensic	evidence	about	potential suspicious/unauthorized	activities.	Any	such	activities	may	be	a	cause	for	further investigation.	In	addition,	organization	security	policies	and	industry/government regulations	may	require	logging	of	all	user	activities	involving	access	to	the	database."
@@ -1438,7 +1417,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"WITH CIS_AUDIT(AUDIT_OPTION) AS ( SELECT * FROM TABLE( DBMSOUTPUT_LINESARRAY( ''SELECT ANY DICTIONARY'' ) ) ), AUDIT_ENABLED AS ( SELECT DISTINCT AUDIT_OPTION FROM AUDIT_UNIFIED_POLICIES AUD WHERE AUD.AUDIT_OPTION IN (''SELECT ANY DICTIONARY'' ) AND AUD.AUDIT_OPTION_TYPE = ''SYSTEM PRIVILEGE'' AND EXISTS (SELECT * FROM AUDIT_UNIFIED_ENABLED_POLICIES ENABLED WHERE ENABLED.SUCCESS = ''YES'' AND ENABLED.FAILURE = ''YES'' AND ENABLED.ENABLED_OPTION = ''BY USER'' AND ENABLED.ENTITY_NAME = ''ALL USERS'' AND ENABLED.POLICY_NAME = AUD.POLICY_NAME) ) SELECT C.AUDIT_OPTION FROM CIS_AUDIT C LEFT JOIN AUDIT_ENABLED E ON C.AUDIT_OPTION = E.AUDIT_OPTION WHERE E.AUDIT_OPTION IS NULL ;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.2.19 Ensure the 'AUDSYS.AUD$UNIFIED' Access Audit Is Enabled
-  - id: 24598
+  - id: 24597
     title: "Ensure the 'AUDSYS.AUD$UNIFIED' Access Audit Is Enabled"
     description: "The	AUDSYS.AUD$UNIFIED holds	audit	trail	records	generated	by	the	database.	Enabling	this audit	action	causes	logging	of	all	access	attempts	to	the	AUDSYS.AUD$UNIFIED,	whether successful	or	unsuccessful,	regardless	of	the	privileges	held	by	the	users	to	issue	such statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	access	the	AUDSYS.AUD$UNIFIED,	whether successful	or	unsuccessful,	may	provide	clues	and	forensic	evidence	about	potential suspicious/unauthorized	activities.	Any	such	activities	may	be	a	cause	for	further investigation.	In	addition,	organization	security	policies	and industry/government regulations	may	require	logging	of	all	user	activities	involving	access	to	this	table."
@@ -1451,7 +1430,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"WITH CIS_AUDIT(AUDIT_OPTION) AS ( SELECT * FROM TABLE( DBMSOUTPUT_LINESARRAY( ''AUD$UNIFIED'' ) ) ), AUDIT_ENABLED AS ( SELECT DISTINCT OBJECT_NAME FROM AUDIT_UNIFIED_POLICIES AUD WHERE AUD.AUDIT_OPTION IN (''ALL'' ) AND AUD.AUDIT_OPTION_TYPE = ''OBJECT ACTION'' AND AUD.OBJECT_SCHEMA = ''AUDSYS'' AND AUD.OBJECT_NAME = ''AUD$UNIFIED'' AND EXISTS (SELECT * FROM AUDIT_UNIFIED_ENABLED_POLICIES ENABLED WHERE ENABLED.SUCCESS = ''YES'' AND ENABLED.FAILURE = ''YES'' AND ENABLED.ENABLED_OPTION = ''BY USER'' AND ENABLED.ENTITY_NAME = ''ALL USERS'' AND ENABLED.POLICY_NAME = AUD.POLICY_NAME) ) SELECT C.AUDIT_OPTION FROM CIS_AUDIT C LEFT JOIN AUDIT_ENABLED E ON C.AUDIT_OPTION = E.OBJECT_NAME WHERE E.OBJECT_NAME IS NULL;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.2.20 Ensure the 'CREATE PROCEDURE/FUNCTION/PACKAGE/PACKAGE BODY' Action Audit Is Enabled
-  - id: 24599
+  - id: 24598
     title: "Ensure the 'CREATE PROCEDURE/FUNCTION/PACKAGE/PACKAGE BODY' Action Audit Is Enabled"
     description: "Oracle	database	procedures,	function,	packages,	and	package	bodies,	which	are	stored within	the	database,	are	created	to	perform	business	functions	and	access	database	as defined	by	PL/SQL	code	and	SQL	statements	contained	within	these	objects.	Enabling	this unified	action	audit	causes	logging	of	all	CREATE PROCEDURE,	CREATE FUNCTION,	CREATE PACKAGE and	CREATE PACKAGE BODY statements,	successful	or	unsuccessful,	statements issued	by	the	users	regardless	of	the	privileges	held	by	the	users	to	issue	such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	create	procedures,	functions,	packages	or package	bodies,	whether	successful	or	unsuccessful,	may	provide	clues	and	forensic evidence	about	potential	suspicious/unauthorized	activities.	Any	such	activities	may	be	a cause for	further	investigation.	In	addition,	organization	security	policies	and industry/government	regulations	may	require	logging	of	all	user	activities	involving creation	of	procedures,	functions,	packages	or	package	bodies."
@@ -1464,7 +1443,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"WITH CIS_AUDIT(AUDIT_OPTION) AS ( SELECT * FROM TABLE( DBMSOUTPUT_LINESARRAY( ''CREATE PROCEDURE'',''CREATE FUNCTION'',''CREATE PACKAGE'',''CREATE PACKAGE BODY'' ) ) ), AUDIT_ENABLED AS ( SELECT DISTINCT AUDIT_OPTION FROM AUDIT_UNIFIED_POLICIES AUD WHERE AUD.AUDIT_OPTION IN (''CREATE PROCEDURE'',''CREATE FUNCTION'',''CREATE PACKAGE'',''CREATE PACKAGE BODY'' ) AND AUD.AUDIT_OPTION_TYPE = ''STANDARD ACTION'' AND EXISTS (SELECT * FROM AUDIT_UNIFIED_ENABLED_POLICIES ENABLED WHERE ENABLED.SUCCESS = ''YES'' AND ENABLED.FAILURE = ''YES'' AND ENABLED.ENABLED_OPTION = ''BY USER'' AND ENABLED.ENTITY_NAME = ''ALL USERS'' AND ENABLED.POLICY_NAME = AUD.POLICY_NAME) ) SELECT C.AUDIT_OPTION FROM CIS_AUDIT C LEFT JOIN AUDIT_ENABLED E ON C.AUDIT_OPTION = E.AUDIT_OPTION WHERE E.AUDIT_OPTION IS NULL;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.2.21 Ensure the 'ALTER PROCEDURE/FUNCTION/PACKAGE/PACKAGE BODY' Action Audit Is Enabled
-  - id: 24600
+  - id: 24599
     title: "Ensure the 'ALTER PROCEDURE/FUNCTION/PACKAGE/PACKAGE BODY' Action Audit Is Enabled"
     description: "Oracle	database	procedures,	functions,	packages,	and	package	bodies,	which	are	stored within	the	database,	are	created	to	carry	out	business	functions	and	access	database	as defined	by	PL/SQL	code	and	SQL	statements	contained	within	these	objects.	Enabling	this unified	action	audit	causes	logging	of	all	ALTER PROCEDURE,	ALTER FUNCTION,	ALTER PACKAGE and	ALTER PACKAGE BODY statements,	successful	or	unsuccessful,	issued	by	the users	regardless	of	the	privileges	held	by	the	users	to	issue	such	statements."
     rationale: "Unauthorized	alteration	of	procedures,	functions,	packages	or	package	bodies	may	impact critical	business	functions	or	compromise	integrity	of	the	database.	Logging	and monitoring	of	all	attempts,	whether	successful	or	unsuccessful,	to	alter	procedures, functions,	packages	or	package	bodies	may	provide	clues	and	forensic	evidence	about potential	suspicious/unauthorized	activities.	Any	such	activities	may	be	a	cause	for	further investigation.	In	addition,	organization	security	policies	and	industry/government regulations	may	require	logging	of	all	user	activities	involving	alteration	of	procedures, functions,	packages	or	package	bodies."
@@ -1477,7 +1456,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"WITH CIS_AUDIT(AUDIT_OPTION) AS ( SELECT * FROM TABLE( DBMSOUTPUT_LINESARRAY( ''ALTER PROCEDURE'',''ALTER FUNCTION'',''ALTER PACKAGE'',''ALTER PACKAGE BODY'' ) ) ), AUDIT_ENABLED AS ( SELECT DISTINCT AUDIT_OPTION FROM AUDIT_UNIFIED_POLICIES AUD WHERE AUD.AUDIT_OPTION IN (''ALTER PROCEDURE'',''ALTER FUNCTION'',''ALTER PACKAGE'',''ALTER PACKAGE BODY'' ) AND AUD.AUDIT_OPTION_TYPE = ''STANDARD ACTION'' AND EXISTS (SELECT * FROM AUDIT_UNIFIED_ENABLED_POLICIES ENABLED WHERE ENABLED.SUCCESS = ''YES'' AND ENABLED.FAILURE = ''YES'' AND ENABLED.ENABLED_OPTION = ''BY USER'' AND ENABLED.ENTITY_NAME = ''ALL USERS'' AND ENABLED.POLICY_NAME = AUD.POLICY_NAME) ) SELECT C.AUDIT_OPTION FROM CIS_AUDIT C LEFT JOIN AUDIT_ENABLED E ON C.AUDIT_OPTION = E.AUDIT_OPTION WHERE E.AUDIT_OPTION IS NULL;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.2.22 Ensure the 'DROP PROCEDURE/FUNCTION/PACKAGE/PACKAGE BODY' Action Audit Is Enabled
-  - id: 24601
+  - id: 24600
     title: "Ensure the 'DROP PROCEDURE/FUNCTION/PACKAGE/PACKAGE BODY' Action Audit Is Enabled"
     description: "Oracle	database	procedures,	functions,	packages,	and	package	bodies,	which	are	stored within	the	database,	are	created	to	carry	out	business	functions	and	access	database	as defined	by	PL/SQL	code	and	SQL	statements	contained	within	these	objects.	Enabling	this unified	action	audit	causes	logging	of	all	DROP PROCEDURE,	DROP FUNCTION,	DROP PACKAGE or DROP PACKAGE BODY statements,	successful	or	unsuccessful,	issued	by	the	users	regardless of	the	privileges	held	by	the	users	to	issue	such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts,	whether	successful	or	unsuccessful,	to	drop procedures,	functions,	packages	or	package	bodies	may	provide	forensic	evidence	about potential	suspicious/unauthorized	activities.	Any	such	activities	may	be	a	cause	for	further investigation.	In	addition,	organization	security	policies	and	industry/government regulations	may	require	logging	of	all	user	activities	involving	dropping	procedures, functions,	packages	or	package	bodies."
@@ -1490,7 +1469,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"WITH CIS_AUDIT(AUDIT_OPTION) AS (SELECT * FROM TABLE( DBMSOUTPUT_LINESARRAY( ''DROP PROCEDURE'',''DROP FUNCTION'',''DROP PACKAGE'',''DROP PACKAGE BODY'' ) ) ), AUDIT_ENABLED AS ( SELECT DISTINCT AUDIT_OPTION FROM AUDIT_UNIFIED_POLICIES AUD WHERE AUD.AUDIT_OPTION IN (''DROP PROCEDURE'',''DROP FUNCTION'',''DROP PACKAGE'',''DROP PACKAGE BODY'' ) AND AUD.AUDIT_OPTION_TYPE = ''STANDARD ACTION'' AND EXISTS (SELECT * FROM AUDIT_UNIFIED_ENABLED_POLICIES ENABLED WHERE ENABLED.SUCCESS = ''YES'' AND ENABLED.FAILURE = ''YES'' AND ENABLED.ENABLED_OPTION = ''BY USER'' AND ENABLED.ENTITY_NAME = ''ALL USERS'' AND ENABLED.POLICY_NAME = AUD.POLICY_NAME) ) SELECT C.AUDIT_OPTION FROM CIS_AUDIT C LEFT JOIN AUDIT_ENABLED E ON C.AUDIT_OPTION = E.AUDIT_OPTION WHERE E.AUDIT_OPTION IS NULL;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.2.23 Ensure the 'ALTER SYSTEM' Privilege Audit Is Enabled
-  - id: 24602
+  - id: 24601
     title: "Ensure the 'ALTER SYSTEM' Privilege Audit Is Enabled"
     description: "The	ALTER SYSTEM privilege	allows	the	user	to	change	instance	settings	which	could	impact security	posture,	performance	or	normal	operation	of	the	database.	Additionally,	the	ALTER SYSTEM privilege	may	be	used	to	run	operating	system	commands	using	undocumented Oracle	functionality.	Enabling	this	unified	audit	causes	logging	of	activities	that	involve exercise	of	this	privilege,	whether	successful	or	unsuccessful,	issued	by	the	users regardless	of	the	privileges	held	by	the	users	to	issue	such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	execute	ALTER SYSTEM statements,	whether successful	or	unsuccessful,	may	provide	forensic	evidence	about	potential suspicious/unauthorized	activities.	Any	such	activities	may	be	a	cause	for	further investigation.	In	addition,	organization	security	policies	and	industry/government regulations	may	require	logging	of	all	user	activities	that	involve	ALTER SYSTEM statements."
@@ -1503,7 +1482,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"WITH CIS_AUDIT(AUDIT_OPTION) AS ( SELECT * FROM TABLE( DBMSOUTPUT_LINESARRAY( ''ALTER SYSTEM'' ) ) ), AUDIT_ENABLED AS ( SELECT DISTINCT AUDIT_OPTION FROM AUDIT_UNIFIED_POLICIES AUD WHERE AUD.AUDIT_OPTION IN (''ALTER SYSTEM'' ) AND AUD.AUDIT_OPTION_TYPE = ''SYSTEM PRIVILEGE'' AND EXISTS (SELECT * FROM AUDIT_UNIFIED_ENABLED_POLICIES ENABLED WHERE ENABLED.SUCCESS = ''YES'' AND ENABLED.FAILURE = ''YES'' AND ENABLED.ENABLED_OPTION = ''BY USER'' AND ENABLED.ENTITY_NAME = ''ALL USERS'' AND ENABLED.POLICY_NAME = AUD.POLICY_NAME) ) SELECT C.AUDIT_OPTION FROM CIS_AUDIT C LEFT JOIN AUDIT_ENABLED E ON C.AUDIT_OPTION = E.AUDIT_OPTION WHERE E.AUDIT_OPTION IS NULL;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.2.24 Ensure the 'CREATE TRIGGER' Action Audit Is Enabled
-  - id: 24603
+  - id: 24602
     title: "Ensure the 'CREATE TRIGGER' Action Audit Is Enabled"
     description: "Oracle	database	triggers	are	executed	automatically	when	specified	conditions	on	the underlying	objects	occur.	Trigger	bodies	contain	the	code,	quite	often	to	perform	data validation,	ensure	data	integrity/security	or	enforce	critical	constraints	on	allowable actions	on	data.	Enabling	this	unified	audit	causes	logging	of	all	CREATE TRIGGER statements,	whether	successful	or	unsuccessful,	issued	by	the	users	regardless	of	the privileges	held	by	the	users	to	issue	such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	create	triggers,	whether	successful	or unsuccessful,	may	provide	clues	and	forensic	evidence	about	potential suspicious/unauthorized	activities.	Any	such	activities	may	be	a	cause	for	further investigation.	In	addition,	organization	security	policies	and	industry/government regulations	may	require	logging	of	all	user	activities	involving	creation	of	triggers."
@@ -1516,7 +1495,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"WITH CIS_AUDIT(AUDIT_OPTION) AS ( SELECT * FROM TABLE( DBMSOUTPUT_LINESARRAY( ''CREATE TRIGGER'' ) ) ), AUDIT_ENABLED AS ( SELECT DISTINCT AUDIT_OPTION FROM AUDIT_UNIFIED_POLICIES AUD WHERE AUD.AUDIT_OPTION IN (''CREATE TRIGGER'' ) AND AUD.AUDIT_OPTION_TYPE = ''STANDARD ACTION'' AND EXISTS (SELECT * FROM AUDIT_UNIFIED_ENABLED_POLICIES ENABLED WHERE ENABLED.SUCCESS = ''YES'' AND ENABLED.FAILURE = ''YES'' AND ENABLED.ENABLED_OPTION = ''BY USER'' AND ENABLED.ENTITY_NAME = ''ALL USERS'' AND ENABLED.POLICY_NAME = AUD.POLICY_NAME) ) SELECT C.AUDIT_OPTION FROM CIS_AUDIT C LEFT JOIN AUDIT_ENABLED E ON C.AUDIT_OPTION = E.AUDIT_OPTION WHERE E.AUDIT_OPTION IS NULL;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.2.25 Ensure the 'ALTER TRIGGER' Action Audit IS Enabled
-  - id: 24604
+  - id: 24603
     title: "Ensure the 'ALTER TRIGGER' Action Audit IS Enabled"
     description: "Oracle	database	triggers	are	executed	automatically	when	specified	conditions	on	the underlying	objects	occur.	Trigger	bodies	contain	the	code,	quite	often	to	perform	data validation,	ensure	data	integrity/security	or	enforce	critical	constraints	on	allowable actions	on	data.	Enabling	this	unified	audit	causes	logging	of	all	ALTER TRIGGER statements, whether	successful	or	unsuccessful,	issued	by	the	users	regardless	of	the	privileges	held	by the	users	to	issue	such	statements."
     rationale: "Unauthorized	alteration	of	triggers	may	impact	critical	business	functions	or	compromise integrity/security	of	the	database.	Logging	and	monitoring	of	all	attempts	to	alter	triggers, whether	successful	or	unsuccessful,	may	provide	clues	and	forensic	evidence	about potential	suspicious/unauthorized	activities.	Any	such	activities	may	be	a	cause	for	further investigation.	In	addition,	organization	security	policies	and	industry/government regulations	may	require	logging	of	all	user	activities	involving	alteration	of	triggers."
@@ -1529,7 +1508,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"WITH CIS_AUDIT(AUDIT_OPTION) AS ( SELECT * FROM TABLE( DBMSOUTPUT_LINESARRAY( ''ALTER TRIGGER'' ) ) ), AUDIT_ENABLED AS ( SELECT DISTINCT AUDIT_OPTION FROM AUDIT_UNIFIED_POLICIES AUD WHERE AUD.AUDIT_OPTION IN (''ALTER TRIGGER'' ) AND AUD.AUDIT_OPTION_TYPE = ''STANDARD ACTION'' AND EXISTS (SELECT * FROM AUDIT_UNIFIED_ENABLED_POLICIES ENABLED WHERE ENABLED.SUCCESS = ''YES'' AND ENABLED.FAILURE = ''YES'' AND ENABLED.ENABLED_OPTION = ''BY USER'' AND ENABLED.ENTITY_NAME = ''ALL USERS'' AND ENABLED.POLICY_NAME = AUD.POLICY_NAME) ) SELECT C.AUDIT_OPTION FROM CIS_AUDIT C LEFT JOIN AUDIT_ENABLED E ON C.AUDIT_OPTION = E.AUDIT_OPTION WHERE E.AUDIT_OPTION IS NULL;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.2.26 Ensure the 'DROP TRIGGER' Action Audit Is Enabled
-  - id: 24605
+  - id: 24604
     title: "Ensure the 'DROP TRIGGER' Action Audit Is Enabled"
     description: "Oracle	database	triggers	are	executed	automatically	when	specified	conditions	on	the underlying	objects	occur.	Trigger	bodies	contain	the	code,	quite	often	to	perform	data validation,	ensure	data	integrity/security	or	enforce	critical	constraints	on	allowable actions	on	data.	Enabling	this	unified	audit	causes	logging	of	all	DROP TRIGGER statements, whether	successful	or	unsuccessful,	issued	by	the	users	regardless	of	the	privileges	held	by the	users	to	issue	such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	drop	triggers,	whether	successful	or unsuccessful,	may	provide	forensic	evidence	about	potential	suspicious/unauthorized activities.	Any	such	activities	may	be	a	cause	for	further	investigation.	In	addition, organization	security	policies	and	industry/government	regulations	may	require	logging	of all	user	activities	involving	dropping	triggers."
@@ -1542,7 +1521,7 @@ public	links	to	be	audited."
       - 'c:sudo -u oracle bash -c ". ~/.bash_profile; echo \"WITH CIS_AUDIT(AUDIT_OPTION) AS ( SELECT * FROM TABLE( DBMSOUTPUT_LINESARRAY( ''DROP TRIGGER'' ) ) ), AUDIT_ENABLED AS ( SELECT DISTINCT AUDIT_OPTION FROM AUDIT_UNIFIED_POLICIES AUD WHERE AUD.AUDIT_OPTION IN (''DROP TRIGGER'' ) AND AUD.AUDIT_OPTION_TYPE = ''STANDARD ACTION'' AND EXISTS (SELECT * FROM AUDIT_UNIFIED_ENABLED_POLICIES ENABLED WHERE ENABLED.SUCCESS = ''YES'' AND ENABLED.FAILURE = ''YES'' AND ENABLED.ENABLED_OPTION = ''BY USER'' AND ENABLED.ENTITY_NAME = ''ALL USERS'' AND ENABLED.POLICY_NAME = AUD.POLICY_NAME) ) SELECT C.AUDIT_OPTION FROM CIS_AUDIT C LEFT JOIN AUDIT_ENABLED E ON C.AUDIT_OPTION = E.AUDIT_OPTION WHERE E.AUDIT_OPTION IS NULL;\" | sqlplus / as sysdba | grep \"no rows selected\"" -> no rows selected'
 
 # 6.2.27 Ensure the 'LOGON' AND 'LOGOFF' Actions Audit Is Enabled
-  - id: 24606
+  - id: 24605
     title: "Ensure the 'LOGON' AND 'LOGOFF' Actions Audit Is Enabled"
     description: "Oracle	database	users	log	on	to	the	database	to	perform	their	work.	Enabling	this	unified audit	causes	logging	of	all	LOGON actions,	whether	successful	or	unsuccessful,	issued	by	the users	regardless	of	the	privileges	held	by	the	users	to	log	into	the	database.	In	addition, LOGOFF action	audit	captures	logoff	activities.	This	audit	action	also	captures	logon/logoff	to the	open	database	by	SYSDBA and	SYSOPER."
     rationale: "Logging	and	monitoring	of	all	attempts	to	logon	to	the	database,	whether	successful	or unsuccessful,	may	provide	forensic	evidence	about	potential	suspicious/unauthorized activities.	Any	such	activities	may	be	a	cause	for	further	investigation.	In	addition, organization	security	policies	and	industry/government	regulations	may	require	logging	of all	user	activities	involving	LOGON and	LOGOFF."

--- a/ruleset/sca/oracledb/cis_oracle_database_19c.yml
+++ b/ruleset/sca/oracledb/cis_oracle_database_19c.yml
@@ -37,7 +37,7 @@ checks:
 ###############################################
 # 2.1.1 Ensure 'extproc' Is Not Present in 'listener.ora'
   - id: 24500
-    title: "Ensure 'extproc' Is Not Present in 'listener.ora'"
+    title: "Ensure 'extproc' Is Not Present in 'listener.ora'."
     description: "extproc should be removed from the listener.ora to mitigate the risk that OS libraries can be invoked by the Oracle instance."
     rationale: "extproc allows the database to run procedures from OS libraries. These library calls can, in turn, run any OS command."
     remediation: "Remove extproc from the listener.ora file."
@@ -50,7 +50,7 @@ checks:
 
 # 2.1.2 Ensure 'ADMIN_RESTRICTIONS_' Is Set to 'ON'
   - id: 24501
-    title: "Ensure 'ADMIN_RESTRICTIONS_' Is Set to 'ON'"
+    title: "Ensure 'ADMIN_RESTRICTIONS_' Is Set to 'ON'."
     description: "The	admin_restrictions_<listener_name> setting	in	the	listener.ora file	can	require that	any	attempted	real-time	alteration	of	the	parameters	in	the	listener	via	the	set command	file	be	refused	unless	the	listener.ora file	is	manually	altered,	then	restarted by	a	privileged	user."
     rationale: "Blocking	unprivileged	users	from	making	alterations	of	the	listener.ora file,	where remote	data/service	settings	are	specified,	will	help	protect	data	confidentiality."
     remediation: "Use	a	text	editor	such	as	vi to	set	the	admin_restrictions_<listener_name> to	the	value ON"
@@ -66,7 +66,7 @@ checks:
 ###############################################
 # 2.2.1 Ensure 'AUDIT_SYS_OPERATIONS' Is Set to 'TRUE'
   - id: 24502
-    title: "Ensure 'AUDIT_SYS_OPERATIONS' Is Set to 'TRUE'"
+    title: "Ensure 'AUDIT_SYS_OPERATIONS' Is Set to 'TRUE'."
     description: "The	AUDIT_SYS_OPERATIONS setting	provides	for	the	auditing	of	all	user	activities	conducted under	the	SYSOPER and	SYSDBA accounts.	The	setting	should	be	set	to	TRUE to	enable	this auditing."
     rationale: "If	the	parameter	AUDIT_SYS_OPERATIONS is	FALSE,	all	statements	except	for Startup/Shutdown	and	Logon	by	SYSDBA/SYSOPER users	are	not	audited."
     remediation: "To	remediate	this	setting,	execute	the	following	SQL	statement	and	restart	the	instance. ALTER SYSTEM SET AUDIT_SYS_OPERATIONS = TRUE SCOPE=SPFILE;"
@@ -79,7 +79,7 @@ checks:
 
 # 2.2.2 Ensure 'AUDIT_TRAIL' Is Set to 'DB', 'XML', 'OS', 'DB,EXTENDED', or 'XML,EXTENDED'
   - id: 24503
-    title: "Ensure 'AUDIT_TRAIL' Is Set to 'DB', 'XML', 'OS', 'DB,EXTENDED', or 'XML,EXTENDED'"
+    title: "Ensure 'AUDIT_TRAIL' Is Set to 'DB', 'XML', 'OS', 'DB,EXTENDED', or 'XML,EXTENDED'."
     description: "The	audit_trail setting	determines	whether	or	not	Oracle's	basic	audit	features	are enabled.	It	can	be	set	to	Operating	System(OS);	DB;	DB,EXTENDED;	XML;	or	XML,EXTENDED. The	value	should	be	set	according	to	the	needs	of	the	organization."
     rationale: "Enabling	the	basic	auditing	features	for	the	Oracle	instance	permits	the	collection	of	data	to troubleshoot	problems,	as	well	as	provides	valuable	forensic	logs	in	the	case	of	a	system breach	this	value	should	be	set	according	to	the	needs	of	the	organization."
     remediation: "To	remediate	this	setting,	execute	one	of	the	following	SQL	statements	and	restart	the instance. ALTER SYSTEM SET AUDIT_TRAIL = DB, EXTENDED SCOPE = SPFILE; ALTER SYSTEM SET AUDIT_TRAIL = OS SCOPE = SPFILE; ALTER SYSTEM SET AUDIT_TRAIL = XML, EXTENDED SCOPE = SPFILE; ALTER SYSTEM SET AUDIT_TRAIL = DB SCOPE = SPFILE; ALTER SYSTEM SET AUDIT_TRAIL = XML SCOPE = SPFILE;"
@@ -92,7 +92,7 @@ checks:
 
 # 2.2.3 Ensure 'GLOBAL_NAMES' Is Set to 'TRUE'
   - id: 24504
-    title: "Ensure 'GLOBAL_NAMES' Is Set to 'TRUE'"
+    title: "Ensure 'GLOBAL_NAMES' Is Set to 'TRUE'."
     description: "The	global_names setting	requires	that	the	name	of	a	database	link	matches	that	of	the remote	database	it	will	connect	to.	This	setting	should	have	a	value	of	TRUE."
     rationale: "Not	requiring	database	connections	to	match	the	domain	that	is	being	called	remotely could	allow	unauthorized	domain	sources	to	potentially	connect	via	brute-force	tactics."
     remediation: "To	remediate	this	setting,	execute	the	following	SQL	statement. ALTER SYSTEM SET GLOBAL_NAMES = TRUE SCOPE = SPFILE;"
@@ -106,7 +106,7 @@ checks:
 
 # 2.2.4 Ensure 'OS_ROLES' Is Set to 'FALSE'
   - id: 24505
-    title: "Ensure 'OS_ROLES' Is Set to 'FALSE'"
+    title: "Ensure 'OS_ROLES' Is Set to 'FALSE'."
     description: "The	os_roles setting	permits	externally	created	groups	to	be	applied	to	database management"
     rationale: "Allowing	the	OS	to	use	external	groups	for	database	management	could	cause	privilege overlaps	and	generally	weaken	security."
     remediation: "ALTER SYSTEM SET OS_ROLES = FALSE SCOPE = SPFILE;"
@@ -120,7 +120,7 @@ checks:
 
 # 2.2.5 Ensure 'REMOTE_LISTENER' Is Empty
   - id: 24506
-    title: "Ensure 'REMOTE_LISTENER' Is Empty"
+    title: "Ensure 'REMOTE_LISTENER' Is Empty."
     description: "The	remote_listener setting	determines	whether	or	not	a	valid	listener	can	be	established on	a	system	separate	from	the	database	instance.	This	setting	should	be	empty	unless	the organization	specifically	needs	a	valid	listener	on	a	separate	system	or	on	nodes	running Oracle RAC	instances"
     rationale: "Permitting	a	remote	listener	for	connections	to	the	database	instance	can	allow	for	the potential	spoofing	of	connections	and	that	could	compromise	data	confidentiality	and integrity."
     remediation: "ALTER SYSTEM SET REMOTE_LISTENER = '' SCOPE = SPFILE;"
@@ -134,7 +134,7 @@ checks:
 
 # 2.2.6 Ensure 'REMOTE_LOGIN_PASSWORDFILE' Is Set to 'NONE'
   - id: 24507
-    title: "Ensure 'REMOTE_LOGIN_PASSWORDFILE' Is Set to 'NONE'"
+    title: "Ensure 'REMOTE_LOGIN_PASSWORDFILE' Is Set to 'NONE'."
     description: "The	remote_login_passwordfile setting	specifies	whether	or	not	Oracle	checks	for	a password	file	during	login	and	how	many	databases	can	use	the	password	file.	The	setting should	have	a	value	of	NONE or	in	the	event	you	are	running	DR/Data	Guard,	EXCLUSIVE is an	allowable	value."
     rationale: "The	use	of	this	sort	of	password	login	file	could	permit	unsecured,	privileged	connections to	the	database."
     remediation: "ALTER SYSTEM SET REMOTE_LOGIN_PASSWORDFILE = 'NONE' SCOPE = SPFILE;"
@@ -147,7 +147,7 @@ checks:
 
 # 2.2.7 Ensure 'REMOTE_OS_AUTHENT' Is Set to 'FALSE'
   - id: 24508
-    title: "Ensure 'REMOTE_OS_AUTHENT' Is Set to 'FALSE'"
+    title: "Ensure 'REMOTE_OS_AUTHENT' Is Set to 'FALSE'."
     description: "The	remote_os_authent setting	determines	whether	or	not	OS	'roles'	with	the	attendant privileges	are	allowed	for	remote	client	connections.	This	setting	should	have	a	value	of FALSE."
     rationale: "Permitting	OS roles	for	database	connections	can	allow	the	spoofing	of	connections	and permit	granting	the	privileges	of	an	OS	role	to	unauthorized	users	to	make	connections, this	value	should	be	restricted	according	to	the	needs	of	the	organization."
     remediation: "ALTER SYSTEM SET REMOTE_OS_AUTHENT = FALSE SCOPE = SPFILE;"
@@ -160,7 +160,7 @@ checks:
 
 # 2.2.8 Ensure 'REMOTE_OS_ROLES' Is Set to 'FALSE'
   - id: 24509
-    title: "Ensure 'REMOTE_OS_ROLES' Is Set to 'FALSE'"
+    title: "Ensure 'REMOTE_OS_ROLES' Is Set to 'FALSE'."
     description: "The	remote_os_roles setting	permits	remote	users'	OS	roles	to	be	applied	to	database management.	This	setting	should	have	a	value	of	FALSE."
     rationale: "Allowing	remote	clients	OS	roles	to	have	permissions	for	database	management	could cause	privilege	overlaps	and	generally	weaken	security"
     remediation: "ALTER SYSTEM SET REMOTE_OS_ROLES = FALSE SCOPE = SPFILE;"
@@ -173,7 +173,7 @@ checks:
 
 # 2.2.9 Ensure 'SEC_CASE_SENSITIVE_LOGON' Is Set to 'TRUE'
   - id: 24510
-    title: "Ensure 'SEC_CASE_SENSITIVE_LOGON' Is Set to 'TRUE' "
+    title: "Ensure 'SEC_CASE_SENSITIVE_LOGON' Is Set to 'TRUE' ."
     description: "The	SEC_CASE_SENSITIVE_LOGON information	determines	whether	or	not	case-sensitivity	is required	for	passwords	during	login. Note: This	parameter	has	been	deprecated	in	12.1	and	higher	versions."
     rationale: "Oracle	database	password	case-sensitivity	increases	the	pool	of	characters	that can	be chosen	for	the	passwords,	making	brute-force	password	attacks	quite	difficult."
     remediation: "ALTER SYSTEM SET SEC_CASE_SENSITIVE_LOGON = TRUE SCOPE = SPFILE;"
@@ -186,7 +186,7 @@ checks:
 
 # 2.2.10 Ensure 'SEC_MAX_FAILED_LOGIN_ATTEMPTS' Is '3' or Less
   - id: 24511
-    title: "Ensure 'SEC_MAX_FAILED_LOGIN_ATTEMPTS' Is '3' or Less37"
+    title: "Ensure 'SEC_MAX_FAILED_LOGIN_ATTEMPTS' Is '3' or Less37."
     description: "The	SEC_MAX_FAILED_LOGIN_ATTEMPTS parameter	determines	how	many	failed	login attempts	are	allowed	before	Oracle	closes	the	login connection."
     rationale: "Allowing	an	unlimited	number	of	login	attempts	for	a	user	connection	can	facilitate	both brute-force	login	attacks	and	the	occurrence	of	denial-of-service."
     remediation: "ALTER SYSTEM SET SEC_MAX_FAILED_LOGIN_ATTEMPTS = 3 SCOPE = SPFILE;"
@@ -199,7 +199,7 @@ checks:
 
 # 2.2.11 Ensure 'SEC_PROTOCOL_ERROR_FURTHER_ACTION' Is Set to '(DROP,3)'
   - id: 24512
-    title: "Ensure 'SEC_PROTOCOL_ERROR_FURTHER_ACTION' Is Set to '(DROP,3)'"
+    title: "Ensure 'SEC_PROTOCOL_ERROR_FURTHER_ACTION' Is Set to '(DROP,3)'."
     description: "The	SEC_PROTOCOL_ERROR_FURTHER_ACTION setting	determines	the	Oracle	server's	response to	bad/malformed	packets	received	from	the	client.	This	setting	should	have	a	value	of (DROP,3),	which	will	cause	a	connection	to	be	dropped	after	three	bad/malformed	packets."
     rationale: "Bad	packets	received	from	the	client	can	potentially	indicate	packet-based	attacks	on	the system,	such	as	TCP	SYN	Flood	or	Smurf	attacks,	which	could	result	in	a	denial-ofservice	condition,	this	value	should	be	set	according	to	the	needs	of	the	organization."
     remediation: "ALTER SYSTEM SET SEC_PROTOCOL_ERROR_FURTHER_ACTION = '(DROP,3)' SCOPE = SPFILE;"
@@ -212,7 +212,7 @@ checks:
 
 # 2.2.12 Ensure 'SEC_PROTOCOL_ERROR_TRACE_ACTION' Is Set to 'LOG'
   - id: 24513
-    title: "Ensure 'SEC_PROTOCOL_ERROR_TRACE_ACTION' Is Set to 'LOG'"
+    title: "Ensure 'SEC_PROTOCOL_ERROR_TRACE_ACTION' Is Set to 'LOG'."
     description: "The	SEC_PROTOCOL_ERROR_TRACE_ACTION setting	determines	the	Oracle's	server's	logging response	level	to	bad/malformed	packets	received	from	the	client	by	generating	ALERT, LOG,	or	TRACE levels	of	detail	in	the	log	files.	This	setting	should	have	a	value	of	LOG unless the	organization	has	a	compelling	reason	to	use	a	different	value	because	LOG should	cause the	necessary	information	to	be	logged.	Setting	the	value	as	TRACE can	generate	an enormous	amount	of	log	output	and	should	be	reserved	for	debugging	only."
     rationale: "Bad	packets	received	from	the	client	can	potentially	indicate	packet-based	attacks	on	the system,	which	could	result	in	a	denial-of-service	condition."
     remediation: "ALTER SYSTEM SET SEC_PROTOCOL_ERROR_TRACE_ACTION=LOG SCOPE = SPFILE;"
@@ -225,7 +225,7 @@ checks:
 
 # 2.2.13 Ensure 'SEC_RETURN_SERVER_RELEASE_BANNER' Is Set to 'FALSE'
   - id: 24514
-    title: "Ensure 'SEC_RETURN_SERVER_RELEASE_BANNER' Is Set to 'FALSE'"
+    title: "Ensure 'SEC_RETURN_SERVER_RELEASE_BANNER' Is Set to 'FALSE'."
     description: "The	information	about	patch/update	release	number	provides	information	about	the	exact patch/update	release	that	is	currently	running	on	the	database.	This	is	sensitive information	that	should	not	be	revealed	to	anyone	who	requests	it."
     rationale: "Allowing	the	database	to	return	information	about	the	patch/update	release	number	could facilitate	unauthorized	users'	attempts	to	gain	access	based	upon	known	patch	weaknesses."
     remediation: "ALTER SYSTEM SET SEC_RETURN_SERVER_RELEASE_BANNER = FALSE SCOPE = SPFILE;"
@@ -238,7 +238,7 @@ checks:
 
 # 2.2.14 Ensure 'SQL92_SECURITY' Is Set to 'TRUE'
   - id: 24515
-    title: "Ensure 'SQL92_SECURITY' Is Set to 'TRUE'"
+    title: "Ensure 'SQL92_SECURITY' Is Set to 'TRUE'."
     description: "The	SQL92_SECURITY parameter	setting	TRUE requires	that	a	user	must	also	be	granted	the SELECT object	privilege	before	being	able	to	perform	UPDATE or	DELETE operations	on	tables that	have	WHERE or	SET clauses.	The	setting	should	have	a	value	of	TRUE."
     rationale: "A	user	without	SELECT privilege	can	still	infer	the	value	stored	in	a	column	by	referring	to that	column	in	a	DELETE or	UPDATE statement.	This	setting	prevents	inadvertent	information disclosure	by	ensuring	that	only	users	who	already	have	SELECT privilege	can	execute	the statements	that	would	allow	them	to	infer	the	stored	values."
     remediation: "ALTER SYSTEM SET SQL92_SECURITY = TRUE SCOPE = SPFILE;"
@@ -254,7 +254,7 @@ checks:
 
 # 2.2.16 Ensure 'RESOURCE_LIMIT' Is Set to 'TRUE'
   - id: 24516
-    title: "Ensure 'RESOURCE_LIMIT' Is Set to 'TRUE'"
+    title: "Ensure 'RESOURCE_LIMIT' Is Set to 'TRUE'."
     description: "RESOURCE_LIMIT determines	whether	resource	limits	are	enforced	in	database	profiles. This	setting	should	have	a	value	of	TRUE."
     rationale: "If	RESOURCE_LIMIT is	set	to	FALSE,	none	of	the	system	resource	limits	that	are	set	in	any database	profiles	are	enforced.	If	RESOURCE_LIMIT is	set	to	TRUE,	the	limits	set	in	database profiles	are	enforced."
     remediation: "ALTER SYSTEM SET RESOURCE_LIMIT = TRUE SCOPE = SPFILE;"
@@ -271,7 +271,7 @@ checks:
 ###############################################
 # 3.1 Ensure 'FAILED_LOGIN_ATTEMPTS' Is Less than or Equal to '5'
   - id: 24517
-    title: "Ensure 'FAILED_LOGIN_ATTEMPTS' Is Less than or Equal to '5'"
+    title: "Ensure 'FAILED_LOGIN_ATTEMPTS' Is Less than or Equal to '5'."
     description: "The	FAILED_LOGIN_ATTEMPTS setting	determines	how	many	failed	login	attempts	are permitted	before	the	system	locks	the	user's	account.	While	different	profiles	can	have different	and	more	restrictive	settings,	such	as	USERS and	APPS,	the	minimum(s) recommended	here	should	be	set	on	the	DEFAULT profile."
     rationale: "Repeated	failed	login	attempts	can	indicate	the	initiation	of	a	brute-force	login	attack,	this value	should	be	set	according	to	the	needs	of	the	organization.	(See	the	Notes for	a	warning on	a	known	bug	that	can	make	this	security	measure	backfire.)"
     remediation: "ALTER PROFILE <profile_name> LIMIT FAILED_LOGIN_ATTEMPTS 5;"
@@ -285,7 +285,7 @@ checks:
 
 # 3.2 Ensure 'PASSWORD_LOCK_TIME' Is Greater than or Equal to '1'
   - id: 24518
-    title: "Ensure 'PASSWORD_LOCK_TIME' Is Greater than or Equal to '1'"
+    title: "Ensure 'PASSWORD_LOCK_TIME' Is Greater than or Equal to '1'."
     description: "The	PASSWORD_LOCK_TIME setting	determines	how	many	days	must	pass	for	the	user's account	to	be	unlocked	after	the	set	number	of	failed	login	attempts	has	occurred.	The suggested	value	for	this	is	one	day	or	greater."
     rationale: "Locking	the	user	account	after	repeated	failed	login	attempts	can	block	further	brute-force login	attacks,	but	can	create	administrative	headaches	as	this	account	unlocking	process always	requires	DBA	intervention."
     remediation: "ALTER PROFILE <profile_name> LIMIT PASSWORD_LOCK_TIME 1;"
@@ -301,7 +301,7 @@ checks:
 
 # 3.3 Ensure 'PASSWORD_LIFE_TIME' Is Less than or Equal to '90'
   - id: 24519
-    title: "Ensure 'PASSWORD_LIFE_TIME' Is Less than or Equal to '90'"
+    title: "Ensure 'PASSWORD_LIFE_TIME' Is Less than or Equal to '90'."
     description: "The	PASSWORD_LIFE_TIME setting	determines	how	long	a	password	may	be	used	before	the user	is	required	to	be	change	it.	The	suggested	value	for	this	is	90	days	or	less."
     rationale: "Allowing	passwords	to	remain	unchanged	for	long	periods	makes	the	success	of	bruteforce	login	attacks	more	likely."
     remediation: "ALTER PROFILE <profile_name> LIMIT PASSWORD_LIFE_TIME 90;"
@@ -317,7 +317,7 @@ checks:
 
 # 3.4 Ensure 'PASSWORD_REUSE_MAX' Is Greater than or Equal to '20'
   - id: 24520
-    title: "Ensure 'PASSWORD_REUSE_MAX' Is Greater than or Equal to '20'"
+    title: "Ensure 'PASSWORD_REUSE_MAX' Is Greater than or Equal to '20'."
     description: "The	PASSWORD_REUSE_MAX setting	determines	how	many	different	passwords	must	be	used before	the	user	is	allowed	to	reuse	a	prior	password.	The	suggested	value	for	this	is	20 passwords	or	greater."
     rationale: "Allowing	reuse	of	a	password	within	a	short	period	of	time	after	the	password's	initial	use can	make	the	success	of	both	social-engineering	and	brute-force	password-based	attacks more	likely."
     remediation: "ALTER PROFILE <profile_name> LIMIT PASSWORD_REUSE_MAX 20;"
@@ -333,7 +333,7 @@ checks:
 
 # 3.5 Ensure 'PASSWORD_REUSE_TIME' Is Greater than or Equal to '365'
   - id: 24521
-    title: "Ensure 'PASSWORD_REUSE_TIME' Is Greater than or Equal to '365'"
+    title: "Ensure 'PASSWORD_REUSE_TIME' Is Greater than or Equal to '365'."
     description: "The	PASSWORD_REUSE_TIME setting	determines	the	amount	of	time	in	days	that	must	pass before	the	same	password	may	be	reused.	The	suggested	value	for	this	is 365	days	or greater."
     rationale: "Reusing	the	same	password	after	only	a	short	period	of	time	has	passed	makes	the	success of	brute-force	login	attacks	more	likely."
     remediation: "ALTER PROFILE <profile_name> LIMIT PASSWORD_REUSE_TIME 365;"
@@ -349,7 +349,7 @@ checks:
 
 # 3.6 Ensure 'PASSWORD_GRACE_TIME' Is Less than or Equal to '5'
   - id: 24522
-    title: "Ensure 'PASSWORD_GRACE_TIME' Is Less than or Equal to '5'"
+    title: "Ensure 'PASSWORD_GRACE_TIME' Is Less than or Equal to '5'."
     description: "The	PASSWORD_GRACE_TIME setting	determines	how	many	days	can	pass	after	the	user's password	expires	before	the	user's	login	capability	is	automatically locked	out.	The suggested	value	for	this	is	five	days	or	less."
     rationale: "Locking	the	user	account	after	the	expiration	of	the	password	change	requirement's	grace period	can	help	prevent	password-based	attacks	against	any	forgotten	or	disused	accounts, while	still	allowing	the	account	and	its	information	to	be	accessible	by	DBA	intervention."
     remediation: "ALTER PROFILE <profile_name> LIMIT PASSWORD_GRACE_TIME 5;"
@@ -365,7 +365,7 @@ checks:
 
 # 3.7 Ensure 'PASSWORD_VERIFY_FUNCTION' Is Set for All Profiles
   - id: 24523
-    title: "Ensure 'PASSWORD_VERIFY_FUNCTION' Is Set for All Profiles"
+    title: "Ensure 'PASSWORD_VERIFY_FUNCTION' Is Set for All Profiles."
     description: "The	PASSWORD_VERIFY_FUNCTION determines	password	settings	requirements	when	a	user password	is	changed	at	the	SQL	command	prompt.	It	should	be	set	for	all	profiles.	Note	that this	setting	does	not	apply	for	users	managed	by	the	Oracle	password	file."
     rationale: "Through Oracle	database	profiles,	password	complexity	rules	(mixed	cases	with	digits	and special	characters),	blocking	of	simple	combinations,	and	enforcing	change/history	settings can	potentially	thwart	unauthorized	logins	by	an	unauthorized	user."
     remediation: "Create	a	custom	password	verification	function	which	fulfills	the	password	requirements	of the	organization."
@@ -379,7 +379,7 @@ checks:
 
 # 3.8 Ensure 'SESSIONS_PER_USER' Is Less than or Equal to '10'
   - id: 24524
-    title: "Ensure 'SESSIONS_PER_USER' Is Less than or Equal to '10'"
+    title: "Ensure 'SESSIONS_PER_USER' Is Less than or Equal to '10'."
     description: "The	SESSIONS_PER_USER setting	determines	the	maximum	number	of	user	sessions	that	are allowed	to	be	open	concurrently.	The	suggested	value	for	this	is	10	or	less."
     rationale: "Limiting	the	number	of	the	SESSIONS_PER_USER can	help	prevent	memory	resource exhaustion	by	poorly	formed	requests	or	intentional	denial-of-service	attacks."
     remediation: "ALTER PROFILE <profile_name> LIMIT SESSIONS_PER_USER 10;"
@@ -395,7 +395,7 @@ checks:
 
 # 3.9 Ensure 'INACTIVE_ACCOUNT_TIME' Is Less than or Equal to '120
   - id: 24525
-    title: "Ensure 'INACTIVE_ACCOUNT_TIME' Is Less than or Equal to '120"
+    title: "Ensure 'INACTIVE_ACCOUNT_TIME' Is Less than or Equal to '120'."
     description: "The	'INACTIVE_ACCOUNT_TIME'	setting	determines	the	maximum	number	of	days	of inactivity	(no	logins	at	all)	after	which	the	account	will	be	locked.	The	suggested	value	for this	is	120	or	less."
     rationale: "Setting	'INACTIVE_ACCOUNT_TIME'	can	help	with	deactivation	of	inactive	or	unused accounts."
     remediation: "ALTER PROFILE <profile_name> LIMIT INACTIVE_ACCOUNT_TIME 120;"
@@ -414,7 +414,7 @@ checks:
 ###############################################
 # 4.1 Ensure All Default Passwords Are Changed
   - id: 24526
-    title: "Ensure All Default Passwords Are Changed"
+    title: "Ensure All Default Passwords Are Changed."
     description: "Default	passwords	should	not	be	used	by	Oracle	database	users."
     rationale: "Default	passwords	should	be	considered	well	known	to	attackers.	Consequently,	if	default passwords	remain	in	place,	any	attacker	with	access	to	the	database	can	authenticate	as	the	user	with	that	default	password."
     remediation: ""
@@ -428,7 +428,7 @@ checks:
 
 # 4.2 Ensure All Sample Data And Users Have Been Removed
   - id: 24527
-    title: "Ensure All Sample Data And Users Have Been Removed"
+    title: "Ensure All Sample Data And Users Have Been Removed."
     description: "Oracle	sample	schemas	can	be	used	to	create	sample	users	(BI,HR,IX,OE,PM,SCOTT,SH),	with well-known	default	passwords,	particular	views,	and	procedures/functions,	in	addition	to tables	and	fictitious	data.	The	sample	schemas	should	be	removed."
     rationale: "The	sample	schemas	are	typically	not	required	for	production	operations	of	the	database. The	default	users,	views,	and/or	procedures/functions	created	by	sample	schemas	could be	used	to	launch	exploits	against	production	environments."
     remediation: "$ORACLE_HOME/demo/schema/drop_sch.sql DROP USER SCOTT CASCADE;"
@@ -442,7 +442,7 @@ checks:
 
 # 4.3 Ensure 'DBA_USERS.AUTHENTICATION_TYPE' Is Not Set to 'EXTERNAL' for Any User
   - id: 24528
-    title: "Ensure 'DBA_USERS.AUTHENTICATION_TYPE' Is Not Set to 'EXTERNAL' for Any User"
+    title: "Ensure 'DBA_USERS.AUTHENTICATION_TYPE' Is Not Set to 'EXTERNAL' for Any User."
     description: "The	authentication_type=''EXTERNAL'' setting	determines	whether	or	not	a	user	can	be authenticated	by	a	remote	OS	to	allow	access	to	the	database	with	full	authorization.	This setting	should	not	be	used."
     rationale: "Allowing	remote	OS	authentication	of	a	user	to	the	database	can	potentially	allow	supposed privileged	users	to	connect	as	authenticated,	even	when	the	remote	system	is compromised."
     remediation: "ALTER USER <username> IDENTIFIED BY <password>;"
@@ -456,7 +456,7 @@ checks:
 
 # 4.4 Ensure No Users Are Assigned the 'DEFAULT' Profile
   - id: 24529
-    title: "Ensure No Users Are Assigned the 'DEFAULT' Profile"
+    title: "Ensure No Users Are Assigned the 'DEFAULT' Profile."
     description: "Upon	creation	database	users	are	assigned	to	the	DEFAULT profile	unless	otherwise specified.	No	users	should	be	assigned	to	that	profile."
     rationale: "Users	should	be	created	with	function-appropriate	profiles.	The	DEFAULT profile,	being defined	by	Oracle,	is	subject	to	change	at	any	time	(e.g.	by	patch	or	version	update).	The DEFAULT profile	has	unlimited	settings	that	are	often	required	by	the	SYS user	when patching;	such	unlimited	settings	should	be	tightly	reserved	and	not	applied	to unnecessary	users."
     remediation: "ALTER USER <username> PROFILE <appropriate_profile>;"
@@ -470,7 +470,7 @@ checks:
 
 # 4.5 Ensure 'SYS.USER$MIG' Has Been Dropped
   - id: 24530
-    title: "Ensure 'SYS.USER$MIG' Has Been Dropped"
+    title: "Ensure 'SYS.USER$MIG' Has Been Dropped."
     description: "The	table	sys.user$mig is	created	during	migration	and	contains	the	Oracle	password hashes	before	the	migration	starts.	This	table	should	be	dropped."
     rationale: "The	table	sys.user$mig is	not	deleted	after	the	migration.	An	attacker	could	access	the table	containing	the	Oracle	password	hashes."
     remediation: "DROP TABLE SYS.USER$MIG;"
@@ -484,7 +484,7 @@ checks:
 
 # 4.6 Ensure No Public Database Links Exist
   - id: 24531
-    title: "Ensure No Public Database Links Exist"
+    title: "Ensure No Public Database Links Exist."
     description: "Public	Database	links	are	used	to	allow	connections	between	databases."
     rationale: "Using	public	database	links	in	the	database	can	allow	anyone	with	a	connection	to	the database	to	query,	update,	insert,	delete	data	on	a	remote	database	depending	on	the userid	that	is	part	of	the	link."
     remediation: "DROP PUBLIC DATABASE LINK <DB_LINK>;"
@@ -506,7 +506,7 @@ checks:
 ###############################################
 # 5.1.1.1 Ensure 'EXECUTE' is revoked from 'PUBLIC' on "Network" Packages
   - id: 24532
-    title: "Ensure 'EXECUTE' is revoked from 'PUBLIC' on Network Packages"
+    title: "Ensure 'EXECUTE' is revoked from 'PUBLIC' on Network Packages."
     description: "As	described	below,	Oracle	Database	PL/SQL	Network	packages	- DBMS_LDAP,	UTL_INADDR, UTL_TCP,	UTL_MAIL,	UTL_SMTP,	UTL_DBWS,	UTL_ORAMTS,	UTL_HTTP and	type	HTTPURITYPE – provide	PL/SQL	APIs	to	interact	or	access	remote	servers.	The	PUBLIC	should	not	be	able to	execute	these	packages. • The	Oracle	database	DBMS_LDAP package	contains	functions	and	procedures	that enable	programmers	to	access	data	from	LDAP	servers. • The	Oracle	database	UTL_INADDR package	provides	an	API	to	retrieve	host	names and	IP	addresses	of	local	and	remote	hosts. • The	Oracle	database	UTL_TCP package	can	be	used	to	read/write	file	to	TCP	sockets on	the	server	where	the	Oracle	instance	is	installed. • The	Oracle	database	UTL_MAIL package	can	be	used	to	send	email	from	the	server where	the	Oracle	instance	is	installed. • The	Oracle	database	UTL_SMTP package	can	be	used	to	send	email	from	the	server where	the	Oracle	instance	is	installed.	The	user	PUBLIC should	not	be	able	to	execute UTL_SMTP. • The	Oracle	database	UTL_DBWS package	can	be	used	to	read/write	file	to	web-based applications	on	the	server	where	the	Oracle	instance	is	installed.	This	package	is	not automatically	installed	for	security	reasons. • The	Oracle	database	UTL_ORAMTS package	can	be	used	to	perform	HTTP	requests. This	could	be	used	to	send	information	to	the	outside.85 |	P a g e • The	Oracle	database	UTL_HTTP package	can	be	used	to	perform	HTTP	requests.	This could	be	used	to	send	information	to	the	outside. • The	Oracle	database	HTTPURITYPE object	type	can	be	used	to	perform	HTTP requests."
     rationale: "As	described	below,	Oracle	Database	PL/SQL	packages	- DBMS_LDAP,	UTL_INADDR,	UTL_TCP, UTL_MAIL,	UTL_SMTP,	UTL_DBWS,	UTL_ORAMTS,	UTL_HTTP and	type	HTTPURITYPE can	be	used	by unauthorized	users	to	create	specially	crafted	error	messages	or	send	information	to external	servers.	The	PUBLIC should	not	be	able	to	execute	these	packages. • The	use	of	the	DBMS_LDAP package	can	be	used	to	create	specially	crafted	error messages	or	send	information	via	DNS	to	the	outside. • The	UTL_INADDR package	can	be	used	to	create	specially	crafted	error	messages	or send	information	via	DNS	to the	outside. • The	UTL_TCP package	could	allow	an	unauthorized	user	to	corrupt	the	TCP	stream used	to	carry	the	protocols	that	communicate	with	the	instance's	external communications. • The	UTL_MAIL package	could	allow	an	unauthorized	user	to	corrupt	the	SMTP function	to	accept	or	generate	junk	mail	that	can	result	in	a	denial-of-service condition	due	to	network	saturation. • The	UTL_SMTP package	could	allow	an	unauthorized	user	to	corrupt	the	SMTP function	to	accept	or	generate	junk	mail	that	can	result	in	a	denial-of-service condition	due	to	network	saturation. • The	UTL_DBWS package	could	allow	an	unauthorized	user	to	corrupt	the	HTTP stream	used	to	carry	the	protocols	that	communicate	for	the	instance's	web-based external	communications. • The	UTL_ORAMTS package	could	be	used	to	send	(sensitive)	information	to	external websites.	The	use	of	this	package	should	be	restricted	according	to	the	needs	of	the organization. • The	UTL_HTTP package	could	be	used	to	send	(sensitive)	information	to	external websites. • The	use	of this	package	should	be	restricted	according	to	the	needs	of	the organization. • The	ability	to	perform	HTTP	requests	could	be	used	to	leak	information	from	the database	to	an	external	destination."
     remediation: "REVOKE EXECUTE ON DBMS_LDAP FROM PUBLIC; REVOKE EXECUTE ON UTL_INADDR FROM PUBLIC; REVOKE EXECUTE ON UTL_TCP FROM PUBLIC; REVOKE EXECUTE ON UTL_MAIL FROM PUBLIC; REVOKE EXECUTE ON UTL_SMTP FROM PUBLIC; REVOKE EXECUTE ON UTL_DBWS FROM PUBLIC; REVOKE EXECUTE ON UTL_ORAMTS FROM PUBLIC; REVOKE EXECUTE ON UTL_HTTP FROM PUBLIC; REVOKE EXECUTE ON HTTPURITYPE FROM PUBLIC;"
@@ -520,7 +520,7 @@ checks:
 
 # 5.1.1.2 Ensure 'EXECUTE' is revoked from 'PUBLIC' on "File System" Packages
   - id: 24533
-    title: "Ensure 'EXECUTE' is revoked from 'PUBLIC' on File System Packages"
+    title: "Ensure 'EXECUTE' is revoked from 'PUBLIC' on File System Packages."
     description: "As	described	below,	Oracle	Database	PL/SQL	File	System	packages	- DBMS_ADVISOR, DBMS_LOB and	UTL_FILE – provide	PL/SQL	APIs	to	access	files	on	the	servers.	The	user PUBLIC should	not	be	able	to	execute	these	packages. • The	Oracle	database	DBMS_ADVISOR package	can	be	used	to	write	files	located	on	the server	where	the	Oracle	instance	is	installed.	The	user	PUBLIC	should	not	be	able	to execute	DBMS_ADVISOR. • The	Oracle	database	DBMS_LOB package	provides	subprograms	that	can	manipulate and	read/write	on	BLOB's,	CLOB's,	NCLOB's,	BFILE's,	and	temporary	LOB's.	The	user PUBLIC should	not	be	able	to	execute	DBMS_LOB. • The	Oracle	database	UTL_FILE package	can	be	used	to	read/write	files	located	on the	server	where	the	Oracle	instance	is	installed.	The	user	PUBLIC should	not	be	able to	execute	UTL_FILE."
     rationale: "As	described	below,	Oracle	Database	PL/SQL	File	System	packages	- DBMS_ADVISOR, DBMS_LOB and	UTL_FILE – should	not	be	granted	to	PUBLIC. • Use	of	the	DBMS_ADVISOR package	could	allow	an	unauthorized	user	to	corrupt operating	system	files	on	the	instance's	host. • Use	of	the	DBMS_LOB package	could	allow	an	unauthorized	user	to	manipulate	BLOB's, CLOB's,	NCLOB's,	BFILE's,	and	temporary	LOBs	on	the	instance,	either	destroying	data or	causing	a	denial-of-service	condition	due	to	corruption	of	disk	space. • Use	of	the	UTL_FILE package	could	allow	a	user	to	read	OS	files.	These	files	could contain	sensitive	information	(e.g.	passwords	in	.bash_history)"
     remediation: "REVOKE EXECUTE ON DBMS_ADVISOR FROM PUBLIC; REVOKE EXECUTE ON DBMS_LOB FROM PUBLIC; REVOKE EXECUTE ON UTL_FILE FROM PUBLIC;"
@@ -534,7 +534,7 @@ checks:
 
 # 5.1.1.3 Ensure 'EXECUTE' is revoked from 'PUBLIC' on "Encryption" Packages
   - id: 24534
-    title: "Ensure 'EXECUTE' is revoked from 'PUBLIC' on Encryption Packages"
+    title: "Ensure 'EXECUTE' is revoked from 'PUBLIC' on Encryption Packages."
     description: "As	described	below,	Oracle	Database	PL/SQL	Encryption	packages	- DBMS_CRYPTO, DBMS_OBFUSCATION_TOOLKIT and	DBMS_RANDOM – provide	PL/SQL	APIs	to	perform	functions related	to	cryptography.	The	PUBLIC should	not	be	able	to	execute	these	packages. • The	DBMS_CRYPTO settings	provide	a	toolset	that	determines	the	strength	of	the encryption	algorithm	used	to	encrypt	application	data	and	is	part	of	the	SYS schema. The	DES (56-bit	key),	3DES (168-bit	key),	3DES-2KEY (112-bit	key),	AES (128/192/256-bit	keys),	and	RC4 are	available. • The	DBMS_OBFUSCATION_TOOLKIT provides	one	of	the	tools	that	determine	the strength	of	the	encryption	algorithm	used	to	encrypt	application	data	and	is	part	of the	SYS	schema.	The	DES (56-bit	key)	and	3DES (168-bit	key)	are	the	only	two	types available. • The	Oracle	database	DBMS_RANDOM package	is	used	for	generating	random	numbers but	should	not	be	used	for	cryptographic	purposes."
     rationale: "As	described	below,	Oracle	Database	PL/SQL	Encryption	packages	- DBMS_CRYPTO, DBMS_OBFUSCATION_TOOLKIT and	DBMS_RANDOM – should	not	be	granted	to	PUBLIC. • Execution	of	the	DBMS_CRYPTO procedures	by	the	PUBLIC can	potentially	endanger portions	of	or	all	of	the	data	storage. • Allowing	the	PUBLIC privileges	to	access	this	capability	can	be	potentially	harm	data storage. • Use	of	the	DBMS_RANDOM package	can	allow	the	unauthorized	application	of	the random	number-generating	function."
     remediation: "REVOKE EXECUTE ON DBMS_CRYPTO FROM PUBLIC; REVOKE EXECUTE ON DBMS_OBFUSCATION_TOOLKIT FROM PUBLIC; REVOKE EXECUTE ON DBMS_RANDOM FROM PUBLIC;"
@@ -548,7 +548,7 @@ checks:
 
 # 5.1.1.4 Ensure 'EXECUTE' is revoked from 'PUBLIC' on "Java" Packages
   - id: 24535
-    title: "Ensure 'EXECUTE' is revoked from 'PUBLIC' on Java Packages"
+    title: "Ensure 'EXECUTE' is revoked from 'PUBLIC' on Java Packages."
     description: "As	described	below,	Oracle	Database	PL/SQL	Java	packages	- DBMS_JAVA and DBMS_JAVA_TEST – provide	APIs	to	run	Java	classes	or	grant	Java	packages.	The	user	PUBLIC should	not	be	able	to	execute	these	packages. • The	Oracle	database	DBMS_JAVA package	can	run	Java	classes	(e.g.	OS	commands)	or grant	Java	privileges.	The	user	PUBLIC should	not	be	able	to	execute	DBMS_JAVA. • The	Oracle	database	DBMS_JAVA_TEST package	can	run	Java	classes	(e.g.	OS commands)	or	grant	Java	privileges.	The	user	PUBLIC should	not	be	able	to	execute DBMS_JAVA_TEST."
     rationale: "As	described	below,	Oracle	Database	PL/SQL	Java	packages	- DBMS_JAVA and DBMS_JAVA_TEST – should	not	be	granted	to	PUBLIC. • The	DBMS_JAVA package	could	allow	an	attacker	to	run	OS	commands	from	the database. • The	DBMS_JAVA_TEST package	could	allow	an	attacker	to	run	operating	system commands	from	the	database."
     remediation: "REVOKE EXECUTE ON DBMS_JAVA FROM PUBLIC; REVOKE EXECUTE ON DBMS_JAVA_TEST FROM PUBLIC;"
@@ -562,7 +562,7 @@ checks:
 
 # 5.1.1.5 Ensure 'EXECUTE' is revoked from 'PUBLIC' on "Job Scheduler" Packages
   - id: 24536
-    title: "Ensure 'EXECUTE' is revoked from 'PUBLIC' on Job Scheduler Packages"
+    title: "Ensure 'EXECUTE' is revoked from 'PUBLIC' on Job Scheduler Packages."
     description: "As	described	below,	Oracle	Database	PL/SQL	Job	Scheduler	packages	- DBMS_SCHEDULER and	DBMS_JOB – provide	APIs	to	schedule	jobs.	The	user	PUBLIC should	not	be	able	to execute	these	packages. • The	Oracle	database	DBMS_SCHEDULER package	schedules	and	manages	the	database and	operating	system	jobs.	The	user	PUBLIC should	not	be	able	to	execute DBMS_SCHEDULER. • The	Oracle	database	DBMS_JOB package	schedules	and	manages	the	jobs	sent	to	the job	queue	and	has	been	superseded	by	the	DBMS_SCHEDULER package,	even	though DBMS_JOB has	been	retained	for	backwards	compatibility.	The	user	PUBLIC should not	be	able	to	execute	DBMS_JOB."
     rationale: "As	described	below,	Oracle	Database	PL/SQL	Job	Scheduler	packages	- DBMS_SCHEDULER and	DBMS_JOB – should	not	be	granted	to	the user	PUBLIC. • Use	of	the	DBMS_SCHEDULER package	could	allow	an	unauthorized	user	to	run database	or	operating	system	jobs. • Use	of	the	DBMS_JOB package	could	allow	an	unauthorized	user	to	disable	or overload	the	job	queue.	It	has	been	superseded	by	the	DBMS_SCHEDULER package"
     remediation: "REVOKE EXECUTE ON DBMS_JOB FROM PUBLIC; REVOKE EXECUTE ON DBMS_SCHEDULER FROM PUBLIC;"
@@ -576,7 +576,7 @@ checks:
 
 # 5.1.1.6 Ensure 'EXECUTE' is revoked from 'PUBLIC' on "SQL Injection Helper" Packages
   - id: 24537
-    title: "Ensure 'EXECUTE' is revoked from 'PUBLIC' on SQL Injection Helper Packages"
+    title: "Ensure 'EXECUTE' is revoked from 'PUBLIC' on SQL Injection Helper Packages."
     description: "As	described	below,	Oracle	Database	PL/SQL	SQL	Injection	Helper	Packages	packages	- DBMS_SQL,	DBMS_XMLGEN,	DBMS_XMLQUERY,	DBMS_XLMSTORE,	DBMS_XLMSAVE and	DBMS_REDACT – provide	APIs	to	schedule	jobs.	The	user	PUBLIC should	not	be	able	to	execute	these packages. • The	Oracle	database	DBMS_SQL package	is	used	for	running	dynamic	SQL	statements. • The	DBMS_XMLGEN package	takes	an	arbitrary	SQL	query	as	input,	converts	it	to	XML format,	and	returns	the	result	as	a	CLOB. • The	Oracle	package	DBMS_XMLQUERY takes	an	arbitrary	SQL	query,	converts	it	to	XML format,	and	returns	the	result.	This	package	is	similar	to	DBMS_XMLGEN. • The	DBMS_XLMSTORE package	provides	XML	functionality.	It	accepts	a	table	name	and XML	as	input	to	perform	DML operations	against	the	table. • The	DBMS_XLMSAVE package	provides	XML	functionality.	It	accepts	a	table	name	and XML	as	input	and	then	inserts	into	or	updates	that	table. • The	DBMS_REDACT	package provides	an	interface	to	Oracle	Data	Redaction,	which enables	you	to	mask	(redact)	data	that	is	returned	from	queries	issued	by	lowprivileged	users	or	an	application."
     rationale: "As	described	below,	Oracle	Database	PL/SQL	SQL	Injection	Helper	Packages	packages	- DBMS_SQL,	DBMS_XMLGEN,	DBMS_XMLQUERY,	DBMS_XLMSTORE,	DBMS_XLMSAVE and 'DBMS_REDACT'	– should	not	be	granted	to	PUBLIC. • The	DBMS_SQL package	could	allow	privilege	escalation	if	input	validation	is	not	done properly. • The	package	DBMS_XMLGEN can	be	used	to	search	the	entire	database	for	sensitive information	like	credit	card	numbers • The	package	DBMS_XMLQUERY can	be	used	to	search	the	entire	database	for	sensitive information	like	credit	card	numbers.	Malicious	users	may	be	able	to	exploit	this package	as	an	auxiliary	inject	function	in	a	SQL	injection	attack. • Malicious	users	may	be	able	to	exploit	the	DBMS_XLMSTORE package	as	an	auxiliary inject	function	in	a	SQL	injection	attack. • Malicious	users	may	be	able	to	exploit	the	DBMS_XLMSAVE package	as	an	auxiliary inject	function	in	a	SQL	injection	attack. • Malicious	users	may	be	able	to	exploit	DBMS_REDACT	as	an	auxiliary	inject	function in	a	SQL	injection	attack."
     remediation: "REVOKE EXECUTE ON DBMS_SQL FROM PUBLIC; REVOKE EXECUTE ON DBMS_XMLGEN FROM PUBLIC; REVOKE EXECUTE ON DBMS_XMLQUERY FROM PUBLIC; REVOKE EXECUTE ON DBMS_XMLSAVE FROM PUBLIC; REVOKE EXECUTE ON DBMS_XMLSTORE FROM PUBLIC; REVOKE EXECUTE ON DBMS_AW FROM PUBLIC;REVOKE EXECUTE ON OWA_UTIL FROM PUBLIC; REVOKE EXECUTE ON DBMS_REDACT FROM PUBLIC;"
@@ -593,7 +593,7 @@ checks:
 ###############################################
 # 5.1.2.1 Ensure 'EXECUTE' is not granted to 'PUBLIC' on "Non-default" Packages
   - id: 24538
-    title: "Ensure 'EXECUTE' is not granted to 'PUBLIC' on Non-default Packages"
+    title: "Ensure 'EXECUTE' is not granted to 'PUBLIC' on Non-default Packages."
     description: "The	packages	described	in	this	control	are	not	granted	to	PUBLIC by	default	(Non-default packages).	These	packages	should	not	be	granted	to	PUBLIC. • The	Oracle	database	DBMS_BACKUP_RESTORE package	is	used	for	applying	PL/SQL commands	to	the	native	RMAN sequences. • The	Oracle	database	DBMS_FILE_TRANSFER package	allows	a	user	to	transfer	files from	one	database	server	to	another. • The	Oracle	database	DBMS_SYS_SQL,DBMS_REPCAT_SQL_UTL,	INITJVMAUX, DBMS_AQADM_SYS,	DBMS_STREAMS_RPC,	DBMS_PRVTAQIM,	LTADM and DBMS_IJOB packages are	shipped	as	undocumented."
     rationale: "As	described	below,	these	non-default	group	of	PL/SQL	packages,	which	are	not	granted to	PUBLIC by	default,	packages	should	not	be	granted	to	PUBLIC. • The	DBMS_BACKUP_RESTORE package	can	allow	access	to	OS	files. • The	DBMS_FILE_TRANSFER package	could	allow	to	transfer	files	from	one	database server	to	another	without	authorization	to	do	so. • The	DBMS_SYS_SQL package	could	allow	a	user	to	run	code	as	a	different	user without	entering	valid	credentials. • The	DBMS_REPCAT_SQL_UTL package	could	allow	an	unauthorized	user	to	run	SQL commands	as	user	SYS. • The	INITJVMAUX package	could	allow	an	unauthorized	user	to	run	SQL	commands	as user	SYS. • The	DBMS_AQADM_SYS package	could	allow	an	unauthorized	user	to	run SQL commands	as	user	SYS. • The	DBMS_STREAMS_RPC package	could	allow	an	unauthorized	user	to	run	SQL commands	as	user	SYS.102 |	P a g e • The	DBMS_PRVTAQIM package	could	allow	an	unauthorized	user	to	escalate	privileges because	any	SQL	statements	could	be	executed	as	user SYS. • The	LTADM package	could	allow	an	unauthorized	user	to	run	any	SQL	command	as user	SYS.	It	allows	privilege	escalation	if	granted	to	unprivileged	users. • The	DBMS_IJOB package	could	allow	an	attacker	to	change	identities	by	using	a different	username	to	execute	a	database	job.	It	allows	a	user	to	run	database	jobs	in the	context	of	another	user."
     remediation: "REVOKE EXECUTE ON DBMS_BACKUP_RESTORE FROM PUBLIC; REVOKE EXECUTE ON DBMS_FILE_TRANSFER FROM PUBLIC; REVOKE EXECUTE ON DBMS_SYS_SQL FROM PUBLIC; REVOKE EXECUTE ON DBMS_REPCAT_SQL_UTL FROM PUBLIC; REVOKE EXECUTE ON INITJVMAUX FROM PUBLIC; REVOKE EXECUTE ON DBMS_AQADM_SYS FROM PUBLIC; REVOKE EXECUTE ON DBMS_STREAMS_RPC FROM PUBLIC; REVOKE EXECUTE ON DBMS_PRVTAQIM FROM PUBLIC; REVOKE EXECUTE ON LTADM FROM PUBLIC; REVOKE EXECUTE ON DBMS_IJOB FROM PUBLIC; REVOKE EXECUTE ON DBMS_PDB_EXEC_SQL FROM PUBLIC;"
@@ -610,7 +610,7 @@ checks:
 ###############################################
 # 5.1.3.1 Ensure 'ALL' Is Revoked from Unauthorized 'GRANTEE' on 'AUD$'
   - id: 24539
-    title: "Ensure 'ALL' Is Revoked from Unauthorized 'GRANTEE' on 'AUD$'"
+    title: "Ensure 'ALL' Is Revoked from Unauthorized 'GRANTEE' on 'AUD$'."
     description: "The	Oracle	database	SYS.AUD$ table	contains	all	the	audit	records	for	the	database	of	the non-Data	Manipulation	Language	(DML)	events,	such	as	ALTER,	DROP,	and	CREATE,	and	so forth.	(DML	changes	need	trigger-based	audit	events	to	record	data	alterations.) Unauthorized	grantees	should not	have	full	access	to	that	table."
     rationale: "Permitting	non-privileged	users	the	authorization	to	manipulate	the	SYS.AUD$ table	can allow	distortion	of	the	audit	records,	hiding	unauthorized	activities."
     remediation: "REVOKE ALL ON AUD$ FROM <grantee>;"
@@ -624,7 +624,7 @@ checks:
 
 # 5.1.3.2 Ensure 'ALL' Is Revoked from Unauthorized 'GRANTEE' on 'DBA_%'
   - id: 24540
-    title: "Ensure 'ALL' Is Revoked from Unauthorized 'GRANTEE' on 'DBA_%'"
+    title: "Ensure 'ALL' Is Revoked from Unauthorized 'GRANTEE' on 'DBA_%'."
     description: "The	Oracle	database	DBA_ views	show	all	information	which	is	relevant	to	administrative accounts.	Unauthorized	grantees	should	not	have	full	access	to	those	views."
     rationale: "Permitting	users	the	authorization	to	manipulate	the	DBA_ views	can	expose	sensitive	data."
     remediation: "REVOKE ALL ON <DBA_%> FROM <Non-DBA/SYS grantee>;"
@@ -638,7 +638,7 @@ checks:
 
 # 5.1.3.3 Ensure 'ALL' Is Revoked on 'Sensitive' Tables
   - id: 24541
-    title: "Ensure 'ALL' Is Revoked on 'Sensitive' Tables "
+    title: "Ensure 'ALL' Is Revoked on 'Sensitive' Tables ."
     description: "The	Oracle	database	tables	listed	below	may	contain	sensitive	information,	and	should	not be	accessible	to	unauthorized	users. • USER$,	USER_HISTORY$,	XS$VERIFIERS and	DEFAULT_PWD$ may	contain	password hashes. • CDB_LOCAL_ADMINAUTH$ and	PDB_SYNC$ may	contain	DDLs. • LINK$ and	SCHEDULER$_CREDENTIAL may	contain	encrypted	passwords. • ENC$ may	contains	encryption	keys. • HISTGRM$ and	HIST_HEAD$ may	contain	sensitive	data."
     rationale: "Access	to	sensitive	information	such	as	hashed	passwords	may	allow	unauthorized	users	to decrypt	the	passwords	hashes	which	could	potentially	result	in	complete	compromise	of the	database."
     remediation: "REVOKE ALL ON SYS.CDB_LOCAL_ADMINAUTH$ FROM <grantee>; REVOKE ALL ON SYS.DEFAULT_PWD$ FROM <grantee>; REVOKE ALL ON SYS.ENC$ FROM <grantee>; REVOKE ALL ON SYS.HISTGRM$ FROM <grantee>; REVOKE ALL ON SYS.HIST_HEAD$ FROM <grantee>; REVOKE ALL ON SYS.LINK$ FROM <grantee>; REVOKE ALL ON SYS.PDB_SYNC$ FROM <grantee>; REVOKE ALL ON SYS.SCHEDULER$_CREDENTIAL FROM <grantee>; REVOKE ALL ON SYS.USER$ FROM <grantee>; REVOKE ALL ON SYS.USER_HISTORY$ FROM <grantee>; REVOKE ALL ON SYS.XS$VERIFIERS FROM <grantee>;"
@@ -655,7 +655,7 @@ checks:
 ###############################################
 # 5.2.1 Ensure '%ANY%' Is Revoked from Unauthorized 'GRANTEE'
   - id: 24542
-    title: "Ensure '%ANY%' Is Revoked from Unauthorized 'GRANTEE'"
+    title: "Ensure '%ANY%' Is Revoked from Unauthorized 'GRANTEE'."
     description: "The	Oracle	database	ANY keyword	provides	the	user	the	capability	to	alter	any	item	in	the catalog	of	the	database.	Unauthorized	grantees	should	not	have	that	keyword	assigned	to them"
     rationale: "Authorization	to	use	the	ANY expansion	of	a	privilege	can	allow	an	unauthorized	user to potentially	change	confidential	data	or	damage	the	data	catalog."
     remediation: "REVOKE '<ANY Privilege>' FROM <grantee>;"
@@ -669,7 +669,7 @@ checks:
 
 # 5.2.2 Ensure 'DBA_SYS_PRIVS.%' Is Revoked from Unauthorized 'GRANTEE' with 'ADMIN_OPTION' Set to 'YES'
   - id: 24543
-    title: "Ensure 'DBA_SYS_PRIVS.%' Is Revoked from Unauthorized 'GRANTEE' with 'ADMIN_OPTION' Set to 'YES'"
+    title: "Ensure 'DBA_SYS_PRIVS.%' Is Revoked from Unauthorized 'GRANTEE' with 'ADMIN_OPTION' Set to 'YES'."
     description: "The	Oracle	database	WITH_ADMIN privilege	allows	the	designated	user	to	grant	another	user the	same	privileges.	Unauthorized	grantees	should	not	have	that	privilege."
     rationale: "Assignment	of	the	WITH_ADMIN privilege	can	allow	the	granting	of	a	restricted	privilege	to an	unauthorized	user."
     remediation: "REVOKE <privilege> FROM <grantee>;"
@@ -683,7 +683,7 @@ checks:
 
 # 5.2.3 Ensure 'EXECUTE ANY PROCEDURE' Is Revoked from 'OUTLN'
   - id: 24544
-    title: "Ensure 'EXECUTE ANY PROCEDURE' Is Revoked from 'OUTLN'"
+    title: "Ensure 'EXECUTE ANY PROCEDURE' Is Revoked from 'OUTLN'."
     description: "Remove	unneeded	EXECUTE ANY PROCEDURE privileges	from	OUTLN."
     rationale: "Migrated	OUTLN users	have	more	privileges	than	required."
     remediation: "REVOKE EXECUTE ANY PROCEDURE FROM OUTLN;"
@@ -697,7 +697,7 @@ checks:
 
 # 5.2.4 Ensure 'EXECUTE ANY PROCEDURE' Is Revoked from 'DBSNMP'
   - id: 24545
-    title: "Ensure 'EXECUTE ANY PROCEDURE' Is Revoked from 'DBSNMP'"
+    title: "Ensure 'EXECUTE ANY PROCEDURE' Is Revoked from 'DBSNMP'."
     description: "Remove	unneeded	EXECUTE ANY PROCEDURE privileges	from	DBSNMP."
     rationale: "Migrated	DBSNMP users	have	more	privileges	than	required."
     remediation: "REVOKE EXECUTE ANY PROCEDURE FROM DBSNMP;"
@@ -711,7 +711,7 @@ checks:
 
 # 5.2.5 Ensure 'SELECT ANY DICTIONARY' Is Revoked from Unauthorized 'GRANTEE'
   - id: 24546
-    title: "Ensure 'SELECT ANY DICTIONARY' Is Revoked from Unauthorized 'GRANTEE'"
+    title: "Ensure 'SELECT ANY DICTIONARY' Is Revoked from Unauthorized 'GRANTEE'."
     description: "The	Oracle	database	SELECT ANY DICTIONARY privilege	allows	the	designated	user	to	access SYS schema	objects.	Unauthorized	grantees	should	not	have	that	privilege."
     rationale: "SELECT ANY DICTIONARY is	a	powerful	system	privilege	which	would	allow	an unauthorized	user	to	gather	information	about	the database	through	data	dictionary objects.	Information	collected	could	potentially	be	used	to	exploit	the	database."
     remediation: "REVOKE SELECT ANY DICTIONARY FROM <grantee>;"
@@ -725,7 +725,7 @@ checks:
 
 # 5.2.6 Ensure 'SELECT ANY TABLE' Is Revoked from Unauthorized 'GRANTEE'
   - id: 24547
-    title: "Ensure 'SELECT ANY TABLE' Is Revoked from Unauthorized 'GRANTEE'"
+    title: "Ensure 'SELECT ANY TABLE' Is Revoked from Unauthorized 'GRANTEE'."
     description: "The	Oracle	database	SELECT ANY TABLE privilege	allows	the	designated	user	to	open	any table,	except	SYS,	to	view	it.	Unauthorized	grantees	should	not	have	that	privilege."
     rationale: "Assignment	of	the	SELECT ANY TABLE privilege	can	allow	the	unauthorized	viewing	of sensitive	data."
     remediation: "REVOKE SELECT ANY TABLE FROM <grantee>;"
@@ -739,7 +739,7 @@ checks:
 
 # 5.2.7 Ensure 'AUDIT SYSTEM' Is Revoked from Unauthorized 'GRANTEE'
   - id: 24548
-    title: "Ensure 'AUDIT SYSTEM' Is Revoked from Unauthorized 'GRANTEE'"
+    title: "Ensure 'AUDIT SYSTEM' Is Revoked from Unauthorized 'GRANTEE'."
     description: "The	Oracle	database	AUDIT SYSTEM privilege	allows	changes	to	auditing	activities	on	the system.	Unauthorized	grantees	should	not	have	that	privilege."
     rationale: "The	AUDIT SYSTEM privilege	can	allow	the	unauthorized	alteration	of	system	audit activities,	such	as	disabling	the	creation	of	audit	trails."
     remediation: "REVOKE AUDIT SYSTEM FROM <grantee>;"
@@ -753,7 +753,7 @@ checks:
 
 # 5.2.8 Ensure 'EXEMPT ACCESS POLICY' Is Revoked from Unauthorized 'GRANTEE'
   - id: 24549
-    title: "Ensure 'EXEMPT ACCESS POLICY' Is Revoked from Unauthorized 'GRANTEE'"
+    title: "Ensure 'EXEMPT ACCESS POLICY' Is Revoked from Unauthorized 'GRANTEE'."
     description: "The	Oracle	database	EXEMPT ACCESS POLICY keyword	provides	the	user	the	capability	to access	all	the	table	rows	regardless	of	row-level	security	lockouts.	Unauthorized	grantees should	not	have	that	keyword	assigned	to	them."
     rationale: "The	EXEMPT ACCESS POLICY privilege	can	allow	an	unauthorized	user	to	potentially	access and	change	data."
     remediation: "REVOKE EXEMPT ACCESS POLICY FROM <grantee>;"
@@ -767,7 +767,7 @@ checks:
 
 # 5.2.9 Ensure 'BECOME USER' Is Revoked from Unauthorized 'GRANTEE'
   - id: 24550
-    title: "Ensure 'BECOME USER' Is Revoked from Unauthorized 'GRANTEE'"
+    title: "Ensure 'BECOME USER' Is Revoked from Unauthorized 'GRANTEE'."
     description: "The	Oracle	database	BECOME USER privilege	allows	the	designated	user	to	inherit	the	rights of	another	user.	Unauthorized	grantees	should	not	have	that	privilege."
     rationale: "The	BECOME USER privilege	can	allow	the	unauthorized	use	of	another	user's	privileges,	this capability	should	be	restricted	according	to	the	needs	of	the	organization."
     remediation: "REVOKE BECOME USER FROM <grantee>;"
@@ -781,7 +781,7 @@ checks:
 
 # 5.2.10 Ensure 'CREATE PROCEDURE' Is Revoked from Unauthorized 'GRANTEE'
   - id: 24551
-    title: "Ensure 'CREATE PROCEDURE' Is Revoked from Unauthorized 'GRANTEE'"
+    title: "Ensure 'CREATE PROCEDURE' Is Revoked from Unauthorized 'GRANTEE'."
     description: "The	Oracle	database	CREATE PROCEDURE privilege	allows	the	designated	user	to	create	a stored	procedure	that	will	fire	when	given	the	correct	command	sequence.	Unauthorized grantees	should	not	have	that	privilege."
     rationale: "The	CREATE PROCEDURE privilege	can	lead	to	severe	problems	in	unauthorized	hands,	such as	rogue	procedures	facilitating	data	theft	or	denial-of-service	by	corrupting	data	tables."
     remediation: "REVOKE CREATE PROCEDURE FROM <grantee>;"
@@ -795,7 +795,7 @@ checks:
 
 # 5.2.11 Ensure 'ALTER SYSTEM' Is Revoked from Unauthorized 'GRANTEE'
   - id: 24552
-    title: "Ensure 'ALTER SYSTEM' Is Revoked from Unauthorized 'GRANTEE'"
+    title: "Ensure 'ALTER SYSTEM' Is Revoked from Unauthorized 'GRANTEE'."
     description: "The	Oracle	database	ALTER SYSTEM privilege	allows	the	designated	user	to	dynamically alter	the	instance's	running	operations.	Unauthorized	grantees	should	not	have	that privilege."
     rationale: "The	ALTER SYSTEM privilege	can	lead	to	severe	problems,	such	as	the	instance's	session being	killed	or	the	stopping	of	redo	log	recording,	which	would	make	transactions unrecoverable."
     remediation: "REVOKE ALTER SYSTEM FROM <grantee>;"
@@ -809,7 +809,7 @@ checks:
 
 # 5.2.12 Ensure 'CREATE ANY LIBRARY' Is Revoked from Unauthorized 'GRANTEE'
   - id: 24553
-    title: "Ensure 'CREATE ANY LIBRARY' Is Revoked from Unauthorized 'GRANTEE'"
+    title: "Ensure 'CREATE ANY LIBRARY' Is Revoked from Unauthorized 'GRANTEE'."
     description: "The	Oracle	database	CREATE ANY LIBRARY privilege	allows	the	designated	user	to	create objects	that	are	associated	to	the	shared	libraries.	Unauthorized	grantees	should	not	have that	privilege."
     rationale: "The	CREATE ANY LIBRARY privilege	can	allow	the	creation	of	numerous	library-associated objects	and	potentially	corrupt	the	libraries'	integrity."
     remediation: "REVOKE CREATE ANY LIBRARY FROM <grantee>;"
@@ -823,7 +823,7 @@ checks:
 
 # 5.2.13 Ensure 'CREATE LIBRARY' Is Revoked from Unauthorized 'GRANTEE'
   - id: 24554
-    title: "Ensure 'CREATE LIBRARY' Is Revoked from Unauthorized 'GRANTEE'"
+    title: "Ensure 'CREATE LIBRARY' Is Revoked from Unauthorized 'GRANTEE'."
     description: "The	Oracle	database	CREATE LIBRARY privilege	allows	the	designated	user	to	create	objects that	are	associated	to	the	shared	libraries.	Unauthorized	grantees	should	not	have	that privilege."
     rationale: "The	CREATE LIBRARY privilege	can	allow	the	creation	of	numerous	library-associated objects	and	potentially	corrupt	the	libraries'	integrity"
     remediation: "REVOKE CREATE LIBRARY FROM <grantee>;"
@@ -837,7 +837,7 @@ checks:
 
 # 5.2.14 Ensure 'GRANT ANY OBJECT PRIVILEGE' Is Revoked from Unauthorized 'GRANTEE'
   - id: 24555
-    title: "Ensure 'GRANT ANY OBJECT PRIVILEGE' Is Revoked from Unauthorized 'GRANTEE'"
+    title: "Ensure 'GRANT ANY OBJECT PRIVILEGE' Is Revoked from Unauthorized 'GRANTEE'."
     description: "The	Oracle	database	GRANT ANY OBJECT PRIVILEGE keyword	provides	the	grantee	the capability	to	grant	access	to	any	single	or	multiple	combinations	of	objects	to	any	grantee in	the	catalog	of	the	database.	Unauthorized	grantees	should	not	have	that	keyword assigned	to	them."
     rationale: "The	GRANT ANY OBJECT PRIVILEGE capability	can	allow	an	unauthorized	user	to	potentially access	or	change	confidential	data,	or	damage	the	data	catalog	due	to	potential	complete instance	access."
     remediation: "REVOKE GRANT ANY OBJECT PRIVILEGE FROM <grantee>;"
@@ -851,7 +851,7 @@ checks:
 
 # 5.2.15 Ensure 'GRANT ANY ROLE' Is Revoked from Unauthorized 'GRANTEE'
   - id: 24556
-    title: "Ensure 'GRANT ANY ROLE' Is Revoked from Unauthorized 'GRANTEE'"
+    title: "Ensure 'GRANT ANY ROLE' Is Revoked from Unauthorized 'GRANTEE'."
     description: "The	Oracle	database	GRANT ANY ROLE keyword	provides	the	grantee	the	capability	to	grant any	single	role	to	any	grantee	in	the	catalog	of	the	database.	Unauthorized	grantees	should not	have	that	keyword	assigned	to	them."
     rationale: "The	GRANT ANY ROLE capability	can	allow	an	unauthorized	user	to	potentially	access	or change	confidential	data	or	damage	the	data	catalog	due	to	potential	complete	instance access."
     remediation: "REVOKE GRANT ANY ROLE FROM <grantee>;"
@@ -865,7 +865,7 @@ checks:
 
 # 5.2.16 Ensure 'GRANT ANY PRIVILEGE' Is Revoked from Unauthorized 'GRANTEE'
   - id: 24557
-    title: "Ensure 'GRANT ANY PRIVILEGE' Is Revoked from Unauthorized 'GRANTEE'"
+    title: "Ensure 'GRANT ANY PRIVILEGE' Is Revoked from Unauthorized 'GRANTEE'."
     description: "The	Oracle	database	GRANT ANY PRIVILEGE keyword	provides	the	grantee	the	capability	to grant	any	single	privilege	to	any	item	in	the	catalog	of	the	database.	Unauthorized	grantees should	not	have	that	privilege."
     rationale: "The	GRANT ANY PRIVILEGE capability	can	allow	an	unauthorized	user	to	potentially	access or	change	confidential	data	or	damage	the	data	catalog	due	to	potential	complete	instance access."
     remediation: "REVOKE GRANT ANY PRIVILEGE FROM <grantee>;"
@@ -882,7 +882,7 @@ checks:
 ###############################################
 # 5.3.1 Ensure 'SELECT_CATALOG_ROLE' Is Revoked from Unauthorized 'GRANTEE'
   - id: 24558
-    title: "Ensure 'SELECT_CATALOG_ROLE' Is Revoked from Unauthorized 'GRANTEE'"
+    title: "Ensure 'SELECT_CATALOG_ROLE' Is Revoked from Unauthorized 'GRANTEE'."
     description: "The	Oracle	database	SELECT_CATALOG_ROLE provides	SELECT privileges	on	all	data dictionary	views	held	in	the	SYS schema.	Unauthorized	grantees	should	not	have	that	role."
     rationale: "Permitting	unauthorized	access	to	the	SELECT_CATALOG_ROLE can	allow	the	disclosure	of	all dictionary	data."
     remediation: "REVOKE SELECT_CATALOG_ROLE FROM <grantee>;"
@@ -896,7 +896,7 @@ checks:
 
 # 5.3.2 Ensure 'EXECUTE_CATALOG_ROLE' Is Revoked from Unauthorized 'GRANTEE'
   - id: 24559
-    title: "Ensure 'EXECUTE_CATALOG_ROLE' Is Revoked from Unauthorized 'GRANTEE'"
+    title: "Ensure 'EXECUTE_CATALOG_ROLE' Is Revoked from Unauthorized 'GRANTEE'."
     description: "The	Oracle	database	EXECUTE_CATALOG_ROLE provides	EXECUTE privileges	for	a	number	of packages	and	procedures	in	the	data	dictionary	in	the	SYS schema.	Unauthorized	grantees should	not	have	that	role."
     rationale: "Permitting	unauthorized	access	to	the	EXECUTE_CATALOG_ROLE can	allow	the	disruption	of operations	by	initialization	of	rogue	procedures,	this	capability	should	be	restricted according	to	the	needs	of	the	organization."
     remediation: "REVOKE EXECUTE_CATALOG_ROLE FROM <grantee>;"
@@ -910,7 +910,7 @@ checks:
 
 # 5.3.3 Ensure 'DBA' Is Revoked from Unauthorized 'GRANTEE'
   - id: 24560
-    title: "Ensure 'DBA' Is Revoked from Unauthorized 'GRANTEE'"
+    title: "Ensure 'DBA' Is Revoked from Unauthorized 'GRANTEE'."
     description: "The	Oracle	database	DBA role	is	the	default	database	administrator role	provided	for	the allocation	of	administrative	privileges.	Unauthorized	grantees	should	not	have	that	role."
     rationale: "Assignment	of	the	DBA role	to	an	ordinary	user	can	provide	a	great	number	of	unnecessary privileges	to	that	user	and	open	the	door	to	data	breaches,	integrity	violations,	and	denialof-service	conditions."
     remediation: "REVOKE DBA FROM <grantee>;"
@@ -930,7 +930,7 @@ checks:
 ###############################################
 # 6.1.1 Ensure the 'USER' Audit Option Is Enabled
   - id: 24561
-    title: "Ensure the 'USER' Audit Option Is Enabled"
+    title: "Ensure the 'USER' Audit Option Is Enabled."
     description: "The	USER object	allows	for	creating	accounts	that	can	interact	with	the	database	according to	the	roles	and	privileges	allotted	to	the	account.	It	may	also	own	database	objects. Enabling	the	audit option	causes	auditing	of	all	activities	and	requests	to	create,	drop	or alter	a	user,	including	a	user	changing	their	own	password.	(The	latter	is	not	audited	by audit ALTER USER.)"
     rationale: "Any	unauthorized	attempts	to	create,	drop	or	alter	a	user	should	cause	concern,	whether successful	or	not.	Auditing	can	also	be	useful	in	forensics	if	an	account	is	compromised,	and auditing	is	mandated	by	many	common	security	initiatives.	An	abnormally	high	number	of these	activities	in	a	given	period	might	be	worth	investigation.	Any	failed	attempt	to	drop	a user	or	create	a	user	may	be	worth	further	review."
     remediation: "AUDIT USER;"
@@ -944,7 +944,7 @@ checks:
 
 # 6.1.2 Ensure the 'ROLE' Audit Option Is Enabled
   - id: 24562
-    title: "Ensure the 'ROLE' Audit Option Is Enabled"
+    title: "Ensure the 'ROLE' Audit Option Is Enabled."
     description: "The	ROLE object	allows	for	the	creation	of	a	set	of	privileges	that	can	be	granted	to	users	or other	roles.	Enabling	the	audit	option	causes	auditing	of	all	attempts,	successful	or	not,	to create,	drop,	alter	or	set	roles."
     rationale: "Roles	are a	key	database	security	infrastructure	component.	Any	attempt	to	create,	drop	or alter	a	role	should	be	audited.	This	statement	auditing	option	also	audits	attempts, successful	or	not,	to	set	a	role	in	a	session.	Any	unauthorized	attempts	to	create,	drop	or alter	a	role	may	be	worthy	of	investigation.	Attempts	to	set	a	role	by	users	without	the	role privilege	may	warrant	investigation."
     remediation: "AUDIT ROLE;"
@@ -958,7 +958,7 @@ checks:
 
 # 6.1.3 Ensure the 'SYSTEM GRANT' Audit Option Is Enabled
   - id: 24563
-    title: "Ensure the 'SYSTEM GRANT' Audit Option Is Enabled"
+    title: "Ensure the 'SYSTEM GRANT' Audit Option Is Enabled."
     description: "Enabling	the	audit	option	for	the	SYSTEM GRANT object	causes	auditing	of	any	attempt, successful	or	not,	to	grant	or	revoke	any	system	privilege	or	role,	regardless	of	privilege held	by	the	user	attempting	the	operation."
     rationale: "Logging	of	all	grant	and	revokes	(roles	and	system	privileges)	can	provide	forensic evidence	about	a	pattern	of	suspect/unauthorized	activities.	Any	unauthorized	attempt may	be	cause	for	further	investigation."
     remediation: "AUDIT SYSTEM GRANT;"
@@ -972,7 +972,7 @@ checks:
 
 # 6.1.4 Ensure the 'PROFILE' Audit Option Is Enabled
   - id: 24564
-    title: "Ensure the 'PROFILE' Audit Option Is Enabled"
+    title: "Ensure the 'PROFILE' Audit Option Is Enabled."
     description: "The	PROFILE object	allows	for	the	creation	of	a	set	of	database	resource	limits	that	can	be assigned	to	a	user,	so	that	that	user	cannot	exceed	those	resource	limitations.	Enabling	the audit	option	causes	auditing	of	all	attempts,	successful	or	not,	to	create,	drop	or	alter	any profile."
     rationale: "As	profiles	are	part	of	the	database	security	infrastructure,	auditing	the	creation, modification,	and	deletion	of	profiles	is	recommended."
     remediation: "AUDIT PROFILE;"
@@ -986,7 +986,7 @@ checks:
 
 # 6.1.5 Ensure the 'DATABASE LINK' Audit Option Is Enabled
   - id: 24565
-    title: "Ensure the 'DATABASE LINK' Audit Option Is Enabled"
+    title: "Ensure the 'DATABASE LINK' Audit Option Is Enabled."
     description: "Enabling	the	audit	option	for	the	DATABASE	LINK	object	causes	all	activities	on	database links	to	be	audited."
     rationale: "As	the	logging	of	user	activities	involving	the	creation	or	dropping	of	a	DATABASE LINK can provide	forensic	evidence	about	a	pattern	of	unauthorized	activities,	the	audit	capability should	be	enabled."
     remediation: "AUDIT DATABASE LINK;"
@@ -1000,7 +1000,7 @@ checks:
 
 # 6.1.6 Ensure the 'PUBLIC DATABASE LINK' Audit Option Is Enabled
   - id: 24566
-    title: "Ensure the 'PUBLIC DATABASE LINK' Audit Option Is Enabled"
+    title: "Ensure the 'PUBLIC DATABASE LINK' Audit Option Is Enabled."
     description: "The	PUBLIC DATABASE LINK object	allows	for	the	creation	of	a	public	link	for	an application-based	user	to	access	the	database	for	connections/session	creation.	Enabling the	audit	option	causes	all	user	activities	involving	the	creation,	alteration,	or	dropping	of public	links	to	be	audited."
     rationale: "As	the	logging	of	user	activities	involving	the	creation,	alteration,	or	dropping	of	a	PUBLIC DATABASE LINK can	provide	forensic	evidence	about	a	pattern	of	unauthorized	activities, the	audit	capability	should	be	enabled."
     remediation: "AUDIT PUBLIC DATABASE LINK;"
@@ -1014,7 +1014,7 @@ checks:
 
 # 6.1.7 Ensure the 'PUBLIC SYNONYM' Audit Option Is Enabled
   - id: 24567
-    title: "Ensure the 'PUBLIC SYNONYM' Audit Option Is Enabled"
+    title: "Ensure the 'PUBLIC SYNONYM' Audit Option Is Enabled."
     description: "The	PUBLIC SYNONYM object	allows	for	the	creation	of	an	alternate	description	of	an	object. Public	synonyms	are	accessible	by	all	users	that	have	the	appropriate	privileges	to	the underlying	object.	Enabling	the	audit	option	causes	all	user	activities	involving	the	creation or	dropping	of	public	synonyms	to	be	audited."
     rationale: "As	the	logging	of	user	activities	involving	the	creation	or	dropping	of	a	PUBLIC SYNONYM can provide	forensic	evidence	about	a	pattern	of	unauthorized	activities,	the	audit	capability should	be	enabled."
     remediation: "AUDIT PUBLIC SYNONYM;"
@@ -1028,7 +1028,7 @@ checks:
 
 # 6.1.8 Ensure the 'SYNONYM' Audit Option Is Enabled
   - id: 24568
-    title: "Ensure the 'SYNONYM' Audit Option Is Enabled"
+    title: "Ensure the 'SYNONYM' Audit Option Is Enabled."
     description: "The	SYNONYM operation	allows	for	the	creation	of	an	alternative	name	for	a	database	object such	as	a	Java	class	schema	object,	materialized	view,	operator,	package,	procedure, sequence,	stored	function,	table,	view,	user-defined	object	type,	or	even	another	synonym. This	synonym	puts	a	dependency	on	its	target	and	is	rendered	invalid	if	the	target	object	is changed/dropped.	Enabling	the	audit	option	causes	all	user	activities	involving	the	creation or	dropping	of	synonyms	to	be	audited."
     rationale: "As	the	logging	of	user	activities	involving	the	creation	or	dropping	of	a	SYNONYM can	provide forensic	evidence	about	a	pattern	of	suspect/unauthorized	activities,	the	audit	capability should	be	enabled."
     remediation: "AUDIT SYNONYM;"
@@ -1042,7 +1042,7 @@ checks:
 
 # 6.1.9 Ensure the 'DIRECTORY' Audit Option Is Enabled
   - id: 24569
-    title: "Ensure the 'DIRECTORY' Audit Option Is Enabled"
+    title: "Ensure the 'DIRECTORY' Audit Option Is Enabled."
     description: "The	DIRECTORY object	allows	for	the	creation	of	a	directory	object	that	specifies	an	alias	for a	directory	on	the	server	file	system,	where	the	external	binary	file	LOBs (BFILEs)/	table data	are	located.	Enabling	this	audit	option	causes	all	user	activities	involving	the	creation or	dropping	of	a	directory	alias	to	be	audited."
     rationale: "As	the	logging	of	user	activities	involving	the	creation	or	dropping	of	a	DIRECTORY can provide	forensic	evidence	about	a	pattern	of	unauthorized	activities,	the	audit	capability should	be	enabled."
     remediation: "AUDIT DIRECTORY;"
@@ -1056,7 +1056,7 @@ checks:
 
 # 6.1.10 Ensure the 'SELECT ANY DICTIONARY' Audit Option Is Enabled
   - id: 24570
-    title: "Ensure the 'SELECT ANY DICTIONARY' Audit Option Is Enabled"
+    title: "Ensure the 'SELECT ANY DICTIONARY' Audit Option Is Enabled."
     description: "The	SELECT ANY DICTIONARY capability	allows	the	user	to	view	the	definitions	of	all	schema objects	in	the	database.	Enabling	the	audit	option	causes	all	user	activities	involving	this capability	to	be	audited."
     rationale: "As	the	logging	of	user	activities	involving	the	capability	to	access	the	description	of	all schema	objects	in	the	database	can	provide	forensic	evidence	about	a	pattern	of unauthorized	activities,	the	audit	capability	should	be	enabled."
     remediation: "AUDIT SELECT ANY DICTIONARY;"
@@ -1070,7 +1070,7 @@ checks:
 
 # 6.1.11 Ensure the 'GRANT ANY OBJECT PRIVILEGE' Audit Option Is Enabled
   - id: 24571
-    title: "Ensure the 'GRANT ANY OBJECT PRIVILEGE' Audit Option Is Enabled"
+    title: "Ensure the 'GRANT ANY OBJECT PRIVILEGE' Audit Option Is Enabled."
     description: "GRANT ANY OBJECT PRIVILEGE allows	the	user	to	grant	or	revoke	any	object	privilege, which	includes	privileges	on	tables,	directories,	mining	models,	etc.	Enabling	this	audit option	causes	auditing	of	all	uses	of	that	privilege."
     rationale: "Logging	of	privilege	grants	that	can	lead	to	the	creation,	alteration,	or	deletion	of	critical data,	the	modification	of	objects,	object	privilege	propagation	and	other	such	activities	can be	critical	to	forensic	investigations."
     remediation: "AUDIT GRANT ANY OBJECT PRIVILEGE;"
@@ -1084,7 +1084,7 @@ checks:
 
 # 6.1.12 Ensure the 'GRANT ANY PRIVILEGE' Audit Option Is Enabled
   - id: 24572
-    title: "Ensure the 'GRANT ANY PRIVILEGE' Audit Option Is Enabled"
+    title: "Ensure the 'GRANT ANY PRIVILEGE' Audit Option Is Enabled."
     description: "GRANT ANY PRIVILEGE allows	a	user	to	grant	any	system	privilege,	including	the	most powerful	privileges	typically	available	only	to	administrators	- to	change	the	security infrastructure,	to	drop/add/modify	users	and	more."
     rationale: "Auditing	the	use	of	this	privilege	is	part	of	a	comprehensive	auditing	policy	that	can	help	in detecting	issues	and	can	be	useful	in	forensics."
     remediation: "AUDIT GRANT ANY PRIVILEGE;"
@@ -1098,7 +1098,7 @@ checks:
 
 # 6.1.13 Ensure the 'DROP ANY PROCEDURE' Audit Option Is Enabled
   - id: 24573
-    title: "Ensure the 'DROP ANY PROCEDURE' Audit Option Is Enabled"
+    title: "Ensure the 'DROP ANY PROCEDURE' Audit Option Is Enabled."
     description: "The	AUDIT DROP ANY PROCEDURE command	is	auditing	the	dropping	of	procedures. Enabling	the	option	causes	auditing	of	all	such	activities."
     rationale: "Dropping	procedures	of	another	user	could	be	part	of	a	privilege	escalation	exploit	and should	be	audited."
     remediation: "AUDIT DROP ANY PROCEDURE;"
@@ -1112,7 +1112,7 @@ checks:
 
 # 6.1.14 Ensure the 'ALL' Audit Option on 'SYS.AUD$' Is Enabled
   - id: 24574
-    title: "Ensure the 'ALL' Audit Option on 'SYS.AUD$' Is Enabled"
+    title: "Ensure the 'ALL' Audit Option on 'SYS.AUD$' Is Enabled."
     description: "The	logging	of	attempts	to	alter	the	audit	trail	in	the	SYS.AUD$ table	(open	for read/update/delete/view)	will	provide	a	record	of	any	activities	that	may	indicate unauthorized	attempts	to	access	the	audit	trail.	Enabling	the	audit	option	will	cause	these activities	to	be	audited."
     rationale: "As	the	logging	of	attempts	to	alter	the	SYS.AUD$ table	can	provide	forensic	evidence	of	the initiation	of	a	pattern	of	unauthorized	activities,	this	logging	capability	should	be	enabled."
     remediation: "AUDIT ALL ON SYS.AUD$ BY ACCESS;"
@@ -1125,7 +1125,7 @@ checks:
 
 # 6.1.15 Ensure the 'PROCEDURE' Audit Option Is Enabled
   - id: 24575
-    title: "Ensure the 'PROCEDURE' Audit Option Is Enabled"
+    title: "Ensure the 'PROCEDURE' Audit Option Is Enabled."
     description: "In	this	statement	audit,	PROCEDURE means	any	procedure,	function,	package	or	library. Enabling	this	audit	option	causes	any	attempt,	successful	or	not,	to	create	or	drop	any	of these	types	of	objects	to	be	audited,	regardless	of	privilege	or	lack	thereof.	Java	schema objects	(sources,	classes,	and	resources)	are	considered	the	same	as	procedures	for	the purposes	of	auditing	SQL	statements."
     rationale: "Any	unauthorized	attempts	to	create	or	drop	a	procedure	in	another's	schema	should	cause concern,	whether	successful	or	not.	Changes	to	critical	stored	code	can	dramatically	change the	behavior	of	the	application	and	produce	serious	security	consequences,	including enabling	privilege	escalation	and	introducing	SQL	injection	vulnerabilities.	Audit	records	of such	changes	can	be	helpful	in	forensics."
     remediation: "AUDIT PROCEDURE;"
@@ -1139,7 +1139,7 @@ checks:
 
 # 6.1.16 Ensure the 'ALTER SYSTEM' Audit Option Is Enabled
   - id: 24576
-    title: "Ensure the 'ALTER SYSTEM' Audit Option Is Enabled"
+    title: "Ensure the 'ALTER SYSTEM' Audit Option Is Enabled."
     description: "ALTER SYSTEM allows	one	to	change	instance	settings,	including	security	settings	and auditing	options.	Additionally,	ALTER SYSTEM can	be	used	to	run	operating	system commands	using	undocumented	Oracle	functionality.	Enabling	the	audit	option	will	audit all	attempts	to	perform	ALTER SYSTEM,	whether	successful	or	not	and	regardless	of	whether or	not	the	ALTER SYSTEM privilege	is	held	by	the	user	attempting	the	action."
     rationale: "Any	unauthorized	attempt	to	alter	the	system	should	be	cause	for	concern.	Alterations outside	of	some	specified	maintenance	window	may	be	of	concern.	In	forensics,	these	audit records	could	be	quite	useful."
     remediation: "AUDIT ALTER SYSTEM;"
@@ -1153,7 +1153,7 @@ checks:
 
 # 6.1.17 Ensure the 'TRIGGER' Audit Option Is Enabled
   - id: 24577
-    title: "Ensure the 'TRIGGER' Audit Option Is Enabled"
+    title: "Ensure the 'TRIGGER' Audit Option Is Enabled."
     description: "A	TRIGGER may	be	used	to	modify	DML actions	or	invoke	other	(recursive)	actions	when some	types	of	user-initiated	actions	occur.	Enabling	this	audit	option	will	cause	auditing	of any	attempt,	successful	or	not,	to	create,	drop,	enable	or	disable	any	schema	trigger	in	any schema	regardless	of	privilege	or	lack	thereof.	For	enabling	and	disabling	a	trigger,	it covers	both	ALTER TRIGGER and	ALTER TABLE."
     rationale: "Triggers	are	often	part	of	schema	security,	data	validation	and	other	critical	constraints upon	actions	and	data.	A	trigger	in	another	schema	may	be	used	to	escalate	privileges, redirect	operations,	transform	data	and	perform	other	sorts	of	perhaps	undesired	actions. Any	unauthorized	attempt	to	create,	drop	or	alter	a	trigger	in	another	schema	may	be	cause for	investigation."
     remediation: "AUDIT TRIGGER;"
@@ -1167,7 +1167,7 @@ checks:
 
 # 6.1.18 Ensure the 'CREATE SESSION' Audit Option Is Enabled
   - id: 24578
-    title: "Ensure the 'CREATE SESSION' Audit Option Is Enabled"
+    title: "Ensure the 'CREATE SESSION' Audit Option Is Enabled."
     description: "Enabling	this	audit	option	will	cause	auditing	of	all	attempts	to	connect	to	the	database, whether	successful	or	not,	as	well	as	audit	session	disconnects/logoffs.	The	commands	to audit	SESSION,	CONNECT or	CREATE SESSION all	accomplish	the	same	thing	- they	initiate statement	auditing	of	the	connect	statement	used	to	create	a	database	session."
     rationale: "Auditing	attempts	to	connect	to	the	database	is	basic	and	mandated	by	most	security initiatives.	Any	attempt	to	logon	to	a	locked	account,	failed	attempts	to	logon	to	default accounts	or	an	unusually	high	number	of	failed	logon	attempts	of	any	sort,	for	any	user,	in	a particular	time	period	may	indicate	an	intrusion	attempt.	In	forensics,	the	logon	record may	be	first	in	a	chain	of	evidence	and	contain	information	found	in	no	other	type	of	audit record	for	the	session.	Logon	and	logoff	in	the	audit	trail	define	the	period	and	duration	of the	session."
     remediation: "AUDIT SESSION;"
@@ -1184,7 +1184,7 @@ checks:
 ###############################################
 # 6.2.1 Ensure the 'CREATE USER' Action Audit Is Enabled
   - id: 24579
-    title: "Ensure the 'CREATE USER' Action Audit Is Enabled"
+    title: "Ensure the 'CREATE USER' Action Audit Is Enabled."
     description: "The	CREATE USER statement	is	used	to create	Oracle	database	accounts	and	assign	database properties	to	them.	Enabling	this	unified	action	audit	causes	logging	of	all	CREATE USER statements,	whether	successful	or	unsuccessful,	issued	by	the	users	regardless	of	the privileges	held	by	the	users to	issue	such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	create	user	accounts,	whether	successful	or unsuccessful,	may	provide	clues	and	forensic	evidences	about	potential suspicious/unauthorized	activities.	Any	such	activities	may	be	a	cause	for	further investigation.	In	addition,	organization	security	policies	and	industry/government regulations	may	require	logging	of	all	activities	involving	CREATE USER."
     remediation: "ALTER AUDIT POLICY CIS_UNIFIED_AUDIT_POLICY ADD ACTIONS CREATE USER;"
@@ -1197,7 +1197,7 @@ checks:
 
 # 6.2.2 Ensure the 'ALTER USER' Action Audit Is Enabled
   - id: 24580
-    title: "Ensure the 'ALTER USER' Action Audit Is Enabled"
+    title: "Ensure the 'ALTER USER' Action Audit Is Enabled."
     description: "The	ALTER USER statement	is	used	to	change	database	users’	password,	lock	accounts,	and expire	passwords.	In	addition,	this	statement	is	used	to	change	database	properties	of	user accounts	such	as	database	profiles,	default	and	temporary	tablespaces,	and	tablespace quotas.	This	unified	audit	action	enables	logging	of	all	ALTER USER statements,	whether successful	or	unsuccessful,	issued	by	the	users	regardless	of	the	privileges	held	by	the	users to	issue	such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	alter	user	accounts,	whether	successful	or unsuccessful,	may	provide	clues	and	forensic	evidences	about	potential suspicious/unauthorized	activities.	Any	such	activities	may	be	a	cause	for	further investigation.	In	addition,	organization	security	policies	and	industry/government regulations	may	require	logging	of	all	activities	involving	ALTER USER."
     remediation: "ALTER AUDIT POLICY CIS_UNIFIED_AUDIT_POLICY ADD ACTIONS ALTER USER;"
@@ -1210,7 +1210,7 @@ checks:
 
 # 6.2.3 Ensure the 'DROP USER' Audit Option Is Enabled
   - id: 24581
-    title: "Ensure the 'DROP USER' Audit Option Is Enabled"
+    title: "Ensure the 'DROP USER' Audit Option Is Enabled."
     description: "The	DROP USER statement	is	used	to	drop	Oracle	database	accounts	and	schemas	associated with	them.	Enabling	this	unified	action	audit	enables	logging	of	all	DROP USER statements, whether	successful	or	unsuccessful,	issued	by	the	users	regardless	of	the	privileges	held	by the	users	to	issue	such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	drop	user,	whether	successful	or	unsuccessful, may	provide	clues	and	forensic	evidence	about	potential	suspicious/unauthorized activities.	Any	such	activities	may	be	a	cause	for	further	investigation.	In	addition, organization	security	policies	and	industry/government	regulations	may	require	logging	of all	activities	involving	DROP USER."
     remediation: "ALTER AUDIT POLICY CIS_UNIFIED_AUDIT_POLICY ADD ACTIONS DROP USER;"
@@ -1223,7 +1223,7 @@ checks:
 
 # 6.2.4 Ensure the 'CREATE ROLE' Action Audit Is Enabled
   - id: 24582
-    title: "Ensure the 'CREATE ROLE' Action Audit Is Enabled"
+    title: "Ensure the 'CREATE ROLE' Action Audit Is Enabled."
     description: "An	Oracle	database	role	is	a	collection	or	set	of	privileges	that	can	be	granted	to	users	or other	roles.	Roles	may	include	system	privileges,	object	privileges	or	other	roles.	Enabling this	unified	audit	action	enables	logging	of	all	CREATE ROLE statements,	whether	successful or	unsuccessful,	issued	by	the	users	regardless	of	the	privileges	held	by	the	users	to	issue such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	create	roles,	whether	successful	or	unsuccessful, may	provide	clues	and	forensic	evidence	about	potential	suspicious/unauthorized activities.	Any	such	activities	may	be	a	cause	for	further	investigation.	In	addition, organization	security	policies	and	industry/government	regulations	may	require	logging	of all	user	activities	involving	CREATE ROLE."
     remediation: "ALTER AUDIT POLICY CIS_UNIFIED_AUDIT_POLICY ADD ACTIONS CREATE ROLE;"
@@ -1236,7 +1236,7 @@ checks:
 
 # 6.2.5 Ensure the 'ALTER ROLE' Action Audit Is Enabled
   - id: 24583
-    title: "Ensure the 'ALTER ROLE' Action Audit Is Enabled"
+    title: "Ensure the 'ALTER ROLE' Action Audit Is Enabled."
     description: "An	Oracle	database	role	is	a	collection	or	set	of	privileges	that	can	be	granted	to	users	or other	roles.	Roles	may	include	system	privileges,	object	privileges	or	other	roles.	The	ALTER ROLE statement	is	used	to	change	the	authorization	needed	to	enable	a	role.	Enabling	this unified	action	audit	causes	logging	of	all	ALTER ROLE statements,	whether	successful	or unsuccessful,	issued	by	the	users	regardless	of	the	privileges	held	by	the	users	to	issue	such statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	alter	roles,	whether	successful	or	unsuccessful, may	provide	clues	and	forensic	evidence	about	potential	suspicious/unauthorized activities.	Any	such	activities	may	be	a	cause	for	further	investigation.	In	addition, organization	security	policies	and	industry/government	regulations	may	require	logging	of all	user	activities	involving	alteration	of	roles."
     remediation: "ALTER AUDIT POLICY CIS_UNIFIED_AUDIT_POLICY ADD ACTIONS ALTER ROLE;"
@@ -1249,7 +1249,7 @@ checks:
 
 # 6.2.6 Ensure the 'DROP ROLE' Action Audit Is Enabled
   - id: 24584
-    title: "Ensure the 'DROP ROLE' Action Audit Is Enabled"
+    title: "Ensure the 'DROP ROLE' Action Audit Is Enabled."
     description: "An	Oracle	database	role	is	a	collection	or	set	of	privileges	that	can	be	granted	to	users	or other	roles.	Roles	may	include	system	privileges,	object	privileges	or	other	roles.	Enabling this	unified	audit	action	enables	logging	of	all	DROP ROLE statements,	successful	or unsuccessful,	issued	by	the	users	regardless	of	the	privileges	held	by	the	users	to	issue	such statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	drop	roles,	whether	successful	or	unsuccessful, may	provide	clues	and	forensic	evidence	about	potential	suspicious/unauthorized activities.	Any	such	activities	may	be	a	cause	for	further	investigation.	In	addition, organization	security	policies	and	industry/government	regulations	may	require	logging	of all	user	activities	involving	DROP ROLE."
     remediation: "ALTER AUDIT POLICY CIS_UNIFIED_AUDIT_POLICY ADD ACTIONS DROP ROLE;"
@@ -1262,7 +1262,7 @@ checks:
 
 # 6.2.7 Ensure the 'GRANT' Action Audit Is Enabled
   - id: 24585
-    title: "Ensure the 'GRANT' Action Audit Is Enabled"
+    title: "Ensure the 'GRANT' Action Audit Is Enabled."
     description: "GRANT statements	are	used	to	grant	privileges	to	Oracle	database	users	and	roles,	including the	most	powerful	privileges	and	roles	typically	available	to	the	database	administrators. Enabling	this	unified	action	audit	enables	logging	of	all	GRANT statements,	whether successful	or	unsuccessful,	issued	by	the	users	regardless	of	the	privileges	held	by	the	users to	issue	such	statements."
     rationale: "With	unauthorized	grants	and	permissions,	a	malicious	user	may	be	able	to	change	the security	of	the	database,	access/update	confidential	data,	or	compromise	the	integrity	of the	database.	Logging	and	monitoring	of	all	attempts	to	grant	system	privileges,	object privileges	or	roles,	whether	successful	or	unsuccessful,	may	provide	forensic	evidence about	potential	suspicious/unauthorized	activities	as	well	as	privilege	escalation	activities. Any	such	activities	may	be	a	cause	for	further	investigation.	In	addition,	organization security	policies	and	industry/government	regulations	may	require	logging	of	all	user activities	involving	GRANT."
     remediation: "ALTER AUDIT POLICY CIS_UNIFIED_AUDIT_POLICY ADD ACTIONS GRANT;"
@@ -1275,7 +1275,7 @@ checks:
 
 # 6.2.8 Ensure the 'REVOKE' Action Audit Is Enabled
   - id: 24586
-    title: "Ensure the 'REVOKE' Action Audit Is Enabled"
+    title: "Ensure the 'REVOKE' Action Audit Is Enabled."
     description: "REVOKE statements	are	used	to	revoke	privileges	from	Oracle	database	users	and	roles. Enabling	this	unified	action	audit	enables	logging	of	all	REVOKE statements,	successful	or unsuccessful,	issued	by	the	users	regardless	of	the	privileges	held	by	the	users	to	issue	such statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	revoke	system	privileges,	object	privileges	or roles,	whether	successful	or	unsuccessful,	may	provide	clues	and	forensic	evidence	about potential	suspicious/unauthorized	activities.	Any	such	activities	may	be	a	cause	for	further investigation.	In	addition,	organization	security	policies	and	industry/government regulations	may	require	logging	of	all	user	activities	involving	REVOKE."
     remediation: "ALTER AUDIT POLICY CIS_UNIFIED_AUDIT_POLICY ADD ACTIONS REVOKE;"
@@ -1288,7 +1288,7 @@ checks:
 
 # 6.2.9 Ensure the 'CREATE PROFILE' Action Audit Is Enabled
   - id: 24587
-    title: "Ensure the 'CREATE PROFILE' Action Audit Is Enabled"
+    title: "Ensure the 'CREATE PROFILE' Action Audit Is Enabled."
     description: "Oracle	database	profiles	are	used	to	enforce	resource	usage	limits	and	implement password	policies	such	as	password	complexity	rules	and	reuse	restrictions.	Enabling	this unified	action	audit	enables	logging	of	all	CREATE PROFILE statements,	whether	successful or	unsuccessful,	issued	by	the	users	regardless	of	the	privileges	held	by	the	users	to	issue such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	create	profiles,	whether	successful	or unsuccessful,	may	provide	clues	and	forensic	evidence	about	potential suspicious/unauthorized	activities.	Any	such	activities	may	be	a	cause	for	further investigation.	In	addition,	organization	security	policies	and	industry/government regulations	may	require	logging	of	all	user	activities	involving	creation	of	database	profiles."
     remediation: "ALTER AUDIT POLICY CIS_UNIFIED_AUDIT_POLICY ADD ACTIONS CREATE PROFILE;"
@@ -1301,7 +1301,7 @@ checks:
 
 # 6.2.10 Ensure the 'ALTER PROFILE' Action Audit Is Enabled
   - id: 24588
-    title: "Ensure the 'ALTER PROFILE' Action Audit Is Enabled"
+    title: "Ensure the 'ALTER PROFILE' Action Audit Is Enabled."
     description: "Oracle	database	profiles	are	used	to	enforce	resource	usage	limits	and	implement password	policies	such	as	password	complexity	rules	and	reuse	restrictions.	Enabling	this unified	action	audit	enables	logging	of	all	ALTER PROFILE statements,	whether	successful	or unsuccessful,	issued	by	the	users	regardless	of	the	privileges	held	by	the	users	to	issue	such statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	alter	profiles,	whether	successful	or	unsuccessful, may	provide	forensic	evidence	about	potential	suspicious/unauthorized	activities.	Any such	activities	may	be	a	cause	for	further	investigation.	In	addition,	organization	security policies	and	industry/government	regulations	may	require	logging	of	all	user	activities involving	alteration	of	database	profiles."
     remediation: "ALTER AUDIT POLICY CIS_UNIFIED_AUDIT_POLICY ADD ACTIONS ALTER PROFILE;"
@@ -1314,7 +1314,7 @@ checks:
 
 # 6.2.11 Ensure the 'DROP PROFILE' Action Audit Is Enabled
   - id: 24589
-    title: "Ensure the 'DROP PROFILE' Action Audit Is Enabled "
+    title: "Ensure the 'DROP PROFILE' Action Audit Is Enabled ."
     description: "Oracle	database	profiles	are	used	to	enforce	resource	usage	limits	and	implement password	policies	such	as	password	complexity	rules	and	reuse	restrictions.	Enabling	this unified	action	audit	enables	logging	of	all	DROP PROFILE statements,	whether	successful	or unsuccessful,	issued	by	the	users	regardless	of	the	privileges	held	by	the	users	to	issue	such statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	drop	profiles,	whether	successful	or unsuccessful,	may	provide	clues	and	forensic	evidence	about	potential suspicious/unauthorized	activities.	Any	such	activities	may	be	a	cause	for	further investigation.	In	addition,	organization	security	policies	and	industry/government regulations	may	require	logging	of	all	user	activities	involving	dropping	database	profiles."
     remediation: "ALTER AUDIT POLICY CIS_UNIFIED_AUDIT_POLICY ADD ACTIONS DROP PROFILE;"
@@ -1327,7 +1327,7 @@ checks:
 
 # 6.2.12 Ensure the 'CREATE DATABASE LINK' Action Audit Is Enabled
   - id: 24590
-    title: "Ensure the 'CREATE DATABASE LINK' Action Audit Is Enabled"
+    title: "Ensure the 'CREATE DATABASE LINK' Action Audit Is Enabled."
     description: "Oracle	database	links	are	used	to	establish	database-to-database	connections	to	other databases.	These	connections	are	available	without	further	authentication	once	the	link	is established.	Enabling	this	unified	action	audit	causes	logging	of	all	CREATE DATABASE and CREATE PUBLIC DATABASE statements,	whether	successful	or	unsuccessful,	issued	by	the users	regardless	of	the	privileges	held	by	the	users	to	issue	such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	create	database	links,	whether	successful	or unsuccessful,	may	provide	forensic	evidence	about	potential	suspicious/unauthorized activities.	Any	such	activities	may	be	a	cause	for	further	investigation.	In	addition, organization	security	policies	and	industry/government	regulations	may	require	logging	of all	user	activities	involving	creation	of	database	links."
     remediation: "ALTER AUDIT POLICY CIS_UNIFIED_AUDIT_POLICY ADD ACTIONS CREATE DATABASE LINK;"
@@ -1340,7 +1340,7 @@ checks:
 
 # 6.2.13 Ensure the 'ALTER DATABASE LINK' Action Audit Is Enabled
   - id: 24591
-    title: "Ensure the 'ALTER DATABASE LINK' Action Audit Is Enabled"
+    title: "Ensure the 'ALTER DATABASE LINK' Action Audit Is Enabled."
     description: "Oracle	database	links	are	used	to	establish	database-to-database	connections	to	other databases.	These	connections	are	always	available	without	further	authentication	once	the link	is	established.	Enabling	this	unified	action	audit	causes	logging	of	all	ALTER DATABASE and	ALTER PUBLIC DATABASE statements,	whether	successful	or	unsuccessful,	issued	by	the users	regardless	of	the	privileges	held	by	the	users	to	issue	such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	alter	database	links,	whether	successful	or unsuccessful,	may	provide	forensic	evidence	about	potential	suspicious/unauthorized activities.	Any	such	activities	may	be	a	cause	for	further	investigation.	In	addition, organization	security	policies	and	industry/government	regulations	may	require	logging	of all	user	activities	involving	alteration	of	database	links."
     remediation: "ALTER AUDIT POLICY CIS_UNIFIED_AUDIT_POLICY ADD ACTIONS ALTER DATABASE LINK;"
@@ -1353,7 +1353,7 @@ checks:
 
 # 6.2.14 Ensure the 'DROP DATABASE LINK' Action Audit Is Enabled
   - id: 24592
-    title: "Ensure the 'DROP DATABASE LINK' Action Audit Is Enabled"
+    title: "Ensure the 'DROP DATABASE LINK' Action Audit Is Enabled."
     description: "Oracle	database	links	are	used	to	establish	database-to-database	connections	to	other databases.	These	connections	are	always	available	without	further	authentication	once	the link	is	established.	Enabling	this	unified	action	audit	causes	logging	of	all	DROP DATABASE and	DROP PUBLIC DATABASE,	whether	successful	or	unsuccessful,	statements	issued	by	the users	regardless	of	the	privileges	held	by	the	users	to	issue	such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	drop	database	links,	whether	successful	or unsuccessful,	may	provide	forensic	evidence	about	potential	suspicious/unauthorized activities.	Any	such	activities	may	be	a	cause	for	further	investigation.	In	addition, organization	security	policies	and	industry/government	regulations	may	require	logging	of all	user	activities	involving	dropping	database	links."
     remediation: "ALTER AUDIT POLICY CIS_UNIFIED_AUDIT_POLICY ADD ACTIONS DROP DATABASE LINK;"
@@ -1366,7 +1366,7 @@ checks:
 
 # 6.2.15 Ensure the 'CREATE SYNONYM' Action Audit Is Enabled
   - id: 24593
-    title: "Ensure the 'CREATE SYNONYM' Action Audit Is Enabled"
+    title: "Ensure the 'CREATE SYNONYM' Action Audit Is Enabled."
     description: "An	Oracle	database	synonym	is	used	to	create	an	alternative	name	for	a	database	object such	as	table,	view,	procedure,	java	object	or	even	another	synonym,	etc.	Enabling	this unified	action	audit	causes	logging	of	all	CREATE SYNONYM and	CREATE PUBLIC SYNONYM statements,	whether	successful	or	unsuccessful,	issued	by	the	users	regardless	of	the privileges	held	by	the	users	to	issue	such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	create	synonyms,	whether	successful	or unsuccessful,	may	provide	clues	and	forensic	evidence	about	potential suspicious/unauthorized	activities.	Any	such	activities	may	be	a	cause	for	further investigation.	In	addition,	organization	security	policies	and	industry/government regulations	may	require	logging	of	all	user	activities	involving	creation	of	synonyms	or public	synonyms."
     remediation: "ALTER AUDIT POLICY CIS_UNIFIED_AUDIT_POLICY ADD ACTIONS CREATE SYNONYM;"
@@ -1379,7 +1379,7 @@ checks:
 
 # 6.2.16 Ensure the 'ALTER SYNONYM' Action Audit Is Enabled
   - id: 24594
-    title: "Ensure the 'ALTER SYNONYM' Action Audit Is Enabled"
+    title: "Ensure the 'ALTER SYNONYM' Action Audit Is Enabled."
     description: "An	Oracle	database	synonym	is	used	to	create	an	alternative	name	for	a	database	object such	as	table,	view,	procedure,	or	java	object,	or	even	another	synonym.	Enabling	this unified	action	audit	causes	logging	of	all	ALTER SYNONYM and	ALTER PUBLIC SYNONYM statements,	whether	successful	or	unsuccessful,	issued	by	the	users	regardless	of	the privileges	held	by	the	users	to	issue	such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	alter	synonyms,	whether	successful	or unsuccessful,	may	provide	clues	and	forensic	evidence	about	potential suspicious/unauthorized	activities.	Any	such	activities	may	be	a	cause	for	further investigation.	In	addition,	organization	security	policies	and	industry/government regulations	may	require	logging	of	all	user	activities	involving	alteration	of	synonyms	or public	synonyms."
     remediation: "ALTER AUDIT POLICY CIS_UNIFIED_AUDIT_POLICY ADD ACTIONS ALTER SYNONYM;"
@@ -1392,7 +1392,7 @@ checks:
 
 # 6.2.17 Ensure the 'DROP SYNONYM' Action Audit Is Enabled
   - id: 24595
-    title: "Ensure the 'DROP SYNONYM' Action Audit Is Enabled"
+    title: "Ensure the 'DROP SYNONYM' Action Audit Is Enabled."
     description: "An	Oracle	database	synonym	is	used	to	create	an	alternative	name	for	a	database	object such	as	table,	view,	procedure,	or	java	object,	or	even	another	synonym.	Enabling	his unified	action	audit	causes	logging	of	all	DROP SYNONYM and	DROP PUBLIC SYNONYM statements,	whether	successful	or	unsuccessful,	issued	by	the	users	regardless	of	the privileges	held	by	the	users	to	issue	such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	drop	synonyms,	whether	successful	or unsuccessful,	may	provide	forensic	evidence	about	potential	suspicious/unauthorized activities.	Any	such	activities	may	be	a	cause	for	further	investigation.	In	addition, organization	security	policies	and	industry/government	regulations	may	require	logging	of all	user	activities involving	dropping	of	synonyms	or	public	synonyms."
     remediation: "ALTER AUDIT POLICY CIS_UNIFIED_AUDIT_POLICY ADD ACTIONS DROP SYNONYM;"
@@ -1405,7 +1405,7 @@ checks:
 
 # 6.2.18 Ensure the 'SELECT ANY DICTIONARY' Privilege Audit Is Enabled
   - id: 24596
-    title: "Ensure the 'SELECT ANY DICTIONARY' Privilege Audit Is Enabled"
+    title: "Ensure the 'SELECT ANY DICTIONARY' Privilege Audit Is Enabled."
     description: "The	SELECT ANY DICTIONARY system	privilege	allows	the	user	to	view	the	definition	of	all schema	objects	in	the	database.	It	grants	SELECT privileges	on	the	data	dictionary	objects	to the	grantees,	including	SELECT on	DBA_ views,	V$ views,	X$ views	and	underlying	SYS tables such	as	TAB$ and	OBJ$.	This	privilege	also	allows	grantees	to	create	stored	objects	such	as procedures,	packages	and	views	on	the	underlying	data	dictionary	objects.	Please	note	that this	privilege	does	not	grant	SELECT on	tables	with	password	hashes	such	as	USER$, DEFAULT_PWD$,	LINK$,	and	USER_HISTORY$.	Enabling	this	audit	causes	logging	of	activities that	exercise	this	privilege."
     rationale: "Logging	and	monitoring	of	all	attempts	to	access	a	data	dictionary,	whether	successful	or unsuccessful,	may	provide	clues	and	forensic	evidence	about	potential suspicious/unauthorized	activities.	Any	such	activities	may	be	a	cause	for	further investigation.	In	addition,	organization	security	policies	and	industry/government regulations	may	require	logging	of	all	user	activities	involving	access	to	the	database."
     remediation: "ALTER AUDIT POLICY CIS_UNIFIED_AUDIT_POLICY ADD PRIVILEGES SELECT ANY DICTIONARY;"
@@ -1418,7 +1418,7 @@ checks:
 
 # 6.2.19 Ensure the 'AUDSYS.AUD$UNIFIED' Access Audit Is Enabled
   - id: 24597
-    title: "Ensure the 'AUDSYS.AUD$UNIFIED' Access Audit Is Enabled"
+    title: "Ensure the 'AUDSYS.AUD$UNIFIED' Access Audit Is Enabled."
     description: "The	AUDSYS.AUD$UNIFIED holds	audit	trail	records	generated	by	the	database.	Enabling	this audit	action	causes	logging	of	all	access	attempts	to	the	AUDSYS.AUD$UNIFIED,	whether successful	or	unsuccessful,	regardless	of	the	privileges	held	by	the	users	to	issue	such statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	access	the	AUDSYS.AUD$UNIFIED,	whether successful	or	unsuccessful,	may	provide	clues	and	forensic	evidence	about	potential suspicious/unauthorized	activities.	Any	such	activities	may	be	a	cause	for	further investigation.	In	addition,	organization	security	policies	and industry/government regulations	may	require	logging	of	all	user	activities	involving	access	to	this	table."
     remediation: "ALTER AUDIT POLICY CIS_UNIFIED_AUDIT_POLICY ADD ACTIONS ALL on AUDSYS.AUD$UNIFIED;"
@@ -1431,7 +1431,7 @@ checks:
 
 # 6.2.20 Ensure the 'CREATE PROCEDURE/FUNCTION/PACKAGE/PACKAGE BODY' Action Audit Is Enabled
   - id: 24598
-    title: "Ensure the 'CREATE PROCEDURE/FUNCTION/PACKAGE/PACKAGE BODY' Action Audit Is Enabled"
+    title: "Ensure the 'CREATE PROCEDURE/FUNCTION/PACKAGE/PACKAGE BODY' Action Audit Is Enabled."
     description: "Oracle	database	procedures,	function,	packages,	and	package	bodies,	which	are	stored within	the	database,	are	created	to	perform	business	functions	and	access	database	as defined	by	PL/SQL	code	and	SQL	statements	contained	within	these	objects.	Enabling	this unified	action	audit	causes	logging	of	all	CREATE PROCEDURE,	CREATE FUNCTION,	CREATE PACKAGE and	CREATE PACKAGE BODY statements,	successful	or	unsuccessful,	statements issued	by	the	users	regardless	of	the	privileges	held	by	the	users	to	issue	such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	create	procedures,	functions,	packages	or package	bodies,	whether	successful	or	unsuccessful,	may	provide	clues	and	forensic evidence	about	potential	suspicious/unauthorized	activities.	Any	such	activities	may	be	a cause for	further	investigation.	In	addition,	organization	security	policies	and industry/government	regulations	may	require	logging	of	all	user	activities	involving creation	of	procedures,	functions,	packages	or	package	bodies."
     remediation: "ALTER AUDIT POLICY CIS_UNIFIED_AUDIT_POLICY ADD ACTIONS CREATE PROCEDURE, CREATE FUNCTION, CREATE PACKAGE, CREATE PACKAGE BODY;"
@@ -1444,7 +1444,7 @@ checks:
 
 # 6.2.21 Ensure the 'ALTER PROCEDURE/FUNCTION/PACKAGE/PACKAGE BODY' Action Audit Is Enabled
   - id: 24599
-    title: "Ensure the 'ALTER PROCEDURE/FUNCTION/PACKAGE/PACKAGE BODY' Action Audit Is Enabled"
+    title: "Ensure the 'ALTER PROCEDURE/FUNCTION/PACKAGE/PACKAGE BODY' Action Audit Is Enabled."
     description: "Oracle	database	procedures,	functions,	packages,	and	package	bodies,	which	are	stored within	the	database,	are	created	to	carry	out	business	functions	and	access	database	as defined	by	PL/SQL	code	and	SQL	statements	contained	within	these	objects.	Enabling	this unified	action	audit	causes	logging	of	all	ALTER PROCEDURE,	ALTER FUNCTION,	ALTER PACKAGE and	ALTER PACKAGE BODY statements,	successful	or	unsuccessful,	issued	by	the users	regardless	of	the	privileges	held	by	the	users	to	issue	such	statements."
     rationale: "Unauthorized	alteration	of	procedures,	functions,	packages	or	package	bodies	may	impact critical	business	functions	or	compromise	integrity	of	the	database.	Logging	and monitoring	of	all	attempts,	whether	successful	or	unsuccessful,	to	alter	procedures, functions,	packages	or	package	bodies	may	provide	clues	and	forensic	evidence	about potential	suspicious/unauthorized	activities.	Any	such	activities	may	be	a	cause	for	further investigation.	In	addition,	organization	security	policies	and	industry/government regulations	may	require	logging	of	all	user	activities	involving	alteration	of	procedures, functions,	packages	or	package	bodies."
     remediation: "ALTER AUDIT POLICY CIS_UNIFIED_AUDIT_POLICY ADD ACTIONS ALTER PROCEDURE, ALTER FUNCTION, ALTER PACKAGE, ALTER PACKAGE BODY;"
@@ -1457,7 +1457,7 @@ checks:
 
 # 6.2.22 Ensure the 'DROP PROCEDURE/FUNCTION/PACKAGE/PACKAGE BODY' Action Audit Is Enabled
   - id: 24600
-    title: "Ensure the 'DROP PROCEDURE/FUNCTION/PACKAGE/PACKAGE BODY' Action Audit Is Enabled"
+    title: "Ensure the 'DROP PROCEDURE/FUNCTION/PACKAGE/PACKAGE BODY' Action Audit Is Enabled."
     description: "Oracle	database	procedures,	functions,	packages,	and	package	bodies,	which	are	stored within	the	database,	are	created	to	carry	out	business	functions	and	access	database	as defined	by	PL/SQL	code	and	SQL	statements	contained	within	these	objects.	Enabling	this unified	action	audit	causes	logging	of	all	DROP PROCEDURE,	DROP FUNCTION,	DROP PACKAGE or DROP PACKAGE BODY statements,	successful	or	unsuccessful,	issued	by	the	users	regardless of	the	privileges	held	by	the	users	to	issue	such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts,	whether	successful	or	unsuccessful,	to	drop procedures,	functions,	packages	or	package	bodies	may	provide	forensic	evidence	about potential	suspicious/unauthorized	activities.	Any	such	activities	may	be	a	cause	for	further investigation.	In	addition,	organization	security	policies	and	industry/government regulations	may	require	logging	of	all	user	activities	involving	dropping	procedures, functions,	packages	or	package	bodies."
     remediation: "ALTER AUDIT POLICY CIS_UNIFIED_AUDIT_POLICY ADD ACTIONS DROP PROCEDURE, DROP FUNCTION, DROP PACKAGE, DROP PACKAGE BODY;"
@@ -1470,7 +1470,7 @@ checks:
 
 # 6.2.23 Ensure the 'ALTER SYSTEM' Privilege Audit Is Enabled
   - id: 24601
-    title: "Ensure the 'ALTER SYSTEM' Privilege Audit Is Enabled"
+    title: "Ensure the 'ALTER SYSTEM' Privilege Audit Is Enabled."
     description: "The	ALTER SYSTEM privilege	allows	the	user	to	change	instance	settings	which	could	impact security	posture,	performance	or	normal	operation	of	the	database.	Additionally,	the	ALTER SYSTEM privilege	may	be	used	to	run	operating	system	commands	using	undocumented Oracle	functionality.	Enabling	this	unified	audit	causes	logging	of	activities	that	involve exercise	of	this	privilege,	whether	successful	or	unsuccessful,	issued	by	the	users regardless	of	the	privileges	held	by	the	users	to	issue	such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	execute	ALTER SYSTEM statements,	whether successful	or	unsuccessful,	may	provide	forensic	evidence	about	potential suspicious/unauthorized	activities.	Any	such	activities	may	be	a	cause	for	further investigation.	In	addition,	organization	security	policies	and	industry/government regulations	may	require	logging	of	all	user	activities	that	involve	ALTER SYSTEM statements."
     remediation: "ALTER AUDIT POLICY CIS_UNIFIED_AUDIT_POLICY ADD ACTIONS ALTER SYSTEM;"
@@ -1483,7 +1483,7 @@ checks:
 
 # 6.2.24 Ensure the 'CREATE TRIGGER' Action Audit Is Enabled
   - id: 24602
-    title: "Ensure the 'CREATE TRIGGER' Action Audit Is Enabled"
+    title: "Ensure the 'CREATE TRIGGER' Action Audit Is Enabled."
     description: "Oracle	database	triggers	are	executed	automatically	when	specified	conditions	on	the underlying	objects	occur.	Trigger	bodies	contain	the	code,	quite	often	to	perform	data validation,	ensure	data	integrity/security	or	enforce	critical	constraints	on	allowable actions	on	data.	Enabling	this	unified	audit	causes	logging	of	all	CREATE TRIGGER statements,	whether	successful	or	unsuccessful,	issued	by	the	users	regardless	of	the privileges	held	by	the	users	to	issue	such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	create	triggers,	whether	successful	or unsuccessful,	may	provide	clues	and	forensic	evidence	about	potential suspicious/unauthorized	activities.	Any	such	activities	may	be	a	cause	for	further investigation.	In	addition,	organization	security	policies	and	industry/government regulations	may	require	logging	of	all	user	activities	involving	creation	of	triggers."
     remediation: "ALTER AUDIT POLICY CIS_UNIFIED_AUDIT_POLICY ADD ACTIONS CREATE TRIGGER;"
@@ -1496,7 +1496,7 @@ checks:
 
 # 6.2.25 Ensure the 'ALTER TRIGGER' Action Audit IS Enabled
   - id: 24603
-    title: "Ensure the 'ALTER TRIGGER' Action Audit IS Enabled"
+    title: "Ensure the 'ALTER TRIGGER' Action Audit IS Enabled."
     description: "Oracle	database	triggers	are	executed	automatically	when	specified	conditions	on	the underlying	objects	occur.	Trigger	bodies	contain	the	code,	quite	often	to	perform	data validation,	ensure	data	integrity/security	or	enforce	critical	constraints	on	allowable actions	on	data.	Enabling	this	unified	audit	causes	logging	of	all	ALTER TRIGGER statements, whether	successful	or	unsuccessful,	issued	by	the	users	regardless	of	the	privileges	held	by the	users	to	issue	such	statements."
     rationale: "Unauthorized	alteration	of	triggers	may	impact	critical	business	functions	or	compromise integrity/security	of	the	database.	Logging	and	monitoring	of	all	attempts	to	alter	triggers, whether	successful	or	unsuccessful,	may	provide	clues	and	forensic	evidence	about potential	suspicious/unauthorized	activities.	Any	such	activities	may	be	a	cause	for	further investigation.	In	addition,	organization	security	policies	and	industry/government regulations	may	require	logging	of	all	user	activities	involving	alteration	of	triggers."
     remediation: "ALTER AUDIT POLICY CIS_UNIFIED_AUDIT_POLICY ADD ACTIONS ALTER TRIGGER;"
@@ -1509,7 +1509,7 @@ checks:
 
 # 6.2.26 Ensure the 'DROP TRIGGER' Action Audit Is Enabled
   - id: 24604
-    title: "Ensure the 'DROP TRIGGER' Action Audit Is Enabled"
+    title: "Ensure the 'DROP TRIGGER' Action Audit Is Enabled."
     description: "Oracle	database	triggers	are	executed	automatically	when	specified	conditions	on	the underlying	objects	occur.	Trigger	bodies	contain	the	code,	quite	often	to	perform	data validation,	ensure	data	integrity/security	or	enforce	critical	constraints	on	allowable actions	on	data.	Enabling	this	unified	audit	causes	logging	of	all	DROP TRIGGER statements, whether	successful	or	unsuccessful,	issued	by	the	users	regardless	of	the	privileges	held	by the	users	to	issue	such	statements."
     rationale: "Logging	and	monitoring	of	all	attempts	to	drop	triggers,	whether	successful	or unsuccessful,	may	provide	forensic	evidence	about	potential	suspicious/unauthorized activities.	Any	such	activities	may	be	a	cause	for	further	investigation.	In	addition, organization	security	policies	and	industry/government	regulations	may	require	logging	of all	user	activities	involving	dropping	triggers."
     remediation: "ALTER AUDIT POLICY CIS_UNIFIED_AUDIT_POLICY ADD ACTIONS DROP TRIGGER;"
@@ -1522,7 +1522,7 @@ checks:
 
 # 6.2.27 Ensure the 'LOGON' AND 'LOGOFF' Actions Audit Is Enabled
   - id: 24605
-    title: "Ensure the 'LOGON' AND 'LOGOFF' Actions Audit Is Enabled"
+    title: "Ensure the 'LOGON' AND 'LOGOFF' Actions Audit Is Enabled."
     description: "Oracle	database	users	log	on	to	the	database	to	perform	their	work.	Enabling	this	unified audit	causes	logging	of	all	LOGON actions,	whether	successful	or	unsuccessful,	issued	by	the users	regardless	of	the	privileges	held	by	the	users	to	log	into	the	database.	In	addition, LOGOFF action	audit	captures	logoff	activities.	This	audit	action	also	captures	logon/logoff	to the	open	database	by	SYSDBA and	SYSOPER."
     rationale: "Logging	and	monitoring	of	all	attempts	to	logon	to	the	database,	whether	successful	or unsuccessful,	may	provide	forensic	evidence	about	potential	suspicious/unauthorized activities.	Any	such	activities	may	be	a	cause	for	further	investigation.	In	addition, organization	security	policies	and	industry/government	regulations	may	require	logging	of all	user	activities	involving	LOGON and	LOGOFF."
     remediation: "ALTER AUDIT POLICY CIS_UNIFIED_AUDIT_POLICY ADD ACTIONS LOGON, LOGOFF;"


### PR DESCRIPTION
|Related PR|
|---|
|https://github.com/wazuh/wazuh/issues/8977|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR reworks the changes added in the previous https://github.com/wazuh/wazuh/pull/8977

The effected changes were:
- Reordered the ID of the checks to make them continuous.
- Fixed wrongly implemented checks.
- Added consistency to indexation.
- Fixed YML format.

After these changes, another iteration will be needed to add the missing checks.

## SCA Checks
### Syntax and semantic

- [x] a) ID of each policy must be contiguous.
- [x] b) The order and format set in [Documentation](https://documentation.wazuh.com/current/user-manual/capabilities/sec-config-assessment/creating-custom-policies.html) must be respected.
- [x] c) YML must be valid to avoid errors.

### Content

- [x] a) Compare each check with its analogue from CIS Benchmark.
- [x] b) Try to maintain each rule as similar as possible with the `Audit` section from the CIS check.
- [x] c) Check that the commands provide the expected output.
- [x] d) When a failure is discovered, check similar policies to avoid repetition of the issue.

### Unit testing

- [x] a) Output from `agent.log` after the SCA scan and a raw output of the result of the checks.
<details><summary>Tests results</summary>
<p>

#### Analysisd (server or local)
analysisd.debug=2

#### Auth daemon debug (server)
authd.debug=0

#### Exec daemon debug (server, local, or Unix agent)
execd.debug=0

#### Monitor daemon debug (server, local, or Unix agent)
monitord.debug=0

#### Log collector (server, local or Unix agent)
logcollector.debug=0

#### Integrator daemon debug (server, local or Unix agent)
integrator.debug=0

#### Unix agentd
agent.debug=2

</p>
</details>

### Deployment

- [x] a) If the policy it's new, it must be added to the `sca.files` templates.
- [x] b) If the OS has many supported SCA policies, a policy must be set as default policy. ([as example](https://github.com/wazuh/wazuh/blob/master/etc/templates/config/centos/sca.files))
