### PR TITLE
Added wdb_integrity tests for group hash

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -6,7 +6,7 @@ list(APPEND wdb_tests_names "test_wdb_integrity")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug1 -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,sqlite3_step -Wl,--wrap,sqlite3_errmsg \
                          -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,EVP_DigestInit_ex -Wl,--wrap,EVP_DigestUpdate -Wl,--wrap,_DigestFinal_ex \
                          -Wl,--wrap,sqlite3_bind_int64 -Wl,--wrap,sqlite3_column_text -Wl,--wrap,_mdebug2 -Wl,--wrap,wdb_exec_stmt \
-                         -Wl,--wrap,time ${DEBUG_OP_WRAPPERS}")
+                         -Wl,--wrap,time ${DEBUG_OP_WRAPPERS} -Wl,--wrap,wdb_init_stmt_in_cache")
 
 # Add server specific tests to the list
 list(APPEND wdb_tests_names "test_wdb_fim")

--- a/src/unit_tests/wazuh_db/test_wdb_integrity.c
+++ b/src/unit_tests/wazuh_db/test_wdb_integrity.c
@@ -1535,9 +1535,12 @@ void test_wdb_global_group_hash_cache_clear_success(void **state)
     os_sha1 hexdigest;
     int ret;
 
+    /* Storing a dummy hash value before clearing it */
+    snprintf(global_group_hash, sizeof(global_group_hash), "bd612e9ae2faf8a44b387eeb9f3d5a5e577c8c64");
+
     ret = wdb_global_group_hash_cache(operation, hexdigest);
 
-    assert_false(global_group_hash[0]);
+    assert_int_equal(global_group_hash[0], 0);
     assert_int_equal(ret, OS_SUCCESS);
 }
 
@@ -1547,9 +1550,12 @@ void test_wdb_global_group_hash_cache_read_fail(void **state)
     os_sha1 hexdigest;
     int ret;
 
+    /* Clearing the variable before reading it */
+    global_group_hash[0] = 0;
+
     ret = wdb_global_group_hash_cache(operation, hexdigest);
 
-    assert_false(global_group_hash[0]);
+    assert_int_equal(global_group_hash[0], 0);
     assert_int_equal(ret, OS_INVALID);
 }
 
@@ -1563,6 +1569,9 @@ void test_wdb_global_group_hash_cache_write_success(void **state)
 
     assert_string_equal(global_group_hash, hexdigest);
     assert_int_equal(ret, OS_SUCCESS);
+
+    /* Clearing the variable after writing it */
+    global_group_hash[0] = 0;
 }
 
 void test_wdb_global_group_hash_cache_read_success(void **state)
@@ -1571,10 +1580,16 @@ void test_wdb_global_group_hash_cache_read_success(void **state)
     os_sha1 hexdigest;
     int ret;
 
+    /* Storing a dummy hash value before reading it */
+    snprintf(global_group_hash, sizeof(global_group_hash), "bd612e9ae2faf8a44b387eeb9f3d5a5e577c8c64");
+
     ret = wdb_global_group_hash_cache(operation, hexdigest);
 
     assert_string_equal(hexdigest, "bd612e9ae2faf8a44b387eeb9f3d5a5e577c8c64");
     assert_int_equal(ret, OS_SUCCESS);
+
+    /* Clearing the variable after reading it */
+    global_group_hash[0] = 0;
 }
 
 void test_wdb_global_group_hash_cache_invalid_mode(void **state)
@@ -1598,11 +1613,17 @@ void wdb_get_global_group_hash_read_success(void **state)
     os_sha1 hexdigest;
     int ret;
 
+    /* Storing a dummy hash value before reading it */
+    snprintf(global_group_hash, sizeof(global_group_hash), "bd612e9ae2faf8a44b387eeb9f3d5a5e577c8c64");
+
     expect_string(__wrap__mdebug2, formatted_msg, "Using global group hash from cache");
 
     ret = wdb_get_global_group_hash(data, hexdigest);
 
     assert_int_equal(ret, OS_SUCCESS);
+
+    /* Clearing the variable after reading it */
+    global_group_hash[0] = 0;
 }
 
 void wdb_get_global_group_hash_invalid_db_structure(void **state)
@@ -1610,6 +1631,7 @@ void wdb_get_global_group_hash_invalid_db_structure(void **state)
     os_sha1 hexdigest;
     int ret;
 
+    /* Clearing the variable before reading it */
     global_group_hash[0] = 0;
 
     expect_string(__wrap__mdebug1, formatted_msg, "Database structure not initialized. Unable to calculate global group hash.");
@@ -1625,6 +1647,9 @@ void wdb_get_global_group_hash_invalid_statement(void **state)
     os_sha1 hexdigest;
     int ret;
 
+    /* Clearing the variable before reading it */
+    global_group_hash[0] = 0;
+
     expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_GLOBAL_GROUP_HASH_GET);
     will_return(__wrap_wdb_init_stmt_in_cache, NULL);
 
@@ -1639,11 +1664,14 @@ void wdb_get_global_group_hash_calculate_fail(void **state)
     os_sha1 hexdigest;
     int ret;
 
+    /* Clearing the variable before reading it */
+    global_group_hash[0] = 0;
+
     expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_GLOBAL_GROUP_HASH_GET);
     will_return(__wrap_wdb_init_stmt_in_cache, 1);
 
-    will_return(__wrap_sqlite3_step, 0);
-    will_return(__wrap_sqlite3_step, 101);
+    will_return(__wrap_sqlite3_step, SQLITE_OK);
+    will_return(__wrap_sqlite3_step, SQLITE_DONE);
 
     expect_string(__wrap__mdebug2, formatted_msg, "No group hash was found to calculate the global group hash.");
 
@@ -1659,13 +1687,16 @@ void wdb_get_global_group_hash_calculate_success(void **state)
     os_sha1 hexdigest;
     int ret;
 
+    /* Clearing the variable before reading it */
+    global_group_hash[0] = 0;
+
     expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_GLOBAL_GROUP_HASH_GET);
     will_return(__wrap_wdb_init_stmt_in_cache, 1);
 
-    will_return(__wrap_sqlite3_step, 0);
-    will_return(__wrap_sqlite3_step, 100);
-    will_return(__wrap_sqlite3_step, 0);
-    will_return(__wrap_sqlite3_step, 0);
+    will_return(__wrap_sqlite3_step, SQLITE_OK);
+    will_return(__wrap_sqlite3_step, SQLITE_ROW);
+    will_return(__wrap_sqlite3_step, SQLITE_OK);
+    will_return(__wrap_sqlite3_step, SQLITE_OK);
     expect_value(__wrap_sqlite3_column_text, iCol, 0);
     will_return(__wrap_sqlite3_column_text, NULL);
 

--- a/src/unit_tests/wazuh_db/test_wdb_integrity.c
+++ b/src/unit_tests/wazuh_db/test_wdb_integrity.c
@@ -1526,6 +1526,147 @@ void test_wdbi_last_completion_step_fail(void **state)
 
 }
 
+// Test wdb_global_group_hash_cache
+
+void test_wdb_global_group_hash_cache_clear_success(void **state)
+{
+    wdb_global_group_hash_operations_t operation = WDB_GLOBAL_GROUP_HASH_CLEAR;
+    os_sha1 hexdigest;
+    int ret;
+
+    ret = wdb_global_group_hash_cache(operation, hexdigest);
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
+void test_wdb_global_group_hash_cache_read_fail(void **state)
+{
+    wdb_global_group_hash_operations_t operation = WDB_GLOBAL_GROUP_HASH_READ;
+    os_sha1 hexdigest = "bd612e9ae2faf8a44b387eeb9f3d5a5e577c8c64";
+    int ret;
+
+    ret = wdb_global_group_hash_cache(operation, hexdigest);
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_global_group_hash_cache_write_success(void **state)
+{
+    wdb_global_group_hash_operations_t operation = WDB_GLOBAL_GROUP_HASH_WRITE;
+    os_sha1 hexdigest = "bd612e9ae2faf8a44b387eeb9f3d5a5e577c8c64";
+    int ret;
+
+    ret = wdb_global_group_hash_cache(operation, hexdigest);
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
+void test_wdb_global_group_hash_cache_read_success(void **state)
+{
+    wdb_global_group_hash_operations_t operation = WDB_GLOBAL_GROUP_HASH_READ;
+    os_sha1 hexdigest;
+    int ret;
+
+    ret = wdb_global_group_hash_cache(operation, hexdigest);
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
+void test_wdb_global_group_hash_cache_invalid_mode(void **state)
+{
+    wdb_global_group_hash_operations_t operation = 3;
+    os_sha1 hexdigest;
+    int ret;
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Invalid mode for global group hash operation.");
+
+    ret = wdb_global_group_hash_cache(operation, hexdigest);
+    assert_int_equal(ret, OS_INVALID);
+}
+
+// Test wdb_get_global_group_hash
+
+void wdb_get_global_group_hash_read_success(void **state)
+{
+    wdb_t * data = *state;
+    os_sha1 hexdigest;
+    int ret;
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Using global group hash from cache");
+
+    ret = wdb_get_global_group_hash(data, hexdigest);
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
+void wdb_get_global_group_hash_invalid_db_structure(void **state)
+{
+    wdb_global_group_hash_operations_t operation = WDB_GLOBAL_GROUP_HASH_CLEAR;
+    os_sha1 hexdigest;
+    int ret;
+
+    wdb_global_group_hash_cache(operation, hexdigest);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Database structure not initialized. Unable to calculate global group hash.");
+
+    ret = wdb_get_global_group_hash(NULL, hexdigest);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void wdb_get_global_group_hash_invalid_statement(void **state)
+{
+    wdb_t * data = *state;
+    os_sha1 hexdigest;
+    int ret;
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_GLOBAL_GROUP_HASH_GET);
+    will_return(__wrap_wdb_init_stmt_in_cache, NULL);
+
+    ret = wdb_get_global_group_hash(data, hexdigest);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void wdb_get_global_group_hash_calculate_fail(void **state)
+{
+    wdb_t * data = *state;
+    os_sha1 hexdigest;
+    int ret;
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_GLOBAL_GROUP_HASH_GET);
+    will_return(__wrap_wdb_init_stmt_in_cache, 1);
+
+    will_return(__wrap_sqlite3_step, 0);
+    will_return(__wrap_sqlite3_step, 101);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "No group hash was found to calculate the global group hash.");
+
+    ret = wdb_get_global_group_hash(data, hexdigest);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void wdb_get_global_group_hash_calculate_success(void **state)
+{
+    wdb_t * data = *state;
+    data->id = strdup("000");
+    os_sha1 hexdigest;
+    int ret;
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_GLOBAL_GROUP_HASH_GET);
+    will_return(__wrap_wdb_init_stmt_in_cache, 1);
+
+    will_return(__wrap_sqlite3_step, 0);
+    will_return(__wrap_sqlite3_step, 100);
+    will_return(__wrap_sqlite3_step, 0);
+    will_return(__wrap_sqlite3_step, 0);
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, NULL);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "DB(000) has a NULL  checksum.");
+    expect_string(__wrap__mdebug2, formatted_msg, "New global group hash calculated and stored in cache.");
+
+    ret = wdb_get_global_group_hash(data, hexdigest);
+
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         //Test wdb_calculate_stmt_checksum
@@ -1619,6 +1760,20 @@ int main(void) {
 
         // Test wdbi_last_completion
         cmocka_unit_test_setup_teardown(test_wdbi_last_completion_step_fail, setup_wdb_t, teardown_wdb_t),
+
+        // Test wdb_global_group_hash_cache
+        cmocka_unit_test(test_wdb_global_group_hash_cache_clear_success),
+        cmocka_unit_test(test_wdb_global_group_hash_cache_read_fail),
+        cmocka_unit_test(test_wdb_global_group_hash_cache_write_success),
+        cmocka_unit_test(test_wdb_global_group_hash_cache_read_success),
+        cmocka_unit_test(test_wdb_global_group_hash_cache_invalid_mode),
+
+        // Test wdb_get_global_group_hash
+        cmocka_unit_test_setup_teardown(wdb_get_global_group_hash_read_success, setup_wdb_t, teardown_wdb_t),
+        cmocka_unit_test_setup_teardown(wdb_get_global_group_hash_invalid_db_structure, setup_wdb_t, teardown_wdb_t),
+        cmocka_unit_test_setup_teardown(wdb_get_global_group_hash_invalid_statement, setup_wdb_t, teardown_wdb_t),
+        cmocka_unit_test_setup_teardown(wdb_get_global_group_hash_calculate_fail, setup_wdb_t, teardown_wdb_t),
+        cmocka_unit_test_setup_teardown(wdb_get_global_group_hash_calculate_success, setup_wdb_t, teardown_wdb_t),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/unit_tests/wazuh_db/test_wdb_integrity.c
+++ b/src/unit_tests/wazuh_db/test_wdb_integrity.c
@@ -27,6 +27,7 @@
 #include "os_err.h"
 
 int wdb_calculate_stmt_checksum(wdb_t * wdb, sqlite3_stmt * stmt, wdb_component_t component, os_sha1 hexdigest);
+extern os_sha1 global_group_hash;
 
 /* setup/teardown */
 static int setup_wdb_t(void **state) {
@@ -1535,16 +1536,20 @@ void test_wdb_global_group_hash_cache_clear_success(void **state)
     int ret;
 
     ret = wdb_global_group_hash_cache(operation, hexdigest);
+
+    assert_false(global_group_hash[0]);
     assert_int_equal(ret, OS_SUCCESS);
 }
 
 void test_wdb_global_group_hash_cache_read_fail(void **state)
 {
     wdb_global_group_hash_operations_t operation = WDB_GLOBAL_GROUP_HASH_READ;
-    os_sha1 hexdigest = "bd612e9ae2faf8a44b387eeb9f3d5a5e577c8c64";
+    os_sha1 hexdigest;
     int ret;
 
     ret = wdb_global_group_hash_cache(operation, hexdigest);
+
+    assert_false(global_group_hash[0]);
     assert_int_equal(ret, OS_INVALID);
 }
 
@@ -1555,6 +1560,8 @@ void test_wdb_global_group_hash_cache_write_success(void **state)
     int ret;
 
     ret = wdb_global_group_hash_cache(operation, hexdigest);
+
+    assert_string_equal(global_group_hash, hexdigest);
     assert_int_equal(ret, OS_SUCCESS);
 }
 
@@ -1565,6 +1572,8 @@ void test_wdb_global_group_hash_cache_read_success(void **state)
     int ret;
 
     ret = wdb_global_group_hash_cache(operation, hexdigest);
+
+    assert_string_equal(hexdigest, "bd612e9ae2faf8a44b387eeb9f3d5a5e577c8c64");
     assert_int_equal(ret, OS_SUCCESS);
 }
 
@@ -1577,6 +1586,7 @@ void test_wdb_global_group_hash_cache_invalid_mode(void **state)
     expect_string(__wrap__mdebug2, formatted_msg, "Invalid mode for global group hash operation.");
 
     ret = wdb_global_group_hash_cache(operation, hexdigest);
+
     assert_int_equal(ret, OS_INVALID);
 }
 
@@ -1591,16 +1601,16 @@ void wdb_get_global_group_hash_read_success(void **state)
     expect_string(__wrap__mdebug2, formatted_msg, "Using global group hash from cache");
 
     ret = wdb_get_global_group_hash(data, hexdigest);
+
     assert_int_equal(ret, OS_SUCCESS);
 }
 
 void wdb_get_global_group_hash_invalid_db_structure(void **state)
 {
-    wdb_global_group_hash_operations_t operation = WDB_GLOBAL_GROUP_HASH_CLEAR;
     os_sha1 hexdigest;
     int ret;
 
-    wdb_global_group_hash_cache(operation, hexdigest);
+    global_group_hash[0] = 0;
 
     expect_string(__wrap__mdebug1, formatted_msg, "Database structure not initialized. Unable to calculate global group hash.");
 

--- a/src/wazuh_db/wdb_integrity.c
+++ b/src/wazuh_db/wdb_integrity.c
@@ -40,6 +40,8 @@ static const char * COMPONENT_NAMES[] = {
 /* Remove static qualifier when unit testing */
 #define static
 
+os_sha1 global_group_hash;
+
 /* Replace assert with mock_assert */
 extern void mock_assert(const int result, const char* const expression,
                         const char * const file, const int line);
@@ -666,7 +668,9 @@ int wdb_get_global_group_hash(wdb_t * wdb, os_sha1 hexdigest) {
 }
 
 int wdb_global_group_hash_cache(wdb_global_group_hash_operations_t operation, os_sha1 hexdigest) {
-    static os_sha1 global_group_hash = {0};
+    #ifndef WAZUH_UNIT_TESTING
+        static os_sha1 global_group_hash = {0};
+    #endif
 
     if (WDB_GLOBAL_GROUP_HASH_READ == operation) {
         if (global_group_hash[0] == 0) {


### PR DESCRIPTION
|Related issue|
|---|
|#11754|

## Description

This PR adds UT cases for: 

- wdb_get_global_group_hash
- wdb_global_group_hash_cache

## Dod

### Valgrind 

![2](https://user-images.githubusercontent.com/13010397/150214994-6f9ae758-79a5-424d-8607-318f8c5fefde.png)

### Coverage

![1](https://user-images.githubusercontent.com/13010397/150215023-d1aed7a3-8937-4232-a49a-626c50ef72a8.png)

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Valgrind (memcheck and descriptor leaks check)

- [X] Added unit tests (for new features)
