### PR TITLE
Rework of #10658 - PR: Create rules for Cloudflare WAF 

### DIFF
--- a/ruleset/rules/0935-cloudflare-waf_rules.xml
+++ b/ruleset/rules/0935-cloudflare-waf_rules.xml
@@ -1,111 +1,119 @@
+<!--
+    Copyright (C) 2015-2021, Wazuh Inc.
+-->
+
+<!--
+Cloudflare WAF rules ID: 92501 - 92517
+-->
+
 <group name="WAF, Cloudflare">
 
   <rule id="92501" level="0">
     <decoded_as>json</decoded_as>
     <field name="WAFAction" type="pcre2">.+</field>
-    <description>WAF rules</description>
+    <description>Cloudflare WAF rules</description>
   </rule>
 
   <rule id="92502" level="4">
     <if_sid>92501</if_sid>
     <field name="ClientRequestMethod" type="pcre2">GET</field>
-    <description>WAF: GET request $(ClientRequestURI)</description>
+    <description>Cloudflare WAF: GET request $(ClientRequestURI)</description>
   </rule>
 
   <rule id="92503" level="5">
     <if_sid>92501</if_sid>
     <field name="ClientRequestMethod" type="pcre2">POST</field>
-    <description>WAF: POST request $(ClientRequestURI)</description>
+    <description>Cloudflare WAF: POST request $(ClientRequestURI)</description>
   </rule>
 
   <rule id="92504" level="5">
     <if_sid>92501</if_sid>
     <field name="ClientRequestMethod" type="pcre2">PUT</field>
-    <description>WAF: PUT request $(ClientRequestURI)</description>
+    <description>Cloudflare WAF: PUT request $(ClientRequestURI)</description>
     <group>hipaa_164.312.c.1</group>
   </rule>
 
   <rule id="92505" level="7">
     <if_sid>92501</if_sid>
     <field name="ClientRequestURI" type="pcre2">/auth/login</field>
-    <description>WAF: Authentication attempt</description>
+    <description>Cloudflare WAF: Authentication attempt</description>
   </rule>
 
   <rule id="92506" level="4">
     <if_sid>92505</if_sid>
     <field name="EdgeResponseStatus" type="pcre2">200</field>
-    <description>WAF: Authentication success from $(OriginIP)</description>
+    <description>Cloudflare WAF: Authentication success from $(OriginIP)</description>
     <group>hipaa_164.312.d,pci_dss_8.2</group>
   </rule>
 
   <rule id="92507" level="7">
     <if_sid>92505</if_sid>
     <field name="EdgeResponseStatus" type="pcre2" negate="yes">200</field>
-    <description>WAF: Authentication failure from $(OriginIP)</description>
+    <description>Cloudflare WAF: Authentication failure from $(OriginIP)</description>
     <group>hipaa_164.312.e.1,gpg13_3.3,nist_800_53_AC.7,pci_dss_8.2</group>
   </rule>
 
   <rule id="92508" level="7">
-   <if_sid>92501</if_sid>
-   <field name="EdgeResponseStatus" negate="yes">200</field>
-   <description>WAF: $(ClientRequestURI) response code returned error</description>
-   <group>gpg13_4.3</group>
+    <if_sid>92501</if_sid>
+    <field name="EdgeResponseStatus" negate="yes">200</field>
+    <description>Cloudflare WAF: $(ClientRequestURI) response code returned error</description>
+    <group>gpg13_4.3</group>
   </rule>
 
   <rule id="92509" level="4">
-   <if_sid>92508</if_sid>
-   <field name="EdgeResponseStatus">400</field>
-   <description>WAF: $(ClientRequestURI) Bad request.</description>
+    <if_sid>92508</if_sid>
+    <field name="EdgeResponseStatus">400</field>
+    <description>Cloudflare WAF: $(ClientRequestURI) Bad request.</description>
   </rule>
 
   <rule id="92510" level="8">
-   <if_sid>92508</if_sid>
-   <field name="EdgeResponseStatus">401</field>
-   <description>WAF: $(ClientRequestURI) Unauthorized.</description>
-   <group>gpg13_4.3,tsc_cc6.8,hipaa_164.312.e.1</group>
+    <if_sid>92508</if_sid>
+    <field name="EdgeResponseStatus">401</field>
+    <description>Cloudflare WAF: $(ClientRequestURI) Unauthorized.</description>
+    <group>gpg13_4.3,tsc_cc6.8,hipaa_164.312.e.1</group>
   </rule>
 
   <rule id="92511" level="7">
-   <if_sid>92508</if_sid>
-   <field name="EdgeResponseStatus">403</field>
-   <description>WAF: $(ClientRequestURI) Permission denied.</description>
-   <group>gpg13_4.3,tsc_cc6.8,hipaa_164.312.e.1,pci_dss_7.1,pci_dss_10.2.4,nist_800_53_AC.7</group>
+    <if_sid>92508</if_sid>
+    <field name="EdgeResponseStatus">403</field>
+    <description>Cloudflare WAF: $(ClientRequestURI) Permission denied.</description>
+    <group>gpg13_4.3,tsc_cc6.8,hipaa_164.312.e.1,pci_dss_7.1,pci_dss_10.2.4,nist_800_53_AC.7</group>
   </rule>
 
   <rule id="92512" level="4">
-   <if_sid>92508</if_sid>
-   <field name="EdgeResponseStatus">404</field>
-   <description>WAF: $(ClientRequestURI) Resource not found.</description>
+    <if_sid>92508</if_sid>
+    <field name="EdgeResponseStatus">404</field>
+    <description>cloudflare WAF: $(ClientRequestURI) Resource not found.</description>
   </rule>
 
   <rule id="92513" level="4">
-   <if_sid>92508</if_sid>
-   <field name="EdgeResponseStatus">405</field>
-   <description>WAF: $(ClientRequestURI) Invalid HTTP method.</description>
+    <if_sid>92508</if_sid>
+    <field name="EdgeResponseStatus">405</field>
+    <description>Cloudflare WAF: $(ClientRequestURI) Invalid HTTP method.</description>
   </rule>
 
   <rule id="92514" level="4">
-   <if_sid>92508</if_sid>
-   <field name="EdgeResponseStatus">413</field>
-   <description>WAF: $(ClientRequestURI) Maximum request body size exceeded</description>
+    <if_sid>92508</if_sid>
+    <field name="EdgeResponseStatus">413</field>
+    <description>Cloudflare WAF: $(ClientRequestURI) Maximum request body size exceeded</description>
   </rule>
 
   <rule id="92515" level="4">
-   <if_sid>92508</if_sid>
-   <field name="EdgeResponseStatus">500</field>
-   <description>WAF: $(ClientRequestURI) Internal error</description>
+    <if_sid>92508</if_sid>
+    <field name="EdgeResponseStatus">500</field>
+    <description>Cloudflare WAF: $(ClientRequestURI) Internal error</description>
   </rule>
 
   <rule id="92516" level="3">
     <if_sid>92501</if_sid>
     <field name="WAFAction" type="pcre2">unknown</field>
-    <description>WAF: unknown acction, take no further action</description>
+    <description>Cloudflare WAF: unknown acction, take no further action</description>
   </rule>
 
   <rule id="92517" level="3">
     <if_sid>92501</if_sid>
     <field name="WAFAction" type="pcre2">simulate</field>
-    <description>WAF: Take no action other than logging the event</description>
+    <description>Cloudflare WAF: Take no action other than logging the event</description>
   </rule>
 
 </group>

