### PR TITLE
Rework PR 8977 - MongoDB 3.6 - Add new sca files for MS IIS, Oracle Database 19c, MongoDB 3.6, Nginx, SQL Server and SLES

### DIFF
--- a/ruleset/sca/mongodb/cis_mongodb_36.yml
+++ b/ruleset/sca/mongodb/cis_mongodb_36.yml
@@ -19,7 +19,7 @@ policy:
     - https://www.cisecurity.org/cis-benchmarks/
 
 requirements:
-  title: "Check that MongoDB is installed on the system."
+  title: "Check that MongoDB is installed on the system.."
   description: "Requirements for running the SCA scan against the MongoDB policy."
   condition: any
   rules:
@@ -31,28 +31,12 @@ variables:
 
 checks:
 #1 Installation and Patching
-#1.1
-  - id: 23500
-    title: "Ensure the appropriate MongoDB software version/patches are installed"
-    description: "The MongoDB installation version, along with the patch level, should be the most recent that is compatible with the organization's operational needs."
-    rationale: "Using the most recent MongoDB software version along with all applicable patches, helps limit the possibilities for vulnerabilities in the software. The installation version and/or patches applied should be selected according to the needs of the organization. At a minimum, the software version should be supported."
-    remediation: "Upgrade to the latest version of the MongoDB software: 1. Backup the data set. 2. Download the binaries for the latest MongoDB revision from the MongoDB Download Page and store the binaries in a temporary location. The binaries download as compressed files that extract to the directory structure used by the MongoDB installation. 3. Shutdown the MongoDB instance. 4. Replace the existing MongoDB binaries with the downloaded binaries. 5. Restart the MongoDB instance."
-    compliance:
-      - cis: ["1.1"]
-      - cis_csc: ["4", "2.2"]
-    references:
-      - https://docs.mongodb.com/v3.6/tutorial/upgrade-revision/
-      - https://docs.mongodb.com/v3.6/release-notes/
-      - https://www.mongodb.com/download-center#community
-      - https://www.mongodb.com/support-policy
-    condition: all
-    rules:
-      - 'c:mongod --version'
+#1.1 Ensure the appropriate MongoDB software version/patches are installed - Not implemented
 
 #2 Authentication
 #2.1
-  - id: 23501
-    title: "Ensure Authentication is configured"
+  - id: 23500
+    title: "Ensure Authentication is configured."
     description: "This setting ensures that all clients, users, servers are required to authenticate before being granted access to the MongoDB database. Authentication is the process of verifying the identity of a client. When access control, i.e. authorization, is enabled, MongoDB requires all clients to authenticate themselves in order to determine their access. To authenticate as a user, you must provide a username, password, and the authentication database associated with that user."
     rationale: "Failure to authenticate clients, users, servers can enable unauthorized access to the MongoDB database and can prevent tracing actions back to their sources."
     remediation: "The authentication mechanism should be implemented before anyone accesses the MongoDB Server. To enable the authentication mechanism: Start the MongoDB instance without authentication. Create the system user administrator, ensuring that its password meets organizationally-defined password complexity requirements. Open mongod.conf and change for authorization value to enabled. Restart the MongoDB instance."
@@ -63,11 +47,11 @@ checks:
       - https://docs.mongodb.com/v3.6/core/authentication/
     condition: all
     rules:
-      - 'c:cat /etc/mongod.conf | grep \-A4 "security:" -> r:authorization: "enabled"'
+      - 'c:sh -c "cat /etc/mongod.conf | grep \\-A4 \"security:\""" -> r:authorization: "enabled"'
 
 #2.2
-  - id: 23502
-    title: "Ensure that MongoDB does not bypass authentication via the localhost exception"
+  - id: 23501
+    title: "Ensure that MongoDB does not bypass authentication via the localhost exception."
     description: "MongoDB should not be set to bypass authentication via the localhost exception. The localhost exception allows the user to enable authorization before creating the first user in the system. When active, the localhost exception allows all connections from the localhost interface to have full access to that instance. The exception applies only when there are no users created in the MongoDB instance. Note: This recommendation only applies when there are no users created in the MongoDB instance."
     rationale: "Disabling this exception will prevent unauthorized local access to the MongoDB database. It will also ensure the traceability of each database activity to a specific user. Localhost Exception allows direct connect to Mongod’s without any UN/PW."
     remediation: "To disable local authentication on the MongoDB database, type OS Console Command: mongod --setParameter enableLocalhostAuthBypass=0, or manually configure use the setParameter option in the mongo configuration file to set it to false ."
@@ -78,11 +62,11 @@ checks:
       - https://docs.mongodb.com/v3.6/reference/parameters/#param.enableLocalhostAuthBypass
     condition: all
     rules:
-      - 'f:$main-conf -> r:enableLocalhostAuthBypass: 0|false'
+      - 'f:$main-conf -> r:enableLocalhostAuthBypass: \(0|false\)'
 
 #2.3
-  - id: 23503
-    title: "Ensure authentication is enabled in the sharded cluster"
+  - id: 23502
+    title: "Ensure authentication is enabled in the sharded cluster."
     description: "Authentication is enabled in a sharded cluster when the certificate or key files are created and configured for all components. This ensures that every client that accesses the cluster must provide credentials, to include MongoDB instances that access each other within the cluster. With keyfile authentication, each mongod or mongos instance in the sharded cluster uses the contents of the keyfile as the shared password for authenticating other members in the deployment. Only mongod or mongos instances with the correct keyfile can join the sharded cluster. For Production Environment: x.509 certificate authentication with secure TSL/SSL connection must be used for authentication. For Development Purpose: Key file can be used as an authentication mechanism between the shared cluster. Keyfiles are bare-minimum forms of security and are best suited for testing or development environments."
     rationale: "Enforcing a key or certificate on a sharded cluster prevents unauthorized access to the MongoDB database and provides traceability of database activities to a specific user or component. A MongoDB sharded cluster can enforce user authentication as well as internal authentication of its components to secure against unauthorized access."
     remediation: "To authenticate to servers, clients can use x.509 certificates instead of usernames and passwords. MongoDB supports x.509 certificate authentication for use with a secure TLS/SSL connection. The x.509 client authentication allows clients to authenticate to servers with certificates rather than with a username and password."
@@ -95,18 +79,18 @@ checks:
       - https://docs.mongodb.com/v3.6/tutorial/configure-x509-member-authentication/
     condition: all
     rules:
-      - 'c:cat /etc/mongod.conf | grep \-A12 "ssl:" -> r:PEMKeyFile'
-      - 'c:cat /etc/mongod.conf | grep \-A12 "ssl:" -> r:clusterFile'
-      - 'c:cat /etc/mongod.conf | grep \-A12 "ssl:" -> r:CAFile'
-      - 'c:cat /etc/mongod.conf | grep \-A10 "security:" -> r:clusterAuthMode: "x509"'
-      - 'c:cat /etc/mongod.conf | grep \-A10 "security:" -> r:authenticationMechanisms: "MONGODB-X509"'
+      - 'c:sh -c "cat /etc/mongod.conf | grep \\-A12 \"ssl:\"" -> r:PEMKeyFile'
+      - 'c:sh -c "cat /etc/mongod.conf | grep \\-A12 "ssl:\"" -> r:clusterFile'
+      - 'c:sh -c "cat /etc/mongod.conf | grep \\-A12 \"ssl:\"" -> r:CAFile'
+      - 'c:sh -c "cat /etc/mongod.conf | grep \\-A10 \"security:\"" -> r:clusterAuthMode: "x509"'
+      - 'c:sh -c "cat /etc/mongod.conf | grep \\-A10 \"security:\"" -> r:authenticationMechanisms: "MONGODB-X509"'
 
 #3 Access Control
 #3.1 - Requires mongo shell commands, currently not supported
 
 #3.2
-  - id: 23504
-    title: "Ensure that MongoDB only listens for network connections on authorized interfaces"
+  - id: 23503
+    title: "Ensure that MongoDB only listens for network connections on authorized interfaces."
     description: "Ensuring that MongoDB runs in a trusted network environment involves limiting the network interfaces on which MongoDB instances listen for incoming connections. Any untrusted network connections should be dropped by MongoDB. Firewalls allow administrators to filter and control access to a system by providing granular control over network communications. For administrators of MongoDB, the following capabilities are important: 1. Limiting incoming traffic on a specific port to specific systems, 2. Limiting incoming traffic from untrusted hosts. On Linux systems, the iptables interface provides access to the underlying netfilter firewall. On Windows systems, netsh command line interface provides access to the underlying Windows Firewall."
     rationale: "This configuration blocks connections from untrusted networks, leaving only systems on authorized and trusted networks able to attempt to connect to the MongoDB. If not configured, this may lead to unauthorized connections from untrusted networks to MongoDB."
     remediation: "Configure the MongoDB configuration file to limit its exposure to only the network interfaces on which MongoDB instances should listen for incoming connections."
@@ -119,11 +103,11 @@ checks:
       - https://docs.mongodb.com/v3.6/core/security-network/
     condition: all
     rules:
-      - 'c:cat /etc/mongod.conf | grep \-A12 "net:" -> r:bindIp'
+      - 'c:sh -c "cat /etc/mongod.conf | grep \\-A12 "net:" -> r:bindIp'
 
 #3.3
-  - id: 23505
-    title: "Ensure that MongoDB is run using a Least Privileges, dedicated service account"
+  - id: 23504
+    title: "Ensure that MongoDB is run using a Least Privileges, dedicated service account."
     description: "The MongoDB service should not be run using a privileged account such as 'root' because this unnecessarily exposes the operating system to high risk. This setting ensures that the monogd service runs as a least-privileged user."
     rationale: "Using a non-privileged, dedicated service account restricts the database from accessing the critical areas of the operating system which are not required by MongoDB. This will also mitigate the potential for unauthorized access via a compromised, privileged account on the operating system. Anyone who has been a victim of viruses, worms, and other malicious software (malware) will appreciate the security principle of “least privilege.” If all processes ran with the minial set of privileges needed to perform the user's tasks, it would be more difficult for malware to infect a machine and propagate to other machines."
     remediation: "1. Create a user which is only used for running Mongodb and directly related processes. This user must not have administrative rights to the system. Steps to create user. 2. Set the Database data files, the keyfile, and the SSL private key files to only be readable by the mongod/mongos user and then set ownership to mongodb user only. 3. Set the log files to only be writable by the mongod/mongos user and readable only by root."
@@ -134,24 +118,24 @@ checks:
       - https://docs.mongodb.com/v3.6/tutorial/manage-users-and-roles/
     condition: all
     rules:
-      - 'not c:ps -aef | grep mongod -> r:root'
+      - 'not c:sh -c "ps -aef | grep mongod" -> r:root'
 
 #3.4 - Requires mongo shell commands, currently not supported
 #  - id: 23507
-#    title: "Ensure that each role for each MongoDB database is needed and grants only the necessary privileges"
+#    title: "Ensure that each role for each MongoDB database is needed and grants only the necessary privileges."
 
 #3.5 - Requires mongo shell commands, currently not supported
 #  - id: 23508
-#    title: "Review User-Defined Roles"
+#    title: "Review User-Defined Roles."
 
 #3.6 - Requires mongo shell commands, currently not supported
 #  - id: 23509
-#    title: "Review Superuser/Admin Roles"
+#    title: "Review Superuser/Admin Roles."
 
 #4 Data Encryption
 #4.1
-  - id: 23506
-    title: "Ensure Encryption of Data in Transit TLS/SSL (Transport Encryption)"
+  - id: 23505
+    title: "Ensure Encryption of Data in Transit TLS/SSL (Transport Encryption)."
     description: "Use TLS or SSL to protect all incoming and outgoing connections. This should include using TLS or SSL to encrypt communication between the mongod and mongos components of a MongoDB client as well as between all applications and MongoDB. MongoDB supports TLS/SSL (Transport Layer Security/Secure Sockets Layer) to encrypt all of MongoDB’s network traffic. TLS/SSL ensures that MongoDB network traffic is only readable by the intended client."
     rationale: "This prevents sniffing of cleartext traffic between MongoDB components or performing a man-in-the-middle attack for MongoDB."
     remediation: "Configure MongoDB servers to require the use of SSL or TLS to encrypt all MongoDB network communications. To implement SSL or TLS to encrypt all MongoDB network communication, perform the following steps: For mongod (“Primary daemon process for the MongoDB system”) In the configuration file /etc/mongod.conf , set the PEMKeyFile option to the certificate file’s path and then start the component"
@@ -166,11 +150,11 @@ checks:
       - https://docs.mongodb.com/v3.6/tutorial/configure-x509-member-authentication/
     condition: all
     rules:
-      - 'c:cat /etc/mongod.conf | grep \-A12 "ssl:" -> r:mode: "requireSSL"'
+      - 'c:sh -c "cat /etc/mongod.conf | grep \\-A12 \"ssl:\"" -> r:mode: "requireSSL"'
 
 #4.2
-  - id: 23507
-    title: "Ensure Federal Information Processing Standard (FIPS) is enabled"
+  - id: 23506
+    title: "Ensure Federal Information Processing Standard (FIPS) is enabled."
     description: "The Federal Information Processing Standard (FIPS) is a computer security standard used to certify software modules and libraries that encrypt and decrypt data securely. You can configure MongoDB to run with a FIPS 140-2 certified library for OpenSSL. FIPS is a property of the encryption system and not the access control system. However, the environment requires FIPS compliant encryption and access control. Organizations must ensure that the access control system uses only FIPS-compliant encryption."
     rationale: "FIPS is an industry standard which dictates how data should be encrypted at rest and during transmission."
     remediation: "Configuring FIPS mode, ensure that your certificate is FIPS compliant. Run mongod or mongos instance in FIPS mode. Make changes to configuration file, to configure your mongod or mongos instance to use FIPS mode, shut down the instance and update the configuration file"
@@ -181,16 +165,16 @@ checks:
       - https://docs.mongodb.com/v3.6/tutorial/configure-fips/
     condition: all
     rules:
-      - 'c:cat /etc/mongod.conf | grep \-A12 "ssl:" -> r:FIPSMode: 1|true'
+      - 'c:sh -c "cat /etc/mongod.conf | grep \\-A12 \"ssl:\"" -> r:FIPSMode: \(1|true\)'
 
 #4.3 - Does not provide audit steps
 #  - id: 23512
-#    title: "Ensure Encryption of Data at Rest"
+#    title: "Ensure Encryption of Data at Rest."
 
 #5 Auditing
 #5.1
-  - id: 23508
-    title: "Ensure that system activity is audited"
+  - id: 23507
+    title: "Ensure that system activity is audited."
     description: "Track access and changes to database configurations and data. MongoDB Enterprise includes a system auditing facility that can record system events (e.g. user operations, connection events) on a MongoDB instance. These audit records permit forensic analysis and allow administrators to verify proper controls."
     rationale: "System level logs can be handy while troubleshooting an operational problem or handling a security incident."
     remediation: "Set the value of auditLog.destination to the appropriate value"
@@ -201,11 +185,11 @@ checks:
       - https://docs.mongodb.com/v3.6/tutorial/configure-auditing/
     condition: all
     rules:
-      - 'c:cat /etc/mongod.conf | grep \-A4 "auditLog" -> r:destination'
+      - 'c:sh -c "cat /etc/mongod.conf | grep \\-A4 \"auditLog\"" -> r:destination'
 
 #5.2
-  - id: 23509
-    title: "Ensure that system activity is audited"
+  - id: 23508
+    title: "Ensure that system activity is audited."
     description: "MongoDB Enterprise supports auditing of various operations. When enabled, the audit facility, by default, records all auditable operations as detailed in Audit Event Actions, Details, and Results. To specify which events to record, the audit feature includes the --auditFilter option. This check is only for Enterprise editions."
     rationale: "All operations carried out on the database are logged. This helps in backtracking and tracing any incident that occurs."
     remediation: "Set the audit filters based on the organization’s requirements."
@@ -217,11 +201,11 @@ checks:
       - https://docs.mongodb.com/v3.6/tutorial/configure-audit-filters/
     condition: all
     rules:
-      - 'c:cat /etc/mongod.conf | grep \-A10 "auditLog" -> r:filter'
+      - 'c:sh -c "cat /etc/mongod.conf | grep \\-A10 \"auditLog\"" -> r:filter'
 
 #5.3
-  - id: 23510
-    title: "Ensure that audit filters are configured properly"
+  - id: 23509
+    title: "Ensure that audit filters are configured properly."
     description: "The SystemLog.quiet option stops logging of information such as:connection events, authentication events, replication sync activitie, evidence of some potentially impactful commands being run (eg: drop , dropIndexes , validate ). This information should be logged whenever possible. This check is only for Enterprise editions."
     rationale: "The use of SystemLog.quiet makes troubleshooting problems and investigating possible security incidents much more difficult."
     remediation: "Set SystemLog.quiet to false in the /etc/mongod.conf file to disable it."
@@ -232,11 +216,11 @@ checks:
       - https://docs.mongodb.com/v3.6/reference/configuration-options/#systemLog.quiet
     condition: all
     rules:
-      - 'f:$main-conf -> r:quiet: 0|false'
+      - 'f:$main-conf -> r:quiet: \(0|false\)'
 
 #5.4
-  - id: 23511
-    title: "Ensure that new entries are appended to the end of the log file"
+  - id: 23510
+    title: "Ensure that new entries are appended to the end of the log file."
     description: "By default, new log entries will overwrite old entries after a restart of the mongod or mongos service. Enabling the systemLog.logAppend setting causes new entries to be appended to the end of the log file rather than overwriting the existing content of the log when the mongod or mongos instance restarts."
     rationale: "Allowing old entries to be overwritten by new entries instead of appending new entries to the end of the log may destroy old log data that is needed for a variety of purposes."
     remediation: "Set systemLog.logAppend to true in the /etc/mongod.conf file."
@@ -247,12 +231,12 @@ checks:
       - https://docs.mongodb.com/v3.6/reference/configuration-options/#systemLog.logAppend
     condition: all
     rules:
-      - 'c:cat /etc/mongod.conf | grep \-A10 "systemLog" -> r:logAppend: 1|true'
+      - 'c:sh -c "cat /etc/mongod.conf | grep \\-A10 \"systemLog\"" -> r:logAppend: \(1|true\)'
 
 #6 Operating System Hardening
 #6.1
-  - id: 23512
-    title: "Ensure that MongoDB uses a non-default port"
+  - id: 23511
+    title: "Ensure that MongoDB uses a non-default port."
     description: "Changing the default port used by MongoDB makes it harder for attackers to find the database and target it."
     rationale: "Standard ports are used in automated attacks and by attackers to verify which applications are running on a server."
     remediation: "Change the port for MongoDB server to a number other than 27017."
@@ -267,11 +251,11 @@ checks:
 
 #6.2 - Has to be done manually as it is specific to the MongoDB deployment
 #  - id: 23518
-#    title: "Ensure that operating system resource limits are set for MongoDB"
+#    title: "Ensure that operating system resource limits are set for MongoDB."
 
 #6.3
