### PR TITLE
Fix analysisd segfault when queues sizes are zero

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -2350,47 +2350,47 @@ void w_get_initial_queues_size(){
 
 void w_init_queues(){
      /* Init the archives writer queue */
-    writer_queue = queue_init(getDefine_Int("analysisd", "archives_queue_size", 0, 2000000));
+    writer_queue = queue_init(getDefine_Int("analysisd", "archives_queue_size", 128, 2000000));
 
     /* Init the alerts log writer queue */
-    writer_queue_log = queue_init(getDefine_Int("analysisd", "alerts_queue_size", 0, 2000000));
+    writer_queue_log = queue_init(getDefine_Int("analysisd", "alerts_queue_size", 128, 2000000));
 
     /* Init statistical the log writer queue */
-    writer_queue_log_statistical = queue_init(getDefine_Int("analysisd", "statistical_queue_size", 0, 2000000));
+    writer_queue_log_statistical = queue_init(getDefine_Int("analysisd", "statistical_queue_size", 128, 2000000));
 
     /* Init the firewall log writer queue */
-    writer_queue_log_firewall = queue_init(getDefine_Int("analysisd", "firewall_queue_size", 0, 2000000));
+    writer_queue_log_firewall = queue_init(getDefine_Int("analysisd", "firewall_queue_size", 128, 2000000));
 
     /* Init the FTS log writer queue */
-    writer_queue_log_fts = queue_init(getDefine_Int("analysisd", "fts_queue_size", 0, 2000000));
+    writer_queue_log_fts = queue_init(getDefine_Int("analysisd", "fts_queue_size", 128, 2000000));
 
     /* Init the decode syscheck queue input */
-    decode_queue_syscheck_input = queue_init(getDefine_Int("analysisd", "decode_syscheck_queue_size", 0, 2000000));
+    decode_queue_syscheck_input = queue_init(getDefine_Int("analysisd", "decode_syscheck_queue_size", 128, 2000000));
 
     /* Init the decode syscollector queue input */
-    decode_queue_syscollector_input = queue_init(getDefine_Int("analysisd", "decode_syscollector_queue_size", 0, 2000000));
+    decode_queue_syscollector_input = queue_init(getDefine_Int("analysisd", "decode_syscollector_queue_size", 128, 2000000));
 
     /* Init the decode rootcheck queue input */
-    decode_queue_rootcheck_input = queue_init(getDefine_Int("analysisd", "decode_rootcheck_queue_size", 0, 2000000));
+    decode_queue_rootcheck_input = queue_init(getDefine_Int("analysisd", "decode_rootcheck_queue_size", 128, 2000000));
 
     /* Init the decode rootcheck json queue input */
-    decode_queue_sca_input = queue_init(getDefine_Int("analysisd", "decode_sca_queue_size", 0, 2000000));
+    decode_queue_sca_input = queue_init(getDefine_Int("analysisd", "decode_sca_queue_size", 128, 2000000));
 
     /* Init the decode hostinfo queue input */
-    decode_queue_hostinfo_input = queue_init(getDefine_Int("analysisd", "decode_hostinfo_queue_size", 0, 2000000));
+    decode_queue_hostinfo_input = queue_init(getDefine_Int("analysisd", "decode_hostinfo_queue_size", 128, 2000000));
 
     /* Init the decode winevt queue input */
-    decode_queue_winevt_input = queue_init(getDefine_Int("analysisd", "decode_winevt_queue_size", 0, 2000000));
+    decode_queue_winevt_input = queue_init(getDefine_Int("analysisd", "decode_winevt_queue_size", 128, 2000000));
 
     /* Init the decode event queue input */
-    decode_queue_event_input = queue_init(getDefine_Int("analysisd", "decode_event_queue_size", 0, 2000000));
+    decode_queue_event_input = queue_init(getDefine_Int("analysisd", "decode_event_queue_size", 128, 2000000));
 
     /* Init the decode event queue output */
-    decode_queue_event_output = queue_init(getDefine_Int("analysisd", "decode_output_queue_size", 0, 2000000));
+    decode_queue_event_output = queue_init(getDefine_Int("analysisd", "decode_output_queue_size", 128, 2000000));
 
     /* Initialize database synchronization message queue */
-    dispatch_dbsync_input = queue_init(getDefine_Int("analysisd", "dbsync_queue_size", 0, 2000000));
+    dispatch_dbsync_input = queue_init(getDefine_Int("analysisd", "dbsync_queue_size", 128, 2000000));
 
     /* Initialize upgrade module message queue */
-    upgrade_module_input = queue_init(getDefine_Int("analysisd", "upgrade_queue_size", 0, 2000000));
+    upgrade_module_input = queue_init(getDefine_Int("analysisd", "upgrade_queue_size", 128, 2000000));
 }


### PR DESCRIPTION
|Related issue|
|---|
|#11447|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hi team!

This PR aims to solve analysisd segfault when some `internal_opfions.conf` configuration values related to analysisd queues sizes are zero, leading to divide-by-zero exception.
Minimum values allowed were changed to 128 to be aligned with current documentation https://documentation.wazuh.com/current/user-manual/reference/internal-options.html#analysisd, and this way guarantee a valid division.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [X] Source installation
- [X] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report
  - [ ] Coverity
  - [X] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors

Regards,
Nico