### PR TITLE
Add variable with status of previous iteration of `local_integrity`

### DIFF
--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -1005,7 +1005,8 @@ class Master(server.AbstractServer):
             file_integrity_logger.info("Starting.")
             try:
                 self.integrity_control = await cluster.run_in_pool(self.loop, self.task_pool,
-                                                                   wazuh.core.cluster.cluster.get_files_status)
+                                                                   wazuh.core.cluster.cluster.get_files_status,
+                                                                   self.integrity_control)
             except Exception as e:
                 file_integrity_logger.error(f"Error calculating local file integrity: {e}")
             finally:


### PR DESCRIPTION
## Description

In this PR we have fixed a bug that caused the integrity task to calculate at each iteration all the MD5 of all the files.

This meant that the CPU and time consumption was approximately twice as high as with this fix.

Regards,
Adrián Peña