### PR TITLE
Rework of #8623 - Detect 5.A - Ingress and Lateral Tool Transfer

### DIFF
--- a/ruleset/rules/0850-audit_rules.xml
+++ b/ruleset/rules/0850-audit_rules.xml
@@ -11,60 +11,60 @@
   <rule id="92100" level="0">
     <if_group>audit</if_group>
     <field name="audit.exe" type="pcre2">python</field>
+    <description>Executed python script.</description>
     <mitre>
       <id>T1059.006</id>
     </mitre>
-    <description>Executed python script.</description>
   </rule>
 
   <rule id="92101" level="6">
     <if_sid>92100</if_sid>
     <match type="pcre2">a\d="\w+\.py".+cwd="/tmp"|a\d="/tmp/.+\.py</match>
+    <description>Executed python script from /tmp/ folder.</description>
     <mitre>
       <id>T1059.006</id>
     </mitre>
-    <description>Executed python script from /tmp/ folder.</description>
   </rule>
 
   <rule id="92102" level="12">
     <if_sid>92100, 92101</if_sid>
     <match type="pcre2">psexec.py|smbexec.py</match>
     <match type="pcre2">a\d="-hashes".+a\d=".+:.+</match>
+    <description>Suspicious python script matches Impacket signature, possible use of stolen credentials or pass the hash attack.</description>
     <mitre>
       <id>T1059.006</id>
       <id>T1550.002</id>
     </mitre>
-    <description>Suspicious python script matches Impacket signature, possible use of stolen credentials or pass the hash attack.</description>
   </rule>
 
   <rule id="92106" level="6">
     <if_group>audit</if_group>
     <field name="audit.command" type="pcre2">scp</field>
     <field name="audit.file.name" type="pcre2">.+</field>
+    <description>A file was copied to this system over SSH using SCP.</description>
     <mitre>
       <id>T1021.004</id>
     </mitre>
-    <description>A file was copied to this system over SSH using SCP.</description>
   </rule>
 
   <rule id="92162" level="6">
     <if_group>audit</if_group>
     <field name="audit.execve.a0" type="pcre2">ps</field>
     <field name="audit.execve.a1" type="pcre2">^(?=.*a)(?=.*x)</field>
+    <description>Processes running for all users were queried with ps command.</description>
     <mitre>
       <id>T1057</id>
     </mitre>
-    <description>Processes running for all users were queried with ps command.</description>
   </rule>
 
   <rule id="92163" level="6">
     <if_group>audit</if_group>
     <field name="audit.execve.a0" type="pcre2">ls</field>
     <field name="audit.execve.a2" type="pcre2">^(?=.*a)(?=.*R)</field>
+    <description>Executed recursive query of all files using ls command.</description>
     <mitre>
       <id>T1083</id>
     </mitre>
-    <description>Executed recursive query of all files using ls command.</description>
   </rule>
 
 </group>

--- a/ruleset/rules/0850-audit_rules.xml
+++ b/ruleset/rules/0850-audit_rules.xml
@@ -1,83 +1,70 @@
 <!--
-  -  General Linux Audit module channel detection rules
-  -  Created by Wazuh, Inc.
-  -  Copyright (C) 2015-2021, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  Copyright (C) 2015-2021, Wazuh Inc.
+-->
+
+<!-- 
+  General Linux Audit module channel detection rules:           92100 - 92200
 -->
 
 <group name="audit_detections,">
 
-    <!-- Sample: type=SYSCALL msg=audit(1624476656.044:9687): arch=c000003e syscall=59 success=yes exit=0 a0=c4f630 a1=b370a0 a2=b3df40 a3=7ffe0c9f12e0 items=2 ppid=3177 pid=4646 auid=1198400500 uid=1198400500 gid=1198400513 euid=1198400500 suid=1198400500 fsuid=1198400500 egid=1198400513 sgid=1198400513 fsgid=1198400513 tty=pts0 ses=4 comm="ps" exe="/usr/bin/ps" subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key="recon"\u001DARCH=x86_64 SYSCALL=execve AUID="administrator@ExchangeTest.com" UID="administrator@ExchangeTest.com" GID=646F6D61696E2075736572734045786368616E6765546573742E636F6D EUID="administrator@ExchangeTest.com" SUID="administrator@ExchangeTest.com" FSUID="administrator@ExchangeTest.com" EGID=646F6D61696E2075736572734045786368616E6765546573742E636F6D SGID=646F6D61696E2075736572734045786368616E6765546573742E636F6D FSGID=646F6D61696E2075736572734045786368616E6765546573742E636F6D type=EXECVE msg=audit(1624476656.044:9687): argc=2 a0="ps" a1="ax" type=CWD msg=audit(1624476656.044:9687):  cwd="/home/administrator@ExchangeTest.com" type=PATH msg=audit(1624476656.044:9687): item=0 name="/usr/bin/ps" inode=574271 dev=fd:00 mode=0100755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:bin_t:s0 objtype=NORMAL cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0\u001DOUID="root" OGID="root" type=PATH msg=audit(1624476656.044:9687): item=1 name="/lib64/ld-linux-x86-64.so.2" inode=4636927 dev=fd:00 mode=0100755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:ld_so_t:s0 objtype=NORMAL cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0\u001DOUID="root" OGID="root" type=PROCTITLE msg=audit(1624476656.044:9687): proctitle=7073006178 -->
-    <!-- This rule requires endpoint side tracking ps execution from audit with this rule: -a always,exit -F arch=b64 -S execve -F exe=/usr/bin/ps -F key=recon -->
-    <rule id="92162" level="6">
-        <if_group>audit</if_group>
-        <field name="audit.execve.a0" type="pcre2">ps</field>
-        <field name="audit.execve.a1" type="pcre2">^(?=.*a)(?=.*x)</field>
-        <description>Processes running for all users were queried with ps command</description>
-        <mitre>
-            <id>T1057</id>
-        </mitre>
-    </rule>
+  <rule id="92100" level="0">
+    <if_group>audit</if_group>
+    <field name="audit.exe" type="pcre2">python</field>
+    <mitre>
+      <id>T1059.006</id>
+    </mitre>
+    <description>Executed python script.</description>
+  </rule>
 
