### PR TITLE
Unit tests - Tests for `wdb_close`, `wdb_leave` and `wdb_finalize_all_statements`

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -89,7 +89,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                              -Wl,--wrap,sqlite3_column_count -Wl,--wrap,sqlite3_column_type -Wl,--wrap,sqlite3_column_name -Wl,--wrap,sqlite3_column_double \
                              -Wl,--wrap,sqlite3_column_text -Wl,--wrap,sqlite3_prepare_v2 -Wl,--wrap,sqlite3_finalize -Wl,--wrap,sqlite3_reset \
                              -Wl,--wrap,sqlite3_clear_bindings -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,sqlite3_sql -Wl,--wrap,OS_SendSecureTCP  \
-                             -Wl,--wrap,OS_SetSendTimeout ${HASH_OP_WRAPPERS} ${DEBUG_OP_WRAPPERS}")
+                             -Wl,--wrap,OS_SetSendTimeout -Wl,--wrap,time ${HASH_OP_WRAPPERS} ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_upgrade")
 list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_metadata_table_check \

--- a/src/unit_tests/wazuh_db/test_wdb.c
+++ b/src/unit_tests/wazuh_db/test_wdb.c
@@ -763,6 +763,7 @@ void test_wdb_get_config(){
     cJSON_Delete(ret);
 }
 
+/* wdb_exec_stmt_single_column */
 void test_wdb_exec_single_column(){
     char col_text[4][16] = { 0 };
 
@@ -791,7 +792,7 @@ void test_wdb_exec_single_column(){
 void test_wdb_exec_single_column_invalid_stmt(){
     expect_string(__wrap__mdebug1, formatted_msg, "Invalid SQL statement.");
 
-    cJSON *ret = wdb_exec_stmt_single_column(0);
+    cJSON *ret = wdb_exec_stmt_single_column(NULL);
 
     assert_null(ret);
 }
@@ -829,9 +830,7 @@ void test_wdb_finalize_all_statements(){
     struct stmt_cache_list** c = &(wdb.cache_list);
     for(int i = 0; i < kMaxStmt; ++i){
         *c = calloc(1, sizeof(struct stmt_cache_list));
-
         (*c)->value.stmt = (sqlite3_stmt*) 0xDEADBEEF;
-
         c = &((*c)->next);
     }
 
@@ -839,7 +838,6 @@ void test_wdb_finalize_all_statements(){
 
     // free the prepared statements
     will_return_count(__wrap_sqlite3_finalize, 1, kMaxStmt);
-
     // free the statement cache
     will_return_count(__wrap_sqlite3_finalize, 1, kMaxStmt);
 
@@ -849,6 +847,7 @@ void test_wdb_finalize_all_statements(){
     assert_null(wdb.cache_list);
 }
 
+/* wdb_close*/
 void test_wdb_close_refcount_error(){
     wdb_t wdb = {0};
     wdb.refcount = 1;
@@ -876,7 +875,7 @@ void test_wdb_close_no_commit_sqlerror(){
     assert_int_equal(-1, wdb_close(&wdb, 0));
 }
 
-void test_wdb_close(){
+void test_wdb_close_success(){
     wdb_t *wdb = calloc(1, sizeof(wdb_t));
     wdb->id = strdup("agent");
 
@@ -954,7 +953,7 @@ int main() {
         // wdb_close
         cmocka_unit_test(test_wdb_close_refcount_error),
         cmocka_unit_test(test_wdb_close_no_commit_sqlerror),
-        cmocka_unit_test(test_wdb_close),
+        cmocka_unit_test(test_wdb_close_success),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -1278,6 +1278,8 @@ void wdb_finalize_all_statements(wdb_t * wdb) {
         os_free(node_stmt);
         node_stmt = temp;
     }
+
+    wdb->cache_list = NULL;
 }
 
 void wdb_leave(wdb_t * wdb) {


### PR DESCRIPTION
|Related issue|
|---|
|#11754|

## Description
Adding unit tests for new wdb functions` wdb_close`, `wdb_leave` and `wdb_finalize_all_statements`
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)