### PR TITLE
Fixing decoder, rules and ini for Cisco FTD

### DIFF
--- a/ruleset/decoders/0062-cisco-ftd_decoders.xml
+++ b/ruleset/decoders/0062-cisco-ftd_decoders.xml
@@ -1,48 +1,45 @@
 <!--
-  -  Cisco VPN Concentrator decoders
-  -  Created by Wazuh, Inc.
-  -  Copyright (C) 2015-2021, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  Copyright (C) 2015-2021, Wazuh Inc.
 -->
 
 <!-- General decoder -->
 <decoder name="cisco-ftd">
-    <prematch type="pcre2">[^%]*%FTD-[0-7]-[^:\s]+[:\s].*</prematch>
+  <prematch type="pcre2">[^%]*%FTD-[0-7]-[^:\s]+[:\s].*</prematch>
 </decoder>
 
 
 <!--
-%ftd-2-106001: Inbound TCP connection denied from 111.93.241.59/54322 to 116.6.127.122/1433 flags SYN on interface outside
+  %ftd-2-106001: Inbound TCP connection denied from 111.93.241.59/54322 to 116.6.127.122/1433 flags SYN on interface outside
 -->
 <decoder name="cisco-ftd-inbound-connection-denied">
-    <parent>cisco-ftd</parent>
-    <prematch>2-106001</prematch>
-    <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\sfrom\s(\S+)/(\S+)\sto\s(\S+)/(\S+)\sflags\s(.+)\son\sinterface\s(\S+))</regex>
-    <order>header, product.name, event.severity, event.id, message, description, src_ip, src_port, dst_ip, dst_port, flags, interface</order>
+  <parent>cisco-ftd</parent>
+  <prematch>2-106001</prematch>
+  <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\sfrom\s(\S+)/(\S+)\sto\s(\S+)/(\S+)\sflags\s(.+)\son\sinterface\s(\S+))</regex>
+  <order>header, product.name, event.severity, event.id, message, description, src_ip, src_port, dst_ip, dst_port, flags, interface</order>
 </decoder>
 
 <!--
-%ftd-5-718060: Inbound socket select fail: context=21312
+  %ftd-5-718060: Inbound socket select fail: context=21312
 -->
 <decoder name="cisco-ftd-inbound-socket">
-    <parent>cisco-ftd</parent>
-    <prematch>5-718060|5-718061</prematch>
-    <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+):\scontext=(\d+))</regex>
-    <order>header, product.name, event.severity, event.id, message, description, context_ID</order>
+  <parent>cisco-ftd</parent>
+  <prematch>5-718060|5-718061</prematch>
+  <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+):\scontext=(\d+))</regex>
+  <order>header, product.name, event.severity, event.id, message, description, context_ID</order>
 </decoder>
 
 <!--
 %ftd-5-718062: Inbound thread is awake (context=21312)
 -->
 <decoder name="cisco-ftd-inbound-thread">
-    <parent>cisco-ftd</parent>
-    <prematch>5-718062</prematch>
-    <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\(context=(\d+)\))</regex>
-    <order>header, product.name, event.severity, event.id, message, description, context_ID</order>
+  <parent>cisco-ftd</parent>
+  <prematch>5-718062</prematch>
+  <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\(context=(\d+)\))</regex>
+  <order>header, product.name, event.severity, event.id, message, description, context_ID</order>
 </decoder>
 
 <!--
-%ftd-1-106022: Deny protocol connection spoof from 192.168.0.1 to 192.168.0.2 on interface interface_name.
+  %ftd-1-106022: Deny protocol connection spoof from 192.168.0.1 to 192.168.0.2 on interface interface_name.
 -->
 <decoder name="cisco-ftd-attacks">
   <parent>cisco-ftd</parent>
@@ -52,7 +49,7 @@
 </decoder>
 
 <!--
-%ftd-4-401004 Shunned packet: 192.168.0.1 = 192.168.0.2 on interface interfacename
+  %ftd-4-401004 Shunned packet: 192.168.0.1 = 192.168.0.2 on interface interfacename
 -->
 <decoder name="cisco-ftd-shunned">
   <parent>cisco-ftd</parent>
@@ -62,17 +59,17 @@
 </decoder>
 
 <!--
-%ftd-2-106017: Deny IP due to Land Attack from 193.17.108.1 to 193.17.108.1
+  %ftd-2-106017: Deny IP due to Land Attack from 193.17.108.1 to 193.17.108.1
 -->
 <decoder name="cisco-ftd-deny-land-attack">
-    <parent>cisco-ftd</parent>
-    <prematch>2-106017</prematch>
-    <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\sfrom\s(\S+)\sto\s(\S+))</regex>
-    <order>header, product.name, event.severity, event.id, message, description, srcip, dstip</order>
+  <parent>cisco-ftd</parent>
+  <prematch>2-106017</prematch>
+  <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\sfrom\s(\S+)\sto\s(\S+))</regex>
+  <order>header, product.name, event.severity, event.id, message, description, srcip, dstip</order>
 </decoder>
 
 <!--
-%ftd-2-106006: Deny inbound UDP from 185.158.113.158/53306 to 116.6.127.123/53413 on interface outside
+  %ftd-2-106006: Deny inbound UDP from 185.158.113.158/53306 to 116.6.127.123/53413 on interface outside
 -->
 <decoder name="cisco-ftd-deny-inbound-udp">
     <parent>cisco-ftd</parent>
@@ -82,7 +79,7 @@
 </decoder>
 
 <!--
-%ftd-3-710003: TCP access denied by ACL from 192.168.0.1/11 to outside:192.168.0.2/22
+  %ftd-3-710003: TCP access denied by ACL from 192.168.0.1/11 to outside:192.168.0.2/22
 -->
 <decoder name="cisco-ftd-fw2">
   <parent>cisco-ftd</parent>
@@ -92,7 +89,7 @@
 </decoder>
 
 <!--
-%ftd-4-106023: Deny tcp src inside:111.11.11.1/2143 dst YYY:172.11.1.11/139 by access-group "inside_inbound"
+  %ftd-4-106023: Deny tcp src inside:111.11.11.1/2143 dst YYY:172.11.1.11/139 by access-group "inside_inbound"
 -->
 <decoder name="cisco-ftd-fw3">
   <parent>cisco-ftd</parent>
@@ -112,7 +109,7 @@
 </decoder>
 
 <!--
-%ftd-6-308001: console enable password incorrect for number tries (from 192.168.0.1)
+  %ftd-6-308001: console enable password incorrect for number tries (from 192.168.0.1)
 -->
 <decoder name="cisco-ftd-srcip">
   <parent>cisco-ftd</parent>
@@ -122,8 +119,8 @@
 </decoder>
 
 <!--
-%FTD-6-605004: Login denied from 192.168.2.10/32597 to outside:192.168.2.14/ssh for user "root"
-%FTD-6-605005: Login permitted from 192.168.0.1/11 to outside:192.168.0.2/ssh for user "username"
+  %FTD-6-605004: Login denied from 192.168.2.10/32597 to outside:192.168.2.14/ssh for user "root"
+  %FTD-6-605005: Login permitted from 192.168.0.1/11 to outside:192.168.0.2/ssh for user "username"
 -->
 <decoder name="cisco-ftd-srcip-port">
   <parent>cisco-ftd</parent>
@@ -133,224 +130,223 @@
 </decoder>
 
 <!--
-%ftd-4-733100: Object drop rate 15 exceeded. Current burst rate is 9 per second, max configured rate is 10; Current average rate is 15 per second, max configured rate is 5; Cumulative total count is 9198
+  %ftd-4-733100: Object drop rate 15 exceeded. Current burst rate is 9 per second, max configured rate is 10; Current average rate is 15 per second, max configured rate is 5; Cumulative total count is 9198
 -->
 <decoder name="cisco-ftd-drop-rate-exceeded">
-    <parent>cisco-ftd</parent>
-    <prematch>4-733100</prematch>
-    <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?(Object\sdrop\srate\s(\d+)\sexceeded.\sCurrent\sburst\srate\sis\s(\S+)\sper\ssecond,\smax\sconfigured\srate\sis\s(\S+);\sCurrent\saverage\srate\sis\s(\S+)\sper\ssecond,\smax\sconfigured\srate\sis\s(\S+);\sCumulative\stotal\scount\sis\s(\S+))</regex>
-    <order>header, product.name, event.severity, event.id, message, rate_ID, burst_rate, max_burst_rate, average_rate, max_average_rate, cumulative_count</order>
+  <parent>cisco-ftd</parent>
+  <prematch>4-733100</prematch>
+  <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?(Object\sdrop\srate\s(\d+)\sexceeded.\sCurrent\sburst\srate\sis\s(\S+)\sper\ssecond,\smax\sconfigured\srate\sis\s(\S+);\sCurrent\saverage\srate\sis\s(\S+)\sper\ssecond,\smax\sconfigured\srate\sis\s(\S+);\sCumulative\stotal\scount\sis\s(\S+))</regex>
+  <order>header, product.name, event.severity, event.id, message, rate_ID, burst_rate, max_burst_rate, average_rate, max_average_rate, cumulative_count</order>
 </decoder>
 
 <!--
-%ftd-5-111008: User 'impssnagios' executed the 'enable' command.
+  %ftd-5-111008: User 'impssnagios' executed the 'enable' command.
 -->
 <decoder name="cisco-ftd-executed-command">
-    <parent>cisco-ftd</parent>
-    <prematch>5-111008</prematch>
-    <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?(User\s(\S+)\s(\S+)\sthe\s(.+))</regex>
-    <order>header, product.name, event.severity, event.id, message, username, type, command</order>
+  <parent>cisco-ftd</parent>
+  <prematch>5-111008</prematch>
+  <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?(User\s(\S+)\s(\S+)\sthe\s(.+))</regex>
+  <order>header, product.name, event.severity, event.id, message, username, type, command</order>
 </decoder>
 
 
 <!--
-%ftd-5-502103: User priv level changed: Uname: impssnagios From: 1 To: 15
+  %ftd-5-502103: User priv level changed: Uname: impssnagios From: 1 To: 15
 -->
 <decoder name="cisco-ftd-user-privileged-changed">
-    <parent>cisco-ftd</parent>
-    <prematch>5-502103</prematch>
-    <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+):\sUname:\s(\S+)\sFrom:\s(\S+)\sTo:\s(\S+))</regex>
-    <order>header, product.name, event.severity, event.id, message, description, username, from_level, to_level</order>
+  <parent>cisco-ftd</parent>
+  <prematch>5-502103</prematch>
+  <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+):\sUname:\s(\S+)\sFrom:\s(\S+)\sTo:\s(\S+))</regex>
+  <order>header, product.name, event.severity, event.id, message, description, username, from_level, to_level</order>
 </decoder>
 
 <!--
-%ftd-3-421001: UDP flow from WLC-LAN_inside:10.233.19.92/60803 to outside:8.8.8.8/53 is dropped because application has failed.
+  %ftd-3-421001: UDP flow from WLC-LAN_inside:10.233.19.92/60803 to outside:8.8.8.8/53 is dropped because application has failed.
 -->
 <decoder name="cisco-ftd-user-flow-dropped">
-    <parent>cisco-ftd</parent>
-    <prematch>3-421001</prematch>
-    <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\sfrom\s(\S+):(\S+)/(\S+)\sto\s(\S+):(\S+)/(\S+)\sis\sdropped\sbecause\sapplication\shas\sfailed)</regex>
-    <order>header, product.name, event.severity, event.id, message, description, src, src_ip, src_port, dst, dst_ip, dst_port</order>
+  <parent>cisco-ftd</parent>
+  <prematch>3-421001</prematch>
+  <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\sfrom\s(\S+):(\S+)/(\S+)\sto\s(\S+):(\S+)/(\S+)\sis\sdropped\sbecause\sapplication\shas\sfailed)</regex>
+  <order>header, product.name, event.severity, event.id, message, description, src, src_ip, src_port, dst, dst_ip, dst_port</order>
 </decoder>
 
 
 <!--
-%ftd-3-421007: UDP flow from WLC-LAN_inside:10.233.19.92/60803 to outside:8.8.8.8/53 is skipped because application has failed.
+  %ftd-3-421007: UDP flow from WLC-LAN_inside:10.233.19.92/60803 to outside:8.8.8.8/53 is skipped because application has failed.
 -->
 <decoder name="cisco-ftd-user-flow-skipped">
-    <parent>cisco-ftd</parent>
-    <prematch>3-421007</prematch>
-    <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\sfrom\s(\S+):(\S+)/(\S+)\sto\s(\S+):(\S+)/(\S+)\sis\sskipped\sbecause\sapplication\shas\sfailed)</regex>
-    <order>header, product.name, event.severity, event.id, message, description, src, src_ip, src_port, dst, dst_ip, dst_port</order>
+  <parent>cisco-ftd</parent>
+  <prematch>3-421007</prematch>
+  <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\sfrom\s(\S+):(\S+)/(\S+)\sto\s(\S+):(\S+)/(\S+)\sis\sskipped\sbecause\sapplication\shas\sfailed)</regex>
+  <order>header, product.name, event.severity, event.id, message, description, src, src_ip, src_port, dst, dst_ip, dst_port</order>
 </decoder>
 
 <!--
-%ftd-3-106014: Deny inbound icmp src outside:151.80.47.231 dst outside:116.6.127.112 (type 3, code 2)
+  %ftd-3-106014: Deny inbound icmp src outside:151.80.47.231 dst outside:116.6.127.112 (type 3, code 2)
 -->
 <decoder name="cisco-ftd-deny-inbound-icmp">
-    <parent>cisco-ftd</parent>
-    <prematch>3-106014</prematch>
-    <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\ssrc\s(\S+):(\S+)\sdst\s(\S+):(\S+)\s(\(.+\)))</regex>
-    <order>header, product.name, event.severity, event.id, message, description, src, src_ip, dst, dst_ip, code</order>
+  <parent>cisco-ftd</parent>
+  <prematch>3-106014</prematch>
+  <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\ssrc\s(\S+):(\S+)\sdst\s(\S+):(\S+)\s(\(.+\)))</regex>
+  <order>header, product.name, event.severity, event.id, message, description, src, src_ip, dst, dst_ip, code</order>
 </decoder>
 
-
 <!--
-%ftd-4-500004: Invalid transport field for protocol=UDP, from 10.235.91.49/45682 to 80.98.44.227/0
+  %ftd-4-500004: Invalid transport field for protocol=UDP, from 10.235.91.49/45682 to 80.98.44.227/0
 -->
 <decoder name="cisco-ftd-invalid-transport-field">
-    <parent>cisco-ftd</parent>
-    <prematch>4-500004</prematch>
-    <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\sfor\sprotocol=(\S+),\sfrom\s(\S+)/(\S+)\sto\s(\S+)/(\S+))</regex>
-    <order>header, product.name, event.severity, event.id, message, description, protocol, src_ip, src_port, dst_ip, dst_port</order>
+  <parent>cisco-ftd</parent>
+  <prematch>4-500004</prematch>
+  <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\sfor\sprotocol=(\S+),\sfrom\s(\S+)/(\S+)\sto\s(\S+)/(\S+))</regex>
+  <order>header, product.name, event.severity, event.id, message, description, protocol, src_ip, src_port, dst_ip, dst_port</order>
 </decoder>
 
-
 <!--
-%ftd-4-313009: Denied invalid ICMP code 9, for serverlan:EUCH1AAISE/38706 (EUCH1AAISE/38706) to WLC-LAN_inside:10.235.50.134/0 (10.235.50.134/0), ICMP id 295, ICMP type 8
+  %ftd-4-313009: Denied invalid ICMP code 9, for serverlan:EUCH1AAISE/38706 (EUCH1AAISE/38706) to WLC-LAN_inside:10.235.50.134/0 (10.235.50.134/0), ICMP id 295, ICMP type 8
 -->
 <decoder name="cisco-ftd-denied-invalid-icmp">
-    <parent>cisco-ftd</parent>
-    <prematch>4-313009</prematch>
-    <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\scode\s(\S+),\sfor\s\S+:(\S+)/(\S+)\s\(\S+\)\sto\s(\S+):(\S+)/(\S+)\s\(\S+\),\sICMP\sid\s(\S+),\sICMP\stype\s(\S+))</regex>
-    <order>header, product.name, event.severity, event.id, message, description, code, src, src_port, dst, dst_ip, dst_port, icmp_id, icmp_type</order>
+  <parent>cisco-ftd</parent>
+  <prematch>4-313009</prematch>
+  <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\scode\s(\S+),\sfor\s\S+:(\S+)/(\S+)\s\(\S+\)\sto\s(\S+):(\S+)/(\S+)\s\(\S+\),\sICMP\sid\s(\S+),\sICMP\stype\s(\S+))</regex>
+  <order>header, product.name, event.severity, event.id, message, description, code, src, src_port, dst, dst_ip, dst_port, icmp_id, icmp_type</order>
 </decoder>
 
 
 <!--
-%ftd-4-209005: Discard IP fragment set with more than 24 elements:  src = 10.235.211.237, dest = 86.29.145.200, proto = UDP, id = 48916
+  %ftd-4-209005: Discard IP fragment set with more than 24 elements:  src = 10.235.211.237, dest = 86.29.145.200, proto = UDP, id = 48916
 -->
 <decoder name="cisco-ftd-discard-ip-fragment">
-    <parent>cisco-ftd</parent>
-    <prematch>4-209005</prematch>
-    <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\s\ssrc\s=\s(\S+),\sdest\s=\s(\S+),\sproto\s=\s(\S+),\sid\s=\s(\S+))</regex>
-    <order>header, product.name, event.severity, event.id, message, description, src, dst, protocol, fragment_id</order>
+  <parent>cisco-ftd</parent>
+  <prematch>4-209005</prematch>
+  <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\s\ssrc\s=\s(\S+),\sdest\s=\s(\S+),\sproto\s=\s(\S+),\sid\s=\s(\S+))</regex>
+  <order>header, product.name, event.severity, event.id, message, description, src, dst, protocol, fragment_id</order>
 </decoder>
 
 <!--
-%FTD-6-305012: Teardown dynamic TCP translation from WLC-LAN_inside:10.233.16.130/6890 to outside:193.17.108.1/6890 duration 0:02:32
+  %FTD-6-305012: Teardown dynamic TCP translation from WLC-LAN_inside:10.233.16.130/6890 to outside:193.17.108.1/6890 duration 0:02:32
 -->
 <decoder name="cisco-ftd-teardown-translation">
-    <parent>cisco-ftd</parent>
-    <prematch>6-305012</prematch>
-    <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\sfrom\s(\S+):(\S+)/(\S+)\sto\s(\S+):(\S+)/(\S+)\sduration\s(\d+:\d+:\d+))</regex>
-    <order>header, product.name, event.severity, event.id, message, description, src, src_ip, src_port, dst, dst_ip, dst_port, duration</order>
+  <parent>cisco-ftd</parent>
+  <prematch>6-305012</prematch>
+  <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\sfrom\s(\S+):(\S+)/(\S+)\sto\s(\S+):(\S+)/(\S+)\sduration\s(\d+:\d+:\d+))</regex>
+  <order>header, product.name, event.severity, event.id, message, description, src, src_ip, src_port, dst, dst_ip, dst_port, duration</order>
 </decoder>
 
 <!--
-%ftd-5-111010: User 'pgskyadm', running 'CLI' from IP 143.16.64.46, executed 'terminal pager 0'
+  %ftd-5-111010: User 'pgskyadm', running 'CLI' from IP 143.16.64.46, executed 'terminal pager 0'
 -->
 <decoder name="cisco-ftd-user-running-executed">
-    <parent>cisco-ftd</parent>
-    <prematch>5-111010</prematch>
-    <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?(User\s(\S+),\srunning\s(\S+)\sfrom\sIP\s(\S+),\s(\S+)\s(.+))</regex>
-    <order>header, product.name, event.severity, event.id, message, username, running, ip, type, command</order>
+  <parent>cisco-ftd</parent>
+  <prematch>5-111010</prematch>
+  <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?(User\s(\S+),\srunning\s(\S+)\sfrom\sIP\s(\S+),\s(\S+)\s(.+))</regex>
+  <order>header, product.name, event.severity, event.id, message, username, running, ip, type, command</order>
 </decoder>
 
 <!--
-%ftd-1-505015: Module ips, application up "IPS", version "7.2(2)E4" Normal Operation
+  %ftd-1-505015: Module ips, application up "IPS", version "7.2(2)E4" Normal Operation
 -->
 <decoder name="cisco-ftd-module-ips">
-    <parent>cisco-ftd</parent>
-    <prematch>1-505015</prematch>
-    <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?(Module\s(.+),\sapplication\sup\s(\S+),\sversion\s(\S+))</regex>
-    <order>header, product.name, event.severity, event.id, message, module_id, app_up, version</order>
+  <parent>cisco-ftd</parent>
+  <prematch>1-505015</prematch>
+  <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?(Module\s(.+),\sapplication\sup\s(\S+),\sversion\s(\S+))</regex>
+  <order>header, product.name, event.severity, event.id, message, module_id, app_up, version</order>
 </decoder>
+
 <!--
-%FTD-6-302014: Teardown TCP connection 4211 for external:171.70.168.183/53 to mgmt:192.168.1.185/1032 duration 0:00:00 bytes 526
-%FTD-6-302016: Teardown UDP connection 4211 for external:171.70.168.183/53 to mgmt:192.168.1.185/1032 duration 0:00:00 bytes 526
+  %FTD-6-302014: Teardown TCP connection 4211 for external:171.70.168.183/53 to mgmt:192.168.1.185/1032 duration 0:00:00 bytes 526
+  %FTD-6-302016: Teardown UDP connection 4211 for external:171.70.168.183/53 to mgmt:192.168.1.185/1032 duration 0:00:00 bytes 526
 -->
 <decoder name="cisco-ftd-teardown-connection-tcpudp">
-    <parent>cisco-ftd</parent>
-    <prematch>6-302014|6-302016</prematch>
-    <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\s(\d+)\sfor\s(\S+):(\S+)/(\S+)\sto\s(\S+):(\S+)/(\S+)\sduration\s(\d+:\d+:\d+)\sbytes\s(\d+))</regex>
-    <order>header, product.name, event.severity, event.id, message, description, connection, src, src_ip, src_port, dst, dst_ip, dst_port, duration, bytes</order>
+  <parent>cisco-ftd</parent>
+  <prematch>6-302014|6-302016</prematch>
+  <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\s(\d+)\sfor\s(\S+):(\S+)/(\S+)\sto\s(\S+):(\S+)/(\S+)\sduration\s(\d+:\d+:\d+)\sbytes\s(\d+))</regex>
+  <order>header, product.name, event.severity, event.id, message, description, connection, src, src_ip, src_port, dst, dst_ip, dst_port, duration, bytes</order>
 </decoder>
 
 <!--
-%ftd-4-419002: Duplicate TCP SYN from WLC-LAN_inside:10.233.209.119/42736 to outside:192.168.0.8/52082 with different initial sequence number
+  %ftd-4-419002: Duplicate TCP SYN from WLC-LAN_inside:10.233.209.119/42736 to outside:192.168.0.8/52082 with different initial sequence number
 -->
 <decoder name="cisco-ftd-duplicate-syn">
-    <parent>cisco-ftd</parent>
-    <prematch>4-419002</prematch>
-    <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\sfrom\s(\S+):(\S+)/(\S+)\sto\s(\S+):(\S+)/(\S+)\swith\sdifferent\sinitial\ssequence\snumber)</regex>
-    <order>header, product.name, event.severity, event.id, message, description, src, src_ip, src_port, dst, dst_ip, dst_port</order>
+  <parent>cisco-ftd</parent>
+  <prematch>4-419002</prematch>
+  <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\sfrom\s(\S+):(\S+)/(\S+)\sto\s(\S+):(\S+)/(\S+)\swith\sdifferent\sinitial\ssequence\snumber)</regex>
+  <order>header, product.name, event.severity, event.id, message, description, src, src_ip, src_port, dst, dst_ip, dst_port</order>
 </decoder>
 
 <!--
-%FTD-4-405001: Received ARP {request | response} collision from 192.168.1.59/MAC_address on interface interface_name to 192.168.1.59/MAC_address on interface interface_name
+  %FTD-4-405001: Received ARP {request | response} collision from 192.168.1.59/MAC_address on interface interface_name to 192.168.1.59/MAC_address on interface interface_name
 -->
 <decoder name="cisco-ftd-response-collision">
-    <parent>cisco-ftd</parent>
-    <prematch>4-405001</prematch>
-    <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\sfrom\s(\S+)/(\S+)\son\sinterface\s(\S+)\sto\s(\S+)/(\S+)\son\sinterface\s(\S+))</regex>
-   <order>header, product.name, event.severity, event.id, message, description, src_ip, new_arp, interface, existing_arp</order>
+  <parent>cisco-ftd</parent>
+  <prematch>4-405001</prematch>
+  <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\sfrom\s(\S+)/(\S+)\son\sinterface\s(\S+)\sto\s(\S+)/(\S+)\son\sinterface\s(\S+))</regex>
+  <order>header, product.name, event.severity, event.id, message, description, src_ip, new_arp, interface, existing_arp</order>
 </decoder>
 
 <!--
-%ftd-2-106020: Deny IP teardrop fragment (size = 1480, offset = 0) from 10.235.224.228 to 10.235.0.1
+  %ftd-2-106020: Deny IP teardrop fragment (size = 1480, offset = 0) from 10.235.224.228 to 10.235.0.1
 -->
 <decoder name="cisco-ftd-deny-teardrop-fragment">
