### PR TITLE
Added UT cases for select groups belong

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -46,7 +46,8 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_open_global -Wl,--wrap,wdb_leave -Wl
                              -Wl,--wrap,wdb_global_get_all_agents -Wl,--wrap,wdb_global_get_agent_info -Wl,--wrap,wdb_global_reset_agents_connection \
                              -Wl,--wrap,wdb_global_get_agents_by_connection_status -Wl,--wrap,wdb_global_get_agents_to_disconnect \
                              -Wl,--wrap,sqlite3_step -Wl,--wrap,wdb_global_get_groups_integrity -Wl,--wrap,wdb_global_get_backups \
-                             -Wl,--wrap,wdb_global_restore_backup -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_mutex_unlock ${DEBUG_OP_WRAPPERS}")
+                             -Wl,--wrap,wdb_global_restore_backup -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_mutex_unlock \
+                             -Wl,--wrap,wdb_global_select_group_belong ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_global")
 list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_begin2 -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,sqlite3_bind_int \
@@ -56,7 +57,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg -Wl,-
                             -Wl,--wrap,sqlite3_prepare_v2 -Wl,--wrap,w_get_timestamp -Wl,--wrap,wdb_exec_stmt_silent -Wl,--wrap,w_compress_gzfile \
                             -Wl,--wrap,sqlite3_finalize -Wl,--wrap,unlink -Wl,--wrap,getpid -Wl,--wrap,opendir -Wl,--wrap,closedir -Wl,--wrap,readdir \
                             -Wl,--wrap,stat -Wl,--wrap,w_uncompress_gzfile -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_close -Wl,--wrap,rename -Wl,--wrap,time \
-                            ${DEBUG_OP_WRAPPERS} ${STDIO_OP_WRAPPERS}")
+                            -Wl,--wrap,wdb_exec_stmt_single_column ${DEBUG_OP_WRAPPERS} ${STDIO_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_agents")
 list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_init_stmt_in_cache -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,wdb_exec_stmt_silent  -Wl,--wrap,sqlite3_step \

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -4193,32 +4193,32 @@ void test_wdb_global_insert_agent_group_success(void **state)
 
 void test_wdb_global_select_group_belong_transaction_fail(void **state)
 {
-    cJSON *output = NULL;
+    cJSON *j_result = NULL;
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    output = wdb_global_select_group_belong(data->wdb, 1);
-    assert_null(output);
+    j_result = wdb_global_select_group_belong(data->wdb, 1);
+    assert_null(j_result);
 }
 
 void test_wdb_global_select_group_belong_cache_fail(void **state)
 {
-    cJSON *output = NULL;
+    cJSON *j_result = NULL;
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    output = wdb_global_select_group_belong(data->wdb, 1);
-    assert_null(output);
+    j_result = wdb_global_select_group_belong(data->wdb, 1);
+    assert_null(j_result);
 }
 
 void test_wdb_global_select_group_belong_bind_fail(void **state)
 {
-    cJSON *output = NULL;
+    cJSON *j_result = NULL;
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_wdb_begin2, 1);
@@ -4229,13 +4229,13 @@ void test_wdb_global_select_group_belong_bind_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    output = wdb_global_select_group_belong(data->wdb, 1);
-    assert_null(output);
+    j_result = wdb_global_select_group_belong(data->wdb, 1);
+    assert_null(j_result);
 }
 
 void test_wdb_global_select_group_belong_exec_fail(void **state)
 {
-    cJSON *output = NULL;
+    cJSON *j_result = NULL;
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_wdb_begin2, 1);
@@ -4247,31 +4247,31 @@ void test_wdb_global_select_group_belong_exec_fail(void **state)
     will_return(__wrap_wdb_exec_stmt_single_column, NULL);
     expect_string(__wrap__mdebug1, formatted_msg, "wdb_exec_stmt(): ERROR MESSAGE");
 
-    output = wdb_global_select_group_belong(data->wdb, 1);
-    assert_null(output);
+    j_result = wdb_global_select_group_belong(data->wdb, 1);
+    assert_null(j_result);
 }
 
 void test_wdb_global_select_group_belong_success(void **state)
 {
-    cJSON *output = NULL;
-    cJSON *root = NULL;
+    cJSON *j_result = NULL;
+    cJSON *j_root = NULL;
     test_struct_t *data  = (test_struct_t *)*state;
 
-    root = cJSON_CreateArray();
-    cJSON_AddItemToArray(root, cJSON_CreateString("default"));
-    cJSON_AddItemToArray(root, cJSON_CreateString("new_group"));
+    j_root = cJSON_Parse("[\"default\",\"new_group\"]");
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_any_always(__wrap_sqlite3_bind_int, index);
     expect_any_always(__wrap_sqlite3_bind_int, value);
     will_return_always(__wrap_sqlite3_bind_int, SQLITE_OK);
-    will_return(__wrap_wdb_exec_stmt_single_column, root);
+    will_return(__wrap_wdb_exec_stmt_single_column, j_root);
 
-    output = wdb_global_select_group_belong(data->wdb, 1);
+    j_result = wdb_global_select_group_belong(data->wdb, 1);
 
-    assert_ptr_equal(output, root);
-    __real_cJSON_Delete(root);
+    char *result = cJSON_PrintUnformatted(j_result);
+    assert_string_equal(result, "[\"default\",\"new_group\"]");
+    __real_cJSON_Delete(j_root);
+    os_free(result);
 }
 
 /* Tests wdb_global_insert_agent_belong */

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -4189,6 +4189,91 @@ void test_wdb_global_insert_agent_group_success(void **state)
     assert_int_equal(result, OS_SUCCESS);
 }
 
+/* Tests wdb_global_select_group_belong */
+
+void test_wdb_global_select_group_belong_transaction_fail(void **state)
+{
+    cJSON *output = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    will_return(__wrap_wdb_begin2, -1);
+    expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
+
+    output = wdb_global_select_group_belong(data->wdb, 1);
+    assert_null(output);
+}
+
+void test_wdb_global_select_group_belong_cache_fail(void **state)
+{
+    cJSON *output = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, -1);
+    expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
+
+    output = wdb_global_select_group_belong(data->wdb, 1);
+    assert_null(output);
+}
+
+void test_wdb_global_select_group_belong_bind_fail(void **state)
+{
+    cJSON *output = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
+    expect_value(__wrap_sqlite3_bind_int, index, 1);
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
+    will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
+
+    output = wdb_global_select_group_belong(data->wdb, 1);
+    assert_null(output);
+}
+
+void test_wdb_global_select_group_belong_exec_fail(void **state)
+{
+    cJSON *output = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
+    expect_any_always(__wrap_sqlite3_bind_int, index);
+    expect_any_always(__wrap_sqlite3_bind_int, value);
+    will_return_always(__wrap_sqlite3_bind_int, SQLITE_OK);
+    will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
+    will_return(__wrap_wdb_exec_stmt_single_column, NULL);
+    expect_string(__wrap__mdebug1, formatted_msg, "wdb_exec_stmt(): ERROR MESSAGE");
+
+    output = wdb_global_select_group_belong(data->wdb, 1);
+    assert_null(output);
+}
+
+void test_wdb_global_select_group_belong_success(void **state)
+{
+    cJSON *output = NULL;
+    cJSON *root = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    root = cJSON_CreateArray();
+    cJSON_AddItemToArray(root, cJSON_CreateString("default"));
+    cJSON_AddItemToArray(root, cJSON_CreateString("new_group"));
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
+    expect_any_always(__wrap_sqlite3_bind_int, index);
+    expect_any_always(__wrap_sqlite3_bind_int, value);
+    will_return_always(__wrap_sqlite3_bind_int, SQLITE_OK);
+    will_return(__wrap_wdb_exec_stmt_single_column, root);
+
+    output = wdb_global_select_group_belong(data->wdb, 1);
+
+    assert_ptr_equal(output, root);
+    __real_cJSON_Delete(root);
+}
+
 /* Tests wdb_global_insert_agent_belong */
 
 void test_wdb_global_insert_agent_belong_transaction_fail(void **state)
@@ -6011,6 +6096,12 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_global_insert_agent_group_bind_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_insert_agent_group_step_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_insert_agent_group_success, test_setup, test_teardown),
+        /* Tests wdb_global_select_group_belong */
+        cmocka_unit_test_setup_teardown(test_wdb_global_select_group_belong_transaction_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_select_group_belong_cache_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_select_group_belong_bind_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_select_group_belong_exec_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_select_group_belong_success, test_setup, test_teardown),
         /* Tests wdb_global_insert_agent_belong */
         cmocka_unit_test_setup_teardown(test_wdb_global_insert_agent_belong_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_insert_agent_belong_cache_fail, test_setup, test_teardown),

