### PR TITLE
Replace the old update agent group method with the new set agent group implementation.

### DIFF
--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -872,7 +872,7 @@ void* run_writer(__attribute__((unused)) void *arg) {
                                              WDB_GROUP_MODE_OVERRIDE,
                                              "synced",
                                              WDB_GROUP_SOURCE_MANUAL,
-                                             NULL)) {
+                                             &wdb_sock)) {
                     merror("Unable to set agent centralized group: %s (internal error)", cur->group);
                 }
 

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -867,7 +867,12 @@ void* run_writer(__attribute__((unused)) void *arg) {
 
             gettime(&t0);
             if (cur->group) {
-                if (wdb_update_agent_group(atoi(cur->id),cur->group, &wdb_sock) == -1) {
+                if (wdb_set_agent_groups_csv(atoi(cur->id),
+                                             cur->group,
+                                             WDB_GROUP_MODE_OVERRIDE,
+                                             "synced",
+                                             WDB_GROUP_SOURCE_MANUAL,
+                                             NULL)) {
                     merror("Unable to set agent centralized group: %s (internal error)", cur->group);
                 }
 
@@ -875,7 +880,7 @@ void* run_writer(__attribute__((unused)) void *arg) {
             }
 
             gettime(&t1);
-            mdebug2("[Writer] wdb_update_agent_group(): %d µs.", (int)(1000000. * (double)time_diff(&t0, &t1)));
+            mdebug2("[Writer] wdb_set_agent_groups_csv(): %d µs.", (int)(1000000. * (double)time_diff(&t0, &t1)));
 
             os_free(cur->id);
             os_free(cur->name);

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -1004,7 +1004,12 @@ STATIC int lookfor_agent_group(const char *agent_id, char *msg, char **r_group, 
     if (agt_group = w_parser_get_agent(agent_id), agt_group) {
         strncpy(group, agt_group->group, OS_SIZE_65536);
         group[OS_SIZE_65536 - 1] = '\0';
-        wdb_update_agent_group(atoi(agent_id), group, NULL);
+        wdb_set_agent_groups_csv(atoi(agent_id),
+                                 group,
+                                 WDB_GROUP_MODE_OVERRIDE_ALL,
+                                 w_is_worker() ? "syncreq" : "synced",
+                                 WDB_GROUP_SOURCE_REMOTE,
+                                 NULL);
     } else if (get_agent_group(atoi(agent_id), group, OS_SIZE_65536, wdb_sock) < 0) {
         group[0] = '\0';
     }
@@ -1075,10 +1080,15 @@ STATIC int lookfor_agent_group(const char *agent_id, char *msg, char **r_group, 
         /* Unlock mutex */
         w_mutex_unlock(&files_mutex);
 
-        wdb_update_agent_group(atoi(agent_id), group, NULL);
+        wdb_set_agent_groups_csv(atoi(agent_id),
+                                 group,
+                                 WDB_GROUP_MODE_EMPTY_ONLY,
+                                 w_is_worker() ? "syncreq" : "synced",
+                                 WDB_GROUP_SOURCE_MANUAL,
+                                 NULL);
+
         os_strdup(group, *r_group);
         ret = OS_SUCCESS;
-        mdebug2("Group assigned: '%s'", group);
         break;
     }
 

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -73,6 +73,12 @@ typedef enum wdb_groups_set_mode_t {
         WDB_GROUP_INVALID_MODE  ///< Invalid mode
 } wdb_groups_set_mode_t;
 
+#define WDB_GROUP_SOURCE_MANUAL "manual"
+#define WDB_GROUP_SOURCE_REMOTE "remote"
+#define WDB_GROUP_MODE_EMPTY_ONLY "empty_only"
+#define WDB_GROUP_MODE_OVERRIDE "override"
+#define WDB_GROUP_MODE_OVERRIDE_ALL "override_all"
+
 #define WDB_GROUP_HASH_SIZE        8 /* Size of the groups hash */
 
 #define WDB_BLOCK_SEND_TIMEOUT_S   1 /* Max time in seconds waiting for the client to receive the information sent with a blocking method*/

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -78,6 +78,7 @@ typedef enum wdb_groups_set_mode_t {
 #define WDB_GROUP_MODE_EMPTY_ONLY "empty_only"
 #define WDB_GROUP_MODE_OVERRIDE "override"
 #define WDB_GROUP_MODE_OVERRIDE_ALL "override_all"
+#define WDB_GROUP_MODE_APPEND "append"
 
 #define WDB_GROUP_HASH_SIZE        8 /* Size of the groups hash */
 


### PR DESCRIPTION
|Related issue|
|---|
|#11446|

## Description

This PR makes the changes required to use the new set group implementation as part of #11006. The call is performed during.
- Shared download configuration.
- Remoted guess logic.
- Agent registration (Authd).

## Dod

Scan-build report.
![image](https://user-images.githubusercontent.com/13010397/147965453-74743646-6500-433a-bf08-5b537210fab6.png)

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report