### PR TITLE
Add process start time to JSON object (macOS)

### DIFF
--- a/src/data_provider/src/sysInfoMac.cpp
+++ b/src/data_provider/src/sysInfoMac.cpp
@@ -94,6 +94,7 @@ static nlohmann::json getProcessInfo(const ProcessTaskInfo& taskInfo, const pid_
     jsProcessInfo["priority"]   = taskInfo.ptinfo.pti_priority;
     jsProcessInfo["nice"]       = taskInfo.pbsd.pbi_nice;
     jsProcessInfo["vm_size"]    = taskInfo.ptinfo.pti_virtual_size / KByte;
+    jsProcessInfo["start_time"] = taskInfo.pbsd.pbi_start_tvsec;
     return jsProcessInfo;
 }
 


### PR DESCRIPTION
Closes #11820.


## Description
This PR adds the start time (in Unix format) to the JSON object corresponding to processes in macOS.
<!--
Add a clear description of how the problem has been solved.
-->

## Tests
There are no units tests to be updated and creating them requires some refactoring some direct calls to system functions.

## Evidence
![image](https://user-images.githubusercontent.com/6182640/149807155-2dfa5606-0184-4901-8fb1-c2959f431bc4.png)

