### PR TITLE
Rework of PR #9238 - OracleDB 12c Integration

### DIFF
--- a/ruleset/decoders/0560-oracledb_decoders.xml
+++ b/ruleset/decoders/0560-oracledb_decoders.xml
@@ -28,26 +28,60 @@
     DBID:[10] '3320902093'
 
   Alert examples:
-    {"timestamp":"2021-07-14T11:21:33.363-0700","rule":{"level":3,"description":"OracleDB transaction","id":"89100","firedtimes":1,"mail":false,"groups":["oracle","oracledb"],"pci_dss":["10.6.2"],"hipaa":["164.312.b"]},"agent":{"id":"000","name":"localhost.localdomain"},"manager":{"name":"localhost.localdomain"},"id":"1626286893.177547","full_log":"Jul 14 11:21:33 localhost.localdomain oracledb: \nFri Jul 09 11:11:00 2021 +05:32\nLENGTH : '563'\nACTION :[412] 'select /*+  no_parallel(t) no_parallel_index(t) dbms_stats cursor_sharing_exact use_weak_name_resl dynamic_sampling(0) no_monitoring xmlindex_sel_idx_tbl no_substrb_pad  */ substrb(dump(\"INSTANCE_NUMBER\",16,0,64),1,240) val, \n                      rowidtochar(rowid) rwid from \"SYS\".\"WWW$_SEC_THAT\" t where rowid in (chartorowid('AAAAO0AADAAASALAAA'),chartorowid('AAAAO0AADAAAAAJAAA')) order by \"INSTANCE_NUMBER\"'\nDATABASE USER:[3] 'SYS'\nPRIVILEGE :[4] 'NONE'\nCLIENT USER:[0] ''\nCLIENT TERMINAL:[7] 'UNKNOWN'\nSTATUS:[1] '0'\nDBID:[10] '1120301032'","predecoder":{"program_name":"oracledb","timestamp":"Jul 14 11:21:33","hostname":"localhost.localdomain"},"decoder":{"name":"oracledb_log"},"data":{"action":"select /*+  no_parallel(t) no_parallel_index(t) dbms_stats cursor_sharing_exact use_weak_name_resl dynamic_sampling(0) no_monitoring xmlindex_sel_idx_tbl no_substrb_pad  */ substrb(dump(\"INSTANCE_NUMBER\",16,0,64),1,240) val, \n                      rowidtochar(rowid) rwid from \"SYS\".\"WWW$_SEC_THAT\" t where rowid in (chartorowid('AAAAO0AADAAASALAAA'),chartorowid('AAAAO0AADAAAAAJAAA')) order by \"INSTANCE_NUMBER\"","status":"0","length":"563","database_user":"SYS","privilege_level":"NONE","client_terminal":"UNKNOWN","database_id":"1120301032"},"location":"/tmp/oracle/CDBTST000_j000_11111_20212020231542600818143795.aud"}
+    {"timestamp":"2021-07-14T11:21:33.363-0700","rule":{"level":3,"description":"OracleDB transaction","id":"89100","firedtimes":1,"mail":false,"groups":["oracle","oracledb"],"pci_dss":["10.6.2"],"hipaa":["164.312.b"]},"agent":{"id":"000","name":"localhost.localdomain"},"manager":{"name":"localhost.localdomain"},"id":"1626286893.177547","full_log":"Jul 14 11:21:33 localhost.localdomain oracledb: \nFri Jul 09 11:11:00 2021 +05:32\nLENGTH : '563'\nACTION :[412] 'select /*+  no_parallel(t) no_parallel_index(t) dbms_stats cursor_sharing_exact use_weak_name_resl dynamic_sampling(0) no_monitoring xmlindex_sel_idx_tbl no_substrb_pad  */ substrb(dump(\"INSTANCE_NUMBER\",16,0,64),1,240) val, \n                      rowidtochar(rowid) rwid from \"SYS\".\"WWW$_SEC_THAT\" t where rowid in (chartorowid('AAAAO0AADAAASALAAA'),chartorowid('AAAAO0AADAAAAAJAAA')) order by \"INSTANCE_NUMBER\"'\nDATABASE USER:[3] 'SYS'\nPRIVILEGE :[4] 'NONE'\nCLIENT USER:[0] ''\nCLIENT TERMINAL:[7] 'UNKNOWN'\nSTATUS:[1] '0'\nDBID:[10] '1120301032'","predecoder":{"program_name":"oracledb","timestamp":"Jul 14 11:21:33","hostname":"localhost.localdomain"},"decoder":{"name":"oracledb-log"},"data":{"action":"select /*+  no_parallel(t) no_parallel_index(t) dbms_stats cursor_sharing_exact use_weak_name_resl dynamic_sampling(0) no_monitoring xmlindex_sel_idx_tbl no_substrb_pad  */ substrb(dump(\"INSTANCE_NUMBER\",16,0,64),1,240) val, \n                      rowidtochar(rowid) rwid from \"SYS\".\"WWW$_SEC_THAT\" t where rowid in (chartorowid('AAAAO0AADAAASALAAA'),chartorowid('AAAAO0AADAAAAAJAAA')) order by \"INSTANCE_NUMBER\"","status":"0","length":"563","database_user":"SYS","privilege_level":"NONE","client_terminal":"UNKNOWN","database_id":"1120301032"},"location":"/tmp/oracle/CDBTST000_j000_11111_20212020231542600818143795.aud"}
 -->
 
-<decoder name="oracledb_log">
+<decoder name="oracledb-log">
   <program_name>^oracledb$</program_name>
 </decoder>
 
-<decoder name="oracledb_transaction_fields">
-  <parent>oracledb_log</parent>
-  <regex>(?Ums)^LENGTH : '(\d+)'\n</regex>
-  <regex>^ACTION :\[\d+] '(.+)'\n</regex>
-  <regex>^DATABASE USER:\[\d+] '(.+)'\n</regex>
-  <regex>^PRIVILEGE :\[\d+] '(.+)'\n</regex>
-  <regex>^CLIENT USER:\[\d+] '(.*)'\n</regex>
-  <regex>^CLIENT TERMINAL:\[\d+] '(.*)'\n</regex>
-  <regex>^STATUS:\[\d+] '(.*)'\n</regex>
-  <regex type="pcre2">^DBID:\[\d+] '(.*)'</regex>
-  <order>length, action, database_user, privilege_level, client_user, client_terminal, status, database_id</order>
+<decoder name="oracledb-transaction-fields">
+  <parent>oracledb-log</parent>
+  <regex type="pcre2">(?Ums)^LENGTH : '(\d+)'\n</regex>
+  <order>length</order>
 </decoder>
 
