### PR TITLE
Fix an argument injection hazard in the Pagerduty integration script

### DIFF
--- a/integrations/pagerduty
+++ b/integrations/pagerduty
@@ -43,7 +43,7 @@ send_payload () {
         #echo  -n "-------\nSending:\n${payload}\n"
 
         # Send the pagerduty notification
-        curl -H "Content-type: application/json" -X POST --data "@$postfile" $WEBHOOK
+        curl -H "Content-type: application/json" -X POST --data "@$postfile" "$WEBHOOK"
 
         if [ ! $? = 0 ]; then
             echo "Error sending the alert to pagerduty"


### PR DESCRIPTION
We've been reported a bug in the Pagerduty integration that might allow the user to add extra arguments to the `curl` command.

## Configuration

```xml
<ossec_config>
   <integration>
    <name>pagerduty</name>
    <api_key>topsecret</api_key>
    <hook_url>example.org\ -o\ /var/ossec/etc/some_file</hook_url>
  </integration>
</ossec-config>
```

## Rationale

The value of option `<hook_url>` in the configuration ends up being assigned to variable `$WEBHOOK` of the Pagerduty integration script. Since the variable dereference is not enclosed in double-quotes, each word of the string will become a different argument in the command.

The scope of this problem is limited by:
- The options available in the `curl` command.
- The file access granted to the user `wazuh`, which is the owner of the integration scripts as they inherit from the Integratord process.

We were unable to reproduce an arbitrary command execution issue.

This bug affects Wazuh Manager as of version 3.9.0 (#2403).

## Mitigation

- Enclose the `$WEBHOOK` variable dereference in double-quotes so that the full string value is not splitted into different arguments.

We've confirmed that the proposed fix mitigates the problem, and we've not found command execution issues, like
```xml
<hook_url>$(echo example.org)</hook_url>
```

## Tests

- [X] The issue is no longer reproducible by inserting extra arguments with spaces.
- [X] The integration does not execute commands defined with backticks (` `` `) or `$()`.

### Testing this issue

1. Set up the configuration above.
2. Restart the manager. Wait until at less one alert gets printed in `alerts.json`.
3. Check that `/var/ossec/etc/some_file` does not exist.