### PR TITLE
Rework of PR #9195 - Fixed srcip and dstip values in SonicWall decoder

### DIFF
--- a/ruleset/decoders/0295-sonicwall_decoders.xml
+++ b/ruleset/decoders/0295-sonicwall_decoders.xml
@@ -21,8 +21,8 @@
   -->
 
 <decoder name="sonicwall">
-   <prematch>^\<\d+>\s*id=\w+\s+sn=\w+\s+time="\.+"\s+fw=\S+ |^\s*id=\w+\s+sn=\w+\s+time="\.+"\s+fw=\S+ </prematch>
-   <plugin_decoder>SonicWall_Decoder</plugin_decoder>
+  <plugin_decoder>SonicWall_Decoder</plugin_decoder>
+  <prematch>^\<\d+>\s*id=\w+\s+sn=\w+\s+time="\.+"\s+fw=\S+ |^\s*id=\w+\s+sn=\w+\s+time="\.+"\s+fw=\S+ </prematch>
 </decoder>
 
 <decoder name="sonicwall-fields">
@@ -66,7 +66,6 @@
   <regex offset="after_regex">proto=(\S+)</regex>
   <order>protocol</order>
 </decoder>
-
 
 <decoder name="sonicwall-fields">
   <parent>sonicwall</parent>

--- a/ruleset/decoders/0295-sonicwall_decoders.xml
+++ b/ruleset/decoders/0295-sonicwall_decoders.xml
@@ -1,23 +1,24 @@
 <!--
-  -  SonicWall decoders
-  -  Author: Daniel Cid.
-  -  Updated by Wazuh, Inc.
-  -  Copyright (C) 2015-2021, Wazuh Inc.
-  -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  Copyright (C) 2015-2021, Wazuh Inc.
 -->
 
 <!--
-  - Will extract action, srcip, dstip, protocol, srcport and dstport
-  - Examples:
-  - Jan  3 13:45:36 192.168.5.1 id=firewall sn=000SERIAL time="2007-01-03 14:48:06" fw=1.1.1.1 pri=6 c=262144 m=98 msg="Connection Opened" n=23419 src=2.2.2.2:36701:WAN dst=1.1.1.1:50000:WAN proto=tcp/50000
-  - Jan  3 13:45:36 192.168.5.1 id=firewall sn=000SERIAL time="2007-01-03 14:48:07" fw=1.1.1.1 pri=1 c=32 m=30 msg="Administrator login denied due to bad credentials" n=7 src=2.2.2.2:36701:WAN dst=1.1.1.1:50000:WAN
-  - id=firewall sn=00301E0526B1 time="2004-04-01 10:39:35" fw=67.32.44.2 pri=5 c=64 m=36 msg="TCP connection dropped" n=2686 src=67.101.200.27:4507:WAN dst=67.32.44.2:445:LAN rule=0
-  - id=firewall sn=C0EAE4599999 time="2019-02-15 09:45:17 UTC" fw=2.228.169.242 pri=5 c=512 m=1233 msg="Unhandled link-local or multicast IPv6 packet dropped" n=56642 srcV6=fe80::9851:b780:9d9d:a29e src=:49702:X0-V514 dstV6=ff02::1:3 dst=:5355 srcMac=90:e6:ba:32:5c:45 dstMac=33:33:00:01:00:03 proto=udp/5355
-  - id=NSA3500BR sn=0017C5DFCEEC time="2019-03-14 16:37:19 UTC" fw=172.29.169.2 pri=1 c=32 m=1388 msg="IPSec VPN Decryption Failed" n=1064050271 src=37.186.204.2 dst=172.29.168.2 note="Replay check failure."
-  - id=NSA3600  sn=C0EAE4599999 time="2019-02-27 12:55:40 UTC" fw=2.228.169.242 pri=5 c=0 m=1197 msg="NAT Mapping" n=4748427 src=10.12.14.9::X0-V500 dst=217.56.236.4::X3 proto=icmp note="Source: 2.228.169.242, 63130, Destination: 217.56.236.4, 8, Protocol: 1" rule="17 (LAN->WAN)"
-  - id=NSA2650GG sn=18B169D79980 time="2019-03-19 06:44:01 UTC" fw=83.211.91.146 pri=3 c=4 m=14 msg="Web site access denied" app=49177 appName="General HTTPS" n=856789 src=192.168.0.46:59668:X0:nb020.example.com dst=34.194.213.204:443:X1:example.com srcMac=a0:ce:c8:13:99:c5 dstMac=1a:b1:69:d7:99:80 proto=tcp/https dstname=example.com arg=/ code=49 Category="Freeware/Software Downloads"
-  - id=NSA2650GG sn=18B169D79980 time="2019-03-18 08:33:45 UTC" fw=83.211.91.146 pri=3 c=4 m=14 msg="Web site access denied" app=49177 appName="General HTTPS" n=838005 src=192.168.0.62:54993:X0:pc048.example.com dst=151.101.242.49:443:X1 srcMac=c8:9c:dc:fd:9d:02 dstMac=1a:b1:69:d7:99:80 proto=tcp/https dstname=example.com arg=/ code=49 Category="Freeware/Software Downloads"
+  SonicWall decoders:
+
+  Comments:
+    Will extract action, srcip, dstip, protocol, srcport and dstport
+
+    The field <plugin_decoder> is required for SonicWall: https://documentation.wazuh.com/current/user-manual/ruleset/ruleset-xml-syntax/decoders.html#plugin-decoder
+   
+  Examples logs:
+    Jan  3 13:45:36 192.168.5.1 id=firewall sn=000SERIAL time="2007-01-03 14:48:06" fw=1.1.1.1 pri=6 c=262144 m=98 msg="Connection Opened" n=23419 src=2.2.2.2:36701:WAN dst=1.1.1.1:50000:WAN proto=tcp/50000
+    Jan  3 13:45:36 192.168.5.1 id=firewall sn=000SERIAL time="2007-01-03 14:48:07" fw=1.1.1.1 pri=1 c=32 m=30 msg="Administrator login denied due to bad credentials" n=7 src=2.2.2.2:36701:WAN dst=1.1.1.1:50000:WAN
+    id=firewall sn=00301E0526B1 time="2004-04-01 10:39:35" fw=67.32.44.2 pri=5 c=64 m=36 msg="TCP connection dropped" n=2686 src=67.101.200.27:4507:WAN dst=67.32.44.2:445:LAN rule=0
+    id=firewall sn=C0EAE4599999 time="2019-02-15 09:45:17 UTC" fw=2.228.169.242 pri=5 c=512 m=1233 msg="Unhandled link-local or multicast IPv6 packet dropped" n=56642 srcV6=fe80::9851:b780:9d9d:a29e src=:49702:X0-V514 dstV6=ff02::1:3 dst=:5355 srcMac=90:e6:ba:32:5c:45 dstMac=33:33:00:01:00:03 proto=udp/5355
+    id=NSA3500BR sn=0017C5DFCEEC time="2019-03-14 16:37:19 UTC" fw=172.29.169.2 pri=1 c=32 m=1388 msg="IPSec VPN Decryption Failed" n=1064050271 src=37.186.204.2 dst=172.29.168.2 note="Replay check failure."
+    id=NSA3600  sn=C0EAE4599999 time="2019-02-27 12:55:40 UTC" fw=2.228.169.242 pri=5 c=0 m=1197 msg="NAT Mapping" n=4748427 src=10.12.14.9::X0-V500 dst=217.56.236.4::X3 proto=icmp note="Source: 2.228.169.242, 63130, Destination: 217.56.236.4, 8, Protocol: 1" rule="17 (LAN->WAN)"
+    id=NSA2650GG sn=18B169D79980 time="2019-03-19 06:44:01 UTC" fw=83.211.91.146 pri=3 c=4 m=14 msg="Web site access denied" app=49177 appName="General HTTPS" n=856789 src=192.168.0.46:59668:X0:nb020.example.com dst=34.194.213.204:443:X1:example.com srcMac=a0:ce:c8:13:99:c5 dstMac=1a:b1:69:d7:99:80 proto=tcp/https dstname=example.com arg=/ code=49 Category="Freeware/Software Downloads"
+    id=NSA2650GG sn=18B169D79980 time="2019-03-18 08:33:45 UTC" fw=83.211.91.146 pri=3 c=4 m=14 msg="Web site access denied" app=49177 appName="General HTTPS" n=838005 src=192.168.0.62:54993:X0:pc048.example.com dst=151.101.242.49:443:X1 srcMac=c8:9c:dc:fd:9d:02 dstMac=1a:b1:69:d7:99:80 proto=tcp/https dstname=example.com arg=/ code=49 Category="Freeware/Software Downloads"
   -->
 
 <decoder name="sonicwall">

--- a/ruleset/testing/tests/SonicWall.ini
+++ b/ruleset/testing/tests/SonicWall.ini
@@ -1,3 +1,11 @@
+;   Copyright (C) 2015-2021, Wazuh Inc.
+;
+;   Tests for products: 
+;     SonicWall
+;
+;   Sample logs source: 
+;     Software Name: SonicWall
+
 [SonicWall: acl ]
 log 1 pass = id=NSA3600  sn=C0EAE4599999 time="2019-02-27 12:55:40 UTC" fw=2.228.169.242 pri=5 c=0 m=1197 msg="NAT Mapping" n=4748427 src=10.12.14.9::X0-V500 dst=217.56.236.4::X3 proto=icmp note="Source: 2.228.169.242, 63130, Destination: 217.56.236.4, 8, Protocol: 1" rule="17 (LAN->WAN)"
 log 2 pass = id=firewall sn=C0EAE4599999 time="2019-02-15 09:45:17 UTC" fw=2.228.169.242 pri=5 c=512 m=1233 msg="Unhandled link-local or multicast IPv6 packet dropped" n=56642 srcV6=fe80::9851:b780:9d9d:a29e src=:49702:X0-V514 dstV6=ff02::1:3 dst=:5355 srcMac=90:e6:ba:32:5c:45 dstMac=33:33:00:01:00:03 proto=udp/5355

--- a/ruleset/testing/tests/SonicWall.ini
+++ b/ruleset/testing/tests/SonicWall.ini
@@ -2,6 +2,7 @@
 log 1 pass = id=NSA3600  sn=C0EAE4599999 time="2019-02-27 12:55:40 UTC" fw=2.228.169.242 pri=5 c=0 m=1197 msg="NAT Mapping" n=4748427 src=10.12.14.9::X0-V500 dst=217.56.236.4::X3 proto=icmp note="Source: 2.228.169.242, 63130, Destination: 217.56.236.4, 8, Protocol: 1" rule="17 (LAN->WAN)"
 log 2 pass = id=firewall sn=C0EAE4599999 time="2019-02-15 09:45:17 UTC" fw=2.228.169.242 pri=5 c=512 m=1233 msg="Unhandled link-local or multicast IPv6 packet dropped" n=56642 srcV6=fe80::9851:b780:9d9d:a29e src=:49702:X0-V514 dstV6=ff02::1:3 dst=:5355 srcMac=90:e6:ba:32:5c:45 dstMac=33:33:00:01:00:03 proto=udp/5355
 log 3 pass = id=firewall sn=00301E0526B1 time="2004-04-01 10:39:35" fw=67.32.44.2 pri=5 c=64 m=36 msg="TCP connection dropped" n=2686 src=67.101.200.27:4507:WAN dst=67.32.44.2:445:LAN rule=0
+log 4 pass = id=NSA3600  sn=C0EAE4599999 time="2019-02-27 12:55:40 UTC" fw=2.228.169.242 pri=5 c=0 m=1197 msg="NAT Mapping" n=4748427 src=10.12.14.100::X0-V500 dst=217.56.236.200::X3 proto=icmp note="Source: 2.228.169.242, 63130, Destination: 217.56.236.200, 8, Protocol: 1" rule="17 (LAN->WAN)"
 
 rule = 4805
 alert = 0
@@ -9,6 +10,7 @@ decoder = sonicwall
 
 [SonicWall : ac2 ]
 log 1 pass = Jan  3 13:45:36 192.168.5.1 id=firewall sn=000SERIAL time="2007-01-03 14:48:06" fw=1.1.1.1 pri=6 c=262144 m=98 msg="Connection Opened" n=23419 src=2.2.2.2:36701:WAN dst=1.1.1.1:50000:WAN proto=tcp/50000
+log 2 pass = Jan  3 13:45:36 192.168.5.1 id=firewall sn=000SERIAL time="2007-01-03 14:48:06" fw=1.1.1.1 pri=6 c=262144 m=98 msg="Connection Opened" n=23419 src=2.2.2.200:36701:WAN dst=1.1.1.100:50000:WAN proto=tcp/50000
 
 rule = 4806
 alert = 0
@@ -17,6 +19,7 @@ decoder = sonicwall
 [SonicWall : ac3 ]
 log 1 pass = id=NSA3500BR sn=0017C5DFCEEC time="2019-03-14 16:37:19 UTC" fw=172.29.169.2 pri=1 c=32 m=1388 msg="IPSec VPN Decryption Failed" n=1064050271 src=37.186.204.2 dst=172.29.168.2 note="Replay check failure."
 log 2 pass = Jan  3 13:45:36 192.168.5.1 id=firewall sn=000SERIAL time="2007-01-03 14:48:07" fw=1.1.1.1 pri=1 c=32 m=30 msg="Administrator login denied due to bad credentials" n=7 src=2.2.2.2:36701:WAN dst=1.1.1.1:50000:WAN
+log 3 pass = id=NSA3500BR sn=0017C5DFCEEC time="2019-03-14 16:37:19 UTC" fw=172.29.169.2 pri=1 c=32 m=1388 msg="IPSec VPN Decryption Failed" n=1064050271 src=37.186.204.200 dst=172.29.168.100 note="Replay check failure."
 
 rule = 4801
 alert = 8


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/11260|

## Description

This PR aims to resolve issues detected under #10025 and #10046 PRs. Closes #10970 
The issues resolved are:
- Missing copyright headers.
- Fixed indentation issues.
- Added testing.

## Checks and changes 

### Syntax

- [x] 1.a Rule tags order must be compliant.
- [x] 1.b Decoder tags order must be compliant.
- [x] 1.c XML blocks must as compact as possible.
- [X] 1.d Only one empty line between rule/decoder and the next rule/decoder.
- [X] 1.e Decoder extracted fields names must use '_' whether a space is needed.
- [X] 1.f Decoder name must use '-' whether a space is needed.
 
### Grammar

- [X] 2.a Grammar quality.
- [X] 2.b Similar phrases must keep tenses and expressions.
- [X] 2.c Grammar basic rules like capitalization, punctuation marks, sentence construction, and others.


### Semantic

- [x] 3.a New decoder, rule, or test are written in the correct file and grouped correctly inside the file.
- [x] 3.b Group similar rules under same ID's group.
- [x] 3.c: 
     - [x] 3.c1 Find and reuse group name before creating a new one.
     - [x] 3.c2 Include a new group definition in a PR comment.
     - [x] 3.c3 Any group name must use '_' whether it does need a space char.
     - [x] 3.c4 The groups inside a tag must be sorted in alphabetical order.