+<decoder name="oracledb-transaction-fields">
+  <parent>oracledb-log</parent>
+  <regex type="pcre2">^ACTION :\[\d+] '(.+)'\n</regex>
+  <order>action</order>
+</decoder>
+
+<decoder name="oracledb-transaction-fields">
+  <parent>oracledb-log</parent>
+  <regex type="pcre2">^DATABASE USER:\[\d+] '(.+)'\n</regex>
+  <order>database_user</order>
+</decoder>
+
+<decoder name="oracledb-transaction-fields">
+  <parent>oracledb-log</parent>
+  <regex type="pcre2">^PRIVILEGE :\[\d+] '(.+)'\n</regex>
+  <order>privilege_level</order>
+</decoder>
+
+<decoder name="oracledb-transaction-fields">
+  <parent>oracledb-log</parent>
+  <regex type="pcre2">^CLIENT USER:\[\d+] '(.*)'\n</regex>
+  <order>client_user</order>
+</decoder>
+
+<decoder name="oracledb-transaction-fields">
+  <parent>oracledb-log</parent>
+  <regex type="pcre2">^CLIENT TERMINAL:\[\d+] '(.*)'\n</regex>
+  <order>client_terminal</order>
+</decoder>
+
+<decoder name="oracledb-transaction-fields">
+  <parent>oracledb-log</parent>
+  <regex type="pcre2">^STATUS:\[\d+] '(.*)'\n</regex>
+  <order>status</order>
+</decoder>
+
+<decoder name="oracledb-transaction-fields">
+  <parent>oracledb-log</parent>
+  <regex type="pcre2">^DBID:\[\d+] '(.*)'</regex>
+  <order>database_id</order>
+</decoder>
 
 <!--
   Configuration:
@@ -71,9 +105,9 @@
     opidrv aborting process M000 ospid (70621) as a result of ORA-603
     Process m000 died, see its trace file
   Alert examples:
-    {"timestamp":"2021-07-14T11:20:43.107-0700","rule":{"level":7,"description":"Oracle DB alerts","id":"89101","firedtimes":1,"mail":false,"groups":["oracle","oracledb"],"pci_dss":["10.6.1"],"hipaa":["164.312.b"]},"agent":{"id":"000","name":"localhost.localdomain"},"manager":{"name":"localhost.localdomain"},"id":"1626286843.176665","full_log":"Jul 14 11:20:43 localhost.localdomain oracledb_alerts: Tue Feb 23 11:53:46 2021\anyword: mtype: 61 process 70621 failed because of a resource problem in the OS. The OS has most likely run out of buffers (rval: 4)\nErrors in file /opt/oracle/app/oracle/diag/rdbms/cdbtst00/CDBTST000/trace/CDBTST000_m000_10111.trc  (incident=346445):\nORA-00603: ORACLE server session terminated by fatal error\nORA-27504: IPC error creating OSD context\nORA-27300: OS system dependent operation:sendmsg failed with status: 105\nORA-27301: OS failure message: No buffer space available\nORA-27302: failure occurred at: anyword\nopidrv aborting process M000 ospid (70621) as a result of ORA-603\nProcess m000 died, see its trace file","predecoder":{"program_name":"oracledb_alerts","timestamp":"Jul 14 11:20:43","hostname":"localhost.localdomain"},"decoder":{"name":"oracledb_alerts"},"location":"/tmp/oracle/alert_CDBTST931.log"}
+    {"timestamp":"2021-07-14T11:20:43.107-0700","rule":{"level":7,"description":"Oracle DB alerts","id":"89101","firedtimes":1,"mail":false,"groups":["oracle","oracledb"],"pci_dss":["10.6.1"],"hipaa":["164.312.b"]},"agent":{"id":"000","name":"localhost.localdomain"},"manager":{"name":"localhost.localdomain"},"id":"1626286843.176665","full_log":"Jul 14 11:20:43 localhost.localdomain oracledb_alerts: Tue Feb 23 11:53:46 2021\anyword: mtype: 61 process 70621 failed because of a resource problem in the OS. The OS has most likely run out of buffers (rval: 4)\nErrors in file /opt/oracle/app/oracle/diag/rdbms/cdbtst00/CDBTST000/trace/CDBTST000_m000_10111.trc  (incident=346445):\nORA-00603: ORACLE server session terminated by fatal error\nORA-27504: IPC error creating OSD context\nORA-27300: OS system dependent operation:sendmsg failed with status: 105\nORA-27301: OS failure message: No buffer space available\nORA-27302: failure occurred at: anyword\nopidrv aborting process M000 ospid (70621) as a result of ORA-603\nProcess m000 died, see its trace file","predecoder":{"program_name":"oracledb_alerts","timestamp":"Jul 14 11:20:43","hostname":"localhost.localdomain"},"decoder":{"name":"oracledb-alerts"},"location":"/tmp/oracle/alert_CDBTST931.log"}
 -->
-<decoder name="oracledb_alerts">
-  <program_name>^oracledb_alerts$</program_name>
+<decoder name="oracledb-alerts">
+  <program_name>^oracledb-alerts$</program_name>
   <prematch type="pcre2">ORA\-</prematch>
 </decoder>

