### PR TITLE
Restoring the agents database creation to the database synchronization module to avoid errors in authd

### DIFF
--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -70,9 +70,6 @@ extern struct keynode * volatile *remove_tail;
 pthread_mutex_t mutex_keys = PTHREAD_MUTEX_INITIALIZER;
 pthread_cond_t cond_pending = PTHREAD_COND_INITIALIZER;
 
-uid_t uid;
-gid_t gid;
-
 
 /* Print help statement */
 static void help_authd(char * home_path)
@@ -158,6 +155,7 @@ int main(int argc, char **argv)
     int test_config = 0;
     int status;
     int run_foreground = 0;
+    gid_t gid;
     const char *group = GROUPGLOBAL;
     char buf[4096 + 1];
 
@@ -386,9 +384,8 @@ int main(int argc, char **argv)
     }
 
     /* Check if the user/group given are valid */
-    uid = Privsep_GetUser(ROOTUSER);
     gid = Privsep_GetGroup(group);
-    if (uid == (uid_t) - 1 || gid == (gid_t) - 1) {
+    if (gid == (gid_t) - 1) {
         merror_exit(USER_ERROR, "", group, strerror(errno), errno);
     }
 
@@ -400,9 +397,6 @@ int main(int argc, char **argv)
     /* Privilege separation */
     if (Privsep_SetGroup(gid) < 0) {
         merror_exit(SETGID_ERROR, group, errno, strerror(errno));
-    }
-    if (Privsep_SetUser(uid) < 0) {
-        merror_exit(SETUID_ERROR, ROOTUSER, errno, strerror(errno));
     }
 
     /* Signal manipulation */
@@ -797,14 +791,6 @@ void* run_writer(__attribute__((unused)) void *arg) {
 
     struct timespec global_t0, global_t1;
     struct timespec t0, t1;
-
-    /* Privilege separation */
-    if (Privsep_SetGroup(gid) < 0) {
-        merror_exit(SETGID_ERROR, GROUPGLOBAL, errno, strerror(errno));
-    }
-    if (Privsep_SetUser(uid) < 0) {
-        merror_exit(SETUID_ERROR, ROOTUSER, errno, strerror(errno));
-    }
 
     while (running) {
         int inserted_agents = 0;

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -705,7 +705,6 @@ int wdb_create_profile(const char *path) {
 /* Create new database file from SQL script */
 int wdb_create_file(const char *path, const char *source) {
     const char *ROOT = "root";
-    const int ROOT_UID = 0;
     const char *sql;
     const char *tail;
     sqlite3 *db;
@@ -753,7 +752,7 @@ int wdb_create_file(const char *path, const char *source) {
         return OS_INVALID;
 
     case 0:
-        uid = ROOT_UID;
+        uid = Privsep_GetUser(ROOT);
         gid = Privsep_GetGroup(GROUPGLOBAL);
 
         if (uid == (uid_t) - 1 || gid == (gid_t) - 1) {

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -299,7 +299,16 @@ void wm_sync_agents() {
     OS_PassEmptyKeyfile();
     OS_ReadKeys(&keys, W_RAW_KEY, 0);
 
-    sync_keys_with_wdb(&keys, &wdb_wmdb_sock);
+    // The client.keys file should only be synchronized with the database in the
+    // worker nodes. In the case of the master, we should only synchronize the
+    // agents artifacts.
+    if (is_worker) {
+        sync_keys_with_wdb(&keys, &wdb_wmdb_sock);
+    }
+    else {
+        sync_keys_with_agents_db(&keys);
+        sync_agents_artifacts_dbs_with_wdb();
+    }
 
     OS_FreeKeys(&keys);
     mtdebug1(WM_DATABASE_LOGTAG, "Agents synchronization completed.");
@@ -309,7 +318,12 @@ void wm_sync_agents() {
 }
 
 /**
- * @brief Synchronizes a keystore with the agent table of global.db.
+ * @brief Synchronizes a keystore with the agent table of global.db. It will insert
+ *        the agents that are in the keystore and are not in global.db. It also
+ *        will create all the agent artifacts.
+ *        In addition it will remove from global.db in wazuh-db all the agents that
+ *        are not in the keystore. Also it will remove all the artifacts for those
+ *        agents.
  *
  * @param keys The keystore structure to be synchronized
  * @param wdb_sock The socket to be used in the calls to Wazuh DB
@@ -329,7 +343,7 @@ void sync_keys_with_wdb(keystore *keys, int *wdb_sock) {
         entry = keys->keyentries[i];
         int id;
 
-        mdebug2("Synchronizing agent %s '%s'.", entry->id, entry->name);
+        mtdebug2(WM_DATABASE_LOGTAG, "Synchronizing agent %s '%s'.", entry->id, entry->name);
 
         if (!(id = atoi(entry->id))) {
             merror("At sync_keys_with_wdb(): invalid ID number.");
@@ -343,63 +357,134 @@ void sync_keys_with_wdb(keystore *keys, int *wdb_sock) {
         if (wdb_insert_agent(id, entry->name, NULL, OS_CIDRtoStr(entry->ip, cidr, 20) ?
                              entry->ip->ip : cidr, entry->raw_key, *group ? group : NULL,1, wdb_sock)) {
             // The agent already exists, update group only.
-            mdebug2("The agent %s '%s' already exist in the database.", entry->id, entry->name);
+            mtdebug2(WM_DATABASE_LOGTAG, "The agent %s '%s' already exist in the database.", entry->id, entry->name);
+        }
+        if (OS_INVALID == wdb_create_agent_db(id, entry->name)) {
+            mtdebug2(WM_DATABASE_LOGTAG, "Failed to create the database for agent %s '%s'.", entry->id, entry->name);
         }
     }
 
-    // Delete from the database all the agents without a key
-
+    // Delete from the database all the agents without a key and all its atirfacts
     if ((agents = wdb_get_all_agents(FALSE, wdb_sock))) {
         char id[9];
-        char wdbquery[OS_SIZE_128 + 1];
-        char *wdboutput = NULL;
-        int error;
 
         for (i = 0; agents[i] != -1; i++) {
             snprintf(id, 9, "%03d", agents[i]);
 
             if (OS_IsAllowedID(keys, id) == -1) {
-                char *name = wdb_get_agent_name(agents[i], wdb_sock);
+                char *agent_name = wdb_get_agent_name(agents[i], wdb_sock);
 
                 if (wdb_remove_agent(agents[i], wdb_sock) < 0) {
-                    mdebug1("Couldn't remove agent %s", id);
-                    os_free(name);
+                    mtdebug1(WM_DATABASE_LOGTAG, "Couldn't remove agent %s", id);
+                    os_free(agent_name);
                     continue;
                 }
 
-                if (wdboutput == NULL) {
-                    os_malloc(OS_SIZE_1024, wdboutput);
-                }
-
-                snprintf(wdbquery, OS_SIZE_128, "wazuhdb remove %s", id);
-                error = wdbc_query_ex(wdb_sock, wdbquery, wdboutput, OS_SIZE_1024);
-
-                if (error == 0) {
-                    mdebug1("DB from agent %s was deleted '%s'", id, wdboutput);
-                } else {
-                    merror("Could not remove the DB of the agent %s. Error: %d.", id, error);
-                }
+                // Agent not found. Removing agent artifacts
+                wm_clean_agent_artifacts(agents[i], agent_name);
 
                 // Remove agent-related files
                 OS_RemoveCounter(id);
                 OS_RemoveAgentTimestamp(id);
 
-                if (name == NULL || *name == '\0') {
-                    os_free(name);
-                    continue;
-                }
-
-                delete_diff(name);
-
-                free(name);
+                os_free(agent_name);
             }
         }
 
-        os_free(wdboutput);
         os_free(agents);
     }
 
     os_free(group);
+}
+
+/**
+ * @brief Synchronizes a keystore with the legacy agents databases in var/db/agents.
+ *        It will create a database for the agents in the keystore that doesn't
+ *        have it created.
+ *
+ * @param keys The keystore structure to be synchronized
+ */
+void sync_keys_with_agents_db(keystore *keys) {
+    keyentry *entry = NULL;
+    unsigned int i;
+
+    // Add new agents databases
+
+    for (i = 0; i < keys->keysize; i++) {
+        entry = keys->keyentries[i];
+        int id;
+
+        mtdebug2(WM_DATABASE_LOGTAG, "Synchronizing agent %s '%s' database.", entry->id, entry->name);
+
+        if (!(id = atoi(entry->id))) {
+            merror("At sync_keys_with_agents_ds(): invalid ID number.");
+            continue;
+        }
+
+        if (OS_INVALID == wdb_create_agent_db(id, entry->name)) {
+            mtdebug2(WM_DATABASE_LOGTAG, "Failed to create the database for agent %s '%s'.", entry->id, entry->name);
+        }
+    }
+}
+
+/**
+ * @brief Synchronizes the agents artifacts with wazuh-db. It will remove
+ *        the databases of agents that are not in the agent table of
+ *        global.db.
+ */
+void sync_agents_artifacts_dbs_with_wdb() {
+    // Delete the databases of all the agents without a key
+    DIR *dir = NULL;
+    struct dirent * dirent = NULL;
+
+    if (!(dir = opendir(WDB_DIR "/agents"))) {
+        mterror(WM_DATABASE_LOGTAG, "Couldn't open directory '%s': %s.", WDB_DIR "/agents", strerror(errno));
+        return;
+    }
+
+    while ((dirent = readdir(dir)) != NULL) {
+        char *end = NULL;
+        if (end = strchr(dirent->d_name, '-'), end) {
+            int agent_id = (int)strtol(dirent->d_name, &end, 10);
+            char *agent_name = NULL;
+            if (agent_id > 0 && (agent_name = wdb_get_agent_name(agent_id, &wdb_wmdb_sock)) != NULL) {
+                if (*agent_name == '\0') {
+                    // Agent not found. Removing agent artifacts
+                    wm_clean_agent_artifacts(agent_id, agent_name);
+                }
+                os_free(agent_name);
+            }
+        }
+    }
+
+    closedir(dir);
+}
+
+/**
+ * @brief This function removes the legacy agent DB, the wazuh-db agent DB
+ *        and the diff folder of an agent.
+ *
+ * @param agent_id The ID of the agent.
+ * @param agent_name The name of the agent.
+ */
+void wm_clean_agent_artifacts(int agent_id, const char* agent_name) {
+    int result = OS_INVALID;
+
+    // Removing legacy database
+    if (result = wdb_remove_agent_db(agent_id, agent_name), result) {
+        mtdebug1(WM_DATABASE_LOGTAG, "Could not remove the legacy DB of the agent %d.", agent_id);
+    }
+
+    // Removing wazuh-db database
+    char wdbquery[OS_SIZE_128 + 1];
+    char *wdboutput = NULL;
+    snprintf(wdbquery, OS_SIZE_128, "wazuhdb remove %d", agent_id);
+    if (result = wdbc_query_ex(&wdb_wmdb_sock, wdbquery, wdboutput, OS_SIZE_1024), result) {
+        mtdebug1(WM_DATABASE_LOGTAG, "Could not remove the wazuh-db DB of the agent %d.", agent_id);
+    }
+    os_free(wdboutput);
+
+    delete_diff(agent_name);
 }
 
 // Clean dangling database files

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -79,14 +79,14 @@ static void wm_check_agents();
  * @brief Method to synchronize 'client.keys' and 'global.db'. All new agents found
  *        in 'client.keys will be added to the DB and any agent in the DB that doesn't
  *        have a key will be removed.
- *        This method will also create and remove the agents artifacts acorting to
+ *        This method will also create and remove the agents artifacts according to
  *        the action taken in the database with the agent.
  */
 static void wm_sync_agents();
 
 /**
  * @brief Method to synchronize the agent artifacts with 'client.keys' and 'global.db'.
- *        For all new agents found in 'client.keys will be created its artifacts.
+ *        For all new agents found in 'client.keys, its artifacts will be created.
  *        All the artifacts corresponding to an agent that is not in the database will
  *        be removed.
  */
@@ -392,7 +392,7 @@ void sync_keys_with_wdb(keystore *keys) {
         }
     }
 
-    // Delete from the database all the agents without a key and all its atirfacts
+    // Delete from the database all the agents without a key and all its artifacts
     if ((agents = wdb_get_all_agents(FALSE, &wdb_wmdb_sock))) {
         char id[9];
 
@@ -445,7 +445,7 @@ void sync_keys_with_agents_artifacts(keystore *keys) {
         mtdebug2(WM_DATABASE_LOGTAG, "Synchronizing agent %s '%s' database.", entry->id, entry->name);
 
         if (!(id = atoi(entry->id))) {
-            merror("At sync_keys_with_agents_ds(): invalid ID number.");
+            merror("At sync_keys_with_agents_artifacts(): invalid ID number.");
             continue;
         }
 

--- a/src/wazuh_modules/wm_database.h
+++ b/src/wazuh_modules/wm_database.h
@@ -45,14 +45,14 @@ void sync_keys_with_wdb(keystore *keys);
  *
  * @param keys The keystore structure to be synchronized
  */
-void sync_keys_with_agents_db(keystore *keys);
+void sync_keys_with_agents_artifacts(keystore *keys);
 
 /**
  * @brief Synchronizes the agents artifacts with wazuh-db. It will remove
  *        the databases of agents that are not in the agent table of
  *        global.db.
  */
-void sync_agents_artifacts_dbs_with_wdb();
+void sync_agents_artifacts_with_wdb();
 
 /**
  * @brief This function removes the legacy agent DB, the wazuh-db agent DB

--- a/src/wazuh_modules/wm_database.h
+++ b/src/wazuh_modules/wm_database.h
@@ -27,11 +27,41 @@ extern int wdb_wmdb_sock;
 wmodule* wm_database_read();
 
 /**
- * @brief Synchronizes a keystore with the agent table of global.db.
+ * @brief Synchronizes a keystore with the agent table of global.db. It will insert
+ *        the agents that are in the keystore and are not in global.db. It also
+ *        will create all the agent artifacts.
+ *        In addition it will remove from global.db in wazuh-db all the agents that
+ *        are not in the keystore. Also it will remove all the artifacts for those
+ *        agents.
  *
  * @param keys The keystore structure to be synchronized
  * @param wdb_sock The socket to be used in the calls to Wazuh DB
  */
 void sync_keys_with_wdb(keystore *keys, int *wdb_sock);
+
+/**
+ * @brief Synchronizes a keystore with the legacy agents databases in var/db/agents.
+ *        It will create a database for the agents in the keystore that doesn't
+ *        have it created.
+ *
+ * @param keys The keystore structure to be synchronized
+ */
+void sync_keys_with_agents_db(keystore *keys);
+
+/**
+ * @brief Synchronizes the agents artifacts with wazuh-db. It will remove
+ *        the databases of agents that are not in the agent table of
+ *        global.db.
+ */
+void sync_agents_artifacts_dbs_with_wdb();
+
+/**
+ * @brief This function removes the legacy agent DB, the wazuh-db agent DB
+ *        and the diff folder of an agent.
+ *
+ * @param agent_id The ID of the agent.
+ * @param agent_name The name of the agent.
+ */
+void wm_clean_agent_artifacts(int agent_id, const char* agent_name);
 
 #endif /* WM_DATABASE */

--- a/src/wazuh_modules/wm_database.h
+++ b/src/wazuh_modules/wm_database.h
@@ -35,9 +35,8 @@ wmodule* wm_database_read();
  *        agents.
  *
  * @param keys The keystore structure to be synchronized
- * @param wdb_sock The socket to be used in the calls to Wazuh DB
  */
-void sync_keys_with_wdb(keystore *keys, int *wdb_sock);
+void sync_keys_with_wdb(keystore *keys);
 
 /**
  * @brief Synchronizes a keystore with the legacy agents databases in var/db/agents.


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/11744 |

## Description

This PR moves the logic to create and remove the agents' databases from `authd` to the `wm_database` synchronization module as it was before. This was causing errors in the `authd` module as it hasn't permissions to request the ID of the ROOT user and the Wazuh group.

With this changes, now the manager behaves in this way:

- In the master nodes, `authd` will add the agents to the `global.db` in `wazuh-db`. Then, the creation and removal of the database will be held by `wm_database`.
- In the worker nodes, all the work will be done by the `wm_database` module.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade

- Memory tests for Linux
  - [x] Scan-build report
![image](https://user-images.githubusercontent.com/5703274/148877639-fe15d651-b7b3-4f40-92c3-2f1f58b03ef3.png)