- [x] 3.d Rule level should be compliant with the [documentation](https://documentation.wazuh.com/current/user-manual/ruleset/rules-classification.html).

### Unit testing

- [X] 4.a A metadata block at the beginning of the .ini file describing software, version, and logs source.
- [X] 4.b Each new rule must have at least one test entry in the correct .ini file.
- [x] 4.c Runtest.py must pass and must include the results in raw format here.
Test of eset.ini

```
root@ubuntu-focal:/var/ossec/ruleset/feed/ruleset/testing# python3 runtests.py -t tests/eset.ini 
Restarting wazuh-manager...
- [ File = ./tests/eset.ini ] ---------
........

|Component |  Tested  |  Total   | Coverage |
| -------- | -------- | -------- | -------- |
|  Rules   |    8     |   4174   |  0.19%   |
| Decoders |    1     |   172    |  0.58%   |

|          File           |  Passed  |  Failed  |  Status  |
|        --------         | -------- | -------- | -------- |
|./tests/eset.ini         |    8     |    0     |    ✅     |
Restarting wazuh-manager...
```

<details><summary>All rules and decoders test.</summary>
<p>

```
root@ubuntu-focal:/var/ossec/ruleset/feed/ruleset/testing# python3 runtests.py
Restarting wazuh-manager...
- [ File = ./tests/samba.ini ] ---------
....

- [ File = ./tests/fortigate.ini ] ---------
........................................

- [ File = ./tests/apparmor.ini ] ---------
.....

- [ File = ./tests/pam.ini ] ---------
.....

- [ File = ./tests/audit_lateral.ini ] ---------
......

- [ File = ./tests/systemd.ini ] ---------
..

- [ File = ./tests/arbor.ini ] ---------
..

- [ File = ./tests/dovecot.ini ] ---------
...............

- [ File = ./tests/mailscanner.ini ] ---------
.

- [ File = ./tests/ossec.ini ] ---------
.....

- [ File = ./tests/vuln_detector.ini ] ---------
..

- [ File = ./tests/squid_rules.ini ] ---------
..

- [ File = ./tests/pix.ini ] ---------
......................

- [ File = ./tests/huawei_usg.ini ] ---------
...

- [ File = ./tests/checkpoint_smart1.ini ] ---------
..................

- [ File = ./tests/junos.ini ] ---------
...

- [ File = ./tests/web_appsec.ini ] ---------
...............................

- [ File = ./tests/cimserver.ini ] ---------
..

- [ File = ./tests/cisco_ftd.ini ] ---------
..........................................

- [ File = ./tests/firewalld.ini ] ---------
..

- [ File = ./tests/audit_recon.ini ] ---------
..

- [ File = ./tests/openldap.ini ] ---------
.........

- [ File = ./tests/sophos_fw.ini ] ---------
..........

- [ File = ./tests/owlh.ini ] ---------
....

- [ File = ./tests/freepbx.ini ] ---------
......

- [ File = ./tests/syslog.ini ] ---------
......

- [ File = ./tests/openvpn_ldap.ini ] ---------
..

- [ File = ./tests/sophos.ini ] ---------
........

- [ File = ./tests/unbound.ini ] ---------


- [ File = ./tests/github.ini ] ---------
....................................................................................................................................................................................................................................................................................................................................

- [ File = ./tests/cpanel.ini ] ---------
.......

- [ File = ./tests/fireeye.ini ] ---------
...

- [ File = ./tests/fortiauth.ini ] ---------
....

- [ File = ./tests/iptables.ini ] ---------
........

- [ File = ./tests/named.ini ] ---------
.....

- [ File = ./tests/sophos-utm-firewall.ini ] ---------
......

- [ File = ./tests/nginx.ini ] ---------
............

- [ File = ./tests/exim.ini ] ---------
.......

- [ File = ./tests/opensmtpd.ini ] ---------
.......

- [ File = ./tests/oscap.ini ] ---------
................................

- [ File = ./tests/gitlab.ini ] ---------
.........................

- [ File = ./tests/paloalto.ini ] ---------
................

- [ File = ./tests/api.ini ] ---------
............................

- [ File = ./tests/aws_s3_access.ini ] ---------
.......

- [ File = ./tests/exchange.ini ] ---------
..

- [ File = ./tests/f5_big_ip.ini ] ---------
...........................................

- [ File = ./tests/cisco_asa.ini ] ---------
........................................................................................

- [ File = ./tests/nextcloud.ini ] ---------
.......

- [ File = ./tests/trendmicro-cloud-one.ini ] ---------
.................

- [ File = ./tests/pfsense.ini ] ---------
..

- [ File = ./tests/vsftpd.ini ] ---------
....

- [ File = ./tests/web_rules.ini ] ---------
..........

- [ File = ./tests/apache.ini ] ---------
..................

- [ File = ./tests/eset.ini ] ---------
........

- [ File = ./tests/doas.ini ] ---------
....

- [ File = ./tests/sysmon.ini ] ---------
...

- [ File = ./tests/gcp.ini ] ---------
...........

- [ File = ./tests/icinga.ini ] ---------
....

- [ File = ./tests/postfix.ini ] ---------
..

- [ File = ./tests/audit_scp.ini ] ---------
.

- [ File = ./tests/dropbear.ini ] ---------
...

- [ File = ./tests/rsh.ini ] ---------
..

- [ File = ./tests/kernel_usb.ini ] ---------
......

- [ File = ./tests/mcafee_epo.ini ] ---------
.

- [ File = ./tests/netscreen.ini ] ---------
....

- [ File = ./tests/panda_paps.ini ] ---------
........

- [ File = ./tests/auditd.ini ] ---------
...

- [ File = ./tests/cylance.ini ] ---------
.......

- [ File = ./tests/modsecurity.ini ] ---------
......

- [ File = ./tests/cloudlfare-waf.ini ] ---------
.............

- [ File = ./tests/office365.ini ] ---------
................................................................................................................................

- [ File = ./tests/sshd.ini ] ---------
...........................................

- [ File = ./tests/cisco_ios.ini ] ---------
.................

- [ File = ./tests/glpi.ini ] ---------
...

- [ File = ./tests/sudo.ini ] ---------
........

- [ File = ./tests/su.ini ] ---------
.....

- [ File = ./tests/proftpd.ini ] ---------
.......

- [ File = ./tests/SonicWall.ini ] ---------
........

|Component |  Tested  |  Total   | Coverage |
| -------- | -------- | -------- | -------- |
|  Rules   |   982    |   4174   |  23.53%  |
| Decoders |    76    |   172    |  44.19%  |

|          File           |  Passed  |  Failed  |  Status  |
|        --------         | -------- | -------- | -------- |
|./tests/samba.ini        |    4     |    0     |    ✅     |
|./tests/fortigate.ini    |    40    |    0     |    ✅     |
|./tests/apparmor.ini     |    5     |    0     |    ✅     |
|./tests/pam.ini          |    5     |    0     |    ✅     |
|./tests/audit_lateral.ini|    6     |    0     |    ✅     |
|./tests/systemd.ini      |    2     |    0     |    ✅     |
|./tests/arbor.ini        |    2     |    0     |    ✅     |
|./tests/dovecot.ini      |    15    |    0     |    ✅     |
|./tests/mailscanner.ini  |    1     |    0     |    ✅     |
|./tests/ossec.ini        |    5     |    0     |    ✅     |
|./tests/vuln_detector.ini|    2     |    0     |    ✅     |
|./tests/squid_rules.ini  |    2     |    0     |    ✅     |
|./tests/pix.ini          |    22    |    0     |    ✅     |
|./tests/huawei_usg.ini   |    3     |    0     |    ✅     |
|./tests/checkpoint_smart1.ini|    18    |    0     |    ✅     |
|./tests/junos.ini        |    3     |    0     |    ✅     |
|./tests/web_appsec.ini   |    31    |    0     |    ✅     |
|./tests/cimserver.ini    |    2     |    0     |    ✅     |
|./tests/cisco_ftd.ini    |    42    |    0     |    ✅     |
|./tests/firewalld.ini    |    2     |    0     |    ✅     |
|./tests/audit_recon.ini  |    2     |    0     |    ✅     |
|./tests/openldap.ini     |    9     |    0     |    ✅     |
|./tests/sophos_fw.ini    |    10    |    0     |    ✅     |
|./tests/owlh.ini         |    4     |    0     |    ✅     |
|./tests/freepbx.ini      |    6     |    0     |    ✅     |
|./tests/syslog.ini       |    6     |    0     |    ✅     |
|./tests/openvpn_ldap.ini |    2     |    0     |    ✅     |
|./tests/sophos.ini       |    8     |    0     |    ✅     |
|./tests/unbound.ini      |    0     |    0     |    ✅     |
|./tests/github.ini       |   324    |    0     |    ✅     |
|./tests/cpanel.ini       |    7     |    0     |    ✅     |
|./tests/fireeye.ini      |    3     |    0     |    ✅     |
|./tests/fortiauth.ini    |    4     |    0     |    ✅     |
|./tests/iptables.ini     |    8     |    0     |    ✅     |
|./tests/named.ini        |    5     |    0     |    ✅     |
|./tests/sophos-utm-firewall.ini|    6     |    0     |    ✅     |
|./tests/nginx.ini        |    12    |    0     |    ✅     |
|./tests/exim.ini         |    7     |    0     |    ✅     |
|./tests/opensmtpd.ini    |    7     |    0     |    ✅     |
|./tests/oscap.ini        |    32    |    0     |    ✅     |
|./tests/gitlab.ini       |    25    |    0     |    ✅     |
|./tests/paloalto.ini     |    16    |    0     |    ✅     |
|./tests/api.ini          |    28    |    0     |    ✅     |
|./tests/aws_s3_access.ini|    7     |    0     |    ✅     |
|./tests/exchange.ini     |    2     |    0     |    ✅     |
|./tests/f5_big_ip.ini    |    43    |    0     |    ✅     |
|./tests/cisco_asa.ini    |    88    |    0     |    ✅     |
|./tests/nextcloud.ini    |    7     |    0     |    ✅     |
|./tests/trendmicro-cloud-one.ini|    17    |    0     |    ✅     |
|./tests/pfsense.ini      |    2     |    0     |    ✅     |
|./tests/vsftpd.ini       |    4     |    0     |    ✅     |
|./tests/web_rules.ini    |    10    |    0     |    ✅     |
|./tests/apache.ini       |    18    |    0     |    ✅     |
|./tests/eset.ini         |    8     |    0     |    ✅     |
|./tests/doas.ini         |    4     |    0     |    ✅     |
|./tests/sysmon.ini       |    3     |    0     |    ✅     |
|./tests/gcp.ini          |    11    |    0     |    ✅     |
|./tests/icinga.ini       |    4     |    0     |    ✅     |
|./tests/postfix.ini      |    2     |    0     |    ✅     |
|./tests/audit_scp.ini    |    1     |    0     |    ✅     |
|./tests/dropbear.ini     |    3     |    0     |    ✅     |
|./tests/rsh.ini          |    2     |    0     |    ✅     |
|./tests/kernel_usb.ini   |    6     |    0     |    ✅     |
|./tests/mcafee_epo.ini   |    1     |    0     |    ✅     |
|./tests/netscreen.ini    |    4     |    0     |    ✅     |
|./tests/panda_paps.ini   |    8     |    0     |    ✅     |
|./tests/auditd.ini       |    3     |    0     |    ✅     |
|./tests/cylance.ini      |    7     |    0     |    ✅     |
|./tests/modsecurity.ini  |    6     |    0     |    ✅     |
|./tests/cloudlfare-waf.ini|    13    |    0     |    ✅     |
|./tests/office365.ini    |   128    |    0     |    ✅     |
|./tests/sshd.ini         |    43    |    0     |    ✅     |
|./tests/cisco_ios.ini    |    17    |    0     |    ✅     |
|./tests/glpi.ini         |    3     |    0     |    ✅     |
|./tests/sudo.ini         |    8     |    0     |    ✅     |
|./tests/su.ini           |    5     |    0     |    ✅     |
|./tests/proftpd.ini      |    7     |    0     |    ✅     |
|./tests/SonicWall.ini    |    8     |    0     |    ✅     |
Restarting wazuh-manager...
```
</p>
</details>

- [X] 4.d New CDB lists must include the proper test entry in the correct .ini file.

### E2E testing

- [x]5.a Logs for new or modified decoder/rules sent to a manager running with this PR ruleset appear in Kibana.
![image](https://user-images.githubusercontent.com/25141115/144195513-755c558f-dc93-4a36-b6b4-2189b04eac03.png)

- [x]5.b There are not affected or broken visualizations on Kibana.
![image](https://user-images.githubusercontent.com/25141115/144195601-46ebcb7f-c283-4f98-92b3-9b51f370266c.png)
![image](https://user-images.githubusercontent.com/25141115/144195817-3b52fd16-9900-4b9c-b51d-25841c894996.png)

- [x]5.c New or modified items can be seen correctly using APP ruleset navigation.
![image](https://user-images.githubusercontent.com/25141115/144196051-21b93a9b-2a3f-4a84-a9da-8c07464f3cd2.png)


### Elasticsearch Template

- [X] 6.a Known fields with output format managed and usually used for searching are included in template array index.query.default_field. 
- [X] 6.b The new field with the correct date format is stored as a "date" type field in the template.
- [X] 6.c The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 
- [X] 6.d Known fields with output format managed and usually used for searching are included in the template.

### Stoppers

- [x] 7.a No previous rule ID changes without triple check.
- [x] 7.b No previous decoder name changes without triple check.
- [x] 7.c No previous file name changes without triple check.
- [x] 7.d No previous test changes its 'rule' field value without triple check.

### Others

- [x] 8.a Each file has the correct copyright block.
- [x] 8.b The copyright block doesn't have "Author" only "Created by Wazuh". To include an "Author" request triple check.
- [x] 8.c The copyright block doesn't use "-". 
- [x] 8.d The rule files don't have any sample log.
- [x] 8.e The decoder file has sample logs next to the decoder that matches that log.
- [x] 8.f The decoder and rule files have information about software, version, and any helpful information.
- [x] 8.g The PR has a single commit with CHANGELOG changes in the correct format.
- [x] 8.h The new rule ID is not in use.
- [x] 8.i The new rule ID must be in the defined IDs range. 
- [x] 8.j New rules ID range must be verified with a triple check and noted in the rules ID document.
- [x] 8.k The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 