### PR TITLE
Allow DBSyncTxn to not own TXN_HANDLE handle

### DIFF
--- a/src/shared_modules/dbsync/include/dbsync.hpp
+++ b/src/shared_modules/dbsync/include/dbsync.hpp
@@ -221,6 +221,7 @@ public:
 
 private:
     TXN_HANDLE m_txn;
+    bool m_shouldBeRemoved;
 };
 
 

--- a/src/shared_modules/dbsync/src/dbsync.cpp
+++ b/src/shared_modules/dbsync/src/dbsync.cpp
@@ -785,7 +785,8 @@ DBSyncTxn::DBSyncTxn(const TXN_HANDLE handle)
 
 DBSyncTxn::~DBSyncTxn()
 {
-    if (m_shouldBeRemoved) {
+    if (m_shouldBeRemoved)
+    {
         try
         {
             PipelineFactory::instance().destroy(m_txn);

--- a/src/shared_modules/dbsync/src/dbsync.cpp
+++ b/src/shared_modules/dbsync/src/dbsync.cpp
@@ -766,6 +766,7 @@ DBSyncTxn::DBSyncTxn(const DBSYNC_HANDLE   handle,
                      const unsigned int    threadNumber,
                      const unsigned int    maxQueueSize,
                      ResultCallbackData    callbackData)
+    : m_shouldBeRemoved {true}
 {
     const auto callbackWrapper
     {
@@ -779,17 +780,20 @@ DBSyncTxn::DBSyncTxn(const DBSYNC_HANDLE   handle,
 
 DBSyncTxn::DBSyncTxn(const TXN_HANDLE handle)
     : m_txn { handle }
+    , m_shouldBeRemoved {false}
 { }
 
 DBSyncTxn::~DBSyncTxn()
 {
-    try
-    {
-        PipelineFactory::instance().destroy(m_txn);
-    }
-    catch (const DbSync::dbsync_error& ex)
-    {
-        log_message(ex.what());
+    if (m_shouldBeRemoved) {
+        try
+        {
+            PipelineFactory::instance().destroy(m_txn);
+        }
+        catch (const DbSync::dbsync_error& ex)
+        {
+            log_message(ex.what());
+        }
     }
 }
 

--- a/src/shared_modules/dbsync/tests/interface/dbsync_test.cpp
+++ b/src/shared_modules/dbsync/tests/interface/dbsync_test.cpp
@@ -1816,6 +1816,40 @@ TEST_F(DBSyncTest, constructorWithHandle)
 
 }
 
+TEST_F(DBSyncTest, txnDestructorOwnsHandle)
+{
+    const auto sql{ "CREATE TABLE processes(`pid` BIGINT, `name` TEXT, PRIMARY KEY (`pid`)) WITHOUT ROWID;"};
+    const auto tables { R"({"table": "processes"})" };
+    auto handle { dbsync_create(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, sql) };
+    ResultCallbackData callback { [](ReturnTypeCallback, const nlohmann::json&) {}};
+    TXN_HANDLE txHandle = nullptr;
+    {
+        // Use the overload that creates TXN_HANDLE from within and as such, has ownership of it.
+        DBSyncTxn tx(handle, nlohmann::json::parse(tables), 1, 100, callback);
+        tx = tx.handle();
+    }
+    EXPECT_NE(dbsync_close_txn(txHandle), 0);
+}
+
+TEST_F(DBSyncTest, txnDestructorDoesNotOwnHandle)
+{
+    const auto sql{ "CREATE TABLE processes(`pid` BIGINT, `name` TEXT, PRIMARY KEY (`pid`)) WITHOUT ROWID;"};
+    const auto tables { R"({"table": "processes"})" };
+    const std::unique_ptr<DummyContext> dummyCtx { std::make_unique<DummyContext>()};
+    auto handle { dbsync_create(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, sql) };
+    const std::unique_ptr<cJSON, smartDeleterJson> jsonTables { cJSON_Parse(tables) };
+    callback_data_t callbackData { callback, dummyCtx.get() };
+    TXN_HANDLE txHandle = dbsync_create_txn(handle, jsonTables.get(), 1, 100, callbackData);
+    {
+        // Use the overload that only takes a TXN_HANDLE and sets up the destructor to NOT release the handle.
+        DBSyncTxn tx(txHandle);
+        tx = tx.handle();
+    }
+    EXPECT_EQ(dbsync_close_txn(txHandle), 0);
+
+}
+
+
 TEST_F(DBSyncTest, teardown)
 {
     EXPECT_NO_THROW(DBSync::teardown());


### PR DESCRIPTION
|Related issue|
|---|
|Closes #11443|

## Description
This PR fixes an issue in which the DbSyncTX (a C++ abstraction around DBSync's TXN_HANDLE) didn't provide a way to "release" the handle, i.e. untether it from DBSyncTx's RAII semantics.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors