### PR TITLE
Rework of #9020 - Updated exim4 rules, decoders and .ini to support new logs

### DIFF
--- a/ruleset/decoders/0445-exim_decoders.xml
+++ b/ruleset/decoders/0445-exim_decoders.xml
@@ -2,15 +2,15 @@
   Copyright (C) 2015-2021, Wazuh Inc.
 -->
 
-<!-- Exim decoders
-  - Examples:
-  - 2017-01-23 03:44:14 dovecot_login authenticator failed for (hydra) [10.101.1.18]:35686: 535 Incorrect authentication data (set_id=user)
-  - 2017-01-24 05:22:29 dovecot_plain authenticator failed for (test) [::1]:39454: 535 Incorrect authentication data (set_id=test)
-  - 2017-01-24 03:09:46 SMTP connection from [10.101.1.10]:55010 (TCP/IP connection count = 1)
-  - 2017-01-24 02:53:13 SMTP connection from (hydra) [10.101.1.10]:53682 lost
-  - 2017-01-24 05:36:23 SMTP call from (000000) [::1]:39480 dropped: too many syntax or protocol errors (last command was "123")
-  - 2019-10-20 11:14:38 SMTP protocol synchronization error (input sent without waiting for greeting): rejected connection from H=[134.234.45.34] input="GET / HTTP/1.1\r\nHost: 24.255.212.213:98\r\nUser-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:47.0) Gecko/20100101 Firefox/47.0\r\nAccept: */*\r\n"
-  - 2019-10-20 09:56:39 H=123-123-12-123.example.example.net [123.123.12.123] F=<example@example.com> rejected RCPT <example@exampley.com>: Unrouteable address
+<!-- Exim 4 decoders
+  Examples:
+    2017-01-23 03:44:14 dovecot_login authenticator failed for (hydra) [10.101.1.18]:35686: 535 Incorrect authentication data (set_id=user)
+    2017-01-24 05:22:29 dovecot_plain authenticator failed for (test) [::1]:39454: 535 Incorrect authentication data (set_id=test)
+    2017-01-24 03:09:46 SMTP connection from [10.101.1.10]:55010 (TCP/IP connection count = 1)
+    2017-01-24 02:53:13 SMTP connection from (hydra) [10.101.1.10]:53682 lost
+    2017-01-24 05:36:23 SMTP call from (000000) [::1]:39480 dropped: too many syntax or protocol errors (last command was "123")
+    2019-10-20 11:14:38 SMTP protocol synchronization error (input sent without waiting for greeting): rejected connection from H=[134.234.45.34] input="GET / HTTP/1.1\r\nHost: 24.255.212.213:98\r\nUser-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:47.0) Gecko/20100101 Firefox/47.0\r\nAccept: */*\r\n"
+    2019-10-20 09:56:39 H=123-123-12-123.example.example.net [123.123.12.123] F=<example@example.com> rejected RCPT <example@exampley.com>: Unrouteable address
 -->
 
 <decoder name="exim-authfailed">
@@ -52,5 +52,5 @@
   <parent>windows-date-format</parent>
   <prematch offset="after_parent">rejected RCPT</prematch>
   <regex>H=(\.*) [(\d*.\d*.\d*.\d*)]\.*rejected RCPT \<(\.*)>: (\.*)</regex>
-  <order>host,host_ip,src_email,error_message</order>
+  <order>host,dstip,src_email,error_message</order>
 </decoder>

--- a/ruleset/decoders/0445-exim_decoders.xml
+++ b/ruleset/decoders/0445-exim_decoders.xml
@@ -1,14 +1,8 @@
 <!--
-  -  Exim decoders
-  -  Author: Alexandr Garaga.
-  -  Updated by Wazuh, Inc.
-  -  Copyright (C) 2015-2021, Wazuh Inc.
-  -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modif$
+  Copyright (C) 2015-2021, Wazuh Inc.
 -->
 
-
-<!-- Exim
+<!-- Exim decoders
   - Examples:
   - 2017-01-23 03:44:14 dovecot_login authenticator failed for (hydra) [10.101.1.18]:35686: 535 Incorrect authentication data (set_id=user)
   - 2017-01-24 05:22:29 dovecot_plain authenticator failed for (test) [::1]:39454: 535 Incorrect authentication data (set_id=test)

--- a/ruleset/rules/0515-exim_rules.xml
+++ b/ruleset/rules/0515-exim_rules.xml
@@ -1,69 +1,69 @@
 <!--
-  -  Exim rules
-  -  Author: Alexandr Garaga.
-  -  Updated by Wazuh, Inc.
-  -  Copyright (C) 2015-2021, Wazuh Inc.
-  -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  Copyright (C) 2015-2021, Wazuh Inc.
+-->
+
+<!--
+  Exim rules 87500 - 87512
 -->
 
 <group name="exim,">
-    <rule id="87500" level="0">
-      <decoded_as>windows-date-format</decoded_as>
-      <regex>^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d SMTP </regex>
-      <description>Exim SMTP Messages Grouped.</description>
-    </rule>
+  <rule id="87500" level="0">
+    <decoded_as>windows-date-format</decoded_as>
+    <regex>^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d SMTP </regex>
+    <description>Exim SMTP Messages Grouped.</description>
+  </rule>
 
-    <rule id="87501" level="0">
-      <decoded_as>windows-date-format</decoded_as>
-      <regex>^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d dovecot</regex>
-      <description>dovecot messages grouped.</description>
-    </rule>
+  <rule id="87501" level="0">
+    <decoded_as>windows-date-format</decoded_as>
+    <regex>^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d dovecot</regex>
+    <description>dovecot messages grouped.</description>
+  </rule>
 
-    <rule id="87506" level="5">
-      <if_sid>87501</if_sid>
-      <match>authenticator failed</match>
-      <description>Exim Auth failed</description>
-      <group>invalid_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
-    </rule>
+  <rule id="87506" level="5">
+    <if_sid>87501</if_sid>
+    <match>authenticator failed</match>
+    <description>Exim Auth failed</description>
+    <group>invalid_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+  </rule>
 
-    <rule id="87507" level="10" frequency="8" timeframe="240">
-      <if_matched_sid>87506</if_matched_sid>
-      <same_source_ip />
-      <description>Exim brute force attack (multiple auth failures).</description>
-      <mitre>
-        <id>T1110</id>
-      </mitre>
-        <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
-    </rule>
+  <rule id="87507" level="10" frequency="8" timeframe="240">
+    <if_matched_sid>87506</if_matched_sid>
+    <same_source_ip />
+    <description>Exim brute force attack (multiple auth failures).</description>
+    <mitre>
+      <id>T1110</id>
+    </mitre>
+      <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+  </rule>
 
-    <rule id="87508" level="0">
-      <if_sid>87500</if_sid>
-      <match>connection count =</match>
-      <description>Exim connection</description>
-    </rule>
+  <rule id="87508" level="0">
+    <if_sid>87500</if_sid>
+    <match>connection count =</match>
+    <description>Exim connection</description>
+  </rule>
 
-    <rule id="87509" level="1">
-      <if_sid>87500</if_sid>
-      <match>lost$</match>
-      <description>Exim connection lost</description>
-    </rule>
+  <rule id="87509" level="1">
+    <if_sid>87500</if_sid>
+    <match>lost$</match>
+    <description>Exim connection lost</description>
+  </rule>
 
-    <rule id="87510" level="5">
-      <if_sid>87500</if_sid>
-      <match>dropped: too many syntax or protocol errors</match>
-      <description>Exim syntax or protocol errors</description>
-    </rule>
+  <rule id="87510" level="5">
+    <if_sid>87500</if_sid>
+    <match>dropped: too many syntax or protocol errors</match>
+    <description>Exim syntax or protocol errors</description>
+  </rule>
 
-    <rule id="87511" level="6">
-      <if_sid>87500</if_sid>
-      <match>input sent without waiting for greeting</match>
-      <description>SMTP protocol synchronization error (input sent without waiting for greeting)</description>
-    </rule>
+  <rule id="87511" level="6">
+    <if_sid>87500</if_sid>
+    <match>input sent without waiting for greeting</match>
+    <description>SMTP protocol synchronization error (input sent without waiting for greeting)</description>
+  </rule>
 
-    <rule id="87512" level="6">
-      <decoded_as>windows-date-format</decoded_as>
-      <match>rejected RCPT</match>
-      <description>RCPT rejected. Error: $(error_message)</description>
-    </rule>
+  <rule id="87512" level="6">
+    <decoded_as>windows-date-format</decoded_as>
+    <match>rejected RCPT</match>
+    <description>RCPT rejected. Error: $(error_message)</description>
+  </rule>
+
 </group>

--- a/ruleset/rules/0515-exim_rules.xml
+++ b/ruleset/rules/0515-exim_rules.xml
@@ -23,15 +23,15 @@
     <description>dovecot messages grouped.</description>
   </rule>
 
-  <rule id="87506" level="5">
+  <rule id="87502" level="5">
     <if_sid>87501</if_sid>
     <match>authenticator failed</match>
     <description>Exim: Auth failed</description>
     <group>invalid_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="87507" level="10" frequency="8" timeframe="240">
-    <if_matched_sid>87506</if_matched_sid>
+  <rule id="87503" level="10" frequency="8" timeframe="240">
+    <if_matched_sid>87502</if_matched_sid>
     <same_source_ip />
     <description>Exim: brute force attack (multiple auth failures).</description>
     <mitre>
@@ -40,31 +40,31 @@
     <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
-  <rule id="87508" level="0">
+  <rule id="87504" level="0">
     <if_sid>87500</if_sid>
     <match>connection count =</match>
     <description>Exim: connection.</description>
   </rule>
 
-  <rule id="87509" level="1">
+  <rule id="87505" level="1">
     <if_sid>87500</if_sid>
     <match>lost$</match>
     <description>Exim: connection lost</description>
   </rule>
 
-  <rule id="87510" level="5">
+  <rule id="87506" level="5">
     <if_sid>87500</if_sid>
     <match>dropped: too many syntax or protocol errors</match>
     <description>Exim: syntax or protocol errors</description>
   </rule>
 
-  <rule id="87511" level="6">
+  <rule id="87507" level="6">
     <if_sid>87500</if_sid>
     <match>input sent without waiting for greeting</match>
     <description>Exim: SMTP protocol synchronization error (input sent without waiting for greeting)</description>
   </rule>
 
-  <rule id="87512" level="6">
+  <rule id="87508" level="6">
     <decoded_as>windows-date-format</decoded_as>
     <match>rejected RCPT</match>
     <description>Exim: RCPT rejected. Error: $(error_message)</description>

--- a/ruleset/rules/0515-exim_rules.xml
+++ b/ruleset/rules/0515-exim_rules.xml
@@ -26,7 +26,7 @@
   <rule id="87502" level="5">
     <if_sid>87501</if_sid>
     <match>authenticator failed</match>
-    <description>Exim: Auth failed</description>
+    <description>Exim: Auth failed.</description>
     <group>authentication_failed,gdpr_IV_35.7.d,gdpr_IV_32.2,invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,</group>
   </rule>
 
@@ -49,25 +49,25 @@
   <rule id="87505" level="1">
     <if_sid>87500</if_sid>
     <match>lost$</match>
-    <description>Exim: connection lost</description>
+    <description>Exim: connection lost.</description>
   </rule>
 
   <rule id="87506" level="5">
     <if_sid>87500</if_sid>
     <match>dropped: too many syntax or protocol errors</match>
-    <description>Exim: syntax or protocol errors</description>
+    <description>Exim: syntax or protocol errors.</description>
   </rule>
 
   <rule id="87507" level="6">
     <if_sid>87500</if_sid>
     <match>input sent without waiting for greeting</match>
-    <description>Exim: SMTP protocol synchronization error (input sent without waiting for greeting)</description>
+    <description>Exim: SMTP protocol synchronization error (input sent without waiting for greeting).</description>
   </rule>
 
   <rule id="87508" level="6">
     <decoded_as>windows-date-format</decoded_as>
     <match>rejected RCPT</match>
-    <description>Exim: RCPT rejected. Error: $(error_message)</description>
+    <description>Exim: RCPT rejected. Error: $(error_message).</description>
   </rule>
 
 </group>

--- a/ruleset/rules/0515-exim_rules.xml
+++ b/ruleset/rules/0515-exim_rules.xml
@@ -27,7 +27,7 @@
     <if_sid>87501</if_sid>
     <match>authenticator failed</match>
     <description>Exim: Auth failed</description>
-    <group>invalid_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+    <group>authentication_failed,gdpr_IV_35.7.d,gdpr_IV_32.2,invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,</group>
   </rule>
 
   <rule id="87503" level="10" frequency="8" timeframe="240">
@@ -37,7 +37,7 @@
     <mitre>
       <id>T1110</id>
     </mitre>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+    <group>authentication_failures,gdpr_IV_35.7.d,gdpr_IV_32.2,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,</group>
   </rule>
 
   <rule id="87504" level="0">

--- a/ruleset/rules/0515-exim_rules.xml
+++ b/ruleset/rules/0515-exim_rules.xml
@@ -27,7 +27,7 @@
     <if_sid>87501</if_sid>
     <match>authenticator failed</match>
     <description>Exim: Auth failed.</description>
-    <group>authentication_failed,gdpr_IV_35.7.d,gdpr_IV_32.2,invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,</group>
+    <group>authentication_failed,gdpr_IV_32.2,gdpr_IV_35.7.d,invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,</group>
   </rule>
 
   <rule id="87503" level="10" frequency="8" timeframe="240">