-    <parent>cisco-ftd</parent>
-    <prematch>2-106020</prematch>
-   <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\s\(size\s=\s(\S+),\soffset\s=\s(\S+)\)\sfrom\s(\S+)\sto\s(\S+))</regex>
-   <order>header, product.name, event.severity, event.id, message, description, size, offset, src, dst</order>
+  <parent>cisco-ftd</parent>
+  <prematch>2-106020</prematch>
+  <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\s\(size\s=\s(\S+),\soffset\s=\s(\S+)\)\sfrom\s(\S+)\sto\s(\S+))</regex>
+  <order>header, product.name, event.severity, event.id, message, description, size, offset, src, dst</order>
 </decoder>
 
 <!--
-%ftd-5-500003: Bad TCP hdr length (hdrlen=4, pktlen=74) from 123.146.183.231/34160 to 116.6.127.118/443, flags: INVALID, on interface outside
+  %ftd-5-500003: Bad TCP hdr length (hdrlen=4, pktlen=74) from 123.146.183.231/34160 to 116.6.127.118/443, flags: INVALID, on interface outside
 -->
 <decoder name="cisco-ftd-bad-hdr-length">
-    <parent>cisco-ftd</parent>
-    <prematch>5-500003</prematch>
-   <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\s\(hdrlen=(\S+),\spktlen=(\S+)\)\sfrom\s(\S+)/(\S+)\sto\s(\S+)/(\S+),\sflags:\s(.+),\son\sinterface\s(\S+))</regex>
-   <order>header, product.name, event.severity, event.id, message, description, hdrlen, pktlen, src_ip, src_port, dst_ip, dst_port, flags, interface</order>
+  <parent>cisco-ftd</parent>
+  <prematch>5-500003</prematch>
+  <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\s\(hdrlen=(\S+),\spktlen=(\S+)\)\sfrom\s(\S+)/(\S+)\sto\s(\S+)/(\S+),\sflags:\s(.+),\son\sinterface\s(\S+))</regex>
+  <order>header, product.name, event.severity, event.id, message, description, hdrlen, pktlen, src_ip, src_port, dst_ip, dst_port, flags, interface</order>
 </decoder>
 
 <!--
-%ftd-3-202010: PAT pool exhausted. Unable to create TCP connection from WLC-LAN_inside:10.237.52.235/40012 to outside:183.240.12.88/443
+  %ftd-3-202010: PAT pool exhausted. Unable to create TCP connection from WLC-LAN_inside:10.237.52.235/40012 to outside:183.240.12.88/443
 -->
 <decoder name="cisco-ftd-pat-pool-exhausted">
-    <parent>cisco-ftd</parent>
-    <prematch>3-202010</prematch>
-   <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\sfrom\s(\S+):(\S+)/(\S+)\sto\s(\S+):(\S+)/(\S+))</regex>
-   <order>header, product.name, event.severity, event.id, message, description, src, src_ip, src_port, dst, dst_ip, dst_port</order>
+  <parent>cisco-ftd</parent>
+  <prematch>3-202010</prematch>
+  <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\sfrom\s(\S+):(\S+)/(\S+)\sto\s(\S+):(\S+)/(\S+))</regex>
+  <order>header, product.name, event.severity, event.id, message, description, src, src_ip, src_port, dst, dst_ip, dst_port</order>
 </decoder>
 
 <!--
-%FTD-1-105005: (Secondary) Lost Failover communications with mate on interface WLC-LAN_inside
+  %FTD-1-105005: (Secondary) Lost Failover communications with mate on interface WLC-LAN_inside
 -->
 <decoder name="cisco-ftd-lost-failover">
-    <parent>cisco-ftd</parent>
-    <prematch>1-105005</prematch>
-   <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\sinterface\s(\S+))</regex>
-   <order>header, product.name, event.severity, event.id, message, description, interface</order>
+  <parent>cisco-ftd</parent>
+  <prematch>1-105005</prematch>
+  <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\sinterface\s(\S+))</regex>
+  <order>header, product.name, event.severity, event.id, message, description, interface</order>
 </decoder>
 
 
 <!--
-%FTD-1-106101 The number of ACL log deny-flows has reached limit (number).
+  %FTD-1-106101 The number of ACL log deny-flows has reached limit (number).
 -->
 <decoder name="cisco-ftd-deny-flows">
-    <parent>cisco-ftd</parent>
-    <prematch>1-106101</prematch>
-   <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?(The\snumber\sof\s(\S+)\s(.+)\shas\sreached\slimit\s\((\S+)\))</regex>
-   <order>header, product.name, event.severity, event.id, message, log, description, log, limit</order>
+  <parent>cisco-ftd</parent>
+  <prematch>1-106101</prematch>
+  <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?(The\snumber\sof\s(\S+)\s(.+)\shas\sreached\slimit\s\((\S+)\))</regex>
+  <order>header, product.name, event.severity, event.id, message, log, description, log, limit</order>
 </decoder>
 
 <!--
-%FTD-4-409023: Attempting AAA Fallback method LOCAL for Authentication request for user impssnagios : Auth-server group IMPSS unreachable
+  %FTD-4-409023: Attempting AAA Fallback method LOCAL for Authentication request for user impssnagios : Auth-server group IMPSS unreachable
 -->
 <decoder name="cisco-ftd-attempting-fallback">
-    <parent>cisco-ftd</parent>
-    <prematch>4-409023</prematch>
-   <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\sfor\suser\s([^:]+):(.+))</regex>
-   <order>header, product.name, event.severity, event.id, message, description, username, message</order>
+  <parent>cisco-ftd</parent>
+  <prematch>4-409023</prematch>
+  <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\sfor\suser\s([^:]+):(.+))</regex>
+  <order>header, product.name, event.severity, event.id, message, description, username, message</order>
 </decoder>
 
 
 <!--
-%FTD-4-711004: Task ran for 435 msec, Process = DATAPATH-0-1879, PC = 0, Call stack = 0x090b0155
+  %FTD-4-711004: Task ran for 435 msec, Process = DATAPATH-0-1879, PC = 0, Call stack = 0x090b0155
 -->
 <decoder name="cisco-ftd-task-ran">
     <parent>cisco-ftd</parent>
@@ -360,38 +356,38 @@
 </decoder>
 
 <!--
-%FTD-4-411001: Line protocol on Interface GigabitEthernet0/0 changed state to up
+  %FTD-4-411001: Line protocol on Interface GigabitEthernet0/0 changed state to up
 -->
 <decoder name="cisco-ftd-line-protocol-interface">
-    <parent>cisco-ftd</parent>
-    <prematch type="pcre2">[^%]*%FTD-4-411001[:\s].*</prematch>
-   <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\son\sinterface\s(\S+)\s(.+))</regex>
-   <order>header, product.name, event.severity, event.id, message, description, interface, action</order>
+  <parent>cisco-ftd</parent>
+  <prematch type="pcre2">[^%]*%FTD-4-411001[:\s].*</prematch>
+  <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((.+)\son\sinterface\s(\S+)\s(.+))</regex>
+  <order>header, product.name, event.severity, event.id, message, description, interface, action</order>
 </decoder>
 
 <!--
-%FTD-2-321006: System Memory usage reached 93%
+  %FTD-2-321006: System Memory usage reached 93%
 -->
 <decoder name="cisco-ftd-system-memory">
-    <parent>cisco-ftd</parent>
-    <prematch type="pcre2">[^%]*%FTD-2-321006[:\s].*</prematch>
-   <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((System\smemory\susage)\sreached\sutilization\s(\S+))</regex>
-   <order>header, product.name, event.severity, event.id, message, description, percentage</order>
+  <parent>cisco-ftd</parent>
+  <prematch type="pcre2">[^%]*%FTD-2-321006[:\s].*</prematch>
+  <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((System\smemory\susage)\sreached\sutilization\s(\S+))</regex>
+  <order>header, product.name, event.severity, event.id, message, description, percentage</order>
 </decoder>
 
 <!--
-%FTD-4-405003: IP address collision detected between host 1.0.0.2 at 00e0.ed27.620f and interface FAILOVER, 00e0.ed22.eb39
+  %FTD-4-405003: IP address collision detected between host 1.0.0.2 at 00e0.ed27.620f and interface FAILOVER, 00e0.ed22.eb39
 -->
 <decoder name="cisco-ftd-ip-collision">
-    <parent>cisco-ftd</parent>
-    <prematch type="pcre2">[^%]*%FTD-4-405003[:\s].*</prematch>
-   <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((IP\saddress\scollision)\sdetected\sbetween\shost\s(\S+)\sat\s(\S+)\sand\sinterface\s(\S+),\s(\S+))</regex>
-   <order>header, product.name, event.severity, event.id, message, description, host_ip, src_mac, interface, int_mac_address</order>
+  <parent>cisco-ftd</parent>
+  <prematch type="pcre2">[^%]*%FTD-4-405003[:\s].*</prematch>
+  <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?((IP\saddress\scollision)\sdetected\sbetween\shost\s(\S+)\sat\s(\S+)\sand\sinterface\s(\S+),\s(\S+))</regex>
+  <order>header, product.name, event.severity, event.id, message, description, host_ip, src_mac, interface, int_mac_address</order>
 </decoder>
 
 <!-- General decoder -->
 <decoder name="cisco-ftd">
-    <parent>cisco-ftd</parent>
-    <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?(.+)?</regex>
-    <order>header, product.name, event.severity, event.id, message</order>
+  <parent>cisco-ftd</parent>
+  <regex type="pcre2">([^%]+)?%(FTD)-([0-7])-([^:\s]+):?\s?(.+)?</regex>
+  <order>header, product.name, event.severity, event.id, message</order>
 </decoder>

--- a/ruleset/rules/0905-cisco-ftd_rules.xml
+++ b/ruleset/rules/0905-cisco-ftd_rules.xml
@@ -1,230 +1,234 @@
 <!--
-  -  Cisco FTD rules
-  -  Created by Wazuh, Inc.
-  -  Copyright (C) 2015-2021, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  Copyright (C) 2015-2021, Wazuh Inc.
+
+  Cisco FTD rule ID: 91500 - 91530
 -->
+
 <group name="cisco, cisco-ftd,">
-    <!-- General rule -->
-    <rule id="91500" level="0">
-        <decoded_as>cisco-ftd</decoded_as>
-        <description>cisco-ftd rules</description>
-    </rule>
 
-    <rule id="91501" level="7">
-        <if_sid>91500</if_sid>
-        <field name="event.severity">1</field>
-        <description>FTD alert message.</description>
-    </rule>
+  <!-- General rule -->
+  <rule id="91500" level="0">
+    <decoded_as>cisco-ftd</decoded_as>
+    <description>cisco-ftd rules</description>
+  </rule>
 
-    <rule id="91502" level="5">
-        <if_sid>91500</if_sid>
-        <field name="event.severity">2</field>
-        <description>FTD critical message.</description>
-    </rule>
+  <rule id="91501" level="7">
+    <if_sid>91500</if_sid>
+    <field name="event.severity">1</field>
+    <description>FTD alert message.</description>
+  </rule>
 
-    <rule id="91503" level="4">
-        <if_sid>91500</if_sid>
-        <field name="event.severity">3</field>
-        <description>FTD error message.</description>
-    </rule>
+  <rule id="91502" level="5">
+    <if_sid>91500</if_sid>
+    <field name="event.severity">2</field>
+    <description>FTD critical message.</description>
+  </rule>
 
-    <rule id="91504" level="3">
-        <if_sid>91500</if_sid>
-        <field name="event.severity">4</field>
-        <description>FTD warning message.</description>
-    </rule>
+  <rule id="91503" level="4">
+    <if_sid>91500</if_sid>
+    <field name="event.severity">3</field>
+    <description>FTD error message.</description>
+  </rule>
 
-    <rule id="91505" level="2">
-        <if_sid>91500</if_sid>
-        <field name="event.severity">5|6</field>
-        <description>FTD notification/informational message.</description>
-    </rule>
+  <rule id="91504" level="3">
+    <if_sid>91500</if_sid>
+    <field name="event.severity">4</field>
+    <description>FTD warning message.</description>
+  </rule>
 
-    <rule id="91506" level="0">
-        <if_sid>91500</if_sid>
-        <field name="event.severity">7</field>
-        <description>FTD debug message.</description>
-    </rule>
+  <rule id="91505" level="2">
+    <if_sid>91500</if_sid>
+    <field name="event.severity">5|6</field>
+    <description>FTD notification/informational message.</description>
+  </rule>
 
-    <rule id="91507" level="9">
-        <if_sid>91505</if_sid>
-        <field name="event.id">605004</field>
-        <description>FTD: Failed login attempt.</description>
-        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-    </rule>
+  <rule id="91506" level="0">
+    <if_sid>91500</if_sid>
+    <field name="event.severity">7</field>
+    <description>FTD debug message.</description>
+  </rule>
 
-    <rule id="91508" level="3">
-        <if_sid>91505</if_sid>
-        <field name="event.id">502103</field>
-        <description>FTD: User privilege changed.</description>
-        <group>pci_dss_10.2.7,pci_dss_10.6.1,gpg13_7.9,gdpr_IV_35.7.d,gdpr_IV_32.2,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-    </rule>
+  <rule id="91507" level="9">
+    <if_sid>91505</if_sid>
+    <field name="event.id">605004</field>
+    <description>FTD: Failed login attempt.</description>
+    <group>authentication_failed,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
 
-    <rule id="91509" level="3">
-        <if_sid>91505</if_sid>
-        <field name="event.id">605005</field>
-        <description>FTD: Successful login.</description>
-        <group>authentication_success,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_32.2,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-    </rule>
+  <rule id="91508" level="3">
+    <if_sid>91505</if_sid>
+    <field name="event.id">502103</field>
+    <description>FTD: User privilege changed.</description>
+    <group>gpg13_7.9,gdpr_IV_35.7.d,gdpr_IV_32.2,pci_dss_10.2.7,pci_dss_10.6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
 
-    <rule id="91510" level="8">
-        <if_sid>91504</if_sid>
-        <field name="event.id">405001</field>
-        <description>FTD: ARP collision detected.</description>
-        <mitre>
-            <id>T1095</id>
-        </mitre>
-        <group>pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
-    </rule>
+  <rule id="91509" level="3">
+    <if_sid>91505</if_sid>
+    <field name="event.id">605005</field>
+    <description>FTD: Successful login.</description>
+    <group>authentication_success,gpg13_7.8,gdpr_IV_32.2,pci_dss_10.2.5,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
 
-    <rule id="91511" level="8">
-        <if_sid>91504</if_sid>
-        <field name="event.id">401004</field>
-        <description>FTD: Attempt to connect from a blocked (shunned) IP.</description>
-        <group>access_denied,pci_dss_10.2.4,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-    </rule>
+  <rule id="91510" level="8">
+    <if_sid>91504</if_sid>
+    <field name="event.id">405001</field>
+    <description>FTD: ARP collision detected.</description>
+    <mitre>
+      <id>T1095</id>
+    </mitre>
+    <group>gpg13_4.12,gdpr_IV_35.7.d,pci_dss_10.6.1,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
 
-    <rule id="91512" level="8">
-        <if_sid>91506</if_sid>
-        <field name="event.id">710004</field>
-        <description>FTD: Connection limit exceeded.</description>
-        <group>pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
-    </rule>
+  <rule id="91511" level="8">
+    <if_sid>91504</if_sid>
+    <field name="event.id">401004</field>
+    <description>FTD: Attempt to connect from a blocked (shunned) IP.</description>
+    <group>access_denied,gpg13_4.12,gdpr_IV_35.7.d,pci_dss_10.2.4,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
 
-    <!--rule id="91513" level="8">
-        <if_sid>91501</if_sid>
-        <field name="event.id">106021|106022</field>
-        <description>FTD: Attack in progress detected.</description>
-        <group>gdpr_IV_35.7.d,</group>
-    </rule>
+  <rule id="91512" level="8">
+    <if_sid>91506</if_sid>
+    <field name="event.id">710004</field>
+    <description>FTD: Connection limit exceeded.</description>
+    <group>gdpr_IV_35.7.d,pci_dss_10.6.1,gpg13_4.12,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
 
-    <rule id="91514" level="8">
-        <if_sid>91502</if_sid>
-        <field name="event.id">106012|106017|106020</field>
-        <description>FTD: Attack in progress detected.</description>
-        <group>gdpr_IV_35.7.d,</group>
-    </rule-->
+  <!--
+  <rule id="91513" level="8">
+      <if_sid>91501</if_sid>
+      <field name="event.id">106021|106022</field>
+      <description>FTD: Attack in progress detected.</description>
+      <group>gdpr_IV_35.7.d,</group>
+  </rule>
 
-    <!-- Grouping of attack in progress messages. The two above
-      -  will never be alerted, but this one instead.
-      -->
-    <rule id="91515" level="8">
-        <if_sid>91501,91502,91505</if_sid>
-        <field name="event.id">106012|106022|106021|106017|106020</field>
-        <description>FTD: Attack in progress detected</description>
-        <group>ids,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-    </rule>
+  <rule id="91514" level="8">
+      <if_sid>91502</if_sid>
+      <field name="event.id">106012|106017|106020</field>
+      <description>FTD: Attack in progress detected.</description>
+      <group>gdpr_IV_35.7.d,</group>
+  </rule>
+  -->
 
-    <rule id="91516" level="5">
-        <if_sid>91505</if_sid>
-        <field name="event.id">113005</field>
-        <description>FTD: AAA (VPN) authentication failed.</description>
-        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-    </rule>
+  <!--
+    Grouping of attack in progress messages. The two above will never be alerted, but this one instead.
+  -->
+  <rule id="91515" level="8">
+    <if_sid>91501,91502,91505</if_sid>
+    <field name="event.id">106012|106022|106021|106017|106020</field>
+    <description>FTD: Attack in progress detected</description>
+    <group>ids,gpg13_4.12,gdpr_IV_35.7.d,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
 
-    <rule id="91517" level="3">
-        <if_sid>91505</if_sid>
-        <field name="event.id">113004</field>
-        <description>FTD: AAA (VPN) authentication successful.</description>
-        <mitre>
-            <id>T1078</id>
-        </mitre>
-        <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-    </rule>
+  <rule id="91516" level="5">
+    <if_sid>91505</if_sid>
+    <field name="event.id">113005</field>
+    <description>FTD: AAA (VPN) authentication failed.</description>
+    <group>authentication_failed,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
 
-    <rule id="91518" level="8">
-        <if_sid>91505</if_sid>
-        <field name="event.id">113006</field>
-        <description>FTD: AAA (VPN) user locked out.</description>
-        <mitre>
-            <id>T1133</id>
-        </mitre>
-        <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-    </rule>
+  <rule id="91517" level="3">
+    <if_sid>91505</if_sid>
+    <field name="event.id">113004</field>
+    <description>FTD: AAA (VPN) authentication successful.</description>
+    <mitre>
+      <id>T1078</id>
+    </mitre>
+    <group>authentication_success,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,pci_dss_10.2.5,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
 
-    <rule id="91519" level="8">
-        <if_sid>91503</if_sid>
-        <field name="event.id">201008</field>
-        <description>FTD: Disallowing new connections.</description>
-        <group>service_availability,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
-    </rule>
+  <rule id="91518" level="8">
+    <if_sid>91505</if_sid>
+    <field name="event.id">113006</field>
+    <description>FTD: AAA (VPN) user locked out.</description>
+    <mitre>
+      <id>T1133</id>
+    </mitre>
+    <group>authentication_failed,gpg13_7.1,gpg13_7.5,gdpr_IV_35.7.d,gdpr_IV_32.2,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
 
-    <rule id="91520" level="8">
-        <if_sid>91501</if_sid>
-        <field name="event.id">105005|105009|105043</field>
-        <match>Failed|Lost Failover</match>
-        <description>FTD: Firewall failover pair communication problem.</description>
-        <group>service_availability,pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
-    </rule>
+  <rule id="91519" level="8">
+    <if_sid>91503</if_sid>
+    <field name="event.id">201008</field>
+    <description>FTD: Disallowing new connections.</description>
+    <group>gpg13_4.12,gdpr_IV_35.7.d,pci_dss_10.6.1,service_availability,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
 
-    <rule id="91521" level="8">
-        <if_sid>91505</if_sid>
-        <field name="event.id">111003</field>
-        <description>FTD: Firewall configuration deleted.</description>
-        <group>config_changed,pci_dss_1.1.1,pci_dss_10.4,gpg13_4.13,gdpr_IV_35.7.d,tsc_CC8.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-    </rule>
+  <rule id="91520" level="8">
+    <if_sid>91501</if_sid>
+    <field name="event.id">105005|105009|105043</field>
+    <match>Failed|Lost Failover</match>
+    <description>FTD: Firewall failover pair communication problem.</description>
+    <group>gpg13_4.12,gdpr_IV_35.7.d,pci_dss_10.6.1,service_availability,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
 
-    <rule id="91522" level="8">
-        <if_sid>91505</if_sid>
-        <field name="event.id">111005|111004|111002|111007</field>
-        <description>FTD: Firewall configuration changed.</description>
-        <mitre>
-            <id>T1089</id>
-        </mitre>
-        <group>config_changed,pci_dss_1.1.1,pci_dss_10.4,gpg13_4.13,gdpr_IV_35.7.d,tsc_CC8.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-    </rule>
+  <rule id="91521" level="8">
+    <if_sid>91505</if_sid>
+    <field name="event.id">111003</field>
+    <description>FTD: Firewall configuration deleted.</description>
+    <group>config_changed,gpg13_4.13,gdpr_IV_35.7.d,pci_dss_1.1.1,pci_dss_10.4,tsc_CC8.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
 
-    <rule id="91523" level="3">
-        <if_sid>91505</if_sid>
-        <field name="event.id">111008</field>
-        <description>FTD: Firewall command executed (for accounting only).</description>
-    </rule>
+  <rule id="91522" level="8">
+    <if_sid>91505</if_sid>
+    <field name="event.id">111005|111004|111002|111007</field>
+    <description>FTD: Firewall configuration changed.</description>
+    <mitre>
+      <id>T1089</id>
+    </mitre>
+    <group>config_changed,gpg13_4.13,gdpr_IV_35.7.d,pci_dss_1.1.1,pci_dss_10.4,tsc_CC8.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
 
-    <rule id="91524" level="3">
-        <if_sid>91506</if_sid>
-        <field name="event.id">111009</field>
-        <description>FTD: Firewall command executed (for accounting only).</description>
-    </rule>
+  <rule id="91523" level="3">
+    <if_sid>91505</if_sid>
+    <field name="event.id">111008</field>
+    <description>FTD: Firewall command executed (for accounting only).</description>
+  </rule>
 
-    <rule id="91525" level="8">
-        <if_sid>91505</if_sid>
-        <field name="event.id">502101|502102</field>
-        <description>FTD: User created or modified on the Firewall.</description>
-        <mitre>
-            <id>T1089</id>
-        </mitre>
-        <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-    </rule>
+  <rule id="91524" level="3">
+    <if_sid>91506</if_sid>
+    <field name="event.id">111009</field>
+    <description>FTD: Firewall command executed (for accounting only).</description>
+  </rule>
 
-    <rule id="91526" level="10" frequency="8" timeframe="360">
-        <if_matched_sid>91501</if_matched_sid>
-        <description>Multiple FTD alert messages.</description>
-        <group>pci_dss_10.6.1,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,</group>
-    </rule>
+  <rule id="91525" level="8">
+    <if_sid>91505</if_sid>
+    <field name="event.id">502101|502102</field>
+    <description>FTD: User created or modified on the Firewall.</description>
+    <mitre>
+      <id>T1089</id>
+    </mitre>
+    <group>account_changed,adduser,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,pci_dss_8.1.2,pci_dss_10.2.5,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
 
-    <rule id="91527" level="10" frequency="8" timeframe="360">
-        <if_matched_sid>91502</if_matched_sid>
-        <description>FTD: Multiple critical messages.</description>
-        <group>pci_dss_10.6.1,pci_dss_11.4,gpg13_4.1,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,</group>
-    </rule>
+  <rule id="91526" level="10" frequency="8" timeframe="360">
+    <if_matched_sid>91501</if_matched_sid>
+    <description>Multiple FTD alert messages.</description>
+    <group>gpg13_4.12,gdpr_IV_35.7.d,pci_dss_10.6.1,pci_dss_11.4,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,</group>
+  </rule>
 
-    <rule id="91528" level="10" frequency="10" timeframe="120">
-        <if_matched_sid>91503</if_matched_sid>
-        <description>FTD: Multiple error messages.</description>
-        <group>system_error,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.3,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,</group>
-    </rule>
+  <rule id="91527" level="10" frequency="8" timeframe="360">
+    <if_matched_sid>91502</if_matched_sid>
+    <description>FTD: Multiple critical messages.</description>
+    <group>gpg13_4.1,gdpr_IV_35.7.d,pci_dss_10.6.1,pci_dss_11.4,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,</group>
+  </rule>
 
-    <rule id="91529" level="10" frequency="10" timeframe="120">
-        <if_matched_sid>91504</if_matched_sid>
-        <description>FTD: Multiple warning messages.</description>
-        <group>pci_dss_10.6.1,gpg13_4.12,gdpr_IV_35.7.d,tsc_CC7.2,tsc_CC7.3,</group>
-    </rule>
+  <rule id="91528" level="10" frequency="10" timeframe="120">
+    <if_matched_sid>91503</if_matched_sid>
+    <description>FTD: Multiple error messages.</description>
+    <group>gdpr_IV_35.7.d,pci_dss_10.6.1,pci_dss_11.4,gpg13_4.3,system_error,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,</group>
+  </rule>
 
-    <rule id="91530" level="8">
-        <if_sid>91502</if_sid>
-        <field name="event.id">106016</field>
-        <description>FTD: IP spoofing attack detected.</description>
-        <group>gdpr_IV_35.7.d,</group>
-    </rule>
+  <rule id="91529" level="10" frequency="10" timeframe="120">
+    <if_matched_sid>91504</if_matched_sid>
+    <description>FTD: Multiple warning messages.</description>
+    <group>gpg13_4.12,gdpr_IV_35.7.d,pci_dss_10.6.1,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+
+  <rule id="91530" level="8">
+    <if_sid>91502</if_sid>
+    <field name="event.id">106016</field>
+    <description>FTD: IP spoofing attack detected.</description>
+    <group>gdpr_IV_35.7.d,</group>
+  </rule>
+
 </group>

--- a/ruleset/testing/tests/cisco_ftd.ini
+++ b/ruleset/testing/tests/cisco_ftd.ini
@@ -1,198 +1,176 @@
-[Severity 1: alerts]
+;   Copyright (C) 2015-2021, Wazuh Inc.
+;
+;   Tests for products:
+;     Cisco FTD
+;
+;   Sample logs source: https://www.cisco.com/c/en/us/td/docs/security/firepower/Syslogs/b_fptd_syslog_guide.html
+;
+
+[Cisco FTD: High severity alert]
 log 1 pass = %FTD-1-101001: (Primary) Failover cable OK.
 log 2 pass = %FTD-1-101002: (Primary) Bad failover cable.
-
 rule = 91501
 alert = 7
 decoder = cisco-ftd
 
-[91520]
-log 22 pass = %FTD-1-105005: (Primary) Lost Failover communications with mate on interface interface_name.
-log 26 pass = %FTD-1-105009: (Primary) Testing on interface interface_name {Passed|Failed}.
-log 41 pass = %FTD-1-105043: (Primary) Failover interface failed
-
+[Cisco FTD: Firewall failover pair communication problem]
+log 1 pass = %FTD-1-105005: (Primary) Lost Failover communications with mate on interface interface_name.
+log 2 pass = %FTD-1-105009: (Primary) Testing on interface interface_name {Passed|Failed}.
+log 3 pass = %FTD-1-105043: (Primary) Failover interface failed
 rule = 91520
 alert = 8
 decoder = cisco-ftd
 
-[91515]
+[Cisco FTD: Attack in progress detected]
 log 1 pass = %FTD-6-106012: Deny IP from 192.168.1.59 to 192.168.1.59, IP options hex.
-log 48 pass = %FTD-1-106022: Deny protocol connection spoof from 192.168.1.59 to 192.168.1.59 on interface interface_name
-log 47 pass = %FTD-1-106021: Deny protocol reverse path check from 192.168.1.59 to 192.168.1.59 on interface interface_name
-log 7 pass = %FTD-2-106017: Deny IP due to Land Attack from 192.168.1.59 to 192.168.1.59
-log 9 pass = %FTD-2-106020: Deny IP teardrop fragment (size = number, offset = number) from 192.168.1.59 to 192.168.1.59
-
-
+log 2 pass = %FTD-1-106022: Deny protocol connection spoof from 192.168.1.59 to 192.168.1.59 on interface interface_name
+log 3 pass = %FTD-1-106021: Deny protocol reverse path check from 192.168.1.59 to 192.168.1.59 on interface interface_name
+log 4 pass = %FTD-2-106017: Deny IP due to Land Attack from 192.168.1.59 to 192.168.1.59
+log 5 pass = %FTD-2-106020: Deny IP teardrop fragment (size = number, offset = number) from 192.168.1.59 to 192.168.1.59
 rule = 91515
 alert = 8
 decoder = cisco-ftd
 
-[91530]
-log 6 pass = %FTD-2-106016: Deny IP spoof from (192.168.1.59) to 192.168.1.59 on interface interface_name.
+[Cisco FTD: IP spoofing attack detected]
+log 1 pass = %FTD-2-106016: Deny IP spoof from (192.168.1.59) to 192.168.1.59 on interface interface_name.
 rule = 91530
 alert = 8
 decoder = cisco-ftd
 
-
-[Severity 2: critical]
+[Cisco FTD: Critical severity alert]
 log 1 pass = %FTD-2-106001: Inbound TCP connection denied from 192.168.1.59/port to 192.168.1.59/port flags tcp_flags on interface interface_name
 log 2 pass = %FTD-2-106002: protocol Connection denied by outbound list acl_ID src inside_address dest outside_address
-
 rule = 91502
 alert = 5
 decoder = cisco-ftd
 
-[Severity 3: error]
+[Cisco FTD: Error alert]
 log 1 pass = %FTD-3-106010: Deny inbound protocol src [interface_name: 192.168.1.59/source_port] [([idfw_user | FQDN_string], sg_info)] dst [interface_name: 192.168.1.59/dest_port}[([idfw_user | FQDN_string], sg_info)]
 log 2 pass = %FTD-3-106011: Deny inbound (No xlate) string
-
 rule = 91503
 alert = 4
 decoder = cisco-ftd
 
-
-[91519]
-log 43 pass = %FTD-3-201008: Disallowing new connections.
-
+[Cisco FTD: Disallowing new connections]
+log 1 pass = %FTD-3-201008: Disallowing new connections.
 rule = 91519
 alert = 8
 decoder = cisco-ftd
 
-
-[Severity 4: warning]
+[Cisco FTD: Warning alert]
 log 1 pass = %FTD-4-106023: Deny tcp src inside:111.11.11.1/2143 dst YYY:172.11.1.11/139 by access-group "inside_inbound"
 log 2 pass = %FTD-4-106027: Deny src [source address] dst [destination address] by access-group "access-list name".
-
 rule = 91504
 alert = 3
 decoder = cisco-ftd
 
-[91510]
-log 64 pass = %FTD-4-405001: Received ARP {request | response} collision from 192.168.1.59/MAC_address on interface interface_name to 192.168.1.59/MAC_address on interface interface_name
-
+[Cisco FTD: ARP collision detected]
+log 1 pass = %FTD-4-405001: Received ARP {request | response} collision from 192.168.1.59/MAC_address on interface interface_name to 192.168.1.59/MAC_address on interface interface_name
 rule = 91510
 alert = 8
 decoder = cisco-ftd
 
-
-[91511]
-log 45 pass = %FTD-4-401004: Shunned packet: 192.168.1.59 = 192.168.1.59 on interface interface_name
-
-
+[Cisco FTD: Attempt to connect from a blocked IP]
+log 1 pass = %FTD-4-401004: Shunned packet: 192.168.1.59 = 192.168.1.59 on interface interface_name
 rule = 91511
 alert = 8
 decoder = cisco-ftd
 
-[Severity 5: notification]
+[Cisco FTD: Notification alerts]
 log 1 pass = %FTD-5-106029: New reverse carrier <protocol> <ingress_ifc>:<source_addr> to <egress_ifc>:<destination_addr> overshadows existing <ingress_ifc2>:<source_addr2> to <egress_ifc2>:<destination_addr2>
 log 2 pass = %FTD-5-109012: Authen Session End: user 'user', sid number, elapsed number seconds
-
 rule = 91505
 alert = 2
 decoder = cisco-ftd
 
-[91522]
-log 6 pass = %FTD-5-111002: Begin configuration: 192.168.1.59 reading from device
-log 8 pass = %FTD-5-111004: 192.168.1.59 end configuration: {FAILED|OK}
-log 9 pass = %FTD-5-111005: 192.168.1.59 end configuration: OK
-log 10 pass = %FTD-5-111007: Begin configuration: 192.168.1.59 reading from device.
-
+[Cisco FTD: Firewall configuration changed]
+log 1 pass = %FTD-5-111002: Begin configuration: 192.168.1.59 reading from device
+log 2 pass = %FTD-5-111004: 192.168.1.59 end configuration: {FAILED|OK}
+log 3 pass = %FTD-5-111005: 192.168.1.59 end configuration: OK
+log 4 pass = %FTD-5-111007: Begin configuration: 192.168.1.59 reading from device.
 rule = 91522
 alert = 8
 decoder = cisco-ftd
 
-[91521]
-log 7 pass = %FTD-5-111003: 192.168.1.59 Erase configuration
-
+[Cisco FTD: Firewall configuration deleted]
+log 1 pass = %FTD-5-111003: 192.168.1.59 Erase configuration
 rule = 91521
 alert = 8
 decoder = cisco-ftd
 
-[91523]
-log 11 pass = %FTD-5-111008: User user executed the command string
-
+[Cisco FTD: Firewall command executed (for accounting only)]
+log 1 pass = %FTD-5-111008: User user executed the command string
 rule = 91523
 alert = 3
 decoder = cisco-ftd
 
