### PR TITLE
Remove unnecessary AWS API calls when the last log processed is earlier than the `only_logs_after` value in VPCFlow and Config modules

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -1168,7 +1168,12 @@ class AWSConfigBucket(AWSLogsBucket):
                     aws_region=aws_region,
                     prefix=self.prefix))
                 # query returns an integer
-                last_date_processed = str(query_date_last_log.fetchone()[0])
+                db_date = str(query_date_last_log.fetchone()[0])
+                if self.only_logs_after:
+                    last_date_processed = db_date if datetime.strptime(db_date, '%Y%m%d') > self.only_logs_after else \
+                        datetime.strftime(self.only_logs_after, '%Y%m%d')
+                else:
+                    last_date_processed = db_date
             # if DB is empty
             except (TypeError, IndexError):
                 last_date_processed = self.only_logs_after.strftime('%Y%m%d') if self.only_logs_after \
@@ -1673,7 +1678,12 @@ class AWSVPCFlowBucket(AWSLogsBucket):
                     aws_region=aws_region,
                     flow_log_id=flow_log_id))
                 # query returns an integer
-                last_date_processed = str(query_date_last_log.fetchone()[0])
+                db_date = str(query_date_last_log.fetchone()[0])
+                if self.only_logs_after:
+                    last_date_processed = db_date if datetime.strptime(db_date, '%Y%m%d') > self.only_logs_after else \
+                        datetime.strftime(self.only_logs_after, '%Y%m%d')
+                else:
+                    last_date_processed = db_date
             # if DB is empty
             except (TypeError, IndexError) as e:
                 last_date_processed = self.only_logs_after.strftime('%Y%m%d') if self.only_logs_after \


### PR DESCRIPTION
|Related issue|
|---|
|Closes #11472 |

## Description
In this PR we reduce an unnecessary amount of calls to the AWS API that were being made by the `Config` and `VPCFlow` modules when the date of the last log processed is prior to the `only_logs_after` parameter used.

To fix that, we modified the code of the `get_date_last_log` method from the `AWSConfigBucket` and `AWSVPCFlowBucket` to consider the `only_logs_after` parameter in the following manner.
https://github.com/wazuh/wazuh/blob/b0648a11b99d964dc09ecfc744436384ed4afa53/wodles/aws/aws_s3.py#L1171-L1176

## Tests performed
All the tests performed to check that the changes are working fine passed.

### VPCFlow
Remove the `/var/ossec/wodles/aws/s3_cloudtrail.db` file and run the module using the following command to obtain every log from the VPCFlow bucket for the given date.

#### First execution without specifying an only_logs_after value
Upload one log file to the bucket with the date of execution. Then execute the command. It should use as marker an string with the date of execution and collect the uploaded log.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@ad0eb89e1411:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/31
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/31/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211231T0000Z_ce6176d8.log.gz
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### First execution specifying an only_logs_after value set in the past
Remove the database file and run the command the using `2021-NOV-09` date as `only_logs_after`. 4 logs should be collected and sent to analysisd.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -s 2021-Dec-20 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@ad0eb89e1411:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -s 2021-Dec-20 -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/20
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/22
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/23
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/23/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211223T0000Z_ce6176d8.log.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/24
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/24/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211224T0000Z_ce6176d8.log.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/25
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/26
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/27
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/28
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/29
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/30
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/30/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211230T0000Z_ce6176d8.log.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/31
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/31/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211231T0000Z_ce6176d8.log.gz
	DEBUG: +++ DB Maintenance

</details>

Keep the database file and run the same command again to ensure no duplicate logs have been processed.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -s 2021-Dec-20 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@ad0eb89e1411:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -s 2021-Dec-20 -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/31/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211231T0000Z_ce6176d8.log.gz
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1

</details>

##### Conclusions
The module worked as expected.

#### Execute the command again with an only_logs_after value set earlier in the past

Run the module again, keeping the database file, using the `2021-NOV-05` date as `only_logs_after`. It should use as marker an string with the date of execution and not consider the `only_logs_after` value.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -s 2021-NOV-05 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@ad0eb89e1411:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -s 2021-NOV-05 -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/31/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211231T0000Z_ce6176d8.log.gz
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1

</details>

##### Conclusions
The module worked as expected.

#### Execute the module having a last key set and no only_logs_after value
Without removing the database, execute `sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db 'delete from vpcflow where created_date in (select max(created_date) from vpcflow);'`. This command will remove the more recents logs. Then execute the module without specifying an `only_logs_after` value. It should only collect the previously uploaded log.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@ad0eb89e1411:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/30/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211230T0000Z_ce6176d8.log.gz
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/31
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/31/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211231T0000Z_ce6176d8.log.gz
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### Execute the module having an only_logs_after later than the last key
The module should only fetch the logs corresponding to the days set by the only_logs_after date onwards, and it should skip the logs in between. 1 log should be processed.
Keeping the database file, execute `sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db 'delete from vpcflow where created_date not in (select min(created_date) from vpcflow );'`. 

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -p dev -d2 -s YYYY-MMM-DD
```
Being `YYYY-MMM-DD` the data corresponding to the date of execution.

<details><summary>Command output</summary>

	root@ad0eb89e1411:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -p dev -d2 -s 2021-dec-31
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/31
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/31/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211231T0000Z_ce6176d8.log.gz
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### Execute the module having an only_logs_after earlier than the last key
Without removing the database, execute `sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db 'delete from vpcflow where created_date not in (select min(created_date) from vpcflow);'`. This command will remove all the logs but the older ones. The execution of the module must result in collecting 3 logs, using as marker the last key.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -p dev -d2 -s 2021-Nov-05
```

<details>
    <summary>Command output</summary>

	root@ad0eb89e1411:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -p dev -d2 -s 2021-Nov-05
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/23/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211223T0000Z_ce6176d8.log.gz
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/24
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/24/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211224T0000Z_ce6176d8.log.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/25
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/26
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/27
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/28
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/29
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/30
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/30/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211230T0000Z_ce6176d8.log.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/31
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/31/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211231T0000Z_ce6176d8.log.gz
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### Execute the module having new logs to collect
Remove the database file, then execute the module without specifying an only_logs_after, upload a new log and execute it again. The module should collect the log uploaded in the second execution using the first one collected as marker.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -p dev -d2
```

<details>
    <summary>Command output of the first execution</summary>

	root@ad0eb89e1411:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/31
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/31/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211231T0000Z_ce6176d8.log.gz
	DEBUG: +++ DB Maintenance

</details>


<details>
    <summary>Command output of the second execution</summary>

	root@ad0eb89e1411:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/31/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211231T0000Z_ce6176d8.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/31/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211231T0100Z_ce6176d8.log.gz
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

### Config

Remove the `/var/ossec/wodles/aws/s3_cloudtrail.db` file and run the module using the following command to obtain every log from the Config bucket for the given date.

#### First execution without specifying an only_logs_after value
Upload one log file to the bucket with the date of execution. Then execute the command. It should use as marker an string with the date of execution and collect the uploaded log.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@ad0eb89e1411:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211231T004303Z_20211231T025123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

Upload a new log after the last one and run the module again without specifying an `only_logs_after` value. The module should fetch and process the new log.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@ad0eb89e1411:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20211231T004303Z_20211231T025123Z_1.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20211231T034303Z_20211231T035123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### First execution specifying an only_logs_after value set in the past
Remove the database file and run the command the using `2021-Dec-01` date as `only_logs_after`. 5 logs should be collected and sent to analysisd.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -s 2021-Dec-01 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@ad0eb89e1411:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -s 2021-Dec-01 -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/1
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/2
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/3
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/4
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/5
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/6
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/7
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/8
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/9
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/9/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211209T004303Z_20211209T025123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/10
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/11
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/12
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/13
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/14
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/15
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/16
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/17
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/18
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/19
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/20
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/21
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/22
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/23
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/23/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211223T004303Z_20211223T025123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/24
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/25
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/26
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/27
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/28
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/29
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/30
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/30/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211230T004303Z_20211230T025123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20211231T004303Z_20211231T025123Z_1.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20211231T034303Z_20211231T035123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

Keep the database file and run the same command again to ensure no duplicate logs have been processed.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -s 2021-Dec-01 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@ad0eb89e1411:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -s 2021-Dec-01 -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20211231T034303Z_20211231T035123Z_1.json.gz
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### Execute the command again with an only_logs_after value set earlier in the past

Run the module again, keeping the database file, using the `2021-NOV-05` date as `only_logs_after`. It should use as marker an string with the date of execution and not consider the `only_logs_after` value.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -s 2021-NOV-05 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@ad0eb89e1411:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -s 2021-NOV-05 -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20211231T034303Z_20211231T035123Z_1.json.gz
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### Execute the module having a last key set and no only_logs_after value
Without removing the database, execute `sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db 'delete from config where created_date in (select max(created_date) from config);'`. This command will remove the more recents logs. Then execute the module without specifying an `only_logs_after` value. It should only collect the previously uploaded logs.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@ad0eb89e1411:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/30/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211230T004303Z_20211230T025123Z_1.json.gz
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20211231T004303Z_20211231T025123Z_1.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20211231T034303Z_20211231T035123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### Execute the module having an only_logs_after later than the last key
The module should only fetch the logs corresponding to the days set by the only_logs_after date onwards, and it should skip the logs in between. 2 logs should be processed.
Keeping the database file, execute `sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db 'delete from config where created_date not in (select min(created_date) from config );'`. 

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -p dev -d2 -s YYYY-MMM-DD
```
Being `YYYY-MMM-DD` the data corresponding to the date of execution.

<details><summary>Command output</summary>

	root@ad0eb89e1411:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -p dev -d2 -s 2021-dec-31
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20211231T004303Z_20211231T025123Z_1.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20211231T034303Z_20211231T035123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### Execute the module having an only_logs_after earlier than the last key
Without removing the database, execute `sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db 'delete from config where created_date not in (select min(created_date) from config);'`. This command will remove all the logs but the older ones. The execution of the module must result in collecting 4 logs, using as marker the last key.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -p dev -d2 -s 2021-Nov-05
```

<details>
    <summary>Command output</summary>

	root@ad0eb89e1411:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -p dev -d2 -s 2021-Nov-05
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/9/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211209T004303Z_20211209T025123Z_1.json.gz
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/10
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/11
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/12
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/13
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/14
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/15
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/16
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/17
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/18
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/19
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/20
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/21
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/22
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/23
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/23/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211223T004303Z_20211223T025123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/24
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/25
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/26
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/27
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/28
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/29
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/30
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/30/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211230T004303Z_20211230T025123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20211231T004303Z_20211231T025123Z_1.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20211231T034303Z_20211231T035123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

