### PR TITLE
Fix heap overrun in Vulnerability Detector

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -3767,7 +3767,7 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
             }
         } else if (dist == FEED_REDHAT && !strcmp(node[i]->element, XML_RPM_ARCHITECTURE)) {
             if (node[i]->attributes && *node[i]->attributes && node[i]->content && *node[i]->content) {
-                os_calloc(1, sizeof(char *), parsed_oval->info_states->arch);
+                os_calloc(2, sizeof(char *), parsed_oval->info_states->arch);
                 for (j = 0; node[i]->attributes[j]; j++) {
                     if (!strcmp(node[i]->attributes[j], XML_OPERATION)) {
                         if (node[i]->values[j] && !strcmp(node[i]->values[j], "equals")) {


### PR DESCRIPTION
## Related issue

This PR closes #11210.

## Description

This change should fix a memory issue in the `arch` string array at Vulnerability Detector, which misses a terminating null pointer when only one value is placed. This happens on the `equals` operator.

## Tests

- [x] AddressSanitizer.
- [x] Coverity.
- [x] Vuln Detector does not longer crash using jemalloc.