### PR TITLE
Fix CentOS 5 Compilation

### DIFF
--- a/src/data_provider/cppcheckSuppress.txt
+++ b/src/data_provider/cppcheckSuppress.txt
@@ -1,6 +1,6 @@
 *:*src/packages/pkgWrapper.h:105
 *:*src/packages/packagesWindowsParserHelper.h:55
-*:*src/data_provider/src/packages/packageLinuxParserRpm.cpp:29
+*:*src/data_provider/src/packages/packageLinuxParserRpm.cpp:31
 *:*src/sysInfo.cpp:14
 *:*src/sysInfo_test.cpp:96
 *:*src/sysInfoLinux.cpp:259

--- a/src/data_provider/src/packages/packageLinuxDataRetriever.h
+++ b/src/data_provider/src/packages/packageLinuxDataRetriever.h
@@ -90,11 +90,6 @@ class FactoryPackagesCreator<LinuxType::LEGACY> final
     public:
         static void getPackages(std::function<void(nlohmann::json&)> callback)
         {
-            if (Utils::existsDir(DPKG_PATH))
-            {
-                getDpkgInfo(DPKG_STATUS_PATH, callback);
-            }
-
             if (Utils::existsDir(RPM_PATH))
             {
                 getRpmInfoLegacy(callback);

--- a/src/data_provider/src/packages/packageLinuxParserDeb.cpp
+++ b/src/data_provider/src/packages/packageLinuxParserDeb.cpp
@@ -11,6 +11,7 @@
 
 #include "sharedDefs.h"
 #include "packageLinuxParserHelper.h"
+#include <fstream>
 
 void getDpkgInfo(const std::string& fileName, std::function<void(nlohmann::json&)> callback)
 {

--- a/src/data_provider/src/packages/packageLinuxParserHelper.h
+++ b/src/data_provider/src/packages/packageLinuxParserHelper.h
@@ -12,13 +12,9 @@
 #ifndef _PACKAGE_LINUX_PARSER_HELPER_H
 #define _PACKAGE_LINUX_PARSER_HELPER_H
 
-#include <fstream>
-#include "sharedDefs.h"
-#include "cmdHelper.h"
 #include "stringHelper.h"
 #include "json.hpp"
 #include "timeHelper.h"
-#include "rpmPackageManager.h"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
@@ -27,84 +23,6 @@
 // Parse helpers for standard Linux packaging systems (rpm, dpkg, ...)
 namespace PackageLinuxHelper
 {
-    static nlohmann::json parseRpm(const RpmPackageManager::Package& package)
-    {
-        nlohmann::json ret;
-        auto version { package.version };
-
-        if (package.epoch)
-        {
-            version = std::to_string(package.epoch) + ":" + version;
-        }
-
-        if (!package.release.empty())
-        {
-            version += "-" + package.release;
-        }
-
-        if (package.name.compare("gpg-pubkey") != 0 && !package.name.empty())
-        {
-            ret["name"]         = package.name;
-            ret["size"]         = package.size;
-            ret["install_time"] = package.installTime;
-            ret["groups"]       = package.group;
-            ret["version"]      = version;
-            ret["architecture"] = package.architecture;
-            ret["format"]       = "rpm";
-            ret["vendor"]       = package.vendor;
-            ret["description"]  = package.description;
-        }
-
-        return ret;
-    }
-
-    static nlohmann::json parseRpm(const std::string& packageInfo)
-    {
-        nlohmann::json ret;
-        const auto fields { Utils::split(packageInfo, '\t') };
-        constexpr auto DEFAULT_VALUE { "(none)" };
-
-        if (RPMFields::RPM_FIELDS_SIZE <= fields.size())
-        {
-            std::string name             { fields.at(RPMFields::RPM_FIELDS_NAME) };
-
-            if (name.compare("gpg-pubkey") != 0 && !name.empty())
-            {
-                std::string size         { fields.at(RPMFields::RPM_FIELDS_PACKAGE_SIZE) };
-                std::string install_time { fields.at(RPMFields::RPM_FIELDS_INSTALLTIME) };
-                std::string groups       { fields.at(RPMFields::RPM_FIELDS_GROUPS) };
-                std::string version      { fields.at(RPMFields::RPM_FIELDS_VERSION) };
-                std::string architecture { fields.at(RPMFields::RPM_FIELDS_ARCHITECTURE) };
-                std::string vendor       { fields.at(RPMFields::RPM_FIELDS_VENDOR) };
-                std::string description  { fields.at(RPMFields::RPM_FIELDS_SUMMARY) };
-
-                std::string release      { fields.at(RPMFields::RPM_FIELDS_RELEASE) };
-                std::string epoch        { fields.at(RPMFields::RPM_FIELDS_EPOCH) };
-
-                if (!epoch.empty() && epoch.compare(DEFAULT_VALUE) != 0)
-                {
-                    version = epoch + ":" + version;
-                }
-
-                if (!release.empty() && release.compare(DEFAULT_VALUE) != 0)
-                {
-                    version += "-" + release;
-                }
-
-                ret["name"]         = name;
-                ret["size"]         = size.empty() || size.compare(DEFAULT_VALUE) == 0 ? 0 : stoi(size);
-                ret["install_time"] = install_time.empty() || install_time.compare(DEFAULT_VALUE) == 0 ? "" : install_time;
-                ret["groups"]       = groups.empty() || groups.compare(DEFAULT_VALUE) == 0 ? "" : groups;
-                ret["version"]      = version.empty() || version.compare(DEFAULT_VALUE) == 0 ? "" : version;
-                ret["architecture"] = architecture.empty() || architecture.compare(DEFAULT_VALUE) == 0 ? "" : architecture;
-                ret["format"]       = "rpm";
-                ret["vendor"]       = vendor.empty() || vendor.compare(DEFAULT_VALUE) == 0 ? "" : vendor;
-                ret["description"]  = description.empty() || description.compare(DEFAULT_VALUE) == 0 ? "" : description;
-            }
-        }
-
-        return ret;
-    }
 
     static nlohmann::json parseDpkg(const std::vector<std::string>& entries)
     {

--- a/src/data_provider/src/packages/packageLinuxParserHelper.h
+++ b/src/data_provider/src/packages/packageLinuxParserHelper.h
@@ -135,4 +135,6 @@ namespace PackageLinuxHelper
 
 };
 
+#pragma GCC diagnostic pop
+
 #endif // _PACKAGE_LINUX_PARSER_HELPER_H

--- a/src/data_provider/src/packages/packageLinuxParserHelperExtra.h
+++ b/src/data_provider/src/packages/packageLinuxParserHelperExtra.h
@@ -66,4 +66,6 @@ namespace PackageLinuxHelper
 
 };
 
+#pragma GCC diagnostic pop
+
 #endif // _PACKAGE_LINUX_PARSER_HELPER_EXTRA_H

--- a/src/data_provider/src/packages/packageLinuxParserRpm.cpp
+++ b/src/data_provider/src/packages/packageLinuxParserRpm.cpp
@@ -13,8 +13,10 @@
 #include "iberkeleyDbWrapper.h"
 #include "berkeleyRpmDbHelper.h"
 #include "sharedDefs.h"
-#include "packageLinuxParserHelper.h"
+#include "packageLinuxRpmParserHelper.h"
+#include "packageLinuxRpmParserHelperLegacy.h"
 #include "filesystemHelper.h"
+#include "stringHelper.h"
 #include "rpmlib.h"
 
 void getRpmInfo(std::function<void(nlohmann::json&)> callback)

--- a/src/data_provider/src/packages/packageLinuxParserRpmLegacy.cpp
+++ b/src/data_provider/src/packages/packageLinuxParserRpmLegacy.cpp
@@ -11,7 +11,7 @@
 #include "iberkeleyDbWrapper.h"
 #include "sharedDefs.h"
 #include "berkeleyRpmDbHelper.h"
-#include "packageLinuxParserHelper.h"
+#include "packageLinuxRpmParserHelperLegacy.h"
 
 void getRpmInfoLegacy(std::function<void(nlohmann::json&)> callback)
 {

--- a/src/data_provider/src/packages/packageLinuxRpmParserHelper.h
+++ b/src/data_provider/src/packages/packageLinuxRpmParserHelper.h
@@ -1,0 +1,57 @@
+/*
+ * Wazuh SYSINFO
+ * Copyright (C) 2015-2021, Wazuh Inc.
+ * January 28, 2021.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _PACKAGE_LINUX_RPM_PARSER_HELPER_H
+#define _PACKAGE_LINUX_RPM_PARSER_HELPER_H
+
+#include "json.hpp"
+#include "rpmPackageManager.h"
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+
+
+namespace PackageLinuxHelper
+{
+    static nlohmann::json parseRpm(const RpmPackageManager::Package& package)
+    {
+        nlohmann::json ret;
+        auto version { package.version };
+
+        if (package.epoch)
+        {
+            version = std::to_string(package.epoch) + ":" + version;
+        }
+
+        if (!package.release.empty())
+        {
+            version += "-" + package.release;
+        }
+
+        if (package.name.compare("gpg-pubkey") != 0 && !package.name.empty())
+        {
+            ret["name"]         = package.name;
+            ret["size"]         = package.size;
+            ret["install_time"] = package.installTime;
+            ret["groups"]       = package.group;
+            ret["version"]      = version;
+            ret["architecture"] = package.architecture;
+            ret["format"]       = "rpm";
+            ret["vendor"]       = package.vendor;
+            ret["description"]  = package.description;
+        }
+
+        return ret;
+    }
+
+};
+
+#endif // _PACKAGE_LINUX_RPM_PARSER_HELPER_H

--- a/src/data_provider/src/packages/packageLinuxRpmParserHelper.h
+++ b/src/data_provider/src/packages/packageLinuxRpmParserHelper.h
@@ -54,4 +54,6 @@ namespace PackageLinuxHelper
 
 };
 
+#pragma GCC diagnostic pop
+
 #endif // _PACKAGE_LINUX_RPM_PARSER_HELPER_H

--- a/src/data_provider/src/packages/packageLinuxRpmParserHelperLegacy.h
+++ b/src/data_provider/src/packages/packageLinuxRpmParserHelperLegacy.h
@@ -1,0 +1,76 @@
+/*
+ * Wazuh SYSINFO
+ * Copyright (C) 2015-2021, Wazuh Inc.
+ * January 28, 2021.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _PACKAGE_LINUX_RPM_PARSER_LEGACY_HELPER_H
+#define _PACKAGE_LINUX_RPM_PARSER_LEGACY_HELPER_H
+
+#include "sharedDefs.h"
+#include "stringHelper.h"
+#include "json.hpp"
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+
+
+namespace PackageLinuxHelper
+{
+
+    static nlohmann::json parseRpm(const std::string& packageInfo)
+    {
+        nlohmann::json ret;
+        const auto fields { Utils::split(packageInfo, '\t') };
+        constexpr auto DEFAULT_VALUE { "(none)" };
+
+        if (RPMFields::RPM_FIELDS_SIZE <= fields.size())
+        {
+            std::string name             { fields.at(RPMFields::RPM_FIELDS_NAME) };
+
+            if (name.compare("gpg-pubkey") != 0 && !name.empty())
+            {
+                std::string size         { fields.at(RPMFields::RPM_FIELDS_PACKAGE_SIZE) };
+                std::string install_time { fields.at(RPMFields::RPM_FIELDS_INSTALLTIME) };
+                std::string groups       { fields.at(RPMFields::RPM_FIELDS_GROUPS) };
+                std::string version      { fields.at(RPMFields::RPM_FIELDS_VERSION) };
+                std::string architecture { fields.at(RPMFields::RPM_FIELDS_ARCHITECTURE) };
+                std::string vendor       { fields.at(RPMFields::RPM_FIELDS_VENDOR) };
+                std::string description  { fields.at(RPMFields::RPM_FIELDS_SUMMARY) };
+
+                std::string release      { fields.at(RPMFields::RPM_FIELDS_RELEASE) };
+                std::string epoch        { fields.at(RPMFields::RPM_FIELDS_EPOCH) };
+
+                if (!epoch.empty() && epoch.compare(DEFAULT_VALUE) != 0)
+                {
+                    version = epoch + ":" + version;
+                }
+
+                if (!release.empty() && release.compare(DEFAULT_VALUE) != 0)
+                {
+                    version += "-" + release;
+                }
+
+                ret["name"]         = name;
+                ret["size"]         = size.empty() || size.compare(DEFAULT_VALUE) == 0 ? 0 : stoi(size);
+                ret["install_time"] = install_time.empty() || install_time.compare(DEFAULT_VALUE) == 0 ? "" : install_time;
+                ret["groups"]       = groups.empty() || groups.compare(DEFAULT_VALUE) == 0 ? "" : groups;
+                ret["version"]      = version.empty() || version.compare(DEFAULT_VALUE) == 0 ? "" : version;
+                ret["architecture"] = architecture.empty() || architecture.compare(DEFAULT_VALUE) == 0 ? "" : architecture;
+                ret["format"]       = "rpm";
+                ret["vendor"]       = vendor.empty() || vendor.compare(DEFAULT_VALUE) == 0 ? "" : vendor;
+                ret["description"]  = description.empty() || description.compare(DEFAULT_VALUE) == 0 ? "" : description;
+            }
+        }
+
+        return ret;
+    }
+
+};
+
+#endif // _PACKAGE_LINUX_RPM_PARSER_LEGACY_HELPER_H

--- a/src/data_provider/src/packages/packageLinuxRpmParserHelperLegacy.h
+++ b/src/data_provider/src/packages/packageLinuxRpmParserHelperLegacy.h
@@ -73,4 +73,6 @@ namespace PackageLinuxHelper
 
 };
 
+#pragma GCC diagnostic pop
+
 #endif // _PACKAGE_LINUX_RPM_PARSER_LEGACY_HELPER_H

--- a/src/data_provider/tests/sysInfoPackagesLinuxHelper/sysInfoPackagesLinuxHelper_test.cpp
+++ b/src/data_provider/tests/sysInfoPackagesLinuxHelper/sysInfoPackagesLinuxHelper_test.cpp
@@ -12,6 +12,8 @@
 #include "sysInfoPackagesLinuxHelper_test.h"
 #include "packages/packageLinuxParserHelper.h"
 #include "packages/packageLinuxParserHelperExtra.h"
+#include "packages/packageLinuxRpmParserHelper.h"
+#include "packages/packageLinuxRpmParserHelperLegacy.h"
 #include "packages/rpmPackageManager.h"
 #include <alpm.h>
 #include <package.h>

--- a/src/shared_modules/utils/timeHelper.h
+++ b/src/shared_modules/utils/timeHelper.h
@@ -50,4 +50,6 @@ namespace Utils
     }
 };
 
+#pragma GCC diagnostic pop
+
 #endif // _TIME_HELPER_H


### PR DESCRIPTION
|Related issue|
|---|
| Closes #11573 |

This PR rearranges headers so we don't include librpm headers when compiling for CentOS 5.