### PR TITLE
Adding new columns for sync and group order

### DIFF
--- a/src/wazuh_db/helpers/wdb_global_helpers.c
+++ b/src/wazuh_db/helpers/wdb_global_helpers.c
@@ -151,7 +151,7 @@ int wdb_insert_group(const char *name, int *sock) {
     return result;
 }
 
-int wdb_update_agent_belongs(int id_group, int id_agent, int *sock) {
+int wdb_update_agent_belongs(int id_group, int id_agent, int priority, int *sock) {
     int result = 0;
     char wdbquery[WDBQUERY_SIZE] = "";
     char wdboutput[WDBOUTPUT_SIZE] = "";
@@ -167,6 +167,7 @@ int wdb_update_agent_belongs(int id_group, int id_agent, int *sock) {
 
     cJSON_AddNumberToObject(data_in, "id_group", id_group);
     cJSON_AddNumberToObject(data_in, "id_agent", id_agent);
+    cJSON_AddNumberToObject(data_in, "priority", priority);
 
     data_in_str = cJSON_PrintUnformatted(data_in);
     cJSON_Delete(data_in);
@@ -1275,6 +1276,7 @@ int wdb_remove_agent_db(int id, const char * name) {
 int wdb_update_agent_multi_group(int id, char *group, int *sock) {
     int aux_sock = -1;
     int* query_sock = sock?sock:&aux_sock;
+    int priority = 0;
 
     /* Wipe out the agent multi groups relation for this agent */
     if (wdb_delete_agent_belongs(id, query_sock) < 0) {
@@ -1302,7 +1304,7 @@ int wdb_update_agent_multi_group(int id, char *group, int *sock) {
                     id_group = wdb_find_group(multi_group, query_sock);
                 }
 
-                if (OS_SUCCESS != wdb_update_agent_belongs(id_group, id, query_sock)) {
+                if (OS_SUCCESS != wdb_update_agent_belongs(id_group, id, priority, query_sock)) {
                     if (!sock) {
                         wdbc_close(&aux_sock);
                     }
@@ -1310,6 +1312,7 @@ int wdb_update_agent_multi_group(int id, char *group, int *sock) {
                 }
 
                 multi_group = strtok_r(NULL, delim, &save_ptr);
+                ++priority;
             }
         } else {
             /* Update de groups table */
@@ -1319,7 +1322,7 @@ int wdb_update_agent_multi_group(int id, char *group, int *sock) {
                 id_group = wdb_find_group(group, query_sock);
             }
 
-            if (OS_SUCCESS != wdb_update_agent_belongs(id_group, id, query_sock)) {
+            if (OS_SUCCESS != wdb_update_agent_belongs(id_group, id, priority, query_sock)) {
                 if (!sock) {
                     wdbc_close(&aux_sock);
                 }

--- a/src/wazuh_db/helpers/wdb_global_helpers.h
+++ b/src/wazuh_db/helpers/wdb_global_helpers.h
@@ -78,10 +78,11 @@ int wdb_insert_group(const char *name, int *sock);
  *
  * @param[in] id_group Id of the group to be updated.
  * @param[in] id_agent Id of the agent to be updated.
+ * @param[in] priority Priority of the agent group to be updated.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return Returns OS_SUCCESS on success or OS_INVALID on failure.
  */
-int wdb_update_agent_belongs(int id_group, int id_agent, int *sock);
+int wdb_update_agent_belongs(int id_group, int id_agent, int priority, int *sock);
 
 /**
  * @brief Update agent name in global.db.

--- a/src/wazuh_db/schema_global.sql
+++ b/src/wazuh_db/schema_global.sql
@@ -33,7 +33,7 @@ CREATE TABLE IF NOT EXISTS agent (
     date_add INTEGER NOT NULL,
     last_keepalive INTEGER,
     `group` TEXT DEFAULT 'default',
-    group_source TEXT NOT NULL CHECK (group_source IN ('manual', 'remote', 'undefined')) DEFAULT 'undefined',
+    group_source TEXT NOT NULL CHECK (group_source IN ('manual', 'remote', 'unknown')) DEFAULT 'unknown',
     group_sync_with_master TEXT NOT NULL CHECK (group_sync_with_master IN ('synced', 'syncreq')) DEFAULT 'synced',
     sync_status TEXT NOT NULL CHECK (sync_status IN ('synced', 'syncreq')) DEFAULT 'synced',
     connection_status TEXT NOT NULL CHECK (connection_status IN ('pending', 'never_connected', 'active', 'disconnected')) DEFAULT 'never_connected',

--- a/src/wazuh_db/schema_global.sql
+++ b/src/wazuh_db/schema_global.sql
@@ -33,6 +33,8 @@ CREATE TABLE IF NOT EXISTS agent (
     date_add INTEGER NOT NULL,
     last_keepalive INTEGER,
     `group` TEXT DEFAULT 'default',
+    group_source TEXT NOT NULL CHECK (group_source IN ('manual', 'remote')) DEFAULT 'manual',
+    group_sync_with_master TEXT NOT NULL CHECK (group_sync_with_master IN ('synced', 'syncreq')) DEFAULT 'synced',
     sync_status TEXT NOT NULL CHECK (sync_status IN ('synced', 'syncreq')) DEFAULT 'synced',
     connection_status TEXT NOT NULL CHECK (connection_status IN ('pending', 'never_connected', 'active', 'disconnected')) DEFAULT 'never_connected',
     disconnection_time INTEGER DEFAULT 0,
@@ -64,7 +66,9 @@ CREATE TABLE IF NOT EXISTS `group` (
 
 CREATE TABLE IF NOT EXISTS belongs (
     id_agent INTEGER REFERENCES agent (id) ON DELETE CASCADE,
-    id_group INTEGER REFERENCES `group`(id) ON DELETE CASCADE,
+    id_group INTEGER REFERENCES `group` (id) ON DELETE CASCADE,    
+    priority INTEGER NOT NULL DEFAULT 0,
+    UNIQUE (id_agent, priority),
     PRIMARY KEY (id_agent, id_group)
 );
 

--- a/src/wazuh_db/schema_global.sql
+++ b/src/wazuh_db/schema_global.sql
@@ -33,7 +33,7 @@ CREATE TABLE IF NOT EXISTS agent (
     date_add INTEGER NOT NULL,
     last_keepalive INTEGER,
     `group` TEXT DEFAULT 'default',
-    group_source TEXT NOT NULL CHECK (group_source IN ('manual', 'remote')) DEFAULT 'manual',
+    group_source TEXT NOT NULL CHECK (group_source IN ('manual', 'remote', 'undefined')) DEFAULT 'undefined',
     group_sync_with_master TEXT NOT NULL CHECK (group_sync_with_master IN ('synced', 'syncreq')) DEFAULT 'synced',
     sync_status TEXT NOT NULL CHECK (sync_status IN ('synced', 'syncreq')) DEFAULT 'synced',
     connection_status TEXT NOT NULL CHECK (connection_status IN ('pending', 'never_connected', 'active', 'disconnected')) DEFAULT 'never_connected',

--- a/src/wazuh_db/schema_global_upgrade_v4.sql
+++ b/src/wazuh_db/schema_global_upgrade_v4.sql
@@ -10,7 +10,9 @@
 
 CREATE TABLE IF NOT EXISTS _belongs (
     id_agent INTEGER REFERENCES agent (id) ON DELETE CASCADE,
-    id_group INTEGER REFERENCES `group`(id) ON DELETE CASCADE,
+    id_group INTEGER REFERENCES `group` (id) ON DELETE CASCADE,
+    priority INTEGER NOT NULL DEFAULT 0,
+    UNIQUE (id_agent, priority),
     PRIMARY KEY (id_agent, id_group)
 );
 
@@ -19,13 +21,52 @@ CREATE INDEX IF NOT EXISTS belongs_id_group ON belongs (id_group);
 
 BEGIN;
 
-INSERT INTO _belongs (id_agent, id_group) SELECT id_agent, id_group FROM belongs WHERE id_agent IN (SELECT id FROM agent) AND id_group IN (SELECT id FROM `group`);
+INSERT INTO _belongs (id_agent, id_group, priority) SELECT id_agent, id_group, belongs.rowid FROM belongs WHERE id_agent IN (SELECT id FROM agent) AND id_group IN (SELECT id FROM `group`);
 
 END;
 
 DROP TABLE IF EXISTS belongs;
 ALTER TABLE _belongs RENAME TO belongs;
 
+CREATE TABLE IF NOT EXISTS _agent (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    ip TEXT,
+    register_ip TEXT,
+    internal_key TEXT,
+    os_name TEXT,
+    os_version TEXT,
+    os_major TEXT,
+    os_minor TEXT,
+    os_codename TEXT,
+    os_build TEXT,
+    os_platform TEXT,
+    os_uname TEXT,
+    os_arch TEXT,
+    version TEXT,
+    config_sum TEXT,
+    merged_sum TEXT,
+    manager_host TEXT,
+    node_name TEXT DEFAULT 'unknown',
+    date_add INTEGER NOT NULL,
+    last_keepalive INTEGER,
+    `group` TEXT DEFAULT 'default',
+    group_source TEXT NOT NULL CHECK (group_source IN ('manual', 'remote')) DEFAULT 'manual',
+    group_sync_with_master TEXT NOT NULL CHECK (group_sync_with_master IN ('synced', 'syncreq')) DEFAULT 'synced',
+    sync_status TEXT NOT NULL CHECK (sync_status IN ('synced', 'syncreq')) DEFAULT 'synced',
+    connection_status TEXT NOT NULL CHECK (connection_status IN ('pending', 'never_connected', 'active', 'disconnected')) DEFAULT 'never_connected',
+    disconnection_time INTEGER DEFAULT 0
+);
+
+BEGIN;
+
+INSERT INTO _agent (id, name, ip, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename, os_build, os_platform, os_uname, os_arch, version, config_sum, merged_sum, manager_host, node_name, date_add, last_keepalive, `group`, sync_status, connection_status) SELECT id, name, ip, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename, os_build, os_platform, os_uname, os_arch, version, config_sum, merged_sum, manager_host, node_name, date_add, last_keepalive, `group`, sync_status, connection_status FROM agent;
+UPDATE _agent SET group_source = 'manual', group_sync_with_master = 'synced';
+
+END;
+
+DROP TABLE IF EXISTS agent;
+ALTER TABLE _agent RENAME TO agent;
 ALTER TABLE agent ADD COLUMN groups_hash TEXT default NULL;
 CREATE INDEX IF NOT EXISTS agent_name ON agent (name);
 CREATE INDEX IF NOT EXISTS agent_ip ON agent (ip);

--- a/src/wazuh_db/schema_global_upgrade_v4.sql
+++ b/src/wazuh_db/schema_global_upgrade_v4.sql
@@ -22,6 +22,7 @@ CREATE INDEX IF NOT EXISTS belongs_id_group ON belongs (id_group);
 BEGIN;
 
 INSERT INTO _belongs (id_agent, id_group, priority) SELECT id_agent, id_group, belongs.rowid FROM belongs WHERE id_agent IN (SELECT id FROM agent) AND id_group IN (SELECT id FROM `group`);
+UPDATE _belongs SET priority=(SELECT temp.r_num - 1 FROM (SELECT *, row_number() OVER(PARTITION BY id_agent ORDER BY belongs.rowid) r_num FROM belongs) temp WHERE _belongs.id_agent = temp.id_agent AND _belongs.id_group = temp.id_group);
 
 END;
 
@@ -51,7 +52,7 @@ CREATE TABLE IF NOT EXISTS _agent (
     date_add INTEGER NOT NULL,
     last_keepalive INTEGER,
     `group` TEXT DEFAULT 'default',
-    group_source TEXT NOT NULL CHECK (group_source IN ('manual', 'remote', 'undefined')) DEFAULT 'undefined',
+    group_source TEXT NOT NULL CHECK (group_source IN ('manual', 'remote', 'unknown')) DEFAULT 'unknown',
     group_sync_with_master TEXT NOT NULL CHECK (group_sync_with_master IN ('synced', 'syncreq')) DEFAULT 'synced',
     sync_status TEXT NOT NULL CHECK (sync_status IN ('synced', 'syncreq')) DEFAULT 'synced',
     connection_status TEXT NOT NULL CHECK (connection_status IN ('pending', 'never_connected', 'active', 'disconnected')) DEFAULT 'never_connected',

--- a/src/wazuh_db/schema_global_upgrade_v4.sql
+++ b/src/wazuh_db/schema_global_upgrade_v4.sql
@@ -51,7 +51,7 @@ CREATE TABLE IF NOT EXISTS _agent (
     date_add INTEGER NOT NULL,
     last_keepalive INTEGER,
     `group` TEXT DEFAULT 'default',
-    group_source TEXT NOT NULL CHECK (group_source IN ('manual', 'remote')) DEFAULT 'manual',
+    group_source TEXT NOT NULL CHECK (group_source IN ('manual', 'remote', 'undefined')) DEFAULT 'undefined',
     group_sync_with_master TEXT NOT NULL CHECK (group_sync_with_master IN ('synced', 'syncreq')) DEFAULT 'synced',
     sync_status TEXT NOT NULL CHECK (sync_status IN ('synced', 'syncreq')) DEFAULT 'synced',
     connection_status TEXT NOT NULL CHECK (connection_status IN ('pending', 'never_connected', 'active', 'disconnected')) DEFAULT 'never_connected',
@@ -61,7 +61,6 @@ CREATE TABLE IF NOT EXISTS _agent (
 BEGIN;
 
 INSERT INTO _agent (id, name, ip, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename, os_build, os_platform, os_uname, os_arch, version, config_sum, merged_sum, manager_host, node_name, date_add, last_keepalive, `group`, sync_status, connection_status) SELECT id, name, ip, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename, os_build, os_platform, os_uname, os_arch, version, config_sum, merged_sum, manager_host, node_name, date_add, last_keepalive, `group`, sync_status, connection_status FROM agent;
-UPDATE _agent SET group_source = 'manual', group_sync_with_master = 'synced';
 
 END;
 

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -155,7 +155,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_UPDATE_AGENT_GROUP] = "UPDATE agent SET `group` = ? WHERE id = ?;",
     [WDB_STMT_GLOBAL_UPDATE_AGENT_GROUPS_HASH] = "UPDATE agent SET groups_hash = ? WHERE id = ?;",
     [WDB_STMT_GLOBAL_INSERT_AGENT_GROUP] = "INSERT INTO `group` (name) VALUES(?);",
-    [WDB_STMT_GLOBAL_INSERT_AGENT_BELONG] = "INSERT INTO belongs (id_group, id_agent) VALUES(?,?);",
+    [WDB_STMT_GLOBAL_INSERT_AGENT_BELONG] = "INSERT INTO belongs (id_group, id_agent, priority) VALUES(?,?,?);",
     [WDB_STMT_GLOBAL_DELETE_AGENT_BELONG] = "DELETE FROM belongs WHERE id_agent = ?;",
     [WDB_STMT_GLOBAL_DELETE_GROUP_BELONG] = "DELETE FROM belongs WHERE id_group = (SELECT id FROM 'group' WHERE name = ?);",
     [WDB_STMT_GLOBAL_DELETE_GROUP] = "DELETE FROM `group` WHERE name = ?;",

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -1659,9 +1659,10 @@ int wdb_global_insert_agent_group(wdb_t *wdb, char* group_name);
  * @param [in] wdb The Global struct database.
  * @param [in] id_group The group id.
  * @param [in] id_agent The agent id.
+ * @param [in] priority The group priority.
  * @return Returns 0 on success or -1 on error.
  */
-int wdb_global_insert_agent_belong(wdb_t *wdb, int id_group, int id_agent);
+int wdb_global_insert_agent_belong(wdb_t *wdb, int id_group, int id_agent, int priority);
 
 /**
  * @brief Function to delete a group from belongs table using the group name.

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -767,7 +767,7 @@ int wdb_global_insert_agent_group(wdb_t *wdb, char* group_name) {
     }
 }
 
-int wdb_global_insert_agent_belong(wdb_t *wdb, int id_group, int id_agent) {
+int wdb_global_insert_agent_belong(wdb_t *wdb, int id_group, int id_agent, int priority) {
     sqlite3_stmt *stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
@@ -787,6 +787,10 @@ int wdb_global_insert_agent_belong(wdb_t *wdb, int id_group, int id_agent) {
         return OS_INVALID;
     }
     if (sqlite3_bind_int(stmt, 2, id_agent) != SQLITE_OK) {
+        merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+        return OS_INVALID;
+    }
+    if (sqlite3_bind_int(stmt, 3, priority) != SQLITE_OK) {
         merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
         return OS_INVALID;
     }

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5178,6 +5178,7 @@ int wdb_parse_global_insert_agent_belong(wdb_t * wdb, char * input, char * outpu
     const char *error = NULL;
     cJSON *j_id_group = NULL;
     cJSON *j_id_agent = NULL;
+    cJSON *j_priority = NULL;
 
     agent_data = cJSON_ParseWithOpts(input, &error, TRUE);
     if (!agent_data) {
@@ -5188,13 +5189,15 @@ int wdb_parse_global_insert_agent_belong(wdb_t * wdb, char * input, char * outpu
     } else {
         j_id_group = cJSON_GetObjectItem(agent_data, "id_group");
         j_id_agent = cJSON_GetObjectItem(agent_data, "id_agent");
+        j_priority = cJSON_GetObjectItem(agent_data, "priority");
 
-        if (cJSON_IsNumber(j_id_group) && cJSON_IsNumber(j_id_agent)) {
+        if (cJSON_IsNumber(j_id_group) && cJSON_IsNumber(j_id_agent) && cJSON_IsNumber(j_priority)) {
             // Getting each field
             int id_group = j_id_group->valueint;
             int id_agent = j_id_agent->valueint;
+            int priority = j_priority->valueint;
 
-            if (OS_SUCCESS != wdb_global_insert_agent_belong(wdb, id_group, id_agent)) {
+            if (OS_SUCCESS != wdb_global_insert_agent_belong(wdb, id_group, id_agent, priority)) {
                 mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db: %s", WDB2_DIR, WDB_GLOB_NAME, sqlite3_errmsg(wdb->db));
                 snprintf(output, OS_MAXSTR + 1, "err Cannot execute Global database query; %s", sqlite3_errmsg(wdb->db));
                 cJSON_Delete(agent_data);


### PR DESCRIPTION
|Related issue|
|---|
|#11220|

## Description

This PR adds the capability to assign a group priority in the belongs table.

## Dod

Creating groups in v4.1
![3](https://user-images.githubusercontent.com/13010397/145596933-8a01e418-44f7-42af-b5d7-a6ce9e870dd3.png)
Upgrade to v4.4
![4](https://user-images.githubusercontent.com/13010397/145596740-c7402f49-ecd8-4a22-ac52-9a6c0d15c1b0.png)
Group hash after upgrade
![5](https://user-images.githubusercontent.com/13010397/145596750-05160cb6-bc7e-4ba8-9047-2abe26aaa489.png)
Testing priority column upgrade with mocked database
![image](https://user-images.githubusercontent.com/13010397/145604526-09155bac-792e-46bc-aa82-42b1951869bc.png)
Scan-build report 
![image](https://user-images.githubusercontent.com/13010397/145597027-a3abeca5-06ec-4a3c-81a1-ca4fe2871bcd.png)

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Source upgrade
- [X] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report