### PR TITLE
Remove xfail mark from agent_PUT API integration test

### DIFF
--- a/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
@@ -784,9 +784,6 @@ stages:
 ---
 test_name: PUT /agents/node/{node_id}/restart
 
-marks:
-  - xfail # Agents stay with "pending" status for too long - https://github.com/wazuh/wazuh/issues/10162
-
 stages:
 
   - name: Get agents belonging to a node
@@ -844,9 +841,6 @@ stages:
 
 ---
 test_name: PUT /agents/upgrade
-
-marks:
-  - xfail # Agents stay with "pending" status for too long - https://github.com/wazuh/wazuh/issues/10162
 
 stages:
 
@@ -1135,9 +1129,6 @@ stages:
 
 ---
 test_name: PUT /agents/{agent_id}/upgrade_custom
-
-marks:
-  - xfail # Agents stay with "pending" status for too long - https://github.com/wazuh/wazuh/issues/10162
 
 stages:
 


### PR DESCRIPTION

## Description

This PR removes the xfail mark from `agent_PUT` API integration test after solving #10162.

As it was said in https://github.com/wazuh/wazuh/issues/10162#issuecomment-1016441338, issue #10162 was solved in https://github.com/wazuh/wazuh/issues/10913.