### PR TITLE
Review of PR 7663 - 7662 - add SCA CIS policies for amazon linux 1

### DIFF
--- a/ruleset/sca/amazon/cis_amazon_linux_1.yml
+++ b/ruleset/sca/amazon/cis_amazon_linux_1.yml
@@ -19,7 +19,7 @@ policy:
     - https://www.cisecurity.org/cis-benchmarks/
 
 requirements:
-  title: "Check Amazon Linux version"
+  title: "Check Amazon Linux version."
   description: "Requirements for running the policy against Amazon Linux 1."
   condition: any
   rules:
@@ -31,7 +31,7 @@ variables:
 checks:
 # 1.1.1.1 cramfs: filesystem
   - id: 20000 
-    title: "Ensure mounting of cramfs filesystems is disabled"
+    title: "Ensure mounting of cramfs filesystems is disabled."
     description: "The cramfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems. A cramfs image can be used without having to first decompress the image."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the server. If this filesystem type is not needed, disable it."
     remediation: "Edit or create the file /etc/modprobe.d/CIS.conf and add the following line: install cramfs /bin/true. Run the following command to unload the cramfs module: rmmod cramfs"
@@ -49,7 +49,7 @@ checks:
 
 # 1.1.1.2 freevxfs: filesystem
   - id: 20001 
-    title: "Ensure mounting of freevxfs filesystems is disabled"
+    title: "Ensure mounting of freevxfs filesystems is disabled."
     description: "The freevxfs filesystem type is a free version of the Veritas type filesystem. This is the primary filesystem type for HP-UX operating systems."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
     remediation: "Edit or create the file /etc/modprobe.d/CIS.conf and add the following line: install freevxfs /bin/true. Run the following command to unload the freevxfs module: rmmod freevxfs"
@@ -67,7 +67,7 @@ checks:
 
 # 1.1.1.3 jffs2: filesystem
   - id: 20002 
-    title: "Ensure mounting of jffs2 filesystems is disabled"
+    title: "Ensure mounting of jffs2 filesystems is disabled."
     description: "The jffs2 (journaling flash filesystem 2) filesystem type is a log-structured filesystem used in flash memory devices."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
     remediation: "Edit or create the file /etc/modprobe.d/CIS.conf and add the following line: install jffs2 /bin/true. Run the following command to unload the jffs2 module: rmmod jffs2"
@@ -85,7 +85,7 @@ checks:
 
 # 1.1.1.4 hfs: filesystem
   - id: 20003 
-    title: "Ensure mounting of hfs filesystems is disabled"
+    title: "Ensure mounting of hfs filesystems is disabled."
     description: "The hfs filesystem type is a hierarchical filesystem that allows you to mount Mac OS filesystems."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
     remediation: "Edit or create the file /etc/modprobe.d/CIS.conf and add the following line: install hfs /bin/true. Run the following command to unload the hfs module: rmmod hfs"
@@ -100,9 +100,10 @@ checks:
     rules:
       - 'c:modprobe -n -v hfs -> r:install /bin/true|Module hfs not found'
       - 'not c:lsmod -> r:hfs'
+
 # 1.1.1.5 hfsplus: filesystem
   - id: 20004 
-    title: "Ensure mounting of hfsplus filesystems is disabled"
+    title: "Ensure mounting of hfsplus filesystems is disabled."
     description: "The hfsplus filesystem type is a hierarchical filesystem designed to replace hfs that allows you to mount Mac OS filesystems."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
     remediation: "Edit or create the file /etc/modprobe.d/CIS.conf and add the following line: install hfsplus /bin/true. Run the following command to unload the hfsplus module: rmmod hfsplus"
@@ -117,9 +118,10 @@ checks:
     rules:
       - 'c:modprobe -n -v hfsplus -> r:install /bin/true|Module hfsplus not found'
       - 'not c:lsmod -> r:hfsplus'
+      
 # 1.1.1.6 squashfs: filesystem
   - id: 20005 
-    title: "Ensure mounting of squashfs filesystems is disabled"
+    title: "Ensure mounting of squashfs filesystems is disabled."
     description: "The squashfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems (similar to cramfs ). A squashfs image can be used without having to first decompress the image."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
     remediation: "Edit or create the file /etc/modprobe.d/CIS.conf and add the following line: install squashfs /bin/true. Run the following command to unload the squashfs module: rmmod squashfs"
@@ -137,7 +139,7 @@ checks:
 
 # 1.1.1.7 udfs: filesystem
   - id: 20006 
-    title: "Ensure mounting of udf filesystems is disabled"
+    title: "Ensure mounting of udf filesystems is disabled."
     description: "The udf filesystem type is the universal disk format used to implement ISO/IEC 13346 and ECMA-167 specifications. This is an open vendor filesystem type for data storage on a broad range of media. This filesystem type is necessary to support writing DVDs and newer optical disc formats."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
     remediation: "Edit or create the file /etc/modprobe.d/CIS.conf and add the following line: install udf /bin/true. Run the following command to unload the udf module: rmmod udf"
@@ -155,7 +157,7 @@ checks:
 
 # 1.1.1.8 FAT: filesystem
   - id: 20007 
-    title: "Ensure mounting of FAT filesystems is disabled"
+    title: "Ensure mounting of FAT filesystems is disabled."
     description: "The FAT filesystem format is primarily used on older windows systems and portable USB drives or flash modules. It comes in three types FAT12 , FAT16 , and FAT32 all of which are supported by the vfat kernel module."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
     remediation: "Edit or create the file /etc/modprobe.d/CIS.conf and add the following line: install vfat /bin/true. Run the following command to unload the vfat module: rmmod vfat"
@@ -173,7 +175,7 @@ checks:
 
 # 1.1.2 /tmp: partition
   - id: 20008 
-    title: "Ensure separate partition exists for /tmp"
+    title: "Ensure separate partition exists for /tmp."
     description: "The /tmp directory is a world-writable directory used for temporary storage by all users and some applications."
     rationale: "Since the /tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. In addition, making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw."
     remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /tmp. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
@@ -188,10 +190,9 @@ checks:
     rules:
       - 'c:mount -> r:\s/tmp\s'
 
-
 # 1.1.3 /tmp: nodev
   - id: 20009 
-    title: "Ensure nodev option set on /tmp partition"
+    title: "Ensure nodev option set on /tmp partition."
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /tmp."
     remediation: "Edit the /etc/fstabfile and add nodev to the fourth field (mounting options) for the /tmp partition. See the fstab(5)manual page for more information. Run the following command to remount /tmp:# mount -o remount,nodev /tmp"
@@ -206,7 +207,7 @@ checks:
 
 # 1.1.4 /tmp: nosuid
   - id: 20010 
-    title: "Ensure nosuid option set on /tmp partition"
+    title: "Ensure nosuid option set on /tmp partition."
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /tmp."
     remediation: "Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /tmp partition. See the fstab(5)manual page for more information. Run the following command to remount /tmp: # mount -o remount,nosuid /tmp"
@@ -221,7 +222,7 @@ checks:
 
 # 1.1.5 /tmp: noexec
   - id: 20011 
-    title: "Ensure noexec option set on /tmp partition"
+    title: "Ensure noexec option set on /tmp partition."
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /tmp."
     remediation: "Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /tmp partition. See the fstab(5)manual page for more information. Run the following command to remount /tmp: # mount -o remount,noexec /tmp"
@@ -235,10 +236,9 @@ checks:
     rules:
       - 'c:mount -> r:\s/tmp\s && r:noexec'
 
-
 # 1.1.6 Build considerations - Partition scheme.
   - id: 20012 
-    title: "Ensure separate partition exists for /var"
+    title: "Ensure separate partition exists for /var."
     description: "The /var directory is used by daemons and other system services to temporarily store dynamic data. Some directories created by these processes may be world-writable."
     rationale: "Since the /var directory may contain world-writable files and directories, there is a risk of resource exhaustion if it is not bound to a separate partition."
     remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
@@ -255,7 +255,7 @@ checks:
 
 # 1.1.7 bind mount /var/tmp to /tmp
   - id: 20013 
-    title: "Ensure separate partition exists for /var/tmp"
+    title: "Ensure separate partition exists for /var/tmp."
     description: "The /var/tmp directory is a world-writable directory used for temporary storage by all users and some applications."
     rationale: "Since the /var/tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. In addition, making /var/tmp its own file system allows an administrator to set the noexec option on the mount, making /var/tmp useless for an attacker to install executable code."
     remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/tmp. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
@@ -268,11 +268,9 @@ checks:
     rules:
       - 'c:mount -> r:\s/var/tmp\s'
 
-
-
 # 1.1.8 nodev set on /var/tmp
   - id: 20014 
-    title: "Ensure nodev option set on /var/tmp partition"
+    title: "Ensure nodev option set on /var/tmp partition."
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /var/tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /var/tmp ."
     remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /var/tmp partition. See the fstab(5) manual page for more information."
@@ -287,7 +285,7 @@ checks:
 
 # 1.1.9 nosuid set on /var/tmp
   - id: 20015 
-    title: "Ensure nosuid option set on /var/tmp partition"
+    title: "Ensure nosuid option set on /var/tmp partition."
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /var/tmp."
     remediation: "Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var/tmp partition. See the fstab(5) manual page for more information."
@@ -302,7 +300,7 @@ checks:
 
 # 1.1.10 noexec set on /var/tmp
   - id: 20016 
-    title: "Ensure noexec option set on /var/tmp partition"
+    title: "Ensure noexec option set on /var/tmp partition."
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /var/tmp."
     remediation: "Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /var/tmp partition. See the fstab(5) manual page for more information."
@@ -316,11 +314,9 @@ checks:
     rules:
       - 'c:mount -> r:\s/var/tmp\s && r:noexec'
 
-
-
 # 1.1.11 /var/log: partition
   - id: 20017 
-    title: "Ensure separate partition exists for /var/log"
+    title: "Ensure separate partition exists for /var/log."
     description: "The /var/log directory is used by system services to store log data ."
     rationale: "There are two important reasons to ensure that system logs are stored on a separate partition: protection against resource exhaustion (since logs can grow quite large) and protection of audit data."
     remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/log. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
@@ -338,7 +334,7 @@ checks:
 
 # 1.1.12 /var/log/audit: partition
   - id: 20018 
-    title: "Ensure separate partition exists for /var/log/audit"
+    title: "Ensure separate partition exists for /var/log/audit."
     description: "The auditing daemon, auditd , stores log data in the /var/log/audit directory."
     rationale: "There are two important reasons to ensure that data gathered by auditd is stored on a separate partition: protection against resource exhaustion (since the audit.log file can grow quite large) and protection of audit data."
     remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/log/audit. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
@@ -356,7 +352,7 @@ checks:
 
 # 1.1.13 /home: partition
   - id: 20019 
-    title: "Ensure separate partition exists for /home"
+    title: "Ensure separate partition exists for /home."
     description: "The /home directory is used to support disk storage needs of local users."
     rationale: "If the system is intended to support local users, create a separate partition for the /home directory to protect against resource exhaustion and restrict the type of files that can be stored under /home."
     remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /home. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
@@ -371,10 +367,9 @@ checks:
     rules:
       - 'c:mount -> r:\s/home\s'
 
-
 # 1.1.14 /home: nodev
   - id: 20020 
-    title: "Ensure nodev option set on /home partition"
+    title: "Ensure nodev option set on /home partition."
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the user partitions are not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices."
     remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /home partition. # mount -o remount,nodev /home"
@@ -389,7 +384,7 @@ checks:
 
 # 1.1.15 /dev/shm: nodev
   - id: 20021 
-    title: "Ensure nodev option set on /dev/shm partition"
+    title: "Ensure nodev option set on /dev/shm partition."
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /dev/shm filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create special devices in /dev/shm partitions."
     remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /dev/shm partition. Run the following command to remount /dev/shm: # mount -o remount,nodev /dev/shm"
@@ -404,7 +399,7 @@ checks:
 
 # 1.1.16 /dev/shm: nosuid
   - id: 20022 
-    title: "Ensure nosuid option set on /dev/shm partition"
+    title: "Ensure nosuid option set on /dev/shm partition."
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Setting this option on a file system prevents users from introducing privileged programs onto the system and allowing non-root users to execute them."
     remediation: "Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /dev/shm partition. Run the following command to remount /dev/shm: # mount -o remount,nosuid /dev/shm"
@@ -419,7 +414,7 @@ checks:
 
 # 1.1.17 /dev/shm: noexec
   - id: 20023 
-    title: "Ensure noexec option set on /dev/shm partition"
+    title: "Ensure noexec option set on /dev/shm partition."
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Setting this option on a file system prevents users from executing programs from shared memory. This deters users from introducing potentially malicious software on the system."
     remediation: "Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /dev/shm partition. Run the following command to remount /dev/shm: # mount -o remount,noexec /dev/shm"
@@ -433,10 +428,9 @@ checks:
     rules:
       - 'c:mount -> r:\s/dev/shm\s && r:noexec'
 
-
 # 1.1.19 Disable Automounting
   - id: 20024 
-    title: "Disable Automounting"
+    title: "Disable Automounting."
     description: "autofs allows automatic mounting of devices, typically including CD/DVDs and USB drives."
     rationale: "With automounting enabled anyone with physical access could attach a USB drive or disc and have its contents available in system even if they lacked permissions to mount it themselves."
     remediation: "Run the following command to disable autofs: # chkconfig autofs off"
@@ -456,7 +450,7 @@ checks:
 
 # 1.2.3 Activate gpgcheck
   - id: 20025 
-    title: "Ensure gpgcheck is globally activated"
+    title: "Ensure gpgcheck is globally activated."
     description: "The gpgcheck option, found in the main section of the /etc/yum.conf and individual /etc/yum/repos.d/* files determines if an RPM package's signature is checked prior to its installation."
     rationale: "It is important to ensure that an RPM's package signature is always checked prior to installation to ensure that the software is obtained from a trusted source."
     remediation: "Edit /etc/yum.conf and set ' gpgcheck=1 ' in the [main] section. Edit any failing files in /etc/yum.repos.d/* and set all instances of gpgcheck to ' 1 '."
@@ -474,14 +468,13 @@ checks:
       - 'f:/etc/yum.conf -> r:^gpgcheck=1'
       - 'not c:grep -Rh ^gpgcheck /etc/yum.repos.d/ -> r:gpgcheck=0'
 
-
 ###############################################
 # 1.3 Filesystem Integrity Checking
 ###############################################
 
 # 1.3.1 install AIDE
   - id: 20026 
-    title: "Ensure AIDE is installed"
+    title: "Ensure AIDE is installed."
     description: "AIDE takes a snapshot of filesystem state including modification times, permissions, and file hashes which can then be used to compare against the current state of the filesystem to detect modifications to the system."
     rationale: "By monitoring the filesystem state compromised files can be detected to prevent or limit the exposure of accidental or malicious misconfigurations or modified binaries."
     remediation: "Run the following command to install aide: yum install aide // Configure AIDE as appropriate for your environment. Consult the AIDE documentation for options. Initialize AIDE: aide --init && mv /var/lib/aide/aide.db.new.gz /var/lib/aide/aide.db.gz"
@@ -497,7 +490,7 @@ checks:
 
 # 1.3.2 AIDE regular checks
   - id: 20027 
-    title: "Ensure filesystem integrity is regularly checked"
+    title: "Ensure filesystem integrity is regularly checked."
     description: "Periodic checking of the filesystem integrity is needed to detect changes to the filesystem."
     rationale: "Periodic file checking allows the system administrator to determine on a regular basis if critical files have been changed in an unauthorized fashion."
     remediation: "Run the following command: crontab -u root -e // Add the following line to the crontab: 0 5 * * * /usr/sbin/aide --check  // Notes: The checking in this recommendation occurs every day at 5am. Alter the frequency and time of the checks in compliance with site policy.  "
@@ -511,13 +504,12 @@ checks:
       - 'c:crontab -u root -l -> r:aide'
       - 'c:grep -r aide /etc/cron.* /etc/crontab -> r:aide'
 
-
 ###############################################
 # 1.4 Secure Boot Settings
 ###############################################
 # 1.4.1 Configure bootloader
   - id: 20028 
-    title: "Ensure permissions on bootloader config are configured"
+    title: "Ensure permissions on bootloader config are configured."
     description: "The grub configuration file contains information on boot settings and passwords for unlocking boot options. The grub configuration is usually located at /boot/grub/menu.lst and linked as /boot/grub/grub.conf and /etc/grub.conf ."
     rationale: "Setting the permissions to read and write for root only prevents non-root users from seeing the boot parameters or changing them. Non-root users who read the boot parameters may be able to identify weaknesses in security upon boot and be able to exploit them."
     remediation: "Run the following commands to set permissions on your grub configuration: # chown root:root /boot/grub/menu.lst # chmod og-rwx /boot/grub/menu.lst"
@@ -531,11 +523,9 @@ checks:
     rules:
       - 'c:stat /boot/grub/menu.lst -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
-
-
 # 1.4.2 Single user authentication
   - id: 20029 
-    title: "Ensure authentication required for single user mode"
+    title: "Ensure authentication required for single user mode."
     description: "Single user mode is used for recovery when the system detects an issue during boot or by manual selection from the bootloader."
     rationale: "Requiring authentication in single user mode prevents an unauthorized user from rebooting the system into single user to gain root privileges without credentials."
     remediation: "Edit /etc/sysconfig/init and set SINGLE to ' /sbin/sulogin':  SINGLE=/sbin/sulogin"
@@ -551,7 +541,7 @@ checks:
 
 # 1.4.3 Ensure interactive boot is not enabled (Scored)
   - id: 20030 
-    title: "Ensure interactive boot is not enabled"
+    title: "Ensure interactive boot is not enabled."
     description: "Interactive boot allows console users to interactively select which services start on boot. The PROMPT option provides console users the ability to interactively boot the system and select which services to start on boot . "
     rationale: "Turn off the PROMPT option on the console to prevent console users from potentially overriding established security settings. "
     remediation: "Edit the /etc/sysconfig/init file and set PROMPT to ' no ': PROMPT=no"
@@ -562,13 +552,12 @@ checks:
     rules:
       - 'f:/etc/sysconfig/init -> r:PROMPT\s*=\s*no'
 
-
 ###############################################
 # 1.5 Additional Process Hardening
 ###############################################
 # 1.5.1 Restrict Core Dumps (Scored)
   - id: 20031 
-    title: "Ensure core dumps are restricted"
+    title: "Ensure core dumps are restricted."
     description: "A core dump is the memory of an executable program. It is generally used to determine why a program aborted. It can also be used to glean confidential information from a core file."
     rationale: "Setting a hard limit on core dumps prevents users from overriding the soft variable. If core dumps are required, consider setting limits for user groups (see limits.conf). In addition, setting the fs.suid_dumpable variable to 0 will prevent setuid programs from dumping core."
     remediation: "Add the following line to /etc/security/limits.conf or a /etc/security/limits.d/* file: * hard core 0. Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: fs.suid_dumpable = 0 and Run the following command to set the active kernel parameter: # sysctl -w fs.suid_dumpable=0"
@@ -586,7 +575,7 @@ checks:
 
 # 1.5.2 XD/NX enabled
   - id: 20032 
-    title: "Ensure XD/NX support is enabled"
+    title: "Ensure XD/NX support is enabled."
     description: "Recent processors in the x86 family support the ability to prevent code execution on a per memory page basis. Generically and on AMD processors, this ability is called No Execute (NX), while on Intel processors it is called Execute Disable (XD). This ability can help prevent exploitation of buffer overflow vulnerabilities and should be activated whenever possible. Extra steps must be taken to ensure that this protection is enabled, particularly on 32-bit x86 systems. Other processors, such as Itanium and POWER, have included such support since inception and the standard kernel for those platforms supports the feature."
     rationale: "Enabling any feature that can protect against buffer overflow attacks enhances the security of the system."
     remediation: "On 32 bit systems install a kernel with PAE support, no installation is required on 64 bit systems: If necessary configure your bootloader to load the new kernel and reboot the system. You may need to enable NX or XD support in your bios."
@@ -602,7 +591,7 @@ checks:
 
 # 1.5.3 Enable Randomized Virtual Memory Region Placement (Scored)
   - id: 20033 
-    title: "Ensure address space layout randomization (ASLR) is enabled"
+    title: "Ensure address space layout randomization (ASLR) is enabled."
     description: "Address space layout randomization (ASLR) is an exploit mitigation technique which randomly arranges the address space of key data areas of a process."
     rationale: "Randomly placing virtual memory regions will make it difficult to write memory page exploits as the memory placement will be consistently shifting."
     remediation: "Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: kernel.randomize_va_space = 2. Run the following command to set the active kernel parameter: # sysctl -w kernel.randomize_va_space=2"
@@ -619,7 +608,7 @@ checks:
 
 # 1.5.4 Disable prelink
   - id: 20034 
-    title: "Ensure prelink is disabled"
+    title: "Ensure prelink is disabled."
     description: "prelink is a program that modifies ELF shared libraries and ELF dynamically linked binaries in such a way that the time needed for the dynamic linker to perform relocations at startup significantly decreases."
     rationale: "The prelinking feature can interfere with the operation of AIDE, because it changes binaries. Prelinking can also increase the vulnerability of the system if a malicious user is able to compromise a common library such as libc."
     remediation: "Run the following commands to restore binaries to normal and uninstall prelink: prelink -ua && yum remove prelink"
@@ -633,14 +622,13 @@ checks:
     rules:
       - 'c:rpm -q prelink -> package prelink is not installed'
 
-
 ###############################################
 # 1.6 Configure SELinux
 ###############################################
 
 # 1.6.1.1 SELinux not disabled
   - id: 20035 
-    title: "Ensure SELinux is not disabled in bootloader configuration"
+    title: "Ensure SELinux is not disabled in bootloader configuration."
     description: "Configure SELINUX to be enabled at boot time and verify that it has not been overwritten by the grub boot parameters."
     rationale: "SELinux must be enabled at boot time in your grub configuration to ensure that the controls it provides are not overridden."
     remediation: "Edit /boot/grub/menu.lst and remove all instances of selinux=0 and enforcing=0 on all kernel lines"
@@ -656,7 +644,7 @@ checks:
 
 # 1.6.1.2 Set selinux state
   - id: 20036 
-    title: "Ensure the SELinux state is enforcing"
+    title: "Ensure the SELinux state is enforcing."
     description: "Set SELinux to enable when the system is booted."
     rationale: "SELinux must be enabled at boot time in to ensure that the controls it provides are in effect at all times."
     remediation: "Edit the /etc/selinux/config file to set the SELINUX parameter: SELINUX=enforcing"
@@ -675,7 +663,7 @@ checks:
 
 # 1.6.1.3 Set selinux policy
   - id: 20037 
-    title: "Ensure SELinux policy is configured"
+    title: "Ensure SELinux policy is configured."
     description: "Configure SELinux to meet or exceed the default targeted policy, which constrains daemons and system software only."
     rationale: "Security configuration requirements vary from site to site. Some sites may mandate a policy that is stricter than the default policy, which is perfectly acceptable. This item is intended to ensure that at least the default recommendations are met."
     remediation: "Edit the /etc/selinux/config file to set the SELINUXTYPE parameter: SELINUXTYPE=targeted"
@@ -691,7 +679,7 @@ checks:
 
 # 1.6.1.4 Remove SETroubleshoot
   - id: 20038 
-    title: "Ensure SETroubleshoot is not installed"
+    title: "Ensure SETroubleshoot is not installed."
     description: "The SETroubleshoot service notifies desktop users of SELinux denials through a user-friendly interface. The service provides important information around configuration errors, unauthorized intrusions, and other potential errors."
     rationale: "The SETroubleshoot service is an unnecessary daemon to have running on a server, especially if X Windows is disabled."
     remediation: "Run the following command to uninstall setroubleshoot: # yum remove setroubleshoot"
@@ -706,7 +694,7 @@ checks:
 
 # 1.6.1.5 Disable MCS Translation service mcstrans
   - id: 20039 
-    title: "Ensure the MCS Translation Service (mcstrans) is not installed"
+    title: "Ensure the MCS Translation Service (mcstrans) is not installed."
     description: "The mcstransd daemon provides category label information to client processes requesting information. The label translations are defined in /etc/selinux/targeted/setrans.conf"
     rationale: "Since this service is not used very often, remove it to reduce the amount of potentially vulnerable code running on the system."
     remediation: "Run the following command to uninstall mcstrans: # yum remove mcstrans"
@@ -721,7 +709,7 @@ checks:
 
 # 1.6.1.6 Ensure no unconfined daemons exist
   - id: 20040 
-    title: "Ensure no unconfined daemons exist"
+    title: "Ensure no unconfined daemons exist."
     description: "Daemons that are not defined in SELinux policy will inherit the security context of their parent process."
     rationale: "Since daemons are launched and descend from the init process, they will inherit the security context label initrc_t . This could cause the unintended consequence of giving the process more permission than it requires."
     remediation: "Investigate any unconfined daemons found during the audit action. They may need to have an existing security context assigned to them or a policy built for them."
@@ -734,9 +722,10 @@ checks:
     condition: none
     rules:
       - 'c:ps -eZ -> r:initrc && !r:tr|ps|egrep|bash|awk'
+
 # 1.6.2 Install SELinux
   - id: 20041 
-    title: "Ensure SELinux is installed"
+    title: "Ensure SELinux is installed."
     description: "SELinux provides Mandatory Access Controls."
     rationale: "Without a Mandatory Access Control system installed only the default Discretionary Access Control system will be available."
     remediation: "Run the following command to install libselinux: yum install libselinux"
@@ -750,13 +739,12 @@ checks:
     rules:
       - 'c:rpm -q libselinux -> r:libselinux-\S+'
 
-
 ###############################################
 # 1.7  Warning Banners
 ###############################################
 # 1.7.1.1 Configure message of the day (Scored)
   - id: 20042 
-    title: "Ensure message of the day is configured properly"
+    title: "Ensure message of the day is configured properly."
     description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version"
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
     remediation: "Edit the /etc/motd file with the appropriate contents according to your site policy, remove any instances of \\m , \\r , \\s , or \\v."
@@ -770,7 +758,7 @@ checks:
 
 # 1.7.1.2 Configure local login warning banner (Not Scored)
   - id: 20043 
-    title: "Ensure local login warning banner is configured properly"
+    title: "Ensure local login warning banner is configured properly."
     description: "The contents of the /etc/issue file are displayed to users prior to login for local terminals. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version"
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
     remediation: "Edit the /etc/issue file with the appropriate contents according to your site policy, remove any instances of \\m , \\r , \\s , or \\v: # echo \"Authorized uses only. All activity may be monitored and reported.\" > /etc/issue"
@@ -784,7 +772,7 @@ checks:
 
 # 1.7.1.3 Configure remote login warning banner (Not Scored)
   - id: 20044 
-    title: "Ensure remote login warning banner is configured properly"
+    title: "Ensure remote login warning banner is configured properly."
     description: "The contents of the /etc/issue.net file are displayed to users prior to login for remote connections from configured services. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version"
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
     remediation: "Edit the /etc/issue.net file with the appropriate contents according to your site policy, remove any instances of \\m , \\r , \\s , or \\v: # echo \"Authorized uses only. All activity may be monitored and reported.\" > /etc/issue.net"
@@ -798,7 +786,7 @@ checks:
 
 # 1.7.1.4 Configure /etc/motd permissions (Not Scored)
   - id: 20045 
-    title: "Ensure permissions on /etc/motd are configured"
+    title: "Ensure permissions on /etc/motd are configured."
     description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users."
     rationale: "If the /etc/motd file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
     remediation: "Run the following commands to set permissions on /etc/motd: # chown root:root /etc/motd # chmod 644 /etc/motd"
@@ -817,7 +805,7 @@ checks:
 
 # 1.7.1.5 Configure /etc/issue permissions (Scored)
   - id: 20046 
-    title: "Ensure permissions on /etc/issue are configured"
+    title: "Ensure permissions on /etc/issue are configured."
     description: "The contents of the /etc/issue file are displayed to users prior to login for local terminals."
     rationale: "If the /etc/issue file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
     remediation: "Run the following commands to set permissions on /etc/issue: # chown root:root /etc/issue # chmod 644 /etc/issue"
@@ -833,9 +821,10 @@ checks:
     condition: all
     rules:
       - 'c:stat /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+
 # 1.7.1.6 Configure /etc/issue.net permissions (Not Scored)
   - id: 20047 
-    title: "Ensure permissions on /etc/issue.net are configured"
+    title: "Ensure permissions on /etc/issue.net are configured."
     description: "The contents of the /etc/issue.net file are displayed to users prior to login for remote connections from configured services."
     rationale: "If the /etc/issue.net file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
     remediation: "Run the following commands to set permissions on /etc/issue.net: # chown root:root /etc/issue.net # chmod 644 /etc/issue.net"
@@ -852,10 +841,9 @@ checks:
     rules:
       - 'c:stat /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
-
 # 1.8 Ensure updates, patches, and additional security software are installed (Not Scored)
   - id: 20048 
-    title: "Ensure updates, patches, and additional security software are installed"
+    title: "Ensure updates, patches, and additional security software are installed."
     description: "Periodically patches are released for included software either due to security flaws or to include additional functionality."
     rationale: "Newer patches may contain security enhancements that would not be available through the latest full update. As a result, it is recommended that the latest software patches be used to take advantage of the latest functionality. As with any software installation, organizations need to determine if a given update meets their requirements and verify the compatibility and supportability of any additional software against the update revision that is selected."
     remediation: "Site policy may mandate a testing period before install onto production systems for available updates. The audit and remediation here only cover security updates. Non-security updates can be audited with and comparing against site policy: # yum check-update"
@@ -881,7 +869,7 @@ checks:
 # 2.1.1 Disable chargen services (Scored)
 
   - id: 20049 
-    title: "Ensure chargen services are not enabled"
+    title: "Ensure chargen services are not enabled."
     description: "chargen is a network service that responds with 0 to 512 ASCII characters for each connection it receives. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
     rationale: "Disabling this service will reduce the remote attack surface of the system."
     remediation: "Run the following commands to disable chargen-dgram and chargen-stream: # chkconfig chargen-dgram off; # chkconfig chargen-stream off"
@@ -901,7 +889,7 @@ checks:
 
 # 2.1.2 Disable daytime services (Scored)
   - id: 20050 
-    title: "Ensure daytime services are not enabled"
+    title: "Ensure daytime services are not enabled."
     description: "daytime is a network service that responds with the server's current date and time. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
     rationale: "Disabling this service will reduce the remote attack surface of the system."
     remediation: "Run the following commands to disable daytime-dgram and daytime-stream: # chkconfig daytime-dgram off; # chkconfig daytime-stream off"
@@ -921,7 +909,7 @@ checks:
 
 # 2.1.3 Disable discard services (Scored)
   - id: 20051 
-    title: "Ensure discard services are not enabled"
+    title: "Ensure discard services are not enabled."
     description: "discardis a network service that simply discards all data it receives. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
     rationale: "Disabling this service will reduce the remote attack surface of the system."
     remediation: "Run the following commands to disable discard-dgram and discard-stream: # chkconfig discard-dgram off; # chkconfig discard-stream off"
@@ -941,7 +929,7 @@ checks:
 
 # 2.1.4 Disable echo-dgram (Scored)
   - id: 20052 
-    title: "Ensure echo services are not enabled"
+    title: "Ensure echo services are not enabled."
     description: "echo is a network service that responds to clients with the data sent to it by the client. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
     rationale: "Disabling this service will reduce the remote attack surface of the system."
     remediation: "Run the following commands to disable echo-dgram and echo-stream: # chkconfig echo-dgram off; # chkconfig echo-stream off"
@@ -961,7 +949,7 @@ checks:
 
 # 2.1.5 Disable time-stream (Scored)
   - id: 20053 
-    title: "Ensure time services are not enabled"
+    title: "Ensure time services are not enabled."
     description: "time is a network service that responds with the server's current date and time as a 32 bit integer. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
     rationale: "Disabling this service will reduce the remote attack surface of the system."
     remediation: "Run the following commands to disable time-dgram and time-stream: # chkconfig time-dgram off; # chkconfig time-stream off"
@@ -981,7 +969,7 @@ checks:
 
 # 2.1.6 Remove rsh-server (Scored)
   - id: 20054 
-    title: "Ensure rsh server is not enabled"
+    title: "Ensure rsh server is not enabled."
     description: "The Berkeley rsh-server ( rsh , rlogin , rexec ) package contains legacy services that exchange credentials in clear-text."
     rationale: "These legacy services contain numerous security exposures and have been replaced with the more secure SSH package."
     remediation: "Run the following commands to disable rsh, rlogin, and rexec: # chkconfig rsh off   # chkconfig rlogin off  # chkconfig rexec off"
@@ -1000,10 +988,9 @@ checks:
       - 'c:chkconfig --list rlogin -> r:^\s*\t*rlogin:\s*\t*on'
       - 'c:chkconfig --list rsh -> r:^\s*\t*rsh:\s*\t*on'
 
-
 # 2.1.7 Remove talk server (Scored)
   - id: 20055 
-    title: "Ensure talk server is not enabled"
+    title: "Ensure talk server is not enabled."
     description: "The talk software makes it possible for users to send and receive messages across systems through a terminal session. The talk client (allows initiate of talk sessions) is installed by default."
     rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
     remediation: "Run the following command to disable talk: # chkconfig talk off"
@@ -1022,7 +1009,7 @@ checks:
 
 # 2.1.8 Remove telnet-server (Scored)
   - id: 20056 
-    title: "Ensure telnet server is not enabled"
+    title: "Ensure telnet server is not enabled."
     description: "The telnet-server package contains the telnet daemon, which accepts connections from users from other systems via the telnet protocol."
     rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow a user with access to sniff network traffic the ability to steal credentials. The ssh package provides an encrypted session and stronger security."
     remediation: "Run the following command to disable telnet: # chkconfig telnet off"
@@ -1041,7 +1028,7 @@ checks:
 
 # 2.1.9 Ensure tftp server is not enabled (Scored)
   - id: 20057 
-    title: "Ensure tftp server is not enabled"
+    title: "Ensure tftp server is not enabled."
     description: "Trivial File Transfer Protocol (TFTP) is a simple file transfer protocol, typically used to automatically transfer configuration or boot machines from a boot server. The package tftp-server is used to define and support a TFTP server."
     rationale: "TFTP does not support authentication nor does it ensure the confidentiality or integrity of data. It is recommended that TFTP be removed, unless there is a specific need for TFTP. In that case, extreme caution must be used when configuring the services."
     remediation: "Run the following command to disable tftp: # chkconfig tftp off"
@@ -1060,7 +1047,7 @@ checks:
 
 # 2.1.10 Remove rsync service (Scored)
   - id: 20058 
-    title: "Ensure rsync service is not enabled"
+    title: "Ensure rsync service is not enabled."
     description: "The rsyncd service can be used to synchronize files between systems over network links."
     rationale: "The rsyncd service presents a security risk as it uses unencrypted protocols for communication."
     remediation: "Run the following command to disable rsync: # chkconfig rsyncd off"
@@ -1079,7 +1066,7 @@ checks:
 
 # 2.1.11 Remove xinetd (Scored)
   - id: 20059 
-    title: "Ensure xinetd is not enabled"
+    title: "Ensure xinetd is not enabled."
     description: "The eXtended InterNET Daemon ( xinetd ) is an open source super daemon that replaced the original inetd daemon. The xinetd daemon listens for well known services and dispatches the appropriate daemon to properly respond to service requests."
     rationale: "If there are no xinetd services required, it is recommended that the daemon be disabled."
     remediation: "Run the following command to disable xinetd: # chkconfig xinetd off"
@@ -1102,7 +1089,7 @@ checks:
 
 # 2.2.1.1 Ensure time synchronization is in use (Not Scored)
   - id: 20060 
-    title: "Ensure time synchronization is in use"
+    title: "Ensure time synchronization is in use."
     description: "System time should be synchronized between all systems in an environment. This is typically done by establishing an authoritative time server or set of servers and having all systems synchronize their clocks to them."
     rationale: "Time synchronization is important to support time sensitive security mechanisms like Kerberos and also ensures log files have consistent time records across the enterprise, which aids in forensic investigations."
     remediation: "On physical systems or virtual systems where host based time synchronization is not available run the following commands and verify either ntp or chrony is installed: # rpm -q ntp # rpm -q chrony  On virtual systems where host based time synchronization is available consult your virtualization software documentation and verify that host based synchronization is in use."
@@ -1119,7 +1106,7 @@ checks:
 
 # 2.2.1.2 Configure Network Time Protocol (NTP) (Scored)
   - id: 20061 
-    title: "Ensure ntp is configured"
+    title: "Ensure ntp is configured."
     description: "ntp is a daemon which implements the Network Time Protocol (NTP). It is designed to synchronize system clocks across a variety of systems and use a source that is highly accurate. More information on NTP can be found at https://www.ntp.org. ntp can be configured to be a client and/or a server."
     rationale: "If ntp is in use on the system proper configuration is vital to ensuring time synchronization is working properly."
     remediation: "1) Add or edit restrict lines in /etc/ntp.conf to match the following: - restrict -4 default kod nomodify notrap nopeer noquery and - restrict -4 default kod nomodify notrap nopeer noquery. 2) Add or edit server or pool lines to /etc/ntp.conf as appropriate: server <remote-server>. 3) Add or edit the daemonline in/etc/init.d/ntpd to include ' -u ntp:ntp ': daemon $prog -u ntp:ntp -p /var/run/ntpd.pid $OPTIONS"
@@ -1138,7 +1125,7 @@ checks:
 
 # 2.2.1.3 Configure Network Time Protocol (Chrony) (Scored)
   - id: 20062 
-    title: "Ensure chrony is configured"
+    title: "Ensure chrony is configured."
     description: "chrony is a daemon which implements the Network Time Protocol (NTP). It is designed to synchronize system clocks across a variety of systems and use a source that is highly accurate. More information on NTP can be found at https://www.ntp.org. ntp can be configured to be a client and/or a server."
     rationale: "If chrony is in use on the system proper configuration is vital to ensuring time synchronization is working properly."
     remediation: "1) Add or edit restrict lines in /etc/chrony.conf to match the following: - 1) Add or edit server or pool lines to /etc/chrony.conf as appropriate: server <remote-server>. 3) Add or edit the OPTIONS in /etc/sysconfig/chronyd to include: - OPTIONS='-u chronyd'"
@@ -1155,7 +1142,7 @@ checks:
 
 # 2.2.2 Remove X Windows (Scored)
   - id: 20063 
-    title: "Ensure X Window System is not installed"
+    title: "Ensure X Window System is not installed."
     description: "The X Window System provides a Graphical User Interface (GUI) where users can have multiple windows in which to run programs and various add on. The X Windows system is typically used on workstations where users login, but not on servers where users typically do not login."
     rationale: "Unless your organization specifically requires graphical login access via X Windows, remove it to reduce the potential attack surface."
     remediation: "Run the following command to remove the X Windows System packages: # yum remove xorg-x11*"
@@ -1171,7 +1158,7 @@ checks:
 
 # 2.2.3 Disable Avahi Server (Scored)
   - id: 20064 
-    title: "Ensure Avahi Server is not enabled"
+    title: "Ensure Avahi Server is not enabled."
     description: "Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD service discovery. Avahi allows programs to publish and discover services and hosts running on a local network with no specific configuration. For example, a user can plug a computer into a network and Avahi automatically finds printers to print to, files to look at and people to talk to, as well as network services running on the machine."
     rationale: "Automatic discovery of network services is not normally required for system functionality. It is recommended to disable the service to reduce the potential attack surface."
     remediation: "Run the following command to disable avahi-daemon: # chkconfig avahi-daemon off"
@@ -1187,7 +1174,7 @@ checks:
 
 # 2.2.4 Ensure CUPS is not enabled (Scored)
   - id: 20065 
-    title: "Ensure CUPS is not enabled"
+    title: "Ensure CUPS is not enabled."
     description: "The Common Unix Print System (CUPS) provides the ability to print to both local and network printers. A system running CUPS can also accept print jobs from remote systems and print them to local printers. It also provides a web based remote administration capability."
     rationale: "If the system does not need to print jobs or accept print jobs from other systems, it is recommended that CUPS be disabled to reduce the potential attack surface."
     remediation: "Run the following command to disable cups : # chkconfig cups off"
@@ -1203,7 +1190,7 @@ checks:
 
 # 2.2.5 Remove DHCP Server (Scored)
   - id: 20066 
-    title: "Ensure DHCP Server is not enabled"
+    title: "Ensure DHCP Server is not enabled."
     description: "The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be dynamically assigned IP addresses."
     rationale: "Unless a system is specifically set up to act as a DHCP server, it is recommended that this service be disabled to reduce the potential attack surface."
     remediation: "Run the following command to disable dhcpd: # chkconfig dhcpd off"
@@ -1221,7 +1208,7 @@ checks:
 
 # 2.2.6 Remove LDAP Server (Scored)
   - id: 20067 
-    title: "Ensure LDAP Server is not enabled"
+    title: "Ensure LDAP Server is not enabled."
     description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
     rationale: "If the system will not need to act as an LDAP server, it is recommended that the software be disabled to reduce the potential attack surface."
     remediation: "Run the following command to disable slapd: # chkconfig slapd off"
@@ -1237,11 +1224,9 @@ checks:
     rules:
       - 'c:chkconfig --list slapd -> r:^\s*\t*slapd\.*on'
 
-
-
 # 2.2.7 Disable NFS and RPC (Scored)
   - id: 20068 
-    title: "Ensure NFS and RPC are not enabled"
+    title: "Ensure NFS and RPC are not enabled."
     description: "The Network File System (NFS) is one of the first and most widely distributed file systems in the UNIX environment. It provides the ability for systems to mount file systems of other servers through the network."
     rationale: "If the system does not export NFS shares or act as an NFS client, it is recommended that these services be disabled to reduce remote attack surface."
     remediation: "Run the following commands to disable nfs, nfs-server and rpcbind: # chkconfig nfs off; # chkconfig rpcbind off"
@@ -1258,7 +1243,7 @@ checks:
 
 # 2.2.8 Ensure DNS Server is not enabled (Scored)
   - id: 20069 
-    title: "Ensure DNS Server is not enabled"
+    title: "Ensure DNS Server is not enabled."
     description: "The Domain Name System (DNS) is a hierarchical naming system that maps names to IP addresses for computers, services and other resources connected to a network."
     rationale: "Unless a system is specifically designated to act as a DNS server, it is recommended that the service be disabled to reduce the potential attack surface."
     remediation: "Run the following command to disable named : # chkconfig named off"
@@ -1274,7 +1259,7 @@ checks:
 
 # 2.2.9 Remove FTP Server (Scored)
   - id: 20070 
-    title: "Ensure FTP Server is not enabled"
+    title: "Ensure FTP Server is not enabled."
     description: "The File Transfer Protocol (FTP) provides networked computers with the ability to transfer files."
     rationale: "FTP does not protect the confidentiality of data or authentication credentials. It is recommended sftp be used if file transfer is required. Unless there is a need to run the system as a FTP server (for example, to allow anonymous downloads), it is recommended that the service be disabled to reduce the potential attack surface."
     remediation: "Run the following command to disable vsftpd: # chkconfig vsftpd off"
@@ -1290,7 +1275,7 @@ checks:
 
 # 2.2.10 Remove HTTP Server (Scored)
   - id: 20071 
-    title: "Ensure HTTP server is not enabled"
+    title: "Ensure HTTP server is not enabled."
     description: "HTTP or web servers provide the ability to host web site content."
     rationale: "Unless there is a need to run the system as a web server, it is recommended that the service be disabled to reduce the potential attack surface."
     remediation: "Run the following command to disable httpd: # chkconfig httpd off"
@@ -1306,7 +1291,7 @@ checks:
 
 # 2.2.11 Remove Dovecot (IMAP and POP3 services) (Scored)
   - id: 20072 
-    title: "Ensure IMAP and POP3 server is not enabled"
+    title: "Ensure IMAP and POP3 server is not enabled."
     description: "dovecot is an open source IMAP and POP3 server for Linux based systems."
     rationale: "Unless POP3 and/or IMAP servers are to be provided by this system, it is recommended that the service be disabled to reduce the potential attack surface."
     remediation: "Run the following command to disable dovecot: # chkconfig dovecot off"
@@ -1322,7 +1307,7 @@ checks:
 
 # 2.2.12 Remove Samba (Scored)
   - id: 20073 
-    title: "Ensure Samba is not enabled"
+    title: "Ensure Samba is not enabled."
     description: "The Samba daemon allows system administrators to configure their Linux systems to share file systems and directories with Windows desktops. Samba will advertise the file systems and directories via the Small Message Block (SMB) protocol. Windows desktop users will be able to mount these directories and file systems as letter drives on their systems."
     rationale: "If there is no need to mount directories and file systems to Windows systems, then this service can be disabled to reduce the potential attack surface."
     remediation: "Run the following command to disable smb: # chkconfig smb off"
@@ -1338,7 +1323,7 @@ checks:
 
 # 2.2.13 Remove HTTP Proxy Server (Scored)
   - id: 20074 
-    title: "Ensure HTTP Proxy Server is not enabled"
+    title: "Ensure HTTP Proxy Server is not enabled."
     description: "Squid is a standard proxy server used in many distributions and environments."
     rationale: "If there is no need for a proxy server, it is recommended that the squid proxy be disabled to reduce the potential attack surface."
     remediation: "Run the following command to disable squid: # chkconfig squid off"
@@ -1354,7 +1339,7 @@ checks:
 
 # 2.2.14 Remove SNMP Server (Not Scored)
   - id: 20075 
-    title: "Ensure SNMP Server is not enabled"
+    title: "Ensure SNMP Server is not enabled."
     description: "The Simple Network Management Protocol (SNMP) server is used to listen for SNMP commands from an SNMP management system, execute the commands or collect the information and then send results back to the requesting system."
     rationale: "The SNMP server can communicate using SNMP v1, which transmits data in the clear and does not require authentication to execute commands. Unless absolutely necessary, it is recommended that the SNMP service not be used. If SNMP is required the server should be configured to disallow SNMP v1."
     remediation: "Run the following command to disable snmpd: # chkconfig snmpd off"
@@ -1370,7 +1355,7 @@ checks:
 
 # 2.2.15 Ensure mail transfer agent is configured for local-only mode (Scored)
   - id: 20076 
-    title: "Ensure mail transfer agent is configured for local-only mode"
+    title: "Ensure mail transfer agent is configured for local-only mode."
     description: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
     rationale: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
     remediation: "Edit /etc/postfix/main.cf and add the following line to the RECEIVING MAIL section. If the line already exists, change it to look like the line below: inet_interfaces = loopback-only Restart postfix: # service postfix restart"
@@ -1386,7 +1371,7 @@ checks:
 
 # 2.2.16 Remove NIS Server (Scored)
   - id: 20077 
-    title: "Ensure NIS Server is not enabled"
+    title: "Ensure NIS Server is not enabled."
     description: "The Network Information Service (NIS) (formally known as Yellow Pages) is a client-server directory service protocol for distributing system configuration files. The NIS server is a collection of programs that allow for the distribution of configuration files."
     rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be disabled and other, more secure services be used"
     remediation: "Run the following command to disable ypserv: # chkconfig ypserv off"
@@ -1408,7 +1393,7 @@ checks:
 ###############################################
 # 2.3.1 Remove NIS Client (Scored)
   - id: 20078 
-    title: "Ensure NIS Client is not installed"
+    title: "Ensure NIS Client is not installed."
     description: "The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server directory service protocol used to distribute system configuration files. The NIS client ( ypbind ) was used to bind a machine to an NIS server and receive the distributed configuration files."
     rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed."
     remediation: "Run the following command to uninstall ypbind: # yum remove ypbind"
@@ -1427,7 +1412,7 @@ checks:
 
 # 2.3.2 Ensure rsh client is not installed (Scored)
   - id: 20079 
-    title: "Ensure rsh client is not installed"
+    title: "Ensure rsh client is not installed."
     description: "The rsh package contains the client commands for the rsh services."
     rationale: "These legacy clients contain numerous security exposures and have been replaced with the more secure SSH package. Even if the server is removed, it is best to ensure the clients are also removed to prevent users from inadvertently attempting to use these commands and therefore exposing their credentials. Note that removing the rsh package removes the clients for rsh , rcp and rlogin ."
     remediation: "Run the following command to uninstall rsh : # yum remove rsh"
@@ -1446,7 +1431,7 @@ checks:
 
 # 2.3.3 Ensure talk client is not installed (Scored)
   - id: 20080 
-    title: "Ensure talk client is not installed"
+    title: "Ensure talk client is not installed."
     description: "The talk software makes it possible for users to send and receive messages across systems through a terminal session. The talk client, which allows initialization of talk sessions, is installed by default."
     rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
     remediation: "Run the following command to uninstall talk : # yum remove talk"
@@ -1465,7 +1450,7 @@ checks:
 
 # 2.3.4 Ensure telnet client is not installed (Scored)
   - id: 20081 
-    title: "Ensure telnet client is not installed"
+    title: "Ensure telnet client is not installed."
     description: "The telnet package contains the telnet client, which allows users to start connections to other systems via the telnet protocol."
     rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow an unauthorized user to steal credentials. The ssh package provides an encrypted session and stronger security and is included in most Linux distributions."
     remediation: "Run the following command to uninstall telnet : # yum remove telnet"
