### PR TITLE
Added GCP CloudSQL rules

### DIFF
--- a/ruleset/rules/0690-gcp_rules.xml
+++ b/ruleset/rules/0690-gcp_rules.xml
@@ -626,5 +626,55 @@ ID: 65000 - 65499
         <field name="gcp.bucket" type="pcre2">^(?!^$).+$</field>
         <description>GCP VPC Storage event</description>
     </rule>
+  
+    <!-- GCP Cloud SQL rules-->
+    <rule id="65080" level="0">
+        <if_group>gcp</if_group>
+        <field name="gcp.resource.type">^cloudsql_database$</field>
+        <description>GCP Cloud SQL event on project $(gcp.resource.labels.project_id)</description>
+        <options>no_full_log</options>
+    </rule>
+
+    <rule id="65081" level="2">
+        <if_sid>65080</if_sid>
+        <field name="gcp.severity">^INFO$</field>
+        <description>GCP Cloud SQL info event with source user $(gcp.protoPayload.request.privUser) on project $(gcp.resource.labels.project_id)</description>
+        <options>no_full_log</options>
+    </rule>
+
+    <rule id="65082" level="5">
+        <if_sid>65080</if_sid>
+        <field name="gcp.severity">^WARNING$</field>
+        <description>GCP Cloud SQL warning event with source user $(gcp.protoPayload.request.privUser) on project $(gcp.resource.labels.project_id)</description>
+        <options>no_full_log</options>
+    </rule>
+
+    <rule id="65083" level="3">
+        <if_sid>65080</if_sid>
+        <field name="gcp.severity">^NOTICE$</field>
+        <description>GCP Cloud SQL notice event with source user $(gcp.protoPayload.request.privUser) on project $(gcp.resource.labels.project_id)</description>
+        <options>no_full_log</options>
+    </rule>
+
+    <rule id="65084" level="7">
+        <if_sid>65080</if_sid>
+        <field name="gcp.severity">^ERROR$</field>
+        <description>GCP Cloud SQL error event with source user $(gcp.protoPayload.request.privUser) on project $(gcp.resource.labels.project_id)</description>
+        <options>no_full_log</options>
+    </rule>
+
+    <rule id="65085" level="9">
+        <if_sid>65080</if_sid>
+        <field name="gcp.severity">^CRITICAL$</field>
+        <description>GCP Cloud SQL critical event with source user $(gcp.protoPayload.request.privUser) on project $(gcp.resource.labels.project_id)</description>
+        <options>no_full_log</options>
+    </rule>
+
+    <rule id="65090" level="10">
+        <if_sid>65080</if_sid>
+        <field name="gcp.protoPayload.methodName">^cloudsql.databases.delete$</field>
+        <description>GCP Cloud SQL delete event on the resource $(gcp.protoPayload.resourceName)</description>
+        <options>no_full_log</options>
+    </rule>
 
 </group>


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/10779 |



## Description
These are general rules for the Cloud SQL Service, they match with the `gcp` group and with the resource type.

## Configuration options
The configuration needed for this to take place is stated on these documents from the vendor:
- [Configuring database flags  |  Cloud SQL for MySQL  |  Google Cloud](https://cloud.google.com/sql/docs/mysql/flags)
- [Configure Data Access audit logs  |  Cloud Logging  |  Google Cloud](https://cloud.google.com/logging/docs/audit/configure-data-access)

## Logs/Alerts example
```
{"integration": "gcp", "gcp": {"insertId":"2#932916862913#3862201339289823758#cloudsql_mysql_audit#1640356113610293579#000000000004f0c6-0-0@a1","labels":{"LOG_BUCKET_NUM":"73"},"logName":"projects/wazuh-dev-258815/logs/cloudaudit.googleapis.com%2Fdata_access","protoPayload":{"@type":"type.googleapis.com/google.cloud.audit.AuditLog","methodName":"cloudsql.instances.query","request":{"@type":"type.googleapis.com/google.cloud.sql.audit.v1.MysqlAuditEntry","cmd":"insert","date":"2021-12-28T12:41:44.213514Z","host":"localhost","msgType":"activity","objects":[{"db":"mysql","name":"audit_log_supported_ops","objType":"TABLE"}],"privUser":"root","query":"INSERT INTO mysql.audit_log_supported_ops(op_name) VALUES\\n\\t\\t('dql'),\\n\\t\\t('dml'),\\n\\t\\t('ddl'),\\n\\t\\t('dcl'),\\n\\t\\t('show'),\\n\\t\\t('call'),\\n\\t\\t('create_udf'),\\n\\t\\t('drop_function'),\\n\\t\\t('create_procedure'),\\n\\t\\t('create_function'),\\n\\t\\t('drop_procedure'),\\n\\t\\t('alter_procedure'),\\n\\t\\t('alter_function'),\\n\\t\\t('create_trigger'),\\n\\t\\t('drop_trigger'),\\n\\t\\t('create_event'),\\n\\t\\t('alter_event'),\\n\\t\\t('drop_event'),\\n\\t\\t('create_db'),\\n\\t\\t('drop_db'),\\n\\t\\t('alter_db'),\\n\\t\\t('create_user'),\\n\\t\\t('drop_user'),\\n\\t\\t('rename_user'),\\n\\t\\t('alter_user'),\\n\\t\\t('create_table'),\\n\\t\\t('create_index'),\\n\\t\\t('alter_table'),\\n\\t\\t('drop_table'),\\n\\t\\t('drop_index'),\\n\\t\\t('create_view'),\\n\\t\\t('drop_view'),\\n\\t\\t('rename_table'),\\n\\t\\t('update'),\\n\\t\\t('insert'),\\n\\t\\t('insert_select'),\\n\\t\\t('delete'),\\n\\t\\t('truncate'),\\n\\t\\t('replace'),\\n\\t\\t('replace_select'),\\n\\t\\t('delete_multi'),\\n\\t\\t('update_multi'),\\n\\t\\t('load'),\\n\\t\\t('select'),\\n\\t\\t('call_procedure'),\\n\\t\\t('connect'),\\n\\t\\t('disconnect'),\\n\\t\\t('grant'),\\n\\t\\t('revoke'),\\n\\t\\t('revoke_all'),\\n\\t\\t('show_triggers'),\\n\\t\\t('show_create_proc'),\\n\\t\\t('show_create_func'),\\n\\t\\t('show_procedure_code'),\\n\\t\\t('show_function_code'),\\n\\t\\t('show_create_event'),\\n\\t\\t('show_events'),\\n\\t\\t('show_create_trigger'),\\n\\t\\t('show_grants'),\\n\\t\\t('show_binlog_events'),\\n\\t\\t('show_relaylog_events')\\n\\t\\tON DUPLICATE KEY UPDATE op_name = op_name","queryId":"655843","status":"successful","threadId":"284072","user":"root"},"resourceName":"instances/operations","serviceName":"cloudsql.googleapis.com"},"receiveTimestamp":"2021-12-28T12:41:46.314461632Z","resource":{"labels":{"database_id":"wazuh-dev-258815:operations","project_id":"wazuh-dev-258815","region":"us-central"},"type":"cloudsql_database"},"severity":"INFO","timestamp":"2021-12-28T12:41:44.213514Z"}}
```

## Tests
```
**Phase 1: Completed pre-decoding.

**Phase 2: Completed decoding.
	name: 'json'
	gcp.insertId: '2#932916862913#3862201339289823758#cloudsql_mysql_audit#1640356113610293579#000000000004f0c6-0-0@a1'
	gcp.labels.LOG_BUCKET_NUM: '73'
	gcp.logName: 'projects/wazuh-dev-258815/logs/cloudaudit.googleapis.com%2Fdata_access'
	gcp.protoPayload.@type: 'type.googleapis.com/google.cloud.audit.AuditLog'
	gcp.protoPayload.methodName: 'cloudsql.instances.query'
	gcp.protoPayload.request.@type: 'type.googleapis.com/google.cloud.sql.audit.v1.MysqlAuditEntry'
	gcp.protoPayload.request.cmd: 'insert'
	gcp.protoPayload.request.date: '2021-12-28T12:41:44.213514Z'
	gcp.protoPayload.request.host: 'localhost'
	gcp.protoPayload.request.msgType: 'activity'
	gcp.protoPayload.request.objects: '[{'db': 'mysql', 'name': 'audit_log_supported_ops', 'objType': 'TABLE'}]'
	gcp.protoPayload.request.privUser: 'root'
	gcp.protoPayload.request.query: 'INSERT INTO mysql.audit_log_supported_ops(op_name) VALUES\n\t\t('dql'),\n\t\t('dml'),\n\t\t('ddl'),\n\t\t('dcl'),\n\t\t('show'),\n\t\t('call'),\n\t\t('create_udf'),\n\t\t('drop_function'),\n\t\t('create_procedure'),\n\t\t('create_function'),\n\t\t('drop_procedure'),\n\t\t('alter_procedure'),\n\t\t('alter_function'),\n\t\t('create_trigger'),\n\t\t('drop_trigger'),\n\t\t('create_event'),\n\t\t('alter_event'),\n\t\t('drop_event'),\n\t\t('create_db'),\n\t\t('drop_db'),\n\t\t('alter_db'),\n\t\t('create_user'),\n\t\t('drop_user'),\n\t\t('rename_user'),\n\t\t('alter_user'),\n\t\t('create_table'),\n\t\t('create_index'),\n\t\t('alter_table'),\n\t\t('drop_table'),\n\t\t('drop_index'),\n\t\t('create_view'),\n\t\t('drop_view'),\n\t\t('rename_table'),\n\t\t('update'),\n\t\t('insert'),\n\t\t('insert_select'),\n\t\t('delete'),\n\t\t('truncate'),\n\t\t('replace'),\n\t\t('replace_select'),\n\t\t('delete_multi'),\n\t\t('update_multi'),\n\t\t('load'),\n\t\t('select'),\n\t\t('call_procedure'),\n\t\t('connect'),\n\t\t('disconnect'),\n\t\t('grant'),\n\t\t('revoke'),\n\t\t('revoke_all'),\n\t\t('show_triggers'),\n\t\t('show_create_proc'),\n\t\t('show_create_func'),\n\t\t('show_procedure_code'),\n\t\t('show_function_code'),\n\t\t('show_create_event'),\n\t\t('show_events'),\n\t\t('show_create_trigger'),\n\t\t('show_grants'),\n\t\t('show_binlog_events'),\n\t\t('show_relaylog_events')\n\t\tON DUPLICATE KEY UPDATE op_name = op_name'
	gcp.protoPayload.request.queryId: '655843'
	gcp.protoPayload.request.status: 'successful'
	gcp.protoPayload.request.threadId: '284072'
	gcp.protoPayload.request.user: 'root'
	gcp.protoPayload.resourceName: 'instances/operations'
	gcp.protoPayload.serviceName: 'cloudsql.googleapis.com'
	gcp.receiveTimestamp: '2021-12-28T12:41:46.314461632Z'
	gcp.resource.labels.database_id: 'wazuh-dev-258815:operations'
	gcp.resource.labels.project_id: 'wazuh-dev-258815'
	gcp.resource.labels.region: 'us-central'
	gcp.resource.type: 'cloudsql_database'
	gcp.severity: 'INFO'
	gcp.timestamp: '2021-12-28T12:41:44.213514Z'
	integration: 'gcp'

**Phase 3: Completed filtering (rules).
	id: '65081'
	level: '2'
	description: 'GCP Cloud SQL info event with source user root on project wazuh-dev-258815'
	groups: '['gcp-cloud-sql']'
	firedtimes: '1'
	mail: 'False'
```

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors