### PR TITLE
Discarded packages from OVAL with 'only' version

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -2742,6 +2742,17 @@ void test_wm_checks_package_vulnerability_alas_eq_ignore_epoch(void **state)
     assert_int_equal(VU_VULNERABLE, ret);
 }
 
+void test_wm_checks_package_vulnerability_lt_only_version(void **state)
+{
+    char *version_a = "5.7.36-1ubuntu18.04";
+    char *version_b = "8.0 only";
+    char *operation = "less than";
+
+    int ret = wm_checks_package_vulnerability(version_a, operation, version_b, VER_TYPE_DEB);
+
+    assert_int_equal(VU_ERROR_CMP, ret);
+}
+
 /* wm_vuldel_truncate_revision */
 
 void test_wm_vuldel_truncate_revision_null(void ** state) {
@@ -20771,6 +20782,7 @@ int main(void)
         cmocka_unit_test(test_wm_checks_package_vulnerability_ne),
         cmocka_unit_test(test_wm_checks_package_vulnerability_centos_gt),
         cmocka_unit_test(test_wm_checks_package_vulnerability_alas_eq_ignore_epoch),
+        cmocka_unit_test(test_wm_checks_package_vulnerability_lt_only_version),
         // Tests wm_vuldet_truncate_revision
         cmocka_unit_test(test_wm_vuldel_truncate_revision_null),
         cmocka_unit_test(test_wm_vuldel_truncate_revision),

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -798,6 +798,12 @@ int wm_checks_package_vulnerability(char *version_a, const char *operation, cons
             wm_vuldel_truncate_revision(crelease_it);
         }
 
+        if (vertype == VER_TYPE_DEB) {
+            if (strstr(cversion_it, " only") != NULL) {
+                return VU_ERROR_CMP;
+            }
+        }
+
         os_calloc(1, sizeof(struct pkg_version), package_version);
         os_calloc(1, sizeof(struct pkg_version), package_feed_version);
         package_version->epoch = epoch;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -799,6 +799,7 @@ int wm_checks_package_vulnerability(char *version_a, const char *operation, cons
         }
 
         if (vertype == VER_TYPE_DEB) {
+            // This exception is caused by https://github.com/wazuh/wazuh/issues/11363
             if (strstr(cversion_it, " only") != NULL) {
                 return VU_ERROR_CMP;
             }


### PR DESCRIPTION
|Related issue|
|---|
|#11363|

## Description

This PR fixes the false positive of the MySQL package found in the issue #11363 and that affects _OVAL_ - `Bionic` and `Xenial`.

Currently, instead of checking if it is lower than version 8.0, it treats it as a vulnerability that cannot be compared, so when checking that the version contains the string `" only"`, it is discarded.

## Configuration options

```
<vulnerability-detector>
    <enabled>yes</enabled>
    <interval>2m</interval>
    <min_full_scan_interval>5m</min_full_scan_interval>
    <run_on_start>yes</run_on_start>

    <!-- Ubuntu OS vulnerabilities -->
    <provider name="canonical">
      <enabled>yes</enabled>
      <os>xenial</os>
      <os>bionic</os>
      <update_interval>1h</update_interval>
    </provider>
...
    <provider name="nvd">
      <enabled>yes</enabled>
      <update_from_year>2010</update_from_year>
      <update_interval>1h</update_interval>
    </provider>
</vulnerability-detector>
```

## Logs/Alerts example

```
wazuh-modulesd:vulnerability-detector[39219] wm_vuln_detector.c:2274 at wm_vuldet_linux_oval_vulnerabilities(): DEBUG: (5487): Unknown relation 'less than' between versions '5.7.36-1ubuntu18.04' and '8.0 only' for package 'mysql-client'
wazuh-modulesd:vulnerability-detector[39219] wm_vuln_detector.c:2274 at wm_vuldet_linux_oval_vulnerabilities(): DEBUG: (5487): Unknown relation 'less than' between versions '5.7.36-1ubuntu18.04' and '8.x only' for package 'mysql-client'
wazuh-modulesd:vulnerability-detector[39219] wm_vuln_detector.c:2274 at wm_vuldet_linux_oval_vulnerabilities(): DEBUG: (5487): Unknown relation 'less than' between versions '5.7.36-1ubuntu18.04' and '8.0.x only' for package 'mysql-client'
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)
