### PR TITLE
Add predicate to fix the gracefull shutdown.

### DIFF
--- a/src/headers/mq_op.h
+++ b/src/headers/mq_op.h
@@ -53,6 +53,23 @@ int StartMQ(const char *key, short int type, short int n_attempts) __attribute__
  * @param message string containing the message
  * @param locmsg path to the queue file
  * @param loc  queue location (WIN32)
+ * @param fn_ptr function pointer to the function that will check if the process is shutting down
+ * @return
+ * UNIX -> 0 if file descriptor is still available
+ * UNIX -> -1 if there is an error in the socket. The socket will be closed before returning (StartMQ should be called to restore queue)
+ * WIN32 -> 0 on success
+ * WIN32 -> -1 on error
+ * Notes: (UNIX) If the socket is busy when trying to send a message a DEBUG2 message will be loggeed but the return code will be 0
+ */
+
+int SendMSGPredicated(int queue, const char *message, const char *locmsg, char loc, bool (*fn_ptr)()) __attribute__((nonnull));
+
+/**
+ * Sends a message string through a message queue
+ * @param queue file descriptor of the queue where the message will be sent (UNIX)
+ * @param message string containing the message
+ * @param locmsg path to the queue file
+ * @param loc  queue location (WIN32)
  * @return
  * UNIX -> 0 if file descriptor is still available
  * UNIX -> -1 if there is an error in the socket. The socket will be closed before returning (StartMQ should be called to restore queue)

--- a/src/headers/wait_op.h
+++ b/src/headers/wait_op.h
@@ -14,6 +14,7 @@
 void os_setwait(void);
 void os_delwait(void);
 void os_wait(void);
+void os_wait_predicate(bool (*fn_ptr)());
 
 /**
  * @brief Check whether the agent wait mark is on (manager is disconnected)

--- a/src/shared/wait_op.c
+++ b/src/shared/wait_op.c
@@ -46,8 +46,19 @@ void os_delwait()
  * process is allowed to lock).
  */
 #ifdef WIN32
