### PR TITLE
Add IDs to connection enrollment logs

### DIFF
--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -68,6 +68,8 @@
 #define PORT_ERROR      "(1205): Invalid port number: '%d'."
 #define BIND_ERROR      "(1206): Unable to Bind port '%d' due to [(%d)-(%s)]"
 #define RCONFIG_ERROR   "(1207): %s remote configuration in '%s' is corrupted."
+#define AUTH_CONN_ERROR "(1208): Unable to connect to the Auth service at '%s:%d'."
+#define AUTH_CONNECTED  "(1209): Connected to the Auth service at '%s:%d'."
 #define QUEUE_ERROR     "(1210): Queue '%s' not accessible: '%s'"
 #define QUEUE_FATAL     "(1211): Unable to access queue: '%s'. Giving up."
 #define PID_ERROR       "(1212): Unable to create PID file."

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -218,7 +218,7 @@ static int w_enrollment_connect(w_enrollment_ctx *cfg, const char * server_addre
     /* Connect via TCP */
     int sock = OS_ConnectTCP((u_int16_t) cfg->target_cfg->port, ip_address, 0);
     if (sock < 0) {
-        merror("Unable to connect to %s:%d", ip_address, cfg->target_cfg->port);
+        merror(AUTH_CONN_ERROR, ip_address, cfg->target_cfg->port);
         os_free(ip_address);
         SSL_CTX_free(ctx);
         return ENROLLMENT_CONNECTION_FAILURE;
@@ -240,7 +240,7 @@ static int w_enrollment_connect(w_enrollment_ctx *cfg, const char * server_addre
         return ENROLLMENT_CONNECTION_FAILURE;
     }
 
-    mdebug1("Connected to %s:%d", ip_address, cfg->target_cfg->port);
+    mdebug1(AUTH_CONNECTED, ip_address, cfg->target_cfg->port);
 
     w_enrollment_verify_ca_certificate(cfg->ssl, cfg->cert_cfg->ca_cert, server_address);
 

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -505,7 +505,7 @@ void test_w_enrollment_connect_socket_error(void **state) {
     expect_value(__wrap_OS_ConnectTCP, ipv6, 0);
     will_return(__wrap_OS_ConnectTCP, -1);
 
-    expect_string(__wrap__merror, formatted_msg, "Unable to connect to 127.0.0.1:1234");
+    expect_string(__wrap__merror, formatted_msg, "(1208): Unable to connect to the Auth service at '127.0.0.1:1234'.");
     int ret = w_enrollment_connect(cfg, cfg->target_cfg->manager_name);
     assert_int_equal(ret, ENROLLMENT_CONNECTION_FAILURE);
 }
@@ -574,7 +574,7 @@ void test_w_enrollment_connect_success(void **state) {
     will_return(__wrap_SSL_new, cfg->ssl);
     will_return(__wrap_SSL_connect, 1);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "Connected to 127.0.0.1:1234");
+    expect_string(__wrap__mdebug1, formatted_msg, "(1209): Connected to the Auth service at '127.0.0.1:1234'.");
 
     // verify_ca_certificate
     expect_value(__wrap_check_x509_cert, ssl, cfg->ssl);
@@ -1022,7 +1022,7 @@ void test_w_enrollment_request_key(void **state) {
         will_return(__wrap_SSL_new, cfg->ssl);
         will_return(__wrap_SSL_connect, 1);
 
-        expect_string(__wrap__mdebug1, formatted_msg, "Connected to 192.168.1.1:1234");
+        expect_string(__wrap__mdebug1, formatted_msg, "(1209): Connected to the Auth service at '192.168.1.1:1234'.");
 
         // verify_ca_certificate
         expect_value(__wrap_check_x509_cert, ssl, cfg->ssl);


### PR DESCRIPTION
|Related issue|
|---|
| #11101 |

## Description

This pull request adds the ID to the following logs to the enrollment connection process as requested:
- Connection fail
- Connection success

## Logs/Alerts example

Before:
```
2021/11/29 17:25:02 wazuh-agentd: ERROR: Unable to connect to 172.17.0.2:1515
2021/11/29 17:25:02 wazuh-agentd: DEBUG: Connected to 172.17.0.2:1515
```

After:
```
2021/11/29 17:25:02 wazuh-agentd: ERROR: Unable to connect to the Auth service at '172.17.0.2:1515'.
2021/11/29 17:25:02 wazuh-agentd: DEBUG: Connected to the Auth service at '172.17.0.2:1515'.
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language