### PR TITLE
Review PR 10406 - Wazuh 420 sca rules centos7 

### DIFF
--- a/ruleset/sca/centos/7/cis_centos7_linux.yml
+++ b/ruleset/sca/centos/7/cis_centos7_linux.yml
@@ -19,7 +19,7 @@ policy:
     - https://www.cisecurity.org/cis-benchmarks/
 
 requirements:
-  title: "Check CentOS 7 platform"
+  title: "Check CentOS 7 platform."
   description: "Requirements for running the policy against CentOS 7."
   condition: any
   rules:
@@ -36,7 +36,7 @@ checks:
 
 # 1.1.1.1 cramfs: filesystem
   - id: 6000
-    title: "Ensure mounting of cramfs filesystems is disabled"
+    title: "Ensure mounting of cramfs filesystems is disabled."
     description: "The cramfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems. A cramfs image can be used without having to first decompress the image."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the server. If this filesystem type is not needed, disable it."
     remediation: "Edit or create a file in the /etc/modprobe.d/directory ending in .conf. Example: vim /etc/modprobe.d/cramfs.confand add the following line: install cramfs /bin/true. Run the following command to unload the cramfs module: rmmod cramfs"
@@ -55,7 +55,7 @@ checks:
 
 # 1.1.1.2 squashfs: filesystem
   - id: 6001
-    title: "Ensure mounting of squashfs filesystems is disabled"
+    title: "Ensure mounting of squashfs filesystems is disabled."
     description: "The squashfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems (similar to cramfs ). A squashfs image can be used without having to first decompress the image."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
     remediation: "Edit or create the file /etc/modprobe.d/CIS.conf and add the following line: install squashfs /bin/true. Run the following command to unload the squashfs module: rmmod squashfs"
@@ -74,7 +74,7 @@ checks:
 
 # 1.1.1.3 udf: filesystem
   - id: 6002
-    title: "Ensure mounting of udf filesystems is disabled"
+    title: "Ensure mounting of udf filesystems is disabled."
     description: "The udf filesystem type is the universal disk format used to implement ISO/IEC 13346 and ECMA-167 specifications. This is an open vendor filesystem type for data storage on a broad range of media. This filesystem type is necessary to support writing DVDs and newer optical disc formats."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
     remediation: "Edit or create the file /etc/modprobe.d/CIS.conf and add the following line: install udf /bin/true. Run the following command to unload the udf module: rmmod udf"
@@ -93,7 +93,7 @@ checks:
 
 # 1.1.1.4 FAT: filesystem
   - id: 6003
-    title: "Ensure mounting of FAT filesystems is disabled"
+    title: "Ensure mounting of FAT filesystems is disabled."
     description: "The FAT filesystem format is primarily used on older windows systems and portable USB drives or flash modules. It comes in three types FAT12, FAT16, and FAT32 all of which are supported by the vfat kernel module."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
     remediation: "If utilizing UEFI the FAT filesystem format is required. If this case, ensure that the FAT filesystem is only used where appropriate. Run the following command: grep -E -i '\\svfat\\s' /etc/fstab And review that any output is appropriate for your environment.  If not utilizing UEFI: Edit or create a file in the /etc/modprobe.d/ directory ending in .conf and add the following lines: Example: vim /etc/modprobe.d/fat.conf    install fat /bin/true        install vfat /bin/true         install msdos /bin/true  Run the following commands to unload the msdos, vfat, and fatmodules:  # rmmod msdos   # rmmod vfat  # rmmod fat "
@@ -116,7 +116,7 @@ checks:
 
 # 1.1.2 /tmp: partition
   - id: 6004
-    title: "Ensure /tmp is configured"
+    title: "Ensure /tmp is configured."
     description: "The /tmp directory is a world-writable directory used for temporary storage by all users and some applications."
     rationale: "Since the /tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. In addition, making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw."
     remediation: "Create or update an entry for /tmp in either /etc/fstab  OR   in a systemd tmp.mount file:  If /etc/fstab is used:  Configure /etc/fstab as appropriate. Example: tmpfs /tmp tmpfs     defaults,rw,nosuid,nodev,noexec,relatime  0 0         Run the following command to remount /tmp:  # mount -o remount,noexec,nodev,nosuid /tmp        OR        If systemd tmp.mount file is used:    Run the following command to create the file /etc/systemd/system/tmp.mount if it doesn't exist:                 # [ ! -f /etc/systemd/system/tmp.mount ] && cp -v /usr/lib/systemd/system/tmp.mount /etc/systemd/system/                      Edit the file /etc/systemd/system/tmp.mount:  [Mount]   What=tmpfs    Where=/tmp    Type=tmpfs    Options=mode=1777,strictatime,noexec,nodev,nosuid     Run the following command to reload the systemd daemon:# systemctl daemon-reload                  Run the following command to unmask tmp.mount:    # systemctl unmask tmp.mpunt                  Run the following command to enable and start tmp.mount:    # systemctl enable --now tmp.mount"
@@ -137,7 +137,7 @@ checks:
 
 # 1.1.3 /tmp: noexec
   - id: 6005
-    title: "Ensure noexec option set on /tmp partition"
+    title: "Ensure noexec option set on /tmp partition."
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /tmp."
     remediation: "Edit the /etc/fstab file OR  the /etc/systemd/system/local-fs.target.wants/tmp.mount file:    IF /etc/fstab is used to mount /tmp       Edit the /etc/fstabfile and add noexecto the fourth field (mounting options) for the /tmp partition. See the fstab(5) manual page for more information. Run the following command to remount /tmp:      # mount -o remount,noexec /tmp        OR           IF systemd is used to mount /tmp: Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to add noexec to the /tmp mount options:       [Mount]      Options=mode=1777,strictatime,noexec,nodev,nosuid         Run the following command to restart the systemd daemon: #  systemctl daemon-reload               Run the following command to restart tmp.mount               # systemctl restart tmp.mount"
@@ -154,7 +154,7 @@ checks:
 
 # 1.1.4 /tmp: nodev
   - id: 6006
-    title: "Ensure nodev option set on /tmp partition"
+    title: "Ensure nodev option set on /tmp partition."
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /tmp."
     remediation: "Edit the /etc/fstab   file OR the /etc/systemd/system/local-fs.target.wants/tmp.mount file:   IF /etc/fstab is used to mount /tmp  Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /tmp partition. See the fstab(5) manual page for more information. Run the following command to remount /tmp:          # mount -o remount,nodev /tmp         OR        IF systemd is used to mount /tmp: Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to add nodev to the /tmp mount options:    [Mount]   Options=mode=1777,strictatime,noexec,nodev,nosuid                   Run the following command to restart the systemd daemon: #  systemctl daemon-reload               Run the following command to restart tmp.mount            # systemctl restart tmp.mount"
@@ -171,7 +171,7 @@ checks:
 
 # 1.1.5 /tmp: nosuid
   - id: 6007
-    title: "Ensure nosuid option set on /tmp partition"
+    title: "Ensure nosuid option set on /tmp partition."
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /tmp."
     remediation: "IF /etc/fstab is used to mount /tmp Edit the /etc/fstab   file OR the /etc/systemd/system/local-fs.target.wants/tmp.mount file:   IF /etc/fstab is used to mount /tmp  Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /tmp partition. See the fstab(5) manual page for more information. Run the following command to remount /tmp:          # mount -o remount,nosuid /tmp         OR        IF systemd is used to mount /tmp: Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to add nosuid to the /tmp mount options:    [Mount]   Options=mode=1777,strictatime,noexec,nosuid,nosuid                   Run the following command to restart the systemd daemon: #  systemctl daemon-reload               Run the following command to restart tmp.mount            # systemctl restart tmp.mount"
@@ -188,7 +188,7 @@ checks:
 
 # 1.1.6 /dev/shm:
   - id: 6008
-    title: "Ensure /dev/shm is configured "
+    title: "Ensure /dev/shm is configured ."
     description: "/dev/shm is a traditional shared memory concept. One program will create a memory portion, which other processes (if permitted) can access. Mounting tmpfs at /dev/shm is handled automatically by systemd."
     rationale: "Any user can upload and execute files inside the /dev/shm similar to the /tmp partition. Configuring /dev/shm allows an administrator to set the noexec option on the mount, making /dev/shm useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw."
     remediation: "Edit /etc/fstab and add or edit the following line: tmpfs      /dev/shm    tmpfs   defaults,noexec,nodev,nosuid,seclabel   0 0        Run the following command to remount /dev/shm: # mount -o remount,noexec,nodev,nosuid /dev/shm"
@@ -206,7 +206,7 @@ checks:
 
 # 1.1.7 /dev/shm: noexec
   - id: 6009
-    title: "Ensure noexec option set on /dev/shm partition"
+    title: "Ensure noexec option set on /dev/shm partition."
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Setting this option on a file system prevents users from executing programs from shared memory. This deters users from introducing potentially malicious software on the system."
     remediation: "Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /dev/shm partition. Run the following command to remount /dev/shm: # mount -o remount,noexec /dev/shm"
@@ -223,7 +223,7 @@ checks:
 
 # 1.1.8 /dev/shm: nodev
   - id: 6010
-    title: "Ensure nodev option set on /dev/shm partition"
+    title: "Ensure nodev option set on /dev/shm partition."
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /dev/shm filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create special devices in /dev/shm partitions."
     remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /dev/shm partition. Run the following command to remount /dev/shm: # mount -o remount,nodev /dev/shm"
@@ -240,7 +240,7 @@ checks:
 
 # 1.1.9 /dev/shm: nosuid
   - id: 6011
-    title: "Ensure nosuid option set on /dev/shm partition"
+    title: "Ensure nosuid option set on /dev/shm partition."
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Setting this option on a file system prevents users from introducing privileged programs onto the system and allowing non-root users to execute them."
     remediation: "Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /dev/shm partition. Run the following command to remount /dev/shm: # mount -o remount,nosuid /dev/shm"
@@ -257,7 +257,7 @@ checks:
 
 # 1.1.10 Build considerations - Partition scheme.
   - id: 6012
-    title: "Ensure separate partition exists for /var"
+    title: "Ensure separate partition exists for /var."
     description: "The /var directory is used by daemons and other system services to temporarily store dynamic data. Some directories created by these processes may be world-writable."
     rationale: "Since the /var directory may contain world-writable files and directories, there is a risk of resource exhaustion if it is not bound to a separate partition."
     remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
@@ -276,7 +276,7 @@ checks:
 
 # 1.1.11 bind mount /var/tmp to /tmp
   - id: 6013
-    title: "Ensure separate partition exists for /var/tmp"
+    title: "Ensure separate partition exists for /var/tmp."
     description: "The /var/tmp directory is a world-writable directory used for temporary storage by all users and some applications and is intended for temporary files that are preserved across reboots."
     rationale: "Since the /var/tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. In addition, making /var/tmp its own file system allows an administrator to set the noexec option on the mount, making /var/tmp useless for an attacker to install executable code."
     remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/tmp. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
@@ -293,7 +293,7 @@ checks:
 
 # 1.1.12 noexec set on /var/tmp
   - id: 6014
-    title: "Ensure noexec option set on /var/tmp partition"
+    title: "Ensure noexec option set on /var/tmp partition."
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /var/tmp."
     remediation: "Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /var/tmp partition. See the fstab(5) manual page for more information. un the following command to remount /var/tmp: # mount -o remount,noexec /var/tmp"
@@ -310,7 +310,7 @@ checks:
 
 # 1.1.13 nodev set on /var/tmp
   - id: 6015
-    title: "Ensure nodev option set on /var/tmp partition"
+    title: "Ensure nodev option set on /var/tmp partition."
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /var/tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /var/tmp ."
     remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /var/tmp partition. See the fstab(5) manual page for more information. Run the following command to remount /var/tmp: # mount -o remount,nodev /var/tmp"
@@ -327,7 +327,7 @@ checks:
 
 # 1.1.14 nosuid set on /var/tmp
   - id: 6016
-    title: "Ensure nosuid option set on /var/tmp partition"
+    title: "Ensure nosuid option set on /var/tmp partition."
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /var/tmp."
     remediation: "Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var/tmp partition. See the fstab(5) manual page for more information. Run the following command to remount /var/tmp: # mount -o remount,nosuid /var/tmp"
@@ -344,7 +344,7 @@ checks:
 
 # 1.1.15 /var/log: partition
   - id: 6017
-    title: "Ensure separate partition exists for /var/log"
+    title: "Ensure separate partition exists for /var/log."
     description: "The /var/log directory is used by system services to store log data ."
     rationale: "There are two important reasons to ensure that system logs are stored on a separate partition: protection against resource exhaustion (since logs can grow quite large) and protection of audit data."
     remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/log. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
@@ -363,7 +363,7 @@ checks:
 
 # 1.1.16 /var/log/audit: partition
   - id: 6018
-    title: "Ensure separate partition exists for /var/log/audit"
+    title: "Ensure separate partition exists for /var/log/audit."
     description: "The auditing daemon, auditd, stores log data in the /var/log/audit directory."
     rationale: "There are two important reasons to ensure that data gathered by auditd is stored on a separate partition: protection against resource exhaustion (since the audit.log file can grow quite large) and protection of audit data."
     remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/log/audit. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
@@ -382,7 +382,7 @@ checks:
 
 # 1.1.17 /home: partition
   - id: 6019
-    title: "Ensure separate partition exists for /home"
+    title: "Ensure separate partition exists for /home."
     description: "The /home directory is used to support disk storage needs of local users."
     rationale: "If the system is intended to support local users, create a separate partition for the /home directory to protect against resource exhaustion and restrict the type of files that can be stored under /home."
     remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /home. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
@@ -401,7 +401,7 @@ checks:
 
 # 1.1.18 /home: nodev
   - id: 6020
-    title: "Ensure nodev option set on /home partition"
+    title: "Ensure nodev option set on /home partition."
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the user partitions are not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices."
     remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /home partition. # mount -o remount,nodev /home"
@@ -426,7 +426,7 @@ checks:
 
 # 1.1.23 Disable Automounting
   - id: 6021
-    title: "Disable Automounting"
+    title: "Disable Automounting."
     description: "autofs allows automatic mounting of devices, typically including CD/DVDs and USB drives."
     rationale: "With automounting enabled anyone with physical access could attach a USB drive or disc and have its contents available in system even if they lacked permissions to mount it themselves."
     remediation: "Run the following command to disable autofs: systemctl disable autofs"
@@ -443,7 +443,7 @@ checks:
 
 # 1.1.24 Disable USB Storage
   - id: 6022
-    title: "Disable USB Storage"
+    title: "Disable USB Storage."
     description: "USB storage provides a means to transfer and store files insuring persistence and availability of the files independent of network connection status. Its popularity and utility has led to USB-based malware being a simple and common means for network infiltration and a first step to establishing a persistent threat within a networked environment."
     rationale: "Restricting USB access on the system will decrease the physical attack surface for a device and diminish the possible vectors to introduce malware."
     remediation: "Edit or create a file in the /etc/modprobe.d/ directory ending in .conf Example: vim /etc/modprobe.d/usb_storage.conf  Add the following line: install usb-storage /bin/true    Run the following command to unload the usb-storage module:  rmmod usb-storage"
@@ -470,7 +470,7 @@ checks:
 
 # 1.2.3 Activate gpgcheck
   - id: 6023
-    title: "Ensure gpgcheck is globally activated"
+    title: "Ensure gpgcheck is globally activated."
     description: "The gpgcheck option, found in the main section of the /etc/yum.conf and individual /etc/yum/repos.d/* files determines if an RPM package's signature is checked prior to its installation."
     rationale: "It is important to ensure that an RPM's package signature is always checked prior to installation to ensure that the software is obtained from a trusted source."
     remediation: "Edit /etc/yum.conf and set ' gpgcheck=1 ' in the [main] section. Edit any failing files in /etc/yum.repos.d/* and set all instances of gpgcheck to ' 1 '."
@@ -496,7 +496,7 @@ checks:
 
 # 1.3.1 install sudo
   - id: 6024
-    title: "Ensure sudo is installed"
+    title: "Ensure sudo is installed."
     description: "sudo allows a permitted user to execute a command as the superuser or another user, as specified by the security policy. The invoking user's real (not effective) user ID is used to determine the user name with which to query the security policy."
     rationale: "sudo supports a plugin architecture for security policies and input/output logging. Third parties can develop and distribute their own policy and I/O logging plugins to work seamlessly with the sudo front end. The default security policy is sudoers, which is configured via the file /etc/sudoers. The security policy determines what privileges, if any, a user has to run sudo. The policy may require that users authenticate themselves with a password or another authentication mechanism. If authentication is required, sudo will exit if the user's password is not entered within a configurable time limit. This limit is policy-specific."
     remediation: "Run the following command to install sudo. # yum install sudo"
@@ -507,14 +507,15 @@ checks:
       - nist_800_53: ["CM.1"]
       - tsc: ["CC5.2"]
       - cis_level: ["1"]
-    references: "AIDE stable manual: http://aide.sourceforge.net/stable/manual.html"
+    references: 
+      - "AIDE stable manual: http://aide.sourceforge.net/stable/manual.html"
     condition: all
     rules:
       - 'c:rpm -q sudo -> r:sudo-\S*'
 
 # 1.3.2 Configure sudo
   - id: 6025
-    title: "Ensure sudo commands use pty"
+    title: "Ensure sudo commands use pty."
     description: "sudo can be configured to run only from a pseudo-pty"
     rationale: "Attackers can run a malicious program using sudo, which would again fork a background process that remains even when the main program has finished executing. This can be mitigated by configuring sudo to run other commands only from a pseudo-pty, whether I/O logging is turned on or not."
     remediation: "Edit the file /etc/sudoers or a file in /etc/sudoers.d/ with visudo or visudo -f <PATH TO FILE> and add the following line: Defaults use_pty"
@@ -525,7 +526,8 @@ checks:
       - nist_800_53: ["CM.1"]
       - tsc: ["CC5.2"]
       - cis_level: ["1"]
-    references: "AIDE stable manual: http://aide.sourceforge.net/stable/manual.html"
+    references: 
+      - "AIDE stable manual: http://aide.sourceforge.net/stable/manual.html"
     condition: any
     rules:
       - 'f:/etc/sudoers -> r:^\s*Defaults\s*\t*use_pty'
@@ -533,7 +535,7 @@ checks:
 
 # 1.3.3 Ensure sudo log file exists
   - id: 6026
-    title: "Ensure sudo log file exists"
+    title: "Ensure sudo log file exists."
     description: "sudo can use a custom log file"
     rationale: "A sudo log file simplifies auditing of sudo commands"
     remediation: "Edit the file /etc/sudoers or a file in /etc/sudoers.d/ with visudo or visudo -f <PATH TO FILE> and add the following line: Defaults logfile='<PATH TO CUSTOM LOG FILE>'   Example:Defaults  logfile=\"/var/log/sudo.log\""
@@ -556,7 +558,7 @@ checks:
 
 # 1.4.1 install AIDE
   - id: 6027
-    title: "Ensure AIDE is installed"
+    title: "Ensure AIDE is installed."
     description: "AIDE takes a snapshot of filesystem state including modification times, permissions, and file hashes which can then be used to compare against the current state of the filesystem to detect modifications to the system."
     rationale: "By monitoring the filesystem state compromised files can be detected to prevent or limit the exposure of accidental or malicious misconfigurations or modified binaries."
     remediation: "Run the following command to install AIDE: yum install aide // Configure AIDE as appropriate for your environment. Consult the AIDE documentation for options. Initialize AIDE: aide --init && mv /var/lib/aide/aide.db.new.gz /var/lib/aide/aide.db.gz"
@@ -566,14 +568,15 @@ checks:
       - pci_dss: ["11.5"]
       - tsc: ["PI1.4","PI1.5","CC6.8","CC7.2","CC7.3","CC7.4"]
       - cis_level: ["1"]
-    references: "AIDE stable manual: http://aide.sourceforge.net/stable/manual.html"
+    references: 
+      - "AIDE stable manual: http://aide.sourceforge.net/stable/manual.html"
     condition: all
     rules:
       - 'c:rpm -q aide -> r:aide-\S*'
 
 # 1.4.2 AIDE regular checks
   - id: 6028
-    title: "Ensure filesystem integrity is regularly checked"
+    title: "Ensure filesystem integrity is regularly checked."
     description: "Periodic checking of the filesystem integrity is needed to detect changes to the filesystem."
     rationale: "Periodic file checking allows the system administrator to determine on a regular basis if critical files have been changed in an unauthorized fashion."
     remediation: "If cron will be used to schedule and run aide check run the following command: crontab -u root -e         Add the following line to the crontab: 0 5 * * * /usr/sbin/aide --check  // Notes: The checking in this recommendation occurs every day at 5am. Alter the frequency and time of the checks in compliance with site policy.              OR        If aidecheck.service and aidecheck.timer will be used to schedule and run aide check: Create or edit the file /etc/systemd/system/aidecheck.service and add the following lines:    [Unit]      Description=Aide Check    [Service]     Type=simpleExecStart=/usr/sbin/aide --check      [Install]     WantedBy=multi-user.target      Create or edit the file  /etc/systemd/system/aidecheck.timer and add the following lines:   [Unit]   Description=Aide check every day at 5AM      [Timer]     OnCalendar=*-*-* 05:00:00      Unit=aidecheck.service      [Install]     WantedBy=multi-user.target        Run the following commands:        # chown root:root /etc/systemd/system/aidecheck.*         # chmod 0644 /etc/systemd/system/aidecheck.*           # systemctl daemon-reload          # systemctl enable aidecheck.service        # systemctl --now enable aidecheck.timer "
@@ -597,7 +600,7 @@ checks:
 ###############################################
 # 1.5.1 Set Boot Loader Password (Scored)
   - id: 6029
-    title: "Ensure bootloader password is set"
+    title: "Ensure bootloader password is set."
     description: "Setting the boot loader password will require that anyone rebooting the system must enter a password before being able to set command line boot parameters."
     rationale: "Requiring a boot password upon execution of the boot loader will prevent an unauthorized user from entering boot parameters or changing the boot partition. This prevents users from weakening security (e.g. turning off SELinux at boot time)."
     remediation: "For newergrub2based systems (centOS/RHEL 7.2 and newer): Create an encrypted password with grub2-setpassword: # grub2-setpassword             OR        For older  grub2based systems: create an encrypted password with grub2-mkpasswd-pbkdf2:   # grub2-mkpasswd-pbkdf2   Enter password: <password>    Reenter password: <password>     Your PBKDF2 is <encrypted-password>     Add the following into /etc/grub.d/01_users or a custom /etc/grub.d configuration file:  cat <<EOFset superusers=\"<username>\"password_pbkdf2 <username> <encrypted-password>EOF  Run the following command to update the grub2 configuration:  # grub2-mkconfig -o /boot/grub2/grub.cfg"
@@ -616,7 +619,7 @@ checks:
 
 # 1.5.2 Configure bootloader
   - id: 6030
-    title: "Ensure permissions on bootloader config are configured"
+    title: "Ensure permissions on bootloader config are configured."
     description: "The grub configuration file contains information on boot settings and passwords for unlocking boot options. The grub configuration is usually located at /boot/grub2/grub.cfg and linked as /etc/grub2.cfg .  On newer grub2 systems the encrypted bootloader password is contained in /boot/grub2/user.cfg"
     rationale: "Setting the permissions to read and write for root only prevents non-root users from seeing the boot parameters or changing them. Non-root users who read the boot parameters may be able to identify weaknesses in security upon boot and be able to exploit them."
     remediation: "Run the following commands to set permissions on your grub configuration: # chown root:root /boot/grub2/grub.cfg    # chmod og-rwx /boot/grub2/grub.cfg  # chown root:root /boot/grub2/user.cfg  # chmod og-rwx /boot/grub2/user.cfg"
@@ -634,7 +637,7 @@ checks:
 
 # 1.5.3 Single user authentication
   - id: 6031
-    title: "Ensure authentication required for single user mode"
+    title: "Ensure authentication required for single user mode."
     description: "Single user mode (rescue mode) is used for recovery when the system detects an issue during boot or by manual selection from the bootloader."
     rationale: "Requiring authentication in single user mode (rescue mode) prevents an unauthorized user from rebooting the system into single user to gain root privileges without credentials."
     remediation: "Edit /usr/lib/systemd/system/rescue.service and /usr/lib/systemd/system/emergency.service and set ExecStart to use /sbin/sulogin or /usr/sbin/sulogin: ExecStart=-/bin/sh -c \"/sbin/sulogin; /usr/bin/systemctl --fail --no-block default\" "
@@ -656,7 +659,7 @@ checks:
 ###############################################
 # 1.6.1 Restrict Core Dumps (Scored)
   - id: 6032
-    title: "Ensure core dumps are restricted"
+    title: "Ensure core dumps are restricted."
     description: "A core dump is the memory of an executable program. It is generally used to determine why a program aborted. It can also be used to glean confidential information from a core file."
     rationale: "Setting a hard limit on core dumps prevents users from overriding the soft variable. If core dumps are required, consider setting limits for user groups (see limits.conf). In addition, setting the fs.suid_dumpable variable to 0 will prevent setuid programs from dumping core."
     remediation: "Add the following line to /etc/security/limits.conf or a /etc/security/limits.d/* file: * hard core 0. Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: fs.suid_dumpable = 0. Run the following command to set the active kernel parameter: # sysctl -w fs.suid_dumpable=0"
@@ -675,7 +678,7 @@ checks:
 
 # 1.6.2 XD/NX enabled
   - id: 6033
-    title: "Ensure XD/NX support is enabled"
+    title: "Ensure XD/NX support is enabled."
     description: "Recent processors in the x86 family support the ability to prevent code execution on a per memory page basis. Generically and on AMD processors, this ability is called No Execute (NX), while on Intel processors it is called Execute Disable (XD). This ability can help prevent exploitation of buffer overflow vulnerabilities and should be activated whenever possible. Extra steps must be taken to ensure that this protection is enabled, particularly on 32-bit x86 systems. Other processors, such as Itanium and POWER, have included such support since inception and the standard kernel for those platforms supports the feature."
     rationale: "Enabling any feature that can protect against buffer overflow attacks enhances the security of the system."
     remediation: "On 32 bit systems install a kernel with PAE support, no installation is required on 64 bit systems: If necessary configure your bootloader to load the new kernel and reboot the system. You may need to enable NX or XD support in your bios."
@@ -693,7 +696,7 @@ checks:
 
 # 1.6.3 Enable Randomized Virtual Memory Region Placement (Scored)
   - id: 6034
-    title: "Ensure address space layout randomization (ASLR) is enabled"
+    title: "Ensure address space layout randomization (ASLR) is enabled."
     description: "Address space layout randomization (ASLR) is an exploit mitigation technique which randomly arranges the address space of key data areas of a process."
     rationale: "Randomly placing virtual memory regions will make it difficult to write memory page exploits as the memory placement will be consistently shifting."
     remediation: "Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: kernel.randomize_va_space = 2. Run the following command to set the active kernel parameter: # sysctl -w kernel.randomize_va_space=2"
@@ -711,7 +714,7 @@ checks:
 
 # 1.6.4 Disable prelink
   - id: 6035
-    title: "Ensure prelink is disabled"
+    title: "Ensure prelink is disabled."
     description: "prelink is a program that modifies ELF shared libraries and ELF dynamically linked binaries in such a way that the time needed for the dynamic linker to perform relocations at startup significantly decreases."
     rationale: "The prelinking feature can interfere with the operation of AIDE, because it changes binaries. Prelinking can also increase the vulnerability of the system if a malicious user is able to compromise a common library such as libc."
     remediation: "Run the following commands to restore binaries to normal: # prelink -ua     Run the following command to uninstall prelink: # yum remove prelink"
@@ -733,7 +736,7 @@ checks:
 
 # 1.7.1.1 Install SELinux
   - id: 6036
-    title: "Ensure SELinux is installed"
+    title: "Ensure SELinux is installed."
     description: "SELinux provides Mandatory Access Controls."
     rationale: "Without a Mandatory Access Control system installed only the default Discretionary Access Control system will be available."
     remediation: "Run the following command to install libselinux: # yum install libselinux"
@@ -750,7 +753,7 @@ checks:
 
 # 1.7.1.2 SELinux not disabled
   - id: 6037
-    title: "Ensure SELinux is not disabled in bootloader configuration"
+    title: "Ensure SELinux is not disabled in bootloader configuration."
     description: "Configure SELINUX to be enabled at boot time and verify that it has not been overwritten by the grub boot parameters."
     rationale: "SELinux must be enabled at boot time in your grub configuration to ensure that the controls it provides are not overridden."
     remediation: "Edit /etc/default/grub and remove all instances of selinux=0 and enforcing=0 from all CMDLINE_LINUX parameters: GRUB_CMDLINE_LINUX_DEFAULT=\"quiet\" GRUB_CMDLINE_LINUX=\"\"  || Run the following command to update the grub2 configuration: grub2-mkconfig -o /boot/grub2/grub.cfg"
@@ -767,7 +770,7 @@ checks:
 
 # 1.7.1.3 Set selinux policy
   - id: 6038
-    title: "Ensure SELinux policy is configured"
+    title: "Ensure SELinux policy is configured."
     description: "Configure SELinux to meet or exceed the default targeted policy, which constrains daemons and system software only."
     rationale: "Security configuration requirements vary from site to site. Some sites may mandate a policy that is stricter than the default policy, which is perfectly acceptable. This item is intended to ensure that at least the default recommendations are met."
     remediation: "Edit the /etc/selinux/config file to set the SELINUXTYPE parameter: SELINUXTYPE=targeted"
@@ -785,7 +788,7 @@ checks:
 
 # 1.7.1.4 Set selinux mode
   - id: 6039
-    title: "Ensure the SELinux mode is enforcing or permissive"
+    title: "Ensure the SELinux mode is enforcing or permissive."
     description: "SELinux can run in one of three modes: disabled, permissive, or enforcing:  Enforcing - Is the default, and recommended, mode of operation; in enforcing mode SELinux operates normally, enforcing the loaded security policy on the entire system.  Permissive - The system acts as if SELinux is enforcing the loaded security policy, including labeling objects and emitting access denial entries in the logs, but it does not actually deny any operations. While not recommended for production systems, permissive mode can be helpful for SELinux policy development.   Disabled -Is strongly discouraged; not only does the system avoid enforcing the SELinux policy, it also avoids labeling any persistent objects such as files, making it difficult to enable SELinux in the future"
     rationale: "Running SELinux in disabled modeis strongly discouraged; not only does the system avoid enforcing the SELinux policy, it also avoids labeling any persistent objects such as files, making it difficult to enable SELinux in the future."
     remediation: "Run one of the following commands to set SELinux's running mode: To set SELinux mode to Enforcing: # setenforce 1       OR       To set SELinux mode to Permissive: # setenforce 0       Edit the /etc/selinux/config  file to set the SELINUX parameter: For Enforcing mode: SELINUX=enforcing       OR     For Permissive mode:  SELINUX=permissive"
@@ -805,7 +808,7 @@ checks:
 
 # 1.7.1.6 Ensure no unconfined services exist
   - id: 6040
-    title: "Ensure no unconfined services exist"
+    title: "Ensure no unconfined services exist."
     description: "Unconfined processes run in unconfined domains"
     rationale: "For unconfined processes, SELinux policy rules are applied, but policy rules exist that allow processes running in unconfined domains almost all access. Processes running in unconfined domains fall back to using DAC rules exclusively. If an unconfined process is compromised, SELinux does not prevent an attacker from gaining access to system resources and data, but of course, DAC rules are still used. SELinux is a security enhancement on top of DAC rules – it does not replace them"
     remediation: "Investigate any unconfined processes found during the audit action. They may need to have an existing security context assigned to them or a policy built for them."
@@ -822,7 +825,7 @@ checks:
 
 # 1.7.1.7 Remove SETroubleshoot
   - id: 6041
-    title: "Ensure SETroubleshoot is not installed"
+    title: "Ensure SETroubleshoot is not installed."
     description: "The SETroubleshoot service notifies desktop users of SELinux denials through a user-friendly interface. The service provides important information around configuration errors, unauthorized intrusions, and other potential errors."
     rationale: "The SETroubleshoot service is an unnecessary daemon to have running on a server, especially if X Windows is disabled."
     remediation: "Run the following command to uninstall setroubleshoot: # yum remove setroubleshoot"
@@ -839,7 +842,7 @@ checks:
 
 # 1.7.1.8 Disable MCS Translation service mcstrans
   - id: 6042
-    title: "Ensure the MCS Translation Service (mcstrans) is not installed"
+    title: "Ensure the MCS Translation Service (mcstrans) is not installed."
     description: "The mcstransd daemon provides category label information to client processes requesting information. The label translations are defined in /etc/selinux/targeted/setrans.conf"
     rationale: "Since this service is not used very often, remove it to reduce the amount of potentially vulnerable code running on the system."
     remediation: "Run the following command to uninstall mcstrans: # yum remove mcstrans"
@@ -860,7 +863,7 @@ checks:
 ###############################################
 # 1.8.1.1 Configure message of the day (Scored)
   - id: 6043
-    title: "Ensure message of the day is configured properly"
+    title: "Ensure message of the day is configured properly."
     description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version"
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
     remediation: "Edit the /etc/motd file with the appropriate contents according to your site policy, remove any instances of \\m, \\r, \\s, \\v  or references to the OS platform    OR    If the motd is not used, this file can be removed. Run the following command to remove the motd file: # rm /etc/motd"
@@ -876,7 +879,7 @@ checks:
 
 # 1.8.1.2 Configure local login warning banner (Not Scored)
   - id: 6044
-    title: "Ensure local login warning banner is configured properly"
+    title: "Ensure local login warning banner is configured properly."
     description: "The contents of the /etc/issue file are displayed to users prior to login for local terminals. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version -or the operating system's name."
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
     remediation: "Edit the /etc/issue file with the appropriate contents according to your site policy, remove any instances of \\m, \\r, \\s, or \\v: # echo \"Authorized uses only. All activity may be monitored and reported.\" > /etc/issue"
@@ -892,7 +895,7 @@ checks:
 
 # 1.8.1.3 Configure remote login warning banner (Not Scored)
   - id: 6045
-    title: "Ensure remote login warning banner is configured properly"
+    title: "Ensure remote login warning banner is configured properly."
     description: "The contents of the /etc/issue.net file are displayed to users prior to login for remote connections from configured services. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version"
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
     remediation: "Edit the /etc/issue.net file with the appropriate contents according to your site policy, remove any instances of \\m, \\r, \\s, or \\v: # echo \"Authorized uses only. All activity may be monitored and reported.\" > /etc/issue.net"
@@ -908,7 +911,7 @@ checks:
 
 # 1.8.1.4 Configure /etc/motd permissions (Not Scored)
   - id: 6046
-    title: "Ensure permissions on /etc/motd are configured"
+    title: "Ensure permissions on /etc/motd are configured."
     description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users."
     rationale: "If the /etc/motd file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
     remediation: "Run the following commands to set permissions on /etc/motd: # chown root:root /etc/motd # chmod 644 /etc/motd"
@@ -928,7 +931,7 @@ checks:
 
 # 1.8.1.5 Configure /etc/issue permissions (Scored)
   - id: 6047
-    title: "Ensure permissions on /etc/issue are configured"
+    title: "Ensure permissions on /etc/issue are configured."
     description: "The contents of the /etc/issue file are displayed to users prior to login for local terminals."
     rationale: "If the /etc/issue file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
     remediation: "Run the following commands to set permissions on /etc/issue: # chown root:root /etc/issue # chmod 644 /etc/issue"
@@ -948,7 +951,7 @@ checks:
 
 # 1.8.1.6 Configure /etc/issue.net permissions (Not Scored)
   - id: 6048
-    title: "Ensure permissions on /etc/issue.net are configured"
+    title: "Ensure permissions on /etc/issue.net are configured."
     description: "The contents of the /etc/issue.net file are displayed to users prior to login for remote connections from configured services."
     rationale: "If the /etc/issue.net file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
     remediation: "Run the following commands to set permissions on /etc/issue.net: # chown root:root /etc/issue.net # chmod 644 /etc/issue.net"
@@ -968,7 +971,7 @@ checks:
 
 # 1.9 Ensure updates, patches, and additional security software are installed
   - id: 6049
-    title: "Ensure updates, patches, and additional security software are installed"
+    title: "Ensure updates, patches, and additional security software are installed."
     description: "Periodically patches are released for included software either due to security flaws or to include additional functionality."
     rationale: "Newer patches may contain security enhancements that would not be available through the latest full update. As a result, it is recommended that the latest software patches be used to take advantage of the latest functionality. As with any software installation, organizations need to determine if a given update meets their requirements and verify the compatibility and supportability of any additional software against the update revision that is selected."
     remediation: "Use your package manager to update all packages on the system according to site policy. The following command will install all available packages # yum update  "
@@ -988,7 +991,7 @@ checks:
 
 # 1.10 Ensure GDM login banner is configured (Scored)
   - id: 6050
-    title: "Ensure GDM login banner is configured"
+    title: "Ensure GDM login banner is configured."
     description: "GDM is the GNOME Display Manager which handles graphical login for GNOME based systems."
     rationale: "If a graphical login is not required, it should be removed to reduce the attack surface of the system. If a graphical login is required, last logged in user display should be disabled, and a warning banner should be configured. Displaying the last logged in user eliminates half of the Userid/Password equation that an unauthorized person would need to log on. Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place."
     remediation: "Run the following command to remove gdm: # yum remove gdm OR If GDM is required: Edit or create the file /etc/dconf/profile/gdm and add the following:      user-db:user      system-db:gdm         file-db:/usr/share/gdm/greeter-dconf-defaults          Edit or create the file /etc/dconf/db/gdm.d/  and add the following: (This is typically /etc/dconf/db/gdm.d/01-banner-message)          [org/gnome/login-screen]        banner-message-enable=true      banner-message-text='<banner message>'          Example Banner Text:  'Authorized uses only. All activity may be monitored and reported. 'Edit or create the file /etc/dconf/db/gdm.d/and add the following: (This is typically /etc/dconf/db/gdm.d/00-login-screen)     [org/gnome/login-screen]     # Do not show the user list     disable-user-list=true  Run the following command to update the system databases:  # dconf update"
@@ -1017,7 +1020,7 @@ checks:
 
 # 2.1.1 Ensure xinetd is not installed (Automated)
   - id: 6051
-    title: "Ensure daytime services are not enabled"
+    title: "Ensure daytime services are not enabled."
     description: "The eXtended InterNET Daemon ( xinetd ) is an open source super daemon that replaced the original inetd daemon. The xinetd daemon listens for well known services and dispatches the appropriate daemon to properly respond to service requests."
     rationale: "If there are no xinetd services required, it is recommended that the package be removed to reduce the attack surface area of the system. Note: If an xinetd service or services are required, ensure that any xinetd service not required is stopped and disabled"
     remediation: "Run the following command to remove xinetd: # yum remove xinetd"
@@ -1042,7 +1045,7 @@ checks:
 
 # 2.2.1.1 Ensure time synchronization is in use (Manual)
   - id: 6052
-    title: "Ensure time synchronization is in use"
+    title: "Ensure time synchronization is in use."
     description: "System time should be synchronized between all systems in an environment. This is typically done by establishing an authoritative time server or set of servers and having all systems synchronize their clocks to them."
     rationale: "Time synchronization is important to support time sensitive security mechanisms like Kerberos and also ensures log files have consistent time records across the enterprise, which aids in forensic investigations."
     remediation: "Run One of the following commands to install chrony or NTP: to install chrony run the following command: # yum install chrony OR to install ntp: run the following command: # yum install ntp"
@@ -1060,7 +1063,7 @@ checks:
 
 # 2.2.1.2  Ensure chrony is configured (Automated)
   - id: 6053
-    title: "Ensure chrony is configured"
+    title: "Ensure chrony is configured."
     description: "chrony is a daemon which implements the Network Time Protocol (NTP) and is designed to synchronize system clocks across a variety of systems and use a source that is highly accurate. More information on chrony can be found at http://chrony.tuxfamily.org/. chrony can be configured to be a client and/or a server."
     rationale: "If chrony is in use on the system proper configuration is vital to ensuring time synchronization is working properly. Note: This recommendation only applies if chrony is in use on the system."
     remediation: "1) Add or edit server or pool lines to /etc/chrony.conf as appropriate: server <remote-server>. 2) Add or edit the OPTIONS in /etc/sysconfig/chronyd to include '-u chrony':OPTIONS=\"-u chrony\""
@@ -1078,7 +1081,7 @@ checks:
 
 # 2.2.1.3  Ensure ntp is configured (Automated)
   - id: 6054
-    title: "Ensure ntp is configured"
+    title: "Ensure ntp is configured."
     description: "ntp is a daemon which implements the Network Time Protocol (NTP). It is designed to synchronize system clocks across a variety of systems and use a source that is highly accurate. More information on NTP can be found at https://www.ntp.org. ntp can be configured to be a client and/or a server."
     rationale: "If ntp is in use on the system proper configuration is vital to ensuring time synchronization is working properly."
     remediation: "1) Add or edit restrict lines in /etc/ntp.conf to match the following: - restrict -4 default kod nomodify notrap nopeer noquery and - restrict -4 default kod nomodify notrap nopeer noquery. 2) Add or edit server or pool lines to /etc/ntp.conf as appropriate: server <remote-server>. 3) Add or edit the OPTIONS in /etc/sysconfig/ntpd to include ' -u ntp:ntp ': - OPTIONS='-u ntp:ntp'"
@@ -1099,7 +1102,7 @@ checks:
 
 # 2.2.2 Remove X Windows (Scored)
   - id: 6055
-    title: " Ensure X11 Server components are not installed"
+    title: " Ensure X11 Server components are not installed."
     description: "The X Window System provides a Graphical User Interface (GUI) where users can have multiple windows in which to run programs and various add on. The X Windows system is typically used on workstations where users login, but not on servers where users typically do not login."
     rationale: "Unless your organization specifically requires graphical login access via X Windows, remove it to reduce the potential attack surface."
     remediation: "Run the following command to remove the X Windows System packages: # yum remove xorg-x11*"
@@ -1116,7 +1119,7 @@ checks:
 
 # 2.2.3 Ensure Avahi Server is not installed (Automated)
   - id: 6056
-    title: " Ensure Avahi Server is not installed"
+    title: " Ensure Avahi Server is not installed."
     description: "Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD service discovery. Avahi allows programs to publish and discover services and hosts running on a local network with no specific configuration. For example, a user can plug a computer into a network and Avahi automatically finds printers to print to, files to look at and people to talk to, as well as network services running on the machine."
     rationale: "Automatic discovery of network services is not normally required for system functionality. It is recommended to remove this package to reduce the potential attack surface."
     remediation: "Run the following commands to stop, mask and remove avahi-autoipd and avahi: # systemctl stop avahi-daemon.socket avahi-daemon.service; # yum remove avahi-autoipd avahi"
@@ -1134,7 +1137,7 @@ checks:
 
 # 2.2.4 Ensure CUPS is not installed (Automated)
   - id: 6057
-    title: "Ensure CUPS is not installed"
+    title: "Ensure CUPS is not installed."
     description: "The Common Unix Print System (CUPS) provides the ability to print to both local and network printers. A system running CUPS can also accept print jobs from remote systems and print them to local printers. It also provides a web based remote administration capability."
     rationale: "If the system does not need to print jobs or accept print jobs from other systems, it is recommended that CUPS be removed to reduce the potential attack surface. Disabling CUPS will prevent printing from the system, a common task for workstation systems."
     remediation: "Run the following command to remove cups: # yum remove cups"
@@ -1151,7 +1154,7 @@ checks:
 
 # 2.2.5 Ensure DHCP Server is not installed (Automated)
   - id: 6058
-    title: "Ensure DHCP Server is not installed"
+    title: "Ensure DHCP Server is not installed."
     description: "The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be dynamically assigned IP addresses."
     rationale: "Unless a system is specifically set up to act as a DHCP server, it is recommended that this the dhcp package be removed to reduce the potential attack surface."
     remediation: "Run the following command to remove dhcpd: # yum remove dhcp"
@@ -1170,7 +1173,7 @@ checks:
 
 # 2.2.6  Ensure LDAP server is not installed (Automated)
   - id: 6059
-    title: "Ensure LDAP Server is not installed"
+    title: "Ensure LDAP Server is not installed."
     description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
     rationale: "If the system will not need to act as an LDAP server, it is recommended that the software be removed to reduce the potential attack surface."
     remediation: "Run the following command to remove slapd: # yum remove openldap-servers"
@@ -1189,7 +1192,7 @@ checks:
 
 # 2.2.7 Ensure nfs-utils is not installed or the nfs-server service is masked (Automated)
   - id: 6060
-    title: "Ensure nfs-utils is not installed or the nfs-server service is masked"
+    title: "Ensure nfs-utils is not installed or the nfs-server service is masked."
     description: "The Network File System (NFS) is one of the first and most widely distributed file systems in the UNIX environment. It provides the ability for systems to mount file systems of other servers through the network."
     rationale: "If the system does not require network shares, it is recommended that the nfs-utils package be removed to reduce the attack surface of the system."
     remediation: "Run the following command to remove nfs-utils: # yum remove nfs-utils; OR if the nfs-package is required as a dependency: run the following command to stop and mask the nfs-server service: # systemctl --now mask nfs-server"
@@ -1207,7 +1210,7 @@ checks:
 
 # 2.2.8 Ensure rpcbind is not installed or the rpcbind services are masked (Automated)
   - id: 6061
-    title: "Ensure rpcbind is not installed or the rpcbind services are masked"
+    title: "Ensure rpcbind is not installed or the rpcbind services are masked."
     description: "The rpcbind utility maps RPC services to the ports on which they listen. RPC processes notify rpcbind when they start, registering the ports they are listening on and the RPC program numbers they expect to serve. The client system then contacts rpcbind on the server with a particular RPC program number. The rpcbind service redirects the client to the proper port number so it can communicate with the requested service Portmapper is an RPC service, which always listens on tcp and udp 111, and is used to map other RPC services (such as nfs, nlockmgr, quotad, mountd, etc.) to their corresponding port number on the server. When a remote host makes an RPC call to that server, it first consults with portmap to determine where the RPC server is listening"
     rationale: "A small request (~82 bytes via UDP) sent to the Portmapper generates a large response (7x to 28x amplification), which makes it a suitable tool for DDoS attacks. If rpcbind is not required, it is recommended that the rpcbind package be removed to reduce the attack surface of the system."
     remediation: "Run the following command to remove nfs-utils: # yum remove nfs-utils; OR if the nfs-package is required as a dependency: run the following command to stop and mask the nfs-server service: # systemctl --now mask nfs-server"
@@ -1225,7 +1228,7 @@ checks:
 
 # 2.2.9 Ensure DNS Server is not installed (Automate)
   - id: 6062
-    title: " Ensure DNS Server is not installed "
+    title: " Ensure DNS Server is not installed ."
     description: "The Domain Name System (DNS) is a hierarchical naming system that maps names to IP addresses for computers, services and other resources connected to a network."
     rationale: "Unless a system is specifically designated to act as a DNS server, it is recommended that the package be removed to reduce the potential attack surface."
     remediation: "Run the following command to disable named: # yum remove bind"
@@ -1242,7 +1245,7 @@ checks:
 
 # 2.2.10 Ensure FTP Server is not installed (Automated)
   - id: 6063
-    title: "Ensure FTP Server is not installed"
+    title: "Ensure FTP Server is not installed."
     description: "FTP (File Transfer Protocol) is a traditional and widely used standard tool for transferring files between a server and clients over a network, especially where no authentication is necessary (permits anonymous users to connect to a server)"
     rationale: "FTP does not protect the confidentiality of data or authentication credentials. It is recommended sftp be used if file transfer is required. Unless there is a need to run the system as a FTP server (for example, to allow anonymous downloads), it is recommended that the package be removed to reduce the potential attack surface."
     remediation: "Run the following command to disable vsftpd: # yum remove vsftpd"
@@ -1259,7 +1262,7 @@ checks:
 
 # 2.2.11 Ensure HTTP server is not installed (Automated)
   - id: 6064
-    title: "Ensure HTTP server is not installed"
+    title: "Ensure HTTP server is not installed."
     description: "HTTP or web servers provide the ability to host web site content."
     rationale: "Unless there is a need to run the system as a web server, it is recommended that the package be removed to reduce the potential attack surface."
     remediation: "Run the following command to disable httpd: # yum remove httpd"
@@ -1276,7 +1279,7 @@ checks:
 
 # 2.2.12 Ensure IMAP and POP3 server is not installed (Automated)
   - id: 6065
-    title: "Ensure IMAP and POP3 server is not installed"
+    title: "Ensure IMAP and POP3 server is not installed."
     description: "dovecot is an open source IMAP and POP3 server for Linux based systems."
     rationale: "Unless POP3 and/or IMAP servers are to be provided by this system, it is recommended that the package be removed to reduce the potential attack surface."
     remediation: "Run the following command to disable dovecot: # yum remove dovecot"
@@ -1293,7 +1296,7 @@ checks:
 
 # 2.2.13 Ensure Samba is not installed (Automated)
   - id: 6066
-    title: "Ensure Samba is not installed"
+    title: "Ensure Samba is not installed."
     description: "The Samba daemon allows system administrators to configure their Linux systems to share file systems and directories with Windows desktops. Samba will advertise the file systems and directories via the Small Message Block (SMB) protocol. Windows desktop users will be able to mount these directories and file systems as letter drives on their systems."
     rationale: "If there is no need to mount directories and file systems to Windows systems, then this package can be removed to reduce the potential attack surface."
     remediation: "Run the following command to disable smb: # yum remove samba"
@@ -1310,7 +1313,7 @@ checks:
 
 # 2.2.14 Ensure HTTP Proxy Server is not installed (Automated)
   - id: 6067
-    title: "Ensure HTTP Proxy Server is not installed"
+    title: "Ensure HTTP Proxy Server is not installed."
     description: "Squid is a standard proxy server used in many distributions and environments."
     rationale: "If there is no need for a proxy server, it is recommended that the squid package be removed to reduce the potential attack surface."
     remediation: "Run the following command to disable squid: # yum remove squid"
@@ -1327,7 +1330,7 @@ checks:
 
 # 2.2.15 Ensure net-snmp is not installed (Automated)
   - id: 6068
-    title: "Ensure SNMP Server is not installed"
+    title: "Ensure SNMP Server is not installed."
     description: "The Simple Network Management Protocol (SNMP) server is used to listen for SNMP commands from an SNMP management system, execute the commands or collect the information and then send results back to the requesting system."
     rationale: "The SNMP server can communicate using SNMPv1, which transmits data in the clear and does not require authentication to execute commands. SNMPv3replaces the simple/clear text password sharing used in SNMPv2with more securely encoded parameters. If the SNMP service is not required, the net-snmp package should be removed to reduce the attack surface of the system."
     remediation: "Run the following command to disable snmpd: # # yum remove net-snmp"
@@ -1344,7 +1347,7 @@ checks:
 
 # 2.2.16 Ensure mail transfer agent is configured for local-only mode (Automated)
   - id: 6069
-    title: "Ensure mail transfer agent is configured for local-only mode"
+    title: "Ensure mail transfer agent is configured for local-only mode."
     description: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
     rationale: "The software for all Mail Transfer Agents is complex and most have a long history of security issues. While it is important to ensure that the system can process local mail messages, it is not necessary to have the MTA's daemon listening on a port unless the server is intended to be a mail server that receives and processes mail from other systems."
     remediation: "Edit /etc/postfix/main.cf and add the following line to the RECEIVING MAIL section. If the line already exists, change it to look like the line below: inet_interfaces = loopback-only . Restart postfix: # systemctl restart postfix"
@@ -1361,7 +1364,7 @@ checks:
 
 # 2.2.17 Ensure rsync is not installed or the service is masked (Automated)
   - id: 6070
-    title: "Ensure rsync is not installed or the rsyncd service is masked"
+    title: "Ensure rsync is not installed or the rsyncd service is masked."
     description: "The rsyncd service can be used to synchronize files between systems over network links."
     rationale: "Unless required, the rsync package should be removed to reduce the attack surface area of the system. The rsyncd service presents a security risk as it uses unencrypted protocols for communication."
     remediation: "Run the following command to remove the rsync package: # yum remove rsync; OR run the following command to mask the rsyncd service: # systemctl --now mask rsyncd"
@@ -1379,7 +1382,7 @@ checks:
 
   # 2.2.18 Ensure NIS server is not installed (Automated)
   - id: 6071
-    title: "Ensure NIS Server is not installed"
+    title: "Ensure NIS Server is not installed."
     description: "The ypserv package provides the Network Information Service (NIS). This service, formally known as Yellow Pages, is a client-server directory service protocol for distributing system configuration files. The NIS server is a collection of programs that allow for the distribution of configuration files."
     rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the ypservpackage be removed, and if required a more secure services be used."
     remediation: "Run the following command to disable ypserv: # yum remove ypserv"
@@ -1399,7 +1402,7 @@ checks:
 
 # 2.2.19 Ensure telnet-server is not installed (Automated)
   - id: 6072
-    title: "Ensure telnet server is not installed"
+    title: "Ensure telnet server is not installed."
     description: "The telnet-server package contains the telnet daemon, which accepts connections from users from other systems via the telnet protocol."
     rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow a user with access to sniff network traffic the ability to steal credentials. The ssh package provides an encrypted session and stronger security."
     remediation: "Run the following command to disable telnet: # yum remove telnet-server"
@@ -1423,7 +1426,7 @@ checks:
 
 # 2.3.1 Ensure NIS Client is not installed (Automated)
   - id: 6073
-    title: "Ensure NIS Client is not installed"
+    title: "Ensure NIS Client is not installed."
     description: "The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server directory service protocol used to distribute system configuration files. The NIS client ( ypbind ) was used to bind a machine to an NIS server and receive the distributed configuration files."
     rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed."
     remediation: "Run the following command to uninstall ypbind: # yum remove ypbind"
@@ -1443,7 +1446,7 @@ checks:
 
 # 2.3.2 Ensure rsh client is not installed (Automated)
   - id: 6074
-    title: "Ensure rsh client is not installed"
+    title: "Ensure rsh client is not installed."
     description: "The rsh package contains the client commands for the rsh services."
     rationale: "These legacy clients contain numerous security exposures and have been replaced with the more secure SSH package. Even if the server is removed, it is best to ensure the clients are also removed to prevent users from inadvertently attempting to use these commands and therefore exposing their credentials. Note that removing the rsh package removes the clients for rsh, rcp and rlogin ."
     remediation: "Run the following command to uninstall rsh: # yum remove rsh"
@@ -1463,7 +1466,7 @@ checks:
 
 # 2.3.3 Ensure talk client is not installed (Automated)
   - id: 6075
-    title: "Ensure talk client is not installed"
+    title: "Ensure talk client is not installed."
     description: "The talk software makes it possible for users to send and receive messages across systems through a terminal session. The talk client, which allows initialization of talk sessions, is installed by default."
     rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
     remediation: "Run the following command to uninstall talk: # yum remove talk"
@@ -1483,7 +1486,7 @@ checks:
 
 # 2.3.4 Ensure telnet client is not installed (Automated)
   - id: 6076
-    title: "Ensure telnet client is not installed"
+    title: "Ensure telnet client is not installed."
     description: "The telnet package contains the telnet client, which allows users to start connections to other systems via the telnet protocol."
     rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow an unauthorized user to steal credentials. The ssh package provides an encrypted session and stronger security and is included in most Linux distributions."
     remediation: "Run the following command to uninstall telnet: # yum remove telnet"
@@ -1503,7 +1506,7 @@ checks:
 
 # 2.3.5 Ensure LDAP client is not installed (Automated)
   - id: 6077
-    title: "Ensure LDAP client is not installed"
+    title: "Ensure LDAP client is not installed."
     description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
     rationale: "If the system will not need to act as an LDAP client, it is recommended that the software be removed to reduce the potential attack surface."
     remediation: "Run the following command to uninstall openldap-clients: # yum remove openldap-clients"
@@ -1523,7 +1526,7 @@ checks:
 
 # 2.4 Ensure nonessential services are removed or masked (Manual)
   - id: 6078
-    title: "Ensure nonessential services are removed or masked"
+    title: "Ensure nonessential services are removed or masked."
     description: "A network port is identified by its number, the associated IP address, and the type of the communication protocol such as TCP or UDP.A listening port is a network port on which an application or process listens on, acting as a communication endpoint. Each listening port can be open or closed (filtered) using a firewall. In general terms, an open port is a network port that accepts incoming packets from remote locations"
     rationale: "Services listening on the system pose a potential risk as an attack vector. These services should be reviewed, and if not required, the service should be stopped, and the package containing the service should be removed. If required packages have a dependency, the service should be stopped and masked to reduce the attack surface of the system."
     remediation: "Review the output of: # lsof -i -P -n | grep -v '(ESTABLISHED)'; to ensure that all services listed are required on the system. If a listed service is not required, remove the package containing the service. If the package containing the service is required, stop and mask the service. Run the following command to remove the package containing the service:# yum remove <package_name> OR if required packages have a dependency: run the following command to stop and mask the service:# systemctl --now mask <service_name>"
@@ -1551,7 +1554,7 @@ checks:
 
 # 3.1.1 Disable IPv6 (Manual)
   - id: 6079
-    title: "Disable IPv6"
+    title: "Disable IPv6."
     description: "Although IPv6 has many advantages over IPv4, not all organizations have IPv6 or dual stack configurations implemented."
     rationale: "If IPv6 or dual stack is not to be used, it is recommended that IPv6be disabled to reduce the attack surface of the system."
     remediation: "To disable IPv6 through the GRUB2 config: edit /etc/default/gruband add ipv6.disable=1 to the GRUB_CMDLINE_LINUX parameters: GRUB_CMDLINE_LINUX=\"ipv6.disable=1\" Run the following command to update the grub2 configuration:# grub2-mkconfig –o /boot/grub2/grub.cfg; OR to disable IPv6 through sysctl settings: set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: # net.ipv6.conf.all.disable_ipv6 = 1; # net.ipv6.conf.default.disable_ipv6 = 1; Run the following commands to set the active kernel parameters: # sysctl -w net.ipv6.conf.all.disable_ipv6=1; # sysctl -w net.ipv6.conf.default.disable_ipv6=1; # sysctl -w net.ipv6.route.flush=1"
@@ -1570,7 +1573,7 @@ checks:
 
 # 3.1.2 Ensure wireless interfaces are disabled (Manual)
   - id: 6080
-    title: "Ensure wireless interfaces are disabled"
+    title: "Ensure wireless interfaces are disabled."
     description: "Wireless networking is used when wired networks are unavailable."
     rationale: "If wireless is not to be used, wireless devices should be disabled to reduce the potential attack surface"
     remediation: "Run the following command to disable any wireless interfaces: # ip link set <interface> down"
@@ -1592,7 +1595,7 @@ checks:
 
 # 3.2.1 Ensure IP forwarding is disabled (Automated)
   - id: 6081
-    title: "Ensure IP forwarding is disabled"
+    title: "Ensure IP forwarding is disabled."
     description: "The net.ipv4.ip_forward flag is used to tell the system whether it can forward packets or not."
     rationale: "Setting the flag to 0 ensures that a system with multiple interfaces (for example, a hard proxy), will never be able to forward packets, and therefore, never serve as a router."
     remediation: "Run the following commands to restore the default parameters and set the active kernel parameters: # grep -Els '^\\s*net\\.ipv4\\.ip_forward\\s*=\\s*1' /etc/sysctl.conf /etc/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /run/sysctl.d/*.conf | while read filename; do sed -ri 's/^\\s*(net\\.ipv4\\.ip_forward\\s*)(=)(\\s*\\S+\\b).*$/# *REMOVED* \\1/' $filename; done; sysctl -w net.ipv4.ip_forward=0; sysctl -w net.ipv4.route.flush=1"
@@ -1612,7 +1615,7 @@ checks:
 
 # 3.2.2 Ensure packet redirect sending is disabled (Automated)
   - id: 6082
-    title: "Ensure packet redirect sending is disabled"
+    title: "Ensure packet redirect sending is disabled."
     description: "ICMP Redirects are used to send routing information to other hosts. As a host itself does not act as a router (in a host only configuration), there is no need to send redirects."
     rationale: "An attacker could use a compromised host to send invalid ICMP redirects to other router devices in an attempt to corrupt routing and have users access a system set up by the attacker as opposed to a valid system."
     remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.send_redirects = 0; net.ipv4.conf.default.send_redirects = 0 and set the active kernel parameters. Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.conf.all.send_redirects=0; # sysctl -w net.ipv4.conf.default.send_redirects=0; # sysctl -w net.ipv4.route.flush=1"
@@ -1637,7 +1640,7 @@ checks:
 
 # 3.3.1 Ensure source routed packets are not accepted (Automated)
   - id: 6083
-    title: "Ensure source routed packets are not accepted"
+    title: "Ensure source routed packets are not accepted."
     description: "In networking, source routing allows a sender to partially or fully specify the route packets take through a network. In contrast, non-source routed packets travel a path determined by routers in the network. In some cases, systems may not be routable or reachable from some locations (e.g. private addresses vs. Internet routable), and so source routed packets would need to be used."
     rationale: "Setting net.ipv4.conf.all.accept_source_route and net.ipv4.conf.default.accept_source_route to 0 disables the system from accepting source routed packets. Assume this system was capable of routing packets to Internet routable addresses on one interface and private addresses on another interface. Assume that the private addresses were not routable to the Internet routable addresses and vice versa. Under normal routing circumstances, an attacker from the Internet routable addresses could not use the system as a way to reach the private address systems. If, however, source routed packets were allowed, they could be used to gain access to the private address systems as the route could be specified, rather than rely on routing protocols that did not allow this routing."
     remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.accept_source_route = 0; net.ipv4.conf.default.accept_source_route = 0 and set the active kernel parameters:       # sysctl -w net.ipv4.conf.all.accept_source_route=0       # sysctl -w net.ipv4.conf.default.accept_source_route=0        # sysctl -w net.ipv4.route.flush=1"
@@ -1661,7 +1664,7 @@ checks:
 
 # 3.3.2 Ensure ICMP redirects are not accepted (Automated)
   - id: 6084
-    title: "Ensure ICMP redirects are not accepted"
+    title: "Ensure ICMP redirects are not accepted."
     description: "ICMP redirect messages are packets that convey routing information and tell your host (acting as a router) to send packets via an alternate path. It is a way of allowing an outside routing device to update your system routing tables."
     rationale: "Attackers could use bogus ICMP redirect messages to maliciously alter the system routing tables and get them to send packets to incorrect networks and allow your system packets to be captured."
     remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.accept_redirects = 0; net.ipv4.conf.default.accept_redirects = 0 and set the active kernel parameters:      # sysctl -w net.ipv4.conf.all.accept_redirects=0          # sysctl -w net.ipv4.conf.default.accept_redirects=0            # sysctl -w net.ipv4.route.flush=1"
@@ -1682,7 +1685,7 @@ checks:
 
 # 3.3.3 Ensure secure ICMP redirects are not accepted (Automated)
   - id: 6085
-    title: "Ensure secure ICMP redirects are not accepted"
+    title: "Ensure secure ICMP redirects are not accepted."
     description: "Secure ICMP redirects are the same as ICMP redirects, except they come from gateways listed on the default gateway list. It is assumed that these gateways are known to your system, and that they are likely to be secure."
     rationale: "It is still possible for even known gateways to be compromised. Setting net.ipv4.conf.all.secure_redirects to 0 protects the system from routing table updates by possibly compromised known gateways."
     remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.secure_redirects = 0; net.ipv4.conf.default.secure_redirects = 0 and set the active kernel parameters:  # sysctl -w net.ipv4.conf.all.secure_redirects=0         # sysctl -w net.ipv4.conf.default.secure_redirects=0          # sysctl -w net.ipv4.route.flush=1"
@@ -1702,7 +1705,7 @@ checks:
 
 # 3.3.4 Ensure suspicious packets are logged (Automated)
   - id: 6086
-    title: "Ensure suspicious packets are logged"
+    title: "Ensure suspicious packets are logged."
     description: "When enabled, this feature logs packets with un-routable source addresses to the kernel log."
     rationale: "Enabling this feature and logging these packets allows an administrator to investigate the possibility that an attacker is sending spoofed packets to their system."
     remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.log_martians = 1; net.ipv4.conf.default.log_martians = 1 and set the active kernel parameters:    # sysctl -w net.ipv4.conf.all.log_martians=1       # sysctl -w net.ipv4.conf.default.log_martians=1          # sysctl -w net.ipv4.route.flush=1"
@@ -1722,7 +1725,7 @@ checks:
 
 # 3.3.5 Ensure broadcast ICMP requests are ignored (Automated)
   - id: 6087
-    title: "Ensure broadcast ICMP requests are ignored"
+    title: "Ensure broadcast ICMP requests are ignored."
     description: "Setting net.ipv4.icmp_echo_ignore_broadcasts to 1 will cause the system to ignore all ICMP echo and timestamp requests to broadcast and multicast addresses."
     rationale: "Accepting ICMP echo and timestamp requests with broadcast or multicast destinations for your network could be used to trick your host into starting (or participating) in a Smurf attack. A Smurf attack relies on an attacker sending large amounts of ICMP broadcast messages with a spoofed source address. All hosts receiving this message and responding would send echo-reply messages back to the spoofed address, which is probably not routable. If many hosts respond to the packets, the amount of traffic on the network could be significantly multiplied."
     remediation: "Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.icmp_echo_ignore_broadcasts = 1 and set the active kernel parameters:     # sysctl -w net.ipv4.icmp_echo_ignore_broadcasts=1           # sysctl -w net.ipv4.route.flush=1"
@@ -1740,7 +1743,7 @@ checks:
 
 # 3.3.6 Ensure bogus ICMP responses are ignored (Automated)
   - id: 6088
-    title: "Ensure bogus ICMP responses are ignored"
+    title: "Ensure bogus ICMP responses are ignored."
     description: "Setting icmp_ignore_bogus_error_responses to 1 prevents the kernel from logging bogus responses (RFC-1122 non-compliant) from broadcast reframes, keeping file systems from filling up with useless log messages."
     rationale: "Some routers (and some attackers) will send responses that violate RFC-1122 and attempt to fill up a log file system with many useless error messages."
     remediation: "Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.icmp_ignore_bogus_error_responses = 1 and set the active kernel parameters: # sysctl -w net.ipv4.icmp_ignore_bogus_error_responses=1      # sysctl -w net.ipv4.route.flush=1"
@@ -1758,7 +1761,7 @@ checks:
 
 # 3.3.7 Ensure Reverse Path Filtering is enabled (Automated)
   - id: 6089
-    title: "Ensure Reverse Path Filtering is enabled"
+    title: "Ensure Reverse Path Filtering is enabled."
     description: "Setting net.ipv4.conf.all.rp_filter and net.ipv4.conf.default.rp_filter to 1 forces the Linux kernel to utilize reverse path filtering on a received packet to determine if the packet was valid. Essentially, with reverse path filtering, if the return packet does not go out the same interface that the corresponding source packet came from, the packet is dropped (and logged if log_martians is set)."
     rationale: "Setting these flags is a good way to deter attackers from sending your server bogus packets that cannot be responded to. One instance where this feature breaks down is if asymmetrical routing is employed. This would occur when using dynamic routing protocols (bgp, ospf, etc) on your system. If you are using asymmetrical routing on your system, you will not be able to enable this feature without breaking the routing."
     remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.rp_filter = 1; net.ipv4.conf.default.rp_filter = 1 and set the active kernel parameters:   # sysctl -w net.ipv4.conf.all.rp_filter=1         # sysctl -w net.ipv4.conf.default.rp_filter=1         # sysctl -w net.ipv4.route.flush=1"
@@ -1778,7 +1781,7 @@ checks:
 
 # 3.3.8 Ensure TCP SYN Cookies is enabled (Automated)
   - id: 6090
-    title: "Ensure TCP SYN Cookies is enabled"
+    title: "Ensure TCP SYN Cookies is enabled."
     description: "When tcp_syncookies is set, the kernel will handle TCP SYN packets normally until the half-open connection queue is full, at which time, the SYN cookie functionality kicks in. SYN cookies work by not using the SYN queue at all. Instead, the kernel simply replies to the SYN with a SYN|ACK, but will include a specially crafted TCP sequence number that encodes the source and destination IP address and port number and the time the packet was sent."
     rationale: "Attackers use SYN flood attacks to perform a denial of service attacked on a system by sending many SYN packets without completing the three way handshake. This will quickly use up slots in the kernel's half-open connection queue and prevent legitimate connections from succeeding. SYN cookies allow the system to keep accepting valid connections, even if under a denial of service attack."
     remediation: "Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.tcp_syncookies = 1 and set the active kernel parameters: # sysctl -w net.ipv4.tcp_syncookies=1     # sysctl -w net.ipv4.route.flush=1"
@@ -1796,7 +1799,7 @@ checks:
 
 # 3.3.9 Ensure IPv6 router advertisements are not accepted (Automated)
   - id: 6091
-    title: "Ensure IPv6 router advertisements are not accepted"
+    title: "Ensure IPv6 router advertisements are not accepted."
     description: "This setting disables the system's ability to accept IPv6 router advertisements."
     rationale: "It is recommended that systems not accept router advertisements as they could be tricked into routing traffic to compromised machines. Setting hard routes within the system (usually a single default route to a trusted router) protects the system from bad routes."
     remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file:       net.ipv6.conf.all.accept_ra = 0        and          net.ipv6.conf.default.accept_ra = 0            Then, run the following commands to set the active kernel parameters:  # sysctl -w net.ipv6.conf.all.accept_ra=0              # sysctl -w net.ipv6.conf.default.accept_ra=0           # sysctl -w net.ipv6.route.flush=1"
@@ -1824,7 +1827,7 @@ checks:
 
 # 3.4.1 Ensure DCCP is disabled (Automated)
   - id: 6092
-    title: "Ensure DCCP is disabled"
+    title: "Ensure DCCP is disabled."
     description: "The Datagram Congestion Control Protocol (DCCP) is a transport layer protocol that supports streaming media and telephony. DCCP provides a way to gain access to congestion control, without having to do it at the application layer, but does not provide in-sequence delivery."
     rationale: "If the protocol is not required, it is recommended that the drivers not be installed to reduce the potential attack surface."
     remediation: "Edit or create the file /etc/modprobe.d/CIS.conf and add the following line: install dccp /bin/true"
@@ -1845,7 +1848,7 @@ checks:
 
 # 3.4.2 Ensure SCTP is disabled (Automated)
   - id: 6093
-    title: "Ensure SCTP is disabled"
+    title: "Ensure SCTP is disabled."
     description: "The Stream Control Transmission Protocol (SCTP) is a transport layer protocol used to support message oriented communication, with several streams of messages in one connection. It serves a similar function as TCP and UDP, incorporating features of both. It is message-oriented like UDP, and ensures reliable in-sequence transport of messages with congestion control like TCP."
     rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
     remediation: "Edit or create the file /etc/modprobe.d/CIS.conf and add the following line: install sctp /bin/true"
@@ -1877,7 +1880,7 @@ checks:
 # 3.5.3.1.1 Ensure iptables packages are installed (Automated)
 # 3 rules here:
   - id: 6094
-    title: "Ensure FirewallD or nftables or iptables-services is installed"
+    title: "Ensure FirewallD or nftables or iptables-services is installed."
     description: "firewalld is a firewall management tool for Linux operating systems. It provides firewall features by acting as a front-end for the Linux kernel's net filter framework via the iptables backend or provides firewall features by acting as a front-end for the Linux kernel's netfilter framework via the nftables utility. FirewallD replaces iptables as the default firewall management tool. Use the firewalld utility to configure a firewall for less complex firewalls. The utility is easy to use and covers the typical use cases scenario. FirewallD supports both IPv4 and IPv6 networks and can administer separate firewall zones with varying degrees of trust as defined in zone profiles."
     rationale: "A firewall utility is required to configure the Linux kernel's netfilter framework via the iptables or nftables back-end. The Linux kernel's netfilter framework host-based firewall can protect against threats originating from within a corporate network to include malicious mobile code and poorly configured software on a host."
     remediation: "Run the following command to install firewalld: # yum install firewalld iptables; OR to  install nftables: # yum install nftables; OR to install  iptables-services: # yum install iptables-services iptables"
@@ -1897,7 +1900,7 @@ checks:
 # 3.5.3.1.3 Ensure firewalld is not installed or stopped and masked(Automated)
 # both of the rules are here
   - id: 6095
-    title: "Ensure iptables-services and FirewallD are not installed at the same time"
+    title: "Ensure iptables-services and FirewallD are not installed at the same time."
     description: "The iptables-services package contains the iptables.service and ip6tables.service. These services allow for management of the Host Based Firewall provided by the iptables package."
     rationale: "iptables.service and ip6tables.service are still supported and can be installed with the iptables-services package. Running both firewalld and the services included in the iptables-services package may lead to conflict."
     remediation: "Run the following commands to stop the services included in the iptables-services package and remove the iptables-services package: # systemctl stop iptables; # systemctl stop ip6tables; # yum remove iptables-services. OR Run the following command to remove firewalld: # yum remove firewalld OR Run the following command to stop and mask firewalld: # systemctl --now mask firewalld"
@@ -1916,7 +1919,7 @@ checks:
 # 3.5.2.2 Ensure firewalld is not installed or stopped and masked (Automated)
 # Both of the rules are here
   - id: 6096
-    title: "Ensure nftables and FirewallD are not installed at the same time or ensure one of them is stopped and masked"
+    title: "Ensure nftables and FirewallD are not installed at the same time or ensure one of them is stopped and masked."
     description: "nftables is a subsystem of the Linux kernel providing filtering and classification of network packets/datagrams/frames and is the successor to iptables.Note: Support for using nftables as the back-end for firewalld was added in release v0.6.0. In Fedora 19 Linux derivatives, firewalld utilizes iptables as its back-end by default."
     rationale: "Running both firewalld and nftables may lead to conflict."
     remediation: "Run the following command to remove nftables:# yum remove nftables; OR run the following command to stop and mask nftables: # systemctl --now mask nftables. OR Run the following command to remove firewalld: # yum remove firewalld OR Run the following command to stop and mask firewalld: # systemctl --now mask firewalld"
@@ -1934,7 +1937,7 @@ checks:
 # 3.5.3.1.2 Ensure nftables is not installed (Automated)
 # Both of the rules are here
   - id: 6097
-    title: "Ensure nftables and iptables-services are not installed at the same time or ensure one of them is stopped and masked"
+    title: "Ensure nftables and iptables-services are not installed at the same time or ensure one of them is stopped and masked."
     description: "nftables is a subsystem of the Linux kernel providing filtering and classification of network packets/datagrams/frames and is the successor to iptables.Note: Support for using nftables as the back-end for firewalld was added in release v0.6.0. In Fedora 19 Linux derivatives, firewalld utilizes iptables as its back-end by default."
     rationale: "Running both nftables and nftables may lead to conflict."
     remediation: "Run the following command to remove nftables:# yum remove nftables; OR run the following command to stop and mask nftables: # systemctl --now mask nftables. OR Run the following command to remove iptables# # systemctl stop iptables; # systemctl stop ip6tables; # yum remove iptables-services"
@@ -1952,7 +1955,7 @@ checks:
 
 # 3.5.1.4 Ensure firewalld service is enabled and running (Automated)
   - id: 6098
-    title: "Ensure firewalld service is enabled and running"
+    title: "Ensure firewalld service is enabled and running."
     description: "firewalld.serviceenables the enforcement of firewall rules configured through firewalld"
     rationale: "Ensure that the firewalld.service is enabled and running to enforce firewall rules configured through firewalld"
     remediation: "Run the following command to unmask firewalld: # systemctl unmask firewalld; Run the following command to enable and start firewalld: # systemctl --now enable firewalld"
@@ -1982,7 +1985,7 @@ checks:
 
 # 3.5.2.5 Ensure a table exists (Automated)
   - id: 6099
-    title: "Ensure a table exists"
+    title: "Ensure a table exists."
     description: "nTables hold chains. Each table only has one address family and only applies to packets of this family. Tables can have one of five families."
     rationale: "nftables doesn't have any default tables. Without a table being build, nftables will not filter network traffic."
     remediation: "Run the following command to create a table in nftables: # nft create table inet <table name>"
@@ -1998,7 +2001,7 @@ checks:
 
 # 3.5.2.6 Ensure base chains exist (Automated)
   - id: 6100
-    title: "Ensure base chains exist"
+    title: "Ensure base chains exist."
     description: "Chains are containers for rules. They exist in two kinds, base chains and regular chains. A base chain is an entry point for packets from the networking stack, a regular chain may be used as jump target and is used for better rule organization."
     rationale: "If a base chain doesn't exist with a hook for input, forward, and delete, packets that would flow through those chains will not be touched by nftables."
     remediation: "Run the following command to create the base chains: # nft createchain inet <table name> <base chain name> { type filter hook <(input|forward|output)> priority 0 \\; } "
@@ -2016,7 +2019,7 @@ checks:
 
 # 3.5.2.7 Ensure loopback traffic is configured (Automated)
   - id: 6101
-    title: "Ensure loopback traffic is configured"
+    title: "Ensure loopback traffic is configured."
     description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network"
     rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure."
     remediation: "Run the following commands to implement the loopback rules: # nft add rule inet filter input iif lo accept;   # nft create rule inet filter input ip saddr 127.0.0.0/8 counter drop; IF IPv6 is enabled: run the following command to implement the IPv6 loopback rules: # nft add rule inet filter input ip6 saddr::1 counter drop"
@@ -2033,7 +2036,7 @@ checks:
 
 # 3.5.2.8 Ensure outbound and established connections are configured (Manual)
   - id: 6102
