### PR TITLE
Rework of #10768 - PR: Merge macos-sshd ruleset into sshd ruleset

### DIFF
--- a/ruleset/decoders/0310-ssh_decoders.xml
+++ b/ruleset/decoders/0310-ssh_decoders.xml
@@ -233,6 +233,7 @@
 </decoder>
 
 <!-- Reverse lookup error -->
+<!-- 2020-03-25 09:01:30.852002-0700  localhost sshd[11885]: Address 192.168.33.1 maps to hostname, but this does not map back to the address. -->
 <decoder name="sshd-rmap">
   <parent>sshd</parent>
   <prematch>but this does not map back</prematch>
@@ -241,6 +242,7 @@
 </decoder>
 
 <!-- connection reset -->
+<!-- 2020-03-25 08:23:20.933154-0700  localhost sshd[9265]: Connection reset by authenticating user user 192.168.33.1 port 51772 [preauth] -->
 <decoder name="sshd-reset">
   <parent>sshd</parent>
   <prematch>Connection reset</prematch>
@@ -249,6 +251,7 @@
 </decoder>
 
 <!-- Dissconected from user -->
+<!-- 2020-03-24 08:38:47.230409-0700  localhost sshd[2531]: Disconnected from user user 172.18.1.100 port 43042 -->
 <decoder name="sshd-disconnect">
   <parent>sshd</parent>
   <prematch>Disconnected from user </prematch>

--- a/ruleset/decoders/0310-ssh_decoders.xml
+++ b/ruleset/decoders/0310-ssh_decoders.xml
@@ -179,22 +179,6 @@
   <order>srcip</order>
 </decoder>
 
-<!--XXX
-<decoder name="ssh-pam">
-  <parent>sshd</parent>
-  <prematch>PAM: Module</prematch>
-  <regex>for (\S+) from (\S+)$</regex>
-  <order>user, srcip</order>
-</decoder>
-
-<decoder name="ssh-connect-to">
-  <parent>sshd</parent>
-  <prematch>connect_to</prematch>
-  <regex>connect_to: (\S+) port (\d+):</regex>
-  <order>dstip,dstport</order>
-</decoder>
--->
-
 <decoder name="sshd-ldap">
   <parent>sshd</parent>
   <prematch>^pam_ldap: </prematch>
@@ -215,15 +199,6 @@
   <regex>rhost=(\S+)\s+user=(\S+)</regex>
   <order>srcip, user</order>
 </decoder>
-
-<!--
-<decoder name="sshd-invalid">
-  <parent>sshd</parent>
-  <prematch>^input_user_auth_request: </prematch>
-  <regex offset="after_prematch"> user (\S+)</regex>
-  <order>user</order>
-</decoder>
--->
 
 <decoder name="sshd-exceed">
   <parent>sshd</parent>

--- a/ruleset/decoders/0310-ssh_decoders.xml
+++ b/ruleset/decoders/0310-ssh_decoders.xml
@@ -1,59 +1,54 @@
 <!--
-  -  SSH decoders
-  -  Author: Daniel Cid.
-  -  Updated by Wazuh, Inc.
-  -  Copyright (C) 2015-2021, Wazuh Inc.
-  -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  Copyright (C) 2015-2021, Wazuh Inc.
 -->
 
 
 <!--
-  -  Will extract username and srcip from the logs.
-  -  Only add to the FTS if the login was successful
-  -  If the login failed, just extract the username/srcip for correlation
-  -  Examples:
-  -  sshd[8813]: Accepted password for root from 192.168.10.1 port 1066 ssh2
-  -  sshd[2404]: Accepted password for root from 192.168.11.1 port 2011 ssh2
-  -  sshd[21405]: Accepted password for root from 192.1.1.1 port 6023 ssh2
-  -  sshd[21487]: Failed password for root from 192.168.1.1 port 1045 ssh2
-  -  sshd[8813]: Failed none for root from 192.168.10.161 port 1066 ssh2
-  -  sshd[12675]: Failed password for invalid user lala11 from x.x.x.x ..
-  -  sshd[12914]: Failed password for invalid user lala6 from ...
-  -  sshd[8267]: Failed password for illegal user test from 62.67.45.4 port 39141 ssh2
-  -  sshd[11259]: Invalid user abc from 127.0.0.1
-  -  "" Failed keyboard-interactive for root from 192.1.1.1 port 1066 ssh2
-  -  sshd[23857]: [ID 702911 auth.notice] User xxx, coming from zzzz,
-  -  authenticated.
-  -  sshd[23578]: reverse mapping checking getaddrinfo for pib4.catv-bauer.at failed - POSSIBLE BREAKIN ATTEMPT!
-  -  sshd[61834]: reverse mapping checking getaddrinfo for sv.tvcm.ch
-  -  failed - POSSIBLE BREAKIN ATTEMPT!
-  -  sshd[3251]: User root not allowed because listed in DenyUsers
-  -  [Time 2006.12.28 15:53:55 UTC] [Facility auth] [Sender sshd] [PID 483] [Message error: PAM: Authentication failure for username from 192.168.0.2] [Level 3] [UID -2] [GID -2] [Host Hostname]
-  -  [Time 2006.11.02 11:41:44 UTC] [Facility auth] [Sender sshd] [PID 800] [Message refused connect from 51.124.44.34] [Level 4] [UID -2] [GID -2] [Host test2-emac]
-  -  Apr 23 07:03:53 machinename sshd[29961]: User root from 12.3.4.5
+  Will extract username and srcip from the logs.
+  Only add to the FTS if the login was successful
+  If the login failed, just extract the username/srcip for correlation
+  Examples:
+    sshd[8813]: Accepted password for root from 192.168.10.1 port 1066 ssh2
+    sshd[2404]: Accepted password for root from 192.168.11.1 port 2011 ssh2
+    sshd[21405]: Accepted password for root from 192.1.1.1 port 6023 ssh2
+    sshd[21487]: Failed password for root from 192.168.1.1 port 1045 ssh2
+    sshd[8813]: Failed none for root from 192.168.10.161 port 1066 ssh2
+    sshd[12675]: Failed password for invalid user lala11 from x.x.x.x ..
+    sshd[12914]: Failed password for invalid user lala6 from ...
+    sshd[8267]: Failed password for illegal user test from 62.67.45.4 port 39141 ssh2
+    sshd[11259]: Invalid user abc from 127.0.0.1
+    "" Failed keyboard-interactive for root from 192.1.1.1 port 1066 ssh2
+    sshd[23857]: [ID 702911 auth.notice] User xxx, coming from zzzz,
+    authenticated.
+    sshd[23578]: reverse mapping checking getaddrinfo for pib4.catv-bauer.at failed - POSSIBLE BREAKIN ATTEMPT!
+    sshd[61834]: reverse mapping checking getaddrinfo for sv.tvcm.ch
+    failed - POSSIBLE BREAKIN ATTEMPT!
+    sshd[3251]: User root not allowed because listed in DenyUsers
+    [Time 2006.12.28 15:53:55 UTC] [Facility auth] [Sender sshd] [PID 483] [Message error: PAM: Authentication failure for username from 192.168.0.2] [Level 3] [UID -2] [GID -2] [Host Hostname]
+    [Time 2006.11.02 11:41:44 UTC] [Facility auth] [Sender sshd] [PID 800] [Message refused connect from 51.124.44.34] [Level 4] [UID -2] [GID -2] [Host test2-emac]
+    Apr 23 07:03:53 machinename sshd[29961]: User root from 12.3.4.5
   not allowed because not listed in AllowUsers
