### PR TITLE
Rework of #8116 - Update Amazon Macie Rules

### DIFF
--- a/ruleset/rules/0350-amazon_rules.xml
+++ b/ruleset/rules/0350-amazon_rules.xml
@@ -1,597 +1,632 @@
 <!--
-  -  Amazon rules
-  -  Created by Wazuh, Inc.
-  -  Copyright (C) 2015-2021, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  Copyright (C) 2015-2021, Wazuh Inc.
 -->
 
 <!--
-ID: 80200 - 80499
+  Amazon AWS rules ID:
+    AWS base: 80200
+    Cloudtrail: 80202 - 80307
+    Elastic Load Balancing: 80325 - 80328
+    Macie: 80350 - 80355
+    VPC Flow: 80400 - 80402
+    AWS WAF: 80440 - 80443
+    AWS Config: 80450 - 80476
+    AWS Trusted Advisor: 80480 - 80483
+    AWS KMS (Key Management Service): 80490 - 80494
+    AWS Inspector: 80495 - 80499
+    S3 Access rules: 80360 - 80366
+
 -->
 
 <group name="amazon,aws,">
 
-    <!-- AWS wodle -->
-    <rule id="80200" level="0">
-        <decoded_as>json</decoded_as>
-        <field name="integration">aws</field>
-        <description>AWS alert.</description>
-        <options>no_full_log</options>
-    </rule>
+  <!-- AWS wodle -->
+  <rule id="80200" level="0">
+    <decoded_as>json</decoded_as>
+    <field name="integration">aws</field>
+    <options>no_full_log</options>
+    <description>AWS alert.</description>
+  </rule>
 
-    <!-- Cloudtrail -->
+  <!-- Cloudtrail -->
+  <!-- Filter by eventName: etc/lists/amazon/aws-eventnames -->
+  <rule id="80202" level="3">
+    <if_sid>80200</if_sid>
+    <field name="aws.source">cloudtrail</field>
+    <list field="aws.eventName" lookup="match_key">etc/lists/amazon/aws-eventnames</list>
+    <options>no_full_log</options>
+    <description>AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName).</description>
+    <group>aws_cloudtrail,hipaa_164.312.b,nist_800_53_AU.6,pci_dss_10.6.1,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
 
-    <!-- Filter by eventName: etc/lists/amazon/aws-eventnames -->
-    <rule id="80202" level="3">
-        <if_sid>80200</if_sid>
-        <field name="aws.source">cloudtrail</field>
-        <list field="aws.eventName" lookup="match_key">etc/lists/amazon/aws-eventnames</list>
-        <description>AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName).</description>
-        <group>aws_cloudtrail,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,tsc_CC7.2,tsc_CC7.3,</group>
-        <options>no_full_log</options>
-    </rule>
+  <!-- If there is an error code: increase the level and change description -->
+  <rule id="80203" level="4">
+    <if_sid>80202</if_sid>
+    <field name="aws.errorCode">\.+</field>
+    <options>no_full_log</options>
+    <description>AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName). Error: $(aws.errorCode).</description>
+    <group>aws_cloudtrail,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,pci_dss_10.6.1,amazon-error,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
 
-    <!-- If there is an error code: increase the level and change description -->
-    <rule id="80203" level="4">
-        <if_sid>80202</if_sid>
-        <field name="aws.errorCode">\.+</field>
-        <description>AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName). Error: $(aws.errorCode).</description>
-        <group>aws_cloudtrail,pci_dss_10.6.1,amazon-error,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,tsc_CC7.2,tsc_CC7.3,</group>
-        <options>no_full_log</options>
-    </rule>
+  <!-- Specific rules -->
 
-    <!-- Specific rules -->
+  <!-- Events with errors -->
+  <rule id="80250" level="5">
+    <if_sid>80203</if_sid>
+    <field name="aws.errorCode">AccessDenied</field>
+    <options>no_full_log</options>
+    <description>AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName). Error: $(aws.errorCode).</description>
+    <group>
+      aws_cloudtrail,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,
+    </group>
+  </rule>
 
-    <!-- Events with errors -->
-    <rule id="80250" level="5">
-        <if_sid>80203</if_sid>
-        <field name="aws.errorCode">AccessDenied</field>
-        <description>AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName). Error: $(aws.errorCode).</description>
-        <group>aws_cloudtrail,pci_dss_10.6.1,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,</group>
-        <options>no_full_log</options>
-    </rule>
+  <!-- Events with no errors -->
+  <rule id="80251" level="3">
+    <if_sid>80202</if_sid>
+    <field name="aws.eventName">DeleteObjects</field>
+    <options>no_full_log</options>
+    <description>AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName).</description>
+    <group>aws_cloudtrail,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,pci_dss_10.6.1,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
 
-    <!-- Events with no errors -->
-    <rule id="80251" level="3">
-        <if_sid>80202</if_sid>
-        <field name="aws.eventName">DeleteObjects</field>
-        <description>AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName).</description>
-        <group>aws_cloudtrail,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,tsc_CC7.2,tsc_CC7.3,</group>
-        <options>no_full_log</options>
-    </rule>
+  <rule id="80252" level="10" frequency="22" timeframe="600">
+    <if_matched_sid>80251</if_matched_sid>
+    <options>no_full_log</options>
+    <description>AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName) - high number of deleted object.</description>
+    <mitre>
+      <id>T1485</id>
+    </mitre>
+    <group>aws_cloudtrail,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,pci_dss_10.6.1,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
 
-    <rule id="80252" level="10" frequency="22" timeframe="600">
-        <if_matched_sid>80251</if_matched_sid>
-        <description>AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName) - high number of deleted object.</description>
-        <mitre>
-            <id>T1485</id>
-        </mitre>
-        <group>aws_cloudtrail,pci_dss_10.6.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,tsc_CC7.2,tsc_CC7.3,</group>
-        <options>no_full_log</options>
-    </rule>
+  <!-- Logins -->
+  <rule id="80253" level="3">
+    <if_sid>80202</if_sid>
+    <field name="aws.eventName">ConsoleLogin</field>
+    <options>no_full_log</options>
+    <description>AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName) - User Login Success.</description>
+    <mitre>
+      <id>T1078</id>
+    </mitre>
+    <group>authentication_success,aws_cloudtrail,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.5,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
+    </group>
+  </rule>
 
-    <!-- Logins -->
-    <rule id="80253" level="3">
-        <if_sid>80202</if_sid>
-        <field name="aws.eventName">ConsoleLogin</field>
-        <description>AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName) - User Login Success.</description>
-        <mitre>
-            <id>T1078</id>
-        </mitre>
-        <group>aws_cloudtrail,authentication_success,pci_dss_10.2.5,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-        <options>no_full_log</options>
-    </rule>
+  <rule id="80254" level="5">
+    <if_sid>80253</if_sid>
+    <field name="aws.responseElements.ConsoleLogin">Failure</field>
+    <options>no_full_log</options>
+    <description>AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName) - User Login failed.</description>
+    <group>
+      authentication_failed,aws_cloudtrail,pci_dss_10.2.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
+    </group>
+  </rule>
 
-    <rule id="80254" level="5">
-        <if_sid>80253</if_sid>
-        <field name="aws.responseElements.ConsoleLogin">Failure</field>
-        <description>AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName) - User Login failed.</description>
-        <group>aws_cloudtrail,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-        <options>no_full_log</options>
-    </rule>
+  <rule id="80255" level="10" frequency="6" timeframe="360">
+    <if_matched_sid>80254</if_matched_sid>
+    <options>no_full_log</options>
+    <description>AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName) - Possible breaking attempt (high number of login attempts).</description>
+    <mitre>
+      <id>T1110</id>
+    </mitre>
+    <group>
+      authentication_failures,aws_cloudtrail,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SI.4,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
+    </group>
+  </rule>
 
-    <rule id="80255" level="10" frequency="6" timeframe="360">
-        <if_matched_sid>80254</if_matched_sid>
-        <description>AWS Cloudtrail: $(aws.eventSource) - $(aws.eventName) - Possible breaking attempt (high number of login attempts).</description>
-        <mitre>
-            <id>T1110</id>
-        </mitre>
-        <group>aws_cloudtrail,authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SI.4,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-        <options>no_full_log</options>
-    </rule>
+  <!-- Guard Duty -->
+  <!-- Documentation: https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types.html -->
+  <rule id="80300" level="0">
+    <if_sid>80200</if_sid>
+    <field name="aws.source">guardduty</field>
+    <options>no_full_log</options>
+    <description>AWS GuardDuty alert.</description>
+    <group>aws_guardduty,</group>
+  </rule>
 
-    <!-- Guard Duty -->
-    <!-- Documentation: https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types.html -->
-    <rule id="80300" level="0">
-        <if_sid>80200</if_sid>
-        <field name="aws.source">guardduty</field>
-        <description>AWS GuardDuty alert.</description>
-        <group>aws_guardduty,</group>
-        <options>no_full_log</options>
-    </rule>
+  <!-- Guard Duty severity levels: https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_findings.html#guardduty_findings-severity -->
+  <rule id="80301" level="3">
+    <if_sid>80300</if_sid>
+    <field name="aws.severity">0|1|2|3</field>
+    <options>no_full_log</options>
+    <description>AWS GuardDuty: $(aws.service.action.actionType) - $(aws.title)</description>
+    <group>aws_guardduty,</group>
+  </rule>
 
-    <!-- Guard Duty severity levels: https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_findings.html#guardduty_findings-severity -->
-    <rule id="80301" level="3">
-        <if_sid>80300</if_sid>
-        <field name="aws.severity">0|1|2|3</field>
-        <description>AWS GuardDuty: $(aws.service.action.actionType) - $(aws.title)</description>
-        <group>aws_guardduty,</group>
-        <options>no_full_log</options>
-    </rule>
-    <rule id="80302" level="6">
-        <if_sid>80300</if_sid>
-        <field name="aws.severity">4|5|6</field>
-        <description>AWS GuardDuty: $(aws.service.action.actionType) - $(aws.title)</description>
-        <group>aws_guardduty,</group>
-        <options>no_full_log</options>
-    </rule>
+  <rule id="80302" level="6">
+    <if_sid>80300</if_sid>
+    <field name="aws.severity">4|5|6</field>
+    <options>no_full_log</options>
+    <description>AWS GuardDuty: $(aws.service.action.actionType) - $(aws.title)</description>
+    <group>aws_guardduty,</group>
+  </rule>
 
-    <rule id="80303" level="10">
-        <if_sid>80300</if_sid>
-        <field name="aws.severity">7|8|9</field>
-        <description>AWS GuardDuty: $(aws.service.action.actionType) - $(aws.title)</description>
-        <group>aws_guardduty,</group>
-        <options>no_full_log</options>
-    </rule>
+  <rule id="80303" level="10">
+    <if_sid>80300</if_sid>
+    <field name="aws.severity">7|8|9</field>
+    <options>no_full_log</options>
+    <description>AWS GuardDuty: $(aws.service.action.actionType) - $(aws.title)</description>
+    <group>aws_guardduty,</group>
+  </rule>
 
-    <!-- PORT_PROBE rules -->
-    <rule id="80305" level="3">
-        <if_sid>80301</if_sid>
-        <field name="aws.service.action.actionType">PORT_PROBE</field>
-        <description>AWS GuardDuty: $(aws.service.action.actionType) - $(aws.title) [IP: $(aws.service.action.portProbeAction.portProbeDetails.remoteIpDetails.ipAddressV4)] [Port: $(aws.service.action.portProbeAction.portProbeDetails.localPortDetails.port)]</description>
-        <group>aws_guardduty,</group>
-        <options>no_full_log</options>
-    </rule>
+  <!-- PORT_PROBE rules -->
+  <rule id="80305" level="3">
+    <if_sid>80301</if_sid>
+    <field name="aws.service.action.actionType">PORT_PROBE</field>
+    <options>no_full_log</options>
+    <description>AWS GuardDuty: $(aws.service.action.actionType) - $(aws.title) [IP:
+      $(aws.service.action.portProbeAction.portProbeDetails.remoteIpDetails.ipAddressV4)] [Port:
+      $(aws.service.action.portProbeAction.portProbeDetails.localPortDetails.port)]
+    </description>
+    <group>aws_guardduty,</group>
+  </rule>
 
-    <rule id="80306" level="6">
-        <if_sid>80302</if_sid>
-        <field name="aws.service.action.actionType">PORT_PROBE</field>
-        <description>AWS GuardDuty: $(aws.service.action.actionType) - $(aws.title) [IP: $(aws.service.action.portProbeAction.portProbeDetails.remoteIpDetails.ipAddressV4)] [Port: $(aws.service.action.portProbeAction.portProbeDetails.localPortDetails.port)]</description>
-        <group>aws_guardduty,</group>
-        <options>no_full_log</options>
-    </rule>
+  <rule id="80306" level="6">
+    <if_sid>80302</if_sid>
+    <field name="aws.service.action.actionType">PORT_PROBE</field>
+    <options>no_full_log</options>
+    <description>AWS GuardDuty: $(aws.service.action.actionType) - $(aws.title) [IP:
+      $(aws.service.action.portProbeAction.portProbeDetails.remoteIpDetails.ipAddressV4)] [Port:
+      $(aws.service.action.portProbeAction.portProbeDetails.localPortDetails.port)]
+    </description>
+    <group>aws_guardduty,</group>
+  </rule>
 
-    <rule id="80307" level="10">
-        <if_sid>80303</if_sid>
-        <field name="aws.service.action.actionType">PORT_PROBE</field>
-        <description>AWS GuardDuty: $(aws.service.action.actionType) - $(aws.title) [IP: $(aws.service.action.portProbeAction.portProbeDetails.remoteIpDetails.ipAddressV4)] [Port: $(aws.service.action.portProbeAction.portProbeDetails.localPortDetails.port)]</description>
-        <group>aws_guardduty,</group>
-        <options>no_full_log</options>
-    </rule>
+  <rule id="80307" level="10">
+    <if_sid>80303</if_sid>
+    <field name="aws.service.action.actionType">PORT_PROBE</field>
+    <options>no_full_log</options>
+    <description>AWS GuardDuty: $(aws.service.action.actionType) - $(aws.title) [IP:
+      $(aws.service.action.portProbeAction.portProbeDetails.remoteIpDetails.ipAddressV4)] [Port:
+      $(aws.service.action.portProbeAction.portProbeDetails.localPortDetails.port)]
+    </description>
+    <group>aws_guardduty,</group>
+  </rule>
 