--- a/ruleset/testing/tests/cloudflare-waf.ini
+++ b/ruleset/testing/tests/cloudflare-waf.ini
@@ -1,77 +1,86 @@
-[WAF GET method event]
+;   Copyright (C) 2015-2021, Wazuh Inc.
+;
+;   Tests for products:
+;     Cloudflare WAF
+;
+;   Sample logs source:
+;    Software Name: Cloudflare
+;    WAF logs: Wazuh Ops team
+;
+
+[Cloudflare WAF GET method event]
 log 1 pass = {"ClientIP":"54.76.123.133","ClientRequestHost":"ae-preprod.yap.com","ClientRequestMethod":"GET","ClientRequestURI":"/messages/actuator/health","EdgeEndTimestamp":"2021-07-27T21:26:42Z","EdgeResponseBytes":845,"EdgeResponseStatus":200,"EdgeStartTimestamp":"2021-07-27T21:26:42Z","RayID":"6758f291eb0b60df","FirewallMatchesActions":[],"FirewallMatchesRuleIDs":[],"FirewallMatchesSources":[],"OriginIP":"99.83.222.19","OriginSSLProtocol":"TLSv1.2","OriginResponseBytes":0,"OriginResponseHTTPExpires":"","OriginResponseHTTPLastModified":"","OriginResponseStatus":200,"OriginResponseTime":20000000,"WAFAction":"unknown","WAFFlags":"0","WAFMatchedVar":"","WAFProfile":"unknown","WAFRuleID":"","WAFRuleMessage":"","WorkerCPUTime":0,"WorkerStatus":"unknown","WorkerSubrequest":false,"WorkerSubrequestCount":0,"CacheCacheStatus":"unknown","CacheTieredFill":false,"CacheResponseBytes":1981,"CacheResponseStatus":200,"ClientCountry":"ie","ClientDeviceType":"desktop","ClientIPClass":"noRecord","ZoneID":276192118,"ZoneName":"yap.com","SecurityLevel":"unk"}
 rule = 92502
 alert = 4
 decoder = json
 
-[WAF POST method event]
+[Cloudflare WAF POST method event]
 log 1 pass = {"ClientIP":"52.17.243.194","ClientRequestHost":"ae-preprod.yap.com","ClientRequestMethod":"POST","ClientRequestURI":"/digi-ocr/detect/","EdgeEndTimestamp":"2021-07-27T21:26:38Z","EdgeResponseBytes":625,"EdgeResponseStatus":200,"EdgeStartTimestamp":"2021-07-27T21:26:38Z","RayID":"6758f27939a260c2","FirewallMatchesActions":[],"FirewallMatchesRuleIDs":[],"FirewallMatchesSources":[],"OriginIP":"75.2.33.181","OriginSSLProtocol":"TLSv1.2","OriginResponseBytes":0,"OriginResponseHTTPExpires":"","OriginResponseHTTPLastModified":"","OriginResponseStatus":200,"OriginResponseTime":19000000,"WAFAction":"unknown","WAFFlags":"0","WAFMatchedVar":"","WAFProfile":"unknown","WAFRuleID":"","WAFRuleMessage":"","WorkerCPUTime":0,"WorkerStatus":"unknown","WorkerSubrequest":false,"WorkerSubrequestCount":0,"CacheCacheStatus":"unknown","CacheTieredFill":false,"CacheResponseBytes":1678,"CacheResponseStatus":200,"ClientCountry":"ie","ClientDeviceType":"desktop","ClientIPClass":"noRecord","ZoneID":276192118,"ZoneName":"yap.com","SecurityLevel":"unk"}
 rule = 92503
 alert = 5
 decoder = json
 
-[WAF PUT method event]
+[Cloudflare WAF PUT method event]
 log 1 pass = {"ClientIP":"2001:8f8:1821:9fb3:1101:67f6:7f43:b124","ClientRequestHost":"ae-prod.yap.com","ClientRequestMethod":"PUT","ClientRequestURI":"/customers/api/stop-display","EdgeEndTimestamp":"2021-07-27T21:38:19Z","EdgeResponseBytes":997,"EdgeResponseStatus":200,"EdgeStartTimestamp":"2021-07-27T21:38:19Z","RayID":"675903985d4608ab","FirewallMatchesActions":[],"FirewallMatchesRuleIDs":[],"FirewallMatchesSources":[],"OriginIP":"99.83.253.40","OriginSSLProtocol":"TLSv1.2","OriginResponseBytes":0,"OriginResponseHTTPExpires":"","OriginResponseHTTPLastModified":"","OriginResponseStatus":200,"OriginResponseTime":134000000,"WAFAction":"unknown","WAFFlags":"0","WAFMatchedVar":"","WAFProfile":"unknown","WAFRuleID":"","WAFRuleMessage":"","WorkerCPUTime":0,"WorkerStatus":"unknown","WorkerSubrequest":false,"WorkerSubrequestCount":0,"CacheCacheStatus":"unknown","CacheTieredFill":false,"CacheResponseBytes":2050,"CacheResponseStatus":200,"ClientCountry":"ae","ClientDeviceType":"desktop","ClientIPClass":"noRecord","ZoneID":276192118,"ZoneName":"yap.com","SecurityLevel":"med"}
 rule = 92504
 alert = 5
 decoder = json
 