-    title: "Ensure outbound and established connections are configured"
+    title: "Ensure outbound and established connections are configured."
     description: "Configure the firewall rules for new outbound and established connections."
     rationale: "If rules are not in place for new outbound and established connections, all packets will be dropped by the default policy preventing network usage."
     remediation: "Configure nftables in accordance with site policy. The following commands will implement a policy to allow all outbound connections and all established connections: # nft add rule inet filter input ip protocol tcp ct state established accept; # nft add rule inet filter input ip protocol udp ct state established accept;  # nft add rule inet filter input ip protocol icmp ct state established accept;  # nft add rule inet filter output ip protocol tcp ct state new,related,established accept;  # nft add rule inet filter output ip protocol udp ct state new,related,established accept;   # nft add rule inet filter output ip protocol icmp ct state new,related,established accept"
@@ -2054,7 +2057,7 @@ checks:
 
 # 3.5.2.9 Ensure default deny firewall policy (Automated)
   - id: 6103
-    title: "Ensure default deny firewall policy"
+    title: "Ensure default deny firewall policy."
     description: "Base chain policy is the default verdict that will be applied to packets reaching the end of the chain."
     rationale: "There are two policies: accept (Default) and drop. If the policy is set to accept, the firewall will accept any packet that is not configured to be denied and the packet will continue traversing the network stack. It is easier to white list acceptable usage than to black list unacceptable usage."
     remediation: "Run the following command for the base chains with the input, forward, and output hooks to implement a default DROP policy: # nft chain <table family> <table name> <chain name> { policy drop \\; }"
@@ -2072,7 +2075,7 @@ checks:
 
 # 3.5.2.10 Ensure nftables service is enabled (Automated)
   - id: 6104
-    title: "Ensure nftables service is enabled"
+    title: "Ensure nftables service is enabled."
     description: "The nftables service allows for the loading of nftables rulesets during boot, or starting on the nftables service"
     rationale: "The nftables service restores the nftables rules from the rules files referenced in the /etc/sysconfig/nftables.conffile during boot or the starting of the nftables service"
     remediation: "Run the following command to enable the nftables service: # systemctl enable nftables"
@@ -2089,7 +2092,7 @@ checks:
 
 # 3.5.2.11 Ensure nftables rules are permanent (Automated)
   - id: 6105
-    title: "Ensure nftables rules are permanent"
+    title: "Ensure nftables rules are permanent."
     description: "nftables is a subsystem of the Linux kernel providing filtering and classification of network packets/datagrams/frames. The nftables service reads the /etc/sysconfig/nftables.conffile for a nftables file or files to include in the nftables ruleset. A nftables ruleset containing the input, forward, and output base chains allow network traffic to be filtered."
     remediation: "Run the following command to enable the nftables service: # systemctl enable nftables"
     rationale: "Changes made to nftables ruleset only affect the live system, you will also need to configure the nftables ruleset to apply on boot"
@@ -2114,7 +2117,7 @@ checks:
 
 # 3.5.3.2.1 Ensure default deny firewall policy (Automated)
   - id: 6106
-    title: "Ensure default deny firewall policy"
+    title: "Ensure default deny firewall policy."
     description: "A default deny all policy on connections ensures that any unconfigured network usage will be rejected."
     rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage."
     remediation: "Run the following commands to implement a default DROP policy: # iptables -P INPUT DROP   # iptables -P OUTPUT DROP      # iptables -P FORWARD DROP"
@@ -2132,7 +2135,7 @@ checks:
 
 # 3.5.3.2.2 Ensure loopback traffic is configured (Automated)
   - id: 6107
-    title: "Ensure loopback traffic is configured"
+    title: "Ensure loopback traffic is configured."
     description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network (127.0.0.0/8)."
     rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network (127.0.0.0/8) traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure."
     remediation: "Run the following commands to implement the loopback rules: # iptables -A INPUT -i lo -j ACCEPT     # iptables -A OUTPUT -o lo -j ACCEPT           # iptables -A INPUT -s 127.0.0.0/8 -j DROP"
@@ -2156,7 +2159,7 @@ checks:
 
 # 3.5.3.2.6 Ensure iptables is enabled and running (Automated)
   - id: 6108
-    title: "Ensure iptables is enabled and running"
+    title: "Ensure iptables is enabled and running."
     description: "iptables.service is a utility for configuring and maintaining iptables."
     rationale: "iptables.service willload the iptables rules saved in the file /etc/sysconfig/iptablesat boot, otherwise the iptables rules will be cleared during a re-boot of the system."
     remediation: "Run the following commands to implement a default DROP policy: # ip6tables -P INPUT DROP; # ip6tables -P OUTPUT DROP; # ip6tables -PFORWARD DROP"
@@ -2178,7 +2181,7 @@ checks:
 
 # 3.5.3.3.1 Ensure IPv6 default deny firewall policy (Automated)
   - id: 6109
-    title: "Ensure IPv6 default deny firewall policy"
+    title: "Ensure IPv6 default deny firewall policy."
     description: "A default deny all policy on connections ensures that any unconfigured network usage will be rejected."
     rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage."
     remediation: "Run the following commands to implement a default DROP policy: # ip6tables -P INPUT DROP; # ip6tables -P OUTPUT DROP; # ip6tables -PFORWARD DROP"
@@ -2196,7 +2199,7 @@ checks:
 
 # 3.5.3.3.2 Ensure IPv6 loopback traffic is configured (Automated)
   - id: 6110
-    title: "Ensure IPv6 loopback traffic is configured"
+    title: "Ensure IPv6 loopback traffic is configured."
     description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic tothe loopback network (::1)."
     rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network (::1) traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure"
     remediation: "Run the following commands to implement the loopback rules:# ip6tables -A INPUT -i lo -j ACCEPT# ip6tables -A OUTPUT -o lo -j ACCEPT# ip6tables -A INPUT -s::1 -j DROP"
@@ -2214,7 +2217,7 @@ checks:
 
 # 3.5.3.3.3 Ensure IPv6 outbound and established connections are configured (Manual)
   - id: 6111
-    title: "Ensure IPv6 outbound and established connections are configured"
+    title: "Ensure IPv6 outbound and established connections are configured."
     description: "Configure the firewall rules for new outbound, and established IPv6 connections."
     rationale: "If rules are not in place for new outbound, and established connections all packets will be dropped by the default policy preventing network usage"
     remediation: "Configure iptables in accordance with site policy. The following commands will implement a policy to allow all outbound connections and all established connections:# ip6tables -AOUTPUT -p tcp -m state --state NEW,ESTABLISHED -j ACCEPT# ip6tables -A OUTPUT -p udp -m state --state NEW,ESTABLISHED -j ACCEPT# ip6tables -A OUTPUT -p icmp -m state --state NEW,ESTABLISHED -j ACCEPT# ip6tables -A INPUT -p tcp -m state --state ESTABLISHED -j ACCEPT# ip6tables -A INPUT -p udp -m state --state ESTABLISHED -j ACCEPT# ip6tables -A INPUT -p icmp -m state --state ESTABLISHED -j ACCEPT"
@@ -2235,7 +2238,7 @@ checks:
 
 # 3.5.3.3.6 Ensure ip6tables is enabled and running (Automated)
   - id: 6112
-    title: "Ensure ip6tables is enabled and running"
+    title: "Ensure ip6tables is enabled and running."
     description: "ip6tables.service is a utility for configuring and maintaining ip6tables."
     rationale: "ip6tables.service will load the iptables rules saved in the file /etc/sysconfig/ip6tables at boot, otherwise the ip6tables rules will be cleared during a re-boot of the system."
     remediation: "Run the following command to enable and start ip6tables: # systemctl --now start ip6tables"
@@ -2260,7 +2263,7 @@ checks:
 
 # 4.1.1.1 Ensure auditd is installed
   - id: 6113
-    title: "Ensure auditd is installed"
+    title: "Ensure auditd is installed."
     description: "auditd is the userspace component to the Linux Auditing System. It's responsible for writing audit records to the disk."
     rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
     remediation: "Run the following command to Install auditd  # yum install audit audit-libs"
@@ -2277,7 +2280,7 @@ checks:
 
 # 4.1.1.2 Ensure auditd service is enabled (Scored)
   - id: 6114
-    title: "Ensure auditd service is enabled and running"
+    title: "Ensure auditd service is enabled and running."
     description: "Turn on the auditd daemon to record system events."
     rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
     remediation: "Run the following command to enable auditd: # systemctl --now enable auditd"
@@ -2294,7 +2297,7 @@ checks:
 
 # 4.1.1.3 Ensure auditing for processes that start prior to auditd is enabled (Scored)
   - id: 6115
-    title: "Ensure auditing for processes that start prior to auditd is enabled"
+    title: "Ensure auditing for processes that start prior to auditd is enabled."
     description: "Configure grub so that processes that are capable of being audited can be audited even if they start up prior to auditd startup."
     rationale: "Audit events need to be captured on processes that start up prior to auditd, so that potential malicious activity cannot go undetected. Note: This recommendation is designed around the grub2 bootloader, if LILO or another bootloader is in use in your environment enact equivalent settings."
     remediation: "Edit /etc/default/grub and add audit=1 to GRUB_CMDLINE_LINUX: GRUB_CMDLINE_LINUX=\"audit=1\" . Run the following command to update the grub2 configuration: # grub2-mkconfig -o /boot/grub2/grub.cfg"
@@ -2312,7 +2315,7 @@ checks:
 
 # 4.1.2.1 Ensure audit log storage size is configured (Not Scored)
   - id: 6116
-    title: "Ensure audit log storage size is configured"
+    title: "Ensure audit log storage size is configured."
     description: "Configure the maximum size of the audit log file. Once the log reaches the maximum size, it will be rotated and a new log file will be started."
     rationale: "It is important that an appropriate size is determined for log files so that they do not impact the system and audit data is not lost."
     remediation: "Set the following parameter in /etc/audit/auditd.conf in accordance with site policy: max_log_file = <MB>"
@@ -2327,7 +2330,7 @@ checks:
 
 # 4.1.2.2 Ensure audit logs are not automatically deleted (Scored)
   - id: 6117
-    title: "Ensure audit logs are not automatically deleted"
+    title: "Ensure audit logs are not automatically deleted."
     description: "The max_log_file_action setting determines how to handle the audit log file reaching the max file size. A value of keep_logs will rotate the logs but never delete old logs."
     rationale: "In high security contexts, the benefits of maintaining a long audit history exceed the cost of storing the audit history."
     remediation: "Set the following parameter in /etc/audit/auditd.conf: max_log_file_action = keep_logs"
@@ -2342,7 +2345,7 @@ checks:
 
 # 4.1.2.3 Ensure system is disabled when audit logs are full (Scored)
   - id: 6118
-    title: "Ensure system is disabled when audit logs are full"
+    title: "Ensure system is disabled when audit logs are full."
     description: "The auditd daemon can be configured to halt the system when the audit logs are full."
     rationale: "In high security contexts, the risk of detecting unauthorized access or nonrepudiation exceeds the benefit of the system's availability."
     remediation: "Set the following parameters in /etc/audit/auditd.conf: space_left_action = email   action_mail_acct = root   admin_space_left_action = halt"
@@ -2359,7 +2362,7 @@ checks:
 
 # 4.1.2.4 Ensure audit_backlog_limit is sufficient
   - id: 6119
-    title: "Ensure audit_backlog_limit is sufficient"
+    title: "Ensure audit_backlog_limit is sufficient."
     description: "The backlog limit has a default setting of 64"
     rationale: "During boot if audit=1, then the backlog will hold 64 records. If more than 64 records are created during boot, auditd records will be lost and potential malicious activity could go undetected"
     remediation: "Edit /etc/default/grub and add audit_backlog_limit=<BACKLOG SIZE>  to GRUB_CMDLINE_LINUX:   Example:  GRUB_CMDLINE_LINUX=\"audit_backlog_limit=8192\"    Run the following command to update the grub2 configuration: # grub2-mkconfig -o /boot/grub2/grub.cfg"
@@ -2374,7 +2377,7 @@ checks:
 
 # 4.1.3 Ensure events that modify date and time information are collected (Scored)
   - id: 6120
-    title: "Ensure events that modify date and time information are collected"
+    title: "Ensure events that modify date and time information are collected."
     description: "Capture events where the system date and/or time has been modified. The parameters in this section are set to determine if the adjtimex (tune kernel clock), settimeofday (Set time, using timeval and timezone structures) stime (using seconds since 1/1/1970) or clock_settime (allows for the setting of several internal clocks and timers) system calls have been executed and always write an audit record to the /var/log/audit.log file upon exit, tagging the records with the identifier \"time-change\"."
     rationale: "Unexpected changes in system date and/or time could be a sign of malicious activity on the system."
     remediation: "For 32 bit systems edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/time-change.rules and add the following lines: -a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change   -a always,exit -F arch=b32 -S clock_settime -k time-change   -w /etc/localtime -p wa -k time-change   For 64 bit systems edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/time-change.rules and add the following lines:   -a always,exit -F arch=b64 -S adjtimex -S settimeofday -k time-change   -a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change   -a always,exit -F arch=b64 -S clock_settime -k time-change   -a always,exit -Farch=b32 -S clock_settime -k time-change   -w /etc/localtime -p wa -k time-change. Notes: Reloading the auditd config to set active settings may require a system reboot."
@@ -2396,7 +2399,7 @@ checks:
 
 # 4.1.4 Ensure events that modify user/group information are collected (Scored)
   - id: 6121
-    title: "Ensure events that modify user/group information are collected"
+    title: "Ensure events that modify user/group information are collected."
     description: "Record events affecting the group, passwd (user IDs), shadow and gshadow (passwords) or /etc/security/opasswd (old passwords, based on remember parameter in the PAM configuration) files. The parameters in this section will watch the files to see if they have been opened for write or have had attribute changes (e.g. permissions) and tag them with the identifier \"identity\" in the audit log file."
     rationale: "Unexpected changes to these files could be an indication that the system has been compromised and that an unauthorized user is attempting to hide their activities or compromise additional accounts."
     remediation: "Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/identity.rules and add the following lines:    -w /etc/group -p wa -k identity    -w /etc/passwd -p wa -k identity    -w /etc/gshadow -p wa -k identity    -w /etc/shadow -p wa -k identity    -w /etc/security/opasswd -p wa -k identity. Notes: Reloading the auditd config to set active settings may require a system reboot."
@@ -2420,7 +2423,7 @@ checks:
 
 # 4.1.5 Ensure events that modify the system's network environment are collected (Scored)
   - id: 6122
-    title: "Ensure events that modify the system's network environment are collected"
+    title: "Ensure events that modify the system's network environment are collected."
     description: "Record changes to network environment files or system calls. The below parameters monitor the sethostname (set the systems host name) or setdomainname (set the systems domainname) system calls, and write an audit event on system call exit. The other parameters monitor the /etc/issue and /etc/issue.net files (messages displayed pre-login), /etc/hosts (file containing host names and associated IP addresses), /etc/sysconfig/network file and /etc/sysconfig/network-scripts/ directory (containing network interface scripts and configurations)."
     rationale: "Monitoring sethostname and setdomainname will identify potential unauthorized changes to host and domainname of a system. The changing of these names could potentially break security parameters that are set based on those names. The /etc/hosts file is monitored for changes in the file that can indicate an unauthorized intruder is trying to change machine associations with IP addresses and trick users and processes into connecting to unintended machines. Monitoring /etc/issue and /etc/issue.net is important, as intruders could put disinformation into those files and trick users into providing information to the intruder. Monitoring /etc/sysconfig/network and /etc/sysconfig/network-scripts/ is important as it can show if network interfaces or scripts are being modified in a way that can lead to the machine becoming unavailable or compromised. All audit records will be tagged with the identifier \"system-locale.\""
     remediation: "For 32 bit systems edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/system-locale.rules and add the following lines:    -a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale    -w /etc/issue -p wa -k system-locale    -w /etc/issue.net -p wa -k system-locale    -w /etc/hosts -p wa -k system-locale    -w /etc/sysconfig/network -p wa -k system-locale            For 64 bit systems edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/system-locale.rules and add the following lines:    -a always,exit -F arch=b64 -S sethostname -S setdomainname -k system-locale    -a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale    -w /etc/issue -p wa -k system-locale    -w /etc/issue.net -p wa -k system-locale    -w /etc/hosts -p wa -k system-locale    -w /etc/sysconfig/network -p wa -k system-locale "
@@ -2445,7 +2448,7 @@ checks:
 
 # 4.1.6 Ensure events that modify the system's Mandatory Access Controls are collected (Scored)
   - id: 6123
-    title: "Ensure events that modify the system's Mandatory Access Controls are collected"
+    title: "Ensure events that modify the system's Mandatory Access Controls are collected."
     description: "Monitor SELinux mandatory access controls. The parameters below monitor any write access (potential additional, deletion or modification of files in the directory) or attribute changes to  the /etc/selinux/ and /usr/share/selinux/ directories."
     rationale: "Changes to files in the /etc/selinux/ and /usr/share/selinux/ directories could indicate that an unauthorized user is attempting to modify access controls and change security contexts, leading to a compromise of the system."
     remediation: "Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/MAC-policy.rules and add the following lines: -w /etc/selinux/ -p wa -k MAC-policy -w /usr/share/selinux/ -p wa -k MAC-policy ."
@@ -2466,7 +2469,7 @@ checks:
 
 # 4.1.7 Ensure login and logout events are collected (Scored)
   - id: 6124
-    title: "Ensure login and logout events are collected"
+    title: "Ensure login and logout events are collected."
     description: "Monitor login and logout events. The parameters below track changes to files associated with login/logout events. The file /var/log/faillog tracks failed events from login. The file /var/log/lastlog maintain records of the last time a user successfully logged in. The /var/run/faillock/ directory maintains records of login failures via the pam_faillock module. The file /var/log/tallylog maintains records of failures via the pam_tally2 module"
     rationale: "Monitoring login/logout events could provide a system administrator with information associated with brute force attacks against user logins."
     remediation: "Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/logins.rules and add the following lines:  -w /var/log/lastlog -p wa -k logins   -w /var/run/faillog/ -p wa -k logins   IF   the pam_faillock.so module is used: Also include the line:  -w /var/run/faillock/ -p wa -k logins   OR IF the pam_tally2.so module is used: Also include the line:  -w /var/log/tallylog -p wa -k logins"
@@ -2487,7 +2490,7 @@ checks:
 
 # 4.1.8 Ensure session initiation information is collected (Scored)
   - id: 6125
-    title: "Ensure session initiation information is collected"
+    title: "Ensure session initiation information is collected."
     description: "Monitor session initiation events. The parameters in this section track changes to the files associated with session events. The file /var/run/utmp file tracks all currently logged in users. All audit records will be tagged with the identifier \"session.\" The /var/log/wtmp file tracks logins, logouts, shutdown, and reboot events. The file /var/log/btmp keeps track of failed login attempts and can be read by entering the command /usr/bin/last -f /var/log/btmp . All audit records will be tagged with the identifier \"logins.\"."
     rationale: "Monitoring these files for changes could alert a system administrator to logins occurring at unusual hours, which could indicate intruder activity (i.e. a user logging in at a time when they do not normally log in)."
     remediation: "Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/logins.rules and add the following lines:   -w /var/run/utmp -p wa -k session   -w /var/log/wtmp -p wa -k logins   -w /var/log/btmp -p wa -k logins . Notes: The last command can be used to read /var/log/wtmp ( last with no parameters) and /var/run/utmp ( last -f /var/run/utmp ) Reloading the auditd config to set active settings may require a system reboot."
@@ -2504,7 +2507,7 @@ checks:
 
 # 4.1.9 Ensure discretionary access control permission modification events are collected (Scored)
   - id: 6126
-    title: "Ensure discretionary access control permission modification events are collected"
+    title: "Ensure discretionary access control permission modification events are collected."
     description: "Monitor changes to file permissions, attributes, ownership and group. The parameters in this section track changes for system calls that affect file permissions and attributes. The chmod, fchmod and fchmodat system calls affect the permissions associated with a file. The chown, fchown, fchownat and lchown system calls affect owner and group attributes on a file. The setxattr, lsetxattr, fsetxattr (set extended file attributes) and removexattr, lremovexattr, fremovexattr (remove extended file attributes) control extended file attributes. In all cases, an audit record will only be written for non-system user ids (auid >= 1000) and will ignore Daemon events (auid = 4294967295). All audit records will be tagged with the identifier \"perm_mod.\""
     rationale: "Monitoring for changes in file attributes could alert a system administrator to activity that could indicate intruder activity or policy violation."
     remediation: "For 32 bit systems edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/perm_mod.rules and add the following lines:   -a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod   -a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod   -a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod   For 64 bit systems edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/perm_mod.rules and add the following lines:   -a always,exit -F arch=b64 -S chmod -S fchmod -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod   -a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod   -a always,exit -F arch=b64 -S chown -S fchown -S fchownat -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod   -a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod   -a always,exit -F arch=b64 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod   -a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lrem . Notes: Reloading the auditd config to set active settings may require a system reboot."
@@ -2526,7 +2529,7 @@ checks:
 
 # 4.1.10 Ensure unsuccessful unauthorized file access attempts are collected (Scored)
   - id: 6127
-    title: "Ensure unsuccessful unauthorized file access attempts are collected"
+    title: "Ensure unsuccessful unauthorized file access attempts are collected."
     description: "Monitor for unsuccessful attempts to access files. The parameters below are associated  with system calls that control creation ( creat ), opening ( open, openat ) and truncation (  truncate, ftruncate ) of files. An audit log record will only be written if the user is a non-  privileged user (auid > = 1000), is not a Daemon event (auid=4294967295) and if the  system call returned EACCES (permission denied to the file) or EPERM (some other  permanent error associated with the specific system call). All audit records will be tagged  with the identifier \"access.\""
     rationale: "Failed attempts to open, create or truncate files could be an indication that an individual or process is trying to gain unauthorized access to the system."
     remediation: "For 32 bit systems edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/access.rules and add the following lines:   -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access   -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access   For 64 bit systems edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/access.rules and add the following lines:   -a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access   -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access   -a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access   -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access . Notes: Reloading the auditd config to set active settings may require a system reboot."
@@ -2549,7 +2552,7 @@ checks:
 
 # 4.1.12 Ensure successful file system mounts are collected (Scored)
   - id: 6128
-    title: "Ensure successful file system mounts are collected"
+    title: "Ensure successful file system mounts are collected."
     description: "Monitor the use of the mount system call. The mount (and umount ) system call controls the mounting and unmounting of file systems. The parameters below configure the system to create an audit record when the mount system call is used by a non-privileged user."
     rationale: "It is highly unusual for a non privileged user to mount file systems to the system. While tracking mount commands gives the system administrator evidence that external media may have been mounted (based on a review of the source of the mount and confirming it's an external media type), it does not conclusively indicate that data was exported to the media. System administrators who wish to determine if data were exported, would also have to track successful open, creat and truncate system calls requiring write access to a file under the mount point of the external media file system. This could give a fair indication that a write occurred. The only way to truly prove it, would be to track successful writes to the external media. Tracking write system calls could quickly fill up the audit log and is not recommended. Recommendations on configuration options to track data export to media is beyond the scope of this document."
     remediation: "For 32 bit systems edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/mount.rules and add the following lines:   -a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts   For 64 bit systems edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/mounts.rules and add the following lines:   -a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts   -a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts . Notes: This tracks successful and unsuccessful mount commands. File system mounts do not have to come from external media and this action still does not verify write (e.g. CD ROMS). Reloading the auditd config to set active settings may require a system reboot."
@@ -2569,7 +2572,7 @@ checks:
 
 # 4.1.13 Ensure file deletion events by users are collected (Scored)
   - id: 6129
-    title: "Ensure file deletion events by users are collected"
+    title: "Ensure file deletion events by users are collected."
     description: "Monitor the use of system calls associated with the deletion or renaming of files and file attributes. This configuration statement sets up monitoring for ollowing system calls and tags them with the identifier \"delete\": unlink -remove a file     unlinkat - remove a file attribute), rename (rename a file and renameat - rename a file attribute."
     rationale: "Monitoring these calls from non-privileged users could provide a system administrator with evidence that inappropriate removal of files and file attributes associated with protected files is occurring. While this audit option will look at all events, system administrators will want to look for specific privileged files that are being deleted or altered."
     remediation: "For 32 bit systems edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/delete.rules and add the following lines:   -a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete   For 64 bit systems edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/delete.rules and add the following lines:   -a always,exit -F arch=b64 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete   -a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete . Notes: At a minimum, configure the audit system to collect file deletion events for all users and root. Reloading the auditd config to set active settings may require a system reboot."
@@ -2585,7 +2588,7 @@ checks:
 
 # 4.1.14 Ensure changes to system administration scope (sudoers) is collected (Scored)
   - id: 6130
-    title: "Ensure changes to system administration scope (sudoers) is collected"
+    title: "Ensure changes to system administration scope (sudoers) is collected."
     description: "Monitor scope changes for system administrators. If the system has been properly configured to force system administrators to log in as themselves first and then use the sudo command to execute privileged commands, it is possible to monitor changes in scope. The file /etc/sudoers or a file in the /etc/sudoers.d directory will be written to when the file or its attributes have changed."
     rationale: "Changes in the /etc/sudoers file, or a file in the /etc/sudoers.d/ directory can indicate that an unauthorized change has been made to scope of system administrator activity."
     remediation: "Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/scope.rules and add the following lines::   -w /etc/sudoers -p wa -k scope   -w /etc/sudoers.d/ -p wa -k scope . Notes: Reloading the auditd config to set active settings may require a system reboot."
@@ -2606,7 +2609,7 @@ checks:
 
 # 4.1.15 Ensure system administrator actions (sudolog) are collected (Scored)
   - id: 6131
-    title: "Ensure system administrator actions (sudolog) are collected"
+    title: "Ensure system administrator actions (sudolog) are collected."
     description: "Monitor the sudo log file. The sudo log file is configured in /etc/sudoersor a file in /etc/sudoers.d. If the system has been properly configured to disable the use of the su command and force all administrators to have to log in first and then use sudo to execute privileged commands, then all administrator commands will be logged to the sudo log file. Any time a command is executed, an audit event will be triggered as the sudo log file will be opened for write and the executed administration command will be written to the log."
     rationale: "Changes in /var/log/sudo.log indicate that an administrator has executed a command or the log file itself has been tampered with. Administrators will want to correlate the events written to the audit trail with the records written to /var/log/sudo.log to verify if unauthorized commands have been executed."
     remediation: "Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules . Example: vi /etc/audit/rules.d/action.rules and add the following lines:   -w /var/log/sudo.log -p wa -k actions ."
@@ -2626,7 +2629,7 @@ checks:
 
 # 4.1.16 Ensure kernel module loading and unloading is collected (Scored)
   - id: 6132
-    title: "Ensure kernel module loading and unloading is collected"
+    title: "Ensure kernel module loading and unloading is collected."
     description: "Monitor the loading and unloading of kernel modules. The programs insmod (install a kernel module), rmmod (remove a kernel module), and modprobe (a more sophisticated program to load and unload modules, as well as some other features) control loading and unloading of modules. The init_module (load a module) and delete_module (delete a module) system calls control loading and unloading of modules. Any execution of the loading and unloading module programs and system calls will trigger an audit record with an identifier of \"modules\"."
     rationale: "Monitoring the use of insmod, rmmod and modprobe could provide system administrators with evidence that an unauthorized user loaded or unloaded a kernel module, possibly compromising the security of the system. Monitoring of the init_module and delete_module system calls would reflect an unauthorized user attempting to use a different program to load and unload modules."
     remediation: "Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/modules.rules and add the following lines:  -w /sbin/insmod -p x -k modules                   -w /sbin/rmmod -p x -k modules           -w /sbin/modprobe -p x -k modules        -a always,exit -F arch=b32 -S init_module -S delete_module -k modules For 64 bit systems Edit or create a file in the /etc/audit/rules.d/directory ending in .rules  Example: vi /etc/audit/rules.d/modules.rules Add the following lines:             -w /sbin/insmod -p x -k modules              -w /sbin/rmmod -p x -k modules                -w /sbin/modprobe -p x -k modules           -a always,exit -F arch=b64 -S init_module -S delete_module -k modules "
@@ -2649,7 +2652,7 @@ checks:
 
 # 4.1.17 Ensure the audit configuration is immutable (Scored)
   - id: 6133
-    title: "Ensure the audit configuration is immutable"
+    title: "Ensure the audit configuration is immutable."
     description: "Set system audit so that audit rules cannot be modified with auditctl . Setting the flag \"-e 2\" forces audit to be put in immutable mode. Audit changes can only be made on system reboot."
     rationale: "In immutable mode, unauthorized users cannot execute changes to the audit system to potentially hide malicious activity and then put the audit rules back. Users would most likely notice a system reboot and that could alert administrators of an attempt to make unauthorized audit changes."
     remediation: "Edit or create the file /etc/audit/rules.d/99-finalize.rulesand add the following line at the end of the file:  -e 2"
@@ -2670,7 +2673,7 @@ checks:
 
 # 4.2.1.1 Ensure rsyslog is installed (Scored)
   - id: 6134
-    title: "Ensure rsyslog is installed"
+    title: "Ensure rsyslog is installed."
     description: "The rsyslog software is a recommended replacement to the original syslogd daemon. rsyslog provides improvements over syslogd, including:   - connection-oriented (i.e. TCP) transmission of logs     - The option to log to database formats    - Encryption of log data en route to a central logging server"
     rationale: "The security enhancements of rsyslog and syslog-ng such as connection-oriented (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of log data en route to a central logging server) justify installing and configuring the package."
     remediation: "Run the following command to install rsyslog: # yum install rsyslog"
@@ -2686,7 +2689,7 @@ checks:
 
 # 4.2.1.2 Ensure rsyslog Service is enabled (Scored)
   - id: 6135
-    title: "Ensure rsyslog Service is enabled and running"
+    title: "Ensure rsyslog Service is enabled and running."
     description: "rsyslogneeds to be enabled and running to perform logging"
     rationale: "If the rsyslog service is not activated the system may default to the syslogd service or lackblogging instead."
     remediation: "Run the following command to enable rsyslog:   # systemctl --now enable rsyslog"
@@ -2703,7 +2706,7 @@ checks:
 
 # 4.2.1.3 Ensure rsyslog default file permissions configured (Scored)
   - id: 6136
-    title: "Ensure rsyslog default file permissions configured"
+    title: "Ensure rsyslog default file permissions configured."
     description: "rsyslog will create logfiles that do not already exist on the system. This setting controls what permissions will be applied to these newly created files."
     rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitive data is archived and protected."
     remediation: "Edit the /etc/rsyslog.conf and /etc/rsyslog.d/*.conf files and set $FileCreateMode to 0640 or more restrictive:   $FileCreateMode 0640"
@@ -2722,7 +2725,7 @@ checks:
 
 # 4.2.1.5 Ensure rsyslog is configured to send logs to a remote log host (Scored)
   - id: 6137
-    title: "Ensure rsyslog is configured to send logs to a remote log host"
+    title: "Ensure rsyslog is configured to send logs to a remote log host."
     description: "The rsyslog utility supports the ability to send logs it gathers to a remote log host running syslogd(8) or to receive messages from remote hosts, reducing administrative overhead."
     rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
     remediation: "Edit the /etc/rsyslog.conf and /etc/rsyslog.d/*.conf files and add the following line (where loghost.example.com is the name of your central log host).   *.* @@loghost.example.com   Run the following command to reload the rsyslogd configuration: #  systemctl restart rsyslog"
@@ -2745,7 +2748,7 @@ checks:
 
 # 4.2.2.1 Ensure journald is configured to send logs to rsyslog
   - id: 6138
-    title: "Ensure journald is configured to send logs to rsyslog "
+    title: "Ensure journald is configured to send logs to rsyslog ."
     description: "Data from journald may be stored in volatile memory or persisted locally on the server. Utilities exist to accept remote export of journald logs, however, use of the rsyslog service provides a consistent means of log collection and export."
     rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
     remediation: "Edit the /etc/systemd/journald.conf file and add the following line: ForwardToSyslog=yes"
@@ -2761,7 +2764,7 @@ checks:
 
 # 4.2.2.2 Ensure journald is configured to compress large log files
   - id: 6139
-    title: "Ensure journald is configured to compress large log files"
+    title: "Ensure journald is configured to compress large log files."
     description: "The journald system includes the capability of compressing overly large files to avoid filling up the system with logs or making the logs unmanageably large."
     rationale: "Uncompressed large files may unexpectedly fill a filesystem leading to resource unavailability. Compressing logs prior to write can prevent sudden, unexpected filesystem impacts."
     remediation: "Edit the /etc/systemd/journald.conf file and add the following line: Compress=yes"
@@ -2777,7 +2780,7 @@ checks:
 
 # 4.2.2.3 Ensure journald is configured to write logfiles to persistent disk
   - id: 6140
-    title: "Ensure journald is configured to write logfiles to persistent disk"
+    title: "Ensure journald is configured to write logfiles to persistent disk."
     description: "Data from journald may be stored in volatile memory or persisted locally on the server. Logs in memory will be lost upon a system reboot. By persisting logs to local disk on the server they are protected from loss."
     rationale: "Writing log data to disk will provide the ability to forensically reconstruct events which may have impacted the operations or security of a system even after a system crash or reboot."
     remediation: "Edit the /etc/systemd/journald.conf file and add the following line: Storage=persistent"
@@ -2793,7 +2796,7 @@ checks:
 
   # 4.2.3 Ensure permissions on all logfiles are configured (Scored)
   - id: 6141
-    title: "Ensure permissions on all logfiles are configured"
+    title: "Ensure permissions on all logfiles are configured."
     description: "Log files stored in /var/log/ contain logged information from many services on the system, or on log hosts others as well."
     rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitive data is archived and protected.  Other/world should not have the ability to view this information. Group should not have the ability to modify this information."
     remediation: "Run the following command to set permissions on all existing log files: # find /var/log -type f -exec chmod g-wx,o-rwx \"{}\" + -o -type d -exec chmod g-wx,o-rwx \"{}\" +"
@@ -2819,7 +2822,7 @@ checks:
 
 # 5.1.1 Ensure cron daemon is enabled and running (Automated)
   - id: 6142
-    title: "Ensure cron daemon is enabled"
+    title: "Ensure cron daemon is enabled."
     description: "The cron daemon is used to execute batch jobs on the system."
     rationale: "While there may not be user jobs that need to be run on the system, the system does have maintenance jobs that may include security monitoring that have to run, and cron is used to execute them."
     remediation: "Run the following command to enable cron : # systemctl enable crond;   OR run the following command to remove cron: # yum remove cronie"
@@ -2837,7 +2840,7 @@ checks:
 
 # 5.1.2 Ensure permissions on /etc/crontab are configured (Automated)
   - id: 6143
-    title: "Ensure permissions on /etc/crontab are configured"
+    title: "Ensure permissions on /etc/crontab are configured."
     description: "The /etc/crontab file is used by cron to control its own jobs. The commands in this item make sure that root is the user and group owner of the file and that only the owner can access the file."
     rationale: "This file contains information on what system jobs are run by cron. Write access to these files could provide unprivileged users with the ability to elevate their privileges. Read access to these files could provide users with the ability to gain insight on system jobs that run on the system and could provide them a way to gain unauthorized privileged access."
     remediation: "Run the following commands to set ownership and permissions on /etc/crontab : # chown root:root /etc/crontab; # chmod og-rwx /etc/crontab; OR run the following command to remove cron: # yum remove cronie"
@@ -2854,7 +2857,7 @@ checks:
 
 # 5.1.3 Ensure permissions on /etc/cron.hourly are configured (Automated)
   - id: 6144
-    title: "Ensure permissions on /etc/cron.hourly are configured"
+    title: "Ensure permissions on /etc/cron.hourly are configured."
     description: "This directory contains system cron jobs that need to run on an hourly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
     remediation: "Run the following commands to set ownership and permissions on /etc/cron.hourly : chown root:root /etc/cron.hourly; # chmod og-rwx /etc/cron.hourly;     OR run the following command to remove cron: # yum remove cronie"
@@ -2871,7 +2874,7 @@ checks:
 
 # 5.1.4 Ensure permissions on /etc/cron.daily are configured (Automated)
   - id: 6145
-    title: "Ensure permissions on /etc/cron.daily are configured"
+    title: "Ensure permissions on /etc/cron.daily are configured."
     description: "The /etc/cron.daily directory contains system cron jobs that need to run on a daily basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
     remediation: "Run the following commands to set ownership and permissions on /etc/cron.daily : chown root:root /etc/cron.daily; # chmod og-rwx /etc/cron.daily;    OR run the following command to remove cron: # yum remove cronie"
@@ -2888,7 +2891,7 @@ checks:
 
 # 5.1.5 Ensure permissions on /etc/cron.weekly are configured (Automated)
   - id: 6146
-    title: "Ensure permissions on /etc/cron.weekly are configured"
+    title: "Ensure permissions on /etc/cron.weekly are configured."
     description: "The /etc/cron.weekly directory contains system cron jobs that need to run on a weekly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
     remediation: "Run the following commands to set ownership and permissions on /etc/cron.weekly : chown root:root /etc/cron.weekly; # chmod og-rwx /etc/cron.weekly;     OR run the following command to remove cron: # yum remove cronie"
@@ -2905,7 +2908,7 @@ checks:
 
 # 5.1.6 Ensure permissions on /etc/cron.monthly are configured (Automated)
   - id: 6147
-    title: "Ensure permissions on /etc/cron.monthly are configured"
+    title: "Ensure permissions on /etc/cron.monthly are configured."
     description: "The /etc/cron.monthly directory contains system cron jobs that need to run on a monthly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
     remediation: "Run the following commands to set ownership and permissions on /etc/cron.monthly : chown root:root /etc/cron.monthly; # chmod og-rwx /etc/cron.monthly;  OR run the following command to remove cron: # yum remove cronie"
@@ -2922,7 +2925,7 @@ checks:
 
 # 5.1.7 Ensure permissions on /etc/cron.d are configured (Automated)
   - id: 6148
-    title: "Ensure permissions on /etc/cron.d are configured"
+    title: "Ensure permissions on /etc/cron.d are configured."
     description: "The /etc/cron.d/directory contains system cronjobs that need to run in a similar manner to the hourly, daily weekly and monthly jobs from /etc/crontab, but require more granular control as to when they run. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
     remediation: "Run the following commands to set ownership and permissions on /etc/cron.d :   # chown root:root /etc/cron.d;   # chmod og-rwx /etc/cron.d;   OR run the following command to remove cron: # yum remove cronie"
@@ -2939,7 +2942,7 @@ checks:
 
 # 5.1.8 Ensure cron is restricted to authorized users (Scored)
   - id: 6149
-    title: "Ensure cron is restricted to authorized users"
+    title: "Ensure cron is restricted to authorized users."
     description: "If cronis installed in the system, configure /etc/cron.allowto allow specific users to use these services. If /etc/cron.allowdoes not exist, then /etc/cron.denyis checked. Any user not specifically defined in those files is allowed to use cron. By removing the file, only users in /etc/cron.alloware allowed to use cron."
     rationale: "On many systems, only the system administrator is authorized to schedule cronjobs. Using the cron.allowfile to control who can run cronjobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
     remediation: "Run the following commands to remove /etc/cron.deny and /etc/at.deny and create and set permissions and ownership for /etc/cron.allow and /etc/at.allow: rm /etc/cron.deny;rm /etc/at.deny;touch /etc/cron.allow; touch /etc/at.allow; chmod og-rwx /etc/cron.allow; chmod og-rwx /etc/at.allow; chown root:root /etc/cron.allow and chown root:root /etc/at.allow"
