### PR TITLE
Improve get host name in `shared.sh`

### DIFF
--- a/src/init/shared.sh
+++ b/src/init/shared.sh
@@ -22,8 +22,14 @@ else
     fi
 fi
 
+# If hostname does not exist, try 'uname -n'
+if command -v hostname > /dev/null 2>&1 ; then
+    HOST=`hostname`
+else
+    HOST=`uname -n`
+fi
+
 OSSEC_INIT="/etc/ossec-init.conf"
-HOST=`hostname`
 NAMESERVERS=`cat /etc/resolv.conf | grep "^nameserver" | cut -d " " -sf 2`
 NAMESERVERS2=`cat /etc/resolv.conf | grep "^nameserver" | cut -sf 2`
 HOST_CMD=`command -v host 2>/dev/null`


### PR DESCRIPTION
|Related issue|
|---|
|#11433|

## Description

With this PR, the obtaining of the host name in the `shared.sh` file is fixed and improved, and thus closes #11433 (host name detection problem in _openSUSE_).

To avoid problems with any other OS, a condition has been added that checks for the `hostname` command, and if it doesn't exist, then run `uname -n` instead. In this way it continues to maintain the same logic as before, but with an improvement in case of failure.

## Logs/Alerts example

Successful installation of RPM package:
```
Checking for file conflicts: ..................................................................[done]
(1/1) Installing: wazuh-manager-4.3.0-hostname.x86_64 .........................................[done]
Executing %posttrans scripts ..................................................................[done]
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
  - [x] Ubuntu 20
- [x] Package installation
  - [x] openSUSE tumbleweed
  - [x] CentOS 7 
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
