### PR TITLE
Rework PR #8969 - Add rules for GCP VPC logs

### DIFF
--- a/ruleset/rules/0690-gcp_rules.xml
+++ b/ruleset/rules/0690-gcp_rules.xml
@@ -14,273 +14,273 @@ ID: 65000 - 65499
         <decoded_as>json</decoded_as>
         <field name="integration">gcp</field>
         <options>no_full_log</options>
-        <description>GCP alert.</description>
+        <description>GCP: alert.</description>
     </rule>
 
     <rule id="65001" level="0">
         <if_sid>65000</if_sid>
         <field name="gcp.resource.type">^dns_query$</field>
         <options>no_full_log</options>
-        <description>GCP dns query event</description>
+        <description>GCP: DNS query event.</description>
     </rule>
 
     <rule id="65002" level="0">
         <if_sid>65001</if_sid>
         <field name="gcp.resource.labels.source_type">^internet$</field>
         <options>no_full_log</options>
-        <description>GCP internet event</description>
+        <description>GCP: internet event.</description>
     </rule>
 
     <rule id="65003" level="0">
         <if_sid>65001</if_sid>
         <field name="gcp.resource.labels.source_type">^gce-vm$</field>
         <options>no_full_log</options>
-        <description>GCP virtual machine event</description>
+        <description>GCP: virtual machine event.</description>
     </rule>
 
     <rule id="65004" level="2">
         <if_sid>65002</if_sid>
         <field name="gcp.severity">^INFO$</field>
         <options>no_full_log</options>
-        <description>GCP info event with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
+        <description>GCP: info event with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode).</description>
     </rule>
 
     <rule id="65005" level="5">
         <if_sid>65002</if_sid>
         <field name="gcp.severity">^WARNING$</field>
         <options>no_full_log</options>
-        <description>GCP warning event with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
+        <description>GCP: warning event with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode).</description>
     </rule>
 
     <rule id="65006" level="3">
         <if_sid>65002</if_sid>
         <field name="gcp.severity">^NOTICE$</field>
         <options>no_full_log</options>
-        <description>GCP notice event with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
+        <description>GCP: notice event with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode).</description>
     </rule>
 
     <rule id="65007" level="7">
         <if_sid>65002</if_sid>
         <field name="gcp.severity">^ERROR$</field>
         <options>no_full_log</options>
-        <description>GCP error with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
+        <description>GCP: error with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode).</description>
     </rule>
 
     <rule id="65008" level="9">
         <if_sid>65002</if_sid>
         <field name="gcp.severity">^CRITICAL$</field>
         <options>no_full_log</options>
-        <description>GCP critical event with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
+        <description>GCP: critical event with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode).</description>
     </rule>
 
     <rule id="65009" level="11">
         <if_sid>65002</if_sid>
         <field name="gcp.severity">^ALERT$</field>
         <options>no_full_log</options>
-        <description>GCP alert event with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
+        <description>GCP: alert event with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode).</description>
     </rule>
 
     <rule id="65010" level="12">
         <if_sid>65002</if_sid>
         <field name="gcp.severity">^EMERGENCY$</field>
         <options>no_full_log</options>
-        <description>GCP emergency event with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
+        <description>GCP: emergency event with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode).</description>
     </rule>
 
     <rule id="65011" level="2">
         <if_sid>65003</if_sid>
         <field name="gcp.severity">^INFO$</field>
         <options>no_full_log</options>
-        <description>GCP info event from VM $(gcp.jsonPayload.vmInstanceName) with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
+        <description>GCP: info event from VM $(gcp.jsonPayload.vmInstanceName) with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode).</description>
     </rule>
 
     <rule id="65012" level="5">
         <if_sid>65003</if_sid>
         <field name="gcp.severity">^WARNING$</field>
         <options>no_full_log</options>
-        <description>GCP warning event from VM $(gcp.jsonPayload.vmInstanceName) with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
+        <description>GCP: warning event from VM $(gcp.jsonPayload.vmInstanceName) with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode).</description>
     </rule>
 
     <rule id="65013" level="3">
         <if_sid>65003</if_sid>
         <field name="gcp.severity">^NOTICE$</field>
         <options>no_full_log</options>
-        <description>GCP notice event from VM $(gcp.jsonPayload.vmInstanceName) with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
+        <description>GCP: notice event from VM $(gcp.jsonPayload.vmInstanceName) with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode).</description>
     </rule>
 
     <rule id="65014" level="7">
         <if_sid>65003</if_sid>
         <field name="gcp.severity">^ERROR$</field>
         <options>no_full_log</options>
-        <description>GCP error event from VM $(gcp.jsonPayload.vmInstanceName) with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
+        <description>GCP: error event from VM $(gcp.jsonPayload.vmInstanceName) with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode).</description>
     </rule>
 
     <rule id="65015" level="9">
         <if_sid>65003</if_sid>
         <field name="gcp.severity">^CRITICAL$</field>
         <options>no_full_log</options>
-        <description>GCP critical event from VM $(gcp.jsonPayload.vmInstanceName) with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
+        <description>GCP: critical event from VM $(gcp.jsonPayload.vmInstanceName) with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode).</description>
     </rule>
 
     <rule id="65016" level="11">
         <if_sid>65003</if_sid>
         <field name="gcp.severity">^ALERT$</field>
         <options>no_full_log</options>
-        <description>GCP alert event from VM $(gcp.jsonPayload.vmInstanceName) with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
+        <description>GCP: alert event from VM $(gcp.jsonPayload.vmInstanceName) with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode).</description>
     </rule>
 
     <rule id="65017" level="12">
         <if_sid>65003</if_sid>
         <field name="gcp.severity">^EMERGENCY$</field>
         <options>no_full_log</options>
-        <description>GCP emergency event from VM $(gcp.jsonPayload.vmInstanceName) with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
+        <description>GCP: emergency event from VM $(gcp.jsonPayload.vmInstanceName) with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode).</description>
     </rule>
 
     <rule id="65018" level="10">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^ERROR$</field>
         <options>no_full_log</options>
-        <description>GCP error with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
+        <description>GCP: error with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity).</description>
     </rule>
 
     <rule id="65019" level="5">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^NXDOMAIN$</field>
         <options>no_full_log</options>
-        <description>Unable to resolve domain name with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
+        <description>GCP: Unable to resolve domain name with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity).</description>
     </rule>
 
     <rule id="65020" level="12">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^SERVFAIL$</field>
         <options>no_full_log</options>
-        <description>Unable to process query due to a problem with the name server with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
+        <description>GCP: Unable to process query due to a problem with the name server with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity).</description>
     </rule>
 
     <rule id="65021" level="5">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^FORMERR$</field>
         <options>no_full_log</options>
-        <description>Unable to interpret query with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
+        <description>GCP: Unable to interpret query with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity).</description>
     </rule>
 
     <rule id="65022" level="5">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^NOTIMP$</field>
         <options>no_full_log</options>
-        <description>Unsupported requested query with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
+        <description>GCP: Unsupported requested query with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity).</description>
     </rule>
 
     <rule id="65023" level="5">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^REFUSED$</field>
         <options>no_full_log</options>
-        <description>Refuse to perform the specified operation for policy reasons with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
+        <description>GCP: Refuse to perform the specified operation for policy reasons with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity).</description>
     </rule>
 
     <rule id="65024" level="10">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^YXDOMAIN$</field>
         <options>no_full_log</options>
-        <description>Specified name already created, when it ought not to exist with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
+        <description>GCP: Specified name already created, when it ought not to exist with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity).</description>
     </rule>
 
     <rule id="65025" level="10">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^YXRRSET$</field>
         <options>no_full_log</options>
-        <description>The specified RR Set already exists with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
+        <description>GCP: The specified RR Set already exists with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity).</description>
     </rule>
 
     <rule id="65026" level="10">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^NXRRSET$</field>
         <options>no_full_log</options>
-        <description>The specified RR Set does not exist, and should with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
+        <description>GCP: The specified RR Set does not exist, and should with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity).</description>
     </rule>
 
     <rule id="65027" level="10">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^NOTAUTH$</field>
         <options>no_full_log</options>
-        <description>Server not authoritative for zone with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
+        <description>GCP: Server not authoritative for zone with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity).</description>
     </rule>
 
     <rule id="65028" level="7">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^NOTZONE$</field>
         <options>no_full_log</options>
-        <description>Name not contained in zone with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
+        <description>GCP: Name not contained in zone with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity).</description>
     </rule>
 
     <rule id="65029" level="5">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^DSOTYPENI$</field>
         <options>no_full_log</options>
-        <description>DSO-TYPE not implemented with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
+        <description>GCP: DSO-TYPE not implemented with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity).</description>
     </rule>
 
     <rule id="65030" level="10">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^BADVERS$</field>
         <options>no_full_log</options>
-        <description>Bad OPT version with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
+        <description>GCP: Bad OPT version with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity).</description>
     </rule>
 
     <rule id="65031" level="7">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^BADSIG$</field>
         <options>no_full_log</options>
-        <description>TSIG Signature Failure with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
+        <description>GCP: TSIG Signature Failure with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity).</description>
     </rule>
 
     <rule id="65032" level="7">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^BADKEY$</field>
         <options>no_full_log</options>
-        <description>Key not recognized with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
+        <description>GCP: Key not recognized with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity).</description>
     </rule>
 
     <rule id="65033" level="7">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^BADTIME$</field>
         <options>no_full_log</options>
-        <description>Signature out of time window with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
+        <description>GCP: Signature out of time window with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity).</description>
     </rule>
 
     <rule id="65034" level="7">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^BADMODE$</field>
         <options>no_full_log</options>
-        <description>Bad TKEY Mode with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
+        <description>GCP: Bad TKEY Mode with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity).</description>
     </rule>
 
     <rule id="65035" level="7">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^BADNAME$</field>
         <options>no_full_log</options>
-        <description>Duplicate key name with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
+        <description>GCP: Duplicate key name with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity).</description>
     </rule>
 
     <rule id="65036" level="7">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^BADALG$</field>
         <options>no_full_log</options>
-        <description>Algorithm not supported with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
+        <description>GCP: Algorithm not supported with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity).</description>
     </rule>
 
     <rule id="65037" level="7">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^BADTRUNC$</field>
         <options>no_full_log</options>
-        <description>Bad Truncation with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
+        <description>GCP: Bad Truncation with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity).</description>
     </rule>
 
     <rule id="65038" level="7">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^BADCOOKIE$</field>
         <options>no_full_log</options>
-        <description>Bad/missing Server Cookie with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
+        <description>GCP: Bad/missing Server Cookie with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity).</description>
     </rule>
 
     <!-- Mitre detection rules  -->
@@ -289,7 +289,7 @@ ID: 65000 - 65499
         <if_sid>65000</if_sid>
         <field name="gcp.protoPayload.methodName" type="pcre2">^google\.pubsub\.v\d*\.Subscriber\.CreateSubscription$</field>
         <field name="gcp.protoPayload.authorizationInfo" type="pcre2">"granted":\strue</field>
-        <description>GCP pub/sub topic subscription created</description>
+        <description>GCP: pub/sub topic subscription created.</description>
         <mitre>
             <id>T1530</id>
         </mitre>
@@ -300,7 +300,7 @@ ID: 65000 - 65499
         <if_sid>65000</if_sid>
         <field name="gcp.protoPayload.methodName" type="pcre2">^google\.pubsub\.v\d*\.Publisher\.CreateTopic$</field>
         <field name="gcp.protoPayload.authorizationInfo" type="pcre2">"granted":\strue</field>
-        <description>GCP pub/sub topic created</description>
+        <description>GCP: pub/sub topic created.</description>
         <mitre>
             <id>T1530</id>
         </mitre>
@@ -310,7 +310,7 @@ ID: 65000 - 65499
     <rule id="65053" level="3">
         <if_sid>65000</if_sid>
         <field name="gcp.protoPayload.methodName" type="pcre2">^v\d*\.compute\.firewalls\.insert$</field>
-        <description>GCP firewall rule created</description>
+        <description>GCP: firewall rule created.</description>
         <mitre>
             <id>T1562</id>
         </mitre>
@@ -320,7 +320,7 @@ ID: 65000 - 65499
     <rule id="65054" level="3">
         <if_sid>65000</if_sid>
         <field name="gcp.protoPayload.methodName" type="pcre2">^v\d*\.compute\.firewalls\.delete$</field>
-        <description>GCP firewall rule deleted</description>
+        <description>GCP: firewall rule deleted.</description>
         <mitre>
             <id>T1562.007</id>
         </mitre>
@@ -330,7 +330,7 @@ ID: 65000 - 65499
     <rule id="65055" level="3">
         <if_sid>65000</if_sid>
         <field name="gcp.protoPayload.methodName" type="pcre2">^v\d*\.compute\.firewalls\.patch$</field>
-        <description>GCP firewall rule modified</description>
+        <description>GCP: firewall rule modified.</description>
         <mitre>
             <id>T1562.007</id>
         </mitre>
@@ -341,7 +341,7 @@ ID: 65000 - 65499
         <if_sid>65000</if_sid>
         <field name="gcp.protoPayload.methodName" type="pcre2">^google\.logging\.v\d*\.ConfigServiceV\d*\.DeleteBucket$</field>
         <field name="gcp.protoPayload.authorizationInfo" type="pcre2">"granted":\strue</field>
-        <description>GCP logging bucket deleted</description>
+        <description>GCP: logging bucket deleted.</description>
         <mitre>
             <id>T1562.008</id>
         </mitre>
@@ -352,7 +352,7 @@ ID: 65000 - 65499
         <if_sid>65000</if_sid>
         <field name="gcp.protoPayload.methodName" type="pcre2">^google\.logging\.v\d*\.ConfigServiceV\*\.DeleteSink$</field>
         <field name="gcp.protoPayload.authorizationInfo" type="pcre2">"granted":\strue</field>
-        <description>GCP logging sink deleted</description>
+        <description>GCP: logging sink deleted.</description>
         <mitre>
             <id>T1562.008</id>
         </mitre>
@@ -363,7 +363,7 @@ ID: 65000 - 65499
         <if_sid>65000</if_sid>
         <field name="gcp.protoPayload.methodName" type="pcre2">^google\.pubsub\.v\d*\.Subscriber\.DeleteSubscription$</field>
         <field name="gcp.protoPayload.authorizationInfo" type="pcre2">"granted":\strue</field>
-        <description>GCP pub/sub subscription deleted</description>
+        <description>GCP: pub/sub subscription deleted.</description>
         <mitre>
             <id>T1562</id>
         </mitre>
@@ -374,7 +374,7 @@ ID: 65000 - 65499
         <if_sid>65000</if_sid>
         <field name="gcp.protoPayload.methodName" type="pcre2">^google\.pubsub\.v\d*\.Publisher\.DeleteTopic$</field>
         <field name="gcp.protoPayload.authorizationInfo" type="pcre2">"granted":\strue</field>
-        <description>GCP pub/sub topic deleted</description>
+        <description>GCP: pub/sub topic deleted.</description>
         <mitre>
             <id>T1562</id>
         </mitre>
@@ -385,7 +385,7 @@ ID: 65000 - 65499
         <if_sid>65000</if_sid>
         <field name="gcp.protoPayload.methodName" type="pcre2">^storage\.buckets\.update$</field>
         <field name="gcp.protoPayload.authorizationInfo" type="pcre2">"granted":\strue</field>
-        <description>GCP storage bucket configuration modified</description>
+        <description>GCP: storage bucket configuration modified.</description>
         <mitre>
             <id>T1222</id>
         </mitre>
@@ -396,7 +396,7 @@ ID: 65000 - 65499
         <if_sid>65000</if_sid>
         <field name="gcp.protoPayload.methodName" type="pcre2">^sstorage\.setIamPermissions$</field>
         <field name="gcp.protoPayload.authorizationInfo" type="pcre2">"granted":\strue</field>
-        <description>GCP storage bucket permissions modified</description>
+        <description>GCP: storage bucket permissions modified.</description>
         <mitre>
             <id>T1222</id>
         </mitre>
@@ -407,7 +407,7 @@ ID: 65000 - 65499
         <if_sid>65000</if_sid>
         <field name="gcp.protoPayload.methodName" type="pcre2">^sgoogle\.logging\.v\d*\.ConfigServiceV\d*\.UpdateSink$</field>
         <field name="gcp.protoPayload.authorizationInfo" type="pcre2">"granted":\strue</field>
-        <description>GCP logging sink modified</description>
+        <description>GCP: logging sink modified.</description>
         <mitre>
             <id>T1537</id>
         </mitre>
@@ -418,7 +418,7 @@ ID: 65000 - 65499
         <if_sid>65000</if_sid>
         <field name="gcp.protoPayload.methodName" type="pcre2">^sgoogle\.iam\.admin\.v\d*\.DeleteRole$</field>
         <field name="gcp.protoPayload.authorizationInfo" type="pcre2">"granted":\strue</field>
-        <description>GCP IAM role deleted</description>
+        <description>GCP: IAM role deleted.</description>
         <mitre>
             <id>T1531</id>
         </mitre>
@@ -429,7 +429,7 @@ ID: 65000 - 65499
         <if_sid>65000</if_sid>
         <field name="gcp.protoPayload.methodName" type="pcre2">^sgoogle\.iam\.admin\.v\d*\.DeleteServiceAccount$</field>
         <field name="gcp.protoPayload.authorizationInfo" type="pcre2">"granted":\strue</field>
-        <description>GCP service account deleted</description>
+        <description>GCP: service account deleted.</description>
         <mitre>
             <id>T1531</id>
         </mitre>
@@ -440,7 +440,7 @@ ID: 65000 - 65499
         <if_sid>65000</if_sid>
         <field name="gcp.protoPayload.methodName" type="pcre2">^google\.iam\.admin\.v\d*\.DisableServiceAccount$</field>
         <field name="gcp.protoPayload.authorizationInfo" type="pcre2">"granted":\strue</field>
-        <description>GCP Service account disabled</description>
+        <description>GCP: Service account disabled.</description>
         <mitre>
             <id>T1531</id>
         </mitre>
@@ -451,7 +451,7 @@ ID: 65000 - 65499
         <if_sid>65000</if_sid>
         <field name="gcp.protoPayload.methodName" type="pcre2">^storage\.buckets\.delete$</field>
         <field name="gcp.protoPayload.authorizationInfo" type="pcre2">"granted":\strue</field>
-        <description>GCP storage bucket deleted</description>
+        <description>GCP: storage bucket deleted.</description>
         <mitre>
             <id>T1485</id>
         </mitre>
@@ -462,7 +462,7 @@ ID: 65000 - 65499
         <if_sid>65000</if_sid>
         <field name="gcp.protoPayload.methodName" type="pcre2">^v\d*\.compute\.networks\.delete$</field>
         <field name="gcp.protoPayload.authorizationInfo" type="pcre2">"granted":\strue</field>
-        <description>GCP Virtual Private Cloud (VPC) network deleted</description>
+        <description>GCP: Virtual Private Cloud (VPC) network deleted.</description>
     </rule>
 
     <!-- impact gcp_virtual_private_cloud_route created -->
