### PR TITLE
Fix uninitialized variable in `RegistryValue::createFimEntry`.

### DIFF
--- a/src/syscheckd/src/db/src/dbRegistryValue.cpp
+++ b/src/syscheckd/src/db/src/dbRegistryValue.cpp
@@ -18,6 +18,7 @@ void RegistryValue::createFimEntry()
     fim_registry_value_data* value = reinterpret_cast<fim_registry_value_data*>(std::calloc(1, sizeof(fim_registry_value_data)));
 
     fim->type = FIM_TYPE_REGISTRY;
+    value->path = const_cast<char *>(m_path.c_str());
     value->size = m_size;
     value->name = const_cast<char*>(m_identifier.c_str());
     std::strncpy(value->hash_md5, m_md5.c_str(), sizeof(value->hash_md5));

--- a/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.cpp
+++ b/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.cpp
@@ -153,7 +153,7 @@ TEST_F(DBTestWinFixture, TestTransactionsRegistryKey)
     });
 }
 
-TEST_F(DBTestWinFixture, DISABLED_TestTransactionsRegistryValue)
+TEST_F(DBTestWinFixture, TestTransactionsRegistryValue)
 {
     EXPECT_NO_THROW(
     {


### PR DESCRIPTION
|Related issue|
|---|
|#11849|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR aims to fix an uninitialized variable error in the `CreateFimEntry` method of the RegistryValue class. 
Also, remove the `DISABLE_` prefix for the test to be run.

Closes #11849 
## Logs/Alerts example

```
-> % ./fim_db_interface_test
[==========] Running 9 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 2 tests from DBTestFixture
[ RUN      ] DBTestFixture.TestFimDBInit
[       OK ] DBTestFixture.TestFimDBInit (6 ms)
[ RUN      ] DBTestFixture.TestTransactionsFile
[       OK ] DBTestFixture.TestTransactionsFile (6 ms)
[----------] 2 tests from DBTestFixture (13 ms total)

[----------] 7 tests from DBTestWinFixture
[ RUN      ] DBTestWinFixture.TestFimDBInitWindows
[       OK ] DBTestWinFixture.TestFimDBInitWindows (4 ms)
[ RUN      ] DBTestWinFixture.TestTransactionsWinFile
[       OK ] DBTestWinFixture.TestTransactionsWinFile (9 ms)
[ RUN      ] DBTestWinFixture.TestTransactionsRegistryKey
[       OK ] DBTestWinFixture.TestTransactionsRegistryKey (8 ms)
[ RUN      ] DBTestWinFixture.TestTransactionsRegistryValue
[       OK ] DBTestWinFixture.TestTransactionsRegistryValue (9 ms)
[ RUN      ] DBTestWinFixture.TestInitTransactionWithInvalidParameters
[       OK ] DBTestWinFixture.TestInitTransactionWithInvalidParameters (2 ms)
[ RUN      ] DBTestWinFixture.TestSyncRowTransactionWithInvalidHandler
[       OK ] DBTestWinFixture.TestSyncRowTransactionWithInvalidHandler (3 ms)
[ RUN      ] DBTestWinFixture.TestSyncDeletedRowsTransactionWithInvalidParameters
[       OK ] DBTestWinFixture.TestSyncDeletedRowsTransactionWithInvalidParameters (2 ms)
[----------] 7 tests from DBTestWinFixture (40 ms total)

[----------] Global test environment tear-down
[==========] 9 tests from 2 test suites ran. (54 ms total)
[  PASSED  ] 9 tests.

  YOU HAVE 4 DISABLED TESTS
```
 

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Source upgrade
<!-- Depending on the affected OS -->
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory