### PR TITLE
Fix AWS integration's Cisco Umbrella module

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2211,6 +2211,7 @@ class CiscoUmbrella(AWSCustomBucket):
     def __init__(self, **kwargs):
         db_table_name = 'cisco_umbrella'
         AWSCustomBucket.__init__(self, db_table_name, **kwargs)
+        self.check_prefix = False
 
     def load_information_from_file(self, log_key):
         """Load data from a Cisco Umbrella log file."""


### PR DESCRIPTION
|Related issue|
|---|
|Closes #11523 |

## Description
In this PR we fix the AWS integration Cisco Umbrella buckets, which were not working after the changes introduced in #10597.

To fix the integration we only had to set the value of the `check_prefix` attribute to `False` in the `CiscoUmbrella` constructor, since this type of buckets have a folder structure that avoids having to check that the files returned by AWS have the expected prefix.

## Tests performed
To check that everything was working smoothly after the changes, we performed the following tests.

| Test | Status |
|---|---|
| Test only_logs_after | :green_circle: |
| Using path            | :green_circle: |
| Using reparse         | :green_circle: |
| Using discard_regex   | :green_circle: |
| Test iplogs   | :green_circle: |
| Test dnslogs   | :green_circle: |
| Test proxylogs   | :green_circle: |
| Test in an agent | :green_circle: |

### Test details
#### Test only_logs_after
Since the three types of Cisco Umbrella buckets use the same underlying logic, we will only need to test that the `only_logs_after` parameter for one of them.

Remove the `/var/ossec/wodles/aws/s3_cloudtrail.db` file and run the module using the following command to obtain every log from the Umbrella bucket for the given date.

##### First execution without specifying an only_logs_after value
Upload one log file to the bucket with the date of execution. Then execute the command. It should use as marker an string with the date of execution and collect the uploaded log.

Use the command:
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l 166157441623/iplogs -t cisco_umbrella -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@9fb0b9d12c89:/var/ossec/wodles/azure# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l 166157441623/iplogs -t cisco_umbrella -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Marker: 166157441623/iplogs/2021-12-24/2021-12-24-00-00-ixla.csv.gz
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-29/2021-12-29-00-00-ixla.csv.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

###### Conclusions
The module worked as expected.

##### First execution specifying an only_logs_after value set in the past
Remove the database file and run the command the using `2021-Dec-20` date as `only_logs_after`. 3 logs should be collected and sent to analysisd.

Use the command:
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l 166157441623/iplogs -t cisco_umbrella -s 2021-Dec-20 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@9fb0b9d12c89:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l 166157441623/iplogs -t cisco_umbrella -s 2021-Dec-20 -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Marker: 166157441623/iplogs/2021-12-20
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-20/2021-12-20-00-00-xoal.csv.gz
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-24/2021-12-24-00-00-ixla.csv.gz
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-29/2021-12-29-00-00-ixla.csv.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

Keep the database file and run the same command again to ensure no duplicate logs have been processed.

Use the command:
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l 166157441623/iplogs -t cisco_umbrella -s 2021-Dec-20 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@9fb0b9d12c89:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l 166157441623/iplogs -t cisco_umbrella -s 2021-Dec-20 -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Marker: 166157441623/iplogs/2021-12-29/2021-12-29-00-00-ixla.csv.gz
	DEBUG: +++ No logs to process in bucket: None/None
	DEBUG: +++ DB Maintenance

</details>

###### Conclusions
The module worked as expected.

##### Execute the command again with an only_logs_after value set earlier in the past

Run the module again, keeping the database file, using the `2021-Dec-01` date as `only_logs_after`. It should use as marker an string with the date of execution and not consider the `only_logs_after` value.

Use the command:
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l 166157441623/iplogs -t cisco_umbrella -s 2021-Dec-01 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@9fb0b9d12c89:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l 166157441623/iplogs -t cisco_umbrella -s 2021-Dec-01 -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Marker: 166157441623/iplogs/2021-12-29/2021-12-29-00-00-ixla.csv.gz
	DEBUG: +++ No logs to process in bucket: None/None
	DEBUG: +++ DB Maintenance

</details>

###### Conclusions
The module worked as expected.

##### Execute the module having a last key set and no only_logs_after value
Without removing the database, execute `sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db 'delete from cisco_umbrella where created_date in (select max(created_date) from cisco_umbrella);'`. This command will remove the more recents logs. Then execute the module without specifying an `only_logs_after` value. It should only collect the previously uploaded log.

Use the command:
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l 166157441623/iplogs -t cisco_umbrella -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@9fb0b9d12c89:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l 166157441623/iplogs -t cisco_umbrella -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Marker: 166157441623/iplogs/2021-12-24/2021-12-24-00-00-ixla.csv.gz
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-29/2021-12-29-00-00-ixla.csv.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

###### Conclusions
The module worked as expected.

##### Execute the module having an only_logs_after later than the last key
The module should only fetch the logs corresponding to the days set by the only_logs_after date onwards, and it should skip the logs in between. 1 log should be processed.
Keeping the database file, execute `sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db 'delete from cisco_umbrella where created_date not in (select min(created_date) from cisco_umbrella);'`. 

Use the command:
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l 166157441623/iplogs -t cisco_umbrella -p dev -d2 -s YYYY-MMM-DD
```
Being `YYYY-MMM-DD` the data corresponding to the date of execution.

<details>
    <summary>Command output</summary>

	root@9fb0b9d12c89:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l 166157441623/iplogs -t cisco_umbrella -p dev -d2 -s 2021-dec-29
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Marker: 166157441623/iplogs/2021-12-29
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-29/2021-12-29-00-00-ixla.csv.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

###### Conclusions
The module worked as expected.

##### Execute the module having an only_logs_after earlier than the last key
Without removing the database, execute `sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db 'delete from cisco_umbrella where created_date not in (select min(created_date) from cisco_umbrella);'`. This command will remove all the logs but the older ones. The execution of the module must result in collecting the last 3 logs, using as marker the last key.

Use the command:
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l 166157441623/iplogs -t cisco_umbrella -p dev -d2 -s 2021-Dec-01 
```

<details>
    <summary>Command output</summary>

	root@9fb0b9d12c89:/var/ossec/wodles/aws# sqlite3 ./s3_cloudtrail.db 'delete from cisco_umbrella where log_key != "166157441623/2021-12-15/2021-12-15-00-00-asge.csv.gz"'
	root@9fb0b9d12c89:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l 166157441623/iplogs -t cisco_umbrella -p dev -d2 -s 2021-Dec-01 
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Marker: 166157441623/iplogs/2021-12-15/2021-12-15-00-00-asge.csv.gz
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-20/2021-12-20-00-00-xoal.csv.gz
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-24/2021-12-24-00-00-ixla.csv.gz
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-29/2021-12-29-00-00-ixla.csv.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

###### Conclusions
After executing the sqlite query, we detected that the `created_date` field of the database wasn't being properly set. We updated #11560 with the new findings to fix that problem for the Umbrella buckets too. After modifying the SQLite query with the one that can be seen in the command output we ensured that the module collected the expected logs.

##### Conclusions of the only_logs_after tests
The module is working as expected.

#### Using path

Run the module providing a `path` value to ensure only logs present in that path are being processed.

Use the command:
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l test_prefix/166157441623/iplogs -t cisco_umbrella -s 2021-Dec-15 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@9fb0b9d12c89:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l test_prefix/166157441623/iplogs -t cisco_umbrella -s 2021-Dec-15 -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Marker: test_prefix/166157441623/iplogs/2021-12-15
	DEBUG: ++ Found new log: test_prefix/166157441623/iplogs/2021-12-15/2021-12-15-00-00-abcd.csv.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### Using reparse

Remove the `/var/ossec/wodles/aws/s3_cloudtrail.db` file and run the module using the following command to obtain every log from the Umbrella bucket for the given date.

Use the command:
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l 166157441623/iplogs -t cisco_umbrella -s 2021-Dec-20 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@9fb0b9d12c89:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l 166157441623/iplogs -t cisco_umbrella -s 2021-Dec-20 -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Marker: 166157441623/iplogs/2021-12-20
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-20/2021-12-20-00-00-xoal.csv.gz
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-24/2021-12-24-00-00-ixla.csv.gz
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-29/2021-12-29-00-00-ixla.csv.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

Run the module again, keeping the database file, using the same `only_logs_after` value and the `reparse` option. The same logs should be processed again, resulting in duplicated events.

Use the command:
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l 166157441623/iplogs -t cisco_umbrella -s 2021-Dec-20 --reparse -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@9fb0b9d12c89:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l 166157441623/iplogs -t cisco_umbrella -s 2021-Dec-20 --reparse -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Marker: 166157441623/iplogs/2021-12-20
	DEBUG: ++ File previously processed, but reparse flag set: 166157441623/iplogs/2021-12-20/2021-12-20-00-00-xoal.csv.gz
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-20/2021-12-20-00-00-xoal.csv.gz
	DEBUG: +++ File already marked complete, but reparse flag set: 166157441623/iplogs/2021-12-20/2021-12-20-00-00-xoal.csv.gz
	DEBUG: ++ File previously processed, but reparse flag set: 166157441623/iplogs/2021-12-24/2021-12-24-00-00-ixla.csv.gz
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-24/2021-12-24-00-00-ixla.csv.gz
	DEBUG: +++ File already marked complete, but reparse flag set: 166157441623/iplogs/2021-12-24/2021-12-24-00-00-ixla.csv.gz
	DEBUG: ++ File previously processed, but reparse flag set: 166157441623/iplogs/2021-12-29/2021-12-29-00-00-ixla.csv.gz
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-29/2021-12-29-00-00-ixla.csv.gz
	DEBUG: +++ File already marked complete, but reparse flag set: 166157441623/iplogs/2021-12-29/2021-12-29-00-00-ixla.csv.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### Using discard_regex
