### PR TITLE
Fix AWS Umbrella buckets first execution when called without specifying an `only_logs_after` parameter

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -356,55 +356,51 @@ class AWSBucket(WazuhIntegration):
     """
     Represents a bucket with events on the inside.
 
-    This is an abstract class
+    This is an abstract class.
+
+    Parameters
+    ----------
+    reparse : bool
+        Whether to parse already parsed logs or not.
+    access_key : str
+        AWS access key id.
+    secret_key : str
+        AWS secret access key.
+    profile : str
+        AWS profile.
+    iam_role_arn : str
+        IAM Role.
+    bucket : str
+        Bucket name to extract logs from.
+    only_logs_after : str
+        Date after which obtain logs.
+    skip_on_error : bool
+        Whether to continue processing logs or stop when an error takes place.
+    account_alias: str
+        Alias of the AWS account where the bucket is.
+    prefix : str
+        Prefix to filter files in bucket.
+    suffix : str
+        Suffix to filter files in bucket.
+    delete_file : bool
+        Whether to delete an already processed file from a bucket or not.
+    aws_organization_id : str
+        The AWS organization ID.
+    discard_field : str
+        Name of the event field to apply the regex value on.
+    discard_regex : str
+        REGEX value to determine whether an event should be skipped.
+
+    Attributes
+    ----------
+    date_format : str
+        The format that the service uses to store the date in the bucket's path.
     """
 
     def __init__(self, reparse, access_key, secret_key, profile, iam_role_arn,
                  bucket, only_logs_after, skip_on_error, account_alias,
                  prefix, suffix, delete_file, aws_organization_id, region,
                  discard_field, discard_regex, sts_endpoint, service_endpoint, iam_role_duration=None):
