### PR TITLE
Fix Wazuh API PID file race condition

### DIFF
--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -54,14 +54,6 @@ def start(foreground: bool, root: bool, config_file: str):
             )
             api_logger.setup_logger()
 
-    # Foreground/Daemon
-    utils.check_pid('wazuh-apid')
-    if not foreground:
-        pyDaemonModule.pyDaemon()
-    pid = os.getpid()
-    if foreground:
-        print(f"Starting API in foreground (pid: {pid})")
-
     if config_file is not None:
         configuration.api_conf.update(configuration.read_yaml_config(config_file=config_file))
     api_conf = configuration.api_conf
@@ -163,7 +155,8 @@ def start(foreground: bool, root: bool, config_file: str):
                 logger.error(msg)
                 raise exc
 
-    # Drop privileges to wazuh
+    utils.check_pid('wazuh-apid')
+    # Drop privileges to ossec
     if not root:
         if api_conf['drop_privileges']:
             os.setgid(common.wazuh_gid())
@@ -171,7 +164,13 @@ def start(foreground: bool, root: bool, config_file: str):
     else:
         print(f"Starting API as root")
 
-    pyDaemonModule.create_pid('wazuh-apid', pid) or register(pyDaemonModule.delete_pid, 'wazuh-apid', pid)
+    # Foreground/Daemon
+    if not foreground:
+        pyDaemonModule.pyDaemon()
+        pid = os.getpid()
+        pyDaemonModule.create_pid('wazuh-apid', pid) or register(pyDaemonModule.delete_pid, 'wazuh-apid', pid)
+    else:
+        print(f"Starting API in foreground")
 
     # Spawn child processes with their own needed imports
     if 'thread_pool' not in common.mp_pools.get():


### PR DESCRIPTION
|Related issue|
|---|
|#11558|

## Description

As a result of the development done in #11559 , we encountered a race condition regarding the Wazuh API PID files where no other daemon would start.

This PR fixes this bug by creating the PID file right after the process fork.

Regards,
Víctor