-  -  sshd[9815]: scanned from 127.0.0.1 with SSH-1.99-AKASSH_Version_Mapper1.  Don't panic.
-  -  Sep  4 23:58:33 junction sshd[9351]: fatal: Write failed: Broken pipe
-  -  Sep 18 14:58:47 ix sshd[11816]: error: Could not load host key: /etc/ssh/ssh_host_ecdsa_key
-  -  Sep 23 10:32:25 server sshd[25209]: pam_ldap: error trying to bind as user "uid=user123,ou=People,dc=domain,dc=com" (Invalid credentials)
-  -  Aug 10 08:38:40 junction sshd[20013]: error: connect_to 192.168.179 port 8080: failed
-  -  Jun  9 00:00:01 ix sshd[9815]: scanned from 127.0.0.1 with SSH-1.99-AKASSH_Version_Mapper1.  Don't panic.
-  -  Jan 26 11:57:26 ix sshd[14879]: error: connect to ix.example.com port 7777 failed: Connection refused
-  -  Oct  8 10:07:27 y sshd[7644]: debug1: attempt 2 failures 2
-  -  Oct  8 08:58:37 y sshd[6956]: fatal: PAM: pam_setcred(): Authentication service cannot retrieve user credentials
-  -  Oct  8 08:48:33 y sshd[6856]: error: Bind to port 22 on 0.0.0.0 failed: Address already in use.
-  -  Oct  8 11:18:26 172.16.51.132 sshd[7618]: error: PAM: Module is unknown for ddp from 172.16.51.1
-  -  Jun 19 20:56:00 tiny sshd[11605]: fatal: Write failed: Host is down
-  -  Jun 11 06:32:17 gorilla sshd[28293]: fatal: buffer_get_bignum2: buffer error
-  -  Jun 11 06:32:17 gorilla sshd[28293]: error: buffer_get_bignum2_ret: negative numbers not supported
-  -  Apr 14 19:28:21 gorilla sshd[31274]: Connection closed by 192.168.1.33
-  -  Jun 22 12:01:13 junction sshd[11283]: Received disconnect from 212.14.228.46: 11: Bye Bye
-  -  Nov  9 07:40:25 ginaz sshd[5973]: error: setsockopt SO_KEEPALIVE: Connection reset by peer
-  -  Nov  2 12:08:27 192.168.17.7 sshd[9665]: fatal: Cannot bind any address.
-  -  Nov  2 12:11:40 192.168.17.7 sshd[9814]: pam_loginuid(sshd:session): set_loginuid failed opening loginuid
-  -  Nov  6 09:53:38 hagal sshd[697]: error: accept: Software caused connection abort
-  -  Nov  9 11:36:55 ecaz sshd[26967]: pam_succeed_if(sshd:auth): error retrieving information about user _z9xxbBW
+    sshd[9815]: scanned from 127.0.0.1 with SSH-1.99-AKASSH_Version_Mapper1.  Don't panic.
+    Sep  4 23:58:33 junction sshd[9351]: fatal: Write failed: Broken pipe
+    Sep 18 14:58:47 ix sshd[11816]: error: Could not load host key: /etc/ssh/ssh_host_ecdsa_key
+    Sep 23 10:32:25 server sshd[25209]: pam_ldap: error trying to bind as user "uid=user123,ou=People,dc=domain,dc=com" (Invalid credentials)
+    Aug 10 08:38:40 junction sshd[20013]: error: connect_to 192.168.179 port 8080: failed
+    Jun  9 00:00:01 ix sshd[9815]: scanned from 127.0.0.1 with SSH-1.99-AKASSH_Version_Mapper1.  Don't panic.
+    Jan 26 11:57:26 ix sshd[14879]: error: connect to ix.example.com port 7777 failed: Connection refused
+    Oct  8 10:07:27 y sshd[7644]: debug1: attempt 2 failures 2
+    Oct  8 08:58:37 y sshd[6956]: fatal: PAM: pam_setcred(): Authentication service cannot retrieve user credentials
+    Oct  8 08:48:33 y sshd[6856]: error: Bind to port 22 on 0.0.0.0 failed: Address already in use.
+    Oct  8 11:18:26 172.16.51.132 sshd[7618]: error: PAM: Module is unknown for ddp from 172.16.51.1
+    Jun 19 20:56:00 tiny sshd[11605]: fatal: Write failed: Host is down
+    Jun 11 06:32:17 gorilla sshd[28293]: fatal: buffer_get_bignum2: buffer error
+    Jun 11 06:32:17 gorilla sshd[28293]: error: buffer_get_bignum2_ret: negative numbers not supported
+    Apr 14 19:28:21 gorilla sshd[31274]: Connection closed by 192.168.1.33
+    Jun 22 12:01:13 junction sshd[11283]: Received disconnect from 212.14.228.46: 11: Bye Bye
+    Nov  9 07:40:25 ginaz sshd[5973]: error: setsockopt SO_KEEPALIVE: Connection reset by peer
+    Nov  2 12:08:27 192.168.17.7 sshd[9665]: fatal: Cannot bind any address.
+    Nov  2 12:11:40 192.168.17.7 sshd[9814]: pam_loginuid(sshd:session): set_loginuid failed opening loginuid
+    Nov  6 09:53:38 hagal sshd[697]: error: accept: Software caused connection abort
+    Nov  9 11:36:55 ecaz sshd[26967]: pam_succeed_if(sshd:auth): error retrieving information about user _z9xxbBW
   -->
 
 <decoder name="sshd">
@@ -146,14 +141,14 @@
 </decoder>
 
 <!--
-Jul 12 16:10:26 cloud sshd[14486]: Bad protocol version identification 'GET http://m.search.yahoo.com/ HTTP/1.1' from 112.98.69.104 port 3533
-Jul 12 16:10:41 cloud sshd[14530]: Bad protocol version identification 'GET http://check2.zennolab.com/proxy.php HTTP/1.1' from 46.182.129.46 port 60866
-Jul 12 16:11:31 cloud sshd[14582]: Bad protocol version identification 'GET http://www.msftncsi.com/ncsi.txt HTTP/1.1' from 88.244.115.169 port 62240
-Jul 12 16:12:15 cloud sshd[14662]: Bad protocol version identification 'GET http://m.search.yahoo.com/ HTTP/1.1' from 118.76.116.187 port 54513
-e.g. OpenSSH > 7.2:
-Sep  4 21:13:05 example sshd[12853]: Did not receive identification string from 192.168.0.1 port 33021
-e.g. OpenSSH <= 7.2:
-Sep  4 21:14:25 example sshd[18368]: Did not receive identification string from 192.168.0.1
+  Jul 12 16:10:26 cloud sshd[14486]: Bad protocol version identification 'GET http://m.search.yahoo.com/ HTTP/1.1' from 112.98.69.104 port 3533
+  Jul 12 16:10:41 cloud sshd[14530]: Bad protocol version identification 'GET http://check2.zennolab.com/proxy.php HTTP/1.1' from 46.182.129.46 port 60866
+  Jul 12 16:11:31 cloud sshd[14582]: Bad protocol version identification 'GET http://www.msftncsi.com/ncsi.txt HTTP/1.1' from 88.244.115.169 port 62240
+  Jul 12 16:12:15 cloud sshd[14662]: Bad protocol version identification 'GET http://m.search.yahoo.com/ HTTP/1.1' from 118.76.116.187 port 54513
+  e.g. OpenSSH > 7.2:
+    Sep  4 21:13:05 example sshd[12853]: Did not receive identification string from 192.168.0.1 port 33021
+  e.g. OpenSSH <= 7.2:
+    Sep  4 21:14:25 example sshd[18368]: Did not receive identification string from 192.168.0.1
 -->
 
 <decoder name="ssh-scan2">

--- a/ruleset/rules/0095-sshd_rules.xml
+++ b/ruleset/rules/0095-sshd_rules.xml
@@ -7,6 +7,7 @@
 -->
 
 <group name="syslog,sshd,">
+
   <rule id="5700" level="0" noalert="1">
     <decoded_as>sshd</decoded_as>
     <description>SSHD messages grouped.</description>
@@ -15,12 +16,11 @@
   <rule id="5701" level="8">
     <if_sid>5700</if_sid>
     <match>Bad protocol version identification</match>
-    <description>sshd: Possible attack on the ssh server </description>
-    <description>(or version gathering).</description>
+    <description>sshd: Possible attack on the ssh server (or version gathering).</description>
     <mitre>
       <id>T1190</id>
     </mitre>
-    <group>recon,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SI.4,pci_dss_11.4,recon,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5702" level="5">
@@ -28,18 +28,17 @@
     <match>^reverse mapping</match>
     <regex>failed - POSSIBLE BREAK</regex>
     <description>sshd: Reverse lookup error (bad ISP or attack).</description>
-    <group>pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SI.4,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5703" level="10" frequency="6" timeframe="360">
     <if_matched_sid>5702</if_matched_sid>
     <same_source_ip />
-    <description>sshd: Possible breakin attempt </description>
-    <description>(high number of reverse lookup errors).</description>
+    <description>sshd: Possible breakin attempt (high number of reverse lookup errors).</description>
     <mitre>
       <id>T1110</id>
     </mitre>
-    <group>pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SI.4,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5704" level="4">
@@ -50,13 +49,12 @@
 
   <rule id="5705" level="10" frequency="6" timeframe="360">
     <if_matched_sid>5704</if_matched_sid>
-    <description>sshd: Possible scan or breakin attempt </description>
-    <description>(high number of login timeouts).</description>
+    <description>sshd: Possible scan or breakin attempt (high number of login timeouts).</description>
     <mitre>
       <id>T1190</id>
       <id>T1110</id>
     </mitre>
-    <group>pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SI.4,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5706" level="6">
@@ -66,7 +64,7 @@
     <mitre>
       <id>T1021.004</id>
     </mitre>
-    <group>recon,pci_dss_11.4,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SI.4,pci_dss_11.4,recon,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5707" level="14">
@@ -77,7 +75,7 @@
       <id>T1210</id>
       <id>T1068</id>
     </mitre>
-    <group>exploit_attempt,pci_dss_11.4,pci_dss_6.2,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SI.4,nist_800_53_SI.2,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>exploit_attempt,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SI.4,nist_800_53_SI.2,pci_dss_11.4,pci_dss_6.2,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5709" level="0">
@@ -95,7 +93,7 @@
     <mitre>
       <id>T1110</id>
     </mitre>
