### PR TITLE
Improve cluster get_health function

### DIFF
--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -1020,9 +1020,14 @@ class Master(server.AbstractServer):
             workers_info.update({self.configuration['node_name']: self.to_dict()})
 
         # Get active agents by node and format last keep alive date format
+        active_agents = Agent.get_agents_overview(filters={'status': 'active', 'node_name': filter_node})['items']
+        for agent in active_agents:
+            if (agent_node := agent["node_name"]) in workers_info.keys():
+                workers_info[agent_node]["info"]["n_active_agents"] = \
+                    workers_info[agent_node]["info"].get("n_active_agents", 0) + 1
         for node_name in workers_info.keys():
-            workers_info[node_name]["info"]["n_active_agents"] = \
-                Agent.get_agents_overview(filters={'status': 'active', 'node_name': node_name})['totalItems']
+            if workers_info[node_name]["info"].get("n_active_agents") is None:
+                workers_info[node_name]["info"]["n_active_agents"] = 0
             if workers_info[node_name]['info']['type'] != 'master':
                 workers_info[node_name]['status']['last_keep_alive'] = str(
                     datetime.fromtimestamp(workers_info[node_name]['status']['last_keep_alive']


### PR DESCRIPTION
|Related issue|
|---|
| close #10868 |

## Description

This pull request improves the get_health function in master.py in order to make faster API requests to GET /cluster/healthcheck and bin/cluster_control -i more in loaded Wazuh environments.

In the [related issue`s comments](https://github.com/wazuh/wazuh/issues/10868#issuecomment-989993599) we can see the request profiling as well as a plot where this improvement is compared in loaded cluster environments:

![image](https://user-images.githubusercontent.com/57481331/145873398-dedbf9fe-c7fe-4ae3-8162-b467e802ef7b.png)


## Test results

```
test_cluster_endpoints.tavern.yaml 
	 45 passed, 47 warnings

test_rbac_black_cluster_endpoints.tavern.yaml 
	 17 passed, 19 warnings

test_rbac_white_cluster_endpoints.tavern.yaml 
	 17 passed, 19 warnings
```

