### PR TITLE
Fix azure configuration parsing

### DIFF
--- a/src/config/wmodules-azure.c
+++ b/src/config/wmodules-azure.c
@@ -386,11 +386,6 @@ int wm_azure_request_read(XML_NODE nodes, wm_azure_request_t * request, unsigned
         return OS_INVALID;
     }
 
-    if (!request->time_offset) {
-        merror("At module '%s': No time offset defined. Skipping request block...", WM_AZURE_CONTEXT.name);
-        return OS_INVALID;
-    }
-
     if (!request->workspace && type == LOG_ANALYTICS) {
         merror("At module '%s': No Workspace ID defined. Skipping request block...", WM_AZURE_CONTEXT.name);
         return OS_INVALID;
@@ -417,7 +412,7 @@ int wm_azure_storage_read(const OS_XML *xml, XML_NODE nodes, wm_azure_storage_t 
             merror(XML_ELEMNULL);
             return OS_INVALID;
 
-        } else if (!nodes[i]->content) {
+        } else if (!nodes[i]->content && strcmp(nodes[i]->element, XML_CONTAINER)) {
             merror(XML_VALUENULL, nodes[i]->element);
             return OS_INVALID;
 
@@ -445,10 +440,6 @@ int wm_azure_storage_read(const OS_XML *xml, XML_NODE nodes, wm_azure_storage_t 
                 storage->container = container;
             }
 
-            if (!(children = OS_GetElementsbyNode(xml, nodes[i]))) {
-                merror(XML_INVELEM, nodes[i]->element);
-                return OS_INVALID;
-            }
 
             // Read name attribute
             if (nodes[i]->attributes) {
@@ -479,17 +470,19 @@ int wm_azure_storage_read(const OS_XML *xml, XML_NODE nodes, wm_azure_storage_t 
                 continue;
             }
 
-            if (wm_azure_container_read(children, container) < 0) {
-                wm_clean_container(container);
-                if (container_prev) {
-                    container = container_prev;
-                    container->next = NULL;
-                } else {
-                    storage->container = container = NULL;
+            if ((children = OS_GetElementsbyNode(xml, nodes[i]))){
+                if (wm_azure_container_read(children, container) < 0) {
+                    wm_clean_container(container);
+                    if (container_prev) {
+                        container = container_prev;
+                        container->next = NULL;
+                    } else {
+                        storage->container = container = NULL;
+                    }
                 }
+                OS_ClearNode(children);
             }
 
-            OS_ClearNode(children);
 
         } else {
             merror(XML_INVELEM, nodes[i]->element);
@@ -584,21 +577,6 @@ int wm_azure_container_read(XML_NODE nodes, wm_azure_container_t * container) {
         }
     }
 
-    /* Validation process */
-    if (!container->blobs) {
-        merror("At module '%s': No blobs defined. Skipping container block...", WM_AZURE_CONTEXT.name);
-        return OS_INVALID;
-    }
-
-    if (!container->time_offset) {
-        merror("At module '%s': No time offset defined. Skipping container block...", WM_AZURE_CONTEXT.name);
-        return OS_INVALID;
-    }
-
-    if (!container->content_type) {
-        merror("At module '%s': No content type defined. Skipping container block...", WM_AZURE_CONTEXT.name);
-        return OS_INVALID;
-    }
 
     return 0;
 }

--- a/src/config/wmodules-azure.c
+++ b/src/config/wmodules-azure.c
@@ -412,7 +412,7 @@ int wm_azure_storage_read(const OS_XML *xml, XML_NODE nodes, wm_azure_storage_t 
             merror(XML_ELEMNULL);
             return OS_INVALID;
 
-        } else if (!nodes[i]->content && strcmp(nodes[i]->element, XML_CONTAINER)) {
+        } else if (!nodes[i]->content && (strcmp(nodes[i]->element, XML_CONTAINER) != 0)) {
             merror(XML_VALUENULL, nodes[i]->element);
             return OS_INVALID;
 
@@ -440,7 +440,6 @@ int wm_azure_storage_read(const OS_XML *xml, XML_NODE nodes, wm_azure_storage_t 
                 storage->container = container;
             }
 
-
             // Read name attribute
             if (nodes[i]->attributes) {
                 if (!strcmp(nodes[i]->attributes[0], XML_CONTAINER_NAME) && *nodes[i]->values[0] != '\0') {
@@ -454,7 +453,6 @@ int wm_azure_storage_read(const OS_XML *xml, XML_NODE nodes, wm_azure_storage_t 
                     } else {
                         storage->container = container = NULL;
                     }
-                    OS_ClearNode(children);
                     continue;
                 }
             } else {
@@ -466,11 +464,10 @@ int wm_azure_storage_read(const OS_XML *xml, XML_NODE nodes, wm_azure_storage_t 
                 } else {
                     storage->container = container = NULL;
                 }
-                OS_ClearNode(children);
                 continue;
             }
 
-            if ((children = OS_GetElementsbyNode(xml, nodes[i]))){
+            if ((children = OS_GetElementsbyNode(xml, nodes[i]))) {
                 if (wm_azure_container_read(children, container) < 0) {
                     wm_clean_container(container);
                     if (container_prev) {

--- a/src/wazuh_modules/wm_azure.c
+++ b/src/wazuh_modules/wm_azure.c
@@ -149,8 +149,10 @@ void wm_azure_log_analytics(wm_azure_api_t *log_analytics) {
         wm_strcat(&command, "--workspace", ' ');
         wm_strcat(&command, curr_request->workspace, ' ');
 
-        wm_strcat(&command, "--la_time_offset", ' ');
-        wm_strcat(&command, curr_request->time_offset, ' ');
+        if(curr_request->time_offset){
+            wm_strcat(&command, "--la_time_offset", ' ');
+            wm_strcat(&command, curr_request->time_offset, ' ');
+        }
 
         // Check timeout defined
         if (curr_request->timeout)
@@ -225,8 +227,10 @@ void wm_azure_graphs(wm_azure_api_t *graph) {
         snprintf(query, OS_SIZE_1024 - 1, "\'%s\'", curr_request->query);
         wm_strcat(&command, query, ' ');
 
-        wm_strcat(&command, "--graph_time_offset", ' ');
-        wm_strcat(&command, curr_request->time_offset, ' ');
+        if(curr_request->time_offset){
+            wm_strcat(&command, "--graph_time_offset", ' ');
+            wm_strcat(&command, curr_request->time_offset, ' ');
+        }
 
         // Check timeout defined
         if (curr_request->timeout)
@@ -297,20 +301,27 @@ void wm_azure_storage(wm_azure_storage_t *storage) {
         wm_strcat(&command, name, ' ');
 
         wm_strcat(&command, "--blobs", ' ');
-        snprintf(blobs, OS_SIZE_256 - 1, "\"%s\"", curr_container->blobs);
+        if(curr_container->blobs)
+            snprintf(blobs, OS_SIZE_256 - 1, "\"%s\"", curr_container->blobs);
+        else
+            snprintf(blobs, OS_SIZE_256 -1, "\"*\"");
         wm_strcat(&command, blobs, ' ');
 
         wm_strcat(&command, "--storage_tag", ' ');
         wm_strcat(&command, storage->tag, ' ');
 
-        if (!strncmp(curr_container->content_type, "json_file", 9)) {
-            wm_strcat(&command, "--json_file", ' ');
-        } else if (!strncmp(curr_container->content_type, "json_inline", 11)) {
-            wm_strcat(&command, "--json_inline", ' ');
+        if(curr_container->content_type){
+            if (!strncmp(curr_container->content_type, "json_file", 9)) {
+                wm_strcat(&command, "--json_file", ' ');
+            } else if (!strncmp(curr_container->content_type, "json_inline", 11)) {
+                wm_strcat(&command, "--json_inline", ' ');
+            }
         }
 
-        wm_strcat(&command, "--storage_time_offset", ' ');
-        wm_strcat(&command, curr_container->time_offset, ' ');
+        if(curr_container->time_offset){
+            wm_strcat(&command, "--storage_time_offset", ' ');
+            wm_strcat(&command, curr_container->time_offset, ' ');
+        }
 
         // Check timeout defined
         if (curr_container->timeout)

--- a/src/wazuh_modules/wm_azure.c
+++ b/src/wazuh_modules/wm_azure.c
@@ -149,7 +149,7 @@ void wm_azure_log_analytics(wm_azure_api_t *log_analytics) {
         wm_strcat(&command, "--workspace", ' ');
         wm_strcat(&command, curr_request->workspace, ' ');
 
-        if(curr_request->time_offset){
+        if (curr_request->time_offset) {
             wm_strcat(&command, "--la_time_offset", ' ');
             wm_strcat(&command, curr_request->time_offset, ' ');
         }
@@ -227,7 +227,7 @@ void wm_azure_graphs(wm_azure_api_t *graph) {
         snprintf(query, OS_SIZE_1024 - 1, "\'%s\'", curr_request->query);
         wm_strcat(&command, query, ' ');
 
-        if(curr_request->time_offset){
+        if (curr_request->time_offset) {
             wm_strcat(&command, "--graph_time_offset", ' ');
             wm_strcat(&command, curr_request->time_offset, ' ');
         }
@@ -301,7 +301,7 @@ void wm_azure_storage(wm_azure_storage_t *storage) {
         wm_strcat(&command, name, ' ');
 
         wm_strcat(&command, "--blobs", ' ');
-        if(curr_container->blobs)
+        if (curr_container->blobs)
             snprintf(blobs, OS_SIZE_256 - 1, "\"%s\"", curr_container->blobs);
         else
             snprintf(blobs, OS_SIZE_256 -1, "\"*\"");
@@ -310,7 +310,7 @@ void wm_azure_storage(wm_azure_storage_t *storage) {
         wm_strcat(&command, "--storage_tag", ' ');
         wm_strcat(&command, storage->tag, ' ');
 
-        if(curr_container->content_type){
+        if (curr_container->content_type) {
             if (!strncmp(curr_container->content_type, "json_file", 9)) {
                 wm_strcat(&command, "--json_file", ' ');
             } else if (!strncmp(curr_container->content_type, "json_inline", 11)) {
@@ -318,7 +318,7 @@ void wm_azure_storage(wm_azure_storage_t *storage) {
             }
         }
 
-        if(curr_container->time_offset){
+        if (curr_container->time_offset) {
             wm_strcat(&command, "--storage_time_offset", ' ');
             wm_strcat(&command, curr_container->time_offset, ' ');
         }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #11116|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
In this PR we change that some configuration options of the Azure integration module were treated as mandatory by the configuration parser when they are actually optional. Those options are `time_offset` for the `Graph`, `Log analytics` and `Storage` modules, and `blobs` and `content_type` for the `Storage` module too.  


## Tests
We have tested several valid configurations and all of then were working as expected. The tested configurations were:

<details><summary>Graph</summary>

```
<wodle name="azure-logs">
  <disabled>no</disabled>
  <interval>10m</interval>
  <run_on_start>yes</run_on_start>

  <graph>
    <auth_path>/var/ossec/wodles/azure/credentials</auth_path>
    <tenantdomain>wazuh.onmicrosoft.com</tenantdomain>
    <request>
        <query>auditLogs/directoryAudits</query>
    </request>

    <request>
        <query>auditLogs/directoryAudits</query>
        <time_offset>2d</time_offset>
    </request>

    <request>
        <query>auditLogs/directoryAudits</query>
        <time_offset>3d</time_offset>
    </request>
  </graph>
</wodle>
```

</details>


<details><summary>Log Analytics</summary>

```
<wodle name="azure-logs">
  <disabled>no</disabled>
  <interval>10m</interval>
  <run_on_start>yes</run_on_start>
   <log_analytics>
    <auth_path>/var/ossec/wodles/azure/credentials-analytics</auth_path>
    <tenantdomain>wazuh.onmicrosoft.com</tenantdomain>

     <request>
      <tag>azure-diagnostics</tag>
      <query>AzureDiagnostics</query>
      <workspace>bc8d21bd-b966-4a4f-8eed-9e0328720cbe</workspace>
    </request>

     <request>
      <tag>azure-activity</tag>
      <query>AzureActivity</query>
      <workspace>bc8d21bd-b966-4a4f-8eed-9e0328720cbe</workspace>
      <time_offset>14d</time_offset>
    </request>

     <request>
      <tag>azure-diagnostics</tag>
      <query>AzureDiagnostics</query>
      <workspace>bc8d21bd-b966-4a4f-8eed-9e0328720cbe</workspace>
      <time_offset>1d</time_offset>
    </request>

     <request>
      <tag>azure-diagnostics</tag>
      <query>AzureDiagnostics</query>
      <workspace>bc8d21bd-b966-4a4f-8eed-9e0328720cbe</workspace>
      <time_offset>30d</time_offset>
    </request>
   </log_analytics>
 </wodle>
```


</details>


<details><summary>Storage</summary>


```
<wodle name="azure-logs">
  <disabled>no</disabled>
  <interval>10m</interval>
  <run_on_start>yes</run_on_start>

  <storage>
      <auth_path>/var/ossec/wodles/azure/credentials-storage</auth_path>
      <tag>azure-activity</tag>

      <container name="frameworktestcontainer">
          <content_type>json_inline</content_type>
          <time_offset>50d</time_offset>
      </container>

      <container name="frameworktestcontainer">
          <blobs>.txt</blobs>
          <time_offset>50d</time_offset>
      </container>

      <container name="frameworktestcontainer">
          <blobs>.txt</blobs>
          <content_type>json_inline</content_type>
      </container>

      <container name="frameworktestcontainer"></container>
      <container name="frameworktestcontainer"/>
  </storage>
</wodle>
```


</details>

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors
