### PR TITLE
ruleset/sca: Add Alibaba Cloud Linux (Aliyun Linux) 2 CIS SCA

### DIFF
--- a/etc/templates/config/alinux/2/sca.files
+++ b/etc/templates/config/alinux/2/sca.files
@@ -1,0 +1,1 @@
+alibaba/cis_aliyun_linux_2.yml

--- a/etc/templates/config/generic/sca.manager.files
+++ b/etc/templates/config/generic/sca.manager.files
@@ -1,4 +1,5 @@
 generic/sca_unix_audit.yml
+alibaba/cis_aliyun_linux_2.yml
 amazon/cis_amazon_linux_1.yml
 amazon/cis_amazon_linux_2.yml
 applications/cis_apache_24.yml

--- a/ruleset/sca/alibaba/cis_aliyun_linux_2.yml
+++ b/ruleset/sca/alibaba/cis_aliyun_linux_2.yml
@@ -1,0 +1,2572 @@
+# Security Configuration Assessment
+# CIS Checks for Alibaba Cloud Linux (Aliyun Linux) 2
+# Copyright (C) 2015-2022, Wazuh Inc.
+#
+# This program is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation
+#
+# Based on:
+# Center for Internet Security Aliyun Linux 2 Benchmark v1.0.0 - 08-16-2019
+
+policy:
+  id: "cis_aliyun_linux_2"
+  file: "cis_aliyun_linux_2.yml"
+  name: "CIS Benchmark for Alibaba Cloud Linux (Aliyun Linux) 2"
+  description: "This document provides prescriptive guidance for establishing a secure configuration posture for Alibaba Cloud Linux (Aliyun Linux) 2 systems running on x86 and x64 platforms. This document was tested against Alibaba Cloud Linux (Aliyun Linux) 2."
+  references:
+    - https://www.cisecurity.org/cis-benchmarks/
+
+requirements:
+  title: "Check that the SSH service and password-related files are present on the system"
+  description: "Requirements for running the SCA scan against the Unix based systems policy."
+  condition: any
+  rules:
+    - 'f:/etc/alinux-release -> r:^Alibaba && r:release 2'
+
+variables:
+  $sshd_file: /etc/ssh/sshd_config
+
+checks:
+
+###############################################
+# 1 Initial Setup
+################################################
+###############################################
+# 1.1 Filesystem Configuration
+###############################################
+
+# 1.1.1 squashfs: filesystem
+  - id: 21000
+    title: "Ensure mounting of squashfs filesystems is disabled (Scored)."
+    description: "The squashfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems (similar to cramfs ). A squashfs image can be used without having to first decompress the image."
+    rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
+    remediation: "Edit or create the file in the /etc/modprobe.d/ directory ending in .conf and add the following line: install squashfs /bin/true. Run the following command to unload the squashfs module: rmmod squashfs"
+    compliance:
+      - cis: ["1.1.1"]
+      - cis_level: ["1"]
+    references:
+      - AJ Lewis, "LVM HOWTO", https://tldp.org/HOWTO/LVM-HOWTO/
+    condition: all
+    rules:
+      - 'c:modprobe -n -v squashfs -> r:install /bin/true|Module squashfs not found'
+      - 'not c:lsmod -> r:squashfs'
+
+# 1.1.2 /tmp: partition
+  - id: 21001
+    title: "Ensure /tmp is configured (Scored)."
+    description: "The /tmp directory is a world-writable directory used for temporary storage by all users and some applications."
+    rationale: "Making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw. This can be accomplished by either mounting tmpfs to /tmp, or creating a separate partition for /tmp."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /tmp . For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate. Example: tmpfs /tmp tmpfs defaults,rw,nosuid,nodev,noexec,relatime 0 0    Run the following command to mount /tmp.  mount tmpfs /tmp -t tmpfs"
+    compliance:
+      - cis: ["1.1.2"]
+      - cis_level: ["1"]
+    references:
+      - AJ Lewis, "LVM HOWTO", https://tldp.org/HOWTO/LVM-HOWTO/
+    condition: any
+    rules:
+      - 'c:mount -> r:\s/tmp\s'
+      - 'f:/etc/fstab -> r:\s/tmp\s'
+      - 'c:systemctl is-enabled tmp.mount -> r:enabled'
+
+# 1.1.3 /tmp: nodev
+  - id: 21002
+    title: "Ensure nodev option set on /tmp partition (Scored)."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /tmp."
+    remediation: "Edit the /etc/fstab   file OR the /etc/systemd/system/local-fs.target.wants/tmp.mount file:   IF /etc/fstab is used to mount /tmp  Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /tmp partition. See the fstab(5) manual page for more information. Run the following command to remount /tmp:          # mount -o remount,nodev /tmp         OR        IF systemd is used to mount /tmp: Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to add nodev to the /tmp mount options:    [Mount]   Options=mode=1777,strictatime,noexec,nodev,nosuid                   Run the following command to restart the systemd daemon: #  systemctl daemon-reload               Run the following command to restart tmp.mount            # systemctl restart tmp.mount"
+    compliance:
+      - cis: ["1.1.3"]
+      - cis_level: ["1"]
+    condition: any
+    rules:
+      - 'c:mount -> r:\s/tmp\s && r:nodev'
+      - 'c:mount -> !r:\s/tmp\s'
+
+# 1.1.4 /tmp: nosuid
+  - id: 21003
+    title: "Ensure nosuid option set on /tmp partition (Scored)."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /tmp."
+    remediation: "IF /etc/fstab is used to mount /tmp Edit the /etc/fstab   file OR the /etc/systemd/system/local-fs.target.wants/tmp.mount file:   IF /etc/fstab is used to mount /tmp  Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /tmp partition. See the fstab(5) manual page for more information. Run the following command to remount /tmp:          # mount -o remount,nosuid /tmp         OR        IF systemd is used to mount /tmp: Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to add nosuid to the /tmp mount options:    [Mount]   Options=mode=1777,strictatime,noexec,nosuid,nosuid                   Run the following command to restart the systemd daemon: #  systemctl daemon-reload               Run the following command to restart tmp.mount            # systemctl restart tmp.mount"
+    compliance:
+      - cis: ["1.1.4"]
+      - cis_level: ["1"]
+    condition: any
+    rules:
+      - 'c:mount -> r:\s/tmp\s && r:nosuid'
+      - 'c:mount -> !r:\s/tmp\s'
+
+# 1.1.5 /tmp: noexec
+  - id: 21004
+    title: "Ensure noexec option set on /tmp partition (Scored)."
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+    rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /tmp."
+    remediation: "Edit the /etc/fstab file OR  the /etc/systemd/system/local-fs.target.wants/tmp.mount file:    IF /etc/fstab is used to mount /tmp       Edit the /etc/fstabfile and add noexecto the fourth field (mounting options) for the /tmp partition. See the fstab(5) manual page for more information. Run the following command to remount /tmp:      # mount -o remount,noexec /tmp        OR           IF systemd is used to mount /tmp: Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to add noexec to the /tmp mount options:       [Mount]      Options=mode=1777,strictatime,noexec,nodev,nosuid         Run the following command to restart the systemd daemon: #  systemctl daemon-reload               Run the following command to restart tmp.mount               # systemctl restart tmp.mount"
+    compliance:
+      - cis: ["1.1.5"]
+      - cis_level: ["1"]
+    condition: any
+    rules:
+      - 'c:mount -> r:\s/tmp\s && r:noexec'
+      - 'c:mount -> !r:\s/tmp\s'
+
+# 1.1.6 Build considerations - Partition scheme.
+  - id: 21005
+    title: "Ensure separate partition exists for /var (Scored)."
+    description: "The /var directory is used by daemons and other system services to temporarily store dynamic data. Some directories created by these processes may be world-writable."
+    rationale: "Since the /var directory may contain world-writable files and directories, there is a risk of resource exhaustion if it is not bound to a separate partition."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    compliance:
+      - cis: ["1.1.6"]
+      - cis_level: ["2"]
+    references:
+      - AJ Lewis, "LVM HOWTO", https://tldp.org/HOWTO/LVM-HOWTO/
+    condition: all
+    rules:
+      - 'c:mount -> r:\s/var\s'
+
+# 1.1.7 bind mount /var/tmp to /tmp
+  - id: 21006
+    title: "Ensure separate partition exists for /var/tmp (Scored)."
+    description: "The /var/tmp directory is a world-writable directory used for temporary storage by all users and some applications."
+    rationale: "Since the /var/tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. In addition, making /var/tmp its own file system allows an administrator to set the noexec option on the mount, making /var/tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/tmp. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    compliance:
+      - cis: ["1.1.7"]
+      - cis_level: ["2"]
+    condition: all
+    rules:
+      - 'c:mount -> r:\s/var/tmp\s'
+
+# 1.1.8 nodev set on /var/tmp
+  - id: 21007
+    title: "Ensure nodev option set on /var/tmp partition (Scored)."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /var/tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /var/tmp ."
+    remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /var/tmp partition. See the fstab(5) manual page for more information. Run the following command to remount /var/tmp: # mount -o remount,nodev /var/tmp"
+    compliance:
+      - cis: ["1.1.8"]
+      - cis_level: ["1"]
+    condition: any
+    rules:
+      - 'c:mount -> r:\s/var/tmp\s && r:nodev'
+      - 'c:mount -> !r:\s/var/tmp\s'
+
+# 1.1.9 nosuid set on /var/tmp
+  - id: 21008
+    title: "Ensure nosuid option set on /var/tmp partition (Scored)."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /var/tmp."
+    remediation: "Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var/tmp partition. See the fstab(5) manual page for more information. Run the following command to remount /var/tmp: # mount -o remount,nosuid /var/tmp"
+    compliance:
+      - cis: ["1.1.9"]
+      - cis_level: ["1"]
+    condition: any
+    rules:
+      - 'c:mount -> r:\s/var/tmp\s && r:nosuid'
+      - 'c:mount -> !r:\s/var/tmp\s'
+
+# 1.1.10 noexec set on /var/tmp
+  - id: 21009
+    title: "Ensure noexec option set on /var/tmp partition (Scored)."
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+    rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /var/tmp."
+    remediation: "Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /var/tmp partition. See the fstab(5) manual page for more information. un the following command to remount /var/tmp: # mount -o remount,noexec /var/tmp"
+    compliance:
+      - cis: ["1.1.10"]
+      - cis_level: ["1"]
+    condition: any
+    rules:
+      - 'c:mount -> r:\s/var/tmp\s && r:noexec'
+      - 'c:mount -> !r:\s/var/tmp\s'
+
+# 1.1.11 /var/log: partition
+  - id: 21010
+    title: "Ensure separate partition exists for /var/log (Scored)."
+    description: "The /var/log directory is used by system services to store log data ."
+    rationale: "There are two important reasons to ensure that system logs are stored on a separate partition: protection against resource exhaustion (since logs can grow quite large) and protection of audit data."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/log. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    compliance:
+      - cis: ["1.1.11"]
+      - cis_level: ["2"]
+    references:
+      - AJ Lewis, "LVM HOWTO", https://tldp.org/HOWTO/LVM-HOWTO/
+    condition: all
+    rules:
+      - 'c:mount -> r:\s/var/log\s'
+
+# 1.1.12 /var/log/audit: partition
+  - id: 21011
+    title: "Ensure separate partition exists for /var/log/audit (Scored)."
+    description: "The auditing daemon, auditd, stores log data in the /var/log/audit directory."
+    rationale: "There are two important reasons to ensure that data gathered by auditd is stored on a separate partition: protection against resource exhaustion (since the audit.log file can grow quite large) and protection of audit data. The audit daemon calculates how much free space is left and performs actions based on the results. If other processes (such as syslog ) consume space in the same partition as auditd , it may not perform as desired."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/log/audit. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    compliance:
+      - cis: ["1.1.12"]
+      - cis_level: ["2"]
+    references:
+      - AJ Lewis, "LVM HOWTO", https://tldp.org/HOWTO/LVM-HOWTO/
+    condition: all
+    rules:
+      - 'c:mount -> r:\s/var/log/audit\s'
+
+# 1.1.13 /home: partition
+  - id: 21012
+    title: "Ensure separate partition exists for /home (Scored)."
+    description: "The /home directory is used to support disk storage needs of local users."
+    rationale: "If the system is intended to support local users, create a separate partition for the /home directory to protect against resource exhaustion and restrict the type of files that can be stored under /home."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /home. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    compliance:
+      - cis: ["1.1.13"]
+      - cis_level: ["2"]
+    references:
+      - AJ Lewis, "LVM HOWTO", https://tldp.org/HOWTO/LVM-HOWTO/
+    condition: all
+    rules:
+      - 'c:mount -> r:\s/home\s'
+
+# 1.1.14 /home: nodev
+  - id: 21013
+    title: "Ensure nodev option set on /home partition (Scored)."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the user partitions are not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices."
+    remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /home partition. # mount -o remount,nodev /home"
+    compliance:
+      - cis: ["1.1.14"]
+      - cis_level: ["1"]
+    condition: any
+    rules:
+      - 'c:mount -> r:\s/home\s && r:nodev'
+      - 'c:mount -> !r:\s/home\s'
+
+# 1.1.15 /dev/shm: nodev
+  - id: 21014
+    title: "Ensure nodev option set on /dev/shm partition (Scored)."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /dev/shm filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create special devices in /dev/shm partitions."
+    remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /dev/shm partition. Run the following command to remount /dev/shm: # mount -o remount,nodev /dev/shm"
+    compliance:
+      - cis: ["1.1.15"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:mount -> r:\s/dev/shm\s && r:nodev'
+
+# 1.1.16 /dev/shm: nosuid
+  - id: 21015
+    title: "Ensure nosuid option set on /dev/shm partition (Scored)."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Setting this option on a file system prevents users from introducing privileged programs onto the system and allowing non-root users to execute them."
+    remediation: "Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /dev/shm partition. Run the following command to remount /dev/shm: # mount -o remount,nosuid /dev/shm"
+    compliance:
+      - cis: ["1.1.16"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:mount -> r:\s/dev/shm\s && r:nosuid'
+
+# 1.1.17 /dev/shm: noexec
+  - id: 21016
+    title: "Ensure noexec option set on /dev/shm partition (Scored)."
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+    rationale: "Setting this option on a file system prevents users from executing programs from shared memory. This deters users from introducing potentially malicious software on the system."
+    remediation: "Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /dev/shm partition. Run the following command to remount /dev/shm: # mount -o remount,noexec /dev/shm"
+    compliance:
+      - cis: ["1.1.17"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:mount -> r:\s/dev/shm\s && r:noexec'
+
+# 1.1.18 Ensure sticky bit is set on all world-writable directories (Scored)
+  - id: 21017
+    title: "Ensure sticky bit is set on all world-writable directories (Scored)."
+    description: "Setting the sticky bit on world writable directories prevents users from deleting or renaming files in that directory that are not owned by them."
+    rationale: "This feature prevents the ability to delete or rename files in world writable directories (such as /tmp ) that are owned by another user."
+    remediation: "Run the following command to set the sticky bit on all world writable directories: # df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -type d \\( -perm -0002 -a ! -perm -1000 \\) 2>/dev/null | xargs -I '{}' chmod a+t '{}'"
+    compliance:
+      - cis: ["1.1.18"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:sh -c "df --local -P 2> /dev/null | awk ''{if (NR!=1) print $6}'' | xargs -I ''{}'' find ''{}'' -xdev -type d \\( -perm -0002 -a ! -perm -1000 \\) 2>/dev/null" -> r:^$'
+
+# 1.1.19 Disable Automounting
+  - id: 21018
+    title: "Disable Automounting (Scored)."
+    description: "autofs allows automatic mounting of devices, typically including CD/DVDs and USB drives."
+    rationale: "With automounting enabled anyone with physical access could attach a USB drive or disc and have its contents available in system even if they lacked permissions to mount it themselves."
+    remediation: "Run the following command to disable autofs: # systemctl disable autofs     # systemctl stop autofs"
+    compliance:
+      - cis: ["1.1.19"]
+      - cis_level: ["1"]
+    condition: none
+    rules:
+      - 'c:systemctl is-enabled autofs -> r:enabled'
+
+###############################################
+# 1.2 Configure Software Updates
+###############################################
+
+# 1.2.1 Ensure package manager repositories are configured (Not Scored)
+
+# 1.2.2 Ensure GPG keys are configured (Not Scored)
+
+# 1.2.3 Activate gpgcheck
+  - id: 21019
+    title: "Ensure gpgcheck is globally activated (Scored)."
+    description: "The gpgcheck option, found in the main section of the /etc/yum.conf and individual /etc/yum/repos.d/* files determines if an RPM package's signature is checked prior to its installation."
+    rationale: "It is important to ensure that an RPM's package signature is always checked prior to installation to ensure that the software is obtained from a trusted source."
+    remediation: "Edit /etc/yum.conf and set ' gpgcheck=1 ' in the [main] section. Edit any failing files in /etc/yum.repos.d/* and set all instances of gpgcheck to ' 1 '."
+    compliance:
+      - cis: ["1.2.3"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'f:/etc/yum.conf -> r:gpgcheck=1'
+      - 'not c:grep -Rh ^gpgcheck /etc/yum.repos.d/ -> r:gpgcheck=0'
+
+###############################################
+# 1.3 Filesystem Integrity Checking
+###############################################
+
+# 1.3.1 install AIDE
+  - id: 21020
+    title: "Ensure AIDE is installed (Scored)."
+    description: "AIDE takes a snapshot of filesystem state including modification times, permissions, and file hashes which can then be used to compare against the current state of the filesystem to detect modifications to the system."
+    rationale: "By monitoring the filesystem state compromised files can be detected to prevent or limit the exposure of accidental or malicious misconfigurations or modified binaries."
+    remediation: "Run the following command to install AIDE: yum install aide // Configure AIDE as appropriate for your environment. Consult the AIDE documentation for options. Initialize AIDE: aide --init && mv /var/lib/aide/aide.db.new.gz /var/lib/aide/aide.db.gz"
+    compliance:
+      - cis: ["1.3.1"]
+      - cis_level: ["1"]
+    references: 
+      - "AIDE stable manual: http://aide.sourceforge.net/stable/manual.html"
+    condition: all
+    rules:
+      - 'c:rpm -q aide -> r:aide-\S*'
+
+# 1.3.2 AIDE regular checks
+  - id: 21021
+    title: "Ensure filesystem integrity is regularly checked (Scored)."
+    description: "Periodic checking of the filesystem integrity is needed to detect changes to the filesystem."
+    rationale: "Periodic file checking allows the system administrator to determine on a regular basis if critical files have been changed in an unauthorized fashion."
+    remediation: "If cron will be used to schedule and run aide check run the following command: crontab -u root -e         Add the following line to the crontab: 0 5 * * * /usr/sbin/aide --check  // Notes: The checking in this recommendation occurs every day at 5am. Alter the frequency and time of the checks in compliance with site policy.              OR        If aidecheck.service and aidecheck.timer will be used to schedule and run aide check: Create or edit the file /etc/systemd/system/aidecheck.service and add the following lines:    [Unit]      Description=Aide Check    [Service]     Type=simpleExecStart=/usr/sbin/aide --check      [Install]     WantedBy=multi-user.target      Create or edit the file  /etc/systemd/system/aidecheck.timer and add the following lines:   [Unit]   Description=Aide check every day at 5AM      [Timer]     OnCalendar=*-*-* 05:00:00      Unit=aidecheck.service      [Install]     WantedBy=multi-user.target        Run the following commands:        # chown root:root /etc/systemd/system/aidecheck.*         # chmod 0644 /etc/systemd/system/aidecheck.*           # systemctl daemon-reload          # systemctl enable aidecheck.service        # systemctl --now enable aidecheck.timer "
+    compliance:
+      - cis: ["1.3.2"]
+      - cis_level: ["1"]
+    condition: any
+    rules:
+      - 'c:crontab -u root -l -> r:aide'
+      - 'c:grep -r aide /etc/cron.* /etc/crontab -> r:aide'
+      - 'c:systemctl is-enabled aidecheck.service -> r:enabled'
+      - 'c:systemctl is-enabled aidecheck.timer -> r:enabled'
+      - 'c:systemctl status aidecheck.timer -> r:enabled'
+
+
+###############################################
+# 1.4 Secure Boot Settings
+###############################################
+# 1.4.1 Configure bootloader
+  - id: 21022
+    title: "Ensure permissions on bootloader config are configured (Scored)."
+    description: "The grub configuration file contains information on boot settings and passwords for unlocking boot options. The grub configuration is usually located at /boot/grub2/grub.cfg and linked as /etc/grub2.cfg .  On newer grub2 systems the encrypted bootloader password is contained in /boot/grub2/user.cfg"
+    rationale: "Setting the permissions to read and write for root only prevents non-root users from seeing the boot parameters or changing them. Non-root users who read the boot parameters may be able to identify weaknesses in security upon boot and be able to exploit them."
+    remediation: "Run the following commands to set permissions on your grub configuration: # chown root:root /boot/grub2/grub.cfg    # chmod og-rwx /boot/grub2/grub.cfg  # chown root:root /boot/grub2/user.cfg  # chmod og-rwx /boot/grub2/user.cfg"
+    compliance:
+      - cis: ["1.4.1"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:stat /boot/grub2/grub.cfg -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat /boot/grub2/user.cfg -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)|cannot stat'
+
+# 1.4.2 Single user authentication
+  - id: 21023
+    title: "Ensure authentication required for single user mode (Scored)."
+    description: "Single user mode (rescue mode) is used for recovery when the system detects an issue during boot or by manual selection from the bootloader."
+    rationale: "Requiring authentication in single user mode (rescue mode) prevents an unauthorized user from rebooting the system into single user to gain root privileges without credentials."
+    remediation: "Edit /usr/lib/systemd/system/rescue.service and /usr/lib/systemd/system/emergency.service and set ExecStart to use /sbin/sulogin or /usr/sbin/sulogin: ExecStart=-/bin/sh -c \"/sbin/sulogin; /usr/bin/systemctl --fail --no-block default\" "
+    compliance:
+      - cis: ["1.4.2"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'f:/usr/lib/systemd/system/rescue.service -> r:ExecStart=-/bin/sh -c "/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"|ExecStart=-/bin/sh -c "/usr/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"'
+      - 'f:/usr/lib/systemd/system/emergency.service -> r:ExecStart=-/bin/sh -c "/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"|ExecStart=-/bin/sh -c "/usr/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"'
+
+
+###############################################
+# 1.5 Additional Process Hardening
+###############################################
+# 1.5.1 Restrict Core Dumps (Scored)
+  - id: 21024
+    title: "Ensure core dumps are restricted (Scored)."
+    description: "A core dump is the memory of an executable program. It is generally used to determine why a program aborted. It can also be used to glean confidential information from a core file. The system provides the ability to set a soft limit for core dumps, but this can be overridden by the user."
+    rationale: "Setting a hard limit on core dumps prevents users from overriding the soft variable. If core dumps are required, consider setting limits for user groups (see limits.conf). In addition, setting the fs.suid_dumpable variable to 0 will prevent setuid programs from dumping core."
+    remediation: "Add the following line to /etc/security/limits.conf or a /etc/security/limits.d/* file: * hard core 0. Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: fs.suid_dumpable = 0. Run the following command to set the active kernel parameter: # sysctl -w fs.suid_dumpable=0"
+    compliance:
+      - cis: ["1.5.1"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:grep -Rh ^*[[:space:]]*hard[[:space:]][[:space:]]*core[[:space:]][[:space:]]* /etc/security/limits.conf /etc/security/limits.d -> r:hard\s*\t*core\s*\t*0$'
+      - 'c:sysctl fs.suid_dumpable -> r:^\s*fs.suid_dumpable\s*=\s*0\s*$'
+      - 'c:grep -Rh fs\.suid_dumpable /etc/sysctl.conf /etc/sysctl.d -> r:^\s*fs.suid_dumpable\s*=\s*0\s*$'
+
+# 1.5.2 Enable Randomized Virtual Memory Region Placement (Scored)
+  - id: 21025
+    title: "Ensure address space layout randomization (ASLR) is enabled (Scored)."
+    description: "Address space layout randomization (ASLR) is an exploit mitigation technique which randomly arranges the address space of key data areas of a process."
+    rationale: "Randomly placing virtual memory regions will make it difficult to write memory page exploits as the memory placement will be consistently shifting."
+    remediation: "Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: kernel.randomize_va_space = 2. Run the following command to set the active kernel parameter: # sysctl -w kernel.randomize_va_space=2"
+    compliance:
+      - cis: ["1.5.2"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:grep -Rh ^kernel\.randomize_va_space /etc/sysctl.conf /etc/sysctl.d -> r:^\s*kernel.randomize_va_space\s*=\s*2$'
+      - 'c:sysctl kernel.randomize_va_space -> r:^\s*kernel.randomize_va_space\s*=\s*2'
+
+# 1.5.3 Disable prelink
+  - id: 21026
+    title: "Ensure prelink is disabled (Scored)."
+    description: "prelink is a program that modifies ELF shared libraries and ELF dynamically linked binaries in such a way that the time needed for the dynamic linker to perform relocations at startup significantly decreases."
+    rationale: "The prelinking feature can interfere with the operation of AIDE, because it changes binaries. Prelinking can also increase the vulnerability of the system if a malicious user is able to compromise a common library such as libc."
+    remediation: "Run the following commands to restore binaries to normal: # prelink -ua     Run the following command to uninstall prelink: # yum remove prelink"
+    compliance:
+      - cis: ["1.5.3"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:rpm -q prelink -> r:package prelink is not installed'
+
+
+###############################################
+# 1.6 Mandatory Access Control
+###############################################
+
+# 1.6.1.1 SELinux not disabled
+  - id: 21027
+    title: "Ensure SELinux is not disabled in bootloader configuration (Scored)."
+    description: "Configure SELINUX to be enabled at boot time and verify that it has not been overwritten by the grub boot parameters."
+    rationale: "SELinux must be enabled at boot time in your grub configuration to ensure that the controls it provides are not overridden."
+    remediation: "Edit /etc/default/grub and remove all instances of selinux=0 and enforcing=0 from all CMDLINE_LINUX parameters: GRUB_CMDLINE_LINUX_DEFAULT=\"quiet\" GRUB_CMDLINE_LINUX=\"\"  || Run the following command to update the grub2 configuration: grub2-mkconfig -o /boot/grub2/grub.cfg"
+    compliance:
+      - cis: ["1.6.1.1"]
+      - cis_level: ["2"]
+    condition: none
+    rules:
+      - 'f:/boot/grub2/grub.cfg -> r:^\s*linux\.+selinux=0|linux\.+enforcing=0'
+
+# 1.6.1.2 Set selinux state
+  - id: 21028
+    title: "Ensure the SELinux state is enforcing (Scored)."
+    description: "Set SELinux to enable when the system is booted."
+    rationale: "SELinux must be enabled at boot time in to ensure that the controls it provides are in effect at all times. If the system is running, resetting the config file may cause some risks."
+    remediation: "Edit the /etc/selinux/config file to set the SELINUX parameter: SELINUX=enforcing"
+    compliance:
+      - cis: ["1.6.1.2"]
+      - cis_level: ["2"]
+    condition: all
+    rules:
+      - 'c:getenforce -> r:^Enforcing'
+      - 'f:/etc/selinux/config -> r:^SELINUX=enforcing'
+
+# 1.6.1.3 Set selinux policy
+  - id: 21029
+    title: "Ensure SELinux policy is configured (Scored)."
+    description: "Configure SELinux to meet or exceed the default targeted policy, which constrains daemons and system software only."
+    rationale: "Security configuration requirements vary from site to site. Some sites may mandate a policy that is stricter than the default policy, which is perfectly acceptable. This item is intended to ensure that at least the default recommendations are met. If the system is running, resetting the config file may cause some risks."
+    remediation: "Edit the /etc/selinux/config file to set the SELINUXTYPE parameter: SELINUXTYPE=targeted"
+    compliance:
+      - cis: ["1.6.1.3"]
+      - cis_level: ["2"]
+    condition: all
+    rules:
+      - 'c:sestatus -> r:^Loaded policy name:\s*\t*targeted$|^Loaded policy name:\s*\t*mls'
+      - 'f:/etc/selinux/config -> r:^\s*SELINUXTYPE\s*=\s*targeted|^\s*SELINUXTYPE\s*=\s*mls'
+
+# 1.6.1.4 Remove SETroubleshoot
+  - id: 21030
+    title: "Ensure SETroubleshoot is not installed (Scored)."
+    description: "The SETroubleshoot service notifies desktop users of SELinux denials through a user-friendly interface. The service provides important information around configuration errors, unauthorized intrusions, and other potential errors."
+    rationale: "The SETroubleshoot service is an unnecessary daemon to have running on a server, especially if X Windows is disabled."
+    remediation: "Run the following command to uninstall setroubleshoot: # yum remove setroubleshoot"
+    compliance:
+      - cis: ["1.6.1.4"]
+      - cis_level: ["2"]
+    condition: all
+    rules:
+      - 'c:rpm -q setroubleshoot -> r:package setroubleshoot is not installed'
+
+# 1.6.1.5 Disable MCS Translation service mcstrans
+  - id: 21031
+    title: "Ensure the MCS Translation Service (mcstrans) is not installed (Scored)."
+    description: "The mcstransd daemon provides category label information to client processes requesting information. The label translations are defined in /etc/selinux/targeted/setrans.conf"
+    rationale: "Since this service is not used very often, remove it to reduce the amount of potentially vulnerable code running on the system."
+    remediation: "Run the following command to uninstall mcstrans: # yum remove mcstrans"
+    compliance:
+      - cis: ["1.6.1.5"]
+      - cis_level: ["2"]
+    condition: all
+    rules:
+      - 'c:rpm -q mcstrans -> r:package mcstrans is not installed'
+
+# 1.6.1.6 Ensure no unconfined services exist
+  - id: 21032
+    title: "Ensure no unconfined services exist (Scored)."
+    description: "Daemons that are not defined in SELinux policy will inherit the security context of their parent process."
+    rationale: "Since daemons are launched and descend from the init process, they will inherit the security context label initrc_t . This could cause the unintended consequence of giving the process more permission than it requires."
+    remediation: "Investigate any unconfined processes found during the audit action. They may need to have an existing security context assigned to them or a policy built for them."
+    compliance:
+      - cis: ["1.6.1.6"]
+      - cis_level: ["2"]
+    condition: none
+    rules:
+      - 'c:ps -eZ -> r:unconfined_service_t'
+
+# 1.6.2 Install SELinux
+  - id: 21033
+    title: "Ensure SELinux is installed (Scored)."
+    description: "SELinux provides Mandatory Access Controls."
+    rationale: "Without a Mandatory Access Control system installed only the default Discretionary Access Control system will be available."
+    remediation: "Run the following command to install libselinux: # yum install libselinux"
+    compliance:
+      - cis: ["1.6.2"]
+      - cis_level: ["2"]
+    condition: all
+    rules:
+      - 'c:rpm -q libselinux -> r:libselinux-\S+'
+
+###############################################
+# 1.7  Warning Banners
+###############################################
+# 1.7.1.1 Configure message of the day (Scored)
+  - id: 21034
+    title: "Ensure message of the day is configured properly (Scored)."
+    description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version"
+    rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
+    remediation: "Edit the /etc/motd file with the appropriate contents according to your site policy, remove any instances of \\m, \\r, \\s, \\v  or references to the OS platform    OR    If the motd is not used, this file can be removed. Run the following command to remove the motd file: # rm /etc/motd"
+    compliance:
+      - cis: ["1.7.1.1"]
+      - cis_level: ["1"]
+    condition: none
+    rules:
+      - 'f:/etc/motd -> r:\\v|\\r|\\m|\\s'
+
+# 1.7.1.2 Configure local login warning banner (Not Scored)
+  - id: 21035
+    title: "Ensure local login warning banner is configured properly (Not Scored)."
+    description: "The contents of the /etc/issue file are displayed to users prior to login for local terminals. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version -or the operating system's name."
+    rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
+    remediation: "Edit the /etc/issue file with the appropriate contents according to your site policy, remove any instances of \\m, \\r, \\s, or \\v: # echo \"Authorized uses only. All activity may be monitored and reported.\" > /etc/issue"
+    compliance:
+      - cis: ["1.7.1.2"]
+      - cis_level: ["1"]
+    condition: none
+    rules:
+      - 'f:/etc/issue -> r:\\v|\\r|\\m|\\s'
+
+# 1.7.1.3 Configure remote login warning banner (Not Scored)
+  - id: 21036
+    title: "Ensure remote login warning banner is configured properly (Not Scored)."
+    description: "The contents of the /etc/issue.net file are displayed to users prior to login for remote connections from configured services. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version"
+    rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
+    remediation: "Edit the /etc/issue.net file with the appropriate contents according to your site policy, remove any instances of \\m, \\r, \\s, or \\v: # echo \"Authorized uses only. All activity may be monitored and reported.\" > /etc/issue.net"
+    compliance:
+      - cis: ["1.7.1.3"]
+      - cis_level: ["1"]
+    condition: none
+    rules:
+      - 'f:/etc/issue.net -> r:\\v|\\r|\\m|\\s'
+
+# 1.7.1.4 Configure /etc/motd permissions (Not Scored)
+  - id: 21037
+    title: "Ensure permissions on /etc/motd are configured (Not Scored)."
+    description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users."
+    rationale: "If the /etc/motd file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
+    remediation: "Run the following commands to set permissions on /etc/motd: # chown root:root /etc/motd # chmod 644 /etc/motd"
+    compliance:
+      - cis: ["1.7.1.4"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:stat /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+
+# 1.7.1.5 Configure /etc/issue permissions (Scored)
+  - id: 21038
+    title: "Ensure permissions on /etc/issue are configured (Scored)."
+    description: "The contents of the /etc/issue file are displayed to users prior to login for local terminals."
+    rationale: "If the /etc/issue file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
+    remediation: "Run the following commands to set permissions on /etc/issue: # chown root:root /etc/issue # chmod 644 /etc/issue"
+    compliance:
+      - cis: ["1.7.1.5"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:stat /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+
+# 1.7.1.6 Configure /etc/issue.net permissions (Not Scored)
+  - id: 21039
+    title: "Ensure permissions on /etc/issue.net are configured (Not Scored)."
+    description: "The contents of the /etc/issue.net file are displayed to users prior to login for remote connections from configured services."
+    rationale: "If the /etc/issue.net file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
+    remediation: "Run the following commands to set permissions on /etc/issue.net: # chown root:root /etc/issue.net # chmod 644 /etc/issue.net"
+    compliance:
+      - cis: ["1.7.1.6"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:stat /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+
+# 1.8 Ensure updates, patches, and additional security software are installed
+  - id: 21040
+    title: "Ensure updates, patches, and additional security software are installed (Scored)."
+    description: "Periodically patches are released for included software either due to security flaws or to include additional functionality."
+    rationale: "Newer patches may contain security enhancements that would not be available through the latest full update. As a result, it is recommended that the latest software patches be used to take advantage of the latest functionality. As with any software installation, organizations need to determine if a given update meets their requirements and verify the compatibility and supportability of any additional software against the update revision that is selected."
+    remediation: "Use your package manager to update all packages on the system according to site policy. The following command will install all available packages # yum update --security"
+    compliance:
+      - cis: ["1.8"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:yum check-update --security -> r:No packages needed for security'
+
+###############################################
+# 2 OS Services
+###############################################
+###############################################
+# 2.1 Special Purpose Services
+###############################################
+
+# 2.1.1.1 Ensure time synchronization is in use (Not Scored)
+  - id: 21041
+    title: "Ensure time synchronization is in use (Not Scored)."
+    description: "System time should be synchronized between all systems in an environment. This is typically done by establishing an authoritative time server or set of servers and having all systems synchronize their clocks to them."
+    rationale: "Time synchronization is important to support time sensitive security mechanisms like Kerberos and also ensures log files have consistent time records across the enterprise, which aids in forensic investigations."
+    remediation: "Run One of the following commands to install chrony or NTP: to install chrony run the following command: # yum install chrony OR to install ntp: run the following command: # yum install ntp"
+    compliance:
+      - cis: ["2.1.1.1"]
+      - cis_level: ["1"]
+    condition: any
+    rules:
+      - 'not c:rpm -q ntp -> r:^package ntp is not installed'
+      - 'not c:rpm -q chrony -> r:^package chrony is not installed'
+
+# 2.1.1.2  Ensure ntp is configured (Scored)
+  - id: 21042
+    title: "Ensure ntp is configured (Scored)."
+    description: "ntp is a daemon which implements the Network Time Protocol (NTP). It is designed to synchronize system clocks across a variety of systems and use a source that is highly accurate. More information on NTP can be found at https://www.ntp.org. ntp can be configured to be a client and/or a server."
+    rationale: "If ntp is in use on the system proper configuration is vital to ensuring time synchronization is working properly."
+    remediation: "1) Add or edit restrict lines in /etc/ntp.conf to match the following: - restrict -4 default kod nomodify notrap nopeer noquery and - restrict -4 default kod nomodify notrap nopeer noquery. 2) Add or edit server or pool lines to /etc/ntp.conf as appropriate: server <remote-server>. 3) Add or edit the OPTIONS in /etc/sysconfig/ntpd to include ' -u ntp:ntp ': - OPTIONS='-u ntp:ntp'"
+    compliance:
+      - cis: ["2.1.1.2"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'f:/etc/ntp.conf -> r:^restrict\s+-4\s*default|^restrict\s+default && r:\s+kod\s+ && r:\s+nomodify\s+ && r:\s+notrap\s+ && r:\s+nopeer\s+ && r:\s+noquery'
+      - 'f:/etc/ntp.conf -> r:^restrict\s+-6\s+default && r:\s+kod\s+ && r:\s+nomodify\s+ && r:\s+notrap\s+ && r:\s+nopeer\s+ && r:\s+noquery'
+      - 'f:/etc/ntp.conf -> r:^server\.+|^pool\.+'
+      - 'f:/etc/sysconfig/ntpd -> r:^OPTIONS\s*=\s* && r:-u ntp:ntp|-g'
+      - 'f:/usr/lib/systemd/system/ntpd.service -> r:^Execstart\s*=\s*/usr/sbin/ntpd\s+-u\s+ntp:ntp'
+
+# 2.1.1.3  Ensure chrony is configured (Scored)
+  - id: 21043
+    title: "Ensure chrony is configured (Scored)."
+    description: "chrony is a daemon which implements the Network Time Protocol (NTP) and is designed to synchronize system clocks across a variety of systems and use a source that is highly accurate. More information on chrony can be found at http://chrony.tuxfamily.org/. chrony can be configured to be a client and/or a server."
+    rationale: "If chrony is in use on the system proper configuration is vital to ensuring time synchronization is working properly. Note: This recommendation only applies if chrony is in use on the system."
+    remediation: "1) Add or edit server or pool lines to /etc/chrony.conf as appropriate: server <remote-server>. 2) Add or edit the OPTIONS in /etc/sysconfig/chronyd to include '-u chrony':OPTIONS=\"-u chrony\""
+    compliance:
+      - cis: ["2.1.1.3"]
+      - cis_level: ["1"]
+    condition: any
+    rules:
+      - 'f:/etc/chrony.conf -> r:^server\.+$|^pool\.+$'
+      - 'f:/etc/sysconfig/chronyd -> r:^OPTIONS\s*=\s* && r:-u chrony'
+
+# 2.1.2 Remove X Windows (Scored)
+  - id: 21044
+    title: " Ensure X Window System is not installed (Scored)."
+    description: "The X Window System provides a Graphical User Interface (GUI) where users can have multiple windows in which to run programs and various add on. The X Windows system is typically used on workstations where users login, but not on servers where users typically do not login."
+    rationale: "Unless your organization specifically requires graphical login access via X Windows, remove it to reduce the potential attack surface."
+    remediation: "Run the following command to remove the X Windows System packages: # yum remove xorg-x11*"
+    compliance:
+      - cis: ["2.1.2"]
+      - cis_level: ["1"]
+    condition: none
+    rules:
+      - 'c:rpm -qa xorg-x11-server* -> r:^xorg-x11-server'
+
+# 2.1.3 Ensure Avahi Server is not enabled (Scored)
+  - id: 21045
+    title: " Ensure Avahi Server is not enabled (Scored)."
+    description: "Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD service discovery. Avahi allows programs to publish and discover services and hosts running on a local network with no specific configuration. For example, a user can plug a computer into a network and Avahi automatically finds printers to print to, files to look at and people to talk to, as well as network services running on the machine."
+    rationale: "Automatic discovery of network services is not normally required for system functionality. It is recommended to remove this package to reduce the potential attack surface."
+    remediation: "Run the following commands to disable avahi-daemon: # systemctl disable avahi-daemon  # systemctl stop avahi-daemon.socket  # systemctl disable avahi-daemon.socket"
+    compliance:
+      - cis: ["2.1.3"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled avahi-daemon.service -> !r:enabled'
+      - 'c:systemctl status avahi-daemon -> r:Active: inactive \(dead\)|not be found'
+      - 'c:systemctl status avahi-daemon.socket -> r:Active: inactive \(dead\)|not be found'
+
+# 2.1.4 Ensure CUPS is not enable (Scored)
+  - id: 21046
+    title: "Ensure CUPS is not enable (Scored)."
+    description: "The Common Unix Print System (CUPS) provides the ability to print to both local and network printers. A system running CUPS can also accept print jobs from remote systems and print them to local printers. It also provides a web based remote administration capability."
+    rationale: "If the system does not need to print jobs or accept print jobs from other systems, it is recommended that CUPS be removed to reduce the potential attack surface. Disabling CUPS will prevent printing from the system, a common task for workstation systems."
+    remediation: "Run the following command to disable cups: # systemctl disable cups # systemctl stop cups"
+    compliance:
+      - cis: ["2.1.4"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled cups -> !r:enabled'
+      - 'c:systemctl status cups -> r:Active: inactive \(dead\)|not be found'
+
+# 2.1.5 Ensure DHCP Server is not enabled (Scored)
+  - id: 21047
+    title: "Ensure DHCP Server is not enabled (Scored)."
+    description: "The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be dynamically assigned IP addresses."
+    rationale: "Unless a system is specifically set up to act as a DHCP server, it is recommended that this the dhcp package be removed to reduce the potential attack surface."
+    remediation: "Run the following command to disable dhcpd: # systemctl disable dhcpd  # systemctl stop dhcpd"
+    compliance:
+      - cis: ["2.1.5"]
+      - cis_level: ["1"]
+    references:
+      - More detailed documentation on DHCP is available at https://www.isc.org/software/dhcp
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled dhcpd -> !r:enabled'
+      - 'c:systemctl status dhcpd -> r:Active: inactive \(dead\)|not be found'
+
+# 2.1.6  Ensure LDAP server is not enabled (Scored)
+  - id: 21048
+    title: "Ensure LDAP Server is not enabled (Scored)."
+    description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
+    rationale: "If the system will not need to act as an LDAP server, it is recommended that the software be removed to reduce the potential attack surface."
+    remediation: "Run the following command to disable slapd: # systemctl disable slapd  # systemctl stop slapd"
+    compliance:
+      - cis: ["2.1.6"]
+      - cis_level: ["1"]
+    references:
+      - More detailed documentation on OpenLDAP is available at https://www.openldap.org
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled slapd -> !r:enabled'
+      - 'c:systemctl status slapd -> r:Active: inactive \(dead\)|not be found'
+
+# 2.1.7 Ensure NFS and RPC are not enabled (Scored)
+  - id: 21049
+    title: "Ensure NFS and RPC are not enabled (Scored)."
+    description: "The Network File System (NFS) is one of the first and most widely distributed file systems in the UNIX environment. It provides the ability for systems to mount file systems of other servers through the network."
+    rationale: "If the system does not require network shares or act as an NFS client, it is recommended that the nfs-utils package be removed to reduce the attack surface of the system."
+    remediation: "Run the following command to disable nfs, nfs-server and rpcbind: # systemctl disable nfs  # systemctl disable nfs-server   # systemctl disable rpcbind   # systemctl stop nfs   # systemctl stop nfs-server  # systemctl stop rpcbind"
+    compliance:
+      - cis: ["2.1.7"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled nfs -> !r:enabled'
+      - 'c:systemctl status nfs -> r:Active: inactive \(dead\)|not be found'
+      - 'c:systemctl is-enabled nfs-server -> r:disabled'
+      - 'c:systemctl status nfs-server -> r:Active: inactive \(dead\)'
+      - 'c:systemctl is-enabled rpcbind -> r:disabled'
+
+# 2.1.8 Ensure DNS Server is not enabled (Scored)
+  - id: 21050
+    title: " Ensure DNS Server is not enabled (Scored)."
+    description: "The Domain Name System (DNS) is a hierarchical naming system that maps names to IP addresses for computers, services and other resources connected to a network."
+    rationale: "Unless a system is specifically designated to act as a DNS server, it is recommended that the package be removed to reduce the potential attack surface."
+    remediation: "Run the following command to disable named: # systemctl disable named  # systemctl stop named"
+    compliance:
+      - cis: ["2.1.8"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled named -> !r:enabled'
+      - 'c:systemctl status named -> r:Active: inactive \(dead\)|not be found'
+
+# 2.1.9 Ensure FTP Server is not enabled (Scored)
+  - id: 21051
+    title: "Ensure FTP Server is not enabled (Scored)."
+    description: "FTP (File Transfer Protocol) is a traditional and widely used standard tool for transferring files between a server and clients over a network, especially where no authentication is necessary (permits anonymous users to connect to a server)"
+    rationale: "FTP does not protect the confidentiality of data or authentication credentials. It is recommended sftp be used if file transfer is required. Unless there is a need to run the system as a FTP server (for example, to allow anonymous downloads), it is recommended that the package be removed to reduce the potential attack surface."
+    remediation: "Run the following command to disable vsftpd: # systemctl disable vsftpd  # systemctl stop vsftpd"
+    compliance:
+      - cis: ["2.1.9"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled vsftpd -> !r:enabled'
+      - 'c:systemctl status vsftpd -> r:Active: inactive \(dead\)|not be found'
+
+# 2.1.10 Ensure HTTP server is not enabled (Scored)
+  - id: 21052
+    title: "Ensure HTTP server is not enabled (Scored)."
+    description: "HTTP or web servers provide the ability to host web site content."
+    rationale: "Unless there is a need to run the system as a web server, it is recommended that the package be removed to reduce the potential attack surface."
+    remediation: "Run the following command to disable httpd: # systemctl disable httpd  # systemctl stop httpd"
+    compliance:
+      - cis: ["2.1.10"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled httpd -> !r:enabled'
+      - 'c:systemctl status httpd -> r:Active: inactive \(dead\)|not be found'
+
+# 2.1.11 Ensure IMAP and POP3 server is not enabled (Scored)
+  - id: 21053
+    title: "Ensure IMAP and POP3 server is not enabled (Scored)."
+    description: "dovecot is an open source IMAP and POP3 server for Linux based systems."
+    rationale: "Unless POP3 and/or IMAP servers are to be provided by this system, it is recommended that the package be removed to reduce the potential attack surface."
+    remediation: "Run the following command to disable dovecot: # systemctl disable dovecot  # systemctl stop dovecot"
+    compliance:
+      - cis: ["2.1.11"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled dovecot -> !r:enabled'
+      - 'c:systemctl status dovecot -> r:Active: inactive \(dead\)|not be found'
+
+# 2.1.12 Ensure Samba is not enabled (Scored)
+  - id: 21054
+    title: "Ensure Samba is not enabled (Scored)."
+    description: "The Samba daemon allows system administrators to configure their Linux systems to share file systems and directories with Windows desktops. Samba will advertise the file systems and directories via the Small Message Block (SMB) protocol. Windows desktop users will be able to mount these directories and file systems as letter drives on their systems."
+    rationale: "If there is no need to mount directories and file systems to Windows systems, then this package can be removed to reduce the potential attack surface."
+    remediation: "Run the following command to disable smb: # systemctl disable smb  # systemctl stop smb"
+    compliance:
+      - cis: ["2.1.12"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled smb -> !r:enabled'
+      - 'c:systemctl status smb -> r:Active: inactive \(dead\)|not be found'
+
+# 2.1.13 Ensure HTTP Proxy Server is not enabled (Scored)
+  - id: 21055
+    title: "Ensure HTTP Proxy Server is not enabled (Scored)."
+    description: "Squid is a standard proxy server used in many distributions and environments."
+    rationale: "If there is no need for a proxy server, it is recommended that the squid package be removed to reduce the potential attack surface."
+    remediation: "Run the following command to disable squid: # systemctl disable squid  # systemctl stop squid"
+    compliance:
+      - cis: ["2.1.13"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled squid -> !r:enabled'
+      - 'c:systemctl status squid -> r:Active: inactive \(dead\)|not be found'
+
+# 2.1.14 Ensure net-snmp is not enabled (Scored)
+  - id: 21056
+    title: "Ensure SNMP Server is not enabled (Scored)."
+    description: "The Simple Network Management Protocol (SNMP) server is used to listen for SNMP commands from an SNMP management system, execute the commands or collect the information and then send results back to the requesting system."
+    rationale: "The SNMP server can communicate using SNMP v1, which transmits data in the clear and does not require authentication to execute commands. Unless absolutely necessary, it is recommended that the SNMP service not be used. If SNMP is required the server should be configured to disallow SNMP v1."
+    remediation: "Run the following command to disable snmpd: # systemctl disable snmpd"
+    compliance:
+      - cis: ["2.1.14"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled snmpd -> !r:enabled'
+      - 'c:systemctl status snmpd -> r:Active: inactive \(dead\)|not be found'
+
+# 2.1.15 Ensure mail transfer agent is configured for local-only mode (Scored)
+  - id: 21057
+    title: "Ensure mail transfer agent is configured for local-only mode (Scored)."
+    description: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
+    rationale: "The software for all Mail Transfer Agents is complex and most have a long history of security issues. While it is important to ensure that the system can process local mail messages, it is not necessary to have the MTA's daemon listening on a port unless the server is intended to be a mail server that receives and processes mail from other systems."
+    remediation: "Edit /etc/postfix/main.cf and add the following line to the RECEIVING MAIL section. If the line already exists, change it to look like the line below: inet_interfaces = loopback-only . Restart postfix: # systemctl restart postfix"
+    compliance:
+      - cis: ["2.1.15"]
+      - cis_level: ["1"]
+    condition: none
+    rules:
+      - 'c:ss -lntu -> r:LISTEN\.*:25\s* && !r:127.0.0.1:25\.*|\s*\.*::1'
+
+# 2.1.16 Ensure NIS server is not enabled (Scored)
+  - id: 21058
+    title: "Ensure NIS Server is not enabled (Scored)."
+    description: "The ypserv package provides the Network Information Service (NIS). This service, formally known as Yellow Pages, is a client-server directory service protocol for distributing system configuration files. The NIS server is a collection of programs that allow for the distribution of configuration files."
+    rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the ypservpackage be removed, and if required a more secure services be used."
+    remediation: "Run the following command to disable ypserv: # systemctl disable ypserv  # systemctl stop ypserv"
+    compliance:
+      - cis: ["2.1.16"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled ypserv -> !r:enabled'
+      - 'c:systemctl status ypserv -> r:Active: inactive \(dead\)|not be found'
+
+# 2.1.17 Ensure rsh server is not enabled (Scored)
+  - id: 21059
+    title: "Ensure rsh server is not enabled (Scored)."
+    description: "The Berkeley rsh-server ( rsh , rlogin , rexec ) package contains legacy services that exchange credentials in clear-text."
+    rationale: "These legacy services contain numerous security exposures and have been replaced with the more secure SSH package.."
+    remediation: "Run the following command to disable rsh, rlogin, and rexec # systemctl disable rsh.socket  # systemctl disable rlogin.socket  # systemctl disable rexec.socket  # systemctl stop rsh.socket  # systemctl stop rlogin.socket  # systemctl stop rexec.socket"
+    compliance:
+      - cis: ["2.1.17"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled rsh.socket -> !r:enabled'
+      - 'c:systemctl status rsh.socket -> r:Active: inactive \(dead\)|not be found'
+      - 'c:systemctl is-enabled rlogin.socket -> !r:enabled'
+      - 'c:systemctl status rlogin.socket -> r:Active: inactive \(dead\)|not be found'
+      - 'c:systemctl is-enabled rexec.socket -> !r:enabled'
+      - 'c:systemctl status rexec.socket -> r:Active: inactive \(dead\)|not be found'
+
+# 2.1.18 Ensure telnet-server is not enabled (Scored)
+  - id: 21060
+    title: "Ensure telnet server is not enabled (Scored)."
+    description: "The telnet-server package contains the telnet daemon, which accepts connections from users from other systems via the telnet protocol."
+    rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow a user with access to sniff network traffic the ability to steal credentials. The ssh package provides an encrypted session and stronger security."
+    remediation: "Run the following command to disable telnet: # systemctl disable telnet.socket  # systemctl stop telnet.socket"
+    compliance:
+      - cis: ["2.1.18"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled telnet.socket -> !r:enabled'
+      - 'c:systemctl status telnet.socket -> r:Active: inactive \(dead\)|not be found'
+
+# 2.1.19 Ensure tftp server is not enabled (Scored)
+  - id: 21061
+    title: "Ensure tftp server is not enabled (Scored)."
+    description: "Trivial File Transfer Protocol (TFTP) is a simple file transfer protocol, typically used to automatically transfer configuration or boot machines from a boot server. The package tftp-server is used to define and support a TFTP server."
+    rationale: "TFTP does not support authentication nor does it ensure the confidentiality or integrity of data. It is recommended that TFTP be removed, unless there is a specific need for TFTP. In that case, extreme caution must be used when configuring the services."
+    remediation: "Run the following command to disable tftp: # systemctl disable tftp.socket  # systemctl stop tftp.socket  # systemctl disable tftp.service  # systemctl stop tftp.service"
+    compliance:
+      - cis: ["2.1.19"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled tftp.socket -> !r:enabled'
+      - 'c:systemctl status tftp.socket -> r:Active: inactive \(dead\)|not be found'
+      - 'c:systemctl is-enabled tftp.service -> !r:enabled'
+      - 'c:systemctl status tftp.service -> r:Active: inactive \(dead\)|not be found'
+
+# 2.1.20 Ensure rsync service is not enabled (Scored)
+  - id: 21062
+    title: "Ensure rsync service is not enabled (Scored)."
+    description: "The rsyncd service can be used to synchronize files between systems over network links."
+    rationale: "Unless required, the rsync package should be removed to reduce the attack surface area of the system. The rsyncd service presents a security risk as it uses unencrypted protocols for communication."
+    remediation: "Run the following command to disable rsync: # systemctl disable rsyncd  # systemctl stop rsyncd"
+    compliance:
+      - cis: ["2.1.20"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled rsyncd -> r:disabled'
+      - 'c:systemctl status rsyncd -> r:Active: inactive \(dead\)'
+
+# 2.1.21 Ensure talk server is not enabled (Scored)
+  - id: 21063
+    title: "Ensure talk server is not enabled (Scored)."
+    description: "The talk software makes it possible for users to send and receive messages across systems through a terminal session. The talk client (allows initiate of talk sessions) is installed by default."
+    rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
+    remediation: "Run the following command to disable talk: # systemctl stop ntalk ntalk.socket  # systemctl disable ntalk ntalk.socket"
+    compliance:
+      - cis: ["2.1.21"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled ntalk -> !r:enabled'
+      - 'c:systemctl status ntalk -> r:Active: inactive \(dead\)|not be found'
+
+###############################################
+# 2.2 Service Clients
+###############################################
+
+# 2.2.1 Ensure NIS Client is not installed (Scored)
+  - id: 21064
+    title: "Ensure NIS Client is not installed (Scored)."
+    description: "The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server directory service protocol used to distribute system configuration files. The NIS client ( ypbind ) was used to bind a machine to an NIS server and receive the distributed configuration files."
+    rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed."
+    remediation: "Run the following command to uninstall ypbind: # yum remove ypbind"
+    compliance:
+      - cis: ["2.2.1"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:rpm -q ypbind -> r:package ypbind is not installed'
+
+# 2.2.2 Ensure rsh client is not installed (Scored)
+  - id: 21065
+    title: "Ensure rsh client is not installed (Scored)."
+    description: "The rsh package contains the client commands for the rsh services."
+    rationale: "These legacy clients contain numerous security exposures and have been replaced with the more secure SSH package. Even if the server is removed, it is best to ensure the clients are also removed to prevent users from inadvertently attempting to use these commands and therefore exposing their credentials. Note that removing the rsh package removes the clients for rsh, rcp and rlogin ."
+    remediation: "Run the following command to uninstall rsh: # yum remove rsh"
+    compliance:
+      - cis: ["2.2.2"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:rpm -q rsh -> r:^package rsh is not installed'
+
+# 2.2.3 Ensure talk client is not installed (Scored)
+  - id: 21066
+    title: "Ensure talk client is not installed (Scored)."
+    description: "The talk software makes it possible for users to send and receive messages across systems through a terminal session. The talk client, which allows initialization of talk sessions, is installed by default."
+    rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
+    remediation: "Run the following command to uninstall talk: # yum remove talk"
+    compliance:
+      - cis: ["2.2.3"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:rpm -q talk -> r:^package talk is not installed'
+
+# 2.2.4 Ensure telnet client is not installed (Scored)
+  - id: 21067
+    title: "Ensure telnet client is not installed (Scored)."
+    description: "The telnet package contains the telnet client, which allows users to start connections to other systems via the telnet protocol."
+    rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow an unauthorized user to steal credentials. The ssh package provides an encrypted session and stronger security and is included in most Linux distributions."
+    remediation: "Run the following command to uninstall telnet: # yum remove telnet"
+    compliance:
+      - cis: ["2.2.4"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:rpm -q telnet -> r:^package telnet is not installed'
+
+# 2.2.5 Ensure LDAP client is not installed (Scored)
+  - id: 21068
+    title: "Ensure LDAP client is not installed (Scored)."
+    description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
+    rationale: "If the system will not need to act as an LDAP client, it is recommended that the software be removed to reduce the potential attack surface."
+    remediation: "Run the following command to uninstall openldap-clients: # yum remove openldap-clients"
+    compliance:
+      - cis: ["2.2.5"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:rpm -q openldap-clients -> r:^package openldap-clients is not installed'
+
+###############################################
+# 3 Network Configuration
+###############################################
+##################################################
+# 3.1 Network Parameters (Host Only)
+##################################################
+
+# 3.1.1 Ensure IP forwarding is disabled (Scored)
+  - id: 21069
+    title: "Ensure IP forwarding is disabled (Scored)."
+    description: "The net.ipv4.ip_forward flag is used to tell the system whether it can forward packets or not."
+    rationale: "Setting the flag to 0 ensures that a system with multiple interfaces (for example, a hard proxy), will never be able to forward packets, and therefore, never serve as a router."
+    remediation: "Run the following commands to restore the default parameters and set the active kernel parameters: # grep -Els '^\\s*net\\.ipv4\\.ip_forward\\s*=\\s*1' /etc/sysctl.conf /etc/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /run/sysctl.d/*.conf | while read filename; do sed -ri 's/^\\s*(net\\.ipv4\\.ip_forward\\s*)(=)(\\s*\\S+\\b).*$/# *REMOVED* \\1/' $filename; done; sysctl -w net.ipv4.ip_forward=0; sysctl -w net.ipv4.route.flush=1"
+    compliance:
+      - cis: ["3.1.1"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv4.ip_forward -> r:^net.ipv4.ip_forward\s*=\s*0$'
+      - 'not c:grep -RhEs "^\s*net\.ipv4\.ip_forward\s*=\s*1" /etc/sysctl.conf /etc/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /run/sysctl.d/*.conf -> r:ip_forward'
+      - 'c:sysctl net.ipv6.conf.all.forwarding -> r:^net.ipv6.conf.all.forwarding\s*=\s*0$'
+      - 'not c:grep -RhEs "^\s*net\.ipv6\.conf\.all\.forwarding\s*=\s*1" /etc/sysctl.conf /etc/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /run/sysctl.d/*.conf -> r:forwarding'
+
+# 3.1.2 Ensure packet redirect sending is disabled (Scored)
+  - id: 21070
+    title: "Ensure packet redirect sending is disabled."
+    description: "ICMP Redirects are used to send routing information to other hosts. As a host itself does not act as a router (in a host only configuration), there is no need to send redirects."
+    rationale: "An attacker could use a compromised host to send invalid ICMP redirects to other router devices in an attempt to corrupt routing and have users access a system set up by the attacker as opposed to a valid system."
+    remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.send_redirects = 0; net.ipv4.conf.default.send_redirects = 0 and set the active kernel parameters. Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.conf.all.send_redirects=0; # sysctl -w net.ipv4.conf.default.send_redirects=0; # sysctl -w net.ipv4.route.flush=1"
+    compliance:
+      - cis: ["3.1.2"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv4.conf.all.send_redirects -> r:^net.ipv4.conf.all.send_redirects\s*=\s*0$'
+      - 'c:sysctl net.ipv4.conf.default.send_redirects -> r:^net.ipv4.conf.default.send_redirects\s*=\s*0$'
+      - 'c:grep -Rh net\.ipv4\.conf\.all\.send_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.send_redirects\s*=\s*0'
+      - 'c:grep -Rh net\.ipv4\.conf\.default\.send_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.send_redirects\s*=\s*0'
+
+
+##################################################
+# 3.2 Network Parameters (Host and Router)
+##################################################
+
+# 3.2.1 Ensure source routed packets are not accepted (Scored)
+  - id: 21071
+    title: "Ensure source routed packets are not accepted (Scored)."
+    description: "In networking, source routing allows a sender to partially or fully specify the route packets take through a network. In contrast, non-source routed packets travel a path determined by routers in the network. In some cases, systems may not be routable or reachable from some locations (e.g. private addresses vs. Internet routable), and so source routed packets would need to be used."
+    rationale: "Setting net.ipv4.conf.all.accept_source_route and net.ipv4.conf.default.accept_source_route to 0 disables the system from accepting source routed packets. Assume this system was capable of routing packets to Internet routable addresses on one interface and private addresses on another interface. Assume that the private addresses were not routable to the Internet routable addresses and vice versa. Under normal routing circumstances, an attacker from the Internet routable addresses could not use the system as a way to reach the private address systems. If, however, source routed packets were allowed, they could be used to gain access to the private address systems as the route could be specified, rather than rely on routing protocols that did not allow this routing."
+    remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.accept_source_route = 0; net.ipv4.conf.default.accept_source_route = 0 and set the active kernel parameters:       # sysctl -w net.ipv4.conf.all.accept_source_route=0       # sysctl -w net.ipv4.conf.default.accept_source_route=0        # sysctl -w net.ipv4.route.flush=1"
+    compliance:
+      - cis: ["3.2.1"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv4.conf.all.accept_source_route -> r:^net.ipv4.conf.all.accept_source_route\s*=\s*0$'
+      - 'c:sysctl net.ipv4.conf.default.accept_source_route -> r:^net.ipv4.conf.default.accept_source_route\s*=\s*0$'
+      - 'c:grep -Rh net\.ipv4\.conf\.all\.accept_source_route /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.accept_source_route\s*=\s*0'
+      - 'c:grep -Rh net\.ipv4\.conf\.default\.accept_source_route /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.accept_source_route\s*=\s*0'
+      - 'c:sysctl net.ipv6.conf.all.accept_source_route -> r:^net.ipv6.conf.all.accept_source_route\s*=\s*0$'
+      - 'c:sysctl net.ipv6.conf.default.accept_source_route -> r:^net.ipv6.conf.default.accept_source_route\s*=\s*0$'
+      - 'c:grep -Rh net\.ipv6\.conf\.all\.accept_source_route /etc/sysctl.conf /etc/sysctl.d/* -> r:^net.ipv6.conf.all.accept_source_route\s*=\s*0'
+      - 'c:grep -Rh net\.ipv6\.conf\.default\.accept_source_route /etc/sysctl.conf /etc/sysctl.d/* -> r:^net.ipv6.conf.default.accept_source_route\s*=\s*0'
+
+# 3.2.2 Ensure ICMP redirects are not accepted (Scored)
+  - id: 21072
+    title: "Ensure ICMP redirects are not accepted (Scored)."
+    description: "ICMP redirect messages are packets that convey routing information and tell your host (acting as a router) to send packets via an alternate path. It is a way of allowing an outside routing device to update your system routing tables."
+    rationale: "Attackers could use bogus ICMP redirect messages to maliciously alter the system routing tables and get them to send packets to incorrect networks and allow your system packets to be captured."
+    remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.accept_redirects = 0; net.ipv4.conf.default.accept_redirects = 0 and set the active kernel parameters:      # sysctl -w net.ipv4.conf.all.accept_redirects=0          # sysctl -w net.ipv4.conf.default.accept_redirects=0            # sysctl -w net.ipv4.route.flush=1"
+    compliance:
+      - cis: ["3.2.2"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv4.conf.all.accept_redirects -> r:^net.ipv4.conf.all.accept_redirects\s*=\s*0$'
+      - 'c:sysctl net.ipv4.conf.default.accept_redirects -> r:^net.ipv4.conf.default.accept_redirects\s*=\s*0$'
+      - 'c:grep -Rh net\.ipv4\.conf\.all\.accept_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.accept_redirects\s*=\s*0'
+      - 'c:grep -Rh net\.ipv4\.conf\.default\.accept_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.accept_redirects\s*=\s*0'
+      - 'c:sysctl net.ipv4.conf.all.accept_redirects -> r:^net.ipv4.conf.all.accept_redirects\s*=\s*0$'
+
+# 3.2.3 Ensure secure ICMP redirects are not accepted (Scored)
+  - id: 21073
+    title: "Ensure secure ICMP redirects are not accepted (Scored)."
+    description: "Secure ICMP redirects are the same as ICMP redirects, except they come from gateways listed on the default gateway list. It is assumed that these gateways are known to your system, and that they are likely to be secure."
+    rationale: "It is still possible for even known gateways to be compromised. Setting net.ipv4.conf.all.secure_redirects to 0 protects the system from routing table updates by possibly compromised known gateways."
+    remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.secure_redirects = 0; net.ipv4.conf.default.secure_redirects = 0 and set the active kernel parameters:  # sysctl -w net.ipv4.conf.all.secure_redirects=0         # sysctl -w net.ipv4.conf.default.secure_redirects=0          # sysctl -w net.ipv4.route.flush=1"
+    compliance:
+      - cis: ["3.2.3"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv4.conf.all.secure_redirects -> r:^net.ipv4.conf.all.secure_redirects\s*=\s*0$'
+      - 'c:sysctl net.ipv4.conf.default.secure_redirects -> r:^net.ipv4.conf.default.secure_redirects\s*=\s*0$'
+      - 'c:grep -Rh net\.ipv4\.conf\.all\.secure_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.secure_redirects\s*=\s*0'
+      - 'c:grep -Rh net\.ipv4\.conf\.default\.secure_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.secure_redirects\s*=\s*0'
+
+# 3.2.4 Ensure suspicious packets are logged (Scored)
+  - id: 21074
+    title: "Ensure suspicious packets are logged (Scored)."
+    description: "When enabled, this feature logs packets with un-routable source addresses to the kernel log."
+    rationale: "Enabling this feature and logging these packets allows an administrator to investigate the possibility that an attacker is sending spoofed packets to their system."
+    remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.log_martians = 1; net.ipv4.conf.default.log_martians = 1 and set the active kernel parameters:    # sysctl -w net.ipv4.conf.all.log_martians=1       # sysctl -w net.ipv4.conf.default.log_martians=1          # sysctl -w net.ipv4.route.flush=1"
+    compliance:
+      - cis: ["3.2.4"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv4.conf.all.log_martians -> r:^net.ipv4.conf.all.log_martians\s*=\s*1$'
+      - 'c:sysctl net.ipv4.conf.default.log_martians -> r:^net.ipv4.conf.default.log_martians\s*=\s*1$'
+      - 'c:grep -Rh net\.ipv4\.conf\.all\.log_martians /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.log_martians\s*=\s*1'
+      - 'c:grep -Rh net\.ipv4\.conf\.default\.log_martians /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.log_martians\s*=\s*1'
+
+# 3.2.5 Ensure broadcast ICMP requests are ignored (Scored)
+  - id: 21075
+    title: "Ensure broadcast ICMP requests are ignored (Scored)."
+    description: "Setting net.ipv4.icmp_echo_ignore_broadcasts to 1 will cause the system to ignore all ICMP echo and timestamp requests to broadcast and multicast addresses."
+    rationale: "Accepting ICMP echo and timestamp requests with broadcast or multicast destinations for your network could be used to trick your host into starting (or participating) in a Smurf attack. A Smurf attack relies on an attacker sending large amounts of ICMP broadcast messages with a spoofed source address. All hosts receiving this message and responding would send echo-reply messages back to the spoofed address, which is probably not routable. If many hosts respond to the packets, the amount of traffic on the network could be significantly multiplied."
+    remediation: "Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.icmp_echo_ignore_broadcasts = 1 and set the active kernel parameters:     # sysctl -w net.ipv4.icmp_echo_ignore_broadcasts=1           # sysctl -w net.ipv4.route.flush=1"
+    compliance:
+      - cis: ["3.2.5"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv4.icmp_echo_ignore_broadcasts -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
+      - 'c:grep -Rh net\.ipv4\.icmp_echo_ignore_broadcasts /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1'
+
+# 3.2.6 Ensure bogus ICMP responses are ignored (Scored)
+  - id: 21076
+    title: "Ensure bogus ICMP responses are ignored (Scored)."
+    description: "Setting icmp_ignore_bogus_error_responses to 1 prevents the kernel from logging bogus responses (RFC-1122 non-compliant) from broadcast reframes, keeping file systems from filling up with useless log messages."
+    rationale: "Some routers (and some attackers) will send responses that violate RFC-1122 and attempt to fill up a log file system with many useless error messages."
+    remediation: "Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.icmp_ignore_bogus_error_responses = 1 and set the active kernel parameters: # sysctl -w net.ipv4.icmp_ignore_bogus_error_responses=1      # sysctl -w net.ipv4.route.flush=1"
+    compliance:
+      - cis: ["3.2.6"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv4.icmp_ignore_bogus_error_responses -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
+      - 'c:grep -Rh net\.ipv4\.icmp_ignore_bogus_error_responses /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1'
+
+# 3.2.7 Ensure Reverse Path Filtering is enabled (Scored)
+  - id: 21077
+    title: "Ensure Reverse Path Filtering is enabled (Scored)."
+    description: "Setting net.ipv4.conf.all.rp_filter and net.ipv4.conf.default.rp_filter to 1 forces the Linux kernel to utilize reverse path filtering on a received packet to determine if the packet was valid. Essentially, with reverse path filtering, if the return packet does not go out the same interface that the corresponding source packet came from, the packet is dropped (and logged if log_martians is set)."
+    rationale: "Setting these flags is a good way to deter attackers from sending your server bogus packets that cannot be responded to. One instance where this feature breaks down is if asymmetrical routing is employed. This would occur when using dynamic routing protocols (bgp, ospf, etc) on your system. If you are using asymmetrical routing on your system, you will not be able to enable this feature without breaking the routing."
+    remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.rp_filter = 1; net.ipv4.conf.default.rp_filter = 1 and set the active kernel parameters:   # sysctl -w net.ipv4.conf.all.rp_filter=1         # sysctl -w net.ipv4.conf.default.rp_filter=1         # sysctl -w net.ipv4.route.flush=1"
+    compliance:
+      - cis: ["3.2.7"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv4.conf.all.rp_filter -> r:^net.ipv4.conf.all.rp_filter\s*=\s*1$'
+      - 'c:sysctl net.ipv4.conf.default.rp_filter -> r:^net.ipv4.conf.default.rp_filter\s*=\s*1$'
+      - 'c:grep -Rh net\.ipv4\.conf\.all\.rp_filter /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.rp_filter\s*=\s*1'
+      - 'c:grep -Rh net\.ipv4\.conf\.default\.rp_filter /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.rp_filter\s*=\s*1'
+
+# 3.2.8 Ensure TCP SYN Cookies is enabled (Scored)
+  - id: 21078
+    title: "Ensure TCP SYN Cookies is enabled (Scored)."
+    description: "When tcp_syncookies is set, the kernel will handle TCP SYN packets normally until the half-open connection queue is full, at which time, the SYN cookie functionality kicks in. SYN cookies work by not using the SYN queue at all. Instead, the kernel simply replies to the SYN with a SYN|ACK, but will include a specially crafted TCP sequence number that encodes the source and destination IP address and port number and the time the packet was sent. A legitimate connection would send the ACK packet of the three way handshake with the specially crafted sequence number. This allows the system to verify that it has received a valid response to a SYN cookie and allow the connection, even though there is no corresponding SYN in the queue."
+    rationale: "Attackers use SYN flood attacks to perform a denial of service attacked on a system by sending many SYN packets without completing the three way handshake. This will quickly use up slots in the kernel's half-open connection queue and prevent legitimate connections from succeeding. SYN cookies allow the system to keep accepting valid connections, even if under a denial of service attack."
+    remediation: "Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.tcp_syncookies = 1 and set the active kernel parameters: # sysctl -w net.ipv4.tcp_syncookies=1     # sysctl -w net.ipv4.route.flush=1"
+    compliance:
+      - cis: ["3.2.8"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv4.tcp_syncookies -> r:^net.ipv4.tcp_syncookies\s*=\s*1$'
+      - 'c:grep -Rh net\.ipv4\.tcp_syncookies /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.tcp_syncookies\s*=\s*1'
+
+# 3.2.9 Ensure IPv6 router advertisements are not accepted (Scored)
+  - id: 21079
+    title: "Ensure IPv6 router advertisements are not accepted (Scored)."
+    description: "This setting disables the system's ability to accept IPv6 router advertisements."
+    rationale: "It is recommended that systems not accept router advertisements as they could be tricked into routing traffic to compromised machines. Setting hard routes within the system (usually a single default route to a trusted router) protects the system from bad routes."
+    remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file:       net.ipv6.conf.all.accept_ra = 0        and          net.ipv6.conf.default.accept_ra = 0            Then, run the following commands to set the active kernel parameters:  # sysctl -w net.ipv6.conf.all.accept_ra=0              # sysctl -w net.ipv6.conf.default.accept_ra=0           # sysctl -w net.ipv6.route.flush=1"
+    compliance:
+      - cis: ["3.2.9"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:sysctl net.ipv6.conf.all.accept_ra -> r:^net.ipv6.conf.all.accept_ra\s*=\s*0$'
+      - 'c:sysctl net.ipv6.conf.default.accept_ra -> r:^net.ipv6.conf.default.accept_ra\s*=\s*0$'
+      - 'c:grep -Rh net\.ipv6\.conf\.all\.accept_ra /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv6.conf.all.accept_ra\s*=\s*0'
+      - 'c:grep -Rh net\.ipv6\.conf\.default\.accept_ra /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv6.conf.default.accept_ra\s*=\s*0'
+
+###############################################
+# 3.3 TCP Wrappers
+###############################################
+
+# 3.3.1 Ensure TCP Wrappers is installed (Scored)
+  - id: 21080
+    title: "Ensure TCP Wrappers is installed (Scored)."
+    description: "TCP Wrappers provides a simple access list and standardized logging method for services capable of supporting it. In the past, services that were called from inetd and xinetd supported the use of tcp wrappers. As inetd and xinetd have been falling in disuse, any service that can support tcp wrappers will have the libwrap.so library attached to it." 
+    rationale: "TCP Wrappers provide a good simple access list mechanism to services that may not have that support built in. It is recommended that all services that can support TCP Wrappers, use it." 
+    remediation: "Run the following command to install tcp_wrappers : # yum install tcp_wrappers"
+    compliance:
+      - cis: ["3.3.1"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:rpm -q tcp_wrappers -> r:tcp_wrappers-'
+      - 'c:rpm -q tcp_wrappers-libs -> r:tcp_wrappers-libs-'
+
+# 3.3.2 Ensure /etc/hosts.allow is configured (Not Scored)
+
+# 3.3.3 Ensure /etc/hosts.deny is configured (Not Scored)
+
+# 3.3.4 Ensure permissions on /etc/hosts.allow are configured (Scored)
+  - id: 21081
+    title: "Ensure permissions on /etc/hosts.allow are configured (Scored)."
+    description: "The /etc/hosts.allow file contains networking information that is used by many applications and therefore must be readable for these applications to operate."
+    rationale: "It is critical to ensure that the /etc/hosts.allow file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
+    remediation: "Run the following commands to set permissions on /etc/hosts.allow : # chown root:root /etc/hosts.allow  # chmod 644 /etc/hosts.allow"
+    compliance:
+      - cis: ["3.3.4"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:stat /etc/hosts.allow -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+
+# 3.3.5 Ensure permissions on /etc/hosts.deny are configured (Scored)
+  - id: 21082
+    title: "Ensure permissions on /etc/hosts.deny are configured (Scored)."
+    description: "The /etc/hosts.deny file contains network information that is used by many system applications and therefore must be readable for these applications to operate."
+    rationale: "It is critical to ensure that the /etc/hosts.deny file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
+    remediation: "Run the following commands to set permissions on /etc/hosts.deny : # chown root:root /etc/hosts.deny # chmod 644 /etc/hosts.deny"
+    compliance:
+      - cis: ["3.3.5"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:stat /etc/hosts.deny -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+
+
+###############################################
+# 3.4 Uncommon Network Protocols
+###############################################
+
+# 3.4.1 Ensure DCCP is disabled (Not Scored)
+  - id: 21083
+    title: "Ensure DCCP is disabled (Not Scored)."
+    description: "The Datagram Congestion Control Protocol (DCCP) is a transport layer protocol that supports streaming media and telephony. DCCP provides a way to gain access to congestion control, without having to do it at the application layer, but does not provide in-sequence delivery."
+    rationale: "If the protocol is not required, it is recommended that the drivers not be installed to reduce the potential attack surface."
+    remediation: "Edit or create the file /etc/modprobe.d/CIS.conf and add the following line: install dccp /bin/true"
+    compliance:
+      - cis: ["3.4.1"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:modprobe -n -v dccp -> r:install /bin/true'
+      - 'not c:lsmod -> r:dccp'
+
+# 3.4.2 Ensure SCTP is disabled (Not Scored)
+  - id: 21084
+    title: "Ensure SCTP is disabled (Not Scored)."
+    description: "The Stream Control Transmission Protocol (SCTP) is a transport layer protocol used to support message oriented communication, with several streams of messages in one connection. It serves a similar function as TCP and UDP, incorporating features of both. It is message-oriented like UDP, and ensures reliable in-sequence transport of messages with congestion control like TCP."
+    rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
+    remediation: "Edit or create the file /etc/modprobe.d/CIS.conf and add the following line: install sctp /bin/true"
+    compliance:
+      - cis: ["3.4.2"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:modprobe -n -v sctp -> r:install /bin/true'
+      - 'not c:lsmod -> r:sctp'
+
+# 3.4.3 Ensure RDS is disabled (Not Scored)
+  - id: 21085
+    title: "Ensure RDS is disabled (Not Scored)"
+    description: "The Reliable Datagram Sockets (RDS) protocol is a transport layer protocol designed to provide low-latency, high-bandwidth communications between cluster nodes. It was developed by the Oracle Corporation."
+    rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
+    remediation: "Edit or create the file /etc/modprobe.d/CIS.conf and add the following line: install rds /bin/true"
+    compliance:
+      - cis: ["3.4.3"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:modprobe -n -v rds -> r:install /bin/true'
+      - 'not c:lsmod -> r:rds'
+
+# 3.4.4 Ensure TIPC is disabled (Not Scored)
+  - id: 21086
+    title: "Ensure TIPC is disabled (Not Scored)"
+    description: "The Transparent Inter-Process Communication (TIPC) protocol is designed to provide communication between cluster nodes."
+    rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
+    remediation: "Edit or create the file /etc/modprobe.d/CIS.conf and add the following line: install tipc /bin/true"
+    compliance:
+      - cis: ["3.4.4"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:modprobe -n -v tipc -> r:install /bin/true'
+      - 'not c:lsmod -> r:tipc'
+
+###############################################
+# 3.5 Firewall Configuration
+###############################################
+###############################################
+#3.5.1 Configure IPv4 iptables
+###############################################
+
+# 3.5.1.1 Ensure default deny firewall policy (Scored)
+  - id: 21087
+    title: "Ensure default deny firewall policy (Scored)."
+    description: "A default deny all policy on connections ensures that any unconfigured network usage will be rejected."
+    rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage."
+    remediation: "Run the following commands to implement a default DROP policy: # iptables -P INPUT DROP   # iptables -P OUTPUT DROP      # iptables -P FORWARD DROP      # service iptables save"
+    compliance:
+      - cis: ["3.5.1.1"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:iptables -L -> r:Chain INPUT \(policy DROP\)'
+      - 'c:iptables -L -> r:Chain FORWARD \(policy DROP\)'
+      - 'c:iptables -L -> r:Chain OUTPUT \(policy DROP\)'
+
+# 3.5.1.2 Ensure loopback traffic is configured (Scored)
+  - id: 21088
+    title: "Ensure loopback traffic is configured (Scored)."
+    description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network (127.0.0.0/8)."
+    rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network (127.0.0.0/8) traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure."
+    remediation: "Run the following commands to implement the loopback rules: # iptables -A INPUT -i lo -j ACCEPT     # iptables -A OUTPUT -o lo -j ACCEPT           # iptables -A INPUT -s 127.0.0.0/8 -j DROP         # service iptables save"
+    compliance:
+      - cis: ["3.5.1.2"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:iptables -L INPUT -v -n -> r:\.*ACCEPT\.*all\.*lo\.**\.*0.0.0.0/0\.*0.0.0.0/0'
+      - 'c:iptables -L INPUT -v -n -> r:\.*DROP\.*all\.**\.**\.*127.0.0.0/8\.*0.0.0.0/0'
+      - 'c:iptables -L OUTPUT -v -n -> r:\.*ACCEPT\.*all\.**\.*lo\.*0.0.0.0/0\.*0.0.0.0/0'
+
+# 3.5.1.3 Ensure outbound and established connections are configured (Not Scored)
+
+# 3.5.1.4 Ensure firewall rules exist for all open ports (Scored)
+
+###############################################
+# 3.5.2 Configure IPv6 ip6tables
+###############################################
+
+# 3.5.2.1 Ensure IPv6 default deny firewall policy (Scored)
+  - id: 21089
+    title: "Ensure IPv6 default deny firewall policy (Scored)."
+    description: "A default deny all policy on connections ensures that any unconfigured network usage will be rejected."
+    rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage."
+    remediation: "Run the following commands to implement a default DROP policy: # ip6tables -P INPUT DROP; # ip6tables -P OUTPUT DROP; # ip6tables -PFORWARD DROP"
+    compliance:
+      - cis: ["3.5.2.1"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:ip6tables -L -> r:Chain INPUT (policy DROP)'
+      - 'c:ip6tables -L -> r:Chain FORWARD (policy DROP)'
+      - 'c:ip6tables -L -> r:Chain OUTPUT (policy DROP)'
+
+# 3.5.2.2 Ensure IPv6 loopback traffic is configured (Scored)
+  - id: 21090
+    title: "Ensure IPv6 loopback traffic is configured (Scored)."
+    description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic tothe loopback network (::1)."
+    rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network (::1) traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure"
+    remediation: "Run the following commands to implement the loopback rules:# ip6tables -A INPUT -i lo -j ACCEPT# ip6tables -A OUTPUT -o lo -j ACCEPT# ip6tables -A INPUT -s::1 -j DROP  # service iptables save"
+    compliance:
+      - cis: ["3.5.2.2"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:ip6tables -L INPUT -v -n -> r:ACCEPT'
+      - 'c:ip6tables -L INPUT -v -n -> r:DROP'
+      - 'c:ip6tables -L OUTPUT -v -n -> r:ACCEPT'
+
+# 3.5.2.3 Ensure IPv6 outbound and established connections are configured (Not Scored)
+  - id: 21091
+    title: "Ensure IPv6 outbound and established connections are configured (Not Scored)."
+    description: "Configure the firewall rules for new outbound, and established IPv6 connections."
+    rationale: "If rules are not in place for new outbound, and established connections all packets will be dropped by the default policy preventing network usage"
+    remediation: "Configure iptables in accordance with site policy. The following commands will implement a policy to allow all outbound connections and all established connections:# ip6tables -AOUTPUT -p tcp -m state --state NEW,ESTABLISHED -j ACCEPT# ip6tables -A OUTPUT -p udp -m state --state NEW,ESTABLISHED -j ACCEPT# ip6tables -A OUTPUT -p icmp -m state --state NEW,ESTABLISHED -j ACCEPT# ip6tables -A INPUT -p tcp -m state --state ESTABLISHED -j ACCEPT# ip6tables -A INPUT -p udp -m state --state ESTABLISHED -j ACCEPT# ip6tables -A INPUT -p icmp -m state --state ESTABLISHED -j ACCEPT # service iptables save"
+    compliance:
+      - cis: ["3.5.2.3"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:ip6tables -L OUTPUT -v -n -> r:state NEW,ESTABLISHED'
+      - 'c:ip6tables -L INPUT -v -n -> r:state ESTABLISHED'
+
+# 3.5.2.4 Ensure IPv6 firewall rules exist for all open ports (Not Scored)
+
+# 3.5.3 Ensure iptables is installed (Scored)
+  - id: 21092
+    title: "Ensure iptables is installed (Scored)."
+    description: "iptables allows configuration of the IPv4 tables in the linux kernel and the rules stored within them. Most firewall configuration utilities operate as a front end to iptables." 
+    rationale: "iptables is required for firewall management and configuration." 
+    remediation: "Run the following command to install iptables # yum install iptables"
+    compliance:
+      - cis: ["3.5.3"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:rpm -q iptables -> r:iptables-'
+
+# 3.6 Disable IPv6 (Not Scored)
+  - id: 21093
+    title: "Disable IPv6 (Not Scored)."
+    description: "Although IPv6 has many advantages over IPv4, not all organizations have IPv6 or dual stack configurations implemented."
+    rationale: "If IPv6 or dual stack is not to be used, it is recommended that IPv6be disabled to reduce the attack surface of the system."
+    remediation: "To disable IPv6 through the GRUB2 config: edit /etc/default/gruband add ipv6.disable=1 to the GRUB_CMDLINE_LINUX parameters: GRUB_CMDLINE_LINUX=\"ipv6.disable=1\" Run the following command to update the grub2 configuration:# grub2-mkconfig –o /boot/grub2/grub.cfg; OR to disable IPv6 through sysctl settings: set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: # net.ipv6.conf.all.disable_ipv6 = 1; # net.ipv6.conf.default.disable_ipv6 = 1; Run the following commands to set the active kernel parameters: # sysctl -w net.ipv6.conf.all.disable_ipv6=1; # sysctl -w net.ipv6.conf.default.disable_ipv6=1; # sysctl -w net.ipv6.route.flush=1"
+    compliance:
+      - cis: ["3.6"]
+      - cis_level: ["2"]
+    condition: none
+    rules:
+      - 'f:/boot/grub2/grub.cfg -> r:^\s*\t*linux && !r:ipv6.disable=1'
+      - 'c:sysctl net.ipv6.conf.all.disable_ipv6 -> r:net.ipv6.conf.all.disable_ipv6\s*=\s*0'
+      - 'c:sysctl net.ipv6.conf.default.disable_ipv6 -> r:net.ipv6.conf.default.disable_ipv6\s*=\s*0'
+
+###############################################
+# 4 Logging and Auditing
+###############################################
+###############################################
+# 4.1 Configure System Accounting (auditd)
+###############################################
+# 4.1.1.1 Ensure audit log storage size is configured (Not Scored)
+  - id: 21094
+    title: "Ensure audit log storage size is configured (Not Scored)."
+    description: "Configure the maximum size of the audit log file. Once the log reaches the maximum size, it will be rotated and a new log file will be started."
+    rationale: "It is important that an appropriate size is determined for log files so that they do not impact the system and audit data is not lost."
+    remediation: "Set the following parameter in /etc/audit/auditd.conf in accordance with site policy: max_log_file = <MB>  Run the following command：# service auditd restart"
+    compliance:
+      - cis: ["4.1.1.1"]
+      - cis_level: ["2"]
+    condition: all
+    rules:
+      - 'f:/etc/audit/auditd.conf -> r:^max_log_file = \d+'
+
+# 4.1.1.2 Ensure system is disabled when audit logs are full (Scored)
+  - id: 21095
+    title: "Ensure system is disabled when audit logs are full (Scored)."
+    description: "The auditd daemon can be configured to halt the system when the audit logs are full."
+    rationale: "In high security contexts, the risk of detecting unauthorized access or nonrepudiation exceeds the benefit of the system's availability."
+    remediation: "Set the following parameters in /etc/audit/auditd.conf: space_left_action = email   action_mail_acct = root   admin_space_left_action = halt"
+    compliance:
+      - cis: ["4.1.1.2"]
+      - cis_level: ["2"]
+    condition: all
+    rules:
+      - 'f:/etc/audit/auditd.conf -> r:^\s*space_left_action\s*=\s*email'
+      - 'f:/etc/audit/auditd.conf -> r:^\s*action_mail_acct\s*=\s*root'
+      - 'f:/etc/audit/auditd.conf -> r:^\s*admin_space_left_action\s*=\s*halt'
+
+# 4.1.1.3 Ensure audit logs are not automatically deleted (Scored)
+  - id: 21096
+    title: "Ensure audit logs are not automatically deleted (Scored)."
+    description: "The max_log_file_action setting determines how to handle the audit log file reaching the max file size. A value of keep_logs will rotate the logs but never delete old logs."
+    rationale: "In high security contexts, the benefits of maintaining a long audit history exceed the cost of storing the audit history."
+    remediation: "Set the following parameter in /etc/audit/auditd.conf: max_log_file_action = keep_logs"
+    compliance:
+      - cis: ["4.1.1.3"]
+      - cis_level: ["2"]
+    condition: all
+    rules:
+      - 'f:/etc/audit/auditd.conf -> r:^\s*max_log_file_action\s*=\s*keep_logs'
+
+# 4.1.2 Ensure auditd service is enabled (Scored)
+  - id: 21097
+    title: "Ensure auditd service is enabled (Scored)."
+    description: "Turn on the auditd daemon to record system events."
+    rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
+    remediation: "Run the following command to enable auditd: # systemctl enable auditd  # systemctl start auditd"
+    compliance:
+      - cis: ["4.1.2"]
+      - cis_level: ["2"]
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled auditd -> r:^enabled'
+      - 'c:systemctl status auditd -> r:Active: active \(running\)'
+
+# 4.1.3 Ensure auditing for processes that start prior to auditd is enabled (Scored)
+  - id: 21098
+    title: "Ensure auditing for processes that start prior to auditd is enabled (Scored)."
+    description: "Configure grub so that processes that are capable of being audited can be audited even if they start up prior to auditd startup."
+    rationale: "Audit events need to be captured on processes that start up prior to auditd, so that potential malicious activity cannot go undetected. Note: This recommendation is designed around the grub2 bootloader, if LILO or another bootloader is in use in your environment enact equivalent settings."
+    remediation: "Edit /etc/default/grub and add audit=1 to GRUB_CMDLINE_LINUX: GRUB_CMDLINE_LINUX=\"audit=1\" . Run the following command to update the grub2 configuration: # grub2-mkconfig -o /boot/grub2/grub.cfg"
+    compliance:
+      - cis: ["4.1.3"]
+      - cis_level: ["2"]
+    condition: none
+    rules:
+      - 'f:/boot/grub2/grub.cfg -> r:^\s*\t*linux && !r:audit=1'
+
+# 4.1.4 Ensure events that modify date and time information are collected (Scored)
+  - id: 21099
+    title: "Ensure events that modify date and time information are collected."
+    description: "Capture events where the system date and/or time has been modified. The parameters in this section are set to determine if the adjtimex (tune kernel clock), settimeofday (Set time, using timeval and timezone structures) stime (using seconds since 1/1/1970) or clock_settime (allows for the setting of several internal clocks and timers) system calls have been executed and always write an audit record to the /var/log/audit.log file upon exit, tagging the records with the identifier \"time-change\"."
+    rationale: "Unexpected changes in system date and/or time could be a sign of malicious activity on the system."
+    remediation: "For 32 bit systems edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/time-change.rules and add the following lines: -a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change   -a always,exit -F arch=b32 -S clock_settime -k time-change   -w /etc/localtime -p wa -k time-change   For 64 bit systems edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/time-change.rules and add the following lines:   -a always,exit -F arch=b64 -S adjtimex -S settimeofday -k time-change   -a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change   -a always,exit -F arch=b64 -S clock_settime -k time-change   -a always,exit -Farch=b32 -S clock_settime -k time-change   -w /etc/localtime -p wa -k time-change. Notes: Reloading the auditd config to set active settings may require a system reboot."
+    compliance:
+      - cis: ["4.1.4"]
+      - cis_level: ["2"]
+    condition: all
+    rules:
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S adjtimex && r:-S settimeofday && r:-S stime && r:-k time-change'
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S clock_settime && r:-k time-change'
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /etc/localtime && r:-p wa && r:-k time-change'
+
+# 4.1.5 Ensure events that modify user/group information are collected (Scored)
+  - id: 21100
+    title: "Ensure events that modify user/group information are collected (Scored)."
+    description: "Record events affecting the group, passwd (user IDs), shadow and gshadow (passwords) or /etc/security/opasswd (old passwords, based on remember parameter in the PAM configuration) files. The parameters in this section will watch the files to see if they have been opened for write or have had attribute changes (e.g. permissions) and tag them with the identifier \"identity\" in the audit log file."
+    rationale: "Unexpected changes to these files could be an indication that the system has been compromised and that an unauthorized user is attempting to hide their activities or compromise additional accounts."
+    remediation: "Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/identity.rules and add the following lines:    -w /etc/group -p wa -k identity    -w /etc/passwd -p wa -k identity    -w /etc/gshadow -p wa -k identity    -w /etc/shadow -p wa -k identity    -w /etc/security/opasswd -p wa -k identity. Notes: Reloading the auditd config to set active settings may require a system reboot."
+    compliance:
+      - cis: ["4.1.5"]
+      - cis_level: ["2"]
+    condition: all
+    rules:
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /etc/group && r:-p wa && r:-k identity'
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /etc/passwd && r:-p wa && r:-k identity'
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /etc/gshadow && r:-p wa && r:-k identity'
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /etc/shadow && r:-p wa && r:-k identity'
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /etc/security/opasswd && r:-p wa && r:-k identity'
+
+# 4.1.6 Ensure events that modify the system's network environment are collected (Scored)
+  - id: 21101
+    title: "Ensure events that modify the system's network environment are collected (Scored)."
+    description: "Record changes to network environment files or system calls. The below parameters monitor the sethostname (set the systems host name) or setdomainname (set the systems domainname) system calls, and write an audit event on system call exit. The other parameters monitor the /etc/issue and /etc/issue.net files (messages displayed pre-login), /etc/hosts (file containing host names and associated IP addresses), /etc/sysconfig/network file and /etc/sysconfig/network-scripts/ directory (containing network interface scripts and configurations)."
+    rationale: "Monitoring sethostname and setdomainname will identify potential unauthorized changes to host and domainname of a system. The changing of these names could potentially break security parameters that are set based on those names. The /etc/hosts file is monitored for changes in the file that can indicate an unauthorized intruder is trying to change machine associations with IP addresses and trick users and processes into connecting to unintended machines. Monitoring /etc/issue and /etc/issue.net is important, as intruders could put disinformation into those files and trick users into providing information to the intruder. Monitoring /etc/sysconfig/network and /etc/sysconfig/network-scripts/ is important as it can show if network interfaces or scripts are being modified in a way that can lead to the machine becoming unavailable or compromised. All audit records will be tagged with the identifier \"system-locale.\""
+    remediation: "For 32 bit systems edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/system-locale.rules and add the following lines:    -a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale    -w /etc/issue -p wa -k system-locale    -w /etc/issue.net -p wa -k system-locale    -w /etc/hosts -p wa -k system-locale    -w /etc/sysconfig/network -p wa -k system-locale            For 64 bit systems edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/system-locale.rules and add the following lines:    -a always,exit -F arch=b64 -S sethostname -S setdomainname -k system-locale    -a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale    -w /etc/issue -p wa -k system-locale    -w /etc/issue.net -p wa -k system-locale    -w /etc/hosts -p wa -k system-locale    -w /etc/sysconfig/network -p wa -k system-locale "
+    compliance:
+      - cis: ["4.1.6"]
+      - cis_level: ["2"]
+    condition: all
+    rules:
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S sethostname && r:-S setdomainname && r:-k system-locale'
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /etc/issue && r:-p wa && r:-k system-locale'
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /etc/issue.net && r:-p wa && r:-k system-locale'
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /etc/hosts && r:-p wa && r:-k system-locale'
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /etc/sysconfig/network && r:-p wa && r:-k system-locale'
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /etc/sysconfig/network-scripts/ && r:-p wa && r:-k system-locale'
+
+# 4.1.7 Ensure events that modify the system's Mandatory Access Controls are collected (Scored)
+  - id: 21102
+    title: "Ensure events that modify the system's Mandatory Access Controls are collected (Scored)."
+    description: "Monitor SELinux mandatory access controls. The parameters below monitor any write access (potential additional, deletion or modification of files in the directory) or attribute changes to  the /etc/selinux/ and /usr/share/selinux/ directories."
+    rationale: "Changes to files in the /etc/selinux/ and /usr/share/selinux/ directories could indicate that an unauthorized user is attempting to modify access controls and change security contexts, leading to a compromise of the system."
+    remediation: "Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/MAC-policy.rules and add the following lines: -w /etc/selinux/ -p wa -k MAC-policy -w /usr/share/selinux/ -p wa -k MAC-policy ."
+    compliance:
+      - cis: ["4.1.7"]
+      - cis_level: ["2"]
+    condition: all
+    rules:
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /etc/selinux/ && r:-p wa && r:-k MAC-policy'
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /usr/share/selinux/ && r:-p wa && r:-k MAC-policy'
+
+# 4.1.8 Ensure login and logout events are collected (Scored)
+  - id: 21103
+    title: "Ensure login and logout events are collected (Scored)."
+    description: "Monitor login and logout events. The parameters below track changes to files associated with login/logout events. The file /var/log/faillog tracks failed events from login. The file /var/log/lastlog maintain records of the last time a user successfully logged in. The /var/run/faillock/ directory maintains records of login failures via the pam_faillock module. The file /var/log/tallylog maintains records of failures via the pam_tally2 module"
+    rationale: "Monitoring login/logout events could provide a system administrator with information associated with brute force attacks against user logins."
+    remediation: "Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/logins.rules and add the following lines:  -w /var/log/lastlog -p wa -k logins   -w /var/run/faillog/ -p wa -k logins   IF   the pam_faillock.so module is used: Also include the line:  -w /var/run/faillock/ -p wa -k logins   OR IF the pam_tally2.so module is used: Also include the line:  -w /var/log/tallylog -p wa -k logins"
+    compliance:
+      - cis: ["4.1.8"]
+      - cis_level: ["2"]
+    condition: all
+    rules:
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /var/log/lastlog && r:-p wa && r:-k logins'
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /var/run/faillock/ && r:-p wa && r:-k logins'
+
+# 4.1.9 Ensure session initiation information is collected (Scored)
+  - id: 21104
+    title: "Ensure session initiation information is collected (Scored)."
+    description: "Monitor session initiation events. The parameters in this section track changes to the files associated with session events. The file /var/run/utmp file tracks all currently logged in users. All audit records will be tagged with the identifier \"session.\" The /var/log/wtmp file tracks logins, logouts, shutdown, and reboot events. The file /var/log/btmp keeps track of failed login attempts and can be read by entering the command /usr/bin/last -f /var/log/btmp . All audit records will be tagged with the identifier \"logins.\"."
+    rationale: "Monitoring these files for changes could alert a system administrator to logins occurring at unusual hours, which could indicate intruder activity (i.e. a user logging in at a time when they do not normally log in)."
+    remediation: "Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/logins.rules and add the following lines:   -w /var/run/utmp -p wa -k session   -w /var/log/wtmp -p wa -k logins   -w /var/log/btmp -p wa -k logins . Notes: The last command can be used to read /var/log/wtmp ( last with no parameters) and /var/run/utmp ( last -f /var/run/utmp ) Reloading the auditd config to set active settings may require a system reboot."
+    compliance:
+      - cis: ["4.1.9"]
+      - cis_level: ["2"]
+    condition: all
+    rules:
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /var/run/utmp && r:-p wa && r:-k session'
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /var/log/wtmp && r:-p wa && r:-k logins'
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /var/log/btmp && r:-p wa && r:-k logins'
+
+# 4.1.10 Ensure discretionary access control permission modification events are collected (Scored)
+  - id: 21105
+    title: "Ensure discretionary access control permission modification events are collected (Scored)."
+    description: "Monitor changes to file permissions, attributes, ownership and group. The parameters in this section track changes for system calls that affect file permissions and attributes. The chmod, fchmod and fchmodat system calls affect the permissions associated with a file. The chown, fchown, fchownat and lchown system calls affect owner and group attributes on a file. The setxattr, lsetxattr, fsetxattr (set extended file attributes) and removexattr, lremovexattr, fremovexattr (remove extended file attributes) control extended file attributes. In all cases, an audit record will only be written for non-system user ids (auid >= 1000) and will ignore Daemon events (auid = 4294967295). All audit records will be tagged with the identifier \"perm_mod.\""
+    rationale: "Monitoring for changes in file attributes could alert a system administrator to activity that could indicate intruder activity or policy violation."
+    remediation: "For 32 bit systems edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/perm_mod.rules and add the following lines:   -a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod   -a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod   -a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod   For 64 bit systems edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/perm_mod.rules and add the following lines:   -a always,exit -F arch=b64 -S chmod -S fchmod -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod   -a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod   -a always,exit -F arch=b64 -S chown -S fchown -S fchownat -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod   -a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod   -a always,exit -F arch=b64 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod   -a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lrem . Notes: Reloading the auditd config to set active settings may require a system reboot."
+    compliance:
+      - cis: ["4.1.10"]
+      - cis_level: ["2"]
+    condition: all
+    rules:
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S chmod && r:-S fchmod && r:-S fchmodat && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k perm_mod'
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S chown && r:-S fchown && r:-S fchownat && r:-S lchown && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k perm_mod'
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S setxattr && r:-S lsetxattr && r:-S fsetxattr && r:-S removexattr && r:-S lremovexattr && r:-S fremovexattr && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k perm_mod'
+
+# 4.1.11 Ensure unsuccessful unauthorized file access attempts are collected (Scored)
+  - id: 21106
+    title: "Ensure unsuccessful unauthorized file access attempts are collected (Scored)."
+    description: "Monitor for unsuccessful attempts to access files. The parameters below are associated  with system calls that control creation ( creat ), opening ( open, openat ) and truncation (  truncate, ftruncate ) of files. An audit log record will only be written if the user is a non-  privileged user (auid > = 1000), is not a Daemon event (auid=4294967295) and if the  system call returned EACCES (permission denied to the file) or EPERM (some other  permanent error associated with the specific system call). All audit records will be tagged  with the identifier \"access.\""
+    rationale: "Failed attempts to open, create or truncate files could be an indication that an individual or process is trying to gain unauthorized access to the system."
+    remediation: "For 32 bit systems edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/access.rules and add the following lines:   -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access   -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access   For 64 bit systems edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/access.rules and add the following lines:   -a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access   -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access   -a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access   -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access . Notes: Reloading the auditd config to set active settings may require a system reboot."
+    compliance:
+      - cis: ["4.1.11"]
+      - cis_level: ["2"]
+    condition: all
+    rules:
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S creat && r:-S open && r:-S openat && r:-S truncate && r:-S ftruncate && r:-F exit=-EACCES && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k access'
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S creat && r:-S open && r:-S openat && r:-S truncate && r:-S ftruncate && r:-F exit=-EPERM && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k access'
+
+# 4.1.12 Ensure use of privileged commands is collected (Scored)
+
+# 4.1.13 Ensure successful file system mounts are collected (Scored)
+  - id: 21107
+    title: "Ensure successful file system mounts are collected (Scored)."
+    description: "Monitor the use of the mount system call. The mount (and umount ) system call controls the mounting and unmounting of file systems. The parameters below configure the system to create an audit record when the mount system call is used by a non-privileged user."
+    rationale: "It is highly unusual for a non privileged user to mount file systems to the system. While tracking mount commands gives the system administrator evidence that external media may have been mounted (based on a review of the source of the mount and confirming it's an external media type), it does not conclusively indicate that data was exported to the media. System administrators who wish to determine if data were exported, would also have to track successful open, creat and truncate system calls requiring write access to a file under the mount point of the external media file system. This could give a fair indication that a write occurred. The only way to truly prove it, would be to track successful writes to the external media. Tracking write system calls could quickly fill up the audit log and is not recommended. Recommendations on configuration options to track data export to media is beyond the scope of this document."
+    remediation: "For 32 bit systems edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/mount.rules and add the following lines:   -a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts   For 64 bit systems edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/mounts.rules and add the following lines:   -a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts   -a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts . Notes: This tracks successful and unsuccessful mount commands. File system mounts do not have to come from external media and this action still does not verify write (e.g. CD ROMS). Reloading the auditd config to set active settings may require a system reboot."
+    compliance:
+      - cis: ["4.1.13"]
+      - cis_level: ["2"]
+    condition: all
+    rules:
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S mount && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k mounts'
+
+# 4.1.14 Ensure file deletion events by users are collected (Scored)
+  - id: 21108
+    title: "Ensure file deletion events by users are collected (Scored)."
+    description: "Monitor the use of system calls associated with the deletion or renaming of files and file attributes. This configuration statement sets up monitoring for ollowing system calls and tags them with the identifier \"delete\": unlink -remove a file     unlinkat - remove a file attribute), rename (rename a file and renameat - rename a file attribute) system calls and tags them with the identifier \"delete\"."
+    rationale: "Monitoring these calls from non-privileged users could provide a system administrator with evidence that inappropriate removal of files and file attributes associated with protected files is occurring. While this audit option will look at all events, system administrators will want to look for specific privileged files that are being deleted or altered."
+    remediation: "For 32 bit systems edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/delete.rules and add the following lines:   -a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete   For 64 bit systems edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/delete.rules and add the following lines:   -a always,exit -F arch=b64 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete   -a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete . Notes: At a minimum, configure the audit system to collect file deletion events for all users and root. Reloading the auditd config to set active settings may require a system reboot."
+    compliance:
+      - cis: ["4.1.14"]
+      - cis_level: ["2"]
+    condition: all
+    rules:
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S unlink && r:-S unlinkat && r:-S rename && r:-S renameat && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k delete'
+
+# 4.1.15 Ensure changes to system administration scope (sudoers) is collected (Scored)
+  - id: 21109
+    title: "Ensure changes to system administration scope (sudoers) is collected (Scored)."
+    description: "Monitor scope changes for system administrators. If the system has been properly configured to force system administrators to log in as themselves first and then use the sudo command to execute privileged commands, it is possible to monitor changes in scope. The file /etc/sudoers or a file in the /etc/sudoers.d directory will be written to when the file or its attributes have changed."
+    rationale: "Changes in the /etc/sudoers file, or a file in the /etc/sudoers.d/ directory can indicate that an unauthorized change has been made to scope of system administrator activity."
+    remediation: "Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/scope.rules and add the following lines::   -w /etc/sudoers -p wa -k scope   -w /etc/sudoers.d/ -p wa -k scope . Notes: Reloading the auditd config to set active settings may require a system reboot."
+    compliance:
+      - cis: ["4.1.15"]
+      - cis_level: ["2"]
+    condition: all
+    rules:
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /etc/sudoers && r:-p wa && r:-k scope'
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /etc/sudoers.d/ && r:-p wa && r:-k scope'
+
+# 4.1.16 Ensure system administrator actions (sudolog) are collected (Scored)
+  - id: 21110
+    title: "Ensure system administrator actions (sudolog) are collected (Scored)."
+    description: "Monitor the sudo log file. The sudo log file is configured in /etc/sudoersor a file in /etc/sudoers.d. If the system has been properly configured to disable the use of the su command and force all administrators to have to log in first and then use sudo to execute privileged commands, then all administrator commands will be logged to the sudo log file. Any time a command is executed, an audit event will be triggered as the sudo log file will be opened for write and the executed administration command will be written to the log."
+    rationale: "Changes in /var/log/sudo.log indicate that an administrator has executed a command or the log file itself has been tampered with. Administrators will want to correlate the events written to the audit trail with the records written to /var/log/sudo.log to verify if unauthorized commands have been executed."
+    remediation: "Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules . Example: vi /etc/audit/rules.d/action.rules and add the following lines:   -w /var/log/sudo.log -p wa -k actions ."
+    compliance:
+      - cis: ["4.1.16"]
+      - cis_level: ["2"]
+    condition: all
+    rules:
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /var/log/sudo.log && r:-p wa && r:-k actions'
+
+# 4.1.17 Ensure kernel module loading and unloading is collected (Scored)
+  - id: 21111
+    title: "Ensure kernel module loading and unloading is collected (Scored)."
+    description: "Monitor the loading and unloading of kernel modules. The programs insmod (install a kernel module), rmmod (remove a kernel module), and modprobe (a more sophisticated program to load and unload modules, as well as some other features) control loading and unloading of modules. The init_module (load a module) and delete_module (delete a module) system calls control loading and unloading of modules. Any execution of the loading and unloading module programs and system calls will trigger an audit record with an identifier of \"modules\"."
+    rationale: "Monitoring the use of insmod, rmmod and modprobe could provide system administrators with evidence that an unauthorized user loaded or unloaded a kernel module, possibly compromising the security of the system. Monitoring of the init_module and delete_module system calls would reflect an unauthorized user attempting to use a different program to load and unload modules."
+    remediation: "Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules. Example: vi /etc/audit/rules.d/modules.rules and add the following lines:  -w /sbin/insmod -p x -k modules                   -w /sbin/rmmod -p x -k modules           -w /sbin/modprobe -p x -k modules        -a always,exit -F arch=b32 -S init_module -S delete_module -k modules For 64 bit systems Edit or create a file in the /etc/audit/rules.d/directory ending in .rules  Example: vi /etc/audit/rules.d/modules.rules Add the following lines:             -w /sbin/insmod -p x -k modules              -w /sbin/rmmod -p x -k modules                -w /sbin/modprobe -p x -k modules           -a always,exit -F arch=b64 -S init_module -S delete_module -k modules "
+    compliance:
+      - cis: ["4.1.17"]
+      - cis_level: ["2"]
+    condition: all
+    rules:
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /sbin/insmod && r:-p x && r:-k modules'
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /sbin/rmmod && r:-p x && r:-k modules'
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /sbin/modprobe && r:-p x && r:-k modules'
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b\d\d && r:-S init_module && r:-S delete_module && r:-k modules'
+
+# 4.1.18 Ensure the audit configuration is immutable (Scored)
+  - id: 21112
+    title: "Ensure the audit configuration is immutable (Scored)."
+    description: "Set system audit so that audit rules cannot be modified with auditctl . Setting the flag \"-e 2\" forces audit to be put in immutable mode. Audit changes can only be made on system reboot."
+    rationale: "In immutable mode, unauthorized users cannot execute changes to the audit system to potentially hide malicious activity and then put the audit rules back. Users would most likely notice a system reboot and that could alert administrators of an attempt to make unauthorized audit changes."
+    remediation: "Edit or create the file /etc/audit/rules.d/99-finalize.rulesand add the following line at the end of the file:  -e 2"
+    compliance:
+      - cis: ["4.1.18"]
+      - cis_level: ["2"]
+    condition: all
+    rules:
+      - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:^-e 2'
+
+
+###############################################
+# 4.2 Configure Logging
+###############################################
+
+# 4.2.1.1 Ensure rsyslog Service is enabled (Scored)
+  - id: 21113
+    title: "Ensure rsyslog Service is enabled (Scored)."
+    description: "Once the rsyslog package is installed it needs to be activated."
+    rationale: "If the rsyslog service is not activated the system may default to the syslogd service or lackblogging instead."
+    remediation: "Run the following command to enable rsyslog:   # systemctl enable rsyslog  # systemctl start rsyslog"
+    compliance:
+      - cis: ["4.2.1.1"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled rsyslog -> enabled'
+      - 'c:systemctl status rsyslog -> r:active \(running\)'
+
+# 4.2.1.2 Ensure logging is configured (Not Scored)
+
+# 4.2.1.3 Ensure rsyslog default file permissions configured (Scored)
+  - id: 21114
+    title: "Ensure rsyslog default file permissions configured (Scored)."
+    description: "rsyslog will create logfiles that do not already exist on the system. This setting controls what permissions will be applied to these newly created files."
+    rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitive data is archived and protected."
+    remediation: "Edit the /etc/rsyslog.conf and /etc/rsyslog.d/*.conf files and set $FileCreateMode to 0640 or more restrictive:   $FileCreateMode 0640  Run the following command to reload the rsyslogd configuration: # pkill -HUP rsyslogd"
+    compliance:
+      - cis: ["4.2.1.3"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode 06\d0|^\$FileCreateMode 04\d0|^\$FileCreateMode 02\d0|^\$FileCreateMode 00\d0 && r:^\$FileCreateMode 0\d40|^\$FileCreateMode 0\d00'
+      - 'd:/etc/rsyslog.d/ -> r:\.*.conf -> r:^\$FileCreateMode 06\d0|^\$FileCreateMode 04\d0|^\$FileCreateMode 02\d0|^\$FileCreateMode 00\d0 && r:^\$FileCreateMode 0\d40|^\$FileCreateMode 0\d00'
+
+# 4.2.1.4 Ensure rsyslog is configured to send logs to a remote log host (Scored)
+  - id: 21115
+    title: "Ensure rsyslog is configured to send logs to a remote log host (Scored)."
+    description: "The rsyslog utility supports the ability to send logs it gathers to a remote log host running syslogd(8) or to receive messages from remote hosts, reducing administrative overhead."
+    rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
+    remediation: "Edit the /etc/rsyslog.conf and /etc/rsyslog.d/*.conf files and add the following line (where loghost.example.com is the name of your central log host).   *.* @@loghost.example.com   Run the following command to reload the rsyslogd configuration: #  pkill -HUP rsyslog"
+    compliance:
+      - cis: ["4.2.1.4"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:grep *.*[^I][^I]*@ /etc/rsyslog.conf /etc/rsyslog.d/*.conf -> !r:# && r:*.* @@\.+'
+
+# 4.2.1.5 Ensure remote rsyslog messages are only accepted on designated log hosts. (Not Scored)
+  - id: 21116
+    title: "Ensure remote rsyslog messages are only accepted on designated log hosts. (Not Scored)."
+    description: "By default, rsyslog does not listen for log messages coming in from remote systems. The ModLoad tells rsyslog to load the imtcp.so module so it can listen over a network via TCP. The InputTCPServerRun option instructs rsyslogd to listen on the specified TCP port."
+    rationale: "The guidance in the section ensures that remote log hosts are configured to only accept rsyslog data from hosts within the specified domain and that those systems that are not designed to be log hosts do not accept any remote rsyslog messages. This provides protection from spoofed log data and ensures that system administrators are reviewing reasonably complete syslog data in a central location."
+    remediation: "For hosts that are designated as log hosts, edit the /etc/rsyslog.conf file and uncomment or add the following lines: $ModLoad imtcp  $InputTCPServerRun 514  For hosts that are not designated as log hosts, edit the /etc/rsyslog.conf file and comment or remove the following lines: # $ModLoad imtcp # $InputTCPServerRun 514"
+    compliance:
+      - cis: ["4.2.1.5"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:grep "$ModLoad imtcp" /etc/rsyslog.conf /etc/rsyslog.d/*.conf -> !r:# && r:$ModLoad imtcp'
+      - 'c:grep "$InputTCPServerRun" /etc/rsyslog.conf /etc/rsyslog.d/*.conf -> !r:# && r:$InputTCPServerRun 514'
+
+# 4.2.2 Ensure rsyslog is installed (Scored)
+  - id: 21117
+    title: "Ensure rsyslog is installed (Scored)."
+    description: "The rsyslog software is a recommended replacement to the original syslogd daemon. rsyslog provides improvements over syslogd, including:   - connection-oriented (i.e. TCP) transmission of logs     - The option to log to database formats    - Encryption of log data en route to a central logging server"
+    rationale: "The security enhancements of rsyslog and syslog-ng such as connection-oriented (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of log data en route to a central logging server) justify installing and configuring the package."
+    remediation: "Run the following command to install rsyslog: # yum install rsyslog"
+    compliance:
+      - cis: ["4.2.2"]
+      - cis_level: ["1"]
+    condition: any
+    rules:
+      - 'c:rpm -q rsyslog -> r:^rsyslog-\S+'
+
+# 4.2.3 Ensure permissions on all logfiles are configured (Scored)
+  - id: 21118
+    title: "Ensure permissions on all logfiles are configured (Scored)."
+    description: "Log files stored in /var/log/ contain logged information from many services on the system, or on log hosts others as well."
+    rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitive data is archived and protected.  Other/world should not have the ability to view this information. Group should not have the ability to modify this information."
+    remediation: "Run the following command to set permissions on all existing log files: # find /var/log -type f -exec chmod g-wx,o-rwx \"{}\" + -o -type d -exec chmod g-wx,o-rwx \"{}\" +"
+    compliance:
+      - cis: ["4.2.3"]
+      - cis_level: ["1"]
+    condition: none
+    rules:
+      - 'c:find /var/log -type f -ls -> r:-\w\w\w\ww\w\w\w\w|-\w\w\w\w\wx\w\w\w|-\w\w\w\w\w\w\ww\w|-\w\w\w\w\w\wr\w\w|-\w\w\w\w\w\w\w\wx'
+
+# 4.3 Ensure logrotate is configured (Not Scored)
+
+####################################################
+# 5 Access, Authentication and Authorization
+####################################################
+####################################################
+# 5.1 Configure cron
+####################################################
+
+# 5.1.1 Ensure cron daemon is enabled (Scored)
+  - id: 21119
+    title: "Ensure cron daemon is enabled (Scored)."
+    description: "The cron daemon is used to execute batch jobs on the system."
+    rationale: "While there may not be user jobs that need to be run on the system, the system does have maintenance jobs that may include security monitoring that have to run, and cron is used to execute them."
+    remediation: "Run the following command to enable cron : # systemctl enable crond"
+    compliance:
+      - cis: ["5.1.1"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:systemctl is-enabled crond -> enabled'
+      - 'c:systemctl status crond -> r:Active: active \(running\) since \w+ \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d'
+
+# 5.1.2 Ensure permissions on /etc/crontab are configured (Scored)
+  - id: 21120
+    title: "Ensure permissions on /etc/crontab are configured (Scored)."
+    description: "The /etc/crontab file is used by cron to control its own jobs. The commands in this item make sure that root is the user and group owner of the file and that only the owner can access the file."
+    rationale: "This file contains information on what system jobs are run by cron. Write access to these files could provide unprivileged users with the ability to elevate their privileges. Read access to these files could provide users with the ability to gain insight on system jobs that run on the system and could provide them a way to gain unauthorized privileged access."
+    remediation: "Run the following commands to set ownership and permissions on /etc/crontab : # chown root:root /etc/crontab; # chmod og-rwx /etc/crontab"
+    compliance:
+      - cis: ["5.1.2"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:stat /etc/crontab -> r:^Access: \(0\w00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+
+# 5.1.3 Ensure permissions on /etc/cron.hourly are configured (Scored)
+  - id: 21121
+    title: "Ensure permissions on /etc/cron.hourly are configured (Scored)."
+    description: "This directory contains system cron jobs that need to run on an hourly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
+    rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
+    remediation: "Run the following commands to set ownership and permissions on /etc/cron.hourly : chown root:root /etc/cron.hourly; # chmod og-rwx /etc/cron.hourly;"
+    compliance:
+      - cis: ["5.1.3"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:stat /etc/cron.hourly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+
+# 5.1.4 Ensure permissions on /etc/cron.daily are configured (Scored)
+  - id: 21122
+    title: "Ensure permissions on /etc/cron.daily are configured (Scored)."
+    description: "The /etc/cron.daily directory contains system cron jobs that need to run on a daily basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
+    rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
+    remediation: "Run the following commands to set ownership and permissions on /etc/cron.daily : chown root:root /etc/cron.daily; # chmod og-rwx /etc/cron.daily"
+    compliance:
+      - cis: ["5.1.4"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:stat /etc/cron.daily -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+
+# 5.1.5 Ensure permissions on /etc/cron.weekly are configured (Scored)
+  - id: 21123
+    title: "Ensure permissions on /etc/cron.weekly are configured (Scored)."
+    description: "The /etc/cron.weekly directory contains system cron jobs that need to run on a weekly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
+    rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
+    remediation: "Run the following commands to set ownership and permissions on /etc/cron.weekly : chown root:root /etc/cron.weekly; # chmod og-rwx /etc/cron.weekly"
+    compliance:
+      - cis: ["5.1.5"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:stat /etc/cron.weekly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+
+# 5.1.6 Ensure permissions on /etc/cron.monthly are configured (Scored)
+  - id: 21124
+    title: "Ensure permissions on /etc/cron.monthly are configured (Scored)."
+    description: "The /etc/cron.monthly directory contains system cron jobs that need to run on a monthly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
+    rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
+    remediation: "Run the following commands to set ownership and permissions on /etc/cron.monthly : chown root:root /etc/cron.monthly; # chmod og-rwx /etc/cron.monthly"
+    compliance:
+      - cis: ["5.1.6"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:stat /etc/cron.monthly -> r:^Access: \(0\w00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+
+# 5.1.7 Ensure permissions on /etc/cron.d are configured (Scored)
+  - id: 21125
+    title: "Ensure permissions on /etc/cron.d are configured (Scored)."
+    description: "The /etc/cron.d/directory contains system cronjobs that need to run in a similar manner to the hourly, daily weekly and monthly jobs from /etc/crontab, but require more granular control as to when they run. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
+    rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
+    remediation: "Run the following commands to set ownership and permissions on /etc/cron.d :   # chown root:root /etc/cron.d;   # chmod og-rwx /etc/cron.d"
+    compliance:
+      - cis: ["5.1.7"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:stat /etc/cron.d -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+
+# 5.1.8 Ensure at/cron is restricted to authorized users (Scored)
+  - id: 21126
+    title: "Ensure at/cron is restricted to authorized users (Scored)."
+    description: "Configure /etc/cron.allow and /etc/at.allow to allow specific users to use these services. If /etc/cron.allow or /etc/at.allow do not exist, then /etc/at.deny and /etc/cron.deny are checked. Any user not specifically defined in those files is allowed to use at and cron. By removing the files, only users in /etc/cron.allow and /etc/at.allow are allowed to use at and cron. Note that even though a given user is not listed in cron.allow , cron jobs can still be run as that user. The cron.allow file only controls administrative access to the crontab command for scheduling and modifying cron jobs."
+    rationale: "On many systems, only the system administrator is authorized to schedule cronjobs. Using the cron.allowfile to control who can run cronjobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
+    remediation: "Run the following commands to remove /etc/cron.deny and /etc/at.deny and create and set permissions and ownership for /etc/cron.allow and /etc/at.allow: rm /etc/cron.deny;rm /etc/at.deny;touch /etc/cron.allow; touch /etc/at.allow; chmod og-rwx /etc/cron.allow; chmod og-rwx /etc/at.allow; chown root:root /etc/cron.allow and chown root:root /etc/at.allow"
+    compliance:
+      - cis: ["5.1.8"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:stat /etc/cron.deny -> r:No such file or directory$'
+      - 'c:stat /etc/cron.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:stat /etc/at.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+
+###############################################
+# 5.2 Configure SSH Server
+###############################################
+
+# 5.2.1 Ensure permissions on /etc/ssh/sshd_config are configured (Scored)
+  - id: 21127
+    title: "Ensure permissions on /etc/ssh/sshd_config are configured (Scored)."
+    description: "The /etc/ssh/sshd_config file contains configuration specifications for sshd. The command below sets the owner and group of the file to root."
+    rationale: "The /etc/ssh/sshd_config file needs to be protected from unauthorized changes by non-privileged users."
+    remediation: "Run the following commands to set ownership and permissions on /etc/ssh/sshd_config: chown root:root /etc/ssh/sshd_config and chmod og-rwx /etc/ssh/sshd_config"
+    compliance:
+      - cis: ["5.2.1"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:stat /etc/ssh/sshd_config -> r:^Access: \(0600/-rw-------\)\s+Uid: \(\s+0/\s+root\)\s+Gid: \(\s+0/\s+root\)$'
+
+# 5.2.2 Ensure SSH Protocol is set to 2 (Scored)
+  - id: 21128
+    title: "Ensure SSH Protocol is set to 2 (Scored)."
+    description: "SSH supports two different and incompatible protocols: SSH1 and SSH2. SSH1 was the original protocol and was subject to security issues. SSH2 is more advanced and secure."
+    rationale: "SSH v1 suffers from insecurities that do not affect SSH v2."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: Protocol 2 Restart sshd : systemctl restart sshd"
+    compliance:
+      - cis: ["5.2.2"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'f:/etc/ssh/sshd_config -> r:Protocol\s*\t*2'
+
+# 5.2.3 Ensure permissions on SSH private host key files are configured (Scored)
+  - id: 21129
+    title: "Ensure permissions on SSH private host key files are configured (Scored)."
+    description: "An SSH private key is one of two files used in SSH public key authentication. In this authentication method, The possession of the private key is proof of identity. Only a private key that corresponds to a public key will be able to authenticate successfully. The private keys need to be stored and handled carefully, and no copies of the private key should be distributed."
+    rationale: "If an unauthorized user obtains the private SSH host key file, the host could be impersonated"
+    remediation: "Run the following commands to set permissions, ownership, and group on the private SSH host key files: # find /etc/ssh -xdev -type f -name 'ssh_host_*_key' -exec chmod u-x,g-wx,o-rwx {} \\;  # find /etc/ssh -xdev -type f -name 'ssh_host_*_key' -exec chown root:ssh_keys {} \\;"
+    compliance:
+      - cis: ["5.2.3"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_rsa_key" -exec stat {} \; -> r:^Access: \(0\d40/\w\w\w\w\w-----\)  Uid: \(    0/    root\)   Gid: \(  997/ssh_keys\)$'
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_ecdsa_key" -exec stat {} \; -> r:^Access: \(0\d40/\w\w\w\w\w-----\)  Uid: \(    0/    root\)   Gid: \(  997/ssh_keys\)$'
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_ed25519_key" -exec stat {} \; -> r:^Access: \(0\d40/\w\w\w\w\w-----\)  Uid: \(    0/    root\)   Gid: \(  997/ssh_keys\)$'
+
+# 5.2.4 Ensure permissions on SSH public host key files are configured (Scored)
+  - id: 21130
+    title: "Ensure permissions on SSH public host key files are configured (Scored)."
+    description: "An SSH public key is one of two files used in SSH public key authentication. In this authentication method, a public key is a key that can be used for verifying digital signatures generated using a corresponding private key. Only a public key that corresponds to a private key will be able to authenticate successfully."
+    rationale: "If a public host key file is modified by an unauthorized user, the SSH service may be compromised."
+    remediation: "Run the following commands to set permissions and ownership on the SSH host public key: # find /etc/ssh -xdev -type f -name 'ssh_host_*_key.pub' -exec chmod u-x,go-wx {} \\;    #find /etc/ssh -xdev -type f -name 'ssh_host_*_key.pub' -exec chown root:root {} \\;"
+    compliance:
+      - cis: ["5.2.4"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_rsa_key.pub" -exec stat {} \; -> r:^Access: \(0\d44/\w\w\w\w\w\w\w\w--\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_ecdsa_key.pub" -exec stat {} \; -> r:^Access: \(0\d44/\w\w\w\w\w\w\w\w--\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+      - 'c:find /etc/ssh -xdev -type f -name "ssh_host_ed25519_key.pub" -exec stat {} \; -> r:^Access: \(0\d44/\w\w\w\w\w\w\w\w--\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
+
+# 5.2.5 Ensure SSH LogLevel is appropriate (Scored)
+  - id: 21131
+    title: "Ensure SSH LogLevel is appropriate (Scored)."
+    description: "INFO level is the basic level that only records login activity of SSH users. In many situations, such as Incident Response, it is important to determine when a particular user was active on a system. The logout record can eliminate those users who disconnected, which helps narrow the field. VERBOSE level specifies that login and logout activity as well as the key fingerprint for any SSH key used for login will be logged. This information is important for SSH key management, especially in legacy environments."
+    rationale: "SSH provides several logging levels with varying amounts of verbosity. DEBUG is specifically not recommended other than strictly for debugging SSH communications since it provides so much data that it is difficult to identify important security information."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: LogLevel VERBOSE or LogLevel INFO Restart sshd : systemctl restart sshd"
+    compliance:
+      - cis: ["5.2.5"]
+      - cis_level: ["1"]
+    condition: any
+    rules:
+      - 'f:$sshd_file -> r:^# && r:LogLevel\s*\t*INFO'
+      - 'f:$sshd_file -> r:^# && r:LogLevel\s*\t*VERBOSE'
+
+# 5.2.6 Ensure SSH X11 forwarding is disabled (Scored)
+  - id: 21132
+    title: "Ensure SSH X11 forwarding is disabled (Scored)."
+    description: "The X11Forwarding parameter provides the ability to tunnel X11 traffic through the connection to enable remote graphic connections."
+    rationale: "Disable X11 forwarding unless there is an operational requirement to use X11 applications directly. There is a small risk that the remote X11 servers of users who are logged in via SSH with X11 forwarding could be compromised by other users on the X11 server. Note that even if X11 forwarding is disabled, users can always install their own forwarders."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: X11Forwarding no  Restart sshd: systemctl restart sshd"
+    compliance:
+      - cis: ["5.2.6"]
+      - cis_level: ["2"]
+    condition: all
+    rules:
+      - 'f:/etc/ssh/sshd_config -> r:^\s*X11Forwarding\s*\t*no'
+
+# 5.2.7 Ensure SSH MaxAuthTries is set to 4 or less (Scored)
+  - id: 21133
+    title: "Ensure SSH MaxAuthTries is set to 4 or less (Scored)."
+    description: "The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection. When the login failure count reaches half the number, error messages will be written to the syslog file detailing the login failure."
+    rationale: "Setting the MaxAuthTries parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. While the recommended setting is 4, set the number based on site policy."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: MaxAuthTries 4  Restart sshd : systemctl restart sshd"
+    compliance:
+      - cis: ["5.2.7"]
+      - cis_level: ["1"]
+    condition: any
+    rules:
+      - 'f:$sshd_file -> !r:^# && n:^MaxAuthTries\s*\t*(\d+) compare <= 4'
+
+# 5.2.8 Ensure SSH IgnoreRhosts is enabled (Scored)
+  - id: 21134
+    title: "Ensure SSH IgnoreRhosts is enabled (Scored)."
+    description: "The IgnoreRhosts parameter specifies that .rhosts and .shosts files will not be used in RhostsRSAAuthentication or HostbasedAuthentication."
+    rationale: "Setting this parameter forces users to enter a password when authenticating with ssh."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: IgnoreRhosts yes  Restart sshd : systemctl restart sshd"
+    compliance:
+      - cis: ["5.2.8"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'f:$sshd_file -> !r:^# && r:IgnoreRhosts\s*\t*yes'
+
+# 5.2.9 Ensure SSH HostbasedAuthentication is disabled (Scored)
+  - id: 21135
+    title: "Ensure SSH HostbasedAuthentication is disabled (Scored)."
+    description: "The HostbasedAuthentication parameter specifies if authentication is allowed through trusted hosts via the user of .rhosts, or /etc/hosts.equiv, along with successful public key client host authentication. This option only applies to SSH Protocol Version 2."
+    rationale: "Even though the .rhosts files are ineffective if support is disabled in /etc/pam.conf, disabling the ability to use .rhosts files in SSH provides an additional layer of protection."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: HostbasedAuthentication no  Restart sshd : systemctl restart sshd"
+    compliance:
+      - cis: ["5.2.9"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'f:$sshd_file -> !r:^# && r:HostbasedAuthentication\s*\t*no'
+
+# 5.2.10 Ensure SSH root login is disabled (Scored)
+  - id: 21136
+    title: "Ensure SSH root login is disabled (Scored)."
+    description: "The PermitRootLogin parameter specifies if the root user can log in using ssh. The default is no."
+    rationale: "Disallowing root logins over SSH requires system admins to authenticate using their own individual account, then escalating to root via sudo or su . This in turn limits opportunity for non-repudiation and provides a clear audit trail in the event of a security incident."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: PermitRootLogin no"
+    compliance:
+      - cis: ["5.2.10"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'f:$sshd_file -> !r:^# && r:PermitRootLogin\s*\t*no'
+
+# 5.2.11 Ensure SSH PermitEmptyPasswords is disabled (Scored)
+  - id: 21137
+    title: "Ensure SSH PermitEmptyPasswords is disabled (Scored)."
+    description: "The PermitEmptyPasswords parameter specifies if the SSH server allows login to accounts with empty password strings."
+    rationale: "Disallowing remote shell access to accounts that have an empty password reduces the probability of unauthorized access to the system."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: PermitEmptyPasswords no  Restart sshd : systemctl restart sshd"
+    compliance:
+      - cis: ["5.2.11"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'f:$sshd_file -> !r:^# && r:PermitEmptyPasswords\s*\t*no'
+
+# 5.2.12 Ensure SSH PermitUserEnvironment is disabled (Scored)
+  - id: 21138
+    title: "Ensure SSH PermitUserEnvironment is disabled (Scored)."
+    description: "The PermitUserEnvironment option allows users to present environment options to the ssh daemon."
+    rationale: "Permitting users the ability to set environment variables through the SSH daemon could potentially allow users to bypass security controls (e.g. setting an execution path that has ssh executing trojan'd programs)"
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: PermitUserEnvironment no Restart sshd : systemctl restart sshd"
+    compliance:
+      - cis: ["5.2.12"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'f:$sshd_file -> r:^\s*PermitUserEnvironment\s*\t*no'
+
+# 5.2.13 Ensure only strong MAC algorithms are used (Scored)
+  - id: 21139
+    title: "Ensure only strong MAC algorithms are used (Scored)."
+    description: "This variable limits the types of MAC algorithms that SSH can use during communication."
+    rationale: "MD5 and 96-bit MAC algorithms are considered weak and have been shown to increase exploitability in SSH downgrade attacks. Weak algorithms continue to have a great deal of attention as a weak spot that can be exploited with expanded computing power. An attacker that breaks the algorithm could take advantage of a MiTM position to decrypt the SSH tunnel and capture credentials and information"
+    remediation: "Edit the /etc/ssh/sshd_config file and add/modify the MACs line to contain a comma separated list of the site approved MACs Example:MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256  Restart sshd : systemctl restart sshd"
+    compliance:
+      - cis: ["5.2.13"]
+      - cis_level: ["1"]
+    condition: none
+    rules:
+      - 'c:sshd -T -> r:macs && !r:hmac-md5|hmac-md5-96|hmac-ripemd160|hmac-sha1|hmac-sha1-96|umac-64@openssh.com|umac-128@openssh.com|hmac-md5-etm@openssh.com|hmac-md5-96-etm@openssh.com|hmac-ripemd160-etm@openssh.com|hmac-sha1-etm@openssh.com|hmac-sha1-96-etm@openssh.com|umac-64-etm@openssh.com|umac-128-etm@openssh.com'
+
+# 5.2.14 Ensure SSH Idle Timeout Interval is configured (Scored)
+  - id: 21140
+    title: "Ensure SSH Idle Timeout Interval is configured (Scored)."
+    description: "The two options ClientAliveInterval and ClientAliveCountMax control the timeout of ssh sessions. When the ClientAliveInterval variable is set, ssh sessions that have no activity for the specified length of time are terminated. When the ClientAliveCountMax variable is set, sshd will send client alive messages at every ClientAliveInterval interval. When the number of consecutive client alive messages are sent with no response from the client, the ssh session is terminated. For example, if the ClientAliveInterval is set to 15 seconds and the ClientAliveCountMax is set to 3, the client ssh session will be terminated after 45 seconds of idle time."
+    rationale: "Having no timeout value associated with a connection could allow an unauthorized user access to another user's ssh session (e.g. user walks away from their computer and doesn't lock the screen). Setting a timeout value at least reduces the risk of this happening. While the recommended setting is 300 seconds (5 minutes), set this timeout value based on site policy. The recommended setting for ClientAliveCountMax is 0. In this case, the client session will be terminated after 5 minutes of idle time and no keepalive messages will be sent."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameters according to site policy: ClientAliveInterval 300 and ClientAliveCountMax 0   Restart sshd : systemctl restart sshd"
+    compliance:
+      - cis: ["5.2.14"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'f:$sshd_file -> n:^\s*ClientAliveInterval\s*\t*(\d+) compare <= 300'
+      - 'f:$sshd_file -> n:^\s*ClientAliveCountMax\s*\t*(\d+) compare <= 3'
+      - 'f:$sshd_file -> n:^\s*ClientAliveInterval\s*\t*(\d+) compare >= 1'
+      - 'f:$sshd_file -> n:^\s*ClientAliveCountMax\s*\t*(\d+) compare >= 1'
+
+# 5.2.15 Ensure SSH LoginGraceTime is set to one minute or less (Scored)
+  - id: 21141
+    title: "Ensure SSH LoginGraceTime is set to one minute or less (Scored)."
+    description: "The LoginGraceTime parameter specifies the time allowed for successful authentication to the SSH server. The longer the Grace period is the more open unauthenticated connections can exist. Like other session controls in this session the Grace Period should be limited to appropriate organizational limits to ensure the service is available for needed access."
+    rationale: "Setting the LoginGraceTime parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. It will also limit the number of concurrent unauthenticated connections While the recommended setting is 60 seconds (1 Minute), set the number based on site policy."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: LoginGraceTime 60  Restart sshd : systemctl restart sshd"
+    compliance:
+      - cis: ["5.2.15"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'f:/etc/ssh/sshd_config -> n:^\s*LoginGraceTime\s*\t*(\d+) compare <= 60'
+
+# 5.2.16 Ensure only strong Key Exchange algorithms are used (Scored)
+  - id: 21142
+    title: "Ensure only strong Key Exchange algorithms are used (Scored)."
+    description: "Key exchange is any method in cryptography by which cryptographic keys are exchanged between two parties, allowing use of a cryptographic algorithm. If the sender and receiver wish to exchange encrypted messages, each must be equipped to encrypt messages to be sent and decrypt messages received"
+    rationale: "Key exchange methods that are considered weak should be removed. A key exchange method may be weak because too few bits are used, or the hashing algorithm is considered too weak. Using weak algorithms could expose connections to man-in-the-middle attacks"
+    remediation: "Edit the /etc/ssh/sshd_config file add/modify the KexAlgorithms line to contain a comma separated list of the site approved key exchange algorithms.Example:'KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256'  Restart sshd : systemctl restart sshd"
+    compliance:
+      - cis: ["5.2.16"]
+      - cis_level: ["1"]
+    condition: none
+    rules:
+      - 'c:sshd -T -> r:kexalgorithms && r:diffie-hellman-group1-sha1|diffie-hellman-group14-sha1|diffie-hellman-group-exchange-sha1'
+
+# 5.2.17 Ensure only strong Ciphers are used (Scored)
+  - id: 21143
+    title: "Ensure only strong ciphers are used (Scored)."
+    description: "This variable limits the ciphers that SSH can use during communication."
+    rationale: "Weak ciphers that are used for authentication to the cryptographic module cannot be relied upon to provide confidentiality or integrity, and system data may be compromised.: The DES, Triple DES, and Blowfish ciphers, as used in SSH, have a birthday bound of approximately four billion blocks, which makes it easier for remote attackers to obtain cleartext data via a birthday attack against a long-duration encrypted session, aka a 'Sweet32' attack; The RC4 algorithm, as used in the TLS protocol and SSL protocol, does not properly combine state data with key data during the initialization phase, which makes it easier for remote attackers to conduct plaintext-recovery attacks against the initial bytes of a stream by sniffing network traffic that occasionally relies on keys affected by the Invariance Weakness, and then using a brute-force approach involvingLSB values, aka the 'Bar Mitzvah' issue; The passwords used during an SSH session encrypted with RC4 can be recovered by an attacker who is able to capture and replay the session; Error handling in the SSH protocol; Client and Server, when using a block cipher algorithm in Cipher Block Chaining (CBC) mode, makes it easier for remote attackers to recover certain plaintext data from an arbitrary block of ciphertext in an SSH session via unknown vectors; The mm_newkeys_from_blob function in monitor_wrap.c, when an AES-GCM cipher is used, does not properly initialize memory for a MAC context data structure, which allows remote authenticated users to bypass intended ForceCommand and login-shell restrictions via packet data that provides a crafted callback address"
+    remediation: "Edit the /etc/ssh/sshd_configfile add/modify the Ciphersline to contain a comma separated list of the site approved ciphersExample:Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr  Restart sshd : systemctl restart sshd"
+    compliance:
+      - cis: ["5.2.17"]
+      - cis_level: ["1"]
+    condition: none
+    rules:
+      - 'c:sshd -T -> r:ciphers && r:3des-cbc|aes192-cbc|aes256-cbc|arcfour|blowfish-cbc|cast128-cbc|rijndael-cbc@lysator.liu.se'
+
+# 5.2.18 Ensure SSH access is limited (Scored)
+  - id: 21144
+    title: "Ensure SSH access is limited (Scored)."
+    description: "There are several options available to limit which users and group can access the system via SSH. It is recommended that at least one of the following options be leveraged: AllowUsers The AllowUsers variable gives the system administrator the option of allowing specific users to ssh into the system. The list consists of space separated user names. Numeric user IDs are not recognized with this variable. If a system administrator wants to restrict user access further by only allowing the allowed users to log in from a particular host, the entry can be specified in the form of user@host. AllowGroups The AllowGroups variable gives the system administrator the option of allowing specific groups of users to ssh into the system. The list consists of space separated group names. Numeric group IDs are not recognized with this variable. DenyUsers The DenyUsers variable gives the system administrator the option of denying specific users to ssh into the system. The list consists of space separated user names. Numeric user IDs are not recognized with this variable. If a system administrator wants to restrict user access further by specifically denying a user's access from a particular host, the entry can be specified in the form of user@host. DenyGroups The DenyGroups variable gives the system administrator the option of denying specific groups of users to ssh into the system. The list consists of space separated group names. Numeric group IDs are not recognized with this variable."
+    rationale: "Restricting which users can remotely access the system via SSH will help ensure that only authorized users access the system."
+    remediation: "Edit the /etc/ssh/sshd_config file to set one or more of the parameter as follows: # AllowUsers <userlist>; # AllowGroups <grouplist>; # DenyUsers <userlist>; # DenyGroups <grouplist>  Restart sshd : #systemctl restart sshd"
+    compliance:
+      - cis: ["5.2.18"]
+      - cis_level: ["1"]
+    condition: any
+    rules:
+      - 'f:$sshd_file -> r:^\s*AllowUsers'
+      - 'f:$sshd_file -> r:^\s*AllowGroups'
+      - 'f:$sshd_file -> r:^\s*DenyUsers'
+      - 'f:$sshd_file -> r:^\s*DenyGroups'
+
+# 5.2.19 Ensure SSH warning banner is configured (Scored)
+  - id: 21145
+    title: "Ensure SSH warning banner is configured (Scored)."
+    description: "The Banner parameter specifies a file whose contents must be sent to the remote user before authentication is permitted. By default, no banner is displayed."
+    rationale: "Banners are used to warn connecting users of the particular site's policy regarding connection. Presenting a warning message prior to the normal user login may assist the prosecution of trespassers on the computer system."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: Banner /etc/issue.net   Restart sshd : systemctl restart sshd"
+    compliance:
+      - cis: ["5.2.19"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'f:$sshd_file -> r:^\s*Banner\s*\t*/etc/issue.net'
+
+# ###############################################
+# 5.3 Configure PAM
+# ###############################################
+
+# 5.3.1 Ensure password creation requirements are configured (Scored)
+  - id: 21146
+    title: "Ensure password creation requirements are configured (Scored)."
+    description: "The pam_pwquality.so module checks the strength of passwords. It performs checks such as making sure a password is not a dictionary word, it is a certain length, contains a mix of characters (e.g. alphabet, numeric, other) and more"
+    rationale: "Strong passwords protect systems from being hacked through brute force methods."
+    remediation: "Edit the file /etc/security/pwquality.conf and add or modify the following line for password length to conform to site policy: minlen = 14     Edit the file /etc/security/pwquality.conf and add or modify the following line for password complexity to conform to site policy: minclass = 4    OR dcredit = -1 ucredit = -1 ocredit = -1 lcredit = -1      Edit the /etc/pam.d/password-auth and /etc/pam.d/system-auth files to include the appropriate options for pam_pwquality.so and to conform to site policy:password requisite pam_pwquality.so try_first_pass retry=3"
+    compliance:
+      - cis: ["5.3.1"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'f:/etc/pam.d/system-auth -> r:password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type='
+      - 'f:/etc/security/pwquality.conf -> n:^minlen=(\d+) compare >= 14'
+
+# 5.3.2 Ensure lockout for failed password attempts is configured (Scored)
+
+# 5.3.3 Ensure password reuse is limited (Scored)
+  - id: 21147
+    title: "Ensure password reuse is limited (Scored)."
+    description: "The /etc/security/opasswd file stores the users' old passwords and can be checked to ensure that users are not recycling recent passwords."
+    rationale: "Forcing users not to reuse their past 5 passwords make it less likely that an attacker will be able to guess the password. Note that these changes only apply to accounts configured on the local system."
+    remediation: "Edit the /etc/pam.d/password-auth and /etc/pam.d/system-auth files to include the remember option and conform to site policy as shown: password sufficient pam_unix.so remember=5   or    password required pam_pwhistory.so remember=5"
+    compliance:
+      - cis: ["5.3.3"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'f:/etc/pam.d/password-auth -> n:^password\s+sufficient\s+pam_unix.so\.+remember=(\d+)|^password\s+required\s+pam_pwhistory.so\.+remember=(\d+) compare >= 5'
+      - 'f:/etc/pam.d/system-auth -> n:^password\s+sufficient\s+pam_unix.so\.+remember=(\d+)|^password\s+required\s+pam_pwhistory.so\.+remember=(\d+) compare >= 5'
+
+
+# 5.3.4 Ensure password hashing algorithm is SHA-512 (Automated)
+  - id: 21148
+    title: "Ensure password hashing algorithm is SHA-512."
+    description: "The commands below change password encryption from md5 to sha512 (a much stronger hashing algorithm). All existing accounts will need to perform a password change to upgrade the stored hashes to the new algorithm."
+    rationale: "The SHA-512 algorithm provides much stronger hashing than MD5, thus providing additional protection to the system by increasing the level of effort for an attacker to successfully determine passwords. Note that these changes only apply to accounts configured on the local system."
+    remediation: "Edit the /etc/pam.d/password-auth and /etc/pam.d/system-auth files to include the sha512 option for pam_unix.so as shown: password sufficient pam_unix.so sha512"
+    compliance:
+      - cis: ["5.3.4"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'f:/etc/pam.d/password-auth -> r:^password\s*sufficient\s*pam_unix.so\s*remember=5\s*sha512'
+      - 'f:/etc/pam.d/system-auth -> r:^password\s*sufficient\s*pam_unix.so\s*remember=5\s*sha512'
+
+###############################################
+# 5.4 User Accounts and Environment
+###############################################
+###############################################
+# 5.4.1 Set Shadow Password Suite Parameters
+###############################################
+
+# 5.4.1.1 Ensure password expiration is 365 days or less (Scored)
+  - id: 21149
+    title: "Ensure password expiration is 365 days or less (Scored)."
+    description: "The PASS_MAX_DAYS parameter in /etc/login.defs allows an administrator to force passwords to expire once they reach a defined age. It is recommended that the PASS_MAX_DAYS parameter be set to less than or equal to 365 days."
+    rationale: "The window of opportunity for an attacker to leverage compromised credentials or successfully compromise credentials via an online brute force attack is limited by the age of the password. Therefore, reducing the maximum age of a password also reduces an attacker's window of opportunity."
+    remediation: "Set the PASS_MAX_DAYS parameter to conform to site policy in /etc/login.defs : PASS_MAX_DAYS 90 and modify user parameters for all users with a password set to match: chage --maxdays 90 <user>"
+    compliance:
+      - cis: ["5.4.1.1"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'f:/etc/login.defs -> n:^\s*PASS_MAX_DAYS\s*\t*(\d+) compare <= 365'
+
+# 5.4.1.2 Ensure minimum days between password changes is configured (Scored)
+  - id: 21150
+    title: "Ensure minimum days between password changes is configured (Scored)."
+    description: "The PASS_MIN_DAYS parameter in /etc/login.defs allows an administrator to prevent users from changing their password until a minimum number of days have passed since the last time the user changed their password. It is recommended that PASS_MIN_DAYS parameter be set to 1 or more days."
+    rationale: "By restricting the frequency of password changes, an administrator can prevent users from repeatedly changing their password in an attempt to circumvent password reuse controls."
+    remediation: "Set the PASS_MIN_DAYS parameter to 1 in /etc/login.defs: PASS_MIN_DAYS 1 and modify user parameters for all users with a password set to match: chage --mindays 1 <user>"
+    compliance:
+      - cis: ["5.4.1.2"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'f:/etc/login.defs -> n:^\s*PASS_MIN_DAYS\s*\t*(\d+) compare >= 1'
+
+# 5.4.1.3 Ensure password expiration warning days is 7 or more (Scored)
+  - id: 21151
+    title: "Ensure minimum days between password changes is 7 or more (Scored)."
+    description: "The PASS_WARN_AGE parameter in /etc/login.defs allows an administrator to notify users that their password will expire in a defined number of days. It is recommended that the PASS_WARN_AGE parameter be set to 7 or more days."
+    rationale: "Providing an advance warning that a password will be expiring gives users time to think of a secure password. Users caught unaware may choose a simple password or write it down where it may be discovered."
+    remediation: "Set the PASS_WARN_AGE parameter to 7 in /etc/login.defs: PASS_WARN_AGE 7 and modify user parameters for all users with a password set to match: chage --warndays 7 <user>"
+    compliance:
+      - cis: ["5.4.1.3"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'f:/etc/login.defs -> n:^\s*PASS_WARN_AGE\s*\t*(\d+) compare >= 7'
+
+# 5.4.1.4 Ensure inactive password lock is 30 days or less (Scored)
+  - id: 21152
+    title: "Ensure inactive password lock is 30 days or less (Scored)."
+    description: "User accounts that have been inactive for over a given period of time can be automatically disabled. It is recommended that accounts that are inactive for 30 days after password expiration be disabled."
+    rationale: "Inactive accounts pose a threat to system security since the users are not logging in to notice failed login attempts or other anomalies."
+    remediation: "Run the following command to set the default password inactivity period to 30 days: useradd -D -f 30 and modify user parameters for all users with a password set to match: chage --inactive 30 <user>"
+    compliance:
+      - cis: ["5.4.1.4"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:useradd -D -> n:^\s*INACTIVE\s*=\s*(\d+) compare <= 30'
+
+# 5.4.1.5 Ensure all users last password change date is in the past (Scored)
+
+# 5.4.2 Ensure system accounts are secured (Scored)
+
+# 5.4.3 Ensure default group for the root account is GID 0 (Scored)
+  - id: 21153
+    title: "Ensure default group for the root account is GID 0 (Scored)."
+    description: "The usermod command can be used to specify which group the root user belongs to. This affects permissions of files that are created by the root user."
+    rationale: "Using GID 0 for the root account helps prevent root -owned files from accidentally becoming accessible to non-privileged users."
+    remediation: "Run the following command to set the root user default group to GID 0: usermod -g 0 root"
+    compliance:
+      - cis: ["5.4.3"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'f:/etc/passwd -> r:^root:\w:\w:0'
+
+# 5.4.4 Ensure default user umask is 027 or more restrictive (Scored)
+  - id: 21154
+    title: "Ensure default user umask is 027 or more restrictive (Scored)."
+    description: "The default umask determines the permissions of files created by users. The user creating the file has the discretion of making their files and directories readable by others via the chmod command. Users who wish to allow their files and directories to be readable by others by default may choose a different default umask by inserting the umask command into the standard shell configuration files ( .profile , .bashrc , etc.) in their home directories."
+    rationale: "Setting a very secure default value for umask ensures that users make a conscious choice about their file permissions. A default umask setting of 077 causes files and directories created by users to not be readable by any other user on the system. A umask of 027 would make files and directories readable by users in the same Unix group, while a umask of 022 would make files readable by every user on the system."
+    remediation: "Edit the /etc/bashrc, /etc/profile and /etc/profile.d/*.sh files (and the appropriate files for any other shell supported on your system) and add or edit any umask parameters as follows: umask 027"
+    compliance:
+      - cis: ["5.4.4"]
+      - cis_level: ["1"]
+    condition: none
+    rules:
+      - 'f:/etc/bashrc -> !r:^\s*\t*# && r:umask \d0\d|umask \d1\d|umask \d4\d|umask \d5\d'
+      - 'f:/etc/bashrc -> !r:^\s*\t*# && n:umask \d\d(\d) compare != 7'
+      - 'f:/etc/profile -> !r:^\s*\t*# && r:umask \d0\d|umask \d1\d|umask \d4\d|umask \d5\d'
+      - 'f:/etc/profile -> !r:^\s*\t*# && n:umask \d\d(\d) compare != 7'
+      - 'd:/etc/profile.d -> .sh -> !r:^\s*\t*# && r:umask \d0\d|umask \d1\d|umask \d4\d|umask \d5\d'
+      - 'd:/etc/profile.d -> .sh -> !r:^\s*t*# && n:umask \d\d(\d) compare != 7'
+
+# 5.4.5 Ensure default user shell timeout is 900 seconds or less (Scored)
+  - id: 21155
+    title: " Ensure default user shell timeout is 900 seconds or less (Scored)."
+    description: "The default TMOUT determines the shell timeout for users. The TMOUT value is measured in seconds."
+    rationale: "Having no timeout value associated with a shell could allow an unauthorized user access to another user's shell session (e.g. user walks away from their computer and doesn't lock the screen). Setting a timeout value at least reduces the risk of this happening."
+    remediation: "Edit the /etc/bashrc and /etc/profile files (and the appropriate files for any other shell supported on your system) and add or edit any umask parameters as follows: TMOUT=600"
+    compliance:
+      - cis: ["5.4.5"]
+      - cis_level: ["2"]
+    condition: all
+    rules:
+      - 'not f:/etc/bashrc -> n:^\s*\t*TMOUT\s*\t*=\s*\t*(\d+) compare > 900'
+      - 'not f:/etc/profile -> n:^\s*\t*TMOUT\s*\t*=\s*\t*(\d+) compare > 900'
+      - 'f:/etc/bashrc -> n:^\s*\t*TMOUT\s*\t*=\s*\t*(\d+) compare <= 900'
+      - 'f:/etc/profile -> n:^\s*\t*TMOUT\s*\t*=\s*\t*(\d+) compare <= 900'
+
+# 5.5 Ensure root login is restricted to system console (Not Scored)
+
+# 5.6 Ensure access to the su command is restricted (Scored)
+  - id: 21156
+    title: "Ensure access to the su command is restricted (Scored)."
+    description: "The su command allows a user to run a command or shell as another user. The program has been superseded by sudo, which allows for more granular control over privileged access. Normally, the su command can be executed by any user. By uncommenting the pam_wheel.so statement in /etc/pam.d/su, the su command will only allow users in the wheel group to execute su ."
+    rationale: "Restricting the use of su, and using sudo in its place, provides system administrators better control of the escalation of user privileges to execute privileged commands. The sudo utility also provides a better logging and audit mechanism, as it can log each command executed via sudo, whereas su can only record that a user executed the su program."
+    remediation: "Add the following line to the /etc/pam.d/su file: auth required pam_wheel.so use_uid  Create a comma separated list of users in the wheel statement in the /etc/group file: wheel:x:10:root,<user list>"
+    compliance:
+      - cis: ["5.6"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'f:/etc/pam.d/su -> r:^auth\s*\t*required\s*\t*pam_wheel.so\s*\t*use_uid'
+
+
+###############################################
+# 6 System Maintenance
+###############################################
+###############################################
+# 6.1 System File Permissions
+###############################################
+
+# 6.1.1 Audit system file permissions (Not Scored) (is level 2)
+
+# 6.1.2 Configure /etc/passwd permissions (Scored)
+  - id: 21157
+    title: "Ensure permissions on /etc/passwd are configured (Scored)."
+    description: "The /etc/passwd file contains user account information that is used by many system utilities and therefore must be readable for these utilities to operate."
+    rationale: "It is critical to ensure that the /etc/passwd file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
+    remediation: "Run the following command to set permissions on /etc/passwd: # chown root:root /etc/passwd   # chmod u-x,g-wx,o-wx /etc/passwd"
+    compliance:
+      - cis: ["6.1.2"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:stat /etc/passwd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+
+# 6.1.3 Ensure permissions on /etc/shadow are configured (Scored)
+  - id: 21158
+    title: "Ensure permissions on /etc/shadow are configured (Scored)."
+    description: "The /etc/shadow file is used to store the information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
+    rationale: "If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/shadow file (such as expiration) could also be useful to subvert the user accounts."
+    remediation: "Run the following command to set permissions on /etc/shadow: # chown root:root /etc/shadow # chmod 000 /etc/shadow"
+    compliance:
+      - cis: ["6.1.3"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:stat /etc/shadow -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+
+# 6.1.4 Ensure permissions on /etc/group are configured (Scored)
+  - id: 21159
+    title: "Ensure permissions on /etc/group are configured (Scored)."
+    description: "The /etc/group file contains a list of all the valid groups defined in the system. The command below allows read/write access for root and read access for everyone else."
+    rationale: "The /etc/group file needs to be protected from unauthorized changes by non-privileged users, but needs to be readable as this information is used with many non-privileged programs."
+    remediation: "Run the following command to set permissions on /etc/group: # chown root:root /etc/group # chmod u-x,g-wx,o-wx /etc/group"
+    compliance:
+      - cis: ["6.1.4"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:stat /etc/group -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+
+# 6.1.5 Ensure permissions on /etc/gshadow are configured (Scored)
+  - id: 21160
+    title: "Ensure permissions on /etc/gshadow are configured (Scored)."
+    description: "The /etc/gshadow file is used to store the information about groups that is critical to the security of those accounts, such as the hashed password and other security information."
+    rationale: "If attackers can gain read access to the /etc/gshadow file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/gshadow file (such as group administrators) could also be useful to subvert the group"
+    remediation: "Run the following command to set permissions on /etc/gshadow: # chown root:root /etc/gshadow # chmod 000 /etc/gshadow"
+    compliance:
+      - cis: ["6.1.5"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:stat /etc/gshadow -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+
+# 6.1.6 Ensure permissions on /etc/passwd- are configured (Scored)
+  - id: 21161
+    title: "Ensure permissions on /etc/passwd- are configured (Scored)."
+    description: "The /etc/passwd- file contains backup user account information."
+    rationale: "It is critical to ensure that the /etc/passwd- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
+    remediation: "Run the following command to set permissions on /etc/passwd-: # chown root:root /etc/passwd- # chmod 644 /etc/passwd-"
+    compliance:
+      - cis: ["6.1.6"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:stat /etc/passwd- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+
+# 6.1.7 Ensure permissions on /etc/shadow- are configured (Scored)
+  - id: 21162
+    title: "Ensure permissions on /etc/shadow- are configured (Scored)."
+    description: "The /etc/shadow- file is used to store backup information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
+    rationale: "It is critical to ensure that the /etc/shadow- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
+    remediation: "Run the following command to set permissions on /etc/shadow-: # chown root:root /etc/shadow- # chmod 000 /etc/shadow-"
+    compliance:
+      - cis: ["6.1.7"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:stat /etc/shadow- -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+
+# 6.1.8 Ensure permissions on /etc/group- are configured (Scored)
+  - id: 21163
+    title: "Ensure permissions on /etc/group- are configured (Scored)."
+    description: "The /etc/group- file contains a backup list of all the valid groups defined in the system."
+    rationale: "It is critical to ensure that the /etc/group- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
+    remediation: "Run the following command to set permissions on /etc/group-: # chown root:root /etc/group- # chmod 644 /etc/group-"
+    compliance:
+      - cis: ["6.1.8"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:stat /etc/group- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+
+# 6.1.9 Ensure permissions on /etc/gshadow-are configured (Scored)
+  - id: 21164
+    title: "Ensure permissions on /etc/gshadow- are configured (Scored)."
+    description: "The /etc/gshadow- file is used to store backup information about groups that is critical to the security of those accounts, such as the hashed password and other security information."
+    rationale: "It is critical to ensure that the /etc/gshadow- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
+    remediation: "Run the following command to set permissions on /etc/gshadow-: # chown root:root /etc/gshadow- # chmod 000 /etc/gshadow-"
+    compliance:
+      - cis: ["6.1.9"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'c:stat /etc/gshadow- -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+
+# 6.1.10 Ensure no world writable files exist (Not Scored)
+
+# 6.1.11 Ensure no unowned files or directories exist (Scored)
+
+# 6.1.12 Ensure no ungrouped files or directories exist (Scored)
+
+# 6.1.13 Audit SUID executables (Not Scored)
+
+# 6.1.14 Audit SGID executables (Not Scored)
+
+
+###############################################
+# 6.2 User and Group Settings
+###############################################
+
+# 6.2.1 Ensure /etc/shadow password fields are not empty (Scored)
+  - id: 21165
+    title: "Ensure password fields are not empty (Scored)."
+    description: "An account with an empty password field means that anybody may log in as that user without providing a password."
+    rationale: "All accounts must have passwords or be locked to prevent the account from being used by an unauthorized user."
+    remediation: "If any accounts in the /etc/shadow file do not have a password, run the following command to lock the account until it can be determined why it does not have a password: passwd -l <username> || Also, check to see if the account is logged in and investigate what it is being used for to determine if it needs to be forced off."
+    compliance:
+      - cis: ["6.2.1"]
+      - cis_level: ["1"]
+    condition: all
+    rules:
+      - 'not f:/etc/shadow -> !r:^# && r:^\w+::'
+
+# 6.2.2 Ensure no legacy "+" entries exist in /etc/passwd (Scored)
+
+# 6.2.3 Ensure no legacy "+" entries exist in /etc/shadow (Scored)
+
+# 6.2.4 Ensure no legacy "+" entries exist in /etc/group (Scored)
+
+# 6.2.5 Ensure root is the only UID 0 account (Scored)
+  - id: 21166
+    title: "Ensure root is the only UID 0 account (Scored)."
+    description: "Any account with UID 0 has superuser privileges on the system."
+    rationale: "This access must be limited to only the default root account and only from the system console. Administrative access must be through an unprivileged account using an approved mechanism as noted in Item 5.6 Ensure access to the su command is restricted."
+    remediation: "Remove any users other than root with UID 0 or assign them a new UID if appropriate."
+    compliance:
+      - cis: ["6.2.5"]
+      - cis_level: ["1"]
+    condition: none
+    rules:
+      - 'f:/etc/passwd -> !r:^# && !r:^\s*\t*root: && r:^\w+:\w+:0:'
+
+# 6.2.6 Ensure root PATH Integrity (Scored)
+
+# 6.2.7 Ensure all users' home directories exist (Scored)
+
+# 6.2.8 Ensure users' home directories permissions are 750 or more restrictive (Scored)
+
+# 6.2.9 Ensure users own their home directories (Scored)
+
+# 6.2.10 Ensure users' dot files are not group or world writable (Scored)
+
+# 6.2.11 Ensure no users have .forward files (Scored)
+
+# 6.2.12 Ensure no users have .netrc files (Scored)
+
+# 6.2.13 Ensure users' .netrc Files are not group or world accessible (Scored)
+
+# 6.2.14 Ensure no users have .rhosts files (Scored)
+
+# 6.2.15 Ensure all groups in /etc/passwd exist in /etc/group (Scored)
+
+# 6.2.16 Ensure no duplicate UIDs exist (Scored)
+
+# 6.2.17 Ensure no duplicate GIDs exist (Scored)
+
+# 6.2.18 Ensure no duplicate user names exist  (Scored)
+
+# 6.2.19 Ensure no duplicate group names exist (Scored)


### PR DESCRIPTION
CIS Aliyun Linux 2 Benchmark v1.0.0
(https://workbench.cisecurity.org/benchmarks/2228) was published
on Aug 16th 2019. Aliyun Linux 2 is compatible with Centos 7 and it's
further renamed as Alibaba Cloud Linux 2. Besides, The ID of Alibaba
Cloud Linux (Aliyun Linux) 2 in /etc/os-release is 'alinux'

I add the Alibaba Cloud Linux (Aliyun Linux) 2 SCA in the wazuh
according to CIS Aliyun Linux 2 Benchmark v1.0.0
(https://workbench.cisecurity.org/benchmarks/2228)

Signed-off-by: YiLin.Li <YiLin.Li@linux.alibaba.com>

|Related issue|
|---|
| #12052  |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ √ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ √ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors