### PR TITLE
Fix registry view statement

### DIFF
--- a/src/syscheckd/db/src/db.cpp
+++ b/src/syscheckd/db/src/db.cpp
@@ -51,6 +51,7 @@ std::string CreateStatement(const bool isWindows)
     {
         ret += CREATE_REGISTRY_KEY_DB_STATEMENT;
         ret += CREATE_REGISTRY_VALUE_DB_STATEMENT;
+        ret += CREATE_REGISTRY_VIEW_STATEMENT;
     }
     return ret;
 }

--- a/src/syscheckd/db/src/fimDB.hpp
+++ b/src/syscheckd/db/src/fimDB.hpp
@@ -95,9 +95,10 @@ constexpr auto CREATE_REGISTRY_VALUE_DB_STATEMENT
 constexpr auto CREATE_REGISTRY_VIEW_STATEMENT
 {
     R"(CREATE VIEW IF NOT EXISTS registry_view (path, checksum) AS
-       SELECT arch || ' ' || replace(replace(path, '\', '\\'), ':', '\:'), checksum FROM registry_key
+       SELECT registry_key.arch || ' ' || replace(replace(registry_key.path, '\', '\\'), ':', '\:'), checksum FROM registry_key
        UNION ALL
-       SELECT arch || ' ' || replace(replace(path, '\', '\\'), ':', '\:') || ':' || replace(replace(name, '\', '\\'), ':', '\:'), registry_data.checksum FROM registry_key INNER JOIN registry_data ON registry_key.id=registry_data.key_id;)"
+       SELECT registry_key.arch || ' ' || replace(replace(registry_key.path, '\', '\\'), ':', '\:') || ':' || replace(replace(name, '\', '\\'), ':', '\:'),
+       registry_data.checksum FROM registry_key INNER JOIN registry_data ON registry_key.path=registry_data.path AND registry_key.arch=registry_data.arch;)"
 };
 
 constexpr auto FIM_FILE_SYNC_CONFIG_STATEMENT


### PR DESCRIPTION
|Related issue|
|---|
|#11730|

## Description
 Fixed errors in registry view statement after the new changes in registry key and registry value tables.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Windows
- [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Windows
  - [ ] Scan-build report