+  <!-- AWS ELB -->
+  <!-- Documentation: https://docs.aws.amazon.com/elasticloadbalancing/index.html -->
+  <rule id="80325" level="0">
+    <if_sid>80200</if_sid>
+    <field name="aws.source">alb</field>
+    <options>no_full_log</options>
+    <description>AWS ALB alert.</description>
+    <group>aws_alb,</group>
+  </rule>
 
-    <!-- AWS ELB -->
-    <!-- Documentation: https://docs.aws.amazon.com/elasticloadbalancing/index.html -->
-    <rule id="80325" level="0">
-      <if_sid>80200</if_sid>
-      <field name="aws.source">alb</field>
-      <description>AWS ALB alert.</description>
-      <group>aws_alb,</group>
-      <options>no_full_log</options>
-    </rule>
+  <rule id="80326" level="3">
+    <if_sid>80325</if_sid>
+    <field name="aws.elb_status_code">500</field>
+    <options>no_full_log</options>
+    <description>AWS ALB: Status error: $(data.aws.error_reason) - $(aws.action_executed) [ELB: $(aws.elb)]</description>
+    <group>aws_alb,</group>
+  </rule>
 
-    <rule id="80326" level="3">
-      <if_sid>80325</if_sid>
-      <field name="aws.elb_status_code">500</field>
-      <description>AWS ALB: Status error: $(data.aws.error_reason) - $(aws.action_executed) [ELB: $(aws.elb)]</description>
-      <group>aws_alb,</group>
-      <options>no_full_log</options>
-    </rule>
+  <rule id="80327" level="3">
+    <if_sid>80325</if_sid>
+    <field name="aws.elb_status_code">503</field>
+    <options>no_full_log</options>
+    <description>AWS ALB: Status error: $(data.aws.error_reason) - $(aws.action_executed) [ELB: $(aws.elb)]</description>
+    <group>aws_alb,</group>
+  </rule>
 
-    <rule id="80327" level="3">
-      <if_sid>80325</if_sid>
-      <field name="aws.elb_status_code">503</field>
-      <description>AWS ALB: Status error: $(data.aws.error_reason) - $(aws.action_executed) [ELB: $(aws.elb)]</description>
-      <group>aws_alb,</group>
-      <options>no_full_log</options>
-    </rule>
+  <rule id="80328" level="5">
+    <if_sid>80325</if_sid>
+    <field name="aws.elb_status_code">403</field>
+    <options>no_full_log</options>
+    <description>AWS ALB: Status error: $(data.aws.error_reason) - $(aws.action_executed) - $(aws.user_agent) [ELB: $(aws.elb)]</description>
+    <group>aws_alb,</group>
+  </rule>
 
-    <rule id="80328" level="5">
-      <if_sid>80325</if_sid>
-      <field name="aws.elb_status_code">403</field>
-      <description>AWS ALB: Status error: $(data.aws.error_reason) - $(aws.action_executed) - $(aws.user_agent) [ELB: $(aws.elb)]</description>
-      <group>aws_alb,</group>
-      <options>no_full_log</options>
-    </rule>
+  <!-- Macie Alerts -->
+  <!-- Documentation: https://docs.aws.amazon.com/macie/latest/userguide/macie-alerts.html#macie-alert-severity -->
+  <rule id="80350" level="0">
+    <if_sid>80200</if_sid>
+    <field name="aws.source">macie</field>
+    <options>no_full_log</options>
+    <description>AWS Macie alert.</description>
+    <group>aws_macie,</group>
+  </rule>
 
-    <!-- Macie Alerts -->
-    <!-- Documentation: https://docs.aws.amazon.com/macie/latest/userguide/macie-alerts.html#macie-alert-severity -->
-    <rule id="80350" level="0">
-        <if_sid>80200</if_sid>
-        <field name="aws.source">macie</field>
-        <description>AWS Macie alert.</description>
-        <group>aws_macie,</group>
-        <options>no_full_log</options>
-    </rule>
+  <rule id="80351" level="3">
+    <if_sid>80350</if_sid>
+    <field name="aws.severity.description">INFO</field>
+    <options>no_full_log</options>
+    <description>AWS Macie $(aws.severity.description): $(aws.name) - $(aws.summary.description)</description>
+    <group>aws_macie,</group>
+  </rule>
 
-    <rule id="80351" level="3">
-        <if_sid>80350</if_sid>
-        <field name="aws.severity.description">INFO</field>
-        <description>AWS Macie $(aws.severity.description): $(aws.name) - $(aws.summary.description)</description>
-        <group>aws_macie,</group>
-        <options>no_full_log</options>
-    </rule>
+  <rule id="80352" level="4">
+    <if_sid>80350</if_sid>
+    <field name="aws.severity.description">LOW</field>
+    <options>no_full_log</options>
+    <description>AWS Macie $(aws.severity.description): $(aws.name) - $(aws.summary.description)</description>
+    <group>aws_macie,</group>
+  </rule>
 
-    <rule id="80352" level="4">
-        <if_sid>80350</if_sid>
-        <field name="aws.severity.description">LOW</field>
-        <description>AWS Macie $(aws.severity.description): $(aws.name) - $(aws.summary.description)</description>
-        <group>aws_macie,</group>
-        <options>no_full_log</options>
-    </rule>
+  <rule id="80353" level="6">
+    <if_sid>80350</if_sid>
+    <field name="aws.severity.description">MEDIUM</field>
+    <options>no_full_log</options>
+    <description>AWS Macie $(aws.severity.description): $(aws.name) - $(aws.summary.description)</description>
+    <group>aws_macie,</group>
+  </rule>
 
-    <rule id="80353" level="6">
-        <if_sid>80350</if_sid>
-        <field name="aws.severity.description">MEDIUM</field>
-        <description>AWS Macie $(aws.severity.description): $(aws.name) - $(aws.summary.description)</description>
-        <group>aws_macie,</group>
-        <options>no_full_log</options>
-    </rule>
+  <rule id="80354" level="8">
+    <if_sid>80350</if_sid>
+    <field name="aws.severity.description">HIGH</field>
+    <options>no_full_log</options>
+    <description>AWS Macie $(aws.severity.description): $(aws.name) - $(aws.summary.description)</description>
+    <group>aws_macie,</group>
+  </rule>
 
-    <rule id="80354" level="8">
-        <if_sid>80350</if_sid>
-        <field name="aws.severity.description">HIGH</field>
-        <description>AWS Macie $(aws.severity.description): $(aws.name) - $(aws.summary.description)</description>
-        <group>aws_macie,</group>
-        <options>no_full_log</options>
-    </rule>
-
-    <rule id="80355" level="12">
-        <if_sid>80350</if_sid>
-        <field name="aws.severity.description">CRITICAL</field>
-        <description>AWS Macie $(aws.severity.description): $(aws.name) - $(aws.summary.description)</description>
-        <group>aws_macie,</group>
-        <options>no_full_log</options>
-    </rule>
-
-
-    <!-- VPC Flow -->
-    <!-- Documentation: https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/flow-logs.html -->
-    <rule id="80400" level="0">
-        <if_sid>80200</if_sid>
-        <field name="aws.source">vpc</field>
-        <description>AWS VPC Flow alert.</description>
-        <group>aws_vpcflow,</group>
-        <options>no_full_log</options>
-    </rule>
-
-    <rule id="80401" level="3">
-        <if_sid>80400</if_sid>
-        <field name="aws.action">ACCEPT</field>
-        <description>AWS VPC Flow: [$(aws.action)] - Interface: $(aws.interface_id) - Protocol: $(aws.protocol)</description>
-        <group>aws_vpcflow,</group>
-        <options>no_full_log</options>
-    </rule>
-
-    <rule id="80402" level="4">
-        <if_sid>80400</if_sid>
-        <field name="aws.action">REJECT</field>
-        <description>AWS VPC Flow: [$(aws.action)] - Interface: $(aws.interface_id) - Protocol: $(aws.protocol)</description>
-        <group>aws_vpcflow,</group>
-        <options>no_full_log</options>
-    </rule>
-
-    <!-- AWS WAF -->
-    <!-- Documentation: https://docs.aws.amazon.com/waf/latest/developerguide/logging.html -->
-    <rule id="80440" level="0">
-        <if_sid>80200</if_sid>
-        <field name="aws.source">waf</field>
-        <description>AWS WAF alert.</description>
-        <group>aws_waf,</group>
-        <options>no_full_log</options>
-    </rule>
-
-    <rule id="80441" level="0">
-        <if_sid>80440</if_sid>
-        <field name="aws.action">ALLOW</field>
-        <description>AWS WAF - Allowed request.</description>
-        <group>aws_waf,aws_waf_allow,</group>
-        <options>no_full_log</options>
-    </rule>
-
-    <rule id="80442" level="3">
-        <if_sid>80440</if_sid>
-        <field name="aws.action">BLOCK</field>
-        <description>AWS WAF - Blocked request.</description>
-        <group>aws_waf,aws_waf_block,</group>
-        <options>no_full_log</options>
-    </rule>
-
-    <rule id="80443" level="10" frequency="8" timeframe="120" ignore="60">
-        <if_matched_sid>80442</if_matched_sid>
-        <description>AWS WAF - Multiple Blocked request.</description>
-        <same_field>aws.httpRequest.clientIp</same_field>
-        <options>no_full_log</options>
-    </rule>
-
-    <!-- AWS Config -->
-    <!-- Documentation: https://docs.aws.amazon.com/config/latest/developerguide/WhatIsConfig.html -->
-    <rule id="80450" level="0">
-        <if_sid>80200</if_sid>
-        <field name="aws.source">config</field>
-        <description>AWS Config alert.</description>
-        <group>aws_config,</group>
-        <options>no_full_log</options>
-    </rule>
-
-    <!-- ConfigHistory vs ConfigSnapshot -->
-    <rule id="80451" level="0">
-        <if_sid>80450</if_sid>
-        <field name="aws.log_info.log_file">\.+ConfigHistory</field>
-        <description>AWS Config - History</description>
-        <group>aws_config,aws_config_history,</group>
-        <options>no_full_log</options>
-    </rule>
-
-    <rule id="80452" level="0">
-        <if_sid>80450</if_sid>
-        <field name="aws.log_info.log_file">\.+ConfigSnapshot</field>
-        <description>AWS Config - Snapshot</description>
-        <group>aws_config,aws_config_snapshot,</group>
-        <options>no_full_log</options>
-    </rule>
-
-    <!-- Config history -->
-    <rule id="80453" level="0">
-        <if_sid>80451</if_sid>
-        <field name="aws.configurationItemStatus">OK</field>
-        <description>AWS Config - History [$(aws.awsAccountId) $(aws.awsRegion)] [$(aws.resourceType)]: $(aws.resourceId) ($(aws.configurationItemStatus))</description>
-        <group>aws_config,aws_config_history,</group>
-        <options>no_full_log</options>
-    </rule>
-
-    <rule id="80454" level="3">
-        <if_sid>80451</if_sid>
-        <field name="aws.configurationItemStatus">ResourceDiscovered</field>
-        <description>The resource was newly discovered. AWS Config - History:  [$(aws.awsAccountId) $(aws.awsRegion)] [$(aws.resourceType)]: $(aws.resourceId) ($(aws.configurationItemStatus))</description>
-        <group>aws_config,aws_config_history,</group>
-        <options>no_full_log</options>
-    </rule>
-
-    <rule id="80455" level="3">
-        <if_sid>80451</if_sid>
-        <field name="aws.configurationItemStatus">ResourceNotRecorded</field>
-        <description>The resource was discovered but its configuration was not recorded since the recorder excludes the recording of resources of this type. AWS Config - History:  [$(aws.awsAccountId) $(aws.awsRegion)] [$(aws.resourceType)]: $(aws.resourceId) ($(aws.configurationItemStatus))</description>
-        <group>aws_config,aws_config_history,</group>
-        <options>no_full_log</options>
-    </rule>
-
-    <rule id="80456" level="3">
-        <if_sid>80451</if_sid>
-        <field name="aws.configurationItemStatus">ResourceDeleted</field>
-        <description>The resource was deleted. AWS Config - History:  [$(aws.awsAccountId) $(aws.awsRegion)] [$(aws.resourceType)]: $(aws.resourceId) ($(aws.configurationItemStatus))</description>
-        <group>aws_config,aws_config_history,</group>
-        <options>no_full_log</options>
-    </rule>
-
-    <rule id="80457" level="3">
-        <if_sid>80451</if_sid>
-        <field name="aws.configurationItemStatus">ResourceDeletedNotRecorded</field>
-        <description>The resource was deleted but its configuration was not recorded since the recorder excludes the recording of resources of this type. AWS Config - History:  [$(aws.awsAccountId) $(aws.awsRegion)] [$(aws.resourceType)]: $(aws.resourceId) ($(aws.configurationItemStatus))</description>
-        <group>aws_config,aws_config_history,</group>
-        <options>no_full_log</options>
-    </rule>
-
-    <!-- Config Snapshot -->
-    <rule id="80475" level="3">
-        <if_sid>80452</if_sid>
-        <description>AWS Config - Snapshot [$(aws.awsAccountId) $(aws.awsRegion)] [$(aws.resourceType)]: $(aws.resourceId) ($(aws.configurationItemStatus))</description>
-        <group>aws_config,aws_config_snapshot,</group>
-        <options>no_full_log</options>
-    </rule>
-
-    <rule id="80476" level="6">
-        <if_sid>80475</if_sid>
-        <field name="aws.configuration.complianceType">\.+</field>
-        <description>AWS Config - Snapshot Compliance [$(aws.awsAccountId) $(aws.awsRegion)] [$(aws.resourceType)] [$(aws.configuration.configRuleList.configRuleName)]: $(aws.resourceId) ($(aws.configurationItemStatus)) $(aws.configuration.complianceType)</description>
-        <group>aws_config,aws_config_snapshot,aws_config_snapshot_compliance,</group>
-        <options>no_full_log</options>
-    </rule>
+  <rule id="80355" level="12">
+    <if_sid>80350</if_sid>
+    <field name="aws.severity.description">CRITICAL</field>
+    <options>no_full_log</options>
+    <description>AWS Macie $(aws.severity.description): $(aws.name) - $(aws.summary.description)</description>
+    <group>aws_macie,</group>
+  </rule>
 
 
-    <!-- AWS Trusted Advisor -->
-    <!-- Documentation: https://docs.aws.amazon.com/awssupport/latest/user/trustedadvisor.html -->
-    <rule id="80480" level="0">
-        <if_sid>80200</if_sid>
-        <field name="aws.source">trustedadvisor</field>
-        <description>AWS Trusted Advisor alert.</description>
-        <group>aws_trusted_advisor,</group>
-        <options>no_full_log</options>
-    </rule>
+  <!-- VPC Flow -->
+  <!-- Documentation: https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/flow-logs.html -->
+  <rule id="80400" level="0">
+    <if_sid>80200</if_sid>
+    <field name="aws.source">vpc</field>
+    <options>no_full_log</options>
+    <description>AWS VPC Flow alert.</description>
+    <group>aws_vpcflow,</group>
+  </rule>
 
-    <rule id="80481" level="5">
-        <if_sid>80480</if_sid>
-        <field name="aws.status">ERROR</field>
-        <description>AWS Trusted Advisor - [$(aws.uuid)] [$(aws.check-name)]: $(aws.status)</description>
-        <group>aws_trusted_advisor,</group>
-        <options>no_full_log</options>
-    </rule>
+  <rule id="80401" level="3">
+    <if_sid>80400</if_sid>
+    <field name="aws.action">ACCEPT</field>
+    <options>no_full_log</options>
+    <description>AWS VPC Flow: [$(aws.action)] - Interface: $(aws.interface_id) - Protocol: $(aws.protocol)</description>
+    <group>aws_vpcflow,</group>
+  </rule>
 
-    <rule id="80482" level="4">
-        <if_sid>80480</if_sid>
-        <field name="aws.status">WARN</field>
-        <description>AWS Trusted Advisor - [$(aws.uuid)] [$(aws.check-name)]: $(aws.status)</description>
-        <group>aws_trusted_advisor,</group>
-        <options>no_full_log</options>
-    </rule>
+  <rule id="80402" level="4">
+    <if_sid>80400</if_sid>
+    <field name="aws.action">REJECT</field>
+    <options>no_full_log</options>
+    <description>AWS VPC Flow: [$(aws.action)] - Interface: $(aws.interface_id) - Protocol: $(aws.protocol)</description>
+    <group>aws_vpcflow,</group>
+  </rule>
 
-    <rule id="80483" level="3">
-        <if_sid>80480</if_sid>
-        <field name="aws.status">OK</field>
-        <description>AWS Trusted Advisor - [$(aws.uuid)] [$(aws.check-name)]: $(aws.status)</description>
-        <group>aws_trusted_advisor,</group>
-        <options>no_full_log</options>
-    </rule>
+  <!-- AWS WAF -->
+  <!-- Documentation: https://docs.aws.amazon.com/waf/latest/developerguide/logging.html -->
+  <rule id="80440" level="0">
+    <if_sid>80200</if_sid>
+    <field name="aws.source">waf</field>
+    <options>no_full_log</options>
+    <description>AWS WAF alert.</description>
+    <group>aws_waf,</group>
+  </rule>
+
+  <rule id="80441" level="0">
+    <if_sid>80440</if_sid>
+    <field name="aws.action">ALLOW</field>
+    <options>no_full_log</options>
+    <description>AWS WAF - Allowed request.</description>
+    <group>aws_waf,aws_waf_allow,</group>
+  </rule>
+
+  <rule id="80442" level="3">
+    <if_sid>80440</if_sid>
+    <field name="aws.action">BLOCK</field>
+    <options>no_full_log</options>
+    <description>AWS WAF - Blocked request.</description>
+    <group>aws_waf,aws_waf_block,</group>
+  </rule>
+
+  <rule id="80443" level="10" frequency="8" timeframe="120" ignore="60">
+    <if_matched_sid>80442</if_matched_sid>
+    <description>AWS WAF - Multiple Blocked request.</description>
+    <same_field>aws.httpRequest.clientIp</same_field>
+    <options>no_full_log</options>
+  </rule>
+
+  <!-- AWS Config -->
+  <!-- Documentation: https://docs.aws.amazon.com/config/latest/developerguide/WhatIsConfig.html -->
+  <rule id="80450" level="0">
+    <if_sid>80200</if_sid>
+    <field name="aws.source">config</field>
+    <options>no_full_log</options>
+    <description>AWS Config alert.</description>
+    <group>aws_config,</group>
+  </rule>
+
+  <!-- ConfigHistory vs ConfigSnapshot -->
+  <rule id="80451" level="0">
+    <if_sid>80450</if_sid>
+    <field name="aws.log_info.log_file">\.+ConfigHistory</field>
+    <options>no_full_log</options>
+    <description>AWS Config - History</description>
+    <group>aws_config,aws_config_history,</group>
+  </rule>
+
+  <rule id="80452" level="0">
+    <if_sid>80450</if_sid>
+    <field name="aws.log_info.log_file">\.+ConfigSnapshot</field>
+    <options>no_full_log</options>
+    <description>AWS Config - Snapshot</description>
+    <group>aws_config,aws_config_snapshot,</group>
+  </rule>
+
+  <!-- Config history -->
+  <rule id="80453" level="0">
+    <if_sid>80451</if_sid>
+    <field name="aws.configurationItemStatus">OK</field>
+    <options>no_full_log</options>
+    <description>AWS Config - History [$(aws.awsAccountId) $(aws.awsRegion)] [$(aws.resourceType)]: $(aws.resourceId) ($(aws.configurationItemStatus))
+    </description>
+    <group>aws_config,aws_config_history,</group>
+  </rule>
+
+  <rule id="80454" level="3">
+    <if_sid>80451</if_sid>
+    <field name="aws.configurationItemStatus">ResourceDiscovered</field>
+    <options>no_full_log</options>
+    <description>The resource was newly discovered. AWS Config - History: [$(aws.awsAccountId) $(aws.awsRegion)] [$(aws.resourceType)]: $(aws.resourceId)
+      ($(aws.configurationItemStatus))
+    </description>
+    <group>aws_config,aws_config_history,</group>
+  </rule>
+
+  <rule id="80455" level="3">
+    <if_sid>80451</if_sid>
+    <field name="aws.configurationItemStatus">ResourceNotRecorded</field>
+    <options>no_full_log</options>
+    <description>The resource was discovered but its configuration was not recorded since the recorder excludes the recording of resources of this type. AWS
+      Config - History: [$(aws.awsAccountId) $(aws.awsRegion)] [$(aws.resourceType)]: $(aws.resourceId) ($(aws.configurationItemStatus))
+    </description>
+    <group>aws_config,aws_config_history,</group>
+  </rule>
+
+  <rule id="80456" level="3">
+    <if_sid>80451</if_sid>
+    <field name="aws.configurationItemStatus">ResourceDeleted</field>
+    <description>The resource was deleted. AWS Config - History: [$(aws.awsAccountId) $(aws.awsRegion)] [$(aws.resourceType)]: $(aws.resourceId)
+      ($(aws.configurationItemStatus))
+    </description>
+    <group>aws_config,aws_config_history,</group>
+    <options>no_full_log</options>
+  </rule>
+
+  <rule id="80457" level="3">
+    <if_sid>80451</if_sid>
+    <field name="aws.configurationItemStatus">ResourceDeletedNotRecorded</field>
+    <options>no_full_log</options>
+    <description>The resource was deleted but its configuration was not recorded since the recorder excludes the recording of resources of this type. AWS Config
+      - History: [$(aws.awsAccountId) $(aws.awsRegion)] [$(aws.resourceType)]: $(aws.resourceId) ($(aws.configurationItemStatus))
+    </description>
+    <group>aws_config,aws_config_history,</group>
+  </rule>
+
+  <!-- Config Snapshot -->
+  <rule id="80475" level="3">
+    <if_sid>80452</if_sid>
+    <options>no_full_log</options>
+    <description>AWS Config - Snapshot [$(aws.awsAccountId) $(aws.awsRegion)] [$(aws.resourceType)]: $(aws.resourceId) ($(aws.configurationItemStatus))
+    </description>
+    <group>aws_config,aws_config_snapshot,</group>
+  </rule>
+
+  <rule id="80476" level="6">
+    <if_sid>80475</if_sid>
+    <field name="aws.configuration.complianceType">\.+</field>
+    <options>no_full_log</options>
+    <description>AWS Config - Snapshot Compliance [$(aws.awsAccountId) $(aws.awsRegion)] [$(aws.resourceType)]
+      [$(aws.configuration.configRuleList.configRuleName)]: $(aws.resourceId) ($(aws.configurationItemStatus)) $(aws.configuration.complianceType)
+    </description>
+    <group>aws_config,aws_config_snapshot,aws_config_snapshot_compliance,</group>
+  </rule>
 
 
-    <!-- AWS KMS (Key Management Service) -->
-    <!-- Documentation: https://docs.aws.amazon.com/kms/latest/developerguide/overview.html -->
-    <rule id="80490" level="0">
-        <if_sid>80200</if_sid>
-        <field name="aws.source">kms</field>
-        <description>AWS KMS alert.</description>
-        <group>aws_kms,</group>
-        <options>no_full_log</options>
-    </rule>
+  <!-- AWS Trusted Advisor -->
+  <!-- Documentation: https://docs.aws.amazon.com/awssupport/latest/user/trustedadvisor.html -->
+  <rule id="80480" level="0">
+    <if_sid>80200</if_sid>
+    <field name="aws.source">trustedadvisor</field>
+    <options>no_full_log</options>
+    <description>AWS Trusted Advisor alert.</description>
+    <group>aws_trusted_advisor,</group>
+  </rule>
 
-    <rule id="80491" level="3">
-        <if_sid>80490</if_sid>
-        <description>AWS KMS: [$(aws.eventName)] $(aws.userIdentity.type)</description>
-        <group>aws_kms,</group>
-        <options>no_full_log</options>
-    </rule>
+  <rule id="80481" level="5">
+    <if_sid>80480</if_sid>
+    <field name="aws.status">ERROR</field>
+    <options>no_full_log</options>
+    <description>AWS Trusted Advisor - [$(aws.uuid)] [$(aws.check-name)]: $(aws.status)</description>
+    <group>aws_trusted_advisor,</group>
+  </rule>
 
-    <rule id="80492" level="3">
-        <if_sid>80491</if_sid>
-        <field name="aws.userIdentity.userName">\.+</field>
-        <description>AWS KMS: [$(aws.eventName)] $(aws.userIdentity.type) - $(aws.userIdentity.userName) - $(aws.sourceIPAddress)</description>
-        <group>aws_kms,</group>
-        <options>no_full_log</options>
-    </rule>
+  <rule id="80482" level="4">
+    <if_sid>80480</if_sid>
+    <field name="aws.status">WARN</field>
+    <options>no_full_log</options>
+    <description>AWS Trusted Advisor - [$(aws.uuid)] [$(aws.check-name)]: $(aws.status)</description>
+    <group>aws_trusted_advisor,</group>
+  </rule>
 
-    <rule id="80493" level="0">
-        <if_sid>80491</if_sid>
-        <field name="aws.userIdentity.invokedBy">AWS Internal</field>
-        <description>AWS KMS: [$(aws.eventName)] $(aws.userIdentity.type)</description>
-        <group>aws_kms,</group>
-        <options>no_full_log</options>
-    </rule>
-
-    <rule id="80494" level="0">
-        <if_sid>80492</if_sid>
-        <field name="aws.userIdentity.invokedBy">AWS Internal</field>
-        <description>AWS KMS: [$(aws.eventName)] $(aws.userIdentity.type) - $(aws.userIdentity.userName) - $(aws.sourceIPAddress)</description>
-        <group>aws_kms,</group>
-        <options>no_full_log</options>
-    </rule>
+  <rule id="80483" level="3">
+    <if_sid>80480</if_sid>
+    <field name="aws.status">OK</field>
+    <options>no_full_log</options>
+    <description>AWS Trusted Advisor - [$(aws.uuid)] [$(aws.check-name)]: $(aws.status)</description>
+    <group>aws_trusted_advisor,</group>
+  </rule>
 
 
-    <!-- AWS Inspector -->
-    <!-- Documentation: https://docs.aws.amazon.com/inspector/latest/userguide/inspector_introduction.html -->
+  <!-- AWS KMS (Key Management Service) -->
+  <!-- Documentation: https://docs.aws.amazon.com/kms/latest/developerguide/overview.html -->
+  <rule id="80490" level="0">
+    <if_sid>80200</if_sid>
+    <field name="aws.source">kms</field>
+    <options>no_full_log</options>
+    <description>AWS KMS alert.</description>
+    <group>aws_kms,</group>
+  </rule>
 
-    <rule id="80495" level="0">
-        <if_sid>80200</if_sid>
-        <field name="aws.source">inspector</field>
-        <description>AWS Inspector - Network assessment [$(aws.createdAt)]: $(aws.title) [$(aws.severity)]</description>
-        <group>aws_inspector,</group>
-        <options>no_full_log</options>
-    </rule>
+  <rule id="80491" level="3">
+    <if_sid>80490</if_sid>
+    <options>no_full_log</options>
+    <description>AWS KMS: [$(aws.eventName)] $(aws.userIdentity.type)</description>
+    <group>aws_kms,</group>
+  </rule>
 
-    <rule id="80496" level="10">
-        <if_sid>80495</if_sid>
-        <field name="aws.severity">High</field>
-        <description>AWS Inspector - Network assessment [$(aws.createdAt)]: $(aws.title) [$(aws.severity)]</description>
-        <group>aws_inspector,</group>
-        <options>no_full_log</options>
-    </rule>
+  <rule id="80492" level="3">
+    <if_sid>80491</if_sid>
+    <field name="aws.userIdentity.userName">\.+</field>
+    <options>no_full_log</options>
+    <description>AWS KMS: [$(aws.eventName)] $(aws.userIdentity.type) - $(aws.userIdentity.userName) - $(aws.sourceIPAddress)</description>
+    <group>aws_kms,</group>
+  </rule>
 
