### PR TITLE
Added get-groups-integrity command

### DIFF
--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -167,6 +167,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_SYNC_SET] = "UPDATE agent SET sync_status = ? WHERE id = ?;",
     [WDB_STMT_GLOBAL_GROUP_SYNC_REQ_GET] = "SELECT id FROM agent WHERE id > ? AND group_sync_status = 'syncreq' LIMIT 1;",
     [WDB_STMT_GLOBAL_GROUP_SYNC_ALL_GET] = "SELECT id FROM agent WHERE id > ? LIMIT 1;",
+    [WDB_STMT_GLOBAL_GROUP_SYNCREQ_FIND] = "SELECT 1 FROM agent WHERE group_sync_status = 'syncreq';",
     [WDB_STMT_GLOBAL_AGENT_GROUPS_GET] = "SELECT id_group from belongs where id_agent = ? ORDER BY priority;",
     [WDB_STMT_GLOBAL_GROUP_SYNC_SET] = "UPDATE agent SET group_sync_status = ? WHERE id = ?;",
     [WDB_STMT_GLOBAL_GROUP_PRIORITY_GET] = "SELECT MAX(priority) FROM belongs WHERE id_agent=?;",

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -218,6 +218,7 @@ typedef enum wdb_stmt {
     WDB_STMT_GLOBAL_SYNC_SET,
     WDB_STMT_GLOBAL_GROUP_SYNC_REQ_GET,
     WDB_STMT_GLOBAL_GROUP_SYNC_ALL_GET,
+    WDB_STMT_GLOBAL_GROUP_SYNCREQ_FIND,
     WDB_STMT_GLOBAL_AGENT_GROUPS_GET,
     WDB_STMT_GLOBAL_GROUP_SYNC_SET,
     WDB_STMT_GLOBAL_GROUP_PRIORITY_GET,
@@ -1063,6 +1064,18 @@ int wdb_parse_global_update_agent_data(wdb_t * wdb, char * input, char * output)
  *        -1 On error: response contains "err" and an error description.
  */
 int wdb_parse_global_get_agent_labels(wdb_t * wdb, char * input, char * output);
+
+/**
+ * @brief Function to check if there is at least one agent that needs to synchronize the group information.
+ *        If not, it looks for mismatch between the calculated hash and the received one.
+ *
+ * @param wdb The global struct database.
+ * @param input String with 'agent_id'.
+ * @param output Response of the query in JSON format.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
+ */
+int wdb_parse_get_groups_integrity(wdb_t * wdb, char * input, char* output);
 
 /**
  * @brief Function to get all the agent information in global.db.
@@ -2011,6 +2024,25 @@ wdbc_result wdb_global_set_agent_group_context(wdb_t *wdb, int id, char* csv, ch
  * @return A cached group hash.
  */
 int wdb_get_global_group_hash(wdb_t *wdb, os_sha1 hash);
+
+/**
+ * @brief
+ *
+ * @param wdb The Global struct database.
+ * @param group_column_hash Hash that represent the group column.
+ * @return TRUE if hashes match. FALSE otherwise.
+ */
+bool wdb_get_global_group_hash(wdb_t *wdb, char *group_column_hash);
+
+/**
+ * @brief
+ *
+ * @param wdb The Global struct database.
+ * @return 1 if at least one entry in the Global DB has the group_sync_status as "syncreq".
+ *         0 if there is a value "synced" for all group_sync_status attribute.
+ *         -1 on error.
+ */
+int wdb_global_groups_synced(wdb_t *wdb);
 
 /**
  * @brief Gets the maximum priority of the groups of an agent.

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -2017,23 +2017,6 @@ char* wdb_global_get_agent_group_csv(wdb_t *wdb, int id);
 wdbc_result wdb_global_set_agent_group_context(wdb_t *wdb, int id, char* csv, char* hash, char* sync_status);
 
 /**
- * @brief
- *
- * @param wdb The Global struct database
- * @return A cached group hash.
- */
-int wdb_get_global_group_hash(wdb_t *wdb, os_sha1 hash);
-
-/**
- * @brief Calculates a hash of the group column.
- *
- * @param wdb The Global struct database.
- * @param hexdigest Calculated hash that represent the group column.
- * @return OS_SUCCESS if the hexdigest variable was written with the global group hash value, OS_INVALID otherwise.
- */
-int wdb_get_global_group_hash(wdb_t *wdb, os_sha1 hexdigest);
-
-/**
  * @brief Verifies if at least one entry in the Global DB has the group_sync_status as "syncreq".
  *        If not, it compares a received hash that represents the group column against a calculated hash.
  *

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -1066,11 +1066,10 @@ int wdb_parse_global_update_agent_data(wdb_t * wdb, char * input, char * output)
 int wdb_parse_global_get_agent_labels(wdb_t * wdb, char * input, char * output);
 
 /**
- * @brief Function to check if there is at least one agent that needs to synchronize the group information.
- *        If not, it looks for mismatch between the calculated hash and the received one.
+ * @brief Function to get the groups integrity information in global.db.
  *
  * @param wdb The global struct database.
- * @param input String with 'agent_id'.
+ * @param input String with 'hash'.
  * @param output Response of the query in JSON format.
  * @return 0 Success: response contains "ok".
  *        -1 On error: response contains "err" and an error description.
@@ -1078,7 +1077,7 @@ int wdb_parse_global_get_agent_labels(wdb_t * wdb, char * input, char * output);
 int wdb_parse_get_groups_integrity(wdb_t * wdb, char * input, char* output);
 
 /**
- * @brief Function to get all the agent information in global.db.
+ * @brief Function to get all the agent information.
  *
  * @param wdb The global struct database.
  * @param input String with 'agent_id'.
@@ -2026,23 +2025,23 @@ wdbc_result wdb_global_set_agent_group_context(wdb_t *wdb, int id, char* csv, ch
 int wdb_get_global_group_hash(wdb_t *wdb, os_sha1 hash);
 
 /**
- * @brief
+ * @brief Calculates a hash of the group column.
  *
  * @param wdb The Global struct database.
- * @param group_column_hash Hash that represent the group column.
- * @return TRUE if hashes match. FALSE otherwise.
+ * @param hexdigest Calculated hash that represent the group column.
+ * @return OS_SUCCESS if the hexdigest variable was written with the global group hash value, OS_INVALID otherwise.
  */
-bool wdb_get_global_group_hash(wdb_t *wdb, char *group_column_hash);
+int wdb_get_global_group_hash(wdb_t *wdb, os_sha1 hexdigest);
 
 /**
- * @brief
+ * @brief Verifies if at least one entry in the Global DB has the group_sync_status as "syncreq".
+ *        If not, it compares a received hash that represents the group column against a calculated hash.
  *
  * @param wdb The Global struct database.
- * @return 1 if at least one entry in the Global DB has the group_sync_status as "syncreq".
- *         0 if there is a value "synced" for all group_sync_status attribute.
- *         -1 on error.
+ * @param hash Received group column hash.
+ * @return cJSON* Returns a cJSON object with the groups integrity status or NULL on error.
  */
-int wdb_global_groups_synced(wdb_t *wdb);
+cJSON* wdb_get_groups_integrity(wdb_t *wdb, os_sha1 hash);
 
 /**
  * @brief Gets the maximum priority of the groups of an agent.

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1225,13 +1225,11 @@ cJSON* wdb_get_groups_integrity(wdb_t* wdb, os_sha1 hash) {
     switch (sqlite3_step(stmt)) {
     case SQLITE_ROW:
         response = cJSON_CreateArray();
-
         cJSON_AddItemToArray(response, cJSON_CreateString("syncreq"));
         return response;
     case SQLITE_DONE:
         response = cJSON_CreateArray();
         os_sha1 hexdigest = {0};
-
         if ( OS_SUCCESS == wdb_get_global_group_hash(wdb, hexdigest) && !strcmp(hexdigest, hash)) {
             cJSON_AddItemToArray(response, cJSON_CreateString("synced"));
         } else {

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1230,7 +1230,7 @@ cJSON* wdb_get_groups_integrity(wdb_t* wdb, os_sha1 hash) {
     case SQLITE_DONE:
         response = cJSON_CreateArray();
         os_sha1 hexdigest = {0};
-        if ( OS_SUCCESS == wdb_get_global_group_hash(wdb, hexdigest) && !strcmp(hexdigest, hash)) {
+        if (OS_SUCCESS == wdb_get_global_group_hash(wdb, hexdigest) && !strcmp(hexdigest, hash)) {
             cJSON_AddItemToArray(response, cJSON_CreateString("synced"));
         } else {
             cJSON_AddItemToArray(response, cJSON_CreateString("hash_mismatch"));

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1213,6 +1213,37 @@ wdbc_result wdb_global_set_agent_group_context(wdb_t *wdb, int id, char* csv, ch
     }
 }
 
+cJSON* wdb_get_groups_integrity(wdb_t* wdb, os_sha1 hash) {
+    sqlite3_stmt* stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_GLOBAL_GROUP_SYNCREQ_FIND);
+
+    if (stmt == NULL) {
+        return NULL;
+    }
+
+    cJSON* response = NULL;
+
+    switch (sqlite3_step(stmt)) {
+    case SQLITE_ROW:
+        response = cJSON_CreateArray();
+
+        cJSON_AddItemToArray(response, cJSON_CreateString("syncreq"));
+        return response;
+    case SQLITE_DONE:
+        response = cJSON_CreateArray();
+        os_sha1 hexdigest = {0};
+
+        if ( OS_SUCCESS == wdb_get_global_group_hash(wdb, hexdigest) && !strcmp(hexdigest, hash)) {
+            cJSON_AddItemToArray(response, cJSON_CreateString("synced"));
+        } else {
+            cJSON_AddItemToArray(response, cJSON_CreateString("hash_mismatch"));
+        }
+        return response;
+    default:
+        mdebug1("DB(%s) sqlite3_step(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+        return response;
+    }
+}
+
 int wdb_global_get_agent_max_group_priority(wdb_t *wdb, int id) {
     sqlite3_stmt *stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_GLOBAL_GROUP_PRIORITY_GET);
 

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -883,8 +883,7 @@ int wdb_parse(char * input, char * output, int peer) {
             } else {
                 result = wdb_parse_global_set_agent_groups(wdb, next, output);
             }
-        }
-        else if (strcmp(query, "sync-agent-info-get") == 0) {
+        } else if (strcmp(query, "sync-agent-info-get") == 0) {
             result = wdb_parse_global_sync_agent_info_get(wdb, next, output);
         } else if (strcmp(query, "sync-agent-info-set") == 0) {
             if (!next) {
@@ -894,6 +893,15 @@ int wdb_parse(char * input, char * output, int peer) {
                 result = OS_INVALID;
             } else {
                 result = wdb_parse_global_sync_agent_info_set(wdb, next, output);
+            }
+        } else if (strcmp(query, "get-groups-integrity") == 0) {
+            if (!next) {
+                mdebug1("Global DB Invalid DB query syntax for disconnect-agents.");
+                mdebug2("Global DB query error near: %s", query);
+                snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
+                result = OS_INVALID;
+            } else {
+                result = wdb_parse_get_groups_integrity(wdb, next, output);
             }
         } else if (strcmp(query, "disconnect-agents") == 0) {
             if (!next) {
@@ -5584,6 +5592,38 @@ int wdb_parse_global_sync_agent_info_set(wdb_t * wdb, char * input, char * outpu
     cJSON_Delete(root);
 
     return OS_SUCCESS;
+}
+
+int wdb_parse_get_groups_integrity(wdb_t* wdb, char* input, char* output) {
+    cJSON *response = NULL;
+    char *out = NULL;
+    char *hash = input;
+    int ret = OS_SUCCESS;
+
+    response = cJSON_CreateArray();
+    int groups_synced = wdb_global_groups_synced(wdb);
+
+    if (groups_synced == 1) {
+        cJSON_AddItemToArray(response, cJSON_CreateString("syncreq"));
+    } else if (groups_synced == 0) {
+        if (wdb_get_global_group_hash(wdb, hash)){
+            cJSON_AddItemToArray(response, cJSON_CreateString("synced"));
+        } else {
+            cJSON_AddItemToArray(response, cJSON_CreateString("hash_mismatch"));
+        }
+    } else {
+        snprintf(output, OS_MAXSTR + 1, "err. Error getting group sync status from global.db.");
+        ret = OS_INVALID;
+        goto end;
+    }
+
+    out = cJSON_PrintUnformatted(response);
+    snprintf(output, OS_MAXSTR + 1, "ok %s", out);
+
+end:
+    cJSON_Delete(response);
+
+    return ret;
 }
 
 int wdb_parse_global_get_agent_info(wdb_t* wdb, char* input, char* output) {

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5597,20 +5597,20 @@ int wdb_parse_global_sync_agent_info_set(wdb_t * wdb, char * input, char * outpu
 int wdb_parse_get_groups_integrity(wdb_t* wdb, char* input, char* output) {
     os_sha1 hash = {0};
     strncpy(hash, input, strlen(input));
-
-    cJSON *result = NULL;
-    if (result = wdb_get_groups_integrity(wdb, hash), !result) {
+    int ret = OS_SUCCESS;
+    cJSON *j_result = wdb_get_groups_integrity(wdb, hash);
+    if (j_result) {
+        char* out = cJSON_PrintUnformatted(j_result);
+        snprintf(output, OS_MAXSTR + 1, "ok %s", out);
+        os_free(out);
+        cJSON_Delete(j_result);
+    } else {
         mdebug1("Error getting groups integrity information from global.db.");
         snprintf(output, OS_MAXSTR + 1, "err Error getting groups integrity information from global.db.");
-        return OS_INVALID;
+        ret = OS_INVALID;
     }
 
-    char* out = cJSON_PrintUnformatted(result);
-    snprintf(output, OS_MAXSTR + 1, "ok %s", out);
-    os_free(out);
-    cJSON_Delete(result);
-
-    return OS_SUCCESS;
+    return ret;
 }
 
 int wdb_parse_global_get_agent_info(wdb_t* wdb, char* input, char* output) {


### PR DESCRIPTION
|Related issue|
|---|
|#11790|

## Description

This PR adds a new Wazuh DB command to verify the group integrity. Thought to be used during cluster synchronization mechanism.

## Scan-build report

![image](https://user-images.githubusercontent.com/13010397/149572622-460c2997-dc88-4bb6-9542-7be4495f2602.png)

## Valgrind 

![2](https://user-images.githubusercontent.com/13010397/149571239-1305bb5d-366d-4389-96f9-c027fb66fca8.png)

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report