--- a/ruleset/decoders/0560-oracledb_decoders.xml
+++ b/ruleset/decoders/0560-oracledb_decoders.xml
@@ -11,7 +11,7 @@
     <localfile>
       <log_format>multi-line-regex</log_format>
       <location>/tmp/oracle/*.aud</$
-      <multiline_regex match="all">(?m)\n\n</multiline_regex>
+      <multiline_regex match="all">\n\n</multiline_regex>
       <out_format>$(timestamp) $(hostname) oracledb: $(log)</out_format>
     </localfile>
 
@@ -37,7 +37,7 @@
 
 <decoder name="oracledb-transaction-fields">
   <parent>oracledb-log</parent>
-  <regex type="pcre2">(?Ums)^LENGTH : '(\d+)'\n</regex>
+  <regex type="pcre2">^LENGTH : '(\d+)'\n</regex>
   <order>length</order>
 </decoder>
 
@@ -89,7 +89,7 @@
   <localfile>
     <log_format>multi-line-regex</log_format>
     <location>/tmp/oracle/alert_CDBTST931.log</location>
-    <multiline_regex match="start">(?m)\w{3}\s\w{3}\s\d{2}\s\d{2}:\d{2}:\d{2}\s\d{4}</multiline_regex>
+    <multiline_regex match="start">\w{3}\s\w{3}\s\d{2}\s\d{2}:\d{2}:\d{2}\s\d{4}</multiline_regex>
     <out_format>$(timestamp) $(hostname) oracledb_alerts: $(log)</out_format>
   </localfile>
 

--- a/ruleset/decoders/0560-oracledb_decoders.xml
+++ b/ruleset/decoders/0560-oracledb_decoders.xml
@@ -1,74 +1,79 @@
 <!--
-  -  OracleDB 12C decoder
-  -  Created by Wazuh, Inc.
-  -  Copyright (C) 2015-2021, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  Copyright (C) 2015-2021, Wazuh Inc.
 -->
 
 <!--
-  localfile implementation example:
-  <localfile>
-    <log_format>multi-line-regex</log_format>
-    <location>/tmp/oracle/*.aud</$
-    <multiline_regex match="all">(?m)\n\n</multiline_regex>
-    <out_format>$(timestamp) $(hostname) oracledb: $(log)</out_format>
-  </localfile>
--->
-<!--
-Log example:
-  Fri Jul 09 11:11:00 2021 +05:32
-  LENGTH : '563'
-  ACTION :[412] 'select /*+  no_parallel(t) no_parallel_index(t) dbms_stats cursor_sharing_exact use_weak_name_resl dynamic_sampling(0) no_monitoring xmlindex_sel_idx_tbl no_substrb_pad  */ substrb(dump("INSTANCE_NUMBER",16,0,64),1,240) val, 
-                        rowidtochar(rowid) rwid from "SYS"."WRH$_SEG_STAT" t where rowid in (chartorowid('AAAAAAAAAAAAAAAAAA'),chartorowid('AAAAAAAAAAAAAAAAAA')) order by "INSTANCE_NUMBER"'
-  DATABASE USER:[3] 'SYS'
-  PRIVILEGE :[4] 'NONE'
-  CLIENT USER:[0] ''
-  CLIENT TERMINAL:[7] 'UNKNOWN'
-  STATUS:[1] '0'
-  DBID:[10] '3320902093'
+  Decoders for:
+    OracleDB 12c.
+  
+  Configuration:
+  The below needs to be added to the manager's ossec.conf localfile implementation to read Oracle's .aud logs:
+    <localfile>
+      <log_format>multi-line-regex</log_format>
+      <location>/tmp/oracle/*.aud</$
+      <multiline_regex match="all">(?m)\n\n</multiline_regex>
+      <out_format>$(timestamp) $(hostname) oracledb: $(log)</out_format>
+    </localfile>
+
+  Log example:
+    Fri Jul 09 11:11:00 2021 +05:32
+    LENGTH : '563'
+    ACTION :[412] 'select /*+  no_parallel(t) no_parallel_index(t) dbms_stats cursor_sharing_exact use_weak_name_resl dynamic_sampling(0) no_monitoring xmlindex_sel_idx_tbl no_substrb_pad  */ substrb(dump("INSTANCE_NUMBER",16,0,64),1,240) val, 
+                          rowidtochar(rowid) rwid from "SYS"."WRH$_SEG_STAT" t where rowid in (chartorowid('AAAAAAAAAAAAAAAAAA'),chartorowid('AAAAAAAAAAAAAAAAAA')) order by "INSTANCE_NUMBER"'
+    DATABASE USER:[3] 'SYS'
+    PRIVILEGE :[4] 'NONE'
+    CLIENT USER:[0] ''
+    CLIENT TERMINAL:[7] 'UNKNOWN'
+    STATUS:[1] '0'
+    DBID:[10] '3320902093'
+
+  Alert examples:
+    {"timestamp":"2021-07-14T11:21:33.363-0700","rule":{"level":3,"description":"OracleDB transaction","id":"89100","firedtimes":1,"mail":false,"groups":["oracle","oracledb"],"pci_dss":["10.6.2"],"hipaa":["164.312.b"]},"agent":{"id":"000","name":"localhost.localdomain"},"manager":{"name":"localhost.localdomain"},"id":"1626286893.177547","full_log":"Jul 14 11:21:33 localhost.localdomain oracledb: \nFri Jul 09 11:11:00 2021 +05:32\nLENGTH : '563'\nACTION :[412] 'select /*+  no_parallel(t) no_parallel_index(t) dbms_stats cursor_sharing_exact use_weak_name_resl dynamic_sampling(0) no_monitoring xmlindex_sel_idx_tbl no_substrb_pad  */ substrb(dump(\"INSTANCE_NUMBER\",16,0,64),1,240) val, \n                      rowidtochar(rowid) rwid from \"SYS\".\"WWW$_SEC_THAT\" t where rowid in (chartorowid('AAAAO0AADAAASALAAA'),chartorowid('AAAAO0AADAAAAAJAAA')) order by \"INSTANCE_NUMBER\"'\nDATABASE USER:[3] 'SYS'\nPRIVILEGE :[4] 'NONE'\nCLIENT USER:[0] ''\nCLIENT TERMINAL:[7] 'UNKNOWN'\nSTATUS:[1] '0'\nDBID:[10] '1120301032'","predecoder":{"program_name":"oracledb","timestamp":"Jul 14 11:21:33","hostname":"localhost.localdomain"},"decoder":{"name":"oracledb_log"},"data":{"action":"select /*+  no_parallel(t) no_parallel_index(t) dbms_stats cursor_sharing_exact use_weak_name_resl dynamic_sampling(0) no_monitoring xmlindex_sel_idx_tbl no_substrb_pad  */ substrb(dump(\"INSTANCE_NUMBER\",16,0,64),1,240) val, \n                      rowidtochar(rowid) rwid from \"SYS\".\"WWW$_SEC_THAT\" t where rowid in (chartorowid('AAAAO0AADAAASALAAA'),chartorowid('AAAAO0AADAAAAAJAAA')) order by \"INSTANCE_NUMBER\"","status":"0","length":"563","database_user":"SYS","privilege_level":"NONE","client_terminal":"UNKNOWN","database_id":"1120301032"},"location":"/tmp/oracle/CDBTST000_j000_11111_20212020231542600818143795.aud"}
 -->
 
 <decoder name="oracledb_log">
-    <program_name>^oracledb$</program_name>
+  <program_name>^oracledb$</program_name>
 </decoder>
 
 <decoder name="oracledb_transaction_fields">
-    <parent>oracledb_log</parent>
-    <regex>(?Ums)^LENGTH : '(\d+)'\n</regex>
-    <regex>^ACTION :\[\d+] '(.+)'\n</regex>
-    <regex>^DATABASE USER:\[\d+] '(.+)'\n</regex>
-    <regex>^PRIVILEGE :\[\d+] '(.+)'\n</regex>
-    <regex>^CLIENT USER:\[\d+] '(.*)'\n</regex>
-    <regex>^CLIENT TERMINAL:\[\d+] '(.*)'\n</regex>
-    <regex>^STATUS:\[\d+] '(.*)'\n</regex>
-    <regex type="pcre2">^DBID:\[\d+] '(.*)'</regex>
-    <order>length, action, database_user, privilege_level, client_user, client_terminal, status, database_id</order>
+  <parent>oracledb_log</parent>
+  <regex>(?Ums)^LENGTH : '(\d+)'\n</regex>
+  <regex>^ACTION :\[\d+] '(.+)'\n</regex>
+  <regex>^DATABASE USER:\[\d+] '(.+)'\n</regex>
+  <regex>^PRIVILEGE :\[\d+] '(.+)'\n</regex>
+  <regex>^CLIENT USER:\[\d+] '(.*)'\n</regex>
+  <regex>^CLIENT TERMINAL:\[\d+] '(.*)'\n</regex>
+  <regex>^STATUS:\[\d+] '(.*)'\n</regex>
+  <regex type="pcre2">^DBID:\[\d+] '(.*)'</regex>
+  <order>length, action, database_user, privilege_level, client_user, client_terminal, status, database_id</order>
 </decoder>
 
 
 <!--
-  localfile implementation example:
+  Configuration:
+  The below needs to be added to the manager's ossec.conf localfile implementation to read Oracle's .log logs:
   <localfile>
     <log_format>multi-line-regex</log_format>
     <location>/tmp/oracle/alert_CDBTST931.log</location>
     <multiline_regex match="start">(?m)\w{3}\s\w{3}\s\d{2}\s\d{2}:\d{2}:\d{2}\s\d{4}</multiline_regex>
     <out_format>$(timestamp) $(hostname) oracledb_alerts: $(log)</out_format>
   </localfile>
--->
-<!--
-Log example:
-  Tue Feb 23 11:53:46 2021
-  anyword: mtype: 61 process 70621 failed because of a resource problem in the OS. The OS has most likely run out of buffers (rval: 4)
-  Errors in file /tmp/oracle/traces/CDBTST111_m000_00001.trc  (incident=346445):
-  ORA-00603: ORACLE server session terminated by fatal error
-  ORA-27504: IPC error creating OSD context
-  ORA-27300: OS system dependent operation:sendmsg failed with status: 105
-  ORA-27301: OS failure message: No buffer space available
-  ORA-27302: failure occurred at: anyword
-  opidrv aborting process M000 ospid (70621) as a result of ORA-603
-  Process m000 died, see its trace file
+
+  Log example:
+    Tue Feb 23 11:53:46 2021
+    anyword: mtype: 61 process 70621 failed because of a resource problem in the OS. The OS has most likely run out of buffers (rval: 4)
+    Errors in file /tmp/oracle/traces/CDBTST111_m000_00001.trc  (incident=346445):
+    ORA-00603: ORACLE server session terminated by fatal error
+    ORA-27504: IPC error creating OSD context
+    ORA-27300: OS system dependent operation:sendmsg failed with status: 105
+    ORA-27301: OS failure message: No buffer space available
+    ORA-27302: failure occurred at: anyword
+    opidrv aborting process M000 ospid (70621) as a result of ORA-603
+    Process m000 died, see its trace file
+  Alert examples:
+    {"timestamp":"2021-07-14T11:20:43.107-0700","rule":{"level":7,"description":"Oracle DB alerts","id":"89101","firedtimes":1,"mail":false,"groups":["oracle","oracledb"],"pci_dss":["10.6.1"],"hipaa":["164.312.b"]},"agent":{"id":"000","name":"localhost.localdomain"},"manager":{"name":"localhost.localdomain"},"id":"1626286843.176665","full_log":"Jul 14 11:20:43 localhost.localdomain oracledb_alerts: Tue Feb 23 11:53:46 2021\anyword: mtype: 61 process 70621 failed because of a resource problem in the OS. The OS has most likely run out of buffers (rval: 4)\nErrors in file /opt/oracle/app/oracle/diag/rdbms/cdbtst00/CDBTST000/trace/CDBTST000_m000_10111.trc  (incident=346445):\nORA-00603: ORACLE server session terminated by fatal error\nORA-27504: IPC error creating OSD context\nORA-27300: OS system dependent operation:sendmsg failed with status: 105\nORA-27301: OS failure message: No buffer space available\nORA-27302: failure occurred at: anyword\nopidrv aborting process M000 ospid (70621) as a result of ORA-603\nProcess m000 died, see its trace file","predecoder":{"program_name":"oracledb_alerts","timestamp":"Jul 14 11:20:43","hostname":"localhost.localdomain"},"decoder":{"name":"oracledb_alerts"},"location":"/tmp/oracle/alert_CDBTST931.log"}
 -->
 <decoder name="oracledb_alerts">
-    <program_name>^oracledb_alerts$</program_name>
-    <prematch type="pcre2">ORA\-</prematch>
+  <program_name>^oracledb_alerts$</program_name>
+  <prematch type="pcre2">ORA\-</prematch>
 </decoder>

--- a/ruleset/decoders/0560-oracledb_decoders.xml
+++ b/ruleset/decoders/0560-oracledb_decoders.xml
@@ -37,49 +37,49 @@
 
 <decoder name="oracledb-transaction-fields">
   <parent>oracledb-log</parent>