-    <group>invalid_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_AU.6,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_failed,invalid_login,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_AU.6,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.6.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5711" level="0">
@@ -109,13 +107,12 @@
 
   <rule id="5712" level="10" frequency="8" timeframe="120" ignore="60">
     <if_matched_sid>5710</if_matched_sid>
-    <description>sshd: brute force trying to get access to </description>
-    <description>the system. Non existent user.</description>
+    <description>sshd: brute force trying to get access to the system. Non existent user.</description>
     <mitre>
       <id>T1110</id>
     </mitre>
     <same_source_ip />
-    <group>authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SI.4,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_failures,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SI.4,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5713" level="6">
@@ -133,7 +130,7 @@
     <mitre>
       <id>T1210</id>
     </mitre>
-    <group>exploit_attempt,pci_dss_11.4,pci_dss_6.2,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SI.4,nist_800_53_SI.2,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>exploit_attempt,gdpr_IV_35.7.d,nist_800_53_SI.4,nist_800_53_SI.2,pci_dss_11.4,pci_dss_6.2,gpg13_4.12,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5715" level="3">
@@ -144,7 +141,7 @@
       <id>T1078</id>
       <id>T1021</id>
     </mitre>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_success,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.5,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5716" level="5">
@@ -154,7 +151,7 @@
     <mitre>
       <id>T1110</id>
     </mitre>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_failed,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5717" level="4">
@@ -170,7 +167,7 @@
     <mitre>
       <id>T1110</id>
     </mitre>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,invalid_login,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5719" level="10" frequency="8" timeframe="120" ignore="60">
@@ -179,7 +176,7 @@
     <mitre>
       <id>T1110</id>
     </mitre>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,invalid_login,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5720" level="10" frequency="8">
@@ -189,7 +186,7 @@
     <mitre>
       <id>T1110</id>
     </mitre>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_failures,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5721" level="0">
@@ -202,7 +199,7 @@
     <if_sid>5700</if_sid>
     <match>Connection closed</match>
     <description>sshd: ssh connection closed.</description>
-    <group>pci_dss_10.2.5,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.5,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5723" level="0">
@@ -210,7 +207,7 @@
     <match>error: buffer_get_bignum2_ret: negative numbers not supported</match>
     <info>This maybe a bad key in authorized_keys.</info>
     <description>sshd: key error.</description>
-    <group>pci_dss_4.1,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.a.2.IV,hipaa_164.312.e.1,hipaa_164.312.e.2.I,hipaa_164.312.e.2.II,hipaa_164.312.b,nist_800_53_SC.8,nist_800_53_AU.6,tsc_CC6.7,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.a.2.IV,hipaa_164.312.e.1,hipaa_164.312.e.2.I,hipaa_164.312.e.2.II,hipaa_164.312.b,nist_800_53_SC.8,nist_800_53_AU.6,pci_dss_4.1,pci_dss_10.6.1,tsc_CC6.7,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5724" level="0">
@@ -218,7 +215,7 @@
     <match>fatal: buffer_get_bignum2: buffer error</match>
     <info>This error may relate to ssh key handling.</info>
     <description>sshd: key error.</description>
-    <group>pci_dss_4.1,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.a.2.IV,hipaa_164.312.e.1,hipaa_164.312.e.2.I,hipaa_164.312.e.2.II,hipaa_164.312.b,nist_800_53_SC.8,nist_800_53_AU.6,tsc_CC6.7,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.a.2.IV,hipaa_164.312.e.1,hipaa_164.312.e.2.I,hipaa_164.312.e.2.II,hipaa_164.312.b,nist_800_53_SC.8,nist_800_53_AU.6,pci_dss_4.1,pci_dss_10.6.1,tsc_CC6.7,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5725" level="0">
@@ -237,7 +234,7 @@
     <if_sid>5700</if_sid>
     <match>failed: Address already in use.</match>
     <description>sshd: Attempt to start sshd when something already bound to the port.</description>
-    <group>pci_dss_10.6.1,pci_dss_2.2.3,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_CM.1,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_CM.1,pci_dss_10.6.1,pci_dss_2.2.3,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5728" level="4">
@@ -245,7 +242,7 @@
     <match>Authentication service cannot retrieve user credentials</match>
     <info>May be related to PAM module errors.</info>
     <description>sshd: Authentication services were not able to retrieve user credentials.</description>
-    <group>authentication_failed,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_failed,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.5,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5729" level="0">
@@ -258,7 +255,7 @@
     <if_sid>5700</if_sid>
     <regex>error: connect to \S+ port \d+ failed: Connection refused</regex>
     <description>sshd: SSHD is not accepting connections.</description>
-    <group>pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,pci_dss_10.6.1,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5731" level="6">
@@ -268,7 +265,7 @@
     <mitre>
       <id>T1046</id>
     </mitre>
-    <group>recon,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,pci_dss_11.4,recon,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5732" level="0">
@@ -281,7 +278,7 @@
     <if_sid>5700</if_sid>
     <match>Invalid credentials</match>
     <description>sshd: User entered incorrect password.</description>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_failures,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5734" level="0">
@@ -308,14 +305,14 @@
     <if_sid>5700</if_sid>
     <match>^fatal: Cannot bind any address.$</match>
     <description>sshd: cannot bind to configured address.</description>
-    <group>pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,pci_dss_10.6.1,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5738" level="5">
     <if_sid>5700</if_sid>
     <match>set_loginuid failed opening loginuid$</match>
     <description>sshd: pam_loginuid could not open loginuid.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_failed,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5739" level="4">
@@ -340,7 +337,7 @@
     <if_sid>5700</if_sid>
     <match>Connection timed out$</match>
     <description>sshd: connection timed out</description>
-    <group>pci_dss_8.1.5,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_AC.2,tsc_CC6.1,</group>
+    <group>gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_AC.2,pci_dss_8.1.5,tsc_CC6.1,</group>
   </rule>
 
   <rule id="5743" level="4">
@@ -378,7 +375,7 @@
     <if_sid>5700</if_sid>
     <match>Corrupted MAC on input.</match>
     <description>sshd: corrupted MAC on input</description>
-    <group>pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,pci_dss_10.6.1,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5749" level="4">
@@ -458,14 +455,14 @@
     <if_sid>5700,5710,5716</if_sid>
     <match>Failed password|Failed keyboard|authentication error</match>
     <description>sshd: authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_failed,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5761" level="0">
     <if_sid>5700</if_sid>
     <match>Disconnected from user</match>
     <description>sshd: ssh connection closed.</description>
-    <group>pci_dss_10.2.5,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.5,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5762" level="4">
@@ -478,20 +475,20 @@
     <if_sid>5750</if_sid>
     <match>not listed in AllowUsers|listed in DenyUsers</match>
     <description>sshd: Attempt to login using a denied user</description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,invalid_login,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5764" level="10" frequency="8" timeframe="120" ignore="60">
     <if_matched_sid>5763</if_matched_sid>
     <description>sshd: Multiple access attempts using a denied user.</description>
-    <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,invalid_login,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5765" level="10" frequency="8" timeframe="120" ignore="60">
     <if_matched_sid>5760</if_matched_sid>
     <description>sshd: brute force trying to get access to the system. Authentication failed.</description>
     <same_source_ip />
-    <group>authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SI.4,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_failures,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SI.4,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
     <mitre>
       <id>T1110</id>
     </mitre>

--- a/ruleset/rules/0095-sshd_rules.xml
+++ b/ruleset/rules/0095-sshd_rules.xml
@@ -471,20 +471,7 @@
     <description>sshd: connection reset</description>
   </rule>
 
-  <rule id="5763" level="5">
-    <if_sid>5750</if_sid>
-    <match>not listed in AllowUsers|listed in DenyUsers</match>
-    <description>sshd: Attempt to login using a denied user</description>
-    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,gpg13_7.1,hipaa_164.312.b,invalid_login,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-  </rule>
-
-  <rule id="5764" level="10" frequency="8" timeframe="120" ignore="60">
-    <if_matched_sid>5763</if_matched_sid>
-    <description>sshd: Multiple access attempts using a denied user.</description>
-    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,gpg13_7.1,hipaa_164.312.b,invalid_login,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-  </rule>
-
-  <rule id="5765" level="10" frequency="8" timeframe="120" ignore="60">
+  <rule id="5763" level="10" frequency="8" timeframe="120" ignore="60">
     <if_matched_sid>5760</if_matched_sid>
     <description>sshd: brute force trying to get access to the system. Authentication failed.</description>
     <same_source_ip />

--- a/ruleset/rules/0095-sshd_rules.xml
+++ b/ruleset/rules/0095-sshd_rules.xml
@@ -20,7 +20,7 @@
     <mitre>
       <id>T1190</id>
     </mitre>
