### PR TITLE
Fix file descriptor leak in Vulnerability Detector

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1291,10 +1291,9 @@ int wm_vuldet_fill_report_oval_data(sqlite3 *db, sqlite3_stmt *stmt, scan_agent 
             report->cvss3->base_score = strtod(cvss3, NULL);
         }
         if (!report->cwe) w_strdup(cwe, report->cwe);
-
-        wdb_finalize(stmt);
-
     }
+
+    wdb_finalize(stmt);
 
     // Adding references URLs (REFERENCES_INFO table)
     if (wm_vuldet_prepare(db, vu_queries[VU_REFS_QUERY], -1, &stmt, NULL) != SQLITE_OK) {
@@ -2954,6 +2953,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
     if (nvd_it) {
         mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_INS_VUL_SEC, "NVD");
         if (wm_vuldet_index_nvd(db, update, nvd_it)) {
+            wm_vuldet_sql_error(db, stmt);
             return OS_INVALID;
         }
         parsed_oval->nvd_vulnerabilities = NULL;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2996,6 +2996,7 @@ int wm_vuldet_check_nvd_logical(sqlite3 *db, char *agent_id, vu_nvd_report *rp, 
             and_conf = sqlite3_column_int(stmt_conf, 0);
 
             if (wm_vuldet_prepare(db, vu_queries[VU_GET_MATCHES_AND], -1, &stmt_match, NULL) != SQLITE_OK) {
+                wdb_finalize(stmt_conf);
                 return wm_vuldet_sql_error(db, stmt_match);
             }
             sqlite3_bind_int(stmt_match, 1, and_conf);
@@ -3006,6 +3007,8 @@ int wm_vuldet_check_nvd_logical(sqlite3 *db, char *agent_id, vu_nvd_report *rp, 
                     and_mach = sqlite3_column_int(stmt_match, 0);
 
                     if (wm_vuldet_prepare(db, vu_queries[VU_GET_CPE_AND], -1, &stmt_cpe, NULL) != SQLITE_OK) {
+                        wdb_finalize(stmt_conf);
+                        wdb_finalize(stmt_match);
                         return wm_vuldet_sql_error(db, stmt_cpe);
                     }
                     sqlite3_bind_int(stmt_match, 1, and_mach);
@@ -3017,6 +3020,9 @@ int wm_vuldet_check_nvd_logical(sqlite3 *db, char *agent_id, vu_nvd_report *rp, 
                             product = (char *)sqlite3_column_text(stmt_cpe, 1);
 
                             if (wm_vuldet_prepare(db, vu_queries[VU_GET_AGENTCPE_AND], -1, &stmt_agentcpe, NULL) != SQLITE_OK) {
+                                wdb_finalize(stmt_conf);
+                                wdb_finalize(stmt_match);
+                                wdb_finalize(stmt_cpe);
                                 return wm_vuldet_sql_error(db, stmt_agentcpe);
                             }
                             sqlite3_bind_text(stmt_agentcpe, 1, vendor, -1, NULL);
@@ -3031,6 +3037,9 @@ int wm_vuldet_check_nvd_logical(sqlite3 *db, char *agent_id, vu_nvd_report *rp, 
                                     break;
 
                                 default:
+                                    wdb_finalize(stmt_conf);
+                                    wdb_finalize(stmt_match);
+                                    wdb_finalize(stmt_cpe);
                                     return wm_vuldet_sql_error(db, stmt_agentcpe);
                                 }
                             }
@@ -3038,6 +3047,8 @@ int wm_vuldet_check_nvd_logical(sqlite3 *db, char *agent_id, vu_nvd_report *rp, 
                             break;
 
                         default:
+                            wdb_finalize(stmt_conf);
+                            wdb_finalize(stmt_match);
                             return wm_vuldet_sql_error(db, stmt_cpe);
                         }
                     }
@@ -3045,6 +3056,7 @@ int wm_vuldet_check_nvd_logical(sqlite3 *db, char *agent_id, vu_nvd_report *rp, 
                     break;
 
                 default:
+                    wdb_finalize(stmt_conf);
                     return wm_vuldet_sql_error(db, stmt_match);
                 }
             }


### PR DESCRIPTION
|Related issue|
|---|
|#11163|

## Description

This PR aims to fix a descriptor leak found in the issue #11163 and that is produced by the `wm_vuldet_fill_report_oval_data()` function in the agent scan in _Vulnerability-Detector_.

This behavior seemed to be introduced in commit:https://github.com/wazuh/wazuh/commit/9fec3ed151aa2297d0e1434f5bc90ff32e76f4f5, when closing an `if()` before finalizing the DB statement [`wdb_finalize(stmt)`]. So when executing `wm_vuldet_step(stmt)`, it may be the case that it is different from `SQLITE_ROW`, leaving the statement open and crushing the value of the `stmt` variable. This causes the reference to be lost and when trying to close the DB, it remains in a “zombie” state because there is an open statement.

In addition, a couple of fixes are also added to prevent potential descriptor leaks.

> Unfinished statements can lead to conflicts when trying to close the database, thus explaining the existence of FD leaks. 
In the following link, you can see the different states in the database after trying to close it: https://sqlite.org/c3ref/close.html

## Descriptor sample

File descriptor list after 10 agents scans (without the fix, a `cve.db` would appear for each scan performed):

```
# lsof -p `pidof wazuh-modulesd` | grep "cve.db" |wc -l
1
# ls -l /proc/`pidof wazuh-modulesd`/fd
total 0
lrwx------. 1 root root 64 dic 15 16:50 0 -> /dev/null
lrwx------. 1 root root 64 dic 15 16:50 1 -> /dev/null
lrwx------. 1 root root 64 dic 15 16:50 10 -> 'socket:[773087]'
lrwx------. 1 root root 64 dic 15 16:50 11 -> 'socket:[773088]'
lrwx------. 1 root root 64 dic 15 16:50 12 -> 'socket:[773089]'
lr-x------. 1 root root 64 dic 15 16:50 13 -> /dev/urandom
lrwx------. 1 root root 64 dic 15 16:50 14 -> 'socket:[773090]'
lrwx------. 1 root root 64 dic 15 16:50 15 -> 'socket:[773099]'
lrwx------. 1 root root 64 dic 15 16:50 16 -> /var/ossec/queue/syscollector/db/local.db
lrwx------. 1 root root 64 dic 15 16:50 17 -> 'socket:[775213]'
lr-x------. 1 root root 64 dic 15 16:50 18 -> anon_inode:inotify
lrwx------. 1 root root 64 dic 15 16:50 19 -> /var/ossec/queue/vulnerabilities/cve.db
lrwx------. 1 root root 64 dic 15 16:50 2 -> /dev/null
lr-x------. 1 root root 64 dic 15 16:50 3 -> /var/lib/sss/mc/group
lrwx------. 1 root root 64 dic 15 16:50 4 -> 'socket:[773081]'
lrwx------. 1 root root 64 dic 15 16:50 5 -> 'socket:[773082]'
lrwx------. 1 root root 64 dic 15 16:50 7 -> 'socket:[773084]'
lrwx------. 1 root root 64 dic 15 16:50 8 -> 'socket:[773086]'
lr-x------. 1 root root 64 dic 15 16:50 9 -> /var/lib/sss/mc/passwd
```

## Configuration

With this configuration, the FD leak has been replicated in a Jenkins environment with a CentOS 8 manager:

```
  <vulnerability-detector>
    <enabled>yes</enabled>
    <interval>3m</interval>
    <min_full_scan_interval>1s</min_full_scan_interval>
    <run_on_start>yes</run_on_start>
    <provider name="redhat">
      <enabled>yes</enabled>
      <update_interval>1m</update_interval>
      <url end="26" start="1">http://ci.wazuh.com/vulnerability-detector/rh-feed/redhat-feed[-].json</url>
      <os url="http://ci.wazuh.com/vulnerability-detector/redhat/rhel-7-including-unpatched.oval.xml.bz2">7</os>
      <os url="http://ci.wazuh.com/vulnerability-detector/redhat/rhel-8-including-unpatched.oval.xml.bz2">8</os>
    </provider>
    <provider name="nvd">
      <url end="2021" start="2020">http://ci.wazuh.com/vulnerability-detector/nvd-feed/nvd-feed[-].json.gz</url>
      <enabled>yes</enabled>
      <update_from_year>2020</update_from_year>
      <update_interval>1m</update_interval>
    </provider>
  </vulnerability-detector>
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] Stress test for affected components