-void os_wait()
-{
+
+void loop_check(bool (*fn_ptr)()) {
+    while (1) {
+        if (!__wait_lock || (fn_ptr && fn_ptr())) {
+            break;
+        }
+
+        /* Sleep LOCK_LOOP seconds and check if lock is gone */
+        sleep(LOCK_LOOP);
+    }
+}
+
+void os_wait_primitive(bool (*fn_ptr)()) {
     static int just_unlocked = 0;
 
     if (!__wait_lock) {
@@ -62,14 +73,8 @@ void os_wait()
     } else {
         mdebug1(WAITING_MSG);
     }
-    while (1) {
-        if (!__wait_lock) {
-            break;
-        }
 
-        /* Sleep LOCK_LOOP seconds and check if lock is gone */
-        sleep(LOCK_LOOP);
-    }
+    loop_check(fn_ptr);
 
     if (just_unlocked) {
         minfo(WAITING_FREE);
@@ -85,8 +90,17 @@ void os_wait()
 
 #else /* !WIN32 */
 
-void os_wait()
-{
+void loop_check(struct stat *file_status, bool (*fn_ptr)()) {
+    while (1) {
+        if (stat(WAIT_FILE, file_status) == -1 || (fn_ptr && fn_ptr())) {
+            break;
+        }
+        /* Sleep LOCK_LOOP seconds and check if lock is gone */
+        sleep(LOCK_LOOP);
+    }
+}
+
+void os_wait_primitive(bool (*fn_ptr)()) {
     struct stat file_status;
     static atomic_int_t just_unlocked = ATOMIC_INT_INITIALIZER(0);
 
@@ -103,14 +117,7 @@ void os_wait()
         mdebug1(WAITING_MSG);
     }
 
-    while (1) {
-        if (stat(WAIT_FILE, &file_status) == -1) {
-            break;
-        }
-
-        /* Sleep LOCK_LOOP seconds and check if lock is gone */
-        sleep(LOCK_LOOP);
-    }
+    loop_check(&file_status, fn_ptr);
 
     if (atomic_int_get(&just_unlocked) == 1) {
         minfo(WAITING_FREE);
@@ -124,6 +131,15 @@ void os_wait()
 }
 
 #endif /* !WIN32 */
+
+void os_wait() {
+    os_wait_primitive(NULL);
+}
+
+void os_wait_predicate(bool (*fn_ptr)()) {
+    os_wait_primitive(fn_ptr);
+}
+
 
 // Check whether the agent wait mark is on (manager is disconnected)
 

--- a/src/wazuh_modules/wm_syscollector.c
+++ b/src/wazuh_modules/wm_syscollector.c
@@ -60,7 +60,7 @@ static void wm_sys_send_diff_message(/*const void* data*/) {
 static void wm_sys_send_dbsync_message(const void* data) {
     if(!os_iswait() && !is_shutdown_process_started()) {
         const int eps = 1000000/syscollector_sync_max_eps;
-        if (wm_sendmsg(eps, queue_fd, data, WM_SYS_LOCATION, DBSYNC_MQ) < 0) {
+        if (wm_sendmsg_ex(eps, queue_fd, data, WM_SYS_LOCATION, DBSYNC_MQ, &is_shutdown_process_started) < 0) {
 #ifdef CLIENT
             mterror(WM_SYS_LOGTAG, "Unable to send message to '%s' (wazuh-agentd might be down). Attempting to reconnect.", DEFAULTQUEUE);
 #else
@@ -69,10 +69,10 @@ static void wm_sys_send_dbsync_message(const void* data) {
             // Since this method is beign called by multiple threads it's necessary this particular portion of code
             // to be mutually exclusive. When one thread is successfully reconnected, the other ones will make use of it.
             w_mutex_lock(&sys_reconnect_mutex);
-            if (!is_shutdown_process_started() && wm_sendmsg(eps, queue_fd, data, WM_SYS_LOCATION, DBSYNC_MQ) < 0) {
+            if (!is_shutdown_process_started() && wm_sendmsg_ex(eps, queue_fd, data, WM_SYS_LOCATION, DBSYNC_MQ, &is_shutdown_process_started) < 0) {
                 if (queue_fd = MQReconnectPredicated(DEFAULTQUEUE, &is_shutdown_process_started), 0 <= queue_fd) {
                     mtinfo(WM_SYS_LOGTAG, "Successfully reconnected to '%s'", DEFAULTQUEUE);
-                    if (wm_sendmsg(eps, queue_fd, data, WM_SYS_LOCATION, DBSYNC_MQ) < 0) {
+                    if (wm_sendmsg_ex(eps, queue_fd, data, WM_SYS_LOCATION, DBSYNC_MQ, &is_shutdown_process_started) < 0) {
                         mterror(WM_SYS_LOGTAG, "Unable to send message to '%s' after a successfull reconnection...", DEFAULTQUEUE);
                     }
                 }

--- a/src/wazuh_modules/wmodules.c
+++ b/src/wazuh_modules/wmodules.c
@@ -345,6 +345,25 @@ int wm_sendmsg(int usec, int queue, const char *message, const char *locmsg, cha
     return 0;
 }
 
+// Send message to a queue waiting for a specific delay
+int wm_sendmsg_ex(int usec, int queue, const char *message, const char *locmsg, char loc, bool (*fn_prd)()) {
+
+#ifdef WIN32
+    int msec = usec / 1000;
+    Sleep(msec);
+#else
+    struct timeval timeout = {0, usec};
+    select(0, NULL, NULL, NULL, &timeout);
+#endif
+
+    if (SendMSGPredicated(queue, message, locmsg, loc, fn_prd) < 0) {
+        merror("At wm_sendmsg(): Unable to send message to queue: (%s)", strerror(errno));
+        return -1;
+    }
+
+    return 0;
+}
+
 // Check if a path is relative or absolute.
 // Returns 0 if absolute, 1 if relative or -1 on error.
 int wm_relative_path(const char * path) {

--- a/src/wazuh_modules/wmodules.h
+++ b/src/wazuh_modules/wmodules.h
@@ -157,6 +157,9 @@ void wm_free(wmodule * c);
 // Send message to a queue with a specific delay
 int wm_sendmsg(int usec, int queue, const char *message, const char *locmsg, char loc) __attribute__((nonnull));
 
+// Send message to a queue with a specific delay, and the option to stop the wait process.
+int wm_sendmsg_ex(int usec, int queue, const char *message, const char *locmsg, char loc, bool (*fn_prd)()) __attribute__((nonnull));
+
 // Check if a path is relative or absolute.
 // Returns 0 if absolute, 1 if relative or -1 on error.
 int wm_relative_path(const char * path);

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -293,16 +293,14 @@ int local_start()
     return (0);
 }
 
-/* SendMSG for Windows */
-int SendMSG(__attribute__((unused)) int queue, const char *message, const char *locmsg, char loc)
+/* SendMSGAction for Windows */
+int SendMSGAction(__attribute__((unused)) int queue, const char *message, const char *locmsg, char loc)
 {
     const char *pl;
     char tmpstr[OS_MAXSTR + 2];
     DWORD dwWaitResult;
     int retval = -1;
     tmpstr[OS_MAXSTR + 1] = '\0';
-
-    os_wait();
 
     /* Using a mutex to synchronize the writes */
     while (1) {
@@ -353,6 +351,18 @@ int SendMSG(__attribute__((unused)) int queue, const char *message, const char *
         merror("Error releasing mutex.");
     }
     return retval;
+}
+
+/* SendMSG for Windows */
+int SendMSG(__attribute__((unused)) int queue, const char *message, const char *locmsg, char loc) {
+    os_wait();
+    return SendMSGAction(queue, message, locmsg, loc);
+}
+
+/* SendMSGPredicated for Windows */
+int SendMSGPredicated(__attribute__((unused)) int queue, const char *message, const char *locmsg, char loc, bool (*fn_ptr)()) {
+    os_wait_predicate(fn_ptr);
+    return SendMSGAction(queue, message, locmsg, loc);
 }
 
 /* StartMQ for Windows */


### PR DESCRIPTION
|Related issue|
|---|
|Closes #11193 |

## Description
When Wazuh Agent fails to connect with the manager it starts a try loop until re-establish the communication. 
During this loop, a service stop command isn´t processed and the agent can´t be stopped.
It can take up to 60 seconds since other modules received the stop until the agent process the TERMINATE signal.
![image](https://user-images.githubusercontent.com/11434230/144633911-c2ebffe2-9a02-4513-ab10-bfd7e6b8d32e.png)

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [x] Windows
  - [ ] MAC OS X
- [X] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors