### PR TITLE
Fix a possible flaw regarding `try`, `except` and `pass` code block

### DIFF
--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -152,7 +152,7 @@ def version():
 def exit_handler(signum, frame):
     """Try to kill API child processes and remove their PID files."""
     api_pid = os.getpid()
-    pyDaemonModule.delete_child_pids(API_MAIN_PROCESS, api_pid)
+    pyDaemonModule.delete_child_pids(API_MAIN_PROCESS, api_pid, logger)
     pyDaemonModule.delete_pid(API_MAIN_PROCESS, api_pid)
 
 
@@ -326,5 +326,5 @@ if __name__ == '__main__':
         print(f'Internal error when trying to start the Wazuh API. {e}')
         sys.exit(1)
     finally:
-        pyDaemonModule.delete_child_pids(API_MAIN_PROCESS, pid)
+        pyDaemonModule.delete_child_pids(API_MAIN_PROCESS, pid, logger)
         pyDaemonModule.delete_pid(API_MAIN_PROCESS, pid)

--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -35,7 +35,7 @@ def exit_handler(signum, frame):
     main_logger.info(f'SIGNAL [({signum})-({signal.Signals(signum).name})] received. Exit...')
 
     # Terminate cluster's child processes
-    pyDaemonModule.delete_child_pids('wazuh-clusterd', cluster_pid)
+    pyDaemonModule.delete_child_pids('wazuh-clusterd', cluster_pid, main_logger)
 
     # Remove cluster's pidfile
     pyDaemonModule.delete_pid('wazuh-clusterd', cluster_pid)
@@ -209,5 +209,5 @@ if __name__ == '__main__':
     except Exception as e:
         main_logger.error(f"Unhandled exception: {e}")
     finally:
-        pyDaemonModule.delete_child_pids('wazuh-clusterd', pid)
+        pyDaemonModule.delete_child_pids('wazuh-clusterd', pid, main_logger)
         pyDaemonModule.delete_pid('wazuh-clusterd', pid)

--- a/framework/wazuh/core/pyDaemonModule.py
+++ b/framework/wazuh/core/pyDaemonModule.py
@@ -5,7 +5,6 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import glob
-import logging
 import os
 import sys
 from os import path
@@ -80,9 +79,8 @@ def delete_pid(name, pid):
         pass
 
 
-def delete_child_pids(name, ppid):
+def delete_child_pids(name, ppid, logger):
     filenames = glob.glob(path.join(common.wazuh_path, common.os_pidfile, f'{name}*.pid'))
-    logger = logging.getLogger('wazuh') if 'clusterd' in name else logging.getLogger('wazuh-api')
 
     for process in psutil.Process(ppid).children(recursive=True):
         try:
@@ -90,7 +88,7 @@ def delete_child_pids(name, ppid):
         except psutil.Error:
             logger.error(f'Error while trying to terminate the process with ID {process.pid}.')
         except Exception as exc:
-            logger.error(f'Unhandled exception: {exc}')
+            logger.error(f'Unhandled exception while trying to terminate the process with ID {process.pid}: {exc}')
         for filename in filenames[:]:
             if str(process.pid) in filename:
                 try:


### PR DESCRIPTION
|Related issue|
|---|
| This PR closes #11343 |

## Description

There was a possible code flaw regarding try, except and pass block at `framework/scripts/wazuh-clusterd.py`.
```json
{
    "code": "             child.kill()\n         except Exception:\n             pass\n \n",
    "filename": "framework/scripts/wazuh-clusterd.py",
    "issue_confidence": "HIGH",
    "issue_severity": "LOW",
    "issue_text": "Try, Except, Pass detected.",
    "line_number": 46,
    "line_range": [
        46,
        47
    ],
    "more_info": "https://bandit.readthedocs.io/en/latest/plugins/b110_try_except_pass.html",
    "test_id": "B110",
    "test_name": "try_except_pass"
},
```

After the merge from `4.3` to `master`, several changes were made to this file.
One of those changes affected this flaw.

The handling of the termination of wazuh cluster and API related processes is now located in another file, which is `framework/wazuh/core/pyDaemonModule.py`.
However, `Bandit` is not triggering an alert with this new modification, since it's not using `except Exception`. This is explained in more depth at https://github.com/wazuh/wazuh/issues/11343#issuecomment-1020488705.


Even if Bandit is not alerting, I think it's necessary to add a proper handling to the termination of these processes.
If it's the case that a process could not be killed for any reason, we should be aware of.

So, I added a better handling of these exceptions.

## Results

* Cluster - Debug mode off:
```log
2022/01/25 12:28:34 ERROR: [Cluster] [Main] Error while trying to terminate the process with ID 34.
```

* Cluster - Debug mode on:
```log
2022/01/25 12:28:58 ERROR: [Cluster] [Main] Error while trying to terminate the process with ID 34.
Traceback (most recent call last):
  File "/var/ossec/framework/python/lib/python3.9/site-packages/psutil/__init__.py", line 1192, in _send_signal
    os.kill(self.pid, sig)
PermissionError: [Errno 1] Operation not permitted

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.4.0-py3.9.egg/wazuh/core/pyDaemonModule.py", line 89, in delete_child_pids
    process.kill()
  File "/var/ossec/framework/python/lib/python3.9/site-packages/psutil/__init__.py", line 292, in wrapper
    return fun(self, *args, **kwargs)
  File "/var/ossec/framework/python/lib/python3.9/site-packages/psutil/__init__.py", line 1255, in kill
    self._send_signal(signal.SIGKILL)
  File "/var/ossec/framework/python/lib/python3.9/site-packages/psutil/__init__.py", line 1202, in _send_signal
    raise AccessDenied(self.pid, self._name)
psutil.AccessDenied: psutil.AccessDenied (pid=34)
```

* API - `DEBUG2` mode off:
```log
2022/01/25 12:31:49 ERROR: Error while trying to terminate the process with ID 34.
```

* API - `DEBUG2` mode on:
```log
2022/01/25 12:31:13 ERROR: Error while trying to terminate the process with ID 34.
Traceback (most recent call last):
  File "/var/ossec/framework/python/lib/python3.9/site-packages/psutil/__init__.py", line 1192, in _send_signal
    os.kill(self.pid, sig)
PermissionError: [Errno 1] Operation not permitted

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.4.0-py3.9.egg/wazuh/core/pyDaemonModule.py", line 89, in delete_child_pids
    process.kill()
  File "/var/ossec/framework/python/lib/python3.9/site-packages/psutil/__init__.py", line 292, in wrapper
    return fun(self, *args, **kwargs)
  File "/var/ossec/framework/python/lib/python3.9/site-packages/psutil/__init__.py", line 1255, in kill
    self._send_signal(signal.SIGKILL)
  File "/var/ossec/framework/python/lib/python3.9/site-packages/psutil/__init__.py", line 1202, in _send_signal
    raise AccessDenied(self.pid, self._name)
psutil.AccessDenied: psutil.AccessDenied (pid=34)
```