### PR TITLE
Cancel cluster running tasks after a timeout

### DIFF
--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -293,6 +293,8 @@ class Handler(asyncio.Protocol):
         self.cluster_items = cluster_items
         # Transports in asyncio are an abstraction of sockets.
         self.transport = None
+        # Tasks to be interrupted.
+        self.interrupted_tasks = set()
 
     def push(self, message: bytes):
         """Send a message to peer.
@@ -475,13 +477,15 @@ class Handler(asyncio.Protocol):
             return b'Error sending request: timeout expired.'
         return response_data
 
-    async def send_file(self, filename: str) -> bytes:
+    async def send_file(self, filename: str, task_id: bytes = None) -> bytes:
         """Send a file to peer, slicing it into chunks.
 
         Parameters
         ----------
         filename : str
             Full path of the file to send.
+        task_id : bytes
+            Task identifier to stop sending file if needed.
 
         Returns
         -------
@@ -502,6 +506,8 @@ class Handler(asyncio.Protocol):
             for chunk in iter(lambda: f.read(self.request_chunk - len(relative_path) - 1), b''):
                 await self.send_request(command=b'file_upd', data=relative_path + b' ' + chunk)
                 file_hash.update(chunk)
+                if task_id in self.interrupted_tasks:
+                    break
 
         # Close the destination file descriptor so the file in memory is dumped to disk.
         await self.send_request(command=b'file_end', data=relative_path + b' ' + file_hash.digest())
@@ -696,8 +702,10 @@ class Handler(asyncio.Protocol):
             return self.str_upd(data)
         elif command == b'err_str':
             return self.process_error_str(data)
-        elif command == b"file_end":
+        elif command == b'file_end':
             return self.end_file(data)
+        elif command == b'cancel_task':
+            return self.cancel_task(data)
         else:
             return self.process_unknown_cmd(command)
 
@@ -801,6 +809,31 @@ class Handler(asyncio.Protocol):
         else:
             del self.in_file[name]
             return b"err", b"File wasn't correctly received. Checksums aren't equal."
+
+    def cancel_task(self, data: bytes) -> Tuple[bytes, bytes]:
+        """Add task_id to interrupted_tasks and log the error message.
+
+        Parameters
+        ----------
+        data : bytes
+            String containing task_id and WazuhJSONEncoded object with the exception details.
+
+        Returns
+        -------
+        bytes
+            Result.
+        bytes
+            Response message.
+        """
+        task_id, error_details = data.split(b' ', 1)
+        error_json = json.loads(error_details, object_hook=as_wazuh_object)
+        if task_id != b'None':
+            self.interrupted_tasks.add(task_id)
+            self.logger.error(f'The task was canceled due to the following error on the remote node: {error_json}')
+        else:
+            self.logger.error(f'The task was requested to be canceled but no task_id was received: {error_json}')
+
+        return b'ok', b'Request received correctly'
 
     def receive_str(self, data: bytes) -> Tuple[bytes, bytes]:
         """Create a bytearray with the string size.

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -654,8 +654,16 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         logger.info(f"Starting.")
 
         logger.debug("Waiting to receive zip file from worker.")
-        await asyncio.wait_for(received_file.wait(),
-                               timeout=self.cluster_items['intervals']['communication']['timeout_receiving_file'])
+        try:
+            await asyncio.wait_for(received_file.wait(),
+                                   timeout=self.cluster_items['intervals']['communication']['timeout_receiving_file'])
+        except Exception:
+            # Notify the sending node to stop its task.
+            await self.send_request(
+                command=b'cancel_task',
+                data=task_id.encode() + b' ' + json.dumps(timeout_exc := exception.WazuhClusterError(3039),
+                                                          cls=c_common.WazuhJSONEncoder).encode())
+            raise timeout_exc
 
         # Full path where the zip sent by the worker is located.
         received_filename = self.sync_tasks[task_id].filename
@@ -715,12 +723,10 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                     raise exc_info
 
                 # Send zip file to the worker into chunks.
-                await self.send_file(compressed_data)
+                await self.send_file(compressed_data, task_id)
                 logger.debug("Zip with files to be synced sent to worker.")
-
-                # Finish the synchronization process and notify where the file corresponding to the taskID is located.
-                result = await self.send_request(command=b'syn_m_c_e',
-                                                 data=task_id + b' ' + os.path.relpath(
+                # Notify what is the zip path for the current taskID.
+                result = await self.send_request(command=b'syn_m_c_e', data=task_id + b' ' + os.path.relpath(
                                                      compressed_data, common.wazuh_path).encode())
                 if isinstance(result, Exception):
                     raise result
@@ -729,17 +735,19 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             except exception.WazuhException as e:
                 # Notify error to worker and delete its received file.
                 self.logger.error(f"Error sending files information: {e}")
-                result = await self.send_request(
+                await self.send_request(
                     command=b'syn_m_c_r', data=task_id + b' ' + json.dumps(e, cls=c_common.WazuhJSONEncoder).encode())
             except Exception as e:
                 # Notify error to worker and delete its received file.
                 self.logger.error(f"Error sending files information: {e}")
                 exc_info = json.dumps(exception.WazuhClusterError(1000, extra_message=str(e)),
                                       cls=c_common.WazuhJSONEncoder).encode()
-                result = await self.send_request(command=b'syn_m_c_r', data=task_id + b' ' + exc_info)
+                await self.send_request(command=b'syn_m_c_r', data=task_id + b' ' + exc_info)
             finally:
                 # Remove local file.
                 os.unlink(compressed_data)
+                # In case task was interrupted, remove its ID from the interrupted set.
+                self.interrupted_tasks.discard(task_id)
                 logger.debug("Finished sending files to worker.")
                 # Log 'Finished in' message only if there are no extra_valid files to sync.
                 if not self.extra_valid_requested:
@@ -752,7 +760,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                     self.integrity_sync_status['date_end_master'] = \
                         self.integrity_sync_status['date_end_master'].strftime(decimals_date_format)
 
-        return result
+        return b'ok'
 
     async def sync_extra_valid(self, task_id: str, received_file: asyncio.Event):
         """Run extra valid sync process and set up necessary parameters.
@@ -790,8 +798,16 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             Logger to use (can't use self since one of the task loggers will be used).
         """
         logger.debug("Waiting to receive zip file from worker.")
-        await asyncio.wait_for(received_file.wait(),
-                               timeout=self.cluster_items['intervals']['communication']['timeout_receiving_file'])
+        try:
+            await asyncio.wait_for(received_file.wait(),
+                                   timeout=self.cluster_items['intervals']['communication']['timeout_receiving_file'])
+        except Exception:
+            # Notify the sending node to stop its task.
+            await self.send_request(
+                command=b'cancel_task',
+                data=task_id.encode() + b' ' + json.dumps(timeout_exc := exception.WazuhClusterError(3039),
+                                                          cls=c_common.WazuhJSONEncoder).encode())
+            raise timeout_exc
 
         # Full path where the zip sent by the worker is located.
         received_filename = self.sync_tasks[task_id].filename

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -641,13 +641,6 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             ID of the asyncio task in charge of doing the sync process.
         received_file : asyncio.Event
             Asyncio event that is holding a lock while the files are not received.
-
-        Returns
-        -------
-        bytes
-            Result.
-        bytes
-            Response message.
         """
         logger = self.task_loggers['Integrity check']
         date_start_master = datetime.utcnow()
@@ -759,8 +752,6 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                         'tmp_date_start_master'].strftime(decimals_date_format)
                     self.integrity_sync_status['date_end_master'] = \
                         self.integrity_sync_status['date_end_master'].strftime(decimals_date_format)
