### PR TITLE
Improve sysinfo `ram_free` information in Linux-based OSes

### DIFF
--- a/src/config/wmodules-azure.c
+++ b/src/config/wmodules-azure.c
@@ -415,18 +415,6 @@ int wm_azure_storage_read(const OS_XML *xml, XML_NODE nodes, wm_azure_storage_t 
             merror(XML_VALUENULL, nodes[i]->element);
             return OS_INVALID;
 
-        } else if (!strcmp(nodes[i]->element, XML_ACCOUNT_NAME)) {
-            if (*nodes[i]->content != '\0')
-                os_strdup(nodes[i]->content, storage->account_name);
-        } else if (!strcmp(nodes[i]->element, XML_ACCOUNT_KEY)) {
-            if (*nodes[i]->content != '\0')
-                os_strdup(nodes[i]->content, storage->account_key);
-        } else if (!strcmp(nodes[i]->element, XML_AUTH_PATH)) {
-            if (*nodes[i]->content != '\0')
-                os_strdup(nodes[i]->content, storage->auth_path);
-        } else if (!strcmp(nodes[i]->element, XML_TAG)) {
-            if (*nodes[i]->content != '\0')
-                os_strdup(nodes[i]->content, storage->tag);
         } else if (!strcmp(nodes[i]->element, XML_CONTAINER)) {
 
             if (container) {
@@ -479,9 +467,22 @@ int wm_azure_storage_read(const OS_XML *xml, XML_NODE nodes, wm_azure_storage_t 
                 OS_ClearNode(children);
             }
 
+        } else if (nodes[i]->content != NULL && *nodes[i]->content != '\0') {
+            if (!strcmp(nodes[i]->element, XML_ACCOUNT_NAME)) {
+                os_strdup(nodes[i]->content, storage->account_name);
+            } else if (!strcmp(nodes[i]->element, XML_ACCOUNT_KEY)) {
+                os_strdup(nodes[i]->content, storage->account_key);
+            } else if (!strcmp(nodes[i]->element, XML_AUTH_PATH)) {
+                os_strdup(nodes[i]->content, storage->auth_path);
+            } else if (!strcmp(nodes[i]->element, XML_TAG)) {
+                os_strdup(nodes[i]->content, storage->tag);
+            } else {
+                merror(XML_INVELEM, nodes[i]->element);
+                return OS_INVALID;
+            }
 
         } else {
-            merror(XML_INVELEM, nodes[i]->element);
+            merror(XML_VALUENULL, nodes[i]->element);
             return OS_INVALID;
         }
     }

--- a/src/data_provider/cppcheckSuppress.txt
+++ b/src/data_provider/cppcheckSuppress.txt
@@ -1,4 +1,4 @@
-*:*src/sysInfoLinux.cpp:261
+*:*src/sysInfoLinux.cpp:266
 *:*src/packages/pkgWrapper.h:105
 *:*src/packages/packagesWindowsParserHelper.h:54
 *:*src/packages/packagesWindowsParserHelper.h:182

--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -212,9 +212,14 @@ void SysInfo::getMemory(nlohmann::json& info) const
         memTotal = std::stoull(itTotal->second);
     }
 
+    const auto& itAvailable { systemInfo.find("MemAvailable") };
     const auto& itFree { systemInfo.find("MemFree") };
 
-    if (itFree != systemInfo.end())
+    if (itAvailable != systemInfo.end())
+    {
+        memFree = std::stoull(itAvailable->second);
+    }
+    else if (itFree != systemInfo.end())
     {
         memFree = std::stoull(itFree->second);
     }


### PR DESCRIPTION
|Related issue|
|---|
|#11577|

## Description

Hi team!
This PR aims to improve `ram_free` information retrieved by sysinfo for Linux-based OSes. Since Linux 3.14, `MemAvailable` from `/proc/meminfo` is more accurate than `MemFree`.
For older kernels, `MemFree` will still be used.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors