### PR TITLE
Move RBAC db creation to `wazuh-apid` service

### DIFF
--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -23,8 +23,6 @@ def spawn_process_pool():
 def spawn_authentication_pool():
     """Import necessary basic Wazuh security modules for the authentication tasks pool and spawn child."""
     from wazuh import security  # noqa
-    from wazuh.rbac.orm import create_rbac_db
-    create_rbac_db()
     return
 
 
@@ -81,6 +79,7 @@ def start(foreground: bool, root: bool, config_file: str):
     from api.signals import modify_response_headers
     from api.uri_parser import APIUriParser
     from api.util import to_relative_path
+    from wazuh.rbac.orm import create_rbac_db
 
     # Check deprecated options. To delete after expected versions
     if 'use_only_authd' in api_conf:

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -23,6 +23,8 @@ def spawn_process_pool():
 def spawn_authentication_pool():
     """Import necessary basic Wazuh security modules for the authentication tasks pool and spawn child."""
     from wazuh import security  # noqa
+    from wazuh.rbac.orm import create_rbac_db
+    create_rbac_db()
     return
 
 
@@ -79,6 +81,7 @@ def start(foreground: bool, root: bool, config_file: str):
     from api.signals import modify_response_headers
     from api.uri_parser import APIUriParser
     from api.util import to_relative_path
+    # from wazuh.rbac.orm import create_rbac_db
 
     # Check deprecated options. To delete after expected versions
     if 'use_only_authd' in api_conf:
@@ -171,6 +174,7 @@ def start(foreground: bool, root: bool, config_file: str):
         pyDaemonModule.create_pid('wazuh-apid', pid) or register(pyDaemonModule.delete_pid, 'wazuh-apid', pid)
     else:
         print(f"Starting API in foreground")
+    create_rbac_db()
 
     # Spawn child processes with their own needed imports
     if 'thread_pool' not in common.mp_pools.get():

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -81,7 +81,6 @@ def start(foreground: bool, root: bool, config_file: str):
     from api.signals import modify_response_headers
     from api.uri_parser import APIUriParser
     from api.util import to_relative_path
-    # from wazuh.rbac.orm import create_rbac_db
 
     # Check deprecated options. To delete after expected versions
     if 'use_only_authd' in api_conf:

--- a/framework/wazuh/rbac/orm.py
+++ b/framework/wazuh/rbac/orm.py
@@ -2443,95 +2443,108 @@ class RolesRulesManager:
         self.session.close()
 
 
-# This is the actual sqlite database creation
-_Base.metadata.create_all(_engine)
-# Only if executing as root
-chown(_auth_db_file, wazuh_uid(), wazuh_gid())
-os.chmod(_auth_db_file, 0o640)
+def create_rbac_db():
+    """Create RBAC database.
 
-default_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'default')
+    Create RBAC database if it does not exist. It also includes the default
+    users, roles and policies and the relationships between them.
+    """
+    # This is the actual sqlite database creation
+    _Base.metadata.create_all(_engine)
+    # Only if executing as root
+    chown(_auth_db_file, wazuh_uid(), wazuh_gid())
+    os.chmod(_auth_db_file, 0o640)
 
-# Create default users if they don't exist yet
-with open(os.path.join(default_path, "users.yaml"), 'r') as stream:
-    default_users = yaml.safe_load(stream)
+    default_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'default')
 
-    with AuthenticationManager() as auth:
-        for d_username, payload in default_users[next(iter(default_users))].items():
-            auth.add_user(username=d_username, password=payload['password'], check_default=False)
-            auth.edit_run_as(user_id=auth.get_user(username=d_username)['id'], allow_run_as=payload['allow_run_as'])
+    # Create default users if they don't exist yet
+    with open(os.path.join(default_path, "users.yaml"), 'r') as stream:
+        default_users = yaml.safe_load(stream)
 
-# Create default roles if they don't exist yet
-with open(os.path.join(default_path, "roles.yaml"), 'r') as stream:
-    default_roles = yaml.safe_load(stream)
+        with AuthenticationManager() as auth:
+            for d_username, payload in default_users[next(iter(default_users))].items():
+                auth.add_user(username=d_username, password=payload['password'], check_default=False)
+                auth.edit_run_as(user_id=auth.get_user(username=d_username)['id'], allow_run_as=payload['allow_run_as'])
 
-    with RolesManager() as rm:
-        for d_role_name, payload in default_roles[next(iter(default_roles))].items():
-            rm.add_role(name=d_role_name, check_default=False)
+    # Create default roles if they don't exist yet
+    with open(os.path.join(default_path, "roles.yaml"), 'r') as stream:
+        default_roles = yaml.safe_load(stream)
 
-with open(os.path.join(default_path, 'rules.yaml'), 'r') as stream:
-    default_rules = yaml.safe_load(stream)
+        with RolesManager() as rm:
+            for d_role_name, payload in default_roles[next(iter(default_roles))].items():
+                rm.add_role(name=d_role_name, check_default=False)
 
-    with RulesManager() as rum:
-        for d_rule_name, payload in default_rules[next(iter(default_rules))].items():
-            rum.add_rule(name=d_rule_name, rule=payload['rule'], check_default=False)
+    with open(os.path.join(default_path, 'rules.yaml'), 'r') as stream:
+        default_rules = yaml.safe_load(stream)
 
-# Create default policies if they don't exist yet
-with open(os.path.join(default_path, "policies.yaml"), 'r') as stream:
-    default_policies = yaml.safe_load(stream)
+        with RulesManager() as rum:
+            for d_rule_name, payload in default_rules[next(iter(default_rules))].items():
+                rum.add_rule(name=d_rule_name, rule=payload['rule'], check_default=False)
 
-    with PoliciesManager() as pm:
-        for d_policy_name, payload in default_policies[next(iter(default_policies))].items():
-            for name, policy in payload['policies'].items():
-                policy_name = f'{d_policy_name}_{name}'
-                policy_result = pm.add_policy(name=policy_name, policy=policy, check_default=False)
-                # Update policy if it exists
-                if policy_result == SecurityError.ALREADY_EXIST:
-                    try:
-                        policy_id = pm.get_policy(policy_name)['id']
-                        if policy_id < max_id_reserved:
-                            pm.update_policy(policy_id=policy_id, name=policy_name, policy=policy, check_default=False)
-                        else:
-                            with RolesPoliciesManager() as rpm:
-                                linked_roles = [role.id for role in rpm.get_all_roles_from_policy(policy_id=policy_id)]
-                                new_positions = dict()
-                                for role in linked_roles:
-                                    new_positions[role] = [p.id for p in rpm.get_all_policies_from_role(role_id=role)] \
-                                        .index(policy_id)
+    # Create default policies if they don't exist yet
+    with open(os.path.join(default_path, "policies.yaml"), 'r') as stream:
+        default_policies = yaml.safe_load(stream)
 
-                                pm.delete_policy(policy_id=policy_id)
-                                pm.add_policy(name=policy_name, policy=policy, check_default=False)
-                                policy_id = pm.get_policy(policy_name)['id']
-                                for role, position in new_positions.items():
-                                    rpm.add_role_to_policy(policy_id=policy_id, role_id=role, position=position,
-                                                           force_admin=True)
+        with PoliciesManager() as pm:
+            for d_policy_name, payload in default_policies[next(iter(default_policies))].items():
+                for name, policy in payload['policies'].items():
+                    policy_name = f'{d_policy_name}_{name}'
+                    policy_result = pm.add_policy(name=policy_name, policy=policy, check_default=False)
+                    # Update policy if it exists
+                    if policy_result == SecurityError.ALREADY_EXIST:
+                        try:
+                            policy_id = pm.get_policy(policy_name)['id']
+                            if policy_id < max_id_reserved:
+                                pm.update_policy(policy_id=policy_id, name=policy_name, policy=policy,
+                                                 check_default=False)
+                            else:
+                                with RolesPoliciesManager() as rpm:
+                                    linked_roles = [role.id for role in
+                                                    rpm.get_all_roles_from_policy(policy_id=policy_id)]
+                                    new_positions = dict()
+                                    for role in linked_roles:
+                                        new_positions[role] = [
+                                            p.id for p in rpm.get_all_policies_from_role(role_id=role)
+                                        ].index(policy_id)
 
-                    except (KeyError, TypeError):
-                        pass
+                                    pm.delete_policy(policy_id=policy_id)
+                                    pm.add_policy(name=policy_name, policy=policy, check_default=False)
+                                    policy_id = pm.get_policy(policy_name)['id']
+                                    for role, position in new_positions.items():
+                                        rpm.add_role_to_policy(policy_id=policy_id, role_id=role, position=position,
+                                                               force_admin=True)
 
-# Create the relationships
-with open(os.path.join(default_path, "relationships.yaml"), 'r') as stream:
-    default_relationships = yaml.safe_load(stream)
+                        except (KeyError, TypeError):
+                            pass
 
-    # User-Roles relationships
-    with UserRolesManager() as urm:
-        for d_username, payload in default_relationships[next(iter(default_relationships))]['users'].items():
-            with AuthenticationManager() as am:
-                d_user_id = am.get_user(username=d_username)['id']
-            for d_role_name in payload['role_ids']:
-                urm.add_role_to_user(user_id=d_user_id, role_id=rm.get_role(name=d_role_name)['id'], force_admin=True)
+    # Create the relationships
+    with open(os.path.join(default_path, "relationships.yaml"), 'r') as stream:
+        default_relationships = yaml.safe_load(stream)
 
-    # Role-Policies relationships
-    with RolesPoliciesManager() as rpm:
-        for d_role_name, payload in default_relationships[next(iter(default_relationships))]['roles'].items():
-            for d_policy_name in payload['policy_ids']:
-                for sub_name in default_policies[next(iter(default_policies))][d_policy_name]['policies'].keys():
-                    rpm.add_policy_to_role(role_id=rm.get_role(name=d_role_name)['id'],
-                                           policy_id=pm.get_policy(name=f'{d_policy_name}_{sub_name}')['id'],
-                                           force_admin=True)
+        # User-Roles relationships
+        with UserRolesManager() as urm:
+            for d_username, payload in default_relationships[next(iter(default_relationships))]['users'].items():
+                with AuthenticationManager() as am:
+                    d_user_id = am.get_user(username=d_username)['id']
+                for d_role_name in payload['role_ids']:
+                    urm.add_role_to_user(user_id=d_user_id, role_id=rm.get_role(name=d_role_name)['id'],
+                                         force_admin=True)
 
-    # Role-Rules relationships
-    with RolesRulesManager() as rrum:
-        for d_role_name, payload in default_relationships[next(iter(default_relationships))]['roles'].items():
-            for d_rule_name in payload['rule_ids']:
-                rrum.add_rule_to_role(role_id=rm.get_role(name=d_role_name)['id'],
-                                      rule_id=rum.get_rule_by_name(d_rule_name)['id'], force_admin=True)
+        # Role-Policies relationships
+        with RolesPoliciesManager() as rpm:
+            for d_role_name, payload in default_relationships[next(iter(default_relationships))]['roles'].items():
+                for d_policy_name in payload['policy_ids']:
+                    for sub_name in default_policies[next(iter(default_policies))][d_policy_name]['policies'].keys():
+                        rpm.add_policy_to_role(role_id=rm.get_role(name=d_role_name)['id'],
+                                               policy_id=pm.get_policy(name=f'{d_policy_name}_{sub_name}')['id'],
+                                               force_admin=True)
+
+        # Role-Rules relationships
+        with RolesRulesManager() as rrum:
+            for d_role_name, payload in default_relationships[next(iter(default_relationships))]['roles'].items():
+                for d_rule_name in payload['rule_ids']:
+                    rrum.add_rule_to_role(role_id=rm.get_role(name=d_role_name)['id'],
+                                          rule_id=rum.get_rule_by_name(d_rule_name)['id'], force_admin=True)
+
+
+# create_rbac_db()

--- a/framework/wazuh/rbac/orm.py
+++ b/framework/wazuh/rbac/orm.py
@@ -2545,6 +2545,3 @@ def create_rbac_db():
                 for d_rule_name in payload['rule_ids']:
                     rrum.add_rule_to_role(role_id=rm.get_role(name=d_role_name)['id'],
                                           rule_id=rum.get_rule_by_name(d_rule_name)['id'], force_admin=True)
-
-
-# create_rbac_db()

--- a/framework/wazuh/rbac/tests/utils.py
+++ b/framework/wazuh/rbac/tests/utils.py
@@ -22,6 +22,7 @@ def init_db(schema, test_data_path):
                 with patch('api.constants.SECURITY_PATH', new=test_data_path):
                     import wazuh.rbac.orm as orm
                     reload(orm)
+                    orm.create_rbac_db()
     try:
         create_memory_db(schema, orm._Session(), test_data_path)
     except OperationalError:

--- a/framework/wazuh/tests/test_security.py
+++ b/framework/wazuh/tests/test_security.py
@@ -56,6 +56,7 @@ def reload_default_rbac_resources():
             with patch('shutil.chown'), patch('os.chmod'):
                 import wazuh.rbac.orm as orm
                 reload(orm)
+                orm.create_rbac_db()
                 import wazuh.rbac.decorators as decorators
                 from wazuh.tests.util import RBAC_bypasser
 
@@ -72,6 +73,7 @@ def db_setup():
                 with patch('api.constants.SECURITY_PATH', new=test_data_path):
                     import wazuh.rbac.orm as orm
                     reload(orm)
+                    orm.create_rbac_db()
                     import wazuh.rbac.decorators as decorators
                     from wazuh.tests.util import RBAC_bypasser
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes #11556 |

## Description

This PR fixes the error reported at #11556. It was related to the RBAC db being locked since two different processes (`wazuh-apid` and `wazuh-clusterd`) could try to create it at the same time. 

The reason was that, as explained at https://github.com/wazuh/wazuh/issues/11556#issuecomment-1002128602, both services import the `wazuh.rbac.orm` module, which tries to create the db when that happens. To avoid this, the logic of creating rbac.db has been moved to a function within the ORM module. As a consequence, importing the module will not be enough for the db to be created.
https://github.com/wazuh/wazuh/blob/16379dbbf6de640c4a3fe55cf8c5e88f28077d81/framework/wazuh/rbac/orm.py#L2446-L2451

Now said function is only invoked within the parent API process, before the children are created.
https://github.com/wazuh/wazuh/blob/1dbf11f55fe8397889d1ba38838140c106f68915/api/scripts/wazuh-apid.py#L176-L179

This will make neither the cluster nor other API processes try to create the db at the same time, so the error should go away (in my tests, it did). Also, the memory usage of the API processes has not changed when compared with the previous behavior.

**Before changes:**
```
wazuh      25866 21.6  0.5 643208 90380 pts/0    Sl+  08:09   0:06 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py -f
wazuh      25893  6.1  0.3 150736 61556 pts/0    S+   08:09   0:01 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py -f
wazuh      25897 13.3  0.3 298520 62044 pts/0    S+   08:09   0:04 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py -f
```

**After changes:**
```
wazuh      51130 17.7  0.5 642576 88796 pts/1    Sl+  11:39   0:04 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py -f
wazuh      51134  0.6  0.3 148396 57176 pts/1    S+   11:39   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py -f
wazuh      51137  8.5  0.3 298672 62228 pts/1    S+   11:39   0:02 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py -f

```
