### PR TITLE
Spawn cluster child process while starting

### DIFF
--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -78,10 +78,8 @@ async def master_main(args, cluster_config, cluster_items, logger):
                                                      concurrency_test=args.concurrency_test, node=my_server,
                                                      configuration=cluster_config, enable_ssl=args.ssl,
                                                      cluster_items=cluster_items)
-    # Spawn pool processes if needed
-    if cluster_items['intervals']['master']['process_pool_debug']:
-        my_server.task_pool.map(cluster_utils.process_spawn_sleep,
-                                range(my_server.task_pool._max_workers))
+    # Spawn pool processes
+    my_server.task_pool.map(cluster_utils.process_spawn_sleep, range(my_server.task_pool._max_workers))
     await asyncio.gather(my_server.start(), my_local_server.start())
 
 
@@ -100,6 +98,10 @@ async def worker_main(args, cluster_config, cluster_items, logger):
                                                          concurrency_test=args.concurrency_test, node=my_client,
                                                          configuration=cluster_config, enable_ssl=args.ssl,
                                                          cluster_items=cluster_items)
+
+        # Spawn pool processes
+        my_client.task_pool.map(cluster_utils.process_spawn_sleep, range(my_client.task_pool._max_workers))
+
         try:
             await asyncio.gather(my_client.start(), my_local_server.start())
         except asyncio.CancelledError:

--- a/framework/wazuh/core/cluster/cluster.json
+++ b/framework/wazuh/core/cluster/cluster.json
@@ -107,7 +107,6 @@
             "timeout_agent_info": 40,
             "check_worker_lastkeepalive": 60,
             "max_allowed_time_without_keepalive": 120,
-            "process_pool_debug": false,
             "max_locked_integrity_time": 1000
         },
 

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -1004,7 +1004,8 @@ class Master(server.AbstractServer):
             before = datetime.now()
             file_integrity_logger.info("Starting.")
             try:
-                task = self.loop.run_in_executor(self.task_pool, wazuh.core.cluster.cluster.get_files_status)
+                task = self.loop.run_in_executor(self.task_pool, partial(wazuh.core.cluster.cluster.get_files_status,
+                                                                         self.integrity_control))
                 # With this we avoid that each worker starts integrity_check more than once per local_integrity
                 self.integrity_control = await asyncio.wait_for(task, timeout=None)
             except Exception as e:

--- a/framework/wazuh/core/cluster/tests/test_utils.py
+++ b/framework/wazuh/core/cluster/tests/test_utils.py
@@ -154,8 +154,7 @@ def test_get_cluster_items():
                                    'master': {'timeout_extra_valid': 40, 'recalculate_integrity': 8,
                                               'check_worker_lastkeepalive': 60,
                                               'max_allowed_time_without_keepalive': 120, 'process_pool_size': 2,
-                                              'timeout_agent_info': 40, 'process_pool_debug': False,
-                                              'max_locked_integrity_time': 1000},
+                                              'timeout_agent_info': 40, 'max_locked_integrity_time': 1000},
                                    'communication': {'timeout_cluster_request': 20, 'timeout_dapi_request': 200,
                                                      'timeout_receiving_file': 120}},
                      'distributed_api': {'enabled': True}}

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -220,7 +220,6 @@ rbac: ContextVar[Dict] = ContextVar('rbac', default={'rbac_mode': 'black'})
 current_user: ContextVar[str] = ContextVar('current_user', default='')
 broadcast: ContextVar[bool] = ContextVar('broadcast', default=False)
 cluster_nodes: ContextVar[list] = ContextVar('cluster_nodes', default=list())
-cluster_integrity_mtime: ContextVar[Dict] = ContextVar('cluster_integrity_mtime', default={})
 origin_module: ContextVar[str] = ContextVar('origin_module', default='framework')
 mp_pools: ContextVar[Dict] = ContextVar('mp_pools', default={
     'process_pool': ProcessPoolExecutor(max_workers=1),


### PR DESCRIPTION
|Related issue|
|---|
| Closes #11378 |

## Description

This PR implements two small changes in order to reduce the amount of memory used by the children processes of the cluster:
1. Create all children at cluster startup. Taking into account that when creating a child process, an exact copy of the parent process is made, doing this we avoid that the children contain duplicated or useless data which they do not need.
2. Make the parent process save the information that was previously stored in context variables in the children. The parent will pass this information on to the children each time they perform the task of calculating MD5 and other files metadata. This will prevent each child from having an old copy of the data or needing to recalculate it and store it in memory, which would also be duplicated.

After those modifications, this is the status of the master's processes after running for a while and having 100,000 agent-groups files. The values inside the red box are the resident size in kb (RES, non-swapped physical memory a task has used):
![image](https://user-images.githubusercontent.com/23361101/146556870-0add93e5-1e25-4540-bfcd-ee48e9d7583c.png)

Sometimes the memory goes up, but then it returns to this state or similar.