@@ -470,7 +470,7 @@ ID: 65000 - 65499
         <if_sid>65000</if_sid>
         <field name="gcp.protoPayload.methodName" type="pcre2">^v\d*\.compute\.routes\.insert$|^beta\.compute\.routes\.insert$</field>
         <field name="gcp.protoPayload.authorizationInfo" type="pcre2">"granted":\strue</field>
-        <description>GCP Virtual Private Cloud (VPC) route created</description>
+        <description>GCP: Virtual Private Cloud (VPC) route created.</description>
     </rule>
 
     <!-- impact gcp_virtual_private_cloud_route deleted -->
@@ -478,7 +478,7 @@ ID: 65000 - 65499
         <if_sid>65000</if_sid>
         <field name="gcp.protoPayload.methodName" type="pcre2">^v\d*\.compute\.routes\.delete$</field>
         <field name="gcp.protoPayload.authorizationInfo" type="pcre2">"granted":\strue</field>
-        <description>GCP Virtual Private Cloud (VPC) route deleted</description>
+        <description>GCP: Virtual Private Cloud (VPC) route deleted.</description>
     </rule>
 
     <!-- persistence gcp_service_account created -->
@@ -486,7 +486,7 @@ ID: 65000 - 65499
         <if_sid>65000</if_sid>
         <field name="gcp.protoPayload.methodName" type="pcre2">^google\.iam\.admin\.v\d*\.CreateServiceAccount$</field>
         <field name="gcp.protoPayload.authorizationInfo" type="pcre2">"granted":\strue</field>
-        <description>GCP New service account created</description>
+        <description>GCP: New service account created.</description>
         <mitre>
             <id>T1136.003</id>
         </mitre>
@@ -497,7 +497,7 @@ ID: 65000 - 65499
         <if_sid>65000</if_sid>
         <field name="gcp.protoPayload.methodName" type="pcre2">^event\.action:google\.iam\.admin\.v\d*\.CreateServiceAccountKey$</field>
         <field name="gcp.protoPayload.authorizationInfo" type="pcre2">"granted":\strue</field>
-        <description>GCP New key is created for a service account</description>
+        <description>GCP: New key is created for a service account.</description>
         <mitre>
             <id>T1098.001</id>
         </mitre>
@@ -508,7 +508,7 @@ ID: 65000 - 65499
         <if_sid>65000</if_sid>
         <field name="gcp.protoPayload.methodName" type="pcre2">^event\.action:google\.iam\.admin\.v\d*\.DeleteServiceAccountKey$</field>
         <field name="gcp.protoPayload.authorizationInfo" type="pcre2">"granted":\strue</field>
-        <description>GCP Identity and Access Management (IAM) service account key deleted</description>
+        <description>GCP: Identity and Access Management (IAM) service account key deleted.</description>
         <mitre>
             <id>T1531</id>
         </mitre>
@@ -519,7 +519,7 @@ ID: 65000 - 65499
         <if_sid>65000</if_sid>
         <field name="gcp.protoPayload.methodName" type="pcre2">^event\.action:google\.iam\.admin\.v\d*\.CreateRole$</field>
         <field name="gcp.protoPayload.authorizationInfo" type="pcre2">"granted":\strue</field>
-        <description>GCP Identity and Access Management (IAM) custom role created</description>
+        <description>GCP: Identity and Access Management (IAM) custom role created.</description>
         <mitre>
             <id>T1098.001</id>
         </mitre>
@@ -530,56 +530,56 @@ ID: 65000 - 65499
         <if_sid>65000</if_sid>
         <field name="gcp.severity">^DEFAULT$</field>
         <options>no_full_log</options>
-        <description>A GCP event with no severity information happened on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type)</description>
+        <description>A GCP event with no severity information happened on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type).</description>
     </rule>
 
     <rule id="65040" level="2">
         <if_sid>65000</if_sid>
         <field name="gcp.severity">^INFO$</field>
         <options>no_full_log</options>
-        <description>GCP information event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type)</description>
+        <description>GCP: information event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type).</description>
     </rule>
 
     <rule id="65041" level="5">
         <if_sid>65000</if_sid>
         <field name="gcp.severity">^WARNING$</field>
         <options>no_full_log</options>
-        <description>GCP warning event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type)</description>
+        <description>GCP: warning event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type).</description>
     </rule>
 
     <rule id="65042" level="3">
         <if_sid>65000</if_sid>
         <field name="gcp.severity">^NOTICE$</field>
         <options>no_full_log</options>
-        <description>GCP notice event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type)</description>
+        <description>GCP: notice event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type).</description>
     </rule>
 
     <rule id="65043" level="7">
         <if_sid>65000</if_sid>
         <field name="gcp.severity">^ERROR$</field>
         <options>no_full_log</options>
-        <description>GCP error event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type)</description>
+        <description>GCP: error event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type).</description>
     </rule>
 
     <rule id="65044" level="9">
         <if_sid>65000</if_sid>
         <field name="gcp.severity">^CRITICAL$</field>
         <options>no_full_log</options>
-        <description>GCP critical event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type)</description>
+        <description>GCP: critical event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type).</description>
     </rule>
 
     <rule id="65045" level="11">
         <if_sid>65000</if_sid>
         <field name="gcp.severity">^ALERT$</field>
         <options>no_full_log</options>
-        <description>GCP alert event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type)</description>
+        <description>GCP: alert event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type).</description>
     </rule>
 
     <rule id="65046" level="12">
         <if_sid>65000</if_sid>
         <field name="gcp.severity">^EMERGENCY$</field>
         <options>no_full_log</options>
-        <description>GCP emergency event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type)</description>
+        <description>GCP: emergency event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type).</description>
     </rule>
 
     <!-- VPC Firewall rules -->
@@ -587,21 +587,21 @@ ID: 65000 - 65499
         <if_sid>65000</if_sid>
         <field name="gcp.jsonPayload.rule_details.reference" type="pcre2">^(?!^$).*</field>
         <options>no_full_log</options>
-        <description>GCP VPC Firewall event</description>
+        <description>GCP: VPC Firewall event.</description>
     </rule>
 
     <rule id="65048" level="5">
         <if_sid>65047</if_sid>
         <field name="gcp.jsonPayload.rule_details.action">DENY</field>
         <options>no_full_log</options>
-        <description>GCP VPC Firewall: DENY rule triggered</description>
+        <description>GCP: VPC Firewall: DENY rule triggered.</description>
     </rule>
 
     <rule id="65049" level="3">
         <if_sid>65047</if_sid>
         <field name="gcp.jsonPayload.rule_details.action">ALLOW</field>
         <options>no_full_log</options>
-        <description>GCP VPC Firewall: ALLOW rule triggered</description>
+        <description>GCP: VPC Firewall: ALLOW rule triggered.</description>
     </rule>
 
     <!-- GCP VPC Flow -->
@@ -609,7 +609,7 @@ ID: 65000 - 65499
         <if_sid>65000</if_sid>
         <field name="gcp.jsonPayload.reporter" type="pcre2">^(?!^$).*</field>
         <options>no_full_log</options>
-        <description>GCP VPC Flow event</description>
+        <description>GCP: VPC Flow event.</description>
     </rule>
 
     <!-- GCP VPC Usage rules-->
@@ -617,14 +617,14 @@ ID: 65000 - 65499
         <if_sid>65000</if_sid>
         <field name="gcp.s_request_id" type="pcre2">^(?!^$).+$</field>
         <options>no_full_log</options>
-        <description>GCP VPC Usage event</description>
+        <description>GCP: VPC Usage event.</description>
     </rule>
 
     <!-- GCP VPC Storage rules-->
     <rule id="65075" level="2">
         <if_sid>65000</if_sid>
         <field name="gcp.bucket" type="pcre2">^(?!^$).+$</field>
-        <description>GCP VPC Storage event</description>
+        <description>GCP: VPC Storage event.</description>
     </rule>
 
 </group>

--- a/ruleset/rules/0690-gcp_rules.xml
+++ b/ruleset/rules/0690-gcp_rules.xml
@@ -371,7 +371,7 @@ ID: 65000 - 65499
         <!-- Mitre detection rules  -->
     <!-- collection gcp_pub_sub subscription creation -->
     <rule id="65051" level="3">
-        <if_sid>65000</if_sid>
+        <if_sid>65042</if_sid>
         <field name="gcp.protoPayload.methodName" type="pcre2">^google\.pubsub\.v\d*\.Subscriber\.CreateSubscription$</field>
         <field name="gcp.protoPayload.authorizationInfo" type="pcre2">"granted":\strue</field>
         <description>GCP: pub/sub topic subscription created.</description>
@@ -382,7 +382,7 @@ ID: 65000 - 65499
 
     <!-- collection gcp_pub_sub topic creation -->
     <rule id="65052" level="3">
-        <if_sid>65000</if_sid>
+        <if_sid>65042</if_sid>
         <field name="gcp.protoPayload.methodName" type="pcre2">^google\.pubsub\.v\d*\.Publisher\.CreateTopic$</field>
         <field name="gcp.protoPayload.authorizationInfo" type="pcre2">"granted":\strue</field>
         <description>GCP: pub/sub topic created.</description>
@@ -413,7 +413,7 @@ ID: 65000 - 65499
 
     <!-- defense evasion gcp_firewall_rule modified -->
     <rule id="65055" level="3">
-        <if_sid>65000</if_sid>
+        <if_sid>65042</if_sid>
         <field name="gcp.protoPayload.methodName" type="pcre2">^v\d*\.compute\.firewalls\.patch$</field>
         <description>GCP: firewall rule modified.</description>
         <mitre>

--- a/ruleset/rules/0690-gcp_rules.xml
+++ b/ruleset/rules/0690-gcp_rules.xml
@@ -13,274 +13,274 @@ ID: 65000 - 65499
     <rule id="65000" level="0">
         <decoded_as>json</decoded_as>
         <field name="integration">gcp</field>
-        <description>GCP alert.</description>
         <options>no_full_log</options>
+        <description>GCP alert.</description>
     </rule>
 
     <rule id="65001" level="0">
         <if_sid>65000</if_sid>
         <field name="gcp.resource.type">^dns_query$</field>
-        <description>GCP dns query event</description>
         <options>no_full_log</options>
+        <description>GCP dns query event</description>
     </rule>
 
     <rule id="65002" level="0">
         <if_sid>65001</if_sid>
         <field name="gcp.resource.labels.source_type">^internet$</field>
-        <description>GCP internet event</description>
         <options>no_full_log</options>
+        <description>GCP internet event</description>
     </rule>
 
     <rule id="65003" level="0">
         <if_sid>65001</if_sid>
         <field name="gcp.resource.labels.source_type">^gce-vm$</field>
-        <description>GCP virtual machine event</description>
         <options>no_full_log</options>
+        <description>GCP virtual machine event</description>
     </rule>
 
     <rule id="65004" level="2">
         <if_sid>65002</if_sid>
         <field name="gcp.severity">^INFO$</field>
-        <description>GCP info event with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
         <options>no_full_log</options>
+        <description>GCP info event with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
     </rule>
 
     <rule id="65005" level="5">
         <if_sid>65002</if_sid>
         <field name="gcp.severity">^WARNING$</field>
-        <description>GCP warning event with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
         <options>no_full_log</options>
+        <description>GCP warning event with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
     </rule>
 
     <rule id="65006" level="3">
         <if_sid>65002</if_sid>
         <field name="gcp.severity">^NOTICE$</field>
-        <description>GCP notice event with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
         <options>no_full_log</options>
+        <description>GCP notice event with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
     </rule>
 
     <rule id="65007" level="7">
         <if_sid>65002</if_sid>
         <field name="gcp.severity">^ERROR$</field>
-        <description>GCP error with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
         <options>no_full_log</options>
+        <description>GCP error with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
     </rule>
 
     <rule id="65008" level="9">
         <if_sid>65002</if_sid>
         <field name="gcp.severity">^CRITICAL$</field>
-        <description>GCP critical event with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
         <options>no_full_log</options>
+        <description>GCP critical event with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
     </rule>
 
     <rule id="65009" level="11">
         <if_sid>65002</if_sid>
         <field name="gcp.severity">^ALERT$</field>
-        <description>GCP alert event with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
         <options>no_full_log</options>
+        <description>GCP alert event with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
     </rule>
 
     <rule id="65010" level="12">
         <if_sid>65002</if_sid>
         <field name="gcp.severity">^EMERGENCY$</field>
-        <description>GCP emergency event with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
         <options>no_full_log</options>
+        <description>GCP emergency event with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
     </rule>
 
     <rule id="65011" level="2">
         <if_sid>65003</if_sid>
         <field name="gcp.severity">^INFO$</field>
-        <description>GCP info event from VM $(gcp.jsonPayload.vmInstanceName) with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
         <options>no_full_log</options>
+        <description>GCP info event from VM $(gcp.jsonPayload.vmInstanceName) with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
     </rule>
 
     <rule id="65012" level="5">
         <if_sid>65003</if_sid>
         <field name="gcp.severity">^WARNING$</field>
-        <description>GCP warning event from VM $(gcp.jsonPayload.vmInstanceName) with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
         <options>no_full_log</options>
+        <description>GCP warning event from VM $(gcp.jsonPayload.vmInstanceName) with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
     </rule>
 
     <rule id="65013" level="3">
         <if_sid>65003</if_sid>
         <field name="gcp.severity">^NOTICE$</field>
-        <description>GCP notice event from VM $(gcp.jsonPayload.vmInstanceName) with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
         <options>no_full_log</options>
+        <description>GCP notice event from VM $(gcp.jsonPayload.vmInstanceName) with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
     </rule>
 
     <rule id="65014" level="7">
         <if_sid>65003</if_sid>
         <field name="gcp.severity">^ERROR$</field>
-        <description>GCP error event from VM $(gcp.jsonPayload.vmInstanceName) with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
         <options>no_full_log</options>
+        <description>GCP error event from VM $(gcp.jsonPayload.vmInstanceName) with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
     </rule>
 
     <rule id="65015" level="9">
         <if_sid>65003</if_sid>
         <field name="gcp.severity">^CRITICAL$</field>
-        <description>GCP critical event from VM $(gcp.jsonPayload.vmInstanceName) with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
         <options>no_full_log</options>
+        <description>GCP critical event from VM $(gcp.jsonPayload.vmInstanceName) with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
     </rule>
 
     <rule id="65016" level="11">
         <if_sid>65003</if_sid>
         <field name="gcp.severity">^ALERT$</field>
-        <description>GCP alert event from VM $(gcp.jsonPayload.vmInstanceName) with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
         <options>no_full_log</options>
+        <description>GCP alert event from VM $(gcp.jsonPayload.vmInstanceName) with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
     </rule>
 
     <rule id="65017" level="12">
         <if_sid>65003</if_sid>
         <field name="gcp.severity">^EMERGENCY$</field>
-        <description>GCP emergency event from VM $(gcp.jsonPayload.vmInstanceName) with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
         <options>no_full_log</options>
+        <description>GCP emergency event from VM $(gcp.jsonPayload.vmInstanceName) with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location) with response code $(gcp.jsonPayload.responseCode)</description>
     </rule>
 
     <rule id="65018" level="10">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^ERROR$</field>
-        <description>GCP error with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
         <options>no_full_log</options>
+        <description>GCP error with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
     </rule>
 
     <rule id="65019" level="5">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^NXDOMAIN$</field>
-        <description>Unable to resolve domain name with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
         <options>no_full_log</options>
+        <description>Unable to resolve domain name with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
     </rule>
 
     <rule id="65020" level="12">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^SERVFAIL$</field>
-        <description>Unable to process query due to a problem with the name server with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
         <options>no_full_log</options>
+        <description>Unable to process query due to a problem with the name server with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
     </rule>
 
     <rule id="65021" level="5">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^FORMERR$</field>
-        <description>Unable to interpret query with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
         <options>no_full_log</options>
+        <description>Unable to interpret query with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
     </rule>
 
     <rule id="65022" level="5">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^NOTIMP$</field>
-        <description>Unsupported requested query with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
         <options>no_full_log</options>
+        <description>Unsupported requested query with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
     </rule>
 
     <rule id="65023" level="5">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^REFUSED$</field>
-        <description>Refuse to perform the specified operation for policy reasons with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
         <options>no_full_log</options>
+        <description>Refuse to perform the specified operation for policy reasons with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
     </rule>
 
     <rule id="65024" level="10">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^YXDOMAIN$</field>
-        <description>Specified name already created, when it ought not to exist with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
         <options>no_full_log</options>
+        <description>Specified name already created, when it ought not to exist with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
     </rule>
 
     <rule id="65025" level="10">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^YXRRSET$</field>
-        <description>The specified RR Set already exists with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
         <options>no_full_log</options>
+        <description>The specified RR Set already exists with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
     </rule>
 
     <rule id="65026" level="10">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^NXRRSET$</field>
-        <description>The specified RR Set does not exist, and should with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
         <options>no_full_log</options>
+        <description>The specified RR Set does not exist, and should with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
     </rule>
 
     <rule id="65027" level="10">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^NOTAUTH$</field>
-        <description>Server not authoritative for zone with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
         <options>no_full_log</options>
+        <description>Server not authoritative for zone with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
     </rule>
 
     <rule id="65028" level="7">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^NOTZONE$</field>
-        <description>Name not contained in zone with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
         <options>no_full_log</options>
+        <description>Name not contained in zone with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
     </rule>
 
     <rule id="65029" level="5">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^DSOTYPENI$</field>
-        <description>DSO-TYPE not implemented with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
         <options>no_full_log</options>
+        <description>DSO-TYPE not implemented with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
     </rule>
 
     <rule id="65030" level="10">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^BADVERS$</field>
-        <description>Bad OPT version with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
         <options>no_full_log</options>
+        <description>Bad OPT version with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
     </rule>
 
     <rule id="65031" level="7">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^BADSIG$</field>
-        <description>TSIG Signature Failure with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
         <options>no_full_log</options>
+        <description>TSIG Signature Failure with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
     </rule>
 
     <rule id="65032" level="7">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^BADKEY$</field>
-        <description>Key not recognized with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
         <options>no_full_log</options>
+        <description>Key not recognized with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
     </rule>
 
     <rule id="65033" level="7">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^BADTIME$</field>
-        <description>Signature out of time window with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
         <options>no_full_log</options>
+        <description>Signature out of time window with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
     </rule>
 
     <rule id="65034" level="7">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^BADMODE$</field>
-        <description>Bad TKEY Mode with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
         <options>no_full_log</options>
+        <description>Bad TKEY Mode with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
     </rule>
 
     <rule id="65035" level="7">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^BADNAME$</field>
-        <description>Duplicate key name with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
         <options>no_full_log</options>
+        <description>Duplicate key name with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
     </rule>
 
     <rule id="65036" level="7">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^BADALG$</field>
-        <description>Algorithm not supported with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
         <options>no_full_log</options>
+        <description>Algorithm not supported with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
     </rule>
 
     <rule id="65037" level="7">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^BADTRUNC$</field>
-        <description>Bad Truncation with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
         <options>no_full_log</options>
+        <description>Bad Truncation with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
     </rule>
 
     <rule id="65038" level="7">
         <if_sid>65002,65003</if_sid>
         <field name="gcp.jsonPayload.responseCode">^BADCOOKIE$</field>
