### PR TITLE
Handle PID files for child processes on Wazuh API and cluster

### DIFF
--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -296,7 +296,7 @@ if __name__ == '__main__':
                 raise exc
 
     # Check for unused PID files
-    utils.check_pids(API_MAIN_PROCESS)
+    utils.clean_pid_files(API_MAIN_PROCESS)
 
     # Foreground/Daemon
     if not args.foreground:

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -15,8 +15,8 @@ from api.constants import API_LOG_FILE_PATH
 from wazuh.core import pyDaemonModule
 
 API_MAIN_PROCESS = 'wazuh-apid'
-API_LOCAL_REQUEST_PROCESS = 'wazuh-apid-exec'
-API_AUTHENTICATION_PROCESS = 'wazuh-apid-auth'
+API_LOCAL_REQUEST_PROCESS = 'wazuh-apid_exec'
+API_AUTHENTICATION_PROCESS = 'wazuh-apid_auth'
 
 
 def spawn_process_pool():
@@ -171,9 +171,7 @@ def start(foreground: bool, root: bool, config_file: str):
                 raise exc
 
     # Check for unused PID files
-    utils.check_pid(API_MAIN_PROCESS)
-    utils.check_pid(API_LOCAL_REQUEST_PROCESS)
-    utils.check_pid(API_AUTHENTICATION_PROCESS)
+    utils.check_pids(API_MAIN_PROCESS)
 
     # Drop privileges to ossec
     if not root:

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -304,7 +304,7 @@ if __name__ == '__main__':
     else:
         print(f"Starting API in foreground")
 
-    # Drop privileges to ossec
+    # Drop privileges to wazuh
     if not args.root:
         if api_conf['drop_privileges']:
             os.setgid(common.wazuh_gid())

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -295,6 +295,9 @@ if __name__ == '__main__':
                 logger.error(msg)
                 raise exc
 
+    # Check for unused PID files
+    utils.check_pids(API_MAIN_PROCESS)
+
     # Foreground/Daemon
     if not args.foreground:
         pyDaemonModule.pyDaemon()
@@ -308,9 +311,6 @@ if __name__ == '__main__':
             os.setuid(common.wazuh_uid())
     else:
         print(f"Starting API as root")
-
-    # Check for unused PID files
-    utils.check_pids(API_MAIN_PROCESS)
 
     pid = os.getpid()
     pyDaemonModule.create_pid(API_MAIN_PROCESS, pid)

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -8,9 +8,7 @@ import argparse
 import os
 import signal
 import sys
-from atexit import register
 
-from api.api_exception import APIError
 from api.constants import API_LOG_FILE_PATH
 from wazuh.core import pyDaemonModule
 
@@ -25,8 +23,8 @@ def spawn_process_pool():
     from wazuh.core import common  # noqa
     from wazuh.core.cluster import dapi  # noqa
 
-    pid = os.getpid()
-    pyDaemonModule.create_pid(API_LOCAL_REQUEST_PROCESS, pid)
+    exec_pid = os.getpid()
+    pyDaemonModule.create_pid(API_LOCAL_REQUEST_PROCESS, exec_pid)
 
     signal.signal(signal.SIGINT, signal.SIG_IGN)
 
@@ -35,160 +33,19 @@ def spawn_authentication_pool():
     """Import necessary basic Wazuh security modules for the authentication tasks pool and spawn child."""
     from wazuh import security  # noqa
 
-    pid = os.getpid()
-    pyDaemonModule.create_pid(API_AUTHENTICATION_PROCESS, pid)
+    auth_pid = os.getpid()
+    pyDaemonModule.create_pid(API_AUTHENTICATION_PROCESS, auth_pid)
 
     signal.signal(signal.SIGINT, signal.SIG_IGN)
 
 
-def start(foreground: bool, root: bool, config_file: str):
+def start():
     """Run the Wazuh API.
 
     If another Wazuh API is running, this function fails.
     This function exits with 0 if successful or 1 if failed because the API was already running.
-
-    Arguments
-    ---------
-    foreground : bool
-        If the API must be daemonized or not
-    root : bool
-        If true, the daemon is run as root. Normally not recommended for security reasons
-    config_file : str
-        Path to the API config file
     """
-    import logging
-    from api import alogging, configuration
-    from wazuh.core import common, utils
 
-    def set_logging(log_path='logs/api.log', foreground_mode=False, debug_mode='info'):
-        for logger_name in ('connexion.aiohttp_app', 'connexion.apis.aiohttp_api', 'wazuh-api'):
-            api_logger = alogging.APILogger(
-                log_path=log_path, foreground_mode=foreground_mode, logger_name=logger_name,
-                debug_level='info' if logger_name != 'wazuh-api' and debug_mode != 'debug2' else debug_mode
-            )
-            api_logger.setup_logger()
-
-    if config_file is not None:
-        configuration.api_conf.update(configuration.read_yaml_config(config_file=config_file))
-    api_conf = configuration.api_conf
-    security_conf = configuration.security_conf
-
-    # Set up logger
-    set_logging(log_path=API_LOG_FILE_PATH, debug_mode=api_conf['logs']['level'], foreground_mode=foreground)
-    logger = logging.getLogger('wazuh-api')
-
-    import asyncio
-    import ssl
-
-    import connexion
-    import uvloop
-    from aiohttp_cache import setup_cache
-    from api import __path__ as api_path
-    # noinspection PyUnresolvedReferences
-    from api import validator
-    from api.api_exception import APIError
-    from api.constants import CONFIG_FILE_PATH
-    from api.middlewares import set_user_name, security_middleware, response_postprocessing, request_logging, \
-        set_secure_headers
-    from api.signals import modify_response_headers
-    from api.uri_parser import APIUriParser
-    from api.util import to_relative_path
-    from wazuh.rbac.orm import create_rbac_db
-
-    # Check deprecated options. To delete after expected versions
-    if 'use_only_authd' in api_conf:
-        del api_conf['use_only_authd']
-        logger.warning("'use_only_authd' option was deprecated on v4.3.0. Wazuh Authd will always be used")
-
-    if 'path' in api_conf['logs']:
-        del api_conf['logs']['path']
-        logger.warning("Log 'path' option was deprecated on v4.3.0. Default path will always be used: "
-                       f"{API_LOG_FILE_PATH}")
-
-    # Set correct permissions on api.log file
-    if os.path.exists(os.path.join(common.wazuh_path, API_LOG_FILE_PATH)):
-        os.chown(os.path.join(common.wazuh_path, API_LOG_FILE_PATH), common.wazuh_uid(), common.wazuh_gid())
-        os.chmod(os.path.join(common.wazuh_path, API_LOG_FILE_PATH), 0o660)
-
-    # Configure https
-    ssl_context = None
-    if api_conf['https']['enabled']:
-        try:
-            # Generate SSL if it does not exist and HTTPS is enabled
-            if not os.path.exists(api_conf['https']['key']) or not os.path.exists(api_conf['https']['cert']):
-                logger.info('HTTPS is enabled but cannot find the private key and/or certificate. '
-                            'Attempting to generate them')
-                private_key = configuration.generate_private_key(api_conf['https']['key'])
-                logger.info(f"Generated private key file in WAZUH_PATH/{to_relative_path(api_conf['https']['key'])}")
-                configuration.generate_self_signed_certificate(private_key, api_conf['https']['cert'])
-                logger.info(f"Generated certificate file in WAZUH_PATH/{to_relative_path(api_conf['https']['cert'])}")
-
-            # Load SSL context
-            allowed_ssl_protocols = {
-                'tls': ssl.PROTOCOL_TLS,
-                'tlsv1': ssl.PROTOCOL_TLSv1,
-                'tlsv1.1': ssl.PROTOCOL_TLSv1_1,
-                'tlsv1.2': ssl.PROTOCOL_TLSv1_2
-            }
-
-            ssl_protocol = allowed_ssl_protocols[api_conf['https']['ssl_protocol'].lower()]
-            ssl_context = ssl.SSLContext(protocol=ssl_protocol)
-
-            if api_conf['https']['use_ca']:
-                ssl_context.verify_mode = ssl.CERT_REQUIRED
-                ssl_context.load_verify_locations(api_conf['https']['ca'])
-
-            ssl_context.load_cert_chain(certfile=api_conf['https']['cert'], keyfile=api_conf['https']['key'])
-
-            # Load SSL ciphers if any has been specified
-            if api_conf['https']['ssl_ciphers']:
-                ssl_ciphers = api_conf['https']['ssl_ciphers'].upper()
-                try:
-                    ssl_context.set_ciphers(ssl_ciphers)
-                except ssl.SSLError:
-                    error = APIError(2003, details='SSL ciphers cannot be selected')
-                    logger.error(error)
-                    raise error
-
-        except ssl.SSLError:
-            error = APIError(2003, details='Private key does not match with the certificate')
-            logger.error(error)
-            raise error
-        except IOError as exc:
-            if exc.errno == 22:
-                error = APIError(2003, details='PEM phrase is not correct')
-                logger.error(error)
-                raise error
-            elif exc.errno == 13:
-                error = APIError(2003, details='Ensure the certificates have the correct permissions')
-                logger.error(error)
-                raise error
-            else:
-                msg = f'Wazuh API SSL ERROR. Please, ensure if path to certificates is correct in the configuration ' \
-                      f'file WAZUH_PATH/{to_relative_path(CONFIG_FILE_PATH)}'
-                print(msg)
-                logger.error(msg)
-                raise exc
-
-    # Check for unused PID files
-    utils.check_pids(API_MAIN_PROCESS)
-
-    # Drop privileges to ossec
-    if not root:
-        if api_conf['drop_privileges']:
-            os.setgid(common.wazuh_gid())
-            os.setuid(common.wazuh_uid())
-    else:
-        print(f"Starting API as root")
-
-    # Foreground/Daemon
-    if not foreground:
-        pyDaemonModule.pyDaemon()
-    else:
-        print(f"Starting API in foreground")
-
-    pid = os.getpid()
-    pyDaemonModule.create_pid(API_MAIN_PROCESS, pid) or register(pyDaemonModule.delete_pid, API_MAIN_PROCESS, pid)
     create_rbac_db()
 
     # Spawn child processes with their own needed imports
@@ -292,9 +149,11 @@ def version():
     sys.exit(0)
 
 
-def exit_handler(signum=None, frame=None):
+def exit_handler(signum, frame):
     """Try to kill API child processes and remove their PID files."""
-    pyDaemonModule.delete_child_pids(API_MAIN_PROCESS, os.getpid())
+    api_pid = os.getpid()
+    pyDaemonModule.delete_child_pids(API_MAIN_PROCESS, api_pid)
+    pyDaemonModule.delete_pid(API_MAIN_PROCESS, api_pid)
 
 
 if __name__ == '__main__':
@@ -312,17 +171,160 @@ if __name__ == '__main__':
 
     if args.version:
         version()
+        sys.exit(0)
+
     elif args.test_config:
         test_config(args.config_file)
-    else:
+        sys.exit(0)
+
+    import logging
+    from api import alogging, configuration
+    from wazuh.core import common, utils
+
+
+    def set_logging(log_path='logs/api.log', foreground_mode=False, debug_mode='info'):
+        for logger_name in ('connexion.aiohttp_app', 'connexion.apis.aiohttp_api', 'wazuh-api'):
+            api_logger = alogging.APILogger(
+                log_path=log_path, foreground_mode=foreground_mode, logger_name=logger_name,
+                debug_level='info' if logger_name != 'wazuh-api' and debug_mode != 'debug2' else debug_mode
+            )
+            api_logger.setup_logger()
+
+
+    if args.config_file is not None:
+        configuration.api_conf.update(configuration.read_yaml_config(config_file=args.config_file))
+    api_conf = configuration.api_conf
+    security_conf = configuration.security_conf
+
+    # Set up logger
+    set_logging(log_path=API_LOG_FILE_PATH, debug_mode=api_conf['logs']['level'], foreground_mode=args.foreground)
+    logger = logging.getLogger('wazuh-api')
+
+    import asyncio
+    import ssl
+
+    import connexion
+    import uvloop
+    from aiohttp_cache import setup_cache
+    from api import __path__ as api_path
+    # noinspection PyUnresolvedReferences
+    from api import validator
+    from api.api_exception import APIError
+    from api.constants import CONFIG_FILE_PATH
+    from api.middlewares import set_user_name, security_middleware, response_postprocessing, request_logging, \
+        set_secure_headers
+    from api.signals import modify_response_headers
+    from api.uri_parser import APIUriParser
+    from api.util import to_relative_path
+    from wazuh.rbac.orm import create_rbac_db
+
+    # Check deprecated options. To delete after expected versions
+    if 'use_only_authd' in api_conf:
+        del api_conf['use_only_authd']
+        logger.warning("'use_only_authd' option was deprecated on v4.3.0. Wazuh Authd will always be used")
+
+    if 'path' in api_conf['logs']:
+        del api_conf['logs']['path']
+        logger.warning("Log 'path' option was deprecated on v4.3.0. Default path will always be used: "
+                       f"{API_LOG_FILE_PATH}")
+
+    # Set correct permissions on api.log file
+    if os.path.exists(os.path.join(common.wazuh_path, API_LOG_FILE_PATH)):
+        os.chown(os.path.join(common.wazuh_path, API_LOG_FILE_PATH), common.wazuh_uid(), common.wazuh_gid())
+        os.chmod(os.path.join(common.wazuh_path, API_LOG_FILE_PATH), 0o660)
+
+    # Configure https
+    ssl_context = None
+    if api_conf['https']['enabled']:
         try:
-            signal.signal(signal.SIGTERM, exit_handler)
-            start(args.foreground, args.root, args.config_file)
-        except APIError as e:
-            print(f"Error when trying to start the Wazuh API. {e}")
-            sys.exit(1)
-        except Exception as e:
-            print(f'Internal error when trying to start the Wazuh API. {e}')
-            sys.exit(1)
-        finally:
-            exit_handler()
+            # Generate SSL if it does not exist and HTTPS is enabled
+            if not os.path.exists(api_conf['https']['key']) or not os.path.exists(api_conf['https']['cert']):
+                logger.info('HTTPS is enabled but cannot find the private key and/or certificate. '
+                            'Attempting to generate them')
+                private_key = configuration.generate_private_key(api_conf['https']['key'])
+                logger.info(
+                    f"Generated private key file in WAZUH_PATH/{to_relative_path(api_conf['https']['key'])}")
+                configuration.generate_self_signed_certificate(private_key, api_conf['https']['cert'])
+                logger.info(
+                    f"Generated certificate file in WAZUH_PATH/{to_relative_path(api_conf['https']['cert'])}")
+
+            # Load SSL context
+            allowed_ssl_protocols = {
+                'tls': ssl.PROTOCOL_TLS,
+                'tlsv1': ssl.PROTOCOL_TLSv1,
+                'tlsv1.1': ssl.PROTOCOL_TLSv1_1,
+                'tlsv1.2': ssl.PROTOCOL_TLSv1_2
+            }
+
+            ssl_protocol = allowed_ssl_protocols[api_conf['https']['ssl_protocol'].lower()]
+            ssl_context = ssl.SSLContext(protocol=ssl_protocol)
+
+            if api_conf['https']['use_ca']:
+                ssl_context.verify_mode = ssl.CERT_REQUIRED
+                ssl_context.load_verify_locations(api_conf['https']['ca'])
+
+            ssl_context.load_cert_chain(certfile=api_conf['https']['cert'], keyfile=api_conf['https']['key'])
+
+            # Load SSL ciphers if any has been specified
+            if api_conf['https']['ssl_ciphers']:
+                ssl_ciphers = api_conf['https']['ssl_ciphers'].upper()
+                try:
+                    ssl_context.set_ciphers(ssl_ciphers)
+                except ssl.SSLError:
+                    error = APIError(2003, details='SSL ciphers cannot be selected')
+                    logger.error(error)
+                    raise error
+
+        except ssl.SSLError:
+            error = APIError(2003, details='Private key does not match with the certificate')
+            logger.error(error)
+            raise error
+        except IOError as exc:
+            if exc.errno == 22:
+                error = APIError(2003, details='PEM phrase is not correct')
+                logger.error(error)
+                raise error
+            elif exc.errno == 13:
+                error = APIError(2003, details='Ensure the certificates have the correct permissions')
+                logger.error(error)
+                raise error
+            else:
+                msg = f'Wazuh API SSL ERROR. Please, ensure if path to certificates is correct in the configuration ' \
+                      f'file WAZUH_PATH/{to_relative_path(CONFIG_FILE_PATH)}'
+                print(msg)
+                logger.error(msg)
+                raise exc
+
+    # Foreground/Daemon
+    if not args.foreground:
+        pyDaemonModule.pyDaemon()
+    else:
+        print(f"Starting API in foreground")
+
+    # Drop privileges to ossec
+    if not args.root:
+        if api_conf['drop_privileges']:
+            os.setgid(common.wazuh_gid())
+            os.setuid(common.wazuh_uid())
+    else:
+        print(f"Starting API as root")
+
+    # Check for unused PID files
+    utils.check_pids(API_MAIN_PROCESS)
+
+    pid = os.getpid()
+    pyDaemonModule.create_pid(API_MAIN_PROCESS, pid)
+
+    signal.signal(signal.SIGTERM, exit_handler)
+
+    try:
+        start()
+    except APIError as e:
+        print(f"Error when trying to start the Wazuh API. {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f'Internal error when trying to start the Wazuh API. {e}')
+        sys.exit(1)
+    finally:
+        pyDaemonModule.delete_child_pids(API_MAIN_PROCESS, pid)
+        pyDaemonModule.delete_pid(API_MAIN_PROCESS, pid)

--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -7,12 +7,11 @@ import argparse
 import asyncio
 import logging
 import os
+import signal
 import sys
-from signal import signal, Signals, SIGTERM, SIG_DFL
+import time
 
-from psutil import Process
-
-from wazuh.core.utils import check_pid
+from wazuh.core.utils import check_pids
 
 
 #
@@ -32,36 +31,21 @@ def print_version():
     print("\n{} {} - {}\n\n{}".format(__wazuh_name__, __version__, __author__, __licence__))
 
 
-def terminate_child_processes(parent_pid):
-    """Stop the execution of all cluster child processes.
-
-    Parameters
-    ----------
-    parent_pid : int
-        Parent process ID.
-    """
-    for child in Process(parent_pid).children(recursive=True):
-        try:
-            child.kill()
-        except Exception:
-            pass
-
-
 def exit_handler(signum, frame):
     cluster_pid = os.getpid()
-    main_logger.info(f'SIGNAL [({signum})-({Signals(signum).name})] received. Exit...')
+    main_logger.info(f'SIGNAL [({signum})-({signal.Signals(signum).name})] received. Exit...')
 
     # Terminate cluster's child processes
-    terminate_child_processes(cluster_pid)
+    pyDaemonModule.delete_child_pids('wazuh-clusterd', cluster_pid)
 
     # Remove cluster's pidfile
     pyDaemonModule.delete_pid('wazuh-clusterd', cluster_pid)
 
     if callable(original_sig_handler):
         original_sig_handler(signum, frame)
-    elif original_sig_handler == SIG_DFL:
+    elif original_sig_handler == signal.SIG_DFL:
         # Call default handler if the original one can't be run
-        signal(signum, SIG_DFL)
+        signal.signal(signum, signal.SIG_DFL)
         os.kill(os.getpid(), signum)
 
 
@@ -205,13 +189,14 @@ if __name__ == '__main__':
         os.setgid(common.wazuh_gid())
         os.setuid(common.wazuh_uid())
 
-    check_pid('wazuh-clusterd')
+    check_pids('wazuh-clusterd')
+
     pid = os.getpid()
     pyDaemonModule.create_pid('wazuh-clusterd', pid)
     if args.foreground:
         print(f"Starting cluster in foreground (pid: {pid})")
 
-    original_sig_handler = signal(SIGTERM, exit_handler)
+    original_sig_handler = signal.signal(signal.SIGTERM, exit_handler)
 
     main_function = master_main if cluster_configuration['node_type'] == 'master' else worker_main
     try:
@@ -224,5 +209,5 @@ if __name__ == '__main__':
     except Exception as e:
         main_logger.error(f"Unhandled exception: {e}")
     finally:
-        terminate_child_processes(pid)
+        pyDaemonModule.delete_child_pids('wazuh-clusterd', pid)
         pyDaemonModule.delete_pid('wazuh-clusterd', pid)

--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -179,6 +179,9 @@ if __name__ == '__main__':
     # clean
     wazuh.core.cluster.cluster.clean_up()
 
+    # Check for unused PID files
+    check_pids('wazuh-clusterd')
+
     # Foreground/Daemon
     if not args.foreground:
         pyDaemonModule.pyDaemon()
@@ -187,8 +190,6 @@ if __name__ == '__main__':
     if not args.root:
         os.setgid(common.wazuh_gid())
         os.setuid(common.wazuh_uid())
-
-    check_pids('wazuh-clusterd')
 
     pid = os.getpid()
     pyDaemonModule.create_pid('wazuh-clusterd', pid)

--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -9,7 +9,6 @@ import logging
 import os
 import signal
 import sys
-import time
 
 from wazuh.core.utils import check_pids
 

--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -10,7 +10,7 @@ import os
 import signal
 import sys
 
-from wazuh.core.utils import check_pids
+from wazuh.core.utils import clean_pid_files
 
 
 #
@@ -180,7 +180,7 @@ if __name__ == '__main__':
     wazuh.core.cluster.cluster.clean_up()
 
     # Check for unused PID files
-    check_pids('wazuh-clusterd')
+    clean_pid_files('wazuh-clusterd')
 
     # Foreground/Daemon
     if not args.foreground:

--- a/framework/wazuh/core/cluster/utils.py
+++ b/framework/wazuh/core/cluster/utils.py
@@ -6,7 +6,9 @@ import json
 import logging
 import os
 import re
+import signal
 import socket
+import time
 import typing
 from contextvars import ContextVar
 from functools import lru_cache
@@ -14,7 +16,7 @@ from glob import glob
 from operator import setitem
 from os.path import join, exists
 
-from wazuh.core import common
+from wazuh.core import common, pyDaemonModule
 from wazuh.core.configuration import get_ossec_conf
 from wazuh.core.exception import WazuhException, WazuhError, WazuhInternalError
 from wazuh.core.results import WazuhResult
@@ -289,6 +291,18 @@ class ClusterLogger(WazuhLogger):
         self.logger.setLevel(debug_level)
 
 
-def process_spawn_sleep():
-    """Simple task to force the cluster pool spawn all its children."""
-    return
+def process_spawn_sleep(child):
+    """Task to force the cluster pool spawn all its children and create their PID files.
+
+    Parameters
+    ----------
+    child: int
+        Process child number.
+    """
+    pid = os.getpid()
+    pyDaemonModule.create_pid(f'wazuh-clusterd_child_{child}', pid)
+
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    # Prevent race conditions
+    time.sleep(0.1)

--- a/framework/wazuh/core/cluster/utils.py
+++ b/framework/wazuh/core/cluster/utils.py
@@ -304,6 +304,6 @@ def process_spawn_sleep(child):
 
     signal.signal(signal.SIGINT, signal.SIG_IGN)
     signal.signal(signal.SIGTERM, signal.SIG_IGN)
-    # Add a delay to force each child process create its own PID file and prevent multiple calls
+    # Add a delay to force each child process to create its own PID file, preventing multiple calls
     # executed by the same child
     time.sleep(0.1)

--- a/framework/wazuh/core/cluster/utils.py
+++ b/framework/wazuh/core/cluster/utils.py
@@ -304,5 +304,6 @@ def process_spawn_sleep(child):
 
     signal.signal(signal.SIGINT, signal.SIG_IGN)
     signal.signal(signal.SIGTERM, signal.SIG_IGN)
-    # Prevent race conditions
+    # Add a delay to force each child process create its own PID file and prevent multiple calls
+    # executed by the same child
     time.sleep(0.1)

--- a/framework/wazuh/core/pyDaemonModule.py
+++ b/framework/wazuh/core/pyDaemonModule.py
@@ -4,8 +4,13 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
+import glob
 import os
 import sys
+from os import path
+
+import psutil
+
 from wazuh.core import common
 from wazuh.core.exception import WazuhInternalError
 
@@ -54,20 +59,38 @@ def pyDaemon():
 
 
 def create_pid(name, pid):
-    filename = f"{common.wazuh_path}/{common.os_pidfile}/{name}-{pid}.pid"
+    filename = path.join(common.wazuh_path, common.os_pidfile, f'{name}-{pid}.pid')
 
     with open(filename, 'a') as fp:
         try:
-            fp.write("{0}\n".format(pid))
+            fp.write(f'{pid}\n')
             os.chmod(filename, 0o640)
         except OSError as e:
             raise WazuhInternalError(3002, str(e))
 
 
 def delete_pid(name, pid):
-    filename = f"{common.wazuh_path}/{common.os_pidfile}/{name}-{pid}.pid"
+    filename = path.join(common.wazuh_path, common.os_pidfile, f'{name}-{pid}.pid')
+
     try:
-        if os.path.exists(filename):
+        if path.exists(filename):
             os.unlink(filename)
     except OSError:
         pass
+
+
+def delete_child_pids(name, ppid):
+    filenames = glob.glob(path.join(common.wazuh_path, common.os_pidfile, f'{name}*.pid'))
+
+    for process in psutil.Process(ppid).children(recursive=True):
+        try:
+            process.kill()
+        except psutil.Error:
+            pass
+        for filename in filenames[:]:
+            if str(process.pid) in filename:
+                try:
+                    path.exists(filename) and os.unlink(filename)
+                except OSError:
+                    pass
+                filenames.remove(filename)

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -2,8 +2,7 @@
 # Copyright (C) 2015-2021, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
-
-
+import glob
 import os
 from collections.abc import KeysView
 from io import StringIO
@@ -13,12 +12,12 @@ from xml.etree.ElementTree import Element, parse
 
 import pytest
 
+
 with patch('wazuh.core.common.wazuh_uid'):
     with patch('wazuh.core.common.wazuh_gid'):
         from wazuh import WazuhException
-        from wazuh.core.utils import *
-        from wazuh.core import exception
         from wazuh.core.agent import WazuhDBQueryAgents
+        from wazuh.core import utils, exception
         from wazuh.core.common import wazuh_path, agent_name_len_limit
 
 # all necessary params
@@ -162,9 +161,9 @@ test_xml = '''
 ])
 def test_previous_moth(month):
     """Test previous_moth function."""
-    result = previous_month(month)
+    result = utils.previous_month(month)
 
-    assert isinstance(result, datetime)
+    assert isinstance(result, utils.datetime)
 
 
 @pytest.mark.parametrize('string, substring, n, expected_index', [
@@ -175,7 +174,7 @@ def test_previous_moth(month):
 ])
 def test_find_nth(string, substring, n, expected_index):
     """Test find_nth function."""
-    result = find_nth(string, substring, n)
+    result = utils.find_nth(string, substring, n)
 
     assert result == expected_index
 
@@ -183,18 +182,19 @@ def test_find_nth(string, substring, n, expected_index):
 @patch('wazuh.core.utils.check_output', return_value='{"data": "Some data", "message": "Some message", "error":0}')
 def test_execute(mock_output):
     """Test execute function."""
-    result = execute('Command')
+    result = utils.execute('Command')
 
     assert isinstance(result, str)
 
 
 @pytest.mark.parametrize('error_effect, expected_exception', [
-    (CalledProcessError(returncode=1000, cmd='Unexpected error', output='{"data":"Some data", "message":"Error", '
-                                                                        '"error":1000}'), 1000),
+    (utils.CalledProcessError(returncode=1000, cmd='Unexpected error', output='{"data":"Some data", "message":"Error", '
+                                                                              '"error":1000}'), 1000),
     (Exception, 1002),
-    (CalledProcessError(returncode=1, cmd='Unexpected error', output={}), 1003),
-    (CalledProcessError(returncode=1, cmd='Unexpected error', output='{"error":1000}'), 1004),
-    (CalledProcessError(returncode=1, cmd='Unexpected error', output='{"data":"Some data", "message":"Error"}'), 1004)
+    (utils.CalledProcessError(returncode=1, cmd='Unexpected error', output={}), 1003),
+    (utils.CalledProcessError(returncode=1, cmd='Unexpected error', output='{"error":1000}'), 1004),
+    (utils.CalledProcessError(returncode=1, cmd='Unexpected error', output='{"data":"Some data", "message":"Error"}'),
+     1004)
 ])
 def test_execute_ko(error_effect, expected_exception):
     """Test execute function for all exceptions.
@@ -208,7 +208,7 @@ def test_execute_ko(error_effect, expected_exception):
     """
     with pytest.raises(exception.WazuhException, match=f'.* {expected_exception} .*'):
         with patch('wazuh.core.utils.check_output', side_effect=error_effect):
-            execute('Command')
+            utils.execute('Command')
 
 
 @pytest.mark.parametrize('array, limit', [
@@ -220,7 +220,7 @@ def test_execute_ko(error_effect, expected_exception):
 @patch('wazuh.core.utils.common.maximum_database_limit', new=10)
 def test_cut_array(array, limit):
     """Test cut_array function."""
-    result = cut_array(array=array, limit=limit, offset=0)
+    result = utils.cut_array(array=array, limit=limit, offset=0)
 
     assert isinstance(result, list)
 
@@ -243,7 +243,7 @@ def test_cut_array_ko(limit, offset, expected_exception):
         * Limit is less than 0
     """
     with pytest.raises(exception.WazuhException, match=f'.* {expected_exception} .*'):
-        cut_array(array=['one', 'two', 'three'], limit=limit, offset=offset)
+        utils.cut_array(array=['one', 'two', 'three'], limit=limit, offset=offset)
 
 
 @pytest.mark.parametrize('array, filters, limit, search_text, sort_by, expected_items, len_expected_items', [
@@ -258,8 +258,8 @@ def test_cut_array_ko(limit, offset, expected_exception):
 ])
 def test_process_array(array, filters, limit, search_text, sort_by, expected_items, len_expected_items):
     """Test cut_array function."""
-    result = process_array(array=array, filters=filters, limit=limit, offset=0, search_text=search_text,
-                           sort_by=sort_by)
+    result = utils.process_array(array=array, filters=filters, limit=limit, offset=0, search_text=search_text,
+                                 sort_by=sort_by)
 
     assert result == {'items': expected_items, 'totalItems': len_expected_items}
 
@@ -293,15 +293,15 @@ def test_process_array_q(array, q, expected_items):
     expected_items : list
         List of items after applying the filter
     """
-    result = process_array(array=array, q=q)
+    result = utils.process_array(array=array, q=q)
 
     assert result == {'items': expected_items, 'totalItems': len(expected_items)}
 
 
 def test_sort_array_type():
     """Test sort_array function."""
-    assert isinstance(sort_array(mock_array, mock_sort_by), list)
-    assert isinstance(sort_array(mock_array, None), list)
+    assert isinstance(utils.sort_array(mock_array, mock_sort_by), list)
+    assert isinstance(utils.sort_array(mock_array, None), list)
 
 
 @pytest.mark.parametrize('array, sort_by, order, expected_exception', [
@@ -319,7 +319,7 @@ def test_sort_array_error(array, sort_by, order, expected_exception):
         * Sort parameter not allow
     """
     with pytest.raises(exception.WazuhException, match=f'.* {expected_exception} .*'):
-        sort_array(array, sort_by, order)
+        utils.sort_array(array, sort_by, order)
 
 
 @pytest.mark.parametrize('array, sort_by, order, allowed_sort_field, output', [
@@ -341,7 +341,7 @@ def test_sort_array(array, sort_by, order, allowed_sort_field, output):
         * Sorted list with dict, sorted by different parameter
         * Sorted list with class
     """
-    assert sort_array(array, sort_by, order, allowed_sort_field) == output
+    assert utils.sort_array(array, sort_by, order, allowed_sort_field) == output
 
 
 @pytest.mark.parametrize('object, fields', [
@@ -352,7 +352,7 @@ def test_sort_array(array, sort_by, order, allowed_sort_field, output):
 ])
 def test_get_values(object, fields):
     """Test get_values function."""
-    result = get_values(o=object, fields=fields)
+    result = utils.get_values(o=object, fields=fields)
 
     assert isinstance(result, list)
     assert isinstance(result[0], str)
@@ -367,7 +367,7 @@ def test_get_values(object, fields):
 ])
 def test_search_array(array, text, negation, length):
     """Test search_array function."""
-    result = search_array(array=array, search_text=text, complementary_search=negation)
+    result = utils.search_array(array=array, search_text=text, complementary_search=negation)
 
     assert isinstance(result, list)
     assert len(result) == length
@@ -375,14 +375,14 @@ def test_search_array(array, text, negation, length):
 
 def test_filemode():
     """Test filemode function."""
-    result = filemode(40960)
+    result = utils.filemode(40960)
 
     assert isinstance(result, str)
 
 
 def test_tail():
     """Test tail function."""
-    result = tail(os.path.join(test_data_path, 'test_log.log'))
+    result = utils.tail(os.path.join(test_data_path, 'test_log.log'))
 
     assert isinstance(result, list)
     assert len(result) == 20
@@ -394,9 +394,9 @@ def test_chmod_r(mock_chmod):
     with TemporaryDirectory() as tmpdirname:
         tmpfile = NamedTemporaryFile(dir=tmpdirname, delete=False)
         dummy_tmp = TemporaryDirectory(dir=tmpdirname)
-        chmod_r(tmpdirname, 0o777)
+        utils.chmod_r(tmpdirname, 0o777)
         mock_chmod.assert_any_call(tmpdirname, 0o777)
-        mock_chmod.assert_any_call(path.join(tmpdirname, tmpfile.name), 0o777)
+        mock_chmod.assert_any_call(os.path.join(tmpdirname, tmpfile.name), 0o777)
 
 
 @patch('wazuh.core.utils.chown')
@@ -405,9 +405,9 @@ def test_chown_r(mock_chown):
     with TemporaryDirectory() as tmp_dirname:
         tmp_file = NamedTemporaryFile(dir=tmp_dirname, delete=False)
         dummy_tmp = TemporaryDirectory(dir=tmp_dirname)
-        chown_r(tmp_dirname, 'test_user', 'test_group')
+        utils.chown_r(tmp_dirname, 'test_user', 'test_group')
         mock_chown.assert_any_call(tmp_dirname, 'test_user', 'test_group')
-        mock_chown.assert_any_call(path.join(tmp_dirname, tmp_file.name), 'test_user', 'test_group')
+        mock_chown.assert_any_call(os.path.join(tmp_dirname, tmp_file.name), 'test_user', 'test_group')
 
 
 @patch('wazuh.core.utils.common.wazuh_path', new='/test/path')
@@ -415,26 +415,26 @@ def test_chown_r(mock_chown):
 @patch('wazuh.core.utils.remove')
 def test_delete_wazuh_file(mock_remove, mock_exists):
     """Check delete_file calls functions with expected params"""
-    assert delete_wazuh_file('/test/path/etc/file')
+    assert utils.delete_wazuh_file('/test/path/etc/file')
     mock_remove.assert_called_once_with('/test/path/etc/file')
 
 
 @patch('wazuh.core.utils.common.wazuh_path', new='/test/path')
 def test_delete_wazuh_file_ko():
     """Check delete_file calls functions with expected params"""
-    with pytest.raises(WazuhError, match=r'\b1907\b'):
-        delete_wazuh_file('/test/different_path/etc/file')
+    with pytest.raises(utils.WazuhError, match=r'\b1907\b'):
+        utils.delete_wazuh_file('/test/different_path/etc/file')
 
-    with pytest.raises(WazuhError, match=r'\b1907\b'):
-        delete_wazuh_file('/test/path/file/../../home')
+    with pytest.raises(utils.WazuhError, match=r'\b1907\b'):
+        utils.delete_wazuh_file('/test/path/file/../../home')
 
     with patch('wazuh.core.utils.path.exists', return_value=False):
-        with pytest.raises(WazuhError, match=r'\b1906\b'):
-            delete_wazuh_file('/test/path/etc/file')
+        with pytest.raises(utils.WazuhError, match=r'\b1906\b'):
+            utils.delete_wazuh_file('/test/path/etc/file')
 
     with patch('wazuh.core.utils.path.exists', return_value=True):
-        with pytest.raises(WazuhError, match=r'\b1907\b'):
-            delete_wazuh_file('/test/path/etc/file')
+        with pytest.raises(utils.WazuhError, match=r'\b1907\b'):
+            utils.delete_wazuh_file('/test/path/etc/file')
 
 
 @pytest.mark.parametrize('ownership, time, permissions',
@@ -450,8 +450,8 @@ def test_safe_move(mock_utime, mock_chmod, mock_chown, ownership, time, permissi
     """Test safe_move function."""
     with TemporaryDirectory() as tmpdirname:
         tmp_file = NamedTemporaryFile(dir=tmpdirname, delete=False)
-        target_file = join(tmpdirname, 'target')
-        safe_move(tmp_file.name, target_file, ownership=ownership, time=time, permissions=permissions)
+        target_file = os.path.join(tmpdirname, 'target')
+        utils.safe_move(tmp_file.name, target_file, ownership=ownership, time=time, permissions=permissions)
         assert (os.path.exists(target_file))
 
         tmp_path = os.path.join(os.path.dirname(tmp_file.name), ".target.tmp")
@@ -469,9 +469,9 @@ def test_safe_move_exception(mock_utime, mock_chmod, mock_chown):
     """Test safe_move function."""
     with TemporaryDirectory() as tmpdirname:
         tmp_file = NamedTemporaryFile(dir=tmpdirname, delete=False)
-        target_file = join(tmpdirname, 'target')
+        target_file = os.path.join(tmpdirname, 'target')
         with patch('wazuh.core.utils.rename', side_effect=OSError(1)):
-            safe_move(tmp_file.name, target_file, ownership=(1000, 1000), time=(12345, 12345), permissions=0o660)
+            utils.safe_move(tmp_file.name, target_file, ownership=(1000, 1000), time=(12345, 12345), permissions=0o660)
         assert (os.path.exists(target_file))
 
 
@@ -485,7 +485,7 @@ def test_safe_move_exception(mock_utime, mock_chmod, mock_chown):
 def test_mkdir_with_mode(mock_mkdir, mock_chmod, dir_name, path_exists):
     """Test mkdir_with_mode function."""
     with patch('wazuh.core.utils.path.exists', return_value=path_exists):
-        mkdir_with_mode(dir_name)
+        utils.mkdir_with_mode(dir_name)
         mock_chmod.assert_any_call(dir_name, 0o770)
         mock_mkdir.assert_any_call(dir_name, 0o770)
 
@@ -500,7 +500,7 @@ def test_mkdir_with_mode_ko(mock_mkdir, dir_name, exists):
     """Test mkdir_with_mode function errors work."""
     with patch('wazuh.core.utils.path.exists', return_value=exists):
         with pytest.raises(OSError):
-            mkdir_with_mode(dir_name)
+            utils.mkdir_with_mode(dir_name)
 
 
 @patch('wazuh.core.utils.open')
@@ -509,7 +509,7 @@ def test_md5(mock_iter, mock_open):
     """Test md5 function."""
     with patch('wazuh.core.utils.hashlib.md5') as md:
         md.return_value.update.side_effect = None
-        result = md5('test')
+        result = utils.md5('test')
 
         assert isinstance(result, MagicMock)
         assert isinstance(result.return_value, MagicMock)
@@ -519,7 +519,7 @@ def test_md5(mock_iter, mock_open):
 def test_protected_get_hashing_algorithm_ko():
     """Test _get_hashing_algorithm function exception."""
     with pytest.raises(exception.WazuhException, match=".* 1723 .*"):
-        get_hash(filename='test_file', hash_algorithm='test')
+        utils.get_hash(filename='test_file', hash_algorithm='test')
 
 
 @patch('wazuh.core.utils.open')
@@ -528,14 +528,14 @@ def test_get_hash(mock_open):
     with patch('wazuh.core.utils.iter', return_value=['1', '2']):
         with patch('wazuh.core.utils.hashlib.new') as md:
             md.return_value.update.side_effect = None
-            result = get_hash(filename='test_file')
+            result = utils.get_hash(filename='test_file')
 
             assert isinstance(result, MagicMock)
             assert isinstance(result.return_value, MagicMock)
             mock_open.assert_called_once_with('test_file', 'rb')
 
     with patch('wazuh.core.utils.iter', return_value=[]):
-        result = get_hash(filename='test_file', return_hex=False)
+        result = utils.get_hash(filename='test_file', return_hex=False)
 
         assert type(result) == bytes
 
@@ -546,7 +546,7 @@ def test_get_hash_ko(mock_iter, mock_open):
     """Test get_hash function error work."""
     with patch('wazuh.core.utils.hashlib.new') as md:
         md.return_value.update.side_effect = IOError
-        result = get_hash(filename='test_file')
+        result = utils.get_hash(filename='test_file')
 
         assert result is None
         mock_open.assert_called_once_with('test_file', 'rb')
@@ -554,7 +554,7 @@ def test_get_hash_ko(mock_iter, mock_open):
 
 def test_get_hash_str():
     """Test get_hash_str function work."""
-    result = get_hash_str('test')
+    result = utils.get_hash_str('test')
 
     assert isinstance(result, str)
     assert all(ord(char) < agent_name_len_limit for char in result)
@@ -562,7 +562,7 @@ def test_get_hash_str():
 
 def test_get_fields_to_nest():
     """Test get_fields_to_nest function."""
-    result_nested, result_non_nested = get_fields_to_nest(mock_keys)
+    result_nested, result_non_nested = utils.get_fields_to_nest(mock_keys)
 
     assert isinstance(result_nested, list)
     assert isinstance(result_non_nested, set)
@@ -571,7 +571,7 @@ def test_get_fields_to_nest():
 
 def test_plain_dict_to_nested_dict():
     """Test plain_dict_to_nested_dict function work."""
-    result = plain_dict_to_nested_dict(data=mock_not_nested_dict)
+    result = utils.plain_dict_to_nested_dict(data=mock_not_nested_dict)
 
     assert isinstance(result, dict)
     assert result == mock_nested_dict
@@ -582,7 +582,7 @@ def test_basic_load_wazuh_xml(mock_compile):
     """Test basic load_wazuh_xml functionality."""
     with patch('wazuh.core.utils.open') as f:
         f.return_value.__enter__.return_value = StringIO(test_xml)
-        result = load_wazuh_xml('test_file')
+        result = utils.load_wazuh_xml('test_file')
 
         assert isinstance(result, Element)
 
@@ -601,7 +601,7 @@ def test_load_wazuh_xml():
         path = os.path.join(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data/test_load_wazuh_xml'),
                             rule_file)
         original = parse(path).getroot()
-        result = load_wazuh_xml(path)
+        result = utils.load_wazuh_xml(path)
 
         assert elements_equal(original, result.find('dummy_tag'))
 
@@ -625,8 +625,8 @@ def test_load_wazuh_xml():
 ])
 def test_version_ok(version1, version2):
     """Test WazuhVersion class."""
-    current_version = WazuhVersion(version1)
-    new_version = WazuhVersion(version2)
+    current_version = utils.WazuhVersion(version1)
+    new_version = utils.WazuhVersion(version2)
 
     assert current_version < new_version
     assert current_version <= new_version
@@ -653,8 +653,8 @@ def test_version_ok(version1, version2):
 def test_version_ko(version1, version2):
     """Test WazuhVersion class."""
     try:
-        WazuhVersion(version1)
-        WazuhVersion(version2)
+        utils.WazuhVersion(version1)
+        utils.WazuhVersion(version2)
     except ValueError:
         return
 
@@ -667,8 +667,8 @@ def test_version_ko(version1, version2):
 ])
 def test_same_version(version1, version2):
     """Test WazuhVersion class."""
-    current_version = WazuhVersion(version1)
-    new_version = WazuhVersion(version2)
+    current_version = utils.WazuhVersion(version1)
+    new_version = utils.WazuhVersion(version2)
 
     assert current_version == new_version
     assert not (current_version < new_version)
@@ -683,14 +683,14 @@ def test_same_version(version1, version2):
 
 def test_WazuhVersion_to_array():
     """Test WazuhVersion.to_array function."""
-    version = WazuhVersion('Wazuh v3.10.0-alpha4')
+    version = utils.WazuhVersion('Wazuh v3.10.0-alpha4')
 
     assert isinstance(version.to_array(), list)
 
 
 def test_WazuhVersion__str__():
     """Test WazuhVersion.__str__ function."""
-    version = WazuhVersion('Wazuh v3.10.0-alpha4')
+    version = utils.WazuhVersion('Wazuh v3.10.0-alpha4')
 
     assert isinstance(version.__str__(), str)
 
@@ -703,8 +703,8 @@ def test_WazuhVersion__str__():
 ])
 def test_WazuhVersion__ge__(version1, version2):
     """Test WazuhVersion.__ge__ function."""
-    current_version = WazuhVersion(version1)
-    new_version = WazuhVersion(version2)
+    current_version = utils.WazuhVersion(version1)
+    new_version = utils.WazuhVersion(version2)
 
     assert not current_version >= new_version
 
@@ -718,7 +718,7 @@ def test_WazuhVersion__ge__(version1, version2):
 ])
 def test_get_timeframe_in_seconds(time):
     """Test get_timeframe_in_seconds function."""
-    result = get_timeframe_in_seconds(time)
+    result = utils.get_timeframe_in_seconds(time)
 
     assert isinstance(result, int)
 
@@ -726,7 +726,7 @@ def test_get_timeframe_in_seconds(time):
 def test_failed_test_get_timeframe_in_seconds():
     """Test get_timeframe_in_seconds function exceptions."""
     with pytest.raises(exception.WazuhException, match=".* 1411 .*"):
-        get_timeframe_in_seconds('error')
+        utils.get_timeframe_in_seconds('error')
 
 
 @pytest.mark.parametrize('value', [
@@ -740,28 +740,28 @@ def test_WazuhDBQuery__init__(mock_socket_conn, mock_isfile, mock_sqli_conn, val
     """Test WazuhDBQuery.__init__."""
     with patch('wazuh.core.utils.glob.glob', return_value=value):
         if value:
-            WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
-                         search=None, select=None, filters=None,
-                         fields={'1': None, '2': None}, default_sort_field=None,
-                         default_sort_order='ASC', query=None,
-                         backend=SQLiteBackend(common.database_path),
-                         min_select_fields=1, count=5, get_data=None,
-                         date_fields={'lastKeepAlive', 'dateAdd'},
-                         extra_fields={'internal_key'})
+            utils.WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
+                               search=None, select=None, filters=None,
+                               fields={'1': None, '2': None}, default_sort_field=None,
+                               default_sort_order='ASC', query=None,
+                               backend=utils.SQLiteBackend(utils.common.database_path),
+                               min_select_fields=1, count=5, get_data=None,
+                               date_fields={'lastKeepAlive', 'dateAdd'},
+                               extra_fields={'internal_key'})
 
             mock_sqli_conn.assert_called_once()
 
         else:
             with pytest.raises(exception.WazuhException, match=".* 1600 .*"):
-                WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
-                             search=None, select=None, filters=None,
-                             fields={'1': None, '2': None},
-                             default_sort_field=None, default_sort_order='ASC',
-                             query=None, get_data=None,
-                             backend=SQLiteBackend(common.database_path),
-                             min_select_fields=1, count=5,
-                             date_fields={'lastKeepAlive', 'dateAdd'},
-                             extra_fields={'internal_key'})
+                utils.WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
+                                   search=None, select=None, filters=None,
+                                   fields={'1': None, '2': None},
+                                   default_sort_field=None, default_sort_order='ASC',
+                                   query=None, get_data=None,
+                                   backend=utils.SQLiteBackend(utils.common.database_path),
+                                   min_select_fields=1, count=5,
+                                   date_fields={'lastKeepAlive', 'dateAdd'},
+                                   extra_fields={'internal_key'})
 
 
 @pytest.mark.parametrize('query_filter, expected_query_filter, expected_wef', [
@@ -777,12 +777,12 @@ def test_WazuhDBQuery__init__(mock_socket_conn, mock_isfile, mock_sqli_conn, val
 def test_WazuhDBQuery_protected_clean_filter(mock_socket_conn, mock_isfile, mock_conn_db, mock_glob, query_filter,
                                              expected_query_filter, expected_wef):
     """Test WazuhDBQuery._clean_filter function."""
-    query = WazuhDBQuery(offset=0, limit=500, table='agent', sort=None,
-                         search=None, select=None, filters=None,
-                         fields={'1': None, '2': None},
-                         default_sort_field=None, query=None,
-                         backend=WazuhDBBackend(agent_id=1),
-                         count=5, get_data=None)
+    query = utils.WazuhDBQuery(offset=0, limit=500, table='agent', sort=None,
+                               search=None, select=None, filters=None,
+                               fields={'1': None, '2': None},
+                               default_sort_field=None, query=None,
+                               backend=utils.WazuhDBBackend(agent_id=1),
+                               count=5, get_data=None)
 
     query._clean_filter(query_filter)
     assert query_filter == expected_query_filter, 'query_filter should have been updated, but it was not'
@@ -802,12 +802,12 @@ def test_WazuhDBQuery_protected_clean_filter(mock_socket_conn, mock_isfile, mock
 def test_WazuhDBQuery_protected_add_limit_to_query(mock_socket_conn, mock_isfile, mock_conn_db, mock_glob, limit, error,
                                                    expected_exception):
     """Test WazuhDBQuery._add_limit_to_query function."""
-    query = WazuhDBQuery(offset=0, limit=limit, table='agent', sort=None,
-                         search=None, select=None, filters=None,
-                         fields={'1': None, '2': None},
-                         default_sort_field=None, query=None,
-                         backend=WazuhDBBackend(agent_id=1),
-                         count=5, get_data=None)
+    query = utils.WazuhDBQuery(offset=0, limit=limit, table='agent', sort=None,
+                               search=None, select=None, filters=None,
+                               fields={'1': None, '2': None},
+                               default_sort_field=None, query=None,
+                               backend=utils.WazuhDBBackend(agent_id=1),
+                               count=5, get_data=None)
 
     if error:
         with pytest.raises(exception.WazuhException, match=f'.* {expected_exception} .*'):
@@ -825,12 +825,12 @@ def test_WazuhDBQuery_protected_add_limit_to_query(mock_socket_conn, mock_isfile
 def test_WazuhDBQuery_protected_sort_query(mock_socket_conn, mock_isfile, mock_conn_db, mock_glob):
     """Tests WazuhDBQuery._sort_query function works"""
 
-    query = WazuhDBQuery(offset=0, limit=1, table='agent',
-                         sort={'order': 'asc'}, search=None, select=None,
-                         filters=None, fields={'1': None, '2': None},
-                         default_sort_field=None, query=None,
-                         backend=WazuhDBBackend(agent_id=1), count=5,
-                         get_data=None)
+    query = utils.WazuhDBQuery(offset=0, limit=1, table='agent',
+                               sort={'order': 'asc'}, search=None, select=None,
+                               filters=None, fields={'1': None, '2': None},
+                               default_sort_field=None, query=None,
+                               backend=utils.WazuhDBBackend(agent_id=1), count=5,
+                               get_data=None)
 
     assert isinstance(query._sort_query('1'), str)
     mock_conn_db.assert_called_once_with()
@@ -851,12 +851,12 @@ def test_WazuhDBQuery_protected_add_sort_to_query(mock_socket_conn, mock_isfile,
                                                   expected_exception):
     """Test WazuhDBQuery._add_sort_to_query function."""
     fields = {'1': 'one', '2': 'two', '3': 'three', '4': 'four'}
-    query = WazuhDBQuery(offset=0, limit=1, table='agent', sort=sort,
-                         search=None, select=None, filters=None,
-                         fields=fields,
-                         default_sort_field=None, query=None,
-                         backend=WazuhDBBackend(agent_id=1),
-                         count=5, get_data=None)
+    query = utils.WazuhDBQuery(offset=0, limit=1, table='agent', sort=sort,
+                               search=None, select=None, filters=None,
+                               fields=fields,
+                               default_sort_field=None, query=None,
+                               backend=utils.WazuhDBBackend(agent_id=1),
+                               count=5, get_data=None)
 
     if expected_exception:
         with pytest.raises(exception.WazuhException, match=f'.* {expected_exception} .*'):
@@ -879,12 +879,12 @@ def test_WazuhDBQuery_protected_add_sort_to_query(mock_socket_conn, mock_isfile,
 @patch('socket.socket.connect')
 def test_WazuhDBQuery_protected_add_search_to_query(mock_socket_conn, mock_isfile, mock_conn_db, mock_glob):
     """Test WazuhDBQuery._add_search_to_query function."""
-    query = WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
-                         search={"negation": True, "value": "1"}, select=None,
-                         filters=None, fields={'1': 'one', '2': 'two'},
-                         default_sort_field=None, query=None,
-                         backend=WazuhDBBackend(agent_id=1),
-                         count=5, get_data=None)
+    query = utils.WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
+                               search={"negation": True, "value": "1"}, select=None,
+                               filters=None, fields={'1': 'one', '2': 'two'},
+                               default_sort_field=None, query=None,
+                               backend=utils.WazuhDBBackend(agent_id=1),
+                               count=5, get_data=None)
 
     query._add_search_to_query()
     mock_conn_db.assert_called_once_with()
@@ -902,12 +902,12 @@ def test_WazuhDBQuery_protected_add_search_to_query(mock_socket_conn, mock_isfil
 def test_WazuhDBQuery_protected_parse_select_filter(mock_socket_conn, mock_isfile, mock_glob, mock_conn_db,
                                                     selector_fields, error, expected_exception):
     """Test WazuhDBQuery._parse_select_filter function."""
-    query = WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
-                         search=None, select=None, filters=None,
-                         fields={'1': None, '2': None},
-                         default_sort_field=None, query=None,
-                         backend=WazuhDBBackend(agent_id=1),
-                         count=5, get_data=None)
+    query = utils.WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
+                               search=None, select=None, filters=None,
+                               fields={'1': None, '2': None},
+                               default_sort_field=None, query=None,
+                               backend=utils.WazuhDBBackend(agent_id=1),
+                               count=5, get_data=None)
 
     if error:
         with pytest.raises(exception.WazuhException, match=f'.* {expected_exception} .*'):
@@ -927,12 +927,12 @@ def test_WazuhDBQuery_protected_parse_select_filter(mock_socket_conn, mock_isfil
 @patch('wazuh.core.utils.WazuhDBQuery._parse_select_filter')
 def test_WazuhDBQuery_protected_add_select_to_query(mock_parse, mock_socket_conn, mock_isfile, mock_conn_db, mock_glob):
     """Test WazuhDBQuery._add_select_to_query function."""
-    query = WazuhDBQuery(offset=0, limit=1, table='agent',
-                         sort={'order': 'asc'}, search=None, select=None,
-                         filters=None, fields={'1': None, '2': None},
-                         default_sort_field=None, query=None,
-                         backend=WazuhDBBackend(agent_id=1),
-                         count=5, get_data=None)
+    query = utils.WazuhDBQuery(offset=0, limit=1, table='agent',
+                               sort={'order': 'asc'}, search=None, select=None,
+                               filters=None, fields={'1': None, '2': None},
+                               default_sort_field=None, query=None,
+                               backend=utils.WazuhDBBackend(agent_id=1),
+                               count=5, get_data=None)
 
     query._add_select_to_query()
     mock_conn_db.assert_called_once_with()
@@ -952,12 +952,12 @@ def test_WazuhDBQuery_protected_add_select_to_query(mock_parse, mock_socket_conn
 def test_WazuhDBQuery_protected_parse_query(mock_socket_conn, mock_isfile, mock_conn_db, mock_glob, q,
                                             error, expected_exception):
     """Test WazuhDBQuery._parse_query function."""
-    query = WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
-                         search=None, select=None, filters=None,
-                         fields={'os.name': None, 'os.version': None},
-                         default_sort_field=None, query=q,
-                         backend=WazuhDBBackend(agent_id=1),
-                         count=5, get_data=None)
+    query = utils.WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
+                               search=None, select=None, filters=None,
+                               fields={'os.name': None, 'os.version': None},
+                               default_sort_field=None, query=q,
+                               backend=utils.WazuhDBBackend(agent_id=1),
+                               count=5, get_data=None)
 
     if error:
         with pytest.raises(exception.WazuhException, match=f'.* {expected_exception} .*'):
@@ -979,12 +979,12 @@ def test_WazuhDBQuery_protected_parse_query(mock_socket_conn, mock_isfile, mock_
 @patch('socket.socket.connect')
 def test_WazuhDBQuery_protected_parse_legacy_filters(mock_socket_conn, mock_isfile, mock_conn_db, mock_glob, filter_):
     """Test WazuhDBQuery._parse_legacy_filters function."""
-    query = WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
-                         search=None, select=None, filters=filter_,
-                         fields={'os.name': 'ubuntu', 'os.version': '18.04'},
-                         default_sort_field=None, query=None,
-                         backend=WazuhDBBackend(agent_id=0),
-                         count=5, get_data=None)
+    query = utils.WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
+                               search=None, select=None, filters=filter_,
+                               fields={'os.name': 'ubuntu', 'os.version': '18.04'},
+                               default_sort_field=None, query=None,
+                               backend=utils.WazuhDBBackend(agent_id=0),
+                               count=5, get_data=None)
 
     query._parse_legacy_filters()
 
@@ -1004,12 +1004,12 @@ def test_WazuhDBQuery_protected_parse_legacy_filters(mock_socket_conn, mock_isfi
 def test_WazuhDBQuery_parse_filters(mock_query, mock_filter, mock_socket_conn, mock_isfile, mock_conn_db, mock_glob,
                                     filter, q):
     """Test WazuhDBQuery._parse_filters function."""
-    query = WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
-                         search={"negation": True, "value": "1"}, select=None,
-                         fields={'os.name': 'ubuntu', 'os.version': '18.04'},
-                         default_sort_field=None, query=q,
-                         backend=WazuhDBBackend(agent_id=0),
-                         count=5, get_data=None)
+    query = utils.WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
+                               search={"negation": True, "value": "1"}, select=None,
+                               fields={'os.name': 'ubuntu', 'os.version': '18.04'},
+                               default_sort_field=None, query=q,
+                               backend=utils.WazuhDBBackend(agent_id=0),
+                               count=5, get_data=None)
 
     query._parse_legacy_filters()
     query._parse_query()
@@ -1035,12 +1035,12 @@ def test_WazuhDBQuery_parse_filters(mock_query, mock_filter, mock_socket_conn, m
 def test_WazuhDBQuery_protected_process_filter(mock_date, mock_status, mock_socket_conn, mock_isfile, mock_conn_db,
                                                mock_glob, field_name, field_filter, q_filter):
     """Tests WazuhDBQuery._process_filter."""
-    query = WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
-                         search=None, select=None,
-                         fields={'os.name': 'ubuntu', 'os.version': '18.04', 'status': 'active'},
-                         default_sort_field=None, query=None,
-                         backend=WazuhDBBackend(agent_id=0), count=5,
-                         get_data=None, date_fields=['date1', 'date2'])
+    query = utils.WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
+                               search=None, select=None,
+                               fields={'os.name': 'ubuntu', 'os.version': '18.04', 'status': 'active'},
+                               default_sort_field=None, query=None,
+                               backend=utils.WazuhDBBackend(agent_id=0), count=5,
+                               get_data=None, date_fields=['date1', 'date2'])
 
     query._process_filter(field_name, field_filter, q_filter)
 
@@ -1057,13 +1057,13 @@ def test_WazuhDBQuery_protected_process_filter(mock_date, mock_status, mock_sock
 def test_WazuhDBQuery_protected_add_filters_to_query(mock_process, mock_socket_conn, mock_isfile,
                                                      mock_conn_db, mock_glob):
     """Test WazuhDBQuery._add_filters_to_query function."""
-    query = WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
-                         search=None, select=['os.name'],
-                         fields={'os.name': 'ubuntu', 'os.version': '18.04'},
-                         default_sort_field=None, query='os.name=ubuntu',
-                         backend=WazuhDBBackend(agent_id=0), distinct=True,
-                         count=5, get_data=None, filters={'os.name': 'ubuntu'},
-                         date_fields=['date1', 'date2'])
+    query = utils.WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
+                               search=None, select=['os.name'],
+                               fields={'os.name': 'ubuntu', 'os.version': '18.04'},
+                               default_sort_field=None, query='os.name=ubuntu',
+                               backend=utils.WazuhDBBackend(agent_id=0), distinct=True,
+                               count=5, get_data=None, filters={'os.name': 'ubuntu'},
+                               date_fields=['date1', 'date2'])
 
     query.query_filters = [{'field': 'os.name', 'value': 'ubuntu', 'level': 0, 'separator': ';'}]
     query._add_filters_to_query()
@@ -1077,12 +1077,12 @@ def test_WazuhDBQuery_protected_add_filters_to_query(mock_process, mock_socket_c
 @patch('socket.socket.connect')
 def test_WazuhDBQuery_protected_get_total_items(mock_socket_conn, mock_isfile, mock_conn_db, mock_glob):
     """Test WazuhDBQuery._get_total_items function."""
-    query = WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
-                         search=None, select=None,
-                         fields={'os.name': 'ubuntu', 'os.version': '18.04'},
-                         default_sort_field=None, query=None,
-                         backend=WazuhDBBackend(agent_id=0), count=5,
-                         get_data=None, date_fields=['date1', 'date2'])
+    query = utils.WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
+                               search=None, select=None,
+                               fields={'os.name': 'ubuntu', 'os.version': '18.04'},
+                               default_sort_field=None, query=None,
+                               backend=utils.WazuhDBBackend(agent_id=0), count=5,
+                               get_data=None, date_fields=['date1', 'date2'])
 
     query._add_select_to_query()
     query._get_total_items()
@@ -1095,12 +1095,12 @@ def test_WazuhDBQuery_protected_get_total_items(mock_socket_conn, mock_isfile, m
 @patch("wazuh.core.database.isfile", return_value=True)
 @patch('socket.socket.connect')
 def test_WazuhDBQuery_protected_get_total_items_mitre(mock_socket_conn, mock_isfile, mock_conn_db, mock_glob):
-    query = WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
-                         search=None, select=None,
-                         fields={'os.name': 'ubuntu', 'os.version': '18.04'},
-                         default_sort_field=None, query=None,
-                         backend=WazuhDBBackend(agent_id=0, query_format='mitre'), count=5,
-                         get_data=None, date_fields=['date1', 'date2'])
+    query = utils.WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
+                               search=None, select=None,
+                               fields={'os.name': 'ubuntu', 'os.version': '18.04'},
+                               default_sort_field=None, query=None,
+                               backend=utils.WazuhDBBackend(agent_id=0, query_format='mitre'), count=5,
+                               get_data=None, date_fields=['date1', 'date2'])
 
     query._add_select_to_query()
     query._get_total_items()
@@ -1113,13 +1113,13 @@ def test_WazuhDBQuery_protected_get_total_items_mitre(mock_socket_conn, mock_isf
 @patch("wazuh.core.database.isfile", return_value=True)
 @patch('socket.socket.connect')
 def test_WazuhDBQuery_substitute_params(mock_socket_conn, mock_isfile, mock_conn_db, mock_glob):
-    """Test WazuhDBQuery._get_total_items function."""
-    query = WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
-                         search=None, select=None,
-                         fields={'os.name': 'ubuntu', 'os.version': '18.04'},
-                         default_sort_field=None, query=None,
-                         backend=WazuhDBBackend(agent_id=0), count=5,
-                         get_data=None, date_fields=['date1', 'date2'])
+    """Test utils.WazuhDBQuery._get_total_items function."""
+    query = utils.WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
+                               search=None, select=None,
+                               fields={'os.name': 'ubuntu', 'os.version': '18.04'},
+                               default_sort_field=None, query=None,
+                               backend=utils.WazuhDBBackend(agent_id=0), count=5,
+                               get_data=None, date_fields=['date1', 'date2'])
     query.request = {'testing': 'testing'}
 
     query._add_select_to_query()
@@ -1134,12 +1134,12 @@ def test_WazuhDBQuery_substitute_params(mock_socket_conn, mock_isfile, mock_conn
 @patch('socket.socket.connect')
 def test_WazuhDBQuery_protected_get_data(mock_socket_conn, mock_isfile, mock_sqli_conn, mock_glob):
     """Test SQLiteBackend._get_data function."""
-    query = WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
-                         search=None, select={'fields': set(['os.name'])},
-                         fields={'os.name': 'ubuntu', 'os.version': '18.04'},
-                         default_sort_field=None, query=None,
-                         backend=SQLiteBackend(common.database_path), count=5,
-                         get_data=None, min_select_fields=set(['os.version']))
+    query = utils.WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
+                               search=None, select={'fields': set(['os.name'])},
+                               fields={'os.name': 'ubuntu', 'os.version': '18.04'},
+                               default_sort_field=None, query=None,
+                               backend=utils.SQLiteBackend(utils.common.database_path), count=5,
+                               get_data=None, min_select_fields=set(['os.version']))
 
     query.backend._get_data()
 
@@ -1151,13 +1151,13 @@ def test_WazuhDBQuery_protected_get_data(mock_socket_conn, mock_isfile, mock_sql
 @patch("wazuh.core.database.isfile", return_value=True)
 @patch('socket.socket.connect')
 def test_WazuhDBQuery_protected_format_data_into_dictionary(mock_socket_conn, mock_isfile, mock_conn_db, mock_glob):
-    """Test WazuhDBQuery._format_data_into_dictionary."""
-    query = WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
-                         search=None, select={'fields': set(['os.name'])},
-                         fields={'os.name': 'ubuntu', 'os.version': '18.04'},
-                         default_sort_field=None, query=None,
-                         backend=WazuhDBBackend(agent_id=0), count=5,
-                         get_data=None, min_select_fields=set(['os.version']))
+    """Test utils.WazuhDBQuery._format_data_into_dictionary."""
+    query = utils.WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
+                               search=None, select={'fields': set(['os.name'])},
+                               fields={'os.name': 'ubuntu', 'os.version': '18.04'},
+                               default_sort_field=None, query=None,
+                               backend=utils.WazuhDBBackend(agent_id=0), count=5,
+                               get_data=None, min_select_fields=set(['os.version']))
 
     query._data = []
 
@@ -1171,14 +1171,14 @@ def test_WazuhDBQuery_protected_format_data_into_dictionary(mock_socket_conn, mo
 @patch("wazuh.core.database.isfile", return_value=True)
 @patch('socket.socket.connect')
 def test_WazuhDBQuery_protected_filter_status(mock_socket_conn, mock_isfile, mock_conn_db, mock_glob):
-    """Test WazuhDBQuery._filter_status function."""
-    query = WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
-                         search=None, select={'fields': set(['os.name'])},
-                         fields={'os.name': 'ubuntu', 'os.version': '18.04'},
-                         default_sort_field=None, query=None,
-                         backend=WazuhDBBackend(agent_id=0),
-                         count=5, get_data=None,
-                         min_select_fields=set(['os.version']))
+    """Test utils.WazuhDBQuery._filter_status function."""
+    query = utils.WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
+                               search=None, select={'fields': set(['os.name'])},
+                               fields={'os.name': 'ubuntu', 'os.version': '18.04'},
+                               default_sort_field=None, query=None,
+                               backend=utils.WazuhDBBackend(agent_id=0),
+                               count=5, get_data=None,
+                               min_select_fields=set(['os.version']))
 
     with pytest.raises(NotImplementedError):
         query._filter_status('status')
@@ -1197,13 +1197,13 @@ def test_WazuhDBQuery_protected_filter_status(mock_socket_conn, mock_isfile, moc
 @patch('socket.socket.connect')
 def test_WazuhDBQuery_protected_filter_date(mock_socket_conn, mock_isfile, mock_conn_db, mock_glob, date_filter,
                                             filter_db_name, time, error):
-    """Test WazuhDBQuery._filter_date function."""
-    query = WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
-                         search=None, select={'fields': set(['os.name'])},
-                         fields={'os.name': 'ubuntu', 'os.version': '18.04'},
-                         default_sort_field=None, query=None,
-                         backend=WazuhDBBackend(agent_id=0), count=5,
-                         get_data=None)
+    """Test utils.WazuhDBQuery._filter_date function."""
+    query = utils.WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
+                               search=None, select={'fields': set(['os.name'])},
+                               fields={'os.name': 'ubuntu', 'os.version': '18.04'},
+                               default_sort_field=None, query=None,
+                               backend=utils.WazuhDBBackend(agent_id=0), count=5,
+                               get_data=None)
 
     query.request = {'time': None}
 
@@ -1225,10 +1225,10 @@ def test_WazuhDBQuery_protected_filter_date(mock_socket_conn, mock_isfile, mock_
 @patch("wazuh.core.database.isfile", return_value=True)
 @patch('socket.socket.connect')
 def test_WazuhDBQuery_general_run(mock_socket_conn, mock_isfile, execute_value, expected_result):
-    """Test WazuhDBQuery.general_run function."""
+    """Test utils.WazuhDBQuery.general_run function."""
     with patch('wazuh.core.utils.WazuhDBBackend.execute', return_value=execute_value):
         query = WazuhDBQueryAgents(offset=0, limit=None, sort=None, search=None, select={'id'},
-                                   query=None, count=False, get_data=True, remove_extra_fields=False)
+                                         query=None, count=False, get_data=True, remove_extra_fields=False)
 
         assert query.general_run() == expected_result
 
@@ -1245,10 +1245,10 @@ def test_WazuhDBQuery_general_run(mock_socket_conn, mock_isfile, execute_value, 
 @patch('socket.socket.connect')
 def test_WazuhDBQuery_oversized_run(mock_socket_conn, mock_isfile, execute_value, rbac_ids, negate,
                                     final_rbac_ids, expected_result):
-    """Test WazuhDBQuery.oversized_run function."""
+    """Test utils.WazuhDBQuery.oversized_run function."""
     with patch('wazuh.core.utils.WazuhDBBackend.execute', side_effect=[execute_value, final_rbac_ids]):
         query = WazuhDBQueryAgents(offset=0, limit=None, sort=None, search=None, select={'id'},
-                                   query=None, count=True, get_data=True, remove_extra_fields=False)
+                                         query=None, count=True, get_data=True, remove_extra_fields=False)
         query.legacy_filters['rbac_ids'] = rbac_ids
         query.rbac_negate = negate
 
@@ -1261,13 +1261,13 @@ def test_WazuhDBQuery_oversized_run(mock_socket_conn, mock_isfile, execute_value
 @patch('socket.socket.connect')
 @patch('wazuh.core.utils.WazuhDBQuery._default_query')
 def test_WazuhDBQuery_reset(mock_query, mock_socket_conn, mock_isfile, mock_conn_db, mock_glob):
-    """Test WazuhDBQuery.reset function."""
-    query = WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
-                         search=None, select={'os.name'},
-                         fields={'os.name': 'ubuntu', 'os.version': '18.04'},
-                         default_sort_field=None, query=None,
-                         backend=WazuhDBBackend(agent_id=0),
-                         count=5, get_data='data')
+    """Test utils.WazuhDBQuery.reset function."""
+    query = utils.WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
+                               search=None, select={'os.name'},
+                               fields={'os.name': 'ubuntu', 'os.version': '18.04'},
+                               default_sort_field=None, query=None,
+                               backend=utils.WazuhDBBackend(agent_id=0),
+                               count=5, get_data='data')
 
     query.reset()
 
@@ -1280,13 +1280,13 @@ def test_WazuhDBQuery_reset(mock_query, mock_socket_conn, mock_isfile, mock_conn
 @patch("wazuh.core.database.isfile", return_value=True)
 @patch('socket.socket.connect')
 def test_WazuhDBQuery_protected_default_query(mock_socket_conn, mock_isfile, mock_conn_db, mock_glob):
-    """Test WazuhDBQuery._default_query function."""
-    query = WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
-                         search=None, select={'fields': set(['os.name'])},
-                         fields={'os.name': 'ubuntu', 'os.version': '18.04'},
-                         default_sort_field=None, query=None, count=5,
-                         backend=WazuhDBBackend(agent_id=1),
-                         get_data='data')
+    """Test utils.WazuhDBQuery._default_query function."""
+    query = utils.WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
+                               search=None, select={'fields': set(['os.name'])},
+                               fields={'os.name': 'ubuntu', 'os.version': '18.04'},
+                               default_sort_field=None, query=None, count=5,
+                               backend=utils.WazuhDBBackend(agent_id=1),
+                               get_data='data')
 
     result = query._default_query()
 
@@ -1299,13 +1299,13 @@ def test_WazuhDBQuery_protected_default_query(mock_socket_conn, mock_isfile, moc
 @patch("wazuh.core.database.isfile", return_value=True)
 @patch('socket.socket.connect')
 def test_WazuhDBQuery_protected_default_count_query(mock_socket_conn, mock_isfile, mock_conn_db, mock_glob):
-    """Test WazuhDBQuery._default_count_query function."""
-    query = WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
-                         search=None, select={'fields': set(['os.name'])},
-                         fields={'os.name': 'ubuntu', 'os.version': '18.04'},
-                         default_sort_field=None, query=None,
-                         backend=WazuhDBBackend(agent_id=1),
-                         count=5, get_data='data')
+    """Test utils.WazuhDBQuery._default_count_query function."""
+    query = utils.WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
+                               search=None, select={'fields': set(['os.name'])},
+                               fields={'os.name': 'ubuntu', 'os.version': '18.04'},
+                               default_sort_field=None, query=None,
+                               backend=utils.WazuhDBBackend(agent_id=1),
+                               count=5, get_data='data')
 
     result = query._default_count_query()
 
@@ -1322,13 +1322,13 @@ def test_WazuhDBQuery_protected_default_count_query(mock_socket_conn, mock_isfil
 @patch("wazuh.core.database.isfile", return_value=True)
 @patch('socket.socket.connect')
 def test_WazuhDBQuery_protected_pass_filter(mock_socket_conn, mock_isfile, mock_conn_db, mock_glob, db_filter):
-    """Test WazuhDBQuery._pass_filter function."""
-    query = WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
-                         search=None, select={'fields': {'os.name'}},
-                         fields={'os.name': 'ubuntu', 'os.version': '18.04'},
-                         default_sort_field=None, query=None,
-                         backend=WazuhDBBackend(agent_id=1),
-                         count=5, get_data='data')
+    """Test utils.WazuhDBQuery._pass_filter function."""
+    query = utils.WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
+                               search=None, select={'fields': {'os.name'}},
+                               fields={'os.name': 'ubuntu', 'os.version': '18.04'},
+                               default_sort_field=None, query=None,
+                               backend=utils.WazuhDBBackend(agent_id=1),
+                               count=5, get_data='data')
 
     result = query._pass_filter(db_filter)
 
@@ -1341,13 +1341,13 @@ def test_WazuhDBQuery_protected_pass_filter(mock_socket_conn, mock_isfile, mock_
 @patch("wazuh.core.database.isfile", return_value=True)
 @patch('socket.socket.connect')
 def test_WazuhDBQueryDistinct_protected_default_query(mock_socket_conn, mock_isfile, mock_conn_db, mock_glob):
-    """Test WazuhDBQueryDistinct._default_query function."""
-    query = WazuhDBQueryDistinct(offset=0, limit=1, sort=None, search=None,
-                                 query=None, select={'fields': ['name']},
-                                 fields={'name': '`group`'}, count=True,
-                                 get_data=True, default_sort_field='`group`',
-                                 backend=WazuhDBBackend(agent_id=1),
-                                 table='agent')
+    """Test utils.WazuhDBQueryDistinct._default_query function."""
+    query = utils.WazuhDBQueryDistinct(offset=0, limit=1, sort=None, search=None,
+                                       query=None, select={'fields': ['name']},
+                                       fields={'name': '`group`'}, count=True,
+                                       get_data=True, default_sort_field='`group`',
+                                       backend=utils.WazuhDBBackend(agent_id=1),
+                                       table='agent')
 
     result = query._default_query()
 
@@ -1361,13 +1361,13 @@ def test_WazuhDBQueryDistinct_protected_default_query(mock_socket_conn, mock_isf
 @patch("wazuh.core.database.isfile", return_value=True)
 @patch('socket.socket.connect')
 def test_WazuhDBQueryDistinct_protected_default_count_query(mock_socket_conn, mock_isfile, mock_conn_db, mock_glob):
-    """Test WazuhDBQueryDistinct._default_count_query function."""
-    query = WazuhDBQueryDistinct(offset=0, limit=1, sort=None, search=None,
-                                 query=None, select={'name'},
-                                 fields={'name': '`group`'}, count=True,
-                                 get_data=True, default_sort_field='`group`',
-                                 backend=WazuhDBBackend(agent_id=1),
-                                 table='agent')
+    """Test utils.WazuhDBQueryDistinct._default_count_query function."""
+    query = utils.WazuhDBQueryDistinct(offset=0, limit=1, sort=None, search=None,
+                                       query=None, select={'name'},
+                                       fields={'name': '`group`'}, count=True,
+                                       get_data=True, default_sort_field='`group`',
+                                       backend=utils.WazuhDBBackend(agent_id=1),
+                                       table='agent')
 
     result = query._default_count_query()
 
@@ -1383,13 +1383,13 @@ def test_WazuhDBQueryDistinct_protected_default_count_query(mock_socket_conn, mo
 @patch('wazuh.core.utils.WazuhDBQuery._add_filters_to_query')
 def test_WazuhDBQueryDistinct_protected_add_filters_to_query(mock_add, mock_socket_conn, mock_isfile, mock_conn_db,
                                                              mock_glob):
-    """Test WazuhDBQueryDistinct._add_filters_to_query function."""
-    query = WazuhDBQueryDistinct(offset=0, limit=1, sort=None, search=None,
-                                 query=None, select={'name'},
-                                 fields={'name': '`group`'}, count=True,
-                                 get_data=True, default_sort_field='`group`',
-                                 backend=WazuhDBBackend(agent_id=1),
-                                 table='agent')
+    """Test utils.WazuhDBQueryDistinct._add_filters_to_query function."""
+    query = utils.WazuhDBQueryDistinct(offset=0, limit=1, sort=None, search=None,
+                                       query=None, select={'name'},
+                                       fields={'name': '`group`'}, count=True,
+                                       get_data=True, default_sort_field='`group`',
+                                       backend=utils.WazuhDBBackend(agent_id=1),
+                                       table='agent')
 
     query._add_filters_to_query()
 
@@ -1407,13 +1407,13 @@ def test_WazuhDBQueryDistinct_protected_add_filters_to_query(mock_add, mock_sock
 @patch('wazuh.core.utils.WazuhDBQuery._add_select_to_query')
 def test_WazuhDBQueryDistinct_protected_add_select_to_query(mock_add, mock_socket_conn, mock_isfile, mock_conn_db,
                                                             mock_glob, select):
-    """Test WazuhDBQueryDistinct._add_select_to_query function."""
-    query = WazuhDBQueryDistinct(offset=0, limit=1, sort=None, search=None,
-                                 query=None, select=select,
-                                 fields={'name': '`group`'},
-                                 count=True, get_data=True,
-                                 backend=WazuhDBBackend(agent_id=1),
-                                 default_sort_field='`group`', table='agent')
+    """Test utils.WazuhDBQueryDistinct._add_select_to_query function."""
+    query = utils.WazuhDBQueryDistinct(offset=0, limit=1, sort=None, search=None,
+                                       query=None, select=select,
+                                       fields={'name': '`group`'},
+                                       count=True, get_data=True,
+                                       backend=utils.WazuhDBBackend(agent_id=1),
+                                       default_sort_field='`group`', table='agent')
 
     if len(select) > 1:
         with pytest.raises(exception.WazuhException, match=".* 1410 .*"):
@@ -1430,14 +1430,14 @@ def test_WazuhDBQueryDistinct_protected_add_select_to_query(mock_add, mock_socke
 @patch('socket.socket.connect')
 def test_WazuhDBQueryDistinct_protected_format_data_into_dictionary(mock_socket_conn, mock_isfile, mock_conn_db,
                                                                     mock_glob):
-    """Test WazuhDBQueryDistinct._format_data_into_dictionary function."""
-    query = WazuhDBQueryDistinct(offset=0, limit=1, sort=None, search=None,
-                                 query=None, select={'fields': ['name']},
-                                 fields={'name': '`group`'}, count=True,
-                                 get_data=True,
-                                 backend=WazuhDBBackend(agent_id=1),
-                                 default_sort_field='`group`',
-                                 table='agent')
+    """Test utils.WazuhDBQueryDistinct._format_data_into_dictionary function."""
+    query = utils.WazuhDBQueryDistinct(offset=0, limit=1, sort=None, search=None,
+                                       query=None, select={'fields': ['name']},
+                                       fields={'name': '`group`'}, count=True,
+                                       get_data=True,
+                                       backend=utils.WazuhDBBackend(agent_id=1),
+                                       default_sort_field='`group`',
+                                       table='agent')
 
     query._data = []
 
@@ -1452,15 +1452,15 @@ def test_WazuhDBQueryDistinct_protected_format_data_into_dictionary(mock_socket_
 @patch("wazuh.core.database.isfile", return_value=True)
 @patch('socket.socket.connect')
 def test_WazuhDBQueryGroupBy__init__(mock_socket_conn, mock_isfile, mock_conn_db, mock_glob):
-    """Tests WazuhDBQueryGroupBy.__init__ function works"""
-    WazuhDBQueryGroupBy(filter_fields=None, offset=0, limit=1, table='agent',
-                        sort=None, search=None, select={'fields': ['name']},
-                        filters=None, fields={'name': '`group`'},
-                        default_sort_field=None, default_sort_order='ASC',
-                        query=None, min_select_fields=None, count=True,
-                        backend=WazuhDBBackend(agent_id=0), get_data=None,
-                        date_fields={'lastKeepAlive', 'dateAdd'},
-                        extra_fields={'internal_key'})
+    """Tests utils.WazuhDBQueryGroupBy.__init__ function works"""
+    utils.WazuhDBQueryGroupBy(filter_fields=None, offset=0, limit=1, table='agent',
+                              sort=None, search=None, select={'fields': ['name']},
+                              filters=None, fields={'name': '`group`'},
+                              default_sort_field=None, default_sort_order='ASC',
+                              query=None, min_select_fields=None, count=True,
+                              backend=utils.WazuhDBBackend(agent_id=0), get_data=None,
+                              date_fields={'lastKeepAlive', 'dateAdd'},
+                              extra_fields={'internal_key'})
 
     mock_conn_db.assert_called_once_with()
 
@@ -1472,17 +1472,17 @@ def test_WazuhDBQueryGroupBy__init__(mock_socket_conn, mock_isfile, mock_conn_db
 @patch('wazuh.core.utils.WazuhDBQuery._get_total_items')
 def test_WazuhDBQueryGroupBy_protected_get_total_items(mock_total, mock_socket_conn, mock_isfile, mock_conn_db,
                                                        mock_glob):
-    """Test WazuhDBQueryGroupBy._get_total_items function."""
-    query = WazuhDBQueryGroupBy(filter_fields={'fields': ['name']}, offset=0,
-                                limit=1, table='agent', sort=None, search=None,
-                                select={'name'}, filters=None,
-                                fields={'name': '`group`'}, query=None,
-                                default_sort_field=None, get_data=None,
-                                default_sort_order='ASC',
-                                min_select_fields=None, count=True,
-                                backend=WazuhDBBackend(agent_id=0),
-                                date_fields={'lastKeepAlive', 'dateAdd'},
-                                extra_fields={'internal_key'})
+    """Test utils.WazuhDBQueryGroupBy._get_total_items function."""
+    query = utils.WazuhDBQueryGroupBy(filter_fields={'fields': ['name']}, offset=0,
+                                      limit=1, table='agent', sort=None, search=None,
+                                      select={'name'}, filters=None,
+                                      fields={'name': '`group`'}, query=None,
+                                      default_sort_field=None, get_data=None,
+                                      default_sort_order='ASC',
+                                      min_select_fields=None, count=True,
+                                      backend=utils.WazuhDBBackend(agent_id=0),
+                                      date_fields={'lastKeepAlive', 'dateAdd'},
+                                      extra_fields={'internal_key'})
 
     query._get_total_items()
     mock_conn_db.assert_called_once_with()
@@ -1496,18 +1496,18 @@ def test_WazuhDBQueryGroupBy_protected_get_total_items(mock_total, mock_socket_c
 @patch('wazuh.core.utils.WazuhDBQuery._parse_select_filter')
 def test_WazuhDBQueryGroupBy_protected_add_select_to_query(mock_parse, mock_add, mock_socket_conn, mock_isfile,
                                                            mock_conn_db, mock_glob):
-    """Test WazuhDBQueryGroupBy._add_select_to_query function."""
-    query = WazuhDBQueryGroupBy(filter_fields={'fields': ['name']}, offset=0,
-                                limit=1, table='agent', sort=None, search=None,
-                                select={'name'}, filters=None,
-                                fields={'name': '`group`'}, query=None,
-                                default_sort_field=None,
-                                default_sort_order='ASC',
-                                min_select_fields=None,
-                                count=True, get_data=None,
-                                backend=WazuhDBBackend(agent_id=0),
-                                date_fields={'lastKeepAlive', 'dateAdd'},
-                                extra_fields={'internal_key'})
+    """Test utils.WazuhDBQueryGroupBy._add_select_to_query function."""
+    query = utils.WazuhDBQueryGroupBy(filter_fields={'fields': ['name']}, offset=0,
+                                      limit=1, table='agent', sort=None, search=None,
+                                      select={'name'}, filters=None,
+                                      fields={'name': '`group`'}, query=None,
+                                      default_sort_field=None,
+                                      default_sort_order='ASC',
+                                      min_select_fields=None,
+                                      count=True, get_data=None,
+                                      backend=utils.WazuhDBBackend(agent_id=0),
+                                      date_fields={'lastKeepAlive', 'dateAdd'},
+                                      extra_fields={'internal_key'})
 
     query._add_select_to_query()
     mock_conn_db.assert_called_once_with()
@@ -1559,10 +1559,10 @@ def test_filter_array_by_query(q, return_length):
     """Test filter by query in an array."""
     if return_length == -1:
         with pytest.raises(exception.WazuhError, match='.* 1407 .*'):
-            filter_array_by_query(q='nameGfirewall', input_array=input_array)
+            utils.filter_array_by_query(q='nameGfirewall', input_array=input_array)
         return
 
-    result = filter_array_by_query(q, input_array)
+    result = utils.filter_array_by_query(q, input_array)
     for item in result:
         # check fields returned in result
         item_keys = set(item.keys())
@@ -1612,10 +1612,10 @@ def test_select_array(select, required_fields, expected_result):
     ]
 
     try:
-        result = select_array(array, select=select, required_fields=required_fields)
+        result = utils.select_array(array, select=select, required_fields=required_fields)
         for element in result:
             assert element == expected_result
-    except WazuhError as e:
+    except utils.WazuhError as e:
         assert e.code == 1724
 
 
@@ -1625,7 +1625,7 @@ def test_select_array(select, required_fields, expected_result):
 ])
 def test_add_dynamic_detail(detail, value, attribs, details):
     """Test add_dynamic_detail core rule function."""
-    add_dynamic_detail(detail, value, attribs, details)
+    utils.add_dynamic_detail(detail, value, attribs, details)
     assert detail in details.keys()
     if detail == next(iter(details.keys())):
         assert details[detail]['pattern'].endswith(value)
@@ -1646,16 +1646,16 @@ def test_validate_wazuh_xml(mock_remote_commands):
     m = mock_open(read_data=xml_file)
 
     with patch('builtins.open', m):
-        validate_wazuh_xml(xml_file)
+        utils.validate_wazuh_xml(xml_file)
     mock_remote_commands.assert_not_called()
 
     with patch('builtins.open', m):
-        validate_wazuh_xml(xml_file, config_file=True)
+        utils.validate_wazuh_xml(xml_file, config_file=True)
     mock_remote_commands.assert_called_once()
 
 
 @pytest.mark.parametrize('effect, expected_exception', [
-    (ExpatError, 1113)
+    (utils.ExpatError, 1113)
 ])
 def test_validate_wazuh_xml_ko(effect, expected_exception):
     """Tests validate_wazuh_xml function works when open function raises an exception.
@@ -1670,7 +1670,7 @@ def test_validate_wazuh_xml_ko(effect, expected_exception):
 
     with patch('wazuh.core.utils.load_wazuh_xml', side_effect=effect):
         with pytest.raises(WazuhException, match=f'.* {expected_exception} .*'):
-            validate_wazuh_xml(input_file)
+            utils.validate_wazuh_xml(input_file)
 
 
 @patch('wazuh.core.utils.copyfile')
@@ -1680,45 +1680,46 @@ def test_delete_file_with_backup(mock_copyfile):
     abs_path = 'testing/dir/subdir/file'
     delete_function = MagicMock()
 
-    delete_file_with_backup(backup_file, abs_path, delete_function)
+    utils.delete_file_with_backup(backup_file, abs_path, delete_function)
 
     mock_copyfile.assert_called_with(abs_path, backup_file)
-    delete_function.assert_called_once_with(filename=basename(abs_path))
+    delete_function.assert_called_once_with(filename=os.path.basename(abs_path))
 
 
 @patch('wazuh.core.utils.copyfile', side_effect=IOError)
 def test_delete_file_with_backup_ko(mock_copyfile):
     """Test delete_file_with_backup function exceptions."""
-    with pytest.raises(WazuhError, match='.* 1019 .*'):
-        delete_file_with_backup('test', 'test', str)
+    with pytest.raises(utils.WazuhError, match='.* 1019 .*'):
+        utils.delete_file_with_backup('test', 'test', str)
 
 
 def test_to_relative_path():
     """Test to_relative_path function."""
     path = 'etc/ossec.conf'
-    assert to_relative_path(join(wazuh_path, path)) == path
+    assert utils.to_relative_path(os.path.join(wazuh_path, path)) == path
 
-    assert to_relative_path(path, prefix='etc') == basename(path)
+    assert utils.to_relative_path(path, prefix='etc') == os.path.basename(path)
 
 
 @patch('wazuh.core.utils.common.ruleset_rules_path', new=test_files_path)
 @patch('wazuh.core.utils.common.user_rules_path', new=test_files_path)
 def test_expand_rules():
-    rules = expand_rules()
-    assert rules == set(map(os.path.basename, glob.glob(os.path.join(test_files_path, f'*{common.RULES_EXTENSION}'))))
+    rules = utils.expand_rules()
+    assert rules == set(map(os.path.basename, glob.glob(os.path.join(test_files_path,
+                                                                     f'*{utils.common.RULES_EXTENSION}'))))
 
 
 @patch('wazuh.core.utils.common.ruleset_decoders_path', new=test_files_path)
 @patch('wazuh.core.utils.common.user_decoders_path', new=test_files_path)
 def test_expand_decoders():
-    decoders = expand_decoders()
+    decoders = utils.expand_decoders()
     assert decoders == set(map(os.path.basename, glob.glob(os.path.join(test_files_path,
-                                                                        f'*{common.DECODERS_EXTENSION}'))))
+                                                                        f'*{utils.common.DECODERS_EXTENSION}'))))
 
 
 @patch('wazuh.core.utils.common.ruleset_lists_path', new=test_files_path)
 @patch('wazuh.core.utils.common.user_lists_path', new=test_files_path)
 def test_expand_lists():
-    lists = expand_lists()
+    lists = utils.expand_lists()
     assert lists == set(filter(lambda x: len(x.split('.')) == 1, map(os.path.basename, glob.glob(os.path.join(
-        test_files_path, f'*{common.LISTS_EXTENSION}')))))
+        test_files_path, f'*{utils.common.LISTS_EXTENSION}')))))

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -44,7 +44,7 @@ if sys.version_info[0] == 3:
 t_cache = TTLCache(maxsize=4500, ttl=60)
 
 
-def check_pids(daemon):
+def clean_pid_files(daemon):
     """Check the existence of '.pid' files for a specified daemon.
 
     Parameters

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -53,7 +53,7 @@ def check_pid(daemon):
     daemon : str
         Daemon's name.
     """
-    regex = rf'{daemon}-(.*).pid'
+    regex = rf'{daemon}-(\d+).pid'
     for pidfile in os.listdir(pidfiles_path):
         if match := re.match(regex, pidfile):
             try:

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -17,7 +17,7 @@ from copy import deepcopy
 from datetime import datetime, timedelta
 from functools import wraps
 from itertools import groupby, chain
-from os import chmod, chown, path, listdir, mkdir, curdir, rename, utime, remove, walk, path
+from os import chmod, chown, listdir, mkdir, curdir, rename, utime, remove, walk, path
 from pyexpat import ExpatError
 from shutil import Error, copyfile, move
 from signal import signal, alarm, SIGALRM
@@ -59,7 +59,7 @@ def check_pids(daemon):
                 os.kill(int(match.group(1)), 0)
             except OSError:
                 print(f'{daemon}: Process {match.group(1)} not used by Wazuh, removing...')
-                path.join(pidfiles_path, pid_file)
+                os.remove(path.join(pidfiles_path, pid_file))
 
 
 def find_nth(string, substring, n):
@@ -513,39 +513,49 @@ def tail(filename, n=20):
     return all_read_text.splitlines()[-total_lines_wanted:]
 
 
-def chmod_r(filepath, mode):
+def chmod_r(file_path, mode):
     """Recursive chmod.
 
-    :param filepath: Path to the file.
-    :param mode: file mode in octal.
+    Parameters
+    ----------
+    file_path: str
+        Path to the file.
+    mode: int
+        File mode in octal.
     """
-    if path.isdir(filepath):
-        for item in listdir(filepath):
-            itempath = path.join(filepath, item)
-            if path.isfile(itempath):
-                chmod(itempath, mode)
-            elif path.isdir(itempath):
-                chmod_r(itempath, mode)
 
-    chmod(filepath, mode)
+    if path.isdir(file_path):
+        for item in listdir(file_path):
+            item_path = path.join(file_path, item)
+            if path.isfile(item_path):
+                chmod(item_path, mode)
+            elif path.isdir(item_path):
+                chmod_r(item_path, mode)
+
+    chmod(file_path, mode)
 
 
-def chown_r(filepath, uid, gid):
-    """Recursive chmod.
+def chown_r(file_path, uid, gid):
+    """Recursive chown.
 
-    :param filepath: Path to the file.
-    :param uid: user ID.
-    :param gid: group ID.
+    Parameters
+    ----------
+    file_path: str
+        Path to the file.
+    uid: int
+        User ID.
+    gid: int
+        Group ID.
     """
-    chown(filepath, uid, gid)
+    chown(file_path, uid, gid)
 
-    if path.isdir(filepath):
-        for item in listdir(filepath):
-            itempath = path.join(filepath, item)
-            if path.isfile(itempath):
-                chown(itempath, uid, gid)
-            elif path.isdir(itempath):
-                chown_r(itempath, uid, gid)
+    if path.isdir(file_path):
+        for item in listdir(file_path):
+            item_path = path.join(file_path, item)
+            if path.isfile(item_path):
+                chown(item_path, uid, gid)
+            elif path.isdir(item_path):
+                chown_r(item_path, uid, gid)
 
 
 def delete_wazuh_file(full_path):
@@ -1731,12 +1741,22 @@ def validate_wazuh_xml(content: str, config_file: bool = False):
         raise WazuhError(1113, str(e))
 
 
-def upload_file(content, path, check_xml_formula_values=True):
-    """
-    Upload files (rules, lists, decoders and ossec.conf)
-    :param content: content of the XML file
-    :param path: Destination of the new XML file
-    :return: Confirmation message
+def upload_file(content, file_path, check_xml_formula_values=True):
+    """Upload files (rules, lists, decoders and ossec.conf).
+
+    Parameters
+    ----------
+    content: str
+        Content of the XML file.
+    file_path: str
+        Destination of the new XML file.
+    check_xml_formula_values: bool
+        Check formula values in the resulting XML if true.
+
+    Returns
+    -------
+    results.WazuhResult
+        Confirmation message.
     """
 
     def escape_formula_values(xml_string):
@@ -1771,7 +1791,7 @@ def upload_file(content, path, check_xml_formula_values=True):
 
     # Move temporary file to group folder
     try:
-        new_conf_path = path.join(common.wazuh_path, path)
+        new_conf_path = path.join(common.wazuh_path, file_path)
         safe_move(tmp_file_path, new_conf_path, permissions=0o660)
     except Error:
         raise WazuhInternalError(1016)


### PR DESCRIPTION
|Related issue|
|---|
|closes #11606 | 

## Description

In addition to the original issue, a few related bugs have been fixed. Now, the Wazuh API and cluster will handle the PID files for their child processes.

No matter the use case, all processes will end gracefully and the PID files will be deleted. Only a kill signal will prevent the files from being deleted, but a mechanism to delete them once the service starts again has been added.

Wazuh API

```shellsession
-rw-r-----. 1 wazuh wazuh    5 Jan 13 11:05 wazuh-apid-1871.pid
-rw-r-----. 1 wazuh wazuh    5 Jan 13 11:06 wazuh-apid_auth-2089.pid
-rw-r-----. 1 wazuh wazuh    5 Jan 13 11:06 wazuh-apid_exec-2086.pid
```

Wazuh Cluster (depending on the number of child processes)

```shellsesion
-rw-r-----. 1 wazuh wazuh    5 Jan 13 11:06 wazuh-clusterd-2296.pid
-rw-r-----. 1 wazuh wazuh    5 Jan 13 11:06 wazuh-clusterd_child_0-2299.pid
-rw-r-----. 1 wazuh wazuh    5 Jan 13 11:06 wazuh-clusterd_child_1-2302.pid
```

## Tests performed

### Manual tests

- Foreground

```shellsession
root@wazuh-master:/# /var/ossec/bin/wazuh-apid -f
Starting API in foreground
2022/01/13 11:24:25 INFO: Listening on 0.0.0.0:55000..
======== Running on https://0.0.0.0:55000 ========
(Press CTRL+C to quit)


root@wazuh-master:/# ps -edf ww | grep api
root        3182    1655  0 11:24 pts/1    S+     0:00 /bin/sh /var/ossec/bin/wazuh-apid -f
wazuh       3187    3182 19 11:24 pts/1    Sl+    0:07 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py -f
wazuh       3188    3187  0 11:24 pts/1    S+     0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py -f
wazuh       3191    3187  0 11:24 pts/1    S+     0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py -f


root@wazuh-master:/# ll /var/ossec/var/run/ | grep api
-rw-r-----. 1 wazuh wazuh   5 Jan 13 11:24 wazuh-apid-3187.pid
-rw-r-----. 1 wazuh wazuh   5 Jan 13 11:24 wazuh-apid_auth-3191.pid
-rw-r-----. 1 wazuh wazuh   5 Jan 13 11:24 wazuh-apid_exec-3188.pid
```

After pressing `CTRL+C`.

```shellsession
root@wazuh-master:/# ll /var/ossec/var/run/ | grep api
root@wazuh-master:/#


root@wazuh-master:/# ps -edf ww | grep api
root        3205    2213  0 11:26 pts/3    S+     0:00 grep --color=auto api
root@wazuh-master:/#
```

- Background

```shellsession
root@wazuh-master:/# ps -edf ww | grep api
wazuh       3262       1 45 11:26 ?        Sl     0:06 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
wazuh       3352    3262  0 11:26 ?        S      0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
wazuh       3355    3262  0 11:26 ?        S      0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py


root@wazuh-master:/# ll /var/ossec/var/run/ | grep api
-rw-r-----. 1 wazuh wazuh    5 Jan 13 11:26 wazuh-apid-3262.pid
-rw-r-----. 1 wazuh wazuh    5 Jan 13 11:26 wazuh-apid_auth-3355.pid
-rw-r-----. 1 wazuh wazuh    5 Jan 13 11:26 wazuh-apid_exec-3352.pid
```

After killing the main process (trying to kill a child process without `kill -9` will not do anything).

```shellsession
root@wazuh-master:/# kill 3262


root@wazuh-master:/# ps -edf ww | grep api
root        4405    2213  0 11:28 pts/3    S+     0:00 grep --color=auto api


root@wazuh-master:/# ll /var/ossec/var/run/ | grep api
root@wazuh-master:/# 

```

- Using `kill -9` on either mode

```shellsession
root@wazuh-master:/# ps -edf ww | grep api
wazuh       9961       1  9 11:42 ?        Sl     0:06 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
wazuh      10030    9961  0 11:42 ?        S      0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
wazuh      10033    9961  0 11:42 ?        S      0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py


root@wazuh-master:/# ll /var/ossec/var/run/ | grep api
-rw-r-----. 1 wazuh wazuh    5 Jan 13 11:42 wazuh-apid-9961.pid
-rw-r-----. 1 wazuh wazuh    6 Jan 13 11:42 wazuh-apid_auth-10033.pid
-rw-r-----. 1 wazuh wazuh    6 Jan 13 11:42 wazuh-apid_exec-10030.pid

```

Killing one of the processes with `kill -9`.

```shellsession
root@wazuh-master:/# kill -9 9961


root@wazuh-master:/# ps -edf ww | grep api
wazuh      10030       1  0 11:42 ?        S      0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
wazuh      10033       1  0 11:42 ?        S      0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py


root@wazuh-master:/# ll /var/ossec/var/run/ | grep api
-rw-r-----. 1 wazuh wazuh    5 Jan 13 11:42 wazuh-apid-9961.pid
-rw-r-----. 1 wazuh wazuh    6 Jan 13 11:42 wazuh-apid_auth-10033.pid
-rw-r-----. 1 wazuh wazuh    6 Jan 13 11:42 wazuh-apid_exec-10030.pid
```

After restarting the service, everything will be restored.

```shellsession
root@wazuh-master:/# service wazuh-manager restart
wazuh-clusterd not running...
wazuh-modulesd not running...
wazuh-monitord not running...
wazuh-logcollector not running...
wazuh-remoted not running...
wazuh-syscheckd not running...
wazuh-analysisd not running...
wazuh-maild not running...
wazuh-execd not running...
wazuh-db not running...
wazuh-authd not running...
wazuh-agentlessd not running...
wazuh-integratord not running...
wazuh-dbd not running...
wazuh-csyslogd not running...
wazuh-apid not running...
Wazuh v4.3.0 Stopped
2022/01/13 11:46:00 wazuh-db[12665] debug_op.c:70 at _log(): DEBUG: Logging module auto-initialized
2022/01/13 11:46:00 wazuh-db[12665] main.c:101 at main(): DEBUG: Wazuh home directory: /var/ossec
2022/01/13 11:46:00 wazuh-remoted[12670] debug_op.c:70 at _log(): DEBUG: Logging module auto-initialized
2022/01/13 11:46:00 wazuh-remoted[12670] main.c:130 at main(): DEBUG: Wazuh home directory: /var/ossec
2022/01/13 11:46:00 wazuh-remoted[12670] main.c:148 at main(): DEBUG: This is not a worker
Starting Wazuh v4.3.0...
wazuh-apid: Process 9961 not used by Wazuh, removing...
Started wazuh-apid...
Started wazuh-csyslogd...
Started wazuh-dbd...
2022/01/13 11:46:02 wazuh-integratord: INFO: Remote integrations not configured. Clean exit.
Started wazuh-integratord...
Started wazuh-agentlessd...
Started wazuh-authd...
2022/01/13 11:46:03 wazuh-db[12749] debug_op.c:70 at _log(): DEBUG: Logging module auto-initialized
2022/01/13 11:46:03 wazuh-db[12749] main.c:101 at main(): DEBUG: Wazuh home directory: /var/ossec
Started wazuh-db...
Started wazuh-execd...
Started wazuh-analysisd...
Started wazuh-syscheckd...
2022/01/13 11:46:07 wazuh-remoted[12906] debug_op.c:70 at _log(): DEBUG: Logging module auto-initialized
2022/01/13 11:46:07 wazuh-remoted[12906] main.c:130 at main(): DEBUG: Wazuh home directory: /var/ossec
2022/01/13 11:46:07 wazuh-remoted[12906] main.c:148 at main(): DEBUG: This is not a worker
Started wazuh-remoted...
Started wazuh-logcollector...
Started wazuh-monitord...
Started wazuh-modulesd...
Started wazuh-clusterd...
Completed.


root@wazuh-master:/# ps -edf ww | grep api
wazuh      12696       1 12 11:46 ?        Sl     0:06 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
wazuh      12765   12696  0 11:46 ?        S      0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
wazuh      12768   12696  0 11:46 ?        S      0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py


root@wazuh-master:/# ll /var/ossec/var/run/ | grep api
-rw-r-----. 1 wazuh wazuh    6 Jan 13 11:46 wazuh-apid-12696.pid
-rw-r-----. 1 wazuh wazuh    6 Jan 13 11:46 wazuh-apid_auth-12768.pid
-rw-r-----. 1 wazuh wazuh    6 Jan 13 11:46 wazuh-apid_exec-12765.pid
```

Regards,
Víctor