### PR TITLE
Block message sending queue when there is no connection.

### DIFF
--- a/src/wazuh_modules/wm_syscollector.c
+++ b/src/wazuh_modules/wm_syscollector.c
@@ -58,7 +58,7 @@ static void wm_sys_send_diff_message(/*const void* data*/) {
  }
 
 static void wm_sys_send_dbsync_message(const void* data) {
-    if(!os_iswait() && !is_shutdown_process_started()) {
+    if(!is_shutdown_process_started()) {
         const int eps = 1000000/syscollector_sync_max_eps;
         if (wm_sendmsg_ex(eps, queue_fd, data, WM_SYS_LOCATION, DBSYNC_MQ, &is_shutdown_process_started) < 0) {
 #ifdef CLIENT


### PR DESCRIPTION
|Related issue|
|---|
|Closes #11829 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

When deploying a Wazuh cluster and after adding agents to it, we have seen that sometimes, the agents have the syscollector scan performed (and therefore we have data in the `syscollector/local.db)` and after that, the syscollector DB synchronization is not done correctly (there is no syscollector information in the `00x.db` database in the node, being `x` the ID of the agent mentioned).

This issue was discovered when investigating https://github.com/wazuh/wazuh/issues/10923. In issue 10923, a random error in our syscollector API integration tests is explained. The error was the following: when requesting syscollector items for an agent via API, we get no information when we expect a non-empty response.

After investigating the issue, we have seen what appears to be an error related to the syscollector databases synchronization, as I said in this issue's first comment.

For instance, this happened to agent 4. (Wazuh version is 4.4.0, but this also happens in 4.3.0)

```
root@wazuh-master:/# /var/ossec/bin/cluster_control -a
ID   NAME           IP           STATUS           VERSION        NODE NAME    
000  wazuh-master   127.0.0.1    active           Wazuh v4.4.0   master-node  
001  wazuh-agent1   172.21.0.6   active           Wazuh v4.4.0   master-node  
002  wazuh-agent2   172.21.0.7   active           Wazuh v4.4.0   worker1      
003  wazuh-agent3   172.21.0.8   active           Wazuh v4.4.0   worker1      
004  wazuh-agent4   172.21.0.9   active           Wazuh v4.4.0   master-node        
005  wazuh-agent5   172.21.0.10  active           Wazuh v3.13.2  worker2      
006  wazuh-agent6   172.21.0.11  active           Wazuh v3.13.2  worker1      
007  wazuh-agent7   172.21.0.12  active           Wazuh v3.13.2  worker1      
008  wazuh-agent8   172.21.0.13  active           Wazuh v3.13.2  worker2      
009  wazuh-agent9   any          disconnected     Wazuh v3.9.2   master-node  
010  wazuh-agent10  any          disconnected     Wazuh v3.9.2   master-node  
011  wazuh-agent11  any          never_connected  unknown        unknown      
012  wazuh-agent12  any          never_connected  unknown        unknown    
```

We can see that the agent with ID 004 does not have syscollector information:

```
root@wazuh-master:/# sqlite3 /var/ossec/queue/db/004.db 
SQLite version 3.31.1 2020-01-27 19:55:54
Enter ".help" for usage hints.
sqlite> select * from sys_processes ;
sqlite> select * from sys_processes ;
sqlite> select * from sys_netaddr ;  
sqlite> select * from sys_netiface ;
sqlite> select * from sys_netproto ;
...
```

However, we see no errors in the logs, as the syscollector evaluation seems to be OK (there are 2 scans due to a restart):

```
root@wazuh-agent4:/# cat /var/ossec/logs/ossec.log | grep syscollector
2022/01/14 11:33:06 wazuh-modulesd:syscollector: INFO: Module started.
2022/01/14 11:33:06 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2022/01/14 11:33:07 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2022/01/14 11:34:19 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.
2022/01/14 11:34:19 wazuh-modulesd:syscollector: INFO: Module finished.
2022/01/14 11:34:26 wazuh-modulesd:syscollector: INFO: Module started.
2022/01/14 11:34:26 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2022/01/14 11:34:27 wazuh-modulesd:syscollector: INFO: Evaluation finished.
```

This error is not present in agent 001, for instance, which has the scan and synchronization done correctly:

```
root@wazuh-agent1:/# cat /var/ossec/logs/ossec.log  | grep syscollector
2022/01/14 11:33:00 wazuh-modulesd:syscollector: INFO: Module started.
2022/01/14 11:33:00 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2022/01/14 11:33:01 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2022/01/14 11:34:43 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.
2022/01/14 11:34:43 wazuh-modulesd:syscollector: INFO: Module finished.
2022/01/14 11:34:49 wazuh-modulesd:syscollector: INFO: Module started.
2022/01/14 11:34:49 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2022/01/14 11:34:51 wazuh-modulesd:syscollector: INFO: Evaluation finished.
```


```
root@wazuh-master:/# sqlite3 /var/ossec/queue/db/001.db 
SQLite version 3.31.1 2020-01-27 19:55:54
Enter ".help" for usage hints.
sqlite> select * from sys_netiface ;
0|2022/01/14 11:34:52|eth0||ethernet|up|1500|02:42:ac:15:00:06|746|902|195242|460099|0|0|0|0|db4dcfae684aa62aef9aadd30300cc61963f0d9d|d4aa8b01955e438235d586585492f3f5edceec1b
sqlite> select * from sys_netproto ;
0|eth0|ipv4|172.21.0.1|unknown|0|48eee1b8e9c59cd1ff826032fde01878d842ad80|d4aa8b01955e438235d586585492f3f5edceec1b
```

After this, I added `wazuh_modules.debug=1` to the agent's local internal options and replicated the error again. This change is useful to see the logs that confirm the syscollector sync was ended properly.

This time, the error happened to agent 001 and  the logs for scan and sync were shown:

```
2022/01/17 10:23:18 wazuh-modulesd:syscollector[1175] wm_syscollector.c:92 at wm_sys_log(): INFO: Module started.
2022/01/17 10:23:18 wazuh-modulesd:syscollector[1175] wm_syscollector.c:92 at wm_sys_log(): INFO: Starting evaluation.
2022/01/17 10:23:19 wazuh-modulesd:syscollector[1175] wm_syscollector.c:92 at wm_sys_log(): INFO: Evaluation finished.
2022/01/17 10:23:19 wazuh-modulesd:syscollector[1175] wm_syscollector.c:95 at wm_sys_log(): DEBUG: Starting syscollector sync
2022/01/17 10:23:19 wazuh-modulesd:syscollector[1175] wm_syscollector.c:95 at wm_sys_log(): DEBUG: Ending syscollector sync
root@wazuh-agent1:/# exit
```

However, there is no information in the syscollector tables of `001.db`:

```
root@wazuh-master:/# ll /var/ossec/queue/db/001.db 
-rw-r----- 1 wazuh wazuh 1105920 Jan 17 10:38 /var/ossec/queue/db/001.db
root@wazuh-master:/# sqlite3 /var/ossec/queue/db/001.db 
SQLite version 3.31.1 2020-01-27 19:55:54
Enter ".help" for usage hints.
sqlite> select * from sys_processes;
sqlite> select * from sys_hwinfo ;
sqlite> select * from sys_netaddr;
```

If we have a look at the agent's `local.db`, we see syscollector information:

```
root@wazuh-agent1:/# sqlite3 /var/ossec/queue/syscollector/db/local.db 
SQLite version 3.31.1 2020-01-27 19:55:54
Enter ".help" for usage hints.
sqlite> select * from dbsync_processes limit 1;
1|bash|S|0|3|1|bash|/scripts/entrypoint.sh nginx-lb wazuh-agent1|root|root|root|root|root|root|root|20|0|994|3976|788|725|1642414908|1|1|1|1|0|0|902677f48a119c16ad53da02a1e6c8f920ac8672|1
sqlite> select * from dbsync_hwinfo limit 1;
|AMD EPYC 7571|2|2201.0|3981764|2743148|32|0c971dd9722dd747391ca691d5fc0d62a417072a|1
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors