### PR TITLE
Number of groups per agent reduction

### DIFF
--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -315,7 +315,7 @@ https://www.gnu.org/licenses/gpl.html\n"
 #define MULTIGROUPS_DIR   "var/multigroups"
 #define MAX_GROUP_NAME 255
 #define MULTIGROUP_SEPARATOR ','
-#define MAX_GROUPS_PER_MULTIGROUP 256
+#define MAX_GROUPS_PER_MULTIGROUP 128
 
 // Incoming directory
 #ifndef WIN32

--- a/src/headers/string_op.h
+++ b/src/headers/string_op.h
@@ -105,6 +105,9 @@ char * wstr_chr(char * str, int character);
 // Free string array
 void free_strarray(char ** array);
 
+// Get the size of a string array
+size_t strarray_size(char ** array);
+
 /* Returns 0 if str is found */
 int wstr_find_in_folder(char *path,const char *str,int strip_new_line);
 

--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -344,9 +344,9 @@ w_err_t w_auth_validate_groups(const char *groups, char *response) {
 
     os_strdup(groups, tmp_groups);
     char *group = strtok_r(tmp_groups, delim, &save_ptr);
-    max_multigroups++;
 
     while ( group != NULL ) {
+        max_multigroups++;
         DIR * dp;
         char dir[PATH_MAX + 1] = {0};
 
@@ -372,7 +372,6 @@ w_err_t w_auth_validate_groups(const char *groups, char *response) {
         }
 
         group = strtok_r(NULL, delim, &save_ptr);
-        max_multigroups++;
         closedir(dp);
     }
     os_free(tmp_groups);

--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -344,6 +344,7 @@ w_err_t w_auth_validate_groups(const char *groups, char *response) {
 
     os_strdup(groups, tmp_groups);
     char *group = strtok_r(tmp_groups, delim, &save_ptr);
+    max_multigroups++;
 
     while ( group != NULL ) {
         DIR * dp;

--- a/src/shared/string_op.c
+++ b/src/shared/string_op.c
@@ -399,6 +399,18 @@ void free_strarray(char ** array) {
     }
 }
 
+// Get the size of a string array
+size_t strarray_size(char ** array) {
+    size_t size = 0;
+
+    if (array) {
+        while (array[size]) {
+            size++;
+        }
+    }
+    return size;
+}
+
 /* Returns 0 if str is found */
 int wstr_find_in_folder(char *path,const char *str,int strip_new_line){
     DIR *dp;

--- a/src/wazuh_db/helpers/wdb_global_helpers.c
+++ b/src/wazuh_db/helpers/wdb_global_helpers.c
@@ -1063,9 +1063,10 @@ int wdb_remove_group_from_belongs_db(const char *name, int *sock) {
 }
 
 int wdb_set_agent_groups_csv(int id, char* groups_csv, char* mode, char* sync_status, char* source, int *sock) {
-    char** groups_array = NULL;
-    wstr_split(groups_csv, ",", NULL, 1, &groups_array);
-    return wdb_set_agent_groups(id, groups_array, mode, sync_status, source, sock);
+    char** groups_array = w_string_split(groups_csv, ",", 0);
+    int ret = wdb_set_agent_groups(id, groups_array, mode, sync_status, source, sock);
+    free_strarray(groups_array);
+    return ret;
 }
 
 int wdb_set_agent_groups(int id, char** groups_array, char* mode, char* sync_status, char* source, int *sock) {


### PR DESCRIPTION
|Related issue|
|---|
|#11312|

## Description

This PR implements the changes to 
- Reduce the number of groups an agent can take using `authd` as the registration method.
- Fixes the counting of groups while reading the comma-separated string. 
- Truncates on upgrades the groups file if it contains more groups than the permitted number.

## Dod

**For simplicity, the maximum number of groups was reduced by 2 temporarily.**
Create and assign some groups to agents.
![2](https://user-images.githubusercontent.com/13010397/146782399-b1a896e5-6fc3-4cab-a9cc-b9b41ab36dc6.png)
Count groups in agent files.
![3](https://user-images.githubusercontent.com/13010397/146782403-438d83b5-5f19-4212-a2f3-a1b93b081ab7.png)
Groups loaded with information read from file prior new function.
![4](https://user-images.githubusercontent.com/13010397/146782404-f0f463ab-0a18-448f-9dd5-7725cbf1b002.png)
Groups after function execution.
![5](https://user-images.githubusercontent.com/13010397/146782409-8343cbf7-2206-46f4-92ab-0c2d92f2e49d.png)
Count groups in agent file.
![6](https://user-images.githubusercontent.com/13010397/146782450-f5f5e1de-4248-4d8d-8431-0176975bf620.png)
Warning log.
![7](https://user-images.githubusercontent.com/13010397/146782452-7cbc7def-1810-4870-a3b7-79edb0dc4d1d.png)
Scan-Build result.
![8](https://user-images.githubusercontent.com/13010397/146782455-cf91e4ff-c644-4aec-a0a1-922bddab5e60.png)
Registering using agent-auth
![10](https://user-images.githubusercontent.com/13010397/146783084-daa7d46c-07fe-4a19-8221-b63034878744.png)

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Source upgrade
- [X] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report