### PR TITLE
General monitord code cleanup and refactor

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -234,12 +234,6 @@ pthread_mutex_t process_event_mutex = PTHREAD_MUTEX_INITIALIZER;
 /* Reported mutexes */
 static pthread_mutex_t writer_threads_mutex = PTHREAD_MUTEX_INITIALIZER;
 
-
-/* To translate between month (int) to month (char) */
-static const char *(month[]) = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                   "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
-                  };
-
 /* CPU Info*/
 static int cpu_cores;
 
@@ -2176,7 +2170,7 @@ void * w_log_rotate_thread(__attribute__((unused)) void * args){
         localtime_r(&c_time, &tm_result);
         day = tm_result.tm_mday;
         year = tm_result.tm_year + 1900;
-        strncpy(mon, month[tm_result.tm_mon], 3);
+        strncpy(mon, get_short_month_name(tm_result.tm_mon), 3);
 
         /* Set the global hour/weekday */
         __crt_hour = tm_result.tm_hour;

--- a/src/analysisd/cleanevent.c
+++ b/src/analysisd/cleanevent.c
@@ -16,12 +16,6 @@
 #include "fts.h"
 #include "config.h"
 
-/* To translate between month (int) to month (char) */
-static const char *(month[]) = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                   "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
-                  };
-
-
 /* Format a received message in the Eventinfo structure */
 int OS_CleanMSG(char *msg, Eventinfo *lf)
 {
@@ -590,7 +584,7 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
     /* Assign hour, day, year and month values */
     lf->day = p.tm_mday;
     lf->year = p.tm_year + 1900;
-    strncpy(lf->mon, month[p.tm_mon], 3);
+    strncpy(lf->mon, get_short_month_name(p.tm_mon), 3);
     snprintf(lf->hour, 9, "%02d:%02d:%02d",
              p.tm_hour,
              p.tm_min,

--- a/src/analysisd/stats.c
+++ b/src/analysisd/stats.c
@@ -25,10 +25,6 @@ static const char *(weekdays[]) = {"Sunday", "Monday", "Tuesday", "Wednesday", "
                       "Friday", "Saturday"
                      };
 
-static const char *(l_month[]) = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug",
-                     "Sep", "Oct", "Nov", "Dec"
-                    };
-
 /* Global variables */
 
 /* Hour 25 is internally used */
@@ -443,7 +439,7 @@ void Start_Time(){
     today = tm_result.tm_mday;
     thishour = tm_result.tm_hour;
     prev_year = tm_result.tm_year + 1900;
-    strncpy(prev_month, l_month[tm_result.tm_mon], 3);
+    strncpy(prev_month, get_short_month_name(tm_result.tm_mon), 3);
     prev_month[3] = '\0';
 
 }

--- a/src/headers/time_op.h
+++ b/src/headers/time_op.h
@@ -18,6 +18,15 @@
 
 #include <time.h>
 
+#define DAY_IN_SECONDS 86400
+
+/**
+ * @brief Get the current short month name (ex "Jan")
+ *
+ * @param month Month number starting at 0
+ */
+const char* get_short_month_name(unsigned month);
+
 /**
  * @brief Get the current calendar time
  *

--- a/src/logcollector/read_djb_multilog.c
+++ b/src/logcollector/read_djb_multilog.c
@@ -15,10 +15,6 @@
 #include "os_crypto/sha1/sha1_op.h"
 
 
-/* To translate between month (int) to month (char) */
-static const char *(djb_month[]) = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                                    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
-                                   };
 static char djb_host[512 + 1];
 
 