-[91525]
-log 40 pass = %FTD-5-502101: New user added to local dbase: Uname: user Priv: privilege_level Encpass: string
-log 41 pass = %FTD-5-502102: User deleted from local dbase: Uname: user Priv: privilege_level Encpass: string
-
+[Cisco FTD: User created or modified on the Firewall]
+log 1 pass = %FTD-5-502101: New user added to local dbase: Uname: user Priv: privilege_level Encpass: string
+log 2 pass = %FTD-5-502102: User deleted from local dbase: Uname: user Priv: privilege_level Encpass: string
 rule = 91525
 alert = 8
 decoder = cisco-ftd
 
-[91508]
-log 42 pass = %FTD-5-502103: User priv level changed: Uname: user From: privilege_level To: privilege_level
-
+[Cisco FTD: User privilege changed]
+log 1 pass = %FTD-5-502103: User priv level changed: Uname: user From: privilege_level To: privilege_level
 rule = 91508
 alert = 3
 decoder = cisco-ftd
 
 
-[Severity 6: informational]
-log 2 pass = %FTD-6-106015: Deny TCP (no connection) from 192.168.1.59/port to 192.168.1.59/port flags tcp_flags on interface interface_name.
-log 3 pass = %FTD-6-106100: access-list acl_ID {permitted | denied | est-allowed} protocol interface_name/192.168.1.59(source_port)(idfw_user, sg_info) interface_name/192.168.1.59(dest_port) (idfw_user, sg_info) hit-cnt number ({first hit | number-second interval})
-
+[Cisco FTD: Informational alerts]
+log 1 pass = %FTD-6-106015: Deny TCP (no connection) from 192.168.1.59/port to 192.168.1.59/port flags tcp_flags on interface interface_name.
+log 2 pass = %FTD-6-106100: access-list acl_ID {permitted | denied | est-allowed} protocol interface_name/192.168.1.59(source_port)(idfw_user, sg_info) interface_name/192.168.1.59(dest_port) (idfw_user, sg_info) hit-cnt number ({first hit | number-second interval})
 rule = 91505
 alert = 2
 decoder = cisco-ftd
 
-[91517]
-log 12 pass = %FTD-6-113004: AAA user aaa_type Successful: server = server_192.168.1.59, User = user
-
+[Cisco FTD: AAA (VPN) authentication successful]
+log 1 pass = %FTD-6-113004: AAA user aaa_type Successful: server = server_192.168.1.59, User = user
 rule = 91517
 alert = 3
 decoder = cisco-ftd
 
-[91516]
-log 13 pass = %FTD-6-113005: AAA user authentication Rejected: reason = string: server = server_192.168.1.59, User = user: user IP = user_ip
-
+[Cisco FTD: AAA (VPN) authentication failed]
+log 1 pass = %FTD-6-113005: AAA user authentication Rejected: reason = string: server = server_192.168.1.59, User = user: user IP = user_ip
 rule = 91516
 alert = 5
 decoder = cisco-ftd
 
-[91518]
-log 14 pass = %FTD-6-113006: User user locked out on exceeding number successive failed authentication attempts
-
+[Cisco FTD: AAA (VPN) user locked out]
+log 1 pass = %FTD-6-113006: User user locked out on exceeding number successive failed authentication attempts
 rule = 91518
 alert = 8
 decoder = cisco-ftd
 
-[91507]
-log 119 pass = %FTD-6-605004: Login denied from source-address/source-port to interface:destination/service for user "username"
-
+[Cisco FTD: Failed login attempt]
+log 1 pass = %FTD-6-605004: Login denied from source-address/source-port to interface:destination/service for user "username"
 rule = 91507
 alert = 9
 decoder = cisco-ftd
 
-[91509]
-log 120 pass = %FTD-6-605005: Login permitted from source-address/source-port to interface:destination/service for user "username"
-
+[Cisco FTD: Successful login]
+log 1 pass = %FTD-6-605005: Login permitted from source-address/source-port to interface:destination/service for user "username"
 rule = 91509
 alert = 3
 decoder = cisco-ftd
 
 
-[Severity 7: debugging]
-log 2 pass = %FTD-7-113028: Extraction of username from VPN client certificate has string. [Request num]
-log 3 pass = %FTD-7-199019: syslog
-
+[Cisco FTD: Debugging alerts]
+log 1 pass = %FTD-7-113028: Extraction of username from VPN client certificate has string. [Request num]
+log 2 pass = %FTD-7-199019: syslog
 rule = 91506
 alert = 0
 decoder = cisco-ftd
 
-[91524]
+[Cisco FTD: Firewall command executed (for accounting only)]
 log 1 pass = %FTD-7-111009: User user executed cmd:string
-
 rule = 91524
 alert = 3
 decoder = cisco-ftd
 
-[91512]
-log 21 pass = %FTD-7-710004: TCP connection limit exceeded from Src_ip/Src_port to In_name:Dest_ip/Dest_port (current connections/connection limit = Curr_conn/Conn_lmt)
-
+[Cisco FTD: Connection limit exceeded]
+log 1 pass = %FTD-7-710004: TCP connection limit exceeded from Src_ip/Src_port to In_name:Dest_ip/Dest_port (current connections/connection limit = Curr_conn/Conn_lmt)
 rule = 91512
 alert = 8
 decoder = cisco-ftd


### PR DESCRIPTION
## Description
|Related issue|Related PR|Closes Issue|
|---|---|---|
| #8211| #8603|#11280|

## Changes & Comments
The aim of this PR is:

- Add Copyright header
- To ensure the rules and decoders from issue #8211work correctly.
- To fix issues regarding indentation, syntax, rule granularity, spellings and ensure the ruleset quality is standard.
- Fin in .ini tests

## Checks 

### Syntax

- [x] 1.a Rule tags order must be compliant.
- [x] 1.b Decoder tags order must be compliant.
- [x] 1.c XML blocks must as compact as possible.
- [x] 1.d Only one empty line between rule/decoder and the next rule/decoder.
- [x] 1.e Decoder extracted fields names must use '_' whether a space is needed.
- [x] 1.f Decoder name must use '-' whether a space is needed.
- [x] 2.d XML and ini files must use correct indentation
 
### Grammar

- [x] 2.a Grammar quality.
- [x] 2.b Similar phrases must keep tenses and expressions.
- [x] 2.c Grammar basic rules like capitalization, punctuation marks, sentence construction, and others.


### Semantic

- [x] 3.a New decoder, rule, or test are written in the correct file and grouped correctly inside the file.
- [x] 3.b Group similar rules under same ID's group.
- [x] 3.c: 
   - [x] 3.c1 Find and reuse group name before creating a new one.
   - [x] 3.c2 Include a new group definition in a PR comment.
   - [x] 3.c3 Any group name must use '_' whether it does need a space char.
   - [x] 3.c4 The groups inside a tag must be sorted in alphabetical order.
   - [x] 3.d Rule level should be compliant with the [documentation](https://documentation.wazuh.com/current/user-manual/ruleset/rules-classification.html).

### Unit testing

- [x] 4.a A metadata block at the beginning of the .ini file describing software, version, and logs source.
- [x] 4.b Each new rule must have at least one test entry in the correct .ini file.
- [x] 4.c Runtest.py must pass and must include the results in raw format here.
<details>
  <statement>Unit Tests</statement>

  ```

  ```
</details>

- [x] 4.d New CDB lists must include the proper test entry in the correct .ini file.

### E2E testing

- [ ] 5.a Logs for new or modified decoder/rules sent to a manager running with this PR ruleset appear in Kibana. 
- [ ] 5.b There are not affected or broken visualizations on Kibana. 
- [ ] 5.c New or modified items can be seen correctly using APP ruleset navigation.


### Elasticsearch Template

- [x] 6.a Known fields with output format managed and usually used for searching are included in template array index.query.default_field. 
- [x] 6.b The new field with the correct date format is stored as a "date" type field in the template.
- [x] 6.c The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 
- [x] 6.d Known fields with output format managed and usually used for searching are included in the template.

### Stoppers

- [x] 7.a No previous rule ID changes without triple check.
- [x] 7.b No previous decoder name changes without triple check.
- [x] 7.c No previous file name changes without triple check.
- [x] 7.d No previous test changes its 'rule' field value without triple check.

### Others

- [x] 8.a Each file has the correct copyright block.
- [x] 8.b The copyright block doesn't have "Author" only "Created by Wazuh". To include an "Author" request triple check.
- [x] 8.c The copyright block doesn't use "-". 
- [x] 8.d The rule files don't have any sample log.
- [x] 8.e The decoder file has sample logs next to the decoder that matches that log.
- [x] 8.f The decoder and rule files have information about software, version, and any helpful information.
- [x] 8.g The PR has a single commit with CHANGELOG changes in the correct format.
- [x] 8.h The new rule ID is not in use.
- [x] 8.i The new rule ID must be in the defined IDs range. 
- [x] 8.j New rules ID range must be verified with a triple check and noted in the rules ID document.
- [x] 8.k The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 