### PR TITLE
Dev 11754 - Wazuh-db `get-config` unit test

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -29,6 +29,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_scan_info_get -Wl,--wrap,wdb_fim_upd
                         -Wl,--wrap,wdb_agents_get_packages -Wl,--wrap,wdb_agents_get_hotfixes -Wl,--wrap,close -Wl,--wrap,getpid \
                         -Wl,--wrap,wdb_package_save -Wl,--wrap,wdb_hotfix_save -Wl,--wrap,wdb_package_update -Wl,--wrap,wdb_package_delete \
                         -Wl,--wrap,wdb_hotfix_delete -Wl,--wrap,time -Wl,--wrap,wdbi_update_attempt  -Wl,--wrap,wdbi_update_completion \
+                        -Wl,--wrap,wdb_get_config -Wl,--wrap,wdb_get_internal_config \
                         ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_global_parser")

--- a/src/unit_tests/wazuh_db/test_wdb.c
+++ b/src/unit_tests/wazuh_db/test_wdb.c
@@ -28,8 +28,6 @@
 #include "../wrappers/wazuh/os_net/os_net_wrappers.h"
 #include "../wrappers/libc/string_wrappers.h"
 
-#include "../wrappers/externals/cJSON/cJSON_wrappers.h"
-
 typedef struct test_struct {
     wdb_t *wdb;
     char *output;

--- a/src/unit_tests/wazuh_db/test_wdb.c
+++ b/src/unit_tests/wazuh_db/test_wdb.c
@@ -735,9 +735,8 @@ void test_wdb_get_config(){
     cJSON *cfg_array = cJSON_GetObjectItem(root, "backup_settings_nodes");
     assert_true(cJSON_IsArray(cfg_array));
 
-    int size = cJSON_GetArraySize(cfg_array);
-    for (int i = 0; i < size; ++i) {
-        cJSON *cfg = cJSON_GetArrayItem(cfg_array, i);
+    cJSON *cfg = 0;
+    cJSON_ArrayForEach(cfg, cfg_array){
         assert_true(cJSON_IsObject(cfg));
 
         cJSON *c0 = cJSON_GetObjectItem(cfg, "node_name");

--- a/src/unit_tests/wazuh_db/test_wdb_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_parser.c
@@ -2386,10 +2386,32 @@ void test_hotfixes_no_action(void **state) {
     os_free(query);
 }
 
+void test_wdb_parse_get_config_internal(){
+    will_return(__wrap_wdb_get_internal_config, 1);
+    cJSON *ret = wdb_parse_get_config("internal");
+    assert_int_equal(ret, 1);
+}
+
+void test_wdb_parse_get_config_wdb(){
+    will_return(__wrap_wdb_get_config, 1);
+    cJSON *ret = wdb_parse_get_config("wdb");
+    assert_int_equal(ret, 1);
+}
+
+void test_wdb_parse_get_config_arg_null(){
+    cJSON *ret = wdb_parse_get_config(0);
+    assert_int_equal(ret, NULL);
+}
+
+void test_wdb_parse_get_config_bad_arg(){
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid configuration source for wazuh-db");
+    cJSON *ret = wdb_parse_get_config("BAD_ARG");
+    assert_int_equal(ret, NULL);
+}
+
 int main()
 {
-    const struct CMUnitTest tests[] =
-    {
+    const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown(test_wdb_parse_syscheck_no_space, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_scan_info_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_scan_info_ok, test_setup, test_teardown),
@@ -2430,7 +2452,9 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_parse_rootcheck_save_date_max_long, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_rootcheck_save_update_cache_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_rootcheck_save_update_success, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_parse_rootcheck_save_update_insert_cache_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_rootcheck_save_update_insert_cache_error,
+                                        test_setup,
+                                        test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_rootcheck_save_update_insert_success, test_setup, test_teardown),
         /* Tests osinfo */
         cmocka_unit_test_setup_teardown(test_osinfo_syntax_error, test_setup, test_teardown),
@@ -2477,7 +2501,9 @@ int main()
         cmocka_unit_test_setup_teardown(test_vuln_cves_update_status_command_success, test_setup, test_teardown),
         // wdb_parse_agents_update_vuln_cves_status_by_type
         cmocka_unit_test_setup_teardown(test_vuln_cves_update_status_by_type_command_error, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_vuln_cves_update_status_by_type_command_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_vuln_cves_update_status_by_type_command_success,
+                                        test_setup,
+                                        test_teardown),
         // wdb_parse_agents_remove_vuln_cves
         cmocka_unit_test_setup_teardown(test_vuln_cves_remove_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_vuln_cves_remove_json_data_error, test_setup, test_teardown),
@@ -2518,6 +2544,10 @@ int main()
         cmocka_unit_test_setup_teardown(test_hotfixes_del_delete_err, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_hotfixes_invalid_action, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_hotfixes_no_action, test_setup, test_teardown),
+        cmocka_unit_test(test_wdb_parse_get_config_wdb),
+        cmocka_unit_test(test_wdb_parse_get_config_internal),
+        cmocka_unit_test(test_wdb_parse_get_config_arg_null),
+        cmocka_unit_test(test_wdb_parse_get_config_bad_arg)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
@@ -338,3 +338,11 @@ int __wrap_wdb_hotfix_delete(__attribute__((unused))wdb_t * wdb,
     check_expected(scan_id);
     return mock();
 }
+
+cJSON *__wrap_wdb_get_internal_config() {
+    return mock_ptr_type(cJSON *);
+}
+
+cJSON *__wrap_wdb_get_config() {
+    return mock_ptr_type(cJSON *);
+}

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
@@ -79,4 +79,8 @@ sqlite3_stmt* __wrap_wdb_init_stmt_in_cache(wdb_t* wdb, wdb_stmt statement_index
 
 int __wrap_wdb_exec_stmt_silent(sqlite3_stmt* stmt);
 
+cJSON *__wrap_wdb_get_internal_config();
+
+cJSON *__wrap_wdb_get_config();
+
 #endif

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -6391,6 +6391,10 @@ int wdb_parse_agents_clear_vuln_cves(wdb_t* wdb, char* output) {
 }
 
 cJSON* wdb_parse_get_config(char* config_source) {
+    if (config_source == 0) {
+        return NULL;
+    }
+
     cJSON* j_wdb_config = NULL;
 
     if (strcmp(config_source, "internal") == 0) {


### PR DESCRIPTION
|Related issue|
|---|
|#11754|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Adding UT to the wazuh-db `get-config` command

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
 
<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)