### PR TITLE
Increase health check total time for API integration tests

### DIFF
--- a/api/test/integration/conftest.py
+++ b/api/test/integration/conftest.py
@@ -73,7 +73,7 @@ def build_and_up(interval: int = 10, interval_build_env: int = 10, build: bool =
     os.chdir(pwd)
     values = {
         'interval': interval,
-        'max_retries': 60,
+        'max_retries': 90,
         'retries': 0
     }
     values_build_env = {

--- a/api/test/integration/env/base/agent/new.Dockerfile
+++ b/api/test/integration/env/base/agent/new.Dockerfile
@@ -9,4 +9,4 @@ RUN /wazuh/install.sh
 
 COPY base/agent/entrypoint.sh /scripts/entrypoint.sh
 
-HEALTHCHECK --retries=600 --interval=1s --timeout=30s --start-period=30s CMD /usr/bin/python3 /tmp/healthcheck/healthcheck.py || exit 1
+HEALTHCHECK --retries=900 --interval=1s --timeout=30s --start-period=30s CMD /usr/bin/python3 /tmp/healthcheck/healthcheck.py || exit 1

--- a/api/test/integration/env/base/agent/old.Dockerfile
+++ b/api/test/integration/env/base/agent/old.Dockerfile
@@ -2,4 +2,4 @@ FROM public.ecr.aws/o5x5t0j3/amd64/api_development:integration_test_wazuh-agent_
 
 COPY base/agent/entrypoint.sh /scripts/entrypoint.sh
 
-HEALTHCHECK --retries=600 --interval=1s --timeout=30s --start-period=30s CMD /usr/bin/python3 /tmp/healthcheck/legacy_healthcheck.py || exit 1
+HEALTHCHECK --retries=900 --interval=1s --timeout=30s --start-period=30s CMD /usr/bin/python3 /tmp/healthcheck/legacy_healthcheck.py || exit 1

--- a/api/test/integration/env/base/manager/manager.Dockerfile
+++ b/api/test/integration/env/base/manager/manager.Dockerfile
@@ -12,4 +12,4 @@ RUN /wazuh/install.sh
 COPY base/manager/entrypoint.sh /scripts/entrypoint.sh
 
 # HEALTHCHECK
-HEALTHCHECK --retries=600 --interval=1s --timeout=30s --start-period=30s CMD /var/ossec/framework/python/bin/python3 /tmp/healthcheck/healthcheck.py || exit 1
+HEALTHCHECK --retries=900 --interval=1s --timeout=30s --start-period=30s CMD /var/ossec/framework/python/bin/python3 /tmp/healthcheck/healthcheck.py || exit 1

--- a/api/test/integration/env/configurations/vulnerability/manager/configuration_files/nvd_providers.sh
+++ b/api/test/integration/env/configurations/vulnerability/manager/configuration_files/nvd_providers.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Remove providers
+sed -i '/<os>xenial<\/os>/d' /var/ossec/etc/ossec.conf
+sed -i '/<os>trusty<\/os>/d' /var/ossec/etc/ossec.conf
+sed -i '/<os>bionic<\/os>/d' /var/ossec/etc/ossec.conf

--- a/api/test/integration/test_vulnerability_endpoints.tavern.yaml
+++ b/api/test/integration/test_vulnerability_endpoints.tavern.yaml
@@ -3,7 +3,6 @@ test_name: GET /vulnerability/{agent_id}
 
 marks:
   - base_tests
-  - xfail # Review and fix vulnerability endpoints API integration test - https://github.com/wazuh/wazuh/issues/10917
 
 stages:
 


### PR DESCRIPTION
|Related issue|
|---|
|closes #10917 |

## Description

After the conclusion in https://github.com/wazuh/wazuh/issues/11112#issuecomment-982669247, the health check total time for the API integration tests has been increased to 900 seconds. This is not the cleanest solution but it is an acceptable workaround given the current AWS instances that we use for automated testing.

In addition, as we are testing this endpoint exclusively on agent 001, a script has been added to configure the nvd providers and only retrieve data from focal, reducing the vulnerability scan time.

Regards,
Víctor