@@ -37,7 +37,7 @@
     <mitre>
       <id>T1110</id>
     </mitre>
-    <group>authentication_failures,gdpr_IV_35.7.d,gdpr_IV_32.2,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,</group>
+    <group>authentication_failures,gdpr_IV_32.2,gdpr_IV_35.7.d,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,</group>
   </rule>
 
   <rule id="87504" level="0">

--- a/ruleset/rules/0515-exim_rules.xml
+++ b/ruleset/rules/0515-exim_rules.xml
@@ -3,8 +3,11 @@
 -->
 
 <!--
-  Exim rules 87500 - 87512
+  Exim 4 rules 
 -->
+
+<!-- ID: 87500 - 87600 -->
+
 
 <group name="exim,">
 
@@ -34,7 +37,7 @@
     <mitre>
       <id>T1110</id>
     </mitre>
-      <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="87508" level="0">

--- a/ruleset/rules/0515-exim_rules.xml
+++ b/ruleset/rules/0515-exim_rules.xml
@@ -7,10 +7,11 @@
 -->
 
 <group name="exim,">
+
   <rule id="87500" level="0">
     <decoded_as>windows-date-format</decoded_as>
     <regex>^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d SMTP </regex>
-    <description>Exim SMTP Messages Grouped.</description>
+    <description>Exim: SMTP Messages Grouped.</description>
   </rule>
 
   <rule id="87501" level="0">
@@ -22,14 +23,14 @@
   <rule id="87506" level="5">
     <if_sid>87501</if_sid>
     <match>authenticator failed</match>
-    <description>Exim Auth failed</description>
+    <description>Exim: Auth failed</description>
     <group>invalid_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
   </rule>
 
   <rule id="87507" level="10" frequency="8" timeframe="240">
     <if_matched_sid>87506</if_matched_sid>
     <same_source_ip />
-    <description>Exim brute force attack (multiple auth failures).</description>
+    <description>Exim: brute force attack (multiple auth failures).</description>
     <mitre>
       <id>T1110</id>
     </mitre>
@@ -39,31 +40,31 @@
   <rule id="87508" level="0">
     <if_sid>87500</if_sid>
     <match>connection count =</match>
-    <description>Exim connection</description>
+    <description>Exim: connection.</description>
   </rule>
 
   <rule id="87509" level="1">
     <if_sid>87500</if_sid>
     <match>lost$</match>
-    <description>Exim connection lost</description>
+    <description>Exim: connection lost</description>
   </rule>
 
   <rule id="87510" level="5">
     <if_sid>87500</if_sid>
     <match>dropped: too many syntax or protocol errors</match>
-    <description>Exim syntax or protocol errors</description>
+    <description>Exim: syntax or protocol errors</description>
   </rule>
 
   <rule id="87511" level="6">
     <if_sid>87500</if_sid>
     <match>input sent without waiting for greeting</match>
-    <description>SMTP protocol synchronization error (input sent without waiting for greeting)</description>
+    <description>Exim: SMTP protocol synchronization error (input sent without waiting for greeting)</description>
   </rule>
 
   <rule id="87512" level="6">
     <decoded_as>windows-date-format</decoded_as>
     <match>rejected RCPT</match>
-    <description>RCPT rejected. Error: $(error_message)</description>
+    <description>Exim: RCPT rejected. Error: $(error_message)</description>
   </rule>
 
 </group>

--- a/ruleset/testing/tests/exim.ini
+++ b/ruleset/testing/tests/exim.ini
@@ -1,7 +1,7 @@
 ;  Copyright (C) 2015-2021, Wazuh Inc.
 ;
 ;  Tests for products:
-;    Exim4
+;    Exim 4
 ;
 
 [exim auth failure]

--- a/ruleset/testing/tests/exim.ini
+++ b/ruleset/testing/tests/exim.ini
@@ -1,42 +1,42 @@
-[auth failure]
+;  Copyright (C) 2015-2021, Wazuh Inc.
+;
+;  Tests for products:
+;    Exim4
+;
+
+[exim auth failure]
 log 1 pass = 2017-01-23 03:44:14 dovecot_login authenticator failed for (hydra) [10.101.1.18]:35686: 535 Incorrect authentication data (set_id=user)
 log 2 pass = 2017-01-24 05:22:29 dovecot_plain authenticator failed for (test) [::1]:39454: 535 Incorrect authentication data (set_id=test)
-
 rule = 87506
 alert = 5
 decoder = windows-date-format
 
 [exim connection]
 log 1 pass = 2017-01-24 03:09:46 SMTP connection from [10.101.1.10]:55010 (TCP/IP connection count = 1)
-
 rule = 87508
 alert = 0
 decoder = windows-date-format
 
 [exim connection lost]
 log 1 pass = 2017-01-24 02:53:13 SMTP connection from (hydra) [10.101.1.10]:53682 lost
-
 rule = 87509
 alert = 1
 decoder = windows-date-format
 
 [exim syntax/protocol error]
 log 1 pass = 2017-01-24 05:36:23 SMTP call from (000000) [::1]:39480 dropped: too many syntax or protocol errors (last command was "123")
-
 rule = 87510
 alert = 5
 decoder = windows-date-format
 
 [exim protocol synchronization error]
 log 1 pass = 2019-10-20 11:14:38 SMTP protocol synchronization error (input sent without waiting for greeting): rejected connection from H=[134.234.45.34] input="GET / HTTP/1.1\r\nHost: 24.255.212.213:98\r\nUser-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:47.0) Gecko/20100101 Firefox/47.0\r\nAccept: */*\r\n"
-
 rule = 87511
 alert = 6
 decoder = windows-date-format
 
 [exim Unrouteable address]
 log 1 pass = 2019-10-20 09:56:39 H=123-123-12-123.example.example.net [123.123.12.123] F=<example@example.com> rejected RCPT <example@exampley.com>: Unrouteable address
-
 rule = 87512
 alert = 6
 decoder = windows-date-format

--- a/ruleset/testing/tests/exim.ini
+++ b/ruleset/testing/tests/exim.ini
@@ -7,36 +7,36 @@
 [exim auth failure]
 log 1 pass = 2017-01-23 03:44:14 dovecot_login authenticator failed for (hydra) [10.101.1.18]:35686: 535 Incorrect authentication data (set_id=user)
 log 2 pass = 2017-01-24 05:22:29 dovecot_plain authenticator failed for (test) [::1]:39454: 535 Incorrect authentication data (set_id=test)
-rule = 87506
+rule = 87502
 alert = 5
 decoder = windows-date-format
 
 [exim connection]
 log 1 pass = 2017-01-24 03:09:46 SMTP connection from [10.101.1.10]:55010 (TCP/IP connection count = 1)
-rule = 87508
+rule = 87504
 alert = 0
 decoder = windows-date-format
 
 [exim connection lost]
 log 1 pass = 2017-01-24 02:53:13 SMTP connection from (hydra) [10.101.1.10]:53682 lost
-rule = 87509
+rule = 87505
 alert = 1
 decoder = windows-date-format
 
 [exim syntax/protocol error]
 log 1 pass = 2017-01-24 05:36:23 SMTP call from (000000) [::1]:39480 dropped: too many syntax or protocol errors (last command was "123")
-rule = 87510
+rule = 87506
 alert = 5
 decoder = windows-date-format
 
 [exim protocol synchronization error]
 log 1 pass = 2019-10-20 11:14:38 SMTP protocol synchronization error (input sent without waiting for greeting): rejected connection from H=[134.234.45.34] input="GET / HTTP/1.1\r\nHost: 24.255.212.213:98\r\nUser-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:47.0) Gecko/20100101 Firefox/47.0\r\nAccept: */*\r\n"
-rule = 87511
+rule = 87507
 alert = 6
 decoder = windows-date-format
 
 [exim Unrouteable address]
 log 1 pass = 2019-10-20 09:56:39 H=123-123-12-123.example.example.net [123.123.12.123] F=<example@example.com> rejected RCPT <example@exampley.com>: Unrouteable address
-rule = 87512
+rule = 87508
 alert = 6
 decoder = windows-date-format


### PR DESCRIPTION
|Related issue|
|---|
|#9020|

## Description

This PR aims to resolve issues detected under #9020 PR.
The issues resolved are:
- Fixed indentation issues.
- Fixed rule header
- Tests format

## Checks and changes 

### Syntax

- [x] 1.a Rule tags order must be compliant.
- [x] 1.b Decoder tags order must be compliant.
- [x] 1.c XML blocks must as compact as possible.
- [x] 1.d Only one empty line between rule/decoder and the next rule/decoder.
- [x] 1.e Decoder extracted fields names must use '_' whether a space is needed.
- [x] 1.f Decoder name must use '-' whether a space is needed.
 
### Grammar

- [x] 2.a Grammar quality.
- [x] 2.b Similar phrases must keep tenses and expressions.
- [x] 2.c Grammar basic rules like capitalization, punctuation marks, sentence construction, and others.


### Semantic