-    <!-- Sample: type=SYSCALL msg=audit(1624476775.094:9702): arch=c000003e syscall=59 success=yes exit=0 a0=c4f630 a1=b3a580 a2=b3df40 a3=7ffe0c9f12e0 items=2 ppid=3177 pid=4697 auid=1198400500 uid=1198400500 gid=1198400513 euid=1198400500 suid=1198400500 fsuid=1198400500 egid=1198400513 sgid=1198400513 fsgid=1198400513 tty=pts0 ses=4 comm="ls" exe="/usr/bin/ls" subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key="recon"\u001DARCH=x86_64 SYSCALL=execve AUID="administrator@ExchangeTest.com" UID="administrator@ExchangeTest.com" GID=646F6D61696E2075736572734045786368616E6765546573742E636F6D EUID="administrator@ExchangeTest.com" SUID="administrator@ExchangeTest.com" FSUID="administrator@ExchangeTest.com" EGID=646F6D61696E2075736572734045786368616E6765546573742E636F6D SGID=646F6D61696E2075736572734045786368616E6765546573742E636F6D FSGID=646F6D61696E2075736572734045786368616E6765546573742E636F6D type=EXECVE msg=audit(1624476775.094:9702): argc=4 a0="ls" a1="--color=auto" a2="-lsahR" a3="/var/" type=CWD msg=audit(1624476775.094:9702):  cwd="/home/administrator@ExchangeTest.com" type=PATH msg=audit(1624476775.094:9702): item=0 name="/usr/bin/ls" inode=416001 dev=fd:00 mode=0100755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:bin_t:s0 objtype=NORMAL cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0\u001DOUID="root" OGID="root" type=PATH msg=audit(1624476775.094:9702): item=1 name="/lib64/ld-linux-x86-64.so.2" inode=4636927 dev=fd:00 mode=0100755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:ld_so_t:s0 objtype=NORMAL cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0\u001DOUID="root" OGID="root" type=PROCTITLE msg=audit(1624476775.094:9702): proctitle=6C73002D2D636F6C6F723D6175746F002D6C73616852002F7661722F -->
-    <!-- This rule requires endpoint side of tracking ls execution from audit with this rule: -a always,exit -F arch=b64 -S execve -F exe=/usr/bin/ls -F key=recon -->
-    <rule id="92163" level="6">
+  <rule id="92101" level="6">
+    <if_sid>92100</if_sid>
+    <match type="pcre2">a\d="\w+\.py".+cwd="/tmp"|a\d="/tmp/.+\.py</match>
+    <mitre>
+      <id>T1059.006</id>
+    </mitre>
+    <description>Executed python script from /tmp/ folder.</description>
+  </rule>
+
+  <rule id="92102" level="12">
+    <if_sid>92100, 92101</if_sid>
+    <match type="pcre2">psexec.py|smbexec.py</match>
+    <match type="pcre2">a\d="-hashes".+a\d=".+:.+</match>
+    <mitre>
+      <id>T1059.006</id>
+      <id>T1550.002</id>
+    </mitre>
+    <description>Suspicious python script matches Impacket signature, possible use of stolen credentials or pass the hash attack.</description>
+  </rule>
+
+  <rule id="92106" level="6">
+    <if_group>audit</if_group>
+    <field name="audit.command" type="pcre2">scp</field>
+    <field name="audit.file.name" type="pcre2">.+</field>
+    <mitre>
+      <id>T1021.004</id>
+    </mitre>
+    <description>A file was copied to this system over SSH using SCP.</description>
+  </rule>
+
+  <rule id="92162" level="6">
+    <if_group>audit</if_group>
+    <field name="audit.execve.a0" type="pcre2">ps</field>
+    <field name="audit.execve.a1" type="pcre2">^(?=.*a)(?=.*x)</field>
+    <mitre>
+      <id>T1057</id>
+    </mitre>
+    <description>Processes running for all users were queried with ps command.</description>
+  </rule>
+
+  <rule id="92163" level="6">
     <if_group>audit</if_group>
     <field name="audit.execve.a0" type="pcre2">ls</field>
     <field name="audit.execve.a2" type="pcre2">^(?=.*a)(?=.*R)</field>
-    <description>Executed recursive query of all files using ls command</description>
     <mitre>
-        <id>T1083</id>
+      <id>T1083</id>
     </mitre>
