### PR TITLE
Improve error messages when using invalid credentials with the Azure integration

### DIFF
--- a/wodles/azure/azure-logs.py
+++ b/wodles/azure/azure-logs.py
@@ -792,23 +792,22 @@ def get_token(client_id: str, secret: str, domain: str, scope: str):
     auth_url = f'{url_logging}/{domain}/oauth2/v2.0/token'
     try:
         token_response = post(auth_url, data=body).json()
-        try:
-            return token_response['access_token']
-        except (ValueError, KeyError):
-            if token_response['error'] == 'unauthorized_client':
-                err_msg = "The application id provided is not valid."
-            elif token_response['error'] == 'invalid_client':
-                err_msg = "The application key provided is not valid."
-            elif token_response['error'] == 'invalid_request' and 90002 in token_response['error_codes']:
-                err_msg = f"The '{domain}' tenant domain was not found."
-            else:
-                err_msg = "Couldn't get the token for authentication."
-            logging.error(f"Error: {err_msg}")
-        sys.exit(1)
+        return token_response['access_token']
+    except (ValueError, KeyError):
+        if token_response['error'] == 'unauthorized_client':
+            err_msg = "The application id provided is not valid."
+        elif token_response['error'] == 'invalid_client':
+            err_msg = "The application key provided is not valid."
+        elif token_response['error'] == 'invalid_request' and 90002 in token_response['error_codes']:
+            err_msg = f"The '{domain}' tenant domain was not found."
+        else:
+            err_msg = "Couldn't get the token for authentication."
+        logging.error(f"Error: {err_msg}")
+
     except RequestException as e:
         logging.error(f"Error: An error occurred while trying to obtain the authentication token: {e}")
-        sys.exit(1)
 
+    sys.exit(1)
 
 def send_message(message: str):
     """Send a message with a header to the analysisd queue.

--- a/wodles/azure/azure-logs.py
+++ b/wodles/azure/azure-logs.py
@@ -800,13 +800,13 @@ def get_token(client_id: str, secret: str, domain: str, scope: str):
             elif token_response['error'] == 'invalid_client':
                 err_msg = "The application key provided is not valid."
             elif token_response['error'] == 'invalid_request' and 90002 in token_response['error_codes']:
-                err_msg = "The tenant domain used was not found."
+                err_msg = f"The '{domain}' tenant domain was not found."
             else:
                 err_msg = "Couldn't get the token for authentication."
             logging.error(f"Error: {err_msg}")
         sys.exit(1)
     except RequestException as e:
-        logging.error(f"Error: An error occurred while trying to connect with Azure: {e}")
+        logging.error(f"Error: An error occurred while trying to obtain the authentication token: {e}")
         sys.exit(1)
 
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #11489|

## Description
In this PR we enhance the error messages that the Azure module outputs when using invalid credentials with the **Graph** and **Log Analytics** integrations. Since the module is using bare HTTP requests instead of the `azure-identity` SDK, we had to investigate which errors could be returned and write accessible error messages for the end-users instead of relying on the ones the SDK would return. We will consider switching to the aforementioned SDK to handle authentication in the future.

We added error messages for the following situations:

- When the user specifies an invalid application ID: `The application ID provided is not valid.`
- When the user specifies an invalid application key: `The application key provided is not valid.`
- When the user specifies an invalid tenant domain: `The tenant domain used was not found.`

### Tests performed
The module worked as expected in all the tested scenarios, and therefore we can say that the changes are working fine.

#### Test Graph
##### Using valid credentials 
The module worked as expected.

<details><summary>Command output</summary>

```
root@f338bb78ecfb:/var/ossec/wodles/azure# /var/ossec/wodles/azure/azure-logs --graph --graph_auth_path /var/ossec/wodles/azure/credentials --graph_tenant_domain wazuh.onmicrosoft.com --graph_tag azure-active_directory --graph_query 'auditLogs/directoryAudits' --graph_time_offset 1d -v
01/18/2022 05:46:45 PM INFO: AZURE Getting the data from /var/ossec/wodles/azure/last_dates.json.
01/18/2022 05:46:45 PM INFO: AZURE Azure Graph starting.
01/18/2022 05:46:45 PM INFO: AZURE Graph: Getting authentication token.
01/18/2022 05:46:45 PM DEBUG: AZURE Starting new HTTPS connection (1): login.microsoftonline.com:443
01/18/2022 05:46:46 PM DEBUG: AZURE https://login.microsoftonline.com:443 "POST /wazuh.onmicrosoft.com/oauth2/v2.0/token HTTP/1.1" 200 1901
01/18/2022 05:46:46 PM INFO: AZURE Graph: Building the url.
01/18/2022 05:46:46 PM INFO: AZURE Graph: The search starts for query: 'auditLogs/directoryAudits' using activityDateTime+gt+2022-01-18T14:50:08.7073117Z
01/18/2022 05:46:46 PM INFO: AZURE Graph: The URL is 'https://graph.microsoft.com/v1.0/auditLogs/directoryAudits?&$filter=activityDateTime+gt+2022-01-18T14:50:08.7073117Z'
01/18/2022 05:46:46 PM INFO: AZURE Graph: Pagination starts
01/18/2022 05:46:46 PM DEBUG: AZURE Starting new HTTPS connection (1): graph.microsoft.com:443
01/18/2022 05:46:46 PM DEBUG: AZURE https://graph.microsoft.com:443 "GET /v1.0/auditLogs/directoryAudits?&$filter=activityDateTime+gt+2022-01-18T14:50:08.7073117Z HTTP/1.1" 200 None
01/18/2022 05:46:46 PM INFO: AZURE Updating /var/ossec/wodles/azure/last_dates.json file.
01/18/2022 05:46:46 PM INFO: AZURE Graph: There are no new results
01/18/2022 05:46:46 PM INFO: AZURE Graph: End

```

</details>

##### Using an invalid tenant domain
The module worked as expected.

<details><summary>Command output</summary>

```
root@f338bb78ecfb:/var/ossec/wodles/azure# /var/ossec/wodles/azure/azure-logs --graph --graph_auth_path /var/ossec/wodles/azure/credentials --graph_tenant_domain wazuh.ondamicrosoft.com --graph_tag azure-active_directory --graph_query 'auditLogs/directoryAudits' --graph_time_offset 1d -v
01/18/2022 05:48:03 PM INFO: AZURE Getting the data from /var/ossec/wodles/azure/last_dates.json.
01/18/2022 05:48:03 PM INFO: AZURE Azure Graph starting.
01/18/2022 05:48:03 PM INFO: AZURE Graph: Getting authentication token.
01/18/2022 05:48:03 PM DEBUG: AZURE Starting new HTTPS connection (1): login.microsoftonline.com:443
01/18/2022 05:48:04 PM DEBUG: AZURE https://login.microsoftonline.com:443 "POST /wazuh.ondamicrosoft.com/oauth2/v2.0/token HTTP/1.1" 400 678
01/18/2022 05:48:04 PM ERROR: AZURE Error: The tenant domain used was not found.
```

</details>

##### Using an invalid application ID
The module worked as expected.

<details><summary>Command output</summary>

```
root@0eb1aa0e566d:/var/ossec/wodles/azure# /var/ossec/wodles/azure/azure-logs --graph --graph_auth_path /var/ossec/wodles/azure/credentials --graph_tenant_domain wazuh.onmicrosoft.com --graph_tag azure-active_directory --graph_query 'auditLogs/directoryAudits' --graph_time_offset 1d -v
01/18/2022 05:51:57 PM INFO: AZURE Getting the data from /var/ossec/wodles/azure/last_dates.json.
01/18/2022 05:51:57 PM INFO: AZURE Azure Graph starting.
01/18/2022 05:51:57 PM INFO: AZURE Graph: Getting authentication token.
01/18/2022 05:51:57 PM DEBUG: AZURE Starting new HTTPS connection (1): login.microsoftonline.com:443
01/18/2022 05:51:58 PM DEBUG: AZURE https://login.microsoftonline.com:443 "POST /wazuh.onmicrosoft.com/oauth2/v2.0/token HTTP/1.1" 400 753
01/18/2022 05:51:58 PM ERROR: AZURE Error: The application ID provided is not valid.
```

</details>

##### Using an invalid application key
The module worked as expected.

<details><summary>Command output</summary>

```
root@0eb1aa0e566d:/var/ossec/wodles/azure# /var/ossec/wodles/azure/azure-logs --graph --graph_auth_path /var/ossec/wodles/azure/credentials --graph_tenant_domain wazuh.onmicrosoft.com --graph_tag azure-active_directory --graph_query 'auditLogs/directoryAudits' --graph_time_offset 1d -v
01/18/2022 05:52:26 PM INFO: AZURE Getting the data from /var/ossec/wodles/azure/last_dates.json.
01/18/2022 05:52:26 PM INFO: AZURE Azure Graph starting.
01/18/2022 05:52:26 PM INFO: AZURE Graph: Getting authentication token.
01/18/2022 05:52:26 PM DEBUG: AZURE Starting new HTTPS connection (1): login.microsoftonline.com:443
01/18/2022 05:52:27 PM DEBUG: AZURE https://login.microsoftonline.com:443 "POST /wazuh.onmicrosoft.com/oauth2/v2.0/token HTTP/1.1" 401 471
01/18/2022 05:52:27 PM ERROR: AZURE Error: The application key provided is not valid.
```

</details>

#### Test Log Analytics
##### Using valid credentials
The module worked as expected.

<details><summary>Command output</summary>

```
root@0eb1aa0e566d:/var/ossec/wodles/azure# /var/ossec/wodles/azure/azure-logs --log_analytics --la_auth_path /var/ossec/wodles/azure/credentials-analytics --la_tenant_domain wazuh.onmicrosoft.com --la_tag azure-activity --la_query "AzureActivity" --workspace bc8d21bd-b966-4a4f-8eed-9e0328720cbe --la_time_offset 2d -v
01/18/2022 05:57:25 PM INFO: AZURE Getting the data from /var/ossec/wodles/azure/last_dates.json.
01/18/2022 05:57:25 PM INFO: AZURE Azure Log Analytics starting.
01/18/2022 05:57:25 PM INFO: AZURE Log Analytics: Getting authentication token.
01/18/2022 05:57:25 PM DEBUG: AZURE Starting new HTTPS connection (1): login.microsoftonline.com:443
01/18/2022 05:57:25 PM DEBUG: AZURE https://login.microsoftonline.com:443 "POST /wazuh.onmicrosoft.com/oauth2/v2.0/token HTTP/1.1" 200 1348
01/18/2022 05:57:25 PM INFO: AZURE f90c15b0327962c9e661142547368572 was not found in /var/ossec/wodles/azure/last_dates.json for log_analytics
01/18/2022 05:57:25 PM INFO: AZURE Log Analytics: The search starts for query: 'AzureActivity | order by TimeGenerated asc | where TimeGenerated >= datetime(2022-01-16T16:57:25.605053Z) '
01/18/2022 05:57:25 PM INFO: AZURE Log Analytics: Sending a request to the Log Analytics API.
01/18/2022 05:57:25 PM DEBUG: AZURE Starting new HTTPS connection (1): api.loganalytics.io:443
01/18/2022 05:57:28 PM DEBUG: AZURE https://api.loganalytics.io:443 "GET /v1/workspaces/bc8d21bd-b966-4a4f-8eed-9e0328720cbe/query?query=AzureActivity+%7C+order+by+TimeGenerated+asc+%7C+where+TimeGenerated+%3E%3D+datetime%282022-01-16T16%3A57%3A25.605053Z%29+ HTTP/1.1" 200 None
01/18/2022 05:57:28 PM INFO: AZURE Log Analytics: There are no new results
01/18/2022 05:57:28 PM INFO: AZURE Azure Log Analytics ending.
```

</details>

##### Using an invalid tenant domain
The module worked as expected.

<details><summary>Command output</summary>

```
root@0eb1aa0e566d:/var/ossec/wodles/azure# /var/ossec/wodles/azure/azure-logs --log_analytics --la_auth_path /var/ossec/wodles/azure/credentials-analytics --la_tenant_domain wazuhed.onmicrosoft.com --la_tag azure-activity --la_query "AzureActivity" --workspace bc8d21bd-b966-4a4f-8eed-9e0328720cbe --la_time_offset 2d -v
01/18/2022 05:58:09 PM INFO: AZURE Getting the data from /var/ossec/wodles/azure/last_dates.json.
01/18/2022 05:58:09 PM INFO: AZURE Azure Log Analytics starting.
01/18/2022 05:58:09 PM INFO: AZURE Log Analytics: Getting authentication token.
01/18/2022 05:58:09 PM DEBUG: AZURE Starting new HTTPS connection (1): login.microsoftonline.com:443
01/18/2022 05:58:09 PM DEBUG: AZURE https://login.microsoftonline.com:443 "POST /wazuhed.onmicrosoft.com/oauth2/v2.0/token HTTP/1.1" 400 678
01/18/2022 05:58:09 PM ERROR: AZURE Error: The tenant domain used was not found.
```

</details>

##### Using an invalid application ID
The module worked as expected.

<details><summary>Command output</summary>

```
root@0eb1aa0e566d:/var/ossec/wodles/azure# /var/ossec/wodles/azure/azure-logs --log_analytics --la_auth_path /var/ossec/wodles/azure/credentials-analytics --la_tenant_domain wazuh.onmicrosoft.com --la_tag azure-activity --la_query "AzureActivity" --workspace bc8d21bd-b966-4a4f-8eed-9e0328720cbe --la_time_offset 2d -v
01/18/2022 06:08:34 PM INFO: AZURE Getting the data from /var/ossec/wodles/azure/last_dates.json.
01/18/2022 06:08:34 PM INFO: AZURE Azure Log Analytics starting.
01/18/2022 06:08:34 PM INFO: AZURE Log Analytics: Getting authentication token.
01/18/2022 06:08:34 PM DEBUG: AZURE Starting new HTTPS connection (1): login.microsoftonline.com:443
01/18/2022 06:08:34 PM DEBUG: AZURE https://login.microsoftonline.com:443 "POST /wazuh.onmicrosoft.com/oauth2/v2.0/token HTTP/1.1" 400 753
01/18/2022 06:08:34 PM ERROR: AZURE Error: The application ID provided is not valid.
```

</details>

##### Using an invalid application key
The module worked as expected.

<details><summary>Command output</summary>

```
root@0eb1aa0e566d:/var/ossec/wodles/azure# /var/ossec/wodles/azure/azure-logs --log_analytics --la_auth_path /var/ossec/wodles/azure/credentials-analytics --la_tenant_domain wazuh.onmicrosoft.com --la_tag azure-activity --la_query "AzureActivity" --workspace bc8d21bd-b966-4a4f-8eed-9e0328720cbe --la_time_offset 2d -v
01/18/2022 06:09:11 PM INFO: AZURE Getting the data from /var/ossec/wodles/azure/last_dates.json.
01/18/2022 06:09:11 PM INFO: AZURE Azure Log Analytics starting.
01/18/2022 06:09:11 PM INFO: AZURE Log Analytics: Getting authentication token.
01/18/2022 06:09:11 PM DEBUG: AZURE Starting new HTTPS connection (1): login.microsoftonline.com:443
01/18/2022 06:09:12 PM DEBUG: AZURE https://login.microsoftonline.com:443 "POST /wazuh.onmicrosoft.com/oauth2/v2.0/token HTTP/1.1" 401 471
01/18/2022 06:09:12 PM ERROR: AZURE Error: The application key provided is not valid.
```

</details>

##### Having no network connection
The module worked as expected.

<details><summary>Command output</summary>

```
root@54ebc8f8b8d9:/# /var/ossec/wodles/azure/azure-logs --log_analytics --la_auth_path /var/ossec/wodles/azure/credentials-analytics --la_tenant_domain wazuh.onmicrosoft.com --la_tag azure-activity --la_query "AzureActivity" --workspace bc8d21bd-b966-4a4f-8eed-37d328720cbe --la_time_offset 2d -v
02/02/2022 01:49:17 PM INFO: AZURE Getting the data from /var/ossec/wodles/azure/last_dates.json.
02/02/2022 01:49:17 PM INFO: AZURE Azure Log Analytics starting.
02/02/2022 01:49:17 PM INFO: AZURE Log Analytics: Getting authentication token.
02/02/2022 01:49:17 PM DEBUG: AZURE Starting new HTTPS connection (1): login.microsoftonline.com:443
02/02/2022 01:49:27 PM ERROR: AZURE Error: An error occurred while trying to obtain the authentication token: HTTPSConnectionPool(host='login.microsoftonline.com', port=443): Max retries exceeded with url: /wazuh.onmicrosoft.com/oauth2/v2.0/token (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7f9d42037220>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution'))

```

</details>
