### PR TITLE
Modify restart script to avoid bug after shared configuration changes

### DIFF
--- a/src/active-response/restart.sh
+++ b/src/active-response/restart.sh
@@ -43,10 +43,20 @@ fi
 
 if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then
     touch ${PWD}/var/run/.restart
+    # Making sure to stop Wazuh even if the service is not active
+    systemctl is-active --quiet wazuh-$TYPE
+    if [ $? -ne 0 ]; then
+        ${PWD}/bin/wazuh-control stop
+    fi
     systemctl restart wazuh-$TYPE
     rm -f ${PWD}/var/run/.restart
 elif command -v service > /dev/null 2>&1; then
     touch ${PWD}/var/run/.restart
+    # Making sure to stop Wazuh even if the service is not active
+    service wazuh-$TYPE status > /dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        ${PWD}/bin/wazuh-control stop
+    fi
     service wazuh-$TYPE restart
     rm -f ${PWD}/var/run/.restart
 else


### PR DESCRIPTION
|Related issue|
|---|
|#11349|

## Description

Hi team,

This _PR_ aims to modify **active response**'s `restart.sh` script to avoid the bug described in #11349.

Said bug was recently introduced in https://github.com/wazuh/wazuh/pull/8357, where the use of `wazuh-control restart` was substituted by `restart.sh`. This script attempts to restart Wazuh by using **systemctl/service** by default.

The problem happens when trying to restart an agent that's been previously deployed with the `wazuh-control` script: As the service keeps being inactive, it ignores stopping Wazuh before starting it, thus failing to restart.

The fix introduced in the script makes sure to stop Wazuh even if the service is inactive.

Best regards.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