--- a/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
@@ -1981,7 +1981,7 @@ void test_wdb_update_agent_connection_status_success(void **state)
 void test_wdb_select_group_belong_error_no_json_response(void **state)
 {
     int id = 1;
-    cJSON* j_data = NULL;
+    cJSON* j_response = NULL;
 
     // Calling Wazuh DB
     will_return(__wrap_wdbc_query_parse_json, 0);
@@ -1989,28 +1989,26 @@ void test_wdb_select_group_belong_error_no_json_response(void **state)
 
     expect_string(__wrap__merror, formatted_msg, "Error querying Wazuh DB to get groups from agent 1.");
 
-    j_data = wdb_select_group_belong(id, NULL);
+    j_response = wdb_select_group_belong(id, NULL);
 
-    assert_null(j_data);
+    assert_null(j_response);
 }
 
 void test_wdb_select_group_belong_success(void **state) {
-    cJSON *root = NULL;
-    cJSON *response = NULL;
+    cJSON *j_root = NULL;
+    cJSON *j_response = NULL;
     int id = 1;
 
-    root = __real_cJSON_CreateArray();
-    __real_cJSON_AddItemToArray(root, __real_cJSON_CreateString("default"));
-    __real_cJSON_AddItemToArray(root, __real_cJSON_CreateString("new_group"));
+    j_root = __real_cJSON_Parse("[\"default\",\"new_group\"]");
 
     // Calling Wazuh DB
     will_return(__wrap_wdbc_query_parse_json, 0);
-    will_return(__wrap_wdbc_query_parse_json, root);
+    will_return(__wrap_wdbc_query_parse_json, j_root);
 
-    response = wdb_select_group_belong(id, NULL);
+    j_response = wdb_select_group_belong(id, NULL);
 
-    assert_ptr_equal(response, root);
-    __real_cJSON_Delete(root);
+    assert_non_null(j_response);
+    __real_cJSON_Delete(j_root);
 }
 
 /* Tests wdb_delete_agent_belongs */

--- a/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
@@ -1976,6 +1976,43 @@ void test_wdb_update_agent_connection_status_success(void **state)
     assert_int_equal(OS_SUCCESS, ret);
 }
 
+/* Tests wdb_select_group_belong */
+
+void test_wdb_select_group_belong_error_no_json_response(void **state)
+{
+    int id = 1;
+    cJSON* j_data = NULL;
+
+    // Calling Wazuh DB
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, NULL);
+
+    expect_string(__wrap__merror, formatted_msg, "Error querying Wazuh DB to get groups from agent 1.");
+
+    j_data = wdb_select_group_belong(id, NULL);
+
+    assert_null(j_data);
+}
+
+void test_wdb_select_group_belong_success(void **state) {
+    cJSON *root = NULL;
+    cJSON *response = NULL;
+    int id = 1;
+
+    root = __real_cJSON_CreateArray();
+    __real_cJSON_AddItemToArray(root, __real_cJSON_CreateString("default"));
+    __real_cJSON_AddItemToArray(root, __real_cJSON_CreateString("new_group"));
+
+    // Calling Wazuh DB
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, root);
+
+    response = wdb_select_group_belong(id, NULL);
+
+    assert_ptr_equal(response, root);
+    __real_cJSON_Delete(root);
+}
+
 /* Tests wdb_delete_agent_belongs */
 
 void test_wdb_delete_agent_belongs_error_socket(void **state)
@@ -3655,6 +3692,9 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_update_agent_connection_status_error_sql_execution, setup_wdb_global_helpers, teardown_wdb_global_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_update_agent_connection_status_error_result, setup_wdb_global_helpers, teardown_wdb_global_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_update_agent_connection_status_success, setup_wdb_global_helpers, teardown_wdb_global_helpers),
+        /* Tests wdb_select_group_belong */
+        cmocka_unit_test_setup_teardown(test_wdb_select_group_belong_error_no_json_response, setup_wdb_global_helpers, teardown_wdb_global_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_select_group_belong_success, setup_wdb_global_helpers, teardown_wdb_global_helpers),
         /* Tests wdb_delete_agent_belongs */
         cmocka_unit_test_setup_teardown(test_wdb_delete_agent_belongs_error_socket, setup_wdb_global_helpers, teardown_wdb_global_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_delete_agent_belongs_error_sql_execution, setup_wdb_global_helpers, teardown_wdb_global_helpers),

