### PR TITLE
Adding the global group hash methods and cache for cluster syncronization

### DIFF
--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -172,7 +172,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_GROUP_PRIORITY_GET] = "SELECT MAX(priority) FROM belongs WHERE id_agent=?;",
     [WDB_STMT_GLOBAL_GROUP_CSV_GET] = "SELECT `group` from agent where id = ?;",
     [WDB_STMT_GLOBAL_GROUP_CTX_SET] = "UPDATE agent SET 'group' = ?, group_local_hash = ?, group_sync_status = ? WHERE id = ?;",
-    [WDB_STMT_GLOBAL_GROUP_HASH_GET] = "SELECT group_local_hash FROM agent WHERE group_local_hash IS NOT NULL;",
+    [WDB_STMT_GLOBAL_GROUP_HASH_GET] = "SELECT group_local_hash FROM agent WHERE group_local_hash IS NOT NULL ORDER BY id;",
     [WDB_STMT_GLOBAL_UPDATE_AGENT_INFO] = "UPDATE agent SET config_sum = :config_sum, ip = :ip, manager_host = :manager_host, merged_sum = :merged_sum, name = :name, node_name = :node_name, os_arch = :os_arch, os_build = :os_build, os_codename = :os_codename, os_major = :os_major, os_minor = :os_minor, os_name = :os_name, os_platform = :os_platform, os_uname = :os_uname, os_version = :os_version, version = :version, last_keepalive = :last_keepalive, connection_status = :connection_status, disconnection_time = :disconnection_time, sync_status = :sync_status WHERE id = :id;",
     [WDB_STMT_GLOBAL_GET_AGENTS] = "SELECT id FROM agent WHERE id > ?;",
     [WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS] = "SELECT id FROM agent WHERE id > ? AND connection_status = ?;",

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -172,6 +172,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_GROUP_PRIORITY_GET] = "SELECT MAX(priority) FROM belongs WHERE id_agent=?;",
     [WDB_STMT_GLOBAL_GROUP_CSV_GET] = "SELECT `group` from agent where id = ?;",
     [WDB_STMT_GLOBAL_GROUP_CTX_SET] = "UPDATE agent SET 'group' = ?, group_local_hash = ?, group_sync_status = ? WHERE id = ?;",
+    [WDB_STMT_GLOBAL_GROUP_HASH_GET] = "SELECT group_local_hash FROM agent WHERE group_local_hash IS NOT NULL;",
     [WDB_STMT_GLOBAL_UPDATE_AGENT_INFO] = "UPDATE agent SET config_sum = :config_sum, ip = :ip, manager_host = :manager_host, merged_sum = :merged_sum, name = :name, node_name = :node_name, os_arch = :os_arch, os_build = :os_build, os_codename = :os_codename, os_major = :os_major, os_minor = :os_minor, os_name = :os_name, os_platform = :os_platform, os_uname = :os_uname, os_version = :os_version, version = :version, last_keepalive = :last_keepalive, connection_status = :connection_status, disconnection_time = :disconnection_time, sync_status = :sync_status WHERE id = :id;",
     [WDB_STMT_GLOBAL_GET_AGENTS] = "SELECT id FROM agent WHERE id > ?;",
     [WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS] = "SELECT id FROM agent WHERE id > ? AND connection_status = ?;",

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -73,6 +73,13 @@ typedef enum wdb_groups_set_mode_t {
         WDB_GROUP_INVALID_MODE  ///< Invalid mode
 } wdb_groups_set_mode_t;
 
+/// Operations with the global group hash cache
+typedef enum wdb_global_group_hash_operations_t {
+    WDB_GLOBAL_GROUP_HASH_READ,  ///< Reads the global group hash value in cache if any
+    WDB_GLOBAL_GROUP_HASH_WRITE, ///< Saves a new global group hash value in cache
+    WDB_GLOBAL_GROUP_HASH_CLEAR  ///< Erases the global group hash value in cache
+} wdb_global_group_hash_operations_t;
+
 #define WDB_GROUP_MODE_EMPTY_ONLY "empty_only"
 #define WDB_GROUP_MODE_OVERRIDE "override"
 #define WDB_GROUP_MODE_APPEND "append"
@@ -353,7 +360,7 @@ typedef enum {
     WDB_SYSCOLLECTOR_NETINFO,        ///< Net info integrity monitoring.
     WDB_SYSCOLLECTOR_HWINFO,         ///< Hardware info integrity monitoring.
     WDB_SYSCOLLECTOR_OSINFO,         ///< OS info integrity monitoring.
-    WDB_GENERIC_COMPONENT,           ///< Defined to re-utilize the methods outside the integrity library
+    WDB_GENERIC_COMPONENT,           ///< Miscellaneous component
 } wdb_component_t;
 
 extern char *schema_global_sql;
@@ -1486,9 +1493,8 @@ void wdbi_set_last_completion(wdb_t * wdb, wdb_component_t component, long times
 int wdbi_check_sync_status(wdb_t *wdb, wdb_component_t component);
 
 /**
- * @brief Method to obtain the hash of the whole group_local_hash column in agent table.
+ * @brief Method to obtain and cache the hash of the whole group_local_hash column in agent table.
  *        If the cache is empty, the global group hash is calculated and stored.
- *        If the value is already in cache, it is directly returned.
  *
  * @param wdb The DB pointer structure.
  * @param hexdigest Variable to return the global group hash.
@@ -1499,13 +1505,13 @@ int wdb_get_global_group_hash(wdb_t * wdb, os_sha1 hexdigest);
 /**
  * @brief Method to perform all the required operations over the global group hash cache.
  *
- * @param mode      "read" : OS_INVALID if there is no value in cache. OS_SUCCESS if a value was found and stored in hexdigest
- *                  "set"  : OS_SUCCESS after writting the hexdigest value in global_group_hash.
- *                  "clear": OS_SUCCESS after clearing the global group hash cache.
- * @param hexdigest Input/Output variable, see "mode".
- * @return int OS_INVALID in case of an unsupported "mode". See "mode" for the rest of cases.
+ * @param operation      WDB_GLOBAL_GROUP_HASH_READ : OS_INVALID if there is no value in cache. OS_SUCCESS if a value was found and stored in hexdigest
+ *                       WDB_GLOBAL_GROUP_HASH_WRITE: OS_SUCCESS after writting the hexdigest value in global_group_hash.
+ *                       WDB_GLOBAL_GROUP_HASH_CLEAR: OS_SUCCESS after clearing the global group hash cache.
+ * @param hexdigest Input/Output variable, see "operation".
+ * @return int OS_INVALID in case of an unsupported "operation". See "operation" for the rest of cases.
  */
-int wdb_global_group_hash_cache_operations(const char* mode, os_sha1 hexdigest);
+int wdb_global_group_hash_cache(wdb_global_group_hash_operations_t operation, os_sha1 hexdigest);
 
 // Functions to manage scan_info table, this table contains the timestamp of every scan of syscheck ¿and syscollector?
 

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -217,6 +217,7 @@ typedef enum wdb_stmt {
     WDB_STMT_GLOBAL_GROUP_PRIORITY_GET,
     WDB_STMT_GLOBAL_GROUP_CSV_GET,
     WDB_STMT_GLOBAL_GROUP_CTX_SET,
+    WDB_STMT_GLOBAL_GROUP_HASH_GET,
     WDB_STMT_GLOBAL_UPDATE_AGENT_INFO,
     WDB_STMT_GLOBAL_GET_AGENTS,
     WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS,
@@ -352,6 +353,7 @@ typedef enum {
     WDB_SYSCOLLECTOR_NETINFO,        ///< Net info integrity monitoring.
     WDB_SYSCOLLECTOR_HWINFO,         ///< Hardware info integrity monitoring.
     WDB_SYSCOLLECTOR_OSINFO,         ///< OS info integrity monitoring.
+    WDB_GENERIC_COMPONENT,           ///< Defined to re-utilize the methods outside the integrity library
 } wdb_component_t;
 
 extern char *schema_global_sql;
@@ -1482,6 +1484,28 @@ int wdbi_get_last_manager_checksum(wdb_t *wdb, wdb_component_t component, os_sha
 void wdbi_set_last_completion(wdb_t * wdb, wdb_component_t component, long timestamp);
 
 int wdbi_check_sync_status(wdb_t *wdb, wdb_component_t component);
+
+/**
+ * @brief Method to obtain the hash of the whole group_local_hash column in agent table.
+ *        If the cache is empty, the global group hash is calculated and stored.
+ *        If the value is already in cache, it is directly returned.
+ *
+ * @param wdb The DB pointer structure.
+ * @param hexdigest Variable to return the global group hash.
+ * @return int OS_SUCCESS if the hexdigest variable was written with the global group hash value, OS_INVALID otherwise.
+ */
+int wdb_get_global_group_hash(wdb_t * wdb, os_sha1 hexdigest);
+
+/**
+ * @brief Method to perform all the required operations over the global group hash cache.
+ *
+ * @param mode      "read" : OS_INVALID if there is no value in cache. OS_SUCCESS if a value was found and stored in hexdigest
+ *                  "set"  : OS_SUCCESS after writting the hexdigest value in global_group_hash.
+ *                  "clear": OS_SUCCESS after clearing the global group hash cache.
+ * @param hexdigest Input/Output variable, see "mode".
+ * @return int OS_INVALID in case of an unsupported "mode". See "mode" for the rest of cases.
+ */
+int wdb_global_group_hash_cache_operations(const char* mode, os_sha1 hexdigest);
 
 // Functions to manage scan_info table, this table contains the timestamp of every scan of syscheck ¿and syscollector?
 

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1307,7 +1307,7 @@ wdbc_result wdb_global_set_agent_groups(wdb_t *wdb, wdb_groups_set_mode_t mode, 
                     merror("There was an error assigning the groups context to agent '%03d'", agent_id);
                 }
                 os_free(agent_groups_csv);
-                wdb_global_group_hash_cache_operations("clear", NULL);
+                wdb_global_group_hash_cache(WDB_GLOBAL_GROUP_HASH_CLEAR, NULL);
             }
             else {
                 ret = WDBC_ERROR;

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1307,6 +1307,7 @@ wdbc_result wdb_global_set_agent_groups(wdb_t *wdb, wdb_groups_set_mode_t mode, 
                     merror("There was an error assigning the groups context to agent '%03d'", agent_id);
                 }
                 os_free(agent_groups_csv);
+                wdb_global_group_hash_cache_operations("clear", NULL);
             }
             else {
                 ret = WDBC_ERROR;


### PR DESCRIPTION
|Related issue|
|---|
|#11793|

## Description

This PR creates the `wdb_get_global_group_hash()` method to calculate the hash of the whole `group_local_hash` column in the **agent** table. The global group hash is stored in cache to avoid calculating it every time and this cache is cleared every time a new group assignment is done.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report