### PR TITLE
Unit tests - Fixing unit tests for `lookfor_agent_group` that now use wazuh-db instead shared-download

### DIFF
--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -24,8 +24,8 @@ include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 
 # Generate remoted tests
 list(APPEND remoted_names "test_manager")
-list(APPEND remoted_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,w_parser_get_agent \
-                            -Wl,--wrap,get_agent_group -Wl,--wrap,_merror")
+list(APPEND remoted_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,get_agent_group \
+-Wl,--wrap,wdb_set_agent_groups_csv -Wl,--wrap,_merror -Wl,--wrap,w_is_worker")
 
 list(APPEND remoted_names "test_secure")
 list(APPEND remoted_flags "-Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,fclose -Wl,--wrap,remove \

--- a/src/unit_tests/wrappers/wazuh/shared/agent_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/agent_op_wrappers.c
@@ -31,14 +31,8 @@ int __wrap_control_check_connection() {
     return mock();
 }
 
-int __wrap_get_agent_group(const char *id, char *group, __attribute__((unused)) size_t size) {
+int __wrap_get_agent_group(int id, char *group, __attribute__((unused)) size_t size, int *wdb_sock) {
     check_expected(id);
     strncpy(group, mock_type(char *), OS_SIZE_65536);
-    return mock();
-}
-
-int __wrap_set_agent_group(const char * id, const char * group) {
-    check_expected(id);
-    check_expected(group);
     return mock();
 }

--- a/src/unit_tests/wrappers/wazuh/shared/agent_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/agent_op_wrappers.h
@@ -11,10 +11,11 @@
 #ifndef AGENT_OP_WRAPPERS_H
 #define AGENT_OP_WRAPPERS_H
 
+#include "stddef.h"
+
 int __wrap_auth_connect();
 char* __wrap_get_agent_id_from_name(__attribute__((unused)) char *agent_name);
 int __wrap_control_check_connection();
-int __wrap_get_agent_group(const char *id, char *group, __attribute__((unused)) size_t size);
-int __wrap_set_agent_group(const char * id, const char * group);
+int __wrap_get_agent_group(int id, char *group, __attribute__((unused)) size_t size, int *wdb_sock);
 
 #endif

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_helpers_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_helpers_wrappers.c
@@ -45,3 +45,12 @@ int* __wrap_wdb_get_all_agents(bool include_manager, __attribute__((unused)) int
 
     return mock_ptr_type(int*);
 }
+
+int __wrap_wdb_set_agent_groups_csv(int id,
+                                    __attribute__((unused)) char *groups_csv,
+                                    __attribute__((unused)) char *mode,
+                                    __attribute__((unused)) char *sync_status,
+                                    __attribute__((unused)) int *sock) {
+    check_expected(id);
+    return mock();
+}

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_helpers_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_helpers_wrappers.h
@@ -13,11 +13,16 @@
 
 #include "wazuh_db/wdb.h"
 
-cJSON* __wrap_wdb_get_agent_labels(int id, int *sock);
+cJSON *__wrap_wdb_get_agent_labels(int id, int *sock);
 int __wrap_wdb_find_agent(const char *name, const char *ip, __attribute__((unused)) int *sock);
-int* __wrap_wdb_disconnect_agents(int keepalive, const char *sync_status, __attribute__((unused)) int *sock);
-cJSON* __wrap_wdb_get_agent_info(int id,  __attribute__((unused)) int *sock);
-int* __wrap_wdb_get_agents_by_connection_status(const char* status, __attribute__((unused)) int *sock);
-int* __wrap_wdb_get_all_agents(bool include_manager, int *sock);
+int *__wrap_wdb_disconnect_agents(int keepalive, const char *sync_status, __attribute__((unused)) int *sock);
+cJSON *__wrap_wdb_get_agent_info(int id, __attribute__((unused)) int *sock);
+int *__wrap_wdb_get_agents_by_connection_status(const char *status, __attribute__((unused)) int *sock);
+int *__wrap_wdb_get_all_agents(bool include_manager, int *sock);
 
+int __wrap_wdb_set_agent_groups_csv(int id,
+                                    __attribute__((unused)) char *groups_csv,
+                                    __attribute__((unused)) char *mode,
+                                    __attribute__((unused)) char *sync_status,
+                                    __attribute__((unused)) int *sock);
 #endif


### PR DESCRIPTION
|Related issue|
|---|
|#11754|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Fixing the unit tests for the `lookfor_agent_group` function that now uses the `wazuh-db` to get the group information as well as to set the agent groups

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] AddressSanitizer