--- a/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
@@ -2007,8 +2007,10 @@ void test_wdb_select_group_belong_success(void **state) {
 
     j_response = wdb_select_group_belong(id, NULL);
 
-    assert_non_null(j_response);
+    char *response = __real_cJSON_PrintUnformatted(j_response);
+    assert_string_equal(response, "[\"default\",\"new_group\"]");
     __real_cJSON_Delete(j_root);
+    os_free(response);
 }
 
 /* Tests wdb_delete_agent_belongs */

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -1367,20 +1367,18 @@ void test_wdb_parse_global_select_group_belong_success(void **state)
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char query[OS_BUFFER_SIZE] = "global select-group-belong 1";
-    cJSON *j_object = NULL;
+    cJSON *j_response = NULL;
 
-    j_object = cJSON_CreateObject();
-    cJSON_AddItemToArray(j_object, cJSON_CreateString("default"));
-    cJSON_AddItemToArray(j_object, cJSON_CreateString("new_group"));
+    j_response = cJSON_Parse("[\"default\",\"new_group\"]");
 
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: select-group-belong 1");
     expect_value(__wrap_wdb_global_select_group_belong, id_agent, 1);
-    will_return(__wrap_wdb_global_select_group_belong, j_object);
+    will_return(__wrap_wdb_global_select_group_belong, j_response);
 
     ret = wdb_parse(query, data->output, 0);
 
-    assert_string_equal(data->output, "ok {\"\":\"default\",\"\":\"new_group\"}");
+    assert_string_equal(data->output, "ok [\"default\",\"new_group\"]");
     assert_int_equal(ret, OS_SUCCESS);
 }
 

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -1325,6 +1325,65 @@ void test_wdb_parse_global_insert_agent_group_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+/* Tests wdb_parse_global_select_group_belong */
+
+void test_wdb_parse_global_select_group_belong_syntax_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global select-group-belong";
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: select-group-belong");
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for select-group-belong.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: select-group-belong");
+
+    ret = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "err Invalid DB query syntax, near 'select-group-belong'");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_select_group_belong_query_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global select-group-belong 1";
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: select-group-belong 1");
+    expect_value(__wrap_wdb_global_select_group_belong, id_agent, 1);
+    will_return(__wrap_wdb_global_select_group_belong, NULL);
+    expect_string(__wrap__mdebug1, formatted_msg, "Error getting agent groups information from global.db.");
+
+    ret = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "err Error getting agent groups information from global.db.");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_select_group_belong_success(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global select-group-belong 1";
+    cJSON *j_object = NULL;
+
+    j_object = cJSON_CreateObject();
+    cJSON_AddItemToArray(j_object, cJSON_CreateString("default"));
+    cJSON_AddItemToArray(j_object, cJSON_CreateString("new_group"));
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: select-group-belong 1");
+    expect_value(__wrap_wdb_global_select_group_belong, id_agent, 1);
+    will_return(__wrap_wdb_global_select_group_belong, j_object);
+
+    ret = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "ok {\"\":\"default\",\"\":\"new_group\"}");
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
 /* Tests wdb_parse_global_delete_group */
 
 void test_wdb_parse_global_delete_group_syntax_error(void **state)
@@ -2388,6 +2447,10 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_insert_agent_group_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_insert_agent_group_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_insert_agent_group_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_select_group_belong */
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_select_group_belong_syntax_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_select_group_belong_query_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_select_group_belong_success, test_setup, test_teardown),
         /* Tests wdb_parse_global_delete_group */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_delete_group_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_delete_group_query_error, test_setup, test_teardown),

