### PR TITLE
Adding unit tests for new Wazuh-DB backup commands

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -30,7 +30,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_scan_info_get -Wl,--wrap,wdb_fim_upd
                         -Wl,--wrap,wdb_package_save -Wl,--wrap,wdb_hotfix_save -Wl,--wrap,wdb_package_update -Wl,--wrap,wdb_package_delete \
                         -Wl,--wrap,wdb_hotfix_delete -Wl,--wrap,time -Wl,--wrap,wdbi_update_attempt  -Wl,--wrap,wdbi_update_completion \
                         -Wl,--wrap,wdb_get_config -Wl,--wrap,wdb_get_internal_config \
-                        -Wl,--wrap,wdb_global_create_backup \
+                        -Wl,--wrap,wdb_global_create_backup -Wl,--wrap,cJSON_Delete \
                         ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_global_parser")
@@ -46,14 +46,15 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_open_global -Wl,--wrap,wdb_leave -Wl
                              -Wl,--wrap,wdb_global_get_all_agents -Wl,--wrap,wdb_global_get_agent_info -Wl,--wrap,wdb_global_reset_agents_connection \
                              -Wl,--wrap,wdb_global_get_agents_by_connection_status -Wl,--wrap,wdb_global_get_agents_to_disconnect \
                              -Wl,--wrap,sqlite3_step -Wl,--wrap,wdb_global_get_groups_integrity -Wl,--wrap,wdb_global_get_backups \
-                             -Wl,--wrap,wdb_global_restore_backup ${DEBUG_OP_WRAPPERS}")
+                             -Wl,--wrap,wdb_global_restore_backup -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_mutex_unlock ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_global")
 list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_begin2 -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,sqlite3_bind_int \
                             -Wl,--wrap,wdb_exec_stmt -Wl,--wrap,wdb_exec_stmt_sized -Wl,--wrap,wdb_step -Wl,--wrap,sqlite3_bind_text \
                             -Wl,--wrap,sqlite3_bind_parameter_index -Wl,--wrap,cJSON_Delete -Wl,--wrap,sqlite3_step -Wl,--wrap,sqlite3_column_int \
-                            -Wl,--wrap,wdb_init_stmt_in_cache -Wl,--wrap,wdb_get_global_group_hash \
-                            ${DEBUG_OP_WRAPPERS}")
+                            -Wl,--wrap,wdb_init_stmt_in_cache -Wl,--wrap,wdb_get_global_group_hash -Wl,--wrap,wdb_commit2 -Wl,--wrap,wdb_finalize_all_statements \
+                            -Wl,--wrap,sqlite3_prepare_v2 -Wl,--wrap,w_get_timestamp -Wl,--wrap,wdb_exec_stmt_silent -Wl,--wrap,w_compress_gzfile \
+                            -Wl,--wrap,sqlite3_finalize -Wl,--wrap,unlink -Wl,--wrap,getpid -Wl,--wrap,opendir ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_agents")
 list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_init_stmt_in_cache -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,wdb_exec_stmt_silent  -Wl,--wrap,sqlite3_step \

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -30,7 +30,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_scan_info_get -Wl,--wrap,wdb_fim_upd
                         -Wl,--wrap,wdb_package_save -Wl,--wrap,wdb_hotfix_save -Wl,--wrap,wdb_package_update -Wl,--wrap,wdb_package_delete \
                         -Wl,--wrap,wdb_hotfix_delete -Wl,--wrap,time -Wl,--wrap,wdbi_update_attempt  -Wl,--wrap,wdbi_update_completion \
                         -Wl,--wrap,wdb_get_config -Wl,--wrap,wdb_get_internal_config \
-                        -Wl,--wrap,wdb_global_create_backup -Wl,--wrap,cJSON_Delete \
+                        -Wl,--wrap,wdb_global_create_backup \
                         ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_global_parser")

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -55,8 +55,8 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg -Wl,-
                             -Wl,--wrap,wdb_init_stmt_in_cache -Wl,--wrap,wdb_get_global_group_hash -Wl,--wrap,wdb_commit2 -Wl,--wrap,wdb_finalize_all_statements \
                             -Wl,--wrap,sqlite3_prepare_v2 -Wl,--wrap,w_get_timestamp -Wl,--wrap,wdb_exec_stmt_silent -Wl,--wrap,w_compress_gzfile \
                             -Wl,--wrap,sqlite3_finalize -Wl,--wrap,unlink -Wl,--wrap,getpid -Wl,--wrap,opendir -Wl,--wrap,closedir -Wl,--wrap,readdir \
-                            -Wl,--wrap,stat -Wl,--wrap,w_uncompress_gzfile -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_close -Wl,--wrap,rename ${DEBUG_OP_WRAPPERS} \
-                            ${STDIO_OP_WRAPPERS}")
+                            -Wl,--wrap,stat -Wl,--wrap,w_uncompress_gzfile -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_close -Wl,--wrap,rename -Wl,--wrap,time \
+                            ${DEBUG_OP_WRAPPERS} ${STDIO_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_agents")
 list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_init_stmt_in_cache -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,wdb_exec_stmt_silent  -Wl,--wrap,sqlite3_step \

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -54,7 +54,9 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg -Wl,-
                             -Wl,--wrap,sqlite3_bind_parameter_index -Wl,--wrap,cJSON_Delete -Wl,--wrap,sqlite3_step -Wl,--wrap,sqlite3_column_int \
                             -Wl,--wrap,wdb_init_stmt_in_cache -Wl,--wrap,wdb_get_global_group_hash -Wl,--wrap,wdb_commit2 -Wl,--wrap,wdb_finalize_all_statements \
                             -Wl,--wrap,sqlite3_prepare_v2 -Wl,--wrap,w_get_timestamp -Wl,--wrap,wdb_exec_stmt_silent -Wl,--wrap,w_compress_gzfile \
-                            -Wl,--wrap,sqlite3_finalize -Wl,--wrap,unlink -Wl,--wrap,getpid -Wl,--wrap,opendir ${DEBUG_OP_WRAPPERS}")
+                            -Wl,--wrap,sqlite3_finalize -Wl,--wrap,unlink -Wl,--wrap,getpid -Wl,--wrap,opendir -Wl,--wrap,closedir -Wl,--wrap,readdir \
+                            -Wl,--wrap,stat -Wl,--wrap,w_uncompress_gzfile -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_close -Wl,--wrap,rename ${DEBUG_OP_WRAPPERS} \
+                            ${STDIO_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_agents")
 list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_init_stmt_in_cache -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,wdb_exec_stmt_silent  -Wl,--wrap,sqlite3_step \

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -30,6 +30,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_scan_info_get -Wl,--wrap,wdb_fim_upd
                         -Wl,--wrap,wdb_package_save -Wl,--wrap,wdb_hotfix_save -Wl,--wrap,wdb_package_update -Wl,--wrap,wdb_package_delete \
                         -Wl,--wrap,wdb_hotfix_delete -Wl,--wrap,time -Wl,--wrap,wdbi_update_attempt  -Wl,--wrap,wdbi_update_completion \
                         -Wl,--wrap,wdb_get_config -Wl,--wrap,wdb_get_internal_config \
+                        -Wl,--wrap,wdb_global_create_backup \
                         ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_global_parser")
@@ -44,7 +45,8 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_open_global -Wl,--wrap,wdb_leave -Wl
                              -Wl,--wrap,wdb_global_sync_agent_info_get -Wl,--wrap,wdb_global_sync_agent_info_set \
                              -Wl,--wrap,wdb_global_get_all_agents -Wl,--wrap,wdb_global_get_agent_info -Wl,--wrap,wdb_global_reset_agents_connection \
                              -Wl,--wrap,wdb_global_get_agents_by_connection_status -Wl,--wrap,wdb_global_get_agents_to_disconnect \
-                             -Wl,--wrap,sqlite3_step -Wl,--wrap,wdb_global_get_groups_integrity ${DEBUG_OP_WRAPPERS}")
+                             -Wl,--wrap,sqlite3_step -Wl,--wrap,wdb_global_get_groups_integrity -Wl,--wrap,wdb_global_get_backups \
+                             -Wl,--wrap,wdb_global_restore_backup ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_global")
 list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_begin2 -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,sqlite3_bind_int \

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -16,6 +16,7 @@
 #include "wazuhdb_op.h"
 
 extern void __real_cJSON_Delete(cJSON *item);
+extern int test_mode;
 
 typedef struct test_struct {
     wdb_t *wdb;
@@ -30,6 +31,7 @@ static int test_setup(void **state) {
     os_calloc(256,sizeof(char),init_data->output);
     os_calloc(1,sizeof(sqlite3 *),init_data->wdb->db);
     *state = init_data;
+    wdb_init_conf();
     return 0;
 }
 
@@ -40,6 +42,7 @@ static int test_teardown(void **state){
     os_free(data->wdb->db);
     os_free(data->wdb);
     os_free(data);
+    wdb_free_conf();
     return 0;
 }
 
@@ -5482,7 +5485,7 @@ void test_wdb_global_create_backup_prepare_failed(void **state) {
     assert_int_equal(result, OS_INVALID);
 }
 
-void test_wdb_global_create_bind_failed(void **state) {
+void test_wdb_global_create_backup_bind_failed(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     int result = OS_INVALID;
     char* test_date = strdup("2015/11/23 12:00:00");
@@ -5504,7 +5507,7 @@ void test_wdb_global_create_bind_failed(void **state) {
     assert_int_equal(result, OS_INVALID);
 }
 
-void test_wdb_global_create_exec_failed(void **state) {
+void test_wdb_global_create_backup_exec_failed(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     int result = OS_INVALID;
     char* test_date = strdup("2015/11/23 12:00:00");
@@ -5527,7 +5530,7 @@ void test_wdb_global_create_exec_failed(void **state) {
     assert_int_equal(result, OS_INVALID);
 }
 
-void test_wdb_global_create_compress_failed(void **state) {
+void test_wdb_global_create_backup_compress_failed(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     int result = OS_INVALID;
     char* test_date = strdup("2015/11/23 12:00:00");
@@ -5555,7 +5558,7 @@ void test_wdb_global_create_compress_failed(void **state) {
     assert_int_equal(result, OS_INVALID);
 }
 
-void test_wdb_global_create_compress_success(void **state) {
+void test_wdb_global_create_backup_success(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     int result = OS_INVALID;
     char* test_date = strdup("2015/11/23 12:00:00");
@@ -5580,13 +5583,255 @@ void test_wdb_global_create_compress_success(void **state) {
     expect_function_call(__wrap_cJSON_Delete);
 
     // wdb_global_remove_old_backups
-    will_return(__wrap_opendir, 0);
+    will_return(__wrap_opendir, NULL);
     expect_string(__wrap__mdebug1, formatted_msg, "Unable to open backup directory 'backup/db'");
 
     result = wdb_global_create_backup(data->wdb, data->output, "-tag");
 
     assert_string_equal(data->output, "ok [\"backup/db/global.db-backup-2015-11-23-12:00:00-tag.gz\"]");
     assert_int_equal(result, OS_SUCCESS);
+}
+
+/* Tests wdb_global_remove_old_backups */
+
+void test_wdb_global_remove_old_backups_opendir_failed(void **state) {
+    int result = OS_INVALID;
+
+    will_return(__wrap_opendir, NULL);
+    expect_string(__wrap__mdebug1, formatted_msg, "Unable to open backup directory 'backup/db'");
+
+    result = wdb_global_remove_old_backups();
+
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_wdb_global_remove_old_backups_success_without_removing(void **state) {
+    int result = OS_INVALID;
+
+    will_return(__wrap_opendir, (DIR*)1);
+    will_return(__wrap_readdir, NULL);
+
+    result = wdb_global_remove_old_backups();
+
+    assert_int_equal(result, OS_SUCCESS);
+}
+
+void test_wdb_global_remove_old_backups_success(void **state) {
+    int result = OS_INVALID;
+    struct dirent* entry = calloc(1, sizeof(struct dirent));
+
+    snprintf(entry->d_name, OS_SIZE_256, "%s", "global.db-backup-TIMESTAMP");
+
+    will_return(__wrap_opendir, (DIR*)1);
+    // To delete a backup, it must find at least one more than max_files
+    wconfig.wdb_backup_settings[WDB_GLOBAL_BACKUP]->max_files = 3;
+    will_return_count(__wrap_readdir, entry, 4);
+    will_return(__wrap_readdir, NULL);
+
+    /* wdb_global_get_oldest_backup */
+    test_mode = 1;
+    will_return(__wrap_opendir, (DIR*)1);
+    will_return(__wrap_readdir, entry);
+    will_return(__wrap_readdir, NULL);
+    struct stat* file_info = calloc(1, sizeof(struct stat));
+    file_info->st_mtime = 0;
+    expect_string(__wrap_stat, __file, "backup/db/global.db-backup-TIMESTAMP");
+    will_return(__wrap_stat, file_info);
+    will_return(__wrap_stat, OS_SUCCESS);
+
+    expect_string(__wrap_unlink, file, "backup/db/global.db-backup-TIMESTAMP");
+    will_return(__wrap_unlink, OS_SUCCESS);
+    expect_string(__wrap__minfo, formatted_msg, "Deleted Global database backup: \"backup/db/global.db-backup-TIMESTAMP\"");
+
+    result = wdb_global_remove_old_backups();
+
+    assert_int_equal(result, OS_SUCCESS);
+    os_free(entry);
+    os_free(file_info);
+    test_mode = 0;
+}
+
+/* Tests wdb_global_get_backups */
+
+void test_wdb_global_get_backups_opendir_failed(void **state) {
+    cJSON* j_result = NULL;
+
+    will_return(__wrap_opendir, NULL);
+    expect_string(__wrap__mdebug1, formatted_msg, "Unable to open backup directory 'backup/db'");
+
+    j_result = wdb_global_get_backups();
+
+    assert_ptr_equal(j_result, NULL);
+}
+
+void test_wdb_global_get_backups_success(void **state) {
+    cJSON* j_result = NULL;
+    struct dirent* entry = calloc(1, sizeof(struct dirent));
+
+    snprintf(entry->d_name, OS_SIZE_256, "%s", "global.db-backup-TIMESTAMP");
+
+    will_return(__wrap_opendir, (DIR*)1);
+    will_return_count(__wrap_readdir, entry, 2);
+    will_return(__wrap_readdir, NULL);
+
+    j_result = wdb_global_get_backups();
+
+    char* str_result = cJSON_PrintUnformatted(j_result);
+    assert_string_equal(str_result, "[\"global.db-backup-TIMESTAMP\",\"global.db-backup-TIMESTAMP\"]");
+    os_free(entry);
+    os_free(str_result);
+    __real_cJSON_Delete(j_result);
+}
+
+/* Tests wdb_global_restore_backup */
+
+void test_wdb_global_restore_backup_pre_restore_failed(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+    int result = OS_INVALID;
+    char* test_date = strdup("2015/11/23 12:00:00");
+
+    will_return(__wrap_w_get_timestamp, test_date);
+    will_return(__wrap_wdb_commit2, OS_INVALID);
+    expect_string(__wrap__merror, formatted_msg, "Creating pre-restore Global DB snapshot failed. Backup restore stopped: "
+                                                 "err Cannot commit current transaction to create backup");
+
+    result = wdb_global_restore_backup(&data->wdb, "global.db-backup-TIMESTAMP", true, data->output);
+
+    assert_string_equal(data->output, "err Cannot commit current transaction to create backup");
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_wdb_global_restore_backup_no_snapshot(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+    int result = OS_INVALID;
+
+    // wdb_global_get_most_recent_backup
+    will_return(__wrap_opendir, NULL);
+    expect_string(__wrap__mdebug1, formatted_msg, "Unable to open backup directory 'backup/db'");
+    expect_string(__wrap__mdebug1, formatted_msg, "Unable to found a snapshot to restore");
+
+    result = wdb_global_restore_backup(&data->wdb, NULL, false, data->output);
+
+    assert_string_equal(data->output, "err Unable to found a snapshot to restore");
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_wdb_global_restore_backup_compression_failed(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+    int result = OS_INVALID;
+
+    expect_string(__wrap_w_uncompress_gzfile, gzfilesrc, "backup/db/global.db-backup-TIMESTAMP.gz");
+    expect_string(__wrap_w_uncompress_gzfile, gzfiledst, "queue/db/global.db.back");
+    will_return(__wrap_w_uncompress_gzfile, OS_INVALID);
+    expect_string(__wrap__mdebug1, formatted_msg, "Failed during backup decompression");
+
+    result = wdb_global_restore_backup(&data->wdb, "global.db-backup-TIMESTAMP.gz", false, data->output);
+
+    assert_string_equal(data->output, "err Failed during backup decompression");
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_wdb_global_restore_backup_success(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+    int result = OS_INVALID;
+    wdb_t *wdb = NULL;
+
+    expect_string(__wrap_w_uncompress_gzfile, gzfilesrc, "backup/db/global.db-backup-TIMESTAMP.gz");
+    expect_string(__wrap_w_uncompress_gzfile, gzfiledst, "queue/db/global.db.back");
+    will_return(__wrap_w_uncompress_gzfile, OS_SUCCESS);
+    will_return(__wrap_wdb_close, OS_SUCCESS);
+    expect_string(__wrap_unlink, file, "queue/db/global.db");
+    will_return(__wrap_unlink, OS_SUCCESS);
+    expect_string(__wrap_rename, __old, "queue/db/global.db.back");
+    expect_string(__wrap_rename, __new, "queue/db/global.db");
+    will_return(__wrap_rename, OS_SUCCESS);
+
+    result = wdb_global_restore_backup(&wdb, "global.db-backup-TIMESTAMP.gz", false, data->output);
+
+    assert_string_equal(data->output, "ok");
+    assert_int_equal(result, OS_SUCCESS);
+}
+
+/* Tests wdb_global_get_most_recent_backup */
+
+void test_wdb_global_get_most_recent_backup_opendir_failed(void **state) {
+    char* most_recent_backup_name = NULL;
+    time_t most_recent_backup_time = OS_INVALID;
+
+    will_return(__wrap_opendir, NULL);
+    expect_string(__wrap__mdebug1, formatted_msg, "Unable to open backup directory 'backup/db'");
+
+    most_recent_backup_time = wdb_global_get_most_recent_backup(&most_recent_backup_name);
+
+    assert_int_equal(most_recent_backup_time, OS_INVALID);
+    assert_ptr_equal(most_recent_backup_name, NULL);
+}
+
+void test_wdb_global_get_most_recent_backup_success(void **state) {
+    char* most_recent_backup_name = NULL;
+    time_t most_recent_backup_time = OS_INVALID;
+    struct dirent* entry = calloc(1, sizeof(struct dirent));
+    struct stat* file_info = calloc(1, sizeof(struct stat));
+
+    test_mode = 1;
+    snprintf(entry->d_name, OS_SIZE_256, "%s", "global.db-backup-TIMESTAMP");
+    will_return(__wrap_opendir, (DIR*)1);
+    will_return(__wrap_readdir, entry);
+    will_return(__wrap_readdir, NULL);
+    file_info->st_mtime = 123;
+    expect_string(__wrap_stat, __file, "backup/db/global.db-backup-TIMESTAMP");
+    will_return(__wrap_stat, file_info);
+    will_return(__wrap_stat, OS_SUCCESS);
+
+    most_recent_backup_time = wdb_global_get_most_recent_backup(&most_recent_backup_name);
+
+    assert_int_equal(most_recent_backup_time, 123);
+    assert_string_equal(most_recent_backup_name, "global.db-backup-TIMESTAMP");
+    os_free(most_recent_backup_name);
+    os_free(entry);
+    os_free(file_info);
+    test_mode = 0;
+}
+
+/* Tests wdb_global_get_oldest_backup */
+
+void test_wdb_global_get_oldest_backup_opendir_failed(void **state) {
+    char* oldest_backup_name = NULL;
+    time_t oldest_backup_time = OS_INVALID;
+
+    will_return(__wrap_opendir, NULL);
+    expect_string(__wrap__mdebug1, formatted_msg, "Unable to open backup directory 'backup/db'");
+
+    oldest_backup_time = wdb_global_get_oldest_backup(&oldest_backup_name);
+
+    assert_int_equal(oldest_backup_time, OS_INVALID);
+    assert_ptr_equal(oldest_backup_name, NULL);
+}
+
+void test_wdb_global_get_oldest_backup_success(void **state) {
+    char* oldest_backup_name = NULL;
+    time_t oldest_backup_time = OS_INVALID;
+    struct dirent* entry = calloc(1, sizeof(struct dirent));
+    struct stat* file_info = calloc(1, sizeof(struct stat));
+
+    test_mode = 1;
+    will_return(__wrap_opendir, (DIR*)1);
+    snprintf(entry->d_name, OS_SIZE_256, "%s", "global.db-backup-TIMESTAMP");
+    will_return(__wrap_readdir, entry);
+    will_return(__wrap_readdir, NULL);
+    file_info->st_mtime = 123;
+    expect_string(__wrap_stat, __file, "backup/db/global.db-backup-TIMESTAMP");
+    will_return(__wrap_stat, file_info);
+    will_return(__wrap_stat, OS_SUCCESS);
+
+    oldest_backup_time = wdb_global_get_oldest_backup(&oldest_backup_name);
+
+    assert_int_equal(oldest_backup_time, 123);
+    assert_string_equal(oldest_backup_name, "global.db-backup-TIMESTAMP");
+    os_free(oldest_backup_name);
+    os_free(entry);
+    os_free(file_info);
+    test_mode = 0;
 }
 
 int main()
@@ -5818,10 +6063,28 @@ int main()
         /* Tests wdb_global_create_backup */
         cmocka_unit_test_setup_teardown(test_wdb_global_create_backup_commit_failed, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_create_backup_prepare_failed, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_create_bind_failed, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_create_exec_failed, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_create_compress_failed, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_create_compress_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_create_backup_bind_failed, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_create_backup_exec_failed, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_create_backup_compress_failed, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_create_backup_success, test_setup, test_teardown),
+        /* Tests wdb_global_remove_old_backups */
+        cmocka_unit_test_setup_teardown(test_wdb_global_remove_old_backups_opendir_failed, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_remove_old_backups_success_without_removing, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_remove_old_backups_success, test_setup, test_teardown),
+        /* Tests wdb_global_get_backups */
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_backups_opendir_failed, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_backups_success, test_setup, test_teardown),
+        /* Tests wdb_global_restore_backup */
+        cmocka_unit_test_setup_teardown(test_wdb_global_restore_backup_pre_restore_failed, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_restore_backup_no_snapshot, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_restore_backup_compression_failed, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_restore_backup_success, test_setup, test_teardown),
+        /* Tests wdb_global_get_most_recent_backup */
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_most_recent_backup_opendir_failed, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_most_recent_backup_success, test_setup, test_teardown),
+        /* Tests wdb_global_get_oldest_backup */
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_oldest_backup_opendir_failed, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_oldest_backup_success, test_setup, test_teardown),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -2203,6 +2203,8 @@ void test_wdb_parse_global_restore_backup_invalid_syntax(void **state) {
     char *query = NULL;
 
     os_strdup("global backup restore {INVALID_JSON}", query);
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: backup restore {INVALID_JSON}");
 
@@ -2223,6 +2225,8 @@ void test_wdb_parse_global_restore_backup_success_missing_snapshot(void **state)
     char *query = NULL;
 
     os_strdup("global backup restore", query);
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: backup restore");
 
@@ -2242,6 +2246,8 @@ void test_wdb_parse_global_restore_backup_success_pre_restore_true(void **state)
     char *query = NULL;
 
     os_strdup("global backup restore {\"snapshot\":\"global.db-backup-TIMESTAMP\",\"save_pre_restore_state\":true}", query);
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: backup restore {\"snapshot\":\"global.db-backup-TIMESTAMP\",\"save_pre_restore_state\":true}");
 
@@ -2262,6 +2268,8 @@ void test_wdb_parse_global_restore_backup_success_pre_restore_false(void **state
     char *query = NULL;
 
     os_strdup("global backup restore {\"snapshot\":\"global.db-backup-TIMESTAMP\",\"save_pre_restore_state\":false}", query);
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: backup restore {\"snapshot\":\"global.db-backup-TIMESTAMP\",\"save_pre_restore_state\":false}");
 
@@ -2282,6 +2290,8 @@ void test_wdb_parse_global_restore_backup_success_pre_restore_missing(void **sta
     char *query = NULL;
 
     os_strdup("global backup restore {\"snapshot\":\"global.db-backup-TIMESTAMP\"}", query);
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: backup restore {\"snapshot\":\"global.db-backup-TIMESTAMP\"}");
 

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -2153,6 +2153,150 @@ void test_wdb_parse_global_get_agents_by_connection_status_query_success(void **
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+
+/* wdb_parse_global_get_backup */
+
+void test_wdb_parse_global_get_backup_failed(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+    int result = OS_INVALID;
+    char *query = NULL;
+
+    os_strdup("global backup get", query);
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: backup get");
+
+    will_return(__wrap_wdb_global_get_backups, NULL);
+
+    result = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "err Cannot execute backup get command, unable to open 'backup/db' folder");
+    assert_int_equal(result, OS_INVALID);
+
+    os_free(query);
+}
+
+void test_wdb_parse_global_get_backup_success(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+    int result = OS_INVALID;
+    char *query = NULL;
+    cJSON* j_backup = cJSON_Parse("[\"global.db-backup-TIMESTAMP\"]");
+
+    os_strdup("global backup get", query);
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: backup get");
+
+    will_return(__wrap_wdb_global_get_backups, j_backup);
+
+    result = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "ok [\"global.db-backup-TIMESTAMP\"]");
+    assert_int_equal(result, OS_SUCCESS);
+
+    os_free(query);
+}
+
+/* wdb_parse_global_restore_backup */
+
+void test_wdb_parse_global_restore_backup_invalid_syntax(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+    int result = OS_INVALID;
+    char *query = NULL;
+
+    os_strdup("global backup restore {INVALID_JSON}", query);
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: backup restore {INVALID_JSON}");
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid backup JSON syntax when restoring snapshot.");
+    expect_string(__wrap__mdebug2, formatted_msg, "JSON error near: NVALID_JSON}");
+
+    result = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "err Invalid JSON syntax, near '{INVALID_JSON}'");
+    assert_int_equal(result, OS_INVALID);
+
+    os_free(query);
+}
+
+void test_wdb_parse_global_restore_backup_success_missing_snapshot(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+    int result = OS_INVALID;
+    char *query = NULL;
+
+    os_strdup("global backup restore", query);
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: backup restore");
+
+    expect_value(__wrap_wdb_global_restore_backup, save_pre_restore_state, false);
+    will_return(__wrap_wdb_global_restore_backup, OS_SUCCESS);
+
+    result = wdb_parse(query, data->output, 0);
+
+    assert_int_equal(result, OS_SUCCESS);
+
+    os_free(query);
+}
+
+void test_wdb_parse_global_restore_backup_success_pre_restore_true(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+    int result = OS_INVALID;
+    char *query = NULL;
+
+    os_strdup("global backup restore {\"snapshot\":\"global.db-backup-TIMESTAMP\",\"save_pre_restore_state\":true}", query);
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: backup restore {\"snapshot\":\"global.db-backup-TIMESTAMP\",\"save_pre_restore_state\":true}");
+
+    expect_string(__wrap_wdb_global_restore_backup, snapshot, "global.db-backup-TIMESTAMP");
+    expect_value(__wrap_wdb_global_restore_backup, save_pre_restore_state, true);
+    will_return(__wrap_wdb_global_restore_backup, OS_SUCCESS);
+
+    result = wdb_parse(query, data->output, 0);
+
+    assert_int_equal(result, OS_SUCCESS);
+
+    os_free(query);
+}
+
+void test_wdb_parse_global_restore_backup_success_pre_restore_false(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+    int result = OS_INVALID;
+    char *query = NULL;
+
+    os_strdup("global backup restore {\"snapshot\":\"global.db-backup-TIMESTAMP\",\"save_pre_restore_state\":false}", query);
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: backup restore {\"snapshot\":\"global.db-backup-TIMESTAMP\",\"save_pre_restore_state\":false}");
+
+    expect_string(__wrap_wdb_global_restore_backup, snapshot, "global.db-backup-TIMESTAMP");
+    expect_value(__wrap_wdb_global_restore_backup, save_pre_restore_state, false);
+    will_return(__wrap_wdb_global_restore_backup, OS_SUCCESS);
+
+    result = wdb_parse(query, data->output, 0);
+
+    assert_int_equal(result, OS_SUCCESS);
+
+    os_free(query);
+}
+
+void test_wdb_parse_global_restore_backup_success_pre_restore_missing(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+    int result = OS_INVALID;
+    char *query = NULL;
+
+    os_strdup("global backup restore {\"snapshot\":\"global.db-backup-TIMESTAMP\"}", query);
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: backup restore {\"snapshot\":\"global.db-backup-TIMESTAMP\"}");
+
+    expect_string(__wrap_wdb_global_restore_backup, snapshot, "global.db-backup-TIMESTAMP");
+    expect_value(__wrap_wdb_global_restore_backup, save_pre_restore_state, false);
+    will_return(__wrap_wdb_global_restore_backup, OS_SUCCESS);
+
+    result = wdb_parse(query, data->output, 0);
+
+    assert_int_equal(result, OS_SUCCESS);
+
+    os_free(query);
+}
+
+
 int main()
 {
     const struct CMUnitTest tests[] = {
@@ -2287,6 +2431,15 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agents_by_connection_status_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agents_by_connection_status_status_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agents_by_connection_status_query_success, test_setup, test_teardown),
+        /* wdb_parse_global_get_backup */
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_backup_failed, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_backup_success, test_setup, test_teardown),
+        /* wdb_parse_global_restore_backup */
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_restore_backup_invalid_syntax, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_restore_backup_success_missing_snapshot, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_restore_backup_success_pre_restore_true, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_restore_backup_success_pre_restore_false, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_restore_backup_success_pre_restore_missing, test_setup, test_teardown),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wazuh_db/test_wdb_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_parser.c
@@ -2407,6 +2407,95 @@ void test_wdb_parse_get_config_bad_arg(){
     expect_string(__wrap__mdebug1, formatted_msg, "Invalid configuration source for wazuh-db");
     cJSON *ret = wdb_parse_get_config("BAD_ARG");
     assert_int_equal(ret, NULL);
+/* wdb_parse_global_backup */
+
+void test_wdb_parse_global_backup_invalid_syntax(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+    int result = OS_INVALID;
+    char *query = NULL;
+
+    os_strdup("global backup", query);
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: backup");
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for backup.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: backup");
+
+    result = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "err Invalid DB query syntax, near 'backup'");
+    assert_int_equal(result, OS_INVALID);
+
+    os_free(query);
+}
+
+void test_wdb_parse_global_backup_missing_action(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+    int result = OS_INVALID;
+    char *query = NULL;
+
+    os_strdup("", query);
+
+    result = wdb_parse_global_backup(NULL, query, data->output);
+
+    assert_string_equal(data->output, "err Missing backup action");
+    assert_int_equal(result, OS_INVALID);
+    os_free(query);
+}
+
+void test_wdb_parse_global_backup_invalid_action(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+    int result = OS_INVALID;
+    char *query = NULL;
+
+    os_strdup("invalid", query);
+
+    result = wdb_parse_global_backup(NULL, query, data->output);
+
+    assert_string_equal(data->output, "err Invalid backup action: invalid");
+    assert_int_equal(result, OS_INVALID);
+    os_free(query);
+}
+
+void test_wdb_parse_global_backup_create_failed(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+    int result = OS_INVALID;
+    char *query = NULL;
+
+    os_strdup("global backup create", query);
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: backup create");
+
+    will_return(__wrap_wdb_global_create_backup, "ERROR MESSAGE");
+    will_return(__wrap_wdb_global_create_backup, OS_INVALID);
+    expect_string(__wrap__merror, formatted_msg, "Creating Global DB snapshot on demand failed: ERROR MESSAGE");
+
+    result = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "ERROR MESSAGE");
+    assert_int_equal(result, OS_INVALID);
+
+    os_free(query);
+}
+
+void test_wdb_parse_global_backup_create_success(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+    int result = OS_INVALID;
+    char *query = NULL;
+
+    os_strdup("global backup create", query);
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: backup create");
+
+    will_return(__wrap_wdb_global_create_backup, "ok SNAPSHOT");
+    will_return(__wrap_wdb_global_create_backup, OS_SUCCESS);
+
+    result = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "ok SNAPSHOT");
+    assert_int_equal(result, OS_SUCCESS);
+
+    os_free(query);
 }
 
 int main()
@@ -2548,8 +2637,13 @@ int main()
         cmocka_unit_test(test_wdb_parse_get_config_internal),
         cmocka_unit_test(test_wdb_parse_get_config_arg_null),
         cmocka_unit_test(test_wdb_parse_get_config_bad_arg)
+        /* wdb_parse_global_backup */
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_backup_invalid_syntax, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_backup_missing_action, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_backup_invalid_action, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_backup_create_failed, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_backup_create_success, test_setup, test_teardown),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);
-
 }

--- a/src/unit_tests/wazuh_db/test_wdb_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_parser.c
@@ -2407,6 +2407,9 @@ void test_wdb_parse_get_config_bad_arg(){
     expect_string(__wrap__mdebug1, formatted_msg, "Invalid configuration source for wazuh-db");
     cJSON *ret = wdb_parse_get_config("BAD_ARG");
     assert_int_equal(ret, NULL);
+
+}
+
 /* wdb_parse_global_backup */
 
 void test_wdb_parse_global_backup_invalid_syntax(void **state) {
@@ -2636,7 +2639,7 @@ int main()
         cmocka_unit_test(test_wdb_parse_get_config_wdb),
         cmocka_unit_test(test_wdb_parse_get_config_internal),
         cmocka_unit_test(test_wdb_parse_get_config_arg_null),
-        cmocka_unit_test(test_wdb_parse_get_config_bad_arg)
+        cmocka_unit_test(test_wdb_parse_get_config_bad_arg),
         /* wdb_parse_global_backup */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_backup_invalid_syntax, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_backup_missing_action, test_setup, test_teardown),

--- a/src/unit_tests/wazuh_db/test_wdb_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_parser.c
@@ -30,6 +30,7 @@ static int test_setup(void **state) {
     init_data->wdb->id = strdup("000");
     init_data->output = malloc(256*sizeof(char));
     init_data->wdb->peer = 1234;
+    init_data->wdb->enabled = true;
 
     *state = init_data;
 

--- a/src/unit_tests/wazuh_db/test_wdb_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_parser.c
@@ -2386,28 +2386,27 @@ void test_hotfixes_no_action(void **state) {
     os_free(query);
 }
 
-void test_wdb_parse_get_config_internal(){
+void test_wdb_parse_get_config_internal() {
     will_return(__wrap_wdb_get_internal_config, 1);
     cJSON *ret = wdb_parse_get_config("internal");
     assert_int_equal(ret, 1);
 }
 
-void test_wdb_parse_get_config_wdb(){
+void test_wdb_parse_get_config_wdb() {
     will_return(__wrap_wdb_get_config, 1);
     cJSON *ret = wdb_parse_get_config("wdb");
     assert_int_equal(ret, 1);
 }
 
-void test_wdb_parse_get_config_arg_null(){
+void test_wdb_parse_get_config_arg_null() {
     cJSON *ret = wdb_parse_get_config(0);
     assert_int_equal(ret, NULL);
 }
 
-void test_wdb_parse_get_config_bad_arg(){
+void test_wdb_parse_get_config_bad_arg() {
     expect_string(__wrap__mdebug1, formatted_msg, "Invalid configuration source for wazuh-db");
     cJSON *ret = wdb_parse_get_config("BAD_ARG");
     assert_int_equal(ret, NULL);
-
 }
 
 /* wdb_parse_global_backup */

--- a/src/unit_tests/wrappers/externals/cJSON/cJSON_wrappers.c
+++ b/src/unit_tests/wrappers/externals/cJSON/cJSON_wrappers.c
@@ -13,6 +13,7 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
+cJSON_wrappers_use_real_flags_t cJSON_wrappers_use_real_flags = {0};
 
 cJSON_bool __wrap_cJSON_AddItemToArray(__attribute__ ((__unused__)) cJSON *array,
                                  __attribute__ ((__unused__)) cJSON *item) {
@@ -83,8 +84,13 @@ cJSON * __wrap_cJSON_CreateString(const char *string) {
     return mock_type(cJSON *);
 }
 
+extern void __real_cJSON_Delete(cJSON *item);
 void __wrap_cJSON_Delete(__attribute__ ((__unused__)) cJSON *item) {
-    function_called();
+    if(cJSON_wrappers_use_real_flags.cJSON_Delete_use_real) {
+        __real_cJSON_Delete(item);
+    } else {
+        function_called();
+    }
     return;
 }
 

--- a/src/unit_tests/wrappers/externals/cJSON/cJSON_wrappers.c
+++ b/src/unit_tests/wrappers/externals/cJSON/cJSON_wrappers.c
@@ -13,8 +13,6 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-cJSON_wrappers_use_real_flags_t cJSON_wrappers_use_real_flags = {0};
-
 cJSON_bool __wrap_cJSON_AddItemToArray(__attribute__ ((__unused__)) cJSON *array,
                                  __attribute__ ((__unused__)) cJSON *item) {
     function_called();
@@ -84,13 +82,8 @@ cJSON * __wrap_cJSON_CreateString(const char *string) {
     return mock_type(cJSON *);
 }
 
-extern void __real_cJSON_Delete(cJSON *item);
 void __wrap_cJSON_Delete(__attribute__ ((__unused__)) cJSON *item) {
-    if(cJSON_wrappers_use_real_flags.cJSON_Delete_use_real) {
-        __real_cJSON_Delete(item);
-    } else {
-        function_called();
-    }
+    function_called();
     return;
 }
 

--- a/src/unit_tests/wrappers/externals/cJSON/cJSON_wrappers.h
+++ b/src/unit_tests/wrappers/externals/cJSON/cJSON_wrappers.h
@@ -19,12 +19,6 @@
 #define WSTD_CALL
 #endif
 
-typedef struct cJSON_wrappers_use_real_flags_t {
-    bool cJSON_Delete_use_real;
-} cJSON_wrappers_use_real_flags_t;
-extern cJSON_wrappers_use_real_flags_t cJSON_wrappers_use_real_flags;
-
-
 cJSON_bool __wrap_cJSON_AddItemToArray(cJSON *array, cJSON *item);
 
 extern cJSON_bool __real_cJSON_AddItemToArray(cJSON *array, cJSON *item);

--- a/src/unit_tests/wrappers/externals/cJSON/cJSON_wrappers.h
+++ b/src/unit_tests/wrappers/externals/cJSON/cJSON_wrappers.h
@@ -7,17 +7,23 @@
  * Foundation
  */
 
-
 #ifndef CJSON_WRAPPERS_H
 #define CJSON_WRAPPERS_H
 
-#include <external/cJSON/cJSON.h>
+#include "external/cJSON/cJSON.h"
+#include <stdbool.h>
 
 #ifdef WIN32
 #define WSTD_CALL __stdcall
 #else
 #define WSTD_CALL
 #endif
+
+typedef struct cJSON_wrappers_use_real_flags_t {
+    bool cJSON_Delete_use_real;
+} cJSON_wrappers_use_real_flags_t;
+extern cJSON_wrappers_use_real_flags_t cJSON_wrappers_use_real_flags;
+
 
 cJSON_bool __wrap_cJSON_AddItemToArray(cJSON *array, cJSON *item);
 
@@ -27,78 +33,78 @@ cJSON_bool __wrap_cJSON_AddItemToObject(cJSON *object, const char *string, cJSON
 
 extern cJSON_bool __real_cJSON_AddItemToObject(cJSON *object, const char *string, cJSON *item);
 
-cJSON * __wrap_cJSON_AddStringToObject(cJSON * const object, const char * const name, const char * const string);
+cJSON *__wrap_cJSON_AddStringToObject(cJSON *const object, const char *const name, const char *const string);
 
-cJSON* __wrap_cJSON_AddObjectToObject(cJSON * const object, const char * const name);
+cJSON *__wrap_cJSON_AddObjectToObject(cJSON *const object, const char *const name);
 
-extern cJSON * __real_cJSON_AddStringToObject(cJSON * const object, const char * const name, const char * const string);
+extern cJSON *__real_cJSON_AddStringToObject(cJSON *const object, const char *const name, const char *const string);
 
-cJSON* __wrap_cJSON_AddArrayToObject(cJSON * const object, const char * const name);
+cJSON *__wrap_cJSON_AddArrayToObject(cJSON *const object, const char *const name);
 
-extern cJSON* __real_cJSON_AddArrayToObject(cJSON * const object, const char * const name);
+extern cJSON *__real_cJSON_AddArrayToObject(cJSON *const object, const char *const name);
 
-cJSON * __wrap_cJSON_AddNumberToObject(cJSON * const object, const char * const name, const double number);
+cJSON *__wrap_cJSON_AddNumberToObject(cJSON *const object, const char *const name, const double number);
 
-extern cJSON * __real_cJSON_AddNumberToObject(cJSON * const object, const char * const name, const double number);
+extern cJSON *__real_cJSON_AddNumberToObject(cJSON *const object, const char *const name, const double number);
 
 #ifdef WIN32
-extern cJSON * __stdcall __real_cJSON_CreateArray(void);
+extern cJSON *__stdcall __real_cJSON_CreateArray(void);
 
-cJSON * __stdcall __wrap_cJSON_CreateArray(void);
+cJSON *__stdcall __wrap_cJSON_CreateArray(void);
 
-extern cJSON * __stdcall __real_cJSON_CreateObject(void);
+extern cJSON *__stdcall __real_cJSON_CreateObject(void);
 
-cJSON * __stdcall __wrap_cJSON_CreateObject(void);
+cJSON *__stdcall __wrap_cJSON_CreateObject(void);
 #else
-extern cJSON * __real_cJSON_CreateArray(void);
+extern cJSON *__real_cJSON_CreateArray(void);
 
-cJSON * __wrap_cJSON_CreateArray(void);
+cJSON *__wrap_cJSON_CreateArray(void);
 
-extern cJSON * __real_cJSON_CreateObject(void);
+extern cJSON *__real_cJSON_CreateObject(void);
 
-cJSON * __wrap_cJSON_CreateObject(void);
+cJSON *__wrap_cJSON_CreateObject(void);
 #endif
 
-cJSON * __wrap_cJSON_CreateNumber(double num);
+cJSON *__wrap_cJSON_CreateNumber(double num);
 
-extern cJSON * __real_cJSON_CreateNumber(double num);
+extern cJSON *__real_cJSON_CreateNumber(double num);
 
-cJSON * __wrap_cJSON_CreateString(const char *string);
+cJSON *__wrap_cJSON_CreateString(const char *string);
 
-extern cJSON * __real_cJSON_CreateString(const char *string);
+extern cJSON *__real_cJSON_CreateString(const char *string);
 
 void __wrap_cJSON_Delete(cJSON *item);
 
 extern void __real_cJSON_Delete(cJSON *item);
 
-cJSON * WSTD_CALL __wrap_cJSON_GetObjectItem(const cJSON * const object, const char * const string);
+cJSON *WSTD_CALL __wrap_cJSON_GetObjectItem(const cJSON *const object, const char *const string);
 
-extern cJSON * __real_cJSON_GetObjectItem(const cJSON * const object, const char * const string);
+extern cJSON *__real_cJSON_GetObjectItem(const cJSON *const object, const char *const string);
 
-char* WSTD_CALL __wrap_cJSON_GetStringValue(cJSON * item);
+char *WSTD_CALL __wrap_cJSON_GetStringValue(cJSON *item);
 
-cJSON_bool __wrap_cJSON_IsNumber(cJSON * item);
+cJSON_bool __wrap_cJSON_IsNumber(cJSON *item);
 
-cJSON_bool __wrap_cJSON_IsObject(cJSON * item);
+cJSON_bool __wrap_cJSON_IsObject(cJSON *item);
 
-cJSON * __wrap_cJSON_Parse(const char *value);
+cJSON *__wrap_cJSON_Parse(const char *value);
 
-cJSON * __wrap_cJSON_ParseWithOpts(const char *value, const char **return_parse_end, cJSON_bool require_null_terminated);
+cJSON *__wrap_cJSON_ParseWithOpts(const char *value, const char **return_parse_end, cJSON_bool require_null_terminated);
 
-extern cJSON * __real_cJSON_Parse(const char *value);
+extern cJSON *__real_cJSON_Parse(const char *value);
 
-char * __wrap_cJSON_PrintUnformatted(const cJSON *item);
+char *__wrap_cJSON_PrintUnformatted(const cJSON *item);
 
-char * __wrap_cJSON_Print(const cJSON *item);
+char *__wrap_cJSON_Print(const cJSON *item);
 
 int __wrap_cJSON_GetArraySize(const cJSON *array);
 
-cJSON * __wrap_cJSON_GetArrayItem(const cJSON *array, int index);
+cJSON *__wrap_cJSON_GetArrayItem(const cJSON *array, int index);
 
-extern cJSON * __real_cJSON_GetArrayItem(const cJSON *array, int index);
+extern cJSON *__real_cJSON_GetArrayItem(const cJSON *array, int index);
 
-cJSON* __wrap_cJSON_Duplicate(const cJSON *item, int recurse);
+cJSON *__wrap_cJSON_Duplicate(const cJSON *item, int recurse);
 
-cJSON* __wrap_cJSON_AddBoolToObject(cJSON * const object, const char * const name, const cJSON_bool boolean);
+cJSON *__wrap_cJSON_AddBoolToObject(cJSON *const object, const char *const name, const cJSON_bool boolean);
 
 #endif

--- a/src/unit_tests/wrappers/wazuh/shared/shared.cmake
+++ b/src/unit_tests/wrappers/wazuh/shared/shared.cmake
@@ -28,3 +28,14 @@ set(DEBUG_OP_WRAPPERS "-Wl,--wrap,_mdebug1 \
                        -Wl,--wrap,_mtinfo \
                        -Wl,--wrap,_mtwarn \
                        -Wl,--wrap,_mwarn")
+
+set(STDIO_OP_WRAPPERS "-Wl,--wrap,fclose \
+                       -Wl,--wrap,fflush \
+                       -Wl,--wrap,fgets \
+                       -Wl,--wrap,fgetpos \
+                       -Wl,--wrap,fopen \
+                       -Wl,--wrap,fread \
+                       -Wl,--wrap,fseek \
+                       -Wl,--wrap,fwrite \
+                       -Wl,--wrap,remove \
+                       -Wl,--wrap,fgetc")

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -261,3 +261,23 @@ int __wrap_wdb_global_agent_exists(wdb_t *wdb, int agent_id) {
     check_expected(agent_id);
     return mock();
 }
+
+cJSON* __wrap_wdb_global_get_backups() {
+    return mock_ptr_type(cJSON*);
+}
+
+int __wrap_wdb_global_create_backup(__attribute__((unused)) wdb_t* wdb,
+                                    char* output,
+                                    const char* tag) {
+    snprintf(output, OS_MAXSTR + 1, "%s%s", mock_ptr_type(char*), tag ? tag : "");
+    return mock();
+}
+
+int __wrap_wdb_global_restore_backup(__attribute__((unused)) wdb_t** wdb,
+                                     char* snapshot,
+                                     bool save_pre_restore_state,
+                                     __attribute__((unused)) char* output) {
+    if (snapshot) {check_expected(snapshot);}
+    check_expected(save_pre_restore_state);
+    return mock();
+}

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -86,4 +86,11 @@ cJSON* __wrap_wdb_global_get_groups_integrity(wdb_t *wdb, os_sha1 hash);
 cJSON* __wrap_wdb_global_get_agents_to_disconnect(wdb_t *wdb, int last_agent_id, int keep_alive, const char *sync_status, wdbc_result* status);
 
 int __wrap_wdb_global_agent_exists(wdb_t *wdb, int agent_id);
+
+cJSON* __wrap_wdb_global_get_backups();
+
+int __wrap_wdb_global_create_backup(wdb_t* wdb, char* output, const char* tag);
+
+int __wrap_wdb_global_restore_backup(wdb_t** wdb, char* snapshot, bool save_pre_restore_state, char* output);
+
 #endif

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
@@ -352,3 +352,11 @@ int __wrap_wdb_get_global_group_hash(__attribute__((unused))wdb_t * wdb,
     check_expected(hexdigest);
     return mock();
 }
+
+int __wrap_wdb_commit2(__attribute__((unused))wdb_t * wdb) {
+    return mock();
+}
+
+void __wrap_wdb_finalize_all_statements(__attribute__((unused))wdb_t * wdb) {
+    function_called();
+}

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
@@ -85,4 +85,8 @@ cJSON *__wrap_wdb_get_config();
 
 int __wrap_wdb_get_global_group_hash(wdb_t * wdb, os_sha1 hexdigest);
 
+int __wrap_wdb_commit2(wdb_t * wdb);
+
+void __wrap_wdb_finalize_all_statements(__attribute__((unused))wdb_t * wdb);
+
 #endif

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1921,6 +1921,7 @@ time_t wdb_global_get_oldest_backup(char **oldest_backup_name) {
 
     struct dirent *entry = NULL;
     time_t oldest_backup_time = OS_INVALID;
+    time_t aux_time_var = OS_INVALID;
     time_t current_time = time(NULL);
     char *tmp_backup_name = NULL;
 
@@ -1933,8 +1934,9 @@ time_t wdb_global_get_oldest_backup(char **oldest_backup_name) {
 
         snprintf(tmp_path, OS_SIZE_512, "%s/%s", WDB_BACKUP_FOLDER, entry->d_name);
         if(!stat(tmp_path, &backup_info) ) {
-            if((current_time - backup_info.st_mtime) >= oldest_backup_time) {
-                oldest_backup_time = current_time - backup_info.st_mtime;
+            if((current_time - backup_info.st_mtime) >= aux_time_var) {
+                aux_time_var = current_time - backup_info.st_mtime;
+                oldest_backup_time = backup_info.st_mtime;
                 tmp_backup_name = entry->d_name;
             }
         }

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1709,7 +1709,6 @@ int wdb_global_create_backup(wdb_t* wdb, char* output, const char* tag) {
 
     // Commiting pending transaction to run VACUUM
     if (wdb_commit2(wdb) == OS_INVALID) {
-        mdebug1("Cannot commit current transaction to create backup");
         snprintf(output, OS_MAXSTR + 1, "err Cannot commit current transaction to create backup");
         return OS_INVALID;
     }
@@ -1720,12 +1719,11 @@ int wdb_global_create_backup(wdb_t* wdb, char* output, const char* tag) {
     sqlite3_stmt *stmt = NULL;
 
     if (sqlite3_prepare_v2(wdb->db, SQL_VACUUM_INTO, -1, &stmt, NULL) != SQLITE_OK) {
-        mdebug1("sqlite3_prepare_v2(): %s", sqlite3_errmsg(wdb->db));
+        snprintf(output, OS_MAXSTR + 1, "err DB(%s) sqlite3_prepare_v2(): %s", wdb->id, sqlite3_errmsg(wdb->db));
         return OS_INVALID;
     }
 
     if (sqlite3_bind_text(stmt, 1, path , -1, NULL) != SQLITE_OK) {
-        merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
         snprintf(output, OS_MAXSTR + 1, "err DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
         sqlite3_finalize(stmt);
         return OS_INVALID;
@@ -1743,10 +1741,10 @@ int wdb_global_create_backup(wdb_t* wdb, char* output, const char* tag) {
         result = w_compress_gzfile(path, path_compressed);
         unlink(path);
         if(OS_SUCCESS == result) {
-            minfo("Created Global database backup \"%s\"", path);
+            minfo("Created Global database backup \"%s\"", path_compressed);
             wdb_global_remove_old_backups();
             cJSON* j_path = cJSON_CreateArray();
-            cJSON_AddItemToArray(j_path, cJSON_CreateString(path));
+            cJSON_AddItemToArray(j_path, cJSON_CreateString(path_compressed));
             char* output_str = cJSON_PrintUnformatted(j_path);
             snprintf(output, OS_MAXSTR + 1, "ok %s", output_str);
             cJSON_Delete(j_path);


### PR DESCRIPTION
|Related issue|
|---|
|#11754|

## Description

This PR adds all the necessary unit tests to cover the Wazuh-DB backup commands parsing and implementation. It also improves some error messages that weren't consistent.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] AddressSanitizer
