### PR TITLE
Reduce number of calls to `db_maintenance` in AWS integration

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -981,9 +981,6 @@ class AWSBucket(WazuhIntegration):
                         debug(f"+++ Remove file from S3 Bucket:{bucket_file['Key']}", 2)
                         self.client.delete_object(Bucket=self.bucket, Key=bucket_file['Key'])
                     self.mark_complete(aws_account_id, aws_region, bucket_file)
-                # Optimize DB
-                self.db_maintenance(aws_account_id=aws_account_id, aws_region=aws_region)
-                self.db_connector.commit()
 
                 if bucket_files['IsTruncated']:
                     new_s3_args = self.build_s3_filter_args(aws_account_id, aws_region, True)
@@ -1354,9 +1351,6 @@ class AWSConfigBucket(AWSLogsBucket):
                     debug("+++ Remove file from S3 Bucket:{0}".format(bucket_file['Key']), 2)
                     self.client.delete_object(Bucket=self.bucket, Key=bucket_file['Key'])
                 self.mark_complete(aws_account_id, aws_region, bucket_file)
-            # Optimize DB
-            self.db_maintenance(aws_account_id=aws_account_id, aws_region=aws_region)
-            self.db_connector.commit()
             # Iterate if there are more logs
             while bucket_files['IsTruncated']:
                 new_s3_args = self.build_s3_filter_args(aws_account_id, aws_region, date, True)
@@ -1391,9 +1385,6 @@ class AWSConfigBucket(AWSLogsBucket):
                         debug("+++ Remove file from S3 Bucket:{0}".format(bucket_file['Key']), 2)
                         self.client.delete_object(Bucket=self.bucket, Key=bucket_file['Key'])
                     self.mark_complete(aws_account_id, aws_region, bucket_file)
-                # Optimize DB
-                self.db_maintenance(aws_account_id=aws_account_id, aws_region=aws_region)
-                self.db_connector.commit()
         except SystemExit:
             raise
         except Exception as err:
@@ -1713,6 +1704,7 @@ class AWSVPCFlowBucket(AWSLogsBucket):
                     date_list = self.get_date_list(aws_account_id, aws_region, flow_log_id)
                     for date in date_list:
                         self.iter_files_in_bucket(aws_account_id, aws_region, date, flow_log_id)
