### PR TITLE
Review or pr 10558 - PR: Adapt CIS benchmark for macOS Big Sur  

### DIFF
--- a/ruleset/sca/darwin/20/cis_apple_macOS_11.1.yml
+++ b/ruleset/sca/darwin/20/cis_apple_macOS_11.1.yml
@@ -19,7 +19,7 @@ policy:
     - https://www.cisecurity.org/cis-benchmarks/
 
 requirements:
-  title: "Check macOS version"
+  title: "Check macOS version."
   description: "Requirements for running the SCA scan against macOS 11.x (Big Sur)."
   condition: any
   rules:
@@ -34,7 +34,7 @@ checks:
 ############################################################
 # 1.1 Verify all Apple provided software is current (Automated)
   - id: 18000
-    title: "Verify all Apple provided software is current"
+    title: "Verify all Apple provided software is current."
     description: "Software vendors release security patches and software updates for their products when security vulnerabilities are discovered. There is no simple way to complete this action without a network connection to an Apple software repository. Please ensure appropriate access for this control. This check is only for what Apple provides through software update."
     rationale: "It is important that these updates be applied in a timely manner to prevent unauthorized persons from exploiting the identified vulnerabilities."
     remediation: "1. In Terminal, run the following: softwareupdate -i -a      2. In Terminal, run the following for any packages that show up in step 1: sudo softwareupdate -i packagename"
@@ -47,7 +47,7 @@ checks:
 
 # 1.2 Enable Auto Update (Automated)
   - id: 18001
-    title: "Enable Auto Update"
+    title: "Enable Auto Update."
     description: "Auto Update verifies that your system has the newest security patches and software updates. If \"Automatically check for updates\" is not selected background updates for new malware definition files from Apple for XProtect and Gatekeeper will not occur."
     rationale: "It is important that a system has the newest updates applied so as to prevent unauthorized persons from exploiting identified vulnerabilities."
     remediation: "Open a terminal session and enter the following command to enable the auto update feature: sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled -bool true"
@@ -63,7 +63,7 @@ checks:
 
 # 1.3 Enable Download new updates when available (Automated)
   - id: 18002
-    title: "Enable Download new updates when available"
+    title: "Enable Download new updates when available."
     description: "In the GUI both \"Install macOS updates\" and \"Install app updates from the App Store\" are dependent on whether \"Download new updates when available\" is selected"
     rationale: "It is important that a system has the newest updates downloaded so that they can be applied."
     remediation: "Open a terminal session and enter the following command to enable the auto update feature: sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticDownload -bool true"
@@ -76,7 +76,7 @@ checks:
 
 # 1.4 Enable app update installs (Automated)
   - id: 18003
-    title: "Enable app update installs"
+    title: "Enable app update installs."
     description: "Ensure that application updates are installed after they are available from Apple. These updates do not require reboots or admin privileges for end users."
     rationale: "Patches need to be applied in a timely manner to reduce the risk of vulnerabilities being exploited."
     remediation: "Open a terminal session and enter the following command to enable the auto update feature: sudo defaults write /Library/Preferences/com.apple.commerce AutoUpdate - bool TRUE"
@@ -89,7 +89,7 @@ checks:
 
 # 1.5 Enable system data files and security update installs (Automated)
   - id: 18004
-    title: "Enable system data files and security update installs"
+    title: "Enable system data files and security update installs."
     description: "Ensure that system and security updates are installed after they are available from Apple.  This setting enables definition updates for XProtect and Gatekeeper, with this setting in place new malware and adware that Apple has added to the list of malware or untrusted software will not execute. These updates do not require reboots or end user admin rights."
     rationale: "Patches need to be applied in a timely manner to reduce the risk of vulnerabilities being exploited"
     remediation: "Open a terminal session and enter the following command to enable install system data files and security updates: sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate ConfigDataInstall -bool true && sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate CriticalUpdateInstall -bool true"
@@ -106,7 +106,7 @@ checks:
 
 # 1.6 Enable macOS update installs (Automated)
   - id: 18005
-    title: "Enable macOS update installs"
+    title: "Enable macOS update installs."
     description: "Ensure that macOS updates are installed after they are available from Apple. This setting enables macOS updates to be automatically installed. Some environments will want to approve and test updates before they are delivered. It is best practice to test first where updates can and have caused disruptions to operations. Automatic updates should be turned off where changes are tightly controlled and there are mature testing and approval processes. Automatic updates should not be turned off so the admin can call the users first to let them know it's ok to install. A dependable repeatable process involving a patch agent or remote management tool should be in place before auto-updates are turned off."
     rationale: "Patches need to be applied in a timely manner to reduce the risk of vulnerabilities being exploited"
     remediation: "Open a terminal session and enter the following command to enable install system data files and security updates: sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticallyInstallMacOSUpdates AutoUpdate - bool TRUE"
@@ -115,7 +115,7 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticallyInstallMacOSUpdates -> 1'
+      - 'c:defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticallyInstallMacOSUpdates -> 1'
 
 ############################################################
 #2 System Preferences
@@ -125,7 +125,7 @@ checks:
 
 # 2.1.1 Turn off Bluetooth, if no paired devices exist (Automated)
   - id: 18006
-    title: "Turn off Bluetooth, if no paired devices exist"
+    title: "Turn off Bluetooth, if no paired devices exist."
     description: "Bluetooth devices use a wireless communications system that replaces the cables used by other peripherals to connect to a system. It is by design a peer-to-peer network technology and typically lacks centralized administration and security enforcement infrastructure."
     rationale: "Bluetooth is particularly susceptible to a diverse set of security vulnerabilities involving identity detection, location tracking, denial of service, unintended control and access of data and voice channels, and unauthorized device control and data access."
     remediation: "Open a terminal session and enter the following command to disable bluetooth: sudo defaults write /Library/Preferences/com.apple.Bluetooth ControllerPowerState -int 0 && sudo killall -HUP blued"
@@ -134,12 +134,12 @@ checks:
       - cis_level: ["1"]
     condition: any
     rules:
-      - 'c:sudo defaults read /Library/Preferences/com.apple.Bluetooth ControllerPowerState -> 0'
-      - 'c:sudo system_profiler SPBluetoothDataType -> r:Connectable: Yes'
+      - 'c:defaults read /Library/Preferences/com.apple.Bluetooth ControllerPowerState -> 0'
+      - 'c:system_profiler SPBluetoothDataType -> r:Connectable: Yes'
 
 # 2.1.2 Show Bluetooth status in menu bar (Automated)
   - id: 18007
-    title: "Show Bluetooth status in menu bar"
+    title: "Show Bluetooth status in menu bar."
     description: "By showing the Bluetooth status in the menu bar, a small Bluetooth icon is placed in the menu bar. This icon quickly shows the status of Bluetooth, and can allow the user to quickly turn Bluetooth on or off."
     rationale: "Enabling Show Bluetooth status in menu bar is a security awareness method that helps understand the current state of Bluetooth, including whether it is enabled, discoverable, what paired devices exist, and what paired devices are currently active. "
     remediation: "For each user, run the following command to enable Bluetooth status in the menu bar: sudo -u <username> defaults -currentHost write com.apple.controlcenter.plist Bluetooth -int 18"
@@ -148,14 +148,14 @@ checks:
       - cis_level: ["1"]
     condition: any
     rules:
-      - 'c:sudo defaults -currentHost read com.apple.controlcenter.plist Bluetooth -> 18'
+      - 'c:defaults -currentHost read com.apple.controlcenter.plist Bluetooth -> 18'
 
 ############################################################
 #2.2 Date & Time
 ############################################################
 # 2.2.1 Enable "Set time and date automatically" (Automated)
   - id: 18008
-    title: "Enable \"Set time and date automatically\""
+    title: "Enable Set time and date automatically."
     description: "Correct date and time settings are required for authentication protocols, file creation, modification dates and log entries."
     rationale: "Kerberos may not operate correctly if the time on the Mac is off by more than 5 minutes.  This in turn can affect Apple's single sign-on feature, Active Directory logons, and other features."
     remediation: "Run the following commands: sudo systemsetup -setnetworktimeserver <timeserver>    sudo systemsetup -setusingnetworktime on"
@@ -168,7 +168,7 @@ checks:
 
 # 2.2.2 Ensure time set is within appropriate limits (Automated)
   - id: 18009
-    title: "Ensure time set is within appropriate limits"
+    title: "Ensure time set is within appropriate limits."
     description: "Correct date and time settings are required for authentication protocols, file creation, modification dates and log entries. Ensure that time on the computer is within acceptable limits. Truly accurate time is measured within milliseconds, for this audit a drift under four and a half minutes passes the control check. Since Kerberos is one of the important features of macOS integration into Directory systems the guidance here is to warn you before there could be an impact to operations. From the perspective of accurate time this check is not strict, it may be too great for your organization, adjust to a smaller offset value as needed. Note: ntpdate has been deprecated with 10.14. sntp replaces that command."
     rationale: "Kerberos may not operate correctly if the time on the Mac is off by more than 5 minutes. This in turn can affect Apple's single sign-on feature, Active Directory logons, and other features. Audit check is for more than 4 minutes and 30 seconds ahead or behind."
     remediation: "Run the following commands to ensure your time is set within an appropriate limit: sudo systemsetup -getnetworktimeserver -> Get the time server name and then run: sudo touch /var/db/ntp-kod && sudo chown root:wheel /var/db/ntp-kod && sudo sntp -sS <YOUR-TIME-SERVER> "
@@ -185,7 +185,7 @@ checks:
 ############################################################
 # 2.3.1 Set an inactivity interval of 20 minutes or less for the screen saver (Automated)
   - id: 18010