-    <group>gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SI.4,pci_dss_11.4,recon,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,gpg13_4.12,nist_800_53_SI.4,pci_dss_11.4,recon,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5702" level="5">
@@ -28,7 +28,7 @@
     <match>^reverse mapping</match>
     <regex>failed - POSSIBLE BREAK</regex>
     <description>sshd: Reverse lookup error (bad ISP or attack).</description>
-    <group>gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SI.4,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,gpg13_4.12,nist_800_53_SI.4,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5703" level="10" frequency="6" timeframe="360">
@@ -38,7 +38,7 @@
     <mitre>
       <id>T1110</id>
     </mitre>
-    <group>gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SI.4,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,gpg13_4.12,nist_800_53_SI.4,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5704" level="4">
@@ -54,7 +54,7 @@
       <id>T1190</id>
       <id>T1110</id>
     </mitre>
-    <group>gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SI.4,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,gpg13_4.12,nist_800_53_SI.4,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5706" level="6">
@@ -64,7 +64,7 @@
     <mitre>
       <id>T1021.004</id>
     </mitre>
-    <group>gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SI.4,pci_dss_11.4,recon,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,gpg13_4.12,nist_800_53_SI.4,pci_dss_11.4,recon,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5707" level="14">
@@ -75,7 +75,7 @@
       <id>T1210</id>
       <id>T1068</id>
     </mitre>
-    <group>exploit_attempt,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SI.4,nist_800_53_SI.2,pci_dss_11.4,pci_dss_6.2,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>exploit_attempt,gdpr_IV_35.7.d,gpg13_4.12,nist_800_53_SI.4,nist_800_53_SI.2,pci_dss_11.4,pci_dss_6.2,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5709" level="0">
@@ -93,7 +93,7 @@
     <mitre>
       <id>T1110</id>
     </mitre>
-    <group>authentication_failed,invalid_login,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_AU.6,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.6.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_failed,gdpr_IV_35.7.d,gdpr_IV_32.2,gpg13_7.1,hipaa_164.312.b,invalid_login,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_AU.6,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.6.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5711" level="0">
@@ -130,7 +130,7 @@
     <mitre>
       <id>T1210</id>
     </mitre>
-    <group>exploit_attempt,gdpr_IV_35.7.d,nist_800_53_SI.4,nist_800_53_SI.2,pci_dss_11.4,pci_dss_6.2,gpg13_4.12,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>exploit_attempt,gdpr_IV_35.7.d,gpg13_4.12,nist_800_53_SI.4,nist_800_53_SI.2,pci_dss_11.4,pci_dss_6.2,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5715" level="3">
@@ -141,7 +141,7 @@
       <id>T1078</id>
       <id>T1021</id>
     </mitre>
-    <group>authentication_success,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.5,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_success,gdpr_IV_32.2,gpg13_7.1,gpg13_7.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.5,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5716" level="5">
@@ -151,7 +151,7 @@
     <mitre>
       <id>T1110</id>
     </mitre>
-    <group>authentication_failed,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_failed,gdpr_IV_35.7.d,gdpr_IV_32.2,gpg13_7.1,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5717" level="4">
@@ -167,7 +167,7 @@
     <mitre>
       <id>T1110</id>
     </mitre>
-    <group>gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,invalid_login,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,gpg13_7.1,hipaa_164.312.b,invalid_login,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5719" level="10" frequency="8" timeframe="120" ignore="60">
@@ -176,7 +176,7 @@
     <mitre>
       <id>T1110</id>
     </mitre>
-    <group>gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,invalid_login,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,gpg13_7.1,hipaa_164.312.b,invalid_login,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5720" level="10" frequency="8">
@@ -186,7 +186,7 @@
     <mitre>
       <id>T1110</id>
     </mitre>
-    <group>authentication_failures,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_failures,gdpr_IV_35.7.d,gdpr_IV_32.2,gpg13_7.1,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5721" level="0">
@@ -207,7 +207,7 @@
     <match>error: buffer_get_bignum2_ret: negative numbers not supported</match>
     <info>This maybe a bad key in authorized_keys.</info>
     <description>sshd: key error.</description>
-    <group>gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.a.2.IV,hipaa_164.312.e.1,hipaa_164.312.e.2.I,hipaa_164.312.e.2.II,hipaa_164.312.b,nist_800_53_SC.8,nist_800_53_AU.6,pci_dss_4.1,pci_dss_10.6.1,tsc_CC6.7,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,gpg13_4.3,hipaa_164.312.a.2.IV,hipaa_164.312.e.1,hipaa_164.312.e.2.I,hipaa_164.312.e.2.II,hipaa_164.312.b,nist_800_53_SC.8,nist_800_53_AU.6,pci_dss_4.1,pci_dss_10.6.1,tsc_CC6.7,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5724" level="0">
@@ -215,7 +215,7 @@
     <match>fatal: buffer_get_bignum2: buffer error</match>
     <info>This error may relate to ssh key handling.</info>
     <description>sshd: key error.</description>
-    <group>gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.a.2.IV,hipaa_164.312.e.1,hipaa_164.312.e.2.I,hipaa_164.312.e.2.II,hipaa_164.312.b,nist_800_53_SC.8,nist_800_53_AU.6,pci_dss_4.1,pci_dss_10.6.1,tsc_CC6.7,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,gpg13_4.3,hipaa_164.312.a.2.IV,hipaa_164.312.e.1,hipaa_164.312.e.2.I,hipaa_164.312.e.2.II,hipaa_164.312.b,nist_800_53_SC.8,nist_800_53_AU.6,pci_dss_4.1,pci_dss_10.6.1,tsc_CC6.7,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5725" level="0">
@@ -234,7 +234,7 @@
     <if_sid>5700</if_sid>
     <match>failed: Address already in use.</match>
     <description>sshd: Attempt to start sshd when something already bound to the port.</description>
-    <group>gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_CM.1,pci_dss_10.6.1,pci_dss_2.2.3,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,gpg13_4.3,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_CM.1,pci_dss_10.6.1,pci_dss_2.2.3,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5728" level="4">
@@ -242,7 +242,7 @@
     <match>Authentication service cannot retrieve user credentials</match>
     <info>May be related to PAM module errors.</info>
     <description>sshd: Authentication services were not able to retrieve user credentials.</description>
-    <group>authentication_failed,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.5,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_failed,gdpr_IV_35.7.d,gdpr_IV_32.2,gpg13_7.1,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.5,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5729" level="0">
@@ -255,7 +255,7 @@
     <if_sid>5700</if_sid>
     <regex>error: connect to \S+ port \d+ failed: Connection refused</regex>
     <description>sshd: SSHD is not accepting connections.</description>
-    <group>gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,pci_dss_10.6.1,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,gpg13_4.3,hipaa_164.312.b,nist_800_53_AU.6,pci_dss_10.6.1,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5731" level="6">
@@ -278,7 +278,7 @@
     <if_sid>5700</if_sid>
     <match>Invalid credentials</match>
     <description>sshd: User entered incorrect password.</description>
-    <group>authentication_failures,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_failures,gdpr_IV_35.7.d,gdpr_IV_32.2,gpg13_7.1,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5734" level="0">
@@ -305,14 +305,14 @@
     <if_sid>5700</if_sid>
     <match>^fatal: Cannot bind any address.$</match>
     <description>sshd: cannot bind to configured address.</description>
-    <group>gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,pci_dss_10.6.1,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,gpg13_4.3,hipaa_164.312.b,nist_800_53_AU.6,pci_dss_10.6.1,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5738" level="5">
     <if_sid>5700</if_sid>
     <match>set_loginuid failed opening loginuid$</match>
     <description>sshd: pam_loginuid could not open loginuid.</description>
-    <group>authentication_failed,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_failed,gdpr_IV_35.7.d,gdpr_IV_32.2,gpg13_7.1,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5739" level="4">
@@ -375,7 +375,7 @@
     <if_sid>5700</if_sid>
     <match>Corrupted MAC on input.</match>
     <description>sshd: corrupted MAC on input</description>
-    <group>gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,pci_dss_10.6.1,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,gpg13_4.3,hipaa_164.312.b,nist_800_53_AU.6,pci_dss_10.6.1,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5749" level="4">
@@ -455,7 +455,7 @@
     <if_sid>5700,5710,5716</if_sid>
     <match>Failed password|Failed keyboard|authentication error</match>
     <description>sshd: authentication failed.</description>
-    <group>authentication_failed,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_failed,gdpr_IV_35.7.d,gdpr_IV_32.2,gpg13_7.1,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5761" level="0">
@@ -475,13 +475,13 @@
     <if_sid>5750</if_sid>
     <match>not listed in AllowUsers|listed in DenyUsers</match>
     <description>sshd: Attempt to login using a denied user</description>
-    <group>gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,invalid_login,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,gpg13_7.1,hipaa_164.312.b,invalid_login,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5764" level="10" frequency="8" timeframe="120" ignore="60">
     <if_matched_sid>5763</if_matched_sid>
     <description>sshd: Multiple access attempts using a denied user.</description>