-        """
-        AWS Bucket constructor.
-
-        Parameters
-        ----------
-        reparse : bool
-            Whether to parse already parsed logs or not.
-        access_key : str
-            AWS access key id.
-        secret_key : str
-            AWS secret access key.
-        profile : str
-            AWS profile.
-        iam_role_arn : str
-            IAM Role.
-        bucket : str
-            Bucket name to extract logs from.
-        only_logs_after : str
-            Date after which obtain logs.
-        skip_on_error : bool
-            Whether to continue processing logs or stop when an error takes place.
-        account_alias: str
-            Alias of the AWS account where the bucket is.
-        prefix : str
-            Prefix to filter files in bucket.
-        suffix : str
-            Suffix to filter files in bucket.
-        delete_file : bool
-            Whether to delete an already processed file from a bucket or not.
-        aws_organization_id : str
-            The AWS organization ID.
-        discard_field : str
-            Name of the event field to apply the regex value on.
-        discard_regex : str
-            REGEX value to determine whether an event should be skipped.
-
-        Attributes
-        ----------
-        date_format : str
-            The format that the service uses to store the date in the bucket's path.
-        """
-
         # common SQL queries
         self.sql_already_processed = """
                           SELECT


### PR DESCRIPTION
| Related issue |
|---|
| Closes #11899 |

## Description
In this PR we fix the bug found in #11755, which made the AWS Umbrella integration not work adequately when executed for the first time without specifying an `only_logs_after` parameter.  

To fix this bug, we added the `date_format` attribute to all the classes that deal with AWS Buckets. This new attribute stores information on the format that the related services use to save the date the logs were uploaded in the bucket path. So far, there are two alternatives - `%Y/%m/%d` and `%Y-%m-%d`- that were hardcoded every time needed. Storing that information in an attribute will make the code easier to maintain and less error-prone.

## Tests performed
### Umbrella
Since the three types of Cisco Umbrella buckets use the same underlying logic, we will only need to test that the `only_logs_after` parameter for one of them.

Remove the `/var/ossec/wodles/aws/s3_cloudtrail.db` file and run the module using the following command to obtain every log from the Umbrella bucket for the given date.

#### First execution without specifying an only_logs_after value
Upload one log file to the bucket with the date of execution. Then execute the command. It should use as marker an string with the date of execution and collect the uploaded log.

Use the command:
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l XXXXXXXXXXXX/iplogs -t cisco_umbrella -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l XXXXXXXXXXXX/iplogs -t cisco_umbrella -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Marker: XXXXXXXXXXXX/iplogs/2022-01-25
	DEBUG: ++ Found new log: XXXXXXXXXXXX/iplogs/2022-01-25/2022-01-25-00-00-xyzs.csv.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### First execution specifying an only_logs_after value set in the past
Remove the database file and run the command the using `2021-Dec-20` date as `only_logs_after`. 6 logs should be collected and sent to analysisd.

Use the command:
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l XXXXXXXXXXXX/iplogs -t cisco_umbrella -s 2021-Dec-20 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l XXXXXXXXXXXX/iplogs -t cisco_umbrella -s 2021-Dec-20 -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Marker: XXXXXXXXXXXX/iplogs/2021-12-20
	DEBUG: ++ Found new log: XXXXXXXXXXXX/iplogs/2021-12-20/2021-12-20-00-00-xoal.csv.gz
	DEBUG: ++ Found new log: XXXXXXXXXXXX/iplogs/2021-12-24/2021-12-24-00-00-ixla.csv.gz
	DEBUG: ++ Found new log: XXXXXXXXXXXX/iplogs/2021-12-29/2021-12-29-00-00-ixla.csv.gz
	DEBUG: ++ Found new log: XXXXXXXXXXXX/iplogs/2022-01-17/2022-01-17-00-00-ixla.csv.gz
	DEBUG: ++ Found new log: XXXXXXXXXXXX/iplogs/2022-01-21/2022-01-21-00-00-ixla.csv.gz
	DEBUG: ++ Found new log: XXXXXXXXXXXX/iplogs/2022-01-25/2022-01-25-00-00-xyzs.csv.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

Keep the database file and run the same command again to ensure no duplicate logs have been processed.

Use the command:
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l XXXXXXXXXXXX/iplogs -t cisco_umbrella -s 2021-Dec-20 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l XXXXXXXXXXXX/iplogs -t cisco_umbrella -s 2021-Dec-20 -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Marker: XXXXXXXXXXXX/iplogs/2022-01-25/2022-01-25-00-00-xyzs.csv.gz
	DEBUG: +++ No logs to process in bucket: None/None
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### Execute the command again with an only_logs_after value set earlier in the past

Run the module again, keeping the database file, using the `2021-Dec-01` date as `only_logs_after`. It should use as marker an string with the date of execution and not consider the `only_logs_after` value.

Use the command:
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l XXXXXXXXXXXX/iplogs -t cisco_umbrella -s 2021-Dec-01 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l XXXXXXXXXXXX/iplogs -t cisco_umbrella -s 2021-Dec-01 -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Marker: XXXXXXXXXXXX/iplogs/2022-01-25/2022-01-25-00-00-xyzs.csv.gz
	DEBUG: +++ No logs to process in bucket: None/None
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### Execute the module having a last key set and no only_logs_after value
Without removing the database, execute `sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db 'delete from cisco_umbrella where created_date in (select max(created_date) from cisco_umbrella);'`. This command will remove the more recents logs. Then execute the module without specifying an `only_logs_after` value. It should only collect the previously uploaded log.

Use the command:
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l XXXXXXXXXXXX/iplogs -t cisco_umbrella -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l XXXXXXXXXXXX/iplogs -t cisco_umbrella -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Marker: XXXXXXXXXXXX/iplogs/2022-01-21/2022-01-21-00-00-ixla.csv.gz
	DEBUG: ++ Found new log: XXXXXXXXXXXX/iplogs/2022-01-25/2022-01-25-00-00-xyzs.csv.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### Execute the module having an only_logs_after later than the last key
The module should only fetch the logs corresponding to the days set by the only_logs_after date onwards, and it should skip the logs in between. 1 log should be processed.
Keeping the database file, execute `sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db 'delete from cisco_umbrella where created_date not in (select min(created_date) from cisco_umbrella);'`. 

Use the command:
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l XXXXXXXXXXXX/iplogs -t cisco_umbrella -p dev -d2 -s YYYY-MMM-DD
```
Being `YYYY-MMM-DD` the data corresponding to the date of execution.

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db 'delete from cisco_umbrella where created_date not in (select min(created_date) from cisco_umbrella);'
	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l XXXXXXXXXXXX/iplogs -t cisco_umbrella -p dev -d2 -s 2022-jan-25
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Marker: XXXXXXXXXXXX/iplogs/2022-01-25
	DEBUG: ++ Found new log: XXXXXXXXXXXX/iplogs/2022-01-25/2022-01-25-00-00-xyzs.csv.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### Execute the module having an only_logs_after earlier than the last key
Without removing the database, execute `sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db 'delete from cisco_umbrella where created_date not in (select min(created_date) from cisco_umbrella);'`. This command will remove all the logs but the older ones. The execution of the module must result in collecting the last 4 logs, using as marker the last key.

Use the command:
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l XXXXXXXXXXXX/iplogs -t cisco_umbrella -p dev -d2 -s 2021-Dec-01 
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-umbrella -l XXXXXXXXXXXX/iplogs -t cisco_umbrella -p dev -d2 -s 2021-Dec-01 
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Marker: XXXXXXXXXXXX/iplogs/2021-12-24/2021-12-24-00-00-ixla.csv.gz
	DEBUG: ++ Found new log: XXXXXXXXXXXX/iplogs/2021-12-29/2021-12-29-00-00-ixla.csv.gz
	DEBUG: ++ Found new log: XXXXXXXXXXXX/iplogs/2022-01-17/2022-01-17-00-00-ixla.csv.gz
	DEBUG: ++ Found new log: XXXXXXXXXXXX/iplogs/2022-01-21/2022-01-21-00-00-ixla.csv.gz
	DEBUG: ++ Found new log: XXXXXXXXXXXX/iplogs/2022-01-25/2022-01-25-00-00-xyzs.csv.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module is working as expected.

### Server Access

Remove the `/var/ossec/wodles/aws/s3_cloudtrail.db` file and run the module using the following command to obtain every log from the Server Access bucket for the given date.

#### First execution without specifying an only_logs_after value
Upload one log file to the bucket with the date of execution. Then execute the command. It should use as marker an string with the date of execution and collect the uploaded log.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-access -t server_access -p dev -d2 | grep -v "Skipping file with another prefix"
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-access -t server_access -p dev -d2 | grep -v "Skipping file with another prefix"
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Marker: 2022-01-25
	DEBUG: ++ Found new log: 2022-01-25-09-12-23-F92E1554CC549BEX
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### First execution specifying an only_logs_after value set in the past
Remove the database file and run the command the using `2021-NOV-12` date as `only_logs_after`. 5 logs should be collected and sent to analysisd.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-access -t server_access -s 2021-NOV-12 -p dev -d2 | grep -v "Skipping file with another prefix"
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-access -t server_access -s 2021-NOV-12 -p dev -d2 | grep -v "Skipping file with another prefix"
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Marker: 2021-11-12
	DEBUG: ++ Found new log: 2021-11-12-09-11-26-B9F9F891E8D0EB13
	DEBUG: ++ Found new log: 2021-11-12-13-11-26-B9F9F891E8D0EB13
	DEBUG: ++ Found new log: 2021-11-15-09-12-25-F92E1554CC549BEE
	DEBUG: ++ Found new log: 2021-12-27-09-12-23-F92E1554CC549BEA
	DEBUG: ++ Found new log: 2022-01-25-09-12-23-F92E1554CC549BEX
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

Keep the database file and run the same command again to ensure no duplicate logs have been processed.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-access -t server_access -s 2021-NOV-12 -p dev -d2 | grep -v "Skipping file with another prefix"
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-access -t server_access -s 2021-NOV-12 -p dev -d2 | grep -v "Skipping file with another prefix"
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Marker: 2022-01-25-09-12-23-F92E1554CC549BEX
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### Execute the command again with an only_logs_after value set earlier in the past

Run the module again, keeping the database file, using the `2018-NOV-09` date as `only_logs_after`. It should use as marker an string with the date of execution and not consider the `only_logs_after` value.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-access -t server_access -s 2018-NOV-09 -p dev -d2 | grep -v "Skipping file with another prefix"
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-access -t server_access -s 2018-NOV-09 -p dev -d2 | grep -v "Skipping file with another prefix"
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Marker: 2022-01-25-09-12-23-F92E1554CC549BEX
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### Execute the module having a last key set and no only_logs_after value
Without removing the database, execute `sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db 'delete from s3_server_access where created_date in (select max(created_date) from s3_server_access);'`. This command will remove the more recents logs. Then execute the module without specifying an `only_logs_after` value. It should only collect the previously uploaded log.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-access -t server_access -p dev -d2 | grep -v "Skipping file with another prefix"
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-access -t server_access -p dev -d2 | grep -v "Skipping file with another prefix"
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Marker: 2021-12-27-09-12-23-F92E1554CC549BEA
	DEBUG: ++ Found new log: 2022-01-25-09-12-23-F92E1554CC549BEX
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### Execute the module having an only_logs_after later than the last key
The module should only fetch the logs corresponding to the days set by the only_logs_after date onwards, and it should skip the logs in between. 1 log should be processed.
Keeping the database file, execute `sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db 'delete from s3_server_access where created_date not in (select min(created_date) from s3_server_access);'`. 

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-access -t server_access -p dev -d2 -s YYYY-MMM-DD | grep -v "Skipping file with another prefix"
```
Being `YYYY-MMM-DD` the data corresponding to the date of execution.

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-access -t server_access -p dev -d2 -s 2022-jan-25 | grep -v "Skipping file with another prefix"
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Marker: 2022-01-25
	DEBUG: ++ Found new log: 2022-01-25-09-12-23-F92E1554CC549BEX
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### Execute the module having an only_logs_after earlier than the last key
Without removing the database, execute `sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db 'delete from s3_server_access where created_date not in (select min(created_date) from s3_server_access);'`. This command will remove all the logs but the older ones. The execution of the module must result in collecting 2 logs, using as marker the last key.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-access -t server_access -p dev -d2 -s 2021-Oct-09 | grep -v "Skipping file with another prefix"
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-access -t server_access -p dev -d2 -s 2021-Oct-09 | grep -v "Skipping file with another prefix"
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Marker: 2021-11-12-13-11-26-B9F9F891E8D0EB13
	DEBUG: ++ Found new log: 2021-11-15-09-12-25-F92E1554CC549BEE
	DEBUG: ++ Found new log: 2021-12-27-09-12-23-F92E1554CC549BEA
	DEBUG: ++ Found new log: 2022-01-25-09-12-23-F92E1554CC549BEX
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

### CloudTrail

Remove the `/var/ossec/wodles/aws/s3_cloudtrail.db` file and run the module using the following command to obtain every log from the CloudTrail bucket for the given date.

#### First execution without specifying an only_logs_after value
Upload one log file to the bucket with the date of execution. Then execute the command. It should use as marker an string with the date of execution and collect the uploaded log.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2022/01/25
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2022/01/25/XXXXXXXXXXXX_CloudTrail_us-west-1_20220125T0000Z_HASDOtJxgfdNInHa.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Working on YYYYYYYYYYYY - us-west-1
	DEBUG: +++ Marker: AWSLogs/YYYYYYYYYYYY/CloudTrail/us-west-1/2022/01/25
	DEBUG: +++ No logs to process in bucket: YYYYYYYYYYYY/us-west-1
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### First execution specifying an only_logs_after value set in the past
Remove the database file and run the command the using `2021-Dec-01` date as `only_logs_after`. 6 logs should be collected and sent to analysisd.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -s 2021-Dec-01 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -s 2021-Dec-01 -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/12/01
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/12/01/XXXXXXXXXXXX_CloudTrail_us-west-1_20211201T0000Z_VZJxNKcpNdyJysGy.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/12/01/XXXXXXXXXXXX_CloudTrail_us-west-1_20211201T0000Z_ZKdiPZvOQPGUJMUh.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/12/01/XXXXXXXXXXXX_CloudTrail_us-west-1_20211201T0000Z_ZsQHQAHDMsYfvPHx.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/12/01/XXXXXXXXXXXX_CloudTrail_us-west-1_20211201T0000Z_wcnIRHvPJuYpSXZr.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/12/23/XXXXXXXXXXXX_CloudTrail_us-west-1_20211223T0000Z_HASDOtJxgfdNInHa.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2022/01/25/XXXXXXXXXXXX_CloudTrail_us-west-1_20220125T0000Z_HASDOtJxgfdNInHa.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Working on YYYYYYYYYYYY - us-west-1
	DEBUG: +++ Marker: AWSLogs/YYYYYYYYYYYY/CloudTrail/us-west-1/2021/12/01
	DEBUG: ++ Found new log: AWSLogs/YYYYYYYYYYYY/CloudTrail/us-west-1/2021/12/23/XXXXXXXXXXXX_CloudTrail_us-west-1_20211223T0000Z_HASDOtJxgfdNInHa.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

Keep the database file and run the same command again to ensure no duplicate logs have been processed.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -s 2021-Dec-01 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -s 2021-Dec-01 -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2022/01/25/XXXXXXXXXXXX_CloudTrail_us-west-1_20220125T0000Z_HASDOtJxgfdNInHa.json.gz
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-west-1
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Working on YYYYYYYYYYYY - us-west-1
	DEBUG: +++ Marker: AWSLogs/YYYYYYYYYYYY/CloudTrail/us-west-1/2021/12/23/XXXXXXXXXXXX_CloudTrail_us-west-1_20211223T0000Z_HASDOtJxgfdNInHa.json.gz
	DEBUG: +++ No logs to process in bucket: YYYYYYYYYYYY/us-west-1
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### Execute the command again with an only_logs_after value set earlier in the past

Run the module again, keeping the database file, using the `2021-NOV-20` date as `only_logs_after`. It should use as marker an string with the date of execution and not consider the `only_logs_after` value.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -s 2021-NOV-20 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -s 2021-NOV-20 -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2022/01/25/XXXXXXXXXXXX_CloudTrail_us-west-1_20220125T0000Z_HASDOtJxgfdNInHa.json.gz
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-west-1
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Working on YYYYYYYYYYYY - us-west-1
	DEBUG: +++ Marker: AWSLogs/YYYYYYYYYYYY/CloudTrail/us-west-1/2021/12/23/XXXXXXXXXXXX_CloudTrail_us-west-1_20211223T0000Z_HASDOtJxgfdNInHa.json.gz
	DEBUG: +++ No logs to process in bucket: YYYYYYYYYYYY/us-west-1
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### Execute the module having a last key set and no only_logs_after value
Without removing the database, execute `sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db 'delete from cloudtrail where created_date in (select max(created_date) from cloudtrail);'`. This command will remove the more recents logs. Then execute the module without specifying an `only_logs_after` value. It should only collect the previously uploaded log.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/12/23/XXXXXXXXXXXX_CloudTrail_us-west-1_20211223T0000Z_HASDOtJxgfdNInHa.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2022/01/25/XXXXXXXXXXXX_CloudTrail_us-west-1_20220125T0000Z_HASDOtJxgfdNInHa.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Working on YYYYYYYYYYYY - us-west-1
	DEBUG: +++ Marker: AWSLogs/YYYYYYYYYYYY/CloudTrail/us-west-1/2021/12/23/XXXXXXXXXXXX_CloudTrail_us-west-1_20211223T0000Z_HASDOtJxgfdNInHa.json.gz
	DEBUG: +++ No logs to process in bucket: YYYYYYYYYYYY/us-west-1
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### Execute the module having an only_logs_after later than the last key
The module should only fetch the logs corresponding to the days set by the only_logs_after date onwards, and it should skip the logs in between. 2 logs should be processed.
Keeping the database file, execute `sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db 'delete from cloudtrail where created_date not in (select min(created_date) from cloudtrail);'`. 

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -p dev -d2 -s YYYY-MMM-DD
```
being `YYYY-MMM-DD` the data corresponding to the date of execution.

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db 'delete from cloudtrail where created_date not in (select min(created_date) from cloudtrail);'
	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -p dev -d2 -s 2022-jan-25
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2022/01/25
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2022/01/25/XXXXXXXXXXXX_CloudTrail_us-west-1_20220125T0000Z_HASDOtJxgfdNInHa.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Working on YYYYYYYYYYYY - us-west-1
	DEBUG: +++ Marker: AWSLogs/YYYYYYYYYYYY/CloudTrail/us-west-1/2022/01/25
	DEBUG: +++ No logs to process in bucket: YYYYYYYYYYYY/us-west-1
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### Execute the module having an only_logs_after earlier than the last key
Without removing the database, execute `sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db 'delete from cloudtrail where created_date not in (select min(created_date) from cloudtrail);'`. This command will remove all the logs but the older ones. The execution of the module must result in collecting 5 logs from the first account, using as marker the last key.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -p dev -d2 -s 2021-Oct-01
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-cloudtrail -t cloudtrail -p dev -d2 -s 2021-Oct-01
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-west-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/12/01/XXXXXXXXXXXX_CloudTrail_us-west-1_20211201T0000Z_VZJxNKcpNdyJysGy.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/12/01/XXXXXXXXXXXX_CloudTrail_us-west-1_20211201T0000Z_ZKdiPZvOQPGUJMUh.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/12/01/XXXXXXXXXXXX_CloudTrail_us-west-1_20211201T0000Z_ZsQHQAHDMsYfvPHx.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/12/01/XXXXXXXXXXXX_CloudTrail_us-west-1_20211201T0000Z_wcnIRHvPJuYpSXZr.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2021/12/23/XXXXXXXXXXXX_CloudTrail_us-west-1_20211223T0000Z_HASDOtJxgfdNInHa.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/CloudTrail/us-west-1/2022/01/25/XXXXXXXXXXXX_CloudTrail_us-west-1_20220125T0000Z_HASDOtJxgfdNInHa.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Working on YYYYYYYYYYYY - us-west-1
	DEBUG: +++ Marker: AWSLogs/YYYYYYYYYYYY/CloudTrail/us-west-1/2021/10/01
	DEBUG: ++ Found new log: AWSLogs/YYYYYYYYYYYY/CloudTrail/us-west-1/2021/12/23/XXXXXXXXXXXX_CloudTrail_us-west-1_20211223T0000Z_HASDOtJxgfdNInHa.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

### Config

#### First execution without specifying an only_logs_after value
Upload one log file to the bucket with the date of execution. Then execute the command. It should use as marker an string with the date of execution and collect the uploaded log.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/25
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/25/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20220125T004303Z_20220125T025123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### First execution specifying an only_logs_after value set in the past
Remove the database file and run the command the using `2021-DEC-30` date as `only_logs_after`. 4 logs should be collected and sent to analysisd.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -s 2021-DEC-30 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -s 2021-DEC-30 -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/30
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/30/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211230T004303Z_20211230T025123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20211231T004303Z_20211231T025123Z_1.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20211231T034303Z_20211231T035123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/1
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/2
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/3
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/4
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/5
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/6
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/7
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/8
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/9
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/10
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/11
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/12
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/13
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/14
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/15
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/16
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/17
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/18
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/19
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/20
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/21
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/22
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/23
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/24
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/25
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/25/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20220125T004303Z_20220125T025123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

Keep the database file and run the same command again to ensure no duplicate logs have been processed.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -s 2021-DEC-30 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -s 2021-DEC-30 -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/25
	DEBUG: ++ Skipping previously processed file: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/25/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20220125T004303Z_20220125T025123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### Execute the command again with an only_logs_after value set earlier in the past

Run the module again, keeping the database file, using the `2021-NOV-06` date as `only_logs_after`. It should use as marker an string with the date of execution and not consider the `only_logs_after` value.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -s 2021-NOV-06 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -s 2021-NOV-06 -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/25
	DEBUG: ++ Skipping previously processed file: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/25/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20220125T004303Z_20220125T025123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### Execute the module having a last key set and no only_logs_after value
Without removing the database, execute `sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db 'delete from config where created_date in (select max(created_date) from config);'`. This command will remove the more recents logs. Then execute the module without specifying an `only_logs_after` value. It should only collect the previously uploaded log.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20211231T034303Z_20211231T035123Z_1.json.gz
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/1
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/2
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/3
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/4
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/5
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/6
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/7
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/8
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/9
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/10
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/11
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/12
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/13
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/14
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/15
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/16
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/17
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/18
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/19
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/20
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/21
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/22
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/23
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/24
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/25
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/25/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20220125T004303Z_20220125T025123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### Execute the module having an only_logs_after later than the last key
The module should only fetch the logs corresponding to the days set by the only_logs_after date onwards, and it should skip the logs in between. 1 log should be processed.
Keeping the database file, execute `sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db 'delete from config where created_date > (select min(created_date) from config);'`. 

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -p dev -d2 -s YYYY-MMM-DD
```
Being `YYYY-MMM-DD` the data corresponding to the date of execution.

<details><summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -p dev -d2 -s 2022-jan-25
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/25
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/25/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20220125T004303Z_20220125T025123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

#### Execute the module having an only_logs_after earlier than the last key
Without removing the database, execute `sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db 'delete from config where created_date not in (select min(created_date) from config);'`. This command will remove all the logs but the older ones. The execution of the module must result in collecting 3 logs, using as marker the last key.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -p dev -d2 -s 2021-Oct-01
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-config -t config -p dev -d2 -s 2021-Oct-01
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/30/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS::Config::ResourceCompliance_20211230T004303Z_20211230T025123Z_1.json.gz
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20211231T004303Z_20211231T025123Z_1.json.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2021/12/31/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20211231T034303Z_20211231T035123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/1
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/2
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/3
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/4
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/5
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/6
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/7
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/8
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/9
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/10
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/11
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/12
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/13
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/14
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/15
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/16
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/17
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/18
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/19
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/20
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/21
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/22
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/23
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/24
	DEBUG: +++ No logs to process in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/25
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/Config/us-east-1/2022/1/25/XXXXXXXXXXXX_Config_us-east-1_ConfigHistory_AWS Config ResourceCompliance_20220125T004303Z_20220125T025123Z_1.json.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module worked as expected.

### VPCFlow

Remove the `/var/ossec/wodles/aws/s3_cloudtrail.db` file and run the module using the following command to obtain every log from the VPCFlow bucket for the given date.

#### First execution without specifying an only_logs_after value
Upload one log file to the bucket with the date of execution. Then execute the command. It should use as marker an string with the date of execution and collect the uploaded log.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/25
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/25/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20220125T0100Z_ce6176d8.log.gz
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module is working as expected.

#### First execution specifying an only_logs_after value set in the past
Remove the database file and run the command the using `2021-Dec-30` date as `only_logs_after`. 5 logs should be collected and sent to analysisd.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -s 2021-Dec-30 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -s 2021-Dec-30 -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Table does not exist; create
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/30
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/30/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211230T0000Z_ce6176d8.log.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/31
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/31/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211231T0000Z_ce6176d8.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/31/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211231T0100Z_ce6176d8.log.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/01
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/02
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/03
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/04
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/05
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/06
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/07
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/08
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/09
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/10
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/11
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/12
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/13
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/14
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/15
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/16
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/17
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/18
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/19
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/20
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/21
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/21/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20220121T0100Z_ce6176d8.log.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/22
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/23
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/24
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/25
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/25/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20220125T0100Z_ce6176d8.log.gz
	DEBUG: +++ DB Maintenance

</details>

Keep the database file and run the same command again to ensure no duplicate logs have been processed.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -s 2021-Dec-30 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -s 2021-Dec-30 -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/25/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20220125T0100Z_ce6176d8.log.gz
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1

</details>

##### Conclusions
The module is working as expected.

#### Execute the command again with an only_logs_after value set earlier in the past

Run the module again, keeping the database file, using the `2021-NOV-05` date as `only_logs_after`. It should use as marker an string with the date of execution and not consider the `only_logs_after` value.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -s 2021-NOV-05 -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -s 2021-NOV-05 -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/25/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20220125T0100Z_ce6176d8.log.gz
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1


</details>

##### Conclusions
The module is working as expected.

#### Execute the module having a last key set and no only_logs_after value
Without removing the database, execute `sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db 'delete from vpcflow where created_date in (select max(created_date) from vpcflow);'`. This command will remove the more recents logs. Then execute the module without specifying an `only_logs_after` value. It should only collect the previously uploaded log.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -p dev -d2
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -p dev -d2
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/21/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20220121T0100Z_ce6176d8.log.gz
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/22
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/23
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/24
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/25
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/25/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20220125T0100Z_ce6176d8.log.gz
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module is working as expected.

#### Execute the module having an only_logs_after later than the last key
The module should only fetch the logs corresponding to the days set by the only_logs_after date onwards, and it should skip the logs in between. 2 logs should be processed.
Keeping the database file, execute `sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db 'delete from vpcflow where created_date != (select min(created_date) from vpcflow);'`. 

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -p dev -d2 -s YYYY-MMM-DD
```
Being `YYYY-MMM-DD` the data corresponding to the date of execution.

<details><summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -p dev -d2 -s 2022-jan-25
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/25
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/25/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20220125T0100Z_ce6176d8.log.gz
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module is working as expected.

#### Execute the module having an only_logs_after earlier than the last key
Without removing the database, execute `sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db 'delete from vpcflow where created_date not in (select min(created_date) from vpcflow);'`. This command will remove all the logs but the older ones. The execution of the module must result in collecting 4 logs, using as marker the last key.

Use the command 
```
/var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -p dev -d2 -s 2021-Nov-05
```

<details>
    <summary>Command output</summary>

	root@1506bc6c9e40:/var/ossec/wodles/aws# /var/ossec/wodles/aws/aws-s3 -b wazuh-aws-wodle-vpcflow -t vpcflow -p dev -d2 -s 2021-Nov-05
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Working on XXXXXXXXXXXX - us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/30/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211230T0000Z_ce6176d8.log.gz
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/31
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/31/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211231T0000Z_ce6176d8.log.gz
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2021/12/31/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20211231T0100Z_ce6176d8.log.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/01
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/02
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/03
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/04
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/05
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/06
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/07
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/08
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/09
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/10
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/11
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/12
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/13
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/14
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/15
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/16
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/17
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/18
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/19
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/20
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/21
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/21/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20220121T0100Z_ce6176d8.log.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/22
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/23
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/24
	DEBUG: +++ No logs to process for fl-03fbf155728a27ded flow log ID in bucket: XXXXXXXXXXXX/us-east-1
	DEBUG: +++ Marker: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/25
	DEBUG: ++ Found new log: AWSLogs/XXXXXXXXXXXX/vpcflowlogs/us-east-1/2022/01/25/XXXXXXXXXXXX_vpcflowlogs_us-east-1_fl-03fbf155728a27ded_20220125T0100Z_ce6176d8.log.gz
	DEBUG: +++ DB Maintenance

</details>

##### Conclusions
The module is working as expected.

### Test in an agent:
After installing the [required dependencies](https://documentation.wazuh.com/current/amazon/services/prerequisites/dependencies.html) in an agent, we executed the module without specifying an `only_logs_after` paramater to ensure that it's working as expected with agents too.

<details></summary>Command output</summary>

	root@e58b5b7b9229:/var/ossec/wodles/aws# python3 ./aws-s3 -b wazuh-aws-wodle-umbrella -t cisco_umbrella -d 2  -p dev -l XXXXXXXXXXXX/iplogs
	DEBUG: +++ Debug mode on - Level: 2
	DEBUG: +++ Marker: XXXXXXXXXXXX/iplogs/2022-01-25
	DEBUG: ++ Found new log: XXXXXXXXXXXX/iplogs/2022-01-25/2022-01-25-00-00-xyzs.csv.gz
	DEBUG: +++ DB Maintenance
	DEBUG: +++ DB Maintenance

</details>

#### Conclusions
The module worked as expected.

