### PR TITLE
Fix Windows agent memory leak in FIM

### DIFF
--- a/src/syscheckd/registry/registry.c
+++ b/src/syscheckd/registry/registry.c
@@ -461,13 +461,7 @@ fim_registry_key *fim_registry_get_key_data(HKEY key_handle, const char *path, c
     if (configuration->opts & CHECK_PERM) {
         int error;
 
-        key->perm_json = cJSON_CreateObject();
-        if (key->perm_json == NULL) {
-            mwarn(FIM_CJSON_ERROR_CREATE_ITEM);
-            fim_registry_free_key(key);
-            return NULL;
-        }
-
+        key->perm_json = NULL;
         error = get_registry_permissions(key_handle, &(key->perm_json));
         if (error) {
             mdebug1(FIM_EXTRACT_PERM_FAIL, path, error);


### PR DESCRIPTION
|Related issue|
|---|
|#11708|

## Description

With this PR, we avoid the memory leak found in the stress tests that use the `syscheck` module for version `4.3`:
- `https://github.com/wazuh/wazuh/issues/11653
- `https://github.com/wazuh/wazuh/issues/11689
> For example, in the [All-except-Syscheck](https://github.com/wazuh/wazuh/issues/11675) stress test we can see that there is no such memory leak.

And commented on issue https://github.com/wazuh/wazuh/issues/11708#issuecomment-1004886921.

To do this, we eliminate the creation of the `cJSON` _object_, since the next call to that object is an assignment to another object already created and with information. So since the `cJSON key->perm_json` is only used to point to the new _object_ `acl_json` created in `get_win_permission()`, then there is no need to create the _object_ from that `cJSON`.
https://github.com/wazuh/wazuh/blob/b1288a3816e97c2a98c9646ca01787efd58980f4/src/shared/syscheck_op.c#L946

In addition, it is initialized to `NULL` so that if there is an **_error_** in the function, it does not cause a crash when trying to execute `cJSON_Delete()`.

## Configuration options

To cause the memory leak, it is only necessary to have a default `syscheck` configuration, and modify the `frequency` value with a very small value to cause repeated scans. Like the following configuration:
```xml
  <!-- File integrity monitoring -->
  <syscheck>
    <disabled>no</disabled>

    <frequency>10</frequency>

    <scan_on_start>yes</scan_on_start>

    <!-- Directories to check  (perform all possible verifications) -->
    <directories>/etc,/usr/bin,/usr/sbin</directories>
    <directories>/bin,/sbin,/boot</directories>

    <!-- Files/directories to ignore -->
    <ignore>/etc/mtab</ignore>
    <ignore>/etc/hosts.deny</ignore>
    <ignore>/etc/mail/statistics</ignore>
    <ignore>/etc/random-seed</ignore>
    <ignore>/etc/random.seed</ignore>
    <ignore>/etc/adjtime</ignore>
    <ignore>/etc/httpd/logs</ignore>
    <ignore>/etc/utmpx</ignore>
    <ignore>/etc/wtmpx</ignore>
    <ignore>/etc/cups/certs</ignore>
    <ignore>/etc/dumpdates</ignore>
    <ignore>/etc/svc/volatile</ignore>
    <ignore>/sys/kernel/security</ignore>
    <ignore>/sys/kernel/debug</ignore>

    <!-- File types to ignore -->
    <ignore type="sregex">.log$|.swp$</ignore>

    <!-- Check the file, but never compute the diff -->
    <nodiff>/etc/ssl/private.key</nodiff>

    <skip_nfs>yes</skip_nfs>
    <skip_dev>yes</skip_dev>
    <skip_proc>yes</skip_proc>
    <skip_sys>yes</skip_sys>

    <!-- Nice value for Syscheck process -->
    <process_priority>10</process_priority>

    <!-- Maximum output throughput -->
    <max_eps>100</max_eps>

    <!-- Database synchronization settings -->
    <synchronization>
      <enabled>yes</enabled>
      <interval>5m</interval>
      <response_timeout>30</response_timeout>
      <queue_size>16384</queue_size>
      <max_eps>10</max_eps>
    </synchronization>
  </syscheck>
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Windows
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade

<!-- Depending on the affected OS -->
- Memory tests for Windows
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory


- [x] Added unit tests (for new features)
- [x] Stress test for affected components
