### PR TITLE
Change FIM scan to use DBSync transactions.

### DIFF
--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -552,6 +552,7 @@
 #else
 #define FIM_ERROR_EXPAND_ENV_VAR                    "(6718): Could not expand the environment variable %s (%ld)."
 #endif
+#define FIM_ERROR_TRANSACTION                       "(6719): Could not start DBSync transaction (%s)"
 
 /* Wazuh Logtest error messsages */
 #define LOGTEST_ERROR_BIND_SOCK                     "(7300): Unable to bind to socket '%s'. Errno: (%d) %s"

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -121,7 +121,7 @@ static void transaction_callback(ReturnTypeCallback resultType, const cJSON* res
         dbsync_event = result_json;
     }
 
-    if (json_path = cJSON_GetObjectItem(dbsync_event, "path"), json_path == NULL) {
+    if (json_path = cJSON_GetObjectItem(dbsync_event, FILE_PRIMARY_KEY), json_path == NULL) {
         goto end;
     }
 
@@ -154,10 +154,10 @@ static void transaction_callback(ReturnTypeCallback resultType, const cJSON* res
 
         case MAX_ROWS:
             mdebug1("Couldn't insert '%s' entry into DB. The DB is full, please check your configuration.", path);
-            goto end;
 
+        // Fallthrough
         default:
-            break;
+            goto end;
     }
 
     json_event = fim_dbsync_json_event(path, diff, dbsync_event, configuration, event_data->evt_data);
@@ -168,7 +168,6 @@ static void transaction_callback(ReturnTypeCallback resultType, const cJSON* res
 
 end:
     os_free(diff);
-
     cJSON_Delete(json_event);
 }
 
@@ -286,7 +285,7 @@ time_t fim_scan() {
     if (syscheck.file_limit_enabled && (nodes_count >= syscheck.file_limit)) {
         w_mutex_lock(&syscheck.fim_scan_mutex);
 
-        db_transaction_handle = fim_db_transaction_start(FIMBD_FILE_TABLE_NAME, transaction_callback, &txn_ctx);
+        db_transaction_handle = fim_db_transaction_start(FIMDB_FILE_TXN_TABLE, transaction_callback, &txn_ctx);
 
         w_rwlock_rdlock(&syscheck.directories_lock);
         OSList_foreach(node_it, syscheck.directories) {

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -171,13 +171,6 @@ end:
     cJSON_Delete(json_event);
 }
 
-/**
- * @brief Update directories configuration with the wildcard list, at runtime
- *
- */
-void update_wildcards_config();
-
-
 void process_delete_event(void * data, void * ctx)
 {
     cJSON *json_event = NULL;

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -283,20 +283,21 @@ time_t fim_scan() {
         */
     }
 
-    /*
     if (syscheck.file_limit_enabled && (nodes_count >= syscheck.file_limit)) {
         w_mutex_lock(&syscheck.fim_scan_mutex);
+
+        db_transaction_handle = fim_db_transaction_start(FIMBD_FILE_TABLE_NAME, transaction_callback, &txn_ctx);
 
         w_rwlock_rdlock(&syscheck.directories_lock);
         OSList_foreach(node_it, syscheck.directories) {
             dir_it = node_it->data;
             char *path;
             event_data_t evt_data = { .mode = FIM_SCHEDULED, .report_event = true, .w_evt = NULL };
-            DEPRECATED CODE
+            /* DEPRECATED CODE
             if (fim_db_is_full(syscheck.database)) {
                 break;
             }
-
+            */
 
             path = fim_get_real_path(dir_it);
 
@@ -317,13 +318,15 @@ time_t fim_scan() {
         w_mutex_unlock(&syscheck.fim_scan_mutex);
 
 #ifdef WIN32
-        DEPRECATED CODE
+        /* DEPRECATED CODE
         if (fim_db_is_full(syscheck.database) != 0) {
             fim_registry_scan();
         }
+        */
 #endif
+        fim_db_transaction_deleted_rows(db_transaction_handle, transaction_callback, &txn_ctx);
+        db_transaction_handle = NULL;
     }
-    */
 
     gettime(&end);
     end_of_scan = time(NULL);

--- a/src/syscheckd/db/include/db.h
+++ b/src/syscheckd/db/include/db.h
@@ -9,9 +9,13 @@
 #ifndef FIMDB_H
 #define FIMDB_H
 #include "fimCommonDefs.h"
+#include "commonDefs.h"
+
 
 #ifdef __cplusplus
 extern "C" {
+#include "syscheck.h"
+#include <openssl/evp.h>
 #endif
 
 #include "syscheck.h"
@@ -132,6 +136,41 @@ void fim_sync_push_msg(const char* msg);
  *
  */
 void fim_run_integrity();
+
+/*
+ * @brief Function that starts a new DBSync transaction.
+ *
+ * @param table Database table that will be used in the DBSync transaction.
+ * @param row_callback Callback that is going to be executed for each insertion or modification.
+ * param user_data Context that will be used in the callback.
+ *
+ * @return TXN_HANDLE Transaction handler.
+ */
+TXN_HANDLE fim_db_transaction_start(const char* table, result_callback_t row_callback, void *user_data);
+
+/**
+ * @brief Function to perform a sync row operation (ADD OR REPLACE).
+ *
+ * @param txn_handler Handler to an active transaction.
+ * @param entry FIM entry to be added/updated.
+ *
+ * @retval FIMDB_OK on success.
+ * @retval FIMDB_FULL if the table limit was reached.
+ * @retval FIMDB_ERR on failure.
+ */
+FIMDBErrorCodes fim_db_transaction_sync_row(TXN_HANDLE txn_handler, const fim_entry* entry);
+
+/**
+ * @brief Function to perform the deleted rows operation.
+ *
+ * @param txn_handler Handler to an active transaction.
+ * @param callback Function to be executed for each deleted entry.
+ *
+ * @retval FIMDB_OK on success.
+ * @retval FIMDB_FULL if the table limit was reached.
+ * @retval FIMDB_ERR on failure.
+ */
+FIMDBErrorCodes fim_db_transaction_deleted_rows(TXN_HANDLE txn_handler, result_callback_t callback);
 
 #ifdef __cplusplus
 }

--- a/src/syscheckd/db/include/db.h
+++ b/src/syscheckd/db/include/db.h
@@ -170,7 +170,9 @@ FIMDBErrorCodes fim_db_transaction_sync_row(TXN_HANDLE txn_handler, const fim_en
  * @retval FIMDB_FULL if the table limit was reached.
  * @retval FIMDB_ERR on failure.
  */
-FIMDBErrorCodes fim_db_transaction_deleted_rows(TXN_HANDLE txn_handler, result_callback_t callback);
+FIMDBErrorCodes fim_db_transaction_deleted_rows(TXN_HANDLE txn_handler,
+                                                result_callback_t callback,
+                                                void* txn_ctx);
 
 #ifdef __cplusplus
 }

--- a/src/syscheckd/db/include/db.h
+++ b/src/syscheckd/db/include/db.h
@@ -14,8 +14,6 @@
 
 #ifdef __cplusplus
 extern "C" {
-#include "syscheck.h"
-#include <openssl/evp.h>
 #endif
 
 #include "syscheck.h"

--- a/src/syscheckd/db/include/fimCommonDefs.h
+++ b/src/syscheckd/db/include/fimCommonDefs.h
@@ -12,6 +12,7 @@
 #include "commonDefs.h"
 
 #define FIMBD_FILE_TABLE_NAME "file_entry"
+#define FIMDB_FILE_TXN_TABLE "{\"table\": \"file_entry\"}"
 #define FILE_PRIMARY_KEY "path"
 
 typedef enum FIMDBErrorCodes

--- a/src/syscheckd/db/include/fimCommonDefs.h
+++ b/src/syscheckd/db/include/fimCommonDefs.h
@@ -9,6 +9,7 @@
 #ifndef DB_COMMONDEFS_H
 #define DB_COMMONDEFS_H
 #include "logging_helper.h"
+#include "commonDefs.h"
 
 #define FIMBD_FILE_TABLE_NAME "file_entry"
 #define FILE_PRIMARY_KEY "path"

--- a/src/syscheckd/db/src/db.cpp
+++ b/src/syscheckd/db/src/db.cpp
@@ -122,10 +122,9 @@ void fim_sync_push_msg(const char* msg)
 
 TXN_HANDLE fim_db_transaction_start(const char* table, result_callback_t row_callback, void *user_data)
 {
-    const auto jsonTable { R"({"table": "file_entry"})" };
     const std::unique_ptr<cJSON, CJsonDeleter> jsInput
     {
-        cJSON_Parse(jsonTable)
+        cJSON_Parse(table)
     };
 
     callback_data_t cb_data = { .callback = row_callback, .user_data = user_data };

--- a/src/syscheckd/db/src/db.cpp
+++ b/src/syscheckd/db/src/db.cpp
@@ -144,14 +144,7 @@ FIMDBErrorCodes fim_db_transaction_sync_row(TXN_HANDLE txn_handler, const fim_en
     if (entry->type == FIM_TYPE_FILE)
     {
         auto syncItem = std::make_unique<FileItem>(entry);
-        json_insert["table"] = FIMBD_FILE_TABLE_NAME;
-        json_insert["data"] = {*(syncItem->toJSON())};
-    }
-    else
-    {
-        // auto syncItem = FileItem(entry);
-        // json_insert["table"] = FIMBD_FILE_TABLE_NAME
-        // json_insert["data"] = syncItem.toJSON();
+        json_insert = *syncItem->toJSON();
     }
 
     const std::unique_ptr<cJSON, CJsonDeleter> jsInput

--- a/src/syscheckd/db/src/db.cpp
+++ b/src/syscheckd/db/src/db.cpp
@@ -8,7 +8,7 @@
 
 #include "dbsync.hpp"
 #include "dbsync.h"
-#include "db.hpp"
+#include "db.h"
 #include "fimCommonDefs.h"
 #include "fimDB.hpp"
 #include "fimDBHelper.hpp"
@@ -142,13 +142,13 @@ FIMDBErrorCodes fim_db_transaction_sync_row(TXN_HANDLE txn_handler, const fim_en
     if (entry->type == FIM_TYPE_FILE)
     {
         auto syncItem = std::make_unique<FileItem>(entry);
-        json_insert["table"] = FIMDB_FILE_TABLENAME;
+        json_insert["table"] = FIMBD_FILE_TABLE_NAME
         json_insert["data"] = {*(syncItem->toJSON())};
     }
     else
     {
         // auto syncItem = FileItem(entry);
-        // json_insert["table"] = FIMDB_FILE_TABLENAME;
+        // json_insert["table"] = FIMBD_FILE_TABLE_NAME
         // json_insert["data"] = syncItem.toJSON();
     }
 

--- a/src/syscheckd/db/src/db.cpp
+++ b/src/syscheckd/db/src/db.cpp
@@ -169,9 +169,11 @@ FIMDBErrorCodes fim_db_transaction_sync_row(TXN_HANDLE txn_handler, const fim_en
     return retVal;
 }
 
-FIMDBErrorCodes fim_db_transaction_deleted_rows(TXN_HANDLE txn_handler, result_callback_t res_callback) {
+FIMDBErrorCodes fim_db_transaction_deleted_rows(TXN_HANDLE txn_handler,
+                                                result_callback_t res_callback,
+                                                void* txn_ctx) {
     auto retVal = FIMDB_OK;
-    callback_data_t cb_data = { .callback = res_callback, .user_data = NULL };
+    callback_data_t cb_data = { .callback = res_callback, .user_data = txn_ctx };
 
     dbsync_get_deleted_rows(txn_handler, cb_data);
     dbsync_close_txn(txn_handler);

--- a/src/syscheckd/db/src/db.cpp
+++ b/src/syscheckd/db/src/db.cpp
@@ -130,7 +130,9 @@ TXN_HANDLE fim_db_transaction_start(const char* table, result_callback_t row_cal
 
     callback_data_t cb_data = { .callback = row_callback, .user_data = user_data };
 
-    TXN_HANDLE dbsyncTxnHandle = dbsync_create_txn(FIMDB::getInstance().handle(), jsInput.get(), 0, QUEUE_SIZE, cb_data);
+    TXN_HANDLE dbsyncTxnHandle = dbsync_create_txn(FIMDB::getInstance().DBSyncHandle(), jsInput.get(), 0,
+                                                   QUEUE_SIZE, cb_data);
+
     return dbsyncTxnHandle;
 }
 
@@ -142,7 +144,7 @@ FIMDBErrorCodes fim_db_transaction_sync_row(TXN_HANDLE txn_handler, const fim_en
     if (entry->type == FIM_TYPE_FILE)
     {
         auto syncItem = std::make_unique<FileItem>(entry);
-        json_insert["table"] = FIMBD_FILE_TABLE_NAME
+        json_insert["table"] = FIMBD_FILE_TABLE_NAME;
         json_insert["data"] = {*(syncItem->toJSON())};
     }
     else

--- a/src/syscheckd/db/src/fimDB.hpp
+++ b/src/syscheckd/db/src/fimDB.hpp
@@ -26,6 +26,11 @@ extern "C"
 #define FIM_COMPONENT_FILE "fim_file"
 #define FIM_COMPONENT_REGISTRY "fim_registry"
 
+constexpr auto QUEUE_SIZE
+{
+    4096
+};
+
 constexpr auto CREATE_FILE_DB_STATEMENT
 {
     R"(CREATE TABLE IF NOT EXISTS file_entry (
@@ -339,6 +344,13 @@ class FIMDB
         {
             m_loggingFunction(logLevel, msg);
         }
+
+        /**
+         * @brief Function to return the DBSync handle.
+         *
+         * @return DBSYNC_HANDLE Handle to DBSync.
+         */
+        DBSYNC_HANDLE DBSyncHandle() { return m_dbsyncHandler->handle(); }
 
     private:
 

--- a/src/syscheckd/db/src/fimDB.hpp
+++ b/src/syscheckd/db/src/fimDB.hpp
@@ -350,7 +350,10 @@ class FIMDB
          *
          * @return DBSYNC_HANDLE Handle to DBSync.
          */
-        DBSYNC_HANDLE DBSyncHandle() { return m_dbsyncHandler->handle(); }
+        DBSYNC_HANDLE DBSyncHandle()
+        {
+            return m_dbsyncHandler->handle();
+        }
 
     private:
 

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -815,7 +815,7 @@ STATIC void fim_link_delete_range(directory_t *configuration) {
 STATIC void fim_link_silent_scan(const char *path, directory_t *configuration) {
     event_data_t evt_data = { .mode = FIM_SCHEDULED, .w_evt = NULL, .report_event = false };
 
-    fim_checker(path, &evt_data, configuration);
+    fim_checker(path, &evt_data, configuration, NULL);
 
     realtime_adddir(path, configuration);
 #ifdef ENABLE_AUDIT

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -11,6 +11,7 @@
 #ifndef SYSCHECK_H
 #define SYSCHECK_H
 
+#include "commonDefs.h"
 #include "config/syscheck-config.h"
 #include "syscheck_op.h"
 #include "external/cJSON/cJSON.h"
@@ -174,8 +175,12 @@ void check_max_fps();
  * @param [in] path Path of the file to check
  * @param [in] evt_data Information associated to the triggered event
  * @param [in] configuration Configuration block associated with a previous event.
+ * @param [in] dbsync_txn Handle to an active dbsync transaction.
  */
-void fim_checker(const char *path, event_data_t *evt_data, const directory_t *configuration);
+void fim_checker(const char *path,
+                 event_data_t *evt_data,
+                 const directory_t *parent_configuration,
+                 TXN_HANDLE dbsync_txn);
 
 /**
  * @brief Check file integrity monitoring on a specific folder
@@ -183,9 +188,11 @@ void fim_checker(const char *path, event_data_t *evt_data, const directory_t *co
  * @param [in] dir
  * @param [in] evt_data Information associated to the triggered event
  * @param [in] configuration Configuration block associated with the directory.
+ * @param [in] txn_handle DBSync transaction handler. Can be NULL.
+ *
  * @return 0 on success, -1 on failure
  */
-int fim_directory(const char *dir, event_data_t *evt_data, const directory_t *configuration) ;
+int fim_directory(const char *dir, event_data_t *evt_data, const directory_t *configuration, TXN_HANDLE txn_handle);
 
 /**
  * @brief Check file integrity monitoring on a specific file
@@ -193,8 +200,9 @@ int fim_directory(const char *dir, event_data_t *evt_data, const directory_t *co
  * @param [in] path Path of the file to check
  * @param [in] configuration Configuration block associated with a previous event.
  * @param [in] evt_data Information associated to the triggered event
+ * @param [in] txn_handle DBSync transaction handler. Can be NULL.
  */
-void fim_file(const char *path, const directory_t *configuration, event_data_t *evt_data);
+void fim_file(const char *path, const directory_t *configuration, event_data_t *evt_data, TXN_HANDLE txn_handle);
 
 /**
  * @brief Process FIM realtime event


### PR DESCRIPTION
|Related issue|
|---|
|#10847|


## Description
Hello team!! 

This PR aims to make the necessary changes in the FIM scan code in order to use DBSync transactions.

Closes #10847 


## Manual testing
I  have performed the following tests to check if the behavior is correct or not:
- Monitor a folder and set the scan frequency to 10 seconds.
- Create a number of files.
- Wait until the scan raises the added events.
- Modify the files
- Wait until the scan raises the modified events.
- Delete all the files
- Wait until the scan raises the deleted events.

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->
# Tests
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Valgrind (memcheck and descriptor leaks check)
- Memory tests for Windows
  - [x] Scan-build report