### PR TITLE
Fix fimdb sync initialization

### DIFF
--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -92,14 +92,9 @@ void fim_sync_check_eps() {
 }
 
 // Send a state synchronization message
-void fim_send_sync_state(const char *location, cJSON * msg) {
-    char *plain = dbsync_state_msg(location, msg);
-    mdebug2(FIM_DBSYNC_SEND, plain);
-
-    fim_send_msg(DBSYNC_MQ, location, plain);
-
-    os_free(plain);
-
+void fim_send_sync_state(const char *location, const char* msg) {
+    mdebug2(FIM_DBSYNC_SEND, msg);
+    fim_send_msg(DBSYNC_MQ, location, msg);
     fim_sync_check_eps();
 }
 

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -78,11 +78,11 @@ void read_internal(int debug_level)
 void fim_initialize() {
     // Create store data
 #ifndef WIN32
-    fim_db_init(syscheck.database_store, syscheck.sync_interval, syscheck.file_limit, NULL,
-                loggingFunction);
+    fim_db_init(syscheck.database_store, syscheck.sync_interval, syscheck.file_limit,
+                fim_send_sync_state, loggingFunction);
 #else
     fim_db_init(syscheck.database_store, syscheck.sync_interval, syscheck.file_limit,
-                syscheck.reg_entry_limit, NULL, loggingFunction);
+                syscheck.reg_entry_limit, fim_send_sync_state, loggingFunction);
 #endif
 
     w_rwlock_init(&syscheck.directories_lock, NULL);

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -950,7 +950,7 @@ int fim_generate_delete_event(const char *file_path,
  * @param location Name of the component
  * @param msg Synchronization data for the message
  */
-void fim_send_sync_state(const char *location, cJSON * msg);
+void fim_send_sync_state(const char *location, const char* msg);
 
 /**
  * @brief Send a control synchronization message


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/11518|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR takes care of fixing the fim_send_sync_state function, so that it can receive the synchronization message in char* format, so that it can be processed and sent by rsync. It also adds the pointer of this same function in the initialization of fimdb, which uses it as callback.

## Test
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report