### PR TITLE
UT cases for get_agent_max_group_priority

### DIFF
--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -878,6 +878,82 @@ void test_wdb_global_get_groups_integrity_error(void **state)
     assert_null(j_result);
 }
 
+/* Tests wdb_global_get_agent_max_group_priority */
+
+void test_wdb_global_get_agent_max_group_priority_statement_fail(void **state)
+{
+    int result = OS_SUCCESS;
+    test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_GLOBAL_GROUP_PRIORITY_GET);
+    will_return(__wrap_wdb_init_stmt_in_cache, NULL);
+
+    result = wdb_global_get_agent_max_group_priority(data->wdb, agent_id);
+
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_wdb_global_get_agent_max_group_priority_bind_fail(void **state)
+{
+    int result = OS_SUCCESS;
+    test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_GLOBAL_GROUP_PRIORITY_GET);
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1);
+    expect_value(__wrap_sqlite3_bind_int, index, 1);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
+    will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
+
+    result = wdb_global_get_agent_max_group_priority(data->wdb, agent_id);
+
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_wdb_global_get_agent_max_group_priority_step_fail(void **state)
+{
+    int result = OS_SUCCESS;
+    test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_GLOBAL_GROUP_PRIORITY_GET);
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1);
+    expect_value(__wrap_sqlite3_bind_int, index, 1);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    will_return(__wrap_wdb_exec_stmt, NULL);
+    will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
+    expect_string(__wrap__mdebug1, formatted_msg, "wdb_exec_stmt(): ERROR MESSAGE");
+
+    result = wdb_global_get_agent_max_group_priority(data->wdb, agent_id);
+
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_wdb_global_get_agent_max_group_priority_success(void **state)
+{
+    int result = OS_SUCCESS;
+    test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
+    cJSON *j_result = cJSON_Parse("[{\"MAX(priority)\":5}]");
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_GLOBAL_GROUP_PRIORITY_GET);
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1);
+    expect_value(__wrap_sqlite3_bind_int, index, 1);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    will_return(__wrap_wdb_exec_stmt, j_result);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    result = wdb_global_get_agent_max_group_priority(data->wdb, agent_id);
+
+    assert_int_equal(result, 5);
+    __real_cJSON_Delete(j_result);
+}
+
 /* Tests wdb_global_sync_agent_info_set */
 
 void test_wdb_global_sync_agent_info_set_transaction_fail(void **state)
@@ -5893,6 +5969,11 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_global_get_groups_integrity_hash_mismatch, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_get_groups_integrity_synced, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_get_groups_integrity_error, test_setup, test_teardown),
+        /* Test _wdb_global_get_agent_max_group_priority */
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_agent_max_group_priority_statement_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_agent_max_group_priority_bind_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_agent_max_group_priority_step_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_agent_max_group_priority_success, test_setup, test_teardown),
         /* Tests wdb_global_sync_agent_info_set */
         cmocka_unit_test_setup_teardown(test_wdb_global_sync_agent_info_set_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_sync_agent_info_set_cache_fail, test_setup, test_teardown),

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1158,6 +1158,10 @@ cJSON* wdb_global_get_groups_integrity(wdb_t* wdb, os_sha1 hash) {
 int wdb_global_get_agent_max_group_priority(wdb_t *wdb, int id) {
     sqlite3_stmt *stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_GLOBAL_GROUP_PRIORITY_GET);
 
+    if (stmt == NULL) {
+        return OS_INVALID;
+    }
+
     if (sqlite3_bind_int(stmt, 1, id) != SQLITE_OK) {
         merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
         return OS_INVALID;

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1128,7 +1128,6 @@ wdbc_result wdb_global_set_agent_group_context(wdb_t *wdb, int id, char* csv, ch
 
 cJSON* wdb_global_get_groups_integrity(wdb_t* wdb, os_sha1 hash) {
     sqlite3_stmt* stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_GLOBAL_GROUP_SYNCREQ_FIND);
-
     if (stmt == NULL) {
         return NULL;
     }
@@ -1157,7 +1156,6 @@ cJSON* wdb_global_get_groups_integrity(wdb_t* wdb, os_sha1 hash) {
 
 int wdb_global_get_agent_max_group_priority(wdb_t *wdb, int id) {
     sqlite3_stmt *stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_GLOBAL_GROUP_PRIORITY_GET);
-
     if (stmt == NULL) {
         return OS_INVALID;
     }


### PR DESCRIPTION
|Related issue|
|---|
|#11754|

## Description

This PR adds UT for `wdb_global_get_agent_max_group_priority`

## Dod

![12](https://user-images.githubusercontent.com/13010397/151194964-b5d267e9-b85f-4f3f-b470-877ce156a78e.png)
![11](https://user-images.githubusercontent.com/13010397/151194959-9f9b8218-b399-4c83-8a59-fe6050099a20.png)

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)