### PR TITLE
Unit test of get_groups_integrity

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -50,7 +50,7 @@ list(APPEND wdb_tests_names "test_wdb_global")
 list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_begin2 -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,sqlite3_bind_int \
                             -Wl,--wrap,wdb_exec_stmt -Wl,--wrap,wdb_exec_stmt_sized -Wl,--wrap,wdb_step -Wl,--wrap,sqlite3_bind_text \
                             -Wl,--wrap,sqlite3_bind_parameter_index -Wl,--wrap,cJSON_Delete -Wl,--wrap,sqlite3_step -Wl,--wrap,sqlite3_column_int \
-                            -Wl,--wrap,wdb_init_stmt_in_cache -Wl,--wrap,wdb_init_stmt_in_cache -Wl,--wrap,wdb_get_global_group_hash \
+                            -Wl,--wrap,wdb_init_stmt_in_cache -Wl,--wrap,wdb_get_global_group_hash \
                             ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_agents")

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -6,7 +6,7 @@ list(APPEND wdb_tests_names "test_wdb_integrity")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug1 -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,sqlite3_step -Wl,--wrap,sqlite3_errmsg \
                          -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,EVP_DigestInit_ex -Wl,--wrap,EVP_DigestUpdate -Wl,--wrap,_DigestFinal_ex \
                          -Wl,--wrap,sqlite3_bind_int64 -Wl,--wrap,sqlite3_column_text -Wl,--wrap,_mdebug2 -Wl,--wrap,wdb_exec_stmt \
-                         -Wl,--wrap,time ${DEBUG_OP_WRAPPERS} -Wl,--wrap,wdb_init_stmt_in_cache")
+                         -Wl,--wrap,time -Wl,--wrap,wdb_init_stmt_in_cache ${DEBUG_OP_WRAPPERS}")
 
 # Add server specific tests to the list
 list(APPEND wdb_tests_names "test_wdb_fim")
@@ -44,12 +44,13 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_open_global -Wl,--wrap,wdb_leave -Wl
                              -Wl,--wrap,wdb_global_sync_agent_info_get -Wl,--wrap,wdb_global_sync_agent_info_set \
                              -Wl,--wrap,wdb_global_get_all_agents -Wl,--wrap,wdb_global_get_agent_info -Wl,--wrap,wdb_global_reset_agents_connection \
                              -Wl,--wrap,wdb_global_get_agents_by_connection_status -Wl,--wrap,wdb_global_get_agents_to_disconnect \
-                             -Wl,--wrap,sqlite3_step ${DEBUG_OP_WRAPPERS}")
+                             -Wl,--wrap,sqlite3_step -Wl,--wrap,wdb_global_get_groups_integrity ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_global")
 list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_begin2 -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,sqlite3_bind_int \
                             -Wl,--wrap,wdb_exec_stmt -Wl,--wrap,wdb_exec_stmt_sized -Wl,--wrap,wdb_step -Wl,--wrap,sqlite3_bind_text \
                             -Wl,--wrap,sqlite3_bind_parameter_index -Wl,--wrap,cJSON_Delete -Wl,--wrap,sqlite3_step -Wl,--wrap,sqlite3_column_int \
+                            -Wl,--wrap,wdb_init_stmt_in_cache -Wl,--wrap,wdb_init_stmt_in_cache -Wl,--wrap,wdb_get_global_group_hash \
                             ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_agents")

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -788,15 +788,15 @@ void test_wdb_global_sync_agent_info_get_size_limit(void **state)
 
 void test_wdb_global_get_groups_integrity_statement_fail(void **state)
 {
-    cJSON* result = NULL;
+    cJSON* j_result = NULL;
     test_struct_t *data  = (test_struct_t *)*state;
 
     expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_GLOBAL_GROUP_SYNCREQ_FIND);
     will_return(__wrap_wdb_init_stmt_in_cache, NULL);
 
-    result = wdb_global_get_groups_integrity(data->wdb, NULL);
+    j_result = wdb_global_get_groups_integrity(data->wdb, NULL);
 
-    assert_null(result);
+    assert_null(j_result);
 }
 
 void test_wdb_global_get_groups_integrity_syncreq(void **state)
@@ -856,7 +856,7 @@ void test_wdb_global_get_groups_integrity_synced(void **state)
 
 void test_wdb_global_get_groups_integrity_error(void **state)
 {
-    cJSON* result = NULL;
+    cJSON* j_result = NULL;
     test_struct_t *data  = (test_struct_t *)*state;
 
     expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_GLOBAL_GROUP_SYNCREQ_FIND);
