### PR TITLE
Adding a getconfig command for Wazuh-DB

### DIFF
--- a/src/config/wazuh_db-config.c
+++ b/src/config/wazuh_db-config.c
@@ -72,18 +72,18 @@ int Read_WazuhDB_Backup(const OS_XML *xml, xml_node * node, int const BACKUP_NOD
     for (int i = 0; chld_node[i]; i++) {
         if (!chld_node[i]->element) {
             merror(XML_ELEMNULL);
-            os_free(chld_node);
+            OS_ClearNode(chld_node);
             return OS_INVALID;
         } else if (!chld_node[i]->content) {
             merror(XML_VALUENULL, chld_node[i]->element);
-            os_free(chld_node);
+            OS_ClearNode(chld_node);
             return OS_INVALID;
         } else if (!strcmp(chld_node[i]->element, xml_enabled)) {
             short tmp_bool = eval_bool(chld_node[i]->content);
 
             if (tmp_bool < 0) {
                 merror(XML_VALUEERR, chld_node[i]->element, chld_node[i]->content);
-                os_free(chld_node);
+                OS_ClearNode(chld_node);
                 return OS_INVALID;
             }
 
@@ -95,13 +95,13 @@ int Read_WazuhDB_Backup(const OS_XML *xml, xml_node * node, int const BACKUP_NOD
                 wconfig.wdb_backup_settings[BACKUP_NODE]->interval = time_value;
             } else {
                 merror(XML_VALUEERR, chld_node[i]->element, chld_node[i]->content);
-                os_free(chld_node);
+                OS_ClearNode(chld_node);
                 return OS_INVALID;
             }
         } else if (!strcmp(chld_node[i]->element, xml_max_files)) {
             if (!OS_StrIsNum(chld_node[i]->content)) {
                 merror(XML_VALUEERR, chld_node[i]->element, chld_node[i]->content);
-                os_free(chld_node);
+                OS_ClearNode(chld_node);
                 return (OS_INVALID);
             }
 
@@ -109,17 +109,17 @@ int Read_WazuhDB_Backup(const OS_XML *xml, xml_node * node, int const BACKUP_NOD
 
             if (wconfig.wdb_backup_settings[BACKUP_NODE]->max_files <= 0) {
                 merror(XML_VALUEERR, chld_node[i]->element, chld_node[i]->content);
-                os_free(chld_node);
+                OS_ClearNode(chld_node);
                 return (OS_INVALID);
             }
         } else {
             merror(XML_INVELEM, chld_node[i]->element);
-            os_free(chld_node);
+            OS_ClearNode(chld_node);
             return OS_INVALID;
         }
     }
 
-    os_free(chld_node);
+    OS_ClearNode(chld_node);
     return OS_SUCCESS;
 }
 
@@ -127,7 +127,7 @@ void wdb_init_conf() {
     os_calloc(WDB_LAST_BACKUP, sizeof(wdb_backup_settings_node*), wconfig.wdb_backup_settings);
 
     for (int i = 0; i < WDB_LAST_BACKUP; i++) {
-        os_calloc(1, sizeof(wdb_backup_settings_node*), wconfig.wdb_backup_settings[i]);
+        os_calloc(1, sizeof(wdb_backup_settings_node), wconfig.wdb_backup_settings[i]);
         wconfig.wdb_backup_settings[i]->enabled = true;
         wconfig.wdb_backup_settings[i]->interval = 86400;
         wconfig.wdb_backup_settings[i]->max_files = 3;

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -1480,3 +1480,47 @@ sqlite3_stmt* wdb_init_stmt_in_cache(wdb_t* wdb, wdb_stmt statement_index){
 
     return wdb->stmt[statement_index];
 }
+
+cJSON* wdb_get_internal_config() {
+    cJSON* wazuh_db_config = cJSON_CreateObject();
+    cJSON *root = cJSON_CreateObject();
+
+    cJSON_AddNumberToObject(wazuh_db_config, "commit_time_max", wconfig.commit_time_max);
+    cJSON_AddNumberToObject(wazuh_db_config, "commit_time_min", wconfig.commit_time_min);
+    cJSON_AddNumberToObject(wazuh_db_config, "open_db_limit", wconfig.open_db_limit);
+    cJSON_AddNumberToObject(wazuh_db_config, "sock_queue_size", wconfig.sock_queue_size);
+    cJSON_AddNumberToObject(wazuh_db_config, "worker_pool_size", wconfig.worker_pool_size);
+
+    cJSON_AddItemToObject(root, "wazuh_db", wazuh_db_config);
+
+    return root;
+}
+
+cJSON* wdb_get_config() {
+    cJSON *root = cJSON_CreateObject();
+    cJSON* wdb_config = cJSON_CreateObject();
+    cJSON* j_wdb_backup_settings_nodes = cJSON_CreateArray();
+
+    for (int i = 0; i < WDB_LAST_BACKUP; i++) {
+        cJSON* j_wdb_backup_settings_node = cJSON_CreateObject();
+
+        switch (i) {
+            case WDB_GLOBAL_BACKUP:
+                cJSON_AddStringToObject(j_wdb_backup_settings_node, "node_name", "global");
+                break;
+            default:
+                break;
+        }
+
+        cJSON_AddBoolToObject(j_wdb_backup_settings_node, "enabled", wconfig.wdb_backup_settings[i]->enabled);
+        cJSON_AddNumberToObject(j_wdb_backup_settings_node, "interval", wconfig.wdb_backup_settings[i]->interval);
+        cJSON_AddNumberToObject(j_wdb_backup_settings_node, "max_files", wconfig.wdb_backup_settings[i]->max_files);
+
+        cJSON_AddItemToArray(j_wdb_backup_settings_nodes, j_wdb_backup_settings_node);
+    }
+
+    cJSON_AddItemToObject(wdb_config, "backup_settings_nodes", j_wdb_backup_settings_nodes);
+    cJSON_AddItemToObject(root, "wdb", wdb_config);
+
+    return root;
+}

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -2368,7 +2368,7 @@ int wdb_task_get_upgrade_task_by_agent_id(wdb_t* wdb, int agent_id, char **node,
 /**
  * @brief Method to parse the "wazuhdb getconfig" commands.
  *
- * @param config_source Where the config will be read from: "internal" or "wdb"
+ * @param config_source Where the config will be read from: "internal" or "wdb" section
  * @return cJSON* Returns a cJSON object with the configuration requested or NULL on error.
  */
 cJSON* wdb_parse_get_config(char* config_source);

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -2365,4 +2365,26 @@ int wdb_task_get_upgrade_task_by_agent_id(wdb_t* wdb, int agent_id, char **node,
 // Finalize a statement securely
 #define wdb_finalize(x) { if (x) { sqlite3_finalize(x); x = NULL; } }
 
+/**
+ * @brief Method to parse the "wazuhdb getconfig" commands.
+ *
+ * @param config_source Where the config will be read from: "internal" or "wdb"
+ * @return cJSON* Returns a cJSON object with the configuration requested or NULL on error.
+ */
+cJSON* wdb_parse_get_config(char* config_source);
+
+/**
+ * @brief Method to read the internal wazuh-db configuration.
+ *
+ * @return cJSON* Returns a cJSON object with the configuration requested.
+ */
+cJSON* wdb_get_internal_config();
+
+/**
+ * @brief Method to read the wdb configuration section.
+ *
+ * @return cJSON* Returns a cJSON object with the configuration requested.
+ */
+cJSON* wdb_get_config();
+
 #endif

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -573,7 +573,17 @@ int wdb_parse(char * input, char * output, int peer) {
         }
         *next++ = '\0';
 
-        if(strcmp(query, "remove") == 0) {
+        if (strcmp(query, "getconfig") == 0) {
+            data = wdb_parse_get_config(next);
+            out = cJSON_PrintUnformatted(data);
+            cJSON_Delete(data);
+            if (out) {
+                snprintf(output, OS_MAXSTR + 1, "ok %s", out);
+                os_free(out);
+            } else {
+                snprintf(output, OS_MAXSTR + 1, "err Failed reading wazuh-db config");
+            }
+        } else if(strcmp(query, "remove") == 0) {
             data = wdb_remove_multiple_agents(next);
             out = cJSON_PrintUnformatted(data);
             snprintf(output, OS_MAXSTR + 1, "ok %s", out);
@@ -6336,4 +6346,18 @@ int wdb_parse_agents_clear_vuln_cves(wdb_t* wdb, char* output) {
         snprintf(output, OS_MAXSTR + 1, "ok");
     }
     return ret;
+}
+
+cJSON* wdb_parse_get_config(char* config_source) {
+    cJSON* j_wdb_config = NULL;
+
+    if (strcmp(config_source, "internal") == 0) {
+        j_wdb_config = wdb_get_internal_config();
+    } else if (strcmp(config_source, "wdb") == 0) {
+        j_wdb_config = wdb_get_config();
+    } else {
+        mdebug1("Invalid configuration source for wazuh-db");
+    }
+
+    return j_wdb_config;
 }


### PR DESCRIPTION
|Related issue|
|---|
|#11732|

## Description

This PR adds a new Wazuh-DB command to get the current configuration, from `internal_options` or from `ossec.conf`.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)

- [x] Configuration on demand reports new parameters