The output should show that some events are being skipped depending on the `discard-field` and `discard-regex` used.
Remove the database file and then use the command:
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l 166157441623/iplogs -t cisco_umbrella -s 2021-dec-01 --discard-field identity --discard-regex 'TheComputerName' -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@9fb0b9d12c89:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l 166157441623/iplogs -t cisco_umbrella -s 2021-dec-01 --discard-field identity --discard-regex 'TheComputerName' -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Marker: 166157441623/iplogs/2021-12-01
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-01/2021-12-01-00-00-xyzs.csv.gz
	DEBUG: +++ The "TheComputerName" regex found a match in the "identity" field. The event will be skipped.
	DEBUG: +++ The "TheComputerName" regex found a match in the "identity" field. The event will be skipped.
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-15/2021-12-15-00-00-asge.csv.gz
	DEBUG: +++ The "TheComputerName" regex found a match in the "identity" field. The event will be skipped.
	DEBUG: +++ The "TheComputerName" regex found a match in the "identity" field. The event will be skipped.
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-20/2021-12-20-00-00-xoal.csv.gz
	DEBUG: +++ The "TheComputerName" regex found a match in the "identity" field. The event will be skipped.
	DEBUG: +++ The "TheComputerName" regex found a match in the "identity" field. The event will be skipped.
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-24/2021-12-24-00-00-ixla.csv.gz
	DEBUG: +++ The "TheComputerName" regex found a match in the "identity" field. The event will be skipped.
	DEBUG: +++ The "TheComputerName" regex found a match in the "identity" field. The event will be skipped.
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-29/2021-12-29-00-00-ixla.csv.gz
	DEBUG: +++ The "TheComputerName" regex found a match in the "identity" field. The event will be skipped.
	DEBUG: +++ The "TheComputerName" regex found a match in the "identity" field. The event will be skipped.
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### Test iplogs
This command should only fetch `iplogs`.
Use the command:
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l 166157441623/iplogs -t cisco_umbrella -s 2021-Dec-20 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@9fb0b9d12c89:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l 166157441623/iplogs -t cisco_umbrella -s 2021-Dec-20 -p dev -d2

	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Marker: 166157441623/iplogs/2021-12-20
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-20/2021-12-20-00-00-xoal.csv.gz
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-24/2021-12-24-00-00-ixla.csv.gz
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-29/2021-12-29-00-00-ixla.csv.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### Test proxylogs
This command should only fetch `proxylogs`.
Use the command:
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l 166157441623/proxylogs -t cisco_umbrella -s 2021-Dec-15 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@9fb0b9d12c89:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l 166157441623/proxylogs -t cisco_umbrella -s 2021-Dec-15 -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Marker: 166157441623/proxylogs/2021-12-15
	DEBUG: ++ Found new log: 166157441623/proxylogs/2021-12-15/2021-12-15-00-00-xjia.csv.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### Test dnslogs
This command should only fetch `dnslogs`.
Use the command:
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l 166157441623/dnslogs -t cisco_umbrella -s 2021-Dec-15 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@9fb0b9d12c89:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l 166157441623/dnslogs -t cisco_umbrella -s 2021-Dec-15 -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Marker: 166157441623/dnslogs/2021-12-15
	DEBUG: ++ Found new log: 166157441623/dnslogs/2021-12-15/2021-12-15-00-00-ioxa.csv
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance
</details>

##### Conclusions
The module worked as expected.

#### Test in an agent
We will test that the module works in an agent after installing the required dependencies with the following command:
```
python3.9 /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l 166157441623/iplogs -t cisco_umbrella -s 2021-Dec-20 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@624a7f9c00e4:/var/ossec/wodles/aws# python3.9 /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l 166157441623/iplogs -t cisco_umbrella -s 2021-Dec-20 -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Marker: 166157441623/iplogs/2021-12-20
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-20/2021-12-20-00-00-xoal.csv.gz
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-24/2021-12-24-00-00-ixla.csv.gz
	DEBUG: ++ Found new log: 166157441623/iplogs/2021-12-29/2021-12-29-00-00-ixla.csv.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.
