### PR TITLE
Remove unnecessary librpm deps

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -44,10 +44,7 @@ EXTERNAL_LIBARCHIVE=external/libarchive/
 endif
 ifeq (${uname_S},Linux)
 EXTERNAL_RPM=external/rpm/
-EXTERNAL_LZMA=external/lzma/
 EXTERNAL_POPT=external/popt/
-EXTERNAL_LIBMAGIC=external/libmagic/
-EXTERNAL_ZSTD=external/zstd/
 endif
 # XXX Becareful NO EXTRA Spaces here
 PG_CONFIG?=pg_config
@@ -804,10 +801,7 @@ LIBFFI_LIB 	= $(EXTERNAL_LIBFFI)$(TARGET)/.libs/libffi.a
 MSGPACK_LIB = $(EXTERNAL_MSGPACK)libmsgpack.a
 BZIP2_LIB   = $(EXTERNAL_BZIP2)libbz2.a
 LIBPCRE2_LIB = $(EXTERNAL_LIBPCRE2).libs/libpcre2-8.a
-ZSTD_LIB = $(EXTERNAL_ZSTD)build/cmake/build/lib/libzstd.a
-LIBMAGIC_LIB = $(EXTERNAL_LIBMAGIC)build/output/src/.libs/libmagic.a
 POPT_LIB = $(EXTERNAL_POPT)build/output/src/.libs/libpopt.a
-LZMA_LIB = $(EXTERNAL_LZMA)build/output/src/liblzma/.libs/liblzma.a
 RPM_LIB = $(EXTERNAL_RPM)builddir/librpm.a
 
 
@@ -829,7 +823,7 @@ EXTERNAL_LIBS += $(LIBFFI_LIB) $(BZIP2_LIB)
 endif
 ifeq (${uname_S},Linux)
 ifneq ($(CHECK_CENTOS5),YES)
-EXTERNAL_LIBS += ${RPM_LIB} ${ZSTD_LIB} ${LIBMAGIC_LIB} ${POPT_LIB} ${LZMA_LIB} ${SQLITE_LIB}
+EXTERNAL_LIBS += ${RPM_LIB} ${POPT_LIB}
 endif
 ifneq (,$(filter ${USE_AUDIT},YES yes y Y 1))
 EXTERNAL_LIBS += ${AUDIT_LIB}
@@ -1098,16 +1092,6 @@ else
 	cd $(EXTERNAL_LIBPCRE2) && CFLAGS=-fPIC ./configure --enable-jit=auto --disable-shared && cp src/pcre2.h include/pcre2.h && ${MAKE}
 endif
 
-### lzma lib ###
-
-LZMA_BUILD_DIR = $(EXTERNAL_LZMA)build/
-
-$(LZMA_LIB): $(LZMA_BUILD_DIR)Makefile
-	cd $(LZMA_BUILD_DIR) && $(MAKE)
-
-$(LZMA_BUILD_DIR)Makefile:
-	mkdir -p $(LZMA_BUILD_DIR) && cd $(LZMA_BUILD_DIR) && cmake ..
-
 ### popt lib ###
 
 POPT_BUILD_DIR = $(EXTERNAL_POPT)build/
@@ -1117,29 +1101,6 @@ $(POPT_LIB): $(POPT_BUILD_DIR)Makefile
 $(POPT_BUILD_DIR)Makefile:
 	mkdir -p $(POPT_BUILD_DIR) && cd $(POPT_BUILD_DIR) && cmake ..
 
