### PR TITLE
Added log messages, hide wazuh-db configuration

### DIFF
--- a/etc/ossec-local.conf
+++ b/etc/ossec-local.conf
@@ -31,15 +31,6 @@
     <protocol>tcp</protocol>
   </remote>
 
-  <!-- Database management -->
-  <wdb>
-    <backup database='global'>
-      <enabled>yes</enabled>
-      <interval>1d</interval>
-      <max_files>3</max_files>
-    </backup>
-  </wdb>
-
   <!-- Policy monitoring -->
   <rootcheck>
     <disabled>no</disabled>

--- a/etc/ossec-server.conf
+++ b/etc/ossec-server.conf
@@ -31,15 +31,6 @@
     <protocol>tcp</protocol>
   </remote>
 
-  <!-- Database management -->
-  <wdb>
-    <backup database='global'>
-      <enabled>yes</enabled>
-      <interval>1d</interval>
-      <max_files>3</max_files>
-    </backup>
-  </wdb>
-
   <!-- Policy monitoring -->
   <rootcheck>
     <disabled>no</disabled>

--- a/etc/ossec.conf
+++ b/etc/ossec.conf
@@ -36,15 +36,6 @@
     <protocol>tcp</protocol>
   </remote>
 
-  <!-- Database management -->
-  <wdb>
-    <backup database='global'>
-      <enabled>yes</enabled>
-      <interval>1d</interval>
-      <max_files>3</max_files>
-    </backup>
-  </wdb>
-
   <!-- Policy monitoring -->
   <rootcheck>
     <disabled>no</disabled>

--- a/etc/templates/config/generic/wdb.template
+++ b/etc/templates/config/generic/wdb.template
@@ -1,8 +1,0 @@
-  <!-- Database management -->
-  <wdb>
-    <backup database='global'>
-      <enabled>yes</enabled>
-      <interval>1d</interval>
-      <max_files>3</max_files>
-    </backup>
-  </wdb>

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -26,7 +26,6 @@ AR_DEFINITIONS_TEMPLATE="./etc/templates/config/generic/ar-definitions.template"
 ALERTS_TEMPLATE="./etc/templates/config/generic/alerts.template"
 LOGGING_TEMPLATE="./etc/templates/config/generic/logging.template"
 REMOTE_SEC_TEMPLATE="./etc/templates/config/generic/remote-secure.template"
-WDB_TEMPLATE="./etc/templates/config/generic/wdb.template"
 
 LOCALFILES_TEMPLATE="./etc/templates/config/generic/localfile-logs/*.template"
 
@@ -466,10 +465,6 @@ WriteManager()
       echo "" >> $NEWCONFIG
     fi
 
-    # Wazuh-DB
-    cat ${WDB_TEMPLATE} >> $NEWCONFIG
-    echo "" >> $NEWCONFIG
-
     # Write rootcheck
     WriteRootcheck "manager"
 
@@ -595,10 +590,6 @@ WriteLocal()
 
     # Logging format
     cat ${LOGGING_TEMPLATE} >> $NEWCONFIG