@@ -1484,7 +1469,7 @@ checks:
 
 # 2.3.5 Ensure LDAP client is not installed (Scored)
   - id: 20082 
-    title: "Ensure LDAP client is not installed"
+    title: "Ensure LDAP client is not installed."
     description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
     rationale: "If the system will not need to act as an LDAP client, it is recommended that the software be removed to reduce the potential attack surface."
     remediation: "Run the following command to uninstall openldap-clients : # yum remove openldap-clients"
@@ -1509,7 +1494,7 @@ checks:
 ###############################################
 # 3.1.1 Disable IP Forwarding (Scored)
   - id: 20083 
-    title: "Ensure IP forwarding is disabled"
+    title: "Ensure IP forwarding is disabled."
     description: "The net.ipv4.ip_forward flag is used to tell the system whether it can forward packets or not."
     rationale: "Setting the flag to 0 ensures that a system with multiple interfaces (for example, a hard proxy), will never be able to forward packets, and therefore, never serve as a router."
     remediation: "Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.ip_forward = 0. Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.ip_forward=0 # sysctl -w net.ipv4.route.flush=1"
@@ -1526,7 +1511,7 @@ checks:
 
 # 3.1.2 Disable Send Packet Redirects (Scored)
   - id: 20084 
-    title: "Ensure packet redirect sending is disabled"
+    title: "Ensure packet redirect sending is disabled."
     description: "ICMP Redirects are used to send routing information to other hosts. As a host itself does not act as a router (in a host only configuration), there is no need to send redirects."
     rationale: "An attacker could use a compromised host to send invalid ICMP redirects to other router devices in an attempt to corrupt routing and have users access a system set up by the attacker as opposed to a valid system."
     remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.send_redirects = 0; net.ipv4.conf.default.send_redirects = 0. Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.conf.all.send_redirects=0; # sysctl -w net.ipv4.conf.default.send_redirects=0; # sysctl -w net.ipv4.route.flush=1"
@@ -1548,7 +1533,7 @@ checks:
 ###############################################
 # 3.2.1 Disable Source Routed Packet Acceptance (Scored)
   - id: 20085 
-    title: "Ensure source routed packets are not accepted"
+    title: "Ensure source routed packets are not accepted."
     description: "In networking, source routing allows a sender to partially or fully specify the route packets take through a network. In contrast, non-source routed packets travel a path determined by routers in the network. In some cases, systems may not be routable or reachable from some locations (e.g. private addresses vs. Internet routable), and so source routed packets would need to be used."
     rationale: "Setting net.ipv4.conf.all.accept_source_route and net.ipv4.conf.default.accept_source_route to 0 disables the system from accepting source routed packets. Assume this system was capable of routing packets to Internet routable addresses on one interface and private addresses on another interface. Assume that the private addresses were not routable to the Internet routable addresses and vice versa. Under normal routing circumstances, an attacker from the Internet routable addresses could not use the system as a way to reach the private address systems. If, however, source routed packets were allowed, they could be used to gain access to the private address systems as the route could be specified, rather than rely on routing protocols that did not allow this routing."
     remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.accept_source_route = 0; net.ipv4.conf.default.accept_source_route = 0. Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.conf.all.accept_source_route=0 # sysctl -w net.ipv4.conf.default.accept_source_route=0 # sysctl -w net.ipv4.route.flush=1"
@@ -1567,7 +1552,7 @@ checks:
 
 # 3.2.2 Disable ICMP Redirect Acceptance (Scored)
   - id: 20086 
-    title: "Ensure ICMP redirects are not accepted"
+    title: "Ensure ICMP redirects are not accepted."
     description: "ICMP redirect messages are packets that convey routing information and tell your host (acting as a router) to send packets via an alternate path. It is a way of allowing an outside routing device to update your system routing tables."
     rationale: "Attackers could use bogus ICMP redirect messages to maliciously alter the system routing tables and get them to send packets to incorrect networks and allow your system packets to be captured."
     remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.accept_redirects = 0; net.ipv4.conf.default.accept_redirects = 0. Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.conf.all.accept_redirects=0 # sysctl -w net.ipv4.conf.default.accept_redirects=0 # sysctl -w net.ipv4.route.flush=1"
@@ -1586,7 +1571,7 @@ checks:
 
 # 3.2.3 Disable Secure ICMP Redirect Acceptance (Scored)
   - id: 20087 
-    title: "Ensure secure ICMP redirects are not accepted"
+    title: "Ensure secure ICMP redirects are not accepted."
     description: "Secure ICMP redirects are the same as ICMP redirects, except they come from gateways listed on the default gateway list. It is assumed that these gateways are known to your system, and that they are likely to be secure."
     rationale: "It is still possible for even known gateways to be compromised. Setting net.ipv4.conf.all.secure_redirects to 0 protects the system from routing table updates by possibly compromised known gateways."
     remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.secure_redirects = 0; net.ipv4.conf.default.secure_redirects = 0. Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.conf.all.secure_redirects=0 # sysctl -w net.ipv4.conf.default.secure_redirects=0 # sysctl -w net.ipv4.route.flush=1"
@@ -1605,7 +1590,7 @@ checks:
 
 # 3.2.4 Log Suspicious Packets (Scored)
   - id: 20088 
-    title: "Ensure suspicious packets are logged"
+    title: "Ensure suspicious packets are logged."
     description: "When enabled, this feature logs packets with un-routable source addresses to the kernel log."
     rationale: "Enabling this feature and logging these packets allows an administrator to investigate the possibility that an attacker is sending spoofed packets to their system."
     remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.log_martians = 1; net.ipv4.conf.default.log_martians = 1. Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.conf.all.log_martians=1 # sysctl -w net.ipv4.conf.default.log_martians=1 # sysctl -w net.ipv4.route.flush=1"
@@ -1624,7 +1609,7 @@ checks:
 
 # 3.2.5 Enable Ignore Broadcast Requests (Scored)
   - id: 20089 
-    title: "Ensure broadcast ICMP requests are ignored"
+    title: "Ensure broadcast ICMP requests are ignored."
     description: "Setting net.ipv4.icmp_echo_ignore_broadcasts to 1 will cause the system to ignore all ICMP echo and timestamp requests to broadcast and multicast addresses."
     rationale: "Accepting ICMP echo and timestamp requests with broadcast or multicast destinations for your network could be used to trick your host into starting (or participating) in a Smurf attack. A Smurf attack relies on an attacker sending large amounts of ICMP broadcast messages with a spoofed source address."
     remediation: "Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.icmp_echo_ignore_broadcasts = 1. Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.icmp_echo_ignore_broadcasts=1 # sysctl -w net.ipv4.route.flush=1"
@@ -1641,7 +1626,7 @@ checks:
 
 # 3.2.6 Enable Bad Error Message Protection (Scored)
   - id: 20090 
-    title: "Ensure bogus ICMP responses are ignored"
+    title: "Ensure bogus ICMP responses are ignored."
     description: "Setting icmp_ignore_bogus_error_responses to 1 prevents the kernel from logging bogus responses (RFC-1122 non-compliant) from broadcast reframes, keeping file systems from filling up with useless log messages."
     rationale: "Some routers (and some attackers) will send responses that violate RFC-1122 and attempt to fill up a log file system with many useless error messages."
     remediation: "Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.icmp_ignore_bogus_error_responses = 1. Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.icmp_ignore_bogus_error_responses=1 # sysctl -w net.ipv4.route.flush=1"
@@ -1658,7 +1643,7 @@ checks:
 
 # 3.2.7 Enable RFC-recommended Source Route Validation (Scored)
   - id: 20091 
-    title: "Ensure Reverse Path Filtering is enabled"
+    title: "Ensure Reverse Path Filtering is enabled."
     description: "Setting net.ipv4.conf.all.rp_filter and net.ipv4.conf.default.rp_filter to 1 forces the Linux kernel to utilize reverse path filtering on a received packet to determine if the packet was valid. Essentially, with reverse path filtering, if the return packet does not go out the same interface that the corresponding source packet came from, the packet is dropped (and logged if log_martians is set)."
     rationale: "Setting these flags is a good way to deter attackers from sending your server bogus packets that cannot be responded to. One instance where this feature breaks down is if asymmetrical routing is employed. This would occur when using dynamic routing protocols (bgp, ospf, etc) on your system. If you are using asymmetrical routing on your system, you will not be able to enable this feature without breaking the routing."
     remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.rp_filter = 1; net.ipv4.conf.default.rp_filter = 1. Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.conf.all.rp_filter=1 # sysctl -w net.ipv4.conf.default.rp_filter=1 # sysctl -w net.ipv4.route.flush=1"
@@ -1677,7 +1662,7 @@ checks:
 
 # 3.2.8 Enable TCP SYN Cookies (Scored)
   - id: 20092 
-    title: "Ensure TCP SYN Cookies is enabled"
+    title: "Ensure TCP SYN Cookies is enabled."
     description: "When tcp_syncookies is set, the kernel will handle TCP SYN packets normally until the half-open connection queue is full, at which time, the SYN cookie functionality kicks in. SYN cookies work by not using the SYN queue at all. Instead, the kernel simply replies to the SYN with a SYN|ACK, but will include a specially crafted TCP sequence number that encodes the source and destination IP address and port number and the time the packet was sent."
     rationale: "Attackers use SYN flood attacks to perform a denial of service attacked on a system by sending many SYN packets without completing the three way handshake. This will quickly use up slots in the kernel's half-open connection queue and prevent legitimate connections from succeeding. SYN cookies allow the system to keep accepting valid connections, even if under a denial of service attack."
     remediation: "Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.tcp_syncookies = 1. Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.tcp_syncookies=1 # sysctl -w net.ipv4.route.flush=1"
@@ -1697,7 +1682,7 @@ checks:
 ###############################################
 # 3.3.1 Ensure IPv6 router advertisements are not accepted (Not Scored)
   - id: 20093 
-    title: "Ensure IPv6 router advertisements are not accepted"
+    title: "Ensure IPv6 router advertisements are not accepted."
     description: "This setting disables the system's ability to accept IPv6 router advertisements."
     rationale: "It is recommended that systems not accept router advertisements as they could be tricked into routing traffic to compromised machines. Setting hard routes within the system (usually a single default route to a trusted router) protects the system from bad routes."
     remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv6.conf.all.accept_ra = 0 and net.ipv6.conf.default.accept_ra = 0 Then, run the following commands to set the active kernel parameters: # sysctl -w net.ipv6.conf.all.accept_ra=0 # sysctl -w net.ipv6.conf.default.accept_ra=0 # sysctl -w net.ipv6.route.flush=1"
@@ -1717,10 +1702,9 @@ checks:
       - 'c:grep -Rh net\.ipv6\.conf\.all\.accept_ra /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv6.conf.all.accept_ra\s*=\s*0'
       - 'c:grep -Rh net\.ipv6\.conf\.default\.accept_ra /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv6.conf.default.accept_ra\s*=\s*0'
 
-
 # 3.3.2 Ensure IPv6 redirects are not accepted (Not Scored)
   - id: 20094 
-    title: "Ensure IPv6 redirects are not accepted"
+    title: "Ensure IPv6 redirects are not accepted."
     description: "This setting prevents the system from accepting ICMP redirects. ICMP redirects tell the system about alternate routes for sending traffic."
     rationale: "It is recommended that systems not accept ICMP redirects as they could be tricked into routing traffic to compromised machines. Setting hard routes within the system (usually a single default route to a trusted router) protects the system from bad routes."
     remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv6.conf.all.accept_redirects = 0  || net.ipv6.conf.default.accept_redirects = 0 Then, run the following commands to set the active kernel parameters: # sysctl -w net.ipv6.conf.all.accept_redirects=0 # sysctl -w net.ipv6.conf.default.accept_redirects=0 # sysctl -w net.ipv6.route.flush=1"
@@ -1742,7 +1726,7 @@ checks:
 
 # 3.3.3 Ensure IPv6 is disabled (Not Scored)
   - id: 20095 
-    title: "Ensure IPv6 is disabled"
+    title: "Ensure IPv6 is disabled."
     description: "Although IPv6 has many advantages over IPv4, few organizations have implemented IPv6."
     rationale: "If IPv6 is not to be used, it is recommended that it be disabled to reduce the attack surface of the system."
     remediation: "Edit /boot/grub/grub.conf to include ipv6.disable=1 on all kernel lines."
@@ -1759,13 +1743,12 @@ checks:
     rules:
       - 'f:/boot/grub/grub.conf -> r:^\s*\t*kernel && !r:ipv6.disable=1'
 
-
 ###############################################
 # 3.4 TCP Wrappers
 ###############################################
 # 3.4.1 Ensure TCP Wrappers is installed (Scored)
   - id: 20096 
-    title: "Ensure TCP Wrappers is installed"
+    title: "Ensure TCP Wrappers is installed."
     description: "TCP Wrappers provides a simple access list and standardized logging method for services capable of supporting it. In the past, services that were called from inetd and xinetd supported the use of tcp wrappers. As inetd and xinetd have been falling in disuse, any service that can support tcp wrappers will have the libwrap.so library attached to it."
     rationale: "TCP Wrappers provide a good simple access list mechanism to services that may not have that support built in. It is recommended that all services that can support TCP Wrappers, use it."
     remediation: "Run the following command to install tcp_wrappers: yum install tcp_wrappers"
@@ -1780,7 +1763,7 @@ checks:
 
 # 3.4.3 Ensure /etc/hosts.deny is configured (Scored)
   - id: 20097 
-    title: "Ensure /etc/hosts.deny is configured"
+    title: "Ensure /etc/hosts.deny is configured."
     description: "The /etc/hosts.deny file specifies which IP addresses are not permitted to connect to the host. It is intended to be used in conjunction with the /etc/hosts.allow file."
     rationale: "The /etc/hosts.allow file supports access control by IP and helps ensure that only authorized systems can connect to the system."
     remediation: "Run the following command to create /etc/hosts.deny: echo 'ALL: ALL' >> /etc/hosts.deny"
@@ -1794,7 +1777,7 @@ checks:
 
 # 3.4.4 Ensure permissions on /etc/hosts.allow are configured (Scored)
   - id: 20098 
-    title: "Ensure permissions on /etc/hosts.allow are configured."
+    title: "Ensure permissions on /etc/hosts.allow are configured.."
     description: "The /etc/hosts.allow file contains networking information that is used by many applications and therefore must be readable for these applications to operate."
     rationale: "It is critical to ensure that the /etc/hosts.allow file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
     remediation: "Run the following commands to set permissions on /etc/hosts.allow : chown root:root /etc/hosts.allow and chmod 644 /etc/hosts.allow"
@@ -1806,10 +1789,9 @@ checks:
     rules:
       - 'c:stat /etc/hosts.allow -> r:^Access: \(0644/-rw-r--r--\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)'
 
-
 # 3.4.5 Ensure permissions on /etc/hosts.deny are configured (Scored)
   - id: 20099 
-    title: "Ensure permissions on /etc/hosts.deny are configured."
+    title: "Ensure permissions on /etc/hosts.deny are configured.."
     description: "The /etc/hosts.deny file contains network information that is used by many system applications and therefore must be readable for these applications to operate."
     rationale: "It is critical to ensure that the /etc/hosts.deny file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
     remediation: "Run the following commands to set permissions on /etc/hosts.deny : chown root:root /etc/hosts.deny and chmod 644 /etc/hosts.deny"
@@ -1822,16 +1804,14 @@ checks:
     rules:
       - 'c:stat /etc/hosts.deny -> r:^Access: \(0644/-rw-r--r--\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
-
 ###############################################
 # 3.5 Uncommon Network Protocols
 ###############################################
 # 3.5.1 Ensure DCCP is disabled (Not Scored)
   - id: 20100 
-    title: "Ensure DCCP is disabled"
+    title: "Ensure DCCP is disabled."
     description: "The Datagram Congestion Control Protocol (DCCP) is a transport layer protocol that supports streaming media and telephony. DCCP provides a way to gain access to congestion control, without having to do it at the application layer, but does not provide in-sequence delivery."
-    rationale: "If the protocol is not required, it is recommended that the drivers not be installed to reduce
-the potential attack surface."
+    rationale: "If the protocol is not required, it is recommended that the drivers not be installed to reduce the potential attack surface."
     remediation: "Edit or create the file /etc/modprobe.d/CIS.conf and add the following line: install dccp /bin/true"
     compliance:
       - cis: ["3.5.1"]
@@ -1847,11 +1827,9 @@ the potential attack surface."
       - 'c:modprobe -n -v dccp -> r:install /bin/true'
       - 'not c:lsmod -> r:dccp'
 
-
-
 # 3.5.2 Ensure SCTP is disabled (Not Scored)
   - id: 20101 
-    title: "Ensure SCTP is disabled"
+    title: "Ensure SCTP is disabled."
     description: "The Stream Control Transmission Protocol (SCTP) is a transport layer protocol used to support message oriented communication, with several streams of messages in one connection. It serves a similar function as TCP and UDP, incorporating features of both. It is message-oriented like UDP, and ensures reliable in-sequence transport of messages with congestion control like TCP."
     rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
     remediation: "Edit or create the file /etc/modprobe.d/CIS.conf and add the following line: install sctp /bin/true"
@@ -1869,10 +1847,9 @@ the potential attack surface."
       - 'c:modprobe -n -v sctp -> r:install /bin/true'
       - 'not c:lsmod -> r:sctp'
 
-
 # 3.5.3 Ensure RDS is disabled (Not Scored)
   - id: 20102 
-    title: "Ensure RDS is disabled"
+    title: "Ensure RDS is disabled."
     description: "The Reliable Datagram Sockets (RDS) protocol is a transport layer protocol designed to provide low-latency, high-bandwidth communications between cluster nodes. It was developed by the Oracle Corporation."
     rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
     remediation: "Edit or create the file /etc/modprobe.d/CIS.conf and add the following line: install rds /bin/true"
@@ -1890,10 +1867,9 @@ the potential attack surface."
       - 'c:modprobe -n -v rds -> r:install /bin/true'
       - 'not c:lsmod -> r:rds'
 
-
 # 3.5.4 Ensure TIPC is disabled (Not Scored)
   - id: 20103 
-    title: "Ensure TIPC is disabled"
+    title: "Ensure TIPC is disabled."
     description: "The Transparent Inter-Process Communication (TIPC) protocol is designed to provide communication between cluster nodes."
     rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
     remediation: "Edit or create the file /etc/modprobe.d/CIS.conf and add the following line: install tipc /bin/true"
@@ -1916,7 +1892,7 @@ the potential attack surface."
 ###############################################
 # 3.6.1 Ensure iptables is installed (Scored)
   - id: 20104 
-    title: "Ensure iptables is installed"
+    title: "Ensure iptables is installed."
     description: "iptables allows configuration of the IPv4 tables in the linux kernel and the rules stored within them. Most firewall configuration utilities operate as a front end to iptables ."
     rationale: "iptables is required for firewall management and configuration."
     remediation: "Run the following command to install iptables : yum install iptables"
@@ -1930,7 +1906,7 @@ the potential attack surface."
 
 # 3.6.2 Ensure default deny firewall policy (Scored)
   - id: 20105 
-    title: "Ensure default deny firewall policy"
+    title: "Ensure default deny firewall policy."
     description: "A default deny all policy on connections ensures that any unconfigured network usage will be rejected."
     rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage."
     remediation: "Run the following commands to implement a default DROP policy: iptables -P INPUT DROP; iptables -P OUTPUT DROP and iptables -P FORWARD DROP"
@@ -1947,7 +1923,7 @@ the potential attack surface."
 
 # 3.6.3 Ensure loopback traffic is configured (Scored)
   - id: 20106 
-    title: "Ensure loopback traffic is configured"
+    title: "Ensure loopback traffic is configured."
     description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network (127.0.0.0/8)."
     rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network (127.0.0.0/8) traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure."
     remediation: "Run the following commands to implement the loopback rules: # iptables -A INPUT -i lo -j ACCEPT # iptables -A OUTPUT -o lo -j ACCEPT # iptables -A INPUT -s 127.0.0.0/8 -j DROP"
@@ -1962,13 +1938,9 @@ the potential attack surface."
       - 'c:iptables -L INPUT -v -n -> r:\.*DROP\.*all\.**\.**\.*127.0.0.0/8\.*0.0.0.0/0'
       - 'c:iptables -L OUTPUT -v -n -> r:\.*ACCEPT\.*all\.**\.*lo\.*0.0.0.0/0\.*0.0.0.0/0'
 
-
 ###############################################
 # 4 Logging and Auditing
 ###############################################
-
-
-
 
 ###############################################
 # 4 Logging and Auditing
@@ -1979,7 +1951,7 @@ the potential attack surface."
 
 # 4.1.1.1 Ensure audit log storage size is configured (Not Scored)
   - id: 20107 
-    title: "Ensure audit log storage size is configured"
+    title: "Ensure audit log storage size is configured."
     description: "Configure the maximum size of the audit log file. Once the log reaches the maximum size, it will be rotated and a new log file will be started."
     rationale: "It is important that an appropriate size is determined for log files so that they do not impact the system and audit data is not lost."
     remediation: "Set the following parameter in /etc/audit/auditd.conf in accordance with site policy: max_log_file = <MB>"
@@ -1993,7 +1965,7 @@ the potential attack surface."
 
 # 4.1.1.2 Ensure system is disabled when audit logs are full (Scored)
   - id: 20108 
-    title: "Ensure system is disabled when audit logs are full"
+    title: "Ensure system is disabled when audit logs are full."
     description: "The auditd daemon can be configured to halt the system when the audit logs are full."
     rationale: "In high security contexts, the risk of detecting unauthorized access or nonrepudiation exceeds the benefit of the system's availability."
     remediation: "Set the following parameters in /etc/audit/auditd.conf: space_left_action = email   action_mail_acct = root   admin_space_left_action = halt"
@@ -2009,7 +1981,7 @@ the potential attack surface."
 
 # 4.1.1.3 Ensure audit logs are not automatically deleted (Scored)
   - id: 20109 
-    title: "Ensure audit logs are not automatically deleted"
+    title: "Ensure audit logs are not automatically deleted."
     description: "The max_log_file_action setting determines how to handle the audit log file reaching the max file size. A value of keep_logs will rotate the logs but never delete old logs."
     rationale: "In high security contexts, the benefits of maintaining a long audit history exceed the cost of storing the audit history."
     remediation: "Set the following parameter in /etc/audit/auditd.conf: max_log_file_action = keep_logs"
@@ -2023,7 +1995,7 @@ the potential attack surface."
 
 # 4.1.2 Ensure auditd service is enabled (Scored)
   - id: 20110 
-    title: "Ensure auditd service is enabled"
+    title: "Ensure auditd service is enabled."
     description: "Turn on the auditd daemon to record system events."
     rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
     remediation: "Run the following command to enable auditd : # chkconfig auditd on"
@@ -2036,10 +2008,9 @@ the potential attack surface."
     rules:
       - 'c:chkconfig --list auditd -> r:2:on && r:3:on && r:4:on && r:5:on'
 
-
 # 4.1.3 Ensure auditing for processes that start prior to auditd is enabled (Scored)
   - id: 20111 
-    title: "Ensure auditing for processes that start prior to auditd is enabled"
+    title: "Ensure auditing for processes that start prior to auditd is enabled."
     description: "Configure grub so that processes that are capable of being audited can be audited even if they start up prior to auditd startup."
     rationale: "Audit events need to be captured on processes that start up prior to auditd, so that potential malicious activity cannot go undetected."
     remediation: "Edit /boot/grub/menu.lst to include audit=1 on all kernel lines. Notes: This recommendation is designed around the grub bootloader, if LILO or another bootloader is in use in your environment enact equivalent settings."
@@ -2056,7 +2027,7 @@ the potential attack surface."
       
 # 4.1.4 Ensure events that modify date and time information are collected (Scored)
   - id: 20112 
-    title: "Ensure events that modify date and time information are collected"
+    title: "Ensure events that modify date and time information are collected."
     description: "Capture events where the system date and/or time has been modified. The parameters in this section are set to determine if the adjtimex (tune kernel clock), settimeofday (Set time, using timeval and timezone structures) stime (using seconds since 1/1/1970) or clock_settime (allows for the setting of several internal clocks and timers) system calls have been executed and always write an audit record to the /var/log/audit.log file upon exit, tagging the records with the identifier \"time-change\"."
     rationale: "Unexpected changes in system date and/or time could be a sign of malicious activity on the system."
     remediation: "For 32 bit systems add the following lines to the /etc/audit/audit.rules file: -a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change   -a always,exit -F arch=b32 -S clock_settime -k time-change   -w /etc/localtime -p wa -k time-change   For 64 bit systems add the following lines to the /etc/audit/audit.rules file:   -a always,exit -F arch=b64 -S adjtimex -S settimeofday -k time-change   -a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change   -a always,exit -F arch=b64 -S clock_settime -k time-change   -a always,exit -Farch=b32 -S clock_settime -k time-change   -w /etc/localtime -p wa -k time-change"
@@ -2077,7 +2048,7 @@ the potential attack surface."
 
 # 4.1.5 Ensure events that modify user/group information are collected (Scored)
   - id: 20113 
-    title: "Ensure events that modify user/group information are collected"
+    title: "Ensure events that modify user/group information are collected."
     description: "Record events affecting the group , passwd (user IDs), shadow and gshadow (passwords) or /etc/security/opasswd (old passwords, based on remember parameter in the PAM configuration) files. The parameters in this section will watch the files to see if they have been opened for write or have had attribute changes (e.g. permissions) and tag them with the identifier \"identity\" in the audit log file."
     rationale: "Unexpected changes to these files could be an indication that the system has been compromised and that an unauthorized user is attempting to hide their activities or compromise additional accounts."
     remediation: "Add the following lines to the /etc/audit/audit.rules file:    -w /etc/group -p wa -k identity    -w /etc/passwd -p wa -k identity    -w /etc/gshadow -p wa -k identity    -w /etc/shadow -p wa -k identity    -w /etc/security/opasswd -p wa -k identity"
@@ -2100,7 +2071,7 @@ the potential attack surface."
 
 # 4.1.6 Ensure events that modify the system's network environment are collected (Scored)
   - id: 20114 
-    title: "Ensure events that modify the system's network environment are collected"
+    title: "Ensure events that modify the system's network environment are collected."
     description: "Record changes to network environment files or system calls. The below parameters monitor the sethostname (set the systems host name) or setdomainname (set the systems domainname) system calls, and write an audit event on system call exit. The other parameters monitor the /etc/issue and /etc/issue.net files (messages displayed pre-login), /etc/hosts (file containing host names and associated IP addresses), /etc/sysconfig/network file and /etc/sysconfig/network-scripts/ directory (containing network interface scripts and configurations)."
     rationale: "Monitoring sethostname and setdomainname will identify potential unauthorized changes to host and domainname of a system. The changing of these names could potentially break security parameters that are set based on those names. The /etc/hosts file is monitored for changes in the file that can indicate an unauthorized intruder is trying to change machine associations with IP addresses and trick users and processes into connecting to unintended machines. Monitoring /etc/issue and /etc/issue.net is important, as intruders could put disinformation into those files and trick users into providing information to the intruder. Monitoring /etc/sysconfig/network and /etc/sysconfig/network-scripts/ is important as it can show if network interfaces or scripts are being modified in a way that can lead to the machine becoming unavailable or compromised. All audit records will be tagged with the identifier \"system-locale.\""
     remediation: "For 32 bit systems add the following lines to the /etc/audit/audit.rules file:    -a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale    -w /etc/issue -p wa -k system-locale    -w /etc/issue.net -p wa -k system-locale    -w /etc/hosts -p wa -k system-locale    -w /etc/sysconfig/network -p wa -k system-locale    -w /etc/sysconfig/network-scripts/ -p wa -k system-locale        For 64 bit systems add the following lines to the /etc/audit/audit.rules file:    -a always,exit -F arch=b64 -S sethostname -S setdomainname -k system-locale    -a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale    -w /etc/issue -p wa -k system-locale    -w /etc/issue.net -p wa -k system-locale    -w /etc/hosts -p wa -k system-locale    -w /etc/sysconfig/network -p wa -k system-locale    -w /etc/sysconfig/network-scripts/ -p wa -k system-locale"
@@ -2124,7 +2095,7 @@ the potential attack surface."
 
 # 4.1.7 Ensure events that modify the system's Mandatory Access Controls are collected (Scored)
   - id: 20115 
-    title: "Ensure events that modify the system's Mandatory Access Controls are collected"
+    title: "Ensure events that modify the system's Mandatory Access Controls are collected."
     description: "Monitor SELinux mandatory access controls. The parameters below monitor any write access (potential additional, deletion or modification of files in the directory) or attribute changes to the /etc/selinux or directory."
     rationale: "Changes to files in these directories could indicate that an unauthorized user is attempting to modify access controls and change security contexts, leading to a compromise of the system."
     remediation: "Add the following lines to the /etc/audit/audit.rules file: -w /etc/selinux/ -p wa -k MAC-policy -w /usr/share/selinux/ -p wa -k MAC-policy"
@@ -2144,7 +2115,7 @@ the potential attack surface."
 
 # 4.1.8 Ensure login and logout events are collected (Scored)
   - id: 20116 
-    title: "Ensure login and logout events are collected"
+    title: "Ensure login and logout events are collected."
     description: "Monitor login and logout events. The parameters below track changes to files associated with login/logout events. The file /var/log/lastlog maintain records of the last time a user successfully logged in. The /var/run/failock directory maintains records of login failures via the pam_faillock module."
     rationale: "Monitoring login/logout events could provide a system administrator with information associated with brute force attacks against user logins."
     remediation: "Add the following lines to the /etc/audit/audit.rules file:  -w /var/log/lastlog -p wa -k logins   -w /var/run/faillock/ -p wa -k logins"
@@ -2164,11 +2135,10 @@ the potential attack surface."
 
 # 4.1.9 Ensure session initiation information is collected (Scored)
   - id: 20117 
-    title: "Ensure session initiation information is collected"
+    title: "Ensure session initiation information is collected."
     description: "Monitor session initiation events. The parameters in this section track changes to the files associated with session events. The file /var/run/utmp file tracks all currently logged in users. All audit records will be tagged with the identifier \"session.\" The /var/log/wtmp file tracks logins, logouts, shutdown, and reboot events. The file /var/log/btmp keeps track of failed login attempts and can be read by entering the command /usr/bin/last -f /var/log/btmp . All audit records will be tagged with the identifier \"logins.\"."
     rationale: "Monitoring these files for changes could alert a system administrator to logins occurring at unusual hours, which could indicate intruder activity (i.e. a user logging in at a time when they do not normally log in)."
     remediation: "Add the following lines to the /etc/audit/audit.rules file:   -w /var/run/utmp -p wa -k session   -w /var/log/wtmp -p wa -k logins   -w /var/log/btmp -p wa -k logins"
-    compliance:
     compliance:
       - cis: ["4.1.8"]
       - cis_csc: ["5.5","16.10","16.4"]
@@ -2181,7 +2151,7 @@ the potential attack surface."
 
 # 4.1.10 Ensure discretionary access control permission modification events are collected (Scored)
   - id: 20118 
-    title: "Ensure discretionary access control permission modification events are collected"
+    title: "Ensure discretionary access control permission modification events are collected."
     description: "Monitor changes to file permissions, attributes, ownership and group. The parameters in this section track changes for system calls that affect file permissions and attributes. The chmod , fchmod and fchmodat system calls affect the permissions associated with a file. The chown , fchown , fchownat and lchown system calls affect owner and group attributes on a file. The setxattr , lsetxattr , fsetxattr (set extended file attributes) and removexattr , lremovexattr , fremovexattr (remove extended file attributes) control extended file attributes. In all cases, an audit record will only be written for non-system user ids (auid >= 500) and will ignore Daemon events (auid = 4294967295). All audit records will be tagged with the identifier \"perm_mod.\""
     rationale: "Monitoring for changes in file attributes could alert a system administrator to activity that could indicate intruder activity or policy violation."
     remediation: "For 32 bit systems add the following lines to the /etc/audit/audit.rules file:   -a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=500 -F auid!=4294967295 -k perm_mod   -a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown -F auid>=500 -F auid!=4294967295 -k perm_mod   -a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod   For 64 bit systems add the following lines to the /etc/audit/audit.rules file:   -a always,exit -F arch=b64 -S chmod -S fchmod -S fchmodat -F auid>=500 -F auid!=4294967295 -k perm_mod   -a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=500 -F auid!=4294967295 -k perm_mod   -a always,exit -F arch=b64 -S chown -S fchown -S fchownat -S lchown -F auid>=500 -F auid!=4294967295 -k perm_mod   -a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown -F auid>=500 -F auid!=4294967295 -k perm_mod   -a always,exit -F arch=b64 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod   -a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lrem"
@@ -2202,7 +2172,7 @@ the potential attack surface."
 
 # 4.1.11 Ensure unsuccessful unauthorized file access attempts are collected (Scored)
   - id: 20119 
-    title: "Ensure unsuccessful unauthorized file access attempts are collected"
+    title: "Ensure unsuccessful unauthorized file access attempts are collected."
     description: "Monitor for unsuccessful attempts to access files. The parameters below are associated  with system calls that control creation ( creat ), opening ( open , openat ) and truncation (  truncate , ftruncate ) of files. An audit log record will only be written if the user is a non-  privileged user (auid > = 500), is not a Daemon event (auid=4294967295) and if the  system call returned EACCES (permission denied to the file) or EPERM (some other  permanent error associated with the specific system call). All audit records will be tagged  with the identifier \"access.\""
     rationale: "Failed attempts to open, create or truncate files could be an indication that an individual or process is trying to gain unauthorized access to the system."
     remediation: "For 32 bit systems add the following lines to the /etc/audit/audit.rules file:   -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access   -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access   For 64 bit systems add the following lines to the /etc/audit/audit.rules file:   -a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access   -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access   -a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access   -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access"
@@ -2222,7 +2192,7 @@ the potential attack surface."
 
 # 4.1.13 Ensure successful file system mounts are collected (Scored)
   - id: 20120 
-    title: "Ensure successful file system mounts are collected"
+    title: "Ensure successful file system mounts are collected."
     description: "Monitor the use of the mount system call. The mount (and umount ) system call controls the mounting and unmounting of file systems. The parameters below configure the system to create an audit record when the mount system call is used by a non-privileged user."
     rationale: "It is highly unusual for a non privileged user to mount file systems to the system. While tracking mount commands gives the system administrator evidence that external media may have been mounted (based on a review of the source of the mount and confirming it's an external media type), it does not conclusively indicate that data was exported to the media. System administrators who wish to determine if data were exported, would also have to track successful open , creat and truncate system calls requiring write access to a file under the mount point of the external media file system. This could give a fair indication that a write occurred. The only way to truly prove it, would be to track successful writes to the external media. Tracking write system calls could quickly fill up the audit log and is not recommended. Recommendations on configuration options to track data export to media is beyond the scope of this document."
     remediation: "For 32 bit systems add the following lines to the /etc/audit/audit.rules file:   -a always,exit -F arch=b32 -S mount -F auid>=500 -F auid!=4294967295 -k mounts   For 64 bit systems add the following lines to the /etc/audit/audit.rules file:   -a always,exit -F arch=b64 -S mount -F auid>=500 -F auid!=4294967295 -k mounts   -a always,exit -F arch=b32 -S mount -F auid>=500 -F auid!=4294967295 -k mounts"
@@ -2239,10 +2209,9 @@ the potential attack surface."
     rules:
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S mount && r:-F auid>=500 && r:-F auid!=4294967295 && r:-k mounts'
 
-
 # 4.1.14 Ensure file deletion events by users are collected (Scored)
   - id: 20121 
-    title: "Ensure file deletion events by users are collected"
+    title: "Ensure file deletion events by users are collected."
     description: "Monitor the use of system calls associated with the deletion or renaming of files and file attributes. This configuration statement sets up monitoring for the unlink (remove a file), unlinkat (remove a file attribute), rename (rename a file) and renameat (rename a file attribute) system calls and tags them with the identifier \"delete\"."
     rationale: "Monitoring these calls from non-privileged users could provide a system administrator with evidence that inappropriate removal of files and file attributes associated with protected files is occurring. While this audit option will look at all events, system administrators will want to look for specific privileged files that are being deleted or altered."
     remediation: "For 32 bit systems add the following lines to the /etc/audit/audit.rules file:   -a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=500 -F auid!=4294967295 -k delete   For 64 bit systems add the following lines to the /etc/audit/audit.rules file:   -a always,exit -F arch=b64 -S unlink -S unlinkat -S rename -S renameat -F auid>=500 -F auid!=4294967295 -k delete   -a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=500 -F auid!=4294967295 -k delete"
@@ -2256,7 +2225,7 @@ the potential attack surface."
 
 # 4.1.15 Ensure changes to system administration scope (sudoers) is collected (Scored)
   - id: 20122 
-    title: "Ensure changes to system administration scope (sudoers) is collected"
+    title: "Ensure changes to system administration scope (sudoers) is collected."
     description: "Monitor scope changes for system administrations. If the system has been properly configured to force system administrators to log in as themselves first and then use the sudo command to execute privileged commands, it is possible to monitor changes in scope. The file /etc/sudoers will be written to when the file or its attributes have changed. The audit records will be tagged with the identifier \"scope.\""
     rationale: "Changes in the /etc/sudoers file can indicate that an unauthorized change has been made to scope of system administrator activity."
     remediation: "Add the following line to the /etc/audit/audit.rules file:   -w /etc/sudoers -p wa -k scope   -w /etc/sudoers.d/ -p wa -k scope"
@@ -2276,7 +2245,7 @@ the potential attack surface."
 
 # 4.1.16 Ensure system administrator actions (sudolog) are collected (Scored)
   - id: 20123 
-    title: "Ensure system administrator actions (sudolog) are collected"
+    title: "Ensure system administrator actions (sudolog) are collected."
     description: "Monitor the sudo log file. If the system has been properly configured to disable the use of the su command and force all administrators to have to log in first and then use sudo to execute privileged commands, then all administrator commands will be logged to /var/log/sudo.log . Any time a command is executed, an audit event will be triggered as the /var/log/sudo.log file will be opened for write and the executed administration command will be written to the log."
     rationale: "Changes in /var/log/sudo.log indicate that an administrator has executed a command or the log file itself has been tampered with. Administrators will want to correlate the events written to the audit trail with the records written to /var/log/sudo.log to verify if unauthorized commands have been executed."
     remediation: "Add the following line to the /etc/audit/audit.rules file:   -w /var/log/sudo.log -p wa -k actions"
@@ -2295,7 +2264,7 @@ the potential attack surface."
 
 # 4.1.17 Ensure kernel module loading and unloading is collected (Scored)
   - id: 20124 
-    title: "Ensure kernel module loading and unloading is collected"
+    title: "Ensure kernel module loading and unloading is collected."
     description: "Monitor the loading and unloading of kernel modules. The programs insmod (install a kernel module), rmmod (remove a kernel module), and modprobe (a more sophisticated program to load and unload modules, as well as some other features) control loading and unloading of modules. The init_module (load a module) and delete_module (delete a module) system calls control loading and unloading of modules. Any execution of the loading and unloading module programs and system calls will trigger an audit record with an identifier of \"modules\"."
     rationale: "Monitoring the use of insmod , rmmod and modprobe could provide system administrators with evidence that an unauthorized user loaded or unloaded a kernel module, possibly compromising the security of the system. Monitoring of the init_module and delete_module system calls would reflect an unauthorized user attempting to use a different program to load and unload modules."
     remediation: "Add the following line to the /etc/audit/audit.rules file:   -w /var/log/sudo.log -p wa -k actions"
@@ -2317,7 +2286,7 @@ the potential attack surface."
 
 # 4.1.18 Ensure the audit configuration is immutable (Scored)
   - id: 20125 
-    title: "Ensure the audit configuration is immutable"
+    title: "Ensure the audit configuration is immutable."
     description: "Set system audit so that audit rules cannot be modified with auditctl . Setting the flag \"-e 2\" forces audit to be put in immutable mode. Audit changes can only be made on system reboot."
     rationale: "In immutable mode, unauthorized users cannot execute changes to the audit system to potentially hide malicious activity and then put the audit rules back. Users would most likely notice a system reboot and that could alert administrators of an attempt to make unauthorized audit changes."
     remediation: "Add the following line to the end of the /etc/audit/audit.rules file.   -e 2"
@@ -2336,7 +2305,7 @@ the potential attack surface."
 
 # 4.2.1.1 Ensure rsyslog Service is enabled (Scored)
   - id: 20126 
-    title: "Ensure rsyslog Service is enabled"
+    title: "Ensure rsyslog Service is enabled."
     description: "Once the rsyslog package is installed it needs to be activated."
     rationale: "If the rsyslog service is not activated the system may default to the syslogd service or lackblogging instead."
     remediation: "Run the following command to enable rsyslog :   # chkconfig rsyslog on"
@@ -2348,9 +2317,10 @@ the potential attack surface."
     condition: all
     rules:
       - 'c:chkconfig --list rsyslog -> r:2:on && r:3:on && r:4:on && r:5:on'
+
 # 4.2.1.3 Ensure rsyslog default file permissions configured (Scored)
   - id: 20127 
-    title: "Ensure rsyslog default file permissions configured"
+    title: "Ensure rsyslog default file permissions configured."
     description: "rsyslog will create logfiles that do not already exist on the system. This setting controls what permissions will be applied to these newly created files."
     rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitive data is archived and protected."
     remediation: "Edit the /etc/rsyslog.conf and /etc/rsyslog.d/*.conf files and set $FileCreateMode to 0640 or more restrictive:   $FileCreateMode 0640"
@@ -2364,7 +2334,7 @@ the potential attack surface."
 
 # 4.2.1.4 Ensure rsyslog is configured to send logs to a remote log host (Scored)
   - id: 20128 
-    title: "Ensure rsyslog is configured to send logs to a remote log host"
+    title: "Ensure rsyslog is configured to send logs to a remote log host."
     description: "The rsyslog utility supports the ability to send logs it gathers to a remote log host running syslogd(8) or to receive messages from remote hosts, reducing administrative overhead."
     rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
     remediation: "Edit the /etc/rsyslog.conf and /etc/rsyslog.d/*.conf files and add the following line (where loghost.example.com is the name of your central log host).   *.* @@loghost.example.com   Run the following command to reload the rsyslogd configuration: # pkill -HUP rsyslogd"
@@ -2378,10 +2348,9 @@ the potential attack surface."
       - 'c:grep *.*[^I][^I]*@ /etc/rsyslog.conf /etc/rsyslog.d/*.conf -> !r:# && r:*.* @@\.+'
   
 
-
 # 4.2.2.1 Ensure syslog-ng service is enabled (Scored)
   - id: 20129 
-    title: "Ensure syslog-ng service is enabled"
+    title: "Ensure syslog-ng service is enabled."
     description: "Once the syslog-ng package is installed it needs to be activated."
     rationale: "If the syslog-ng service is not activated the system may default to the syslogd service or lack logging instead."
     remediation: "Run the following command to enable syslog-ng :   # chkconfig syslog-ng on"
@@ -2396,7 +2365,7 @@ the potential attack surface."
 
 # 4.2.2.3 Ensure syslog-ng default file permissions configured (Scored)
   - id: 20130 
-    title: "Ensure syslog-ng default file permissions configured"
+    title: "Ensure syslog-ng default file permissions configured."
     description: "syslog-ng will create logfiles that do not already exist on the system. This setting controls what permissions will be applied to these newly created files."
     rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitive syslog-ng data is archived and protected."
     remediation: "Edit the /etc/syslog-ng/syslog-ng.conf and set perm option to 0640 or more restrictive:     options { chain_hostnames(off); flush_lines(0); perm(0640); stats_freq(3600); threaded(yes); };"
@@ -2411,7 +2380,7 @@ the potential attack surface."
 
 # 4.2.2.4 Ensure syslog-ng is configured to send logs to a remote log host (Not Scored)
   - id: 20131 
-    title: "Ensure syslog-ng is configured to send logs to a remote log host"
+    title: "Ensure syslog-ng is configured to send logs to a remote log host."
     description: "The syslog-ng utility supports the ability to send logs it gathers to a remote log host or to receive messages from remote hosts, reducing administrative overhead."
     rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
     remediation: "Edit the /etc/syslog-ng/syslog-ng.conf file and add the following lines (where logfile.example.com is the name of your central log host).    destination logserver { tcp(\"logfile.example.com\" port(514)); };    log { source(src); destination(logserver); };   Run the following command to reload the rsyslogd configuration: # pkill -HUP syslog-ng"
@@ -2427,7 +2396,7 @@ the potential attack surface."
 
 # 4.2.3 Ensure rsyslog or syslog-ng is installed (Scored)
   - id: 20132 
-    title: "Ensure rsyslog or syslog-ng is installed"
+    title: "Ensure rsyslog or syslog-ng is installed."
     description: "The rsyslog and syslog-ng software are recommended replacements to the original syslogd daemon which provide improvements over syslogd , such as connection-oriented (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of log data en route to a central logging server."
     rationale: "The security enhancements of rsyslog and syslog-ng such as connection-oriented (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of log data en route to a central logging server) justify installing and configuring the package."
     remediation: "Install rsyslog or syslog-ng using one of the following commands:   # yum install rsyslog   # yum install syslog-ng"
@@ -2443,7 +2412,7 @@ the potential attack surface."
 
   # 4.2.4 Ensure permissions on all logfiles are configured (Scored)
   - id: 20133 
-    title: "Ensure permissions on all logfiles are configured"
+    title: "Ensure permissions on all logfiles are configured."
     description: "Log files stored in /var/log/ contain logged information from many services on the system, or on log hosts others as well."
     rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitivebdata is archived and protected."
     remediation: "Run the following command to set permissions on all existing log files: # find /var/log -type f -exec chmod g-wx,o-rwx {} +"
@@ -2465,7 +2434,7 @@ the potential attack surface."
 
 # 5.1.1 Ensure cron daemon is enabled (Scored)
   - id: 20134 
-    title: "Ensure cron daemon is enabled"
+    title: "Ensure cron daemon is enabled."
     description: "The cron daemon is used to execute batch jobs on the system."
     rationale: "While there may not be user jobs that need to be run on the system, the system does have maintenance jobs that may include security monitoring that have to run, and cron is used to execute them."
     remediation: "Run the following command to enable cron : # chkconfig crond on"
@@ -2481,7 +2450,7 @@ the potential attack surface."
 
 # 5.1.2 Ensure permissions on /etc/crontab are configured (Scored)
   - id: 20135 
-    title: "Ensure permissions on /etc/crontab are configured"
+    title: "Ensure permissions on /etc/crontab are configured."
     description: "The /etc/crontab file is used by cron to control its own jobs. The commands in this item make sure that root is the user and group owner of the file and that only the owner can access the file."
     rationale: "This file contains information on what system jobs are run by cron. Write access to these files could provide unprivileged users with the ability to elevate their privileges. Read access to these files could provide users with the ability to gain insight on system jobs that run on the system and could provide them a way to gain unauthorized privileged access."
     remediation: "Run the following commands to set ownership and permissions on /etc/crontab : chown root:root /etc/crontab and chmod og-rwx /etc/crontab"
@@ -2497,7 +2466,7 @@ the potential attack surface."
 
 # 5.1.3 Ensure permissions on /etc/cron.hourly are configured (Scored)
   - id: 20136 
-    title: "Ensure permissions on /etc/cron.hourly are configured"
+    title: "Ensure permissions on /etc/cron.hourly are configured."
     description: "This directory contains system cron jobs that need to run on an hourly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
     remediation: "Run the following commands to set ownership and permissions on /etc/cron.hourly : chown root:root /etc/cron.hourly and chmod og-rwx /etc/cron.hourly"
@@ -2513,7 +2482,7 @@ the potential attack surface."
 
 # 5.1.4 Ensure permissions on /etc/cron.daily are configured (Scored)
   - id: 20137 
-    title: "Ensure permissions on /etc/cron.daily are configured"
+    title: "Ensure permissions on /etc/cron.daily are configured."
     description: "The /etc/cron.daily directory contains system cron jobs that need to run on a daily basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
     remediation: "Run the following commands to set ownership and permissions on /etc/cron.daily : chown root:root /etc/cron.daily and chmod og-rwx /etc/cron.daily"
@@ -2529,7 +2498,7 @@ the potential attack surface."
 
 # 5.1.5 Ensure permissions on /etc/cron.weekly are configured (Scored)
   - id: 20138 
-    title: "Ensure permissions on /etc/cron.weekly are configured"
+    title: "Ensure permissions on /etc/cron.weekly are configured."
     description: "The /etc/cron.weekly directory contains system cron jobs that need to run on a weekly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
     remediation: "Run the following commands to set ownership and permissions on /etc/cron.weekly : chown root:root /etc/cron.weekly and chmod og-rwx /etc/cron.weekly"
@@ -2543,10 +2512,9 @@ the potential attack surface."
     rules:
       - 'c:stat /etc/cron.weekly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
-
 # 5.1.6 Ensure permissions on /etc/cron.monthly are configured (Scored)
   - id: 20139 
-    title: "Ensure permissions on /etc/cron.monthly are configured"
+    title: "Ensure permissions on /etc/cron.monthly are configured."
     description: "The /etc/cron.monthly directory contains system cron jobs that need to run on a monthly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
     remediation: "Run the following commands to set ownership and permissions on /etc/cron.monthly : chown root:root /etc/cron.monthly and chmod og-rwx /etc/cron.monthly"
@@ -2562,7 +2530,7 @@ the potential attack surface."
 
 # 5.1.7 Ensure permissions on /etc/cron.d are configured (Scored)
   - id: 20140 
-    title: "Ensure permissions on /etc/cron.d are configured"
+    title: "Ensure permissions on /etc/cron.d are configured."
     description: "Configure /etc/cron.allow and /etc/at.allow to allow specific users to use these services. If /etc/cron.allow or /etc/at.allow do not exist, then /etc/at.deny and /etc/cron.deny are checked. Any user not specifically defined in those files is allowed to use at and cron. By removing the files, only users in /etc/cron.allow and /etc/at.allow are allowed to use at and cron. Note that even though a given user is not listed in cron.allow , cron jobs can still be run as that user. The cron.allow file only controls administrative access to the crontab command for scheduling and modifying cron jobs."
     rationale: "On many systems, only the system administrator is authorized to schedule cron jobs. Using the cron.allow file to control who can run cron jobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
     remediation: "Run the following commands to remove /etc/cron.deny and /etc/at.deny and create and set permissions and ownership for /etc/cron.allow and /etc/at.allow: rm /etc/cron.deny;rm /etc/at.deny;touch /etc/cron.allow; touch /etc/at.allow; chmod og-rwx /etc/cron.allow; chmod og-rwx /etc/at.allow; chown root:root /etc/cron.allow and chown root:root /etc/at.allow"
@@ -2578,7 +2546,7 @@ the potential attack surface."
 
 # 5.1.8 Ensure at/cron is restricted to authorized users (Scored)
   - id: 20141 
-    title: "Ensure at/cron is restricted to authorized users"
+    title: "Ensure at/cron is restricted to authorized users."
     description: "Configure /etc/cron.allow and /etc/at.allow to allow specific users to use these services. If /etc/cron.allow or /etc/at.allow do not exist, then /etc/at.deny and /etc/cron.deny are checked. Any user not specifically defined in those files is allowed to use at and cron. By removing the files, only users in /etc/cron.allow and /etc/at.allow are allowed to use at and cron. Note that even though a given user is not listed in cron.allow , cron jobs can still be run as that user. The cron.allow file only controls administrative access to the crontab command for scheduling and modifying cron jobs."
     rationale: "On many systems, only the system administrator is authorized to schedule cron jobs. Using the cron.allow file to control who can run cron jobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
     remediation: "Run the following commands to remove /etc/cron.deny and /etc/at.deny and create and set permissions and ownership for /etc/cron.allow and /etc/at.allow: rm /etc/cron.deny;rm /etc/at.deny;touch /etc/cron.allow; touch /etc/at.allow; chmod og-rwx /etc/cron.allow; chmod og-rwx /etc/at.allow; chown root:root /etc/cron.allow and chown root:root /etc/at.allow"
@@ -2600,7 +2568,7 @@ the potential attack surface."
 ###############################################
 # 5.2.1 Ensure permissions on /etc/ssh/sshd_config are configured (Scored)
   - id: 20142 
-    title: "Ensure permissions on /etc/ssh/sshd_config are configured"
+    title: "Ensure permissions on /etc/ssh/sshd_config are configured."
     description: "The /etc/ssh/sshd_config file contains configuration specifications for sshd. The command below sets the owner and group of the file to root."
     rationale: "The /etc/ssh/sshd_config file needs to be protected from unauthorized changes by non-privileged users."
     remediation: "Run the following commands to set ownership and permissions on /etc/ssh/sshd_config: chown root:root /etc/ssh/sshd_config and chmod og-rwx /etc/ssh/sshd_config"
@@ -2616,7 +2584,7 @@ the potential attack surface."
 
 # 5.2.2 Set SSH Protocol to 2 (Scored)
   - id: 20143 
-    title: "Ensure SSH Protocol is set to 2"
+    title: "Ensure SSH Protocol is set to 2."
     description: "SSH supports two different and incompatible protocols: SSH1 and SSH2. SSH1 was the original protocol and was subject to security issues. SSH2 is more advanced and secure."
     rationale: "SSH v1 suffers from insecurities that do not affect SSH v2."
     remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: Protocol 2"
@@ -2633,7 +2601,7 @@ the potential attack surface."
 
 # 5.2.3 Set LogLevel to INFO (Scored)
   - id: 20144 
-    title: "Ensure SSH LogLevel is set to INFO"
+    title: "Ensure SSH LogLevel is set to INFO."
     description: "The INFO parameter specifies that login and logout activity will be logged."
     rationale: "SSH provides several logging levels with varying amounts of verbosity. DEBUG is specifically not recommended other than strictly for debugging SSH communications since it provides so much data that it is difficult to identify important security information."
     remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: LogLevel INFO"
@@ -2650,7 +2618,7 @@ the potential attack surface."
 
 # 5.2.5 Set SSH MaxAuthTries to 4 or Less (Scored)
   - id: 20145 
-    title: "Ensure SSH MaxAuthTries is set to 4 or less"
+    title: "Ensure SSH MaxAuthTries is set to 4 or less."
     description: "The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection. When the login failure count reaches half the number, error messages will be written to the syslog file detailing the login failure."
     rationale: "Setting the MaxAuthTries parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. While the recommended setting is 4, set the number based on site policy."
     remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: MaxAuthTries 4"
@@ -2666,7 +2634,7 @@ the potential attack surface."
 
 # 5.2.6 Set SSH IgnoreRhosts to Yes (Scored)
   - id: 20146 
-    title: "Ensure SSH IgnoreRhosts is enabled"
+    title: "Ensure SSH IgnoreRhosts is enabled."
     description: "The IgnoreRhosts parameter specifies that .rhosts and .shosts files will not be used in RhostsRSAAuthentication or HostbasedAuthentication."
     rationale: "Setting this parameter forces users to enter a password when authenticating with ssh."
     remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: IgnoreRhosts yes"
@@ -2682,7 +2650,7 @@ the potential attack surface."
 
 # 5.2.7 Set SSH HostbasedAuthentication to No (Scored)
   - id: 20147 
-    title: "Ensure SSH HostbasedAuthentication is disabled"
+    title: "Ensure SSH HostbasedAuthentication is disabled."
     description: "The HostbasedAuthentication parameter specifies if authentication is allowed through trusted hosts via the user of .rhosts , or /etc/hosts.equiv, along with successful public key client host authentication. This option only applies to SSH Protocol Version 2."
     rationale: "Even though the .rhosts files are ineffective if support is disabled in /etc/pam.conf, disabling the ability to use .rhosts files in SSH provides an additional layer of protection."
     remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: HostbasedAuthentication no"
@@ -2699,7 +2667,7 @@ the potential attack surface."
 
 # 5.2.8 Disable SSH Root Login (Scored)
   - id: 20148 
-    title: "Ensure SSH root login is disabled"
+    title: "Ensure SSH root login is disabled."
     description: "The PermitRootLogin parameter specifies if the root user can log in using ssh(1). The default is no."
     rationale: "Disallowing root logins over SSH requires system admins to authenticate using their own individual account, then escalating to root via sudo or su . This in turn limits opportunity for non-repudiation and provides a clear audit trail in the event of a security incident"
     remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: PermitRootLogin no"
@@ -2716,7 +2684,7 @@ the potential attack surface."
 
 # 5.2.9 Set SSH PermitEmptyPasswords to No (Scored)
   - id: 20149 
-    title: "Ensure SSH PermitEmptyPasswords is disabled"
+    title: "Ensure SSH PermitEmptyPasswords is disabled."
     description: "The PermitEmptyPasswords parameter specifies if the SSH server allows login to accounts with empty password strings."
     rationale: "Disallowing remote shell access to accounts that have an empty password reduces the probability of unauthorized access to the system"
     remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: PermitEmptyPasswords no"
@@ -2733,7 +2701,7 @@ the potential attack surface."
 
 # 5.2.10 Ensure SSH PermitUserEnvironment is disabled (Scored)
   - id: 20150 
-    title: "Ensure SSH PermitUserEnvironment is disabled"
+    title: "Ensure SSH PermitUserEnvironment is disabled."
     description: "The PermitUserEnvironment option allows users to present environment options to the ssh daemon."
     rationale: "Permitting users the ability to set environment variables through the SSH daemon could potentially allow users to bypass security controls (e.g. setting an execution path that has ssh executing trojan'd programs)"
     remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: PermitUserEnvironment no"
@@ -2750,7 +2718,7 @@ the potential attack surface."
 
 # 5.2.12 Ensure SSH Idle Timeout Interval is configured (Scored)
   - id: 20151 
-    title: "Ensure SSH Idle Timeout Interval is configured"
+    title: "Ensure SSH Idle Timeout Interval is configured."
     description: "The two options ClientAliveInterval and ClientAliveCountMax control the timeout of ssh sessions. When the ClientAliveInterval variable is set, ssh sessions that have no activity for the specified length of time are terminated. When the ClientAliveCountMax variable is set, sshd will send client alive messages at every ClientAliveInterval interval. When the number of consecutive client alive messages are sent with no response from the client, the ssh session is terminated. For example, if the ClientAliveInterval is set to 15 seconds and the ClientAliveCountMax is set to 3, the client ssh session will be terminated after 45 seconds of idle time."
     rationale: "Having no timeout value associated with a connection could allow an unauthorized user access to another user's ssh session (e.g. user walks away from their computer and doesn't lock the screen). Setting a timeout value at least reduces the risk of this happening. While the recommended setting is 300 seconds (5 minutes), set this timeout value based on site policy. The recommended setting for ClientAliveCountMax is 0. In this case, the client session will be terminated after 5 minutes of idle time and no keepalive messages will be sent."
     remediation: "Edit the /etc/ssh/sshd_config file to set the parameters according to site policy: ClientAliveInterval 300 and ClientAliveCountMax 0"
@@ -2765,7 +2733,7 @@ the potential attack surface."
 
 # 5.2.13 Ensure SSH LoginGraceTime is set to one minute or less (Scored)
   - id: 20152 
-    title: "Ensure SSH LoginGraceTime is set to one minute or less"
+    title: "Ensure SSH LoginGraceTime is set to one minute or less."
     description: "The LoginGraceTime parameter specifies the time allowed for successful authentication to the SSH server. The longer the Grace period is the more open unauthenticated connections can exist. Like other session controls in this session the Grace Period should be limited to appropriate organizational limits to ensure the service is available for needed access."
     rationale: "Setting the LoginGraceTime parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. It will also limit the number of concurrent unauthenticated connections While the recommended setting is 60 seconds (1 Minute), set the number based on site policy."
     remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: LoginGraceTime 60"
@@ -2779,7 +2747,7 @@ the potential attack surface."
 
 # 5.2.14 Ensure SSH access is limited (Scored)
   - id: 20153 
-    title: "Ensure SSH access is limited"
+    title: "Ensure SSH access is limited."
     description: "There are several options available to limit which users and group can access the system via SSH. It is recommended that at least one of the following options be leveraged: AllowUsers The AllowUsers variable gives the system administrator the option of allowing specific users to ssh into the system. The list consists of space separated user names. Numeric user IDs are not recognized with this variable. If a system administrator wants to restrict user access further by only allowing the allowed users to log in from a particular host, the entry can be specified in the form of user@host. AllowGroups The AllowGroups variable gives the system administrator the option of allowing specific groups of users to ssh into the system. The list consists of space separated group names. Numeric group IDs are not recognized with this variable. DenyUsers The DenyUsers variable gives the system administrator the option of denying specific users to ssh into the system. The list consists of space separated user names. Numeric user IDs are not recognized with this variable. If a system administrator wants to restrict user access further by specifically denying a user's access from a particular host, the entry can be specified in the form of user@host. DenyGroups The DenyGroups variable gives the system administrator the option of denying specific groups of users to ssh into the system. The list consists of space separated group names. Numeric group IDs are not recognized with this variable."
     rationale: "Restricting which users can remotely access the system via SSH will help ensure that only authorized users access the system."
     remediation: "Edit the /etc/ssh/sshd_config file to set one or more of the parameter as follows: AllowUsers <userlist>; AllowGroups <grouplist>; DenyUsers <userlist> and DenyGroups <grouplist>"
@@ -2797,7 +2765,7 @@ the potential attack surface."
 
 # 5.2.15 Ensure SSH warning banner is configured (Scored)
   - id: 20154 
-    title: "Ensure SSH warning banner is configured"
+    title: "Ensure SSH warning banner is configured."
     description: "The Banner parameter specifies a file whose contents must be sent to the remote user before authentication is permitted. By default, no banner is displayed."
     rationale: "Banners are used to warn connecting users of the particular site's policy regarding connection. Presenting a warning message prior to the normal user login may assist the prosecution of trespassers on the computer system."
     remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: Banner /etc/issue.net"
@@ -2815,7 +2783,7 @@ the potential attack surface."
 ###############################################
 # 5.3.1 Ensure password creation requirements are configured (Scored)
   - id: 20155 
-    title: "Ensure password creation requirements are configured"
+    title: "Ensure password creation requirements are configured."
     description: "The pam_pwquality.so module checks the strength of passwords. It performs checks such as making sure a password is not a dictionary word, it is a certain length, contains a mix of characters (e.g. alphabet, numeric, other) and more"
     rationale: "Strong passwords protect systems from being hacked through brute force methods."
     remediation: "Edit the /etc/pam.d/password-auth and /etc/pam.d/system-auth files to include the appropriate options for pam_pwquality.so and to conform to site policy: password requisite pam_pwquality.so try_first_pass retry=3 minlen=14 dcredit=-1 ucredit=-1 ocredit=-1 lcredit=-1"
@@ -2836,7 +2804,7 @@ the potential attack surface."
 
 # 5.3.3 Ensure password reuse is limited (Scored)
   - id: 20156 
-    title: "Ensure password reuse is limited"
+    title: "Ensure password reuse is limited."
     description: "The /etc/security/opasswd file stores the users' old passwords and can be checked to ensure that users are not recycling recent passwords."
     rationale: "Forcing users not to reuse their past 5 passwords make it less likely that an attacker will be able to guess the password. Note that these change only apply to accounts configured on the local system."
     remediation: "Edit the /etc/pam.d/password-auth and /etc/pam.d/system-auth files to include the remember option and conform to site policy as shown: password sufficient pam_unix.so remember=5   or    password required pam_pwhistory.so remember=5"
@@ -2852,7 +2820,7 @@ the potential attack surface."
 
 # 5.3.4 Ensure password hashing algorithm is SHA-512 (Scored)
   - id: 20157 
-    title: "Ensure password hashing algorithm is SHA-512"
+    title: "Ensure password hashing algorithm is SHA-512."
     description: "The commands below change password encryption from md5 to sha512 (a much stronger hashing algorithm). All existing accounts will need to perform a password change to upgrade the stored hashes to the new algorithm."
     rationale: "The SHA-512 algorithm provides much stronger hashing than MD5, thus providing additional protection to the system by increasing the level of effort for an attacker to successfully determine passwords. Note that these change only apply to accounts configured on the local system."
     remediation: "Edit the /etc/pam.d/password-auth and /etc/pam.d/system-auth files to include the sha512 option for pam_unix.so as shown: password sufficient pam_unix.so sha512"
@@ -2865,6 +2833,7 @@ the potential attack surface."
     rules:
       - 'f:/etc/pam.d/password-auth -> r:^password\s*sufficient\s*pam_unix.so\s*sha512'
       - 'f:/etc/pam.d/system-auth -> r:^password\s*sufficient\s*pam_unix.so\s*sha512'
+
 ###############################################
 # 5.4 User Accounts and Environment
 ###############################################
@@ -2873,7 +2842,7 @@ the potential attack surface."
 ###############################################
 # 5.4.1.1 Ensure password expiration is 365 days or less (Scored)
   - id: 20158 
-    title: "Ensure password expiration is 365 days or less"
+    title: "Ensure password expiration is 365 days or less."
     description: "The PASS_MAX_DAYS parameter in /etc/login.defs allows an administrator to force passwords to expire once they reach a defined age. It is recommended that the PASS_MAX_DAYS parameter be set to less than or equal to 365 days."
     rationale: "The window of opportunity for an attacker to leverage compromised credentials or successfully compromise credentials via an online brute force attack is limited by the age of the password. Therefore, reducing the maximum age of a password also reduces an attacker's window of opportunity."
     remediation: "Set the PASS_MAX_DAYS parameter to conform to site policy in /etc/login.defs : PASS_MAX_DAYS 90 and modify user parameters for all users with a password set to match: chage --maxdays 90 <user>"
@@ -2888,7 +2857,7 @@ the potential attack surface."
 
 # 5.4.1.2 Ensure minimum days between password changes is 7 or more (Scored)
   - id: 20159 
-    title: "Ensure minimum days between password changes is 7 or more"
+    title: "Ensure minimum days between password changes is 7 or more."
     description: "The PASS_MIN_DAYS parameter in /etc/login.defs allows an administrator to prevent users from changing their password until a minimum number of days have passed since the last time the user changed their password. It is recommended that PASS_MIN_DAYS parameter be set to 7 or more days."
     rationale: "By restricting the frequency of password changes, an administrator can prevent users from repeatedly changing their password in an attempt to circumvent password reuse controls."
     remediation: "Set the PASS_MIN_DAYS parameter to 7 in /etc/login.defs: PASS_MIN_DAYS 7 and modify user parameters for all users with a password set to match: chage --mindays 7 <user>"
@@ -2903,7 +2872,7 @@ the potential attack surface."
 
 # 5.4.1.3 Ensure password expiration warning days is 7 or more (Scored)
   - id: 20160 
-    title: "Ensure password expiration warning days is 7 or more"
+    title: "Ensure password expiration warning days is 7 or more."
     description: "The PASS_WARN_AGE parameter in /etc/login.defs allows an administrator to notify users that their password will expire in a defined number of days. It is recommended that the PASS_WARN_AGE parameter be set to 7 or more days."
     rationale: "Providing an advance warning that a password will be expiring gives users time to think of a secure password. Users caught unaware may choose a simple password or write it down where it may be discovered."
     remediation: "Set the PASS_WARN_AGE parameter to 7 in /etc/login.defs: PASS_WARN_AGE 7 and modify user parameters for all users with a password set to match: chage --warndays 7 <user>"
@@ -2918,7 +2887,7 @@ the potential attack surface."
 
 # 5.4.1.4 Ensure inactive password lock is 30 days or less (Scored)
   - id: 20161 
-    title: "Ensure inactive password lock is 30 days or less"
+    title: "Ensure inactive password lock is 30 days or less."
     description: "User accounts that have been inactive for over a given period of time can be automatically disabled. It is recommended that accounts that are inactive for 30 days after password expiration be disabled."
     rationale: "Inactive accounts pose a threat to system security since the users are not logging in to notice failed login attempts or other anomalies."
     remediation: "Run the following command to set the default password inactivity period to 30 days: useradd -D -f 30 and modify user parameters for all users with a password set to match: chage --inactive 30 <user>"
@@ -2933,7 +2902,7 @@ the potential attack surface."
 
 # 5.4.3 Ensure default group for the root account is GID 0 (Scored)
   - id: 20162 
-    title: "Ensure default group for the root account is GID 0"
+    title: "Ensure default group for the root account is GID 0."
     description: "The usermod command can be used to specify which group the root user belongs to. This affects permissions of files that are created by the root user."
     rationale: "Using GID 0 for the root account helps prevent root -owned files from accidentally becoming accessible to non-privileged users."
     remediation: "Run the following command to set the root user default group to GID 0: usermod -g 0 root"
@@ -2948,7 +2917,7 @@ the potential attack surface."
 
 # 5.4.4 Ensure default user umask is 027 or more restrictive (Scored)
   - id: 20163 
-    title: "Ensure default user umask is 027 or more restrictive"
+    title: "Ensure default user umask is 027 or more restrictive."
     description: "The default umask determines the permissions of files created by users. The user creating the file has the discretion of making their files and directories readable by others via the chmod command. Users who wish to allow their files and directories to be readable by others by default may choose a different default umask by inserting the umask command into the standard shell configuration files ( .profile , .bashrc , etc.) in their home directories."
     rationale: "Setting a very secure default value for umask ensures that users make a conscious choice about their file permissions. A default umask setting of 077 causes files and directories created by users to not be readable by any other user on the system. A umask of 027 would make files and directories readable by users in the same Unix group, while a umask of 022 would make files readable by every user on the system."
     remediation: "Edit the /etc/bashrc , /etc/profile and /etc/profile.d/*.sh files (and the appropriate files for any other shell supported on your system) and add or edit any umask parameters as follows: umask 027"
@@ -2966,11 +2935,9 @@ the potential attack surface."
       - 'd:/etc/profile.d -> .sh -> !r:^\s*\t*# && r:umask \d0\d|umask \d1\d|umask \d4\d|umask \d5\d'
       - 'd:/etc/profile.d -> .sh -> !r:^\s*t*# && n:umask \d\d(\d) compare != 7'
 
-
-
 # 5.4.5 Ensure default user shell timeout is 900 seconds or less (Scored)
   - id: 20164 
-    title: "Ensure default user shell timeout is 900 seconds or less"
+    title: "Ensure default user shell timeout is 900 seconds or less."
     description: "The default TMOUT determines the shell timeout for users. The TMOUT value is measured in seconds."
     rationale: "Having no timeout value associated with a shell could allow an unauthorized user access to another user's shell session (e.g. user walks away from their computer and doesn't lock the screen). Setting a timeout value at least reduces the risk of this happening."
     remediation: "Edit the /etc/bashrc and /etc/profile files (and the appropriate files for any other shell supported on your system) and add or edit any umask parameters as follows: TMOUT=600"
@@ -2985,10 +2952,9 @@ the potential attack surface."
       - 'f:/etc/bashrc -> n:^\s*\t*TMOUT\s*\t*=\s*\t*(\d+) compare <= 900'
       - 'f:/etc/profile -> n:^\s*\t*TMOUT\s*\t*=\s*\t*(\d+) compare <= 900'
 
-
 # 5.6 Ensure access to the su command is restricted (Scored)
   - id: 20165 
-    title: "Ensure access to the su command is restricted."
+    title: "Ensure access to the su command is restricted.."
     description: "The su command allows a user to run a command or shell as another user. The program has been superseded by sudo , which allows for more granular control over privileged access. Normally, the su command can be executed by any user. By uncommenting the pam_wheel.so statement in /etc/pam.d/su , the su command will only allow users in the wheel group to execute su ."
     rationale: "Restricting the use of su , and using sudo in its place, provides system administrators better control of the escalation of user privileges to execute privileged commands. The sudo utility also provides a better logging and audit mechanism, as it can log each command executed via sudo , whereas su can only record that a user executed the su program."
     remediation: "Add the following line to the /etc/pam.d/su file: auth required pam_wheel.so use_uid"
@@ -3005,8 +2971,6 @@ the potential attack surface."
     rules:
       - 'f:/etc/pam.d/su -> r:^auth\s*\t*required\s*\t*pam_wheel.so\s*\t*use_uid'
 
-
-
 ###############################################
 # 6 System Maintenance
 ###############################################
@@ -3014,10 +2978,9 @@ the potential attack surface."
 # 6.1 System File Permissions
 ###############################################
 
-
 # 6.1.2 Configure /etc/passwd permissions (Scored)
   - id: 20166 
-    title: "Ensure permissions on /etc/passwd are configured"
+    title: "Ensure permissions on /etc/passwd are configured."
     description: "The /etc/passwd file contains user account information that is used by many system utilities and therefore must be readable for these utilities to operate."
     rationale: "It is critical to ensure that the /etc/passwd file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
     remediation: "Run the following command to set permissions on /etc/passwd: # chown root:root /etc/passwd # chmod 644 /etc/passwd"
@@ -3031,10 +2994,9 @@ the potential attack surface."
     rules:
       - 'c:stat /etc/passwd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
-
 # 6.1.3 Configure /etc/shadow permissions (Scored)
   - id: 20167 
-    title: "Ensure permissions on /etc/shadow are configured"
+    title: "Ensure permissions on /etc/shadow are configured."
     description: "The /etc/shadow file is used to store the information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/shadow file (such as expiration) could also be useful to subvert the user accounts."
     remediation: "Run the following command to set permissions on /etc/shadow: # chown root:root /etc/shadow # chmod 000 /etc/shadow"
@@ -3050,7 +3012,7 @@ the potential attack surface."
 
 # 6.1.4 Configure /etc/group permissions (Scored)
   - id: 20168 
-    title: "Ensure permissions on /etc/group are configured"
+    title: "Ensure permissions on /etc/group are configured."
     description: "The /etc/group file contains a list of all the valid groups defined in the system. The command below allows read/write access for root and read access for everyone else."
     rationale: "The /etc/group file needs to be protected from unauthorized changes by non-privileged users, but needs to be readable as this information is used with many non-privileged programs."
     remediation: "Run the following command to set permissions on /etc/group: # chown root:root /etc/group # chmod 644 /etc/group"
@@ -3066,7 +3028,7 @@ the potential attack surface."
 
 # 6.1.5 Configure /etc/gshadow permissions (Scored)
   - id: 20169 
-    title: "Ensure permissions on /etc/gshadow are configured"
+    title: "Ensure permissions on /etc/gshadow are configured."
     description: "The /etc/gshadow file is used to store the information about groups that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "If attackers can gain read access to the /etc/gshadow file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/gshadow file (such as group administrators) could also be useful to subvert the group"
     remediation: "Run the following command to set permissions on /etc/gshadow: # chown root:root /etc/gshadow # chmod 000 /etc/gshadow"
@@ -3082,7 +3044,7 @@ the potential attack surface."
 
 # 6.1.6 Configure /etc/passwd- permissions (Scored)
   - id: 20170 
-    title: "Ensure permissions on /etc/passwd- are configured"
+    title: "Ensure permissions on /etc/passwd- are configured."
     description: "The /etc/passwd- file contains backup user account information."
     rationale: "It is critical to ensure that the /etc/passwd- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
     remediation: "Run the following command to set permissions on /etc/passwd-: # chown root:root /etc/passwd- # chmod 644 /etc/passwd-"
@@ -3098,7 +3060,7 @@ the potential attack surface."
 
 # 6.1.7 Configure /etc/shadow- permissions (Scored)
   - id: 20171 
-    title: "Ensure permissions on /etc/shadow- are configured"
+    title: "Ensure permissions on /etc/shadow- are configured."
     description: "The /etc/shadow- file is used to store backup information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "It is critical to ensure that the /etc/shadow- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
     remediation: "Run the following command to set permissions on /etc/shadow-: # chown root:root /etc/shadow- # chmod 000 /etc/shadow-"
@@ -3114,7 +3076,7 @@ the potential attack surface."
 
 # 6.1.8 Configure /etc/group- permissions (Scored)
   - id: 20172 
-    title: "Ensure permissions on /etc/group- are configured"
+    title: "Ensure permissions on /etc/group- are configured."
     description: "The /etc/group- file contains a backup list of all the valid groups defined in the system."
     rationale: "It is critical to ensure that the /etc/group- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
     remediation: "Run the following command to set permissions on /etc/group-: # chown root:root /etc/group- # chmod 644 /etc/group-"
@@ -3130,7 +3092,7 @@ the potential attack surface."
 
 # 6.1.9 Configure /etc/gshadow- permissions (Scored)
   - id: 20173 
-    title: "Ensure permissions on /etc/gshadow- are configured"
+    title: "Ensure permissions on /etc/gshadow- are configured."
     description: "The /etc/gshadow- file is used to store backup information about groups that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "It is critical to ensure that the /etc/gshadow- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
     remediation: "Run the following command to set permissions on /etc/gshadow-: # chown root:root /etc/gshadow- # chmod 000 /etc/gshadow-"
@@ -3149,7 +3111,7 @@ the potential attack surface."
 ###############################################
 # 6.2.1 Check passwords fields (Scored)
   - id: 20174 
-    title: "Ensure password fields are not empty"
+    title: "Ensure password fields are not empty."
     description: "An account with an empty password field means that anybody may log in as that user without providing a password."
     rationale: "All accounts must have passwords or be locked to prevent the account from being used by an unauthorized user."
     remediation: "If any accounts in the /etc/shadow file do not have a password, run the following command to lock the account until it can be determined why it does not have a password: passwd -l <username> || Also, check to see if the account is logged in and investigate what it is being used for to determine if it needs to be forced off."
@@ -3164,7 +3126,7 @@ the potential attack surface."
 
 # 6.2.2 Delete legacy entries in /etc/passwd (Scored)
   - id: 20175 
-    title: "Ensure no legacy \"+\" entries exist in /etc/passwd"
+    title: "Ensure no legacy + entries exist in /etc/passwd."
     description: "The character + in various files used to be markers for systems to insert data from NIS maps at a certain point in a system configuration file. These entries are no longer required on most systems, but may exist in files that have been imported from other platforms."
     rationale: "These entries may provide an avenue for attackers to gain privileged access on the system."
     remediation: "Remove any legacy '+' entries from /etc/passwd if they exist."
@@ -3183,7 +3145,7 @@ the potential attack surface."
 
 # 6.2.3 Delete legacy entries in /etc/shadow (Scored)
   - id: 20176 
-    title: "Ensure no legacy \"+\" entries exist in /etc/shadow"
+    title: "Ensure no legacy + entries exist in /etc/shadow."
     description: "The character + in various files used to be markers for systems to insert data from NIS maps at a certain point in a system configuration file. These entries are no longer required on most systems, but may exist in files that have been imported from other platforms."
     rationale: "These entries may provide an avenue for attackers to gain privileged access on the system."
     remediation: "Remove any legacy '+' entries from /etc/shadow if they exist."
@@ -3202,7 +3164,7 @@ the potential attack surface."
 
 # 6.2.4 Delete legacy entries in /etc/group (Scored)
   - id: 20177 
-    title: "Ensure no legacy \"+\" entries exist in /etc/group"
+    title: "Ensure no legacy + entries exist in /etc/group."
     description: "The character + in various files used to be markers for systems to insert data from NIS maps at a certain point in a system configuration file. These entries are no longer required on most systems, but may exist in files that have been imported from other platforms."
     rationale: "These entries may provide an avenue for attackers to gain privileged access on the system."
     remediation: "Remove any legacy '+' entries from /etc/group if they exist."
@@ -3221,7 +3183,7 @@ the potential attack surface."
 
 # 6.2.5 Verify No UID 0 Accounts Exist Other Than root (Scored)
   - id: 20178 
-    title: "Ensure root is the only UID 0 account"
+    title: "Ensure root is the only UID 0 account."
     description: "Any account with UID 0 has superuser privileges on the system."
     rationale: "This access must be limited to only the default root account and only from the system console. Administrative access must be through an unprivileged account using an approved mechanism as noted in Item 5.6 Ensure access to the su command is restricted."
     remediation: "Remove any users other than root with UID 0 or assign them a new UID if appropriate."


### PR DESCRIPTION
|Related issue|
|---|
|#10403|

## Description

This PR aims to fix PR #10406

The issues resolved are:
- Minimal typos and bad references format.

## Checks and changes 

### Syntax and semantic

- [x] a) ID of each policy must be contiguous.
- [x] b) The order and format set in [Documentation](https://documentation.wazuh.com/current/user-manual/capabilities/sec-config-assessment/creating-custom-policies.html) must be respected.
- [x] c) YML must be valid to avoid errors.

### Content

- [x] a) Compare each check with its analogue from CIS Benchmark.
- [x] b) Try to maintain each rule as similar as possible with the `Audit` section from the CIS check.
- [x] c) Check that the commands provide the expected output.
- [x] d) When a failure is discovered, check similar policies to avoid repetition of the issue.

### Unit testing

- [x] a) Output from `agent.log` after the SCA scan and a raw output of the result of the checks.
```
2021/12/07 20:40:33 sca: INFO: Module started.
2021/12/07 20:40:33 sca: INFO: Loaded policy '/var/ossec/ruleset/sca/cis_rhel8_linux.yml'
2021/12/07 20:40:33 sca: INFO: Starting Security Configuration Assessment scan.
2021/12/07 20:40:33 wazuh-modulesd:control: INFO: Starting control thread.
2021/12/07 20:40:33 sca: INFO: Starting evaluation of policy: '/var/ossec/ruleset/sca/cis_rhel8_linux.yml'
2021/12/07 20:40:33 wazuh-modulesd:syscollector: INFO: Module started.
2021/12/07 20:40:33 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2021/12/07 20:40:33 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2021/12/07 20:40:33 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
2021/12/07 20:40:42 sca: INFO: Evaluation finished for policy '/var/ossec/ruleset/sca/cis_rhel8_linux.yml'
2021/12/07 20:40:42 sca: INFO: Security Configuration Assessment scan finished. Duration: 9 seconds.
2021/12/07 20:40:53 rootcheck: INFO: Ending rootcheck scan.

```

### Deployment

- [x] a) If the policy it's new, it must be added to the `sca.files` templates.
- [x] b) If the OS has many supported SCA policies, a policy must be set as default policy. ([as example](https://github.com/wazuh/wazuh/blob/master/etc/templates/config/centos/sca.files))
