### PR TITLE
Handle exceptions when trying to start the Wazuh API service

### DIFF
--- a/api/api/api_exception.py
+++ b/api/api/api_exception.py
@@ -9,6 +9,7 @@ class APIException(Exception):
     """
     Wazuh API exception
     """
+
     def __init__(self, code: int, details: str = None):
         """
         Constructor
@@ -34,7 +35,8 @@ class APIException(Exception):
             2008: 'Experimental features are disabled. '
                   'It can be changed in the API configuration',
             2009: 'Semicolon (;) is a reserved character and must '
-                  'be percent-encoded (%3B) to use it.'
+                  'be percent-encoded (%3B) to use it.',
+            2010: 'Error while attempting to bind on address: address already in use'
         }
 
     def __str__(self):

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -9,7 +9,6 @@ import sys
 from atexit import register
 
 from api.constants import API_LOG_FILE_PATH
-from wazuh.core import common, utils
 
 
 def spawn_process_pool():
@@ -44,7 +43,7 @@ def start(foreground, root, config_file):
     import logging
     import os
     from api import alogging, configuration
-    from wazuh.core import pyDaemonModule
+    from wazuh.core import pyDaemonModule, common, utils
 
     def set_logging(log_path='logs/api.log', foreground_mode=False, debug_mode='info'):
         for logger_name in ('connexion.aiohttp_app', 'connexion.apis.aiohttp_api', 'wazuh-api'):
@@ -241,11 +240,11 @@ def test_config(config_file):
     config_file : str
         Path of the file
     """
-    from api.configuration import read_yaml_config
     try:
+        from api.configuration import read_yaml_config
         read_yaml_config(config_file=config_file)
-    except Exception as e:
-        print(f"Configuration not valid: {e}")
+    except Exception as exc:
+        print(f"Configuration not valid. ERROR: {exc}")
         sys.exit(1)
     sys.exit(0)
 
@@ -274,4 +273,8 @@ if __name__ == '__main__':
     elif args.test_config:
         test_config(args.config_file)
     else:
-        start(args.foreground, args.root, args.config_file)
+        try:
+            start(args.foreground, args.root, args.config_file)
+        except Exception as e:
+            print(f"Error when trying to start the Wazuh API. {e}")
+            sys.exit(1)

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -25,7 +25,7 @@ def spawn_authentication_pool():
     return
 
 
-def start(foreground, root, config_file):
+def start(foreground: bool, root: bool, config_file: str):
     """Run the Wazuh API.
 
     If another Wazuh API is running, this function fails.
@@ -145,10 +145,10 @@ def start(foreground, root, config_file):
         except ssl.SSLError:
             logger.error(str(APIError(2003, details='Private key does not match with the certificate')))
             sys.exit(1)
-        except IOError as e:
-            if e.errno == 22:
+        except IOError as exc:
+            if exc.errno == 22:
                 logger.error(str(APIError(2003, details='PEM phrase is not correct')))
-            elif e.errno == 13:
+            elif exc.errno == 13:
                 logger.error(str(APIError(2003, details='Ensure the certificates have the correct permissions')))
             else:
                 print('Wazuh API SSL ERROR. Please, ensure if path to certificates is correct in the configuration '
@@ -232,7 +232,7 @@ def print_version():
     print("\n{} {} - {}\n\n{}".format(__wazuh_name__, __version__, __author__, __licence__))
 
 
-def test_config(config_file):
+def test_config(config_file: str):
     """Make an attempt to read the API config file. Exits with 0 code if successful, 1 otherwise.
 
     Arguments


### PR DESCRIPTION
|Related issue|
|---|
|#11326|

This PR closes #11326.

With this pull request, the exceptions raised when trying to start the Wazuh API in the `wazuh-apid.py` script are handled.

When testing the API configuration (done before trying to start), the exceptions were not handled properly. This has also been fixed in this PR.

Exception raised when testing the Wazuh API configuration:

```
# service wazuh-manager restart
wazuh-clusterd not running...
wazuh-modulesd not running...
wazuh-monitord not running...
wazuh-logcollector not running...
wazuh-remoted not running...
wazuh-syscheckd not running...
wazuh-analysisd not running...
wazuh-maild not running...
wazuh-execd not running...
wazuh-db not running...
wazuh-authd not running...
wazuh-agentlessd not running...
wazuh-integratord not running...
wazuh-dbd not running...
wazuh-csyslogd not running...
wazuh-apid not running...
Wazuh v4.3.0 Stopped
Configuration not valid. ERROR: 2000 - Some parameters are not expected in the configuration file (WAZUH_PATH/api/configuration/api.yaml): None is not of type 'object'.
wazuh-apid: Configuration error. Exiting
```

Exception raised when trying to start the API:

```
# /var/ossec/bin/wazuh-apid
Error when trying to start the Wazuh API. 2000 - Some parameters are not expected in the configuration file (WAZUH_PATH/api/configuration/api.yaml): None is not of type 'object'.
```