### PR TITLE
Rework of #8552 - Fixing MSSQL log source

### DIFF
--- a/ruleset/rules/0585-win-application_rules.xml
+++ b/ruleset/rules/0585-win-application_rules.xml
@@ -1,14 +1,10 @@
 <!--
-  -  Windows Event Channel ruleset for the Application channel
-  -  Created by Wazuh, Inc.
-  -  Copyright (C) 2015-2021, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  Copyright (C) 2015-2021, Wazuh Inc.
 -->
 
 <!--
-  -  ID range: 60600 - 61099
+  ID range: 60600 - 61099
 -->
-
 
 <var name="MS_FREQ">8</var>
 
@@ -3438,41 +3434,38 @@
   <rule id="61069" level="0">
     <if_sid>60003</if_sid>
     <field name="win.system.severityValue">^AUDIT_FAILURE$</field>
-    <description>Windows Application audit failure event</description>
     <options>no_full_log</options>
+    <description>Windows Application audit failure event</description>
     <group>gpg13_4.12,</group>
   </rule>
 
   <rule id="61070" level="0">
     <if_sid>60003</if_sid>
     <field name="win.system.severityValue">^AUDIT_SUCCESS$</field>
-    <description>Windows Application audit success event</description>
     <options>no_full_log</options>
+    <description>Windows Application audit success event</description>
     <group>gpg13_4.12,</group>
   </rule>
 
-
   <!-- MS SQL rules -->
-
-  <!-- Sample: {"win":{"system":{"providerName":"MSSQL$SQLEXPRESS","eventID":"18456","level":"0","task":"4","keywords":"0x90000000000000","systemTime":"2021-05-04T00:14:02.000000000Z","eventRecordID":"11930713","channel":"Application","computer":"IPASRV-VPS001","severityValue":"AUDIT_FAILURE","message":"\"Login failed for user 'user'. Reason: Password did not match that for the login provided. [CLIENT: 192.168.0.5]\""},"eventdata":{"binary":"184800000E000000190000004900500041005300520056002D005600500053003000300031005C00530051004C0045005800500052004500530053000000070000006D00610073007400650072000000","data":"user,  Reason: Password did not match that for the login provided.,  [CLIENT: 192.168.0.5]"}}} -->
   <rule id="61071" level="5">
     <if_sid>61069</if_sid>
     <field name="win.system.eventID">^18456$</field>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-    <description>MS SQL Server Logon Failure</description>
     <options>no_full_log</options>
+    <description>MS SQL Server Logon Failure</description>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
-  <!-- Sample: {"win":{"system":{"providerName":"MSSQL$SQLEXPRESS","eventID":"18453","level":"0","task":"4","keywords":"0xa0000000000000","systemTime":"2021-03-19T22:14:38.786376900Z","eventRecordID":"2530","channel":"Application","computer":"WIN2019.wazuh.local","severityValue":"AUDIT_SUCCESS","message":"\"Login succeeded for user 'WAZUH\\Administrator'. Connection made using Integrated authentication. [CLIENT: <local machine>]\""},"eventdata":{"binary":"154800000A00000013000000570049004E0032003000310039005C00530051004C0045005800500052004500530053000000070000006D00610073007400650072000000","data":"WAZUH\\\\Administrator,  [CLIENT: &lt;local machine&gt;]"}}} -->
   <rule id="61072" level="3">
     <if_sid>61070</if_sid>
     <field name="win.system.eventID">^18454$|^18453$</field>
-    <description>MS SQL Server Logon Success</description>
     <options>no_full_log</options>
+    <description>MS SQL Server Logon Success</description>
     <mitre>
       <id>T1078</id>
     </mitre>
     <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
+
 </group>
 

