### PR TITLE
Handle PermissionError and FileNotFoundError in master.py and worker.py

### DIFF
--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -14,14 +14,14 @@ from wazuh.core import common, utils
 def spawn_process_pool():
     """Import necessary basic Wazuh SDK modules for the local request pool and spawn child."""
     from wazuh import agent, manager  # noqa
-    from wazuh.core import common # noqa
-    from wazuh.core.cluster import dapi # noqa
+    from wazuh.core import common  # noqa
+    from wazuh.core.cluster import dapi  # noqa
     return
 
 
 def spawn_authentication_pool():
     """Import necessary basic Wazuh security modules for the authentication tasks pool and spawn child."""
-    from wazuh import security # noqa
+    from wazuh import security  # noqa
     return
 
 
@@ -160,9 +160,11 @@ def start(foreground, root, config_file):
         print(f"Starting API as root")
 
     # Spawn child processes with their own needed imports
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(asyncio.wait([loop.run_in_executor(pool, getattr(sys.modules[__name__], f'spawn_{name}'))
-                                          for name, pool in common.mp_pools.get().items()]))
+    if not common.mp_pools.get().get('thread_pool', None):
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(
+            asyncio.wait([loop.run_in_executor(pool, getattr(sys.modules[__name__], f'spawn_{name}'))
+                          for name, pool in common.mp_pools.get().items()]))
 
     # Set up API
     asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -160,7 +160,7 @@ def start(foreground, root, config_file):
         print(f"Starting API as root")
 
     # Spawn child processes with their own needed imports
-    if not common.mp_pools.get().get('thread_pool', None):
+    if 'thread_pool' not in common.mp_pools.get():
         loop = asyncio.get_event_loop()
         loop.run_until_complete(
             asyncio.wait([loop.run_in_executor(pool, getattr(sys.modules[__name__], f'spawn_{name}'))

--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -101,7 +101,8 @@ async def worker_main(args, cluster_config, cluster_items, logger):
                                                          cluster_items=cluster_items)
 
         # Spawn pool processes
-        my_client.task_pool.map(cluster_utils.process_spawn_sleep, range(my_client.task_pool._max_workers))
+        if my_client.task_pool:
+            my_client.task_pool.map(cluster_utils.process_spawn_sleep, range(my_client.task_pool._max_workers))
 
         try:
             await asyncio.gather(my_client.start(), my_local_server.start())

--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -79,7 +79,7 @@ async def master_main(args, cluster_config, cluster_items, logger):
                                                      configuration=cluster_config, enable_ssl=args.ssl,
                                                      cluster_items=cluster_items)
     # Spawn pool processes
-    if my_server.task_pool:
+    if my_server.task_pool is not None:
         my_server.task_pool.map(cluster_utils.process_spawn_sleep, range(my_server.task_pool._max_workers))
     await asyncio.gather(my_server.start(), my_local_server.start())
 
@@ -101,7 +101,7 @@ async def worker_main(args, cluster_config, cluster_items, logger):
                                                          cluster_items=cluster_items)
 
         # Spawn pool processes
-        if my_client.task_pool:
+        if my_client.task_pool is not None:
             my_client.task_pool.map(cluster_utils.process_spawn_sleep, range(my_client.task_pool._max_workers))
 
         try:

--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -79,7 +79,8 @@ async def master_main(args, cluster_config, cluster_items, logger):
                                                      configuration=cluster_config, enable_ssl=args.ssl,
                                                      cluster_items=cluster_items)
     # Spawn pool processes
-    my_server.task_pool.map(cluster_utils.process_spawn_sleep, range(my_server.task_pool._max_workers))
+    if my_server.task_pool:
+        my_server.task_pool.map(cluster_utils.process_spawn_sleep, range(my_server.task_pool._max_workers))
     await asyncio.gather(my_server.start(), my_local_server.start())
 
 

