### PR TITLE
Fix bug in fim_db_remove_path

### DIFF
--- a/src/syscheckd/db/src/file.cpp
+++ b/src/syscheckd/db/src/file.cpp
@@ -110,7 +110,8 @@ FIMDBErrorCode fim_db_remove_path(const char* path)
     {
         try
         {
-            const auto removeFileCondition { std::string("WHERE path=") + std::string(path) };
+            nlohmann::json removeFileCondition;
+            removeFileCondition["path"] = std::string(path);
             FIMDBHelper::removeFromDB<FIMDB>(FIMBD_FILE_TABLE_NAME, removeFileCondition);
             retVal = FIMDB_OK;
         }

--- a/src/syscheckd/db/src/file.cpp
+++ b/src/syscheckd/db/src/file.cpp
@@ -111,7 +111,7 @@ FIMDBErrorCode fim_db_remove_path(const char* path)
         try
         {
             nlohmann::json removeFileCondition;
-            removeFileCondition["path"] = std::string(path);
+            removeFileCondition["path"] = path;
             FIMDBHelper::removeFromDB<FIMDB>(FIMBD_FILE_TABLE_NAME, removeFileCondition);
             retVal = FIMDB_OK;
         }

--- a/src/syscheckd/db/src/fimDBHelper.hpp
+++ b/src/syscheckd/db/src/fimDBHelper.hpp
@@ -13,6 +13,7 @@
 #define _FIMDBHELPER_HPP
 #include "fimDB.hpp"
 
+
 namespace FIMDBHelper
 {
     template<typename T>
@@ -58,20 +59,17 @@ namespace FIMDBHelper
     *
     */
     template<typename T>
-    void removeFromDB(const std::string& tableName, const std::string& filter)
+    void removeFromDB(const std::string& tableName, const nlohmann::json& filter)
     {
         const auto deleteJsonStatement = R"({
                                                 "table": "",
                                                 "query": {
-                                                    "data":[
-                                                    {
-                                                    }],
-                                                    "where_filter_opt":""
                                                 }
         })";
         auto deleteJson = nlohmann::json::parse(deleteJsonStatement);
         deleteJson["table"] = tableName;
-        deleteJson["query"]["where_filter_opt"] = filter;
+        deleteJson["query"]["data"] = nlohmann::json::array({filter});
+        deleteJson["query"]["where_filter_opt"] = "";
 
         T::getInstance().removeItem(deleteJson);
     }


### PR DESCRIPTION
|EPIC|Component|
|---|---|
| https://github.com/wazuh/wazuh/issues/9103 | FIM |

### Description

The bug was found how to build the json to delete a file from database. This was fixed in current pull-request.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Unit tests passed
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] cppcheck (static code analysis)
  - [x] Coverage (unit tests coverage code)
  - [x] Sformat (code style)

Closes
#11743 