### PR TITLE
Add multiprocessing to workers

### DIFF
--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -349,7 +349,7 @@ async def async_decompress_files(zip_path, ko_files_name="files_metadata.json"):
     zip_dir : str
         Full path to unzipped directory.
     """
-    decompress_files(zip_path, ko_files_name)
+    return decompress_files(zip_path, ko_files_name)
 
 
 def decompress_files(zip_path, ko_files_name="files_metadata.json"):

--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -7,7 +7,9 @@ import logging
 import os.path
 import shutil
 import zipfile
+from asyncio import wait_for
 from datetime import datetime
+from functools import partial
 from operator import eq
 from os import listdir, path, remove, stat, walk
 from random import random
@@ -330,7 +332,27 @@ def compress_files(name, list_path, cluster_control_json=None):
     return zip_file_path
 
 
-async def decompress_files(zip_path, ko_files_name="files_metadata.json"):
+async def async_decompress_files(zip_path, ko_files_name="files_metadata.json"):
+    """Async wrapper for decompress_files() function.
+
+    Parameters
+    ----------
+    zip_path : str
+        Full path to the zip file.
+    ko_files_name : str
+        Name of the metadata json inside zip file.
+
+    Returns
+    -------
+    ko_files : dict
+        Paths (keys) and metadata (values) of the files listed in cluster.json.
+    zip_dir : str
+        Full path to unzipped directory.
+    """
+    decompress_files(zip_path, ko_files_name)
+
+
+def decompress_files(zip_path, ko_files_name="files_metadata.json"):
     """Unzip files in a directory and load the files_metadata.json as a dict.
 
     Parameters
@@ -617,3 +639,34 @@ def unmerge_info(merge_type, path_file, filename):
             bytes_read += st_size
 
             yield path.join(dst_path, name), data, st_mtime
+
+
+async def run_in_pool(loop, pool, f, *args, **kwargs):
+    """Run function in process pool if it exists.
+
+    This function checks if the process pool exists. If it does, the function is run inside it and
+    the result is waited. Otherwise (the pool is None), the function is run in the parent process,
+    as usual.
+
+    Parameters
+    ----------
+    loop : uvloop.EventLoopPolicy
+        Asyncio loop.
+    pool : ProcessPoolExecutor or None
+        Process pool object in charge of running functions.
+    f : callable
+        Function to be executed.
+    *args
+        Arguments list to be passed to function `f`. Default `None`.
+    **kwargs
+        Keyword arguments to be passed to function `f`. Default `None`.
+
+    Returns
+    -------
+    Result of `f(*args, **kwargs)` function.
+    """
+    if pool:
+        task = loop.run_in_executor(pool, partial(f, *args, **kwargs))
+        return await wait_for(task, timeout=None)
+    else:
+        return f(*args, **kwargs)

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -667,7 +667,8 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         logger.debug(f"Received file from worker: '{received_filename}'")
 
         # Path to metadata file (files_metadata.json) and to zipdir (directory with decompressed files).
-        files_metadata, decompressed_files_path = await wazuh.core.cluster.cluster.decompress_files(received_filename)
+        files_metadata, decompressed_files_path = await wazuh.core.cluster.cluster.async_decompress_files(
+            received_filename)
         # There are no files inside decompressed_files_path, only files_metadata.json which has already been loaded.
         shutil.rmtree(decompressed_files_path)
 
@@ -806,7 +807,8 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         logger.debug(f"Received extra-valid file from worker: '{received_filename}'")
 
         # Path to metadata file (files_metadata.json) and to zipdir (directory with decompressed files).
-        files_metadata, decompressed_files_path = await wazuh.core.cluster.cluster.decompress_files(received_filename)
+        files_metadata, decompressed_files_path = await wazuh.core.cluster.cluster.async_decompress_files(
+            received_filename)
         logger.debug(f"Received {len(files_metadata)} extra-valid files to check.")
 
         # Create a child process to run the task.


### PR DESCRIPTION
|Related issue|
|---|
| Closes #11330 |

## Description

This PR adds multiprocessing to worker nodes in the Wazuh cluster. 

As it was reported at #11330, there are some tasks in the `wazuh-clusterd` process of worker nodes that could be slow, for example decompressing files that were sent by the master:
https://github.com/wazuh/wazuh/blob/8bdd7af0ccaac596c2c0506fe3545696ad382165/framework/wazuh/core/cluster/worker.py#L744

Processing those files after being decompressed:
https://github.com/wazuh/wazuh/blob/8bdd7af0ccaac596c2c0506fe3545696ad382165/framework/wazuh/core/cluster/worker.py#L753

Or calculating the files MD5 when the Integrity check task is started:
https://github.com/wazuh/wazuh/blob/8bdd7af0ccaac596c2c0506fe3545696ad382165/framework/wazuh/core/cluster/worker.py#L613

As all these tasks belong to a single thread (the Integrity thread), only one child process in the process pool is needed. The reason is that, even if the parent process is free while the child is working, no new Integrity tasks can start until the child finishes the one in progress. Or what is the same, the tasks inside each thread are "sequential", and there is only one thread of each kind (unlike in the master node).

![worker_mp_2](https://user-images.githubusercontent.com/23361101/146183482-733fe36e-b97d-4ea3-8e5f-aeb1b51324a0.jpg)

## New permission flag
Until now, once the worker started processing the master files, the single `clusterd` process in the worker node was busy and no more Integrity checks/syncs were started in the meantime.

However, after this PR, the worker can start new Integrity checks/sync while its child process is working. Also, when there are no extra-valid files, the master allows the worker to start new syncs as soon as all the files have been sent (even if the worker hasn't processed them yet).

This caused the task to be repeated uselessly several times while the worker's child was still processing the files received in the first iteration. To prevent this problem, a new variable/flag has been added. It is set to `False` as soon as the worker is notified that synchronization is necessary:
```
2021/12/15 12:23:15 INFO: [Worker worker1] [Integrity check] Finished in 3.339s. Sync required.
```
https://github.com/wazuh/wazuh/blob/adfbe64a1a8ca264088dfd1727d60e6186166129/framework/wazuh/core/cluster/worker.py#L501

The flag is released again when all files are processed and `ReceiveIntegrityTask` instance is destroyed. No new Integrity checks can be started while its value is `False`:
https://github.com/wazuh/wazuh/blob/adfbe64a1a8ca264088dfd1727d60e6186166129/framework/wazuh/core/cluster/worker.py#L32-L41

## No process pool
The execution of tasks in child processes is carried out by the new function `run_in_pool`. This function is a generic and reusable way to determine if the pool is `None`. In such a case, everything would work the same as before. Otherwise, it will be executed in a child process:
https://github.com/wazuh/wazuh/blob/adfbe64a1a8ca264088dfd1727d60e6186166129/framework/wazuh/core/cluster/cluster.py#L644-L672

https://github.com/wazuh/wazuh/blob/adfbe64a1a8ca264088dfd1727d60e6186166129/framework/wazuh/core/cluster/worker.py#L755-L756

## Results
If a distributed API request reached a node that was busy processing Integrity check/sync files, that request was not executed until the worker finished its work. This could lead to very long waiting times. For instance, this is the result obtained when running `GET /cluster/worker1/stats/hourly` just after asking the worker1 to synchronize 100000 agent-groups files:
```
2021/12/16 08:12:29 INFO: wazuh 172.20.0.1 "GET /cluster/worker1/stats/hourly" with parameters {} and body {} done in 55.508s: 200
```

Now, since those tasks are performed in a parallel child process, the parent `wazuh-clusterd` process is free to respond to the API among other things. This API requests were performed while the worker1 was processing 100000 agent-groups files again: 
```
2021/12/16 08:08:05 INFO: wazuh 172.20.0.1 "GET /cluster/worker1/stats/hourly" with parameters {} and body {} done in 0.026s: 200
2021/12/16 08:08:07 INFO: wazuh 172.20.0.1 "GET /cluster/worker1/stats/hourly" with parameters {} and body {} done in 0.026s: 200
```