-
-        return b'ok'
 
     async def sync_extra_valid(self, task_id: str, received_file: asyncio.Event):
         """Run extra valid sync process and set up necessary parameters.

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -5,7 +5,7 @@ import asyncio
 import json
 import logging
 import sys
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import patch, MagicMock, call, ANY
 
 import pytest
 import uvloop
@@ -159,6 +159,7 @@ async def test_sync_files_sync_ok(compress_files_mock, unlink_mock, relpath_mock
         def __init__(self):
             self.name = "Testing"
             self.count = 1
+            self.interrupted_tasks = {b'OK', b'abcd'}
 
         async def send_request(self, command, data):
             """Decide with will be the right output depending on the scenario."""
@@ -198,13 +199,13 @@ async def test_sync_files_sync_ok(compress_files_mock, unlink_mock, relpath_mock
         with patch.object(logging.getLogger("wazuh"), "debug") as logger_debug_mock:
             with patch.object(logging.getLogger("wazuh"), "error") as logger_error_mock:
                 await sync_files.sync(files_to_sync, files_metadata)
-                send_file_mock.assert_called_once_with(filename='files/path/')
+                send_file_mock.assert_called_once_with(filename='files/path/', task_id=b'OK')
                 logger_debug_mock.assert_has_calls([call(
                     f"Compressing {'files and ' if files_to_sync else ''}'files_metadata.json' of {len(files_metadata)}"
                     f" files."), call("Sending zip file to master."), call("Zip file sent to master.")])
                 logger_error_mock.assert_called_once_with("Error sending zip file: ")
-                compress_files_mock.assert_called_once_with(name="Testing", list_path=files_to_sync,
-                                                            cluster_control_json=files_metadata)
+                compress_files_mock.assert_has_calls([call(name="Testing", list_path=files_to_sync,
+                                                           cluster_control_json=files_metadata)]*2)
                 unlink_mock.assert_called_once_with("files/path/")
                 relpath_mock.assert_called_once_with('files/path/', core_common.wazuh_path)
                 assert json_dumps_mock.call_count == 2
@@ -218,7 +219,7 @@ async def test_sync_files_sync_ok(compress_files_mock, unlink_mock, relpath_mock
                 # Test elif present in try and first exception
                 worker_mock.count = 3
                 await sync_files.sync(files_to_sync, files_metadata)
-                send_file_mock.assert_called_once_with(filename='files/path/')
+                send_file_mock.assert_called_once_with(filename='files/path/', task_id=b'OK')
                 logger_debug_mock.assert_has_calls([call(
                     f"Compressing {'files and ' if files_to_sync else ''}'files_metadata.json' of {len(files_metadata)}"
                     f" files."), call("Sending zip file to master."), call("Zip file sent to master.")])
@@ -239,7 +240,7 @@ async def test_sync_files_sync_ok(compress_files_mock, unlink_mock, relpath_mock
             # Test return
             worker_mock.count = 4
             assert await sync_files.sync(files_to_sync, files_metadata) is True
-            send_file_mock.assert_called_once_with(filename='files/path/')
+            send_file_mock.assert_called_once_with(filename='files/path/', task_id=b'OK')
             logger_debug_mock.assert_has_calls([call(
                 f"Compressing {'files and ' if files_to_sync else ''}'files_metadata.json' of {len(files_metadata)}"
                 f" files."), call("Sending zip file to master."), call("Zip file sent to master.")])
@@ -247,6 +248,8 @@ async def test_sync_files_sync_ok(compress_files_mock, unlink_mock, relpath_mock
                                                         cluster_control_json=files_metadata)
             unlink_mock.assert_called_once_with("files/path/")
             relpath_mock.assert_called_once_with('files/path/', core_common.wazuh_path)
+
+            assert worker_mock.interrupted_tasks == {b'abcd'}
 
 
 @pytest.mark.asyncio
@@ -875,18 +878,16 @@ async def test_worker_handler_process_files_from_master_ko(send_request_mock, js
     with pytest.raises(Exception):
         worker_handler.sync_tasks["task_id"] = TaskMock()
         await worker_handler.process_files_from_master(name="task_id", file_received=event_mock)
-
-        json_dumps_mock.assert_called_once_with(exception.WazuhClusterError(code=1000, extra_message=str(Exception())),
-                                                cls=core_common.WazuhJSONEncoder)
-        send_request_mock.assert_called_once_with(command=b'syn_i_w_m_r', data=b'None ' + "".encode())
-        wait_mock.assert_called_once_with(event_mock.wait(),
-                                          timeout=cluster_items['intervals']['communication']['timeout_receiving_file'])
+    json_dumps_mock.assert_called_with(exception.WazuhClusterError(code=1000, extra_message=str(Exception())),
+                                       cls=common.WazuhJSONEncoder)
+    send_request_mock.assert_called_with(command=b'syn_i_w_m_r', data=b'None ')
+    wait_mock.assert_called_once_with(event_mock.wait(),
+                                      timeout=cluster_items['intervals']['communication']['timeout_receiving_file'])
 
     wait_mock.side_effect = Exception
     with pytest.raises(exception.WazuhClusterError, match=r".* 3039 .*"):
         await worker_handler.process_files_from_master(name="task_id", file_received=event_mock)
-
-        send_request_mock.assert_called_once_with(command=b'syn_i_w_m_r', data=b'None ' + "".encode())
+    send_request_mock.assert_called_with(command=b'cancel_task', data=b'task_id ')
 
 
 @patch("builtins.open")

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -121,6 +121,12 @@ class SyncFiles(SyncTask):
         bool
             True if files were correctly sent to the master node, None otherwise.
         """
+        self.logger.debug(
+            f"Compressing {'files and ' if files_to_sync else ''}'files_metadata.json' of {len(files_metadata)} files."
+        )
+        compressed_data_path = cluster.compress_files(name=self.worker.name, list_path=files_to_sync,
+                                                      cluster_control_json=files_metadata)
+
         # Start the synchronization process with the master and get a taskID.
         task_id = await self.worker.send_request(command=self.cmd, data=b'')
         if isinstance(task_id, Exception):
@@ -132,22 +138,15 @@ class SyncFiles(SyncTask):
             await self.worker.send_request(command=self.cmd + b'_r', data=b'None ' + exc_info)
             return
 
-        self.logger.debug(
-            f"Compressing {'files and ' if files_to_sync else ''}'files_metadata.json' of {len(files_metadata)} files."
-        )
-        compressed_data_path = cluster.compress_files(name=self.worker.name, list_path=files_to_sync,
-                                                      cluster_control_json=files_metadata)
-
         try:
             # Send zip file to the master into chunks.
             self.logger.debug("Sending zip file to master.")
-            await self.worker.send_file(filename=compressed_data_path)
+            await self.worker.send_file(filename=compressed_data_path, task_id=task_id)
             self.logger.debug("Zip file sent to master.")
 
             # Finish the synchronization process and notify where the file corresponding to the taskID is located.
-            result = await self.worker.send_request(command=self.cmd + b'_e', data=task_id + b' ' +
-                                                                                   os.path.relpath(compressed_data_path,
-                                                                                                   common.wazuh_path).encode())
+            result = await self.worker.send_request(command=self.cmd + b'_e', data=task_id + b' ' + os.path.relpath(
+                    compressed_data_path, common.wazuh_path).encode())
             if isinstance(result, Exception):
                 raise result
             elif result.startswith(b'Error'):
@@ -156,9 +155,8 @@ class SyncFiles(SyncTask):
         except exception.WazuhException as e:
             # Notify error to master and delete its received file.
             self.logger.error(f"Error sending zip file: {e}")
-            await self.worker.send_request(command=self.cmd + b'_r', data=task_id + b' ' +
-                                                                          json.dumps(e,
-                                                                                     cls=c_common.WazuhJSONEncoder).encode())
+            await self.worker.send_request(command=self.cmd + b'_r',
+                                           data=task_id + b' ' + json.dumps(e, cls=c_common.WazuhJSONEncoder).encode())
         except Exception as e:
             # Notify error to master and delete its received file.
             self.logger.error(f"Error sending zip file: {e}")
@@ -167,6 +165,8 @@ class SyncFiles(SyncTask):
             await self.worker.send_request(command=self.cmd + b'_r', data=task_id + b' ' + exc_info)
         finally:
             os.unlink(compressed_data_path)
+            # In case task was interrupted, remove its ID from the interrupted set.
+            self.worker.interrupted_tasks.discard(task_id)
 
 
 class SyncWazuhdb(SyncTask):
@@ -604,10 +604,11 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
             await asyncio.wait_for(file_received.wait(),
                                    timeout=self.cluster_items['intervals']['communication']['timeout_receiving_file'])
         except Exception:
+            # Notify the sending node to stop its task.
             await self.send_request(
-                command=b'syn_i_w_m_r',
-                data=b'None ' + json.dumps(timeout_exc := WazuhClusterError(
-                    3039, extra_message=f'Integrity sync at {self.name}'), cls=c_common.WazuhJSONEncoder).encode())
+                command=b'cancel_task',
+                data=name.encode() + b' ' + json.dumps(timeout_exc := WazuhClusterError(3039),
+                                                       cls=c_common.WazuhJSONEncoder).encode())
             raise timeout_exc
 
         if isinstance(self.sync_tasks[name].filename, Exception):


### PR DESCRIPTION
|Related issue|
|---|
| Closes #10735 |

## Description

This PR adds a new mechanism, as requested in #10735, to cancel a task if a `timeoutError` occurs during file synchronization (Integrity check/sync).

Until now, if there was a timeout while waiting to receive a file, the sending node would continue to send the file until finishing, even if this file would no longer be useful at the receiving node. This also involved unnecessary CPU, disk, and network usage.

Now, if for example a timeout is raised in the worker while waiting for a file from the master, it will notify said node with the command `cancel_task` and the ID of the current task:
https://github.com/wazuh/wazuh/blob/a1ed55f9c46f3c7494c7ea13a838f570b8d6fa2e/framework/wazuh/core/cluster/worker.py#L603-L612

Upon receiving the command, the master will store the ID in a set. When a file is being sent, that set is checked recurrently and if the ID of the current task is found, the sending is stopped.
https://github.com/wazuh/wazuh/blob/a1ed55f9c46f3c7494c7ea13a838f570b8d6fa2e/framework/wazuh/core/cluster/common.py#L506-L510

However, for the receiving node to delete the received file, it is necessary to complete the task (since it is at that moment when the receiving node knows the path of the file). This inevitably logs the following error:
```
2022/01/19 09:41:48 ERROR: [Worker worker1] [Main] Internal error processing request 'b'syn_m_c_e'': Error 3027 - Unknown received task name: e3aaf01e-4ff9-47f4-a803-73d2c661c1f4
```

It is essential that the cluster always try to send the `syn_m_c_e`/`syn_i_w_m_e` command, even if this generates the error seen above, since it is the only way to ensure whether the task exists or not and to delete the file in such a case, without race conditions.

This would be the behavior of the receiving node when raising a `timeoutError`:
```
2022/01/19 09:41:47 INFO: [Worker worker1] [Integrity check] Finished in 3.689s. Sync required.
2022/01/19 09:41:48 ERROR: [Worker worker1] [Main] Error 3039 - Timeout while waiting to receive a file
2022/01/19 09:41:48 ERROR: [Worker worker1] [Main] Internal error processing request 'b'syn_m_c_e'': Error 3027 - Unknown received task name: e3aaf01e-4ff9-47f4-a803-73d2c661c1f4
2022/01/19 09:41:48 ERROR: [Worker worker1] [Main] Error in synchronization process: Error 3027 - Unknown received task name: e3aaf01e-4ff9-47f4-a803-73d2c661c1f4
```

And this is the one of the sending node. As you can see, sending the file stops as soon as the cancellation request is received:
```
2022/01/19 09:41:48 INFO: [Worker worker1] [Main] Sending file
2022/01/19 09:41:48 INFO: [Worker worker1] [Main] Sending file
2022/01/19 09:41:48 INFO: [Worker worker1] [Main] Sending file
2022/01/19 09:41:48 ERROR: [Worker worker1] [Main] The task was canceled due to the following error on the remote node: Error 3039 - Timeout while waiting to receive a file
2022/01/19 09:41:48 ERROR: [Worker worker1] [Main] Error sending files information: Error 3027 - Unknown received task name: e3aaf01e-4ff9-47f4-a803-73d2c661c1f4
2022/01/19 09:41:48 INFO: [Worker worker1] [Integrity sync] Finished in 4.665s.
```