### PR TITLE
Fix memory leak in MSU parser

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -6961,14 +6961,15 @@ vu_cpe_dic_node *wm_vuldet_free_dic_node(vu_cpe_dic_node *dic_node) {
 
 vu_msu_vul_entry *wm_vuldet_free_msu_vul_node(vu_msu_vul_entry *node) {
     vu_msu_vul_entry *prev = node->prev;
-    free(node->cveid);
-    free(node->product);
-    free(node->patch);
-    free(node->title);
-    free(node->url);
-    free(node->subtype);
-    free(node->restart_required);
-    free(node);
+    os_free(node->cveid);
+    os_free(node->product);
+    os_free(node->patch);
+    os_free(node->title);
+    os_free(node->url);
+    os_free(node->subtype);
+    os_free(node->restart_required);
+    os_free(node->check_type);
+    os_free(node);
     return prev;
 }
 
@@ -8097,7 +8098,7 @@ void wm_vuln_check_msu_type(vu_msu_vul_entry *msu, cJSON *patchs) {
     const char *version_pattern = " Version ";
 
     if (strncmp(msu->product, win10_pattern, strlen(win10_pattern))) {
-        msu->check_type = "1";
+        w_strdup("1", msu->check_type);
         return;
     }
 
@@ -8117,7 +8118,7 @@ void wm_vuln_check_msu_type(vu_msu_vul_entry *msu, cJSON *patchs) {
             strncmp(product_name + strlen(win10_pattern), version_pattern, strlen(version_pattern))) {
             continue;
         }
-        msu->check_type = "1";
+        w_strdup("1", msu->check_type);
         break;
     }
 }


### PR DESCRIPTION
|Related issue|
|---|
|#11773|

## Description

After analyzing the feeds with valgrind in issue #11773, the following trace has been obtained indicating a memory leak found in the MSU parser:

```
==20710== 725,175 bytes in 145,035 blocks are definitely lost in loss record 76 of 76
==20710==    at 0x483DFAF: realloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==20710==    by 0x14A18D: w_tolower_str (string_op.c:1027)
==20710==    by 0x1E9FAD: wm_vuln_check_msu_type (wm_vuln_detector.c:8105)
==20710==    by 0x1E43C8: wm_vuldet_json_msu_parser_vuln (wm_vuln_detector.c:6731)
==20710==    by 0x1E49EE: wm_vuldet_json_msu_parser (wm_vuln_detector.c:6777)
==20710==    by 0x1DC7C6: wm_vuldet_json_parser (wm_vuln_detector.c:4942)
==20710==    by 0x1E690F: wm_vuldet_index_json (wm_vuln_detector.c:7207)
==20710==    by 0x1D8B56: wm_vuldet_index_feed (wm_vuln_detector.c:4151)
==20710==    by 0x1C661A: wm_vuldet_sync_feed (wm_vuln_detector.c:649)
==20710==    by 0x1D00F3: wm_vuldet_update_feed (wm_vuln_detector.c:2673)
==20710==    by 0x1D9F9F: wm_vuldet_check_feed (wm_vuln_detector.c:4509)
==20710==    by 0x1DA530: wm_vuldet_run_update (wm_vuln_detector.c:4609)
==20710== 
==20710== LEAK SUMMARY:
==20710==    definitely lost: 725,175 bytes in 145,035 blocks
```

The problem was found when applying the `w_tolower_str()` function, which returned a pointer where its memory was never freed.
To avoid the problem, it is necessary to free the memory stored in the `check_type` variable when the `vu_msu_vul_entry` structure is freed.

## Configuration options

With the following configuration, the memory leak has been replicated:

```xml
  <vulnerability-detector>
    <enabled>yes</enabled>
    <interval>10m</interval>
    <min_full_scan_interval>15m</min_full_scan_interval>
    <run_on_start>yes</run_on_start>
    ...
    <provider name="msu">
      <url>http://ci.wazuh.com/vulnerability-detector/msu/msu-updates.json.gz</url>
      <enabled>yes</enabled>
      <update_interval>1m</update_interval>
    </provider>
    ...
  </vulnerability-detector>
```

## Logs/Alerts example

After applying the fix, as shown below, the commented memory leak no longer appears:
```
==481== LEAK SUMMARY:
==481==    definitely lost: 0 bytes in 0 blocks
==481==    indirectly lost: 0 bytes in 0 blocks
==481==      possibly lost: 3,600 bytes in 12 blocks
==481==    still reachable: 297,882 bytes in 96 blocks
==481==         suppressed: 0 bytes in 0 blocks
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
`scan-build: No bugs found.`
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Added unit tests (for new features)
- [x] Stress test for affected components
