### PR TITLE
Fix azure defects reported by `scan-build`

### DIFF
--- a/src/config/wmodules-azure.c
+++ b/src/config/wmodules-azure.c
@@ -468,25 +468,22 @@ int wm_azure_storage_read(const OS_XML *xml, XML_NODE nodes, wm_azure_storage_t 
                 OS_ClearNode(children);
             }
 
-        // To avoid the defects reported by scan-build in the issue: https://github.com/wazuh/wazuh/issues/11568
-        // It's necessary to check that nodes[i]->content is valid
-        } else if (nodes[i]->content) {
+        } else if (nodes[i]->content != NULL && *nodes[i]->content != '\0') {
             if (!strcmp(nodes[i]->element, XML_ACCOUNT_NAME)) {
-                if (*nodes[i]->content != '\0')
-                    os_strdup(nodes[i]->content, storage->account_name);
+                os_strdup(nodes[i]->content, storage->account_name);
             } else if (!strcmp(nodes[i]->element, XML_ACCOUNT_KEY)) {
-                if (nodes[i]->content && *nodes[i]->content != '\0')
-                    os_strdup(nodes[i]->content, storage->account_key);
+                os_strdup(nodes[i]->content, storage->account_key);
             } else if (!strcmp(nodes[i]->element, XML_AUTH_PATH)) {
-                if (nodes[i]->content && *nodes[i]->content != '\0')
-                    os_strdup(nodes[i]->content, storage->auth_path);
+                os_strdup(nodes[i]->content, storage->auth_path);
             } else if (!strcmp(nodes[i]->element, XML_TAG)) {
-                if (nodes[i]->content && *nodes[i]->content != '\0')
-                    os_strdup(nodes[i]->content, storage->tag);
+                os_strdup(nodes[i]->content, storage->tag);
+            } else {
+                merror(XML_INVELEM, nodes[i]->element);
+                return OS_INVALID;
             }
 
         } else {
-            merror(XML_INVELEM, nodes[i]->element);
+            merror(XML_VALUENULL, nodes[i]->element);
             return OS_INVALID;
         }
     }

--- a/src/config/wmodules-azure.c
+++ b/src/config/wmodules-azure.c
@@ -416,18 +416,6 @@ int wm_azure_storage_read(const OS_XML *xml, XML_NODE nodes, wm_azure_storage_t 
             merror(XML_VALUENULL, nodes[i]->element);
             return OS_INVALID;
 
-        } else if (!strcmp(nodes[i]->element, XML_ACCOUNT_NAME)) {
-            if (*nodes[i]->content != '\0')
-                os_strdup(nodes[i]->content, storage->account_name);
-        } else if (!strcmp(nodes[i]->element, XML_ACCOUNT_KEY)) {
-            if (*nodes[i]->content != '\0')
-                os_strdup(nodes[i]->content, storage->account_key);
-        } else if (!strcmp(nodes[i]->element, XML_AUTH_PATH)) {
-            if (*nodes[i]->content != '\0')
-                os_strdup(nodes[i]->content, storage->auth_path);
-        } else if (!strcmp(nodes[i]->element, XML_TAG)) {
-            if (*nodes[i]->content != '\0')
-                os_strdup(nodes[i]->content, storage->tag);
         } else if (!strcmp(nodes[i]->element, XML_CONTAINER)) {
 
             if (container) {
@@ -480,6 +468,22 @@ int wm_azure_storage_read(const OS_XML *xml, XML_NODE nodes, wm_azure_storage_t 
                 OS_ClearNode(children);
             }
 
+        // To avoid the defects reported by scan-build in the issue: https://github.com/wazuh/wazuh/issues/11568
+        // It's necessary to check that nodes[i]->content is valid
+        } else if (nodes[i]->content) {
+            if (!strcmp(nodes[i]->element, XML_ACCOUNT_NAME)) {
+                if (*nodes[i]->content != '\0')
+                    os_strdup(nodes[i]->content, storage->account_name);
+            } else if (!strcmp(nodes[i]->element, XML_ACCOUNT_KEY)) {
+                if (nodes[i]->content && *nodes[i]->content != '\0')
+                    os_strdup(nodes[i]->content, storage->account_key);
+            } else if (!strcmp(nodes[i]->element, XML_AUTH_PATH)) {
+                if (nodes[i]->content && *nodes[i]->content != '\0')
+                    os_strdup(nodes[i]->content, storage->auth_path);
+            } else if (!strcmp(nodes[i]->element, XML_TAG)) {
+                if (nodes[i]->content && *nodes[i]->content != '\0')
+                    os_strdup(nodes[i]->content, storage->tag);
+            }
 
         } else {
             merror(XML_INVELEM, nodes[i]->element);


### PR DESCRIPTION
|Related issue|
|---|
|#11568|

## Description

With this PR the 4 bugs found by `scan-build` due to a _deference of null pointers_ are fixed.

In order not to change the logic of the last change in which a `<container>` with no `content` is accepted in the azure configuration. The order of the conditions has been modified, and a condition has been added to validate, where necessary, that `nodes[i]->content` does not have a `NULL` value.

## Logs/Alerts example
These are the current results after running `scan-build` with the changes applied:
```
Done building server

scan-build: Removing directory '/tmp/scan-build-2021-12-28-125314-53878-1' because it contains no reports.
scan-build: No bugs found.
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
