### PR TITLE
Fix memory leaks in the Vulnerability Detector's feeds parser

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -14192,6 +14192,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_criterion_test_ref()
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(vulnerability), parsed_oval->vulnerabilities);
+    os_strdup("CVE-1234-1234", parsed_oval->vulnerabilities->cve_id);
 
     //create xml node
     os_calloc(2, sizeof(xml_node *), node);
@@ -14203,7 +14204,6 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_criterion_test_ref()
     os_strdup("value_ref", node[0]->values[0]);
     os_strdup("value_ref1", node[0]->values[1]);
     os_strdup("criterion", node[0]->element);
-    parsed_oval->vulnerabilities->cve_id = "CVE-id";
 
     os_calloc(1, sizeof(update_node), update);
     update->dist_ref = FEED_UBUNTU;
@@ -14215,6 +14215,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_criterion_test_ref()
     os_free(parsed_oval->vulnerabilities->prev->state_id);
     os_free(parsed_oval->vulnerabilities->state_id);
     os_free(parsed_oval->vulnerabilities->cve_id);
+    os_free(parsed_oval->vulnerabilities->prev->cve_id);
     os_free(parsed_oval->vulnerabilities->prev);
     os_free(parsed_oval->vulnerabilities);
     os_free(parsed_oval);
@@ -14231,6 +14232,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_criterion_comment1()
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(vulnerability), parsed_oval->vulnerabilities);
+    os_strdup("CVE-1234-1234", parsed_oval->vulnerabilities->cve_id);
 
     //create xml node
     os_calloc(2, sizeof(xml_node *), node);
@@ -14249,6 +14251,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_criterion_comment1()
     assert_int_equal(ret, 0);
     assert_int_equal(parsed_oval->vulnerabilities->ignore, 1);
 
+    os_free(parsed_oval->vulnerabilities->cve_id);
     os_free(parsed_oval->vulnerabilities);
     os_free(parsed_oval);
     OS_ClearNode(node);
@@ -14264,6 +14267,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_criterion_comment0()
 
     os_calloc(1, sizeof(wm_vuldet_db), parsed_oval);
     os_calloc(1, sizeof(vulnerability), parsed_oval->vulnerabilities);
+    os_strdup("CVE-1234-1234", parsed_oval->vulnerabilities->cve_id);
 
     //create xml node
     os_calloc(2, sizeof(xml_node *), node);
@@ -14282,6 +14286,7 @@ void test_wm_vuldet_oval_xml_parser_ubuntu_dpkg_object_criterion_comment0()
     assert_int_equal(ret, 0);
     assert_int_equal(parsed_oval->vulnerabilities->ignore, 0);
 
+    os_free(parsed_oval->vulnerabilities->cve_id);
     os_free(parsed_oval->vulnerabilities);
     os_free(parsed_oval);
     OS_ClearNode(node);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -3753,6 +3753,10 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
                         // A step backward in order to continue the parse process
                         info_state *state_prev_ptr;
                         state_prev_ptr = parsed_oval->info_states->prev;
+                        w_FreeArray(parsed_oval->info_states->arch);
+                        os_free(parsed_oval->info_states->arch);
+                        os_free(parsed_oval->info_states->operation);
+                        os_free(parsed_oval->info_states->operation_value);
                         os_free(parsed_oval->info_states->id);
                         os_free(parsed_oval->info_states);
                         parsed_oval->info_states= state_prev_ptr;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -3855,7 +3855,9 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
                         new->prev = parsed_oval->info_cves->prev;
                         parsed_oval->info_cves->prev = new;
                         os_strdup(node[i]->values[j], new->cveid);
-                        wm_vuldet_oval_append_rhsa(parsed_oval->vulnerabilities, node[i]->values[j]);
+                        if (dist == FEED_REDHAT) {
+                            wm_vuldet_oval_append_rhsa(parsed_oval->vulnerabilities, node[i]->values[j]);
+                        }
                     } else {
                         os_strdup(node[i]->values[j], parsed_oval->vulnerabilities->cve_id);
                         os_strdup(node[i]->values[j], parsed_oval->info_cves->cveid);
@@ -3946,7 +3948,9 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
                     if (parsed_oval->vulnerabilities->state_id &&
                         parsed_oval->vulnerabilities->cve_id) {
                         wm_vuldet_add_oval_vulnerability(parsed_oval);
-                        wm_vuldet_oval_copy_rhsa(parsed_oval->vulnerabilities->prev, parsed_oval->vulnerabilities);
+                        if (dist == FEED_REDHAT) {
+                            wm_vuldet_oval_copy_rhsa(parsed_oval->vulnerabilities->prev, parsed_oval->vulnerabilities);
+                        }
                         os_strdup(parsed_oval->vulnerabilities->prev->cve_id, parsed_oval->vulnerabilities->cve_id);
                     }
                     os_strdup(node[i]->values[j], parsed_oval->vulnerabilities->state_id);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -3006,11 +3006,11 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
 
         vulnerability *vul_aux = vul_it;
         vul_it = vul_it->prev;
-        free(vul_aux->cve_id);
-        free(vul_aux->state_id);
-        free(vul_aux->package_name);
+        os_free(vul_aux->cve_id);
+        os_free(vul_aux->state_id);
+        os_free(vul_aux->package_name);
         os_free(vul_aux->package_version);
-        free(vul_aux);
+        os_free(vul_aux);
     }
 
     // Adds Debian vulnerabilities