--- a/src/unit_tests/wrappers/externals/cJSON/cJSON_wrappers.h
+++ b/src/unit_tests/wrappers/externals/cJSON/cJSON_wrappers.h
@@ -87,6 +87,8 @@ cJSON *__wrap_cJSON_ParseWithOpts(const char *value, const char **return_parse_e
 
 extern cJSON *__real_cJSON_Parse(const char *value);
 
+extern char *__real_cJSON_PrintUnformatted(cJSON *item);
+
 char *__wrap_cJSON_PrintUnformatted(const cJSON *item);
 
 char *__wrap_cJSON_Print(const cJSON *item);

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -166,6 +166,12 @@ int __wrap_wdb_global_insert_agent_group(__attribute__((unused)) wdb_t *wdb,
     return mock();
 }
 
+cJSON* __wrap_wdb_global_select_group_belong(__attribute__((unused)) wdb_t *wdb,
+                                             int id_agent) {
+    check_expected(id_agent);
+    return mock_ptr_type(cJSON*);
+}
+
 int __wrap_wdb_global_insert_agent_belong(__attribute__((unused)) wdb_t *wdb,
                                           int id_group,
                                           int id_agent) {

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -61,6 +61,8 @@ cJSON* __wrap_wdb_global_find_group(wdb_t *wdb, char* group_name);
 
 int __wrap_wdb_global_insert_agent_group(wdb_t *wdb, char* group_name);
 
+cJSON* __wrap_wdb_global_select_group_belong(wdb_t *wdb, int id_agent);
+
 int __wrap_wdb_global_insert_agent_belong(wdb_t *wdb, int id_group, int id_agent);
 
 int __wrap_wdb_global_delete_group(wdb_t *wdb, char* group_name);

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
@@ -100,6 +100,10 @@ cJSON * __wrap_wdb_exec_stmt(__attribute__((unused)) sqlite3_stmt *stmt) {
     return mock_ptr_type(cJSON *);
 }
 
+cJSON * __wrap_wdb_exec_stmt_single_column(__attribute__((unused)) sqlite3_stmt *stmt) {
+    return mock_ptr_type(cJSON *);
+}
+
 cJSON * __wrap_wdb_exec_stmt_sized(__attribute__((unused)) sqlite3_stmt *stmt,
                                    size_t max_size,
                                    int* status) {

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
@@ -47,6 +47,8 @@ int __wrap_wdb_syscheck_save2(wdb_t *wdb, const char *payload);
 
 cJSON * __wrap_wdb_exec_stmt(sqlite3_stmt *stmt);
 
+cJSON * __wrap_wdb_exec_stmt_single_column(sqlite3_stmt *stmt);
+
 cJSON * __wrap_wdb_exec_stmt_sized(sqlite3_stmt *stmt, size_t max_size, int* status);
 
 int __wrap_wdbc_parse_result(char *result, char **payload);

--- a/src/wazuh_db/helpers/wdb_global_helpers.h
+++ b/src/wazuh_db/helpers/wdb_global_helpers.h
@@ -230,6 +230,14 @@ int wdb_remove_agent(int id, int *sock);
  */
 int wdb_remove_group_db(const char *name, int *sock);
 
+/**
+ * @brief Get groups from agent id in belongs table.
+ *
+ * @param id Id of the agent to get the groups from.
+ * @param sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
+ * @return JSON* with the information on success or NULL on failure.
+ */
+cJSON* wdb_select_group_belong(int id, int *sock);
 
 /**
  * @brief Delete an agent from belongs table in global.db by using its ID.

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5171,7 +5171,7 @@ int wdb_parse_global_select_group_belong(wdb_t *wdb, char *input, char *output) 
     cJSON *agent_groups = NULL;
 
     if (agent_groups = wdb_global_select_group_belong(wdb, agent_id), !agent_groups) {
-        mdebug1("Error getting agent information from global.db.");
+        mdebug1("Error getting agent groups information from global.db.");
         snprintf(output, OS_MAXSTR + 1, "err Error getting agent groups information from global.db.");
         return OS_INVALID;
     }


### PR DESCRIPTION
|Related issue|
|---|
|#11754|

## Description

This PR adds UT cases for:

- wdb_global_select_group_belong()
- wdb_select_group_belong()
- wdb_parse_global_select_group_belong()

## Coverage

![4](https://user-images.githubusercontent.com/13010397/150552018-04caeeb6-ffae-447e-9b16-bdba41c005ad.png)
![5](https://user-images.githubusercontent.com/13010397/150552023-2b59db89-7283-4940-99aa-f01c0749b710.png)
![6](https://user-images.githubusercontent.com/13010397/150552026-102cac8d-d131-49dd-b2e9-ff957357395f.png)
![7](https://user-images.githubusercontent.com/13010397/150552029-566c7cb1-bd98-466f-8b48-91fa4dd5d20c.png)

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Review logs syntax and correct language
- [X] Added unit tests (for new features)