--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -669,7 +669,7 @@ async def run_in_pool(loop, pool, f, *args, **kwargs):
     -------
     Result of `f(*args, **kwargs)` function.
     """
-    if pool:
+    if pool is not None:
         task = loop.run_in_executor(pool, partial(f, *args, **kwargs))
         return await wait_for(task, timeout=None)
     else:

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -31,9 +31,7 @@ from wazuh.core.cluster.cluster import check_cluster_status
 from wazuh.core.exception import WazuhException, WazuhClusterError, WazuhError
 from wazuh.core.wazuh_socket import wazuh_sendsync
 
-process_pool = common.mp_pools.get().get('process_pool', None)
-authentication_pool = common.mp_pools.get().get('authentication_pool', None)
-thread_pool = common.mp_pools.get().get('thread_pool', None)
+pools = common.mp_pools.get()
 
 authentication_funcs = {'check_token', 'check_user_master', 'get_permissions', 'get_security_conf'}
 
@@ -274,12 +272,12 @@ class DistributedAPI:
 
                 else:
                     loop = asyncio.get_event_loop()
-                    if process_pool is None:
-                        pool = thread_pool
+                    if 'thread_pool' in pools:
+                        pool = pools.get('thread_pool')
                     elif self.f.__name__ not in authentication_funcs:
-                        pool = process_pool
+                        pool = pools.get('process_pool')
                     else:
-                        pool = authentication_pool
+                        pool = pools.get('authentication_pool')
 
                     task = loop.run_in_executor(pool, partial(self.run_local, self.f, self.f_kwargs,
                                                               self.logger, self.rbac_permissions,

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -274,10 +274,10 @@ class DistributedAPI:
                     loop = asyncio.get_event_loop()
                     if 'thread_pool' in pools:
                         pool = pools.get('thread_pool')
-                    elif self.f.__name__ not in authentication_funcs:
-                        pool = pools.get('process_pool')
-                    else:
+                    elif self.f.__name__ in authentication_funcs:
                         pool = pools.get('authentication_pool')
+                    else:
+                        pool = pools.get('process_pool')
 
                     task = loop.run_in_executor(pool, partial(self.run_local, self.f, self.f_kwargs,
                                                               self.logger, self.rbac_permissions,

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -31,8 +31,10 @@ from wazuh.core.cluster.cluster import check_cluster_status
 from wazuh.core.exception import WazuhException, WazuhClusterError, WazuhError
 from wazuh.core.wazuh_socket import wazuh_sendsync
 
-process_pool = common.mp_pools.get()['process_pool']
-authentication_pool = common.mp_pools.get()['authentication_pool']
+process_pool = common.mp_pools.get().get('process_pool', None)
+authentication_pool = common.mp_pools.get().get('authentication_pool', None)
+thread_pool = common.mp_pools.get().get('thread_pool', None)
+
 authentication_funcs = {'check_token', 'check_user_master', 'get_permissions', 'get_security_conf'}
 
 
@@ -272,7 +274,9 @@ class DistributedAPI:
 
                 else:
                     loop = asyncio.get_event_loop()
-                    if self.f.__name__ not in authentication_funcs:
+                    if process_pool is None:
+                        pool = thread_pool
+                    elif self.f.__name__ not in authentication_funcs:
                         pool = process_pool
                     else:
                         pool = authentication_pool

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -19,7 +19,7 @@ from uuid import uuid4
 import wazuh.core.cluster.cluster
 from wazuh.core import cluster as metadata, common, exception, utils
 from wazuh.core.agent import Agent
-from wazuh.core.cluster import server, common as c_common
+from wazuh.core.cluster import server, cluster, common as c_common
 from wazuh.core.cluster.dapi import dapi
 from wazuh.core.cluster.utils import context_tag
 from wazuh.core.common import decimals_date_format
@@ -591,11 +591,8 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
 
         # Update chunks in local wazuh-db
         try:
-            task = self.loop.run_in_executor(
-                self.server.task_pool,
-                partial(self.send_data_to_wdb, data, self.cluster_items['intervals']['master']['timeout_agent_info'])
-            )
-            result = await asyncio.wait_for(task, timeout=None)
+            result = await cluster.run_in_pool(self.loop, self.server.task_pool, self.send_data_to_wdb, data,
+                                               self.cluster_items['intervals']['master']['timeout_agent_info'])
         except Exception as e:
             await self.send_request(command=b'syn_m_a_err',
                                     data=f'error processing agent-info chunks in process pool: {str(e)}'.encode())
@@ -813,12 +810,9 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
 
         # Create a child process to run the task.
         try:
-            task = self.loop.run_in_executor(
-                self.server.task_pool,
-                partial(self.process_files_from_worker, files_metadata, decompressed_files_path, self.cluster_items,
-                        self.name, self.cluster_items['intervals']['master']['timeout_extra_valid'])
-            )
-            result = await asyncio.wait_for(task, timeout=None)
+            result = await cluster.run_in_pool(self.loop, self.server.task_pool, self.process_files_from_worker,
+                                               files_metadata, decompressed_files_path, self.cluster_items, self.name,
+                                               self.cluster_items['intervals']['master']['timeout_extra_valid'])
         except Exception as e:
             raise exception.WazuhClusterError(3038, extra_message=str(e))
         finally:
@@ -971,8 +965,21 @@ class Master(server.AbstractServer):
         super().__init__(**kwargs, tag="Master")
         self.integrity_control = {}
         self.handler_class = MasterHandler
-        self.task_pool = ProcessPoolExecutor(
-            max_workers=min(os.cpu_count(), self.cluster_items['intervals']['master']['process_pool_size']))
+        try:
+            self.task_pool = ProcessPoolExecutor(
+                max_workers=min(os.cpu_count(), self.cluster_items['intervals']['master']['process_pool_size']))
+        # Handle exception when the user running Wazuh cannot access /dev/shm
+        except FileNotFoundError:
+            self.logger.warning("In order to take advantage of Wazuh 4.3.0 cluster and API improvements, the "
+                                "directory '/dev/shm' must be accessible by the 'wazuh' user. Opening this regular "
+                                "file could be disallowed for a non-root user if the fs.protected_regular sysctl "
+                                "setting has value 1 or 2. This setting may be activated if you use systemd version "
+                                "241 or higher with Linux kernel 4.19 or higher. To deactivate the setting, use "
+                                "'sysctl fs.protected_regular=0'")
+            self.logger.warning(
+                "The Wazuh cluster will be run without the improvements added in Wazuh 4.3.0 and higher "
+                "versions.")
+            self.task_pool = None
         self.integrity_already_executed = []
         self.dapi = dapi.APIRequestQueue(server=self)
         self.sendsync = dapi.SendSyncRequestQueue(server=self)
@@ -1004,13 +1011,12 @@ class Master(server.AbstractServer):
             before = datetime.now()
             file_integrity_logger.info("Starting.")
             try:
-                task = self.loop.run_in_executor(self.task_pool, partial(wazuh.core.cluster.cluster.get_files_status,
-                                                                         self.integrity_control))
-                # With this we avoid that each worker starts integrity_check more than once per local_integrity
-                self.integrity_control = await asyncio.wait_for(task, timeout=None)
+                self.integrity_control = await cluster.run_in_pool(self.loop, self.task_pool,
+                                                                   wazuh.core.cluster.cluster.get_files_status)
             except Exception as e:
                 file_integrity_logger.error(f"Error calculating local file integrity: {e}")
             finally:
+                # With this we avoid that each worker starts integrity_check more than once per local_integrity
                 self.integrity_already_executed.clear()
 
             file_integrity_logger.info(f"Finished in {(datetime.now() - before).total_seconds():.3f}s. Calculated "

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -969,16 +969,13 @@ class Master(server.AbstractServer):
             self.task_pool = ProcessPoolExecutor(
                 max_workers=min(os.cpu_count(), self.cluster_items['intervals']['master']['process_pool_size']))
         # Handle exception when the user running Wazuh cannot access /dev/shm
-        except FileNotFoundError:
-            self.logger.warning("In order to take advantage of Wazuh 4.3.0 cluster and API improvements, the "
-                                "directory '/dev/shm' must be accessible by the 'wazuh' user. Opening this regular "
-                                "file could be disallowed for a non-root user if the fs.protected_regular sysctl "
-                                "setting has value 1 or 2. This setting may be activated if you use systemd version "
-                                "241 or higher with Linux kernel 4.19 or higher. To deactivate the setting, use "
-                                "'sysctl fs.protected_regular=0'")
+        except (FileNotFoundError, PermissionError):
             self.logger.warning(
-                "The Wazuh cluster will be run without the improvements added in Wazuh 4.3.0 and higher "
-                "versions.")
+                "In order to take advantage of Wazuh 4.3.0 cluster improvements, the directory '/dev/shm' must be "
+                "accessible by the 'wazuh' user. Check that this file has permissions to be accessed by all users. "
+                "Changing the file permissions to 777 will solve this issue.")
+            self.logger.warning(
+                "The Wazuh cluster will be run without the improvements added in Wazuh 4.3.0 and higher versions.")
             self.task_pool = None
         self.integrity_already_executed = []
         self.dapi = dapi.APIRequestQueue(server=self)

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -5,7 +5,7 @@
 import json
 import os
 import subprocess
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from contextvars import ContextVar
 from copy import deepcopy
 from functools import lru_cache
@@ -221,10 +221,16 @@ current_user: ContextVar[str] = ContextVar('current_user', default='')
 broadcast: ContextVar[bool] = ContextVar('broadcast', default=False)
 cluster_nodes: ContextVar[list] = ContextVar('cluster_nodes', default=list())
 origin_module: ContextVar[str] = ContextVar('origin_module', default='framework')
-mp_pools: ContextVar[Dict] = ContextVar('mp_pools', default={
-    'process_pool': ProcessPoolExecutor(max_workers=1),
-    'authentication_pool': ProcessPoolExecutor(max_workers=1)
-})
+try:
+    mp_pools: ContextVar[Dict] = ContextVar('mp_pools', default={
+        'process_pool': ProcessPoolExecutor(max_workers=1),
+        'authentication_pool': ProcessPoolExecutor(max_workers=1)
+    })
+# Handle exception when the user running Wazuh cannot access /dev/shm
+except (FileNotFoundError, PermissionError):
+    mp_pools: ContextVar[Dict] = ContextVar('mp_pools', default={
+        'thread_pool': ThreadPoolExecutor(max_workers=1)
+    })
 
 _context_cache = dict()
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/11347|

This PR closes #11347.

In this PR, I have added the proper exception handling to master.py and worker.py. 

When we try to use multiprocessing without access to /dev/shm, the PermissionError and FileNotFoundError are raised when trying to create the ProcessPoolExecutor instance. These exceptions are now handled and a fallback is done to old cluster and API implementations, without multiprocessing.

A warning message is shown to indicate the problem and how to solve it.