--- a/ruleset/testing/tests/win_application.ini
+++ b/ruleset/testing/tests/win_application.ini
@@ -1,0 +1,21 @@
+;   Copyright (C) 2015-2021, Wazuh Inc.
+;
+;   Tests for products:
+;     MSSQL
+;
+
+
+
+
+;[Sysmon event 13: Added registry content to be executed on next logon]
+;log 1 pass = {"win":{"system":{"providerName":"MSSQL$SQLEXPRESS","eventID":"18456","level":"0","task":"4","keywords":"0x90000000000000","systemTime":"2021-05-04T00:14:02.000000000Z","eventRecordID":"11930713","channel":"Application","computer":"IPASRV-VPS001","severityValue":"AUDIT_FAILURE","message":"\"Login failed for user 'user'. Reason: Password did not match that for the login provided. [CLIENT: 192.168.0.5]\""},"eventdata":{"binary":"184800000E000000190000004900500041005300520056002D005600500053003000300031005C00530051004C0045005800500052004500530053000000070000006D00610073007400650072000000","data":"user,  Reason: Password did not match that for the login provided.,  [CLIENT: 192.168.0.5]"}}}
+;rule = 61071
+;alert = 5
+;decoder = json
+;
+
+;[Sysmon event 13: Suspicious file extension detected in registry ASEP]
+;log 1 pass = {"win":{"system":{"providerName":"MSSQL$SQLEXPRESS","eventID":"18453","level":"0","task":"4","keywords":"0xa0000000000000","systemTime":"2021-03-19T22:14:38.786376900Z","eventRecordID":"2530","channel":"Application","computer":"WIN2019.wazuh.local","severityValue":"AUDIT_SUCCESS","message":"\"Login succeeded for user 'WAZUH\\Administrator'. Connection made using Integrated authentication. [CLIENT: <local machine>]\""},"eventdata":{"binary":"154800000A00000013000000570049004E0032003000310039005C00530051004C0045005800500052004500530053000000070000006D00610073007400650072000000","data":"WAZUH\\\\Administrator,  [CLIENT: &lt;local machine&gt;]"}}}
+;rule = 61072
+;alert = 3
+;decoder = json


### PR DESCRIPTION
|Related issue|
|---|
|#8552|

## Description

This PR aims to resolve issues detected under #8552 PR.
The issues resolved are:
- Fixed rule and test header
- Added .ini tests

## Checks and changes 

### Syntax

- [x] 1.a Rule tags order must be compliant.
- [x] 1.b Decoder tags order must be compliant.
- [x] 1.c XML blocks must as compact as possible.
- [x] 1.d Only one empty line between rule/decoder and the next rule/decoder.
- [x] 1.e Decoder extracted fields names must use '_' whether a space is needed.
- [x] 1.f Decoder name must use '-' whether a space is needed.
 
### Grammar

- [x] 2.a Grammar quality.
- [x] 2.b Similar phrases must keep tenses and expressions.
- [x] 2.c Grammar basic rules like capitalization, punctuation marks, sentence construction, and others.


### Semantic

- [x] 3.a New decoder, rule, or test are written in the correct file and grouped correctly inside the file.
- [x] 3.b Group similar rules under same ID's group.
- [x] 3.c: 
     - [x] 3.c1 Find and reuse group name before creating a new one.
     - [x] 3.c2 Include a new group definition in a PR comment.
     - [x] 3.c3 Any group name must use '_' whether it does need a space char.
     - [x] 3.c4 The groups inside a tag must be sorted in alphabetical order.
- [x] 3.d Rule level should be compliant with the [documentation](https://documentation.wazuh.com/current/user-manual/ruleset/rules-classification.html).

### Unit testing

- [x] 4.a A metadata block at the beginning of the .ini file describing software, version, and logs source.
- [x] 4.b Each new rule must have at least one test entry in the correct .ini file.
- [x] 4.c Runtest.py must pass and must include the results in raw format here.




<details><summary>All rules and decoders test.</summary>
<p>

```

```
</p>
</details>

- [x] 4.d New CDB lists must include the proper test entry in the correct .ini file.

### E2E testing

- [x] 5.a Logs for new or modified decoder/rules sent to a manager running with this PR ruleset appear in Kibana.


- [x] 5.b There are not affected or broken visualizations on Kibana.


- [x] 5.c New or modified items can be seen correctly using APP ruleset navigation.


### Elasticsearch Template

- [x] 6.a Known fields with output format managed and usually used for searching are included in template array index.query.default_field. 
- [x] 6.b The new field with the correct date format is stored as a "date" type field in the template.
- [x] 6.c The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 
- [x] 6.d Known fields with output format managed and usually used for searching are included in the template.

### Stoppers

- [x] 7.a No previous rule ID changes without triple check.
- [x] 7.b No previous decoder name changes without triple check.
- [x] 7.c No previous file name changes without triple check.
- [x] 7.d No previous test changes its 'rule' field value without triple check.

### Others

- [x] 8.a Each file has the correct copyright block.
- [x] 8.b The copyright block doesn't have "Author" only "Created by Wazuh". To include an "Author" request triple check.
- [x] 8.c The copyright block doesn't use "-". 
- [x] 8.d The rule files don't have any sample log.
- [x] 8.e The decoder file has sample logs next to the decoder that matches that log.
- [x] 8.f The decoder and rule files have information about software, version, and any helpful information.
- [x] 8.g The PR has a single commit with CHANGELOG changes in the correct format.
- [x] 8.h The new rule ID is not in use.
- [x] 8.i The new rule ID must be in the defined IDs range. 
- [x] 8.j New rules ID range must be verified with a triple check and noted in the rules ID document.
- [x] 8.k The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 