@@ -3928,6 +3928,10 @@ int wm_vuldet_oval_xml_parser(OS_XML *xml, XML_NODE node, wm_vuldet_db *parsed_o
             }
         }
         else if ((dist == FEED_UBUNTU || dist == FEED_REDHAT) && !strcmp(node[i]->element, XML_CRITERION)) {
+            // To avoid a RHSA with no CVEs
+            if (!parsed_oval->vulnerabilities->cve_id) {
+                goto end;
+            }
             for (j = 0; node[i]->attributes[j]; j++) {
                 // Checks if the package isn't vulnerable
                 if (!strcmp(node[i]->attributes[j], XML_COMMENT)) {


### PR DESCRIPTION
|Related issue|
|---|
|#11773|

## Description

Several memory leaks reported by _`valgrind`_ have been found after analyzing different _RedHat_ and _Debian_ feeds:

```
==11109== 172,086 (108,704 direct, 63,382 indirect) bytes in 2,194 blocks are definitely lost in loss record 82 of 82
==11109==    at 0x483DFAF: realloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==11109==    by 0x1D5B44: wm_vuldet_oval_xml_parser (wm_vuln_detector.c:3791)
==11109==    by 0x1D4084: wm_vuldet_oval_xml_parser (wm_vuln_detector.c:3630)
==11109==    by 0x1D824B: wm_vuldet_oval_xml_parser (wm_vuln_detector.c:4014)
==11109==    by 0x1D858A: wm_vuldet_oval_process (wm_vuln_detector.c:4063)
==11109==    by 0x1D8C92: wm_vuldet_index_feed (wm_vuln_detector.c:4178)
==11109==    by 0x1C661A: wm_vuldet_sync_feed (wm_vuln_detector.c:649)
==11109==    by 0x1D00F3: wm_vuldet_update_feed (wm_vuln_detector.c:2673)
==11109==    by 0x1D9F9F: wm_vuldet_check_feed (wm_vuln_detector.c:4509)
==11109==    by 0x1DA530: wm_vuldet_run_update (wm_vuln_detector.c:4609)
==11109==    by 0x1DD3BD: wm_vuldet_main (wm_vuln_detector.c:5134)
==11109==    by 0x50BF608: start_thread (pthread_create.c:477)
```

```
==42783== 185 bytes in 5 blocks are definitely lost in loss record 57 of 78
==42783==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==42783==    by 0x517B50E: strdup (strdup.c:42)
==42783==    by 0x1D7394: wm_vuldet_oval_xml_parser (wm_vuln_detector.c:3958)
==42783==    by 0x1D6E79: wm_vuldet_oval_xml_parser (wm_vuln_detector.c:3914)
==42783==    by 0x1D6D9B: wm_vuldet_oval_xml_parser (wm_vuln_detector.c:3906)
==42783==    by 0x1D6E79: wm_vuldet_oval_xml_parser (wm_vuln_detector.c:3914)
==42783==    by 0x1D6D9B: wm_vuldet_oval_xml_parser (wm_vuln_detector.c:3906)
==42783==    by 0x1D6411: wm_vuldet_oval_xml_parser (wm_vuln_detector.c:3849)
==42783==    by 0x1D8377: wm_vuldet_oval_xml_parser (wm_vuln_detector.c:4028)
==42783==    by 0x1D86B6: wm_vuldet_oval_process (wm_vuln_detector.c:4077)
==42783==    by 0x1D8DBE: wm_vuldet_index_feed (wm_vuln_detector.c:4192)
==42783==    by 0x1C661A: wm_vuldet_sync_feed (wm_vuln_detector.c:649)
```

```
==20559== 112,371 (45,064 direct, 67,307 indirect) bytes in 303 blocks are definitely lost in loss record 93 of 128
==20559==    at 0x4C2BB58: realloc (vg_replace_malloc.c:785)
==20559==    by 0x49A34A: wm_vuldet_oval_append_rhsa (wm_vuln_detector.c:3529)
==20559==    by 0x49C919: wm_vuldet_oval_xml_parser (wm_vuln_detector.c:3854)
==20559==    by 0x49E344: wm_vuldet_oval_xml_parser (wm_vuln_detector.c:4014)
==20559==    by 0x49C685: wm_vuldet_oval_xml_parser (wm_vuln_detector.c:3835)
==20559==    by 0x49E344: wm_vuldet_oval_xml_parser (wm_vuln_detector.c:4014)
==20559==    by 0x49E5E3: wm_vuldet_oval_process (wm_vuln_detector.c:4063)
==20559==    by 0x49EBB5: wm_vuldet_index_feed (wm_vuln_detector.c:4178)
==20559==    by 0x48DE2D: wm_vuldet_sync_feed (wm_vuln_detector.c:649)
==20559==    by 0x496BE1: wm_vuldet_update_feed (wm_vuln_detector.c:2673)
==20559==    by 0x49FC53: wm_vuldet_check_feed (wm_vuln_detector.c:4509)
==20559==    by 0x4A0163: wm_vuldet_run_update (wm_vuln_detector.c:4609)
```

These memory leaks have been fixed in this PR. The fixes applied have been the following:

- To mitigate a leak that was only found in _RHEL5_, the `arch` memory, which is inside the `info_state` structure, had to be freed. This problem occurred because the feed encounters the _architecture_ (`red-def:arch`) first, so it allocates memory, and then entering the _RHEL5_ condition when it encounters the EVR (`red-def:evr`), said memory was not freed.

- There was another issue with the RedHat feed, where it could parse and allocate memory from an RHSA even though it did not contain any associated CVE. This caused the variable `state_id` to be overwritten. This problem has also been found in the _RHEL5_ feed, where a specific case would be: `RHSA-2016:0561`. To mitigate it, when finding an RHSA that does not have an associated `cve_id`, it is skipped, so that we do not save the information of that RHSA.

- Lastly, after parsing a Debian feed, another memory leak was found where memory was being reserved in the `rhsa_list` variable, when it was not needed for this feed because it does not have any RHSA (only RedHat). To avoid this, a condition has only been added so that `rhsa_list` memory is only reserved when it is a RHEL feed.

## Configuration options

With the following configuration, the memory leak has been replicated:

```xml
  <vulnerability-detector>
    <enabled>yes</enabled>
    <interval>2h</interval>
    <min_full_scan_interval>2h</min_full_scan_interval>
    <run_on_start>yes</run_on_start>
    ...
      <provider name="debian">
      <enabled>yes</enabled>
      <url>http://ci.wazuh.com/vulnerability-detector/debian/security_tracker.json</url>
      <os url="http://ci.wazuh.com/vulnerability-detector/debian/oval-definitions-stretch.xml">stretch</os>
      <update_interval>1h</update_interval>
    </provider>

    <provider name="redhat">
      <enabled>yes</enabled>
      <update_interval>1h</update_interval>
      <url end="26" start="1">http://ci.wazuh.com/vulnerability-detector/rh-feed/redhat-feed[-].json</url>
      <os url="http://ci.wazuh.com/vulnerability-detector/redhat/com.redhat.rhsa-RHEL5.xml.bz2">5</os>
    </provider>
    ...
  </vulnerability-detector>
```

## Logs/Alerts example

After applying the fixes, no more memory leak appears:

```
==10241== LEAK SUMMARY:
==10241==    definitely lost: 0 bytes in 0 blocks
==10241==    indirectly lost: 0 bytes in 0 blocks
==10241==      possibly lost: 3,536 bytes in 12 blocks
==10241==    still reachable: 297,246 bytes in 94 blocks
==10241==         suppressed: 0 bytes in 0 blocks
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)
- [x] Stress test for affected components
