### PR TITLE
Fix memory leak in Vulnerability-Detector agent scan 4.3

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -6138,6 +6138,7 @@ void wm_vuldet_free_scan_agent(scan_agent *agent) {
         free(agent->os_reference);
         free(agent->os_release);
         os_free(agent->os_display_version);
+        os_free(agent->os_version);
         free(agent->kernel_release);
         int i;
         for (i = 0; agent->agent_os_cpe && agent->agent_os_cpe[i]; i++) {


### PR DESCRIPTION
|Related issue|
|---|
|#11392|

## Description

With this PR, we have fixed the problem found in #11392, avoiding memory leaks in the agents' scanner.

The problem was just a variable not being freed, causing memory leaks every time memory was reserved (on every agent scan).

The only necessary fix has been to add this variable to the `wm_vuldet_free_scan_agent` function, so that the memory is freed when it is no longer needed.

## Configuration options

Configuration used to reproduce the memory leak:
```xml
  <vulnerability-detector>
    <enabled>yes</enabled>
    <interval>2m</interval>
    <min_full_scan_interval>1s</min_full_scan_interval>
    <run_on_start>yes</run_on_start>
    <provider name="redhat">
      <enabled>yes</enabled>
      <update_interval>2m</update_interval>
      <url end="26" start="1">http://ci.wazuh.com/vulnerability-detector/rh-feed/redhat-feed[-].json</url>
      <os path="/vagrant/custom-feeds/custom_redhat_oval_feed.xml">7</os>
    </provider>

    <provider name="nvd">
      <path>/vagrant/custom-feeds/real_nvd_feed.json</path>
      <enabled>yes</enabled>
      <update_from_year>2020</update_from_year>
      <update_interval>2m</update_interval>
    </provider>
  </vulnerability-detector>
```
> The custom feeds have been obtained from the QA repository: https://github.com/wazuh/wazuh-qa/tree/master/tests/integration/test_vulnerability_detector/test_scan_results/data/feeds

## Valgrind report
```
==19705== LEAK SUMMARY:
==19705==    definitely lost: 0 bytes in 0 blocks
==19705==    indirectly lost: 0 bytes in 0 blocks
==19705==      possibly lost: 7,856 bytes in 14 blocks
==19705==    still reachable: 219,656 bytes in 68 blocks
==19705==         suppressed: 0 bytes in 0 blocks
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
