### PR TITLE
Rework PR 8977 - SQL Server 20216 - Add new sca files for MS IIS, MongoDB 3.6, Nginx, SQL Server and SLES

### DIFF
--- a/ruleset/sca/applications/cis_sqlserver_2016.yml
+++ b/ruleset/sca/applications/cis_sqlserver_2016.yml
@@ -666,18 +666,3 @@ checks:
     condition: none
     rules:
       - "c:sqlcmd -Q \"SELECT name, permission_set_desc FROM sys.assemblies WHERE is_user_defined = 1;\" -> r:EXTERNAL_ACCESS|UNSAFE"
-
-#
-#  - id:
-#    title:
-#    description:
-#    rationale:
-#    remediation:
-#    compliance:
-#      - cis: [""]
-#      - cis_csc: [""]
-#    references:
-#      -
-#    condition:
-#    rules:
-#      -


### PR DESCRIPTION
|Related PR|
|---|
|https://github.com/wazuh/wazuh/issues/8977|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR reworks the changes added in the previous https://github.com/wazuh/wazuh/pull/8977

The effected changes were:
- Reordered the ID of the checks to make them continuous.
- Fixed wrongly implemented checks.
- Added consistency to indexation.
- Fixed YML format.

After these changes, another iteration will be needed to add the missing checks.

## SCA Checks
### Syntax and semantic

- [x] a) ID of each policy must be contiguous.
- [x] b) The order and format set in [Documentation](https://documentation.wazuh.com/current/user-manual/capabilities/sec-config-assessment/creating-custom-policies.html) must be respected.
- [x] c) YML must be valid to avoid errors.

### Content

- [x] a) Compare each check with its analogue from CIS Benchmark.
- [x] b) Try to maintain each rule as similar as possible with the `Audit` section from the CIS check.
- [x] c) Check that the commands provide the expected output.
- [x] d) When a failure is discovered, check similar policies to avoid repetition of the issue.

### Unit testing

- [x] a) Output from `agent.log` after the SCA scan and a raw output of the result of the checks.
<details><summary>Tests results</summary>
<p>

#### Analysisd (server or local)
analysisd.debug=2

#### Auth daemon debug (server)
authd.debug=0

#### Exec daemon debug (server, local, or Unix agent)
execd.debug=0

#### Monitor daemon debug (server, local, or Unix agent)
monitord.debug=0

#### Log collector (server, local or Unix agent)
logcollector.debug=0

#### Integrator daemon debug (server, local or Unix agent)
integrator.debug=0

#### Unix agentd
agent.debug=2

</p>
</details>

### Deployment

- [x] a) If the policy it's new, it must be added to the `sca.files` templates.
- [x] b) If the OS has many supported SCA policies, a policy must be set as default policy. ([as example](https://github.com/wazuh/wazuh/blob/master/etc/templates/config/centos/sca.files))