-    title: "Set an inactivity interval of 20 minutes or less for the screen saver"
+    title: "Set an inactivity interval of 20 minutes or less for the screen saver."
     description: "A locking screensaver is one of the standard security controls to limit access to a computer and the current user's session when the computer is temporarily unused or unattended. In macOS the screensaver starts after a value selected in a drop down menu, 10 minutes and 20 minutes are both options and either is acceptable. Any value can be selected through the command line or script but a number that is not reflected in the GUI can be problematic. 20 minutes is the default for new accounts."
     rationale: "Setting an inactivity interval for the screensaver prevents unauthorized persons from viewing a system left unattended for an extensive period of time."
     remediation: "Run the following command to verify that the idle time of the screen saver to 20 minutes or less (≤1200): sudo defaults -currentHost write com.apple.screensaver idleTime -int 600 "
@@ -196,10 +196,9 @@ checks:
     rules:
       - 'c:defaults -currentHost read com.apple.screensaver idleTime -> !r:does not exist'
 
-
 # 2.3.2 Secure screen saver corners (Automated)
   - id: 18011
-    title: "Secure screen saver corners"
+    title: "Secure screen saver corners."
     description: "Hot Corners can be configured to disable the screen saver by moving the mouse cursor to a corner of the screen."
     rationale: "Setting a hot corner to disable the screen saver poses a potential security risk since an unauthorized person could use this to bypass the login screen and gain access to the system."
     remediation: "Run the following command to turn off Disable Screen Saver for a Hot Corner: sudo -u <username> defaults write com.apple.dock <corner that is set to '6'> -int 0 "
@@ -220,7 +219,7 @@ checks:
 ############################################################
 # 2.4.1 Disable Remote Apple Events (Automated)
   - id: 18012
-    title: "Disable Remote Apple Events"
+    title: "Disable Remote Apple Events."
     description: "Apple Events is a technology that allows one program to communicate with other programs. Remote Apple Events allows a program on one computer to communicate with a program on a different computer."
     rationale: "Disabling Remote Apple Events mitigates the risk of an unauthorized program gaining access to the system."
     remediation: "Run the following command in Terminal: sudo systemsetup -setremoteappleevents off"
@@ -229,11 +228,11 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo systemsetup -getremoteappleevents -> r:Remote Apple Events:\s*\t*Off'
+      - 'c:systemsetup -getremoteappleevents -> r:Remote Apple Events:\s*\t*Off'
 
 # 2.4.2 Disable Internet Sharing (Automated)
   - id: 18013
-    title: "Disable Internet Sharing"
+    title: "Disable Internet Sharing."
     description: "Internet Sharing uses the open source natd process to share an internet connection with other computers and devices on a local network. This allows the Mac to function as a router and share the connection to other, possibly unauthorized, devices."
     rationale: "Disabling Internet Sharing reduces the remote attack surface of the system."
     remediation: "Run the following command to turn off Internet Sharing: sudo defaults write /Library/Preferences/SystemConfiguration/com.apple.nat NAT -dict Enabled -int 0"
@@ -246,7 +245,7 @@ checks:
 
 # 2.4.3 Disable Screen Sharing (Automated)
   - id: 18014
-    title: "Disable Screen Sharing"
+    title: "Disable Screen Sharing."
     description: "Screen sharing allows a computer to connect to another computer on a network and display the computer’s screen. While sharing the computer’s screen, the user can control what happens on that computer, such as opening documents or applications, opening, moving, or closing windows, and even shutting down the computer."
     rationale: "Disabling screen sharing mitigates the risk of remote connections being made without the user of the console knowing that they are sharing the computer."
     remediation: "Run the following command to turn off Screen Sharing: sudo launchctl disable system/com.apple.screensharing"
@@ -255,11 +254,11 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo launchctl print-disabled system | grep -c ''"com.apple.screensharing" => true'' -> 1'
+      - 'c:launchctl print-disabled system | grep -c ''"com.apple.screensharing" => true'' -> 1'
 
 # 2.4.4 Disable Printer Sharing (Automated)
   - id: 18015
-    title: "Disable Printer Sharing"
+    title: "Disable Printer Sharing."
     description: "By enabling Printer sharing the computer is set up as a print server to accept print jobs from other computers. Dedicated print servers or direct IP printing should be used instead."
     rationale: "Disabling Printer Sharing mitigates the risk of attackers attempting to exploit the print server to gain access to the system."
     remediation: "Run the following command in Terminal: sudo cupsctl --no-share-printers"
@@ -270,11 +269,11 @@ checks:
       - https://support.apple.com/kb/PH11450
     condition: all
     rules:
-      - 'c:sudo cupsctl | grep _share_printers | cut -d ''='' -f2 -> 0'
+      - 'c:sh -c "cupsctl | grep _share_printers | cut -d ''='' -f2" -> 0'
 
 # 2.4.5 Disable Remote Login (Automated)
   - id: 18016
-    title: "Disable Remote Login"
+    title: "Disable Remote Login."
     description: "Remote Login allows an interactive terminal connection to a computer."
     rationale: "Disabling Remote Login mitigates the risk of an unauthorized person gaining access to the system via Secure Shell (SSH). While SSH is an industry standard to connect to posix servers, the scope of the benchmark is for Apple macOS clients, not servers. macOS does have an IP based firewall available (pf, ipfw has been deprecated) that is not enabled or configured. There are more details and links in section 7.5. macOS no longer has TCP Wrappers support built-in and does not have strong Brute-Force password guessing mitigations, or frequent patching of openssh by Apple. Most macOS computers are mobile workstations, managing IP based firewall rules on mobile devices can be very resource intensive. All of these factors can be parts of running a hardened SSH server."
     remediation: "Run the following command in Terminal: sudo systemsetup -setremotelogin off"
@@ -287,7 +286,7 @@ checks:
 
 # 2.4.6 Disable DVD or CD Sharing (Automated)
   - id: 18017
-    title: "Disable DVD or CD Sharing"
+    title: "Disable DVD or CD Sharing."
     description: "DVD or CD Sharing allows users to remotely access the system's optical drive."
     rationale: "Disabling DVD or CD Sharing minimizes the risk of an attacker using the optical drive as a vector for attack and exposure of sensitive data."
     remediation: "Run the following command to disable DVD or CD sharing: sudo launchctl disable system/com.apple.ODSAgent "
@@ -296,11 +295,11 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo launchctl print-disabled system  | grep -c ''"com.apple.ODSAgent" => true'' -> 1'
+      - 'c:sh -c "launchctl print-disabled system  | grep -c ''\"com.apple.ODSAgent\" => true''"" -> 1'
 
 # 2.4.7 Disable Bluetooth Sharing (Automated)
   - id: 18018
-    title: "Disable Bluetooth Sharing "
+    title: "Disable Bluetooth Sharing ."
     description: "Bluetooth Sharing allows files to be exchanged with Bluetooth enabled devices."
     rationale: "Disabling Bluetooth Sharing minimizes the risk of an attacker using Bluetooth to remotely attack the system."
     remediation: "Perform the following to disable Bluetooth Sharing: Graphical Method: 1. Open System Preferences 2. Select Sharing 3. Uncheck Bluetooth Sharing"
@@ -309,11 +308,11 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo defaults -currentHost read com.apple.Bluetooth PrefKeyServicesEnabled -> 0'
+      - 'c:defaults -currentHost read com.apple.Bluetooth PrefKeyServicesEnabled -> 0'
 
 # 2.4.8 Disable File Sharing (Automated)
   - id: 18019
-    title: "Disable File Sharing"
+    title: "Disable File Sharing."
     description: "Apple's File Sharing uses a combination of SMB (Windows sharing) and AFP (Mac sharing)"
     rationale: "By disabling file sharing, the remote attack surface and risk of unauthorized access to files stored on the system is reduced."
     remediation: "Run the following command in Terminal to turn off AFP and SMB file sharing from the command line: sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.smbd.plist"
@@ -322,11 +321,11 @@ checks:
       - cis_level: ["1"]
     condition: none
     rules:
-      - 'c:sudo launchctl print-disabled system | grep -c ''"com.apple.smbd" => true'' -> 1'
+      - 'c:sh -c "launchctl print-disabled system | grep -c ''\"com.apple.smbd\" => true''"" -> 1'
 
 # 2.4.9 Disable Remote Management (Automated)
   - id: 18020
-    title: "Disable Remote Management"
+    title: "Disable Remote Management."
     description: "Remote Management is the client portion of Apple Remote Desktop (ARD). Remote Management can be used by remote administrators to view the current Screen, install software, report on, and generally manage client Macs. The screen sharing options in Remote Management are identical to those in the Screen Sharing section. In fact, only one of the two can be configured. If Remote Management is used, refer to the Screen Sharing section above on issues regard screen sharing. Remote Management should only be enabled when a Directory is in place to manage the accounts with access. Computers will be available on port 5900 on a macOS System and could accept connections from untrusted hosts depending on the configuration, definitely a concern for mobile systems."
     rationale: "Remote management should only be enabled on trusted networks with strong user controls present in a Directory system. Mobile devices without strict controls are vulnerable to exploit and monitoring."
     remediation: "Run the following command to disable remote management: sudo /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources /kickstart -deactivate -stop"
@@ -339,7 +338,7 @@ checks:
 
 # 2.4.10 Disable Content Caching (Automated)
   - id: 18021
-    title: "Disable Content Caching"
+    title: "Disable Content Caching."
     description: "Starting with 10.13 (macOS High Sierra) Apple introduced a service to make it easier deploy data from Apple, including software updates, where there are bandwidth constraints to the Internet and fewer constraints and greater bandwidth on the local subnet. This capability can be very valuable for organizations that have throttled and possibly metered Internet connections. In heterogeneous enterprise networks with multiple subnets the effectiveness of this capability would be determined on how many Macs were on each subnet at the time new large updates were made available upstream. This capability requires the use of mac OS clients as P2P nodes for updated Apple content. Unless there is a business requirement to manage operational Internet connectivity bandwidth user endpoints should not store content and act as a cluster to provision data."
     rationale: "The main use case for Mac computers is as mobile user endpoints. P2P sharing services should not be enabled on laptops that are using untrusted networks. Content Caching can allow a computer to be a server for local nodes on an untrusted network. While there are certainly logical controls that could be used to mitigate risk they add to the management complexity, since the value of the service is in specific use cases organizations with the use case described above can accept risk as necessary."
     remediation: "Run the following command in to disable content caching: sudo AssetCacheManagerUtil deactivate"
@@ -348,12 +347,11 @@ checks:
       - cis_level: ["2"]
     condition: all
     rules:
-      - 'c:sudo defaults read /Library/Preferences/com.apple.AssetCache.plist Activated -> 0'
-
+      - 'c:defaults read /Library/Preferences/com.apple.AssetCache.plist Activated -> 0'
 
 # 2.4.11 Disable Media Sharing (Automated)
   - id: 18022
-    title: "Disable Media Sharing"
+    title: "Disable Media Sharing."
     description: "Starting with macOS 10.15 Apple has provided a control to allow a user to share Apple downloaded content on all Apple devices that are signed in with the same Apple ID. This allows a user to share downloaded Movies, Music or TV shows with other controlled macOS, iOS and iPadOS devices as well as photos with Apple TVs. With this capability guest users can also use media downloaded on the computer. Best practice is not to use the computer as a server but to utilize Apple's cloud storage to download and use content stored there if content stored with Apple is used on multiple devices."
     rationale: "Disabling Media Sharing reduces the remote attack surface of the system."
     remediation: "Run the following command in to disable content caching: sudo AssetCacheManagerUtil deactivate"
@@ -364,11 +362,11 @@ checks:
       - https://support.apple.com/guide/mac-help/set-up-media-sharing-on-mac-mchlp13371337/mac
     condition: all
     rules:
-      - 'c:sudo defaults read com.apple.amp.mediasharingd home-sharing-enabled -> 0'
+      - 'c:defaults read com.apple.amp.mediasharingd home-sharing-enabled -> 0'
 
 # 2.4.12 Ensure AirDrop Is Disabled (Automated)
   - id: 18069
-    title: "Ensure AirDrop Is Disabled"
+    title: "Ensure AirDrop Is Disabled."
     description: "While there are positives to AirDrop, there are privacy concerns that could expose personal information. For that reason, AirDrop should be disabled, and should only be enabled when needed and disabled afterwards."
     rationale: "AirDrop can allow malicious files to be downloaded from unknown sources. Contacts Only limits may expose personal information to devices in the same area."
     remediation: "Run the following commands to disable AirDrop: sudo -u <username> defaults write com.apple.NetworkBrowser DisableAirDrop -bool true"
@@ -380,7 +378,7 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo defaults read com.apple.NetworkBrowser DisableAirDrop -> 1'
+      - 'c:defaults read com.apple.NetworkBrowser DisableAirDrop -> 1'
 
 ############################################################
 # 2.5 Security & Privacy
@@ -389,7 +387,7 @@ checks:
 ############################################################
 # 2.5.1.1 Enable FileVault (Automated)
   - id: 18023
-    title: "Enable FileVault"
+    title: "Enable FileVault."
     description: "FileVault secures a system's data by automatically encrypting its boot volume and requiring a password or recovery key to access it. Filevault may also be enabled using command line using the fdesetup command. To use this functionality, consult the Der Flounder blog for more details: "
     rationale: "Encrypting sensitive data minimizes the likelihood of unauthorized users gaining access to it."
     remediation: "1. Open System Preferences 2. Select Security & Privacy 3. Select FileVault 4. Select Turn on FileVault"
@@ -398,10 +396,10 @@ checks:
       - cis_level: ["1"]
     references:
       - https://derflounder.wordpress.com/2015/02/02/managing-yosemites-filevault-2-with-fdesetup/
-      -  https://derflounder.wordpress.com/2019/01/15/unlock-or-decrypt-your-filevault-encrypted-boot-drive-from-the-command-line-on-macos-mojave/
+      - https://derflounder.wordpress.com/2019/01/15/unlock-or-decrypt-your-filevault-encrypted-boot-drive-from-the-command-line-on-macos-mojave/
     condition: all
     rules:
-      - 'c:sudo fdesetup status -> r:^FileVault\s*\t*is\s*\t*On$'
+      - 'c:fdesetup status -> r:^FileVault\s*\t*is\s*\t*On$'
 
 # not implemented - SCA Limit -> 2.5.1.2 Ensure all user storage APFS volumes are encrypted (Manual)
 # not implemented - SCA Limit -> 2.5.1.3 Ensure all user storage CoreStorage volumes are encrypted (Manual)
@@ -411,7 +409,7 @@ checks:
 ############################################################
 # 2.5.2.1 Enable Gatekeeper (Automated)
   - id: 18024
-    title: "Enable Gatekeeper"
+    title: "Enable Gatekeeper."
     description: "Gatekeeper is Apple's application white-listing control that restricts downloaded applications from launching. It functions as a control to limit applications from unverified sources from running without authorization."
     rationale: "Disallowing unsigned software will reduce the risk of unauthorized or malicious applications from running on the system."
     remediation: "Run the following command in Terminal: sudo spctl --master-enable"
@@ -420,11 +418,11 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo spctl --status -> r:^assessments\s*\t*enabled$'
+      - 'c:spctl --status -> r:^assessments\s*\t*enabled$'
 
 # 2.5.2.2 Enable Firewall (Automated)
   - id: 18025
-    title: "Enable Firewall"
+    title: "Enable Firewall."
     description: "A firewall is a piece of software that blocks unwanted incoming connections to a system.  Apple has posted general documentation about the application firewall."
     rationale: "A firewall minimizes the threat of unauthorized users from gaining access to your system while connected to a network or the Internet."
     remediation: "Run the following command in Terminal: sudo defaults write /Library/Preferences/com.apple.alf globalstate - int <value>    Where <value> is: - 1 = on for specific services - 2 = on for essential services "
@@ -435,11 +433,11 @@ checks:
       - https://support.apple.com/en-us/HT201642
     condition: all
     rules:
-      - 'c:sudo defaults read /Library/Preferences/com.apple.alf globalstate -> r:^1$|^2$'
+      - 'c:defaults read /Library/Preferences/com.apple.alf globalstate -> r:^1$|^2$'
 
 # 2.5.2.3 Enable Firewall Stealth Mode (Automated)
   - id: 18026
-    title: "Enable Firewall Stealth Mode"
+    title: "Enable Firewall Stealth Mode."
     description: "While in Stealth mode the computer will not respond to unsolicited probes, dropping that traffic."
     rationale: "Stealth mode on the firewall minimizes the threat of system discovery tools while connected to a network or the Internet."
     remediation: "Run the following command in Terminal: sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode on"
@@ -450,11 +448,11 @@ checks:
       - https://support.apple.com/en-us/HT201642
     condition: all
     rules:
-      - 'c:sudo /usr/libexec/ApplicationFirewall/socketfilterfw --getstealthmode -> r:^Stealth mode enabled'
+      - 'c:/usr/libexec/ApplicationFirewall/socketfilterfw --getstealthmode -> r:^Stealth mode enabled'
 
 # 2.5.3 Enable Location Services (Automated)
   - id: 18027
-    title: "Enable Location Services"
+    title: "Enable Location Services."
     description: "macOS uses location information gathered through local Wi-Fi networks to enable applications to supply relevant information to users. Users do not need to change the time or the time zone, the computer will do it for them. They do not need to specify their location for weather or travel times and even get alerts on travel times to meetings and appointment where location information is supplied. For the purpose of asset management and time and log management with mobile computers location services simplify some processes.There are some use cases where it is important that the computer not be able to report it's exact location. While the general use case is to enable Location Services, it should not be allowed if the physical location of the computer and the user should not be public knowledge."
     rationale: "Location services are helpful in most use cases and can simplify log and time management where computers change time zones."
     remediation: "Run the following command to enable location services: sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.locationd.plist"
@@ -465,13 +463,13 @@ checks:
       - https://support.apple.com/en-us/HT204690
     condition: all
     rules:
-      - 'c:sudo launchctl list | grep -c com.apple.locationd -> 1'
+      - 'c:launchctl list | grep -c com.apple.locationd -> 1'
 
 # not implemented - process -> 2.5.4 Review Application Firewall Rules (Manual)
 
 # 2.5.5 Disable sending diagnostic and usage data to Apple (Automated)
   - id: 18028
-    title: "Disable sending diagnostic and usage data to Apple"
+    title: "Disable sending diagnostic and usage data to Apple."
     description: "Apple provides a mechanism to send diagnostic and analytics data back to Apple to help them improve the platform. Information sent to Apple may contain internal organizational information that should be controlled and not available for processing by Apple. Turn off all Analytics and Improvements sharing."
     rationale: "Organizations should have knowledge of what is shared with the vendor and the setting automatically forwards information to Apple."
     remediation: "For each needed user, run the following command to enable limited ad tracking: sudo -u <username> defaults -currentHost write /Users/<username>/Library/Preferences/com.apple.Adlib.plist allowApplePersonalizedAdvertising -bool false"
@@ -480,11 +478,11 @@ checks:
       - cis_level: ["2"]
     condition: all
     rules:
-      - 'c:sudo defaults read /Library/Application\ Support/CrashReporter/DiagnosticMessagesHistory.plist AutoSubmit -> 0'
+      - 'c:defaults read /Library/Application\ Support/CrashReporter/DiagnosticMessagesHistory.plist AutoSubmit -> 0'
 
 # 2.5.6 Limit Ad tracking and personalized Ads (Automated)
   - id: 18029
-    title: "Limit Ad tracking and personalized Ads"
+    title: "Limit Ad tracking and personalized Ads."
     description: "Apple provides a framework that allows advertisers to target Apple users and end-users with advertisements. While many people prefer that when they see advertising it is relevant to them and their interests, the detailed information that is data mining collected, correlated, and available to advertisers in repositories is often disconcerting. This information is valuable to both advertisers and attackers and has been used with other metadata to reveal users' identities"
     rationale: "Organizations should manage user privacy settings on managed devices to align with organizational policies and user data protection requirements."
     remediation: "Run the following command in Terminal: sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.auditd.plist"
@@ -493,7 +491,7 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo defaults -currentHost read /Users/<username>/Library/Preferences/com.apple.AdLib.plist allowApplePersonalizedAdvertising -> 0'
+      - 'c:defaults -currentHost read /Users/<username>/Library/Preferences/com.apple.AdLib.plist allowApplePersonalizedAdvertising -> 0'
 
 ############################################################
 # 2.6 iCloud
@@ -508,7 +506,7 @@ checks:
 ############################################################
 # 2.7.1 Time Machine Auto-Backup (Automated)
   - id: 18030
-    title: "Time Machine Auto-Backup"
+    title: "Time Machine Auto-Backup."
     description: "Backup solutions are only effective if the backups run on a regular basis. The time to check for backups is before the hard drive fails or the computer goes missing. In order to simplify the user experience so that backups are more likely to occur Time Machine should be on and set to Back Up Automatically whenever the target volume is available. Operational staff should ensure that backups complete on a regular basis and the backups are tested to ensure that file restoration from backup is possible when needed. Backup dates are available even when the target volume is not available in the Time Machine plist. When the backup volume is connected to the computer more extensive information is available through tmutil. See man tmutil"
     rationale: "Backups should automatically run whenever the backup drive is available."
     remediation: "Run the following enable TimeMachine: sudo sudo tmutil setdestination -a /Volumes/<volumename> && sudo tmutil enable"
@@ -517,13 +515,13 @@ checks:
       - cis_level: ["2"]
     condition: all
     rules:
-      - 'c:sudo defaults read /Library/Preferences/com.apple.TimeMachine.plist AutoBackup -> 1'
+      - 'c:defaults read /Library/Preferences/com.apple.TimeMachine.plist AutoBackup -> 1'
 
 # not implemented - SCA Limit -> 2.7.2 Time Machine Volumes Are Encrypted (Automated)
 
 # 2.8 Disable Wake for network access (Automated)
   - id: 18031
-    title: "Disable Wake for network access"
+    title: "Disable Wake for network access."
     description: "This feature allows the computer to take action when the user is not present and the computer is in energy saving mode. These tools require FileVault to remain unlocked and fully rejoin known networks. Theie macOS feature is meant to allow the computer to resume activity as needed regardless of physical security controls. This feature allows other users to be able to access your computer’s shared resources, such as shared printers or iTunes playlists, even when your computer is in sleep mode. In a closed network when only authorized devices could wake a computer it could be valuable to wake computers in order to do management push activity. Where mobile workstations and agents exist the device will more likely check in to receive updates when already awake. Mobile devices should not be listening for signals on unmanaged network where untrusted devices could send wake signals."
     rationale: "Disabling this feature mitigates the risk of an attacker remotely waking the system and gaining access."
     remediation: "Run the following command to disable Wake for network access: sudo pmset -a womp 0 "
@@ -532,11 +530,11 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo pmset -g | grep -e womp -> r: 0'
+      - 'c:sh -c "pmset -g | grep -e womp" -> r: 0'
 
 # 2.9 Disable Power Nap (Automated)
   - id: 18032
-    title: "Disable Power Nap"
+    title: "Disable Power Nap."
     description: "This features allows the computer to take action when the user is not present and the computer is in energy saving mode. These tools require FileVault to remain unlocked and fully rejoin known networks. This macOS features are meant to allow the computer to resume activity as needed regardless of physical security controls. Power Nap allows the system to stay in low power mode, especially while on battery power and periodically connect to previously named networks with stored credentials for user applications to phone home and get updates. This capability requires FileVault to remain unlocked and the use of previously joined networks to be risk accepted based on the SSID without user input."
     rationale: "Disabling this feature mitigates the risk of an attacker remotely waking the system and gaining access."
     remediation: "Run the following command to disable Power Nap: sudo pmset -a powernap 0"
@@ -545,11 +543,11 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo pmset -g everything | grep -c ''powernap             1''-> 0'
+      - 'c:sh -c "pmset -g everything | grep -c ''powernap             1''"-> 0'
 
 # 2.10 Enable Secure Keyboard Entry in terminal.app (Automated)
   - id: 18033
-    title: "Enable Secure Keyboard Entry in terminal.app"
+    title: "Enable Secure Keyboard Entry in terminal.app."
     description: "Secure Keyboard Entry prevents other applications on the system and/or network from detecting and recording what is typed into Terminal."
     rationale: "Enabling Secure Keyboard Entry minimizes the risk of a key logger from detecting what is entered in Terminal."
     remediation: "Perform the following to implement the prescribed state: 1. Open Terminal 2. Select Terminal 3. Select Secure Keyboard Entry."
@@ -558,11 +556,11 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo defaults read -app Terminal SecureKeyboardEntry -> 1'
+      - 'c:defaults read -app Terminal SecureKeyboardEntry -> 1'
 
 # 2.11 Ensure EFI version is valid and being regularly checked (Automated)
   - id: 18034
-    title: "Ensure EFI version is valid and being regularly checked"
+    title: "Ensure EFI version is valid and being regularly checked."
     description: "In order to mitigate firmware attacks Apple has created a automated Firmware check to ensure that the EFI version running is a known good version from Apple. There is also an automated process to check it every seven days."
     rationale: "If the Firmware of a computer has been compromised the Operating System that the Firmware loads cannot be trusted either."
     remediation: "If EFI does not pass the integrity check you may send a report to Apple. Backing up files and clean installing a known good Operating System and Firmware is recommended."
@@ -571,8 +569,8 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo system_profiler SPiBridgeDataType | grep "T2" -> Model Name: Apple T2 Security Chip'
-      - 'c:sudo launchctl list | grep com.apple.driver.eficheck -> r:^-\s*\t*0\s*\t*com.apple.driver.eficheck$'
+      - 'c:system_profiler SPiBridgeDataType | grep "T2" -> Model Name: Apple T2 Security Chip'
+      - 'c:launchctl list | grep com.apple.driver.eficheck -> r:^-\s*\t*0\s*\t*com.apple.driver.eficheck$'
 
 # not implemented - requires supervision -> 2.12 Automatic Actions for Optical Media (Manual)
 # not implemented - requires supervision -> 2.13 Review Siri Settings (Manual)
@@ -583,7 +581,7 @@ checks:
 ############################################################
 # 3.1 Enable security auditing (Automated)
   - id: 18035
-    title: "Enable security auditing"
+    title: "Enable security auditing."
     description: "macOS's audit facility, auditd, receives notifications from the kernel when certain system calls, such as open, fork, and exit, are made. These notifications are captured and written to an audit log."
     rationale: "Logs generated by auditd may be useful when investigating a security incident as they may help reveal the vulnerable application and the actions taken by a malicious actor."
     remediation: "Run the following command in Terminal: sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.auditd.plist"
@@ -592,14 +590,13 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo launchctl list | grep -i auditd -> r:com.apple.auditd'
+      - 'c:sh -c "launchctl list | grep -i auditd" -> r:com.apple.auditd'
 
 # not implemented - process -> 3.2 Configure Security Auditing Flags per local organizational requirements (Manual)
 
-
 # 3.3 Retain install.log for 365 or more days with no maximum size (Automated)
   - id: 18036
-    title: "Retain install.log for 365 or more days with no maximum size"
+    title: "Retain install.log for 365 or more days with no maximum size."
     description: "macOS writes information pertaining to system-related events to the file /var/log/install.log and has a configurable retention policy for this file. The default logging setting limits the file size of the logs and the maximum size for all logs. The default allows for an errant application to fill the log files and does not enforce sufficient log retention. The Benchmark recommends a value based on standard use cases. The value should align with local requirements within the organization."
     rationale: "Archiving and retaining install.log for at least a year is beneficial in the event of an incident as it will allow the user to view the various changes to the system along with the date and time they occurred."
     remediation: "Perform the following to ensure that install logs are retained for at least 365 days:Edit the /etc/asl/com.apple.install file and add or modify the ttl value to 365 or greater on the file line. Also, remove the all_max= setting and value from the file line."
@@ -608,14 +605,14 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo grep -i ttl /etc/asl/com.apple.install -> n:ttl\w+(\d+) compare > 365'
-      - 'not c:sudo grep -i all_max= /etc/asl/com.apple.install -> r:.*'
+      - 'c:grep -i ttl /etc/asl/com.apple.install -> n:ttl\w+(\d+) compare > 365'
+      - 'c:grep -i all_max= /etc/asl/com.apple.install -> r:^$'
 
 # not implemented - SCA Limit -> 3.4 Ensure security auditing retention (Automated)
 
 # 3.5 Control access to audit records (Automated)
   - id: 18037
-    title: "Control access to audit records"
+    title: "Control access to audit records."
     description: "The audit system on macOS writes important operational and security information that can be both useful for an attacker and a place for an attacker to attempt to obfuscate unwanted changes that were recorded. As part of defense-in-depth the /etc/security/audit_control configuration and the files in /var/audit should be owned only by root with group wheel with read only rights and no other access allowed. macOS ACLs should not be used for these files."
     rationale: "Audit records should never be changed except by the system daemon posting events. Records may be viewed or extracts manipulated but the authoritative files should be protected from unauthorized changes."
     remediation: "Run the following to commands to set the audit records to the root user and wheel group:  sudo chown -R root:wheel /etc/security/audit_control && sudo chown -R root:wheel /var/audit/"
