### PR TITLE
Set maximum limit to the total number of objects in the DB

### DIFF
--- a/framework/wazuh/core/wdb.py
+++ b/framework/wazuh/core/wdb.py
@@ -288,7 +288,7 @@ class WazuhDBConnection:
             except IndexError:
                 total = 0
 
-            limit = lim if lim != 0 else total
+            limit = lim if lim != 0 and lim < total else total
 
             response = []
             if ':limit' not in query_lower:


### PR DESCRIPTION
|Related issue|
|---|
|#11145|

In this PR we have fixed a bug that caused extra requests to WDB in some situations. After this change, the maximum limit on WDB requests will be the total number of items to be queried.