### PR TITLE
Add support for getting CPU frequency on Raspberry PI

### DIFF
--- a/src/data_provider/cppcheckSuppress.txt
+++ b/src/data_provider/cppcheckSuppress.txt
@@ -1,4 +1,6 @@
-*:*src/sysInfoLinux.cpp:266
+*:*src/sysInfoLinux.cpp:206
+*:*src/sysInfoLinux.cpp:210
+*:*src/sysInfoLinux.cpp:304
 *:*src/packages/pkgWrapper.h:105
 *:*src/packages/packagesWindowsParserHelper.h:54
 *:*src/packages/packagesWindowsParserHelper.h:182

--- a/src/data_provider/src/sharedDefs.h
+++ b/src/data_provider/src/sharedDefs.h
@@ -14,6 +14,7 @@
 
 constexpr auto WM_SYS_HW_DIR {"/sys/class/dmi/id/board_serial"};
 constexpr auto WM_SYS_CPU_DIR {"/proc/cpuinfo"};
+constexpr auto WM_SYS_CPU_FREC_DIR { "/sys/devices/system/cpu/" };
 constexpr auto WM_SYS_MEM_DIR {"/proc/meminfo"};
 constexpr auto WM_SYS_IFDATA_DIR {"/sys/class/net/"};
 constexpr auto WM_SYS_IF_FILE {"/etc/network/interfaces"};


### PR DESCRIPTION
…getting it for raspberry pi

|Related issue|
|---|
|#2488|


## Description

Hi Team

This PR aims to add support to the data provider on the way it's getting CPU frequency due to an issue when the Wazuh agent is running on Raspberry PI. The images below are the evidence that now works on Linux ( both Debian and Raspberry pi where tested)

- Debian 

![image](https://user-images.githubusercontent.com/58960358/148496675-d976bb45-5c69-4130-b7e8-4a9b9ea93ef3.png)

- Raspberry pi OS

![image](https://user-images.githubusercontent.com/58960358/148499648-69bae744-e533-4d69-81dd-ff0375353790.png)

Regards
Hanes

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors