### PR TITLE
Fix of tunnel/VPN interfaces, in networks data provider.

### DIFF
--- a/src/data_provider/src/network/networkLinuxWrapper.h
+++ b/src/data_provider/src/network/networkLinuxWrapper.h
@@ -164,6 +164,31 @@ namespace RHInterfaceConfig
     };
 }
 
+namespace NetDevFileFields
+{
+    enum
+    {
+        Iface,
+        RxBytes,
+        RxPackets,
+        RxErrors,
+        RxDropped,
+        RxFifo,
+        RxFrame,
+        RxCompressed,
+        RxMulticast,
+        TxBytes,
+        TxPackets,
+        TxErrors,
+        TxDropped,
+        TxFifo,
+        TxColls,
+        TxCarrier,
+        TxCompressed,
+        FieldsQuantity
+    };
+}
+
 class NetworkLinuxInterface final : public INetworkInterfaceWrapper
 {
         ifaddrs* m_interfaceAddress;
@@ -281,7 +306,7 @@ class NetworkLinuxInterface final : public INetworkInterfaceWrapper
 
         int family() const override
         {
-            return m_interfaceAddress->ifa_addr ? m_interfaceAddress->ifa_addr->sa_family : AF_UNSPEC;
+            return m_interfaceAddress->ifa_addr ? m_interfaceAddress->ifa_addr->sa_family : AF_PACKET;
         }
 
         std::string address() const override
@@ -436,7 +461,49 @@ class NetworkLinuxInterface final : public INetworkInterfaceWrapper
 
         LinkStats stats() const override
         {
-            return m_interfaceAddress->ifa_data ? *reinterpret_cast<LinkStats*>(m_interfaceAddress->ifa_data) : LinkStats();
+            LinkStats retVal {};
+
+            try
+            {
+                const auto devData { Utils::getFileContent(std::string(WM_SYS_NET_DIR) + "dev") };
+
+                if (!devData.empty())
+                {
+                    auto lines { Utils::split(devData, '\n') };
+                    lines.erase(lines.begin());
+                    lines.erase(lines.begin());
+
+                    for (auto& line : lines)
+                    {
+                        line = Utils::trim(line);
+                        Utils::replaceAll(line, "\t", " ");
+                        Utils::replaceAll(line, "  ", " ");
+                        Utils::replaceAll(line, ": ", " ");
+                        const auto fields { Utils::split(line, ' ') };
+
+                        if (NetDevFileFields::FieldsQuantity == fields.size())
+                        {
+                            if (fields.at(NetDevFileFields::Iface).compare(this->name()) == 0)
+                            {
+                                retVal.rxBytes = std::stoul(fields.at(NetDevFileFields::RxBytes));
+                                retVal.txBytes = std::stoul(fields.at(NetDevFileFields::TxBytes));
+                                retVal.rxPackets = std::stoul(fields.at(NetDevFileFields::RxPackets));
+                                retVal.txPackets = std::stoul(fields.at(NetDevFileFields::TxPackets));
+                                retVal.rxErrors = std::stoul(fields.at(NetDevFileFields::RxErrors));
+                                retVal.txErrors = std::stoul(fields.at(NetDevFileFields::TxErrors));
+                                retVal.rxDropped = std::stoul(fields.at(NetDevFileFields::RxDropped));
+                                retVal.txDropped = std::stoul(fields.at(NetDevFileFields::TxDropped));
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            catch (...)
+            {
+            }
+
+            return retVal;
         }
 
         std::string type() const override

--- a/src/shared_modules/utils/networkUnixHelper.h
+++ b/src/shared_modules/utils/networkUnixHelper.h
@@ -50,7 +50,7 @@ namespace Utils
 
                     for (auto ifa = ifaddr; ifa; ifa = ifa->ifa_next)
                     {
-                        if (!(ifa->ifa_flags & IFF_LOOPBACK))
+                        if (!(ifa->ifa_flags & IFF_LOOPBACK) && ifa->ifa_name)
                         {
                             networkInterfaces[substrOnFirstOccurrence(ifa->ifa_name, ":")].push_back(ifa);
                         }


### PR DESCRIPTION
|Related issue|
|---|
| Closes #11822  |


## Description
Reports were received that when connected to a VPN, an exception is being obtained when trying to access the JSON with the "name" field, this happens because the data provider is not returning the interface information because it cannot identify the type.

### Expected
Prevent the cause that causes the exception.

### Actual
Handled exception
2021/12/18 03:20:48 wazuh-modulesd:syscollector: ERROR: [json.exception.out_of_range.403] key 'name' not found

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [x] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors