### PR TITLE
Fix journalctl commands in SCA policies

### DIFF
--- a/ruleset/sca/sles/15/cis_sles15_linux.yml
+++ b/ruleset/sca/sles/15/cis_sles15_linux.yml
@@ -1530,7 +1530,7 @@ checks:
       - cis_csc: ["8.3"]
     condition: all
     rules:
-      - 'c:journalctl -> r:\.*kernel: NX \(Execute Disable\) protection:\s*active'
+      - 'c:sh -c "journalctl | grep \"protection: active\"" -> r:\.*kernel: NX \(Execute Disable\) protection:\s*active'
 
   - id: 7564
     title: Ensure prelink is disabled

--- a/ruleset/sca/ubuntu/cis_ubuntu18-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu18-04.yml
@@ -612,7 +612,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:journalctl -> r:NX \(Execute Disable\) protection: active'
+      - 'c:sh -c "journalctl | grep \"protection: active\"" -> r:NX \(Execute Disable\) protection: active'
 
   - id: 18536 
     title: "Ensure address space layout randomization (ASLR) is enabled"

--- a/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
@@ -581,7 +581,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:journalctl -> r:NX \(Execute Disable\) protection: active'
+      - 'c:sh -c "journalctl | grep \"protection: active\"" -> r:NX \(Execute Disable\) protection: active'
 
   - id: 19038
     title: "Ensure address space layout randomization (ASLR) is enabled"


### PR DESCRIPTION
|Related issue|
|---|
| #11291 |

## Description

This PR aims to avoid a bug already fixed in:

- https://github.com/wazuh/wazuh-ruleset/pull/822
- https://github.com/wazuh/wazuh/pull/7316

but that was propagated to the recently added policies for SCA in 4.3.0.

The bug consists of running large output commands such as `journalctl` that leads SCA to increase the memory usage for every scan.

## Logs/Alerts example

Running the new command in Ubuntu 20.04:

```
2021/12/10 13:54:29 sca[68676] wm_sca.c:986 at wm_sca_do_scan(): DEBUG: Beginning evaluation of check id: 19037 'Ensure XD/NX support is enabled'
2021/12/10 13:54:29 sca[68676] wm_sca.c:987 at wm_sca_do_scan(): DEBUG: Rule aggregation strategy for this check is 'all'
2021/12/10 13:54:29 sca[68676] wm_sca.c:988 at wm_sca_do_scan(): DEBUG: Initial rule-aggregator value por this type of rule is '1'
2021/12/10 13:54:29 sca[68676] wm_sca.c:989 at wm_sca_do_scan(): DEBUG: Beginning rules evaluation.
2021/12/10 13:54:29 sca[68676] wm_sca.c:1014 at wm_sca_do_scan(): DEBUG: Considering rule: 'c:sh -c "journalctl | grep \"protection: active\"" -> r:NX \(Execute Disable\) protection: active'
2021/12/10 13:54:29 sca[68676] wm_sca.c:1128 at wm_sca_do_scan(): DEBUG: Running command: 'sh -c "journalctl | grep \"protection: active\""'
2021/12/10 13:54:29 sca[68676] wm_sca.c:1623 at wm_sca_read_command(): DEBUG: Executing command 'sh -c "journalctl | grep \"protection: active\""', and testing output with pattern 'r:NX \(Execute Disable\) protection: active'
2021/12/10 13:54:48 sca[68676] wm_sca.c:1629 at wm_sca_read_command(): DEBUG: Command 'sh -c "journalctl | grep \"protection: active\""' returned code 0
2021/12/10 13:54:48 sca[68676] wm_sca.c:1895 at wm_sca_pattern_matches(): DEBUG: Testing minterm (r:NX \(Execute Disable\) protection: active)(nov 13 10:47:47 wazuh kernel: NX (Execute Disable) protection: active) -> 1
2021/12/10 13:54:48 sca[68676] wm_sca.c:1898 at wm_sca_pattern_matches(): DEBUG: Pattern test result: (r:NX \(Execute Disable\) protection: active)(nov 13 10:47:47 wazuh kernel: NX (Execute Disable) protection: active) -> 1
2021/12/10 13:54:48 sca[68676] wm_sca.c:1685 at wm_sca_read_command(): DEBUG: Result for (r:NX \(Execute Disable\) protection: active)(sh -c "journalctl | grep \"protection: active\"") -> 1
2021/12/10 13:54:48 sca[68676] wm_sca.c:1131 at wm_sca_do_scan(): DEBUG: Command output matched.
2021/12/10 13:54:48 sca[68676] wm_sca.c:1218 at wm_sca_do_scan(): DEBUG: Result for rule 'c:sh -c "journalctl | grep \"protection: active\"" -> r:NX \(Execute Disable\) protection: active': 1
2021/12/10 13:54:48 sca[68676] wm_sca.c:1241 at wm_sca_do_scan(): DEBUG: Result for check id: 19037 'Ensure XD/NX support is enabled' -> 1
```

To verify the memory usage we have to re-run the 2.5 days footprint test for SCA.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language
- [x] SCA policies run properly