-    echo "" >> $NEWCONFIG
-
-    # Wazuh-DB
-    cat ${WDB_TEMPLATE} >> $NEWCONFIG
     echo "" >> $NEWCONFIG
 
     # Write rootcheck

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -452,8 +452,9 @@ void * run_backup(__attribute__((unused)) void * args) {
                         current_time = time(NULL);
                         if((current_time - last_global_backup_time) >= global_interval) {
                             wdb_t* wdb = wdb_open_global();
-                            wdb_global_create_backup(wdb, output, NULL);
-                            mdebug1("Backup creation result: %s", output);
+                            if (OS_SUCCESS != wdb_global_create_backup(wdb, output, NULL)) {
+                                merror("Creating Global DB snapshot by interval failed: %s", output);
+                            }
                             last_global_backup_time = current_time;
                             wdb_leave(wdb);
                         }

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -442,6 +442,8 @@ void * run_backup(__attribute__((unused)) void * args) {
         last_global_backup_time = time(NULL);
     }
 
+    mdebug2("Database backup thread started.");
+
     while(running) {
         for (int i = 0; i < WDB_LAST_BACKUP; i++) {
             switch (i) {

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1867,7 +1867,7 @@ int wdb_global_restore_backup(wdb_t** wdb, char* snapshot, bool save_pre_restore
     int result = OS_INVALID;
     if (save_pre_restore_state) {
         if (OS_SUCCESS != wdb_global_create_backup(*wdb, output, "-pre_restore")) {
-            merror("Creating pre-restore Global DB snapshot failed. Backup restore stopped.");
+            merror("Creating pre-restore Global DB snapshot failed. Backup restore stopped: %s", output);
             goto end;
         }
     }

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1772,7 +1772,8 @@ int wdb_global_create_backup(wdb_t* wdb, char* output, const char* tag) {
         snprintf(path_compressed, PATH_MAX, "%s.gz", path);
         result = w_compress_gzfile(path, path_compressed);
         unlink(path);
-        if (OS_SUCCESS == result) {
+        if(OS_SUCCESS == result) {
+            minfo("Created Global database backup \"%s\"", path);
             wdb_global_remove_old_backups();
             cJSON* j_path = cJSON_CreateArray();
             cJSON_AddItemToArray(j_path, cJSON_CreateString(path));
@@ -1817,6 +1818,7 @@ int wdb_global_remove_old_backups() {
         if (backup_to_delete_name) {
             snprintf(tmp_path, OS_SIZE_512, "%s/%s", WDB_BACKUP_FOLDER, backup_to_delete_name);
             unlink(tmp_path);
+            minfo("Deleted Global database backup: \"%s\"", tmp_path);
             os_free(backup_to_delete_name);
         }
     }

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5740,6 +5740,9 @@ int wdb_parse_global_backup(wdb_t** wdb, char* input, char* output) {
     }
     else if (strcmp(next, "create") == 0) {
         result = wdb_global_create_backup(*wdb, output, NULL);
+        if (OS_SUCCESS != result) {
+            merror("Creating Global DB snapshot by request failed: %s", output);
+        }
     }
     else if (strcmp(next, "get") == 0) {
         result = wdb_parse_global_get_backup(output);

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5741,7 +5741,7 @@ int wdb_parse_global_backup(wdb_t** wdb, char* input, char* output) {
     else if (strcmp(next, "create") == 0) {
         result = wdb_global_create_backup(*wdb, output, NULL);
         if (OS_SUCCESS != result) {
-            merror("Creating Global DB snapshot by request failed: %s", output);
+            merror("Creating Global DB snapshot on demand failed: %s", output);
         }
     }
     else if (strcmp(next, "get") == 0) {

--- a/src/wazuh_db/wdb_upgrade.c
+++ b/src/wazuh_db/wdb_upgrade.c
@@ -117,7 +117,7 @@ wdb_t * wdb_upgrade_global(wdb_t *wdb) {
 
     if (version < updates_length) {
         if (OS_SUCCESS != wdb_global_create_backup(wdb, output, "-pre_upgrade")) {
-            mwarn("Creating pre-upgrade global DB snapshot failed");
+            mwarn("Creating pre-upgrade Global DB snapshot failed: %s", output);
         }
 
         bool upgrade_success = TRUE;
@@ -134,7 +134,7 @@ wdb_t * wdb_upgrade_global(wdb_t *wdb) {
 
         if (upgrade_success) {
             if (OS_SUCCESS != wdb_global_create_backup(wdb, output, "-post_upgrade")) {
-                mwarn("Creating post-upgrade global DB snapshot failed");
+                mwarn("Creating post-upgrade Global DB snapshot failed: %s", output);
             }
         }
     }


### PR DESCRIPTION
|Related issue|
|---|
|#11777|

## Description

This PR adds some log messages and makes the wazuh-DB configuration hidden.

## Dod

Starting thread log

![1](https://user-images.githubusercontent.com/13010397/149034789-c4a0d46b-68e2-4176-86e9-4b1a745bd8ea.png)

Database backup creation log.

![2](https://user-images.githubusercontent.com/13010397/149034792-d2d26e78-d5b9-4ec5-b722-a097779f413e.png)

Database backup deletion log.

![3](https://user-images.githubusercontent.com/13010397/149034795-c95d20f2-4729-4f34-93a4-d0df8098e12e.png)

Database backup error log.

![4](https://user-images.githubusercontent.com/13010397/149241653-9322c65b-0a32-4311-b9ae-9305775ca259.png)
![5](https://user-images.githubusercontent.com/13010397/149241657-5b932b01-e50d-483f-9680-4c5b2c98bbda.png)


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Source upgrade