-[WAF auth event]
+[Cloudflare WAF auth event]
 log 1 pass = {"ClientIP":"54.76.123.133","ClientRequestHost":"ae-prod.yap.com","ClientRequestMethod":"GET","ClientRequestURI":"/auth/login","EdgeEndTimestamp":"2021-07-27T21:26:46Z","EdgeResponseBytes":2516,"EdgeResponseStatus":200,"EdgeStartTimestamp":"2021-07-27T21:26:46Z","RayID":"6758f2aaedc434cc","FirewallMatchesActions":[],"FirewallMatchesRuleIDs":[],"FirewallMatchesSources":[],"OriginIP":"99.83.253.40","OriginSSLProtocol":"TLSv1.2","OriginResponseBytes":0,"OriginResponseHTTPExpires":"","OriginResponseHTTPLastModified":"","OriginResponseStatus":200,"OriginResponseTime":26000000,"WAFAction":"unknown","WAFFlags":"0","WAFMatchedVar":"","WAFProfile":"unknown","WAFRuleID":"","WAFRuleMessage":"","WorkerCPUTime":0,"WorkerStatus":"unknown","WorkerSubrequest":false,"WorkerSubrequestCount":0,"CacheCacheStatus":"unknown","CacheTieredFill":false,"CacheResponseBytes":3223,"CacheResponseStatus":200,"ClientCountry":"ie","ClientDeviceType":"desktop","ClientIPClass":"noRecord","ZoneID":276192118,"ZoneName":"yap.com","SecurityLevel":"unk"}
 rule = 92506
 alert = 4
 decoder = json
 
-[WAF auth failure event]
+[Cloudflare WAF auth failure event]
 log 1 pass = {"ClientIP":"54.76.123.133","ClientRequestHost":"ae-prod.yap.com","ClientRequestMethod":"GET","ClientRequestURI":"/auth/login","EdgeEndTimestamp":"2021-07-27T21:38:24Z","EdgeResponseBytes":2516,"EdgeResponseStatus":401,"EdgeStartTimestamp":"2021-07-27T21:38:24Z","RayID":"675903b56b1060b6","FirewallMatchesActions":[],"FirewallMatchesRuleIDs":[],"FirewallMatchesSources":[],"OriginIP":"99.83.253.40","OriginSSLProtocol":"TLSv1.2","OriginResponseBytes":0,"OriginResponseHTTPExpires":"","OriginResponseHTTPLastModified":"","OriginResponseStatus":200,"OriginResponseTime":26000000,"WAFAction":"unknown","WAFFlags":"0","WAFMatchedVar":"","WAFProfile":"unknown","WAFRuleID":"","WAFRuleMessage":"","WorkerCPUTime":0,"WorkerStatus":"unknown","WorkerSubrequest":false,"WorkerSubrequestCount":0,"CacheCacheStatus":"unknown","CacheTieredFill":false,"CacheResponseBytes":3224,"CacheResponseStatus":200,"ClientCountry":"ie","ClientDeviceType":"desktop","ClientIPClass":"noRecord","ZoneID":276192118,"ZoneName":"yap.com","SecurityLevel":"unk"}
 rule = 92507
 alert = 7
 decoder = json
 
-
-[WAF returned error event]
+[Cloudflare WAF returned error event]
 log 1 pass = {"ClientIP":"54.76.123.133","ClientRequestHost":"ae-preprod.yap.com","ClientRequestMethod":"GET","ClientRequestURI":"/messages/actuator/health","EdgeEndTimestamp":"2021-07-27T21:38:42Z","EdgeResponseBytes":845,"EdgeResponseStatus":409,"EdgeStartTimestamp":"2021-07-27T21:38:42Z","RayID":"67590425eaa434f5","FirewallMatchesActions":[],"FirewallMatchesRuleIDs":[],"FirewallMatchesSources":[],"OriginIP":"99.83.222.19","OriginSSLProtocol":"TLSv1.2","OriginResponseBytes":0,"OriginResponseHTTPExpires":"","OriginResponseHTTPLastModified":"","OriginResponseStatus":200,"OriginResponseTime":18000000,"WAFAction":"unknown","WAFFlags":"0","WAFMatchedVar":"","WAFProfile":"unknown","WAFRuleID":"","WAFRuleMessage":"","WorkerCPUTime":0,"WorkerStatus":"unknown","WorkerSubrequest":false,"WorkerSubrequestCount":0,"CacheCacheStatus":"unknown","CacheTieredFill":false,"CacheResponseBytes":1984,"CacheResponseStatus":200,"ClientCountry":"ie","ClientDeviceType":"desktop","ClientIPClass":"noRecord","ZoneID":276192118,"ZoneName":"yap.com","SecurityLevel":"unk"}
 rule = 92508
 alert = 7
 decoder = json
 
-[WAF returned 400 code event]
+[Cloudflare WAF returned 400 code event]
 log 1 pass = {"ClientIP":"2.51.28.56","ClientRequestHost":"ae-prod.yap.com","ClientRequestMethod":"GET","ClientRequestURI":"/cards/api/cards/debit/balance","EdgeEndTimestamp":"2021-07-27T22:25:07Z","EdgeResponseBytes":1001,"EdgeResponseStatus":400,"EdgeStartTimestamp":"2021-07-27T22:25:07Z","RayID":"67594824cf622c26","FirewallMatchesActions":[],"FirewallMatchesRuleIDs":[],"FirewallMatchesSources":[],"OriginIP":"75.2.31.168","OriginSSLProtocol":"TLSv1.2","OriginResponseBytes":0,"OriginResponseHTTPExpires":"","OriginResponseHTTPLastModified":"","OriginResponseStatus":400,"OriginResponseTime":343000000,"WAFAction":"unknown","WAFFlags":"0","WAFMatchedVar":"","WAFProfile":"unknown","WAFRuleID":"","WAFRuleMessage":"","WorkerCPUTime":0,"WorkerStatus":"unknown","WorkerSubrequest":false,"WorkerSubrequestCount":0,"CacheCacheStatus":"unknown","CacheTieredFill":false,"CacheResponseBytes":2115,"CacheResponseStatus":400,"ClientCountry":"ae","ClientDeviceType":"desktop","ClientIPClass":"noRecord","ZoneID":276192118,"ZoneName":"yap.com","SecurityLevel":"med"}
 rule = 92509
 alert = 4
 decoder = json
 
-[WAF returned 401 code event]
+[Cloudflare WAF returned 401 code event]
 log 1 pass = {"ClientIP":"2402:8100:3913:f4c8:4150:2d5a:58b3:d6b","ClientRequestHost":"ae-prod.yap.com","ClientRequestMethod":"GET","ClientRequestURI":"/customers/api/mobile-app-versions","EdgeEndTimestamp":"2021-07-27T04:57:43Z","EdgeResponseBytes":950,"EdgeResponseStatus":401,"EdgeStartTimestamp":"2021-07-27T04:57:42Z","RayID":"675349d64f193d60","FirewallMatchesActions":[],"FirewallMatchesRuleIDs":[],"FirewallMatchesSources":[],"OriginIP":"75.2.31.168","OriginSSLProtocol":"TLSv1.2","OriginResponseBytes":0,"OriginResponseHTTPExpires":"","OriginResponseHTTPLastModified":"","OriginResponseStatus":401,"OriginResponseTime":905000000,"WAFAction":"unknown","WAFFlags":"0","WAFMatchedVar":"","WAFProfile":"unknown","WAFRuleID":"","WAFRuleMessage":"","WorkerCPUTime":0,"WorkerStatus":"unknown","WorkerSubrequest":false,"WorkerSubrequestCount":0,"CacheCacheStatus":"unknown","CacheTieredFill":false,"CacheResponseBytes":2039,"CacheResponseStatus":401,"ClientCountry":"in","ClientDeviceType":"desktop","ClientIPClass":"noRecord","ZoneID":276192118,"ZoneName":"yap.com","SecurityLevel":"med"}
 rule = 92510
 alert = 8
 decoder = json
 
-[WAF returned 403 code event]
+[Cloudflare WAF returned 403 code event]
 log 1 pass = {"ClientIP":"154.127.53.235","ClientRequestHost":"www.yap.com","ClientRequestMethod":"GET","ClientRequestURI":"/.env","EdgeEndTimestamp":"2021-07-27T09:49:02Z","EdgeResponseBytes":2111,"EdgeResponseStatus":403,"EdgeStartTimestamp":"2021-07-27T09:49:02Z","RayID":"6754f49cb94be04d","FirewallMatchesActions":["block"],"FirewallMatchesRuleIDs":["100016"],"FirewallMatchesSources":["waf"],"OriginIP":"","OriginSSLProtocol":"unknown","OriginResponseBytes":0,"OriginResponseHTTPExpires":"","OriginResponseHTTPLastModified":"","OriginResponseStatus":0,"OriginResponseTime":0,"WAFAction":"drop","WAFFlags":"0","WAFMatchedVar":"","WAFProfile":"med","WAFRuleID":"100016","WAFRuleMessage":"Version Control - Information Disclosure","WorkerCPUTime":0,"WorkerStatus":"unknown","WorkerSubrequest":false,"WorkerSubrequestCount":0,"CacheCacheStatus":"unknown","CacheTieredFill":false,"CacheResponseBytes":0,"CacheResponseStatus":0,"ClientCountry":"us","ClientDeviceType":"desktop","ClientIPClass":"noRecord","ZoneID":276192118,"ZoneName":"yap.com","SecurityLevel":"med"}
 rule = 92511
 alert = 7
 decoder = json
 
-[WAF returned 404 code event]
+[Cloudflare WAF returned 404 code event]
 log 1 pass = {"ClientIP":"2a03:2880:ff:1c::face:b00c","ClientRequestHost":"www.yap.com","ClientRequestMethod":"GET","ClientRequestURI":"/wp-content/uploads/2018/04/02_FinalLogo_Yap-01-e1552502263276.png","EdgeEndTimestamp":"2021-07-27T09:51:56Z","EdgeResponseBytes":747,"EdgeResponseStatus":404,"EdgeStartTimestamp":"2021-07-27T09:51:55Z","RayID":"6754f8d649badbc8","FirewallMatchesActions":[],"FirewallMatchesRuleIDs":[],"FirewallMatchesSources":[],"OriginIP":"99.83.253.40","OriginSSLProtocol":"TLSv1.2","OriginResponseBytes":0,"OriginResponseHTTPExpires":"","OriginResponseHTTPLastModified":"","OriginResponseStatus":404,"OriginResponseTime":480000000,"WAFAction":"unknown","WAFFlags":"0","WAFMatchedVar":"","WAFProfile":"unknown","WAFRuleID":"","WAFRuleMessage":"","WorkerCPUTime":0,"WorkerStatus":"unknown","WorkerSubrequest":false,"WorkerSubrequestCount":0,"CacheCacheStatus":"miss","CacheTieredFill":false,"CacheResponseBytes":1973,"CacheResponseStatus":404,"ClientCountry":"us","ClientDeviceType":"desktop","ClientIPClass":"unknown","ZoneID":276192118,"ZoneName":"yap.com","SecurityLevel":"med"}
 rule = 92512
 alert = 4
 decoder = json
 
