### PR TITLE
Implement old data reporting

### DIFF
--- a/src/shared_modules/dbsync/cppcheckSuppress.txt
+++ b/src/shared_modules/dbsync/cppcheckSuppress.txt
@@ -1,2 +1,2 @@
-*:*src/sqlite/sqlite_dbengine.cpp:155
+*:*src/sqlite/sqlite_dbengine.cpp:156
 *:*testtool/action.h:617

--- a/src/shared_modules/dbsync/include/dbsync.h
+++ b/src/shared_modules/dbsync/include/dbsync.h
@@ -161,7 +161,7 @@ EXPORTED int dbsync_sync_row(const DBSYNC_HANDLE handle,
  * @brief Select data, based in \p json_data_input data, from the database table.
  *
  * @param handle          Handle assigned as part of the \ref dbsync_create method().
- * @param js_data_input   JSON with table name, fields and filters to apply in the query.
+ * @param js_data_input   JSON with table name, fields, filters and options to apply in the query.
  * @param callback_data   This struct contain the result callback will be called for each result
  *                        and user data space returned in each callback call.
  *

--- a/src/shared_modules/dbsync/src/dbengine.h
+++ b/src/shared_modules/dbsync/src/dbengine.h
@@ -38,7 +38,8 @@ namespace DbSync
             virtual void syncTableRowData(const std::string& table,
                                           const nlohmann::json& data,
                                           const ResultCallback callback,
-                                          const bool inTransaction = false) = 0;
+                                          const bool inTransaction = false,
+                                          const bool returnOldData = false) = 0;
 
             virtual void setMaxRows(const std::string& table,
                                     const unsigned long long maxRows) = 0;

--- a/src/shared_modules/dbsync/src/dbsync_implementation.cpp
+++ b/src/shared_modules/dbsync/src/dbsync_implementation.cpp
@@ -49,6 +49,18 @@ void DBSyncImplementation::insertBulkData(const DBSYNC_HANDLE   handle,
     ctx->m_dbEngine->bulkInsert(json.at("table"), json.at("data"));
 }
 
+static bool shouldReturnOldData(const nlohmann::json& data)
+{
+    auto it { data.find("return_old_data") };
+
+    if (it != data.end())
+    {
+        return *it;
+    }
+
+    return false;
+}
+
 void DBSyncImplementation::syncRowData(const DBSYNC_HANDLE      handle,
                                        const nlohmann::json&    json,
                                        const ResultCallback     callback)
@@ -56,7 +68,9 @@ void DBSyncImplementation::syncRowData(const DBSYNC_HANDLE      handle,
     const auto ctx{ dbEngineContext(handle) };
     ctx->m_dbEngine->syncTableRowData(json.at("table"),
                                       json.at("data"),
-                                      callback);
+                                      callback,
+                                      false,
+                                      shouldReturnOldData(json));
 }
 
 void DBSyncImplementation::syncRowData(const DBSYNC_HANDLE      handle,
@@ -75,7 +89,8 @@ void DBSyncImplementation::syncRowData(const DBSYNC_HANDLE      handle,
     ctx->m_dbEngine->syncTableRowData(json.at("table"),
                                       json.at("data"),
                                       callback,
-                                      true);
+                                      true,
+                                      shouldReturnOldData(json));
 }
 
 void DBSyncImplementation::deleteRowsData(const DBSYNC_HANDLE   handle,

--- a/src/shared_modules/dbsync/src/dbsync_implementation.cpp
+++ b/src/shared_modules/dbsync/src/dbsync_implementation.cpp
@@ -52,13 +52,14 @@ void DBSyncImplementation::insertBulkData(const DBSYNC_HANDLE   handle,
 static bool shouldReturnOldData(const nlohmann::json& data)
 {
     auto it { data.find("return_old_data") };
+    bool result {false};
 
     if (it != data.end())
     {
-        return *it;
+        result = *it;
     }
 
-    return false;
+    return result;
 }
 
 void DBSyncImplementation::syncRowData(const DBSYNC_HANDLE      handle,

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.h
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.h
@@ -125,7 +125,8 @@ class SQLiteDBEngine final : public DbSync::IDbEngine
         void syncTableRowData(const std::string& table,
                               const nlohmann::json& data,
                               const DbSync::ResultCallback callback,
-                              const bool inTransaction = false) override;
+                              const bool inTransaction = false,
+                              const bool returnOldData = false) override;
 
         void setMaxRows(const std::string& table,
                         const unsigned long long maxRows) override;
@@ -187,7 +188,8 @@ class SQLiteDBEngine final : public DbSync::IDbEngine
         bool getRowDiff(const std::vector<std::string>& primaryKeyList,
                         const std::string& table,
                         const nlohmann::json& data,
-                        nlohmann::json& jsResult);
+                        nlohmann::json& updatedData,
+                        nlohmann::json& oldData);
 
         bool insertNewRows(const std::string& table,
                            const std::vector<std::string>& primaryKeyList,

--- a/src/shared_modules/dbsync/tests/interface/dbsync_test.cpp
+++ b/src/shared_modules/dbsync/tests/interface/dbsync_test.cpp
@@ -654,6 +654,101 @@ TEST_F(DBSyncTest, syncRowInsertAndModified)
     EXPECT_NE(0, dbsync_sync_row(handle, jsInsert2.get(), callbackEmpty));
 }
 
+TEST_F(DBSyncTest, syncRowInsertAndModifiedWithOldData)
+{
+    const auto sql{ "CREATE TABLE processes(`pid` BIGINT, `name` TEXT, `tid` BIGINT, PRIMARY KEY (`pid`)) WITHOUT ROWID;"};
+    const auto handle { dbsync_create(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, sql) };
+    ASSERT_NE(nullptr, handle);
+
+    CallbackMock wrapper;
+    EXPECT_CALL(wrapper, callbackMock(INSERTED, nlohmann::json::parse(
+                                          R"(
+        [
+            {
+                "pid":4,
+                "name":"System",
+                "tid":100
+            },
+            {
+                "pid":5,
+                "name":"System",
+                "tid":101
+            },
+            {
+                "pid":6,
+                "name":"System",
+                "tid":102
+            }
+        ]
+        )"))).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(MODIFIED, nlohmann::json::parse(
+                                          R"(
+        [
+            {
+                "new": {
+                    "pid": 4,
+                    "tid": 101
+                },
+                "old": {
+                    "pid": 4,
+                    "tid": 100
+                }
+            }
+        ]
+        )"))).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(MODIFIED, nlohmann::json::parse(
+                                          R"(
+        [
+            {
+                "new": {
+                    "name": "Systemmm",
+                    "pid": 4,
+                    "tid": 105
+                },
+                "old": {
+                    "name": "System",
+                    "pid": 4,
+                    "tid": 101
+                }
+            }
+        ]
+        )"))).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(INSERTED, nlohmann::json::parse(R"([{"pid":7,"name":"Guake"}])"))).Times(1);
+
+
+    const std::unique_ptr<cJSON, smartDeleterJson> jsInsert1{ cJSON_Parse
+                                                              (
+                                                                  R"({"table":"processes", "data":[{"pid":4,"name":"System", "tid":100},
+                                                                  {"pid":5,"name":"System", "tid":101},
+                                                                  {"pid":6,"name":"System", "tid":102}]})"
+                                                              )};
+    const std::unique_ptr<cJSON, smartDeleterJson> jsUpdate1{ cJSON_Parse
+                                                              (
+                                                                  R"({"table":"processes", "return_old_data":true, "data":[{"pid":4,"name":"System", "tid":101}]})"
+                                                              )};
+    const std::unique_ptr<cJSON, smartDeleterJson> jsUpdate2{ cJSON_Parse
+                                                              (
+                                                                  R"({"table":"processes","return_old_data":true, "data":[{"pid":4,"name":"Systemmm", "tid":105}]})"
+                                                              )};
+    const std::unique_ptr<cJSON, smartDeleterJson> jsInsert2{ cJSON_Parse
+                                                              (
+                                                                  R"({"table":"processes","return_old_data":true, "data":[{"pid":7,"name":"Guake"}]})"
+                                                              )};
+
+    callback_data_t callbackData { callback, &wrapper };
+    callback_data_t callbackEmpty { nullptr, nullptr };
+
+    EXPECT_EQ(0, dbsync_sync_row(handle, jsInsert1.get(), callbackData));  // Expect an insert event
+    EXPECT_EQ(0, dbsync_sync_row(handle, jsUpdate1.get(), callbackData));  // Expect a modified event
+    EXPECT_EQ(0, dbsync_sync_row(handle, jsUpdate2.get(), callbackData));  // Expect a modified event
+    EXPECT_EQ(0, dbsync_sync_row(handle, jsInsert2.get(), callbackData));  // Expect an insert event
+    EXPECT_EQ(0, dbsync_sync_row(handle, jsInsert2.get(), callbackData));  // Same as above but EXPECT_CALL Times is 1
+    // Failure cases
+    EXPECT_NE(0, dbsync_sync_row(nullptr, jsInsert2.get(), callbackData));
+    EXPECT_NE(0, dbsync_sync_row(handle, nullptr, callbackData));
+    EXPECT_NE(0, dbsync_sync_row(handle, jsInsert2.get(), callbackEmpty));
+}
+
 TEST_F(DBSyncTest, syncRowInvalidData)
 {
     const auto sql{ "CREATE TABLE processes(`pid` BIGINT, `name` TEXT, `tid` BIGINT, PRIMARY KEY (`pid`)) WITHOUT ROWID;"};


### PR DESCRIPTION
(Closes #11435)
## Description

This PR applies changes to DbSync::syncRow() to optionally return the previous values of rows that were updated. Now DbSync::syncRow checks for a "return_old_data" boolean field, which determines whether we should return the diff or not when syncing a row.

<!--
Add a clear description of how the problem has been solved.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors