### PR TITLE
Increase sysinfo ports inode range

### DIFF
--- a/src/data_provider/src/ports/iportWrapper.h
+++ b/src/data_provider/src/ports/iportWrapper.h
@@ -42,7 +42,7 @@ class IPortWrapper
         virtual int32_t remotePort() const = 0;
         virtual int32_t txQueue() const = 0;
         virtual int32_t rxQueue() const = 0;
-        virtual int32_t inode() const = 0;
+        virtual int64_t inode() const = 0;
         virtual std::string state() const = 0;
         virtual int32_t pid() const = 0;
         virtual std::string processName() const = 0;

--- a/src/data_provider/src/ports/portBSDWrapper.h
+++ b/src/data_provider/src/ports/portBSDWrapper.h
@@ -136,7 +136,7 @@ class BSDPortWrapper final : public IPortWrapper
         {
             return 0;
         }
-        int32_t inode() const override
+        int64_t inode() const override
         {
             return 0;
         }

--- a/src/data_provider/src/ports/portLinuxWrapper.h
+++ b/src/data_provider/src/ports/portLinuxWrapper.h
@@ -226,9 +226,9 @@ class LinuxPortWrapper final : public IPortWrapper
 
             return retVal;
         }
-        int32_t inode() const override
+        int64_t inode() const override
         {
-            return std::stoi(m_fields.at(INODE));
+            return static_cast<int64_t>(std::stoll(m_fields.at(INODE)));
         }
         std::string state() const override
         {

--- a/src/data_provider/src/ports/portLinuxWrapper.h
+++ b/src/data_provider/src/ports/portLinuxWrapper.h
@@ -228,7 +228,16 @@ class LinuxPortWrapper final : public IPortWrapper
         }
         int64_t inode() const override
         {
-            return static_cast<int64_t>(std::stoll(m_fields.at(INODE)));
+            int64_t retVal { -1 };
+
+            try
+            {
+                retVal = static_cast<int64_t>(std::stoll(m_fields.at(INODE)));
+            }
+            catch (...)
+            {}
+
+            return retVal;
         }
         std::string state() const override
         {

--- a/src/data_provider/src/ports/portWindowsWrapper.h
+++ b/src/data_provider/src/ports/portWindowsWrapper.h
@@ -160,7 +160,7 @@ class WindowsPortWrapper final : public IPortWrapper
         {
             return {};
         }
-        int32_t inode() const override
+        int64_t inode() const override
         {
             return {};
         }

--- a/src/data_provider/tests/sysInfoPorts/sysInfoPort_test.cpp
+++ b/src/data_provider/tests/sysInfoPorts/sysInfoPort_test.cpp
@@ -32,7 +32,7 @@ class SysInfoPortWrapperMock: public IPortWrapper
         MOCK_METHOD(int32_t, remotePort, (), (const override));
         MOCK_METHOD(int32_t, txQueue, (), (const override));
         MOCK_METHOD(int32_t, rxQueue, (), (const override));
-        MOCK_METHOD(int32_t, inode, (), (const override));
+        MOCK_METHOD(int64_t, inode, (), (const override));
         MOCK_METHOD(std::string, state, (), (const override));
         MOCK_METHOD(int32_t, pid, (), (const override));
         MOCK_METHOD(std::string, processName, (), (const override));
@@ -49,7 +49,7 @@ TEST_F(SysInfoPortTest, Test_SPEC_Data)
     EXPECT_CALL(*mock, remotePort()).Times(1).WillOnce(Return(5));
     EXPECT_CALL(*mock, txQueue()).Times(1).WillOnce(Return(6));
     EXPECT_CALL(*mock, rxQueue()).Times(1).WillOnce(Return(7));
-    EXPECT_CALL(*mock, inode()).Times(1).WillOnce(Return(8));
+    EXPECT_CALL(*mock, inode()).Times(1).WillOnce(Return(4274126910));
     EXPECT_CALL(*mock, state()).Times(1).WillOnce(Return("9"));
     EXPECT_CALL(*mock, pid()).Times(1).WillOnce(Return(10));
     EXPECT_CALL(*mock, processName()).Times(1).WillOnce(Return("11"));
@@ -62,7 +62,7 @@ TEST_F(SysInfoPortTest, Test_SPEC_Data)
     EXPECT_EQ(5, port.at("remote_port").get<int32_t>());
     EXPECT_EQ(6, port.at("tx_queue").get<int32_t>());
     EXPECT_EQ(7, port.at("rx_queue").get<int32_t>());
-    EXPECT_EQ(8, port.at("inode").get<int32_t>());
+    EXPECT_EQ(4274126910, port.at("inode").get<int64_t>());
     EXPECT_EQ("9", port.at("state").get_ref<const std::string&>());
     EXPECT_EQ(10, port.at("pid").get<int32_t>());
     EXPECT_EQ("11", port.at("process").get_ref<const std::string&>());

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -724,10 +724,10 @@ int wdb_process_save(wdb_t * wdb, const char * scan_id, const char * scan_time, 
 int wdb_process_delete(wdb_t * wdb, const char * scan_id);
 
 // Insert port info tuple. Return 0 on success or -1 on error.
-int wdb_port_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * protocol, const char * local_ip, int local_port, const char * remote_ip, int remote_port, int tx_queue, int rx_queue, int inode, const char * state, int pid, const char * process, const char * checksum, const char * item_id, const bool replace);
+int wdb_port_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * protocol, const char * local_ip, int local_port, const char * remote_ip, int remote_port, int tx_queue, int rx_queue, long long inode, const char * state, int pid, const char * process, const char * checksum, const char * item_id, const bool replace);
 
 // Save port info into DB.
-int wdb_port_save(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * protocol, const char * local_ip, int local_port, const char * remote_ip, int remote_port, int tx_queue, int rx_queue, int inode, const char * state, int pid, const char * process, const char * checksum, const char * item_id, const bool replace);
+int wdb_port_save(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * protocol, const char * local_ip, int local_port, const char * remote_ip, int remote_port, int tx_queue, int rx_queue, long long inode, const char * state, int pid, const char * process, const char * checksum, const char * item_id, const bool replace);
 
 // Delete port info about previous scan from DB.
 int wdb_port_delete(wdb_t * wdb, const char * scan_id);

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -3420,7 +3420,7 @@ int wdb_parse_ports(wdb_t * wdb, char * input, char * output) {
     int remote_port;
     int tx_queue;
     int rx_queue;
-    int inode;
+    long long inode;
     char * state;
     int pid;
     char * process;
@@ -3580,14 +3580,14 @@ int wdb_parse_ports(wdb_t * wdb, char * input, char * output) {
         if (!strncmp(curr, "NULL", 4))
             inode = -1;
         else
-            inode = strtol(curr,NULL,10);
+            inode = strtoll(curr,NULL,10);
 
         *next++ = '\0';
         curr = next;
 
         if (next = strchr(curr, '|'), !next) {
             mdebug1("Invalid Port query syntax.");
-            mdebug2("Port query: %d", inode);
+            mdebug2("Port query: %lld", inode);
             snprintf(output, OS_MAXSTR + 1, "err Invalid Port query syntax, near '%.32s'", curr);
             return -1;
         }

--- a/src/wazuh_db/wdb_syscollector.c
+++ b/src/wazuh_db/wdb_syscollector.c
@@ -798,7 +798,7 @@ int wdb_hardware_insert(wdb_t * wdb, const char * scan_id, const char * scan_tim
 }
 
 // Function to save Port info into the DB. Return 0 on success or -1 on error.
-int wdb_port_save(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * protocol, const char * local_ip, int local_port, const char * remote_ip, int remote_port, int tx_queue, int rx_queue, int inode, const char * state, int pid, const char * process, const char * checksum, const char * item_id, const bool replace) {
+int wdb_port_save(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * protocol, const char * local_ip, int local_port, const char * remote_ip, int remote_port, int tx_queue, int rx_queue, long long inode, const char * state, int pid, const char * process, const char * checksum, const char * item_id, const bool replace) {
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0){
         mdebug1("at wdb_port_save(): cannot begin transaction");
@@ -830,7 +830,7 @@ int wdb_port_save(wdb_t * wdb, const char * scan_id, const char * scan_time, con
 }
 
 // Insert port info tuple. Return 0 on success or -1 on error.
-int wdb_port_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * protocol, const char * local_ip, int local_port, const char * remote_ip, int remote_port, int tx_queue, int rx_queue, int inode, const char * state, int pid, const char * process, const char * checksum, const char * item_id, const bool replace) {
+int wdb_port_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, const char * protocol, const char * local_ip, int local_port, const char * remote_ip, int remote_port, int tx_queue, int rx_queue, long long inode, const char * state, int pid, const char * process, const char * checksum, const char * item_id, const bool replace) {
     sqlite3_stmt *stmt = NULL;
 
     if (wdb_stmt_cache(wdb, replace ? WDB_STMT_PORT_INSERT2 : WDB_STMT_PORT_INSERT) < 0) {
@@ -872,7 +872,7 @@ int wdb_port_insert(wdb_t * wdb, const char * scan_id, const char * scan_time, c
     }
 
     if (inode >= 0) {
-        sqlite3_bind_int(stmt, 10, inode);
+        sqlite3_bind_int64(stmt, 10, (sqlite_int64) inode);
     } else {
         sqlite3_bind_null(stmt, 10);
     }
@@ -1179,7 +1179,7 @@ int wdb_syscollector_port_save2(wdb_t * wdb, const cJSON * attributes)
     const int remote_port = cJSON_GetObjectItem(attributes, "remote_port") ? cJSON_GetObjectItem(attributes, "remote_port")->valueint : 0;
     const int tx_queue = cJSON_GetObjectItem(attributes, "tx_queue") ? cJSON_GetObjectItem(attributes, "tx_queue")->valueint : 0;
     const int rx_queue = cJSON_GetObjectItem(attributes, "rx_queue") ? cJSON_GetObjectItem(attributes, "rx_queue")->valueint : 0;
-    const int inode = cJSON_GetObjectItem(attributes, "inode") ? cJSON_GetObjectItem(attributes, "inode")->valueint : 0;
+    const long long inode = cJSON_GetObjectItem(attributes, "inode") ? (long long) cJSON_GetObjectItem(attributes, "inode")->valuedouble: 0;
     const char * state = cJSON_GetStringValue(cJSON_GetObjectItem(attributes, "state"));
     const int pid = cJSON_GetObjectItem(attributes, "pid") ? cJSON_GetObjectItem(attributes, "pid")->valueint : 0;
     const char * process = cJSON_GetStringValue(cJSON_GetObjectItem(attributes, "process"));


### PR DESCRIPTION
|Related issue|
|---|
|#11079|

## Description

Hi team!

This PR aims to increase port's inode range from 2^31 (`int32_t`) to 2^63 (`int64_t`).

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors