### PR TITLE
Add API and cluster multiprocessing improvements

### DIFF
--- a/api/api/alogging.py
+++ b/api/api/alogging.py
@@ -1,18 +1,18 @@
 # Copyright (C) 2015-2021, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+import binascii
 import json
 import logging
 import re
+from base64 import b64decode
 
 from aiohttp.abc import AbstractAccessLogger
-from werkzeug.exceptions import Unauthorized
 
-from api.authentication import decode_token
 from wazuh.core.wlogging import WazuhLogger
 
 # compile regex when the module is imported so it's not necessary to compile it everytime log.info is called
-request_pattern = re.compile(r'\[.+\]|\s+\*\s+')
+request_pattern = re.compile(r'\[.+]|\s+\*\s+')
 
 # Variable used to specify an unknown user
 UNKNOWN_USER_STRING = "unknown_user"
@@ -34,8 +34,8 @@ class AccessLogger(AbstractAccessLogger):
         user = request.get('user', '')
         if not user:
             try:
-                user = decode_token(request.headers["authorization"][7:])["sub"]
-            except Unauthorized:
+                user = b64decode(request.headers["authorization"].split()[1]).decode().split(':')[0]
+            except (KeyError, IndexError, binascii.Error):
                 user = UNKNOWN_USER_STRING
 
         self.logger.info(f'{user} '

--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -8,7 +8,6 @@ from typing import Union
 from aiohttp import web
 from connexion.lifecycle import ConnexionResponse
 
-from api import configuration
 from api.encoder import dumps, prettify
 from api.models.agent_added_model import AgentAddedModel
 from api.models.agent_inserted_model import AgentInsertedModel

--- a/api/api/test/test_alogging.py
+++ b/api/api/test/test_alogging.py
@@ -13,15 +13,12 @@ from werkzeug.exceptions import Unauthorized
 
 with patch('wazuh.core.common.wazuh_uid'):
     with patch('wazuh.core.common.wazuh_gid'):
-        sys.modules['api.authentication'] = MagicMock()
         from api import alogging
-
-        del sys.modules['api.authentication']
 
 
 @pytest.mark.parametrize('side_effect, user', [
-    (Unauthorized, ''),
-    ([{"sub": "test"}], ''),
+    ('unknown', ''),
+    (None, ''),
     (None, 'wazuh')
 ])
 @patch('api.alogging.json.dumps')
@@ -38,28 +35,28 @@ def test_accesslogger_log(mock_dumps, side_effect, user):
 
     # Create a class with a mocked get method for request
     class MockedRequest(MagicMock):
+        # wazuh:password123
+        headers = {'authorization': 'Basic d2F6dWg6cGFzc3dvcmQxMjM='} if side_effect is None else {}
+
         def get(self, *args, **kwargs):
             return user
 
     # Mock decode_token and logger.info
-    with patch('api.alogging.decode_token', side_effect=side_effect) as mock_decode_token:
-        with patch('logging.Logger.info') as mock_logger_info:
+    with patch('logging.Logger.info') as mock_logger_info:
 
-            # Create an AccessLogger object and log a mocked call
-            test_access_logger = alogging.AccessLogger(logger=logging.getLogger('test'), log_format=MagicMock())
-            test_access_logger.log(request=MockedRequest(), response=MagicMock(), time=0.0)
+        # Create an AccessLogger object and log a mocked call
+        test_access_logger = alogging.AccessLogger(logger=logging.getLogger('test'), log_format=MagicMock())
+        test_access_logger.log(request=MockedRequest(), response=MagicMock(), time=0.0)
 
-            # If not user, decode_token must be called to get the user and logger.info must be called with the user
-            # if we have token_info or UNKNOWN_USER if not
-            if not user:
-                mock_decode_token.assert_called_once()
-                expected_user = side_effect[0][
-                    "sub"] if side_effect is not Unauthorized else alogging.UNKNOWN_USER_STRING
-                assert mock_logger_info.call_args.args[0].split(" ")[0] == expected_user
+        # If not user, decode_token must be called to get the user and logger.info must be called with the user
+        # if we have token_info or UNKNOWN_USER if not
+        if not user:
+            expected_user = 'wazuh' if side_effect is None else alogging.UNKNOWN_USER_STRING
+            assert mock_logger_info.call_args.args[0].split(" ")[0] == expected_user
 
-            # If user, logger.info must be called with the user
-            else:
-                assert mock_logger_info.call_args.args[0].split(" ")[0] == user
+        # If user, logger.info must be called with the user
+        else:
+            assert mock_logger_info.call_args.args[0].split(" ")[0] == user
 
 
 @patch('wazuh.core.wlogging.WazuhLogger.__init__')

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -15,14 +15,14 @@ from wazuh.core import common, utils
 def spawn_process_pool():
     """Import necessary basic Wazuh SDK modules for the local request pool and spawn child."""
     from wazuh import agent, manager  # noqa
-    from wazuh.core import common # noqa
-    from wazuh.core.cluster import dapi # noqa
+    from wazuh.core import common  # noqa
+    from wazuh.core.cluster import dapi  # noqa
     return
 
 
 def spawn_authentication_pool():
     """Import necessary basic Wazuh security modules for the authentication tasks pool and spawn child."""
-    from wazuh import security # noqa
+    from wazuh import security  # noqa
     return
 
 
@@ -165,9 +165,11 @@ def start(foreground, root, config_file):
         print(f"Starting API as root")
 
     # Spawn child processes with their own needed imports
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(asyncio.wait([loop.run_in_executor(pool, getattr(sys.modules[__name__], f'spawn_{name}'))
-                                          for name, pool in common.mp_pools.get().items()]))
+    if 'thread_pool' not in common.mp_pools.get():
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(
+            asyncio.wait([loop.run_in_executor(pool, getattr(sys.modules[__name__], f'spawn_{name}'))
+                          for name, pool in common.mp_pools.get().items()]))
 
     # Set up API
     asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())

--- a/api/test/integration/env/configurations/security/manager/configuration_files/security_config.sh
+++ b/api/test/integration/env/configurations/security/manager/configuration_files/security_config.sh
@@ -3,3 +3,5 @@
 # RBAC configuration
 sqlite3 /var/ossec/api/configuration/security/rbac.db < /tmp/configuration_files/schema_security_test.sql
 sqlite3 /var/ossec/api/configuration/security/rbac.db < /tmp/configuration_files/base_security_test.sql
+chown wazuh:wazuh /var/ossec/api/configuration/security/rbac.db
+chmod 640 /var/ossec/api/configuration/security/rbac.db

--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -79,7 +79,8 @@ async def master_main(args, cluster_config, cluster_items, logger):
                                                      configuration=cluster_config, enable_ssl=args.ssl,
                                                      cluster_items=cluster_items)
     # Spawn pool processes
-    my_server.task_pool.map(cluster_utils.process_spawn_sleep, range(my_server.task_pool._max_workers))
+    if my_server.task_pool is not None:
+        my_server.task_pool.map(cluster_utils.process_spawn_sleep, range(my_server.task_pool._max_workers))
     await asyncio.gather(my_server.start(), my_local_server.start())
 
 
@@ -100,7 +101,8 @@ async def worker_main(args, cluster_config, cluster_items, logger):
                                                          cluster_items=cluster_items)
 
         # Spawn pool processes
-        my_client.task_pool.map(cluster_utils.process_spawn_sleep, range(my_client.task_pool._max_workers))
+        if my_client.task_pool is not None:
+            my_client.task_pool.map(cluster_utils.process_spawn_sleep, range(my_client.task_pool._max_workers))
 
         try:
             await asyncio.gather(my_client.start(), my_local_server.start())

--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -78,10 +78,8 @@ async def master_main(args, cluster_config, cluster_items, logger):
                                                      concurrency_test=args.concurrency_test, node=my_server,
                                                      configuration=cluster_config, enable_ssl=args.ssl,
                                                      cluster_items=cluster_items)
-    # Spawn pool processes if needed
-    if cluster_items['intervals']['master']['process_pool_debug']:
-        my_server.task_pool.map(cluster_utils.process_spawn_sleep,
-                                range(my_server.task_pool._max_workers))
+    # Spawn pool processes
+    my_server.task_pool.map(cluster_utils.process_spawn_sleep, range(my_server.task_pool._max_workers))
     await asyncio.gather(my_server.start(), my_local_server.start())
 
 
@@ -100,6 +98,10 @@ async def worker_main(args, cluster_config, cluster_items, logger):
                                                          concurrency_test=args.concurrency_test, node=my_client,
                                                          configuration=cluster_config, enable_ssl=args.ssl,
                                                          cluster_items=cluster_items)
+
+        # Spawn pool processes
+        my_client.task_pool.map(cluster_utils.process_spawn_sleep, range(my_client.task_pool._max_workers))
+
         try:
             await asyncio.gather(my_client.start(), my_local_server.start())
         except asyncio.CancelledError:

--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -89,20 +89,31 @@ async def master_main(args, cluster_config, cluster_items, logger):
 #
 async def worker_main(args, cluster_config, cluster_items, logger):
     from wazuh.core.cluster import worker, local_server