+                    self.db_maintenance(aws_account_id, aws_region, flow_log_id)
 
     def db_count_region(self, aws_account_id, aws_region, flow_log_id):
         """Counts the number of rows in DB for a region
@@ -1837,10 +1829,6 @@ class AWSVPCFlowBucket(AWSLogsBucket):
                     debug("+++ Remove file from S3 Bucket:{0}".format(bucket_file['Key']), 2)
                     self.client.delete_object(Bucket=self.bucket, Key=bucket_file['Key'])
                 self.mark_complete(aws_account_id, aws_region, bucket_file, flow_log_id)
-            # Optimize DB
-            self.db_maintenance(aws_account_id=aws_account_id, aws_region=aws_region,
-                                flow_log_id=flow_log_id)
-            self.db_connector.commit()
             # Iterate if there are more logs
             while bucket_files['IsTruncated']:
                 new_s3_args = self.build_s3_filter_args(aws_account_id, aws_region, date, flow_log_id, True)
@@ -1877,10 +1865,6 @@ class AWSVPCFlowBucket(AWSLogsBucket):
                         debug("+++ Remove file from S3 Bucket:{0}".format(bucket_file['Key']), 2)
                         self.client.delete_object(Bucket=self.bucket, Key=bucket_file['Key'])
                     self.mark_complete(aws_account_id, aws_region, bucket_file, flow_log_id)
-                # Optimize DB
-                self.db_maintenance(aws_account_id=aws_account_id, aws_region=aws_region,
-                                    flow_log_id=flow_log_id)
-                self.db_connector.commit()
         except SystemExit:
             raise
         except Exception as err:
@@ -2497,9 +2481,6 @@ class AWSServerAccess(AWSCustomBucket):
                         debug(f"+++ Remove file from S3 Bucket:{bucket_file['Key']}", 2)
                         self.client.delete_object(Bucket=self.bucket, Key=bucket_file['Key'])
                     self.mark_complete(aws_account_id, aws_region, bucket_file)
-                # Optimize DB
-                self.db_maintenance(aws_account_id=aws_account_id, aws_region=aws_region)
-                self.db_connector.commit()
 
                 if bucket_files['IsTruncated']:
                     new_s3_args = self.build_s3_filter_args(aws_account_id, aws_region, True)


### PR DESCRIPTION
| Related issue |
|---|
|Closes #10850 |

## Description
In this PR we optimize the number of calls to the `db_maintenance` method by using it only once at the end of every execution for every region, instead of once per batch of logs as it was the case.

## Tests performed
To test that the changes are working fine for every service we decided to make the following test:
After changing the `self.retain_db_records` attribute from 500 to 5, ensuring that, for every service and type of bucket, once the module has been executed and has collected more than 5 logs only **5 logs** are stored in the database. Also, the line `DEBUG: +++ DB Maintenance` should appear only once per region and execution. The results of the tests are the following:

### Conclusions
The changes are working as expected for all the services, however, we discovered a bug in the load balancer buckets, so we opened #11826 to fix that.

### Cloudtrail

<details><summary>Command output</summary>

	root@b1972ef49f85:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-cloudtrail -d2 -t cloudtrail -s 2021-nov-01 -p dev
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/01
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/01/XXXXXXXXXXXX_CloudTrail_us-west-1_20211101T0000Z_rUQtGNUqmrPZMCnu.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/02/XXXXXXXXXXXX_CloudTrail_us-west-1_20211102T0000Z_qJRrDloAWNoOMRAy.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/03/XXXXXXXXXXXX_CloudTrail_us-west-1_20211103T0000Z_OtoPYJqXyVMnScng.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/08/XXXXXXXXXXXX_CloudTrail_us-west-1_20211108T0000Z_rUQtGNUqmrPZMCnu.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/11/XXXXXXXXXXXX_CloudTrail_us-west-1_20211111T0000Z_rUQtGNUqmrPZMCnu.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/15/XXXXXXXXXXXX_CloudTrail_us-west-1_20211115T0000Z_rUQtGNUqmrPZMCnu.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/21/XXXXXXXXXXXX_CloudTrail_us-west-1_20211121T0000Z_rUQtGNUqmrPZMCnu.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/22/XXXXXXXXXXXX_CloudTrail_us-west-1_20211122T0000Z_rUQtGNUqmrPZMCnu.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/11/23/XXXXXXXXXXXX_CloudTrail_us-west-1_20211123T0000Z_rUQtGNUqmrPZMCnu.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/12/01/XXXXXXXXXXXX_CloudTrail_us-west-1_20211201T0000Z_VZJxNKcpNdyJysGy.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/12/01/XXXXXXXXXXXX_CloudTrail_us-west-1_20211201T0000Z_ZKdiPZvOQPGUJMUh.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/12/01/XXXXXXXXXXXX_CloudTrail_us-west-1_20211201T0000Z_ZsQHQAHDMsYfvPHx.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/12/01/XXXXXXXXXXXX_CloudTrail_us-west-1_20211201T0000Z_wcnIRHvPJuYpSXZr.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/12/23/XXXXXXXXXXXX_CloudTrail_us-west-1_20211223T0000Z_HASDOtJxgfdNInHa.json.gz
	DEBUG: +++ DB Maintenance

</details>

After processing 14 files, the number of entries stored in the database is:

```
root@b1972ef49f85:/var/ossec/wodles/aws# sqlite3 ./s3_cloudtrail.db 'select count(*) from cloudtrail'
5
```


### VPCFlow

<details><summary>Command output</summary>

	root@b1972ef49f85:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-vpcflow -d2 -t vpcflow -s 2021-nov-22 -p dev
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/22
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/22/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211122T0000Z_ce6176d8.log.gz
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/23
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/24
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/25
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/26
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/27
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/28
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/29
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/11/30
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/01
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/02
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/03
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/04
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/05
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/06
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/07
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/08
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/09
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/10
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/11
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/12
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/13
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/14
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/15
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/16
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/17
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/18
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/19
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/20
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/21
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/22
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/23
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/23/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211223T0000Z_ce6176d8.log.gz
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/24
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/24/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211224T0000Z_ce6176d8.log.gz
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/25
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/26
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/27
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/28
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/29
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/30
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/30/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211230T0000Z_ce6176d8.log.gz
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/31
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/31/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211231T0000Z_ce6176d8.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/31/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211231T0100Z_ce6176d8.log.gz
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/01
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/02
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/03
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/04
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/05
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/06
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/07
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/08
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/09
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/10
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/11
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/12
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/13
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/14
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/15
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/16
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/17
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ DB Maintenance

</details>

After processing 6 files, the number of entries stored in the database is:

```
root@b1972ef49f85:/var/ossec/wodles/aws# sqlite3 ./s3_cloudtrail.db 'select count(*) from vpcflow'
5
```

### Config

<details><summary>Command output</summary>

	root@b1972ef49f85:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-config -d2 -t config -s 2021-nov-8 -p dev
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/8
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/8/08/ConfigHistory/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20200601T004303Z_20211108T025123Z_1.json.gz
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/9
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/9/09/ConfigHistory/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211109T004303Z_20211109T025123Z_1.json.gz
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/10
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/11
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/12
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/13
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/14
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/15
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/16
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/17
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/18
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/19
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/20
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/21
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/22
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/22/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211122T004303Z_20211122T025123Z_1.json.gz
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/23
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/24
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/24/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211124T004303Z_20211124T025123Z_1.json.gz
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/25
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/26
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/27
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/28
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/29
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/11/30
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/1
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/2
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/3
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/4
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/5
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/6
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/7
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/8
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/9
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/9/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211209T004303Z_20211209T025123Z_1.json.gz
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/10
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/11
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/12
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/13
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/14
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/15
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/16
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/17
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/18
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/19
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/20
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/21
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/22
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/23
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/23/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211223T004303Z_20211223T025123Z_1.json.gz
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/24
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/25
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/26
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/27
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/28
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/29
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/30
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/30/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211230T004303Z_20211230T025123Z_1.json.gz
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20211231T004303Z_20211231T025123Z_1.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20211231T034303Z_20211231T035123Z_1.json.gz
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/1
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/2
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/3
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/4
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/5
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/6
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/7
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/8
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/9
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/10
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/11
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/12
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/13
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/14
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/15
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/16
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/17
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ DB Maintenance

</details>

After processing 9 files, the number of entries stored in the database is:

```
root@b1972ef49f85:/var/ossec/wodles/aws# sqlite3 ./s3_cloudtrail.db 'select count(*) from config'
5
```

### ALB, NLB and CLB

<details><summary>ALB command output</summary>

	root@b1972ef49f85:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-alb -d2 -t alb -s 2020-nov-24 -p dev
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0000Z_52.52.208.49_14pczeay.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0005Z_52.52.208.49_4ufjauyv.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0010Z_52.52.208.49_3y3kmwy9.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0035Z_54.183.224.192_2pvouvk5.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0050Z_54.183.224.192_3y2rm8x8.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0105Z_52.52.208.49_hqtwz2fm.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0115Z_52.52.208.49_5e69fblu.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0115Z_54.183.224.192_3szj8oof.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0220Z_52.52.208.49_4g2aq7gx.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0235Z_54.183.224.192_66qzj35g.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0245Z_52.52.208.49_ze3001l8.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0305Z_52.52.208.49_6c4lz8qi.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0320Z_54.183.224.192_40azmfe3.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0335Z_52.52.208.49_1sdyrgsu.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0405Z_52.52.208.49_3cjalv3z.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0405Z_54.183.224.192_5bnjpiry.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0410Z_52.52.208.49_5sd9sa85.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0420Z_52.52.208.49_3srmgupa.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0440Z_54.183.224.192_3ya2fg97.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0510Z_54.183.224.192_83fcbx9t.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0550Z_52.52.208.49_28kcbdji.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0600Z_54.183.224.192_5meem9vr.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0610Z_54.183.224.192_25mjfiv6.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0625Z_54.183.224.192_1urf21p5.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0640Z_54.183.224.192_4f9mqbp4.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0645Z_52.52.208.49_5uw230pl.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0725Z_52.52.208.49_1u80gfhx.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0750Z_52.52.208.49_5bev8b0n.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0805Z_54.183.224.192_183fpwud.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0820Z_54.183.224.192_392iruuw.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0850Z_54.183.224.192_1f5apg8y.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0855Z_54.183.224.192_1cfug8w1.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0900Z_52.52.208.49_2rwkh8x0.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0925Z_52.52.208.49_5lnvwjm1.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T0945Z_52.52.208.49_2pjaq5nm.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T1035Z_52.52.208.49_ap2j49xo.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T1050Z_52.52.208.49_2snajfgx.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T1105Z_52.52.208.49_zxr5l6dz.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T1115Z_52.52.208.49_66lcfnew.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T1135Z_54.183.224.192_2k4fb5kb.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T1145Z_54.183.224.192_210b62hd.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2020/11/24/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201124T1150Z_52.52.208.49_4rpcaukt.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2021/12/21/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20211221T0000Z_52.52.208.49_14pczeay.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2021/12/22/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20211222T0000Z_52.52.208.49_14pczeay.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/elasticloadbalancing/us-west-1/2021/12/23/XXXXXXXXXXXX_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20211223T0000Z_52.52.208.49_14pczeay.log.gz
	DEBUG: +++ DB Maintenance

</details>

After processing 45 files, the number of entries stored in the database is:

```
root@b1972ef49f85:/var/ossec/wodles/aws# sqlite3 ./s3_cloudtrail.db 'select count(*) from alb'
45
```

After examining why the db maintenance is not working, we realized that there is a problem with how the `db_maintenance` method works that affects the `ALB`, `CLB`, and `NLB` buckets. The issue #11826 was opened to address that.

### KMS

<details><summary>Command output</summary>
We piped the output of the command to `grep -v Skipping` to avoid an unnecessary amount of `DEBUG: ++ Skipping file with another prefix:` lines in the output.

	root@b1972ef49f85:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-kms -t custom -d2 -p dev -s 2021-nov-19 | grep -v Skipping
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Marker: 2021/11/19
	DEBUG: ++ Found new log: 2021/11/19/11/firehose_kms-1-2021-11-19-11-27-26-756d81b8-7031-4a07-a50c-db292e6db64b
	DEBUG: ++ Found new log: 2021/12/20/11/firehose_kms-1-2021-12-20-11-27-26-756d81b8-7031-4a07-a50c-db292e6db64b
	DEBUG: ++ Found new log: 2021/12/23/12/firehose_kms-1-2021-12-23-12-27-26-756d81b8-7031-4a07-a50c-db292e6db64b
	DEBUG: ++ Found new log: 2022/01/15/12/firehose_kms-1-2022-01-15-12-27-26-756d81b8-7031-4a07-a50c-db292e6db64b
	DEBUG: ++ Found new log: 2022/01/16/12/firehose_kms-1-2022-01-16-12-27-26-756d81b8-7031-4a07-a50c-db292e6db64b
	DEBUG: ++ Found new log: 2022/01/17/12/firehose_kms-1-2022-01-17-12-27-26-756d81b8-7031-4a07-a50c-db292e6db64b
	DEBUG: +++ DB Maintenance

</details>

After processing 6 files, the number of entries stored in the database is:

```
root@b1972ef49f85:/var/ossec/wodles/aws# sqlite3 s3_cloudtrail.db 'select count(*) from custom'
5
```

### Macie

<details><summary>Command output</summary>

	root@b1972ef49f85:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-macie -d 2 -t custom -s 2021-oct-19 -p dev | grep -v Skipping

	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Marker: 2021/10/19
	DEBUG: ++ Found new log: 2021/10/19/00/firehose_macie-1-2021-10-19-00-40-40-e269348f-0b8e-4f61-a4e9-995424ftest1
	DEBUG: ++ Found new log: 2021/11/09/00/firehose_macie-1-2021-11-09-00-20-42-eb1f80bc-5d9d-426b-a0a1-e0ad8d3ef656
	DEBUG: ++ Found new log: 2021/11/10/00/firehose_macie-1-2021-11-10-00-20-42-eb1f80bc-5d9d-426b-a0a1-e0ad8d3ef656
	DEBUG: ++ Found new log: 2021/11/11/00/firehose_macie-1-2021-11-11-00-20-42-eb1f80bc-5d9d-426b-a0a1-e0ad8d3ef656
	DEBUG: ++ Found new log: 2021/11/12/00/firehose_macie-1-2021-11-12-00-20-42-eb1f80bc-5d9d-426b-a0a1-e0ad8d3ef656
	DEBUG: ++ Found new log: 2021/12/24/01/firehose_macie-1-2021-12-24-01-20-42-eb1f80bc-5d9d-426b-a0a1-e0ad8d3ef656
	DEBUG: +++ DB Maintenance

</details>

After processing 6 files, the number of entries stored in the database is:

```
root@b1972ef49f85:/var/ossec/wodles/aws# sqlite3 s3_cloudtrail.db 'select count(*) from custom'
5
```

### Trusted Advisor

<details><summary>Command output</summary>

	root@b1972ef49f85:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-trusted-advisor -d 2 -t custom -s 2021-dec-01 -p dev | grep -v Skipping
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Marker: 2021/12/01
	DEBUG: ++ Found new log: 2021/12/01/firehose_trustedadvisor-1-2021-12-01-20-31.gz
	DEBUG: ++ Found new log: 2021/12/15/firehose_trustedadvisor-1-2021-12-15-20-31.gz
	DEBUG: ++ Found new log: 2021/12/20/12/firehose_trustedadvisor-1-2021-12-20-12.gz
	DEBUG: ++ Found new log: 2021/12/24/12/firehose_trustedadvisor-1-2021-12-24-12.gz
	DEBUG: ++ Found new log: 2022/01/16/12/firehose_trustedadvisor-1-2022-01-16-12.gz
	DEBUG: ++ Found new log: 2022/01/17/12/firehose_trustedadvisor-1-2022-01-17-12.gz
	DEBUG: +++ DB Maintenance

</details>

After processing 6 files, the number of entries stored in the database is:

```
root@b1972ef49f85:/var/ossec/wodles/aws# sqlite3 s3_cloudtrail.db 'select count(*) from custom'
5
```

### GuardDuty

<details><summary>Command output</summary>

	root@b1972ef49f85:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-guardduty -d 2 -t guardduty -s 2021-jun-13 -p dev | grep -v Skipping
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Marker: 2021/06/13
	DEBUG: ++ Found new log: 2021/06/13/07/firehose_guardduty-1-2021-06-13-07-30-04-e927d4d1-aeb5-4db0-a7e7-d9748a26be38.zip
	DEBUG: ++ Found new log: 2021/06/18/08/firehose_guardduty-1-2021-06-18-08-45-01-e559a8cf-3eec-49de-805f-704ba7c6e71c.zip
	DEBUG: ++ Found new log: 2021/06/19/06/firehose_guardduty-1-2021-06-19-06-00-05-baf62d64-fe46-40f9-a087-e4048c73119b.zip
	DEBUG: ++ Found new log: 2021/06/22/16/firehose_guardduty-1-2021-06-22-16-15-05-872e154c-1fd8-4369-a151-947ec0438d8d.zip
	DEBUG: ++ Found new log: 2021/07/08/03/firehose_guardduty-1-2021-07-08-03-46-07-12788dc1-723b-4e2b-9d12-07885e967524.zip
	DEBUG: ++ Found new log: 2021/12/24/03/firehose_guardduty-1-2021-12-24-03-46-07-12788dc1-723b-4e2b-9d12-07885e967524.zip
	DEBUG: +++ DB Maintenance

</details>

After processing 6 files, the number of entries stored in the database is:

```
root@b1972ef49f85:/var/ossec/wodles/aws# sqlite3 s3_cloudtrail.db 'select count(*) from guardduty'
5
```

### WAF

<details><summary>Command output</summary>

	root@b1972ef49f85:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-waf -d 2 -t waf -s 2019-oct-22 -p dev | grep -v Skipping
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Marker: 2019/10/22
	DEBUG: ++ Found new log: 2019/10/22/10/aws-waf-logs-delivery-stream-1-2019-10-22-10-32-48-792c6d1f-bfed-4b00-9f5e-88ce44718193
	DEBUG: ++ Found new log: 2019/10/23/10/aws-waf-logs-delivery-stream-1-2019-10-23-10-32-48-792c6d1f-bfed-4b00-9f5e-88ce44718194
	DEBUG: ++ Found new log: 2019/10/23/11/aws-waf-logs-delivery-stream-1-2019-10-23-11-32-48-792c6d1f-bfed-4b00-9f5e-88ce44718194
	DEBUG: ++ Found new log: 2021/12/21/aws-waf-logs-delivery-stream-1-2021-12-21-10-32-48-792c6d1f-bfed-4b00-9f5e-88ce44718193
	DEBUG: ++ Found new log: 2021/12/22/aws-waf-logs-delivery-stream-1-2021-12-22-10-32-48-792c6d1f-bfed-4b00-9f5e-88ce44718193
	DEBUG: ++ Found new log: 2021/12/23/aws-waf-logs-delivery-stream-1-2021-12-23-10-32-48-792c6d1f-bfed-4b00-9f5e-88ce44718193
	DEBUG: ++ Found new log: 2021/12/24/aws-waf-logs-delivery-stream-1-2021-12-24-10-32-48-792c6d1f-bfed-4b00-9f5e-88ce44718193
	DEBUG: +++ DB Maintenance

</details>

After processing 7 files, the number of entries stored in the database is:

```
root@b1972ef49f85:/var/ossec/wodles/aws# sqlite3 s3_cloudtrail.db 'select count(*) from waf'
5
```

### Umbrella

<details><summary>Command output</summary>

	root@b1972ef49f85:/var/ossec/wodles/aws# ./aws-s3 -b wazuh-aws-wodle-umbrella -d 2 -t cisco_umbrella -s 2019-oct-22 -p dev -l XXXXXXXXXXXX/iplogs
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Marker: XXXXXXXXXXXX/iplogs/2019-10-22
	DEBUG: ++ Found new log: XXXXXXXXXXXX/iplogs/2021-12-01/2021-12-01-00-00-xyzs.csv.gz
	DEBUG: ++ Found new log: XXXXXXXXXXXX/iplogs/2021-12-15/2021-12-15-00-00-asge.csv.gz
	DEBUG: ++ Found new log: XXXXXXXXXXXX/iplogs/2021-12-20/2021-12-20-00-00-xoal.csv.gz
	DEBUG: ++ Found new log: XXXXXXXXXXXX/iplogs/2021-12-24/2021-12-24-00-00-ixla.csv.gz
	DEBUG: ++ Found new log: XXXXXXXXXXXX/iplogs/2021-12-29/2021-12-29-00-00-ixla.csv.gz
	DEBUG: ++ Found new log: XXXXXXXXXXXX/iplogs/2022-01-17/2022-01-17-00-00-ixla.csv.gz
	DEBUG: +++ DB Maintenance

</details>

After processing 6 files, the number of entries stored in the database is:

```
root@b1972ef49f85:/var/ossec/wodles/aws# sqlite3 s3_cloudtrail.db 'select count(*) from cisco_umbrella'
5
```

### Inspector
Since we only had two example executions we could use to test the behavior of the `db_maintenance` method, we decided to change the value of `retain_db_records` to 1 instead of 5.

<details><summary>Command output</summary>

	root@b1972ef49f85:/var/ossec/wodles/aws# ./aws-s3 -sr inspector -d 2 -s 2019-oct-22 -p dev -r us-east-1
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Getting alerts from "us-east-1" region.
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Processing new events from us-east-1 region
	DEBUG: +++ Processing new events from us-east-1 region
	DEBUG: +++ Processing new events from us-east-1 region
	DEBUG: +++ Processing new events from us-east-1 region
	DEBUG: +++ Processing new events from us-east-1 region
	DEBUG: +++ Processing new events from us-east-1 region
	DEBUG: +++ Processing new events from us-east-1 region
	DEBUG: +++ Processing new events from us-east-1 region
	DEBUG: +++ Processing new events from us-east-1 region
	DEBUG: +++ Processing new events from us-east-1 region
	DEBUG: +++ Processing new events from us-east-1 region
	DEBUG: +++ Processing new events from us-east-1 region
	DEBUG: +++ Processing new events from us-east-1 region
	DEBUG: +++ Processing new events from us-east-1 region
	DEBUG: +++ Processing new events from us-east-1 region
	DEBUG: +++ Processing new events from us-east-1 region

</details>

After processing 2 executions, the number of entries stored in the database is:

```
root@b1972ef49f85:/var/ossec/wodles/aws# sqlite3 ./aws_services.db 'select count(*) from aws_services'
1
```