-    </rule>
-
-
-    <!-- Sample: type=SYSCALL msg=audit(1624643172.076:11843): arch=c000003e syscall=59 success=yes exit=0 a0=25c81f0 a1=255f000 a2=255df40 a3=7ffc66d5c8e0 items=3 ppid=4353 pid=13331 auid=1198400500 uid=1198400500 gid=1198400513 euid=1198400500 suid=1198400500 fsuid=1198400500 egid=1198400513 sgid=1198400513 fsgid=1198400513 tty=pts0 ses=48 comm="runtime" exe="/usr/bin/python3.6" subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key="wazuh_execution"\u001DARCH=x86_64 SYSCALL=execve AUID="administrator@ExchangeTest.com" UID="administrator@ExchangeTest.com" GID=646F6D61696E2075736572734045786368616E6765546573742E636F6D EUID="administrator@ExchangeTest.com" SUID="administrator@ExchangeTest.com" FSUID="administrator@ExchangeTest.com" EGID=646F6D61696E2075736572734045786368616E6765546573742E636F6D SGID=646F6D61696E2075736572734045786368616E6765546573742E636F6D FSGID=646F6D61696E2075736572734045786368616E6765546573742E636F6D type=EXECVE msg=audit(1624643172.076:11843): argc=6 a0="/usr/bin/python3" a1="./runtime" a2="calc.py" a3="exchangetest.com/administrator@192.168.0.57" a4="-hashes" a5="c615d74f277acb732af4e8680330fcf1:c615d74f277acb732af4e8680330fcf1" type=CWD msg=audit(1624643172.076:11843):  cwd="/var" type=PATH msg=audit(1624643172.076:11843): item=0 name="./runtime" inode=8409155 dev=fd:00 mode=0100755 ouid=1198400500 ogid=1198400513 rdev=00:00 obj=unconfined_u:object_r:user_tmp_t:s0 objtype=NORMAL cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0\u001DOUID="administrator@ExchangeTest.com" OGID=646F6D61696E2075736572734045786368616E6765546573742E636F6D type=PATH msg=audit(1624643172.076:11843): item=1 name="/usr/bin/python3" inode=1691048 dev=fd:00 mode=0100755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:bin_t:s0 objtype=NORMAL cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0\u001DOUID="root" OGID="root" type=PATH msg=audit(1624643172.076:11843): item=2 name="/lib64/ld-linux-x86-64.so.2" inode=4636927 dev=fd:00 mode=0100755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:ld_so_t:s0 objtype=NORMAL cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0\u001DOUID="root" OGID="root" type=PROCTITLE msg=audit(1624643172.076:11843): proctitle=2F7573722F62696E2F707974686F6E33002E2F72756E74696D65007073657865632E70790065786368616E6765746573742E636F6D2F61646D696E6973747261746F72403139322E3136382E302E3537002D6861736865730063363135643734663237376163623733326166346538363830333330666366313A633631356437 -->
-    <!-- Sample 2: type=SYSCALL msg=audit(1624643172.076:11843): arch=c000003e syscall=59 success=yes exit=0 a0=25c81f0 a1=255f000 a2=255df40 a3=7ffc66d5c8e0 items=3 ppid=4353 pid=13331 auid=1198400500 uid=1198400500 gid=1198400513 euid=1198400500 suid=1198400500 fsuid=1198400500 egid=1198400513 sgid=1198400513 fsgid=1198400513 tty=pts0 ses=48 comm="runtime" exe="/usr/bin/python2.7" subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key="wazuh_execution"\u001DARCH=x86_64 SYSCALL=execve AUID="administrator@ExchangeTest.com" UID="administrator@ExchangeTest.com" GID=646F6D61696E2075736572734045786368616E6765546573742E636F6D EUID="administrator@ExchangeTest.com" SUID="administrator@ExchangeTest.com" FSUID="administrator@ExchangeTest.com" EGID=646F6D61696E2075736572734045786368616E6765546573742E636F6D SGID=646F6D61696E2075736572734045786368616E6765546573742E636F6D FSGID=646F6D61696E2075736572734045786368616E6765546573742E636F6D type=EXECVE msg=audit(1624643172.076:11843): argc=6 a0="/usr/bin/python3" a1="./runtime" a2="calc.py" a3="exchangetest.com/administrator@192.168.0.57" a4="-hashes" a5="c615d74f277acb732af4e8680330fcf1:c615d74f277acb732af4e8680330fcf1" type=CWD msg=audit(1624643172.076:11843):  cwd="/var" type=PATH msg=audit(1624643172.076:11843): item=0 name="./runtime" inode=8409155 dev=fd:00 mode=0100755 ouid=1198400500 ogid=1198400513 rdev=00:00 obj=unconfined_u:object_r:user_tmp_t:s0 objtype=NORMAL cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0\u001DOUID="administrator@ExchangeTest.com" OGID=646F6D61696E2075736572734045786368616E6765546573742E636F6D type=PATH msg=audit(1624643172.076:11843): item=1 name="/usr/bin/python3" inode=1691048 dev=fd:00 mode=0100755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:bin_t:s0 objtype=NORMAL cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0\u001DOUID="root" OGID="root" type=PATH msg=audit(1624643172.076:11843): item=2 name="/lib64/ld-linux-x86-64.so.2" inode=4636927 dev=fd:00 mode=0100755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:ld_so_t:s0 objtype=NORMAL cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0\u001DOUID="root" OGID="root" type=PROCTITLE msg=audit(1624643172.076:11843): proctitle=2F7573722F62696E2F707974686F6E33002E2F72756E74696D65007073657865632E70790065786368616E6765746573742E636F6D2F61646D696E6973747261746F72403139322E3136382E302E3537002D6861736865730063363135643734663237376163623733326166346538363830333330666366313A633631356437 -->
-    <!-- This rule requires endpoint detection of commands executed from /tmp/ folder with this audit rule: -w /tmp -p x -k wazuh_execution -->
-    <rule id="92100" level="0">
-        <if_group>audit</if_group>
-        <field name="audit.exe" type="pcre2">python</field>
-        <description>Executed python script</description>
-        <mitre>
-            <id>T1059.006</id>
-        </mitre>
-    </rule>
-
-
-    <!-- Sample: type=SYSCALL msg=audit(1624643172.076:11843): arch=c000003e syscall=59 success=yes exit=0 a0=25c81f0 a1=255f000 a2=255df40 a3=7ffc66d5c8e0 items=3 ppid=4353 pid=13331 auid=1198400500 uid=1198400500 gid=1198400513 euid=1198400500 suid=1198400500 fsuid=1198400500 egid=1198400513 sgid=1198400513 fsgid=1198400513 tty=pts0 ses=48 comm="runtime" exe="/usr/bin/python3.6" subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key="wazuh_execution"\u001DARCH=x86_64 SYSCALL=execve AUID="administrator@ExchangeTest.com" UID="administrator@ExchangeTest.com" GID=646F6D61696E2075736572734045786368616E6765546573742E636F6D EUID="administrator@ExchangeTest.com" SUID="administrator@ExchangeTest.com" FSUID="administrator@ExchangeTest.com" EGID=646F6D61696E2075736572734045786368616E6765546573742E636F6D SGID=646F6D61696E2075736572734045786368616E6765546573742E636F6D FSGID=646F6D61696E2075736572734045786368616E6765546573742E636F6D type=EXECVE msg=audit(1624643172.076:11843): argc=6 a0="/usr/bin/python3" a1="./runtime" a2="calc.py" a3="exchangetest.com/administrator@192.168.0.57" a4="-hashes" a5="c615d74f277acb732af4e8680330fcf1:c615d74f277acb732af4e8680330fcf1" type=CWD msg=audit(1624643172.076:11843):  cwd="/tmp" type=PATH msg=audit(1624643172.076:11843): item=0 name="./runtime" inode=8409155 dev=fd:00 mode=0100755 ouid=1198400500 ogid=1198400513 rdev=00:00 obj=unconfined_u:object_r:user_tmp_t:s0 objtype=NORMAL cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0\u001DOUID="administrator@ExchangeTest.com" OGID=646F6D61696E2075736572734045786368616E6765546573742E636F6D type=PATH msg=audit(1624643172.076:11843): item=1 name="/usr/bin/python3" inode=1691048 dev=fd:00 mode=0100755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:bin_t:s0 objtype=NORMAL cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0\u001DOUID="root" OGID="root" type=PATH msg=audit(1624643172.076:11843): item=2 name="/lib64/ld-linux-x86-64.so.2" inode=4636927 dev=fd:00 mode=0100755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:ld_so_t:s0 objtype=NORMAL cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0\u001DOUID="root" OGID="root" type=PROCTITLE msg=audit(1624643172.076:11843): proctitle=2F7573722F62696E2F707974686F6E33002E2F72756E74696D65007073657865632E70790065786368616E6765746573742E636F6D2F61646D696E6973747261746F72403139322E3136382E302E3537002D6861736865730063363135643734663237376163623733326166346538363830333330666366313A633631356437 -->
-    <!-- Sample 2: type=SYSCALL msg=audit(1624643172.076:11843): arch=c000003e syscall=59 success=yes exit=0 a0=25c81f0 a1=255f000 a2=255df40 a3=7ffc66d5c8e0 items=3 ppid=4353 pid=13331 auid=1198400500 uid=1198400500 gid=1198400513 euid=1198400500 suid=1198400500 fsuid=1198400500 egid=1198400513 sgid=1198400513 fsgid=1198400513 tty=pts0 ses=48 comm="runtime" exe="/usr/bin/python2.7" subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key="wazuh_execution"\u001DARCH=x86_64 SYSCALL=execve AUID="administrator@ExchangeTest.com" UID="administrator@ExchangeTest.com" GID=646F6D61696E2075736572734045786368616E6765546573742E636F6D EUID="administrator@ExchangeTest.com" SUID="administrator@ExchangeTest.com" FSUID="administrator@ExchangeTest.com" EGID=646F6D61696E2075736572734045786368616E6765546573742E636F6D SGID=646F6D61696E2075736572734045786368616E6765546573742E636F6D FSGID=646F6D61696E2075736572734045786368616E6765546573742E636F6D type=EXECVE msg=audit(1624643172.076:11843): argc=6 a0="/usr/bin/python3" a1="./runtime" a2="/tmp/calc.py" a3="exchangetest.com/administrator@192.168.0.57" a4="-hashes" a5="c615d74f277acb732af4e8680330fcf1:c615d74f277acb732af4e8680330fcf1" type=CWD msg=audit(1624643172.076:11843):  cwd="/tmp" type=PATH msg=audit(1624643172.076:11843): item=0 name="./runtime" inode=8409155 dev=fd:00 mode=0100755 ouid=1198400500 ogid=1198400513 rdev=00:00 obj=unconfined_u:object_r:user_tmp_t:s0 objtype=NORMAL cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0\u001DOUID="administrator@ExchangeTest.com" OGID=646F6D61696E2075736572734045786368616E6765546573742E636F6D type=PATH msg=audit(1624643172.076:11843): item=1 name="/usr/bin/python3" inode=1691048 dev=fd:00 mode=0100755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:bin_t:s0 objtype=NORMAL cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0\u001DOUID="root" OGID="root" type=PATH msg=audit(1624643172.076:11843): item=2 name="/lib64/ld-linux-x86-64.so.2" inode=4636927 dev=fd:00 mode=0100755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:ld_so_t:s0 objtype=NORMAL cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0\u001DOUID="root" OGID="root" type=PROCTITLE msg=audit(1624643172.076:11843): proctitle=2F7573722F62696E2F707974686F6E33002E2F72756E74696D65007073657865632E70790065786368616E6765746573742E636F6D2F61646D696E6973747261746F72403139322E3136382E302E3537002D6861736865730063363135643734663237376163623733326166346538363830333330666366313A633631356437 -->
-    <rule id="92101" level="6">
-        <if_sid>92100</if_sid>
-        <match type="pcre2">a\d="\w+\.py".+cwd="/tmp"|a\d="/tmp/.+\.py</match>
-        <description>Executed python script from /tmp/ folder</description>
-        <mitre>
-            <id>T1059.006</id>
-        </mitre>
-    </rule>
-
-    <!-- Sample: type=SYSCALL msg=audit(1624643172.076:11843): arch=c000003e syscall=59 success=yes exit=0 a0=25c81f0 a1=255f000 a2=255df40 a3=7ffc66d5c8e0 items=3 ppid=4353 pid=13331 auid=1198400500 uid=1198400500 gid=1198400513 euid=1198400500 suid=1198400500 fsuid=1198400500 egid=1198400513 sgid=1198400513 fsgid=1198400513 tty=pts0 ses=48 comm="runtime" exe="/usr/bin/python3.6" subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key="wazuh_execution"\u001DARCH=x86_64 SYSCALL=execve AUID="administrator@ExchangeTest.com" UID="administrator@ExchangeTest.com" GID=646F6D61696E2075736572734045786368616E6765546573742E636F6D EUID="administrator@ExchangeTest.com" SUID="administrator@ExchangeTest.com" FSUID="administrator@ExchangeTest.com" EGID=646F6D61696E2075736572734045786368616E6765546573742E636F6D SGID=646F6D61696E2075736572734045786368616E6765546573742E636F6D FSGID=646F6D61696E2075736572734045786368616E6765546573742E636F6D type=EXECVE msg=audit(1624643172.076:11843): argc=6 a0="/usr/bin/python3" a1="./runtime" a2="psexec.py" a3="exchangetest.com/administrator@192.168.0.57" a4="-hashes" a5="c615d74f277acb732af4e8680330fcf1:c615d74f277acb732af4e8680330fcf1" type=CWD msg=audit(1624643172.076:11843):  cwd="/tmp" type=PATH msg=audit(1624643172.076:11843): item=0 name="./runtime" inode=8409155 dev=fd:00 mode=0100755 ouid=1198400500 ogid=1198400513 rdev=00:00 obj=unconfined_u:object_r:user_tmp_t:s0 objtype=NORMAL cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0\u001DOUID="administrator@ExchangeTest.com" OGID=646F6D61696E2075736572734045786368616E6765546573742E636F6D type=PATH msg=audit(1624643172.076:11843): item=1 name="/usr/bin/python3" inode=1691048 dev=fd:00 mode=0100755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:bin_t:s0 objtype=NORMAL cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0\u001DOUID="root" OGID="root" type=PATH msg=audit(1624643172.076:11843): item=2 name="/lib64/ld-linux-x86-64.so.2" inode=4636927 dev=fd:00 mode=0100755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:ld_so_t:s0 objtype=NORMAL cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0\u001DOUID="root" OGID="root" type=PROCTITLE msg=audit(1624643172.076:11843): proctitle=2F7573722F62696E2F707974686F6E33002E2F72756E74696D65007073657865632E70790065786368616E6765746573742E636F6D2F61646D696E6973747261746F72403139322E3136382E302E3537002D6861736865730063363135643734663237376163623733326166346538363830333330666366313A633631356437 -->
-    <rule id="92102" level="12">
-        <if_sid>92100, 92101</if_sid>
-        <match type="pcre2">psexec.py|smbexec.py</match>
-        <match type="pcre2">a\d="-hashes".+a\d=".+:.+</match>
-        <description>Suspicious python script matches Impacket signature, possible use of stolen credentials or pass the hash attack</description>
-        <mitre>
-            <id>T1059.006</id>
-            <id>T1550.002</id>
-        </mitre>
-    </rule>
-
-    <!-- Sample: type=SYSCALL msg=audit(1620937405.872:764): arch=c000003e syscall=2 success=yes exit=4 a0=555c2e4a6fb0 a1=41 a2=1a4 a3=7fcfaf0607b8 items=2 ppid=7903 pid=7909 auid=1198400500 uid=1198400500 gid=1198400513 euid=1198400500 suid=1198400500 fsuid=1198400500 egid=1198400513 sgid=1198400513 fsgid=1198400513 tty=(none) ses=21 comm="scp" exe="/usr/bin/scp" subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key="wazuh_fim" type=CWD msg=audit(1620937405.872:764):  cwd="/home/administrator@ExchangeTest.com" type=PATH msg=audit(1620937405.872:764): item=0 name="/tmp/" inode=8409157 dev=fd:00 mode=041777 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:tmp_t:s0 objtype=PARENT cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0 type=PATH msg=audit(1620937405.872:764): item=1 name="/tmp/ps2.py" inode=9595745 dev=fd:00 mode=0100644 ouid=1198400500 ogid=1198400513 rdev=00:00 obj=unconfined_u:object_r:user_tmp_t:s0 objtype=CREATE cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0 type=PROCTITLE msg=audit(1620937405.872:764): proctitle=736370002D74002F746D702F7073322E7079 -->
-    <rule id="92106" level="6">
-        <if_group>audit</if_group>
-        <field name="audit.command" type="pcre2">scp</field>
-        <field name="audit.file.name" type="pcre2">.+</field>
-        <description>A file was copied to this system over SSH using SCP</description>
-        <mitre>
-            <id>T1021.004</id>
-        </mitre>
-    </rule>
-
+    <description>Executed recursive query of all files using ls command.</description>
+  </rule>
 
 </group>

--- a/ruleset/testing/tests/audit_scp.ini
+++ b/ruleset/testing/tests/audit_scp.ini
@@ -1,3 +1,11 @@
+;  Copyright (C) 2015-2021, Wazuh Inc.
+;
+;  Tests for products: 
+;    Audit_scp.
+;
+;  Sample logs source: 
+;    Audit_scp: member https://github.com/wazuh/wazuh/issues/8623#issuecomment-844449152
+
 [SCP used to copy a file over SSH]
 log 1 pass = type=SYSCALL msg=audit(1620937405.872:764): arch=c000003e syscall=2 success=yes exit=4 a0=555c2e4a6fb0 a1=41 a2=1a4 a3=7fcfaf0607b8 items=2 ppid=7903 pid=7909 auid=1198400500 uid=1198400500 gid=1198400513 euid=1198400500 suid=1198400500 fsuid=1198400500 egid=1198400513 sgid=1198400513 fsgid=1198400513 tty=(none) ses=21 comm="scp" exe="/usr/bin/scp" subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key="wazuh_fim" type=CWD msg=audit(1620937405.872:764):  cwd="/home/administrator@ExchangeTest.com" type=PATH msg=audit(1620937405.872:764): item=0 name="/tmp/" inode=8409157 dev=fd:00 mode=041777 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:tmp_t:s0 objtype=PARENT cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0 type=PATH msg=audit(1620937405.872:764): item=1 name="/tmp/ps2.py" inode=9595745 dev=fd:00 mode=0100644 ouid=1198400500 ogid=1198400513 rdev=00:00 obj=unconfined_u:object_r:user_tmp_t:s0 objtype=CREATE cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0 type=PROCTITLE msg=audit(1620937405.872:764): proctitle=736370002D74002F746D702F7073322E7079
 rule = 92106

--- a/ruleset/testing/tests/audit_scp.ini
+++ b/ruleset/testing/tests/audit_scp.ini
@@ -6,7 +6,7 @@
 ;  Sample logs source: 
 ;    Audit_scp: member https://github.com/wazuh/wazuh/issues/8623#issuecomment-844449152
 
-[SCP used to copy a file over SSH]
+[SCP used to copy a file over SSH.]
 log 1 pass = type=SYSCALL msg=audit(1620937405.872:764): arch=c000003e syscall=2 success=yes exit=4 a0=555c2e4a6fb0 a1=41 a2=1a4 a3=7fcfaf0607b8 items=2 ppid=7903 pid=7909 auid=1198400500 uid=1198400500 gid=1198400513 euid=1198400500 suid=1198400500 fsuid=1198400500 egid=1198400513 sgid=1198400513 fsgid=1198400513 tty=(none) ses=21 comm="scp" exe="/usr/bin/scp" subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key="wazuh_fim" type=CWD msg=audit(1620937405.872:764):  cwd="/home/administrator@ExchangeTest.com" type=PATH msg=audit(1620937405.872:764): item=0 name="/tmp/" inode=8409157 dev=fd:00 mode=041777 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:tmp_t:s0 objtype=PARENT cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0 type=PATH msg=audit(1620937405.872:764): item=1 name="/tmp/ps2.py" inode=9595745 dev=fd:00 mode=0100644 ouid=1198400500 ogid=1198400513 rdev=00:00 obj=unconfined_u:object_r:user_tmp_t:s0 objtype=CREATE cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0 type=PROCTITLE msg=audit(1620937405.872:764): proctitle=736370002D74002F746D702F7073322E7079
 rule = 92106
 alert = 6


### PR DESCRIPTION
## Description
|Related PR|Related Issue|Closes Issue|
|---|---|---|
| [#9143](https://github.com/wazuh/wazuh/pull/9143) | [#8623](https://github.com/wazuh/wazuh/issues/8623) |[#11264](https://github.com/wazuh/wazuh/issues/11264)|

## Changes & Comments
The aim of this PR is:

Add copyright headers
Fix tag ordering and alphabetical order in group tag
To ensure the rules and decoders from issue [#11264] work correctly.
To fix issues regarding indentation, syntax, rule granularity, spellings and ensure the ruleset quality is standard

ruleset\rules\0850-audit_rules.xml
- re-ordered the rules
- removing sample test logs, copyright header, indentation, ordering of tags.

ruleset\testing\tests\audit_scp.ini
- copyright header,

Note that the rule ID: 92081 in the previous PR was changed to 92106 by another PR.
Logtest 
```
**Phase 3: Completed filtering (rules).
        id: '92106'
        level: '6'
        description: 'A file was copied to this system over SSH using SCP.'
        groups: '['audit_detections']'
        firedtimes: '1'
        mail: 'False'
        mitre.id: '['T1021.004']'
        mitre.tactic: '['Lateral Movement']'
        mitre.technique: '['SSH']'
**Alert to be generated.
```
### Ruleset

## Checks 

### Syntax
- [x] 1.a Rule tags order must be compliant.
- [x] 1.b Decoder tags order must be compliant.
- [x] 1.c XML blocks must as compact as possible.
- [x] 1.d Only one empty line between rule/decoder and the next rule/decoder.
- [x] 1.e Decoder extracted fields names must use '_' whether a space is needed.
- [x] 1.f Decoder name must use '-' whether a space is needed.
- [x] 2.d XML and ini files must use correct indentation
 
### Grammar

- [x] 2.a Grammar quality.
- [x] 2.b Similar phrases must keep tenses and expressions.
- [x] 2.c Grammar basic rules like capitalization, punctuation marks, sentence construction, and others.


### Semantic

- [x] 3.a New decoder, rule, or test are written in the correct file and grouped correctly inside the file.
- [x] 3.b Group similar rules under same ID's group.
- [x] 3.c: 
   - [ ] 3.c1 Find and reuse group name before creating a new one.
   - [ ] 3.c2 Include a new group definition in a PR comment.
   - [ ] 3.c3 Any group name must use '_' whether it does need a space char.
   - [ ] 3.c4 The groups inside a tag must be sorted in alphabetical order.
   - [ ] 3.d Rule level should be compliant with the [documentation](https://documentation.wazuh.com/current/user-manual/ruleset/rules-classification.html).

### Unit testing

- [x] 4.a A metadata block at the beginning of the .ini file describing software, version, and logs source.
- [x] 4.b Each new rule must have at least one test entry in the correct .ini file.
- [x] 4.c Runtest.py must pass and must include the results in raw format here.
<details>
  <statement>Unit Tests</statement>

  ```
Restarting wazuh-manager...
- [ File = ./tests/samba.ini ] ---------
....

- [ File = ./tests/fortigate.ini ] ---------
........................................

- [ File = ./tests/apparmor.ini ] ---------
.....

- [ File = ./tests/pam.ini ] ---------
.....

- [ File = ./tests/audit_lateral.ini ] ---------
......

- [ File = ./tests/systemd.ini ] ---------
..

- [ File = ./tests/arbor.ini ] ---------
..

- [ File = ./tests/dovecot.ini ] ---------
...............

- [ File = ./tests/mailscanner.ini ] ---------
.

- [ File = ./tests/ossec.ini ] ---------
.....

- [ File = ./tests/vuln_detector.ini ] ---------
..

- [ File = ./tests/squid_rules.ini ] ---------
..

- [ File = ./tests/pix.ini ] ---------
......................

- [ File = ./tests/huawei_usg.ini ] ---------
...

- [ File = ./tests/checkpoint_smart1.ini ] ---------
..................

- [ File = ./tests/junos.ini ] ---------
...

- [ File = ./tests/web_appsec.ini ] ---------
...............................

- [ File = ./tests/cimserver.ini ] ---------
..

- [ File = ./tests/cisco_ftd.ini ] ---------
..........................................

- [ File = ./tests/firewalld.ini ] ---------
..

- [ File = ./tests/audit_recon.ini ] ---------
..

- [ File = ./tests/openldap.ini ] ---------
.........

- [ File = ./tests/sophos_fw.ini ] ---------
..........

- [ File = ./tests/owlh.ini ] ---------
....

- [ File = ./tests/freepbx.ini ] ---------
......

- [ File = ./tests/syslog.ini ] ---------
......

- [ File = ./tests/openvpn_ldap.ini ] ---------
..

- [ File = ./tests/sophos.ini ] ---------
........

- [ File = ./tests/unbound.ini ] ---------


- [ File = ./tests/github.ini ] ---------
....................................................................................................................................................................................................................................................................................................................................

- [ File = ./tests/cpanel.ini ] ---------
.......

- [ File = ./tests/fireeye.ini ] ---------
...

- [ File = ./tests/fortiauth.ini ] ---------
....

- [ File = ./tests/iptables.ini ] ---------
........

- [ File = ./tests/named.ini ] ---------
.....

- [ File = ./tests/sophos-utm-firewall.ini ] ---------
......

- [ File = ./tests/nginx.ini ] ---------
............

- [ File = ./tests/exim.ini ] ---------
.......

- [ File = ./tests/opensmtpd.ini ] ---------
.......

- [ File = ./tests/oscap.ini ] ---------
................................

- [ File = ./tests/gitlab.ini ] ---------
.........................

- [ File = ./tests/paloalto.ini ] ---------
................

- [ File = ./tests/api.ini ] ---------
............................

- [ File = ./tests/aws_s3_access.ini ] ---------
.......

- [ File = ./tests/exchange.ini ] ---------
..

- [ File = ./tests/f5_big_ip.ini ] ---------
...........................................

- [ File = ./tests/cisco_asa.ini ] ---------
........................................................................................

- [ File = ./tests/nextcloud.ini ] ---------
.......

- [ File = ./tests/trendmicro-cloud-one.ini ] ---------
.................

- [ File = ./tests/pfsense.ini ] ---------
..

- [ File = ./tests/vsftpd.ini ] ---------
....

- [ File = ./tests/web_rules.ini ] ---------
..........

- [ File = ./tests/apache.ini ] ---------
..................

- [ File = ./tests/eset.ini ] ---------
........

- [ File = ./tests/doas.ini ] ---------
....

- [ File = ./tests/sysmon.ini ] ---------
...

- [ File = ./tests/gcp.ini ] ---------
...........

- [ File = ./tests/icinga.ini ] ---------
....

- [ File = ./tests/postfix.ini ] ---------
..

- [ File = ./tests/audit_scp.ini ] ---------
.

- [ File = ./tests/dropbear.ini ] ---------
...

- [ File = ./tests/rsh.ini ] ---------
..

- [ File = ./tests/kernel_usb.ini ] ---------
......

- [ File = ./tests/mcafee_epo.ini ] ---------
.

- [ File = ./tests/netscreen.ini ] ---------
....

- [ File = ./tests/panda_paps.ini ] ---------
........

- [ File = ./tests/powershell.ini ] ---------
...

- [ File = ./tests/auditd.ini ] ---------
...

- [ File = ./tests/cylance.ini ] ---------
.......

- [ File = ./tests/modsecurity.ini ] ---------
......

- [ File = ./tests/cloudlfare-waf.ini ] ---------
.............

- [ File = ./tests/office365.ini ] ---------
................................................................................................................................

- [ File = ./tests/sshd.ini ] ---------
...........................................

- [ File = ./tests/cisco_ios.ini ] ---------
.................

- [ File = ./tests/glpi.ini ] ---------
...

- [ File = ./tests/sudo.ini ] ---------
........

- [ File = ./tests/su.ini ] ---------
.....

- [ File = ./tests/proftpd.ini ] ---------
.......

- [ File = ./tests/SonicWall.ini ] ---------
........

|Component |  Tested  |  Total   | Coverage |
| -------- | -------- | -------- | -------- |
|  Rules   |   985    |   4174   |  23.60%  |
| Decoders |    76    |   172    |  44.19%  |

|          File           |  Passed  |  Failed  |  Status  |
|        --------         | -------- | -------- | -------- |
|./tests/samba.ini        |    4     |    0     |    ✅     |
|./tests/fortigate.ini    |    40    |    0     |    ✅     |
|./tests/apparmor.ini     |    5     |    0     |    ✅     |
|./tests/pam.ini          |    5     |    0     |    ✅     |
|./tests/audit_lateral.ini|    6     |    0     |    ✅     |
|./tests/systemd.ini      |    2     |    0     |    ✅     |
|./tests/arbor.ini        |    2     |    0     |    ✅     |
|./tests/dovecot.ini      |    15    |    0     |    ✅     |
|./tests/mailscanner.ini  |    1     |    0     |    ✅     |
|./tests/ossec.ini        |    5     |    0     |    ✅     |
|./tests/vuln_detector.ini|    2     |    0     |    ✅     |
|./tests/squid_rules.ini  |    2     |    0     |    ✅     |
|./tests/pix.ini          |    22    |    0     |    ✅     |
|./tests/huawei_usg.ini   |    3     |    0     |    ✅     |
|./tests/checkpoint_smart1.ini|    18    |    0     |    ✅     |
|./tests/junos.ini        |    3     |    0     |    ✅     |
|./tests/web_appsec.ini   |    31    |    0     |    ✅     |
|./tests/cimserver.ini    |    2     |    0     |    ✅     |
|./tests/cisco_ftd.ini    |    42    |    0     |    ✅     |
|./tests/firewalld.ini    |    2     |    0     |    ✅     |
|./tests/audit_recon.ini  |    2     |    0     |    ✅     |
|./tests/openldap.ini     |    9     |    0     |    ✅     |
|./tests/sophos_fw.ini    |    10    |    0     |    ✅     |
|./tests/owlh.ini         |    4     |    0     |    ✅     |
|./tests/freepbx.ini      |    6     |    0     |    ✅     |
|./tests/syslog.ini       |    6     |    0     |    ✅     |
|./tests/openvpn_ldap.ini |    2     |    0     |    ✅     |
|./tests/sophos.ini       |    8     |    0     |    ✅     |
|./tests/unbound.ini      |    0     |    0     |    ✅     |
|./tests/github.ini       |   324    |    0     |    ✅     |
|./tests/cpanel.ini       |    7     |    0     |    ✅     |
|./tests/fireeye.ini      |    3     |    0     |    ✅     |
|./tests/fortiauth.ini    |    4     |    0     |    ✅     |
|./tests/iptables.ini     |    8     |    0     |    ✅     |
|./tests/named.ini        |    5     |    0     |    ✅     |
|./tests/sophos-utm-firewall.ini|    6     |    0     |    ✅     |
|./tests/nginx.ini        |    12    |    0     |    ✅     |
|./tests/exim.ini         |    7     |    0     |    ✅     |
|./tests/opensmtpd.ini    |    7     |    0     |    ✅     |
|./tests/oscap.ini        |    32    |    0     |    ✅     |
|./tests/gitlab.ini       |    25    |    0     |    ✅     |
|./tests/paloalto.ini     |    16    |    0     |    ✅     |
|./tests/api.ini          |    28    |    0     |    ✅     |
|./tests/aws_s3_access.ini|    7     |    0     |    ✅     |
|./tests/exchange.ini     |    2     |    0     |    ✅     |
|./tests/f5_big_ip.ini    |    43    |    0     |    ✅     |
|./tests/cisco_asa.ini    |    88    |    0     |    ✅     |
|./tests/nextcloud.ini    |    7     |    0     |    ✅     |
|./tests/trendmicro-cloud-one.ini|    17    |    0     |    ✅     |
|./tests/pfsense.ini      |    2     |    0     |    ✅     |
|./tests/vsftpd.ini       |    4     |    0     |    ✅     |
|./tests/web_rules.ini    |    10    |    0     |    ✅     |
|./tests/apache.ini       |    18    |    0     |    ✅     |
|./tests/eset.ini         |    8     |    0     |    ✅     |
|./tests/doas.ini         |    4     |    0     |    ✅     |
|./tests/sysmon.ini       |    3     |    0     |    ✅     |
|./tests/gcp.ini          |    11    |    0     |    ✅     |
|./tests/icinga.ini       |    4     |    0     |    ✅     |
|./tests/postfix.ini      |    2     |    0     |    ✅     |
|./tests/audit_scp.ini    |    1     |    0     |    ✅     |
|./tests/dropbear.ini     |    3     |    0     |    ✅     |
|./tests/rsh.ini          |    2     |    0     |    ✅     |
|./tests/kernel_usb.ini   |    6     |    0     |    ✅     |
|./tests/mcafee_epo.ini   |    1     |    0     |    ✅     |
|./tests/netscreen.ini    |    4     |    0     |    ✅     |
|./tests/panda_paps.ini   |    8     |    0     |    ✅     |
|./tests/powershell.ini   |    3     |    0     |    ✅     |
|./tests/auditd.ini       |    3     |    0     |    ✅     |
|./tests/cylance.ini      |    7     |    0     |    ✅     |
|./tests/modsecurity.ini  |    6     |    0     |    ✅     |
|./tests/cloudlfare-waf.ini|    13    |    0     |    ✅     |
|./tests/office365.ini    |   128    |    0     |    ✅     |
|./tests/sshd.ini         |    43    |    0     |    ✅     |
|./tests/cisco_ios.ini    |    17    |    0     |    ✅     |
|./tests/glpi.ini         |    3     |    0     |    ✅     |
|./tests/sudo.ini         |    8     |    0     |    ✅     |
|./tests/su.ini           |    5     |    0     |    ✅     |
|./tests/proftpd.ini      |    7     |    0     |    ✅     |
|./tests/SonicWall.ini    |    8     |    0     |    ✅     |
Restarting wazuh-manager...

- [ File = ./tests/audit_scp.ini ] ---------
.

|Component |  Tested  |  Total   | Coverage |
| -------- | -------- | -------- | -------- |
|  Rules   |    1     |   4174   |  0.02%   |
| Decoders |    1     |   172    |  0.58%   |

|          File           |  Passed  |  Failed  |  Status  |
|        --------         | -------- | -------- | -------- |
|./tests/audit_scp.ini    |    1     |    0     |    ✅     |
Restarting wazuh-manager...

```
</details>

- [x] 4.d New CDB lists must include the proper test entry in the correct .ini file.

### E2E testing

- [x] 5.a Logs for new or modified decoder/rules sent to a manager running with this PR ruleset appear in Kibana. 

![image](https://user-images.githubusercontent.com/20155990/145412169-075ce08b-efca-463c-a056-b196a6070d59.png)

- [x] 5.b There are not affected or broken visualizations on Kibana.

![image](https://user-images.githubusercontent.com/20155990/145412449-49a9aeaa-9246-476a-abe9-fb62c03ad81d.png)

- [x] 5.c New or modified items can be seen correctly using APP ruleset navigation.

![image](https://user-images.githubusercontent.com/20155990/145413186-e42ac3c1-f3a6-40b0-b757-30548e78b5ea.png)

### Elasticsearch Template

- [ ] 6.a Known fields with output format managed and usually used for searching are included in template array index.query.default_field. 
- [ ] 6.b The new field with the correct date format is stored as a "date" type field in the template.
- [ ] 6.c The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 
- [ ] 6.d Known fields with output format managed and usually used for searching are included in the template.

### Stoppers

- [x] 7.a No previous rule ID changes without triple check.
- [x] 7.b No previous decoder name changes without triple check.
- [x] 7.c No previous file name changes without triple check.
- [x] 7.d No previous test changes its 'rule' field value without triple check.

### Others

- [x] 8.a Each file has the correct copyright block.
- [x] 8.b The copyright block doesn't have "Author" only "Created by Wazuh". To include an "Author" request triple check.
- [x] 8.c The copyright block doesn't use "-". 
- [x] 8.d The rule files don't have any sample log.
- [x] 8.e The decoder file has sample logs next to the decoder that matches that log.
- [x] 8.f The decoder and rule files have information about software, version, and any helpful information.
- [x] 8.g The PR has a single commit with CHANGELOG changes in the correct format.
- [x] 8.h The new rule ID is not in use.
- [x] 8.i The new rule ID must be in the defined IDs range. 
- [x] 8.j New rules ID range must be verified with a triple check and noted in the rules ID document.
- [x] 8.k The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 