### PR TITLE
Rework of PR #9041 - Gitlab v12 integration

### DIFF
--- a/ruleset/decoders/0540-gitlab_decoders.xml
+++ b/ruleset/decoders/0540-gitlab_decoders.xml
@@ -73,26 +73,31 @@
 </decoder>
 
 <!--
+  Comment:
+    In example logs with [- -], the braces should be removed and the hyphens joined together. 
+    They were put in this format to prevent XML comment from overwriting the whole document.
+
   gitlab_shell.log
-    I, [2015-02-13T06:17:00.671315 #9291]  INFO -/- : Adding project root/example.git at </var/opt/gitlab/git-data/repositories/root/dcdcdcdcd.git>.
+    I, [2015-02-13T06:17:00.671315 #9291]  INFO [- -] : Adding project root/example.git at </var/opt/gitlab/git-data/repositories/root/dcdcdcdcd.git>.
 
   unicorn_stderr.log
-    I, [2015-02-13T06:14:46.680381 #9047]  INFO -/- : Refreshing Gem list
-    W, [2015-02-13T07:16:01.313000 #9094]  WARN -/- : Unicorn::WorkerKiller send SIGQUIT (pid: 9094) alive: 3621 sec (trial 1)
+    I, [2015-02-13T06:14:46.680381 #9047]  INFO [- -] : Refreshing Gem list
+    W, [2015-02-13T07:16:01.313000 #9094]  WARN [- -] : Unicorn::WorkerKiller send SIGQUIT (pid: 9094) alive: 3621 sec (trial 1)
 -->
 <decoder name="gitlab_shell_stderr">
-<prematch>\w, [\d\d\d\d-\d\d-\w+:\d\d:\d\d.\d+ #\d+]  \w+ -- :</prematch>
+  <prematch>\w, [\d\d\d\d-\d\d-\w+:\d\d:\d\d.\d+ #\d+]  \w+ -- :</prematch>
 </decoder>
+
 <decoder name="gitlab_shell_stderr_info">
-<parent>gitlab_shell_stderr</parent>
-<prematch>I, [\d\d\d\d-\d\d-\w+:\d\d:\d\d.\d+ #\d+]</prematch>
-<regex>I, ([\d\d\d\d-\d\d-\w+:\d\d:\d\d.\d+ #\d+])  (INFO) -- : (\.+)</regex>
-<order>timestamp, severity, message</order>
+  <parent>gitlab_shell_stderr</parent>
+  <prematch>I, [\d\d\d\d-\d\d-\w+:\d\d:\d\d.\d+ #\d+]</prematch>
+  <regex>I, ([\d\d\d\d-\d\d-\w+:\d\d:\d\d.\d+ #\d+])  (INFO) -- : (\.+)</regex>
+  <order>timestamp, severity, message</order>
 </decoder>
 
 <decoder name="gitlab_shell_stderr_warn">
-<parent>gitlab_shell_stderr</parent>
-<prematch>W, [\d\d\d\d-\d\d-\w+:\d\d:\d\d.\d+ #\d+]</prematch>
-<regex>W, ([\d\d\d\d-\d\d-\w+:\d\d:\d\d.\d+ #\d+])  (WARN) -- : (\.+)</regex>
-<order>timestamp, severity, message</order>
+  <parent>gitlab_shell_stderr</parent>
+  <prematch>W, [\d\d\d\d-\d\d-\w+:\d\d:\d\d.\d+ #\d+]</prematch>
+  <regex>W, ([\d\d\d\d-\d\d-\w+:\d\d:\d\d.\d+ #\d+])  (WARN) -- : (\.+)</regex>
+  <order>timestamp, severity, message</order>
 </decoder>

--- a/ruleset/decoders/0540-gitlab_decoders.xml
+++ b/ruleset/decoders/0540-gitlab_decoders.xml
@@ -21,26 +21,28 @@
 
 <decoder name="gitlab-application-log-user">
   <parent>gitlab-12-application-log</parent>
-  <regex>(\w+ \d+, \d\d\d\d \d\d:\d\d:) User "(\.+)" \((\.+)\) was created</regex>
+  <prematch offset="after_parent">User "(\.+)" \((\.+)\)</prematch>
+  <regex>(\w+ \d+, \d\d\d\d \d\d:\d\d): User "(\.+)" \((\.+)\) was created</regex>
   <order>timestamp, new_user, e-mail</order>
 </decoder>
 
 <decoder name="gitlab-application-log-user">
   <parent>gitlab-12-application-log</parent>
-  <regex>(\w+ \d+, \d\d\d\d \d\d:\d\d:) User "(\.+)" \((\.+)\)\s+was removed</regex>
+  <regex>(\w+ \d+, \d\d\d\d \d\d:\d\d): User "(\.+)" \((\.+)\)\s+was removed</regex>
   <order>timestamp, removed_user, e-mail</order>
 </decoder>
 
 <decoder name="gitlab-application-log-new-project">
   <parent>gitlab-12-application-log</parent>
-  <regex>(\w+ \d+, \d\d\d\d \d\d:\d\d:) (\.+) created a new project</regex>
+  <prematch offset="after_parent">created a new project</prematch>
+  <regex>(\w+ \d+, \d\d\d\d \d\d:\d\d): (\.+) created a new project</regex>
   <order>timestamp, project_autor</order>
 </decoder>
 
-
 <decoder name="gitlab-application-log-removed-project">
   <parent>gitlab-12-application-log</parent>
-  <regex>(\w+ \d+, \d\d\d\d \d\d:\d\d:) Project "(\.*)" was removed</regex>
+  <prematch offset="after_parent">Project "(\.+)" was removed</prematch>
+  <regex>(\w+ \d+, \d\d\d\d \d\d:\d\d): Project "(\.*)" was removed</regex>
   <order>timestamp, project_removed</order>
 </decoder>
 
@@ -56,12 +58,14 @@
 
 <decoder name="gitlab-sidekiq-info">
   <parent>gitlab-sidekiq</parent>
+  <prematch offset="after_parent">INFO:</prematch>
   <regex>(\d\d\d\d-\d\d-\w+:\d\d:\w+) \w+ TID-\w+ INFO: (\.+)</regex>
   <order>timestamp, info</order>
 </decoder>
 
 <decoder name="gitlab-sidekiq-error">
   <parent>gitlab-sidekiq</parent>
+  <prematch offset="after_parent">ERROR:</prematch>
   <regex>(\d\d\d\d-\d\d-\w+:\d\d:\w+) \w+ TID-\w+ ERROR: (\.+)</regex>
   <order>timestamp, error</order>
 </decoder>
@@ -84,12 +88,14 @@
 
 <decoder name="gitlab-shell-stderr-info">
   <parent>gitlab-shell-stderr</parent>
+  <prematch>I, [\d\d\d\d-\d\d-\w+:\d\d:\d\d.\d+ #\d+]</prematch>
   <regex>I, ([\d\d\d\d-\d\d-\w+:\d\d:\d\d.\d+ #\d+])  (INFO) -- : (\.+)</regex>
   <order>timestamp, severity, message</order>
 </decoder>
 
 <decoder name="gitlab-shell-stderr-warn">
   <parent>gitlab-shell-stderr</parent>
+  <prematch>W, [\d\d\d\d-\d\d-\w+:\d\d:\d\d.\d+ #\d+]</prematch>
   <regex>W, ([\d\d\d\d-\d\d-\w+:\d\d:\d\d.\d+ #\d+])  (WARN) -- : (\.+)</regex>
   <order>timestamp, severity, message</order>
 </decoder>

--- a/ruleset/decoders/0540-gitlab_decoders.xml
+++ b/ruleset/decoders/0540-gitlab_decoders.xml
@@ -21,7 +21,6 @@
 
 <decoder name="gitlab-application-log-user">
   <parent>gitlab-12-application-log</parent>
-  <prematch offset="after_parent">User "(\.+)" \((\.+)\)</prematch>
   <regex>(\w+ \d+, \d\d\d\d \d\d:\d\d:) User "(\.+)" \((\.+)\) was created</regex>
   <order>timestamp, new_user, e-mail</order>
 </decoder>
@@ -34,7 +33,6 @@
 
 <decoder name="gitlab-application-log-new-project">
   <parent>gitlab-12-application-log</parent>
-  <prematch offset="after_parent">created a new project</prematch>
   <regex>(\w+ \d+, \d\d\d\d \d\d:\d\d:) (\.+) created a new project</regex>
   <order>timestamp, project_autor</order>
 </decoder>
@@ -42,7 +40,6 @@
 
 <decoder name="gitlab-application-log-removed-project">
   <parent>gitlab-12-application-log</parent>
-  <prematch offset="after_parent">Project "(\.+)" was removed</prematch>
   <regex>(\w+ \d+, \d\d\d\d \d\d:\d\d:) Project "(\.*)" was removed</regex>
   <order>timestamp, project_removed</order>
 </decoder>
@@ -59,14 +56,12 @@
 
 <decoder name="gitlab-sidekiq-info">
   <parent>gitlab-sidekiq</parent>
-  <prematch offset="after_parent">INFO:</prematch>
   <regex>(\d\d\d\d-\d\d-\w+:\d\d:\w+) \w+ TID-\w+ INFO: (\.+)</regex>
   <order>timestamp, info</order>
 </decoder>
 
 <decoder name="gitlab-sidekiq-error">
   <parent>gitlab-sidekiq</parent>
-  <prematch offset="after_parent">ERROR:</prematch>
   <regex>(\d\d\d\d-\d\d-\w+:\d\d:\w+) \w+ TID-\w+ ERROR: (\.+)</regex>
   <order>timestamp, error</order>
 </decoder>
@@ -89,14 +84,12 @@
 
 <decoder name="gitlab-shell-stderr-info">
   <parent>gitlab-shell-stderr</parent>
-  <prematch>I, [\d\d\d\d-\d\d-\w+:\d\d:\d\d.\d+ #\d+]</prematch>
   <regex>I, ([\d\d\d\d-\d\d-\w+:\d\d:\d\d.\d+ #\d+])  (INFO) -- : (\.+)</regex>
   <order>timestamp, severity, message</order>
 </decoder>
 
 <decoder name="gitlab-shell-stderr-warn">
   <parent>gitlab-shell-stderr</parent>
-  <prematch>W, [\d\d\d\d-\d\d-\w+:\d\d:\d\d.\d+ #\d+]</prematch>
   <regex>W, ([\d\d\d\d-\d\d-\w+:\d\d:\d\d.\d+ #\d+])  (WARN) -- : (\.+)</regex>
   <order>timestamp, severity, message</order>
 </decoder>

--- a/ruleset/decoders/0540-gitlab_decoders.xml
+++ b/ruleset/decoders/0540-gitlab_decoders.xml
@@ -2,7 +2,6 @@
   Copyright (C) 2015-2021, Wazuh Inc.
 -->
 
-
 <!--
   Decoders for:
     GitLab: v12.
@@ -16,33 +15,33 @@
       October 07, 2014 11:25: Project "project133" was removed
  -->
 
-<decoder name="gitlab-12_application_log">
+<decoder name="gitlab-12-application-log">
   <prematch>\w+ \d+, \d\d\d\d \d\d:\d\d: </prematch>
 </decoder>
 
-<decoder name="gitlab_application_log_user">
-  <parent>gitlab-12_application_log</parent>
+<decoder name="gitlab-application-log-user">
+  <parent>gitlab-12-application-log</parent>
   <prematch offset="after_parent">User "(\.+)" \((\.+)\)</prematch>
   <regex>(\w+ \d+, \d\d\d\d \d\d:\d\d:) User "(\.+)" \((\.+)\) was created</regex>
   <order>timestamp, new_user, e-mail</order>
 </decoder>
 
-<decoder name="gitlab_application_log_user">
-  <parent>gitlab-12_application_log</parent>
+<decoder name="gitlab-application-log-user">
+  <parent>gitlab-12-application-log</parent>
   <regex>(\w+ \d+, \d\d\d\d \d\d:\d\d:) User "(\.+)" \((\.+)\)\s+was removed</regex>
   <order>timestamp, removed_user, e-mail</order>
 </decoder>
 
-<decoder name="gitlab_application_log_new_project">
-  <parent>gitlab-12_application_log</parent>
+<decoder name="gitlab-application-log-new-project">
+  <parent>gitlab-12-application-log</parent>
   <prematch offset="after_parent">created a new project</prematch>
   <regex>(\w+ \d+, \d\d\d\d \d\d:\d\d:) (\.+) created a new project</regex>
   <order>timestamp, project_autor</order>
 </decoder>
 
 
-<decoder name="gitlab_application_log_removed_project">
-  <parent>gitlab-12_application_log</parent>
+<decoder name="gitlab-application-log-removed-project">
+  <parent>gitlab-12-application-log</parent>
   <prematch offset="after_parent">Project "(\.+)" was removed</prematch>
   <regex>(\w+ \d+, \d\d\d\d \d\d:\d\d:) Project "(\.*)" was removed</regex>
   <order>timestamp, project_removed</order>
@@ -54,19 +53,19 @@
     2014-06-10T18:18:26Z 14299 TID-55uqo INFO: Booting Sidekiq 3.0.0 with redis options {:url=>"redis://localhost:6379/0", :namespace=>"sidekiq"}
 -->
 
-<decoder name="gitlab_sidekiq">
+<decoder name="gitlab-sidekiq">
   <prematch>\d\d\d\d-\d\d-\w+:\d\d:\w+ \w+ TID-\w+</prematch>
 </decoder>
 
-<decoder name="gitlab_sidekiq_info">
-  <parent>gitlab_sidekiq</parent>
+<decoder name="gitlab-sidekiq-info">
+  <parent>gitlab-sidekiq</parent>
   <prematch offset="after_parent">INFO:</prematch>
   <regex>(\d\d\d\d-\d\d-\w+:\d\d:\w+) \w+ TID-\w+ INFO: (\.+)</regex>
   <order>timestamp, info</order>
 </decoder>
 
-<decoder name="gitlab_sidekiq_error">
-  <parent>gitlab_sidekiq</parent>
+<decoder name="gitlab-sidekiq-error">
+  <parent>gitlab-sidekiq</parent>
   <prematch offset="after_parent">ERROR:</prematch>
   <regex>(\d\d\d\d-\d\d-\w+:\d\d:\w+) \w+ TID-\w+ ERROR: (\.+)</regex>
   <order>timestamp, error</order>
@@ -84,19 +83,19 @@
     I, [2015-02-13T06:14:46.680381 #9047]  INFO [- -] : Refreshing Gem list
     W, [2015-02-13T07:16:01.313000 #9094]  WARN [- -] : Unicorn::WorkerKiller send SIGQUIT (pid: 9094) alive: 3621 sec (trial 1)
 -->
-<decoder name="gitlab_shell_stderr">
+<decoder name="gitlab-shell-stderr">
   <prematch>\w, [\d\d\d\d-\d\d-\w+:\d\d:\d\d.\d+ #\d+]  \w+ -- :</prematch>
 </decoder>
 
-<decoder name="gitlab_shell_stderr_info">
-  <parent>gitlab_shell_stderr</parent>
+<decoder name="gitlab-shell-stderr-info">
+  <parent>gitlab-shell-stderr</parent>
   <prematch>I, [\d\d\d\d-\d\d-\w+:\d\d:\d\d.\d+ #\d+]</prematch>
   <regex>I, ([\d\d\d\d-\d\d-\w+:\d\d:\d\d.\d+ #\d+])  (INFO) -- : (\.+)</regex>
   <order>timestamp, severity, message</order>
 </decoder>
 
-<decoder name="gitlab_shell_stderr_warn">
-  <parent>gitlab_shell_stderr</parent>
+<decoder name="gitlab-shell-stderr-warn">
+  <parent>gitlab-shell-stderr</parent>
   <prematch>W, [\d\d\d\d-\d\d-\w+:\d\d:\d\d.\d+ #\d+]</prematch>
   <regex>W, ([\d\d\d\d-\d\d-\w+:\d\d:\d\d.\d+ #\d+])  (WARN) -- : (\.+)</regex>
   <order>timestamp, severity, message</order>

--- a/ruleset/decoders/0540-gitlab_decoders.xml
+++ b/ruleset/decoders/0540-gitlab_decoders.xml
@@ -1,93 +1,85 @@
 <!--
-  -  Gitlab v12.1 decoders.
-  -  Created by Wazuh, Inc.
-  -  Copyright (C) 2015-2021, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  Copyright (C) 2015-2021, Wazuh Inc.
 -->
 
 
 <!--
-     application.log
+  Decoders for:
+    GitLab: v12.
 
-     October 06, 2014 11:56: User "Administrator" (admin@example.com) was created
-     October 06, 2014 11:56: Documentcloud created a new project "Documentcloud / Underscore"
-     October 06, 2014 11:56: Gitlab Org created a new project "Gitlab Org / Gitlab Ce"
-     October 07, 2014 11:25: User "Claudie Hodkiewicz" (nasir_stehr@olson.co.uk)  was removed
-     October 07, 2014 11:25: Project "project133" was removed
+  Example logs:
+    application.log
+      October 06, 2014 11:56: User "Administrator" (admin@example.com) was created
+      October 06, 2014 11:56: Documentcloud created a new project "Documentcloud / Underscore"
+      October 06, 2014 11:56: Gitlab Org created a new project "Gitlab Org / Gitlab Ce"
+      October 07, 2014 11:25: User "Claudie Hodkiewicz" (nasir_stehr@olson.co.uk)  was removed
+      October 07, 2014 11:25: Project "project133" was removed
  -->
 
 <decoder name="gitlab-12_application_log">
-    <prematch>\w+ \d+, \d\d\d\d \d\d:\d\d: </prematch>
+  <prematch>\w+ \d+, \d\d\d\d \d\d:\d\d: </prematch>
 </decoder>
 
 <decoder name="gitlab_application_log_user">
-<parent>gitlab-12_application_log</parent>
-<prematch offset="after_parent">User "(\.+)" \((\.+)\)</prematch>
-<regex>(\w+ \d+, \d\d\d\d \d\d:\d\d:) User "(\.+)" \((\.+)\) was created</regex>
-<order>timestamp, new_user, e-mail</order>
+  <parent>gitlab-12_application_log</parent>
+  <prematch offset="after_parent">User "(\.+)" \((\.+)\)</prematch>
+  <regex>(\w+ \d+, \d\d\d\d \d\d:\d\d:) User "(\.+)" \((\.+)\) was created</regex>
+  <order>timestamp, new_user, e-mail</order>
 </decoder>
 
 <decoder name="gitlab_application_log_user">
-<parent>gitlab-12_application_log</parent>
-<regex>(\w+ \d+, \d\d\d\d \d\d:\d\d:) User "(\.+)" \((\.+)\)\s+was removed</regex>
-<order>timestamp, removed_user, e-mail</order>
+  <parent>gitlab-12_application_log</parent>
+  <regex>(\w+ \d+, \d\d\d\d \d\d:\d\d:) User "(\.+)" \((\.+)\)\s+was removed</regex>
+  <order>timestamp, removed_user, e-mail</order>
 </decoder>
 
 <decoder name="gitlab_application_log_new_project">
-<parent>gitlab-12_application_log</parent>
-<prematch offset="after_parent">created a new project</prematch>
-<regex>(\w+ \d+, \d\d\d\d \d\d:\d\d:) (\.+) created a new project</regex>
-<order>timestamp, project_autor</order>
+  <parent>gitlab-12_application_log</parent>
+  <prematch offset="after_parent">created a new project</prematch>
+  <regex>(\w+ \d+, \d\d\d\d \d\d:\d\d:) (\.+) created a new project</regex>
+  <order>timestamp, project_autor</order>
 </decoder>
 
 
 <decoder name="gitlab_application_log_removed_project">
-<parent>gitlab-12_application_log</parent>
-<prematch offset="after_parent">Project "(\.+)" was removed</prematch>
-<regex>(\w+ \d+, \d\d\d\d \d\d:\d\d:) Project "(\.*)" was removed</regex>
-<order>timestamp, project_removed</order>
+  <parent>gitlab-12_application_log</parent>
+  <prematch offset="after_parent">Project "(\.+)" was removed</prematch>
+  <regex>(\w+ \d+, \d\d\d\d \d\d:\d\d:) Project "(\.*)" was removed</regex>
+  <order>timestamp, project_removed</order>
 </decoder>
 
-        <!--
-
-            sidekiq.log
-
-            2014-06-10T07:55:20Z 2037 TID-tm504 ERROR: /opt/bitnami/apps/discourse/htdocs/vendor/bundle/ruby/1.9.1/gems/redis-3.0.7/lib/redis/client.rb:228:in `read'
-
-            2014-06-10T18:18:26Z 14299 TID-55uqo INFO: Booting Sidekiq 3.0.0 with redis options {:url=>"redis://localhost:6379/0", :namespace=>"sidekiq"}
-
-
-        -->
+<!--
+  sidekiq.log
+    2014-06-10T07:55:20Z 2037 TID-tm504 ERROR: /opt/bitnami/apps/discourse/htdocs/vendor/bundle/ruby/1.9.1/gems/redis-3.0.7/lib/redis/client.rb:228:in `read'
+    2014-06-10T18:18:26Z 14299 TID-55uqo INFO: Booting Sidekiq 3.0.0 with redis options {:url=>"redis://localhost:6379/0", :namespace=>"sidekiq"}
+-->
 
 <decoder name="gitlab_sidekiq">
-<prematch>\d\d\d\d-\d\d-\w+:\d\d:\w+ \w+ TID-\w+</prematch>
+  <prematch>\d\d\d\d-\d\d-\w+:\d\d:\w+ \w+ TID-\w+</prematch>
 </decoder>
 
 <decoder name="gitlab_sidekiq_info">
-<parent>gitlab_sidekiq</parent>
-<prematch offset="after_parent">INFO:</prematch>
-<regex>(\d\d\d\d-\d\d-\w+:\d\d:\w+) \w+ TID-\w+ INFO: (\.+)</regex>
-<order>timestamp, info</order>
+  <parent>gitlab_sidekiq</parent>
+  <prematch offset="after_parent">INFO:</prematch>
+  <regex>(\d\d\d\d-\d\d-\w+:\d\d:\w+) \w+ TID-\w+ INFO: (\.+)</regex>
+  <order>timestamp, info</order>
 </decoder>
+
 <decoder name="gitlab_sidekiq_error">
-<parent>gitlab_sidekiq</parent>
-<prematch offset="after_parent">ERROR:</prematch>
-<regex>(\d\d\d\d-\d\d-\w+:\d\d:\w+) \w+ TID-\w+ ERROR: (\.+)</regex>
-<order>timestamp, error</order>
+  <parent>gitlab_sidekiq</parent>
+  <prematch offset="after_parent">ERROR:</prematch>
+  <regex>(\d\d\d\d-\d\d-\w+:\d\d:\w+) \w+ TID-\w+ ERROR: (\.+)</regex>
+  <order>timestamp, error</order>
 </decoder>
 
-        <!--
-        gitlab_shell.log
+<!--
+  gitlab_shell.log
+    I, [2015-02-13T06:17:00.671315 #9291]  INFO -/- : Adding project root/example.git at </var/opt/gitlab/git-data/repositories/root/dcdcdcdcd.git>.
 
-        I, [2015-02-13T06:17:00.671315 #9291]  INFO -- : Adding project root/example.git at </var/opt/gitlab/git-data/repositories/root/dcdcdcdcd.git>.
-
-        unicorn_stderr.log
-
-        I, [2015-02-13T06:14:46.680381 #9047]  INFO -- : Refreshing Gem list
-
-        W, [2015-02-13T07:16:01.313000 #9094]  WARN -- : Unicorn::WorkerKiller send SIGQUIT (pid: 9094) alive: 3621 sec (trial 1)
-
-        -->
+  unicorn_stderr.log
+    I, [2015-02-13T06:14:46.680381 #9047]  INFO -/- : Refreshing Gem list
+    W, [2015-02-13T07:16:01.313000 #9094]  WARN -/- : Unicorn::WorkerKiller send SIGQUIT (pid: 9094) alive: 3621 sec (trial 1)
+-->
 <decoder name="gitlab_shell_stderr">
 <prematch>\w, [\d\d\d\d-\d\d-\w+:\d\d:\d\d.\d+ #\d+]  \w+ -- :</prematch>
 </decoder>

--- a/ruleset/rules/0770-gitlab_rules.xml
+++ b/ruleset/rules/0770-gitlab_rules.xml
@@ -20,7 +20,7 @@
     <description>(Gitlab) $(method) request completed succesfully.</description>
   </rule>
 
-  <rule id="65602" level="5">
+  <rule id="65601" level="5">
     <decoded_as>json</decoded_as>
     <status>^400$</status>
     <field name="method">\w+</field>
@@ -31,7 +31,7 @@
     <description>(Gitlab) ERROR: couldn't complete $(method) request.</description>
   </rule>
 
-  <rule id="65603" level="5">
+  <rule id="65602" level="5">
     <decoded_as>json</decoded_as>
     <status>^300$</status>
     <field name="method">\w+</field>
@@ -42,31 +42,31 @@
     <description>(Gitlab) REDIRECTION: The $(method) request has more than one possible response.</description>
   </rule>
 
-  <rule id="65604" level="3">
+  <rule id="65603" level="3">
     <decoded_as>gitlab-12-application-log</decoded_as>
     <field name="new_user">\.+</field>
     <description>(Gitlab) User $(new_user) was created.</description>
   </rule>
 
-  <rule id="65606" level="3">
+  <rule id="65604" level="3">
     <decoded_as>gitlab-12-application-log</decoded_as>
     <field name="project_autor">\.+</field>
     <description>(Gitlab) $(project_autor) created a new project.</description>
   </rule>
 
-  <rule id="65607" level="3">
+  <rule id="65605" level="3">
     <decoded_as>gitlab-12-application-log</decoded_as>
     <field name="removed_user">\.+</field>
     <description>(Gitlab) User $(removed_user) was removed.</description>
   </rule>
 
-  <rule id="65608" level="3">
+  <rule id="65606" level="3">
     <decoded_as>gitlab-12-application-log</decoded_as>
     <field name="project_removed">\.+</field>
     <description>(Gitlab) Project $(project_removed) was removed.</description>
   </rule>
 
-  <rule id="65609" level="5">
+  <rule id="65607" level="5">
     <decoded_as>json</decoded_as>
     <field name="service_class">\w+</field>
     <field name="project_id">\d+</field>
@@ -74,41 +74,41 @@
     <field name="severity">^ERROR$</field>
     <options>no_full_log</options>
     <description>(Gitlab) $(message).</description>
+  </rule>
+
+  <rule id="65608" level="3">
+    <decoded_as>json</decoded_as>
+    <field name="service_class">\w+</field>
+    <field name="project_id">\d+</field>
+    <field name="project_path">\.+</field>
+    <field name="severity">^INFO$</field>
+    <options>no_full_log</options>
+    <description>(Gitlab) $(message).</description>
+  </rule>
+
+  <rule id="65609" level="5">
+    <decoded_as>json</decoded_as>
+    <field name="exception">\.+</field>
+    <field name="error_code">\w+</field>
+    <field name="service">\.+</field>
+    <field name="app_id">\d+</field>
+    <field name="severity">^ERROR$</field>
+    <options>no_full_log</options>
+    <description>(Gitlab) $(severity):$(message).</description>
   </rule>
 
   <rule id="65610" level="3">
     <decoded_as>json</decoded_as>
-    <field name="service_class">\w+</field>
-    <field name="project_id">\d+</field>
-    <field name="project_path">\.+</field>
+    <field name="exception">\.+</field>
+    <field name="error_code">\w+</field>
+    <field name="service">\.+</field>
+    <field name="app_id">\d+</field>
     <field name="severity">^INFO$</field>
     <options>no_full_log</options>
-    <description>(Gitlab) $(message).</description>
+    <description>(Gitlab) $(severity):$(message).</description>
   </rule>
 
   <rule id="65611" level="5">
-    <decoded_as>json</decoded_as>
-    <field name="exception">\.+</field>
-    <field name="error_code">\w+</field>
-    <field name="service">\.+</field>
-    <field name="app_id">\d+</field>
-    <field name="severity">^ERROR$</field>
-    <options>no_full_log</options>
-    <description>(Gitlab) $(severity):$(message).</description>
-  </rule>
-
-  <rule id="65612" level="3">
-    <decoded_as>json</decoded_as>
-    <field name="exception">\.+</field>
-    <field name="error_code">\w+</field>
-    <field name="service">\.+</field>
-    <field name="app_id">\d+</field>
-    <field name="severity">^INFO$</field>
-    <options>no_full_log</options>
-    <description>(Gitlab) $(severity):$(message).</description>
-  </rule>
-
-  <rule id="65613" level="5">
     <decoded_as>json</decoded_as>
     <field name="correlation_id">\w+</field>
     <field name="message">\.+</field>
@@ -117,7 +117,7 @@
     <description>(Gitlab) $(severity):$(message).</description>
   </rule>
 
-  <rule id="65614" level="3">
+  <rule id="65612" level="3">
     <decoded_as>json</decoded_as>
     <field name="author_id">\w*</field>
     <field name="entity_id">\w*</field>
@@ -130,24 +130,24 @@
     <description>(Gitlab) $(severity):changed $(change) from $(from) to $(to).</description>
   </rule>
   
-  <rule id="65615" level="3">
+  <rule id="65613" level="3">
     <decoded_as>gitlab-sidekiq</decoded_as>
     <description>Group of gitlab_sidekiq.</description>
   </rule>
 
-  <rule id="65616" level="3">
-    <if_sid>65615</if_sid>
+  <rule id="65614" level="3">
+    <if_sid>65613</if_sid>
     <field name="info">\.+</field>
     <description>(Gitlab) INFO:$(info).</description>
   </rule>
 
-  <rule id="65617" level="5">
-    <if_sid>65615</if_sid>
+  <rule id="65615" level="5">
+    <if_sid>65613</if_sid>
     <field name="error">\.+</field>
     <description>(Gitlab) ERROR:$(error).</description>
   </rule>
 
-  <rule id="65618" level="3">
+  <rule id="65616" level="3">
     <decoded_as>json</decoded_as>
     <field name="queue">\.+</field>
     <field name="args">\.*</field>
@@ -159,7 +159,7 @@
     <description>(Gitlab) $(severity): $(message).</description>
   </rule>
 
-  <rule id="65619" level="5">
+  <rule id="65617" level="5">
     <decoded_as>json</decoded_as>
     <field name="queue">\.+</field>
     <field name="args">\.*</field>
@@ -171,19 +171,19 @@
     <description>(Gitlab) $(severity): $(message).</description>
   </rule>
   
-  <rule id="65620" level="3">
+  <rule id="65618" level="3">
     <decoded_as>gitlab-shell-stderr</decoded_as>
     <field name="severity">^INFO$</field>
     <description>(Gitlab) $(severity): $(message).</description>
   </rule>
 
-  <rule id="65621" level="5">
+  <rule id="65619" level="5">
     <decoded_as>gitlab-shell-stderr</decoded_as>
     <field name="severity">^WARN$</field>
     <description>(Gitlab) $(severity): $(message).</description>
   </rule>
 
-  <rule id="65622" level="3">
+  <rule id="65620" level="3">
     <decoded_as>json</decoded_as>
     <field name="query_string">\.+</field>
     <field name="complexity">\d*</field>
@@ -192,7 +192,7 @@
     <description>(Gitlab) graphql_query_string: $(query_string).</description>
   </rule>
 
-  <rule id="65623" level="3">
+  <rule id="65621" level="3">
     <decoded_as>json</decoded_as>
     <status>^200$</status>
     <field name="method">\w+</field>
@@ -202,7 +202,7 @@
     <description>(Gitlab) $(method) request completed succesfully.</description>
   </rule>
 
-  <rule id="65624" level="5">
+  <rule id="65622" level="5">
     <decoded_as>json</decoded_as>
     <status>^400$</status>
     <field name="method">\w+</field>
@@ -212,7 +212,7 @@
     <description>(Gitlab) ERROR: couldn't complete $(method) request.</description>
   </rule>
 
-  <rule id="65625" level="5">
+  <rule id="65623" level="5">
     <decoded_as>json</decoded_as>
     <status>^300$</status>
     <field name="method">\w+</field>

--- a/ruleset/rules/0770-gitlab_rules.xml
+++ b/ruleset/rules/0770-gitlab_rules.xml
@@ -1,249 +1,221 @@
 <!--
-  -  Gitlab rules
-  -  Created by Wazuh, Inc.
-  -  Copyright (C) 2015-2021, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  Copyright (C) 2015-2021, Wazuh Inc.
 -->
 
-
-
-
 <!--
-     Production_json
-
-{"method":"GET","path":"/gitlab/gitlab-ce/issues/1234","format":"html","controller":"Projects::IssuesController","action":"show","status":200,"duration":229.03,"view":174.07,"db":13.24,"time":"2017-08-08T20:15:54.821Z","params":[{"key":"param_key","value":"param_value"}],"remote_ip":"18.245.0.1","user_id":1,"username":"admin","gitaly_calls":76,"gitaly_duration":7.41,"queue_duration": 112.47}
-
-{"method":"PUSH","path":"/gitlab/gitlab-ce/issues/1234","format":"html","controller":"Projects::IssuesController","action":"show","status":400,"duration":229.03,"view":174.07,"db":13.24,"time":"2017-08-08T20:15:54.821Z","params":[{"key":"param_key","value":"param_value"}],"remote_ip":"18.245.0.1","user_id":1,"username":"admin","gitaly_calls":76,"gitaly_duration":7.41,"queue_duration": 112.47}
-
-{"method":"PUSH","path":"/gitlab/gitlab-ce/issues/1234","format":"html","controller":"Projects::IssuesController","action":"show","status":300,"duration":229.03,"view":174.07,"db":13.24,"time":"2017-08-08T20:15:54.821Z","params":[{"key":"param_key","value":"param_value"}],"remote_ip":"18.245.0.1","user_id":1,"username":"admin","gitaly_calls":76,"gitaly_duration":7.41,"queue_duration": 112.47}
-
-api_json
-
-{"time":"2018-10-29T12:49:42.123Z","severity":"INFO","duration":709.08,"db":14.59,"view":694.49,"status":200,"method":"GET","path":"/api/v4/projects","params":[{"key":"action","value":"git-upload-pack"},{"key":"changes","value":"_any"},{"key":"key_id","value":"secret"},{"key":"secret_token","value":"[FILTERED]"}],"host":"localhost","ip":"::1","ua":"Ruby","route":"/api/:version/projects","user_id":1,"username":"root","queue_duration":100.31,"gitaly_calls":30,"gitaly_duration":5.36}
-
-
+  Decoders for:
+    GitLab
 -->
 
 <group name="gitlab_v.12_production_json">
-    <rule id="65600" level="3">
-        <decoded_as>json</decoded_as>
-        <regex>"method":"\w+","path":"/gitlab/gitlab-ce/\w+/\.+","format":"\w+","controller":"\.+","action":"\w+"</regex>
-        <match>"status":200</match>
-        <options>no_full_log</options>
-        <description>(Gitlab)$(method) request Completed Succesfully</description>
-    </rule>
-    <rule id="65602" level="5">
-        <decoded_as>json</decoded_as>
-        <regex>"method":"\w+","path":"/gitlab/gitlab-ce/\w+/\.+","format":"\w+","controller":"\.+","action":"\w+"</regex>
-        <match>"status":400</match>
-        <options>no_full_log</options>
-        <description>(Gitlab)ERROR: couldn't complete $(method) request</description>
-    </rule>
-    <rule id="65603" level="5">
-        <decoded_as>json</decoded_as>
-        <regex>"method":"\w+","path":"/gitlab/gitlab-ce/\w+/\.+","format":"\w+","controller":"\.+","action":"\w+"</regex>
-        <match>"status":300</match>
-        <options>no_full_log</options>
-        <description>(Gitlab)REDIRECTION:The $(method) request has more than one possible response</description>
-    </rule>
+    
+  <rule id="65600" level="3">
+    <decoded_as>json</decoded_as>
+    <regex>"method":"\w+","path":"/gitlab/gitlab-ce/\w+/\.+","format":"\w+","controller":"\.+","action":"\w+"</regex>
+    <match>"status":200</match>
+    <options>no_full_log</options>
+    <description>(Gitlab)$(method) request Completed Succesfully.</description>
+  </rule>
+
+  <rule id="65602" level="5">
+    <decoded_as>json</decoded_as>
+    <regex>"method":"\w+","path":"/gitlab/gitlab-ce/\w+/\.+","format":"\w+","controller":"\.+","action":"\w+"</regex>
+    <match>"status":400</match>
+    <options>no_full_log</options>
+    <description>(Gitlab)ERROR: couldn't complete $(method) request.</description>
+  </rule>
+
+  <rule id="65603" level="5">
+    <decoded_as>json</decoded_as>
+    <regex>"method":"\w+","path":"/gitlab/gitlab-ce/\w+/\.+","format":"\w+","controller":"\.+","action":"\w+"</regex>
+    <match>"status":300</match>
+    <options>no_full_log</options>
+    <description>(Gitlab)REDIRECTION:The $(method) request has more than one possible response.</description>
+  </rule>
+
 </group>
+
 <group name="gitlab_v.12_api_json">
-<rule id="65623" level="3">
+
+  <rule id="65623" level="3">
     <decoded_as>json</decoded_as>
     <regex>"method":"\w+","path":"/api/\w+/\.+","params":\.+</regex>
     <match>"status":200</match>
     <options>no_full_log</options>
-    <description>(Gitlab)$(method) request Completed Succesfully</description>
-</rule>
-<rule id="65624" level="5">
+    <description>(Gitlab)$(method) request Completed Succesfully.</description>
+  </rule>
+
+  <rule id="65624" level="5">
     <decoded_as>json</decoded_as>
     <regex>"method":"\w+","path":"/api/\w+/\.+","params":\.+</regex>
     <match>"status":400</match>
     <options>no_full_log</options>
-    <description>(Gitlab)ERROR: couldn't complete $(method) request</description>
-</rule>
-<rule id="65625" level="5">
+    <description>(Gitlab)ERROR: couldn't complete $(method) request.</description>
+  </rule>
+
+  <rule id="65625" level="5">
     <decoded_as>json</decoded_as>
     <regex>"method":"\w+","path":"/api/\w+/\.+","params":\.+</regex>
     <match>"status":300</match>
     <options>no_full_log</options>
-    <description>(Gitlab)REDIRECTION:The $(method) request has more than one possible response</description>
-</rule>
+    <description>(Gitlab)REDIRECTION:The $(method) request has more than one possible response.</description>
+  </rule>
+
 </group>
 
 <group name="gitlab_v.12_application_log">
-<rule id="65604" level="3">
+
+  <rule id="65604" level="3">
     <decoded_as>gitlab-12_application_log</decoded_as>
     <field name="new_user">\.+</field>
-    <description>(Gitlab)User $(new_user) was created</description>
-</rule>
-<rule id="65606" level="3">
+    <description>(Gitlab)User $(new_user) was created.</description>
+  </rule>
+
+  <rule id="65606" level="3">
     <decoded_as>gitlab-12_application_log</decoded_as>
     <field name="project_autor">\.+</field>
-    <description>(Gitlab)$(project_autor) created a new project</description>
-</rule>
-<rule id="65607" level="3">
+    <description>(Gitlab)$(project_autor) created a new project.</description>
+  </rule>
+
+  <rule id="65607" level="3">
     <decoded_as>gitlab-12_application_log</decoded_as>
     <field name="removed_user">\.+</field>
-    <description>(Gitlab)User $(removed_user) was removed</description>
-</rule>
-<rule id="65608" level="3">
+    <description>(Gitlab)User $(removed_user) was removed.</description>
+  </rule>
+
+  <rule id="65608" level="3">
     <decoded_as>gitlab-12_application_log</decoded_as>
     <field name="project_removed">\.+</field>
-    <description>(Gitlab)Project $(project_removed) was removed</description>
-</rule>
+    <description>(Gitlab)Project $(project_removed) was removed.</description>
+  </rule>
+
 </group>
-
-        <!--
-
-        integrations_json
-
-         {"severity":"ERROR","time":"2018-09-06T14:56:20.439Z","service_class":"JiraService","project_id":8,"project_path":"h5bp/html5-boilerplate","message":"Error sending message","client_url":"http://jira.gitlap.com:8080","error":"execution expired"}
-
-        {"severity":"INFO","time":"2018-09-06T17:15:16.365Z","service_class":"JiraService","project_id":3,"project_path":"namespace2/project2","message":"Successfully posted","client_url":"http://jira.example.com"}
-
-        -->
 
 <group name="gitlab_v.12_integrations_json">
-<rule id="65609" level="5">
+
+  <rule id="65609" level="5">
     <decoded_as>json</decoded_as>
     <regex>"service_class":"\w+","project_id":\d+,"project_path":"\.+"</regex>
     <field name="severity">ERROR</field>
     <options>no_full_log</options>
-    <description>(Gitlab)$(message)</description>
-</rule>
-<rule id="65610" level="3">
+    <description>(Gitlab)$(message).</description>
+  </rule>
+
+  <rule id="65610" level="3">
     <decoded_as>json</decoded_as>
     <regex>"service_class":"\w+","project_id":\d+,"project_path":"\.+"</regex>
     <field name="severity">INFO</field>
     <options>no_full_log</options>
-    <description>(Gitlab)$(message)</description>
-</rule>
+    <description>(Gitlab)$(message).</description>
+  </rule>
+
 </group>
-
-        <!--
-
-        kubernetes_json
-
-        {"severity":"ERROR","time":"2018-11-23T15:14:54.652Z","exception":"Kubeclient::HttpError","error_code":401,"service":"Clusters::Applications::CheckInstallationProgressService","app_id":14,"project_ids":[1],"group_ids":[],"message":"Unauthorized"}
-
-        {"severity":"ERROR","time":"2018-11-23T15:42:11.647Z","exception":"Kubeclient::HttpError","error_code":null,"service":"Clusters::Applications::InstallService","app_id":2,"project_ids":[19],"group_ids":[],"message":"SSL_connect returned=1 errno=0 state=error: certificate verify failed (unable to get local issuer certificate)"}
-
-        -->
 
 <group name="gitlab_v.12_kubernetes_json">
-<rule id="65611" level="5">
+
+  <rule id="65611" level="5">
     <decoded_as>json</decoded_as>
     <regex>"exception":"\.+","error_code":\w+,"service":"\.+","app_id":\d+,</regex>
     <field name="severity">ERROR</field>
     <options>no_full_log</options>
     <description>(Gitlab)$(severity):$(message).</description>
-</rule>
-<rule id="65612" level="3">
+  </rule>
+
+  <rule id="65612" level="3">
     <decoded_as>json</decoded_as>
     <regex>"exception":"\.+","error_code":\w+,"service":"\.+","app_id":\d+,</regex>
     <field name="severity">INFO</field>
     <options>no_full_log</options>
     <description>(Gitlab)$(severity):$(message).</description>
-</rule>
+  </rule>
+
 </group>
 
-        <!--
-        githost_json
-
-        {"severity":"ERROR","time":"2019-07-19T22:16:12.528Z","correlation_id":"FeGxww5Hj64","message":"Command failed [1]: /usr/bin/git --git-dir=/Users/vsizov/gitlab-development-kit/gitlab/tmp/tests/gitlab-satellites/group184/gitlabhq/.git --work-tree=/Users/vsizov/gitlab-development-kit/gitlab/tmp/tests/gitlab-satellites/group184/gitlabhq merge --no-ff -mMerge branch 'feature_conflict' into 'feature' source/feature_conflict\n\nerror: failed to push some refs to '/Users/vsizov/gitlab-development-kit/repositories/gitlabhq/gitlab_git.git'"}
-
-        -->
-
 <group name="gitlab_v.12_githost_json">
-<rule id="65613" level="5">
+
+  <rule id="65613" level="5">
     <decoded_as>json</decoded_as>
     <regex>"correlation_id":"\w+","message":"\.+"</regex>
     <field name="severity">ERROR</field>
     <options>no_full_log</options>
     <description>(Gitlab)$(severity):$(message).</description>
-</rule>
+  </rule>
+
 </group>
 
-        <!--
-
-        audit_json
-
-        {"severity":"INFO","time":"2018-10-17T17:38:22.523Z","author_id":3,"entity_id":2,"entity_type":"Project","change":"visibility","from":"Private","to":"Public","author_name":"John Doe4","target_id":2,"target_type":"Project","target_details":"namespace2/project2"}
-
-        {"severity":"INFO","time":"2018-10-17T17:38:22.830Z","author_id":5,"entity_id":3,"entity_type":"Project","change":"name","from":"John Doe7 / project3","to":"John Doe7 / new name","author_name":"John Doe6","target_id":3,"target_type":"Project","target_details":"namespace3/project3"}
-
-        {"severity":"INFO","time":"2018-10-17T17:38:23.175Z","author_id":7,"entity_id":4,"entity_type":"Project","change":"path","from":"","to":"namespace4/newpath","author_name":"John Doe8","target_id":4,"target_type":"Project","target_details":"namespace4/newpath"}
-
-        -->
-
 <group name="gitlab_v.12_audit_json">
-<rule id="65614" level="3">
+
+  <rule id="65614" level="3">
     <decoded_as>json</decoded_as>
     <regex>"author_id":\w*,"entity_id":\w*,"entity_type":"\w*","change":"\w+","from":"\.*","to":"\.*",</regex>
     <field name="severity">INFO</field>
     <options>no_full_log</options>
     <description>(Gitlab)$(severity):changed $(change) from $(from) to $(to).</description>
-</rule>
+  </rule>
+
 </group>
 
 <group name="gitlab_v.12_sidekiq_log">
-<rule id="65615" level="3">
+  
+  <rule id="65615" level="3">
     <decoded_as>gitlab_sidekiq</decoded_as>
-    <description>group of gitlab_sidekiq</description>
-</rule>
-<rule id="65616" level="3">
+    <description>group of gitlab_sidekiq.</description>
+  </rule>
+
+  <rule id="65616" level="3">
     <if_sid>65615</if_sid>
     <field name="info">\.+</field>
     <description>(Gitlab)INFO:$(info).</description>
-</rule>
-<rule id="65617" level="5">
+  </rule>
+
+  <rule id="65617" level="5">
     <if_sid>65615</if_sid>
     <field name="error">\.+</field>
     <description>(Gitlab)ERROR:$(error).</description>
-</rule>
+  </rule>
+
 </group>
 
-        <!--
-
-        sidekiq_json
-
-        {"severity":"INFO","time":"2018-04-03T22:57:22.071Z","queue":"cronjob:update_all_mirrors","args":[],"class":"UpdateAllMirrorsWorker","retry":false,"queue_namespace":"cronjob","jid":"06aeaa3b0aadacf9981f368e","created_at":"2018-04-03T22:57:21.930Z","enqueued_at":"2018-04-03T22:57:21.931Z","pid":10077,"message":"UpdateAllMirrorsWorker JID-06aeaa3b0aadacf9981f368e: done: 0.139 sec","job_status":"done","duration":0.139,"completed_at":"2018-04-03T22:57:22.071Z"}
-
-        -->
-
 <group name="gitlab_v.12_sidekiq_json">
-<rule id="65618" level="3">
+
+  <rule id="65618" level="3">
     <decoded_as>json</decoded_as>
     <regex>"queue":"\.+","args":\.*,"class":"\w*","retry":\w+,"queue_namespace":"\w*","jid":"\w*",</regex>
     <field name="severity">INFO</field>
     <description>(Gitlab)$(severity):$(message).</description>
-</rule>
-<rule id="65619" level="5">
+  </rule>
+
+  <rule id="65619" level="5">
     <decoded_as>json</decoded_as>
     <regex>"queue":"\.+","args":\.*,"class":"\w*","retry":\w+,"queue_namespace":"\w*","jid":"\w*",</regex>
     <field name="severity">ERROR</field>
     <description>(Gitlab)$(severity):$(message).</description>
-</rule>
+  </rule>
+
 </group>
 
 <group name="gitlab_v.12_shell_stderr_log">
-<rule id="65620" level="3">
+  
+  <rule id="65620" level="3">
     <decoded_as>gitlab_shell_stderr</decoded_as>
     <field name="severity">INFO</field>
     <description>(Gitlab)$(severity):$(message).</description>
-</rule>
-<rule id="65621" level="5">
+  </rule>
+
+  <rule id="65621" level="5">
     <decoded_as>gitlab_shell_stderr</decoded_as>
     <field name="severity">WARN</field>
     <description>(Gitlab)$(severity):$(message).</description>
-</rule>
+  </rule>
+
 </group>
 
 <group name="gitlab_v.12_graphql_json">
-<rule id="65622" level="3">
+  
+  <rule id="65622" level="3">
     <decoded_as>json</decoded_as>
     <regex>"query_string":"\.+","variables":\.+,"complexity":\d*,"depth":\d*,"duration":\d*</regex>
     <description>(Gitlab)graphql_query_string:$(query_string).</description>
-</rule>
+  </rule>
+
 </group>

--- a/ruleset/rules/0770-gitlab_rules.xml
+++ b/ruleset/rules/0770-gitlab_rules.xml
@@ -11,23 +11,35 @@
     
   <rule id="65600" level="3">
     <decoded_as>json</decoded_as>
-    <field name="status">^200$</field>
+    <status>^200$</status>
+    <field name="method">\w+</field>
+    <field name="format">\w+</field>
+    <field name="controller">\.+</field>
+    <field name="path">^/gitlab/gitlab-ce/\w+/\.+</field>
     <options>no_full_log</options>
     <description>(Gitlab) $(method) request completed succesfully.</description>
   </rule>
 
   <rule id="65602" level="5">
     <decoded_as>json</decoded_as>
-    <field name="status">^400$</field>
+    <status>^400$</status>
+    <field name="method">\w+</field>
+    <field name="format">\w+</field>
+    <field name="controller">\.+</field>
+    <field name="path">^/gitlab/gitlab-ce/\w+/\.+</field>
     <options>no_full_log</options>
     <description>(Gitlab) ERROR: couldn't complete $(method) request.</description>
   </rule>
 
   <rule id="65603" level="5">
     <decoded_as>json</decoded_as>
-    <field name="status">^300$</field>
+    <status>^300$</status>
+    <field name="method">\w+</field>
+    <field name="format">\w+</field>
+    <field name="controller">\.+</field>
+    <field name="path">^/gitlab/gitlab-ce/\w+/\.+</field>
     <options>no_full_log</options>
-    <description>(Gitlab) REDIRECTION:The $(method) request has more than one possible response.</description>
+    <description>(Gitlab) REDIRECTION: The $(method) request has more than one possible response.</description>
   </rule>
 
   <rule id="65604" level="3">
@@ -174,7 +186,6 @@
   <rule id="65622" level="3">
     <decoded_as>json</decoded_as>
     <field name="query_string">\.+</field>
-    <field name="quevariablesue">\.+</field>
     <field name="complexity">\d*</field>
     <field name="depth">\d*</field>
     <field name="duration">\d*</field>
@@ -183,30 +194,30 @@
 
   <rule id="65623" level="3">
     <decoded_as>json</decoded_as>
+    <status>^200$</status>
     <field name="method">\w+</field>
     <field name="path">^/api/\w+/\.+</field>
     <field name="params">\.+</field>
-    <field name="status">^200$</field>
     <options>no_full_log</options>
     <description>(Gitlab) $(method) request completed succesfully.</description>
   </rule>
 
   <rule id="65624" level="5">
     <decoded_as>json</decoded_as>
+    <status>^400$</status>
     <field name="method">\w+</field>
     <field name="path">^/api/\w+/\.+</field>
     <field name="params">\.+</field>
-    <field name="status">^400$</field>
     <options>no_full_log</options>
     <description>(Gitlab) ERROR: couldn't complete $(method) request.</description>
   </rule>
 
   <rule id="65625" level="5">
     <decoded_as>json</decoded_as>
+    <status>^300$</status>
     <field name="method">\w+</field>
     <field name="path">^/api/\w+/\.+</field>
     <field name="params">\.+</field>
-    <field name="status">^300$</field>
     <options>no_full_log</options>
     <description>(Gitlab) REDIRECTION: The $(method) request has more than one possible response.</description>
   </rule>

--- a/ruleset/rules/0770-gitlab_rules.xml
+++ b/ruleset/rules/0770-gitlab_rules.xml
@@ -11,24 +11,21 @@
     
   <rule id="65600" level="3">
     <decoded_as>json</decoded_as>
-    <regex>"method":"\w+","path":"/gitlab/gitlab-ce/\w+/\.+","format":"\w+","controller":"\.+","action":"\w+"</regex>
-    <match>"status":200</match>
+    <field name="status">^200$</field>
     <options>no_full_log</options>
     <description>(Gitlab) $(method) request completed succesfully.</description>
   </rule>
 
   <rule id="65602" level="5">
     <decoded_as>json</decoded_as>
-    <regex>"method":"\w+","path":"/gitlab/gitlab-ce/\w+/\.+","format":"\w+","controller":"\.+","action":"\w+"</regex>
-    <match>"status":400</match>
+    <field name="status">^400$</field>
     <options>no_full_log</options>
     <description>(Gitlab) ERROR: couldn't complete $(method) request.</description>
   </rule>
 
   <rule id="65603" level="5">
     <decoded_as>json</decoded_as>
-    <regex>"method":"\w+","path":"/gitlab/gitlab-ce/\w+/\.+","format":"\w+","controller":"\.+","action":"\w+"</regex>
-    <match>"status":300</match>
+    <field name="status">^300$</field>
     <options>no_full_log</options>
     <description>(Gitlab) REDIRECTION:The $(method) request has more than one possible response.</description>
   </rule>
@@ -40,7 +37,7 @@
   </rule>
 
   <rule id="65606" level="3">
-    <decoded_as>gitlab-12-application-log/decoded_as>
+    <decoded_as>gitlab-12-application-log</decoded_as>
     <field name="project_autor">\.+</field>
     <description>(Gitlab) $(project_autor) created a new project.</description>
   </rule>
@@ -52,55 +49,71 @@
   </rule>
 
   <rule id="65608" level="3">
-    <decoded_as>gitlab-12-application-log/decoded_as>
+    <decoded_as>gitlab-12-application-log</decoded_as>
     <field name="project_removed">\.+</field>
     <description>(Gitlab) Project $(project_removed) was removed.</description>
   </rule>
 
   <rule id="65609" level="5">
     <decoded_as>json</decoded_as>
-    <regex>"service_class":"\w+","project_id":\d+,"project_path":"\.+"</regex>
-    <field name="severity">ERROR</field>
+    <field name="service_class">\w+</field>
+    <field name="project_id">\d+</field>
+    <field name="project_path">\.+</field>
+    <field name="severity">^ERROR$</field>
     <options>no_full_log</options>
     <description>(Gitlab) $(message).</description>
   </rule>
 
   <rule id="65610" level="3">
     <decoded_as>json</decoded_as>
-    <regex>"service_class":"\w+","project_id":\d+,"project_path":"\.+"</regex>
-    <field name="severity">INFO</field>
+    <field name="service_class">\w+</field>
+    <field name="project_id">\d+</field>
+    <field name="project_path">\.+</field>
+    <field name="severity">^INFO$</field>
     <options>no_full_log</options>
     <description>(Gitlab) $(message).</description>
   </rule>
 
   <rule id="65611" level="5">
     <decoded_as>json</decoded_as>
-    <regex>"exception":"\.+","error_code":\w+,"service":"\.+","app_id":\d+,</regex>
-    <field name="severity">ERROR</field>
+    <field name="exception">\.+</field>
+    <field name="error_code">\w+</field>
+    <field name="service">\.+</field>
+    <field name="app_id">\d+</field>
+    <field name="severity">^ERROR$</field>
     <options>no_full_log</options>
     <description>(Gitlab) $(severity):$(message).</description>
   </rule>
 
   <rule id="65612" level="3">
     <decoded_as>json</decoded_as>
-    <regex>"exception":"\.+","error_code":\w+,"service":"\.+","app_id":\d+,</regex>
-    <field name="severity">INFO</field>
+    <field name="exception">\.+</field>
+    <field name="error_code">\w+</field>
+    <field name="service">\.+</field>
+    <field name="app_id">\d+</field>
+    <field name="severity">^INFO$</field>
     <options>no_full_log</options>
     <description>(Gitlab) $(severity):$(message).</description>
   </rule>
 
   <rule id="65613" level="5">
     <decoded_as>json</decoded_as>
-    <regex>"correlation_id":"\w+","message":"\.+"</regex>
-    <field name="severity">ERROR</field>
+    <field name="correlation_id">\w+</field>
+    <field name="message">\.+</field>
+    <field name="severity">^ERROR$</field>
     <options>no_full_log</options>
     <description>(Gitlab) $(severity):$(message).</description>
   </rule>
 
   <rule id="65614" level="3">
     <decoded_as>json</decoded_as>
-    <regex>"author_id":\w*,"entity_id":\w*,"entity_type":"\w*","change":"\w+","from":"\.*","to":"\.*",</regex>
-    <field name="severity">INFO</field>
+    <field name="author_id">\w*</field>
+    <field name="entity_id">\w*</field>
+    <field name="entity_type">\w*</field>
+    <field name="change">\w+</field>
+    <field name="from">\.*</field>
+    <field name="to">\.*</field>   
+    <field name="severity">^INFO$</field>
     <options>no_full_log</options>
     <description>(Gitlab) $(severity):changed $(change) from $(from) to $(to).</description>
   </rule>
@@ -124,56 +137,76 @@
 
   <rule id="65618" level="3">
     <decoded_as>json</decoded_as>
-    <regex>"queue":"\.+","args":\.*,"class":"\w*","retry":\w+,"queue_namespace":"\w*","jid":"\w*",</regex>
-    <field name="severity">INFO</field>
+    <field name="queue">\.+</field>
+    <field name="args">\.*</field>
+    <field name="class">\w*</field>
+    <field name="retry">\w+</field>
+    <field name="queue_namespace">\w*</field>
+    <field name="jid">\w*</field>
+    <field name="severity">^INFO$</field>
     <description>(Gitlab) $(severity): $(message).</description>
   </rule>
 
   <rule id="65619" level="5">
     <decoded_as>json</decoded_as>
-    <regex>"queue":"\.+","args":\.*,"class":"\w*","retry":\w+,"queue_namespace":"\w*","jid":"\w*",</regex>
-    <field name="severity">ERROR</field>
+    <field name="queue">\.+</field>
+    <field name="args">\.*</field>
+    <field name="class">\w*</field>
+    <field name="retry">\w+</field>
+    <field name="queue_namespace">\w*</field>
+    <field name="jid">\w*</field>
+    <field name="severity">^ERROR$</field>
     <description>(Gitlab) $(severity): $(message).</description>
   </rule>
   
   <rule id="65620" level="3">
     <decoded_as>gitlab-shell-stderr</decoded_as>
-    <field name="severity">INFO</field>
+    <field name="severity">^INFO$</field>
     <description>(Gitlab) $(severity): $(message).</description>
   </rule>
 
   <rule id="65621" level="5">
     <decoded_as>gitlab-shell-stderr</decoded_as>
-    <field name="severity">WARN</field>
+    <field name="severity">^WARN$</field>
     <description>(Gitlab) $(severity): $(message).</description>
   </rule>
 
   <rule id="65622" level="3">
     <decoded_as>json</decoded_as>
-    <regex>"query_string":"\.+","variables":\.+,"complexity":\d*,"depth":\d*,"duration":\d*</regex>
+    <field name="query_string">\.+</field>
+    <field name="quevariablesue">\.+</field>
+    <field name="complexity">\d*</field>
+    <field name="depth">\d*</field>
+    <field name="duration">\d*</field>
     <description>(Gitlab) graphql_query_string: $(query_string).</description>
   </rule>
 
   <rule id="65623" level="3">
     <decoded_as>json</decoded_as>
-    <regex>"method":"\w+","path":"/api/\w+/\.+","params":\.+</regex>
-    <match>"status":200</match>
+    <field name="method">\w+</field>
+    <field name="path">^/api/\w+/\.+</field>
+    <field name="params">\.+</field>
+    <field name="status">^200$</field>
     <options>no_full_log</options>
     <description>(Gitlab) $(method) request completed succesfully.</description>
   </rule>
 
   <rule id="65624" level="5">
     <decoded_as>json</decoded_as>
-    <regex>"method":"\w+","path":"/api/\w+/\.+","params":\.+</regex>
-    <match>"status":400</match>
+    <field name="method">\w+</field>
+    <field name="path">^/api/\w+/\.+</field>
+    <field name="params">\.+</field>
+    <field name="status">^400$</field>
     <options>no_full_log</options>
     <description>(Gitlab) ERROR: couldn't complete $(method) request.</description>
   </rule>
 
   <rule id="65625" level="5">
     <decoded_as>json</decoded_as>
-    <regex>"method":"\w+","path":"/api/\w+/\.+","params":\.+</regex>
-    <match>"status":300</match>
+    <field name="method">\w+</field>
+    <field name="path">^/api/\w+/\.+</field>
+    <field name="params">\.+</field>
+    <field name="status">^300$</field>
     <options>no_full_log</options>
     <description>(Gitlab) REDIRECTION: The $(method) request has more than one possible response.</description>
   </rule>

--- a/ruleset/rules/0770-gitlab_rules.xml
+++ b/ruleset/rules/0770-gitlab_rules.xml
@@ -38,25 +38,25 @@
 <group name="gitlab_v.12_application_log">
 
   <rule id="65604" level="3">
-    <decoded_as>gitlab-12_application_log</decoded_as>
+    <decoded_as>gitlab-12-application-log</decoded_as>
     <field name="new_user">\.+</field>
     <description>(Gitlab) User $(new_user) was created.</description>
   </rule>
 
   <rule id="65606" level="3">
-    <decoded_as>gitlab-12_application_log</decoded_as>
+    <decoded_as>gitlab-12-application-log/decoded_as>
     <field name="project_autor">\.+</field>
     <description>(Gitlab) $(project_autor) created a new project.</description>
   </rule>
 
   <rule id="65607" level="3">
-    <decoded_as>gitlab-12_application_log</decoded_as>
+    <decoded_as>gitlab-12-application-log/decoded_as>
     <field name="removed_user">\.+</field>
     <description>(Gitlab) User $(removed_user) was removed.</description>
   </rule>
 
   <rule id="65608" level="3">
-    <decoded_as>gitlab-12_application_log</decoded_as>
+    <decoded_as>gitlab-12-application-log/decoded_as>
     <field name="project_removed">\.+</field>
     <description>(Gitlab) Project $(project_removed) was removed.</description>
   </rule>
@@ -130,7 +130,7 @@
 <group name="gitlab_v.12_sidekiq_log">
   
   <rule id="65615" level="3">
-    <decoded_as>gitlab_sidekiq</decoded_as>
+    <decoded_as>gitlab-sidekiq</decoded_as>
     <description>Group of gitlab_sidekiq.</description>
   </rule>
 
@@ -169,13 +169,13 @@
 <group name="gitlab_v.12_shell_stderr_log">
   
   <rule id="65620" level="3">
-    <decoded_as>gitlab_shell_stderr</decoded_as>
+    <decoded_as>gitlab-shell-stderr</decoded_as>
     <field name="severity">INFO</field>
     <description>(Gitlab) $(severity): $(message).</description>
   </rule>
 
   <rule id="65621" level="5">
-    <decoded_as>gitlab_shell_stderr</decoded_as>
+    <decoded_as>gitlab-shell-stderr</decoded_as>
     <field name="severity">WARN</field>
     <description>(Gitlab) $(severity): $(message).</description>
   </rule>

--- a/ruleset/rules/0770-gitlab_rules.xml
+++ b/ruleset/rules/0770-gitlab_rules.xml
@@ -7,7 +7,7 @@
     GitLab ID:  65600 - 65699
 -->
 
-<group name="gitlab_v.12_production_json">
+<group name="gitlab_v.12">
     
   <rule id="65600" level="3">
     <decoded_as>json</decoded_as>
@@ -33,10 +33,6 @@
     <description>(Gitlab) REDIRECTION:The $(method) request has more than one possible response.</description>
   </rule>
 
-</group>
-
-<group name="gitlab_v.12_application_log">
-
   <rule id="65604" level="3">
     <decoded_as>gitlab-12-application-log</decoded_as>
     <field name="new_user">\.+</field>
@@ -50,7 +46,7 @@
   </rule>
 
   <rule id="65607" level="3">
-    <decoded_as>gitlab-12-application-log/decoded_as>
+    <decoded_as>gitlab-12-application-log</decoded_as>
     <field name="removed_user">\.+</field>
     <description>(Gitlab) User $(removed_user) was removed.</description>
   </rule>
@@ -60,10 +56,6 @@
     <field name="project_removed">\.+</field>
     <description>(Gitlab) Project $(project_removed) was removed.</description>
   </rule>
-
-</group>
-
-<group name="gitlab_v.12_integrations_json">
 
   <rule id="65609" level="5">
     <decoded_as>json</decoded_as>
@@ -81,10 +73,6 @@
     <description>(Gitlab) $(message).</description>
   </rule>
 
-</group>
-
-<group name="gitlab_v.12_kubernetes_json">
-
   <rule id="65611" level="5">
     <decoded_as>json</decoded_as>
     <regex>"exception":"\.+","error_code":\w+,"service":"\.+","app_id":\d+,</regex>
@@ -101,10 +89,6 @@
     <description>(Gitlab) $(severity):$(message).</description>
   </rule>
 
-</group>
-
-<group name="gitlab_v.12_githost_json">
-
   <rule id="65613" level="5">
     <decoded_as>json</decoded_as>
     <regex>"correlation_id":"\w+","message":"\.+"</regex>
@@ -113,10 +97,6 @@
     <description>(Gitlab) $(severity):$(message).</description>
   </rule>
 
-</group>
-
-<group name="gitlab_v.12_audit_json">
-
   <rule id="65614" level="3">
     <decoded_as>json</decoded_as>
     <regex>"author_id":\w*,"entity_id":\w*,"entity_type":"\w*","change":"\w+","from":"\.*","to":"\.*",</regex>
@@ -124,10 +104,6 @@
     <options>no_full_log</options>
     <description>(Gitlab) $(severity):changed $(change) from $(from) to $(to).</description>
   </rule>
-
-</group>
-
-<group name="gitlab_v.12_sidekiq_log">
   
   <rule id="65615" level="3">
     <decoded_as>gitlab-sidekiq</decoded_as>
@@ -146,10 +122,6 @@
     <description>(Gitlab) ERROR:$(error).</description>
   </rule>
 
-</group>
-
-<group name="gitlab_v.12_sidekiq_json">
-
   <rule id="65618" level="3">
     <decoded_as>json</decoded_as>
     <regex>"queue":"\.+","args":\.*,"class":"\w*","retry":\w+,"queue_namespace":"\w*","jid":"\w*",</regex>
@@ -163,10 +135,6 @@
     <field name="severity">ERROR</field>
     <description>(Gitlab) $(severity): $(message).</description>
   </rule>
-
-</group>
-
-<group name="gitlab_v.12_shell_stderr_log">
   
   <rule id="65620" level="3">
     <decoded_as>gitlab-shell-stderr</decoded_as>
@@ -180,19 +148,11 @@
     <description>(Gitlab) $(severity): $(message).</description>
   </rule>
 
-</group>
-
-<group name="gitlab_v.12_graphql_json">
-  
   <rule id="65622" level="3">
     <decoded_as>json</decoded_as>
     <regex>"query_string":"\.+","variables":\.+,"complexity":\d*,"depth":\d*,"duration":\d*</regex>
     <description>(Gitlab) graphql_query_string: $(query_string).</description>
   </rule>
-
-</group>
-
-<group name="gitlab_v.12_api_json">
 
   <rule id="65623" level="3">
     <decoded_as>json</decoded_as>

--- a/ruleset/rules/0770-gitlab_rules.xml
+++ b/ruleset/rules/0770-gitlab_rules.xml
@@ -3,8 +3,8 @@
 -->
 
 <!--
-  Decoders for:
-    GitLab
+  Rules for:
+    GitLab ID:  65600 - 65699
 -->
 
 <group name="gitlab_v.12_production_json">
@@ -14,7 +14,7 @@
     <regex>"method":"\w+","path":"/gitlab/gitlab-ce/\w+/\.+","format":"\w+","controller":"\.+","action":"\w+"</regex>
     <match>"status":200</match>
     <options>no_full_log</options>
-    <description>(Gitlab)$(method) request Completed Succesfully.</description>
+    <description>(Gitlab) $(method) request completed succesfully.</description>
   </rule>
 
   <rule id="65602" level="5">
@@ -22,7 +22,7 @@
     <regex>"method":"\w+","path":"/gitlab/gitlab-ce/\w+/\.+","format":"\w+","controller":"\.+","action":"\w+"</regex>
     <match>"status":400</match>
     <options>no_full_log</options>
-    <description>(Gitlab)ERROR: couldn't complete $(method) request.</description>
+    <description>(Gitlab) ERROR: couldn't complete $(method) request.</description>
   </rule>
 
   <rule id="65603" level="5">
@@ -30,35 +30,7 @@
     <regex>"method":"\w+","path":"/gitlab/gitlab-ce/\w+/\.+","format":"\w+","controller":"\.+","action":"\w+"</regex>
     <match>"status":300</match>
     <options>no_full_log</options>
-    <description>(Gitlab)REDIRECTION:The $(method) request has more than one possible response.</description>
-  </rule>
-
-</group>
-
-<group name="gitlab_v.12_api_json">
-
-  <rule id="65623" level="3">
-    <decoded_as>json</decoded_as>
-    <regex>"method":"\w+","path":"/api/\w+/\.+","params":\.+</regex>
-    <match>"status":200</match>
-    <options>no_full_log</options>
-    <description>(Gitlab)$(method) request Completed Succesfully.</description>
-  </rule>
-
-  <rule id="65624" level="5">
-    <decoded_as>json</decoded_as>
-    <regex>"method":"\w+","path":"/api/\w+/\.+","params":\.+</regex>
-    <match>"status":400</match>
-    <options>no_full_log</options>
-    <description>(Gitlab)ERROR: couldn't complete $(method) request.</description>
-  </rule>
-
-  <rule id="65625" level="5">
-    <decoded_as>json</decoded_as>
-    <regex>"method":"\w+","path":"/api/\w+/\.+","params":\.+</regex>
-    <match>"status":300</match>
-    <options>no_full_log</options>
-    <description>(Gitlab)REDIRECTION:The $(method) request has more than one possible response.</description>
+    <description>(Gitlab) REDIRECTION:The $(method) request has more than one possible response.</description>
   </rule>
 
 </group>
@@ -68,25 +40,25 @@
   <rule id="65604" level="3">
     <decoded_as>gitlab-12_application_log</decoded_as>
     <field name="new_user">\.+</field>
-    <description>(Gitlab)User $(new_user) was created.</description>
+    <description>(Gitlab) User $(new_user) was created.</description>
   </rule>
 
   <rule id="65606" level="3">
     <decoded_as>gitlab-12_application_log</decoded_as>
     <field name="project_autor">\.+</field>
-    <description>(Gitlab)$(project_autor) created a new project.</description>
+    <description>(Gitlab) $(project_autor) created a new project.</description>
   </rule>
 
   <rule id="65607" level="3">
     <decoded_as>gitlab-12_application_log</decoded_as>
     <field name="removed_user">\.+</field>
-    <description>(Gitlab)User $(removed_user) was removed.</description>
+    <description>(Gitlab) User $(removed_user) was removed.</description>
   </rule>
 
   <rule id="65608" level="3">
     <decoded_as>gitlab-12_application_log</decoded_as>
     <field name="project_removed">\.+</field>
-    <description>(Gitlab)Project $(project_removed) was removed.</description>
+    <description>(Gitlab) Project $(project_removed) was removed.</description>
   </rule>
 
 </group>
@@ -98,7 +70,7 @@
     <regex>"service_class":"\w+","project_id":\d+,"project_path":"\.+"</regex>
     <field name="severity">ERROR</field>
     <options>no_full_log</options>
-    <description>(Gitlab)$(message).</description>
+    <description>(Gitlab) $(message).</description>
   </rule>
 
   <rule id="65610" level="3">
@@ -106,7 +78,7 @@
     <regex>"service_class":"\w+","project_id":\d+,"project_path":"\.+"</regex>
     <field name="severity">INFO</field>
     <options>no_full_log</options>
-    <description>(Gitlab)$(message).</description>
+    <description>(Gitlab) $(message).</description>
   </rule>
 
 </group>
@@ -118,7 +90,7 @@
     <regex>"exception":"\.+","error_code":\w+,"service":"\.+","app_id":\d+,</regex>
     <field name="severity">ERROR</field>
     <options>no_full_log</options>
-    <description>(Gitlab)$(severity):$(message).</description>
+    <description>(Gitlab) $(severity):$(message).</description>
   </rule>
 
   <rule id="65612" level="3">
@@ -126,7 +98,7 @@
     <regex>"exception":"\.+","error_code":\w+,"service":"\.+","app_id":\d+,</regex>
     <field name="severity">INFO</field>
     <options>no_full_log</options>
-    <description>(Gitlab)$(severity):$(message).</description>
+    <description>(Gitlab) $(severity):$(message).</description>
   </rule>
 
 </group>
@@ -138,7 +110,7 @@
     <regex>"correlation_id":"\w+","message":"\.+"</regex>
     <field name="severity">ERROR</field>
     <options>no_full_log</options>
-    <description>(Gitlab)$(severity):$(message).</description>
+    <description>(Gitlab) $(severity):$(message).</description>
   </rule>
 
 </group>
@@ -150,7 +122,7 @@
     <regex>"author_id":\w*,"entity_id":\w*,"entity_type":"\w*","change":"\w+","from":"\.*","to":"\.*",</regex>
     <field name="severity">INFO</field>
     <options>no_full_log</options>
-    <description>(Gitlab)$(severity):changed $(change) from $(from) to $(to).</description>
+    <description>(Gitlab) $(severity):changed $(change) from $(from) to $(to).</description>
   </rule>
 
 </group>
@@ -159,19 +131,19 @@
   
   <rule id="65615" level="3">
     <decoded_as>gitlab_sidekiq</decoded_as>
-    <description>group of gitlab_sidekiq.</description>
+    <description>Group of gitlab_sidekiq.</description>
   </rule>
 
   <rule id="65616" level="3">
     <if_sid>65615</if_sid>
     <field name="info">\.+</field>
-    <description>(Gitlab)INFO:$(info).</description>
+    <description>(Gitlab) INFO:$(info).</description>
   </rule>
 
   <rule id="65617" level="5">
     <if_sid>65615</if_sid>
     <field name="error">\.+</field>
-    <description>(Gitlab)ERROR:$(error).</description>
+    <description>(Gitlab) ERROR:$(error).</description>
   </rule>
 
 </group>
@@ -182,14 +154,14 @@
     <decoded_as>json</decoded_as>
     <regex>"queue":"\.+","args":\.*,"class":"\w*","retry":\w+,"queue_namespace":"\w*","jid":"\w*",</regex>
     <field name="severity">INFO</field>
-    <description>(Gitlab)$(severity):$(message).</description>
+    <description>(Gitlab) $(severity): $(message).</description>
   </rule>
 
   <rule id="65619" level="5">
     <decoded_as>json</decoded_as>
     <regex>"queue":"\.+","args":\.*,"class":"\w*","retry":\w+,"queue_namespace":"\w*","jid":"\w*",</regex>
     <field name="severity">ERROR</field>
-    <description>(Gitlab)$(severity):$(message).</description>
+    <description>(Gitlab) $(severity): $(message).</description>
   </rule>
 
 </group>
@@ -199,13 +171,13 @@
   <rule id="65620" level="3">
     <decoded_as>gitlab_shell_stderr</decoded_as>
     <field name="severity">INFO</field>
-    <description>(Gitlab)$(severity):$(message).</description>
+    <description>(Gitlab) $(severity): $(message).</description>
   </rule>
 
   <rule id="65621" level="5">
     <decoded_as>gitlab_shell_stderr</decoded_as>
     <field name="severity">WARN</field>
-    <description>(Gitlab)$(severity):$(message).</description>
+    <description>(Gitlab) $(severity): $(message).</description>
   </rule>
 
 </group>
@@ -215,7 +187,35 @@
   <rule id="65622" level="3">
     <decoded_as>json</decoded_as>
     <regex>"query_string":"\.+","variables":\.+,"complexity":\d*,"depth":\d*,"duration":\d*</regex>
-    <description>(Gitlab)graphql_query_string:$(query_string).</description>
+    <description>(Gitlab) graphql_query_string: $(query_string).</description>
+  </rule>
+
+</group>
+
+<group name="gitlab_v.12_api_json">
+
+  <rule id="65623" level="3">
+    <decoded_as>json</decoded_as>
+    <regex>"method":"\w+","path":"/api/\w+/\.+","params":\.+</regex>
+    <match>"status":200</match>
+    <options>no_full_log</options>
+    <description>(Gitlab) $(method) request completed succesfully.</description>
+  </rule>
+
+  <rule id="65624" level="5">
+    <decoded_as>json</decoded_as>
+    <regex>"method":"\w+","path":"/api/\w+/\.+","params":\.+</regex>
+    <match>"status":400</match>
+    <options>no_full_log</options>
+    <description>(Gitlab) ERROR: couldn't complete $(method) request.</description>
+  </rule>
+
+  <rule id="65625" level="5">
+    <decoded_as>json</decoded_as>
+    <regex>"method":"\w+","path":"/api/\w+/\.+","params":\.+</regex>
+    <match>"status":300</match>
+    <options>no_full_log</options>
+    <description>(Gitlab) REDIRECTION: The $(method) request has more than one possible response.</description>
   </rule>
 
 </group>

--- a/ruleset/testing/tests/gitlab.ini
+++ b/ruleset/testing/tests/gitlab.ini
@@ -135,3 +135,15 @@ log 1 pass = {"time":"2018-10-29T12:49:42.123Z","severity":"INFO","duration":709
 rule = 65623
 alert = 3
 decoder = json
+
+[ERROR: couldn't complete GET request.]
+log 1 pass = {"method":"GET","path":"/api/v4/projects","format":"html","controller":"Projects::IssuesController","action":"show","status":400,"duration":229.03,"view":174.07,"db":13.24,"time":"2017-08-08T20:15:54.821Z","params":[{"key":"param_key","value":"param_value"}],"remote_ip":"18.245.0.1","user_id":1,"username":"admin","gitaly_calls":76,"gitaly_duration":7.41,"queue_duration": 112.47}
+rule = 65624
+alert = 5
+decoder = json
+
+[REDIRECTION:The GET request has more than one possible response.]
+log 1 pass = {"method":"GET","path":"/api/v4/projects","format":"html","controller":"Projects::IssuesController","action":"show","status":300,"duration":229.03,"view":174.07,"db":13.24,"time":"2017-08-08T20:15:54.821Z","params":[{"key":"param_key","value":"param_value"}],"remote_ip":"18.245.0.1","user_id":1,"username":"admin","gitaly_calls":76,"gitaly_duration":7.41,"queue_duration": 112.47}
+rule = 65625
+alert = 5
+decoder = json

--- a/ruleset/testing/tests/gitlab.ini
+++ b/ruleset/testing/tests/gitlab.ini
@@ -86,16 +86,16 @@ rule = 65614
 alert = 3
 decoder = json
 
-[Gitlab_sidekiq_1 ERROR.]
-log 1 pass = 2014-06-10T07:55:20Z 2037 TID-tm504 ERROR: /opt/bitnami/apps/discourse/htdocs/vendor/bundle/ruby/1.9.1/gems/redis-3.0.7/lib/redis/client.rb:228:in `read'
-rule = 65617
-alert = 5
-decoder = gitlab-sidekiq
-
 [Gitlab_sidekiq_2 INFO.]
 log 1 pass = 2014-06-10T18:18:26Z 14299 TID-55uqo INFO: Booting Sidekiq 3.0.0 with redis options {:url=>"redis://localhost:6379/0", :namespace=>"sidekiq"}
 rule = 65616
 alert = 3
+decoder = gitlab-sidekiq
+
+[Gitlab_sidekiq_1 ERROR.]
+log 1 pass = 2014-06-10T07:55:20Z 2037 TID-tm504 ERROR: /opt/bitnami/apps/discourse/htdocs/vendor/bundle/ruby/1.9.1/gems/redis-3.0.7/lib/redis/client.rb:228:in `read'
+rule = 65617
+alert = 5
 decoder = gitlab-sidekiq
 
 [Gitlab_sidekiq_3 INFO.]

--- a/ruleset/testing/tests/gitlab.ini
+++ b/ruleset/testing/tests/gitlab.ini
@@ -28,25 +28,25 @@ decoder = json
 log 1 pass = October 06, 2014 11:56: User "Administrator" (admin@example.com) was created
 rule = 65604
 alert = 3
-decoder = gitlab-12_application_log
+decoder = gitlab-12-application-log
 
 [Documentcloud created a new project.]
 log 1 pass = October 06, 2014 11:56: Documentcloud created a new project "Documentcloud / Underscore"
 rule = 65606
 alert = 3
-decoder = gitlab-12_application_log
+decoder = gitlab-12-application-log
 
 [User dummy was removed.]
 log 1 pass = October 06, 2014 11:56: User "dummy" (dummy@gmail.com) was removed
 rule = 65607
 alert = 3
-decoder = gitlab-12_application_log
+decoder = gitlab-12-application-log
 
 [Project project133 was removed.]
 log 1 pass = October 07, 2014 11:25: Project "project133" was removed
 rule = 65608
 alert = 3
-decoder = gitlab-12_application_log
+decoder = gitlab-12-application-log
 
 [Error sending message.]
 log 1 pass = {"severity":"ERROR","time":"2018-09-06T14:56:20.439Z","service_class":"JiraService","project_id":8,"project_path":"h5bp/html5-boilerplate","message":"Error sending message","client_url":"http://jira.gitlap.com:8080","error":"execution expired"}
@@ -90,13 +90,13 @@ decoder = json
 log 1 pass = 2014-06-10T07:55:20Z 2037 TID-tm504 ERROR: /opt/bitnami/apps/discourse/htdocs/vendor/bundle/ruby/1.9.1/gems/redis-3.0.7/lib/redis/client.rb:228:in `read'
 rule = 65617
 alert = 5
-decoder = gitlab_sidekiq
+decoder = gitlab-sidekiq
 
 [Gitlab_sidekiq_2 INFO.]
 log 1 pass = 2014-06-10T18:18:26Z 14299 TID-55uqo INFO: Booting Sidekiq 3.0.0 with redis options {:url=>"redis://localhost:6379/0", :namespace=>"sidekiq"}
 rule = 65616
 alert = 3
-decoder = gitlab_sidekiq
+decoder = gitlab-sidekiq
 
 [Gitlab_sidekiq_3 INFO.]
 log 1 pass = {"severity":"INFO","time":"2018-04-03T22:57:22.071Z","queue":"cronjob:update_all_mirrors","args":[],"class":"UpdateAllMirrorsWorker","retry":false,"queue_namespace":"cronjob","jid":"06aeaa3b0aadacf9981f368e","created_at":"2018-04-03T22:57:21.930Z","enqueued_at":"2018-04-03T22:57:21.931Z","pid":10077,"message":"UpdateAllMirrorsWorker JID-06aeaa3b0aadacf9981f368e: done: 0.139 sec","job_status":"done","duration":0.139,"completed_at":"2018-04-03T22:57:22.071Z"}
@@ -115,14 +115,14 @@ log 1 pass = I, [2015-02-13T06:17:00.671315 #9291]  INFO -- : Adding project roo
 log 2 pass = I, [2015-02-13T06:17:00.679433 #9291]  INFO -- : Moving existing hooks directory and symlinking global hooks directory for /var/opt/gitlab/git-data/repositories/root/example.git.
 rule = 65620
 alert = 3
-decoder = gitlab_shell_stderr
+decoder = gitlab-shell-stderr
 
 [Gitlab_shell_stderr_2 WARN.]
 log 1 pass = W, [2015-02-13T07:16:01.312916 #9094]  WARN -- : #<Unicorn::HttpServer:0x0000000208f618>: worker (pid: 9094) exceeds memory limit (320626688 bytes > 247066940 bytes)
 log 2 pass = W, [2015-02-13T07:16:01.313000 #9094]  WARN -- : Unicorn::WorkerKiller send SIGQUIT (pid: 9094) alive: 3621 sec (trial 1)
 rule = 65621
 alert = 5
-decoder = gitlab_shell_stderr
+decoder = gitlab-shell-stderr
 
 [Gitlab_graphql query.]
 log 1 pass = {"query_string":"query IntrospectionQuery{__schema {queryType { name },mutationType { name }}}...(etc)","variables":{"a":1,"b":2},"complexity":181,"depth":1,"duration":7}

--- a/ruleset/testing/tests/gitlab.ini
+++ b/ruleset/testing/tests/gitlab.ini
@@ -6,7 +6,7 @@
 ;  Sample logs source: 
 ;    GitLab: Community, https://github.com/wazuh/wazuh-ruleset/issues/476
 
-[GET request Completed Succesfully.]
+[Gitlab_production_1]
 log 1 pass = {"method":"GET","path":"/gitlab/gitlab-ce/issues/1234","format":"html","controller":"Projects::IssuesController","action":"show","status":200,"duration":229.03,"view":174.07,"db":13.24,"time":"2017-08-08T20:15:54.821Z","params":[{"key":"param_key","value":"param_value"}],"remote_ip":"18.245.0.1","user_id":1,"username":"admin","gitaly_calls":76,"gitaly_duration":7.41,"queue_duration": 112.47}
 rule = 65600
 alert = 3

--- a/ruleset/testing/tests/gitlab.ini
+++ b/ruleset/testing/tests/gitlab.ini
@@ -6,85 +6,79 @@
 ;  Sample logs source: 
 ;    GitLab: Community, https://github.com/wazuh/wazuh-ruleset/issues/476
 
-[Gitlab_production_1]
+[GET request Completed Succesfully.]
 log 1 pass = {"method":"GET","path":"/gitlab/gitlab-ce/issues/1234","format":"html","controller":"Projects::IssuesController","action":"show","status":200,"duration":229.03,"view":174.07,"db":13.24,"time":"2017-08-08T20:15:54.821Z","params":[{"key":"param_key","value":"param_value"}],"remote_ip":"18.245.0.1","user_id":1,"username":"admin","gitaly_calls":76,"gitaly_duration":7.41,"queue_duration": 112.47}
 rule = 65600
 alert = 3
 decoder = json
 
-[Gitlab_production_2]
+[ERROR: couldn't complete PUSH request.]
 log 1 pass = {"method":"PUSH","path":"/gitlab/gitlab-ce/issues/1234","format":"html","controller":"Projects::IssuesController","action":"show","status":400,"duration":229.03,"view":174.07,"db":13.24,"time":"2017-08-08T20:15:54.821Z","params":[{"key":"param_key","value":"param_value"}],"remote_ip":"18.245.0.1","user_id":1,"username":"admin","gitaly_calls":76,"gitaly_duration":7.41,"queue_duration": 112.47}
 rule = 65602
 alert = 5
 decoder = json
 
-[Gitlab_production_3]
+[REDIRECTION:The PUSH request has more than one possible response.]
 log 1 pass = {"method":"PUSH","path":"/gitlab/gitlab-ce/issues/1234","format":"html","controller":"Projects::IssuesController","action":"show","status":300,"duration":229.03,"view":174.07,"db":13.24,"time":"2017-08-08T20:15:54.821Z","params":[{"key":"param_key","value":"param_value"}],"remote_ip":"18.245.0.1","user_id":1,"username":"admin","gitaly_calls":76,"gitaly_duration":7.41,"queue_duration": 112.47}
 rule = 65603
 alert = 5
 decoder = json
 
-[Gitlab_api]
-log 1 pass = {"time":"2018-10-29T12:49:42.123Z","severity":"INFO","duration":709.08,"db":14.59,"view":694.49,"status":200,"method":"GET","path":"/api/v4/projects","params":[{"key":"action","value":"git-upload-pack"},{"key":"changes","value":"_any"},{"key":"key_id","value":"secret"},{"key":"secret_token","value":"[FILTERED]"}],"host":"localhost","ip":"::1","ua":"Ruby","route":"/api/:version/projects","user_id":1,"username":"root","queue_duration":100.31,"gitaly_calls":30,"gitaly_duration":5.36}
-rule = 65623
-alert = 3
-decoder = json
-
-[Gitlab_application_1]
+[User Administrator was created.]
 log 1 pass = October 06, 2014 11:56: User "Administrator" (admin@example.com) was created
 rule = 65604
 alert = 3
 decoder = gitlab-12_application_log
 
-[Gitlab_application_2]
+[Documentcloud created a new project.]
 log 1 pass = October 06, 2014 11:56: Documentcloud created a new project "Documentcloud / Underscore"
 rule = 65606
 alert = 3
 decoder = gitlab-12_application_log
 
-[Gitlab_application_3]
+[User dummy was removed.]
 log 1 pass = October 06, 2014 11:56: User "dummy" (dummy@gmail.com) was removed
 rule = 65607
 alert = 3
 decoder = gitlab-12_application_log
 
-[Gitlab_application_4]
+[Project project133 was removed.]
 log 1 pass = October 07, 2014 11:25: Project "project133" was removed
 rule = 65608
 alert = 3
 decoder = gitlab-12_application_log
 
-[Gitlab_integrations_1]
+[Error sending message.]
 log 1 pass = {"severity":"ERROR","time":"2018-09-06T14:56:20.439Z","service_class":"JiraService","project_id":8,"project_path":"h5bp/html5-boilerplate","message":"Error sending message","client_url":"http://jira.gitlap.com:8080","error":"execution expired"}
 rule = 65609
 alert = 5
 decoder = json
 
-[Gitlab_integrations_2]
+[Successfully posted.]
 log 1 pass = {"severity":"INFO","time":"2018-09-06T17:15:16.365Z","service_class":"JiraService","project_id":3,"project_path":"namespace2/project2","message":"Successfully posted","client_url":"http://jira.example.com"}
 rule = 65610
 alert = 3
 decoder = json
 
-[Gitlab_kubernetes_1]
+[Gitlab_kubernetes_1 ERROR: Unauthorized.]
 log 1 pass = {"severity":"ERROR","time":"2018-11-23T15:14:54.652Z","exception":"Kubeclient::HttpError","error_code":401,"service":"Clusters::Applications::CheckInstallationProgressService","app_id":14,"project_ids":[1],"group_ids":[],"message":"Unauthorized"}
 rule = 65611
 alert = 5
 decoder = json
 
-[Gitlab_kubernetes_2]
+[Gitlab_kubernetes_2 INFO.]
 log 1 pass = {"severity":"INFO","time":"2018-11-23T15:42:11.647Z","exception":"Kubeclient::HttpError","error_code":null,"service":"Clusters::Applications::InstallService","app_id":2,"project_ids":[19],"group_ids":[],"message":"SSL_connect returned=1 errno=0 state=error: certificate verify failed (unable to get local issuer certificate)"}
 rule = 65612
 alert = 3
 decoder = json
 
-[Gitlab_githost]
+[Gitlab_githost ERROR.]
 log 1 pass = {"severity":"ERROR","time":"2019-07-19T22:16:12.528Z","correlation_id":"FeGxww5Hj64","message":"Command failed [1]: /usr/bin/git --git-dir=/Users/vsizov/gitlab-development-kit/gitlab/tmp/tests/gitlab-satellites/group184/gitlabhq/.git --work-tree=/Users/vsizov/gitlab-development-kit/gitlab/tmp/tests/gitlab-satellites/group184/gitlabhq merge --no-ff -mMerge branch 'feature_conflict' into 'feature' source/feature_conflict\n\nerror: failed to push some refs to '/Users/vsizov/gitlab-development-kit/repositories/gitlabhq/gitlab_git.git'"}
 rule = 65613
 alert = 5
 decoder = json
 
-[Gitlab_audit]
+[Gitlab_audit INFO.]
 log 1 pass = {"severity":"INFO","time":"2018-10-17T17:38:22.523Z","author_id":3,"entity_id":2,"entity_type":"Project","change":"visibility","from":"Private","to":"Public","author_name":"John Doe4","target_id":2,"target_type":"Project","target_details":"namespace2/project2"}
 log 2 pass = {"severity":"INFO","time":"2018-10-17T17:38:22.830Z","author_id":5,"entity_id":3,"entity_type":"Project","change":"name","from":"John Doe7 / project3","to":"John Doe7 / new name","author_name":"John Doe6","target_id":3,"target_type":"Project","target_details":"namespace3/project3"}
 log 3 pass = {"severity":"INFO","time":"2018-10-17T17:38:23.175Z","author_id":7,"entity_id":4,"entity_type":"Project","change":"path","from":"","to":"namespace4/newpath","author_name":"John Doe8","target_id":4,"target_type":"Project","target_details":"namespace4/newpath"}
@@ -92,46 +86,52 @@ rule = 65614
 alert = 3
 decoder = json
 
-[Gitlab_sidekiq_1]
+[Gitlab_sidekiq_1 ERROR.]
 log 1 pass = 2014-06-10T07:55:20Z 2037 TID-tm504 ERROR: /opt/bitnami/apps/discourse/htdocs/vendor/bundle/ruby/1.9.1/gems/redis-3.0.7/lib/redis/client.rb:228:in `read'
 rule = 65617
 alert = 5
 decoder = gitlab_sidekiq
 
-[Gitlab_sidekiq_2]
+[Gitlab_sidekiq_2 INFO.]
 log 1 pass = 2014-06-10T18:18:26Z 14299 TID-55uqo INFO: Booting Sidekiq 3.0.0 with redis options {:url=>"redis://localhost:6379/0", :namespace=>"sidekiq"}
 rule = 65616
 alert = 3
 decoder = gitlab_sidekiq
 
-[Gitlab_sidekiq_3]
+[Gitlab_sidekiq_3 INFO.]
 log 1 pass = {"severity":"INFO","time":"2018-04-03T22:57:22.071Z","queue":"cronjob:update_all_mirrors","args":[],"class":"UpdateAllMirrorsWorker","retry":false,"queue_namespace":"cronjob","jid":"06aeaa3b0aadacf9981f368e","created_at":"2018-04-03T22:57:21.930Z","enqueued_at":"2018-04-03T22:57:21.931Z","pid":10077,"message":"UpdateAllMirrorsWorker JID-06aeaa3b0aadacf9981f368e: done: 0.139 sec","job_status":"done","duration":0.139,"completed_at":"2018-04-03T22:57:22.071Z"}
 rule = 65618
 alert = 3
 decoder = json
 
-[Gitlab_sidekiq_4]
+[Gitlab_sidekiq_4 ERROR.]
 log 1 pass = {"severity":"ERROR","time":"2018-04-03T22:57:22.071Z","queue":"cronjob:update_all_mirrors","args":[],"class":"UpdateAllMirrorsWorker","retry":false,"queue_namespace":"cronjob","jid":"06aeaa3b0aadacf9981f368e","created_at":"2018-04-03T22:57:21.930Z","enqueued_at":"2018-04-03T22:57:21.931Z","pid":10077,"message":"UpdateAllMirrorsWorker JID-06aeaa3b0aadacf9981f368e: done: 0.139 sec","job_status":"done","duration":0.139,"completed_at":"2018-04-03T22:57:22.071Z"}
 rule = 65619
 alert = 5
 decoder = json
 
-[Gitlab_shell_stderr_1]
+[Gitlab_shell_stderr_1 INFO.]
 log 1 pass = I, [2015-02-13T06:17:00.671315 #9291]  INFO -- : Adding project root/example.git at </var/opt/gitlab/git-data/repositories/root/dcdcdcdcd.git>.
 log 2 pass = I, [2015-02-13T06:17:00.679433 #9291]  INFO -- : Moving existing hooks directory and symlinking global hooks directory for /var/opt/gitlab/git-data/repositories/root/example.git.
 rule = 65620
 alert = 3
 decoder = gitlab_shell_stderr
 
-[Gitlab_shell_stderr_2]
+[Gitlab_shell_stderr_2 WARN.]
 log 1 pass = W, [2015-02-13T07:16:01.312916 #9094]  WARN -- : #<Unicorn::HttpServer:0x0000000208f618>: worker (pid: 9094) exceeds memory limit (320626688 bytes > 247066940 bytes)
 log 2 pass = W, [2015-02-13T07:16:01.313000 #9094]  WARN -- : Unicorn::WorkerKiller send SIGQUIT (pid: 9094) alive: 3621 sec (trial 1)
 rule = 65621
 alert = 5
 decoder = gitlab_shell_stderr
 
-[Gitlab_graphql]
+[Gitlab_graphql query.]
 log 1 pass = {"query_string":"query IntrospectionQuery{__schema {queryType { name },mutationType { name }}}...(etc)","variables":{"a":1,"b":2},"complexity":181,"depth":1,"duration":7}
 rule = 65622
+alert = 3
+decoder = json
+
+[GET request Completed Succesfully.]
+log 1 pass = {"time":"2018-10-29T12:49:42.123Z","severity":"INFO","duration":709.08,"db":14.59,"view":694.49,"status":200,"method":"GET","path":"/api/v4/projects","params":[{"key":"action","value":"git-upload-pack"},{"key":"changes","value":"_any"},{"key":"key_id","value":"secret"},{"key":"secret_token","value":"[FILTERED]"}],"host":"localhost","ip":"::1","ua":"Ruby","route":"/api/:version/projects","user_id":1,"username":"root","queue_duration":100.31,"gitaly_calls":30,"gitaly_duration":5.36}
+rule = 65623
 alert = 3
 decoder = json

--- a/ruleset/testing/tests/gitlab.ini
+++ b/ruleset/testing/tests/gitlab.ini
@@ -14,67 +14,67 @@ decoder = json
 
 [ERROR: couldn't complete PUSH request.]
 log 1 pass = {"method":"PUSH","path":"/gitlab/gitlab-ce/issues/1234","format":"html","controller":"Projects::IssuesController","action":"show","status":400,"duration":229.03,"view":174.07,"db":13.24,"time":"2017-08-08T20:15:54.821Z","params":[{"key":"param_key","value":"param_value"}],"remote_ip":"18.245.0.1","user_id":1,"username":"admin","gitaly_calls":76,"gitaly_duration":7.41,"queue_duration": 112.47}
-rule = 65602
+rule = 65601
 alert = 5
 decoder = json
 
 [REDIRECTION:The PUSH request has more than one possible response.]
 log 1 pass = {"method":"PUSH","path":"/gitlab/gitlab-ce/issues/1234","format":"html","controller":"Projects::IssuesController","action":"show","status":300,"duration":229.03,"view":174.07,"db":13.24,"time":"2017-08-08T20:15:54.821Z","params":[{"key":"param_key","value":"param_value"}],"remote_ip":"18.245.0.1","user_id":1,"username":"admin","gitaly_calls":76,"gitaly_duration":7.41,"queue_duration": 112.47}
-rule = 65603
+rule = 65602
 alert = 5
 decoder = json
 
 [User Administrator was created.]
 log 1 pass = October 06, 2014 11:56: User "Administrator" (admin@example.com) was created
-rule = 65604
+rule = 65603
 alert = 3
 decoder = gitlab-12-application-log
 
 [Documentcloud created a new project.]
 log 1 pass = October 06, 2014 11:56: Documentcloud created a new project "Documentcloud / Underscore"
-rule = 65606
+rule = 65604
 alert = 3
 decoder = gitlab-12-application-log
 
 [User dummy was removed.]
 log 1 pass = October 06, 2014 11:56: User "dummy" (dummy@gmail.com) was removed
-rule = 65607
+rule = 65605
 alert = 3
 decoder = gitlab-12-application-log
 
 [Project project133 was removed.]
 log 1 pass = October 07, 2014 11:25: Project "project133" was removed
-rule = 65608
+rule = 65606
 alert = 3
 decoder = gitlab-12-application-log
 
 [Error sending message.]
 log 1 pass = {"severity":"ERROR","time":"2018-09-06T14:56:20.439Z","service_class":"JiraService","project_id":8,"project_path":"h5bp/html5-boilerplate","message":"Error sending message","client_url":"http://jira.gitlap.com:8080","error":"execution expired"}
-rule = 65609
+rule = 65607
 alert = 5
 decoder = json
 
 [Successfully posted.]
 log 1 pass = {"severity":"INFO","time":"2018-09-06T17:15:16.365Z","service_class":"JiraService","project_id":3,"project_path":"namespace2/project2","message":"Successfully posted","client_url":"http://jira.example.com"}
-rule = 65610
+rule = 65608
 alert = 3
 decoder = json
 
 [Gitlab_kubernetes_1 ERROR: Unauthorized.]
 log 1 pass = {"severity":"ERROR","time":"2018-11-23T15:14:54.652Z","exception":"Kubeclient::HttpError","error_code":401,"service":"Clusters::Applications::CheckInstallationProgressService","app_id":14,"project_ids":[1],"group_ids":[],"message":"Unauthorized"}
-rule = 65611
+rule = 65609
 alert = 5
 decoder = json
 
 [Gitlab_kubernetes_2 INFO.]
 log 1 pass = {"severity":"INFO","time":"2018-11-23T15:42:11.647Z","exception":"Kubeclient::HttpError","error_code":null,"service":"Clusters::Applications::InstallService","app_id":2,"project_ids":[19],"group_ids":[],"message":"SSL_connect returned=1 errno=0 state=error: certificate verify failed (unable to get local issuer certificate)"}
-rule = 65612
+rule = 65610
 alert = 3
 decoder = json
 
 [Gitlab_githost ERROR.]
 log 1 pass = {"severity":"ERROR","time":"2019-07-19T22:16:12.528Z","correlation_id":"FeGxww5Hj64","message":"Command failed [1]: /usr/bin/git --git-dir=/Users/vsizov/gitlab-development-kit/gitlab/tmp/tests/gitlab-satellites/group184/gitlabhq/.git --work-tree=/Users/vsizov/gitlab-development-kit/gitlab/tmp/tests/gitlab-satellites/group184/gitlabhq merge --no-ff -mMerge branch 'feature_conflict' into 'feature' source/feature_conflict\n\nerror: failed to push some refs to '/Users/vsizov/gitlab-development-kit/repositories/gitlabhq/gitlab_git.git'"}
-rule = 65613
+rule = 65611
 alert = 5
 decoder = json
 
@@ -82,68 +82,68 @@ decoder = json
 log 1 pass = {"severity":"INFO","time":"2018-10-17T17:38:22.523Z","author_id":3,"entity_id":2,"entity_type":"Project","change":"visibility","from":"Private","to":"Public","author_name":"John Doe4","target_id":2,"target_type":"Project","target_details":"namespace2/project2"}
 log 2 pass = {"severity":"INFO","time":"2018-10-17T17:38:22.830Z","author_id":5,"entity_id":3,"entity_type":"Project","change":"name","from":"John Doe7 / project3","to":"John Doe7 / new name","author_name":"John Doe6","target_id":3,"target_type":"Project","target_details":"namespace3/project3"}
 log 3 pass = {"severity":"INFO","time":"2018-10-17T17:38:23.175Z","author_id":7,"entity_id":4,"entity_type":"Project","change":"path","from":"","to":"namespace4/newpath","author_name":"John Doe8","target_id":4,"target_type":"Project","target_details":"namespace4/newpath"}
-rule = 65614
+rule = 65612
 alert = 3
 decoder = json
 
 [Gitlab_sidekiq_2 INFO.]
 log 1 pass = 2014-06-10T18:18:26Z 14299 TID-55uqo INFO: Booting Sidekiq 3.0.0 with redis options {:url=>"redis://localhost:6379/0", :namespace=>"sidekiq"}
-rule = 65616
+rule = 65614
 alert = 3
 decoder = gitlab-sidekiq
 
 [Gitlab_sidekiq_1 ERROR.]
 log 1 pass = 2014-06-10T07:55:20Z 2037 TID-tm504 ERROR: /opt/bitnami/apps/discourse/htdocs/vendor/bundle/ruby/1.9.1/gems/redis-3.0.7/lib/redis/client.rb:228:in `read'
-rule = 65617
+rule = 65615
 alert = 5
 decoder = gitlab-sidekiq
 
 [Gitlab_sidekiq_3 INFO.]
 log 1 pass = {"severity":"INFO","time":"2018-04-03T22:57:22.071Z","queue":"cronjob:update_all_mirrors","args":[],"class":"UpdateAllMirrorsWorker","retry":false,"queue_namespace":"cronjob","jid":"06aeaa3b0aadacf9981f368e","created_at":"2018-04-03T22:57:21.930Z","enqueued_at":"2018-04-03T22:57:21.931Z","pid":10077,"message":"UpdateAllMirrorsWorker JID-06aeaa3b0aadacf9981f368e: done: 0.139 sec","job_status":"done","duration":0.139,"completed_at":"2018-04-03T22:57:22.071Z"}
-rule = 65618
+rule = 65616
 alert = 3
 decoder = json
 
 [Gitlab_sidekiq_4 ERROR.]
 log 1 pass = {"severity":"ERROR","time":"2018-04-03T22:57:22.071Z","queue":"cronjob:update_all_mirrors","args":[],"class":"UpdateAllMirrorsWorker","retry":false,"queue_namespace":"cronjob","jid":"06aeaa3b0aadacf9981f368e","created_at":"2018-04-03T22:57:21.930Z","enqueued_at":"2018-04-03T22:57:21.931Z","pid":10077,"message":"UpdateAllMirrorsWorker JID-06aeaa3b0aadacf9981f368e: done: 0.139 sec","job_status":"done","duration":0.139,"completed_at":"2018-04-03T22:57:22.071Z"}
-rule = 65619
+rule = 65617
 alert = 5
 decoder = json
 
 [Gitlab_shell_stderr_1 INFO.]
 log 1 pass = I, [2015-02-13T06:17:00.671315 #9291]  INFO -- : Adding project root/example.git at </var/opt/gitlab/git-data/repositories/root/dcdcdcdcd.git>.
 log 2 pass = I, [2015-02-13T06:17:00.679433 #9291]  INFO -- : Moving existing hooks directory and symlinking global hooks directory for /var/opt/gitlab/git-data/repositories/root/example.git.
-rule = 65620
+rule = 65618
 alert = 3
 decoder = gitlab-shell-stderr
 
 [Gitlab_shell_stderr_2 WARN.]
 log 1 pass = W, [2015-02-13T07:16:01.312916 #9094]  WARN -- : #<Unicorn::HttpServer:0x0000000208f618>: worker (pid: 9094) exceeds memory limit (320626688 bytes > 247066940 bytes)
 log 2 pass = W, [2015-02-13T07:16:01.313000 #9094]  WARN -- : Unicorn::WorkerKiller send SIGQUIT (pid: 9094) alive: 3621 sec (trial 1)
-rule = 65621
+rule = 65619
 alert = 5
 decoder = gitlab-shell-stderr
 
 [Gitlab_graphql query.]
 log 1 pass = {"query_string":"query IntrospectionQuery{__schema {queryType { name },mutationType { name }}}...(etc)","variables":{"a":1,"b":2},"complexity":181,"depth":1,"duration":7}
-rule = 65622
+rule = 65620
 alert = 3
 decoder = json
 
 [GET request Completed Succesfully.]
 log 1 pass = {"time":"2018-10-29T12:49:42.123Z","severity":"INFO","duration":709.08,"db":14.59,"view":694.49,"status":200,"method":"GET","path":"/api/v4/projects","params":[{"key":"action","value":"git-upload-pack"},{"key":"changes","value":"_any"},{"key":"key_id","value":"secret"},{"key":"secret_token","value":"[FILTERED]"}],"host":"localhost","ip":"::1","ua":"Ruby","route":"/api/:version/projects","user_id":1,"username":"root","queue_duration":100.31,"gitaly_calls":30,"gitaly_duration":5.36}
-rule = 65623
+rule = 65621
 alert = 3
 decoder = json
 
 [ERROR: couldn't complete GET request.]
 log 1 pass = {"method":"GET","path":"/api/v4/projects","format":"html","controller":"Projects::IssuesController","action":"show","status":400,"duration":229.03,"view":174.07,"db":13.24,"time":"2017-08-08T20:15:54.821Z","params":[{"key":"param_key","value":"param_value"}],"remote_ip":"18.245.0.1","user_id":1,"username":"admin","gitaly_calls":76,"gitaly_duration":7.41,"queue_duration": 112.47}
-rule = 65624
+rule = 65622
 alert = 5
 decoder = json
 
 [REDIRECTION:The GET request has more than one possible response.]
 log 1 pass = {"method":"GET","path":"/api/v4/projects","format":"html","controller":"Projects::IssuesController","action":"show","status":300,"duration":229.03,"view":174.07,"db":13.24,"time":"2017-08-08T20:15:54.821Z","params":[{"key":"param_key","value":"param_value"}],"remote_ip":"18.245.0.1","user_id":1,"username":"admin","gitaly_calls":76,"gitaly_duration":7.41,"queue_duration": 112.47}
-rule = 65625
+rule = 65623
 alert = 5
 decoder = json

--- a/ruleset/testing/tests/gitlab.ini
+++ b/ruleset/testing/tests/gitlab.ini
@@ -4,7 +4,7 @@
 ;    GitLab
 ;
 ;  Sample logs source: 
-;    GitLab: Community, 
+;    GitLab: Community, https://github.com/wazuh/wazuh-ruleset/issues/476
 
 [Gitlab_production_1]
 log 1 pass = {"method":"GET","path":"/gitlab/gitlab-ce/issues/1234","format":"html","controller":"Projects::IssuesController","action":"show","status":200,"duration":229.03,"view":174.07,"db":13.24,"time":"2017-08-08T20:15:54.821Z","params":[{"key":"param_key","value":"param_value"}],"remote_ip":"18.245.0.1","user_id":1,"username":"admin","gitaly_calls":76,"gitaly_duration":7.41,"queue_duration": 112.47}

--- a/ruleset/testing/tests/gitlab.ini
+++ b/ruleset/testing/tests/gitlab.ini
@@ -1,3 +1,11 @@
+;  Copyright (C) 2015-2021, Wazuh Inc.
+;
+;  Tests for products: 
+;    GitLab
+;
+;  Sample logs source: 
+;    GitLab: Community, 
+
 [Gitlab_production_1]
 log 1 pass = {"method":"GET","path":"/gitlab/gitlab-ce/issues/1234","format":"html","controller":"Projects::IssuesController","action":"show","status":200,"duration":229.03,"view":174.07,"db":13.24,"time":"2017-08-08T20:15:54.821Z","params":[{"key":"param_key","value":"param_value"}],"remote_ip":"18.245.0.1","user_id":1,"username":"admin","gitaly_calls":76,"gitaly_duration":7.41,"queue_duration": 112.47}
 rule = 65600


### PR DESCRIPTION
|Related issue|
|---|
| #11281 |

## Description

This PR aims to resolve issues detected under #9041 PR. Closes #11293.
The issues resolved are:
- Copyright headers.
- Fixed indentation issues.
- Added a blank line at the EOF.
- Added line breaks in between rules and decoder blocks.

## Checks and changes 

### Syntax

- [x] 1.a Rule tags order must be compliant.
- [x] 1.b Decoder tags order must be compliant.
- [x] 1.c XML blocks must as compact as possible.
- [x] 1.d Only one empty line between rule/decoder and the next rule/decoder.
- [x] 1.e Decoder extracted fields names must use '_' whether a space is needed.
- [x] 1.f Decoder name must use '-' whether a space is needed.
 
### Grammar

- [x] 2.a Grammar quality.
- [x] 2.b Similar phrases must keep tenses and expressions.
- [x] 2.c Grammar basic rules like capitalization, punctuation marks, sentence construction, and others.


### Semantic

- [x] 3.a New decoder, rule, or test are written in the correct file and grouped correctly inside the file.
- [x] 3.b Group similar rules under same ID's group.
- [x] 3.c: 
     - [x] 3.c1 Find and reuse group name before creating a new one.
     - [x] 3.c2 Include a new group definition in a PR comment.
     - [x] 3.c3 Any group name must use '_' whether it does need a space char.
     - [x] 3.c4 The groups inside a tag must be sorted in alphabetical order.
- [x] 3.d Rule level should be compliant with the [documentation](https://documentation.wazuh.com/current/user-manual/ruleset/rules-classification.html).

### Unit testing

- [x] 4.a A metadata block at the beginning of the .ini file describing software, version, and logs source.
- [x] 4.b Each new rule must have at least one test entry in the correct .ini file.
- [x] 4.c Runtest.py must pass and must include the results in raw format here.
<details><summary>GitLab.ini test.</summary>
<p>

```
root@ubuntu-focal:/var/ossec/ruleset/feed/testing# python3 runtests.py --testfile tests/gitlab.ini 
Restarting wazuh-manager...
- [ File = ./tests/gitlab.ini ] ---------
.........................

|Component |  Tested  |  Total   | Coverage |
| -------- | -------- | -------- | -------- |
|  Rules   |    21    |   4174   |  0.50%   |
| Decoders |    4     |   172    |  2.33%   |

|          File           |  Passed  |  Failed  |  Status  |
|        --------         | -------- | -------- | -------- |
|./tests/gitlab.ini       |    25    |    0     |    ✅     |
Restarting wazuh-manager...
root@ubuntu-focal:/var/ossec/ruleset/feed/testing#
```
</p>
</details>

<details><summary>All rules and decoders test.</summary>
<p>

```
root@ubuntu-focal:/var/ossec/ruleset/feed/testing# python3 runtests.py
Restarting wazuh-manager...
- [ File = ./tests/samba.ini ] ---------
....

- [ File = ./tests/fortigate.ini ] ---------
........................................

- [ File = ./tests/apparmor.ini ] ---------
.....

- [ File = ./tests/pam.ini ] ---------
.....

- [ File = ./tests/audit_lateral.ini ] ---------
......

- [ File = ./tests/systemd.ini ] ---------
..

- [ File = ./tests/arbor.ini ] ---------
..

- [ File = ./tests/dovecot.ini ] ---------
...............

- [ File = ./tests/mailscanner.ini ] ---------
.

- [ File = ./tests/ossec.ini ] ---------
.....

- [ File = ./tests/vuln_detector.ini ] ---------
..

- [ File = ./tests/squid_rules.ini ] ---------
..

- [ File = ./tests/pix.ini ] ---------
......................

- [ File = ./tests/huawei_usg.ini ] ---------
...

- [ File = ./tests/checkpoint_smart1.ini ] ---------
..................

- [ File = ./tests/junos.ini ] ---------
...

- [ File = ./tests/web_appsec.ini ] ---------
...............................

- [ File = ./tests/cimserver.ini ] ---------
..

- [ File = ./tests/cisco_ftd.ini ] ---------
..........................................

- [ File = ./tests/firewalld.ini ] ---------
..

- [ File = ./tests/audit_recon.ini ] ---------
..

- [ File = ./tests/openldap.ini ] ---------
.........

- [ File = ./tests/sophos_fw.ini ] ---------
..........

- [ File = ./tests/owlh.ini ] ---------
....

- [ File = ./tests/freepbx.ini ] ---------
......

- [ File = ./tests/syslog.ini ] ---------
......

- [ File = ./tests/openvpn_ldap.ini ] ---------
..

- [ File = ./tests/sophos.ini ] ---------
........

- [ File = ./tests/unbound.ini ] ---------


- [ File = ./tests/github.ini ] ---------
....................................................................................................................................................................................................................................................................................................................................

- [ File = ./tests/cpanel.ini ] ---------
.......

- [ File = ./tests/fireeye.ini ] ---------
...

- [ File = ./tests/fortiauth.ini ] ---------
....

- [ File = ./tests/iptables.ini ] ---------
........

- [ File = ./tests/named.ini ] ---------
.....

- [ File = ./tests/sophos-utm-firewall.ini ] ---------
......

- [ File = ./tests/nginx.ini ] ---------
............

- [ File = ./tests/exim.ini ] ---------
.......

- [ File = ./tests/opensmtpd.ini ] ---------
.......

- [ File = ./tests/oscap.ini ] ---------
................................

- [ File = ./tests/gitlab.ini ] ---------
.........................

- [ File = ./tests/paloalto.ini ] ---------
................

- [ File = ./tests/api.ini ] ---------
............................

- [ File = ./tests/aws_s3_access.ini ] ---------
.......

- [ File = ./tests/exchange.ini ] ---------
..

- [ File = ./tests/f5_big_ip.ini ] ---------
...........................................

- [ File = ./tests/cisco_asa.ini ] ---------
........................................................................................

- [ File = ./tests/nextcloud.ini ] ---------
.......

- [ File = ./tests/trendmicro-cloud-one.ini ] ---------
.................

- [ File = ./tests/pfsense.ini ] ---------
..

- [ File = ./tests/vsftpd.ini ] ---------
....

- [ File = ./tests/web_rules.ini ] ---------
..........

- [ File = ./tests/apache.ini ] ---------
..................

- [ File = ./tests/eset.ini ] ---------
........

- [ File = ./tests/doas.ini ] ---------
....

- [ File = ./tests/sysmon.ini ] ---------
...

- [ File = ./tests/gcp.ini ] ---------
...........

- [ File = ./tests/icinga.ini ] ---------
....

- [ File = ./tests/postfix.ini ] ---------
..

- [ File = ./tests/audit_scp.ini ] ---------
.

- [ File = ./tests/dropbear.ini ] ---------
...

- [ File = ./tests/rsh.ini ] ---------
..

- [ File = ./tests/kernel_usb.ini ] ---------
......

- [ File = ./tests/mcafee_epo.ini ] ---------
.

- [ File = ./tests/netscreen.ini ] ---------
....

- [ File = ./tests/panda_paps.ini ] ---------
........

- [ File = ./tests/auditd.ini ] ---------
...

- [ File = ./tests/cylance.ini ] ---------
.......

- [ File = ./tests/modsecurity.ini ] ---------
......

- [ File = ./tests/cloudlfare-waf.ini ] ---------
.............

- [ File = ./tests/office365.ini ] ---------
................................................................................................................................

- [ File = ./tests/sshd.ini ] ---------
...........................................

- [ File = ./tests/cisco_ios.ini ] ---------
.................

- [ File = ./tests/glpi.ini ] ---------
...

- [ File = ./tests/sudo.ini ] ---------
........

- [ File = ./tests/su.ini ] ---------
.....

- [ File = ./tests/proftpd.ini ] ---------
.......

- [ File = ./tests/SonicWall.ini ] ---------
........

|Component |  Tested  |  Total   | Coverage |
| -------- | -------- | -------- | -------- |
|  Rules   |   982    |   4174   |  23.53%  |
| Decoders |    76    |   172    |  44.19%  |

|          File           |  Passed  |  Failed  |  Status  |
|        --------         | -------- | -------- | -------- |
|./tests/samba.ini        |    4     |    0     |    ✅     |
|./tests/fortigate.ini    |    40    |    0     |    ✅     |
|./tests/apparmor.ini     |    5     |    0     |    ✅     |
|./tests/pam.ini          |    5     |    0     |    ✅     |
|./tests/audit_lateral.ini|    6     |    0     |    ✅     |
|./tests/systemd.ini      |    2     |    0     |    ✅     |
|./tests/arbor.ini        |    2     |    0     |    ✅     |
|./tests/dovecot.ini      |    15    |    0     |    ✅     |
|./tests/mailscanner.ini  |    1     |    0     |    ✅     |
|./tests/ossec.ini        |    5     |    0     |    ✅     |
|./tests/vuln_detector.ini|    2     |    0     |    ✅     |
|./tests/squid_rules.ini  |    2     |    0     |    ✅     |
|./tests/pix.ini          |    22    |    0     |    ✅     |
|./tests/huawei_usg.ini   |    3     |    0     |    ✅     |
|./tests/checkpoint_smart1.ini|    18    |    0     |    ✅     |
|./tests/junos.ini        |    3     |    0     |    ✅     |
|./tests/web_appsec.ini   |    31    |    0     |    ✅     |
|./tests/cimserver.ini    |    2     |    0     |    ✅     |
|./tests/cisco_ftd.ini    |    42    |    0     |    ✅     |
|./tests/firewalld.ini    |    2     |    0     |    ✅     |
|./tests/audit_recon.ini  |    2     |    0     |    ✅     |
|./tests/openldap.ini     |    9     |    0     |    ✅     |
|./tests/sophos_fw.ini    |    10    |    0     |    ✅     |
|./tests/owlh.ini         |    4     |    0     |    ✅     |
|./tests/freepbx.ini      |    6     |    0     |    ✅     |
|./tests/syslog.ini       |    6     |    0     |    ✅     |
|./tests/openvpn_ldap.ini |    2     |    0     |    ✅     |
|./tests/sophos.ini       |    8     |    0     |    ✅     |
|./tests/unbound.ini      |    0     |    0     |    ✅     |
|./tests/github.ini       |   324    |    0     |    ✅     |
|./tests/cpanel.ini       |    7     |    0     |    ✅     |
|./tests/fireeye.ini      |    3     |    0     |    ✅     |
|./tests/fortiauth.ini    |    4     |    0     |    ✅     |
|./tests/iptables.ini     |    8     |    0     |    ✅     |
|./tests/named.ini        |    5     |    0     |    ✅     |
|./tests/sophos-utm-firewall.ini|    6     |    0     |    ✅     |
|./tests/nginx.ini        |    12    |    0     |    ✅     |
|./tests/exim.ini         |    7     |    0     |    ✅     |
|./tests/opensmtpd.ini    |    7     |    0     |    ✅     |
|./tests/oscap.ini        |    32    |    0     |    ✅     |
|./tests/gitlab.ini       |    25    |    0     |    ✅     |
|./tests/paloalto.ini     |    16    |    0     |    ✅     |
|./tests/api.ini          |    28    |    0     |    ✅     |
|./tests/aws_s3_access.ini|    7     |    0     |    ✅     |
|./tests/exchange.ini     |    2     |    0     |    ✅     |
|./tests/f5_big_ip.ini    |    43    |    0     |    ✅     |
|./tests/cisco_asa.ini    |    88    |    0     |    ✅     |
|./tests/nextcloud.ini    |    7     |    0     |    ✅     |
|./tests/trendmicro-cloud-one.ini|    17    |    0     |    ✅     |
|./tests/pfsense.ini      |    2     |    0     |    ✅     |
|./tests/vsftpd.ini       |    4     |    0     |    ✅     |
|./tests/web_rules.ini    |    10    |    0     |    ✅     |
|./tests/apache.ini       |    18    |    0     |    ✅     |
|./tests/eset.ini         |    8     |    0     |    ✅     |
|./tests/doas.ini         |    4     |    0     |    ✅     |
|./tests/sysmon.ini       |    3     |    0     |    ✅     |
|./tests/gcp.ini          |    11    |    0     |    ✅     |
|./tests/icinga.ini       |    4     |    0     |    ✅     |
|./tests/postfix.ini      |    2     |    0     |    ✅     |
|./tests/audit_scp.ini    |    1     |    0     |    ✅     |
|./tests/dropbear.ini     |    3     |    0     |    ✅     |
|./tests/rsh.ini          |    2     |    0     |    ✅     |
|./tests/kernel_usb.ini   |    6     |    0     |    ✅     |
|./tests/mcafee_epo.ini   |    1     |    0     |    ✅     |
|./tests/netscreen.ini    |    4     |    0     |    ✅     |
|./tests/panda_paps.ini   |    8     |    0     |    ✅     |
|./tests/auditd.ini       |    3     |    0     |    ✅     |
|./tests/cylance.ini      |    7     |    0     |    ✅     |
|./tests/modsecurity.ini  |    6     |    0     |    ✅     |
|./tests/cloudlfare-waf.ini|    13    |    0     |    ✅     |
|./tests/office365.ini    |   128    |    0     |    ✅     |
|./tests/sshd.ini         |    43    |    0     |    ✅     |
|./tests/cisco_ios.ini    |    17    |    0     |    ✅     |
|./tests/glpi.ini         |    3     |    0     |    ✅     |
|./tests/sudo.ini         |    8     |    0     |    ✅     |
|./tests/su.ini           |    5     |    0     |    ✅     |
|./tests/proftpd.ini      |    7     |    0     |    ✅     |
|./tests/SonicWall.ini    |    8     |    0     |    ✅     |
Restarting wazuh-manager...
root@ubuntu-focal:/var/ossec/ruleset/feed/testing# 
```
</p>
</details>

- [x] 4.d New CDB lists must include the proper test entry in the correct .ini file.

### E2E testing

- [x] 5.a Logs for new or modified decoder/rules sent to a manager running with this PR ruleset appear in Kibana.
![image](https://user-images.githubusercontent.com/25141115/145789859-966d8d37-ad45-4bf9-8d3c-12f58e35994e.png)

- [x] 5.b There are no affected or broken visualizations on Kibana.
![image](https://user-images.githubusercontent.com/25141115/145790019-19c27a8c-c9b6-4ed1-a290-ddf9580802a9.png)

- [x] 5.c New or modified items can be seen correctly using APP ruleset navigation.
![image](https://user-images.githubusercontent.com/25141115/145790151-03c576a2-08f9-4d1e-8bdb-80d89e4c05ee.png)
![image](https://user-images.githubusercontent.com/25141115/145790527-00c53977-b644-42f9-ba3f-085047605614.png)


### Elasticsearch Template

- [x] 6.a Known fields with output format managed and usually used for searching are included in template array index.query.default_field. 
- [x] 6.b The new field with the correct date format is stored as a "date" type field in the template.
- [x] 6.c The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 
- [x] 6.d Known fields with output format managed and usually used for searching are included in the template.

### Stoppers

- [x] 7.a No previous rule ID changes without triple check.
- [x] 7.b No previous decoder name changes without triple check.
- [x] 7.c No previous file name changes without triple check.
- [x] 7.d No previous test changes its 'rule' field value without triple check.

### Others

- [x] 8.a Each file has the correct copyright block.
- [x] 8.b The copyright block doesn't have "Author" only "Created by Wazuh". To include an "Author" request triple check.
- [x] 8.c The copyright block doesn't use "-". 
- [x] 8.d The rule files don't have any sample log.
- [x] 8.e The decoder file has sample logs next to the decoder that matches that log.
- [x] 8.f The decoder and rule files have information about software, version, and any helpful information.
- [x] 8.g The PR has a single commit with CHANGELOG changes in the correct format.
- [x] 8.h The new rule ID is not in use.
- [x] 8.i The new rule ID must be in the defined IDs range. 
- [x] 8.j New rules ID range must be verified with a triple check and noted in the rules ID document.
- [x] 8.k The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 