-  <regex type="pcre2">^LENGTH : '(\d+)'\n</regex>
+  <regex type="pcre2">(?m)^LENGTH : '(\d+)'\n</regex>
   <order>length</order>
 </decoder>
 
 <decoder name="oracledb-transaction-fields">
   <parent>oracledb-log</parent>
-  <regex type="pcre2">^ACTION :\[\d+] '(.+)'\n</regex>
+  <regex type="pcre2">(?mUs)ACTION :(.*)(?:^[A-Z\s]+:)</regex>
   <order>action</order>
 </decoder>
 
 <decoder name="oracledb-transaction-fields">
   <parent>oracledb-log</parent>
-  <regex type="pcre2">^DATABASE USER:\[\d+] '(.+)'\n</regex>
+  <regex type="pcre2">(?m)^DATABASE USER:\[\d+] '(.+)'\n</regex>
   <order>database_user</order>
 </decoder>
 
 <decoder name="oracledb-transaction-fields">
   <parent>oracledb-log</parent>
-  <regex type="pcre2">^PRIVILEGE :\[\d+] '(.+)'\n</regex>
+  <regex type="pcre2">(?m)^PRIVILEGE :\[\d+] '(.+)'\n</regex>
   <order>privilege_level</order>
 </decoder>
 
 <decoder name="oracledb-transaction-fields">
   <parent>oracledb-log</parent>
-  <regex type="pcre2">^CLIENT USER:\[\d+] '(.*)'\n</regex>
+  <regex type="pcre2">(?m)^CLIENT USER:\[\d+] '(.*)'\n</regex>
   <order>client_user</order>
 </decoder>
 
 <decoder name="oracledb-transaction-fields">
   <parent>oracledb-log</parent>
-  <regex type="pcre2">^CLIENT TERMINAL:\[\d+] '(.*)'\n</regex>
+  <regex type="pcre2">(?m)^CLIENT TERMINAL:\[\d+] '(.*)'\n</regex>
   <order>client_terminal</order>
 </decoder>
 
 <decoder name="oracledb-transaction-fields">
   <parent>oracledb-log</parent>
-  <regex type="pcre2">^STATUS:\[\d+] '(.*)'\n</regex>
+  <regex type="pcre2">(?m)^STATUS:\[\d+] '(.*)'\n</regex>
   <order>status</order>
 </decoder>
 
 <decoder name="oracledb-transaction-fields">
   <parent>oracledb-log</parent>
-  <regex type="pcre2">^DBID:\[\d+] '(.*)'</regex>
+  <regex type="pcre2">(?m)^DBID:\[\d+] '(.*)'</regex>
   <order>database_id</order>
 </decoder>
 

--- a/ruleset/rules/0920-oracledb_rules.xml
+++ b/ruleset/rules/0920-oracledb_rules.xml
@@ -10,13 +10,13 @@
 <group name="oracle,oracledb,">
 
   <rule id="89100" level="3">
-    <decoded_as>oracledb_log</decoded_as>
+    <decoded_as>oracledb-log</decoded_as>
     <description>OracleDB transaction.</description>
     <group>hipaa_164.312.b,pci_dss_10.6.2,</group>
   </rule>
 
   <rule id="89101" level="7">
-    <decoded_as>oracledb_alerts</decoded_as>
+    <decoded_as>oracledb-alerts</decoded_as>
     <description>Oracle DB alerts.</description>
     <group>hipaa_164.312.b,pci_dss_10.6.1,</group>
   </rule>

--- a/ruleset/rules/0920-oracledb_rules.xml
+++ b/ruleset/rules/0920-oracledb_rules.xml
@@ -1,31 +1,24 @@
 <!--
-  - OracleDB rules
-  - Created by Wazuh, Inc.
-  - Copyright (C) 2015-2021, Wazuh Inc.
-  - This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  Copyright (C) 2015-2021, Wazuh Inc.
+-->
+
+<!-- 
+  Rules for:
+    OracleDB ID: 89100 - 89199
 -->
 
 <group name="oracle,oracledb,">
 
-    <!-- RULE ID RANGE: 89100 - 89199 -->
-
-    <!--
-      Alert example:
-      {"timestamp":"2021-07-14T11:21:33.363-0700","rule":{"level":3,"description":"OracleDB transaction","id":"89100","firedtimes":1,"mail":false,"groups":["oracle","oracledb"],"pci_dss":["10.6.2"],"hipaa":["164.312.b"]},"agent":{"id":"000","name":"localhost.localdomain"},"manager":{"name":"localhost.localdomain"},"id":"1626286893.177547","full_log":"Jul 14 11:21:33 localhost.localdomain oracledb: \nFri Jul 09 11:11:00 2021 +05:32\nLENGTH : '563'\nACTION :[412] 'select /*+  no_parallel(t) no_parallel_index(t) dbms_stats cursor_sharing_exact use_weak_name_resl dynamic_sampling(0) no_monitoring xmlindex_sel_idx_tbl no_substrb_pad  */ substrb(dump(\"INSTANCE_NUMBER\",16,0,64),1,240) val, \n                      rowidtochar(rowid) rwid from \"SYS\".\"WWW$_SEC_THAT\" t where rowid in (chartorowid('AAAAO0AADAAASALAAA'),chartorowid('AAAAO0AADAAAAAJAAA')) order by \"INSTANCE_NUMBER\"'\nDATABASE USER:[3] 'SYS'\nPRIVILEGE :[4] 'NONE'\nCLIENT USER:[0] ''\nCLIENT TERMINAL:[7] 'UNKNOWN'\nSTATUS:[1] '0'\nDBID:[10] '1120301032'","predecoder":{"program_name":"oracledb","timestamp":"Jul 14 11:21:33","hostname":"localhost.localdomain"},"decoder":{"name":"oracledb_log"},"data":{"action":"select /*+  no_parallel(t) no_parallel_index(t) dbms_stats cursor_sharing_exact use_weak_name_resl dynamic_sampling(0) no_monitoring xmlindex_sel_idx_tbl no_substrb_pad  */ substrb(dump(\"INSTANCE_NUMBER\",16,0,64),1,240) val, \n                      rowidtochar(rowid) rwid from \"SYS\".\"WWW$_SEC_THAT\" t where rowid in (chartorowid('AAAAO0AADAAASALAAA'),chartorowid('AAAAO0AADAAAAAJAAA')) order by \"INSTANCE_NUMBER\"","status":"0","length":"563","database_user":"SYS","privilege_level":"NONE","client_terminal":"UNKNOWN","database_id":"1120301032"},"location":"/tmp/oracle/CDBTST000_j000_11111_20212020231542600818143795.aud"}
-    -->
-    <rule id="89100" level="3">
-        <decoded_as>oracledb_log</decoded_as>
-        <description>OracleDB transaction</description>
-        <group>pci_dss_10.6.2,hipaa_164.312.b</group>
-    </rule>
-
-    <!--
-      Alert example:
-      {"timestamp":"2021-07-14T11:20:43.107-0700","rule":{"level":7,"description":"Oracle DB alerts","id":"89101","firedtimes":1,"mail":false,"groups":["oracle","oracledb"],"pci_dss":["10.6.1"],"hipaa":["164.312.b"]},"agent":{"id":"000","name":"localhost.localdomain"},"manager":{"name":"localhost.localdomain"},"id":"1626286843.176665","full_log":"Jul 14 11:20:43 localhost.localdomain oracledb_alerts: Tue Feb 23 11:53:46 2021\anyword: mtype: 61 process 70621 failed because of a resource problem in the OS. The OS has most likely run out of buffers (rval: 4)\nErrors in file /opt/oracle/app/oracle/diag/rdbms/cdbtst00/CDBTST000/trace/CDBTST000_m000_10111.trc  (incident=346445):\nORA-00603: ORACLE server session terminated by fatal error\nORA-27504: IPC error creating OSD context\nORA-27300: OS system dependent operation:sendmsg failed with status: 105\nORA-27301: OS failure message: No buffer space available\nORA-27302: failure occurred at: anyword\nopidrv aborting process M000 ospid (70621) as a result of ORA-603\nProcess m000 died, see its trace file","predecoder":{"program_name":"oracledb_alerts","timestamp":"Jul 14 11:20:43","hostname":"localhost.localdomain"},"decoder":{"name":"oracledb_alerts"},"location":"/tmp/oracle/alert_CDBTST931.log"}    
-    -->
-    <rule id="89101" level="7">
-      <decoded_as>oracledb_alerts</decoded_as>
-      <description>Oracle DB alerts</description>
-      <group>pci_dss_10.6.1,hipaa_164.312.b</group>
+  <rule id="89100" level="3">
+    <decoded_as>oracledb_log</decoded_as>
+    <description>OracleDB transaction.</description>
+    <group>hipaa_164.312.b,pci_dss_10.6.2,</group>
   </rule>
+
+  <rule id="89101" level="7">
+    <decoded_as>oracledb_alerts</decoded_as>
+    <description>Oracle DB alerts.</description>
+    <group>hipaa_164.312.b,pci_dss_10.6.1,</group>
+  </rule>
+
 </group>

--- a/ruleset/rules/0920-oracledb_rules.xml
+++ b/ruleset/rules/0920-oracledb_rules.xml
@@ -4,7 +4,7 @@
 
 <!-- 
   Rules for:
-    OracleDB ID: 89100 - 89199
+    OracleDB 12c ID: 89100 - 89199
 -->
 
 <group name="oracle,oracledb,">


### PR DESCRIPTION
|Related issue|
|---|
| #11272 |

## Description

This PR aims to resolve issues detected under #9238 PR. Closes #11272.
The issues resolved are:
- Copyright headers.
- Fixed indentation issues.
- Added a blank line at the EOF.
- Added line breaks in between rules and decoder blocks.
Notes:
- Due to no multiline support in logtest, no .ini file was created.

## Checks and changes 

### Syntax

- [x] 1.a Rule tags order must be compliant.
- [x] 1.b Decoder tags order must be compliant.
- [x] 1.c XML blocks must as compact as possible.
- [x] 1.d Only one empty line between rule/decoder and the next rule/decoder.
- [x] 1.e Decoder extracted fields names must use '_' whether a space is needed.
- [x] 1.f Decoder name must use '-' whether a space is needed.
 
### Grammar

- [x] 2.a Grammar quality.
- [x] 2.b Similar phrases must keep tenses and expressions.
- [x] 2.c Grammar basic rules like capitalization, punctuation marks, sentence construction, and others.


### Semantic

- [x] 3.a New decoder, rule, or test are written in the correct file and grouped correctly inside the file.
- [x] 3.b Group similar rules under same ID's group.
- [x] 3.c: 
     - [x] 3.c1 Find and reuse group name before creating a new one.
     - [x] 3.c2 Include a new group definition in a PR comment.
     - [x] 3.c3 Any group name must use '_' whether it does need a space char.
     - [x] 3.c4 The groups inside a tag must be sorted in alphabetical order.
- [x] 3.d Rule level should be compliant with the [documentation](https://documentation.wazuh.com/current/user-manual/ruleset/rules-classification.html).

### Unit testing

- [x] 4.a A metadata block at the beginning of the .ini file describing software, version, and logs source.
- [x] 4.b Each new rule must have at least one test entry in the correct .ini file.
- [x] 4.c Runtest.py must pass and must include the results in raw format here.


<details><summary>All rules and decoders test.</summary>
<p>

```
root@ubuntu-focal:/var/ossec/ruleset/feed/testing# python3 runtests.py
Restarting wazuh-manager...
- [ File = ./tests/samba.ini ] ---------
....

- [ File = ./tests/fortigate.ini ] ---------
........................................

- [ File = ./tests/apparmor.ini ] ---------
.....

- [ File = ./tests/pam.ini ] ---------
.....

- [ File = ./tests/audit_lateral.ini ] ---------
......

- [ File = ./tests/systemd.ini ] ---------
..

- [ File = ./tests/arbor.ini ] ---------
..

- [ File = ./tests/dovecot.ini ] ---------
...............

- [ File = ./tests/mailscanner.ini ] ---------
.

- [ File = ./tests/ossec.ini ] ---------
.....

- [ File = ./tests/vuln_detector.ini ] ---------
..

- [ File = ./tests/squid_rules.ini ] ---------
..

- [ File = ./tests/pix.ini ] ---------
......................

- [ File = ./tests/huawei_usg.ini ] ---------
...

- [ File = ./tests/checkpoint_smart1.ini ] ---------
..................

- [ File = ./tests/junos.ini ] ---------
...

- [ File = ./tests/web_appsec.ini ] ---------
...............................

- [ File = ./tests/cimserver.ini ] ---------
..

- [ File = ./tests/cisco_ftd.ini ] ---------
..........................................

- [ File = ./tests/firewalld.ini ] ---------
..

- [ File = ./tests/audit_recon.ini ] ---------
..

- [ File = ./tests/openldap.ini ] ---------
.........

- [ File = ./tests/sophos_fw.ini ] ---------
..........

- [ File = ./tests/owlh.ini ] ---------
....

- [ File = ./tests/freepbx.ini ] ---------
......

- [ File = ./tests/syslog.ini ] ---------
......

- [ File = ./tests/openvpn_ldap.ini ] ---------
..

- [ File = ./tests/sophos.ini ] ---------
........

- [ File = ./tests/unbound.ini ] ---------


- [ File = ./tests/github.ini ] ---------
....................................................................................................................................................................................................................................................................................................................................

- [ File = ./tests/cpanel.ini ] ---------
.......

- [ File = ./tests/fireeye.ini ] ---------
...

- [ File = ./tests/fortiauth.ini ] ---------
....

- [ File = ./tests/iptables.ini ] ---------
........

- [ File = ./tests/named.ini ] ---------
.....

- [ File = ./tests/sophos-utm-firewall.ini ] ---------
......

- [ File = ./tests/nginx.ini ] ---------
............

- [ File = ./tests/exim.ini ] ---------
.......

- [ File = ./tests/opensmtpd.ini ] ---------
.......

- [ File = ./tests/oscap.ini ] ---------
................................

- [ File = ./tests/gitlab.ini ] ---------
.........................

- [ File = ./tests/paloalto.ini ] ---------
................

- [ File = ./tests/api.ini ] ---------
............................

- [ File = ./tests/aws_s3_access.ini ] ---------
.......

- [ File = ./tests/exchange.ini ] ---------
..

- [ File = ./tests/f5_big_ip.ini ] ---------
...........................................

- [ File = ./tests/cisco_asa.ini ] ---------
........................................................................................

- [ File = ./tests/nextcloud.ini ] ---------
.......

- [ File = ./tests/trendmicro-cloud-one.ini ] ---------
.................

- [ File = ./tests/pfsense.ini ] ---------
..

- [ File = ./tests/vsftpd.ini ] ---------
....

- [ File = ./tests/web_rules.ini ] ---------
..........

- [ File = ./tests/apache.ini ] ---------
..................

- [ File = ./tests/eset.ini ] ---------
........

- [ File = ./tests/doas.ini ] ---------
....

- [ File = ./tests/sysmon.ini ] ---------
...

- [ File = ./tests/gcp.ini ] ---------
...........

- [ File = ./tests/icinga.ini ] ---------
....

- [ File = ./tests/postfix.ini ] ---------
..

- [ File = ./tests/audit_scp.ini ] ---------
.

- [ File = ./tests/dropbear.ini ] ---------
...

- [ File = ./tests/rsh.ini ] ---------
..

- [ File = ./tests/kernel_usb.ini ] ---------
......

- [ File = ./tests/mcafee_epo.ini ] ---------
.

- [ File = ./tests/netscreen.ini ] ---------
....

- [ File = ./tests/panda_paps.ini ] ---------
........

- [ File = ./tests/auditd.ini ] ---------
...

- [ File = ./tests/cylance.ini ] ---------
.......

- [ File = ./tests/modsecurity.ini ] ---------
......

- [ File = ./tests/cloudlfare-waf.ini ] ---------
.............

- [ File = ./tests/office365.ini ] ---------
................................................................................................................................

- [ File = ./tests/sshd.ini ] ---------
...........................................

- [ File = ./tests/cisco_ios.ini ] ---------
.................

- [ File = ./tests/glpi.ini ] ---------
...

- [ File = ./tests/sudo.ini ] ---------
........

- [ File = ./tests/su.ini ] ---------
.....

- [ File = ./tests/proftpd.ini ] ---------
.......

- [ File = ./tests/SonicWall.ini ] ---------
........

|Component |  Tested  |  Total   | Coverage |
| -------- | -------- | -------- | -------- |
|  Rules   |   982    |   4174   |  23.53%  |
| Decoders |    76    |   172    |  44.19%  |

|          File           |  Passed  |  Failed  |  Status  |
|        --------         | -------- | -------- | -------- |
|./tests/samba.ini        |    4     |    0     |    ✅     |
|./tests/fortigate.ini    |    40    |    0     |    ✅     |
|./tests/apparmor.ini     |    5     |    0     |    ✅     |
|./tests/pam.ini          |    5     |    0     |    ✅     |
|./tests/audit_lateral.ini|    6     |    0     |    ✅     |
|./tests/systemd.ini      |    2     |    0     |    ✅     |
|./tests/arbor.ini        |    2     |    0     |    ✅     |
|./tests/dovecot.ini      |    15    |    0     |    ✅     |
|./tests/mailscanner.ini  |    1     |    0     |    ✅     |
|./tests/ossec.ini        |    5     |    0     |    ✅     |
|./tests/vuln_detector.ini|    2     |    0     |    ✅     |
|./tests/squid_rules.ini  |    2     |    0     |    ✅     |
|./tests/pix.ini          |    22    |    0     |    ✅     |
|./tests/huawei_usg.ini   |    3     |    0     |    ✅     |
|./tests/checkpoint_smart1.ini|    18    |    0     |    ✅     |
|./tests/junos.ini        |    3     |    0     |    ✅     |
|./tests/web_appsec.ini   |    31    |    0     |    ✅     |
|./tests/cimserver.ini    |    2     |    0     |    ✅     |
|./tests/cisco_ftd.ini    |    42    |    0     |    ✅     |
|./tests/firewalld.ini    |    2     |    0     |    ✅     |
|./tests/audit_recon.ini  |    2     |    0     |    ✅     |
|./tests/openldap.ini     |    9     |    0     |    ✅     |
|./tests/sophos_fw.ini    |    10    |    0     |    ✅     |
|./tests/owlh.ini         |    4     |    0     |    ✅     |
|./tests/freepbx.ini      |    6     |    0     |    ✅     |
|./tests/syslog.ini       |    6     |    0     |    ✅     |
|./tests/openvpn_ldap.ini |    2     |    0     |    ✅     |
|./tests/sophos.ini       |    8     |    0     |    ✅     |
|./tests/unbound.ini      |    0     |    0     |    ✅     |
|./tests/github.ini       |   324    |    0     |    ✅     |
|./tests/cpanel.ini       |    7     |    0     |    ✅     |
|./tests/fireeye.ini      |    3     |    0     |    ✅     |
|./tests/fortiauth.ini    |    4     |    0     |    ✅     |
|./tests/iptables.ini     |    8     |    0     |    ✅     |
|./tests/named.ini        |    5     |    0     |    ✅     |
|./tests/sophos-utm-firewall.ini|    6     |    0     |    ✅     |
|./tests/nginx.ini        |    12    |    0     |    ✅     |
|./tests/exim.ini         |    7     |    0     |    ✅     |
|./tests/opensmtpd.ini    |    7     |    0     |    ✅     |
|./tests/oscap.ini        |    32    |    0     |    ✅     |
|./tests/gitlab.ini       |    25    |    0     |    ✅     |
|./tests/paloalto.ini     |    16    |    0     |    ✅     |
|./tests/api.ini          |    28    |    0     |    ✅     |
|./tests/aws_s3_access.ini|    7     |    0     |    ✅     |
|./tests/exchange.ini     |    2     |    0     |    ✅     |
|./tests/f5_big_ip.ini    |    43    |    0     |    ✅     |
|./tests/cisco_asa.ini    |    88    |    0     |    ✅     |
|./tests/nextcloud.ini    |    7     |    0     |    ✅     |
|./tests/trendmicro-cloud-one.ini|    17    |    0     |    ✅     |
|./tests/pfsense.ini      |    2     |    0     |    ✅     |
|./tests/vsftpd.ini       |    4     |    0     |    ✅     |
|./tests/web_rules.ini    |    10    |    0     |    ✅     |
|./tests/apache.ini       |    18    |    0     |    ✅     |
|./tests/eset.ini         |    8     |    0     |    ✅     |
|./tests/doas.ini         |    4     |    0     |    ✅     |
|./tests/sysmon.ini       |    3     |    0     |    ✅     |
|./tests/gcp.ini          |    11    |    0     |    ✅     |
|./tests/icinga.ini       |    4     |    0     |    ✅     |
|./tests/postfix.ini      |    2     |    0     |    ✅     |
|./tests/audit_scp.ini    |    1     |    0     |    ✅     |
|./tests/dropbear.ini     |    3     |    0     |    ✅     |
|./tests/rsh.ini          |    2     |    0     |    ✅     |
|./tests/kernel_usb.ini   |    6     |    0     |    ✅     |
|./tests/mcafee_epo.ini   |    1     |    0     |    ✅     |
|./tests/netscreen.ini    |    4     |    0     |    ✅     |
|./tests/panda_paps.ini   |    8     |    0     |    ✅     |
|./tests/auditd.ini       |    3     |    0     |    ✅     |
|./tests/cylance.ini      |    7     |    0     |    ✅     |
|./tests/modsecurity.ini  |    6     |    0     |    ✅     |
|./tests/cloudlfare-waf.ini|    13    |    0     |    ✅     |
|./tests/office365.ini    |   128    |    0     |    ✅     |
|./tests/sshd.ini         |    43    |    0     |    ✅     |
|./tests/cisco_ios.ini    |    17    |    0     |    ✅     |
|./tests/glpi.ini         |    3     |    0     |    ✅     |
|./tests/sudo.ini         |    8     |    0     |    ✅     |
|./tests/su.ini           |    5     |    0     |    ✅     |
|./tests/proftpd.ini      |    7     |    0     |    ✅     |
|./tests/SonicWall.ini    |    8     |    0     |    ✅     |
Restarting wazuh-manager...
root@ubuntu-focal:/var/ossec/ruleset/feed/testing# 
```
</p>
</details>

- [x] 4.d New CDB lists must include the proper test entry in the correct .ini file.

### E2E testing

- ~~ 5.a Logs for new or modified decoder/rules sent to a manager running with this PR ruleset appear in Kibana.~~

- [x] 5.b There are no affected or broken visualizations on Kibana.
![image](https://user-images.githubusercontent.com/25141115/145439589-03912c5c-1f32-4dd6-8d98-79d2f51b64e3.png)

- [x] 5.c New or modified items can be seen correctly using APP ruleset navigation.
![image](https://user-images.githubusercontent.com/25141115/145439178-d0469109-f4c5-4ff1-9aed-3f96de84734d.png)
![image](https://user-images.githubusercontent.com/25141115/145439461-a5d8cfd1-540b-4e57-a5d6-43cd1e792c83.png)




### Elasticsearch Template

- [x] 6.a Known fields with output format managed and usually used for searching are included in template array index.query.default_field. 
- [x] 6.b The new field with the correct date format is stored as a "date" type field in the template.
- [x] 6.c The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 
- [x] 6.d Known fields with output format managed and usually used for searching are included in the template.

### Stoppers

- [x] 7.a No previous rule ID changes without triple check.
- [x] 7.b No previous decoder name changes without triple check.
- [x] 7.c No previous file name changes without triple check.
- [x] 7.d No previous test changes its 'rule' field value without triple check.

### Others

- [x] 8.a Each file has the correct copyright block.
- [x] 8.b The copyright block doesn't have "Author" only "Created by Wazuh". To include an "Author" request triple check.
- [x] 8.c The copyright block doesn't use "-". 
- [x] 8.d The rule files don't have any sample log.
- [x] 8.e The decoder file has sample logs next to the decoder that matches that log.
- [x] 8.f The decoder and rule files have information about software, version, and any helpful information.
- [x] 8.g The PR has a single commit with CHANGELOG changes in the correct format.
- [x] 8.h The new rule ID is not in use.
- [x] 8.i The new rule ID must be in the defined IDs range. 
- [x] 8.j New rules ID range must be verified with a triple check and noted in the rules ID document.
- [x] 8.k The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 