@@ -865,9 +865,9 @@ void test_wdb_global_get_groups_integrity_error(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__mdebug1, formatted_msg, "DB(global) sqlite3_step(): ERROR MESSAGE");
 
-    result = wdb_global_get_groups_integrity(data->wdb, NULL);
+    j_result = wdb_global_get_groups_integrity(data->wdb, NULL);
 
-    assert_null(result);
+    assert_null(j_result);
 }
 
 /* Tests wdb_global_sync_agent_info_set */

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -27,6 +27,7 @@ static int test_setup(void **state) {
     os_strdup("000",init_data->wdb->id);
     os_calloc(OS_MAXSTR,sizeof(char),init_data->output);
     os_calloc(1,sizeof(sqlite3 *),init_data->wdb->db);
+    init_data->wdb->enabled=true;
     *state = init_data;
     return 0;
 }
@@ -1869,6 +1870,97 @@ void test_wdb_parse_global_sync_agent_info_set_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+/* Tests wbb_parse_global_get_groups_integrity */
+
+void test_wdb_parse_global_get_groups_integrity_syntax_error(void **state)
+{
+    int ret = OS_SUCCESS;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global get-groups-integrity";
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-groups-integrity");
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for get-groups-integrity.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: get-groups-integrity");
+
+    ret = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "err Invalid DB query syntax, near 'get-groups-integrity'");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_get_groups_integrity_query_error(void **state)
+{
+    int ret = OS_SUCCESS;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global get-groups-integrity random_hash";
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-groups-integrity random_hash");
+    expect_string(__wrap_wdb_global_get_groups_integrity, hash, "random_hash");
+    will_return(__wrap_wdb_global_get_groups_integrity, NULL);
+    expect_string(__wrap__mdebug1, formatted_msg, "Error getting groups integrity information from global.db.");
+
+    ret = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "err Error getting groups integrity information from global.db.");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_get_groups_integrity_success_syncreq(void **state)
+{
+    int ret = OS_SUCCESS;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global get-groups-integrity random_hash";
+    cJSON* j_response = cJSON_Parse("[\"syncreq\"]");
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-groups-integrity random_hash");
+    expect_string(__wrap_wdb_global_get_groups_integrity, hash, "random_hash");
+    will_return(__wrap_wdb_global_get_groups_integrity, j_response);
+
+    ret = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "ok [\"syncreq\"]");
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
+void test_wdb_parse_global_get_groups_integrity_success_synced(void **state)
+{
+    int ret = OS_SUCCESS;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global get-groups-integrity random_hash";
+    cJSON* j_response = cJSON_Parse("[\"synced\"]");
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-groups-integrity random_hash");
+    expect_string(__wrap_wdb_global_get_groups_integrity, hash, "random_hash");
+    will_return(__wrap_wdb_global_get_groups_integrity, j_response);
+
+    ret = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "ok [\"synced\"]");
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
+void test_wdb_parse_global_get_groups_integrity_success_hash_mismatch(void **state)
+{
+    int ret = OS_SUCCESS;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global get-groups-integrity random_hash";
+    cJSON* j_response = cJSON_Parse("[\"hash_mismatch\"]");
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-groups-integrity random_hash");
+    expect_string(__wrap_wdb_global_get_groups_integrity, hash, "random_hash");
+    will_return(__wrap_wdb_global_get_groups_integrity, j_response);
+
+    ret = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "ok [\"hash_mismatch\"]");
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
 /* Tests wdb_parse_global_disconnect_agents */
 
 void test_wdb_parse_global_disconnect_agents_syntax_error(void **state)
@@ -2320,6 +2412,12 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_info_set_del_label_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_info_set_set_label_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_info_set_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_get_groups_integrity */
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_groups_integrity_syntax_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_groups_integrity_query_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_groups_integrity_success_syncreq, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_groups_integrity_success_synced, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_groups_integrity_success_hash_mismatch, test_setup, test_teardown),
         /* Tests wdb_parse_global_disconnect_agents */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_disconnect_agents_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_disconnect_agents_last_id_error, test_setup, test_teardown),

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -243,6 +243,13 @@ cJSON* __wrap_wdb_global_get_agents_by_connection_status (__attribute__((unused)
     return mock_ptr_type(cJSON*);
 }
 
+cJSON* __wrap_wdb_global_get_groups_integrity(__attribute__((unused)) wdb_t *wdb,
+                                              os_sha1 hash) {
+
+    check_expected(hash);
+    return mock_ptr_type(cJSON*);
+}
+
 cJSON* __wrap_wdb_global_get_agents_to_disconnect(__attribute__((unused)) wdb_t *wdb,
                                                   int last_agent_id,
                                                   int keep_alive,

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -83,6 +83,8 @@ int __wrap_wdb_global_reset_agents_connection(wdb_t *wdb, const char *sync_statu
 
 cJSON* __wrap_wdb_global_get_agents_by_connection_status (wdb_t *wdb, int last_agent_id, const char* connection_status, wdbc_result* status);
 
+cJSON* __wrap_wdb_global_get_groups_integrity(wdb_t *wdb, os_sha1 hash);
+
 cJSON* __wrap_wdb_global_get_agents_to_disconnect(wdb_t *wdb, int last_agent_id, int keep_alive, const char *sync_status, wdbc_result* status);
 
 int __wrap_wdb_global_agent_exists(wdb_t *wdb, int agent_id);

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
@@ -346,3 +346,9 @@ cJSON *__wrap_wdb_get_internal_config() {
 cJSON *__wrap_wdb_get_config() {
     return mock_ptr_type(cJSON *);
 }
+
+int __wrap_wdb_get_global_group_hash(__attribute__((unused))wdb_t * wdb,
+                                     os_sha1 hexdigest) {
+    check_expected(hexdigest);
+    return mock();
+}

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
@@ -83,4 +83,6 @@ cJSON *__wrap_wdb_get_internal_config();
 
 cJSON *__wrap_wdb_get_config();
 
+int __wrap_wdb_get_global_group_hash(wdb_t * wdb, os_sha1 hexdigest);
+
 #endif

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -1973,7 +1973,7 @@ wdbc_result wdb_global_set_agent_group_context(wdb_t *wdb, int id, char* csv, ch
  * @param hash Received group column hash.
  * @return cJSON* Returns a cJSON object with the groups integrity status or NULL on error.
  */
-cJSON* wdb_get_groups_integrity(wdb_t *wdb, os_sha1 hash);
+cJSON* wdb_global_get_groups_integrity(wdb_t *wdb, os_sha1 hash);
 
 /**
  * @brief Gets the maximum priority of the groups of an agent.

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1124,7 +1124,7 @@ wdbc_result wdb_global_set_agent_group_context(wdb_t *wdb, int id, char* csv, ch
     }
 }
 
-cJSON* wdb_get_groups_integrity(wdb_t* wdb, os_sha1 hash) {
+cJSON* wdb_global_get_groups_integrity(wdb_t* wdb, os_sha1 hash) {
     sqlite3_stmt* stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_GLOBAL_GROUP_SYNCREQ_FIND);
 
     if (stmt == NULL) {
@@ -1133,7 +1133,7 @@ cJSON* wdb_get_groups_integrity(wdb_t* wdb, os_sha1 hash) {
 
     cJSON* response = NULL;
 
-    switch (sqlite3_step(stmt)) {
+    switch (wdb_step(stmt)) {
     case SQLITE_ROW:
         response = cJSON_CreateArray();
         cJSON_AddItemToArray(response, cJSON_CreateString("syncreq"));

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5501,7 +5501,7 @@ int wdb_parse_get_groups_integrity(wdb_t* wdb, char* input, char* output) {
     os_sha1 hash = {0};
     strncpy(hash, input, strlen(input));
     int ret = OS_SUCCESS;
-    cJSON *j_result = wdb_get_groups_integrity(wdb, hash);
+    cJSON *j_result = wdb_global_get_groups_integrity(wdb, hash);
     if (j_result) {
         char* out = cJSON_PrintUnformatted(j_result);
         snprintf(output, OS_MAXSTR + 1, "ok %s", out);


### PR DESCRIPTION
|Related issue|
|---|
|#11754|

## Description

This PR adds UT cases for:

- `get-groups-integrity` command.
- wdb_global_get_groups_integrity()
- wdb_parse_get_groups_integrity()

## Dod

![image](https://user-images.githubusercontent.com/13010397/151048536-8f0054d0-9d0d-468d-9ef8-cbd3f2eaefb5.png)
![8](https://user-images.githubusercontent.com/13010397/151048632-02f2cb10-2657-4465-bcae-da9908cb8e61.png)
![9](https://user-images.githubusercontent.com/13010397/151048642-8a4572b7-c209-4333-8f0a-14a77e6bb501.png)
![10](https://user-images.githubusercontent.com/13010397/151048646-1040e123-6515-4a68-80f8-5423b4329b8c.png)


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)