### PR TITLE
Improve belongs update

### DIFF
--- a/src/headers/agent_op.h
+++ b/src/headers/agent_op.h
@@ -58,9 +58,6 @@ int os_write_agent_info(const char *agent_name, const char *agent_ip, const char
                         const char *cfg_profile_name) __attribute__((nonnull(1, 3)));
 
 #ifndef CLIENT
-/* Read agent group. Returns 0 on success or -1 on failure. */
-int get_agent_group(int id, char *group, size_t size, int* wdb_sock);
-
 int set_agent_multigroup(char * group);
 
 #endif

--- a/src/shared/agent_op.c
+++ b/src/shared/agent_op.c
@@ -272,32 +272,6 @@ int os_write_agent_info(const char *agent_name, __attribute__((unused)) const ch
 }
 
 #ifndef CLIENT
-/* Read group. Returns 0 on success or -1 on failure. */
-int get_agent_group(int id, char *group, size_t size, int* wdb_sock) {
-    cJSON* j_agent_info = NULL;
-    char* agent_group = NULL;
-    int result = OS_INVALID;
-
-    j_agent_info = wdb_get_agent_info(id, wdb_sock);
-
-    if(!j_agent_info) {
-        mdebug1("Unable to get agent info of agent '%d'", id);
-        return OS_INVALID;
-    }
-
-    agent_group = cJSON_GetStringValue(cJSON_GetObjectItem(j_agent_info->child,"group"));
-
-    if(agent_group) {
-        snprintf(group, size, "%s", agent_group);
-        result = OS_SUCCESS;
-    } else {
-        result = OS_INVALID;
-    }
-
-    cJSON_Delete(j_agent_info);
-    return result;
-}
-
 int set_agent_multigroup(char * group) {
     int oldmask;
     char *multigroup = strchr(group,MULTIGROUP_SEPARATOR);

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -24,7 +24,7 @@ include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 
 # Generate remoted tests
 list(APPEND remoted_names "test_manager")
-list(APPEND remoted_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,get_agent_group \
+list(APPEND remoted_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,wdb_get_agent_group \
 -Wl,--wrap,wdb_set_agent_groups_csv -Wl,--wrap,_merror -Wl,--wrap,w_is_worker")
 
 list(APPEND remoted_names "test_secure")

--- a/src/unit_tests/remoted/test_manager.c
+++ b/src/unit_tests/remoted/test_manager.c
@@ -32,9 +32,8 @@ void test_lookfor_agent_group_null_groups()
     char *msg = "Linux |localhost.localdomain |4.18.0-240.22.1.el8_3.x86_64 |#1 SMP Thu Apr 8 19:01:30 UTC 2021 |x86_64 [CentOS Linux|centos: 8.3] - Wazuh v4.2.0 / ab73af41699f13fdd81903b5f23d8d00\nc2305e0ac17e7176e924294c69cc7a24 merged.mg\n#\"_agent_ip\":10.0.2.4";
     char *r_group = NULL;
 
-    expect_value(__wrap_get_agent_group, id, agent_id);
-    will_return(__wrap_get_agent_group, "");
-    will_return(__wrap_get_agent_group, -1);
+    expect_value(__wrap_wdb_get_agent_group, id, agent_id);
+    will_return(__wrap_wdb_get_agent_group, NULL);
 
     expect_string(__wrap__mdebug2, formatted_msg, "Agent '001' group is ''");
     expect_string(__wrap__mdebug2, formatted_msg, "Agent '001' with group '' file 'merged.mg' MD5 'c2305e0ac17e7176e924294c69cc7a24'");
@@ -58,9 +57,8 @@ void test_lookfor_agent_group_set_default_group()
     char *msg = "Linux |localhost.localdomain |4.18.0-240.22.1.el8_3.x86_64 |#1 SMP Thu Apr 8 19:01:30 UTC 2021 |x86_64 [CentOS Linux|centos: 8.3] - Wazuh v4.2.0 / ab73af41699f13fdd81903b5f23d8d00\nc2305e0ac17e7176e924294c69cc7a24 merged.mg\n#\"_agent_ip\":10.0.2.4";
     char *r_group = NULL;
 
-    expect_value(__wrap_get_agent_group, id, agent_id);
-    will_return(__wrap_get_agent_group, "");
-    will_return(__wrap_get_agent_group, -1);
+    expect_value(__wrap_wdb_get_agent_group, id, agent_id);
+    will_return(__wrap_wdb_get_agent_group, NULL);
 
     expect_string(__wrap__mdebug2, formatted_msg, "Agent '001' group is ''");
     expect_string(__wrap__mdebug2, formatted_msg, "Agent '001' with group '' file 'merged.mg' MD5 'c2305e0ac17e7176e924294c69cc7a24'");
@@ -84,9 +82,8 @@ void test_lookfor_agent_group_msg_without_enter()
     char *msg = "Linux |localhost.localdomain |4.18.0-240.22.1.el8_3.x86_64 |#1 SMP Thu Apr 8 19:01:30 UTC 2021 |x86_64 [CentOS Linux|centos: 8.3] - Wazuh v4.2.0 / ab73af41699f13fdd81903b5f23d8d00c2305e0ac17e7176e924294c69cc7a24 merged.mg";
     char *r_group = NULL;
 
-    expect_value(__wrap_get_agent_group, id, agent_id);
-    will_return(__wrap_get_agent_group, "");
-    will_return(__wrap_get_agent_group, -1);
+    expect_value(__wrap_wdb_get_agent_group, id, agent_id);
+    will_return(__wrap_wdb_get_agent_group, NULL);
 
     expect_string(__wrap__mdebug2, formatted_msg, "Agent '002' group is ''");
 
@@ -104,9 +101,8 @@ void test_lookfor_agent_group_bad_message()
     char *msg = "Linux |localhost.localdomain\n#c2305e0ac17e7176e924294c69cc7a24 merged.mg\nc2305e0ac17e7176e924294c69cc7a24merged.mg\n#\"_agent_ip\":10.0.2.4";
     char *r_group = NULL;
 
-    expect_value(__wrap_get_agent_group, id, agent_id);
-    will_return(__wrap_get_agent_group, "");
-    will_return(__wrap_get_agent_group, -1);
+    expect_value(__wrap_wdb_get_agent_group, id, agent_id);
+    will_return(__wrap_wdb_get_agent_group, NULL);
 
     expect_string(__wrap__mdebug2, formatted_msg, "Agent '003' group is ''");
 
@@ -124,9 +120,8 @@ void test_lookfor_agent_group_message_without_second_enter()
     char *msg = "Linux |localhost.localdomain \n#\"_agent_ip\":10.0.2.4";
     char *r_group = NULL;
 
-    expect_value(__wrap_get_agent_group, id, agent_id);
-    will_return(__wrap_get_agent_group, "");
-    will_return(__wrap_get_agent_group, -1);
+    expect_value(__wrap_wdb_get_agent_group, id, agent_id);
+    will_return(__wrap_wdb_get_agent_group, NULL);
 
     expect_string(__wrap__mdebug2, formatted_msg, "Agent '004' group is ''");
 

--- a/src/unit_tests/wrappers/wazuh/shared/agent_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/agent_op_wrappers.c
@@ -30,9 +30,3 @@ char* __wrap_get_agent_id_from_name(__attribute__((unused)) char *agent_name) {
 int __wrap_control_check_connection() {
     return mock();
 }
-
-int __wrap_get_agent_group(int id, char *group, __attribute__((unused)) size_t size, int *wdb_sock) {
-    check_expected(id);
-    strncpy(group, mock_type(char *), OS_SIZE_65536);
-    return mock();
-}

--- a/src/unit_tests/wrappers/wazuh/shared/agent_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/agent_op_wrappers.h
@@ -16,6 +16,5 @@
 int __wrap_auth_connect();
 char* __wrap_get_agent_id_from_name(__attribute__((unused)) char *agent_name);
 int __wrap_control_check_connection();
-int __wrap_get_agent_group(int id, char *group, __attribute__((unused)) size_t size, int *wdb_sock);
 
 #endif

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_helpers_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_helpers_wrappers.c
@@ -54,3 +54,9 @@ int __wrap_wdb_set_agent_groups_csv(int id,
     check_expected(id);
     return mock();
 }
+
+char* __wrap_wdb_get_agent_group(int id,
+                                 __attribute__((unused)) int *wdb_sock) {
+    check_expected(id);
+    return mock_type(char *);
+}

--- a/src/wazuh_db/helpers/wdb_global_helpers.h
+++ b/src/wazuh_db/helpers/wdb_global_helpers.h
@@ -17,7 +17,6 @@
 typedef enum global_db_access {
     WDB_INSERT_AGENT,
     WDB_INSERT_AGENT_GROUP,
-    WDB_INSERT_AGENT_BELONG,
     WDB_UPDATE_AGENT_NAME,
     WDB_UPDATE_AGENT_DATA,
     WDB_UPDATE_AGENT_KEEPALIVE,
@@ -73,17 +72,6 @@ int wdb_insert_agent(int id,
  * @return Returns OS_SUCCESS on success or OS_INVALID on failure.
  */
 int wdb_insert_group(const char *name, int *sock);
-
-/**
- * @brief Update agent belongs table.
- *
- * @param[in] id_group Id of the group to be updated.
- * @param[in] id_agent Id of the agent to be updated.
- * @param[in] priority Priority of the agent group to be updated.
- * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
- * @return Returns OS_SUCCESS on success or OS_INVALID on failure.
- */
-int wdb_update_agent_belongs(int id_group, int id_agent, int priority, int *sock);
 
 /**
  * @brief Update agent name in global.db.
@@ -325,24 +313,6 @@ int* wdb_get_agents_by_connection_status(const char* connection_status, int *soc
  * @return Pointer to the array, on success. NULL if no agents were set as disconnected or an error ocurred.
  */
 int* wdb_disconnect_agents(int keepalive, const char *sync_status, int *sock);
-
-/**
- * @brief Update agent multi group.
- *
- * @param[in] id The agent id.
- * @param[in] group The group name.
- * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
- * @return Returns OS_SUCCESS on success or OS_INVALID on failure.
- */
-int wdb_update_agent_multi_group(int id, char *group, int *sock);
-
-/**
- * @brief Fill belongs table on start.
- * @param [in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
- *
- * @return Returns OS_SUCCESS.
- */
-int wdb_agent_belongs_first_time(int *sock);
 
 /**
  * @brief Get the agent first registration date.

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -172,7 +172,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_GROUP_SYNC_SET] = "UPDATE agent SET group_sync_status = ? WHERE id = ?;",
     [WDB_STMT_GLOBAL_GROUP_PRIORITY_GET] = "SELECT MAX(priority) FROM belongs WHERE id_agent=?;",
     [WDB_STMT_GLOBAL_GROUP_CSV_GET] = "SELECT `group` from agent where id = ?;",
-    [WDB_STMT_GLOBAL_GROUP_CTX_SET] = "UPDATE agent SET 'group' = ?, group_hash = ?, group_sync_status = ?, group_source = ? WHERE id = ?;",
+    [WDB_STMT_GLOBAL_GROUP_CTX_SET] = "UPDATE agent SET 'group' = ?, group_hash = ?, group_sync_status = ? WHERE id = ?;",
     [WDB_STMT_GLOBAL_GROUP_HASH_GET] = "SELECT group_hash FROM agent WHERE group_hash IS NOT NULL ORDER BY id;",
     [WDB_STMT_GLOBAL_UPDATE_AGENT_INFO] = "UPDATE agent SET config_sum = :config_sum, ip = :ip, manager_host = :manager_host, merged_sum = :merged_sum, name = :name, node_name = :node_name, os_arch = :os_arch, os_build = :os_build, os_codename = :os_codename, os_major = :os_major, os_minor = :os_minor, os_name = :os_name, os_platform = :os_platform, os_uname = :os_uname, os_version = :os_version, version = :version, last_keepalive = :last_keepalive, connection_status = :connection_status, disconnection_time = :disconnection_time, sync_status = :sync_status WHERE id = :id;",
     [WDB_STMT_GLOBAL_GET_AGENTS] = "SELECT id FROM agent WHERE id > ?;",

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -1209,17 +1209,6 @@ int wdb_parse_global_insert_agent_group(wdb_t * wdb, char * input, char * output
 int wdb_parse_global_select_group_belong(wdb_t *wdb, char *input, char *output);
 
 /**
- * @brief Function to parse the insert agent to belongs table request.
- *
- * @param [in] wdb The global struct database.
- * @param [in] input String with the group id and agent id in JSON format.
- * @param [out] output Response of the query.
- * @return 0 Success: response contains "ok".
- *        -1 On error: response contains "err" and an error description.
- */
-int wdb_parse_global_insert_agent_belong(wdb_t * wdb, char * input, char * output);
-
-/**
  * @brief Function to parse the delete group from belongs table request.
  *
  * @param [in] wdb The global struct database.

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -1963,16 +1963,6 @@ int wdb_global_set_agent_groups_sync_status(wdb_t *wdb,
                                             int id,
                                             const char* sync_status);
 
-
-/**
- * @brief Gets the csv representation of an agent group from the group column of the agent table.
- *
- * @param [in] wdb The Global struct database.
- * @param [in] id ID of the agent to obtain the group.
- * @return string with the csv of the group. Must be de-allocated by the caller
- */
-char* wdb_global_get_agent_group_csv(wdb_t *wdb, int id);
-
 /**
  * @brief Sets the group information in the agent table.
  * @param [in] wdb The Global struct database.

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -818,15 +818,6 @@ int wdb_parse(char * input, char * output, int peer) {
             } else {
                 result = wdb_parse_global_select_group_belong(wdb, next, output);
             }
-        } else if (strcmp(query, "insert-agent-belong") == 0) {
-            if (!next) {
-                mdebug1("Global DB Invalid DB query syntax for insert-agent-belong.");
-                mdebug2("Global DB query error near: %s", query);
-                snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
-                result = OS_INVALID;
-            } else {
-                result = wdb_parse_global_insert_agent_belong(wdb, next, output);
-            }
         } else if (strcmp(query, "delete-group-belong") == 0) {
             if (!next) {
                 mdebug1("Global DB Invalid DB query syntax for delete-group-belong.");
@@ -5187,50 +5178,6 @@ int wdb_parse_global_select_group_belong(wdb_t *wdb, char *input, char *output) 
     snprintf(output, OS_MAXSTR + 1, "ok %s", out);
     os_free(out);
     cJSON_Delete(agent_groups);
-
-    return OS_SUCCESS;
-}
-
-int wdb_parse_global_insert_agent_belong(wdb_t * wdb, char * input, char * output) {
-    cJSON *agent_data = NULL;
-    const char *error = NULL;
-    cJSON *j_id_group = NULL;
-    cJSON *j_id_agent = NULL;
-    cJSON *j_priority = NULL;
-
-    agent_data = cJSON_ParseWithOpts(input, &error, TRUE);
-    if (!agent_data) {
-        mdebug1("Global DB Invalid JSON syntax when inserting agent to belongs table.");
-        mdebug2("Global DB JSON error near: %s", error);
-        snprintf(output, OS_MAXSTR + 1, "err Invalid JSON syntax, near '%.32s'", input);
-        return OS_INVALID;
-    } else {
-        j_id_group = cJSON_GetObjectItem(agent_data, "id_group");
-        j_id_agent = cJSON_GetObjectItem(agent_data, "id_agent");
-        j_priority = cJSON_GetObjectItem(agent_data, "priority");
-
-        if (cJSON_IsNumber(j_id_group) && cJSON_IsNumber(j_id_agent) && cJSON_IsNumber(j_priority)) {
-            // Getting each field
-            int id_group = j_id_group->valueint;
-            int id_agent = j_id_agent->valueint;
-            int priority = j_priority->valueint;
-
-            if (OS_SUCCESS != wdb_global_insert_agent_belong(wdb, id_group, id_agent, priority)) {
-                mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db: %s", WDB2_DIR, WDB_GLOB_NAME, sqlite3_errmsg(wdb->db));
-                snprintf(output, OS_MAXSTR + 1, "err Cannot execute Global database query; %s", sqlite3_errmsg(wdb->db));
-                cJSON_Delete(agent_data);
-                return OS_INVALID;
-            }
-        } else {
-            mdebug1("Global DB Invalid JSON data when inserting agent to belongs table.");
-            snprintf(output, OS_MAXSTR + 1, "err Invalid JSON data, near '%.32s'", input);
-            cJSON_Delete(agent_data);
-            return OS_INVALID;
-        }
-    }
-
-    snprintf(output, OS_MAXSTR + 1, "ok");
-    cJSON_Delete(agent_data);
 
     return OS_SUCCESS;
 }

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -368,7 +368,7 @@ void sync_keys_with_wdb(keystore *keys) {
             continue;
         }
 
-        char* group = wdb_get_agent_group(atoi(entry->id), NULL);
+        char* group = wdb_get_agent_group(atoi(entry->id), &wdb_wmdb_sock);
         if (wdb_insert_agent(id, entry->name, NULL, OS_CIDRtoStr(entry->ip, cidr, 20) ?
                              entry->ip->ip : cidr, entry->raw_key, group, 1, &wdb_wmdb_sock)) {
             // The agent already exists, update group only.

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -859,7 +859,6 @@ void wm_inotify_setup(wm_database * data) {
             wm_sync_agents_artifacts();
         }
         wm_sync_multi_groups(SHAREDCFG_DIR);
-        wdb_agent_belongs_first_time(&wdb_wmdb_sock);
         wm_clean_dangling_legacy_dbs();
         wm_clean_dangling_wdb_dbs();
     }


### PR DESCRIPTION
|Related issue|
|---|
|#11894|

## Description

This PR fixes the following inconsistencies regarding the update of the belongs table in WDB:
- **wdb_agent_belongs_first_time()** complete logic and dependencies is eliminated.
- **get_agent_group()** is now replaced with **wdb_get_agent_group()**
- **wdb_global_get_agent_group_csv()** is now replaced with **wdb_global_select_agent_group()**.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
Linux
  - [x] Source installation
  - [x] Package installation
  - [x] Source upgrade
  - [x] Package upgrade
  - [x] Review logs syntax and correct language

- Developer testing
  - [x] Test script execution for **set-agent-groups** command
