### PR TITLE
Adapt OS_IPFound and other functions to work with IPv6

### DIFF
--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -576,7 +576,7 @@ int OS_WriteKeys(const keystore *keys) {
 
     unsigned int i;
     File file;
-    char cidr[20];
+    char cidr[IPSIZE];
 
     if (TempFile(&file, KEYS_FILE, 0) < 0)
         return -1;
@@ -584,7 +584,7 @@ int OS_WriteKeys(const keystore *keys) {
    for (i = 0; i < keys->keysize; i++) {
         keyentry *entry = keys->keyentries[i];
 
-        if (fprintf(file.fp, "%s %s %s %s\n", entry->id, entry->name, OS_CIDRtoStr(entry->ip, cidr, 20) ? entry->ip->ip : cidr, entry->raw_key) < 0) {
+        if (fprintf(file.fp, "%s %s %s %s\n", entry->id, entry->name, OS_CIDRtoStr(entry->ip, cidr, IPSIZE) ? entry->ip->ip : cidr, entry->raw_key) < 0) {
             merror(FWRITE_ERROR, file.name, errno, strerror(errno));
             fclose(file.fp);
             goto error;
@@ -813,12 +813,12 @@ int OS_WriteTimestamps(keystore * keys) {
         }
 
         char timestamp[40];
-        char cidr[20];
+        char cidr[IPSIZE];
         struct tm tm_result = { .tm_sec = 0 };
 
         strftime(timestamp, 40, "%Y-%m-%d %H:%M:%S", localtime_r(&entry->time_added, &tm_result));
 
-        if (fprintf(file.fp, "%s %s %s %s\n", entry->id, entry->name, OS_CIDRtoStr(entry->ip, cidr, 20) ? entry->ip->ip : cidr, timestamp) < 0) {
+        if (fprintf(file.fp, "%s %s %s %s\n", entry->id, entry->name, OS_CIDRtoStr(entry->ip, cidr, IPSIZE) ? entry->ip->ip : cidr, timestamp) < 0) {
             merror(FWRITE_ERROR, file.name, errno, strerror(errno));
             r = -1;
             break;

--- a/src/shared/validate_op.c
+++ b/src/shared/validate_op.c
@@ -321,7 +321,7 @@ int OS_IPFound(const char *ip_address, const os_ip *that_ip)
             if ((net6.u.Byte[i] & that_ip->ipv6->netmask[i]) != that_ip->ipv6->ip_address[i]) {
 #endif
                 break;
-            } else if (i >= (16 - 1)) {
+            } else if (i >= (15)) {
                 return (_true);
             }
         }
@@ -371,7 +371,7 @@ int OS_IPFoundList(const char *ip_address, os_ip **list_of_ips)
                 if ((net6.u.Byte[i] & l_ip->ipv6->netmask[i]) != l_ip->ipv6->ip_address[i]) {
 #endif
                     break;
-                } else if (i >= (16 - 1)) {
+                } else if (i >= (15)) {
                     return (_true);
                 }
             }

--- a/src/shared/validate_op.c
+++ b/src/shared/validate_op.c
@@ -909,7 +909,10 @@ int OS_CIDRtoStr(const os_ip * ip, char * string, size_t size) {
     int imask;
     uint32_t hmask;
 
-    if (ip->ipv4->netmask != 0xFFFFFFFF && strcmp(ip->ip, "any")) {
+    if ((ip->is_ipv6 == false) &&
+        (ip->ipv4->netmask != 0xFFFFFFFF) &&
+            strcmp(ip->ip, "any")) {
+
         if (_mask_inited) {
             _init_masks();
         }

--- a/src/unit_tests/wrappers/wazuh/os_net/os_net_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/os_net/os_net_wrappers.c
@@ -126,10 +126,29 @@ uint32_t __wrap_wnet_order(uint32_t value) {
 
 int __wrap_get_ipv4_numeric(__attribute__((unused)) const char *address,
                             __attribute__((unused)) struct in_addr *addr) {
-    return mock();
+    int ret = mock();
+    if(ret > 0) {
+        ret = 0;
+        addr->s_addr = mock();
+    }
+
+    return ret;
 }
 
 int __wrap_get_ipv6_numeric(__attribute__((unused)) const char *address,
                             __attribute__((unused)) struct in6_addr *addr6) {
-    return mock();
+    int ret = mock();
+    if(ret > 0) {
+        ret = 0;
+        int value = mock();
+        for(unsigned int a = 0; a < 16; a++) {
+#ifndef WIN32
+            addr6->s6_addr[a] = value;
+#else
+            addr6->u.Byte[a] = value;
+#endif
+        }
+    }
+
+    return ret;
 }

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -254,7 +254,7 @@ void wm_check_agents() {
 void wm_sync_agents() {
     unsigned int i;
     char * group;
-    char cidr[20];
+    char cidr[IPSIZE];
     keystore keys = KEYSTORE_INITIALIZER;
     keyentry *entry;
     int *agents;
@@ -287,7 +287,7 @@ void wm_sync_agents() {
             *group = 0;
         }
 
-        if (wdb_insert_agent(id, entry->name, NULL, OS_CIDRtoStr(entry->ip, cidr, 20) ?
+        if (wdb_insert_agent(id, entry->name, NULL, OS_CIDRtoStr(entry->ip, cidr, IPSIZE) ?
                              entry->ip->ip : cidr, entry->raw_key, *group ? group : NULL,1, &wdb_wmdb_sock)) {
             // The agent already exists, update group only.
             wm_sync_agent_group(id, entry->id);


### PR DESCRIPTION
|Related issue|
|---|
|[10894](https://github.com/wazuh/wazuh/issues/10894)|


## Description

Goal of following changes is adapt the functions of validate_op file to also work with IPv6 addresses.


## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language
- [x] Added unit tests (for new features)