-  - id: 23513
-    title: "Ensure that server-side scripting is disabled if not needed"
+  - id: 23512
+    title: "Ensure that server-side scripting is disabled if not needed."
     description: "MongoDB supports the execution of JavaScript code for certain server-side operations: mapReduce , group , and $where . If you do not use these operations, server-side scripting should be disabled."
     rationale: "If server-side scripting is not needed and is not disabled, this introduces unnecessary risk which may allow an attacker to take advantage of insecure coding."
     remediation: "If server-side scripting is not required, disable it by using the --noscripting option on the command line."
@@ -282,13 +266,13 @@ checks:
       - https://docs.mongodb.com/v3.6/reference/configuration-options/#security.javascriptEnabled
     condition: all
     rules:
-      - 'c:cat /etc/mongod.conf | grep \-A10 "security" -> r:javascriptEnabled: 0|false'
+      - 'c:sh -c "cat /etc/mongod.conf | grep \\-A10 \"security\"" -> r:javascriptEnabled: 0|false'
 
 #7 File Permissions
 #7.1 - Has to be done manually as it is specific to the MongoDB deployment
 #  - id: 23520
-#    title: "Ensure authentication file permissions are set correctly"
+#    title: "Ensure authentication file permissions are set correctly."
 
 #7.2 - Has to be done manually as it is specific to the MongoDB deployment
 #  - id: 23521
-#    title: "Ensure that database file permissions are set correctly"
+#    title: "Ensure that database file permissions are set correctly."

--- a/ruleset/sca/mongodb/cis_mongodb_36.yml
+++ b/ruleset/sca/mongodb/cis_mongodb_36.yml
@@ -103,11 +103,9 @@ checks:
 
 #3 Access Control
 #3.1 - Requires mongo shell commands, currently not supported
-#  - id: 23504
-#    title: "Ensure that Role-based access control (RBAC) is enabled and configured"
 
 #3.2
-  - id: 23505
+  - id: 23504
     title: "Ensure that MongoDB only listens for network connections on authorized interfaces"
     description: "Ensuring that MongoDB runs in a trusted network environment involves limiting the network interfaces on which MongoDB instances listen for incoming connections. Any untrusted network connections should be dropped by MongoDB. Firewalls allow administrators to filter and control access to a system by providing granular control over network communications. For administrators of MongoDB, the following capabilities are important: 1. Limiting incoming traffic on a specific port to specific systems, 2. Limiting incoming traffic from untrusted hosts. On Linux systems, the iptables interface provides access to the underlying netfilter firewall. On Windows systems, netsh command line interface provides access to the underlying Windows Firewall."
     rationale: "This configuration blocks connections from untrusted networks, leaving only systems on authorized and trusted networks able to attempt to connect to the MongoDB. If not configured, this may lead to unauthorized connections from untrusted networks to MongoDB."
@@ -124,7 +122,7 @@ checks:
       - 'c:cat /etc/mongod.conf | grep \-A12 "net:" -> r:bindIp'
 
 #3.3
-  - id: 23506
+  - id: 23505
     title: "Ensure that MongoDB is run using a Least Privileges, dedicated service account"
     description: "The MongoDB service should not be run using a privileged account such as 'root' because this unnecessarily exposes the operating system to high risk. This setting ensures that the monogd service runs as a least-privileged user."
     rationale: "Using a non-privileged, dedicated service account restricts the database from accessing the critical areas of the operating system which are not required by MongoDB. This will also mitigate the potential for unauthorized access via a compromised, privileged account on the operating system. Anyone who has been a victim of viruses, worms, and other malicious software (malware) will appreciate the security principle of “least privilege.” If all processes ran with the minial set of privileges needed to perform the user's tasks, it would be more difficult for malware to infect a machine and propagate to other machines."
@@ -152,7 +150,7 @@ checks:
 
 #4 Data Encryption
 #4.1