-        <description>Bad/missing Server Cookie with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
         <options>no_full_log</options>
+        <description>Bad/missing Server Cookie with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity)</description>
     </rule>
 
     <!-- Mitre detection rules  -->
@@ -529,95 +529,95 @@ ID: 65000 - 65499
     <rule id="65039" level="0">
         <if_sid>65000</if_sid>
         <field name="gcp.severity">^DEFAULT$</field>
-        <description>A GCP event with no severity information happened on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type)</description>
         <options>no_full_log</options>
+        <description>A GCP event with no severity information happened on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type)</description>
     </rule>
 
     <rule id="65040" level="2">
         <if_sid>65000</if_sid>
         <field name="gcp.severity">^INFO$</field>
-        <description>GCP information event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type)</description>
         <options>no_full_log</options>
+        <description>GCP information event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type)</description>
     </rule>
 
     <rule id="65041" level="5">
         <if_sid>65000</if_sid>
         <field name="gcp.severity">^WARNING$</field>
-        <description>GCP warning event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type)</description>
         <options>no_full_log</options>
+        <description>GCP warning event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type)</description>
     </rule>
 
     <rule id="65042" level="3">
         <if_sid>65000</if_sid>
         <field name="gcp.severity">^NOTICE$</field>
-        <description>GCP notice event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type)</description>
         <options>no_full_log</options>
+        <description>GCP notice event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type)</description>
     </rule>
 
     <rule id="65043" level="7">
         <if_sid>65000</if_sid>
         <field name="gcp.severity">^ERROR$</field>
-        <description>GCP error event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type)</description>
         <options>no_full_log</options>
+        <description>GCP error event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type)</description>
     </rule>
 
     <rule id="65044" level="9">
         <if_sid>65000</if_sid>
         <field name="gcp.severity">^CRITICAL$</field>
-        <description>GCP critical event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type)</description>
         <options>no_full_log</options>
+        <description>GCP critical event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type)</description>
     </rule>
 
     <rule id="65045" level="11">
         <if_sid>65000</if_sid>
         <field name="gcp.severity">^ALERT$</field>
-        <description>GCP alert event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type)</description>
         <options>no_full_log</options>
+        <description>GCP alert event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type)</description>
     </rule>
 
     <rule id="65046" level="12">
         <if_sid>65000</if_sid>
         <field name="gcp.severity">^EMERGENCY$</field>
-        <description>GCP emergency event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type)</description>
         <options>no_full_log</options>
+        <description>GCP emergency event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type)</description>
     </rule>
 
     <!-- VPC Firewall rules -->
     <rule id="65047" level="3">
         <if_sid>65000</if_sid>
         <field name="gcp.jsonPayload.rule_details.reference" type="pcre2">^(?!^$).*</field>
-        <description>GCP VPC Firewall event</description>
         <options>no_full_log</options>
+        <description>GCP VPC Firewall event</description>
     </rule>
 
     <rule id="65048" level="5">
         <if_sid>65047</if_sid>
         <field name="gcp.jsonPayload.rule_details.action">DENY</field>
-        <description>GCP VPC Firewall: DENY rule triggered</description>
         <options>no_full_log</options>
+        <description>GCP VPC Firewall: DENY rule triggered</description>
     </rule>
 
     <rule id="65049" level="3">
         <if_sid>65047</if_sid>
         <field name="gcp.jsonPayload.rule_details.action">ALLOW</field>
-        <description>GCP VPC Firewall: ALLOW rule triggered</description>
         <options>no_full_log</options>
+        <description>GCP VPC Firewall: ALLOW rule triggered</description>
     </rule>
 
     <!-- GCP VPC Flow -->
     <rule id="65050" level="2">
         <if_sid>65000</if_sid>
         <field name="gcp.jsonPayload.reporter" type="pcre2">^(?!^$).*</field>
-        <description>GCP VPC Flow event</description>
         <options>no_full_log</options>
+        <description>GCP VPC Flow event</description>
     </rule>
 
     <!-- GCP VPC Usage rules-->
     <rule id="65074" level="2">
         <if_sid>65000</if_sid>
         <field name="gcp.s_request_id" type="pcre2">^(?!^$).+$</field>
-        <description>GCP VPC Usage event</description>
         <options>no_full_log</options>
+        <description>GCP VPC Usage event</description>
     </rule>
 
     <!-- GCP VPC Storage rules-->

--- a/ruleset/rules/0690-gcp_rules.xml
+++ b/ruleset/rules/0690-gcp_rules.xml
@@ -5,6 +5,7 @@
 <!--
 ID: 65000 - 65499
 -->
+
 <group name="gcp,">
     <!-- GCP wodle -->
     <rule id="65000" level="0">

--- a/ruleset/rules/0690-gcp_rules.xml
+++ b/ruleset/rules/0690-gcp_rules.xml
@@ -1,8 +1,5 @@
 <!--
-  -  Google Cloud Pub/Sub rules
-  -  Created by Wazuh, Inc.
-  -  Copyright (C) 2015-2021, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+    Copyright (C) 2015-2021, Wazuh Inc.
 -->
 
 <!--
@@ -283,7 +280,94 @@ ID: 65000 - 65499
         <description>GCP: Bad/missing Server Cookie with source IP $(gcp.jsonPayload.sourceIP) from $(gcp.resource.labels.location), severity $(gcp.severity).</description>
     </rule>
 
-    <!-- Mitre detection rules  -->
+    <!-- GCP Generic Events -->
+    <rule id="65039" level="0">
+        <if_sid>65000</if_sid>
+        <field name="gcp.severity">^DEFAULT$</field>
+        <options>no_full_log</options>
+        <description>A GCP event with no severity information happened on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type).</description>
+    </rule>
+
+    <rule id="65040" level="2">
+        <if_sid>65000</if_sid>
+        <field name="gcp.severity">^INFO$</field>
+        <options>no_full_log</options>
+        <description>GCP: information event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type).</description>
+    </rule>
+
+    <rule id="65041" level="5">
+        <if_sid>65000</if_sid>
+        <field name="gcp.severity">^WARNING$</field>
+        <options>no_full_log</options>
+        <description>GCP: warning event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type).</description>
+    </rule>
+
+    <rule id="65042" level="3">
+        <if_sid>65000</if_sid>
+        <field name="gcp.severity">^NOTICE$</field>
+        <options>no_full_log</options>
+        <description>GCP: notice event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type).</description>
+    </rule>
+
+    <rule id="65043" level="7">
+        <if_sid>65000</if_sid>
+        <field name="gcp.severity">^ERROR$</field>
+        <options>no_full_log</options>
+        <description>GCP: error event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type).</description>
+    </rule>
+
+    <rule id="65044" level="9">
+        <if_sid>65000</if_sid>
+        <field name="gcp.severity">^CRITICAL$</field>
+        <options>no_full_log</options>
+        <description>GCP: critical event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type).</description>
+    </rule>
+
+    <rule id="65045" level="11">
+        <if_sid>65000</if_sid>
+        <field name="gcp.severity">^ALERT$</field>
+        <options>no_full_log</options>
+        <description>GCP: alert event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type).</description>
+    </rule>
+
+    <rule id="65046" level="12">
+        <if_sid>65000</if_sid>
+        <field name="gcp.severity">^EMERGENCY$</field>
+        <options>no_full_log</options>
+        <description>GCP: emergency event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type).</description>
+    </rule>
+
+    <!-- VPC Firewall rules -->
+    <rule id="65047" level="3">
+        <if_sid>65000</if_sid>
+        <field name="gcp.jsonPayload.rule_details.reference" type="pcre2">^(?!^$).*</field>
+        <options>no_full_log</options>
+        <description>GCP: VPC Firewall event.</description>
+    </rule>
+
+    <rule id="65048" level="5">
+        <if_sid>65047</if_sid>
+        <field name="gcp.jsonPayload.rule_details.action">DENY</field>
+        <options>no_full_log</options>
+        <description>GCP: VPC Firewall: DENY rule triggered.</description>
+    </rule>
+
+    <rule id="65049" level="3">
+        <if_sid>65047</if_sid>
+        <field name="gcp.jsonPayload.rule_details.action">ALLOW</field>
+        <options>no_full_log</options>
+        <description>GCP: VPC Firewall: ALLOW rule triggered.</description>
+    </rule>
+
+    <!-- GCP VPC Flow -->
+    <rule id="65050" level="2">
+        <if_sid>65000</if_sid>
+        <field name="gcp.jsonPayload.reporter" type="pcre2">^(?!^$).*</field>
+        <options>no_full_log</options>
+        <description>GCP: VPC Flow event.</description>
+    </rule>
+
+        <!-- Mitre detection rules  -->
     <!-- collection gcp_pub_sub subscription creation -->
     <rule id="65051" level="3">
         <if_sid>65000</if_sid>
@@ -523,93 +607,6 @@ ID: 65000 - 65499
         <mitre>
             <id>T1098.001</id>
         </mitre>
-    </rule>
-
-    <!-- GCP Generic Events -->
-    <rule id="65039" level="0">
-        <if_sid>65000</if_sid>
-        <field name="gcp.severity">^DEFAULT$</field>
-        <options>no_full_log</options>
-        <description>A GCP event with no severity information happened on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type).</description>
-    </rule>
-
-    <rule id="65040" level="2">
-        <if_sid>65000</if_sid>
-        <field name="gcp.severity">^INFO$</field>
-        <options>no_full_log</options>
-        <description>GCP: information event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type).</description>
-    </rule>
-
-    <rule id="65041" level="5">
-        <if_sid>65000</if_sid>
-        <field name="gcp.severity">^WARNING$</field>
-        <options>no_full_log</options>
-        <description>GCP: warning event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type).</description>
-    </rule>
-
-    <rule id="65042" level="3">
-        <if_sid>65000</if_sid>
-        <field name="gcp.severity">^NOTICE$</field>
-        <options>no_full_log</options>
-        <description>GCP: notice event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type).</description>
-    </rule>
-
-    <rule id="65043" level="7">
-        <if_sid>65000</if_sid>
-        <field name="gcp.severity">^ERROR$</field>
-        <options>no_full_log</options>
-        <description>GCP: error event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type).</description>
-    </rule>
-
-    <rule id="65044" level="9">
-        <if_sid>65000</if_sid>
-        <field name="gcp.severity">^CRITICAL$</field>
-        <options>no_full_log</options>
-        <description>GCP: critical event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type).</description>
-    </rule>
-
-    <rule id="65045" level="11">
-        <if_sid>65000</if_sid>
-        <field name="gcp.severity">^ALERT$</field>
-        <options>no_full_log</options>
-        <description>GCP: alert event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type).</description>
-    </rule>
-
-    <rule id="65046" level="12">
-        <if_sid>65000</if_sid>
-        <field name="gcp.severity">^EMERGENCY$</field>
-        <options>no_full_log</options>
-        <description>GCP: emergency event on project $(gcp.resource.labels.project_id), monitored resource type: $(gcp.resource.type).</description>
-    </rule>
-
-    <!-- VPC Firewall rules -->
-    <rule id="65047" level="3">
-        <if_sid>65000</if_sid>
-        <field name="gcp.jsonPayload.rule_details.reference" type="pcre2">^(?!^$).*</field>
-        <options>no_full_log</options>
-        <description>GCP: VPC Firewall event.</description>
-    </rule>
-
-    <rule id="65048" level="5">
-        <if_sid>65047</if_sid>
-        <field name="gcp.jsonPayload.rule_details.action">DENY</field>
-        <options>no_full_log</options>
-        <description>GCP: VPC Firewall: DENY rule triggered.</description>
-    </rule>
-
-    <rule id="65049" level="3">
-        <if_sid>65047</if_sid>
-        <field name="gcp.jsonPayload.rule_details.action">ALLOW</field>
-        <options>no_full_log</options>
-        <description>GCP: VPC Firewall: ALLOW rule triggered.</description>
-    </rule>
-
-    <!-- GCP VPC Flow -->
-    <rule id="65050" level="2">
-        <if_sid>65000</if_sid>
-        <field name="gcp.jsonPayload.reporter" type="pcre2">^(?!^$).*</field>
-        <options>no_full_log</options>
-        <description>GCP: VPC Flow event.</description>
     </rule>
 
     <!-- GCP VPC Usage rules-->

--- a/ruleset/testing/tests/gcp.ini
+++ b/ruleset/testing/tests/gcp.ini
@@ -1,6 +1,17 @@
+;   Copyright (C) 2015-2021, Wazuh Inc.
+;
+;   Tests for products: 
+;     GCP
+;
+;   Sample logs source: 
+;    Software Name: GCP
+;    VPC Flow logs:   https://cloud.google.com/vpc/docs/flow-logs
+;    Firewall logs:   https://cloud.google.com/vpc/docs/firewall-rules-logging
+;    LB       logs:   https://cloud.google.com/load-balancing/docs/https/https-logging-monitoring
+;    GCS      logs:   https://cloud.google.com/storage/docs/access-logs
+
 [GCP VPC Firewall: ALLOW rule triggered]
 log 1 pass = {"integration":"gcp","gcp":{"insertId":"6dxcl6g15v9cee","jsonPayload":{"connection":{"dest_ip":"10.142.0.2","dest_port":22,"protocol":6,"src_ip":"XX.XX.XX.XX","src_port":43710},"disposition":"ALLOWED","instance":{"project_id":"wazuh-dev-XXXXXX","region":"us-east1","vm_name":"framework-vpc-flow-test-instance","zone":"us-east1-b"},"rule_details":{"action":"ALLOW","direction":"INGRESS","ip_port_info":[{"ip_protocol":"TCP","port_range":["22"]}],"priority":65534,"reference":"network:default/firewall:default-allow-ssh","source_range":["0.0.0.0/0"]},"vpc":{"project_id":"wazuh-dev-XXXXXX","subnetwork_name":"default","vpc_name":"default"}},"logName":"projects/wazuh-dev-XXXXXX/logs/compute.googleapis.com%2Ffirewall","receiveTimestamp":"2021-06-04T13:27:43.45097863Z","resource":{"labels":{"location":"us-east1-b","project_id":"wazuh-dev-XXXXXX","subnetwork_id":"6133410668509430049","subnetwork_name":"default"},"type":"gce_subnetwork"},"timestamp":"2021-06-04T13:27:35.794717819Z"}}
-
 rule = 65049
 alert = 3
 decoder = json
@@ -8,7 +19,6 @@ decoder = json
 
 [GCP VPC Flow rules grouped]
 log 1 pass = {"integration":"gcp","gcp":{"insertId":"g3n55zfjeyg2i","jsonPayload":{"bytes_sent":"8","connection":{"dest_ip":"ff02::2","protocol":58,"src_ip":"XXXXXXXXXXXXXX"},"dest_location":{},"end_time":"2021-06-04T11:18:46.770486824Z","packets_sent":"1","reporter":"SRC","src_instance":{"project_id":"wazuh-dev-XXXXXX","region":"us-east1","vm_name":"framework-vpc-flow-test-instance","zone":"us-east1-b"},"src_vpc":{"project_id":"wazuh-dev-XXXXXX","subnetwork_name":"default","vpc_name":"default"},"start_time":"2021-06-04T11:18:46.770486824Z"},"logName":"projects/wazuh-dev-XXXXXX/logs/compute.googleapis.com%2Fvpc_flows","receiveTimestamp":"2021-06-04T11:19:10.440812789Z","resource":{"labels":{"location":"us-east1-b","project_id":"wazuh-dev-XXXXXX","subnetwork_id":"6133410668509430049","subnetwork_name":"default"},"type":"gce_subnetwork"},"timestamp":"2021-06-04T11:19:10.440812789Z"}}
-
 rule = 65050
 alert = 2
 decoder = json
@@ -16,63 +26,54 @@ decoder = json
 
 [GCP VPC Firewall: DENY rule triggered]
 log 1 pass = {"integration":"gcp","gcp":{"insertId":"6dxcl6g15v9cee","jsonPayload":{"connection":{"dest_ip":"10.142.0.2","dest_port":22,"protocol":6,"src_ip":"XX.XX.XX.XX","src_port":43710},"disposition":"DENIED","instance":{"project_id":"wazuh-dev-XXXXXX","region":"us-east1","vm_name":"framework-vpc-flow-test-instance","zone":"us-east1-b"},"rule_details":{"action":"DENY","direction":"INGRESS","ip_port_info":[{"ip_protocol":"TCP","port_range":["22"]}],"priority":65534,"reference":"network:default/firewall:default-deny-ssh","source_range":["0.0.0.0/0"]},"vpc":{"project_id":"wazuh-dev-XXXXXX","subnetwork_name":"default","vpc_name":"default"}},"logName":"projects/wazuh-dev-XXXXXX/logs/compute.googleapis.com%2Ffirewall","receiveTimestamp":"2021-06-04T13:27:43.45097863Z","resource":{"labels":{"location":"us-east1-b","project_id":"wazuh-dev-XXXXXX","subnetwork_id":"6133410668509430049","subnetwork_name":"default"},"type":"gce_subnetwork"},"timestamp":"2021-06-04T13:27:35.794717819Z"}}
-
 rule = 65048
 alert = 5
 decoder = json
 
 [GCP Generic INFO]
 log 1 pass = {"gcp":{"severity":"INFO","logName":"projects/wazuh-dev-258815/logs/cloudaudit.googleapis.com%2Fdata_access","resource":{"type":"audited_resource","labels":{"method":"google.monitoring.v3.MetricService.ListTimeSeries","project_id":"wazuh-dev-258815","service":"monitoring.googleapis.com"}},"protoPayload":{"requestMetadata":{"requestAttributes":{"time":"2021-06-11T09:35:18.077583788Z"},"callerSuppliedUserAgent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Safari/537.36,gzip(gfe)","callerIp":"80.39.210.176"},"request":{"filter":"metric.type=\"pubsub.googleapis.com/topic/send_message_operation_count\" AND resource.labels.project_id=\"wazuh-dev-258815\" AND resource.labels.topic_id=\"wazuh-gcloud-blog-topic\" AND resource.type=\"pubsub_topic\"","@type":"type.googleapis.com/google.monitoring.v3.ListTimeSeriesRequest","name":"projects/wazuh-dev-258815"},"authenticationInfo":{"principalEmail":"javier.bejar@wazuh.com"},"authorizationInfo":[{"resource":"769054035614","permission":"monitoring.timeSeries.list","resourceAttributes":{},"granted":true}],"@type":"type.googleapis.com/google.cloud.audit.AuditLog","numResponseItems":"1","methodName":"google.monitoring.v3.MetricService.ListTimeSeries","resourceName":"projects/wazuh-dev-258815","serviceName":"monitoring.googleapis.com"},"receiveTimestamp":"2021-06-11T09:35:18.35940193Z","insertId":"s1gmn4e7xlr1","timestamp":"2021-06-11T09:35:18.077460268Z"},"integration":"gcp"}
-
 rule = 65040
 alert = 2
 decoder = json
 
 [GCP Generic Warning]
 log 1 pass = {"integration":"gcp","gcp":{"httpRequest":{"latency":"0.000864s","remoteIp":"YY.YY.YY.YY","requestMethod":"GET","requestSize":"385","requestUrl":"http://XX.XX.XX.XX/favicon.ico","responseSize":"488","status":502,"userAgent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36"},"insertId":"1mtxf1hf2c4idk","jsonPayload":{"@type":"type.googleapis.com/google.cloud.loadbalancing.type.LoadBalancerLogEntry","statusDetails":"failed_to_pick_backend"},"logName":"projects/wazuh-dev-xxxxxx/logs/requests","receiveTimestamp":"2021-06-09T15:17:25.473538144Z","resource":{"labels":{"backend_service_name":"framework-load-balancer-backend-test","forwarding_rule_name":"framework-load-balancer-backend-test","project_id":"wazuh-dev-xxxxxx","target_proxy_name":"framework-load-balancer-test-target-proxy","url_map_name":"framework-load-balancer-test","zone":"global"},"type":"http_load_balancer"},"severity":"WARNING","spanId":"ab6c36e7fc60f24e","timestamp":"2021-06-09T15:17:24.408864Z","trace":"projects/wazuh-dev-xxxxxx/traces/68183a7cda548ce0e79207099a1fea58"}}
-
 rule = 65041
 alert = 5
 decoder = json
 
 [GCP Generic NOTICE]
 log 1 pass = {"gcp":{"severity":"NOTICE","logName":"projects/wazuh-dev-258815/logs/cloudaudit.googleapis.com%2Factivity","resource":{"type":"gce_autoscaler","labels":{"project_id":"wazuh-dev-258815","location":"us-east1-b","autoscaler_id":"6792866887804055843"}},"protoPayload":{"requestMetadata":{"callerSuppliedUserAgent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36,gzip(gfe),gzip(gfe)","callerIp":"213.194.153.13"},"request":{"@type":"type.googleapis.com/compute.autoscalers.insert"},"authenticationInfo":{"principalEmail":"carlos.ridao@wazuh.com"},"@type":"type.googleapis.com/google.cloud.audit.AuditLog","methodName":"beta.compute.autoscalers.insert","resourceName":"projects/wazuh-dev-258815/zones/us-east1-b/autoscalers/framework-test-instance-group-1","serviceName":"compute.googleapis.com"},"receiveTimestamp":"2021-06-08T11:09:02.399625057Z","operation":{"last":"true","producer":"compute.googleapis.com","id":"operation-1623150539438-5c43f2f51f7fe-84f4728e-ac44be61"},"insertId":"suy3z6d14pw","timestamp":"2021-06-08T11:09:02.032595Z"},"integration":"gcp"}
-
 rule = 65042
 alert = 3
 decoder = json
 
 [collection gcp_pub_sub subscription creation]
 log 1 pass = {"gcp":{"severity":"NOTICE","logName":"projects/wazuh-dev-258815/logs/cloudaudit.googleapis.com%2Factivity","resource":{"type":"pubsub_topic","labels":{"project_id":"wazuh-dev-258815","topic_id":"projects/wazuh-dev-258815/topics/threatintel-gcp"}},"protoPayload":{"requestMetadata":{"requestAttributes":{"time":"2021-06-10T15:07:09.68842532Z"},"callerSuppliedUserAgent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Safari/537.36,gzip(gfe)","callerIp":"80.39.210.176"},"request":{"@type":"type.googleapis.com/google.pubsub.v1.Subscription","messageRetentionDuration":"604800s","name":"projects/wazuh-dev-258815/subscriptions/threatintel-gcp-sub","topic":"projects/wazuh-dev-258815/topics/threatintel-gcp","ackDeadlineSeconds":"10"},"authenticationInfo":{"principalSubject":"user:javier.bejar@wazuh.com","principalEmail":"javier.bejar@wazuh.com"},"authorizationInfo":[{"resource":"projects/wazuh-dev-258815/topics/threatintel-gcp","permission":"pubsub.topics.attachSubscription","resourceAttributes":{},"granted":true}],"@type":"type.googleapis.com/google.cloud.audit.AuditLog","response":{"@type":"type.googleapis.com/google.pubsub.v1.Subscription","messageRetentionDuration":"604800s","name":"projects/wazuh-dev-258815/subscriptions/threatintel-gcp-sub","topic":"projects/wazuh-dev-258815/topics/threatintel-gcp","ackDeadlineSeconds":"10"},"methodName":"google.pubsub.v1.Subscriber.CreateSubscription","resourceName":"projects/wazuh-dev-258815/topics/threatintel-gcp","serviceName":"pubsub.googleapis.com"},"receiveTimestamp":"2021-06-10T15:07:15.879792037Z","insertId":"jzee3lb9j","timestamp":"2021-06-10T15:07:09.68170948Z"},"integration":"gcp"}
-
 rule = 65051
 alert = 3
 decoder = json
 
 [collection gcp_pub_sub topic creation]
 log 1 pass = {"gcp":{"severity":"NOTICE","logName":"projects/wazuh-dev-258815/logs/cloudaudit.googleapis.com%2Factivity","resource":{"type":"pubsub_topic","labels":{"project_id":"wazuh-dev-258815","topic_id":"projects/wazuh-dev-258815/topics/threatintel-gcp"}},"protoPayload":{"requestMetadata":{"requestAttributes":{"time":"2021-06-10T15:07:05.408091615Z"},"callerSuppliedUserAgent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Safari/537.36,gzip(gfe)","callerIp":"80.39.210.176"},"request":{"@type":"type.googleapis.com/google.pubsub.v1.Topic","name":"projects/wazuh-dev-258815/topics/threatintel-gcp"},"authenticationInfo":{"principalSubject":"user:javier.bejar@wazuh.com","principalEmail":"javier.bejar@wazuh.com"},"authorizationInfo":[{"resource":"projects/wazuh-dev-258815","permission":"pubsub.topics.create","resourceAttributes":{},"granted":true}],"@type":"type.googleapis.com/google.cloud.audit.AuditLog","response":{"@type":"type.googleapis.com/google.pubsub.v1.Topic","name":"projects/wazuh-dev-258815/topics/threatintel-gcp"},"methodName":"google.pubsub.v1.Publisher.CreateTopic","resourceName":"projects/wazuh-dev-258815/topics/threatintel-gcp","serviceName":"pubsub.googleapis.com"},"receiveTimestamp":"2021-06-10T15:07:09.239238903Z","insertId":"vmyzdgc4u3","timestamp":"2021-06-10T15:07:05.400577592Z"},"integration":"gcp"}
-
 rule = 65052
 alert = 3
 decoder = json
 
 [defense evasion gcp_firewall_rule modified]
 log 1 pass = {"gcp":{"severity":"NOTICE","logName":"projects/wazuh-dev-258815/logs/cloudaudit.googleapis.com%2Factivity","resource":{"type":"gce_firewall_rule","labels":{"project_id":"wazuh-dev-258815","firewall_rule_id":"6352627401320071455"}},"protoPayload":{"requestMetadata":{"callerSuppliedUserAgent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36,gzip(gfe),gzip(gfe)","callerIp":"213.194.154.232"},"request":{"@type":"type.googleapis.com/compute.firewalls.patch"},"authenticationInfo":{"principalEmail":"carlos.ridao@wazuh.com"},"@type":"type.googleapis.com/google.cloud.audit.AuditLog","resourceOriginalState":{"logConfig":{"metadata":"INCLUDE_ALL_METADATA","enable":"false"},"@type":"compute.googleapis.com/patch.state","description":"Allow internal traffic on the default network","priority":"65534","network":"https://www.googleapis.com/compute/v1/projects/wazuh-dev-258815/global/networks/default","selfLink":"https://www.googleapis.com/compute/v1/projects/wazuh-dev-258815/global/firewalls/default-allow-internal","sourceRanges":["10.128.0.0/9"],"selfLinkWithId":"https://www.googleapis.com/compute/v1/projects/wazuh-dev-258815/global/firewalls/6352627401320071455","creationTimestamp":"2021-05-31T12:58:40.887-07:00","name":"default-allow-internal","alloweds":[{"IPProtocol":"tcp","ports":["0-65535"]},{"IPProtocol":"udp","ports":["0-65535"]},{"IPProtocol":"icmp"}],"disabled":"false","id":"6352627401320071455","enableLogging":"false","direction":"INGRESS"},"methodName":"v1.compute.firewalls.patch","resourceName":"projects/wazuh-dev-258815/global/firewalls/default-allow-internal","serviceName":"compute.googleapis.com"},"receiveTimestamp":"2021-06-04T13:26:50.156887429Z","operation":{"last":"true","producer":"compute.googleapis.com","id":"operation-1622813206787-5c3f0a4ba3417-3838b401-5fcfe6fd"},"insertId":"qx0fpcdfo5k","timestamp":"2021-06-04T13:26:49.79784Z"},"integration":"gcp"}
-
 rule = 65055
 alert = 3
 decoder = json
 
 [GCP usage]
 log 1 pass = {"integration": "gcp", "gcp": {"time_micros": "1623657113850001", "c_ip": "34.75.50.245", "c_ip_type": "1", "c_ip_region": "", "cs_method": "GET", "cs_uri": "/download/storage/v1/b/framework-test-bucket/o/usage-logs_usage_2021_06_11_14_00_00_0deb315d529495e45e_v0?alt=media&generation=1623445458746803", "sc_status": "206", "cs_bytes": "0", "sc_bytes": "644", "time_taken_micros": "141000", "cs_host": "storage.googleapis.com", "cs_referer": "", "cs_user_agent": "DataflowBatchWorkerHarness Google-API-Java-Client/1.30.10 Google-HTTP-Java-Client/1.36.0 (gzip)", "s_request_id": "ABg5-UwwFhsTGuOn2WpJdUzroNMTNuh-IabN-9XKEwnEJMi3Hcv_o96mM8lqKU3wWWGko5RL4pEoaepuizcP_NQIKhw", "cs_operation": "storage.objects.get", "cs_bucket": "framework-test-bucket", "cs_object": "usage-logs_usage_2021_06_11_14_00_00_0deb315d529495e45e_v0", "source": "gcp_bucket"}}
-
 rule = 65074
 alert = 2
 decoder = json
 
 [GCP storage]
 log 1 pass = {"integration": "gcp", "gcp": {"bucket": "bucket_name", "storage_byte_hours": "15674"}}
-
 rule = 65075
 alert = 2
 decoder = json


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/11333|

## Description

This PR aims to add testing for PR https://github.com/wazuh/wazuh/pull/8969

The issues resolved are:
- Missing copyright headers.
- Add testing.

## Checks and changes 

### Syntax

- [x] 1.a Rule tags order must be compliant.
~~- [x] 1.b Decoder tags order must be compliant.~~
- [x] 1.c XML blocks must as compact as possible.
- [X] 1.d Only one empty line between rule/decoder and the next rule/decoder.
~~- [X] 1.e Decoder extracted fields names must use '_' whether a space is needed.~~
~~- [X] 1.f Decoder name must use '-' whether a space is needed.~~
 
### Grammar

- [X] 2.a Grammar quality.
- [X] 2.b Similar phrases must keep tenses and expressions.
- [X] 2.c Grammar basic rules like capitalization, punctuation marks, sentence construction, and others.


### Semantic

- [x] 3.a New decoder, rule, or test are written in the correct file and grouped correctly inside the file.
- [x] 3.b Group similar rules under same ID's group.
- [x] 3.c: 
     - [x] 3.c1 Find and reuse group name before creating a new one.
    - [x] 3.c2 Include a new group definition in a PR comment.
    - [x] 3.c3 Any group name must use '_' whether it does need a space char.
    -  [x] 3.c4 The groups inside a tag must be sorted in alphabetical order.
- [x] 3.d Rule level should be compliant with the [documentation](https://documentation.wazuh.com/current/user-manual/ruleset/rules-classification.html).

### Unit testing

- [X] 4.a A metadata block at the beginning of the .ini file describing software, version, and logs source.
- [X] 4.b Each new rule must have at least one test entry in the correct .ini file.
- [x] 4.c Runtest.py must pass and must include the results in raw format here.
Test of gcp.ini

```terminal
root@ubuntu20LTS:/home/vagrant/wazuh/ruleset/testing# python runtests.py -t tests/gcp.ini 
- [ File = ./tests/gcp.ini ] ---------
...........


```

<details><summary>All rules and decoders test.</summary>
<p>

```
root@ubuntu20LTS:/home/vagrant/wazuh/ruleset/testing# python runtests.py 
- [ File = ./tests/doas.ini ] ---------
....

- [ File = ./tests/office365.ini ] ---------
................................................................................................................................

- [ File = ./tests/iptables.ini ] ---------
........

- [ File = ./tests/exim.ini ] ---------
.......

- [ File = ./tests/api.ini ] ---------
............................

- [ File = ./tests/trendmicro-cloud-one.ini ] ---------
.................

- [ File = ./tests/web_appsec.ini ] ---------
...............................

- [ File = ./tests/cisco_asa.ini ] ---------
........................................................................................

- [ File = ./tests/firewalld.ini ] ---------
..

- [ File = ./tests/mailscanner.ini ] ---------
.

- [ File = ./tests/nextcloud.ini ] ---------
.......

- [ File = ./tests/icinga.ini ] ---------
....

- [ File = ./tests/ossec.ini ] ---------
.....

- [ File = ./tests/paloalto.ini ] ---------
................

- [ File = ./tests/named.ini ] ---------
.....

- [ File = ./tests/vsftpd.ini ] ---------
....

- [ File = ./tests/gcp.ini ] ---------
...........

- [ File = ./tests/web_rules.ini ] ---------
..........

- [ File = ./tests/sysmon.ini ] ---------
...

- [ File = ./tests/fireeye.ini ] ---------
...

- [ File = ./tests/arbor.ini ] ---------
..

- [ File = ./tests/cisco_ios.ini ] ---------
.................

- [ File = ./tests/sudo.ini ] ---------
........

- [ File = ./tests/modsecurity.ini ] ---------
......

- [ File = ./tests/postfix.ini ] ---------
..

- [ File = ./tests/freepbx.ini ] ---------
......

- [ File = ./tests/SonicWall.ini ] ---------
........

- [ File = ./tests/audit_scp.ini ] ---------
.

- [ File = ./tests/cimserver.ini ] ---------
..

- [ File = ./tests/nginx.ini ] ---------
............

- [ File = ./tests/junos.ini ] ---------
...

- [ File = ./tests/glpi.ini ] ---------
...

- [ File = ./tests/proftpd.ini ] ---------
.......

- [ File = ./tests/syslog.ini ] ---------
......

- [ File = ./tests/fortigate.ini ] ---------
........................................

- [ File = ./tests/sophos_fw.ini ] ---------
..........

- [ File = ./tests/f5_big_ip.ini ] ---------
...........................................

- [ File = ./tests/opensmtpd.ini ] ---------
.......

- [ File = ./tests/sophos.ini ] ---------
........

- [ File = ./tests/sophos-utm-firewall.ini ] ---------
......

- [ File = ./tests/netscreen.ini ] ---------
....

- [ File = ./tests/apparmor.ini ] ---------
.....

- [ File = ./tests/squid_rules.ini ] ---------
..

- [ File = ./tests/gitlab.ini ] ---------
.........................

- [ File = ./tests/checkpoint_smart1.ini ] ---------
..................

- [ File = ./tests/apache.ini ] ---------
..................

- [ File = ./tests/dovecot.ini ] ---------
...............

- [ File = ./tests/systemd.ini ] ---------
..

- [ File = ./tests/pam.ini ] ---------
.....

- [ File = ./tests/github.ini ] ---------
....................................................................................................................................................................................................................................................................................................................................

- [ File = ./tests/oscap.ini ] ---------
................................

- [ File = ./tests/huawei_usg.ini ] ---------
...

- [ File = ./tests/cpanel.ini ] ---------
.......

- [ File = ./tests/samba.ini ] ---------
....

- [ File = ./tests/audit_lateral.ini ] ---------
......

- [ File = ./tests/vuln_detector.ini ] ---------
..

- [ File = ./tests/owlh.ini ] ---------
....

- [ File = ./tests/exchange.ini ] ---------
..

- [ File = ./tests/cisco_ftd.ini ] ---------
..........................................

- [ File = ./tests/openvpn_ldap.ini ] ---------
..

- [ File = ./tests/panda_paps.ini ] ---------
........

- [ File = ./tests/dropbear.ini ] ---------
...

- [ File = ./tests/mcafee_epo.ini ] ---------
.

- [ File = ./tests/openldap.ini ] ---------
.........

- [ File = ./tests/sshd.ini ] ---------
...........................................

- [ File = ./tests/kernel_usb.ini ] ---------
......

- [ File = ./tests/pix.ini ] ---------
......................

- [ File = ./tests/unbound.ini ] ---------


- [ File = ./tests/rsh.ini ] ---------
..

- [ File = ./tests/cylance.ini ] ---------
.......

- [ File = ./tests/cloudlfare-waf.ini ] ---------
.............

- [ File = ./tests/eset.ini ] ---------
........

- [ File = ./tests/auditd.ini ] ---------
...

- [ File = ./tests/pfsense.ini ] ---------
..

- [ File = ./tests/su.ini ] ---------
.....

- [ File = ./tests/audit_recon.ini ] ---------
..

- [ File = ./tests/aws_s3_access.ini ] ---------
.......

```
</p>
</details>

~~- [X] 4.d New CDB lists must include the proper test entry in the correct .ini file.~~

### E2E testing

- [x] 5.a Logs for new or modified decoder/rules sent to a manager running with this PR ruleset appear in Kibana.
![image](https://user-images.githubusercontent.com/23319307/146177848-6d2d8b2a-66a8-4384-951c-07e2ce97b951.png)


- [x] 5.b There are not affected or broken visualizations on Kibana.
![image](https://user-images.githubusercontent.com/23319307/146177969-64489f9d-43ac-48de-b651-acd6b237c5e8.png)


- [x] 5.c New or modified items can be seen correctly using APP ruleset navigation.
![image](https://user-images.githubusercontent.com/23319307/146178158-029e5721-2c1a-4a5f-ae83-0978573fa32f.png)


### Elasticsearch Template

~~- [X] 6.a Known fields with output format managed and usually used for searching are included in template array index.query.default_field.~~
~~- [X] 6.b The new field with the correct date format is stored as a "date" type field in the template.~~
~~- [X] 6.c The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template.~~ 
~~- [X] 6.d Known fields with output format managed and usually used for searching are included in the template.~~

### Stoppers

- [x] 7.a No previous rule ID changes without triple check.
- [x] 7.b No previous decoder name changes without triple check.
- [x] 7.c No previous file name changes without triple check.
- [x] 7.d No previous test changes its 'rule' field value without triple check.

### Others

- [x] 8.a Each file has the correct copyright block.
- [x] 8.b The copyright block doesn't have "Author" only "Created by Wazuh". To include an "Author" request triple check.
- [x] 8.c The copyright block doesn't use "-". 
- [x] 8.d The rule files don't have any sample log.
~~- [x] 8.e The decoder file has sample logs next to the decoder that matches that log.~~
- [x] 8.f The decoder and rule files have information about software, version, and any helpful information.
~~- [x] 8.g The PR has a single commit with CHANGELOG changes in the correct format.~~
- [x] 8.h The new rule ID is not in use.
- [x] 8.i The new rule ID must be in the defined IDs range.
- [x] 8.j New rules ID range must be verified with a triple check and noted in the rules ID document.
- [x] 8.k The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 