### PR TITLE
Inserting legacy agent groups files in Wazuh-DB at startup

### DIFF
--- a/src/wazuh_db/helpers/wdb_global_helpers.h
+++ b/src/wazuh_db/helpers/wdb_global_helpers.h
@@ -293,6 +293,7 @@ int wdb_set_agent_groups_csv(int id, char* groups_csv, char* mode, char* sync_st
  * @param[in] mode The mode to request the writting.
  * @param[in] sync_status The sync_status to ask the addition (optional).
  * @param[in] source The source to ask the addition (optional).
+ * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return Returns OS_SUCCESS on success or OS_INVALID on failure.
  */
 int wdb_set_agent_groups(int id, char** groups_array, char* mode, char* sync_status, char* source, int *sock);


### PR DESCRIPTION
|Related issue|
|---|
|#11726|

## Description

This PR makes **modulesd** to look for legacy agent groups files at startup. If they are found in the `master` node, they are inserted and deleted. But in the `worker` node they are deleted directly.

Also, the **client.keys** file is also synced before this insertion to allow the groups assignment.

## Tests

The errors reported by scan-build are already solved in https://github.com/wazuh/wazuh/pull/11739

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
 