@@ -156,7 +152,7 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
 
                 /* Syslog time: Apr 27 14:50:32  */
                 snprintf(buffer, OS_MAXSTR, "%s %02d %02d:%02d:%02d %s %s: %s",
-                         djb_month[tm_result.tm_mon],
+                         get_short_month_name(tm_result.tm_mon),
                          tm_result.tm_mday,
                          tm_result.tm_hour,
                          tm_result.tm_min,

--- a/src/monitord/monitor_actions.c
+++ b/src/monitord/monitor_actions.c
@@ -53,7 +53,7 @@ void monitor_agents_disconnection(){
     //The master will disconnect and alert the agents on its own DB. Thus, synchronization is not required.
     agents_array = wdb_disconnect_agents(time(0) - mond.global.agents_disconnection_time,
                                          "synced", &sock);
-    if (mond.monitor_agents != 0 && agents_array) {
+    if (agents_array) {
         for (int i = 0; agents_array[i] != -1; i++) {
             snprintf(str_agent_id, 12, "%d", agents_array[i]);
             if (OSHash_Add(agents_to_alert_hash, str_agent_id, (void*)time(0)) == 0) {
@@ -157,34 +157,6 @@ void monitor_agents_deletion(){
             }
         }
         os_free(agents_array);
-    }
-}
-
-void monitor_logs(bool check_logs_size, char path[PATH_MAX], char path_json[PATH_MAX]) {
-    struct stat buf;
-    off_t size;
-
-    if (check_logs_size == FALSE && mond.rotate_log) {
-        sleep(mond.day_wait);
-        /* Daily rotation and compression of ossec.log/ossec.json */
-        w_rotate_log(mond.compress, mond.keep_log_days, 1, 0, mond.daily_rotations);
-
-    } else if (check_logs_size == TRUE && mond.rotate_log && mond.size_rotate > 0){
-        if (stat(path, &buf) == 0) {
-            size = buf.st_size;
-            /* If log file reachs maximum size, rotate ossec.log */
-            if ( (unsigned long) size >= mond.size_rotate) {
-                w_rotate_log(mond.compress, mond.keep_log_days, 0, 0, mond.daily_rotations);
-            }
-        }
-
-        if (stat(path_json, &buf) == 0) {
-            size = buf.st_size;
-            /* If log file reachs maximum size, rotate ossec.json */
-            if ( (unsigned long) size >= mond.size_rotate) {
-                w_rotate_log(mond.compress, mond.keep_log_days, 0, 1, mond.daily_rotations);
-            }
-        }
     }
 }
 

--- a/src/monitord/monitord.h
+++ b/src/monitord/monitord.h
@@ -25,12 +25,26 @@
 #define CHECK_LOGS_SIZE TRUE
 
 /* Prototypes */
+typedef enum log_extension
+{
+    LE_LOG = 1 << 0,
+    LE_JSON= 1 << 1
+}log_extension_t;
+
+typedef struct {
+    time_t log_creation_time;
+    int configured_daily_rotations;
+    int compress;
+    log_extension_t log_extension;
+}rotate_log_config_t;
+void w_rotate_log(const rotate_log_config_t* config);
+void remove_old_logs(int keep_log_days); 
+
 void Monitord(void) __attribute__((noreturn));
-void manage_files(int cday, int cmon, int cyear);
-void generate_reports(int cday, int cmon, int cyear, const struct tm *p);
+void compress_and_sign_logs(time_t starting_time);
+void generate_reports(time_t starting_time);
 void OS_SignLog(const char *logfile, const char *logfile_old, const char * ext);
 void OS_CompressLog(const char *logfile);
-void w_rotate_log(int compress, int keep_log_days, int new_day, int rotate_json, int daily_rotations);
 int delete_old_agent(const char *agent_id);
 int MonitordConfig(const char *cfg, monitor_config *mond, int no_agents, short day_wait);
 
@@ -154,16 +168,6 @@ cJSON *getReportsOptions(void);
 size_t moncom_dispatch(char * command, char ** output);
 size_t moncom_getconfig(const char * section, char ** output);
 void * moncom_main(__attribute__((unused)) void * arg);
-
-typedef struct _monitor_time_control {
-    long disconnect_counter;
-    long alert_counter;
-    long delete_counter;
-    struct tm current_time;
-    int today;
-    int thismonth;
-    int thisyear;
-} monitor_time_control;
 
 /* Global variables */
 extern monitor_config mond;

--- a/src/shared/file-queue.c
+++ b/src/shared/file-queue.c
@@ -18,12 +18,6 @@ static void file_sleep(void);
 static void GetFile_Queue(file_queue *fileq) __attribute__((nonnull));
 static int Handle_Queue(file_queue *fileq, int flags) __attribute__((nonnull));
 
-/* To translate between month (int) to month (char) */
-static const char *(s_month[]) = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                                  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
-                                 };
-
-
 static void file_sleep() {
 
     struct timeval fp_timeout;
@@ -110,7 +104,7 @@ int Init_FileQueue(file_queue *fileq, const struct tm *p, int flags)
     fileq->day = p->tm_mday;
     fileq->year = p->tm_year + 1900;
 
-    strncpy(fileq->mon, s_month[p->tm_mon], 3);
+    strncpy(fileq->mon, get_short_month_name(p->tm_mon), 3);
     memset(fileq->file_name, '\0', MAX_FQUEUE + 1);
 
     /* Set the supplied flags */
@@ -151,7 +145,7 @@ alert_data *Read_FileMon(file_queue *fileq, const struct tm *p, unsigned int tim
 
     fileq->day = p->tm_mday;
     fileq->year = p->tm_year + 1900;
-    strncpy(fileq->mon, s_month[p->tm_mon], 3);
+    strncpy(fileq->mon, get_short_month_name(p->tm_mon), 3);
 
     /* Get latest file */
     GetFile_Queue(fileq);

--- a/src/shared/log_builder.c
+++ b/src/shared/log_builder.c
@@ -161,9 +161,7 @@ char * log_builder_build(log_builder_t * builder, const char * pattern, const ch
                 // If format is not speficied, use RFC3164
 #ifdef WIN32
                 // strfrime() does not allow %e in Windows
-                const char * MONTHS[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
-
-                if (snprintf(_timestamp, sizeof(_timestamp), "%s %s%d %02d:%02d:%02d", MONTHS[tm.tm_mon], tm.tm_mday < 10 ? " " : "", tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec) < (int)sizeof(_timestamp)) {
+                if (snprintf(_timestamp, sizeof(_timestamp), "%s %s%d %02d:%02d:%02d", get_short_month_name(tm.tm_mon), tm.tm_mday < 10 ? " " : "", tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec) < (int)sizeof(_timestamp)) {
                     field = _timestamp;
                 }
 #else

--- a/src/shared/time_op.c
+++ b/src/shared/time_op.c
@@ -22,6 +22,18 @@
 #include <mach/mach.h>
 #endif
 
+#define LAST_MONTH_INDEX 11
+const char* get_short_month_name(unsigned month)
+{
+    if(month > LAST_MONTH_INDEX) return "NULL";
+
+    static const char * Months[] = { "Jan", "Feb", "Mar", "Apr",
+                                     "May", "Jun", "Jul", "Aug",
+                                     "Sep", "Oct", "Nov", "Dec"};
+
+    return Months[month];
+}
+
 // Get the current calendar time
 
 void gettime(struct timespec *ts) {


### PR DESCRIPTION
- Monitord loop now sleeps until the 'soonest' next action
- Reports are now correctly generated for all the rotated alerts
- Added a get_month_short_name function to deduplicate the months array
  that lived in multiple files
- Refactored the `rotate_log` function to deduplicate a bit of code and
  make it more readable

|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors