### PR TITLE
Fix modulesd tags in API spec file

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -2567,11 +2567,15 @@ components:
             $ref: '#/components/schemas/LogSummary'
           wazuh-modulesd:agent-key-polling:
             $ref: '#/components/schemas/LogSummary'
+          wazuh-modulesd:agent-upgrade:
+            $ref: '#/components/schemas/LogSummary'
           wazuh-modulesd:aws-s3:
             $ref: '#/components/schemas/LogSummary'
           wazuh-modulesd:azure-logs:
             $ref: '#/components/schemas/LogSummary'
           wazuh-modulesd:ciscat:
+            $ref: '#/components/schemas/LogSummary'
+          wazuh-modulesd:control:
             $ref: '#/components/schemas/LogSummary'
           wazuh-modulesd:command:
             $ref: '#/components/schemas/LogSummary'
@@ -2588,6 +2592,8 @@ components:
           wazuh-modulesd:syscollector:
             $ref: '#/components/schemas/LogSummary'
           wazuh-modulesd:vulnerability-detector:
+            $ref: '#/components/schemas/LogSummary'
+          wazuh-modulesd:task-manager:
             $ref: '#/components/schemas/LogSummary'
 
     ConfirmationMessage:
@@ -4731,6 +4737,8 @@ components:
         - wazuh-modulesd:agent-key-polling
         - wazuh-modulesd:aws-s3
         - wazuh-modulesd:azure-logs
+        - wazuh-modulesd:agent-upgrade
+        - wazuh-modulesd:task-manager
         - wazuh-modulesd:ciscat
         - wazuh-modulesd:control
         - wazuh-modulesd:command


### PR DESCRIPTION
|Related issue|
|---|
| This PR closes #11252 |


I added `wazuh-modulesd:task-manager` and `wazuh-modulesd:agent-upgrade` as available tags for the `/manager/logs` and `/cluster/{node_id}/logs` endpoints.

Before:
```
{
  "title": "Bad Request",
  "detail": "'wazuh-modulesd:task-manager' is not one of ['wazuh-agentlessd', 'wazuh-analysisd', 'wazuh-authd', 'wazuh-csyslogd', 'wazuh-dbd', 'wazuh-execd', 'wazuh-integratord', 'wazuh-maild', 'wazuh-monitord', 'wazuh-logcollector', 'wazuh-remoted', 'wazuh-reportd', 'wazuh-rootcheck', 'wazuh-syscheckd', 'sca', 'wazuh-db', 'wazuh-modulesd', 'wazuh-modulesd:agent-key-polling', 'wazuh-modulesd:aws-s3', 'wazuh-modulesd:azure-logs', 'wazuh-modulesd:ciscat', 'wazuh-modulesd:control', 'wazuh-modulesd:command', 'wazuh-modulesd:database', 'wazuh-modulesd:docker-listener', 'wazuh-modulesd:download', 'wazuh-modulesd:oscap', 'wazuh-modulesd:osquery', 'wazuh-modulesd:syscollector', 'wazuh-modulesd:vulnerability-detector']. Failed validating 'enum' in schema: {'enum': ['wazuh-agentlessd', 'wazuh-analysisd', 'wazuh-authd', 'wazuh-csyslogd', 'wazuh-dbd', 'wazuh-execd', 'wazuh-integratord', 'wazuh-maild', 'wazuh-monitord', 'wazuh-logcollector', 'wazuh-remoted', 'wazuh-reportd', 'wazuh-rootcheck', 'wazuh-syscheckd', 'sca', 'wazuh-db', 'wazuh-modulesd', 'wazuh-modulesd:agent-key-polling', 'wazuh-modulesd:aws-s3', 'wazuh-modulesd:azure-logs', 'wazuh-modulesd:ciscat', 'wazuh-modulesd:control', 'wazuh-modulesd:command', 'wazuh-modulesd:database', 'wazuh-modulesd:docker-listener', 'wazuh-modulesd:download', 'wazuh-modulesd:oscap', 'wazuh-modulesd:osquery', 'wazuh-modulesd:syscollector', 'wazuh-modulesd:vulnerability-detector'], 'type': 'string'}. On instance: 'wazuh-modulesd:task-manager'"
}
```
After:
```
{
  "data": {
    "affected_items": [
      {
        "timestamp": "2022-01-04T19:07:50+00:00",
        "tag": "wazuh-modulesd:task-manager",
        "level": "info",
        "description": " (8200): Module Task Manager started."
      },
      {
        "timestamp": "2022-01-04T19:06:19+00:00",
        "tag": "wazuh-modulesd:task-manager",
        "level": "info",
        "description": " (8200): Module Task Manager started."
      }
    ],
    "total_affected_items": 2,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "Logs were successfully read in specified node",
  "error": 0
}
```

Plus, they were added into `WazuhLogsSummary` schema alongside `wazuh-modulesd:control`. This last one added as an additional fix.
![image](https://user-images.githubusercontent.com/84642680/148113468-2222fb03-0b1f-448f-b0cd-b5c56de817ba.png)