### PR TITLE
Rework of #10476 - PR: Update NextCloud rules

### DIFF
--- a/ruleset/rules/0630-nextcloud_rules.xml
+++ b/ruleset/rules/0630-nextcloud_rules.xml
@@ -39,20 +39,20 @@
     <description>NextCloud messages grouped.</description>
   </rule>
 
-  <rule id="88202" level="1">
-    <if_sid>88200,88201</if_sid>
-    <match>Login attempt: </match>
-    <options>no_full_log</options>
-    <description>NextCloud authentication attempt.</description>
-    <group>gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-  </rule>
-
   <rule id="88212" level="6">
     <if_sid>88200,88201</if_sid>
     <match>Login failed: </match>
     <options>no_full_log</options>
     <description>NextCloud authentication failed.</description>
     <group>authentication_failed,gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+  
+  <rule id="88202" level="1">
+    <if_sid>88200,88201</if_sid>
+    <match>Login attempt: </match>
+    <options>no_full_log</options>
+    <description>NextCloud authentication attempt.</description>
+    <group>gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="88203" level="10" frequency="8" timeframe="120">
@@ -124,6 +124,7 @@
     <description>NextCloud authentication successful.</description>
     <group>authentication_success,gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
+
 
   <rule id="88213" level="3">
     <if_sid>88200,88201</if_sid>

--- a/ruleset/rules/0630-nextcloud_rules.xml
+++ b/ruleset/rules/0630-nextcloud_rules.xml
@@ -81,7 +81,7 @@
     <group>gdpr_IV_35.7.d,</group>
   </rule>
 
-  <rule id="88206" level="4">
+  <rule id="88206" level="7">
     <if_sid>88200,88201</if_sid>
     <field name="level">^3$</field>
     <options>no_full_log</options>

--- a/ruleset/rules/0630-nextcloud_rules.xml
+++ b/ruleset/rules/0630-nextcloud_rules.xml
@@ -65,7 +65,7 @@
     <group>authentication_failures,gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,nist_800_53_SI.4,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
-  <rule id="88204" level="6">
+  <rule id="88204" level="3">
     <if_sid>88200,88201</if_sid>
     <match>Passed filename is not valid, might be malicious </match>
     <options>no_full_log</options>
@@ -109,7 +109,7 @@
     <description>NextCloud DEBUG message.</description>
   </rule>
 
-  <rule id="88210" level="6">
+  <rule id="88210" level="3">
     <if_sid>88200,88201</if_sid>
     <match>Logout occurred</match>
     <options>no_full_log</options>
@@ -117,7 +117,7 @@
     <group>gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
-  <rule id="88211" level="6">
+  <rule id="88211" level="3">
     <if_sid>88200,88201</if_sid>
     <match>Login successful: </match>
     <options>no_full_log</options>
@@ -125,7 +125,7 @@
     <group>authentication_success,gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
-  <rule id="88213" level="6">
+  <rule id="88213" level="3">
     <if_sid>88200,88201</if_sid>
     <match>File accessed: </match>
     <options>no_full_log</options>
@@ -133,7 +133,7 @@
     <group>gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
-  <rule id="88214" level="6">
+  <rule id="88214" level="3">
     <if_sid>88200,88201</if_sid>
     <match>File created: </match>
     <options>no_full_log</options>
@@ -141,7 +141,7 @@
     <group>gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,pci_dss_11.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
-  <rule id="88215" level="6">
+  <rule id="88215" level="3">
     <if_sid>88200,88201</if_sid>
     <match>File deleted: </match>
     <options>no_full_log</options>
@@ -149,7 +149,7 @@
     <group>gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,pci_dss_11.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
-  <rule id="88216" level="6">
+  <rule id="88216" level="3">
     <if_sid>88200,88201</if_sid>
     <match>Preview accessed: </match>
     <options>no_full_log</options>

--- a/ruleset/rules/0630-nextcloud_rules.xml
+++ b/ruleset/rules/0630-nextcloud_rules.xml
@@ -125,7 +125,6 @@
     <group>authentication_success,gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
-
   <rule id="88213" level="3">
     <if_sid>88200,88201</if_sid>
     <match>File accessed: </match>

--- a/ruleset/rules/0630-nextcloud_rules.xml
+++ b/ruleset/rules/0630-nextcloud_rules.xml
@@ -1,175 +1,163 @@
 <!--
-  -  NextCloud rules
-  -  Author: banditopazzo.
-  -  Updated by Wazuh, Inc.
-  -  Copyright (C) 2015-2021, Wazuh Inc.
-  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+  Copyright (C) 2015-2021, Wazuh Inc.
+
+  Rules for:
+    NexCloud ID: 88200 - 88299
 -->
 
 <!--
-- It's needed to enable audit in Nextcloud if you want full log
-- It's needed to paste the following in /var/ossec/etc/ossec.conf for the decoder to work properly:
-<localfile>
-	<location>ABSOLUTE_PATH_TO_YOUR_NEXTCLOUD_.json_LOG_FILE</location>
-	<log_format>json</log_format>
-	<label key="@source">NextCloud</label>
-</localfile>
-- OPTIONAL
-<localfile>
-	<location>ABSOLUTE_PATH_TO_YOUR_AUDIT_.json_LOG_FILE</location>
-	<log_format>json</log_format>
-	<label key="@source">NextCloud</label>
-</localfile>
- -->
+  Two log sources are valid for NextCloud rules:
 
-<!-- ID: 88200 - 88299 -->
+  To use the NextCloud decoder paste the following in /var/ossec/etc/ossec.conf:
+  <localfile>
+    <location>ABSOLUTE_PATH_TO_YOUR_NEXTCLOUD_.json_LOG_FILE</location>
+    <log_format>json</log_format>
+    <label key="@source">NextCloud</label>
+  </localfile>
 
-<!-- EXAMPLE LOGS
-- {"reqId":"prLlx9+QIfl1jHtz9C5o","remoteAddr":"127.0.0.1","app":"core","message":"Login failed: 'admin' (Remote IP: '127.0.0.1')","level":2,"time":"2015-07-08T12:12:41+02:00","@source":"NextCloud"}
-- {"reqId":"wLP7a3MdzTo8wgCWret9","remoteAddr":"127.0.0.1","app":"core","message":"Login failed: 'admin' (Remote IP: '127.0.0.1')","level":2,"time":"2015-07-15T09:40:35+02:00","method":"POST","url":"\/","@source":"NextCloud"}
-- {"reqId":"prLlx9+QIfl1jHtz9C5o","remoteAddr":"127.0.0.1","app":"core","message":"Login failed: 'admin' (Remote IP: '127.0.0.1)","level":2,"time":"2015-07-08T12:12:41+02:00","@source":"NextCloud"}
-- {"reqId":"wLP7a3MdzTo8wgCWret9","remoteAddr":"127.0.0.1","app":"core","message":"Login failed: 'admin' (Remote IP: '127.0.0.1)","level":2,"time":"2015-07-15T09:40:35+02:00","method":"POST","url":"\/","@source":"NextCloud"}
-- {"reqId":"f7906a8355f496e3a1947d7839c4a2c3","remoteAddr":"127.0.0.1","app":"core","message":"Login failed: 'admin' (Remote IP: '127.0.0.1', X-Forwarded-For: '')","level":2,"time":"2015-06-09T08:17:43+00:00","@source":"NextCloud"}
-- {"reqId":"9f8edc5558b2b4f8628663d83a092a7f","remoteAddr":"127.0.0.1","app":"core","message":"Login failed: 'admin' (Remote IP: '127.0.0.1', X-Forwarded-For: '')","level":2,"time":"2015-06-09T08:19:02   - +00:00","method":"POST","url":"\/cloud\/index.php","@source":"NextCloud"}
-- {"app":"core","message":"Login failed: 'admin' (Remote IP: '127.0.0.1', X-Forwarded-For: '')","level":2,"time":"2015-06-09T08:16:29+00:00","@source":"NextCloud"}
-- {"reqId":"5576a04643d8e","app":"core","message":"Login failed: 'admin' (Remote IP: '127.0.0.1', X-Forwarded-For: '')","level":2,"time":"2015-06-09T08:13:58+00:00","method":"POST","url":"\/NextCloud\/index.php","@source":"NextCloud"}
-- {"app":"core","message":"Login failed: user 'admin' , wrong password, IP:127.0.0.1","level":2,"time":"2015-06-09T08:10:29+00:00","@source":"NextCloud"}
-- {"reqId":"55769fcacd1e0","app":"core","message":"Login failed: user 'admin' , wrong password, IP:127.0.0.1","level":2,"time":"2015-06-09T08:11:54+00:00","method":"POST","url":"\/NextCloud\/index.php","@source":"NextCloud"}
-- {"reqId":"4ETnKW0UyDBNmL4z\/umV","remoteAddr":"127.0.0.1","app":"PHP","message":"Redis::connect(): connect() failed: No such file or directory at \/var\/www\/NextCloud\/lib\/private\/RedisFactory.php#60","level":3,"time":"2017-08-21T16:00:34+02:00","method":"PROPFIND","url":"\/remote.php\/dav\/addressbooks\/users\/admin\/example\/","user":"admin","@source":"NextCloud"}
-- {"reqId":"4j2DKpvOh0OezXVwfuLO","remoteAddr":"127.0.0.1","app":"PHP","message":"fopen(\/var\/www\/NextCloud\/data\/user 1\/thumbnails\/1234\/32-32.png): failed to open stream: No such file or directory at \/var\/www\/NextCloud\/lib\/private\/Files\/Storage\/Local.php#278","level":3,"time":"2017-07-15T23:59:20+02:00","method":"GET","url":"\/core\/preview.png?file=%2Fexample.txt&c=123&x=32&y=32&forceIcon=0","user":"user 1","@source":"NextCloud"}
-- Examples syslog:
-- Sep  1 20:16:09 foo NextCloud[15463]: {core} Login failed: 'test' (Remote IP: '127.0.0.1')
-- Sep  1 22:16:33 foo NextCloud[15467]: {core-preview} Passed filename is not valid, might be malicious (file:"test";ip:"127.0.0.1","@source":"NextCloud")
+  If you enabled audit in your Nextcloud system you may use those logs instead.
+  Paste the following in /var/ossec/etc/ossec.conf:
+  <localfile>
+    <location>ABSOLUTE_PATH_TO_YOUR_AUDIT_.json_LOG_FILE</location>
+    <log_format>json</log_format>
+    <label key="@source">NextCloud</label>
+  </localfile>
 -->
+
+
 
 <group name="json,nextcloud,">
 
   <rule id="88200" level="0">
     <decoded_as>json</decoded_as>
     <field name="@source">NextCloud</field>
-    <description>NextCloud messages grouped.</description>
     <options>no_full_log</options>
+    <description>NextCloud messages grouped.</description>
   </rule>
 
   <rule id="88201" level="0">
     <decoded_as>nextcloud</decoded_as>
-    <description>NextCloud messages grouped.</description>
     <options>no_full_log</options>
+    <description>NextCloud messages grouped.</description>
   </rule>
 
   <rule id="88202" level="1">
     <if_sid>88200,88201</if_sid>
     <match>Login attempt: </match>
+    <options>no_full_log</options>
     <description>NextCloud authentication attempt.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-    <options>no_full_log</options>
-  </rule>
-
-  <rule id="88210" level="6">
-    <if_sid>88200,88201</if_sid>
-    <match>Logout occurred</match>
-    <description>NextCloud logout successful.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-    <options>no_full_log</options>
-  </rule>
-
-  <rule id="88211" level="6">
-    <if_sid>88200,88201</if_sid>
-    <match>Login successful: </match>
-    <description>NextCloud authentication successful.</description>
-    <group>authentication_success,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-    <options>no_full_log</options>
+    <group>pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="88212" level="6">
     <if_sid>88200,88201</if_sid>
     <match>Login failed: </match>
+    <options>no_full_log</options>
     <description>NextCloud authentication failed.</description>
     <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-    <options>no_full_log</options>
   </rule>
 
   <rule id="88203" level="10" frequency="8" timeframe="120">
-    <if_matched_sid>88202</if_matched_sid>
+    <if_matched_sid>88212</if_matched_sid>
+    <options>no_full_log</options>
     <description>NextCloud brute force (multiple failed logins).</description>
+    <mitre>
+      <id>T1110</id>
+    </mitre>
     <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-    <options>no_full_log</options>
-  </rule>
 
-  <rule id="88213" level="6">
-    <if_sid>88200,88201</if_sid>
-    <match>File accessed: </match>
-    <description>NextCloud file accessed.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-    <options>no_full_log</options>
-  </rule>
-
-  <rule id="88214" level="6">
-    <if_sid>88200,88201</if_sid>
-    <match>File created: </match>
-    <description>NextCloud file created.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-    <options>no_full_log</options>
-  </rule>
-
-  <rule id="88215" level="6">
-    <if_sid>88200,88201</if_sid>
-    <match>File deleted: </match>
-    <description>NextCloud file deleted.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-    <options>no_full_log</options>
-  </rule>
-
-  <rule id="88216" level="6">
-    <if_sid>88200,88201</if_sid>
-    <match>Preview accessed: </match>
-    <description>NextCloud preview accessed.</description>
-    <group>pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-    <options>no_full_log</options>
   </rule>
 
   <rule id="88204" level="6">
     <if_sid>88200,88201</if_sid>
     <match>Passed filename is not valid, might be malicious </match>
+    <options>no_full_log</options>
     <description>NextCloud possible malicious request.</description>
     <group>web,appsec,attack,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SI.4,tsc_CC6.6,tsc_CC7.1,tsc_CC8.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-    <options>no_full_log</options>
   </rule>
 
   <rule id="88205" level="8">
     <if_sid>88200,88201</if_sid>
     <field name="level">^4$</field>
+    <options>no_full_log</options>
     <description>NextCloud FATAL message.</description>
     <group>gdpr_IV_35.7.d,</group>
-    <options>no_full_log</options>
   </rule>
 
   <rule id="88206" level="4">
     <if_sid>88200,88201</if_sid>
     <field name="level">^3$</field>
-    <description>NextCloud ERROR message.</description>
     <options>no_full_log</options>
+    <description>NextCloud ERROR message.</description>
   </rule>
 
   <rule id="88207" level="3">
     <if_sid>88200,88201</if_sid>
     <field name="level">^2$</field>
-    <description>NextCloud WARN message.</description>
     <options>no_full_log</options>
+    <description>NextCloud WARN message.</description>
   </rule>
 
   <rule id="88208" level="2">
     <if_sid>88200,88201</if_sid>
     <field name="level">^1$</field>
-    <description>NextCloud INFO message.</description>
     <options>no_full_log</options>
+    <description>NextCloud INFO message.</description>
   </rule>
 
   <rule id="88209" level="1">
     <if_sid>88200,88201</if_sid>
     <field name="level">^0$</field>
-    <description>NextCloud DEBUG message.</description>
     <options>no_full_log</options>
+    <description>NextCloud DEBUG message.</description>
+  </rule>
+
+  <rule id="88210" level="6">
+    <if_sid>88200,88201</if_sid>
+    <match>Logout occurred</match>
+    <options>no_full_log</options>
+    <description>NextCloud logout successful.</description>
+    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+
+  <rule id="88211" level="6">
+    <if_sid>88200,88201</if_sid>
+    <match>Login successful: </match>
+    <options>no_full_log</options>
+    <description>NextCloud authentication successful.</description>
+    <group>authentication_success,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+
+  <rule id="88213" level="6">
+    <if_sid>88200,88201</if_sid>
+    <match>File accessed: </match>
+    <options>no_full_log</options>
+    <description>NextCloud file accessed.</description>
+    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+
+  <rule id="88214" level="6">
+    <if_sid>88200,88201</if_sid>
+    <match>File created: </match>
+    <options>no_full_log</options>
+    <description>NextCloud file created.</description>
+    <group>pci_dss_11.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+
+  <rule id="88215" level="6">
+    <if_sid>88200,88201</if_sid>
+    <match>File deleted: </match>
+    <options>no_full_log</options>
+    <description>NextCloud file deleted.</description>
+    <group>pci_dss_11.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+
+  <rule id="88216" level="6">
+    <if_sid>88200,88201</if_sid>
+    <match>Preview accessed: </match>
+    <options>no_full_log</options>
+    <description>NextCloud preview accessed.</description>
+    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
 </group>

--- a/ruleset/rules/0630-nextcloud_rules.xml
+++ b/ruleset/rules/0630-nextcloud_rules.xml
@@ -44,7 +44,7 @@
     <match>Login attempt: </match>
     <options>no_full_log</options>
     <description>NextCloud authentication attempt.</description>
-    <group>gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="88212" level="6">
@@ -52,7 +52,7 @@
     <match>Login failed: </match>
     <options>no_full_log</options>
     <description>NextCloud authentication failed.</description>
-    <group>authentication_failed,gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_failed,gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="88203" level="10" frequency="8" timeframe="120">
@@ -62,7 +62,7 @@
     <mitre>
       <id>T1110</id>
     </mitre>
-    <group>authentication_failures,gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_failures,gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,nist_800_53_SI.4,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="88204" level="6">
@@ -70,7 +70,7 @@
     <match>Passed filename is not valid, might be malicious </match>
     <options>no_full_log</options>
     <description>NextCloud possible malicious request.</description>
-    <group>appsec,attack,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SI.4,pci_dss_6.5,pci_dss_11.4,tsc_CC6.6,tsc_CC7.1,tsc_CC8.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,web,</group>
+    <group>appsec,attack,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SI.4,pci_dss_6.5,pci_dss_11.4,tsc_CC6.1,tsc_CC6.6,tsc_CC6.8,tsc_CC7.1,tsc_CC7.2,tsc_CC7.3,tsc_CC8.1,web,</group>
   </rule>
 
   <rule id="88205" level="8">
@@ -114,7 +114,7 @@
     <match>Logout occurred</match>
     <options>no_full_log</options>
     <description>NextCloud logout successful.</description>
-    <group>gdpr_IV_32.2,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_32.2,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="88211" level="6">
@@ -122,7 +122,7 @@
     <match>Login successful: </match>
     <options>no_full_log</options>
     <description>NextCloud authentication successful.</description>
-    <group>authentication_success,gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_success,gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="88213" level="6">
@@ -130,7 +130,7 @@
     <match>File accessed: </match>
     <options>no_full_log</options>
     <description>NextCloud file accessed.</description>
-    <group>gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="88214" level="6">
@@ -138,7 +138,7 @@
     <match>File created: </match>
     <options>no_full_log</options>
     <description>NextCloud file created.</description>
-    <group>gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,pci_dss_11.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,pci_dss_11.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="88215" level="6">
@@ -154,7 +154,7 @@
     <match>Preview accessed: </match>
     <options>no_full_log</options>
     <description>NextCloud preview accessed.</description>
-    <group>gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
 </group>

--- a/ruleset/rules/0630-nextcloud_rules.xml
+++ b/ruleset/rules/0630-nextcloud_rules.xml
@@ -1,5 +1,5 @@
 <!--
-  Copyright (C) 2015-2021, Wazuh Inc.
+  Copyright (C) 2015-2022, Wazuh Inc.
 
   Rules for:
     NexCloud ID: 88200 - 88299
@@ -44,7 +44,7 @@
     <match>Login attempt: </match>
     <options>no_full_log</options>
     <description>NextCloud authentication attempt.</description>
-    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="88212" level="6">
@@ -52,7 +52,7 @@
     <match>Login failed: </match>
     <options>no_full_log</options>
     <description>NextCloud authentication failed.</description>
-    <group>authentication_failed,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_failed,gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="88203" level="10" frequency="8" timeframe="120">
@@ -62,7 +62,7 @@
     <mitre>
       <id>T1110</id>
     </mitre>
-    <group>authentication_failures,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_failures,gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="88204" level="6">
@@ -114,7 +114,7 @@
     <match>Logout occurred</match>
     <options>no_full_log</options>
     <description>NextCloud logout successful.</description>
-    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_32.2,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="88211" level="6">
@@ -122,7 +122,7 @@
     <match>Login successful: </match>
     <options>no_full_log</options>
     <description>NextCloud authentication successful.</description>
-    <group>authentication_success,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_success,gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="88213" level="6">
@@ -130,7 +130,7 @@
     <match>File accessed: </match>
     <options>no_full_log</options>
     <description>NextCloud file accessed.</description>
-    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="88214" level="6">
@@ -138,7 +138,7 @@
     <match>File created: </match>
     <options>no_full_log</options>
     <description>NextCloud file created.</description>
-    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,pci_dss_11.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,pci_dss_11.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="88215" level="6">
@@ -146,7 +146,7 @@
     <match>File deleted: </match>
     <options>no_full_log</options>
     <description>NextCloud file deleted.</description>
-    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,pci_dss_11.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,pci_dss_11.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="88216" level="6">
@@ -154,7 +154,7 @@
     <match>Preview accessed: </match>
     <options>no_full_log</options>
     <description>NextCloud preview accessed.</description>
-    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
 </group>

--- a/ruleset/rules/0630-nextcloud_rules.xml
+++ b/ruleset/rules/0630-nextcloud_rules.xml
@@ -114,7 +114,7 @@
     <match>Logout occurred</match>
     <options>no_full_log</options>
     <description>NextCloud logout successful.</description>
-    <group>gdpr_IV_32.2,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_32.2,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AC.7,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="88211" level="6">

--- a/ruleset/rules/0630-nextcloud_rules.xml
+++ b/ruleset/rules/0630-nextcloud_rules.xml
@@ -24,8 +24,6 @@
   </localfile>
 -->
 
-
-
 <group name="json,nextcloud,">
 
   <rule id="88200" level="0">
@@ -46,7 +44,7 @@
     <match>Login attempt: </match>
     <options>no_full_log</options>
     <description>NextCloud authentication attempt.</description>
-    <group>pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="88212" level="6">
@@ -54,7 +52,7 @@
     <match>Login failed: </match>
     <options>no_full_log</options>
     <description>NextCloud authentication failed.</description>
-    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_failed,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,pci_dss_10.2.4,pci_dss_10.2.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="88203" level="10" frequency="8" timeframe="120">
@@ -64,8 +62,7 @@
     <mitre>
       <id>T1110</id>
     </mitre>
-    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-
+    <group>authentication_failures,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="88204" level="6">
@@ -73,7 +70,7 @@
     <match>Passed filename is not valid, might be malicious </match>
     <options>no_full_log</options>
     <description>NextCloud possible malicious request.</description>
-    <group>web,appsec,attack,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SI.4,tsc_CC6.6,tsc_CC7.1,tsc_CC8.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>appsec,attack,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SI.4,pci_dss_6.5,pci_dss_11.4,tsc_CC6.6,tsc_CC7.1,tsc_CC8.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,web,</group>
   </rule>
 
   <rule id="88205" level="8">
@@ -141,7 +138,7 @@
     <match>File created: </match>
     <options>no_full_log</options>
     <description>NextCloud file created.</description>
-    <group>pci_dss_11.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,pci_dss_11.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="88215" level="6">
@@ -149,7 +146,7 @@
     <match>File deleted: </match>
     <options>no_full_log</options>
     <description>NextCloud file deleted.</description>
-    <group>pci_dss_11.5,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,pci_dss_11.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="88216" level="6">

--- a/ruleset/testing/tests/nextcloud.ini
+++ b/ruleset/testing/tests/nextcloud.ini
@@ -1,48 +1,59 @@
+;  Copyright (C) 2015-2021, Wazuh Inc.
+;
+;  Tests for products:
+;    NextCloud.
+
+[NextCloud Brute force]
+log 1 pass = {"reqId":"XaQ6ehNN-waxXQIsoJHOSgAAAAE","level":2,"time":"October 14, 2019 09:06:02","remoteAddr":"127.0.0.1","user":"--","app":"core","method":"POST","url":"\/index.php\/login","message":"Login failed: 'admin' (Remote IP: '10.3.2.2')","userAgent":"Mozilla\/5.0 (X11; Linux x86_64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/77.0.3865.120 Safari\/537.36","version":"16.0.5.1","@source":"NextCloud"}
+log 1 pass = {"reqId":"XaQ6ehNN-waxXQIsoJHOSgAAAAE","level":2,"time":"October 14, 2019 09:06:02","remoteAddr":"127.0.0.1","user":"--","app":"core","method":"POST","url":"\/index.php\/login","message":"Login failed: 'admin' (Remote IP: '10.3.2.2')","userAgent":"Mozilla\/5.0 (X11; Linux x86_64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/77.0.3865.120 Safari\/537.36","version":"16.0.5.1","@source":"NextCloud"}
+log 1 pass = {"reqId":"XaQ6ehNN-waxXQIsoJHOSgAAAAE","level":2,"time":"October 14, 2019 09:06:02","remoteAddr":"127.0.0.1","user":"--","app":"core","method":"POST","url":"\/index.php\/login","message":"Login failed: 'admin' (Remote IP: '10.3.2.2')","userAgent":"Mozilla\/5.0 (X11; Linux x86_64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/77.0.3865.120 Safari\/537.36","version":"16.0.5.1","@source":"NextCloud"}
+log 1 pass = {"reqId":"XaQ6ehNN-waxXQIsoJHOSgAAAAE","level":2,"time":"October 14, 2019 09:06:02","remoteAddr":"127.0.0.1","user":"--","app":"core","method":"POST","url":"\/index.php\/login","message":"Login failed: 'admin' (Remote IP: '10.3.2.2')","userAgent":"Mozilla\/5.0 (X11; Linux x86_64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/77.0.3865.120 Safari\/537.36","version":"16.0.5.1","@source":"NextCloud"}
+log 1 pass = {"reqId":"XaQ6ehNN-waxXQIsoJHOSgAAAAE","level":2,"time":"October 14, 2019 09:06:02","remoteAddr":"127.0.0.1","user":"--","app":"core","method":"POST","url":"\/index.php\/login","message":"Login failed: 'admin' (Remote IP: '10.3.2.2')","userAgent":"Mozilla\/5.0 (X11; Linux x86_64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/77.0.3865.120 Safari\/537.36","version":"16.0.5.1","@source":"NextCloud"}
+log 1 pass = {"reqId":"XaQ6ehNN-waxXQIsoJHOSgAAAAE","level":2,"time":"October 14, 2019 09:06:02","remoteAddr":"127.0.0.1","user":"--","app":"core","method":"POST","url":"\/index.php\/login","message":"Login failed: 'admin' (Remote IP: '10.3.2.2')","userAgent":"Mozilla\/5.0 (X11; Linux x86_64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/77.0.3865.120 Safari\/537.36","version":"16.0.5.1","@source":"NextCloud"}
+log 1 pass = {"reqId":"XaQ6ehNN-waxXQIsoJHOSgAAAAE","level":2,"time":"October 14, 2019 09:06:02","remoteAddr":"127.0.0.1","user":"--","app":"core","method":"POST","url":"\/index.php\/login","message":"Login failed: 'admin' (Remote IP: '10.3.2.2')","userAgent":"Mozilla\/5.0 (X11; Linux x86_64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/77.0.3865.120 Safari\/537.36","version":"16.0.5.1","@source":"NextCloud"}
+log 1 pass = {"reqId":"XaQ6ehNN-waxXQIsoJHOSgAAAAE","level":2,"time":"October 14, 2019 09:06:02","remoteAddr":"127.0.0.1","user":"--","app":"core","method":"POST","url":"\/index.php\/login","message":"Login failed: 'admin' (Remote IP: '10.3.2.2')","userAgent":"Mozilla\/5.0 (X11; Linux x86_64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/77.0.3865.120 Safari\/537.36","version":"16.0.5.1","@source":"NextCloud"}
+rule = 88203
+alert = 10
+decoder = json
+
 [NextCloud logout successful.]
 log 1 pass = {"reqId":"XaCAfP1v4@1xpIqlElMIVgAAAAk","level":1,"time":"October 11, 2019 13:15:40","remoteAddr":"127.0.0.1","user":"admin","app":"admin_audit","method":"GET","url":"\/index.php\/logout?requesttoken=RPYdKvrWwtB859EZQyfK%2F2DIu5l7HAqMrrNlcMzKoaM%3D%3AFLdvYq6atZJKgeFgEUSglQql0fsQaCHD68EjFKicleg%3D","message":"Logout occurred","userAgent":"Mozilla\/5.0 (X11; Linux x86_64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/77.0.3865.120 Safari\/537.36","version":"16.0.5.1","@source":"NextCloud"}
-
 rule = 88210
 alert = 6
 decoder = json
 
 [NextCloud authentication successful.]
 log 1 pass = {"reqId":"XaQ6fxNN-waxXQIsoJHOTQAAAAE","level":1,"time":"October 14, 2019 09:06:07","remoteAddr":"127.0.0.1","user":"admin","app":"admin_audit","method":"POST","url":"\/index.php\/login?user=admin","message":"Login successful: \"admin\"","userAgent":"Mozilla\/5.0 (X11; Linux x86_64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/77.0.3865.120 Safari\/537.36","version":"16.0.5.1","@source":"NextCloud"}
-
 rule = 88211
 alert = 6
 decoder = json
 
 [NextCloud authentication failed.]
 log 1 pass = {"reqId":"XaQ6ehNN-waxXQIsoJHOSgAAAAE","level":2,"time":"October 14, 2019 09:06:02","remoteAddr":"127.0.0.1","user":"--","app":"core","method":"POST","url":"\/index.php\/login","message":"Login failed: 'admin' (Remote IP: '10.3.2.2')","userAgent":"Mozilla\/5.0 (X11; Linux x86_64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/77.0.3865.120 Safari\/537.36","version":"16.0.5.1","@source":"NextCloud"}
-
 rule = 88212
 alert = 6
 decoder = json
 
 [NextCloud file accessed.]
 log 1 pass = {"reqId":"XaCDUP1v4@1xpIqlElMIaQAAAAk","level":1,"time":"October 11, 2019 13:27:44","remoteAddr":"127.0.0.1","user":"admin","app":"admin_audit","method":"GET","url":"\/remote.php\/webdav\/Nextcloud%20Manual.pdf","message":"File accessed: \"\/Nextcloud Manual.pdf\"","userAgent":"Mozilla\/5.0 (X11; Linux x86_64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/77.0.3865.120 Safari\/537.36","version":"16.0.5.1","@source":"NextCloud"}
-
 rule = 88213
 alert = 6
 decoder = json
 
 [NextCloud file created.]
 log 1 pass = {"reqId":"XaCDuMT03XAQReilx1Z76QAAAAU","level":1,"time":"October 11, 2019 13:29:28","remoteAddr":"127.0.0.1","user":"admin","app":"admin_audit","method":"PUT","url":"\/remote.php\/webdav\/logo.jpg","message":"File created: \"\/\/logo.jpg\"","userAgent":"Mozilla\/5.0 (X11; Linux x86_64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/77.0.3865.120 Safari\/537.36","version":"16.0.5.1","@source":"NextCloud"}
-
 rule = 88214
 alert = 6
 decoder = json
 
 [NextCloud file deleted.]
 log 1 pass = {"reqId":"XaCDX3wkGUtETLC8cVWzdwAAAAI","level":1,"time":"October 11, 2019 13:27:59","remoteAddr":"127.0.0.1","user":"admin","app":"admin_audit","method":"DELETE","url":"\/remote.php\/dav\/files\/admin\/logo.png","message":"File deleted: \"\/logo.png\"","userAgent":"Mozilla\/5.0 (X11; Linux x86_64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/77.0.3865.120 Safari\/537.36","version":"16.0.5.1","@source":"NextCloud"}
-
 rule = 88215
 alert = 6
 decoder = json
 
 [NextCloud preview accessed.]
 log 1 pass = {"reqId":"XaCCwMT03XAQReilx1Z75gAAAAU","level":1,"time":"October 11, 2019 13:25:20","remoteAddr":"127.0.0.1","user":"admin","app":"admin_audit","method":"GET","url":"\/index.php\/core\/preview?fileId=1780&x=1920&y=1080&a=true","message":"Preview accessed: \"\/logo.png\" (width: \"1920\", height: \"1080\" crop: \"\", mode: \"fill\")","userAgent":"Mozilla\/5.0 (X11; Linux x86_64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/77.0.3865.120 Safari\/537.36","version":"16.0.5.1","@source":"NextCloud"}
-
 rule = 88216
 alert = 6
 decoder = json

--- a/ruleset/testing/tests/nextcloud.ini
+++ b/ruleset/testing/tests/nextcloud.ini
@@ -19,13 +19,13 @@ decoder = json
 [NextCloud logout successful.]
 log 1 pass = {"reqId":"XaCAfP1v4@1xpIqlElMIVgAAAAk","level":1,"time":"October 11, 2019 13:15:40","remoteAddr":"127.0.0.1","user":"admin","app":"admin_audit","method":"GET","url":"\/index.php\/logout?requesttoken=RPYdKvrWwtB859EZQyfK%2F2DIu5l7HAqMrrNlcMzKoaM%3D%3AFLdvYq6atZJKgeFgEUSglQql0fsQaCHD68EjFKicleg%3D","message":"Logout occurred","userAgent":"Mozilla\/5.0 (X11; Linux x86_64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/77.0.3865.120 Safari\/537.36","version":"16.0.5.1","@source":"NextCloud"}
 rule = 88210
-alert = 6
+alert = 3
 decoder = json
 
 [NextCloud authentication successful.]
 log 1 pass = {"reqId":"XaQ6fxNN-waxXQIsoJHOTQAAAAE","level":1,"time":"October 14, 2019 09:06:07","remoteAddr":"127.0.0.1","user":"admin","app":"admin_audit","method":"POST","url":"\/index.php\/login?user=admin","message":"Login successful: \"admin\"","userAgent":"Mozilla\/5.0 (X11; Linux x86_64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/77.0.3865.120 Safari\/537.36","version":"16.0.5.1","@source":"NextCloud"}
 rule = 88211
-alert = 6
+alert = 3
 decoder = json
 
 [NextCloud authentication failed.]
@@ -37,23 +37,23 @@ decoder = json
 [NextCloud file accessed.]
 log 1 pass = {"reqId":"XaCDUP1v4@1xpIqlElMIaQAAAAk","level":1,"time":"October 11, 2019 13:27:44","remoteAddr":"127.0.0.1","user":"admin","app":"admin_audit","method":"GET","url":"\/remote.php\/webdav\/Nextcloud%20Manual.pdf","message":"File accessed: \"\/Nextcloud Manual.pdf\"","userAgent":"Mozilla\/5.0 (X11; Linux x86_64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/77.0.3865.120 Safari\/537.36","version":"16.0.5.1","@source":"NextCloud"}
 rule = 88213
-alert = 6
+alert = 3
 decoder = json
 
 [NextCloud file created.]
 log 1 pass = {"reqId":"XaCDuMT03XAQReilx1Z76QAAAAU","level":1,"time":"October 11, 2019 13:29:28","remoteAddr":"127.0.0.1","user":"admin","app":"admin_audit","method":"PUT","url":"\/remote.php\/webdav\/logo.jpg","message":"File created: \"\/\/logo.jpg\"","userAgent":"Mozilla\/5.0 (X11; Linux x86_64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/77.0.3865.120 Safari\/537.36","version":"16.0.5.1","@source":"NextCloud"}
 rule = 88214
-alert = 6
+alert = 3
 decoder = json
 
 [NextCloud file deleted.]
 log 1 pass = {"reqId":"XaCDX3wkGUtETLC8cVWzdwAAAAI","level":1,"time":"October 11, 2019 13:27:59","remoteAddr":"127.0.0.1","user":"admin","app":"admin_audit","method":"DELETE","url":"\/remote.php\/dav\/files\/admin\/logo.png","message":"File deleted: \"\/logo.png\"","userAgent":"Mozilla\/5.0 (X11; Linux x86_64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/77.0.3865.120 Safari\/537.36","version":"16.0.5.1","@source":"NextCloud"}
 rule = 88215
-alert = 6
+alert = 3
 decoder = json
 
 [NextCloud preview accessed.]
 log 1 pass = {"reqId":"XaCCwMT03XAQReilx1Z75gAAAAU","level":1,"time":"October 11, 2019 13:25:20","remoteAddr":"127.0.0.1","user":"admin","app":"admin_audit","method":"GET","url":"\/index.php\/core\/preview?fileId=1780&x=1920&y=1080&a=true","message":"Preview accessed: \"\/logo.png\" (width: \"1920\", height: \"1080\" crop: \"\", mode: \"fill\")","userAgent":"Mozilla\/5.0 (X11; Linux x86_64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/77.0.3865.120 Safari\/537.36","version":"16.0.5.1","@source":"NextCloud"}
 rule = 88216
-alert = 6
+alert = 3
 decoder = json


### PR DESCRIPTION
|Related issues|
|---|
| #10982 | 

## Description

This PR aims to resolve issues related and detected under #10476  PR 

## Checks and changes 
Changes:
- Fixed brute force rule
- Added missing test to ini
- Updated groups and MITRE tags
- Partial reorder of rules by id


### Ruleset

## Checks 

### Syntax

- [x] 1.a Rule tags order must be compliant.
- [x] 1.b Decoder tags order must be compliant.
- [x] 1.c XML blocks must as compact as possible.
- [x] 1.d Only one empty line between rule/decoder and the next rule/decoder.
- [x] 1.e Decoder extracted fields names must use '_' whether a space is needed.
- [x] 1.f Decoder name must use '-' whether a space is needed.
- [x] 2.d XML and ini files must use correct indentation
 
### Grammar

- [x] 2.a Grammar quality.
- [x] 2.b Similar phrases must keep tenses and expressions.
- [x] 2.c Grammar basic rules like capitalization, punctuation marks, sentence construction, and others.


### Semantic

- [x] 3.a New decoder, rule, or test are written in the correct file and grouped correctly inside the file.
- [x] 3.b Group similar rules under same ID's group.
- [x] 3.c: 
   - [x] 3.c1 Find and reuse group name before creating a new one.
   - [x] 3.c2 Include a new group definition in a PR comment.
   - [x] 3.c3 Any group name must use '_' whether it does need a space char.
   - [x] 3.c4 The groups inside a tag must be sorted in alphabetical order.
   - [x] 3.d Rule level should be compliant with the [documentation](https://documentation.wazuh.com/current/user-manual/ruleset/rules-classification.html).

### Unit testing

- [x] 4.a A metadata block at the beginning of the .ini file describing software, version, and logs source.
- [x] 4.b Each new rule must have at least one test entry in the correct .ini file.
- [x] 4.c Runtest.py must pass and must include the results in raw format here.
<details>
  <statement>Unit Tests</statement>

```
- [ File = ./tests/sophos_fw.ini ] ---------
..........

- [ File = ./tests/dropbear.ini ] ---------
...

- [ File = ./tests/squid_rules.ini ] ---------
..

- [ File = ./tests/sudo.ini ] ---------
........

- [ File = ./tests/gitlab.ini ] ---------
.........................

- [ File = ./tests/glpi.ini ] ---------
...

- [ File = ./tests/unbound.ini ] ---------


- [ File = ./tests/mailscanner.ini ] ---------
.

- [ File = ./tests/samba.ini ] ---------
....

- [ File = ./tests/cisco_ios.ini ] ---------
.................

- [ File = ./tests/cimserver.ini ] ---------
..

- [ File = ./tests/audit_recon.ini ] ---------
..

- [ File = ./tests/fortigate.ini ] ---------
........................................

- [ File = ./tests/cisco_asa.ini ] ---------
........................................................................................

- [ File = ./tests/systemd.ini ] ---------
..

- [ File = ./tests/openldap.ini ] ---------
.........

- [ File = ./tests/oscap.ini ] ---------
................................

- [ File = ./tests/github.ini ] ---------
....................................................................................................................................................................................................................................................................................................................................

- [ File = ./tests/pfsense.ini ] ---------
..

- [ File = ./tests/apache.ini ] ---------
..................

- [ File = ./tests/api.ini ] ---------
............................

- [ File = ./tests/SonicWall.ini ] ---------
........

- [ File = ./tests/rsh.ini ] ---------
..

- [ File = ./tests/auditd.ini ] ---------
...

- [ File = ./tests/junos.ini ] ---------
...

- [ File = ./tests/owlh.ini ] ---------
....

- [ File = ./tests/pam.ini ] ---------
.....

- [ File = ./tests/sophos.ini ] ---------
........

- [ File = ./tests/modsecurity.ini ] ---------
......

- [ File = ./tests/paloalto.ini ] ---------
................

- [ File = ./tests/cylance.ini ] ---------
.......

- [ File = ./tests/pix.ini ] ---------
......................

- [ File = ./tests/sophos-utm-firewall.ini ] ---------
......

- [ File = ./tests/exim.ini ] ---------
.......

- [ File = ./tests/freepbx.ini ] ---------
......

- [ File = ./tests/trendmicro-cloud-one.ini ] ---------
.................

- [ File = ./tests/kernel_usb.ini ] ---------
......

- [ File = ./tests/netscreen.ini ] ---------
....

- [ File = ./tests/panda_paps.ini ] ---------
........

- [ File = ./tests/nextcloud.ini ] ---------
........

- [ File = ./tests/aws_s3_access.ini ] ---------
.......

- [ File = ./tests/doas.ini ] ---------
....

- [ File = ./tests/icinga.ini ] ---------
....

- [ File = ./tests/apparmor.ini ] ---------
.....

- [ File = ./tests/sshd.ini ] ---------
...........................................

- [ File = ./tests/opensmtpd.ini ] ---------
.......

- [ File = ./tests/proftpd.ini ] ---------
.......

- [ File = ./tests/named.ini ] ---------
.....

- [ File = ./tests/syslog.ini ] ---------
......

- [ File = ./tests/checkpoint_smart1.ini ] ---------
..................

- [ File = ./tests/fireeye.ini ] ---------
...

- [ File = ./tests/office365.ini ] ---------
................................................................................................................................

- [ File = ./tests/vsftpd.ini ] ---------
....

- [ File = ./tests/openvpn_ldap.ini ] ---------
..

- [ File = ./tests/cpanel.ini ] ---------
.......

- [ File = ./tests/audit_scp.ini ] ---------
.

- [ File = ./tests/cloudlfare-waf.ini ] ---------
.............

- [ File = ./tests/web_appsec.ini ] ---------
...............................

- [ File = ./tests/fortiauth.ini ] ---------
....

- [ File = ./tests/cisco_ftd.ini ] ---------
..........................................

- [ File = ./tests/ossec.ini ] ---------
.....

- [ File = ./tests/arbor.ini ] ---------
..

- [ File = ./tests/huawei_usg.ini ] ---------
...

- [ File = ./tests/exchange.ini ] ---------
..

- [ File = ./tests/postfix.ini ] ---------
..

- [ File = ./tests/su.ini ] ---------
.....

- [ File = ./tests/vuln_detector.ini ] ---------
..

- [ File = ./tests/f5_big_ip.ini ] ---------
...........................................

- [ File = ./tests/mcafee_epo.ini ] ---------
.

- [ File = ./tests/audit_lateral.ini ] ---------
......

- [ File = ./tests/sysmon.ini ] ---------
...

- [ File = ./tests/web_rules.ini ] ---------
..........

- [ File = ./tests/iptables.ini ] ---------
........

- [ File = ./tests/eset.ini ] ---------
........

- [ File = ./tests/gcp.ini ] ---------
...........

- [ File = ./tests/firewalld.ini ] ---------
..

- [ File = ./tests/dovecot.ini ] ---------
...............

- [ File = ./tests/nginx.ini ] ---------
............


|Component |  Tested  |  Total   | Coverage |
| -------- | -------- | -------- | -------- |
|  Rules   |   983    |   4171   |  23.57%  |
| Decoders |    77    |   172    |  44.77%  |

|          File           |  Passed  |  Failed  |  Status  |
|        --------         | -------- | -------- | -------- |
|./tests/sysmon.ini       |    3     |    0     |   ✅    |
|./tests/proftpd.ini      |    7     |    0     |   ✅    |
|./tests/glpi.ini         |    3     |    0     |   ✅    |
|./tests/dovecot.ini      |    15    |    0     |   ✅    |
|./tests/exim.ini         |    7     |    0     |   ✅    |
|./tests/huawei_usg.ini   |    3     |    0     |   ✅    |
|./tests/squid_rules.ini  |    2     |    0     |   ✅    |
|./tests/pix.ini          |    22    |    0     |   ✅    |
|./tests/samba.ini        |    4     |    0     |   ✅    |
|./tests/mcafee_epo.ini   |    1     |    0     |   ✅    |
|./tests/checkpoint_smart1.ini|    18    |    0     |   ✅    |
|./tests/pfsense.ini      |    2     |    0     |   ✅    |
|./tests/iptables.ini     |    8     |    0     |   ✅    |
|./tests/cisco_asa.ini    |    88    |    0     |   ✅    |
|./tests/dropbear.ini     |    3     |    0     |   ✅    |
|./tests/systemd.ini      |    2     |    0     |   ✅    |
|./tests/SonicWall.ini    |    8     |    0     |   ✅    |
|./tests/panda_paps.ini   |    8     |    0     |   ✅    |
|./tests/mailscanner.ini  |    1     |    0     |   ✅    |
|./tests/owlh.ini         |    4     |    0     |   ✅    |
|./tests/fortiauth.ini    |    4     |    0     |   ✅    |
|./tests/cisco_ios.ini    |    17    |    0     |   ✅    |
|./tests/vuln_detector.ini|    2     |    0     |   ✅    |
|./tests/cloudlfare-waf.ini|    13    |    0     |   ✅    |
|./tests/gcp.ini          |    11    |    0     |   ✅    |
|./tests/openldap.ini     |    9     |    0     |   ✅    |
|./tests/unbound.ini      |    0     |    0     |   ✅    |
|./tests/oscap.ini        |    32    |    0     |   ✅    |
|./tests/f5_big_ip.ini    |    43    |    0     |   ✅    |
|./tests/sophos.ini       |    8     |    0     |   ✅    |
|./tests/opensmtpd.ini    |    7     |    0     |   ✅    |
|./tests/exchange.ini     |    2     |    0     |   ✅    |
|./tests/icinga.ini       |    4     |    0     |   ✅    |
|./tests/netscreen.ini    |    4     |    0     |   ✅    |
|./tests/doas.ini         |    4     |    0     |   ✅    |
|./tests/rsh.ini          |    2     |    0     |   ✅    |
|./tests/arbor.ini        |    2     |    0     |   ✅    |
|./tests/office365.ini    |   128    |    0     |   ✅    |
|./tests/paloalto.ini     |    16    |    0     |   ✅    |
|./tests/cylance.ini      |    7     |    0     |   ✅    |
|./tests/fortigate.ini    |    40    |    0     |   ✅    |
|./tests/ossec.ini        |    5     |    0     |   ✅    |
|./tests/web_rules.ini    |    10    |    0     |   ✅    |
|./tests/sudo.ini         |    8     |    0     |   ✅    |
|./tests/audit_lateral.ini|    6     |    0     |   ✅    |
|./tests/cisco_ftd.ini    |    42    |    0     |   ✅    |
|./tests/github.ini       |   324    |    0     |   ✅    |
|./tests/postfix.ini      |    2     |    0     |   ✅    |
|./tests/syslog.ini       |    6     |    0     |   ✅    |
|./tests/kernel_usb.ini   |    6     |    0     |   ✅    |
|./tests/api.ini          |    28    |    0     |   ✅    |
|./tests/sophos-utm-firewall.ini|    6     |    0     |   ✅    |
|./tests/apparmor.ini     |    5     |    0     |   ✅    |
|./tests/audit_scp.ini    |    1     |    0     |   ✅    |
|./tests/nginx.ini        |    12    |    0     |   ✅    |
|./tests/named.ini        |    5     |    0     |   ✅    |
|./tests/sophos_fw.ini    |    10    |    0     |   ✅    |
|./tests/openvpn_ldap.ini |    2     |    0     |   ✅    |
|./tests/cimserver.ini    |    2     |    0     |   ✅    |
|./tests/vsftpd.ini       |    4     |    0     |   ✅    |
|./tests/freepbx.ini      |    6     |    0     |   ✅    |
|./tests/sshd.ini         |    43    |    0     |   ✅    |
|./tests/junos.ini        |    3     |    0     |   ✅    |
|./tests/modsecurity.ini  |    6     |    0     |   ✅    |
|./tests/nextcloud.ini    |    8     |    0     |   ✅    |
|./tests/fireeye.ini      |    3     |    0     |   ✅    |
|./tests/cpanel.ini       |    7     |    0     |   ✅    |
|./tests/trendmicro-cloud-one.ini|    17    |    0     |   ✅    |
|./tests/pam.ini          |    5     |    0     |   ✅    |
|./tests/su.ini           |    5     |    0     |   ✅    |
|./tests/apache.ini       |    18    |    0     |   ✅    |
|./tests/gitlab.ini       |    25    |    0     |   ✅    |
|./tests/aws_s3_access.ini|    7     |    0     |   ✅    |
|./tests/firewalld.ini    |    2     |    0     |   ✅    |
|./tests/eset.ini         |    8     |    0     |   ✅    |
|./tests/auditd.ini       |    3     |    0     |   ✅    |
|./tests/web_appsec.ini   |    31    |    0     |   ✅    |
|./tests/audit_recon.ini  |    2     |    0     |   ✅    |
```

</details>

- [x] 4.d New CDB lists must include the proper test entry in the correct .ini file.

### E2E testing

- ~~[] 5.a Logs for new or modified decoder/rules sent to a manager running with this PR ruleset appear in Kibana. ~~
- ~~[] 5.b There are not affected or broken visualizations on Kibana. ~~
-  ~~[] 5.c New or modified items can be seen correctly using APP ruleset navigation.~~


### Elasticsearch Template

- [x] 6.a Known fields with output format managed and usually used for searching are included in template array index.query.default_field. 
- [x] 6.b The new field with the correct date format is stored as a "date" type field in the template.
- [x] 6.c The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 
- [x] 6.d Known fields with output format managed and usually used for searching are included in the template.

### Stoppers

- [x] 7.a No previous rule ID changes without triple check.
- [x] 7.b No previous decoder name changes without triple check.
- [x] 7.c No previous file name changes without triple check.
- [x] 7.d No previous test changes its 'rule' field value without triple check.

### Others

- [x] 8.a Each file has the correct copyright block.
- [x] 8.b The copyright block doesn't have "Author" only "Created by Wazuh". To include an "Author" request triple check.
- [x] 8.c The copyright block doesn't use "-". 
- [x] 8.d The rule files don't have any sample log.
- [x] 8.e The decoder file has sample logs next to the decoder that matches that log.
- [x] 8.f The decoder and rule files have information about software, version, and any helpful information.
- [x] 8.g The PR has a single commit with CHANGELOG changes in the correct format.
- [x] 8.h The new rule ID is not in use.
- [x] 8.i The new rule ID must be in the defined IDs range. 
- [x] 8.j New rules ID range must be verified with a triple check and noted in the rules ID document.
- [x] 8.k The new extracted IP fields are in the pipeline as "geo" field and "geo_point" type in the template. 