-  - id: 23510
+  - id: 23506
     title: "Ensure Encryption of Data in Transit TLS/SSL (Transport Encryption)"
     description: "Use TLS or SSL to protect all incoming and outgoing connections. This should include using TLS or SSL to encrypt communication between the mongod and mongos components of a MongoDB client as well as between all applications and MongoDB. MongoDB supports TLS/SSL (Transport Layer Security/Secure Sockets Layer) to encrypt all of MongoDB’s network traffic. TLS/SSL ensures that MongoDB network traffic is only readable by the intended client."
     rationale: "This prevents sniffing of cleartext traffic between MongoDB components or performing a man-in-the-middle attack for MongoDB."
@@ -171,7 +169,7 @@ checks:
       - 'c:cat /etc/mongod.conf | grep \-A12 "ssl:" -> r:mode: "requireSSL"'
 
 #4.2
-  - id: 23511
+  - id: 23507
     title: "Ensure Federal Information Processing Standard (FIPS) is enabled"
     description: "The Federal Information Processing Standard (FIPS) is a computer security standard used to certify software modules and libraries that encrypt and decrypt data securely. You can configure MongoDB to run with a FIPS 140-2 certified library for OpenSSL. FIPS is a property of the encryption system and not the access control system. However, the environment requires FIPS compliant encryption and access control. Organizations must ensure that the access control system uses only FIPS-compliant encryption."
     rationale: "FIPS is an industry standard which dictates how data should be encrypted at rest and during transmission."
@@ -191,7 +189,7 @@ checks:
 
 #5 Auditing
 #5.1
-  - id: 23513
+  - id: 23508
     title: "Ensure that system activity is audited"
     description: "Track access and changes to database configurations and data. MongoDB Enterprise includes a system auditing facility that can record system events (e.g. user operations, connection events) on a MongoDB instance. These audit records permit forensic analysis and allow administrators to verify proper controls."
     rationale: "System level logs can be handy while troubleshooting an operational problem or handling a security incident."
@@ -206,7 +204,7 @@ checks:
       - 'c:cat /etc/mongod.conf | grep \-A4 "auditLog" -> r:destination'
 
 #5.2
-  - id: 23514
+  - id: 23509
     title: "Ensure that system activity is audited"
     description: "MongoDB Enterprise supports auditing of various operations. When enabled, the audit facility, by default, records all auditable operations as detailed in Audit Event Actions, Details, and Results. To specify which events to record, the audit feature includes the --auditFilter option. This check is only for Enterprise editions."
     rationale: "All operations carried out on the database are logged. This helps in backtracking and tracing any incident that occurs."
@@ -222,7 +220,7 @@ checks:
       - 'c:cat /etc/mongod.conf | grep \-A10 "auditLog" -> r:filter'
 
 #5.3
-  - id: 23515
+  - id: 23510
     title: "Ensure that audit filters are configured properly"
     description: "The SystemLog.quiet option stops logging of information such as:connection events, authentication events, replication sync activitie, evidence of some potentially impactful commands being run (eg: drop , dropIndexes , validate ). This information should be logged whenever possible. This check is only for Enterprise editions."
     rationale: "The use of SystemLog.quiet makes troubleshooting problems and investigating possible security incidents much more difficult."
@@ -237,7 +235,7 @@ checks:
       - 'f:$main-conf -> r:quiet: 0|false'
 
 #5.4
-  - id: 23516
+  - id: 23511
     title: "Ensure that new entries are appended to the end of the log file"
     description: "By default, new log entries will overwrite old entries after a restart of the mongod or mongos service. Enabling the systemLog.logAppend setting causes new entries to be appended to the end of the log file rather than overwriting the existing content of the log when the mongod or mongos instance restarts."
     rationale: "Allowing old entries to be overwritten by new entries instead of appending new entries to the end of the log may destroy old log data that is needed for a variety of purposes."
@@ -253,7 +251,7 @@ checks:
 
 #6 Operating System Hardening
 #6.1
-  - id: 23517
+  - id: 23512
     title: "Ensure that MongoDB uses a non-default port"
     description: "Changing the default port used by MongoDB makes it harder for attackers to find the database and target it."
     rationale: "Standard ports are used in automated attacks and by attackers to verify which applications are running on a server."
@@ -272,7 +270,7 @@ checks:
 #    title: "Ensure that operating system resource limits are set for MongoDB"
 
 #6.3
-  - id: 23519
+  - id: 23513
     title: "Ensure that server-side scripting is disabled if not needed"
     description: "MongoDB supports the execution of JavaScript code for certain server-side operations: mapReduce , group , and $where . If you do not use these operations, server-side scripting should be disabled."
     rationale: "If server-side scripting is not needed and is not disabled, this introduces unnecessary risk which may allow an attacker to take advantage of insecure coding."

--- a/ruleset/sca/mongodb/cis_mongodb_36.yml
+++ b/ruleset/sca/mongodb/cis_mongodb_36.yml
@@ -19,7 +19,7 @@ policy:
     - https://www.cisecurity.org/cis-benchmarks/
 
 requirements:
-  title: "Check that MongoDB is installed on the system.."
+  title: "Check that MongoDB is installed on the system."
   description: "Requirements for running the SCA scan against the MongoDB policy."
   condition: any
   rules:
@@ -47,7 +47,7 @@ checks:
       - https://docs.mongodb.com/v3.6/core/authentication/
     condition: all
     rules:
-      - 'c:sh -c "cat /etc/mongod.conf | grep \\-A4 \"security:\""" -> r:authorization: "enabled"'
+      - 'c:sh -c "cat /etc/mongod.conf | grep \\-A4 \"security:\"" -> r:authorization: "enabled"'
 
 #2.2
   - id: 23501
@@ -103,7 +103,7 @@ checks:
       - https://docs.mongodb.com/v3.6/core/security-network/
     condition: all
     rules:
-      - 'c:sh -c "cat /etc/mongod.conf | grep \\-A12 "net:" -> r:bindIp'
+      - 'c:sh -c "cat /etc/mongod.conf | grep \\-A12 \"net:\"" -> r:bindIp'
 
 #3.3
   - id: 23504


### PR DESCRIPTION
|Related PR|
|---|
|https://github.com/wazuh/wazuh/issues/8977|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR reworks the changes added in the previous https://github.com/wazuh/wazuh/pull/8977

The effected changes were:
- Reordered the ID of the checks to make them continuous.
- Fixed wrongly implemented checks.
- Added consistency to indexation.
- Fixed YML format.

After these changes, another iteration will be needed to add the missing checks.

## SCA Checks
### Syntax and semantic

- [x] a) ID of each policy must be contiguous.
- [x] b) The order and format set in [Documentation](https://documentation.wazuh.com/current/user-manual/capabilities/sec-config-assessment/creating-custom-policies.html) must be respected.
- [x] c) YML must be valid to avoid errors.

### Content

- [x] a) Compare each check with its analogue from CIS Benchmark.
- [x] b) Try to maintain each rule as similar as possible with the `Audit` section from the CIS check.
- [x] c) Check that the commands provide the expected output.
- [x] d) When a failure is discovered, check similar policies to avoid repetition of the issue.

### Unit testing

- [x] a) Output from `agent.log` after the SCA scan and a raw output of the result of the checks.
<details><summary>Tests results</summary>
<p>

#### Analysisd (server or local)
analysisd.debug=2

#### Auth daemon debug (server)
authd.debug=0

#### Exec daemon debug (server, local, or Unix agent)
execd.debug=0

#### Monitor daemon debug (server, local, or Unix agent)
monitord.debug=0

#### Log collector (server, local or Unix agent)
logcollector.debug=0

#### Integrator daemon debug (server, local or Unix agent)
integrator.debug=0

#### Unix agentd
agent.debug=2

</p>
</details>

### Deployment

- [x] a) If the policy it's new, it must be added to the `sca.files` templates.
- [x] b) If the OS has many supported SCA policies, a policy must be set as default policy. ([as example](https://github.com/wazuh/wazuh/blob/master/etc/templates/config/centos/sca.files))
