### PR TITLE
Decode Pub/Sub messages before sending them to `analysisd`

### DIFF
--- a/wodles/gcloud/pubsub/subscriber.py
+++ b/wodles/gcloud/pubsub/subscriber.py
@@ -110,7 +110,7 @@ class WazuhGCloudSubscriber(WazuhGCloudIntegration):
 
         ack_ids = []
         for received_message in response.received_messages:
-            formatted_message = self.format_msg(received_message.message.data)
+            formatted_message = self.format_msg(received_message.message.data.decode(errors='replace'))
             self.logger.debug(f'Processing event: {formatted_message}')
             ack_ids.append(received_message.ack_id)
             self.send_msg(formatted_message)


### PR DESCRIPTION
|Related issue|
|---|
|Closes #11647 |

## Description
In this PR we fix a bug introduced in https://github.com/wazuh/wazuh/pull/9279 that made the Pub/Sub module send malformed JSON messages to `analysisd`, incurring in the following error:

```
2021/12/31 13:39:16 wazuh-analysisd[4790] json_decoder.c:390 at JSON_Decoder_Exec(): DEBUG: Decoding JSON: '{"integration": "gcp", "gcp": b''
2021/12/31 13:39:16 wazuh-analysisd[4790] json_decoder.c:395 at JSON_Decoder_Exec(): DEBUG: Malformed JSON string '{"integration": "gcp", "gcp": b'{"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 09:31:10 2021"}}'}'
```

To fix it, we only had to decode the message before formatting it.

https://github.com/wazuh/wazuh/blob/7b7c3f8383e57be7c6f1ce28fecede0222c703a3/wodles/gcloud/pubsub/subscriber.py#L113

## Tests performed
Now, after executing the module with a populated topic we can see in the `ossec.log` file that the messages are being decode by `analysisd` without any problems.

<details><summary>Execution of the Pub/Sub module</summary>

	root@ad0eb89e1411:/var/ossec/logs# /var/ossec/wodles/gcloud/gcloud -p wazuh-dev-258815 -s test_subscription -c /var/ossec/wodles/gcloud/credentials.json -T pubsub -m 10 -t 16 -l1
	gcloud_wodle - DEBUG - Setting 16 threads to pull 10 messages in total
	gcloud_wodle - DEBUG - Processing event: {"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:50 2021"}}
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:50 2021"}}'"
	gcloud_wodle - DEBUG - Processing event: {"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:52 2021"}}
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:52 2021"}}'"
	gcloud_wodle - DEBUG - Processing event: {"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:52 2021"}}
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:52 2021"}}'"
	gcloud_wodle - DEBUG - Processing event: {"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:52 2021"}}
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:52 2021"}}'"
	gcloud_wodle - DEBUG - Processing event: {"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:52 2021"}}
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:52 2021"}}'"
	gcloud_wodle - DEBUG - Processing event: {"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:52 2021"}}
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:52 2021"}}'"
	gcloud_wodle - DEBUG - Processing event: {"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:52 2021"}}
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:52 2021"}}'"
	gcloud_wodle - DEBUG - Processing event: {"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:52 2021"}}
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:52 2021"}}'"
	gcloud_wodle - DEBUG - Processing event: {"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:52 2021"}}
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:52 2021"}}'"
	gcloud_wodle - DEBUG - Processing event: {"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:52 2021"}}
	gcloud_wodle - DEBUG - Sending msg to analysisd: "b'1:Wazuh-GCloud:{"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:52 2021"}}'"
	gcloud_wodle - INFO - Received and acknowledged 10 messages
</details>


```
2021/12/31 14:25:19 wazuh-remoted[8978] state.c:59 at rem_write_state(): DEBUG: Updating state file.
2021/12/31 14:25:19 wazuh-analysisd[8784] json_decoder.c:390 at JSON_Decoder_Exec(): DEBUG: Decoding JSON: '{"integration": "gcp", "gcp": {"'
2021/12/31 14:25:19 wazuh-analysisd[8784] json_decoder.c:390 at JSON_Decoder_Exec(): DEBUG: Decoding JSON: '{"integration": "gcp", "gcp": {"'
2021/12/31 14:25:19 wazuh-analysisd[8784] json_decoder.c:390 at JSON_Decoder_Exec(): DEBUG: Decoding JSON: '{"integration": "gcp", "gcp": {"'
2021/12/31 14:25:19 wazuh-analysisd[8784] json_decoder.c:390 at JSON_Decoder_Exec(): DEBUG: Decoding JSON: '{"integration": "gcp", "gcp": {"'
2021/12/31 14:25:19 wazuh-analysisd[8784] json_decoder.c:390 at JSON_Decoder_Exec(): DEBUG: Decoding JSON: '{"integration": "gcp", "gcp": {"'
2021/12/31 14:25:19 wazuh-analysisd[8784] json_decoder.c:390 at JSON_Decoder_Exec(): DEBUG: Decoding JSON: '{"integration": "gcp", "gcp": {"'
2021/12/31 14:25:19 wazuh-analysisd[8784] json_decoder.c:390 at JSON_Decoder_Exec(): DEBUG: Decoding JSON: '{"integration": "gcp", "gcp": {"'
2021/12/31 14:25:19 wazuh-analysisd[8784] json_decoder.c:390 at JSON_Decoder_Exec(): DEBUG: Decoding JSON: '{"integration": "gcp", "gcp": {"'
2021/12/31 14:25:19 wazuh-analysisd[8784] json_decoder.c:390 at JSON_Decoder_Exec(): DEBUG: Decoding JSON: '{"integration": "gcp", "gcp": {"'
2021/12/31 14:25:19 wazuh-analysisd[8784] json_decoder.c:390 at JSON_Decoder_Exec(): DEBUG: Decoding JSON: '{"integration": "gcp", "gcp": {"'
2021/12/31 14:25:19 wazuh-remoted[8978] manager.c:677 at c_files(): DEBUG: Updating shared files sums.

```

If we enable the `logall` option in the `ossec.conf` file, we can see that the events are being properly generated by `analysisd`:

```
2021 Dec 31 14:25:19 ad0eb89e1411->Wazuh-GCloud {"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:50 2021"}}
2021 Dec 31 14:25:19 ad0eb89e1411->Wazuh-GCloud {"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:52 2021"}}
2021 Dec 31 14:25:19 ad0eb89e1411->Wazuh-GCloud {"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:52 2021"}}
2021 Dec 31 14:25:19 ad0eb89e1411->Wazuh-GCloud {"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:52 2021"}}
2021 Dec 31 14:25:19 ad0eb89e1411->Wazuh-GCloud {"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:52 2021"}}
2021 Dec 31 14:25:19 ad0eb89e1411->Wazuh-GCloud {"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:52 2021"}}
2021 Dec 31 14:25:19 ad0eb89e1411->Wazuh-GCloud {"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:52 2021"}}
2021 Dec 31 14:25:19 ad0eb89e1411->Wazuh-GCloud {"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:52 2021"}}
2021 Dec 31 14:25:19 ad0eb89e1411->Wazuh-GCloud {"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:52 2021"}}
2021 Dec 31 14:25:19 ad0eb89e1411->Wazuh-GCloud {"integration": "gcp", "gcp": {"team": "framework", "message": "Test message at Fri Dec 31 14:22:52 2021"}}
```