@@ -2958,7 +2961,7 @@ checks:
 
 # 5.1.9 Ensure at is restricted to authorized users (Automated)
   - id: 6150
-    title: "Ensure at is restricted to authorized users"
+    title: "Ensure at is restricted to authorized users."
     description: "If atis installed in the system, configure /etc/at.allowto allow specific users to use these services. If /etc/at.allowdoes not exist, then /etc/at.denyis checked. Any user not specifically defined in those files is allowed to use at. By removing the file, only users in /etc/at.alloware allowed to use at."
     rationale: "On many systems, only the system administrator is authorized to schedule atjobs. Using the at.allowfile to control who can run atjobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
     remediation: "Run the following commands to remove /etc/cron.deny and /etc/at.deny and create and set permissions and ownership for /etc/cron.allow and /etc/at.allow: rm /etc/cron.deny;rm /etc/at.deny;touch /etc/cron.allow; touch /etc/at.allow; chmod og-rwx /etc/cron.allow; chmod og-rwx /etc/at.allow; chown root:root /etc/cron.allow and chown root:root /etc/at.allow"
@@ -2981,7 +2984,7 @@ checks:
 
 # 5.2.1 Ensure permissions on /etc/ssh/sshd_config are configured (Automated)
   - id: 6151
-    title: "Ensure permissions on /etc/ssh/sshd_config are configured"
+    title: "Ensure permissions on /etc/ssh/sshd_config are configured."
     description: "The /etc/ssh/sshd_config file contains configuration specifications for sshd. The command below sets the owner and group of the file to root."
     rationale: "The /etc/ssh/sshd_config file needs to be protected from unauthorized changes by non-privileged users."
     remediation: "Run the following commands to set ownership and permissions on /etc/ssh/sshd_config: chown root:root /etc/ssh/sshd_config and chmod og-rwx /etc/ssh/sshd_config"
@@ -2998,7 +3001,7 @@ checks:
 
 # 5.2.2 Ensure permissions on SSH private host key files are configured (Automated)
   - id: 6152
-    title: "Ensure permissions on SSH private host key files are configured"
+    title: "Ensure permissions on SSH private host key files are configured."
     description: "An SSH private key is one of two files used in SSH public key authentication. In this authentication method, The possession of the private key is proof of identity. Only a private key that corresponds to a public key will be able to authenticate successfully. The private keys need to be stored and handled carefully, and no copies of the private key should be distributed."
     rationale: "If an unauthorized user obtains the private SSH host key file, the host could be impersonated"
     remediation: "Run the following commands to set permissions, ownership, and group on the private SSH host key files: # find /etc/ssh -xdev -type f -name 'ssh_host_*_key' -exec chmod u-x,g-wx,o-rwx {} \\;  # find /etc/ssh -xdev -type f -name 'ssh_host_*_key' -exec chown root:ssh_keys {} \\;"
@@ -3017,7 +3020,7 @@ checks:
 
 # 5.2.3 Ensure permissions on SSH public host key files are configured  (Automated)
   - id: 6153
-    title: "Ensure permissions on SSH public host key files are configured"
+    title: "Ensure permissions on SSH public host key files are configured."
     description: "An SSH public key is one of two files used in SSH public key authentication. In this authentication method, a public key is a key that can be used for verifying digital signatures generated using a corresponding private key. Only a public key that corresponds to a private key will be able to authenticate successfully."
     rationale: "If a public host key file is modified by an unauthorized user, the SSH service may be compromised."
     remediation: "Run the following commands to set permissions and ownership on the SSH host public key: # find /etc/ssh -xdev -type f -name 'ssh_host_*_key.pub' -exec chmod u-x,go-wx {} \\;    #find /etc/ssh -xdev -type f -name 'ssh_host_*_key.pub' -exec chown root:root {} \\;"
@@ -3036,7 +3039,7 @@ checks:
 
 # 5.2.4 Ensure SSH access is limited (Scored)
   - id: 6154
-    title: "Ensure SSH access is limited"
+    title: "Ensure SSH access is limited."
     description: "There are several options available to limit which users and group can access the system via SSH. It is recommended that at least one of the following options be leveraged: AllowUsers The AllowUsers variable gives the system administrator the option of allowing specific users to ssh into the system. The list consists of space separated user names. Numeric user IDs are not recognized with this variable. If a system administrator wants to restrict user access further by only allowing the allowed users to log in from a particular host, the entry can be specified in the form of user@host. AllowGroups The AllowGroups variable gives the system administrator the option of allowing specific groups of users to ssh into the system. The list consists of space separated group names. Numeric group IDs are not recognized with this variable. DenyUsers The DenyUsers variable gives the system administrator the option of denying specific users to ssh into the system. The list consists of space separated user names. Numeric user IDs are not recognized with this variable. If a system administrator wants to restrict user access further by specifically denying a user's access from a particular host, the entry can be specified in the form of user@host. DenyGroups The DenyGroups variable gives the system administrator the option of denying specific groups of users to ssh into the system. The list consists of space separated group names. Numeric group IDs are not recognized with this variable."
     rationale: "Restricting which users can remotely access the system via SSH will help ensure that only authorized users access the system."
     remediation: "Edit the /etc/ssh/sshd_config file to set one or more of the parameter as follows: # AllowUsers <userlist>; # AllowGroups <grouplist>; # DenyUsers <userlist>; # DenyGroups <grouplist>"
@@ -3055,7 +3058,7 @@ checks:
 
 # 5.2.5 Ensure SSH LogLevel is appropriate (Automated)
   - id: 6155
-    title: "Ensure SSH LogLevel is appropriate"
+    title: "Ensure SSH LogLevel is appropriate."
     description: "INFO level is the basic level that only records login activity of SSH users. In many situations, such as Incident Response, it is important to determine when a particular user was active on a system. The logout record can eliminate those users who disconnected, which helps narrow the field.VERBOSE level specifies that login and logout activity as well as the key fingerprint for any SSH key used for login will be logged. This information is important for SSH key management, especially in legacy environments."
     rationale: "SSH provides several logging levels with varying amounts of verbosity. DEBUG is specifically not recommended other than strictly for debugging SSH communications since it provides so much data that it is difficult to identify important security information."
     remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: LogLevel INFO"
@@ -3074,7 +3077,7 @@ checks:
 
 # 5.2.6 Ensure SSH X11 forwarding is disabled (Automated)
   - id: 6156
-    title: "Ensure SSH X11 forwarding is disabled"
+    title: "Ensure SSH X11 forwarding is disabled."
     description: "The X11Forwarding parameter provides the ability to tunnel X11 traffic through the connection to enable remote graphic connections."
     rationale: "Disable X11 forwarding unless there is an operational requirement to use X11 applications directly. There is a small risk that the remote X11 servers of users who are logged in via SSH with X11 forwarding could be compromised by other users on the X11 server. Note that even if X11 forwarding is disabled, users can always install their own forwarders."
     remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: X11Forwarding no"
@@ -3093,7 +3096,7 @@ checks:
 
 # 5.2.7 Ensure SSH MaxAuthTries is set to 4 or less (Automated)
   - id: 6157
-    title: "Ensure SSH MaxAuthTries is set to 4 or less"
+    title: "Ensure SSH MaxAuthTries is set to 4 or less."
     description: "The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection. When the login failure count reaches half the number, error messages will be written to the syslog file detailing the login failure."
     rationale: "Setting the MaxAuthTries parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. While the recommended setting is 4, set the number based on site policy."
     remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: MaxAuthTries 4"
@@ -3110,7 +3113,7 @@ checks:
 
 # 5.2.8 Ensure SSH IgnoreRhosts is enabled (Automated)
   - id: 6158
-    title: "Ensure SSH IgnoreRhosts is enabled"
+    title: "Ensure SSH IgnoreRhosts is enabled."
     description: "The IgnoreRhosts parameter specifies that .rhosts and .shosts files will not be used in RhostsRSAAuthentication or HostbasedAuthentication."
     rationale: "Setting this parameter forces users to enter a password when authenticating with ssh."
     remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: IgnoreRhosts yes"
@@ -3128,7 +3131,7 @@ checks:
 
 # 5.2.9 Ensure SSH HostbasedAuthentication is disabled (Automated)
   - id: 6159
-    title: "Ensure SSH HostbasedAuthentication is disabled"
+    title: "Ensure SSH HostbasedAuthentication is disabled."
     description: "The HostbasedAuthentication parameter specifies if authentication is allowed through trusted hosts via the user of .rhosts, or /etc/hosts.equiv, along with successful public key client host authentication. This option only applies to SSH Protocol Version 2."
     rationale: "Even though the .rhosts files are ineffective if support is disabled in /etc/pam.conf, disabling the ability to use .rhosts files in SSH provides an additional layer of protection."
     remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: HostbasedAuthentication no"
@@ -3146,7 +3149,7 @@ checks:
 
 # 5.2.10 Ensure SSH root login is disabled (Automated)
   - id: 6160
-    title: "Ensure SSH root login is disabled"
+    title: "Ensure SSH root login is disabled."
     description: "The PermitRootLogin parameter specifies if the root user can log in using ssh. The default is no."
     rationale: "Disallowing root logins over SSH requires system admins to authenticate using their own individual account, then escalating to root via sudo or su . This in turn limits opportunity for non-repudiation and provides a clear audit trail in the event of a security incident."
     remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: PermitRootLogin no"
@@ -3164,7 +3167,7 @@ checks:
 
 # 5.2.11 Ensure SSH PermitEmptyPasswords is disabled (Automated)
   - id: 6161
-    title: "Ensure SSH PermitEmptyPasswords is disabled"
+    title: "Ensure SSH PermitEmptyPasswords is disabled."
     description: "The PermitEmptyPasswords parameter specifies if the SSH server allows login to accounts with empty password strings."
     rationale: "Disallowing remote shell access to accounts that have an empty password reduces the probability of unauthorized access to the system."
     remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: PermitEmptyPasswords no"
@@ -3182,7 +3185,7 @@ checks:
 
 # 5.2.12 Ensure SSH PermitUserEnvironment is disabled (Automated)
   - id: 6162
-    title: "Ensure SSH PermitUserEnvironment is disabled"
+    title: "Ensure SSH PermitUserEnvironment is disabled."
     description: "The PermitUserEnvironment option allows users to present environment options to the ssh daemon."
     rationale: "Permitting users the ability to set environment variables through the SSH daemon could potentially allow users to bypass security controls (e.g. setting an execution path that has ssh executing trojan'd programs)"
     remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: PermitUserEnvironment no"
@@ -3200,7 +3203,7 @@ checks:
 
 # 5.2.13 Ensure only strong Ciphers are used (Automated)
   - id: 6163
-    title: "Ensure SSH Idle Timeout Interval is configured"
+    title: "Ensure SSH Idle Timeout Interval is configured."
     description: "This variable limits the ciphers that SSH can use during communication."
     rationale: "Weak ciphers that are used for authentication to the cryptographic module cannot be relied upon to provide confidentiality or integrity, and system data may be compromised.: The DES, Triple DES, and Blowfish ciphers, as used in SSH, have a birthday bound of approximately four billion blocks, which makes it easier for remote attackers to obtain cleartext data via a birthday attack against a long-duration encrypted session, aka a 'Sweet32' attack; The RC4 algorithm, as used in the TLS protocol and SSL protocol, does not properly combine state data with key data during the initialization phase, which makes it easier for remote attackers to conduct plaintext-recovery attacks against the initial bytes of a stream by sniffing network traffic that occasionally relies on keys affected by the Invariance Weakness, and then using a brute-force approach involvingLSB values, aka the 'Bar Mitzvah' issue; The passwords used during an SSH session encrypted with RC4 can be recovered by an attacker who is able to capture and replay the session; Error handling in the SSH protocol; Client and Server, when using a block cipher algorithm in Cipher Block Chaining (CBC) mode, makes it easier for remote attackers to recover certain plaintext data from an arbitrary block of ciphertext in an SSH session via unknown vectors; The mm_newkeys_from_blob function in monitor_wrap.c, when an AES-GCM cipher is used, does not properly initialize memory for a MAC context data structure, which allows remote authenticated users to bypass intended ForceCommand and login-shell restrictions via packet data that provides a crafted callback address"
     remediation: "Edit the /etc/ssh/sshd_configfile add/modify the Ciphersline to contain a comma separated list of the site approved ciphersExample:Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr"
@@ -3215,7 +3218,7 @@ checks:
 
 # 5.2.14 Ensure only strong MAC algorithms are used (Automated)
   - id: 6164
-    title: "Ensure only strong MAC algorithms are used"
+    title: "Ensure only strong MAC algorithms are used."
     description: "This variable limits the types of MAC algorithms that SSH can use during communication."
     rationale: "MD5 and 96-bit MAC algorithms are considered weak and have been shown to increase exploitability in SSH downgrade attacks. Weak algorithms continue to have a great deal of attention as a weak spot that can be exploited with expanded computing power. An attacker that breaks the algorithm could take advantage of a MiTM position to decrypt the SSH tunnel and capture credentials and information"
     remediation: "Edit the /etc/ssh/sshd_config file and add/modify the MACs line to contain a comma separated list of the site approved MACs Example:MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256"
@@ -3230,7 +3233,7 @@ checks:
 
 # 5.2.15 Ensure only strong Key Exchange algorithms are used (Automated)
   - id: 6165
-    title: "Ensure only strong Key Exchange algorithms are used"
+    title: "Ensure only strong Key Exchange algorithms are used."
     description: "Key exchange is any method in cryptography by which cryptographic keys are exchanged between two parties, allowing use of a cryptographic algorithm. If the sender and receiver wish to exchange encrypted messages, each must be equipped to encrypt messages to be sent and decrypt messages received"
     rationale: "Key exchange methods that are considered weak should be removed. A key exchange method may be weak because too few bits are used, or the hashing algorithm is considered too weak. Using weak algorithms could expose connections to man-in-the-middle attacks"
     remediation: "Edit the /etc/ssh/sshd_config file add/modify the KexAlgorithms line to contain a comma separated list of the site approved key exchange algorithms.Example:'KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256'"
@@ -3245,7 +3248,7 @@ checks:
 
 # 5.2.16 Ensure SSH Idle Timeout Interval is configured (Automated)
   - id: 6166
-    title: "Ensure SSH Idle Timeout Interval is configured"
+    title: "Ensure SSH Idle Timeout Interval is configured."
     description: "The two options ClientAliveInterval and ClientAliveCountMax control the timeout of ssh sessions. When the ClientAliveInterval variable is set, ssh sessions that have no activity for the specified length of time are terminated. When the ClientAliveCountMax variable is set, sshd will send client alive messages at every ClientAliveInterval interval. When the number of consecutive client alive messages are sent with no response from the client, the ssh session is terminated. For example, if the ClientAliveInterval is set to 15 seconds and the ClientAliveCountMax is set to 3, the client ssh session will be terminated after 45 seconds of idle time."
     rationale: "Having no timeout value associated with a connection could allow an unauthorized user access to another user's ssh session (e.g. user walks away from their computer and doesn't lock the screen). Setting a timeout value at least reduces the risk of this happening. While the recommended setting is 300 seconds (5 minutes), set this timeout value based on site policy. The recommended setting for ClientAliveCountMax is 0. In this case, the client session will be terminated after 5 minutes of idle time and no keepalive messages will be sent."
     remediation: "Edit the /etc/ssh/sshd_config file to set the parameters according to site policy: ClientAliveInterval 300 and ClientAliveCountMax 0"
@@ -3263,7 +3266,7 @@ checks:
 
 # 5.2.17 Ensure SSH LoginGraceTime is set to one minute or less (Automated)
   - id: 6167
-    title: "Ensure SSH LoginGraceTime is set to one minute or less"
+    title: "Ensure SSH LoginGraceTime is set to one minute or less."
     description: "The LoginGraceTime parameter specifies the time allowed for successful authentication to the SSH server. The longer the Grace period is the more open unauthenticated connections can exist. Like other session controls in this session the Grace Period should be limited to appropriate organizational limits to ensure the service is available for needed access."
     rationale: "Setting the LoginGraceTime parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. It will also limit the number of concurrent unauthenticated connections While the recommended setting is 60 seconds (1 Minute), set the number based on site policy."
     remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: LoginGraceTime 60"
@@ -3279,7 +3282,7 @@ checks:
 
 # 5.2.18 Ensure SSH warning banner is configured (Automated)
   - id: 6168
-    title: "Ensure SSH warning banner is configured"
+    title: "Ensure SSH warning banner is configured."
     description: "The Banner parameter specifies a file whose contents must be sent to the remote user before authentication is permitted. By default, no banner is displayed."
     rationale: "Banners are used to warn connecting users of the particular site's policy regarding connection. Presenting a warning message prior to the normal user login may assist the prosecution of trespassers on the computer system."
     remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: Banner /etc/issue.net"
@@ -3296,7 +3299,7 @@ checks:
 
 # 5.2.19 Ensure SSH PAM is enabled (Automated)
   - id: 6169
-    title: "Ensure SSH PAM is enabled"
+    title: "Ensure SSH PAM is enabled."
     description: "UsePAM Enables the Pluggable Authentication Module interface. If set to “yes” this will enable PAM authentication using ChallengeResponseAuthenticationand PasswordAuthentication in addition to PAM account and session module processing for all authentication types"
     rationale: "When usePAM is set to yes, PAM runs through account and session types properly. This is important if you want to restrict access to services based off of IP, time or other factors of the account. Additionally, you can make sure users inherit certain environment variables on login or disallow access to the server"
     remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: UsePAM yes"
@@ -3313,7 +3316,7 @@ checks:
 
 # 5.2.20 Ensure SSH AllowTcpForwarding is disabled (Automated)
   - id: 6170
-    title: "Ensure SSH AllowTcpForwarding is disabled"
+    title: "Ensure SSH AllowTcpForwarding is disabled."
     description: "SSH port forwarding is a mechanism in SSH for tunneling application ports from the client to the server, or servers to clients. It can be used for adding encryption to legacy applications, going through firewalls, and some system administrators and IT professionals use it for opening backdoors into the internal network from their home machines"
     rationale: "Leaving port forwarding enabled can expose the organization to security risks and back-doors.SSH connections are protected with strong encryption. This makes their contents invisible to most deployed network monitoring and traffic filtering solutions. This invisibility carries considerable risk potential if it is used for malicious purposes such as data exfiltration. Cybercriminals or malware could exploit SSH to hide their unauthorized communications, or to exfiltrate stolen data from the target network"
     remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: AllowTcpForwarding no"
@@ -3330,7 +3333,7 @@ checks:
 
 # 5.2.21 Ensure SSH MaxStartups is configured (Automated)
   - id: 6171
-    title: "Ensure SSH MaxStartups is configured"
+    title: "Ensure SSH MaxStartups is configured."
     description: "The MaxStartupsparameter specifies the maximum number of concurrent unauthenticated connections to the SSH daemon"
     rationale: "To protect a system from denial of service due to a large number of pending authentication connection attempts, use the rate limiting function of MaxStartups to protect availability of sshd logins and prevent overwhelming the daemon"
     remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: maxstartups 10:30:60"
@@ -3347,7 +3350,7 @@ checks:
 
 # 5.2.22 Ensure SSH MaxSessions is limited (Automated)
   - id: 6172
