### PR TITLE
Create global db pre and post snapshots on upgrades

### DIFF
--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -221,16 +221,15 @@ https://www.gnu.org/licenses/gpl.html\n"
 #endif // WAZUH_UNIT_TESTING
 
 /* Wazuh Database */
-#define WDB_DIR                          "var/db"
-#define WDB2_DIR                         "queue/db"
-#define WDB_GLOB_NAME                    "global"
-#define WDB_MITRE_NAME                   "mitre"
-#define WDB_PROF_NAME                    ".template.db"
-#define WDB_TASK_DIR                     "queue/tasks"
-#define WDB_TASK_NAME                    "tasks"
-#define WDB_BACKUP_FOLDER                "backup/db"
-#define WDB_GLOB_BACKUP_NAME             WDB_GLOB_NAME".db-backup"
-#define WDB_GLOB_PRE_RESTORE_BACKUP_NAME WDB_GLOB_NAME".db-pre_restore-backup"
+#define WDB_DIR                "var/db"
+#define WDB2_DIR               "queue/db"
+#define WDB_GLOB_NAME          "global"
+#define WDB_MITRE_NAME         "mitre"
+#define WDB_PROF_NAME          ".template.db"
+#define WDB_TASK_DIR           "queue/tasks"
+#define WDB_TASK_NAME          "tasks"
+#define WDB_BACKUP_FOLDER      "backup/db"
+#define WDB_GLOB_BACKUP_NAME   WDB_GLOB_NAME".db-backup"
 
 /* Diff queue */
 #define DIFF_DIR        "queue/diff"

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -450,7 +450,7 @@ void * run_backup(__attribute__((unused)) void * args) {
                         current_time = time(NULL);
                         if((current_time - last_global_backup_time) >= global_interval) {
                             wdb_t* wdb = wdb_open_global();
-                            wdb_global_create_backup(wdb, output);
+                            wdb_global_create_backup(wdb, output, NULL);
                             mdebug1("Backup creation result: %s", output);
                             last_global_backup_time = current_time;
                             wdb_leave(wdb);

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -156,7 +156,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_UPDATE_AGENT_GROUP] = "UPDATE agent SET `group` = ? WHERE id = ?;",
     [WDB_STMT_GLOBAL_UPDATE_AGENT_GROUPS_HASH] = "UPDATE agent SET group_local_hash = ? WHERE id = ?;",
     [WDB_STMT_GLOBAL_INSERT_AGENT_GROUP] = "INSERT OR IGNORE INTO `group` (name) VALUES(?);",
-    [WDB_STMT_GLOBAL_SELECT_GROUP_BELONG] = "SELECT name FROM belongs JOIN `group` ON id = id_group WHERE id_agent = ? order by belongs.rowid;",
+    [WDB_STMT_GLOBAL_SELECT_GROUP_BELONG] = "SELECT name FROM belongs JOIN `group` ON id = id_group WHERE id_agent = ? order by priority;",
     [WDB_STMT_GLOBAL_INSERT_AGENT_BELONG] = "INSERT OR REPLACE INTO belongs (id_group, id_agent, priority) VALUES(?,?,?);",
     [WDB_STMT_GLOBAL_DELETE_AGENT_BELONG] = "DELETE FROM belongs WHERE id_agent = ?;",
     [WDB_STMT_GLOBAL_DELETE_GROUP_BELONG] = "DELETE FROM belongs WHERE id_group = (SELECT id FROM 'group' WHERE name = ?);",

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -1380,10 +1380,11 @@ int wdb_parse_global_restore_backup(wdb_t** wdb, char* input, char* output);
  *
  * @param [in] wdb The global struct database.
  * @param [out] output Response of the query.
+ * @param [in] tag Adds extra information to snapshot file name, used in case of upgrades and restores.
  * @retval  0 Success: Backup created successfully.
  * @retval -1 On error: The backup creation failed.
  */
-int wdb_global_create_backup(wdb_t* wdb, char* output);
+int wdb_global_create_backup(wdb_t* wdb, char* output, const char* tag);
 
 /**
  * @brief Function to delete old backups in case the amount exceeds the max_files limit.

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -1356,16 +1356,6 @@ int wdb_parse_global_get_agents_by_connection_status(wdb_t* wdb, char* input, ch
 int wdb_parse_global_backup(wdb_t** wdb, char* input, char* output);
 
 /**
- * @brief Function to parse the global create backup.
- *
- * @param [in] wdb The global struct database.
- * @param [out] output Response of the query in JSON format.
- * @retval  0 Success: Response contains 'ok'.
- * @retval -1 On error: Response contains details of the error.
- */
-int wdb_parse_global_create_backup(wdb_t* wdb, char* output);
-
-/**
  * @brief Function to parse the global get backup.
  *
  * @param [out] output Response of the query in JSON format.

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1776,7 +1776,10 @@ int wdb_global_create_backup(wdb_t* wdb, char* output) {
         unlink(path);
         if(OS_SUCCESS == result) {
             wdb_global_remove_old_backups();
-            snprintf(output, OS_MAXSTR + 1, "ok %s", file_name);
+            cJSON* j_file_name = cJSON_CreateArray();
+            cJSON_AddItemToArray(j_file_name, cJSON_CreateString(file_name));
+            snprintf(output, OS_MAXSTR + 1, "ok %s", cJSON_PrintUnformatted(j_file_name));
+            cJSON_Delete(j_file_name);
         } else {
             snprintf(output, OS_MAXSTR + 1, "err Failed during database backup compression");
         }

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1727,6 +1727,7 @@ cJSON* wdb_global_get_agents_by_connection_status (wdb_t *wdb, int last_agent_id
 
 int wdb_global_create_backup(wdb_t* wdb, char* output) {
     char path[PATH_MAX-3] = {0};
+    char file_name[PATH_MAX] = {0};
     char path_compressed[PATH_MAX] = {0};
     char* timestamp = NULL;
     int result = OS_INVALID;
@@ -1735,6 +1736,7 @@ int wdb_global_create_backup(wdb_t* wdb, char* output) {
     wchr_replace(timestamp, ' ', '-');
     wchr_replace(timestamp, '/', '-');
     snprintf(path, PATH_MAX-3, "%s/%s-%s", WDB_BACKUP_FOLDER, WDB_GLOB_BACKUP_NAME, timestamp);
+    snprintf(file_name, PATH_MAX, "%s-%s", WDB_GLOB_BACKUP_NAME, timestamp);
     os_free(timestamp);
 
     // Commiting pending transaction to run VACUUM
@@ -1774,6 +1776,7 @@ int wdb_global_create_backup(wdb_t* wdb, char* output) {
         unlink(path);
         if(OS_SUCCESS == result) {
             wdb_global_remove_old_backups();
+            snprintf(output, OS_MAXSTR + 1, "ok %s", file_name);
         } else {
             snprintf(output, OS_MAXSTR + 1, "err Failed during database backup compression");
         }

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5739,7 +5739,7 @@ int wdb_parse_global_backup(wdb_t** wdb, char* input, char* output) {
         snprintf(output, OS_MAXSTR + 1, "err Missing backup action");
     }
     else if (strcmp(next, "create") == 0) {
-        result = wdb_global_create_backup(*wdb, output);
+        result = wdb_global_create_backup(*wdb, output, NULL);
     }
     else if (strcmp(next, "get") == 0) {
         result = wdb_parse_global_get_backup(output);
@@ -5788,13 +5788,7 @@ int wdb_parse_global_restore_backup(wdb_t** wdb, char* input, char* output) {
         char* snapshot = cJSON_GetStringValue(cJSON_GetObjectItem(j_parameters, "snapshot"));
         cJSON* j_save_pre_restore_state = cJSON_GetObjectItem(j_parameters, "save_pre_restore_state");
         bool save_pre_restore_state = cJSON_IsBool(j_save_pre_restore_state) ? (bool) j_save_pre_restore_state->valueint : false;
-        if (save_pre_restore_state && snapshot && strncmp(snapshot, WDB_GLOB_PRE_RESTORE_BACKUP_NAME, sizeof(WDB_GLOB_PRE_RESTORE_BACKUP_NAME) - 1) == 0) {
-            mdebug1("Invalid parameters combination for backup restoration.");
-            snprintf(output, OS_MAXSTR + 1, "err Invalid parameters combination for backup restoration.");
-            result = OS_INVALID;
-        } else {
-            result = wdb_global_restore_backup(wdb, snapshot, save_pre_restore_state, output);
-        }
+        result = wdb_global_restore_backup(wdb, snapshot, save_pre_restore_state, output);
     }
 
     cJSON_Delete(j_parameters);

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5739,7 +5739,7 @@ int wdb_parse_global_backup(wdb_t** wdb, char* input, char* output) {
         snprintf(output, OS_MAXSTR + 1, "err Missing backup action");
     }
     else if (strcmp(next, "create") == 0) {
-        result = wdb_parse_global_create_backup(*wdb, output);
+        result = wdb_global_create_backup(*wdb, output);
     }
     else if (strcmp(next, "get") == 0) {
         result = wdb_parse_global_get_backup(output);
@@ -5752,16 +5752,6 @@ int wdb_parse_global_backup(wdb_t** wdb, char* input, char* output) {
     }
     else {
         snprintf(output, OS_MAXSTR + 1, "err Invalid backup action: %s", next);
-    }
-
-    return result;
-}
-
-int wdb_parse_global_create_backup(wdb_t* wdb, char* output) {
-    int result = wdb_global_create_backup(wdb, output);
-
-    if (OS_SUCCESS == result) {
-        snprintf(output, OS_MAXSTR + 1, "ok");
     }
 
     return result;

--- a/src/wazuh_db/wdb_upgrade.c
+++ b/src/wazuh_db/wdb_upgrade.c
@@ -117,7 +117,7 @@ wdb_t * wdb_upgrade_global(wdb_t *wdb) {
 
     if (version < (int)(sizeof(UPDATES)/sizeof(char*))) {
         if (OS_SUCCESS == wdb_global_create_backup(wdb, output)) {
-            mdebug1("Create pre-upgrade global DB snapshot");
+            mdebug1("Create pre-upgrade global DB snapshot %s", output+3);
             post_upgrade = TRUE;
         }
     }
@@ -134,7 +134,7 @@ wdb_t * wdb_upgrade_global(wdb_t *wdb) {
 
     if (post_upgrade) {
         if (OS_SUCCESS == wdb_global_create_backup(wdb, output)) {
-            mdebug1("Create post-upgrade global DB snapshot");
+            mdebug1("Create post-upgrade global DB snapshot %s", output+3);
         }
     }
 

--- a/src/wazuh_db/wdb_upgrade.c
+++ b/src/wazuh_db/wdb_upgrade.c
@@ -120,12 +120,11 @@ wdb_t * wdb_upgrade_global(wdb_t *wdb) {
 
     if (version < updates_length) {
         post_upgrade = TRUE;
-        if (OS_SUCCESS == wdb_global_create_backup(wdb, output)) {
+        if (OS_SUCCESS == wdb_global_create_backup(wdb, output, "-pre_upgrade")) {
             wdbc_parse_result(output, &payload);
             response = cJSON_Parse(payload);
             mdebug1("Creating pre-upgrade global DB snapshot %s", cJSON_GetStringValue(cJSON_GetArrayItem(response, 0)));
             cJSON_Delete(response);
-            sleep(1);
         } else {
             mwarn("Creating pre-upgrade global DB snapshot failed");
         }
@@ -142,7 +141,7 @@ wdb_t * wdb_upgrade_global(wdb_t *wdb) {
     }
 
     if (post_upgrade) {
-        if (OS_SUCCESS == wdb_global_create_backup(wdb, output)) {
+        if (OS_SUCCESS == wdb_global_create_backup(wdb, output, "-post_upgrade")) {
             wdbc_parse_result(output, &payload);
             response = cJSON_Parse(payload);
             mdebug1("Creating post-upgrade global DB snapshot %s", cJSON_GetStringValue(cJSON_GetArrayItem(response, 0)));

--- a/src/wazuh_db/wdb_upgrade.c
+++ b/src/wazuh_db/wdb_upgrade.c
@@ -115,17 +115,10 @@ wdb_t * wdb_upgrade_global(wdb_t *wdb) {
     }
 
     char output[OS_MAXSTR + 1] = {0};
-    cJSON* response = NULL;
-    char* payload = NULL;
 
     if (version < updates_length) {
         post_upgrade = TRUE;
-        if (OS_SUCCESS == wdb_global_create_backup(wdb, output, "-pre_upgrade")) {
-            wdbc_parse_result(output, &payload);
-            response = cJSON_Parse(payload);
-            mdebug1("Creating pre-upgrade global DB snapshot %s", cJSON_GetStringValue(cJSON_GetArrayItem(response, 0)));
-            cJSON_Delete(response);
-        } else {
+        if (OS_SUCCESS != wdb_global_create_backup(wdb, output, "-pre_upgrade")) {
             mwarn("Creating pre-upgrade global DB snapshot failed");
         }
     }
@@ -141,12 +134,7 @@ wdb_t * wdb_upgrade_global(wdb_t *wdb) {
     }
 
     if (post_upgrade) {
-        if (OS_SUCCESS == wdb_global_create_backup(wdb, output, "-post_upgrade")) {
-            wdbc_parse_result(output, &payload);
-            response = cJSON_Parse(payload);
-            mdebug1("Creating post-upgrade global DB snapshot %s", cJSON_GetStringValue(cJSON_GetArrayItem(response, 0)));
-            cJSON_Delete(response);
-        } else {
+        if (OS_SUCCESS != wdb_global_create_backup(wdb, output, "-post_upgrade")) {
            mwarn("Creating post-upgrade global DB snapshot failed");
         }
     }

--- a/src/wazuh_db/wdb_upgrade.c
+++ b/src/wazuh_db/wdb_upgrade.c
@@ -88,7 +88,6 @@ wdb_t * wdb_upgrade_global(wdb_t *wdb) {
 
     char db_version[OS_SIZE_256 + 2];
     int version = 0;
-    bool post_upgrade = FALSE;
     int updates_length = (int)(sizeof(UPDATES)/sizeof(char*));
 
     switch (wdb_metadata_table_check(wdb,"metadata")) {
@@ -117,25 +116,26 @@ wdb_t * wdb_upgrade_global(wdb_t *wdb) {
     char output[OS_MAXSTR + 1] = {0};
 
     if (version < updates_length) {
-        post_upgrade = TRUE;
         if (OS_SUCCESS != wdb_global_create_backup(wdb, output, "-pre_upgrade")) {
             mwarn("Creating pre-upgrade global DB snapshot failed");
         }
-    }
 
-    for (int i = version; i < updates_length; i++) {
-        mdebug2("Updating database '%s' to version %d", wdb->id, i + 1);
+        bool upgrade_success = TRUE;
+        for (int i = version; i < updates_length; i++) {
+            mdebug2("Updating database '%s' to version %d", wdb->id, i + 1);
 
-        if (wdb_sql_exec(wdb, UPDATES[i]) == -1 || wdb_adjust_global_upgrade(wdb, i)) {
-            mwarn("Failed to update global.db to version %d", i + 1);
-            wdb = wdb_backup_global(wdb, version);
-            break;
+            if (wdb_sql_exec(wdb, UPDATES[i]) == -1 || wdb_adjust_global_upgrade(wdb, i)) {
+                mwarn("Failed to update global.db to version %d", i + 1);
+                wdb = wdb_backup_global(wdb, version);
+                upgrade_success = FALSE;
+                break;
+            }
         }
-    }
 
-    if (post_upgrade) {
-        if (OS_SUCCESS != wdb_global_create_backup(wdb, output, "-post_upgrade")) {
-           mwarn("Creating post-upgrade global DB snapshot failed");
+        if (upgrade_success) {
+            if (OS_SUCCESS != wdb_global_create_backup(wdb, output, "-post_upgrade")) {
+                mwarn("Creating post-upgrade global DB snapshot failed");
+            }
         }
     }
 


### PR DESCRIPTION
|Related issue|
|---|
|#11728|

## Description

This PR adds the mechanism to create a pre and a post snapshot during an global DB upgrade.

## Tests

Scan-build report (Updated with https://github.com/wazuh/wazuh/pull/11746/commits/287dd162dd951ccba7bd0bef33cb4bf0e2b9e2ff)

![image](https://user-images.githubusercontent.com/13010397/149214137-393f46cb-491a-4c87-9198-9b0c2ee4d14b.png)

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Source upgrade
- [X] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report