-    <group>gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,invalid_login,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,gpg13_7.1,hipaa_164.312.b,invalid_login,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="5765" level="10" frequency="8" timeframe="120" ignore="60">

--- a/ruleset/rules/0095-sshd_rules.xml
+++ b/ruleset/rules/0095-sshd_rules.xml
@@ -1,10 +1,9 @@
 <!--
-  -  SSH rules
-  -  Author: Daniel Cid.
-  -  Updated by Wazuh, Inc.
-  -  Copyright (C) 2015-2021, Wazuh Inc.
-  -  Copyright (C) 2009 Trend Micro Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  Copyright (C) 2015-2021, Wazuh Inc.
+-->
+
+<!--
+  SSH rules ID: 5700 - 5764
 -->
 
 <group name="syslog,sshd,">
@@ -111,7 +110,7 @@
   <rule id="5712" level="10" frequency="8" timeframe="120" ignore="60">
     <if_matched_sid>5710</if_matched_sid>
     <description>sshd: brute force trying to get access to </description>
-    <description>the system.</description>
+    <description>the system. Non existent user.</description>
     <mitre>
       <id>T1110</id>
     </mitre>
@@ -128,12 +127,12 @@
   <rule id="5714" level="14" timeframe="120" frequency="3">
     <if_matched_sid>5713</if_matched_sid>
     <match>Local: crc32 compensation attack</match>
+    <info type="cve">2001-0144</info>
+    <info type="link">http://www.securityfocus.com/bid/2347/info/</info>
     <description>sshd: SSH CRC-32 Compensation attack</description>
     <mitre>
       <id>T1210</id>
     </mitre>
-    <info type="cve">2001-0144</info>
-    <info type="link">http://www.securityfocus.com/bid/2347/info/</info>
     <group>exploit_attempt,pci_dss_11.4,pci_dss_6.2,gpg13_4.12,gdpr_IV_35.7.d,nist_800_53_SI.4,nist_800_53_SI.2,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
@@ -375,11 +374,6 @@
     <description>sshd: bad client public DH value</description>
   </rule>
 
-  <!-- log sample with context:
-       Nov 22 19:24:52 server sshd[4045]: Connection from 117.117.198.5 port 60304
-       Nov 22 19:24:55 server sshd[4046]: Corrupted MAC on input.
-       Nov 22 19:25:15 server sshd[4046]: Connection closed by 117.117.198.5
-  -->
   <rule id="5748" level="6">
     <if_sid>5700</if_sid>
     <match>Corrupted MAC on input.</match>
@@ -491,6 +485,17 @@
     <if_matched_sid>5763</if_matched_sid>
     <description>sshd: Multiple access attempts using a denied user.</description>
     <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+
+  <rule id="5765" level="10" frequency="8" timeframe="120" ignore="60">
+    <if_matched_sid>5760</if_matched_sid>
+    <description>sshd: brute force trying to get access to </description>
+    <description>the system. Authenthication failed.</description>
+    <same_source_ip />
+    <group>authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SI.4,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <mitre>
+      <id>T1110</id>
+    </mitre>
   </rule>
 
 </group>

--- a/ruleset/rules/0095-sshd_rules.xml
+++ b/ruleset/rules/0095-sshd_rules.xml
@@ -107,11 +107,11 @@
 
   <rule id="5712" level="10" frequency="8" timeframe="120" ignore="60">
     <if_matched_sid>5710</if_matched_sid>
+    <same_source_ip />
     <description>sshd: brute force trying to get access to the system. Non existent user.</description>
     <mitre>
       <id>T1110</id>
     </mitre>
-    <same_source_ip />
     <group>authentication_failures,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SI.4,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
@@ -473,12 +473,12 @@
 
   <rule id="5763" level="10" frequency="8" timeframe="120" ignore="60">
     <if_matched_sid>5760</if_matched_sid>
+    <same_source_ip/>
     <description>sshd: brute force trying to get access to the system. Authentication failed.</description>
-    <same_source_ip />
-    <group>authentication_failures,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SI.4,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
     <mitre>
       <id>T1110</id>
     </mitre>
+    <group>authentication_failures,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SI.4,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
 </group>

--- a/ruleset/rules/0095-sshd_rules.xml
+++ b/ruleset/rules/0095-sshd_rules.xml
@@ -489,8 +489,7 @@
 
   <rule id="5765" level="10" frequency="8" timeframe="120" ignore="60">
     <if_matched_sid>5760</if_matched_sid>
-    <description>sshd: brute force trying to get access to </description>
-    <description>the system. Authenthication failed.</description>
+    <description>sshd: brute force trying to get access to the system. Authentication failed.</description>
     <same_source_ip />
     <group>authentication_failures,pci_dss_11.4,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_SI.4,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
     <mitre>

--- a/ruleset/testing/tests/sshd.ini
+++ b/ruleset/testing/tests/sshd.ini
@@ -176,6 +176,19 @@ rule = 5718
 alert = 5
 decoder = sshd
 
+[sshd: Multiple access attempts using a denied user]
+log 1 pass = 2020-03-25 07:46:15.205351-0700  localhost sshd[6738]: User root from 192.168.33.1 not allowed because not listed in AllowUsers
+log 1 pass = 2020-03-31 13:15:57.368975-0700  localhost sshd[2440]: User root from 172.18.1.100 not allowed because listed in DenyUsers
+log 1 pass = 2020-03-25 07:46:15.205351-0700  localhost sshd[6738]: User root from 192.168.33.1 not allowed because not listed in AllowUsers
+log 1 pass = 2020-03-31 13:15:57.368975-0700  localhost sshd[2440]: User root from 172.18.1.100 not allowed because listed in DenyUsers
+log 1 pass = 2020-03-25 07:46:15.205351-0700  localhost sshd[6738]: User root from 192.168.33.1 not allowed because not listed in AllowUsers
+log 1 pass = 2020-03-31 13:15:57.368975-0700  localhost sshd[2440]: User root from 172.18.1.100 not allowed because listed in DenyUsers
+log 1 pass = 2020-03-25 07:46:15.205351-0700  localhost sshd[6738]: User root from 192.168.33.1 not allowed because not listed in AllowUsers
+log 1 pass = 2020-03-31 13:15:57.368975-0700  localhost sshd[2440]: User root from 172.18.1.100 not allowed because listed in DenyUsers
+rule = 5719
+alert = 10
+decoder = sshd
+
 [SSHD: Reverse lookup error]
 log 1 pass = 2020-03-25 09:18:41.510217-0700  localhost sshd[2549]: reverse mapping checking getaddrinfo for hostname [172.18.1.1] failed - POSSIBLE BREAK.
 rule = 5702

--- a/ruleset/testing/tests/sshd.ini
+++ b/ruleset/testing/tests/sshd.ini
@@ -1,55 +1,53 @@
+;   Copyright (C) 2015-2021, Wazuh Inc.
+;
+;   Tests for products:
+;     SSH
+;
+
 [SSHD configuration error (AuthorizedKeysCommand)]
 log 1 pass = Feb  9 11:44:56 someserver sshd[1234]: error: Could not stat AuthorizedKeysCommand "/usr/local/sbin/ssh-ldap-authorized_keys": No such file or directory
-
 rule = 5739
 alert = 4
 decoder = sshd
 
 [ssh connection reset by peer]
 log 1 pass = Feb 10 23:21:05 someserver sshd[1234]: Read error from remote host 192.168.1.1: Connection reset by peer
-
 rule = 5740
 alert = 4
 decoder = sshd
 
 [ssh connection refused]
 log 1 pass = Feb 11 06:41:50 someserver sshd[1234]: debug1: channel 5: connection failed: Connection refused
-
 rule = 5741
 alert = 4
 decoder = sshd
 
 [ssh connection timed out]
 log 1 pass = Feb 12 17:45:09 someserver sshd[1234]: debug1: channel 3: connection failed: Connection timed out
-
 rule = 5742
 alert = 4
 decoder = sshd
 
 [ssh no route to host]
 log 1 pass = Jan 30 18:55:24 someserver sshd[1234]: debug1: channel 1: connection failed: No route to host
-
 rule = 5743
 alert = 4
 decoder = sshd
 
 [ssh port forwarding issue]
 log 1 pass = Feb 13 22:54:51 someserver sshd[1234]: debug1: server_input_channel_open: failure direct-tcpip
-
 rule = 5744
 alert = 4
 decoder = sshd
 
 [ssh transport endpoint is not connected]
 log 1 pass = Feb  6 12:28:17 someserver sshd[1234]: debug1: getpeername failed: Transport endpoint is not connected
-
 rule = 5745
 alert = 4
 decoder = sshd
 
 [ssh get_remote_port failed]
 log 1 pass = Feb  6 12:28:17 someserver sshd[1234]: debug1: get_remote_port failed
-
 rule = 5746
 alert = 4
 decoder = sshd