-    title: "Ensure SSH MaxSessions is limited"
+    title: "Ensure SSH MaxSessions is limited."
     description: "The MaxSessionsparameter specifies the maximum number of open sessions permitted from a given connection."
     rationale: "To protect a system from denial of service due to a large number of pending authentication connection attempts, use the rate limiting function of MaxStartups to protect availability of sshd logins and prevent overwhelming the daemon"
     remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: MaxSessions 10"
@@ -3369,7 +3372,7 @@ checks:
 
 # 5.3.1 Ensure password creation requirements are configured (Automated)
   - id: 6173
-    title: "Ensure password creation requirements are configured"
+    title: "Ensure password creation requirements are configured."
     description: "The pam_pwquality.so module checks the strength of passwords. It performs checks such as making sure a password is not a dictionary word, it is a certain length, contains a mix of characters (e.g. alphabet, numeric, other) and more"
     rationale: "Strong passwords protect systems from being hacked through brute force methods."
     remediation: "Edit the file /etc/security/pwquality.conf and add or modify the following line for password length to conform to site policy: minlen = 14     Edit the file /etc/security/pwquality.conf and add or modify the following line for password complexity to conform to site policy: minclass = 4    OR dcredit = -1 ucredit = -1 ocredit = -1 lcredit = -1      Edit the /etc/pam.d/password-auth and /etc/pam.d/system-auth files to include the appropriate options for pam_pwquality.so and to conform to site policy:password requisite pam_pwquality.so try_first_pass retry=3"
@@ -3390,7 +3393,7 @@ checks:
 
 # 5.3.3 Ensure password hashing algorithm is SHA-512 (Automated)
   - id: 6174
-    title: "Ensure password hashing algorithm is SHA-512"
+    title: "Ensure password hashing algorithm is SHA-512."
     description: "The commands below change password encryption from md5 to sha512 (a much stronger hashing algorithm). All existing accounts will need to perform a password change to upgrade the stored hashes to the new algorithm."
     rationale: "The SHA-512 algorithm provides much stronger hashing than MD5, thus providing additional protection to the system by increasing the level of effort for an attacker to successfully determine passwords. Note that these changes only apply to accounts configured on the local system."
     remediation: "Edit the /etc/pam.d/password-auth and /etc/pam.d/system-auth files to include the sha512 option for pam_unix.so as shown: password sufficient pam_unix.so sha512"
@@ -3407,7 +3410,7 @@ checks:
 
 # 5.3.4 Ensure password reuse is limited (Automated)
   - id: 6175
-    title: "Ensure password reuse is limited"
+    title: "Ensure password reuse is limited."
     description: "The /etc/security/opasswd file stores the users' old passwords and can be checked to ensure that users are not recycling recent passwords."
     rationale: "Forcing users not to reuse their past 5 passwords make it less likely that an attacker will be able to guess the password. Note that these changes only apply to accounts configured on the local system."
     remediation: "Edit the /etc/pam.d/password-auth and /etc/pam.d/system-auth files to include the remember option and conform to site policy as shown: password sufficient pam_unix.so remember=5   or    password required pam_pwhistory.so remember=5"
@@ -3432,7 +3435,7 @@ checks:
 
 # 5.4.1.1 Ensure password expiration is 365 days or less (Automated)
   - id: 6176
-    title: "Ensure password expiration is 365 days or less"
+    title: "Ensure password expiration is 365 days or less."
     description: "The PASS_MAX_DAYS parameter in /etc/login.defs allows an administrator to force passwords to expire once they reach a defined age. It is recommended that the PASS_MAX_DAYS parameter be set to less than or equal to 365 days."
     rationale: "The window of opportunity for an attacker to leverage compromised credentials or successfully compromise credentials via an online brute force attack is limited by the age of the password. Therefore, reducing the maximum age of a password also reduces an attacker's window of opportunity."
     remediation: "Set the PASS_MAX_DAYS parameter to conform to site policy in /etc/login.defs : PASS_MAX_DAYS 90 and modify user parameters for all users with a password set to match: chage --maxdays 90 <user>"
@@ -3448,7 +3451,7 @@ checks:
 
 # 5.4.1.2 Ensure minimum days between password changes is configured (Automated)
   - id: 6177
-    title: "Ensure minimum days between password changes is configured"
+    title: "Ensure minimum days between password changes is configured."
     description: "The PASS_MIN_DAYS parameter in /etc/login.defs allows an administrator to prevent users from changing their password until a minimum number of days have passed since the last time the user changed their password. It is recommended that PASS_MIN_DAYS parameter be set to 1 or more days."
     rationale: "By restricting the frequency of password changes, an administrator can prevent users from repeatedly changing their password in an attempt to circumvent password reuse controls."
     remediation: "Set the PASS_MIN_DAYS parameter to 1 in /etc/login.defs: PASS_MIN_DAYS 1 and modify user parameters for all users with a password set to match: chage --mindays 1 <user>"
@@ -3464,7 +3467,7 @@ checks:
 
 # 5.4.1.3 Ensure password expiration warning days is 7 or more (Automated)
   - id: 6178
-    title: "Ensure minimum days between password changes is 7 or more"
+    title: "Ensure minimum days between password changes is 7 or more."
     description: "The PASS_WARN_AGE parameter in /etc/login.defs allows an administrator to notify users that their password will expire in a defined number of days. It is recommended that the PASS_WARN_AGE parameter be set to 7 or more days."
     rationale: "Providing an advance warning that a password will be expiring gives users time to think of a secure password. Users caught unaware may choose a simple password or write it down where it may be discovered."
     remediation: "Set the PASS_WARN_AGE parameter to 7 in /etc/login.defs: PASS_WARN_AGE 7 and modify user parameters for all users with a password set to match: chage --warndays 7 <user>"
@@ -3480,7 +3483,7 @@ checks:
 
 # 5.4.1.4 Ensure inactive password lock is 30 days or less (Automated)
   - id: 6179
-    title: "Ensure inactive password lock is 30 days or less"
+    title: "Ensure inactive password lock is 30 days or less."
     description: "User accounts that have been inactive for over a given period of time can be automatically disabled. It is recommended that accounts that are inactive for 30 days after password expiration be disabled."
     rationale: "Inactive accounts pose a threat to system security since the users are not logging in to notice failed login attempts or other anomalies."
     remediation: "Run the following command to set the default password inactivity period to 30 days: useradd -D -f 30 and modify user parameters for all users with a password set to match: chage --inactive 30 <user>"
@@ -3500,7 +3503,7 @@ checks:
 
 # 5.4.3 Ensure default group for the root account is GID 0 (Automated)
   - id: 6180
-    title: "Ensure default group for the root account is GID 0"
+    title: "Ensure default group for the root account is GID 0."
     description: "The usermod command can be used to specify which group the root user belongs to. This affects permissions of files that are created by the root user."
     rationale: "Using GID 0 for the root account helps prevent root -owned files from accidentally becoming accessible to non-privileged users."
     remediation: "Run the following command to set the root user default group to GID 0: usermod -g 0 root"
@@ -3516,7 +3519,7 @@ checks:
 
 # 5.4.4 Ensure default user shell timeout is configured (Automated)
   - id: 6181
-    title: " Ensure default user shell timeout is configured"
+    title: " Ensure default user shell timeout is configured."
     description: "TMOUT is an environmental setting that determines the timeout of a shell in seconds."
     rationale: "Setting a timeout value reduces the window of opportunity for unauthorized user access to another user's shell session that has been left unattended. It also ends the inactive session and releases the resources associated with that session."
     remediation: "Edit the /etc/bashrc and /etc/profile files (and the appropriate files for any other shell supported on your system) and add or edit any umask parameters as follows: TMOUT=600"
@@ -3534,7 +3537,7 @@ checks:
 
 # 5.4.5 Ensure default user umask is configured (Automated)
   - id: 6182
-    title: "Ensure default user umask is configured"
+    title: "Ensure default user umask is configured."
     description: "The user file-creation mode mask (umask) is use to determine the file permission for newly created directories and files. In Linux, the default permissions for any newly created directory is 0777 (rwxrwxrwx), and for any newly created file it is 0666 (rw-rw-rw-). The umask modifies the default Linux permissions by restricting (masking) these permissions. The umask is not simply subtracted, but is processed bitwise. Bits set in the umaskare cleared in the resulting file mode."
     rationale: "Setting a very secure default value for umask ensures that users make a conscious choice about their file permissions. A default umask setting of 077 causes files and directories created by users to not be readable by any other user on the system. A umask of 027 would make files and directories readable by users in the same Unix group, while a umask of 022 would make files readable by every user on the system."
     remediation: "Edit the /etc/bashrc, /etc/profile and /etc/profile.d/*.sh files (and the appropriate files for any other shell supported on your system) and add or edit any umask parameters as follows: umask 027"
@@ -3557,7 +3560,7 @@ checks:
 
 # 5.6 Ensure access to the su command is restricted (Automated)
   - id: 6183
-    title: "Ensure access to the su command is restricted."
+    title: "Ensure access to the su command is restricted.."
     description: "The su command allows a user to run a command or shell as another user. The program has been superseded by sudo, which allows for more granular control over privileged access. Normally, the su command can be executed by any user. By uncommenting the pam_wheel.so statement in /etc/pam.d/su, the su command will only allow users in the wheel group to execute su ."
     rationale: "Restricting the use of su, and using sudo in its place, provides system administrators better control of the escalation of user privileges to execute privileged commands. The sudo utility also provides a better logging and audit mechanism, as it can log each command executed via sudo, whereas su can only record that a user executed the su program."
     remediation: "Add the following line to the /etc/pam.d/su file: auth required pam_wheel.so use_uid"
@@ -3587,7 +3590,7 @@ checks:
 
 # 6.1.2 Configure /etc/passwd permissions (Automated)
   - id: 6184
-    title: "Ensure permissions on /etc/passwd are configured"
+    title: "Ensure permissions on /etc/passwd are configured."
     description: "The /etc/passwd file contains user account information that is used by many system utilities and therefore must be readable for these utilities to operate."
     rationale: "It is critical to ensure that the /etc/passwd file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
     remediation: "Run the following command to set permissions on /etc/passwd: # chown root:root /etc/passwd   # chmod u-x,g-wx,o-wx /etc/passwd"
@@ -3604,7 +3607,7 @@ checks:
 
 # 6.1.3 Ensure permissions on /etc/shadow are configured (Automated)
   - id: 6185
-    title: "Ensure permissions on /etc/shadow are configured"
+    title: "Ensure permissions on /etc/shadow are configured."
     description: "The /etc/shadow file is used to store the information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/shadow file (such as expiration) could also be useful to subvert the user accounts."
     remediation: "Run the following command to set permissions on /etc/shadow: # chown root:root /etc/shadow # chmod 000 /etc/shadow"
@@ -3620,7 +3623,7 @@ checks:
 
 # 6.1.4 Ensure permissions on /etc/group are configured (Automated)
   - id: 6186
-    title: "Ensure permissions on /etc/group are configured"
+    title: "Ensure permissions on /etc/group are configured."
     description: "The /etc/group file contains a list of all the valid groups defined in the system. The command below allows read/write access for root and read access for everyone else."
     rationale: "The /etc/group file needs to be protected from unauthorized changes by non-privileged users, but needs to be readable as this information is used with many non-privileged programs."
     remediation: "Run the following command to set permissions on /etc/group: # chown root:root /etc/group # chmod u-x,g-wx,o-wx /etc/group"
@@ -3637,7 +3640,7 @@ checks:
 
 # 6.1.5 Ensure permissions on /etc/gshadow are configured (Automated)
   - id: 6187
-    title: "Ensure permissions on /etc/gshadow are configured"
+    title: "Ensure permissions on /etc/gshadow are configured."
     description: "The /etc/gshadow file is used to store the information about groups that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "If attackers can gain read access to the /etc/gshadow file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/gshadow file (such as group administrators) could also be useful to subvert the group"
     remediation: "Run the following command to set permissions on /etc/gshadow: # chown root:root /etc/gshadow # chmod 000 /etc/gshadow"
@@ -3654,7 +3657,7 @@ checks:
 
 # 6.1.6 Ensure permissions on /etc/passwd-are configured (Automated)
   - id: 6188
-    title: "Ensure permissions on /etc/passwd- are configured"
+    title: "Ensure permissions on /etc/passwd- are configured."
     description: "The /etc/passwd- file contains backup user account information."
     rationale: "It is critical to ensure that the /etc/passwd- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
     remediation: "Run the following command to set permissions on /etc/passwd-: # chown root:root /etc/passwd- # chmod 644 /etc/passwd-"
@@ -3671,7 +3674,7 @@ checks:
 
 # 6.1.7 Ensure permissions on /etc/shadow-are configured (Automated)
   - id: 6189
-    title: "Ensure permissions on /etc/shadow- are configured"
+    title: "Ensure permissions on /etc/shadow- are configured."
     description: "The /etc/shadow- file is used to store backup information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "It is critical to ensure that the /etc/shadow- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
     remediation: "Run the following command to set permissions on /etc/shadow-: # chown root:root /etc/shadow- # chmod 000 /etc/shadow-"
@@ -3688,7 +3691,7 @@ checks:
 
 # 6.1.8 Ensure permissions on /etc/group-are configured (Automated)
   - id: 6190
-    title: "Ensure permissions on /etc/group- are configured"
+    title: "Ensure permissions on /etc/group- are configured."
     description: "The /etc/group- file contains a backup list of all the valid groups defined in the system."
     rationale: "It is critical to ensure that the /etc/group- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
     remediation: "Run the following command to set permissions on /etc/group-: # chown root:root /etc/group- # chmod 644 /etc/group-"
@@ -3705,7 +3708,7 @@ checks:
 
 # 6.1.9 Ensure permissions on /etc/gshadow-are configured (Automated)
   - id: 6191
-    title: "Ensure permissions on /etc/gshadow- are configured"
+    title: "Ensure permissions on /etc/gshadow- are configured."
     description: "The /etc/gshadow- file is used to store backup information about groups that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "It is critical to ensure that the /etc/gshadow- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
     remediation: "Run the following command to set permissions on /etc/gshadow-: # chown root:root /etc/gshadow- # chmod 000 /etc/gshadow-"
@@ -3737,7 +3740,7 @@ checks:
 
 # 6.2.1 Ensure accounts in /etc/passwd use shadowed passwords (Automated)
   - id: 6192
-    title: "Ensure accounts in /etc/passwd use shadowed passwords"
+    title: "Ensure accounts in /etc/passwd use shadowed passwords."
     description: "Local accounts can uses shadowed passwords. With shadowed passwords, The passwords are saved in shadow password file, /etc/shadow, encrypted by a salted one-way hash. Accounts with a shadowed password have an xin the second field in /etc/passwd."
     rationale: "The /etc/passwd file also contains information like user ID's and group ID's that are used by many system programs. Therefore, the /etc/passwd file must remain world readable. In spite of encoding the password with a randomly-generated one-way hash function, an attacker could still break the system if they got access to the /etc/passwd file. This can be mitigated by using shadowed passwords, thus moving the passwords in the /etc/passwd file to /etc/shadow. The /etc/shadow file is set so only root will be able to read and write. This helps mitigate the risk of an attacker gaining access to the encoded passwords with which to perform a dictionary attack."
     remediation: "If any accounts in the /etc/passwd file do not have a single x in the password field, run the following command to set these accounts to use shadowed passwords:# sed -e 's/^\\([a-zA-Z0-9_]*\\):[^:]*:/\\1:x:/' -i /etc/passwdInvestigate to determine if the account is logged in and what it is being used for, to determine if it needs to be forced off."
@@ -3753,7 +3756,7 @@ checks:
 
 # 6.2.2 Ensure /etc/shadow password fields are not empty (Automated)
   - id: 6193
-    title: "Ensure password fields are not empty"
+    title: "Ensure password fields are not empty."
     description: "An account with an empty password field means that anybody may log in as that user without providing a password."
     rationale: "All accounts must have passwords or be locked to prevent the account from being used by an unauthorized user."
     remediation: "If any accounts in the /etc/shadow file do not have a password, run the following command to lock the account until it can be determined why it does not have a password: passwd -l <username> || Also, check to see if the account is logged in and investigate what it is being used for to determine if it needs to be forced off."
@@ -3769,7 +3772,7 @@ checks:
 
 # 6.2.3 Ensure root is the only UID 0 account (Automated)
   - id: 6194
-    title: "Ensure root is the only UID 0 account"
+    title: "Ensure root is the only UID 0 account."
     description: "Any account with UID 0 has superuser privileges on the system."
     rationale: "This access must be limited to only the default root account and only from the system console. Administrative access must be through an unprivileged account using an approved mechanism as noted in Item 5.6 Ensure access to the su command is restricted."
     remediation: "Remove any users other than root with UID 0 or assign them a new UID if appropriate."
@@ -3817,7 +3820,7 @@ checks:
 
 # 6.2.18 Ensure shadow group is empty (Automated)
   - id: 6195
-    title: "Ensure shadow group is empty"
+    title: "Ensure shadow group is empty."
     description: "The shadow group allows system programs which require access the ability to read the /etc/shadow file. No users should be assigned to the shadow group"
     rationale: "Any users assigned to the shadow group would be granted read access to the /etc/shadow file. If attackers can gain read access to the /etc/shadow file, they can easily runa password cracking program against the hashed passwords to break them. Other security information that is stored in the /etc/shadow file (such as expiration) could also be useful to subvert additional user accounts."
     remediation: "Remove any legacy '+' entries from /etc/shadow if they exist."


### PR DESCRIPTION
|Related issue|
|---|
|#10403|

## Description

This PR aims to fix PR #10406

The issues resolved are:
- Minimal typos and bad references format.

## Checks and changes 

### Syntax and semantic

- [x] a) ID of each policy must be contiguous.
- [x] b) The order and format set in [Documentation](https://documentation.wazuh.com/current/user-manual/capabilities/sec-config-assessment/creating-custom-policies.html) must be respected.
- [x] c) YML must be valid to avoid errors.

### Content

- [x] a) Compare each check with its analogue from CIS Benchmark.
- [x] b) Try to maintain each rule as similar as possible with the `Audit` section from the CIS check.
- [x] c) Check that the commands provide the expected output.
- [x] d) When a failure is discovered, check similar policies to avoid repetition of the issue.

### Unit testing

- [x] a) Output from `agent.log` after the SCA scan and a raw output of the result of the checks.
```
2021/12/07 20:40:33 sca: INFO: Module started.
2021/12/07 20:40:33 sca: INFO: Loaded policy '/var/ossec/ruleset/sca/cis_rhel8_linux.yml'
2021/12/07 20:40:33 sca: INFO: Starting Security Configuration Assessment scan.
2021/12/07 20:40:33 wazuh-modulesd:control: INFO: Starting control thread.
2021/12/07 20:40:33 sca: INFO: Starting evaluation of policy: '/var/ossec/ruleset/sca/cis_rhel8_linux.yml'
2021/12/07 20:40:33 wazuh-modulesd:syscollector: INFO: Module started.
2021/12/07 20:40:33 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2021/12/07 20:40:33 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2021/12/07 20:40:33 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
2021/12/07 20:40:42 sca: INFO: Evaluation finished for policy '/var/ossec/ruleset/sca/cis_rhel8_linux.yml'
2021/12/07 20:40:42 sca: INFO: Security Configuration Assessment scan finished. Duration: 9 seconds.
2021/12/07 20:40:53 rootcheck: INFO: Ending rootcheck scan.

```

### Deployment

- [x] a) If the policy it's new, it must be added to the `sca.files` templates.
- [x] b) If the OS has many supported SCA policies, a policy must be set as default policy. ([as example](https://github.com/wazuh/wazuh/blob/master/etc/templates/config/centos/sca.files))