@@ -624,12 +621,12 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo ls -le /etc/security/audit_control -> r:root\s*\t*wheel|root'
-      - 'c:sudo ls -le /var/audit/ -> r:root\s*\t*wheel|root'
+      - 'c:ls -le /etc/security/audit_control -> r:root\s*\t*wheel|root'
+      - 'c:ls -le /var/audit/ -> r:root\s*\t*wheel|root'
 
 # 3.6 Ensure Firewall is configured to log (Automated)
   - id: 18038
-    title: "Ensure Firewall is configured to log"
+    title: "Ensure Firewall is configured to log."
     description: "The socketfilter firewall is what is used when the firewall is turned on in the Security PreferencePane. In order to appropriately monitor what access is allowed and denied logging must be enabled."
     rationale: "In order to troubleshoot the successes and failures of a firewall logging should be enabled."
     remediation: "Run the following command to enable logging of the firewall: sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setloggingmode on"
@@ -638,7 +635,7 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo /usr/libexec/ApplicationFirewall/socketfilterfw --getloggingmode -> r:Log mode is on'
+      - 'c:/usr/libexec/ApplicationFirewall/socketfilterfw --getloggingmode -> r:Log mode is on'
 
 # not implemented - process -> 3.7 Software Inventory Considerations (Manual)
 
@@ -647,7 +644,7 @@ checks:
 ############################################################
 # 4.1 Disable Bonjour advertising service (Automated)
   - id: 18039
-    title: "Disable Bonjour advertising service"
+    title: "Disable Bonjour advertising service."
     description: "Bonjour is an auto-discovery mechanism for TCP/IP devices which enumerate devices and services within a local subnet. DNS on macOS is integrated with Bonjour and should not be turned off, but the Bonjour advertising service can be disabled."
     rationale: "Bonjour can simplify device discovery from an internal rogue or compromised host. An attacker could use Bonjour's multicast DNS feature to discover a vulnerable or poorly- configured service or additional information to aid a targeted attack. Implementing this control disables the continuous broadcasting of \"I'm here!\" messages. Typical end-user endpoints should not have to advertise services to other computers.. This setting does not stop the computer from sending out service discovery messages when looking for services on an internal subnet, if the computer is looking for a printer or server and using service discovery. To block all Bonjour traffic except to approved devices the pf or other firewall would be needed."
     remediation: "Run the following command in Terminal: sudo defaults write /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements -bool true"
@@ -656,14 +653,14 @@ checks:
       - cis_level: ["2"]
     condition: all
     rules:
-      - 'c:sudo defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements -> 1'
+      - 'c:defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements -> 1'
 
 # not implemented - SCA Limit -> 4.2 Enable "Show Wi-Fi status in menu bar" (Automated)
 # not implemented - process -> 4.3 Create network specific locations (Manual)
 
 # 4.4 Ensure http server is not running (Automated)
-  - id: 18041
-    title: "Ensure http server is not running"
+  - id: 18040
+    title: "Ensure http server is not running."
     description: "macOS used to have a graphical front-end to the embedded Apache web server in the Operating System. Personal web sharing could be enabled to allow someone on another computer to download files or information from the user's computer. Personal web sharing from a user endpoint has long been considered questionable and Apple has removed that capability from the GUI. Apache however is still part of the Operating System and can be easily turned on to share files and provide remote connectivity to an end user computer.  Web sharing should only be done through hardened web servers and appropriate cloud services."
     rationale: "Web serving should not be done from a user desktop. Dedicated webservers or appropriate cloud storage should be used. Open ports make it easier to exploit the computer."
     remediation: "Ensure that the Web Server is not running and is not set to start at boot Stop the Web Server: sudo apachectl stop    Ensure that the web server will not auto-start at boot sudo: defaults write /System/Library/LaunchDaemons/org.apache.httpd Disabled - bool true"
@@ -676,8 +673,8 @@ checks:
       - 'p:/usr/sbin/httpd'
 
 # 4.5 Ensure nfs server is not running (Scored)
-  - id: 18042
-    title: "Ensure nfs server is not running"
+  - id: 18041
+    title: "Ensure nfs server is not running."
     description: "macOS can act as an NFS fileserver. NFS sharing could be enabled to allow someone on another computer to mount shares and gain access to information from the user's computer. File sharing from a user endpoint has long been considered questionable and Apple has removed that capability from the GUI. NFSD is still part of the Operating System and can be easily turned on to export shares and provide remote connectivity to an end user computer."
     rationale: "File serving should not be done from a user desktop, dedicated servers should be used.  Open ports make it easier to exploit the computer."
     remediation: "Ensure that the NFS Server is not running and is not set to start at boot Stop the NFS Server: sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.nfsd.plist   Remove the exported Directory listing: sudo rm /etc/export"
@@ -686,9 +683,8 @@ checks:
       - cis_level: ["1"]
     condition: none
     rules:
-      - 'p:nfsd'
-      - 'p:/sbin/nfsd'
       - 'f:/etc/exports'
+      - 'not c:sh -c "launchctl print-disabled system | grep -c ''\"com.apple.nfsd\" => true''" -> 1'
 
 # not implemented - Review -> 4.6 Review Wi-Fi Settings (Manual)
 
@@ -700,8 +696,8 @@ checks:
 # not implemented - SCA Limit -> 5.1.1 Secure Home Folders (Automated)
 
 # 5.1.2 Check System Wide Applications for appropriate permissions (Automated)
-  - id: 18044
-    title: "Check System Wide Applications for appropriate permissions"
+  - id: 18042
+    title: "Check System Wide Applications for appropriate permissions."
     description: "Applications in the System Applications Directory (/Applications) should be world executable since that is their reason to be on the system. They should not be world writable and allow any process or user to alter them for other processes or users to then execute modified versions"
     rationale: "Unauthorized modifications of applications could lead to the execution of malicious code."
     remediation: "Run the following command to change the permissions for each application that does not meet the requirements: sudo chmod -R o-w /Applications/<applicationname>"
@@ -710,11 +706,11 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo find /Applications -iname "*.app" -type d -perm -2 -ls -> r:^$'
+      - 'c:find /Applications -iname "*.app" -type d -perm -2 -ls -> r:^$'
 
 # 5.1.3 Check System folder for world writable files (Automated)
-  - id: 18045
-    title: "Check System folder for world writable files"
+  - id: 18043
+    title: "Check System folder for world writable files."
     description: "Software sometimes insists on being installed in the /System Directory and have inappropriate world writable permissions."
     rationale: "Folders in /System should not be world writable. The audit check excludes the \"Drop Box\" folder that is part of Apple's default user template."
     remediation: "Run the following command to set permissions so that folders are not world writable in the /System folder: sudo chmod -R o-w /Path/<baddirectory>"
@@ -726,8 +722,8 @@ checks:
       - 'c:find /System -type d -perm -2 -ls -> r:^$'
 
 # 5.1.4 Check Library folder for world writable files (Automated)
-  - id: 18046
-    title: "Check Library folder for world writable files"
+  - id: 18044
+    title: "Check Library folder for world writable files."
     description: "Software sometimes insists on being installed in the /Library Directory and have inappropriate world writable permissions."
     rationale: "Folders in /Library should not be world writable. The audit check excludes the /Library/Caches folder where the sticky bit is set."
     remediation: "Run the following command to set permissions so that folders are not world writable in the /Library folder: sudo chmod -R o-w /Library/<baddirectory>"
@@ -736,7 +732,7 @@ checks:
       - cis_level: ["2"]
     condition: all
     rules:
-      - 'c:sudo find /System/Volumes/Data/Library -type d -perm -2 -ls | grep -v Caches | grep -v Audio -> r:^$'
+      - 'c:find /System/Volumes/Data/Library -type d -perm -2 -ls | grep -v Caches | grep -v Audio -> r:^$'
 
 ############################################################
 # 5.2 Password Management
@@ -751,8 +747,8 @@ checks:
 # not implemented - SCA Limit -> 5.2.8 Password History (Automated)
 
 # 5.3 Reduce the sudo timeout period (Automated) 18051
-  - id: 18051
-    title: "Reduce the sudo timeout period"
+  - id: 18045
+    title: "Reduce the sudo timeout period."
     description: "The sudo command allows the user to run programs as the root user. Working as the root user allows the user an extremely high level of configurability within the system."
     rationale: "The sudo command stays logged in as the root user for five minutes before timing out and re-requesting a password. This five minute window should be eliminated since it leaves the system extremely vulnerable. This is especially true if an exploit were to gain access to the system, since they would be able to make changes as a root user."
     remediation: "Run the following command to edit the sudo settings: sudo visudo -> Add the line Defaults timestamp_timeout=0 in the Override built-in defaults section. "
@@ -761,13 +757,13 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo grep -e "timestamp" /etc/sudoers -> r:Defaults timestamp_timeout=0'
+      - 'c:grep -e "timestamp" /etc/sudoers -> r:Defaults timestamp_timeout=0'
 
 # not implemented - SCA Limit -> 5.4 Automatically lock the login keychain for inactivity (Manual)
 
 # 5.5 Use a separate timestamp for each user/tty combo (Automated)
-  - id: 18052
-    title: "Use a separate timestamp for each user/tty combo"
+  - id: 18046
+    title: "Use a separate timestamp for each user/tty combo."
     description: "Using tty tickets ensures that a user must enter the sudo password in each Terminal session. With sudo versions 1.8 and higher, introduced in 10.12, the default value is to have tty tickets for each interface so that root access is limited to a specific terminal. The default configuration can be overwritten or not configured correctly on earlier versions of macOS."
     rationale: "In combination with removing the sudo timeout grace period a further mitigation should be in place to reduce the possibility of a background process using elevated rights when a user elevates to root in an explicit context or tty. Additional mitigation should be in place to reduce the risk of privilege escalation of background processes."
     remediation: "Run the following command to edit the sudo settings: sudo visudo -> Add the line Defaults timestamp_timeout=0 in the Override built-in defaults section. "
@@ -776,14 +772,14 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo grep -E -s ''!tty_tickets'' /etc/sudoers /etc/sudoers.d/* -> r:^$'
-      - 'c:sudo grep -E -s "timestamp_type" /etc/sudoers /etc/sudoers.d/* -> r:^$|!timestamp_type=ppid|!timestamp_type=global'
+      - 'c:grep -E -s ''!tty_tickets'' /etc/sudoers /etc/sudoers.d/* -> r:^$'
+      - 'c:grep -E -s "timestamp_type" /etc/sudoers /etc/sudoers.d/* -> r:^$|!timestamp_type=ppid|!timestamp_type=global'
 
 # not implemented - SCA Limit -> 5.6 Ensure login keychain is locked when the computer sleeps (Manual)
 
 # 5.7 Do not enable the "root" account (Automated)
-  - id: 18053
-    title: "Do not enable the \"root\" account"
+  - id: 18047
+    title: "Do not enable the root account"
     description: "The root account is a superuser account that has access privileges to perform any actions and read/write to any file on the computer. With some Linux distros the system administrator may commonly uses the root account to perform administrative functions."
     rationale: "Enabling and using the root account puts the system at risk since any successful exploit or mistake while the root account is in use could have unlimited access privileges within the system. Using the sudo command allows users to perform functions as a root user while limiting and password protecting the access privileges. By default the root account is not enabled on a macOS computer. An administrator can escalate privileges using the sudo command (use -s or -i to get a root shell)."
     remediation: "Open System Preferences, Uses & Groups. Click the lock icon to unlock it. In the Network Account Server section, click Join or Edit. Click Open Directory Utility. Click the lock icon to unlock it. Select the Edit menu > Disable Root User. Terminal Method: Run the following command to disable the root user: sudo dsenableroot -d"
@@ -792,11 +788,11 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo dscl . -read /Users/root AuthenticationAuthority -> r:^No such key: AuthenticationAuthority'
+      - 'c:dscl . -read /Users/root AuthenticationAuthority -> r:^No such key: AuthenticationAuthority'
 
 # 5.8 Disable automatic login (Automated)
-  - id: 18054
-    title: "Disable automatic login"
+  - id: 18048
+    title: "Disable automatic login."
     description: "The automatic login feature saves a user's system access credentials and bypasses the login screen, instead the system automatically loads to the user's desktop screen."
     rationale: "Disabling automatic login decreases the likelihood of an unauthorized person gaining access to a system."
     remediation: "Run the following command in Terminal: sudo defaults delete /Library/Preferences/com.apple.loginwindow autoLoginUser"
@@ -805,13 +801,13 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo defaults read /Library/Preferences/com.apple.loginwindow autoLoginUser -> r:^$'
+      - 'c:defaults read /Library/Preferences/com.apple.loginwindow autoLoginUser -> r:^$'
 
 # not implemented - process - 5.9 Require a password to wake the computer from sleep or screen saver (Manual)
 # not implemented - SCA Limit -> 5.10 Ensure system is set to hibernate (Automated)
 # 5.11 Require an administrator password to access system-wide preferences (Automated)
-  - id: 18056
-    title: "Require an administrator password to access system-wide preferences"
+  - id: 18049
+    title: "Require an administrator password to access system-wide preferences."
     description: "System Preferences controls system and user settings on a macOS Computer. System Preferences allows the user to tailor their experience on the computer as well as allowing the System Administrator to configure global security settings. Some of the settings should only be altered by the person responsible for the computer. "
     rationale: "By requiring a password to unlock system-wide System Preferences the risk is mitigated of a user changing configurations that affect the entire system and requires an admin user to re-authenticate to make changes."
     remediation: "Perform the following to verify that an administrator password is required to access system-wide preferences: 1.  Open System Preferences 2.  Select Security & Privacy 3.  Select General 4.  Select Advanced... 5.  Set Require an administrator password to access system-wide preferences"
@@ -820,10 +816,11 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo security authorizationdb read system.preferences 2> /dev/null | grep -A1 shared | grep false -> r:^<false/>'
+      - 'c:sh -c "security authorizationdb read system.preferences 2> /dev/null | grep -A1 shared | grep false" -> r:^<false/>'
+
 # 5.12 Disable ability to login to another user's active and locked session (Automated)
-  - id: 18057
-    title: "Ensure an administrator account cannot login to another user's active and locked session"
+  - id: 18050
+    title: "Ensure an administrator account cannot login to another user's active and locked session."
     description: "macOS has a privilege that can be granted to any user that will allow that user to unlock active user's sessions."
     rationale: "Disabling the admins and/or user's ability to log into another user's active and locked session prevents unauthorized persons from viewing potentially sensitive and/or personal information."
     remediation: "Run the following command to disable a user logging into another user's active and/or locked session: $ sudo security authorizationdb write system.login.screensaver use-login-window-ui"
@@ -832,11 +829,11 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo security authorizationdb read system.login.screensaver 2>&1 | /usr/bin/grep -c ''use-login-window-ui'' -> 1'
+      - 'c:sh -c "security authorizationdb read system.login.screensaver 2>&1 | grep -c ''use-login-window-ui''" -> 1'
 
 # 5.13 Create a custom message for the Login Screen (Automated)
-  - id: 18058
-    title: "Create a custom message for the Login Screen"
+  - id: 18051
+    title: "Create a custom message for the Login Screen."
     description: "An access warning informs the user that the system is reserved for authorized use only, and that the use of the system may be monitored."
     rationale: "An access warning may reduce a casual attacker's tendency to target the system. Access warnings may also aid in the prosecution of an attacker by evincing the attacker's knowledge of the system's private status, acceptable use policy, and authorization requirements."
     remediation: "Run the following command to enable a custom login screen message: sudo defaults write /Library/Preferences/com.apple.loginwindow LoginwindowText \"<custom.message>\""
@@ -845,11 +842,11 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo defaults read /Library/Preferences/com.apple.loginwindow.plist LoginwindowText -> !r:does not exist'
+      - 'c:defaults read /Library/Preferences/com.apple.loginwindow.plist LoginwindowText -> !r:does not exist'
 
 # 5.14 Create a Login window banner (Automated)
-  - id: 18059
-    title: "Create a Login window banner"
+  - id: 18052
+    title: "Create a Login window banner."
     description: "A Login window banner warning informs the user that the system is reserved for authorized use only. It enforces an acknowledgment by the user that they have been informed of the use policy in the banner if required. The system recognizes either the .txt and the .rtf formats."
     rationale: "An access warning may reduce a casual attacker's tendency to target the system. Access warnings may also aid in the prosecution of an attacker by evincing the attacker's knowledge of the system's private status, acceptable use policy, and authorization requirements."
     remediation: "Edit (or create) a PolicyBanner.txt or PolicyBanner.rtf file, in the /Library/Security/ folder, to include the required login window banner text."
@@ -858,13 +855,13 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'd:/Library/Security -> !r:^no matches found: /Library/Security/PolicyBanner'
+      - 'd:/Library/Security -> r:PolyBanner.* -> r:^$'
 
 # not implemented - SCA Limit -> 5.15 Do not enter a password-related hint (Automated)
 
 # 5.16 Disable Fast User Switching (Manual)
-  - id: 18060
-    title: "Disable Fast User Switching"
+  - id: 18053
+    title: "Disable Fast User Switching."
     description: "Fast user switching allows a person to quickly log in to the computer with a different account. While only a minimal security risk, when a second user is logged in, that user might be able to see what processes the first user is using, or possibly gain other information about the first user. In a large directory environment where it is difficult to limit login access many valid users can login to other user's assigned computers."
     rationale: "Fast user switching allows multiple users to run applications simultaneously at console. There can be information disclosed about processes running under a different user. Without a specific configuration to save data and log out users can have unsaved data running in a background session that is not obvious."
     remediation: "Run the following command to turn fast user switching off:  sudo defaults write /Library/Preferences/.GlobalPreferences MultipleSessionEnabled -bool false"
@@ -873,14 +870,14 @@ checks:
       - cis_level: ["2"]
     condition: any
     rules:
-      - 'c:sudo defaults read /Library/Preferences/.GlobalPreferences.plist MultipleSessionEnabled -> r:does not exist'
-      - 'c:sudo defaults read /Library/Preferences/.GlobalPreferences.plist MultipleSessionEnabled -> 0'
+      - 'c:defaults read /Library/Preferences/.GlobalPreferences.plist MultipleSessionEnabled -> r:does not exist'
+      - 'c:defaults read /Library/Preferences/.GlobalPreferences.plist MultipleSessionEnabled -> 0'
 
 # not implemented - process - 5.17 Secure individual keychains and items (Manual)
 
 # 5.18 System Integrity Protection status (Automated)
-  - id: 18061
-    title: "System Integrity Protection status"
+  - id: 18054
+    title: "System Integrity Protection status."
     description: "System Integrity Protection is a security feature introduced in OS X 10.11 El Capitan. System Integrity Protection restricts access to System domain locations and restricts runtime attachment to system processes. Any attempt to attempt to inspect or attach to a system process will fail. Kernel Extensions are now restricted to /Library/Extensions and are required to be signed with a Developer ID."
     rationale: "Running without System Integrity Protection on a production system runs the risk of the modification of system binaries or code injection of system processes that would otherwise be protected by SIP."
     remediation: "Perform the following while booted in macOS Recovery Partition.  1. Select Terminal from the Utilities menu    2. Run the following command in Terminal: /usr/bin/csrutil enable   3. The output should be: Successfully enabled System Integrity Protection. Please restart the machine for the changes to take effect.    4. Reboot."
@@ -889,11 +886,11 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo /usr/bin/csrutil status -> r:^System Integrity Protection status: enabled'
+      - 'c:/usr/bin/csrutil status -> r:^System Integrity Protection status: enabled'
 
 # 5.19 Enable Sealed System Volume (SSV) (Automated)
-  - id: 18070
-    title: "Enable Sealed System Volume (SSV)"
+  - id: 18055
+    title: "Enable Sealed System Volume (SSV)."
     description: "SThe seal is verified by the boot loader at startup. macOS will not boot if system files have been tampered with. If validation fails, the user will be instructed to reinstall the operating system. During read operations for files located in the Sealed System Volume, a hash is calculated and compared to the value stored in the Merkle tree."
     rationale: "Running without Sealed System Volume on a production system could run the risk of Apple software, that integrates directly with macOS, being modified. "
     remediation: "Perform the following while booted in macOS Recovery Partition.  1. Select Terminal from the Utilities menu    2. Run the following command in Terminal: /usr/bin/csrutil enable authenticated-root 3. The output should be: Successfully enabled System authenticated root. Please restart the machine for the changes to take effect.    4. Reboot."
@@ -902,11 +899,11 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo /usr/bin/csrutil authenticated-root status  -> r:^SAuthenticated Root status: enabled'
+      - 'c:/usr/bin/csrutil authenticated-root status  -> r:^SAuthenticated Root status: enabled'
 
 # 5.20 Enable Library Validation (Automated)
-  - id: 18071
-    title: "Enable Library Validation"
+  - id: 18056
+    title: "Enable Library Validation."
     description: "Library Validation is a security feature introduced in macOS 10.10 Yosemite. Library Validation protects processes from loading arbitrary libraries. This stops root from loading arbitrary libraries into any process (depending on SIP status),and keeps root from becoming more powerful. Security is strengthened, because some user processes can no longer be fooled to run additional code without root's explicit request, which may grant access to daemons that depend on LibraryValidation for secure validation of code identity."
     rationale: "Running without Library Validation on a production system runs the risk of the modification of system binaries or code injection of system processes that would otherwise be protected by Library Validation."
     remediation: "Run the following command to set Library Validation: sudo defaults write /Library/Preferences/com.apple.security.libraryvalidation.plist DisableLibraryValidation DisableLibraryValidation -bool false"
@@ -919,7 +916,7 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo defaults read /Library/Preferences/com.apple.security.libraryvalidation.plist DisableLibraryValidation  -> 0'
+      - 'c:defaults read /Library/Preferences/com.apple.security.libraryvalidation.plist DisableLibraryValidation  -> 0'
 
 ############################################################
 # 6 User Accounts and Environment
@@ -927,8 +924,8 @@ checks:
 # 6.1 Accounts Preferences Action Items
 ############################################################
 # 6.1.1 Display login window as name and password (Automated)
-  - id: 18062
-    title: "Display login window as name and password"
+  - id: 18057
+    title: "Display login window as name and password."
     description: "The login window prompts a user for his/her credentials, verifies their authorization level and then allows or denies the user access to the system."
     rationale: "Prompting the user to enter both their username and password makes it twice as hard for unauthorized users to gain access to the system since they must discover two attributes."
     remediation: "Run the following command to enable the login window to display name and password: sudo defaults write /Library/Preferences/com.apple.loginwindow SHOWFULLNAME -bool true"
@@ -937,11 +934,11 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo defaults read /Library/Preferences/com.apple.loginwindow SHOWFULLNAME -> 1'
+      - 'c:defaults read /Library/Preferences/com.apple.loginwindow SHOWFULLNAME -> 1'
 
 # 6.1.2 Disable "Show password hints" (Automated)
-  - id: 18063
-    title: "Disable \"Show password hints\""
+  - id: 18058
+    title: "Disable Show password hints."
     description: "Password hints are user created text displayed when an incorrect password is used for an account."
     rationale: "Password hints make it easier for unauthorized persons to gain access to systems by providing information to anyone that the user provided to assist remembering the password. This info could include the password itself or other information that might be readily discerned with basic knowledge of the end user."
     remediation: "Run the following command to disable password hints: sudo defaults write /Library/Preferences/com.apple.loginwindow RetriesUntilHint -int 0"
@@ -950,12 +947,12 @@ checks:
       - cis_level: ["1"]
     condition: any
     rules:
-      - 'c:sudo defaults read /Library/Preferences/com.apple.loginwindow RetriesUntilHint -> 0'
-      - 'c:sudo defaults read /Library/Preferences/com.apple.loginwindow RetriesUntilHint -> r:does not exist'
+      - 'c:defaults read /Library/Preferences/com.apple.loginwindow RetriesUntilHint -> 0'
+      - 'c:defaults read /Library/Preferences/com.apple.loginwindow RetriesUntilHint -> r:does not exist'
 
 # 6.1.3 Disable guest account login (Automated)
-  - id: 18064
-    title: "Disable guest account login"
+  - id: 18059
+    title: "Disable guest account login."
     description: "The guest account allows users access to the system without having to create an account or password. Guest users are unable to make setting changes, cannot remotely login to the system and all created files, caches, and passwords are deleted upon logging out."
     rationale: "Disabling the guest account mitigates the risk of an untrusted user doing basic reconnaissance and possibly using privilege escalation attacks to take control of the system."
     remediation: "Run the following command in Terminal: sudo defaults write /Library/Preferences/com.apple.loginwindow GuestEnabled - bool false"
@@ -964,11 +961,11 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo defaults read /Library/Preferences/com.apple.loginwindow.plist GuestEnabled -> 0'
+      - 'c:defaults read /Library/Preferences/com.apple.loginwindow.plist GuestEnabled -> 0'
 
 # 6.1.4 Disable "Allow guests to connect to shared folders" (Automated)
-  - id: 18065
-    title: "Disable \"Allow guests to connect to shared folders\""
+  - id: 18060
+    title: "Disable Allow guests to connect to shared folders"
     description: "Allowing guests to connect to shared folders enables users to access selected shared folders and their contents from different computers on a network."
     rationale: "Not allowing guests to connect to shared folders mitigates the risk of an untrusted user doing basic reconnaissance and possibly use privilege escalation attacks to take control of the system."
     remediation: "Run the following command in Terminal: sudo defaults write /Library/Preferences/com.apple.loginwindow GuestEnabled - bool false"
@@ -983,8 +980,8 @@ checks:
       - 'c:defaults read /Library/Preferences/SystemConfiguration/com.apple.smb.server AllowGuestAccess -> r:does not exist'
 
 # 6.1.5 Remove Guest home folder (Automated)
-  - id: 18066
-    title: "Remove Guest home folder"
+  - id: 18061
+    title: "Remove Guest home folder."
     description: "In the previous two controls the guest account login has been disabled and sharing to guests has been disabled as well. There is no need for the legacy Guest home folder to remain in the file system. When normal user accounts are removed you have the option to archive it, leave it in place or delete. In the case of the guest folder the folder remains in place without a GUI option to remove it. If at some point in the future a Guest account is needed it will be re-created. The presence of the Guest home folder can cause automated audits to fail when looking for compliant settings within all User folders as well. Rather than ignoring the folders continued existence it is best removed."
     rationale: "The Guest home folders are unneeded after the Guest account is disabled and could be used inappropriately."
     remediation: "1. Run the following command in Terminal: sudo rm -R /Users/Guest  2. Make sure there is no output"
@@ -996,8 +993,8 @@ checks:
       - 'd:/Users/Guest'
 
 # 6.2 Turn on filename extensions (Automated)
-  - id: 18067
-    title: "Turn on filename extensions"
+  - id: 18062
+    title: "Turn on filename extensions."
     description: "A filename extension is a suffix added to a base filename that indicates the base filename's file format."
     rationale: "Visible filename extensions allows the user to identify the file type and the application it is associated with which leads to quick identification of misrepresented malicious files."
     remediation: "Perform the following to implement the prescribed state: 1. Select Finder 2. Select Preferences 3. Check Show all filename extensions    Alternatively, use the following command: defaults write NSGlobalDomain AppleShowAllExtensions -bool true"
@@ -1007,11 +1004,10 @@ checks:
     condition: all
     rules:
       - 'c:defaults read NSGlobalDomain AppleShowAllExtensions -> 1'
-      # - 'c:defaults read /Users/<username>/Library/Preferences/.GlobalPreferences.plist AppleShowAllExtensions -> 1'
 
 # 6.3 Disable the automatic run of safe files in Safari (Automated)
-  - id: 18068
-    title: "Disable the automatic run of safe files in Safari"
+  - id: 18063
+    title: "Disable the automatic run of safe files in Safari."
     description: "Safari will automatically run or execute what it considers safe files. This can include installers and other files that execute on the operating system. Safari bases file safety by using a list of filetypes maintained by Apple. The list of files include text, image, video and archive formats that would be run in the context of the OS rather than the browser."
     rationale: "Hackers have taken advantage of this setting via drive-by attacks. These attacks occur when a user visits a legitimate website that has been corrupted. The user unknowingly downloads a malicious file either by closing an infected pop-up or hovering over a malicious banner. An attacker can create a malicious file that will fall within Safari's safe file list that will download and execute without user input."
     remediation: "Perform the following to implement the prescribed state: 1. Open Safari 2. Select Safari from the menu bar 3. Select Preferences 4. Select General 5. Uncheck Open \"safe\" files after downloading    Alternatively run the following command in Terminal: defaults write com.apple.Safari AutoOpenSafeDownloads -boolean no       Terminal Method: Run the following command to disable safe files from not opening in Safari: sudo -u <username> defaults write /Users/<username>/LibraryContainers/com.apple.Safari/Data/Library/Preferences/com.apple.Safari AutoOpenSafeDownloads -bool false"
@@ -1020,4 +1016,4 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sudo defaults read com.apple.Safari AutoOpenSafeDownloads -> 0'
+      - 'c:defaults read com.apple.Safari AutoOpenSafeDownloads -> 0'

--- a/ruleset/sca/darwin/20/cis_apple_macOS_11.1.yml
+++ b/ruleset/sca/darwin/20/cis_apple_macOS_11.1.yml
@@ -192,9 +192,9 @@ checks:
     compliance:
       - cis: ["2.3.1"]
       - cis_level: ["1"]
-    condition: all
+    condition: none
     rules:
-      - 'c:defaults -currentHost read com.apple.screensaver idleTime -> !r:does not exist'
+      - 'c:defaults -currentHost read com.apple.screensaver idleTime -> r:does not exist'
 
 # 2.3.2 Secure screen saver corners (Automated)
   - id: 18011
@@ -239,14 +239,14 @@ checks:
     compliance:
       - cis: ["2.4.2"]
       - cis_level: ["1"]
-    condition: all
+    condition: none
     rules:
-      - 'c:defaults read /Library/Preferences/SystemConfiguration/com.apple.nat -> !r:Enabled\s*\t*=\s*\t*1'
+      - 'c:defaults read /Library/Preferences/SystemConfiguration/com.apple.nat -> r:Enabled\s*\t*=\s*\t*1'
 
 # 2.4.3 Disable Screen Sharing (Automated)
   - id: 18014
     title: "Disable Screen Sharing."
-    description: "Screen sharing allows a computer to connect to another computer on a network and display the computer’s screen. While sharing the computer’s screen, the user can control what happens on that computer, such as opening documents or applications, opening, moving, or closing windows, and even shutting down the computer."
+    description: "Screen sharing allows a computer to connect to another computer on a network and display the computer's screen. While sharing the computer's screen, the user can control what happens on that computer, such as opening documents or applications, opening, moving, or closing windows, and even shutting down the computer."
     rationale: "Disabling screen sharing mitigates the risk of remote connections being made without the user of the console knowing that they are sharing the computer."
     remediation: "Run the following command to turn off Screen Sharing: sudo launchctl disable system/com.apple.screensharing"
     compliance:
@@ -254,7 +254,7 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:launchctl print-disabled system | grep -c ''"com.apple.screensharing" => true'' -> 1'
+      - 'c:sh -c "launchctl print-disabled system | grep -c ''\"com.apple.screensharing\" => true''" -> 1'
 
 # 2.4.4 Disable Printer Sharing (Automated)
   - id: 18015
@@ -295,7 +295,7 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sh -c "launchctl print-disabled system  | grep -c ''\"com.apple.ODSAgent\" => true''"" -> 1'
+      - 'c:sh -c "launchctl print-disabled system | grep -c ''\"com.apple.ODSAgent\" => true''" -> 1'
 
 # 2.4.7 Disable Bluetooth Sharing (Automated)
   - id: 18018
@@ -321,7 +321,7 @@ checks:
       - cis_level: ["1"]
     condition: none
     rules:
-      - 'c:sh -c "launchctl print-disabled system | grep -c ''\"com.apple.smbd\" => true''"" -> 1'
+      - 'c:sh -c "launchctl print-disabled system | grep -c ''\"com.apple.smbd\" => true''" -> 1'
 
 # 2.4.9 Disable Remote Management (Automated)
   - id: 18020
@@ -463,7 +463,7 @@ checks:
       - https://support.apple.com/en-us/HT204690
     condition: all
     rules:
-      - 'c:launchctl list | grep -c com.apple.locationd -> 1'
+      - 'c:sh -c "launchctl list | grep -c com.apple.locationd" -> 1'
 
 # not implemented - process -> 2.5.4 Review Application Firewall Rules (Manual)
 
@@ -522,7 +522,7 @@ checks:
 # 2.8 Disable Wake for network access (Automated)
   - id: 18031
     title: "Disable Wake for network access."
-    description: "This feature allows the computer to take action when the user is not present and the computer is in energy saving mode. These tools require FileVault to remain unlocked and fully rejoin known networks. Theie macOS feature is meant to allow the computer to resume activity as needed regardless of physical security controls. This feature allows other users to be able to access your computer’s shared resources, such as shared printers or iTunes playlists, even when your computer is in sleep mode. In a closed network when only authorized devices could wake a computer it could be valuable to wake computers in order to do management push activity. Where mobile workstations and agents exist the device will more likely check in to receive updates when already awake. Mobile devices should not be listening for signals on unmanaged network where untrusted devices could send wake signals."
+    description: "This feature allows the computer to take action when the user is not present and the computer is in energy saving mode. These tools require FileVault to remain unlocked and fully rejoin known networks. Theie macOS feature is meant to allow the computer to resume activity as needed regardless of physical security controls. This feature allows other users to be able to access your computer's shared resources, such as shared printers or iTunes playlists, even when your computer is in sleep mode. In a closed network when only authorized devices could wake a computer it could be valuable to wake computers in order to do management push activity. Where mobile workstations and agents exist the device will more likely check in to receive updates when already awake. Mobile devices should not be listening for signals on unmanaged network where untrusted devices could send wake signals."
     rationale: "Disabling this feature mitigates the risk of an attacker remotely waking the system and gaining access."
     remediation: "Run the following command to disable Wake for network access: sudo pmset -a womp 0 "
     compliance:
@@ -530,7 +530,7 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sh -c "pmset -g | grep -e womp" -> r: 0'
+      - 'c:sh -c "pmset -g | grep -e womp" -> r:0'
 
 # 2.9 Disable Power Nap (Automated)
   - id: 18032
@@ -543,7 +543,7 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:sh -c "pmset -g everything | grep -c ''powernap             1''"-> 0'
+      - 'c:sh -c "pmset -g everything | grep -e powernap" -> r:powernap\s+0'
 
 # 2.10 Enable Secure Keyboard Entry in terminal.app (Automated)
   - id: 18033
@@ -569,8 +569,8 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'c:system_profiler SPiBridgeDataType | grep "T2" -> Model Name: Apple T2 Security Chip'
-      - 'c:launchctl list | grep com.apple.driver.eficheck -> r:^-\s*\t*0\s*\t*com.apple.driver.eficheck$'
+      - 'c:sh -c "system_profiler SPiBridgeDataType | grep \"T2\"" -> r:Model Name: Apple T2 Security Chip'
+      - 'c:sh -c "launchctl list | grep com.apple.driver.eficheck" -> r:^-\s*\t*0\s*\t*com.apple.driver.eficheck$'
 
 # not implemented - requires supervision -> 2.12 Automatic Actions for Optical Media (Manual)
 # not implemented - requires supervision -> 2.13 Review Siri Settings (Manual)
@@ -732,7 +732,7 @@ checks:
       - cis_level: ["2"]
     condition: all
     rules:
-      - 'c:find /System/Volumes/Data/Library -type d -perm -2 -ls | grep -v Caches | grep -v Audio -> r:^$'
+      - 'c:sh -c "find /System/Volumes/Data/Library -type d -perm -2 -ls | grep -v Caches | grep -v Audio" -> r:^$'
 
 ############################################################
 # 5.2 Password Management
@@ -855,7 +855,7 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - 'd:/Library/Security -> r:PolyBanner.* -> r:^$'
+      - 'd:/Library/Security -> r:^PolicyBanner'
 
 # not implemented - SCA Limit -> 5.15 Do not enter a password-related hint (Automated)
 


### PR DESCRIPTION
|Related issue|
|---|
|#10558|

## Description

This PR aims to review and update PR #10558

The issues resolved are:
- Minimal typos and bad references format.

## Checks and changes 

### Syntax and semantic

- [x] a) ID of each policy must be contiguous.
- [x] b) The order and format set in [Documentation](https://documentation.wazuh.com/current/user-manual/capabilities/sec-config-assessment/creating-custom-policies.html) must be respected.
- [x] c) YML must be valid to avoid errors.

### Content

- [x] a) Compare each check with its analogue from CIS Benchmark.
- [x] b) Try to maintain each rule as similar as possible with the `Audit` section from the CIS check.
- [x] c) Check that the commands provide the expected output.
- [x] d) When a failure is discovered, check similar policies to avoid repetition of the issue.

### Unit testing

- [x] a) Output from `agent.log` after the SCA scan and a raw output of the result of the checks.
```
2021/12/07 20:40:33 sca: INFO: Module started.
2021/12/07 20:40:33 sca: INFO: Loaded policy '/var/ossec/ruleset/sca/cis_rhel8_linux.yml'
2021/12/07 20:40:33 sca: INFO: Starting Security Configuration Assessment scan.
2021/12/07 20:40:33 wazuh-modulesd:control: INFO: Starting control thread.
2021/12/07 20:40:33 sca: INFO: Starting evaluation of policy: '/var/ossec/ruleset/sca/cis_rhel8_linux.yml'
2021/12/07 20:40:33 wazuh-modulesd:syscollector: INFO: Module started.
2021/12/07 20:40:33 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2021/12/07 20:40:33 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2021/12/07 20:40:33 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
2021/12/07 20:40:42 sca: INFO: Evaluation finished for policy '/var/ossec/ruleset/sca/cis_rhel8_linux.yml'
2021/12/07 20:40:42 sca: INFO: Security Configuration Assessment scan finished. Duration: 9 seconds.
2021/12/07 20:40:53 rootcheck: INFO: Ending rootcheck scan.

```

### Deployment

- [x] a) If the policy it's new, it must be added to the `sca.files` templates.
- [x] b) If the OS has many supported SCA policies, a policy must be set as default policy. ([as example](https://github.com/wazuh/wazuh/blob/master/etc/templates/config/centos/sca.files))