-    <rule id="80497" level="7">
-        <if_sid>80495</if_sid>
-        <field name="aws.severity">Medium</field>
-        <description>AWS Inspector - Network assessment [$(aws.createdAt)]: $(aws.title) [$(aws.severity)]</description>
-        <group>aws_inspector,</group>
-        <options>no_full_log</options>
-    </rule>
+  <rule id="80493" level="0">
+    <if_sid>80491</if_sid>
+    <field name="aws.userIdentity.invokedBy">AWS Internal</field>
+    <options>no_full_log</options>
+    <description>AWS KMS: [$(aws.eventName)] $(aws.userIdentity.type)</description>
+    <group>aws_kms,</group>
+  </rule>
 
-    <rule id="80498" level="4">
-        <if_sid>80495</if_sid>
-        <field name="aws.severity">Low</field>
-        <description>AWS Inspector - Network assessment [$(aws.createdAt)]: $(aws.title) [$(aws.severity)]</description>
-        <group>aws_inspector,</group>
-        <options>no_full_log</options>
-    </rule>
+  <rule id="80494" level="0">
+    <if_sid>80492</if_sid>
+    <field name="aws.userIdentity.invokedBy">AWS Internal</field>
+    <options>no_full_log</options>
+    <description>AWS KMS: [$(aws.eventName)] $(aws.userIdentity.type) - $(aws.userIdentity.userName) - $(aws.sourceIPAddress)</description>
+    <group>aws_kms,</group>
+  </rule>
 
-    <rule id="80499" level="3">
-        <if_sid>80495</if_sid>
-        <field name="aws.severity">Informational</field>
-        <description>AWS Inspector - Network assessment [$(aws.createdAt)]: $(aws.title) [$(aws.severity)]</description>
-        <group>aws_inspector,</group>
-        <options>no_full_log</options>
-    </rule>
+
+  <!-- AWS Inspector -->
+  <!-- Documentation: https://docs.aws.amazon.com/inspector/latest/userguide/inspector_introduction.html -->
+  <rule id="80495" level="0">
+    <if_sid>80200</if_sid>
+    <field name="aws.source">inspector</field>
+    <options>no_full_log</options>
+    <description>AWS Inspector - Network assessment [$(aws.createdAt)]: $(aws.title) [$(aws.severity)]</description>
+    <group>aws_inspector,</group>
+  </rule>
+
+  <rule id="80496" level="10">
+    <if_sid>80495</if_sid>
+    <field name="aws.severity">High</field>
+    <description>AWS Inspector - Network assessment [$(aws.createdAt)]: $(aws.title) [$(aws.severity)]</description>
+    <options>no_full_log</options>
+    <group>aws_inspector,</group>
+  </rule>
+
+  <rule id="80497" level="7">
+    <if_sid>80495</if_sid>
+    <field name="aws.severity">Medium</field>
+    <options>no_full_log</options>
+    <description>AWS Inspector - Network assessment [$(aws.createdAt)]: $(aws.title) [$(aws.severity)]</description>
+    <group>aws_inspector,</group>
+  </rule>
+
+  <rule id="80498" level="4">
+    <if_sid>80495</if_sid>
+    <field name="aws.severity">Low</field>
+    <options>no_full_log</options>
+    <description>AWS Inspector - Network assessment [$(aws.createdAt)]: $(aws.title) [$(aws.severity)]</description>
+    <group>aws_inspector,</group>
+  </rule>
+
+  <rule id="80499" level="3">
+    <if_sid>80495</if_sid>
+    <field name="aws.severity">Informational</field>
+    <options>no_full_log</options>
+    <description>AWS Inspector - Network assessment [$(aws.createdAt)]: $(aws.title) [$(aws.severity)]</description>
+    <group>aws_inspector,</group>
+  </rule>
 
 </group>
 
 <!-- S3 Access rules -->
 <group name="amazon, aws, s3">
 
-    <rule id="80360" level="0">
-        <if_sid>80200</if_sid>
-        <field name="aws.source">s3_server_access</field>
-        <description>AWS S3 Access Log events group</description>
-    </rule>
+  <rule id="80360" level="0">
+    <if_sid>80200</if_sid>
+    <field name="aws.source">s3_server_access</field>
+    <description>AWS S3 Access Log events group</description>
+  </rule>
 
-     <!-- Error events -->
-    <rule id="80367" level="5">
-        <if_sid>80360</if_sid>
-        <field name="aws.error_code" type="pcre2">^(?!^$|^-$).*</field>
-        <description>AWS S3 Error: $(aws.error_code)</description>
-    </rule>
+  <!-- Error events -->
+  <rule id="80367" level="5">
+    <if_sid>80360</if_sid>
+    <field name="aws.error_code" type="pcre2">^(?!^$|^-$).*</field>
+    <description>AWS S3 Error: $(aws.error_code)</description>
+  </rule>
 
-    <!-- Acces denied errors -->
-    <rule id="80368" level="5">
-        <if_sid>80367</if_sid>
-        <field name="aws.error_code" type="pcre2">^(?:AccessDenied|LambdaPermissionError|AccountNotAuthorized|OrganizationAccessDenied|UnauthorizedAccess)$</field>
-        <description>AWS S3 Error: $(aws.error_code), operation: $(aws.operation)</description>
-    </rule>
+  <!-- Acces denied errors -->
+  <rule id="80368" level="5">
+    <if_sid>80367</if_sid>
+    <field name="aws.error_code" type="pcre2">^(?:AccessDenied|LambdaPermissionError|AccountNotAuthorized|OrganizationAccessDenied|UnauthorizedAccess)$</field>
+    <description>AWS S3 Error: $(aws.error_code), operation: $(aws.operation)</description>
+  </rule>
 
-    <rule id="80369" level="10" frequency="10" timeframe="60">
-        <if_matched_sid>80368</if_matched_sid>
-        <same_field>aws.error_code</same_field>
-        <description>AWS S3 Error: Multiple Access Denied</description>
-    </rule>
+  <rule id="80369" level="10" frequency="10" timeframe="60">
+    <if_matched_sid>80368</if_matched_sid>
+    <same_field>aws.error_code</same_field>
+    <description>AWS S3 Error: Multiple Access Denied</description>
+  </rule>
 
-    <!-- Authentication failure -->
-    <rule id="80370" level="5">
-        <if_sid>80367</if_sid>
-        <field name="aws.error_code" type="pcre2">^InvalidSecurity$</field>
-        <description>AWS S3 Authentication Failure: $(aws.error_code), from: $(aws.requester)</description>
-    </rule>
+  <!-- Authentication failure -->
+  <rule id="80370" level="5">
+    <if_sid>80367</if_sid>
+    <field name="aws.error_code" type="pcre2">^InvalidSecurity$</field>
+    <description>AWS S3 Authentication Failure: $(aws.error_code), from: $(aws.requester)</description>
+  </rule>
 
-    <rule id="80371" level="10" frequency="10" timeframe="60">
-        <if_matched_sid>80370</if_matched_sid>
-        <description>AWS S3 Multiple Authentication Failures</description>
-        <mitre>
-            <id>T1110</id>
-        </mitre>
-    </rule>
+  <rule id="80371" level="10" frequency="10" timeframe="60">
+    <if_matched_sid>80370</if_matched_sid>
+    <description>AWS S3 Multiple Authentication Failures</description>
+    <mitre>
+      <id>T1110</id>
+    </mitre>
+  </rule>
 
-    <rule id="80361" level="3">
-        <if_sid>80360</if_sid>
-        <field name="aws.operation">DELETE</field>
-        <description>AWS S3: DELETE operation: $(aws.request_uri)</description>
-    </rule>
+  <rule id="80361" level="3">
+    <if_sid>80360</if_sid>
+    <field name="aws.operation">DELETE</field>
+    <description>AWS S3: DELETE operation: $(aws.request_uri)</description>
+  </rule>
 
-    <rule id="80362" level="2">
-        <if_sid>80360</if_sid>
-        <field name="aws.operation">GET</field>
-        <description>AWS S3: GET operation: $(aws.request_uri)</description>
-    </rule>
+  <rule id="80362" level="2">
+    <if_sid>80360</if_sid>
+    <field name="aws.operation">GET</field>
+    <description>AWS S3: GET operation: $(aws.request_uri)</description>
+  </rule>
 
-    <!-- Silence general REST.GET.OBJECT with status code 200 -->
-    <rule id="80363" level="0">
-        <if_sid>80362</if_sid>
-        <field name="aws.operation">^REST.GET.OBJECT$</field>
-        <field name="aws.http_status">200</field>
-        <description>AWS S3: GET with 200 status code</description>
-    </rule>
+  <!-- Silence general REST.GET.OBJECT with status code 200 -->
+  <rule id="80363" level="0">
+    <if_sid>80362</if_sid>
+    <field name="aws.operation">^REST.GET.OBJECT$</field>
+    <field name="aws.http_status">200</field>
+    <description>AWS S3: GET with 200 status code</description>
+  </rule>
 
-    <rule id="80364" level="3">
-        <if_sid>80360</if_sid>
-        <field name="aws.operation">PUT</field>
-        <description>AWS S3: PUT operation: $(aws.request_uri)</description>
-    </rule>
+  <rule id="80364" level="3">
+    <if_sid>80360</if_sid>
+    <field name="aws.operation">PUT</field>
+    <description>AWS S3: PUT operation: $(aws.request_uri)</description>
+  </rule>
 
-    <!-- Silence events when S3 puts a file into the bucket -->
-    <rule id="80365" level="0">
-        <if_sid>80364</if_sid>
-        <field name="aws.requester">^svc:s3.amazonaws.com$</field>
-        <description>AWS S3: PUT operation: $(aws.request_uri) from S3 service</description>
-    </rule>
+  <!-- Silence events when S3 puts a file into the bucket -->
+  <rule id="80365" level="0">
+    <if_sid>80364</if_sid>
+    <field name="aws.requester">^svc:s3.amazonaws.com$</field>
+    <description>AWS S3: PUT operation: $(aws.request_uri) from S3 service</description>
+  </rule>
 
-    <rule id="80366" level="2">
-        <if_sid>80360</if_sid>
-        <field name="aws.operation">POST</field>
-        <description>AWS S3: POST operation: $(aws.request_uri)</description>
-    </rule>
+  <rule id="80366" level="2">
+    <if_sid>80360</if_sid>
+    <field name="aws.operation">POST</field>
+    <description>AWS S3: POST operation: $(aws.request_uri)</description>
+  </rule>
 
 </group>


### PR DESCRIPTION
## Description
|Related issue|Related PR|Closes Issue|
|---|---|---|
| #8116 | #8783    |#11275|

## Changes & Comments
The aim of this PR is:

- Add Copyright header
- To ensure the rules and decoders from issue #8116 work correctly.
- To fix issues regarding indentation, syntax, rule granularity, spellings and ensure the ruleset quality is standard.

### Ruleset

## Checks 

### Syntax

- [x] 1.a Rule tags order must be compliant.
- [x] 1.b Decoder tags order must be compliant.
- [x] 1.c XML blocks must as compact as possible.
- [x] 1.d Only one empty line between rule/decoder and the next rule/decoder.
- [x] 1.e Decoder extracted fields names must use '_' whether a space is needed.
- [x] 1.f Decoder name must use '-' whether a space is needed.
- [x] 2.d XML and ini files must use correct indentation
 
### Grammar

- [x] 2.a Grammar quality.
- [x] 2.b Similar phrases must keep tenses and expressions.
- [x] 2.c Grammar basic rules like capitalization, punctuation marks, sentence construction, and others.


### Semantic

- [x] 3.a New decoder, rule, or test are written in the correct file and grouped correctly inside the file.
- [x] 3.b Group similar rules under same ID's group.
- [x] 3.c: 
   - [x] 3.c1 Find and reuse group name before creating a new one.
   - [x] 3.c2 Include a new group definition in a PR comment.
   - [x] 3.c3 Any group name must use '_' whether it does need a space char.
   - [x] 3.c4 The groups inside a tag must be sorted in alphabetical order.
   - [x] 3.d Rule level should be compliant with the [documentation](https://documentation.wazuh.com/current/user-manual/ruleset/rules-classification.html).

### Unit testing

- [x] 4.a A metadata block at the beginning of the .ini file describing software, version, and logs source.
- [x] 4.b Each new rule must have at least one test entry in the correct .ini file.
- [x] 4.c Runtest.py must pass and must include the results in raw format here.
<details>
  <statement>Unit Tests</statement>

  ```

  ```
</details>

- [x] 4.d New CDB lists must include the proper test entry in the correct .ini file.

### E2E testing

- ~~[] 5.a Logs for new or modified decoder/rules sent to a manager running with this PR ruleset appear in Kibana. ~~
- ~~[] 5.b There are not affected or broken visualizations on Kibana. ~~
-  ~~[] 5.c New or modified items can be seen correctly using APP ruleset navigation.~~


### Elasticsearch Template

- [x] 6.a Known fields with output format managed and usually used for searching are included in template array index.query.default_field. 
- [x] 6.b The new field with the correct date format is stored as a "date" type field in the template.
- [x] 6.c The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 
- [x] 6.d Known fields with output format managed and usually used for searching are included in the template.

### Stoppers

- [x] 7.a No previous rule ID changes without triple check.
- [x] 7.b No previous decoder name changes without triple check.
- [x] 7.c No previous file name changes without triple check.
- [x] 7.d No previous test changes its 'rule' field value without triple check.

### Others

- [x] 8.a Each file has the correct copyright block.
- [x] 8.b The copyright block doesn't have "Author" only "Created by Wazuh". To include an "Author" request triple check.
- [x] 8.c The copyright block doesn't use "-". 
- [x] 8.d The rule files don't have any sample log.
- [x] 8.e The decoder file has sample logs next to the decoder that matches that log.
- [x] 8.f The decoder and rule files have information about software, version, and any helpful information.
- [x] 8.g The PR has a single commit with CHANGELOG changes in the correct format.
- [x] 8.h The new rule ID is not in use.
- [x] 8.i The new rule ID must be in the defined IDs range. 
- [x] 8.j New rules ID range must be verified with a triple check and noted in the rules ID document.
- [x] 8.k The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 