### PR TITLE
Rework PR #8769 - f5 big ip lb

### DIFF
--- a/ruleset/decoders/0525-f5_bigip_decoders.xml
+++ b/ruleset/decoders/0525-f5_bigip_decoders.xml
@@ -1,38 +1,40 @@
 <!--
-  -  F5 Networks BIG-IP  decoders
-  -  Created by Wazuh, Inc.
-  -  Copyright (C) 2015-2021, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+    Copyright (C) 2015-2021, Wazuh Inc.
 -->
 
 <!--
+Log references:
+  - https://support.f5.com/csp/article/K15521451
+  - https://support.f5.com/csp/article/K16197
+  - https://support.f5.com/csp/article/K57555038
+
 Log fields:
-<time stamp> <host name> <level> <service[pid]> <message code> <message text>
+  <time stamp> <host name> <level> <service[pid]> <message code> <message text>
 
 Log samples:
 
-May 24 11:15:01 HOSTNAME notice logrotate[3582]: ALERT exited abnormally with [1]
-May 24 11:15:25 HOSTNAME warning tmm1[18463]: 01260013:4: SSL Handshake failed for TCP 192.168.1.15:50932 -> 11.22.33.44:443
-May 17 11:28:20 HOSTNAME alert gtmd[13220]: 011ae0f2:1: Monitor instance /Common/Monitor_1.1.1.1 192.168.1.1:1526 UP -> DOWN from /Common/F5-LAN-SF (no reply from big3d: timed out)
-May 17 11:28:21 HOSTNAME alert gtmd[13202]: 011a4003:1: SNMP_TRAP: Pool /Common/hostname member pmtdbaf5-SF (ip:port=10.1.1.1:5443) state change green -> red ( Monitor /Common/Monitor_1.1.1.1 from /Common/F5-LAN-SF : no reply from big3d: timed out)
-May 17 11:28:22 HOSTNAME alert gtmd[13202]: 011a6006:1: SNMP_TRAP: VS virtual_server_name (ip:port=192.168.1.2:1526) (Server /Common/virtual_server_name) state change green -> red ( Monitor /Common/Monitor_1.1.1.1 from /Common/F5-LAN-SF : no reply from big3d: timed out)
+  May 24 11:15:01 HOSTNAME notice logrotate[3582]: ALERT exited abnormally with [1]
+  May 24 11:15:25 HOSTNAME warning tmm1[18463]: 01260013:4: SSL Handshake failed for TCP 192.168.1.15:50932 -> 11.22.33.44:443
+  May 17 11:28:20 HOSTNAME alert gtmd[13220]: 011ae0f2:1: Monitor instance /Common/Monitor_1.1.1.1 192.168.1.1:1526 UP -> DOWN from /Common/F5-LAN-SF (no reply from big3d: timed out)
+  May 17 11:28:21 HOSTNAME alert gtmd[13202]: 011a4003:1: SNMP_TRAP: Pool /Common/hostname member pmtdbaf5-SF (ip:port=10.1.1.1:5443) state change green -> red ( Monitor /Common/Monitor_1.1.1.1 from /Common/F5-LAN-SF : no reply from big3d: timed out)
+  May 17 11:28:22 HOSTNAME alert gtmd[13202]: 011a6006:1: SNMP_TRAP: VS virtual_server_name (ip:port=192.168.1.2:1526) (Server /Common/virtual_server_name) state change green -> red ( Monitor /Common/Monitor_1.1.1.1 from /Common/F5-LAN-SF : no reply from big3d: timed out)
 -->
 
 <!-- Group BigIP F5  decoders-->
-<decoder name="f5_bigip">
+<decoder name="f5-bigip">
   <type>syslog</type>
 	<prematch type="pcre2">^\S+\s[^\[]+\[\d+\]:\s[0-9a-fA-F]+:\d+:\s</prematch>
 </decoder>
 
 <!-- General decoder catch all-->
-<decoder name="f5_bigip_general_fields">
+<decoder name="f5-bigip-general-fields">
    <parent>f5_bigip</parent>
    <regex type="pcre2">^(\S+)\s([^\[]+)\[(\d+)\]:\s([0-9a-fA-F]+):(\d+):\s(.*)$</regex>
    <order>event.type, process.name, process.pid, event.code, log.level, message</order>
 </decoder>
 
 <!-- 01010251 : Virtual %s exceeded configured rate limit. -->
-<decoder name="f5_bigip_general_fields">
+<decoder name="f5-bigip-general-fields">
   <parent>f5_bigip</parent>
   <regex type="pcre2">.*01010251:.*\s(Virtual\s(\S+)\s.*)</regex>
    <order>server_name</order>
@@ -42,304 +44,304 @@ May 17 11:28:22 HOSTNAME alert gtmd[13202]: 011a6006:1: SNMP_TRAP: VS virtual_se
 <!-- 01010240 : Syncookie HW mode activated, server = %A:%d, HSB modId = %d -->
 <!-- 01010241 : Syncookie HW mode exited, server = %A:%d, HSB modId = %d from %s. -->
 <!-- 01010344 : Syncookie SW mode exited, server = %A:%d -->
-<decoder name="f5_bigip_general_fields">
+<decoder name="f5-bigip-general-fields">
   <parent>f5_bigip</parent>
   <regex type="pcre2">.*server = ([^:]):(\d+)</regex>
    <order>server_ip, server_port</order>
 </decoder>
 
 <!-- 01310027 : ASM subsystem error (%s,%s): %s -->
-<decoder name="f5_bigip_general_fields">
+<decoder name="f5-bigip-general-fields">
   <parent>f5_bigip</parent>
   <regex type="pcre2">.*01310027:.*\sASM\ssubsystem\serror\s([^:\s]+)[:\s]+(.*)</regex>
   <order>bigip.asm.subsystem, error.message</order>
 </decoder>
 
 <!-- Group BigIP F5 cef decoders-->
-<decoder name="f5_bigip_cef">
+<decoder name="f5-bigip-cef">
   <type>syslog</type>
   <program_name>ASM</program_name>
 </decoder>
 
-<decoder name="f5_bigip_cef">
+<decoder name="f5-bigip-cef">
   <type>syslog</type>
   <prematch type="pcre2">CEF:0\|F5\|ASM\|[^\|]+\|(.+)|CEF:0\|F5\|%s\|[^\|]+\|.+</prematch>
 </decoder>
 
 <!-- General decoder message-->
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">CEF:0\|F5\|ASM\|[^\|]+\|(.+)|CEF:0\|F5\|%s\|[^\|]+\|(.+)</regex>
   <order>message</order>
 </decoder>
 
 <!-- Structured fields -->
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">dvchost=(\S+)?\s</regex>
   <order>dvchost</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">dvc=(\S+)?\s</regex>
   <order>dvc</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">cs1=(\S+)?\s</regex>
   <order>cs1</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">cs1Label=(\S+)?\s</regex>
   <order>cs1Label</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">cs2=(\S+)?\s</regex>
   <order>cs2</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">cs2Label=(\S+)?\s</regex>
   <order>cs2Label</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">deviceCustomDate1=(\w+\s\d{1,2}\s\d{4}\s\d{2}:\d{2}:\d{2})\s</regex>
   <order>deviceCustomDate1</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">deviceCustomDate1Label=(\S+)?\s</regex>
   <order>deviceCustomDate1Label</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">externalId=(\S+)?\s</regex>
   <order>externalId</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">act=(\S+)?\s</regex>
   <order>act</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">cn1=(\S+)?\s</regex>
   <order>cn1</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">cn1Label=(\S+)?\s</regex>
   <order>cn1Label</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">src=(\S+)?\s</regex>
   <order>src</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">spt=(\S+)?\s</regex>
   <order>spt</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">dst=(\S+)?\s</regex>
   <order>dst</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">dpt=(\S+)?\s</regex>
   <order>dpt</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">requestMethod=(\S+)?\s</regex>
   <order>requestMethod</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">app=(\S+)?\s</regex>
   <order>app</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">cs5=(\S+)?\s</regex>
   <order>cs5</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">cs5Label=(\S+)?\s</regex>
   <order>cs5Label</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">rt=(\w+\s\d{1,2}\s\d{4}\s\d{2}:\d{2}:\d{2})\s</regex>
   <order>rt</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">deviceExternalId=(\S+)?\s</regex>
   <order>deviceExternalId</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">cs4=(.*)\scs4Label=(\S+)?\s</regex>
   <order>cs4, cs4Label</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">cs6=(\S+)?\s</regex>
   <order>cs6</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">cs6Label=(\S+)?\s</regex>
   <order>cs6Label</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">c6a1=(\S+)?\s</regex>
   <order>c6a1</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">c6a1Label=(\S+)?\s</regex>
   <order>c6a1Label</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">c6a2=(\S+)?\s</regex>
   <order>c6a2</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">c6a2Label=(\S+)?\s</regex>
   <order>c6a2Label</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">c6a3=(\S+)?\s</regex>
   <order>c6a3</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">c6a3Label=(\S+)?\s</regex>
   <order>c6a3Label</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">c6a4=(\S+)?\s</regex>
   <order>c6a4</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">c6a4Label=(\S+)?\s</regex>
   <order>c6a4Label</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">msg=(\S+)?\s</regex>
   <order>msg</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">suid=(\S+)?\s</regex>
   <order>suid</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">suser=(\S+)?\s</regex>
   <order>suser</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">cn2=(\S+)?\s</regex>
   <order>cn2</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">cn2Label=(\S+)?\s</regex>
   <order>cn2Label</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">cn3=(\S+)?\s</regex>
   <order>cn3</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">cn3Label=(\S+)?\s</regex>
   <order>cn3Label</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">microservice=(\S+)?\s</regex>
   <order>microservice</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">request=(\S+)?\s</regex>
   <order>request</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">cs3Label=(\S+)?\s</regex>
   <order>cs3Label</order>
 </decoder>
 
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">cs3=(.*)</regex>
   <order>cs3</order>
 </decoder>
 
 <!-- Illegal action-->
-<decoder name="f5_bigip_cef_general_fields">
+<decoder name="f5-bigip-cef-general-fields">
   <parent>f5_bigip_cef</parent>
   <regex type="pcre2">(?:(Illegal)\s([^\|]+)\|){2}</regex>
   <order>type, action</order>

--- a/ruleset/decoders/0525-f5_bigip_decoders.xml
+++ b/ruleset/decoders/0525-f5_bigip_decoders.xml
@@ -28,14 +28,14 @@ Log samples:
 
 <!-- General decoder catch all-->
 <decoder name="f5-bigip-general-fields">
-   <parent>f5_bigip</parent>
+   <parent>f5-bigip</parent>
    <regex type="pcre2">^(\S+)\s([^\[]+)\[(\d+)\]:\s([0-9a-fA-F]+):(\d+):\s(.*)$</regex>
    <order>event.type, process.name, process.pid, event.code, log.level, message</order>
 </decoder>
 
 <!-- 01010251 : Virtual %s exceeded configured rate limit. -->
 <decoder name="f5-bigip-general-fields">
-  <parent>f5_bigip</parent>
+  <parent>f5-bigip</parent>
   <regex type="pcre2">.*01010251:.*\s(Virtual\s(\S+)\s.*)</regex>
    <order>server_name</order>
 </decoder>
@@ -45,14 +45,14 @@ Log samples:
 <!-- 01010241 : Syncookie HW mode exited, server = %A:%d, HSB modId = %d from %s. -->
 <!-- 01010344 : Syncookie SW mode exited, server = %A:%d -->
 <decoder name="f5-bigip-general-fields">
-  <parent>f5_bigip</parent>
+  <parent>f5-bigip</parent>
   <regex type="pcre2">.*server = ([^:]):(\d+)</regex>
    <order>server_ip, server_port</order>
 </decoder>
 
 <!-- 01310027 : ASM subsystem error (%s,%s): %s -->
 <decoder name="f5-bigip-general-fields">
-  <parent>f5_bigip</parent>
+  <parent>f5-bigip</parent>
   <regex type="pcre2">.*01310027:.*\sASM\ssubsystem\serror\s([^:\s]+)[:\s]+(.*)</regex>
   <order>bigip.asm.subsystem, error.message</order>
 </decoder>
@@ -70,279 +70,279 @@ Log samples:
 
 <!-- General decoder message-->
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">CEF:0\|F5\|ASM\|[^\|]+\|(.+)|CEF:0\|F5\|%s\|[^\|]+\|(.+)</regex>
   <order>message</order>
 </decoder>
 
 <!-- Structured fields -->
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">dvchost=(\S+)?\s</regex>
   <order>dvchost</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">dvc=(\S+)?\s</regex>
   <order>dvc</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">cs1=(\S+)?\s</regex>
   <order>cs1</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">cs1Label=(\S+)?\s</regex>
   <order>cs1Label</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">cs2=(\S+)?\s</regex>
   <order>cs2</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">cs2Label=(\S+)?\s</regex>
   <order>cs2Label</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">deviceCustomDate1=(\w+\s\d{1,2}\s\d{4}\s\d{2}:\d{2}:\d{2})\s</regex>
   <order>deviceCustomDate1</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">deviceCustomDate1Label=(\S+)?\s</regex>
   <order>deviceCustomDate1Label</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">externalId=(\S+)?\s</regex>
   <order>externalId</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">act=(\S+)?\s</regex>
   <order>act</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">cn1=(\S+)?\s</regex>
   <order>cn1</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">cn1Label=(\S+)?\s</regex>
   <order>cn1Label</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">src=(\S+)?\s</regex>
   <order>src</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">spt=(\S+)?\s</regex>
   <order>spt</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">dst=(\S+)?\s</regex>
   <order>dst</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">dpt=(\S+)?\s</regex>
   <order>dpt</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">requestMethod=(\S+)?\s</regex>
   <order>requestMethod</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">app=(\S+)?\s</regex>
   <order>app</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">cs5=(\S+)?\s</regex>
   <order>cs5</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">cs5Label=(\S+)?\s</regex>
   <order>cs5Label</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">rt=(\w+\s\d{1,2}\s\d{4}\s\d{2}:\d{2}:\d{2})\s</regex>
   <order>rt</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">deviceExternalId=(\S+)?\s</regex>
   <order>deviceExternalId</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">cs4=(.*)\scs4Label=(\S+)?\s</regex>
   <order>cs4, cs4Label</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">cs6=(\S+)?\s</regex>
   <order>cs6</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">cs6Label=(\S+)?\s</regex>
   <order>cs6Label</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">c6a1=(\S+)?\s</regex>
   <order>c6a1</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">c6a1Label=(\S+)?\s</regex>
   <order>c6a1Label</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">c6a2=(\S+)?\s</regex>
   <order>c6a2</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">c6a2Label=(\S+)?\s</regex>
   <order>c6a2Label</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">c6a3=(\S+)?\s</regex>
   <order>c6a3</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">c6a3Label=(\S+)?\s</regex>
   <order>c6a3Label</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">c6a4=(\S+)?\s</regex>
   <order>c6a4</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">c6a4Label=(\S+)?\s</regex>
   <order>c6a4Label</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">msg=(\S+)?\s</regex>
   <order>msg</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">suid=(\S+)?\s</regex>
   <order>suid</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">suser=(\S+)?\s</regex>
   <order>suser</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">cn2=(\S+)?\s</regex>
   <order>cn2</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">cn2Label=(\S+)?\s</regex>
   <order>cn2Label</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">cn3=(\S+)?\s</regex>
   <order>cn3</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">cn3Label=(\S+)?\s</regex>
   <order>cn3Label</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">microservice=(\S+)?\s</regex>
   <order>microservice</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">request=(\S+)?\s</regex>
   <order>request</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">cs3Label=(\S+)?\s</regex>
   <order>cs3Label</order>
 </decoder>
 
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">cs3=(.*)</regex>
   <order>cs3</order>
 </decoder>
 
 <!-- Illegal action-->
 <decoder name="f5-bigip-cef-general-fields">
-  <parent>f5_bigip_cef</parent>
+  <parent>f5-bigip-cef</parent>
   <regex type="pcre2">(?:(Illegal)\s([^\|]+)\|){2}</regex>
   <order>type, action</order>
 </decoder>

--- a/ruleset/rules/0695-f5_bigip_rules.xml
+++ b/ruleset/rules/0695-f5_bigip_rules.xml
@@ -2,11 +2,11 @@
     Copyright (C) 2015-2021, Wazuh Inc.
 -->
 
-<group name="f5_bigip,">
+<group name="f5-bigip,">
 
      <!-- F5 BigIP LTM decoded grouped rules -->
     <rule id="65260" level="0">
-        <decoded_as>f5_bigip</decoded_as>
+        <decoded_as>f5-bigip</decoded_as>
         <description>F5 Networks BigIP events</description>
     </rule>
 
@@ -280,7 +280,7 @@
 
     <!-- CEF decoded grouped rules -->
     <rule id="65293" level="0">
-        <decoded_as>f5_bigip_cef</decoded_as>
+        <decoded_as>f5-bigip-cef</decoded_as>
         <description>CEF decoded grouped alerts</description>
     </rule>
 

--- a/ruleset/rules/0695-f5_bigip_rules.xml
+++ b/ruleset/rules/0695-f5_bigip_rules.xml
@@ -1,8 +1,5 @@
 <!--
-  -  F5 Networks BIG-IP LTM rules
-  -  Created by Wazuh, Inc.
-  -  Copyright (C) 2015-2021, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+    Copyright (C) 2015-2021, Wazuh Inc.
 -->
 
 <group name="f5_bigip,">

--- a/ruleset/testing/tests/f5_big_ip.ini
+++ b/ruleset/testing/tests/f5_big_ip.ini
@@ -192,7 +192,7 @@ decoder = f5-bigip
 log 1 pass = May  4 13:42:12 some.host.name crit server_handler.pl[24895]: 01310027:2: ASM subsystem error (asm_config_server.pl,(eval)): Couldn't pass call to async process - ignoring
 rule = 65292
 alert = 7
-decoder = f5-bigipcef
+decoder = f5-bigip-cef
 
 
 [ASM Illegal Action]

--- a/ruleset/testing/tests/f5_big_ip.ini
+++ b/ruleset/testing/tests/f5_big_ip.ini
@@ -192,7 +192,7 @@ decoder = f5-bigip
 log 1 pass = May  4 13:42:12 some.host.name crit server_handler.pl[24895]: 01310027:2: ASM subsystem error (asm_config_server.pl,(eval)): Couldn't pass call to async process - ignoring
 rule = 65292
 alert = 7
-decoder = f5-bigip-cef
+decoder = f5-bigip
 
 
 [ASM Illegal Action]

--- a/ruleset/testing/tests/f5_big_ip.ini
+++ b/ruleset/testing/tests/f5_big_ip.ini
@@ -2,152 +2,152 @@
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 01010251:0: Virtual %s exceeded configured rate limit.
 rule = 65261
 alert = 9
-decoder = f5_bigip
+decoder = f5-bigip
 
 [SYN flood attack]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 01010343:0: Syncookie SW mode activated, server = %A:%d
 rule = 65262
 alert = 13
-decoder = f5_bigip
+decoder = f5-bigip
 
 [Stopped throttling traffic]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 011e0001:0: Limiting %s from %d to %d packets/sec for traffic-group %s
 rule = 65263
 alert = 9
-decoder = f5_bigip
+decoder = f5-bigip
 
 [SYN cookie threshold is reached]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 01010038:0: Syncookie counter %d exceeded vip threshold %u for virtual = %A:%d
 rule = 65264
 alert = 9
-decoder = f5_bigip
+decoder = f5-bigip
 
 [Detected a syncookie DOS attack]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 01010240:0: Syncookie HW mode activated, server = %A:%d, HSB modId = %d
 rule = 65265
 alert = 13
-decoder = f5_bigip
+decoder = f5-bigip
 
 [Ongoing DDos attack]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 01010329:0: BDoS: (TMM) Signature %s: threshold_mode=%s detection=%u mitigation_curr=%llu
 rule = 65266
 alert = 13
-decoder = f5_bigip
+decoder = f5-bigip
 
 [Created/Updated (AFM) BDoS dynamic signature by the AFM bdosd daemon during an attack]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 01010302:0: BDoS: (TMM) %s signature (%s) for context %s at idx %u (detection=%u mitigation=%u state=%s transient=%s retired=%s).
 rule = 65267
 alert = 11
-decoder = f5_bigip
+decoder = f5-bigip
 
 [Number of allowed new connections per second for pool member has been exceeded]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 01010250:0: Pool member %A:%u exceeded configured rate limit.
 rule = 65268
 alert = 10
-decoder = f5_bigip
+decoder = f5-bigip
 
 [Syncookie DOS attack has stopped]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 01010241:0: Syncookie HW mode exited, server = %A:%d, HSB modId = %d from %s.
 rule = 65269
 alert = 6
-decoder = f5_bigip
+decoder = f5-bigip
 
 [Syncookie counter exceeded vip threshold]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 01010056:0: Syncookie counter %d exceeded vip threshold %u for virtual = %s
 rule = 65270
 alert = 10
-decoder = f5_bigip
+decoder = f5-bigip
 
 [SYN cookie state exited]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 01010344:0: Syncookie SW mode exited, server = %A:%d
 rule = 65271
 alert = 2
-decoder = f5_bigip
+decoder = f5-bigip
 
 [SSLv2 is no longer supported and has been removed]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 01071bee:0: SSLv2 is no longer supported and has been removed. The 'sslv2' keyword in the cipher string has been ignored.
 rule = 65272
 alert = 4
-decoder = f5_bigip
+decoder = f5-bigip
 
 [User is prevented from doing things they are not authorized to do.]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 01070822:0: "Access Denied: %s"
 rule = 65273
 alert = 5
-decoder = f5_bigip
+decoder = f5-bigip
 
 [Mcpd has detected that sync traffic is being sent over a VLAN that is not the correct one.]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 01071bd1:0: Inbound CMI connection from IP (%s) denied because it came from VLAN (%s), not from expected VLAN (%s).
 rule = 65274
 alert = 9
-decoder = f5_bigip
+decoder = f5-bigip
 
 [Too many SIP media sessions have been established for the current configuration.]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 01860017:0: MR_SIP: Too many media sessions %d / %d. Error Code %d
 rule = 65275
 alert = 10
-decoder = f5_bigip
+decoder = f5-bigip
 
 [Critical error for TMM. It restarts. Attempts to reconnect will be made after that.]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 01010020:0: MCP Connection %s, exiting
 rule = 65276
 alert = 10
-decoder = f5_bigip
+decoder = f5-bigip
 
 [Errors could be caused by a broken feature or critical system errors.]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 01071d0b:0: adm: %s
 rule = 65277
 alert = 12
-decoder = f5_bigip
+decoder = f5-bigip
 
 [The HAL daemon might not be able to correctly identify the platform or publish the hardware abstraction configuration at startup, or has encountered a critical failure during normal operation.]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 012a0002:0: "LIBHAL reporting critical conditions"
 log 2 pass = May  5 04:26:19 hostname type process[20175]: 012a0003:0: LIBHAL reporting error conditions
 rule = 65278
 alert = 10
-decoder = f5_bigip
+decoder = f5-bigip
 
 [Hardware sensor critical alarm.]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 012a0013:0: Blade %d hardware sensor critical alarm: %s
 rule = 65279
 alert = 13
-decoder = f5_bigip
+decoder = f5-bigip
 
 [AOM has indicated that a temperature sensor has crossed a 'critical' level threshold.]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 012a0031:0: %s
 rule = 65280
 alert = 12
-decoder = f5_bigip
+decoder = f5-bigip
 
 [AOM has indicated that a fan sensor has crossed a 'critical' threshold.]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 012a0037:0: %s
 rule = 65281
 alert = 12
-decoder = f5_bigip
+decoder = f5-bigip
 
 [AOM has indicated that a power sensor has crossed a 'critical' threshold.]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 012a0043:0: %s
 rule = 65282
 alert = 12
-decoder = f5_bigip
+decoder = f5-bigip
 
 [Critical error that prevents the broadcom switch from operating at the proper configuration required by BIG-IP.]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 012c0011:0: BCM56XXD SDK error
 rule = 65283
 alert = 12
-decoder = f5_bigip
+decoder = f5-bigip
 
 [Critical errors in communication between TMM threads, specifically by MPI proxy.]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 01340003:0: Cluster error: %s
 rule = 65284
 alert = 10
-decoder = f5_bigip
+decoder = f5-bigip
 
 [Serious issue preventing the guest from starting or shutting down.]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 01510003:0: %s
 rule = 65285
 alert = 9
-decoder = f5_bigip
+decoder = f5-bigip
 
 [Critical: The BIG-IP system is not allowed not to go Active.]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 01550004:0: Critical:
@@ -155,63 +155,64 @@ log 2 pass = May  5 04:26:19 hostname type process[20175]: 01550005:0: Critical:
 log 3 pass = May  5 04:26:19 hostname type process[20175]: 01550006:0: Critical:
 rule = 65286
 alert = 12
-decoder = f5_bigip
+decoder = f5-bigip
 
 [Critical: The errdefsd daemon is out of memory.]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 01940007:0: "Failed to allocate the errdefs tmconf handle!"
 rule = 65287
 alert = 7
-decoder = f5_bigip
+decoder = f5-bigip
 
 [Critical: The file /PLATFORM isn't found, and licensing logic cannot determine the platform type.]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 01a70028:0: The platform was not found in %s.
 rule = 65288
 alert = 7
-decoder = f5_bigip
+decoder = f5-bigip
 
 [Bot Defense]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 01071d94:0: Bot Defense Profile (%s) Micro Service (%s): Missing required field (%s).
 log 2 pass = May  5 04:26:19 hostname type process[20175]: 01071d9e:0: Bot defense anomaly %s not found.
 rule = 65289
 alert = 3
-decoder = f5_bigip
+decoder = f5-bigip
 
 [Tcp Dump]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 013e0002:0: Tcpdump stopping on %la:%u from %la:%u
 rule = 65290
 alert = 2
-decoder = f5_bigip
+decoder = f5-bigip
 
 [Tcp Dump remote session]
 log 1 pass = May  5 04:26:19 hostname type process[20175]: 013e0005:0: Tcpdump starting remote to %A from %A
 rule = 65291
 alert = 3
-decoder = f5_bigip
+decoder = f5-bigip
 
 [ASM Error]
 log 1 pass = May  4 13:42:12 some.host.name crit server_handler.pl[24895]: 01310027:2: ASM subsystem error (asm_config_server.pl,(eval)): Couldn't pass call to async process - ignoring
 rule = 65292
 alert = 7
-decoder = f5_bigip
+decoder = f5-bigipcef
+
 
 [ASM Illegal Action]
 log 1 pass = May  4 18:23:02 some.host.name ASM: CEF:0|F5|ASM|14.1.2|Illegal HTTP status in response|Illegal HTTP status in response|2|dvchost=some.host.name dvc=192.168.1.000 cs1=/Common/webportal-waf-policy cs1Label=policy_name cs2=/Common/webportal-waf-policy cs2Label=http_class_name deviceCustomDate1=May 03 2021 16:57:44 deviceCustomDate1Label=policy_apply_date externalId=15489460216395818345 act=alerted cn1=409 cn1Label=response_code src=00.00.00.00 spt=59270 dst=111.1111.11.1 dpt=443 requestMethod=GET app=HTTPS cs5=22.22.22.22 cs5Label=x_forwarded_for_header_value rt=May 04 2021 18:23:02 deviceExternalId=0 cs4=Information Leakage cs4Label=attack_type cs6=N/A cs6Label=geo_location c6a1= c6a1Label=device_address c6a2= c6a2Label=source_address c6a3= c6a3Label=destination_address c6a4= c6a4Label=ip_address_intelligence msg=N/A suid=2b2f405ccde7b7ed suser=N/A cn2=1 cn2Label=violation_rating cn3=0 cn3Label=device_id microservice=N/A request=/some/path cs3Label=full_request cs3=GET /other/path HTTP/1.1\r\nHost: some.host\r\nConnection: keep-alive\r\nsec-ch-ua: " Not A;Brand";v\="99", "Chromium";v\="90", "Google Chrome";v\="90"\r\nsec-ch-ua-mobile: ?0\r\nX-AUSERNAME: auser.g\r\nUser-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 Safari/537.36\r\nContent-Type: application/json\r\nAccept: application/json, text/javascript, */*; q\=0.01\r\nX-Requested-With: XMLHttpRequest\r\nX-AUSERID: 1516\r\nSec-Fetch-Site: same-origin\r\nSec-Fetch-Mode: cors\r\nSec-Fetch-Dest: empty\r\nReferer: https://some.url?until\=refs%2Fheads%2Fgcp_migration_stage\r\nAccept-Encoding: gzip, deflate, br\r\nAccept-Language: en-GB,en-US;q\=0.9,en;q\=0.8\r\nCookie: _atl_bitbucket_remember_me\=M2ExMjNiMDE5MDExMTU1MTg2NzZjMGEwOTVkMWUwY2I0NTk5ZDUxMjo3MzA5NzM2NmVmMWEwYTRlNzIxMjdhYjFjYTEyN2I3NDAwMWE5M2U2; JSESSIONID\=9B114064A2D6E2CC7693BB809D66F136; TS01e7480f\=012bb8697ce2411b8d331492ed24011b153e498024e63bf863baf9f23364ced5fd2cd43bc3739eaad01a5225f494649800c636a4889315f38d7febb1900a774eb2cfa0c6788a91c93eab0ff7a4e61eb422fe089b57\r\nX-Forwarded-For: 00.0.000.110\r\n\r\n#015
 rule = 65294
 alert = 12
-decoder = f5_bigip_cef
+decoder = f5-bigip-cef
 
 [ASM SQL injection]
 log 1 pass = May  5 01:34:01 lb1.corp.ovo.id ASM: CEF:0|F5|ASM|14.1.2|200002273|SQL-INJ exec()|5|dvchost=lb1.corp.ovo.id dvc=192.168.10.4 cs1=/Common/www.ovo.id-waf-policy cs1Label=policy_name cs2=/Common/www.ovo.id-waf-policy cs2Label=http_class_name deviceCustomDate1=Apr 30 2021 07:40:41 deviceCustomDate1Label=policy_apply_date externalId=15489460216395963001 act=blocked cn1=0 cn1Label=response_code src=167.71.70.165 spt=13370 dst=10.50.72.35 dpt=443 requestMethod=GET app=HTTPS cs5=167.71.70.165 cs5Label=x_forwarded_for_header_value rt=May 05 2021 01:34:00 deviceExternalId=0 cs4=SQL-Injection cs4Label=attack_type cs6=NL cs6Label=geo_location c6a1= c6a1Label=device_address c6a2= c6a2Label=source_address c6a3= c6a3Label=destination_address c6a4= c6a4Label=ip_address_intelligence msg=N/A suid=0 suser=N/A cn2=5 cn2Label=violation_rating cn3=0 cn3Label=device_id microservice=N/A request=/solr/atom/select?q\=1&&wt\=velocity&v.template\=custom&v.template.custom\=%23set($x\=%27%27)+%23set($rt\=$x.class.forName(%27java.lang.Runtime%27))+%23set($chr\=$x.class.forName(%27java.lang.Character%27))+%23set($str\=$x.class.forName(%27java.lang.String%27))+%23set($ex\=$rt.getRuntime().exec(%27cat%20/etc/passwd%27))+$ex.waitFor()+%23set($out\=$ex.getInputStream())+%23foreach($i+in+[1..$out.available()])$str.valueOf($chr.toChars($out.read()))%23end cs3Label=full_request cs3=GET /solr/atom/select?q\=1&&wt\=velocity&v.template\=custom&v.template.custom\=%23set($x\=%27%27)+%23set($rt\=$x.class.forName(%27java.lang.Runtime%27))+%23set($chr\=$x.class.forName(%27java.lang.Character%27))+%23set($str\=$x.class.forName(%27java.lang.String%27))+%23set($ex\=$rt.getRuntime().exec(%27cat%20/etc/passwd%27))+$ex.waitFor()+%23set($out\=$ex.getInputStream())+%23foreach($i+in+[1..$out.available()])$str.valueOf($chr.toChars($out.read()))%23end HTTP/1.0\r\nHost: upgrade.ovo.id\r\nUser-Agent: Mozilla/5.0 (Windows NT 10.0; rv:68.0) Gecko/20100101 Firefox/68.0\r\nAccept: text/html,application/xhtml+xml,application/xml;q\=0.9,*/*;q\=0.8\r\nAccept-Language: en-US,en;q\=0.5\r\nX-Cnection: close\r\nUpgrade-Insecure-Requests: 1\r\nX-Forwarded-For: 167.71.70.165\r\nConnection: Keep-Alive\r\n\r\n#015
 rule = 65295
 alert = 13
-decoder = f5_bigip_cef
+decoder = f5-bigip-cef
 
 [BigIP ASM: Violation detected]
 log 1 pass = <134>Sep 19 13:35:00 bigip-4.pme-ds.f5.com ASM:CEF:0|F5|ASM|11.3.0|Successful Request|Successful Request|2| dvchost=bigip-4.pme-ds.f5.com dvc=172.16.73.34 cs1=topaz4-web4 cs1Label=policy_name cs2=/Common/topaz4-web4 cs2Label=http_class_name deviceCustomDate1=Sep 19 2012 11:38:36 deviceCustomDate1Label=policy_apply_date externalId=18205860747014045699 act=passed cn1=200 cn1Label=response_code src=10.4.1.101 spt=52963 dst=10.4.1.200 dpt=80 requestMethod=GET app=HTTP cs5=N/A cs5Label=x_forwarded_for_header_value rt=Sep 19 2012 13:35:00 deviceExternalId=0 cs4=N/A cs4Label=attack_type cs6=N/A cs6Label=geo_location c6a1= c6a1Label=device_address c6a2= c6a2Label=source_address c6a3= c6a3Label=destination_address c6a4=N/A c6a4Label=ip_address_intelligence msg=N/A suid=2e769a9e1ea8b777 suser=N/A request=/ cs3Label=full_request cs3=GET / HTTP/1.0\r\nUser-Agent: Wget/1.12 (linux-gnu)\r\nAccept: */*\r\nHost: 10.4.1.200\r\nConnection: Keep-Alive\r\n\r\n
 log 2 pass = <131>Sep 19 13:53:34 bigip-4.pme-ds.f5.com ASM:CEF:0|F5|ASM|11.3.0|200021069|Automated client access "wget"|5|dvchost=bigip-4.pme-ds.f5.com dvc=172.16.73.34 cs1=topaz4-web4 cs1Label=policy_name cs2=/Common/topaz4-web4 cs2Label=http_class_name deviceCustomDate1=Sep 19 2012 13:49:25 deviceCustomDate1Label=policy_apply_date externalId=18205860747014045723 act=blocked cn1=0 cn1Label=response_code src=10.4.1.101 spt=52975 dst=10.4.1.200 dpt=80 requestMethod=GET app=HTTP cs5=N/A cs5Label=x_forwarded_for_header_value rt=Sep 19 2012 13:53:33 deviceExternalId=0 cs4=Non-browser Client cs4Label=attack_type cs6=N/A cs6Label=geo_location c6a1= c6a1Label=device_address c6a2= c6a2Label=source_address c6a3= c6a3Label=destination_address c6a4=N/A c6a4Label=ip_address_intelligence msg=N/A suid=86c4f8bf7349cac9 suser=N/A request=/ cs3Label=full_request cs3=GET / HTTP/1.0\r\nUser-Agent: Wget/1.12 (linux-gnu)\r\nAccept: */*\r\nHost: 10.4.1.200\r\nConnection: Keep-Alive\r\n\r\n
 rule = 65296
 alert = 12
-decoder = f5_bigip_cef
+decoder = f5-bigip-cef
 
 [BigIP ASM: Anomaly detected]
 log 1 pass = <131>Sep 19 13:53:34 bigip-4.pme-ds.f5.com ASM:CEF:0|F5|%s|%s|%s|%s|%d| dvchost=%s dvc=%s cs1=%s cs1Label=policy_name cs2=%s cs2Label=web_application_name deviceCustomDate1=%s deviceCustomDate1Label=policy_apply_date act=%s cn3=%llu cn3Label=attack_id cs4=%s cs4Label=attack_status request=%s src=%s cs6=%s cs6Label=geo_location cs5=%s cs5Label=detection_mode rt=%s cn1=%d cn1Label=detection_average cn2=%llu cn2Label=dropped_requests
@@ -219,4 +220,4 @@ log 2 pass = <131>Sep 19 13:53:34 bigip-4.pme-ds.f5.com ASM:CEF:0|F5|%s|%s|%s|%s
 log 3 pass = <131>Sep 19 13:53:34 bigip-4.pme-ds.f5.com ASM:CEF:0|F5|%s|%s|%s|%s|%d| dvchost=%s dvc=%s cs1=%s cs1Label=policy_name cs2=%s cs2Label=web_application_name deviceCustomDate1=%s deviceCustomDate1Label=policy_apply_date act=%s cn3=%llu cn3Label=attack_id cs4=%s cs4Label=attack_status src=%s cs6=%s cs6Label=geo_location rt=%s cn2=%llu cn2Label=dropped_requests cn4=%u cn4Label=violation_counter
 rule = 65297
 alert = 12
-decoder = f5_bigip_cef
+decoder = f5-bigip-cef


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/11382|

## Description

This PR aims to add testing for PR https://github.com/wazuh/wazuh/pull/8769

The issues resolved are:
- Missing copyright headers.
- Add testing.
- Enhanced description.

## Checks and changes 

### Syntax

- [x] 1.a Rule tags order must be compliant.
- [x] 1.b Decoder tags order must be compliant.
- [x] 1.c XML blocks must as compact as possible.
- [X] 1.d Only one empty line between rule/decoder and the next rule/decoder.
- [X] 1.e Decoder extracted fields names must use '_' whether a space is needed.
- [X] 1.f Decoder name must use '-' whether a space is needed.
 
### Grammar

- [X] 2.a Grammar quality.
- [X] 2.b Similar phrases must keep tenses and expressions.
- [X] 2.c Grammar basic rules like capitalization, punctuation marks, sentence construction, and others.


### Semantic

- [x] 3.a New decoder, rule, or test are written in the correct file and grouped correctly inside the file.
- [x] 3.b Group similar rules under same ID's group.
- [x] 3.c: 
     - [x] 3.c1 Find and reuse group name before creating a new one.
    - [x] 3.c2 Include a new group definition in a PR comment.
    - [x] 3.c3 Any group name must use '_' whether it does need a space char.
    -  [x] 3.c4 The groups inside a tag must be sorted in alphabetical order.
- [x] 3.d Rule level should be compliant with the [documentation](https://documentation.wazuh.com/current/user-manual/ruleset/rules-classification.html).

### Unit testing

- [X] 4.a A metadata block at the beginning of the .ini file describing software, version, and logs source.
- [X] 4.b Each new rule must have at least one test entry in the correct .ini file.
- [x] 4.c Runtest.py must pass and must include the results in raw format here.

<details><summary>All rules and decoders test.</summary>
<p>

```
root@ubuntu20LTS:/home/vagrant/wazuh/ruleset/testing# python runtests.py 
- [ File = ./tests/doas.ini ] ---------
....

- [ File = ./tests/office365.ini ] ---------
................................................................................................................................

- [ File = ./tests/iptables.ini ] ---------
........

- [ File = ./tests/exim.ini ] ---------
.......

- [ File = ./tests/api.ini ] ---------
............................

- [ File = ./tests/trendmicro-cloud-one.ini ] ---------
.................

- [ File = ./tests/web_appsec.ini ] ---------
...............................

- [ File = ./tests/cisco_asa.ini ] ---------
........................................................................................

- [ File = ./tests/firewalld.ini ] ---------
..

- [ File = ./tests/mailscanner.ini ] ---------
.

- [ File = ./tests/nextcloud.ini ] ---------
.......

- [ File = ./tests/icinga.ini ] ---------
....

- [ File = ./tests/ossec.ini ] ---------
.....

- [ File = ./tests/paloalto.ini ] ---------
................

- [ File = ./tests/named.ini ] ---------
.....

- [ File = ./tests/vsftpd.ini ] ---------
....

- [ File = ./tests/gcp.ini ] ---------
...........

- [ File = ./tests/web_rules.ini ] ---------
..........

- [ File = ./tests/sysmon.ini ] ---------
...

- [ File = ./tests/fireeye.ini ] ---------
...

- [ File = ./tests/arbor.ini ] ---------
..

- [ File = ./tests/cisco_ios.ini ] ---------
.................

- [ File = ./tests/sudo.ini ] ---------
........

- [ File = ./tests/modsecurity.ini ] ---------
......

- [ File = ./tests/postfix.ini ] ---------
..

- [ File = ./tests/freepbx.ini ] ---------
......

- [ File = ./tests/SonicWall.ini ] ---------
........

- [ File = ./tests/audit_scp.ini ] ---------
.

- [ File = ./tests/cimserver.ini ] ---------
..

- [ File = ./tests/nginx.ini ] ---------
............

- [ File = ./tests/junos.ini ] ---------
...

- [ File = ./tests/glpi.ini ] ---------
...

- [ File = ./tests/proftpd.ini ] ---------
.......

- [ File = ./tests/syslog.ini ] ---------
......

- [ File = ./tests/fortigate.ini ] ---------
........................................

- [ File = ./tests/sophos_fw.ini ] ---------
..........

- [ File = ./tests/f5_big_ip.ini ] ---------
...........................................

- [ File = ./tests/opensmtpd.ini ] ---------
.......

- [ File = ./tests/sophos.ini ] ---------
........

- [ File = ./tests/sophos-utm-firewall.ini ] ---------
......

- [ File = ./tests/netscreen.ini ] ---------
....

- [ File = ./tests/apparmor.ini ] ---------
.....

- [ File = ./tests/squid_rules.ini ] ---------
..

- [ File = ./tests/gitlab.ini ] ---------
.........................

- [ File = ./tests/checkpoint_smart1.ini ] ---------
..................

- [ File = ./tests/apache.ini ] ---------
..................

- [ File = ./tests/dovecot.ini ] ---------
...............

- [ File = ./tests/systemd.ini ] ---------
..

- [ File = ./tests/pam.ini ] ---------
.....

- [ File = ./tests/github.ini ] ---------
....................................................................................................................................................................................................................................................................................................................................

- [ File = ./tests/oscap.ini ] ---------
................................

- [ File = ./tests/huawei_usg.ini ] ---------
...

- [ File = ./tests/cpanel.ini ] ---------
.......

- [ File = ./tests/samba.ini ] ---------
....

- [ File = ./tests/audit_lateral.ini ] ---------
......

- [ File = ./tests/vuln_detector.ini ] ---------
..

- [ File = ./tests/owlh.ini ] ---------
....

- [ File = ./tests/exchange.ini ] ---------
..

- [ File = ./tests/cisco_ftd.ini ] ---------
..........................................

- [ File = ./tests/openvpn_ldap.ini ] ---------
..

- [ File = ./tests/panda_paps.ini ] ---------
........

- [ File = ./tests/dropbear.ini ] ---------
...

- [ File = ./tests/mcafee_epo.ini ] ---------
.

- [ File = ./tests/openldap.ini ] ---------
.........

- [ File = ./tests/sshd.ini ] ---------
...........................................

- [ File = ./tests/kernel_usb.ini ] ---------
......

- [ File = ./tests/pix.ini ] ---------
......................

- [ File = ./tests/unbound.ini ] ---------


- [ File = ./tests/rsh.ini ] ---------
..

- [ File = ./tests/cylance.ini ] ---------
.......

- [ File = ./tests/cloudlfare-waf.ini ] ---------
.............

- [ File = ./tests/eset.ini ] ---------
........

- [ File = ./tests/auditd.ini ] ---------
...

- [ File = ./tests/pfsense.ini ] ---------
..

- [ File = ./tests/su.ini ] ---------
.....

- [ File = ./tests/audit_recon.ini ] ---------
..

- [ File = ./tests/aws_s3_access.ini ] ---------
.......


```
</p>
</details>

~~- [X] 4.d New CDB lists must include the proper test entry in the correct .ini file.~~

### E2E testing

- [x] 5.a Logs for new or modified decoder/rules sent to a manager running with this PR ruleset appear in Kibana.



- [x] 5.b There are not affected or broken visualizations on Kibana.



- [x] 5.c New or modified items can be seen correctly using APP ruleset navigation.




### Elasticsearch Template

~~- [X] 6.a Known fields with output format managed and usually used for searching are included in template array index.query.default_field.~~
~~- [X] 6.b The new field with the correct date format is stored as a "date" type field in the template.~~
~~- [X] 6.c The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template.~~ 
~~- [X] 6.d Known fields with output format managed and usually used for searching are included in the template.~~

### Stoppers

- [x] 7.a No previous rule ID changes without triple check.
- [x] 7.b No previous decoder name changes without triple check.
- [x] 7.c No previous file name changes without triple check.
- [x] 7.d No previous test changes its 'rule' field value without triple check.

### Others

- [x] 8.a Each file has the correct copyright block.
- [x] 8.b The copyright block doesn't have "Author" only "Created by Wazuh". To include an "Author" request triple check.
- [x] 8.c The copyright block doesn't use "-". 
- [ ] 8.d The rule files don't have any sample log.
- [x] 8.e The decoder file has sample logs next to the decoder that matches that log.
- [x] 8.f The decoder and rule files have information about software, version, and any helpful information.
~~- [x] 8.g The PR has a single commit with CHANGELOG changes in the correct format.~~
- [x] 8.h The new rule ID is not in use.
- [x] 8.i The new rule ID must be in the defined IDs range.
- [x] 8.j New rules ID range must be verified with a triple check and noted in the rules ID document.
- [x] 8.k The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 