-[WAF returned 405 code event]
+[Cloudflare WAF returned 405 code event]
 log 1 pass = {"ClientIP":"52.114.6.38","ClientRequestHost":"ae-preprod.yap.com","ClientRequestMethod":"GET","ClientRequestURI":"/auth/oauth/oidc/token?client_id=jith@yopmail.com&client_secret=1212&grant_type=client_credentials","EdgeEndTimestamp":"2021-07-27T06:16:50Z","EdgeResponseBytes":833,"EdgeResponseStatus":405,"EdgeStartTimestamp":"2021-07-27T06:16:50Z","RayID":"6753bdc13cf51944","FirewallMatchesActions":[],"FirewallMatchesRuleIDs":[],"FirewallMatchesSources":[],"OriginIP":"75.2.33.181","OriginSSLProtocol":"TLSv1.2","OriginResponseBytes":0,"OriginResponseHTTPExpires":"","OriginResponseHTTPLastModified":"","OriginResponseStatus":405,"OriginResponseTime":746000000,"WAFAction":"unknown","WAFFlags":"0","WAFMatchedVar":"","WAFProfile":"unknown","WAFRuleID":"","WAFRuleMessage":"","WorkerCPUTime":0,"WorkerStatus":"unknown","WorkerSubrequest":false,"WorkerSubrequestCount":0,"CacheCacheStatus":"unknown","CacheTieredFill":false,"CacheResponseBytes":1973,"CacheResponseStatus":405,"ClientCountry":"hk","ClientDeviceType":"desktop","ClientIPClass":"unknown","ZoneID":276192118,"ZoneName":"yap.com","SecurityLevel":"med"}
 rule = 92513
 alert = 4
 decoder = json
 
-[WAF returned 413 code event]
+[Cloudflare WAF returned 413 code event]
 log 1 pass = {"ClientIP":"2600:1f14:b62:9e04:9e4d:874f:5c00:d627","ClientRequestHost":"www.yap.com","ClientRequestMethod":"GET","ClientRequestURI":"/administrator/","EdgeEndTimestamp":"2021-07-27T20:53:26Z","EdgeResponseBytes":413,"EdgeResponseStatus":413,"EdgeStartTimestamp":"2021-07-27T20:53:26Z","RayID":"6758c1d5ab061392","FirewallMatchesActions":[],"FirewallMatchesRuleIDs":[],"FirewallMatchesSources":[],"OriginIP":"","OriginSSLProtocol":"unknown","OriginResponseBytes":0,"OriginResponseHTTPExpires":"","OriginResponseHTTPLastModified":"","OriginResponseStatus":0,"OriginResponseTime":0,"WAFAction":"unknown","WAFFlags":"0","WAFMatchedVar":"","WAFProfile":"unknown","WAFRuleID":"","WAFRuleMessage":"","WorkerCPUTime":0,"WorkerStatus":"unknown","WorkerSubrequest":false,"WorkerSubrequestCount":0,"CacheCacheStatus":"unknown","CacheTieredFill":false,"CacheResponseBytes":0,"CacheResponseStatus":0,"ClientCountry":"us","ClientDeviceType":"desktop","ClientIPClass":"noRecord","ZoneID":276192118,"ZoneName":"yap.com","SecurityLevel":"med"}
 rule = 92514
 alert = 4
 decoder = json
 
-[WAF returned 500 code event]
+[Cloudflare WAF returned 500 code event]
 log 1 pass = {"ClientIP":"103.27.22.10","ClientRequestHost":"ae-preprod.yap.com","ClientRequestMethod":"GET","ClientRequestURI":"/customers/api/accounts","EdgeEndTimestamp":"2021-07-27T04:48:26Z","EdgeResponseBytes":1552,"EdgeResponseStatus":500,"EdgeStartTimestamp":"2021-07-27T04:48:25Z","RayID":"67533c3d9ed0d3f7","FirewallMatchesActions":[],"FirewallMatchesRuleIDs":[],"FirewallMatchesSources":[],"OriginIP":"75.2.33.181","OriginSSLProtocol":"TLSv1.2","OriginResponseBytes":0,"OriginResponseHTTPExpires":"","OriginResponseHTTPLastModified":"","OriginResponseStatus":500,"OriginResponseTime":1125000000,"WAFAction":"unknown","WAFFlags":"0","WAFMatchedVar":"","WAFProfile":"unknown","WAFRuleID":"","WAFRuleMessage":"","WorkerCPUTime":0,"WorkerStatus":"unknown","WorkerSubrequest":false,"WorkerSubrequestCount":0,"CacheCacheStatus":"unknown","CacheTieredFill":false,"CacheResponseBytes":2224,"CacheResponseStatus":500,"ClientCountry":"pk","ClientDeviceType":"desktop","ClientIPClass":"noRecord","ZoneID":276192118,"ZoneName":"yap.com","SecurityLevel":"unk"}
 rule = 92515
 alert = 4


### PR DESCRIPTION
|Related issue|
|---|
|#10428|

## Description

This PR aims to resolve issues detected under #10428 PR.
The issues resolved are:
- Fixed rules descriptions
- Fixed decoder names
- Fixed indentation issues.
- Fixed rule and decoder header


## Checks and changes 

### Syntax

- [x] 1.a Rule tags order must be compliant.
- [x] 1.b Decoder tags order must be compliant.
- [x] 1.c XML blocks must as compact as possible.
- [x] 1.d Only one empty line between rule/decoder and the next rule/decoder.
- [x] 1.e Decoder extracted fields names must use '_' whether a space is needed.
- [x] 1.f Decoder name must use '-' whether a space is needed.
 
### Grammar

- [x] 2.a Grammar quality.
- [x] 2.b Similar phrases must keep tenses and expressions.
- [x] 2.c Grammar basic rules like capitalization, punctuation marks, sentence construction, and others.


### Semantic

- [x] 3.a New decoder, rule, or test are written in the correct file and grouped correctly inside the file.
- [x] 3.b Group similar rules under same ID's group.
- [x] 3.c: 
     - [x] 3.c1 Find and reuse group name before creating a new one.
     - [x] 3.c2 Include a new group definition in a PR comment.
     - [x] 3.c3 Any group name must use '_' whether it does need a space char.
     - [x] 3.c4 The groups inside a tag must be sorted in alphabetical order.
- [x] 3.d Rule level should be compliant with the [documentation](https://documentation.wazuh.com/current/user-manual/ruleset/rules-classification.html).

### Unit testing

- [x] 4.a A metadata block at the beginning of the .ini file describing software, version, and logs source.
- [x] 4.b Each new rule must have at least one test entry in the correct .ini file.
- [x] 4.c Runtest.py must pass and must include the results in raw format here.




<details><summary>All rules and decoders test.</summary>
<p>

```


```
</p>
</details>

- [x] 4.d New CDB lists must include the proper test entry in the correct .ini file.

### E2E testing

- [x] 5.a Logs for new or modified decoder/rules sent to a manager running with this PR ruleset appear in Kibana.


- [x] 5.b There are not affected or broken visualizations on Kibana.


- [x] 5.c New or modified items can be seen correctly using APP ruleset navigation.


### Elasticsearch Template

- [x] 6.a Known fields with output format managed and usually used for searching are included in template array index.query.default_field. 
- [x] 6.b The new field with the correct date format is stored as a "date" type field in the template.
- [x] 6.c The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 
- [x] 6.d Known fields with output format managed and usually used for searching are included in the template.

### Stoppers

- [x] 7.a No previous rule ID changes without triple check.
- [x] 7.b No previous decoder name changes without triple check.
- [x] 7.c No previous file name changes without triple check.
- [x] 7.d No previous test changes its 'rule' field value without triple check.

### Others

- [x] 8.a Each file has the correct copyright block.
- [x] 8.b The copyright block doesn't have "Author" only "Created by Wazuh". To include an "Author" request triple check.
- [x] 8.c The copyright block doesn't use "-". 
- [x] 8.d The rule files don't have any sample log.
- [x] 8.e The decoder file has sample logs next to the decoder that matches that log.
- [x] 8.f The decoder and rule files have information about software, version, and any helpful information.
- [x] 8.g The PR has a single commit with CHANGELOG changes in the correct format.
- [x] 8.h The new rule ID is not in use.
- [x] 8.i The new rule ID must be in the defined IDs range. 
- [x] 8.j New rules ID range must be verified with a triple check and noted in the rules ID document.
- [x] 8.k The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 