-### libmagic lib ###
-
-LIBMAGIC_CFLAGS = -I$(ROUTE_PATH)/$(EXTERNAL_ZLIB -L$(ROUTE_PATH)/$(ZLIB_LIB)
-LIBMAGIC_BUILD_DIR = $(EXTERNAL_LIBMAGIC)build/
-
-
-$(LIBMAGIC_LIB): $(LIBMAGIC_BUILD_DIR)Makefile
-	cd $(LIBMAGIC_BUILD_DIR) && $(MAKE)
-
-$(LIBMAGIC_BUILD_DIR)Makefile: $(ZLIB_LIB)
-	mkdir -p $(LIBMAGIC_BUILD_DIR) && cd $(LIBMAGIC_BUILD_DIR) && cmake -E env CFLAGS="${LIBMAGIC_CFLAGS}" cmake ..
-
-### zstd lib ###
-
-ZSTD_CMAKE_DIR = $(EXTERNAL_ZSTD)/build/cmake/
-ZSTD_BUILD_DIR = $(ZSTD_CMAKE_DIR)/build/
-
-$(ZSTD_LIB): $(ZSTD_BUILD_DIR)/Makefile
-	cd $(ZSTD_BUILD_DIR) && $(MAKE)
-
-$(ZSTD_BUILD_DIR)/Makefile:
-	mkdir -p $(ZSTD_BUILD_DIR) && cd $(ZSTD_BUILD_DIR) && cmake ..
-
 ### rpm lib ###
 
 RPM_BUILD_DIR = ${EXTERNAL_RPM}/builddir
@@ -1147,17 +1108,11 @@ RPM_BUILD_DIR = ${EXTERNAL_RPM}/builddir
 RPM_INC_PATHS = -I${ROUTE_PATH}/${EXTERNAL_OPENSSL}include \
 				-I${ROUTE_PATH}/${EXTERNAL_ZLIB} \
 				-I${ROUTE_PATH}/${EXTERNAL_POPT}/src \
-				-I${ROUTE_PATH}/${EXTERNAL_LIBMAGIC}/build/output/src \
-				-I${ROUTE_PATH}/${EXTERNAL_LZMA}/src/liblzma/api \
-				-I${ROUTE_PATH}/${EXTERNAL_ZSTD}/lib \
 				-I${ROUTE_PATH}/${EXTERNAL_SQLITE}
 
 RPM_LIB_PATHS = -L${ROUTE_PATH}/${EXTERNAL_OPENSSL} \
 				-L${ROUTE_PATH}/${EXTERNAL_ZLIB} \
 				-L${ROUTE_PATH}/${EXTERNAL_POPT}/build/output/src/.libs/ \
-				-L${ROUTE_PATH}/${EXTERNAL_LIBMAGIC}/build/output/src/.libs/ \
-				-L${ROUTE_PATH}/${EXTERNAL_LZMA}/build/output/src/liblzma/.libs/ \
-				-L${ROUTE_PATH}/${EXTERNAL_ZSTD}/build/cmake/build/lib/ \
 				-L${ROUTE_PATH}/${EXTERNAL_SQLITE}
 
 RPM_CFLAGS = -fPIC ${RPM_INC_PATHS} ${RPM_LIB_PATHS}
@@ -1166,7 +1121,7 @@ RPM_CC = gcc
 ${RPM_LIB}: ${RPM_BUILD_DIR}/Makefile
 	cd ${RPM_BUILD_DIR} && ${MAKE}
 
-${RPM_BUILD_DIR}/Makefile: ${OPENSSL_LIB} ${ZLIB_LIB} ${POPT_LIB} ${LIBMAGIC_LIB} ${LZMA_LIB} ${ZSTD_LIB} ${SQLITE_LIB}
+${RPM_BUILD_DIR}/Makefile: ${OPENSSL_LIB} ${ZLIB_LIB} ${POPT_LIB} ${SQLITE_LIB}
 	mkdir -p ${RPM_BUILD_DIR} && cd ${RPM_BUILD_DIR} && cmake -E env CFLAGS="${RPM_CFLAGS}" CC=${RPM_CC} cmake ..
 
 
@@ -1222,7 +1177,7 @@ PRECOMPILED_RES := $(PRECOMPILED_OS)$(PRECOMPILED_ARCH)
 endif
 
 # Agent dependencies
-EXTERNAL_RES := cJSON curl libdb libffi libyaml openssl procps sqlite zlib audit-userspace msgpack bzip2 nlohmann googletest libpcre2 libplist pacman libarchive lzma libmagic zstd popt rpm
+EXTERNAL_RES := cJSON curl libdb libffi libyaml openssl procps sqlite zlib audit-userspace msgpack bzip2 nlohmann googletest libpcre2 libplist pacman libarchive popt rpm
 ifneq (${TARGET},agent)
 ifneq (${TARGET},winagent)
 	# Manager extra dependency
@@ -2379,9 +2334,6 @@ ifneq ($(wildcard external/*/*),)
 	rm -rf $(EXTERNAL_GOOGLE_TEST)build
 	-cd ${EXTERNAL_LIBPLIST} && ${MAKE} clean && rm -rf bin/*
 	-cd ${EXTERNAL_LIBPCRE2} && ${MAKE} distclean && rm include/*
-	rm -rf ${LIBMAGIC_BUILD_DIR}
-	rm -rf ${ZSTD_BUILD_DIR}
-	rm -rf ${LZMA_BUILD_DIR}
 	rm -rf ${POPT_BUILD_DIR}
 	rm -rf ${RPM_BUILD_DIR}
 


### PR DESCRIPTION
|Related issue|
|---|
| #11355 |

## Description

Hi team!

This PR aims to reduce librpm footprint impact by re-analyzing if assumed dependencies were really needed to only read rpm databases (no fully-featured librpm with building capabilities)

Next dependencies were removed
- zstd
- libmagic
- lzma

Also librpm compilation was reduced by removing the code of unused features (rpm build, sign and fts). Precompiled packages will be needed.

Please @Dwordcito, for https://packages.wazuh.com/deps/16 :
Remove:
- Precompiled deps and source deps for every arch: zstd lzma libmagic

Update
- Precompiled and source for every arch: rpm

## Exploratory
- openSUSE Tumbleweed
- Fedora 35
## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors