### PR TITLE
Fix find_account_ids function in AWS module

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -687,10 +687,9 @@ class AWSBucket(WazuhIntegration):
 
     def find_account_ids(self):
         try:
-            common_prefixes = self.client.list_objects_v2(Bucket=self.bucket, Prefix=self.get_base_prefix(),
-                                                          Delimiter='/')['CommonPrefixes']
-            return [prefix['Prefix'].split('/')[-2] for prefix in common_prefixes if
-                    self.prefix_regex.match(prefix['Prefix'].split('/')[-2])]
+            prefixes = self.client.list_objects_v2(Bucket=self.bucket, Prefix=self.get_base_prefix(),
+                                                   Delimiter='/')['CommonPrefixes']
+            return [account_id for p in prefixes if self.prefix_regex.match(account_id := p['Prefix'].split('/')[-2])]
         except KeyError:
             bucket_types = {'cloudtrail', 'config', 'vpcflow', 'guardduty', 'waf', 'custom'}
             print(f"ERROR: Invalid type of bucket. The bucket was set up as '{get_script_arguments().type.lower()}' "

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -501,6 +501,7 @@ class AWSBucket(WazuhIntegration):
         self.bucket_path = self.bucket + '/' + self.prefix
         self.aws_organization_id = aws_organization_id
         self.date_regex = re.compile(r'(\d{4}/\d{2}/\d{2})')
+        self.prefix_regex= re.compile("^\d{12}$")
         self.check_prefix = False
 
     def _same_prefix(self, match_start: int or None, aws_account_id: str, aws_region: str) -> bool:
@@ -686,11 +687,10 @@ class AWSBucket(WazuhIntegration):
 
     def find_account_ids(self):
         try:
-            return [common_prefix['Prefix'].split('/')[-2] for common_prefix in
-                    self.client.list_objects_v2(Bucket=self.bucket,
-                                                Prefix=self.get_base_prefix(),
-                                                Delimiter='/')['CommonPrefixes']
-                    ]
+            common_prefixes = self.client.list_objects_v2(Bucket=self.bucket, Prefix=self.get_base_prefix(),
+                                                          Delimiter='/')['CommonPrefixes']
+            return [prefix['Prefix'].split('/')[-2] for prefix in common_prefixes if
+                    self.prefix_regex.match(prefix['Prefix'].split('/')[-2])]
         except KeyError:
             bucket_types = {'cloudtrail', 'config', 'vpcflow', 'guardduty', 'waf', 'custom'}
             print(f"ERROR: Invalid type of bucket. The bucket was set up as '{get_script_arguments().type.lower()}' "


### PR DESCRIPTION

## Description

The `find_account_ids` function present in our AWS module is used to get the different account IDs with data available for a given bucket. This is needed because the bucket itself may contain logs from different account IDs and if that's the case these logs will be stored using a path that starts with a folder named as the Account ID the data belongs to. Here is an example:

```
bucketA/AWSLogs/111111111111/CloudTrail/us-east-1/2021/11/24/filename
bucketA/AWSLogs/22222222222/CloudTrail/us-east-1/2021/11/24/filename
bucketA/AWSLogs/33333333333/CloudTrail/us-east-1/2021/11/24/filename
```

The function was already fixed and successfully merged or the master branch in #10952. This PR brings these changes from the master branch to `4.3`.