### PR TITLE
Fix MacOS compilation.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -62,7 +62,7 @@ FIMDB=syscheckd/db/
 ifeq (${TARGET},winagent)
 FIMDB_LIB=${FIMDB}build/lib/libfimdb.a
 else ifeq (${uname_S},Darwin)
-FIMDB_LIB=${FIMDB}build/lib/libfimdb.a
+FIMDB_LIB=${FIMDB}build/lib/libfimdb.dylib
 else
 FIMDB_LIB=${FIMDB}build/lib/libfimdb.so
 endif

--- a/src/syscheckd/db/CMakeLists.txt
+++ b/src/syscheckd/db/CMakeLists.txt
@@ -80,7 +80,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
                            # ${CMAKE_SOURCE_DIR}/src/registry.cpp
                            ${CMAKE_SOURCE_DIR}/src/dbFileItem.cpp)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-  add_library(fimdb STATIC ${CMAKE_SOURCE_DIR}/src/db.cpp
+  add_library(fimdb SHARED ${CMAKE_SOURCE_DIR}/src/db.cpp
                            ${CMAKE_SOURCE_DIR}/src/file.cpp
                            ${CMAKE_SOURCE_DIR}/src/fimDB.cpp
                            ${CMAKE_SOURCE_DIR}/src/dbFileItem.cpp)


### PR DESCRIPTION
|Related issue|
|---|
|#11650|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR aims to fix the MacOS compilation in the branch https://github.com/wazuh/wazuh/tree/9103-replace-fim-db-dbsync

Closes #11650

## Logs/Alerts example



<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] MAC OS X
- [X] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