@@ -57,7 +55,6 @@ decoder = sshd
 [ssh bad client public DH value]
 log 1 pass = Feb  4 23:05:57 someserver sshd[1234]: Disconnecting: bad client public DH value [preauth]
 log 1 pass = Feb  4 23:05:57 someserver sshd[1234]: Disconnecting: bad client public DH value
-
 rule = 5747
 alert = 6
 decoder = sshd
@@ -65,7 +62,6 @@ decoder = sshd
 [ssh corrupted MAC on input]
 log 1 pass = Feb 14 14:34:15 someserver sshd[1234]: Corrupted MAC on input. [preauth]
 log 2 pass = Nov 22 19:24:55 server sshd[4046]: Corrupted MAC on input.
-
 rule = 5748
 alert = 6
 decoder = sshd
@@ -73,14 +69,12 @@ decoder = sshd
 [ssh bad packet length]
 log 1 pass = Mar  4 13:34:59 someserver sshd[5396]: Bad packet length 4081586742. [preauth]
 log 2 pass = Mar  4 13:34:59 someserver sshd[5396]: Bad packet length 4081586742.
-
 rule = 5749
 alert = 4
 decoder = sshd
 
 [ssh unable to negotiate]
 log 1 pass = Mar  3 10:56:18 junction sshd[32065]: fatal: Unable to negotiate with 202.191.177.33 port 3579: no matching cipher found. Their offer: 3des-cbc,aes128-cbc,aes192-cbc,aes256-cbc [preauth]
-
 rule = 5753
 alert = 2
 decoder = sshd
@@ -88,7 +82,6 @@ decoder = sshd
 [ssh no matching key exchange]
 log 1 pass = Sep 16 05:46:56 junction sshd[1961]: fatal: Unable to negotiate with 108.229.36.174: no matching key exchange method found. Their offer: diffie-hellman-group1-sha1,diffie-hellman-group-exchange-sha1 [preauth]
 log 2 pass = Apr 18 21:27:08 web2 sshd[23484]: fatal: Unable to negotiate a key exchange method [preauth]
-
 rule = 5752
 alert = 2
 decoder = sshd
@@ -99,35 +92,30 @@ log 2 fail = 2013-10-30T14:51:24.139258+01:00 srv sshd[12664]: error: PAM: User 
 log 3 pass = 2013-10-30T14:51:30.267401+01:00 srv sshd[12671]: Invalid user opcione from 192.241.237.101
 log 4 fail = 2013-10-30T14:51:30.267906+01:00 srv sshd[12671]: input_userauth_request: invalid user opcione [preauth]
 log 5 pass = 2020-03-23 06:47:42.801612-0700  localhost sshd[3186]: error: PAM: unknown user for illegal user badguy from 192.168.33.1
-
 rule = 5710
 alert = 5
 decoder = sshd
 
 [failed to create session]
 log 1 pass = May  4 17:48:43 collectd sshd[15044]: pam_systemd(sshd:session): Failed to create session: Access denied
-
 rule = 5754
 alert = 1
 decoder = sshd
 
 [bad authorized_keys]
 log 1 pass = May  4 18:30:04 collectd sshd[15191]: Authentication refused: bad ownership or modes for file /home/ansible/.ssh/authorized_keys
-
 rule = 5755
 alert = 3
 decoder = sshd
 
 [subsystem failed]
 log 1 pass = May  5 05:00:38 junction sshd[28395]: subsystem request for netconf by user checker failed, subsystem not found
-
 rule = 5756
 alert = 0
 decoder = sshd
 
 [login failed]
 log 1 pass = Aug 18 07:30:25 192.168.1.5 sshd[20247]: [ID 800047 auth.notice] Failed none for root from 192.168.1.1 port 36942 ssh2
-
 rule = 5716
 alert = 5
 decoder = sshd
@@ -135,7 +123,6 @@ decoder = sshd
 [bad dns]
 log 1 pass = Oct 20 12:33:07 ar-agent sshd[3433]: Address 192.168.18.54 maps to nmap.18.168.192.in-addr.arpa, but this does not map back to the address - POSSIBLE BREAK-IN ATTEMPT!
 log 2 pass = 2020-03-25 09:01:30.852002-0700  localhost sshd[11885]: Address 192.168.33.1 maps to hostname, but this does not map back to the address - POSSIBLE BREAK-IN ATTEMPT!
-
 rule = 5757
 alert = 0
 decoder = sshd
@@ -144,7 +131,6 @@ decoder = sshd
 log 1 pass = Dec 27 03:23:51 r1 sshd[21183]: error: maximum authentication attempts exceeded for root from 183.106.179.x port 34100 ssh2 [preauth]
 log 2 pass = 2020-03-23 08:14:32.766049-0700  localhost sshd[8981]: error: maximum authentication attempts exceeded for invalid user badguy from 192.168.33.1 port 55146 ssh2 [preauth]
 log 3 pass = 2020-03-23 09:58:27.102292-0700  localhost sshd[18093]: error: maximum authentication attempts exceeded for user from 192.168.33.1 port 55764 ssh2 [preauth]
-
 rule = 5758
 alert = 8
 decoder = sshd
@@ -155,62 +141,75 @@ log 2 pass = 2020-03-24 08:38:42.344447-0700  localhost sshd[2519]: Failed passw
 log 3 pass = 2020-03-25 08:01:34.584936-0700  localhost sshd[1551]: Failed keyboard-interactive/pam for invalid user user from 172.18.1.1 port 32982 ssh2
 log 4 pass = 2013-10-30T14:51:24.140565+01:00 srv sshd[12664]: Failed keyboard-interactive/pam for invalid user warez from 192.241.237.101 port 54197 ssh2
 log 5 pass = 2020-03-23 08:14:02.777660-0700  localhost sshd[8981]: error: PAM: authentication error for illegal user badguy from 192.168.33.1
-
 rule = 5760
 alert = 5
 decoder = sshd
 
 [SSHD Connection close]
 log 1 pass = 2020-03-24 06:07:15.245255-0700  localhost sshd[195]: Connection closed by 10.0.2.2 port 55462 [preauth]
-
 rule = 5722
 alert = 0
 decoder = sshd
 
 [SSHD Disconnected from]
 log 2 pass = 2020-03-24 08:38:47.230409-0700  localhost sshd[2531]: Disconnected from user user 172.18.1.100 port 43042
-
 rule = 5761
 alert = 0
 decoder = sshd
 
 [SSHD insecure connection attempt]
-
 log 1 pass = 2020-03-24 10:32:31.672920-0700  localhost sshd[5374]: Did not receive identification string from 172.18.1.1 port 45824
-
 rule = 5706
 alert = 6
 decoder = sshd
 
 [SSHD: connection reset]
-
 log 1 pass = 2020-03-25 08:23:20.933154-0700  localhost sshd[9265]: Connection reset by authenticating user user 192.168.33.1 port 51772 [preauth]
-
 rule = 5762
 alert = 4
 decoder = sshd
 
 [SSHD: denied user]
-
 log 1 pass = 2020-03-25 07:46:15.205351-0700  localhost sshd[6738]: User root from 192.168.33.1 not allowed because not listed in AllowUsers
 log 2 pass = 2020-03-31 13:15:57.368975-0700  localhost sshd[2440]: User root from 172.18.1.100 not allowed because listed in DenyUsers
-
 rule = 5718
 alert = 5
 decoder = sshd
 
 [SSHD: Reverse lookup error]
 log 1 pass = 2020-03-25 09:18:41.510217-0700  localhost sshd[2549]: reverse mapping checking getaddrinfo for hostname [172.18.1.1] failed - POSSIBLE BREAK.
-
 rule = 5702
 alert = 5
 decoder = sshd
 
 [SSHD: possible attack]
-
 log 1 pass = 2020-03-25 06:37:50.176931-0700  localhost sshd[852]: Bad protocol version identification 'ls' from 172.18.1.1 port 59920
-
-
 rule = 5701
 alert = 8
+decoder = sshd
+
+[sshd brute force rule]
+log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
+log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
+log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
+log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
+log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
+log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
+log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
+log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
+rule = 5765
+alert = 10
+decoder = sshd
+
+[sshd brute force rule 2]
+log 1 pass = May 29 11:31:00 vagrant sshd[30016]: Invalid user user from 212.64.151.233
+log 1 pass = May 29 11:31:00 vagrant sshd[30016]: Invalid user user from 212.64.151.233
+log 1 pass = May 29 11:31:00 vagrant sshd[30016]: Invalid user user from 212.64.151.233
+log 1 pass = May 29 11:31:00 vagrant sshd[30016]: Invalid user user from 212.64.151.233
+log 1 pass = May 29 11:31:00 vagrant sshd[30016]: Invalid user user from 212.64.151.233
+log 1 pass = May 29 11:31:00 vagrant sshd[30016]: Invalid user user from 212.64.151.233
+log 1 pass = May 29 11:31:00 vagrant sshd[30016]: Invalid user user from 212.64.151.233
+log 1 pass = May 29 11:31:00 vagrant sshd[30016]: Invalid user user from 212.64.151.233
+rule = 5712
+alert = 10
 decoder = sshd

--- a/ruleset/testing/tests/sshd.ini
+++ b/ruleset/testing/tests/sshd.ini
@@ -210,7 +210,7 @@ log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid us
 log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
 log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
 log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
-rule = 5765
+rule = 5763
 alert = 10
 decoder = sshd
 

--- a/ruleset/testing/tests/test_features.ini
+++ b/ruleset/testing/tests/test_features.ini
@@ -1,13 +1,16 @@
+; Copyright (C) 2015-2022, Wazuh Inc.
+;
+; test_features
+;
+
 [overwrite & list]
 log 1 fail =  May 27 14:49:04 testUser ow_test[13244]: overwrite and list test
-
 rule = 99900
 alert = 7
 decoder = ow_test
 
 [overwrite & field]
 log 1 pass =  Apr 14 13:38:51 testUser test_overwrite_field[13244]: Test example 'TEST2' field
-
 rule = 99901
 alert = 6
 decoder = test_overwrite
@@ -16,7 +19,6 @@ decoder = test_overwrite
 log 1 pass = Dec 25 20:45:02 MyHost test_same_fields[12345]: User 'admin' logged from '192.168.1.100' 5 this is the same_fields test
 log 1 pass = Dec 25 20:45:02 MyHost test_same_fields[12345]: User 'admin' logged from '192.168.1.100' 5 this is the same_fields test
 log 1 pass = Dec 25 20:45:02 MyHost test_same_fields[12345]: User 'admin' logged from '192.168.1.100' 5 this is the same_fields test
-
 rule = 999206
 alert = 7
 decoder = test_same
@@ -25,21 +27,18 @@ decoder = test_same
 log 1 pass = Dec 25 20:45:02 MyHost test_same_fields[12345]: User 'admin' logged from '192.168.1.100' 5 this is the not_same_fields test
 log 1 pass = Dec 25 20:45:02 MyHost test_same_fields[12345]: User 'admin' logged from '192.168.1.100' 6 this is the not_same_fields test
 log 1 pass = Dec 25 20:45:02 MyHost test_same_fields[12345]: User 'admin' logged from '192.168.1.100' 7 this is the not_same_fields test
-
 rule = 999208
 alert = 7
 decoder = test_same
 
 [noalert enabled]
 log 1 fail = Dec 19 17:20:08 User test_noalert[12345]:Test noalert=1
-
 rule =
 alert =
 decoder = test_noalert
 
 [noalert disabled]
 log 1 pass = Dec 19 17:20:08 User test_noalert[12345]:Test noalert=0
-
 rule = 999274
 alert = 3
 decoder = test_noalert

--- a/ruleset/testing/tests/test_features.ini
+++ b/ruleset/testing/tests/test_features.ini
@@ -30,20 +30,6 @@ rule = 999208
 alert = 7
 decoder = test_same
 
-[sshd brute force rule]
-log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
-log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
-log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
-log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
-log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
-log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
-log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
-log 1 pass = May 29 11:31:00 vagrant sshd[23119]: Failed password for invalid user adasdasd from 127.0.0.1 port 59264 ssh2
-
-rule = 5712
-alert = 10
-decoder = sshd
-
 [noalert enabled]
 log 1 fail = Dec 19 17:20:08 User test_noalert[12345]:Test noalert=1
 


### PR DESCRIPTION
|Related issue|
|---|
|#10768|

## Description

This PR aims to resolve issues detected under #10768 PR.
The issues resolved are:
- Fixed rules descriptions
- Fixed indentation issues.
- Fixed rule and test header
- Fixed .ini filename
- Fixed test placed in wrong file


## Checks and changes 

### Syntax

- [x] 1.a Rule tags order must be compliant.
- [x] 1.b Decoder tags order must be compliant.
- [x] 1.c XML blocks must as compact as possible.
- [x] 1.d Only one empty line between rule/decoder and the next rule/decoder.
- [x] 1.e Decoder extracted fields names must use '_' whether a space is needed.
- [x] 1.f Decoder name must use '-' whether a space is needed.
 
### Grammar

- [x] 2.a Grammar quality.
- [x] 2.b Similar phrases must keep tenses and expressions.
- [x] 2.c Grammar basic rules like capitalization, punctuation marks, sentence construction, and others.


### Semantic

- [x] 3.a New decoder, rule, or test are written in the correct file and grouped correctly inside the file.
- [x] 3.b Group similar rules under same ID's group.
- [x] 3.c: 
     - [x] 3.c1 Find and reuse group name before creating a new one.
     - [x] 3.c2 Include a new group definition in a PR comment.
     - [x] 3.c3 Any group name must use '_' whether it does need a space char.
     - [x] 3.c4 The groups inside a tag must be sorted in alphabetical order.
- [x] 3.d Rule level should be compliant with the [documentation](https://documentation.wazuh.com/current/user-manual/ruleset/rules-classification.html).

### Unit testing

- [x] 4.a A metadata block at the beginning of the .ini file describing software, version, and logs source.
- [x] 4.b Each new rule must have at least one test entry in the correct .ini file.
- [x] 4.c Runtest.py must pass and must include the results in raw format here.




<details><summary>All rules and decoders test.</summary>
<p>

```
- [ File = ./tests/sophos_fw.ini ] ---------
..........

- [ File = ./tests/dropbear.ini ] ---------
...

- [ File = ./tests/squid_rules.ini ] ---------
..

- [ File = ./tests/sudo.ini ] ---------
........

- [ File = ./tests/gitlab.ini ] ---------
.........................

- [ File = ./tests/glpi.ini ] ---------
...

- [ File = ./tests/unbound.ini ] ---------


- [ File = ./tests/mailscanner.ini ] ---------
.

- [ File = ./tests/samba.ini ] ---------
....

- [ File = ./tests/cisco_ios.ini ] ---------
.................

- [ File = ./tests/cimserver.ini ] ---------
..

- [ File = ./tests/audit_recon.ini ] ---------
..

- [ File = ./tests/fortigate.ini ] ---------
........................................

- [ File = ./tests/cisco_asa.ini ] ---------
........................................................................................

- [ File = ./tests/systemd.ini ] ---------
..

- [ File = ./tests/openldap.ini ] ---------
.........

- [ File = ./tests/oscap.ini ] ---------
................................

- [ File = ./tests/github.ini ] ---------
....................................................................................................................................................................................................................................................................................................................................

- [ File = ./tests/pfsense.ini ] ---------
..

- [ File = ./tests/apache.ini ] ---------
..................

- [ File = ./tests/api.ini ] ---------
............................

- [ File = ./tests/SonicWall.ini ] ---------
........

- [ File = ./tests/rsh.ini ] ---------
..

- [ File = ./tests/auditd.ini ] ---------
...

- [ File = ./tests/junos.ini ] ---------
...

- [ File = ./tests/owlh.ini ] ---------
....

- [ File = ./tests/pam.ini ] ---------
.....

- [ File = ./tests/sophos.ini ] ---------
........

- [ File = ./tests/modsecurity.ini ] ---------
......

- [ File = ./tests/paloalto.ini ] ---------
................

- [ File = ./tests/cylance.ini ] ---------
.......

- [ File = ./tests/pix.ini ] ---------
......................

- [ File = ./tests/sophos-utm-firewall.ini ] ---------
......

- [ File = ./tests/exim.ini ] ---------
.......

- [ File = ./tests/freepbx.ini ] ---------
......

- [ File = ./tests/trendmicro-cloud-one.ini ] ---------
.................

- [ File = ./tests/kernel_usb.ini ] ---------
......

- [ File = ./tests/netscreen.ini ] ---------
....

- [ File = ./tests/panda_paps.ini ] ---------
........

- [ File = ./tests/nextcloud.ini ] ---------
.......

- [ File = ./tests/aws_s3_access.ini ] ---------
.......

- [ File = ./tests/doas.ini ] ---------
....

- [ File = ./tests/icinga.ini ] ---------
....

- [ File = ./tests/apparmor.ini ] ---------
.....

- [ File = ./tests/sshd.ini ] ---------
.............................................

- [ File = ./tests/opensmtpd.ini ] ---------
.......

- [ File = ./tests/proftpd.ini ] ---------
.......

- [ File = ./tests/named.ini ] ---------
.....

- [ File = ./tests/syslog.ini ] ---------
......

- [ File = ./tests/checkpoint_smart1.ini ] ---------
..................

- [ File = ./tests/fireeye.ini ] ---------
...

- [ File = ./tests/office365.ini ] ---------
................................................................................................................................

- [ File = ./tests/vsftpd.ini ] ---------
....

- [ File = ./tests/openvpn_ldap.ini ] ---------
..

- [ File = ./tests/cpanel.ini ] ---------
.......

- [ File = ./tests/audit_scp.ini ] ---------
.

- [ File = ./tests/cloudlfare-waf.ini ] ---------
.............

- [ File = ./tests/web_appsec.ini ] ---------
...............................

- [ File = ./tests/fortiauth.ini ] ---------
....

- [ File = ./tests/cisco_ftd.ini ] ---------
..........................................

- [ File = ./tests/ossec.ini ] ---------
.....

- [ File = ./tests/arbor.ini ] ---------
..

- [ File = ./tests/huawei_usg.ini ] ---------
...

- [ File = ./tests/exchange.ini ] ---------
..

- [ File = ./tests/postfix.ini ] ---------
..

- [ File = ./tests/su.ini ] ---------
.....

- [ File = ./tests/vuln_detector.ini ] ---------
..

- [ File = ./tests/f5_big_ip.ini ] ---------
...........................................

- [ File = ./tests/mcafee_epo.ini ] ---------
.

- [ File = ./tests/audit_lateral.ini ] ---------
......

- [ File = ./tests/sysmon.ini ] ---------
...

- [ File = ./tests/web_rules.ini ] ---------
..........

- [ File = ./tests/iptables.ini ] ---------
........

- [ File = ./tests/eset.ini ] ---------
........

- [ File = ./tests/gcp.ini ] ---------
...........

- [ File = ./tests/firewalld.ini ] ---------
..

- [ File = ./tests/dovecot.ini ] ---------
...............

- [ File = ./tests/nginx.ini ] ---------
............

|Component |  Tested  |  Total   | Coverage |
| -------- | -------- | -------- | -------- |
|  Rules   |   984    |   4175   |  23.57%  |
| Decoders |    77    |   172    |  44.77%  |

|          File           |  Passed  |  Failed  |  Status  |
|        --------         | -------- | -------- | -------- |
|./tests/sysmon.ini       |    3     |    0     |   ✅    |
|./tests/proftpd.ini      |    7     |    0     |   ✅    |
|./tests/glpi.ini         |    3     |    0     |   ✅    |
|./tests/dovecot.ini      |    15    |    0     |   ✅    |
|./tests/exim.ini         |    7     |    0     |   ✅    |
|./tests/huawei_usg.ini   |    3     |    0     |   ✅    |
|./tests/squid_rules.ini  |    2     |    0     |   ✅    |
|./tests/pix.ini          |    22    |    0     |   ✅    |
|./tests/samba.ini        |    4     |    0     |   ✅    |
|./tests/mcafee_epo.ini   |    1     |    0     |   ✅    |
|./tests/checkpoint_smart1.ini|    18    |    0     |   ✅    |
|./tests/pfsense.ini      |    2     |    0     |   ✅    |
|./tests/iptables.ini     |    8     |    0     |   ✅    |
|./tests/cisco_asa.ini    |    88    |    0     |   ✅    |
|./tests/dropbear.ini     |    3     |    0     |   ✅    |
|./tests/systemd.ini      |    2     |    0     |   ✅    |
|./tests/SonicWall.ini    |    8     |    0     |   ✅    |
|./tests/panda_paps.ini   |    8     |    0     |   ✅    |
|./tests/mailscanner.ini  |    1     |    0     |   ✅    |
|./tests/owlh.ini         |    4     |    0     |   ✅    |
|./tests/fortiauth.ini    |    4     |    0     |   ✅    |
|./tests/cisco_ios.ini    |    17    |    0     |   ✅    |
|./tests/vuln_detector.ini|    2     |    0     |   ✅    |
|./tests/cloudlfare-waf.ini|    13    |    0     |   ✅    |
|./tests/gcp.ini          |    11    |    0     |   ✅    |
|./tests/openldap.ini     |    9     |    0     |   ✅    |
|./tests/unbound.ini      |    0     |    0     |   ✅    |
|./tests/oscap.ini        |    32    |    0     |   ✅    |
|./tests/f5_big_ip.ini    |    43    |    0     |   ✅    |
|./tests/sophos.ini       |    8     |    0     |   ✅    |
|./tests/opensmtpd.ini    |    7     |    0     |   ✅    |
|./tests/exchange.ini     |    2     |    0     |   ✅    |
|./tests/icinga.ini       |    4     |    0     |   ✅    |
|./tests/netscreen.ini    |    4     |    0     |   ✅    |
|./tests/doas.ini         |    4     |    0     |   ✅    |
|./tests/rsh.ini          |    2     |    0     |   ✅    |
|./tests/arbor.ini        |    2     |    0     |   ✅    |
|./tests/office365.ini    |   128    |    0     |   ✅    |
|./tests/paloalto.ini     |    16    |    0     |   ✅    |
|./tests/cylance.ini      |    7     |    0     |   ✅    |
|./tests/fortigate.ini    |    40    |    0     |   ✅    |
|./tests/ossec.ini        |    5     |    0     |   ✅    |
|./tests/web_rules.ini    |    10    |    0     |   ✅    |
|./tests/sudo.ini         |    8     |    0     |   ✅    |
|./tests/audit_lateral.ini|    6     |    0     |   ✅    |
|./tests/cisco_ftd.ini    |    42    |    0     |   ✅    |
|./tests/github.ini       |   324    |    0     |   ✅    |
|./tests/postfix.ini      |    2     |    0     |   ✅    |
|./tests/syslog.ini       |    6     |    0     |   ✅    |
|./tests/kernel_usb.ini   |    6     |    0     |   ✅    |
|./tests/api.ini          |    28    |    0     |   ✅    |
|./tests/sophos-utm-firewall.ini|    6     |    0     |   ✅    |
|./tests/apparmor.ini     |    5     |    0     |   ✅    |
|./tests/audit_scp.ini    |    1     |    0     |   ✅    |
|./tests/nginx.ini        |    12    |    0     |   ✅    |
|./tests/named.ini        |    5     |    0     |   ✅    |
|./tests/sophos_fw.ini    |    10    |    0     |   ✅    |
|./tests/openvpn_ldap.ini |    2     |    0     |   ✅    |
|./tests/cimserver.ini    |    2     |    0     |   ✅    |
|./tests/vsftpd.ini       |    4     |    0     |   ✅    |
|./tests/freepbx.ini      |    6     |    0     |   ✅    |
|./tests/sshd.ini         |    45    |    0     |   ✅    |
|./tests/junos.ini        |    3     |    0     |   ✅    |
|./tests/modsecurity.ini  |    6     |    0     |   ✅    |
|./tests/nextcloud.ini    |    7     |    0     |   ✅    |
|./tests/fireeye.ini      |    3     |    0     |   ✅    |
|./tests/cpanel.ini       |    7     |    0     |   ✅    |
|./tests/trendmicro-cloud-one.ini|    17    |    0     |   ✅    |
|./tests/pam.ini          |    5     |    0     |   ✅    |
|./tests/su.ini           |    5     |    0     |   ✅    |
|./tests/apache.ini       |    18    |    0     |   ✅    |
|./tests/gitlab.ini       |    25    |    0     |   ✅    |
|./tests/aws_s3_access.ini|    7     |    0     |   ✅    |
|./tests/firewalld.ini    |    2     |    0     |   ✅    |
|./tests/eset.ini         |    8     |    0     |   ✅    |
|./tests/auditd.ini       |    3     |    0     |   ✅    |
|./tests/web_appsec.ini   |    31    |    0     |   ✅    |
|./tests/audit_recon.ini  |    2     |    0     |   ✅    |


```
</p>
</details>

- [x] 4.d New CDB lists must include the proper test entry in the correct .ini file.

### E2E testing

- [x] 5.a Logs for new or modified decoder/rules sent to a manager running with this PR ruleset appear in Kibana.


- [x] 5.b There are not affected or broken visualizations on Kibana.


- [x] 5.c New or modified items can be seen correctly using APP ruleset navigation.


### Elasticsearch Template

- [x] 6.a Known fields with output format managed and usually used for searching are included in template array index.query.default_field. 
- [x] 6.b The new field with the correct date format is stored as a "date" type field in the template.
- [x] 6.c The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 
- [x] 6.d Known fields with output format managed and usually used for searching are included in the template.

### Stoppers

- [x] 7.a No previous rule ID changes without triple check.
- [x] 7.b No previous decoder name changes without triple check.
- [x] 7.c No previous file name changes without triple check.
- [x] 7.d No previous test changes its 'rule' field value without triple check.

### Others

- [x] 8.a Each file has the correct copyright block.
- [x] 8.b The copyright block doesn't have "Author" only "Created by Wazuh". To include an "Author" request triple check.
- [x] 8.c The copyright block doesn't use "-". 
- [x] 8.d The rule files don't have any sample log.
- [x] 8.e The decoder file has sample logs next to the decoder that matches that log.
- [x] 8.f The decoder and rule files have information about software, version, and any helpful information.
- [x] 8.g The PR has a single commit with CHANGELOG changes in the correct format.
- [x] 8.h The new rule ID is not in use.
- [x] 8.i The new rule ID must be in the defined IDs range. 
- [x] 8.j New rules ID range must be verified with a triple check and noted in the rules ID document.
- [x] 8.k The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 