+    from concurrent.futures import ProcessPoolExecutor
     cluster_utils.context_tag.set('Worker')
+
+    # Pool is defined here so the child process is not recreated when the connection with master node is broken.
+    try:
+        task_pool = ProcessPoolExecutor(max_workers=1)
+    # Handle exception when the user running Wazuh cannot access /dev/shm
+    except (FileNotFoundError, PermissionError):
+        main_logger.warning(
+            "In order to take advantage of Wazuh 4.3.0 cluster improvements, the directory '/dev/shm' must be "
+            "accessible by the 'wazuh' user. Check that this file has permissions to be accessed by all users. "
+            "Changing the file permissions to 777 will solve this issue.")
+        main_logger.warning(
+            "The Wazuh cluster will be run without the improvements added in Wazuh 4.3.0 and higher versions.")
+        task_pool = None
+
     while True:
         my_client = worker.Worker(configuration=cluster_config, enable_ssl=args.ssl,
                                   performance_test=args.performance_test, concurrency_test=args.concurrency_test,
                                   file=args.send_file, string=args.send_string, logger=logger,
-                                  cluster_items=cluster_items)
+                                  cluster_items=cluster_items, task_pool=task_pool)
         my_local_server = local_server.LocalServerWorker(performance_test=args.performance_test, logger=logger,
                                                          concurrency_test=args.concurrency_test, node=my_client,
                                                          configuration=cluster_config, enable_ssl=args.ssl,
                                                          cluster_items=cluster_items)
-
-        # Spawn pool processes
-        if my_client.task_pool is not None:
-            my_client.task_pool.map(cluster_utils.process_spawn_sleep, range(my_client.task_pool._max_workers))
 
         try:
             await asyncio.gather(my_client.start(), my_local_server.start())

--- a/framework/wazuh/core/cluster/cluster.json
+++ b/framework/wazuh/core/cluster/cluster.json
@@ -107,7 +107,6 @@
             "timeout_agent_info": 40,
             "check_worker_lastkeepalive": 60,
             "max_allowed_time_without_keepalive": 120,
-            "process_pool_debug": false,
             "max_locked_integrity_time": 1000
         },
 

--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -669,7 +669,7 @@ async def run_in_pool(loop, pool, f, *args, **kwargs):
     -------
     Result of `f(*args, **kwargs)` function.
     """
-    if pool:
+    if pool is not None:
         task = loop.run_in_executor(pool, partial(f, *args, **kwargs))
         return await wait_for(task, timeout=None)
     else:

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -10,7 +10,7 @@ import operator
 import os
 import time
 from collections import defaultdict
-from concurrent.futures import process, ProcessPoolExecutor
+from concurrent.futures import process
 from copy import copy, deepcopy
 from functools import reduce, partial
 from operator import or_
@@ -31,8 +31,8 @@ from wazuh.core.cluster.cluster import check_cluster_status
 from wazuh.core.exception import WazuhException, WazuhClusterError, WazuhError
 from wazuh.core.wazuh_socket import wazuh_sendsync
 
-process_pool = ProcessPoolExecutor(max_workers=1)
-authentication_pool = ProcessPoolExecutor(max_workers=1)
+process_pool = common.mp_pools.get()['process_pool']
+authentication_pool = common.mp_pools.get()['authentication_pool']
 authentication_funcs = {'check_token', 'check_user_master', 'get_permissions', 'get_security_conf'}
 
 

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -667,7 +667,8 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         logger.debug(f"Received file from worker: '{received_filename}'")
 
         # Path to metadata file (files_metadata.json) and to zipdir (directory with decompressed files).
-        files_metadata, decompressed_files_path = await wazuh.core.cluster.cluster.decompress_files(received_filename)
+        files_metadata, decompressed_files_path = await wazuh.core.cluster.cluster.async_decompress_files(
+            received_filename)
         # There are no files inside decompressed_files_path, only files_metadata.json which has already been loaded.
         shutil.rmtree(decompressed_files_path)
 
@@ -806,7 +807,8 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         logger.debug(f"Received extra-valid file from worker: '{received_filename}'")
 
         # Path to metadata file (files_metadata.json) and to zipdir (directory with decompressed files).
-        files_metadata, decompressed_files_path = await wazuh.core.cluster.cluster.decompress_files(received_filename)
+        files_metadata, decompressed_files_path = await wazuh.core.cluster.cluster.async_decompress_files(
+            received_filename)
         logger.debug(f"Received {len(files_metadata)} extra-valid files to check.")
 
         # Create a child process to run the task.

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -19,7 +19,7 @@ from uuid import uuid4
 import wazuh.core.cluster.cluster
 from wazuh.core import cluster as metadata, common, exception, utils
 from wazuh.core.agent import Agent
-from wazuh.core.cluster import server, common as c_common
+from wazuh.core.cluster import server, cluster, common as c_common
 from wazuh.core.cluster.dapi import dapi
 from wazuh.core.cluster.utils import context_tag
 from wazuh.core.common import decimals_date_format
@@ -591,11 +591,8 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
 
         # Update chunks in local wazuh-db
         try:
-            task = self.loop.run_in_executor(
-                self.server.task_pool,
-                partial(self.send_data_to_wdb, data, self.cluster_items['intervals']['master']['timeout_agent_info'])
-            )
-            result = await asyncio.wait_for(task, timeout=None)
+            result = await cluster.run_in_pool(self.loop, self.server.task_pool, self.send_data_to_wdb, data,
+                                               self.cluster_items['intervals']['master']['timeout_agent_info'])
         except Exception as e:
             await self.send_request(command=b'syn_m_a_err',
                                     data=f'error processing agent-info chunks in process pool: {str(e)}'.encode())
@@ -813,12 +810,9 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
 
         # Create a child process to run the task.
         try:
-            task = self.loop.run_in_executor(
-                self.server.task_pool,
-                partial(self.process_files_from_worker, files_metadata, decompressed_files_path, self.cluster_items,
-                        self.name, self.cluster_items['intervals']['master']['timeout_extra_valid'])
-            )
-            result = await asyncio.wait_for(task, timeout=None)
+            result = await cluster.run_in_pool(self.loop, self.server.task_pool, self.process_files_from_worker,
+                                               files_metadata, decompressed_files_path, self.cluster_items, self.name,
+                                               self.cluster_items['intervals']['master']['timeout_extra_valid'])
         except Exception as e:
             raise exception.WazuhClusterError(3038, extra_message=str(e))
         finally:
@@ -971,8 +965,18 @@ class Master(server.AbstractServer):
         super().__init__(**kwargs, tag="Master")
         self.integrity_control = {}
         self.handler_class = MasterHandler
-        self.task_pool = ProcessPoolExecutor(
-            max_workers=min(os.cpu_count(), self.cluster_items['intervals']['master']['process_pool_size']))
+        try:
+            self.task_pool = ProcessPoolExecutor(
+                max_workers=min(os.cpu_count(), self.cluster_items['intervals']['master']['process_pool_size']))
+        # Handle exception when the user running Wazuh cannot access /dev/shm
+        except (FileNotFoundError, PermissionError):
+            self.logger.warning(
+                "In order to take advantage of Wazuh 4.3.0 cluster improvements, the directory '/dev/shm' must be "
+                "accessible by the 'wazuh' user. Check that this file has permissions to be accessed by all users. "
+                "Changing the file permissions to 777 will solve this issue.")
+            self.logger.warning(
+                "The Wazuh cluster will be run without the improvements added in Wazuh 4.3.0 and higher versions.")
+            self.task_pool = None
         self.integrity_already_executed = []
         self.dapi = dapi.APIRequestQueue(server=self)
         self.sendsync = dapi.SendSyncRequestQueue(server=self)
@@ -1004,13 +1008,12 @@ class Master(server.AbstractServer):
             before = datetime.now()
             file_integrity_logger.info("Starting.")
             try:
-                task = self.loop.run_in_executor(self.task_pool, partial(wazuh.core.cluster.cluster.get_files_status,
-                                                                         self.integrity_control))
-                # With this we avoid that each worker starts integrity_check more than once per local_integrity
-                self.integrity_control = await asyncio.wait_for(task, timeout=None)
+                self.integrity_control = await cluster.run_in_pool(self.loop, self.task_pool,
+                                                                   wazuh.core.cluster.cluster.get_files_status)
             except Exception as e:
                 file_integrity_logger.error(f"Error calculating local file integrity: {e}")
             finally:
+                # With this we avoid that each worker starts integrity_check more than once per local_integrity
                 self.integrity_already_executed.clear()
 
             file_integrity_logger.info(f"Finished in {(datetime.now() - before).total_seconds():.3f}s. Calculated "

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -1004,7 +1004,8 @@ class Master(server.AbstractServer):
             before = datetime.now()
             file_integrity_logger.info("Starting.")
             try:
-                task = self.loop.run_in_executor(self.task_pool, wazuh.core.cluster.cluster.get_files_status)
+                task = self.loop.run_in_executor(self.task_pool, partial(wazuh.core.cluster.cluster.get_files_status,
+                                                                         self.integrity_control))
                 # With this we avoid that each worker starts integrity_check more than once per local_integrity
                 self.integrity_control = await asyncio.wait_for(task, timeout=None)
             except Exception as e:

--- a/framework/wazuh/core/cluster/tests/test_utils.py
+++ b/framework/wazuh/core/cluster/tests/test_utils.py
@@ -154,8 +154,7 @@ def test_get_cluster_items():
                                    'master': {'timeout_extra_valid': 40, 'recalculate_integrity': 8,
                                               'check_worker_lastkeepalive': 60,
                                               'max_allowed_time_without_keepalive': 120, 'process_pool_size': 2,
-                                              'timeout_agent_info': 40, 'process_pool_debug': False,
-                                              'max_locked_integrity_time': 1000},
+                                              'timeout_agent_info': 40, 'max_locked_integrity_time': 1000},
                                    'communication': {'timeout_cluster_request': 20, 'timeout_dapi_request': 200,
                                                      'timeout_receiving_file': 120}},
                      'distributed_api': {'enabled': True}}

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -5,7 +5,7 @@
 import json
 import os
 import subprocess
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from contextvars import ContextVar
 from copy import deepcopy
 from functools import lru_cache
@@ -221,10 +221,16 @@ current_user: ContextVar[str] = ContextVar('current_user', default='')
 broadcast: ContextVar[bool] = ContextVar('broadcast', default=False)
 cluster_nodes: ContextVar[list] = ContextVar('cluster_nodes', default=list())
 origin_module: ContextVar[str] = ContextVar('origin_module', default='framework')
-mp_pools: ContextVar[Dict] = ContextVar('mp_pools', default={
-    'process_pool': ProcessPoolExecutor(max_workers=1),
-    'authentication_pool': ProcessPoolExecutor(max_workers=1)
-})
+try:
+    mp_pools: ContextVar[Dict] = ContextVar('mp_pools', default={
+        'process_pool': ProcessPoolExecutor(max_workers=1),
+        'authentication_pool': ProcessPoolExecutor(max_workers=1)
+    })
+# Handle exception when the user running Wazuh cannot access /dev/shm
+except (FileNotFoundError, PermissionError):
+    mp_pools: ContextVar[Dict] = ContextVar('mp_pools', default={
+        'thread_pool': ThreadPoolExecutor(max_workers=1)
+    })
 
 _context_cache = dict()
 

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -220,7 +220,6 @@ rbac: ContextVar[Dict] = ContextVar('rbac', default={'rbac_mode': 'black'})
 current_user: ContextVar[str] = ContextVar('current_user', default='')
 broadcast: ContextVar[bool] = ContextVar('broadcast', default=False)
 cluster_nodes: ContextVar[list] = ContextVar('cluster_nodes', default=list())
-cluster_integrity_mtime: ContextVar[Dict] = ContextVar('cluster_integrity_mtime', default={})
 origin_module: ContextVar[str] = ContextVar('origin_module', default='framework')
 mp_pools: ContextVar[Dict] = ContextVar('mp_pools', default={
     'process_pool': ProcessPoolExecutor(max_workers=1),

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -5,6 +5,7 @@
 import json
 import os
 import subprocess
+from concurrent.futures import ProcessPoolExecutor
 from contextvars import ContextVar
 from copy import deepcopy
 from functools import lru_cache
@@ -221,6 +222,10 @@ broadcast: ContextVar[bool] = ContextVar('broadcast', default=False)
 cluster_nodes: ContextVar[list] = ContextVar('cluster_nodes', default=list())
 cluster_integrity_mtime: ContextVar[Dict] = ContextVar('cluster_integrity_mtime', default={})
 origin_module: ContextVar[str] = ContextVar('origin_module', default='framework')
+mp_pools: ContextVar[Dict] = ContextVar('mp_pools', default={
+    'process_pool': ProcessPoolExecutor(max_workers=1),
+    'authentication_pool': ProcessPoolExecutor(max_workers=1)
+})
 
 _context_cache = dict()
 


### PR DESCRIPTION
This PR includes API and cluster improvements after the addition of the multiprocessing capabilities.

The issues solved with the merge of this branch into 4.3 are the following:

- Cluster/API error when using multiprocessing without access to /dev/shm #11347
- Create all cluster child processes when starting clustered #11378
- Reduce memory on API child processes after implementing multiprocessing #11350
- Execute in a child process the file processing master -> worker #11330