- [x] 3.a New decoder, rule, or test are written in the correct file and grouped correctly inside the file.
- [x] 3.b Group similar rules under same ID's group.
- [x] 3.c: 
     - [x] 3.c1 Find and reuse group name before creating a new one.
     - [x] 3.c2 Include a new group definition in a PR comment.
     - [x] 3.c3 Any group name must use '_' whether it does need a space char.
     - [x] 3.c4 The groups inside a tag must be sorted in alphabetical order.
- [x] 3.d Rule level should be compliant with the [documentation](https://documentation.wazuh.com/current/user-manual/ruleset/rules-classification.html).

### Unit testing

- [x] 4.a A metadata block at the beginning of the .ini file describing software, version, and logs source.
- [x] 4.b Each new rule must have at least one test entry in the correct .ini file.
- [x] 4.c Runtest.py must pass and must include the results in raw format here.




<details><summary>All rules and decoders test.</summary>
<p>

```
root@ubuntu-focal:/var/ossec/ruleset/feed/testing# python3 runtests.py
Restarting wazuh-manager...
- [ File = ./tests/samba.ini ] ---------
....

- [ File = ./tests/fortigate.ini ] ---------
........................................

- [ File = ./tests/apparmor.ini ] ---------
.....

- [ File = ./tests/pam.ini ] ---------
.....

- [ File = ./tests/audit_lateral.ini ] ---------
......

- [ File = ./tests/systemd.ini ] ---------
..

- [ File = ./tests/arbor.ini ] ---------
..

- [ File = ./tests/dovecot.ini ] ---------
...............

- [ File = ./tests/mailscanner.ini ] ---------
.

- [ File = ./tests/ossec.ini ] ---------
.....

- [ File = ./tests/vuln_detector.ini ] ---------
..

- [ File = ./tests/squid_rules.ini ] ---------
..

- [ File = ./tests/pix.ini ] ---------
......................

- [ File = ./tests/huawei_usg.ini ] ---------
...

- [ File = ./tests/checkpoint_smart1.ini ] ---------
..................

- [ File = ./tests/junos.ini ] ---------
...

- [ File = ./tests/web_appsec.ini ] ---------
...............................

- [ File = ./tests/cimserver.ini ] ---------
..

- [ File = ./tests/cisco_ftd.ini ] ---------
..........................................

- [ File = ./tests/firewalld.ini ] ---------
..

- [ File = ./tests/audit_recon.ini ] ---------
..

- [ File = ./tests/openldap.ini ] ---------
.........

- [ File = ./tests/sophos_fw.ini ] ---------
..........

- [ File = ./tests/owlh.ini ] ---------
....

- [ File = ./tests/freepbx.ini ] ---------
......

- [ File = ./tests/syslog.ini ] ---------
......

- [ File = ./tests/openvpn_ldap.ini ] ---------
..

- [ File = ./tests/sophos.ini ] ---------
........

- [ File = ./tests/unbound.ini ] ---------


- [ File = ./tests/github.ini ] ---------
....................................................................................................................................................................................................................................................................................................................................

- [ File = ./tests/cpanel.ini ] ---------
.......

- [ File = ./tests/fireeye.ini ] ---------
...

- [ File = ./tests/fortiauth.ini ] ---------
....

- [ File = ./tests/iptables.ini ] ---------
........

- [ File = ./tests/named.ini ] ---------
.....

- [ File = ./tests/sophos-utm-firewall.ini ] ---------
......

- [ File = ./tests/nginx.ini ] ---------
............

- [ File = ./tests/exim.ini ] ---------
.......

- [ File = ./tests/opensmtpd.ini ] ---------
.......

- [ File = ./tests/oscap.ini ] ---------
................................

- [ File = ./tests/gitlab.ini ] ---------
.........................

- [ File = ./tests/paloalto.ini ] ---------
................

- [ File = ./tests/api.ini ] ---------
............................

- [ File = ./tests/aws_s3_access.ini ] ---------
.......

- [ File = ./tests/exchange.ini ] ---------
..

- [ File = ./tests/f5_big_ip.ini ] ---------
...........................................

- [ File = ./tests/cisco_asa.ini ] ---------
........................................................................................

- [ File = ./tests/nextcloud.ini ] ---------
.......

- [ File = ./tests/trendmicro-cloud-one.ini ] ---------
.................

- [ File = ./tests/pfsense.ini ] ---------
..

- [ File = ./tests/vsftpd.ini ] ---------
....

- [ File = ./tests/web_rules.ini ] ---------
..........

- [ File = ./tests/apache.ini ] ---------
..................

- [ File = ./tests/eset.ini ] ---------
........

- [ File = ./tests/doas.ini ] ---------
....

- [ File = ./tests/sysmon.ini ] ---------
...

- [ File = ./tests/gcp.ini ] ---------
...........

- [ File = ./tests/icinga.ini ] ---------
....

- [ File = ./tests/postfix.ini ] ---------
..

- [ File = ./tests/audit_scp.ini ] ---------
.

- [ File = ./tests/dropbear.ini ] ---------
...

- [ File = ./tests/rsh.ini ] ---------
..

- [ File = ./tests/kernel_usb.ini ] ---------
......

- [ File = ./tests/mcafee_epo.ini ] ---------
.

- [ File = ./tests/netscreen.ini ] ---------
....

- [ File = ./tests/panda_paps.ini ] ---------
........

- [ File = ./tests/auditd.ini ] ---------
...

- [ File = ./tests/cylance.ini ] ---------
.......

- [ File = ./tests/modsecurity.ini ] ---------
......

- [ File = ./tests/cloudlfare-waf.ini ] ---------
.............

- [ File = ./tests/office365.ini ] ---------
................................................................................................................................

- [ File = ./tests/sshd.ini ] ---------
...........................................

- [ File = ./tests/cisco_ios.ini ] ---------
.................

- [ File = ./tests/glpi.ini ] ---------
...

- [ File = ./tests/sudo.ini ] ---------
........

- [ File = ./tests/su.ini ] ---------
.....

- [ File = ./tests/proftpd.ini ] ---------
.......

- [ File = ./tests/SonicWall.ini ] ---------
........

|Component |  Tested  |  Total   | Coverage |
| -------- | -------- | -------- | -------- |
|  Rules   |   982    |   4174   |  23.53%  |
| Decoders |    76    |   172    |  44.19%  |

|          File           |  Passed  |  Failed  |  Status  |
|        --------         | -------- | -------- | -------- |
|./tests/samba.ini        |    4     |    0     |    ✅     |
|./tests/fortigate.ini    |    40    |    0     |    ✅     |
|./tests/apparmor.ini     |    5     |    0     |    ✅     |
|./tests/pam.ini          |    5     |    0     |    ✅     |
|./tests/audit_lateral.ini|    6     |    0     |    ✅     |
|./tests/systemd.ini      |    2     |    0     |    ✅     |
|./tests/arbor.ini        |    2     |    0     |    ✅     |
|./tests/dovecot.ini      |    15    |    0     |    ✅     |
|./tests/mailscanner.ini  |    1     |    0     |    ✅     |
|./tests/ossec.ini        |    5     |    0     |    ✅     |
|./tests/vuln_detector.ini|    2     |    0     |    ✅     |
|./tests/squid_rules.ini  |    2     |    0     |    ✅     |
|./tests/pix.ini          |    22    |    0     |    ✅     |
|./tests/huawei_usg.ini   |    3     |    0     |    ✅     |
|./tests/checkpoint_smart1.ini|    18    |    0     |    ✅     |
|./tests/junos.ini        |    3     |    0     |    ✅     |
|./tests/web_appsec.ini   |    31    |    0     |    ✅     |
|./tests/cimserver.ini    |    2     |    0     |    ✅     |
|./tests/cisco_ftd.ini    |    42    |    0     |    ✅     |
|./tests/firewalld.ini    |    2     |    0     |    ✅     |
|./tests/audit_recon.ini  |    2     |    0     |    ✅     |
|./tests/openldap.ini     |    9     |    0     |    ✅     |
|./tests/sophos_fw.ini    |    10    |    0     |    ✅     |
|./tests/owlh.ini         |    4     |    0     |    ✅     |
|./tests/freepbx.ini      |    6     |    0     |    ✅     |
|./tests/syslog.ini       |    6     |    0     |    ✅     |
|./tests/openvpn_ldap.ini |    2     |    0     |    ✅     |
|./tests/sophos.ini       |    8     |    0     |    ✅     |
|./tests/unbound.ini      |    0     |    0     |    ✅     |
|./tests/github.ini       |   324    |    0     |    ✅     |
|./tests/cpanel.ini       |    7     |    0     |    ✅     |
|./tests/fireeye.ini      |    3     |    0     |    ✅     |
|./tests/fortiauth.ini    |    4     |    0     |    ✅     |
|./tests/iptables.ini     |    8     |    0     |    ✅     |
|./tests/named.ini        |    5     |    0     |    ✅     |
|./tests/sophos-utm-firewall.ini|    6     |    0     |    ✅     |
|./tests/nginx.ini        |    12    |    0     |    ✅     |
|./tests/exim.ini         |    7     |    0     |    ✅     |
|./tests/opensmtpd.ini    |    7     |    0     |    ✅     |
|./tests/oscap.ini        |    32    |    0     |    ✅     |
|./tests/gitlab.ini       |    25    |    0     |    ✅     |
|./tests/paloalto.ini     |    16    |    0     |    ✅     |
|./tests/api.ini          |    28    |    0     |    ✅     |
|./tests/aws_s3_access.ini|    7     |    0     |    ✅     |
|./tests/exchange.ini     |    2     |    0     |    ✅     |
|./tests/f5_big_ip.ini    |    43    |    0     |    ✅     |
|./tests/cisco_asa.ini    |    88    |    0     |    ✅     |
|./tests/nextcloud.ini    |    7     |    0     |    ✅     |
|./tests/trendmicro-cloud-one.ini|    17    |    0     |    ✅     |
|./tests/pfsense.ini      |    2     |    0     |    ✅     |
|./tests/vsftpd.ini       |    4     |    0     |    ✅     |
|./tests/web_rules.ini    |    10    |    0     |    ✅     |
|./tests/apache.ini       |    18    |    0     |    ✅     |
|./tests/eset.ini         |    8     |    0     |    ✅     |
|./tests/doas.ini         |    4     |    0     |    ✅     |
|./tests/sysmon.ini       |    3     |    0     |    ✅     |
|./tests/gcp.ini          |    11    |    0     |    ✅     |
|./tests/icinga.ini       |    4     |    0     |    ✅     |
|./tests/postfix.ini      |    2     |    0     |    ✅     |
|./tests/audit_scp.ini    |    1     |    0     |    ✅     |
|./tests/dropbear.ini     |    3     |    0     |    ✅     |
|./tests/rsh.ini          |    2     |    0     |    ✅     |
|./tests/kernel_usb.ini   |    6     |    0     |    ✅     |
|./tests/mcafee_epo.ini   |    1     |    0     |    ✅     |
|./tests/netscreen.ini    |    4     |    0     |    ✅     |
|./tests/panda_paps.ini   |    8     |    0     |    ✅     |
|./tests/auditd.ini       |    3     |    0     |    ✅     |
|./tests/cylance.ini      |    7     |    0     |    ✅     |
|./tests/modsecurity.ini  |    6     |    0     |    ✅     |
|./tests/cloudlfare-waf.ini|    13    |    0     |    ✅     |
|./tests/office365.ini    |   128    |    0     |    ✅     |
|./tests/sshd.ini         |    43    |    0     |    ✅     |
|./tests/cisco_ios.ini    |    17    |    0     |    ✅     |
|./tests/glpi.ini         |    3     |    0     |    ✅     |
|./tests/sudo.ini         |    8     |    0     |    ✅     |
|./tests/su.ini           |    5     |    0     |    ✅     |
|./tests/proftpd.ini      |    7     |    0     |    ✅     |
|./tests/SonicWall.ini    |    8     |    0     |    ✅     |
Restarting wazuh-manager...
root@ubuntu-focal:/var/ossec/ruleset/feed/testing# 
```
</p>
</details>

- [x] 4.d New CDB lists must include the proper test entry in the correct .ini file.

### E2E testing

- [x] 5.a Logs for new or modified decoder/rules sent to a manager running with this PR ruleset appear in Kibana.


- [x] 5.b There are not affected or broken visualizations on Kibana.


- [x] 5.c New or modified items can be seen correctly using APP ruleset navigation.


### Elasticsearch Template

- [x] 6.a Known fields with output format managed and usually used for searching are included in template array index.query.default_field. 
- [x] 6.b The new field with the correct date format is stored as a "date" type field in the template.
- [x] 6.c The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 
- [x] 6.d Known fields with output format managed and usually used for searching are included in the template.

### Stoppers

- [x] 7.a No previous rule ID changes without triple check.
- [x] 7.b No previous decoder name changes without triple check.
- [x] 7.c No previous file name changes without triple check.
- [x] 7.d No previous test changes its 'rule' field value without triple check.

### Others

- [x] 8.a Each file has the correct copyright block.
- [x] 8.b The copyright block doesn't have "Author" only "Created by Wazuh". To include an "Author" request triple check.
- [x] 8.c The copyright block doesn't use "-". 
- [x] 8.d The rule files don't have any sample log.
- [x] 8.e The decoder file has sample logs next to the decoder that matches that log.
- [x] 8.f The decoder and rule files have information about software, version, and any helpful information.
- [x] 8.g The PR has a single commit with CHANGELOG changes in the correct format.
- [x] 8.h The new rule ID is not in use.
- [x] 8.i The new rule ID must be in the defined IDs range. 
- [x] 8.j New rules ID range must be verified with a triple check and noted in the rules ID document.
- [x] 8.k The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 