### PR TITLE
Adding unit test cases for functions related to the upgrade of the global database

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -105,7 +105,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_metadata_table_check \
                              -Wl,--wrap,unlink -Wl,--wrap,getpid -Wl,--wrap,time -Wl,--wrap,sqlite3_open_v2 -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,sqlite3_close_v2 \
                              -Wl,--wrap,sqlite3_prepare_v2 -Wl,--wrap,sqlite3_step -Wl,--wrap,sqlite3_column_int -Wl,--wrap,sqlite3_finalize -Wl,--wrap,fgetpos \
                              -Wl,--wrap,fgetc -Wl,--wrap,wdb_global_create_backup -Wl,--wrap,wdb_global_get_most_recent_backup -Wl,--wrap,wdb_global_restore_backup \
-                             -Wl,--wrap,wdb_global_update_all_agents_groups_hash ${DEBUG_OP_WRAPPERS}")
+                             -Wl,--wrap,wdb_global_adjust_v4 ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_metadata")
 list(APPEND wdb_tests_flags "-Wl,--wrap,sqlite3_prepare_v2 -Wl,--wrap,sqlite3_errmsg \

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -103,8 +103,9 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_metadata_table_check \
                              -Wl,--wrap,remove -Wl,--wrap,opendir -Wl,--wrap,readdir -Wl,--wrap,closedir -Wl,--wrap,fflush -Wl,--wrap,fseek -Wl,--wrap,fgets \
                              -Wl,--wrap,wdb_init -Wl,--wrap,wdb_close -Wl,--wrap,wdb_create_global -Wl,--wrap,wdb_pool_append -Wl,--wrap,chmod -Wl,--wrap,stat \
                              -Wl,--wrap,unlink -Wl,--wrap,getpid -Wl,--wrap,time -Wl,--wrap,sqlite3_open_v2 -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,sqlite3_close_v2 \
-                             -Wl,--wrap,sqlite3_prepare_v2 -Wl,--wrap,sqlite3_step -Wl,--wrap,sqlite3_column_int \
-                             -Wl,--wrap,sqlite3_finalize -Wl,--wrap,fgetpos -Wl,--wrap=fgetc ${DEBUG_OP_WRAPPERS}")
+                             -Wl,--wrap,sqlite3_prepare_v2 -Wl,--wrap,sqlite3_step -Wl,--wrap,sqlite3_column_int -Wl,--wrap,sqlite3_finalize -Wl,--wrap,fgetpos \
+                             -Wl,--wrap,fgetc -Wl,--wrap,wdb_global_create_backup -Wl,--wrap,wdb_global_get_most_recent_backup -Wl,--wrap,wdb_global_restore_backup \
+                             -Wl,--wrap,wdb_global_update_all_agents_groups_hash ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_metadata")
 list(APPEND wdb_tests_flags "-Wl,--wrap,sqlite3_prepare_v2 -Wl,--wrap,sqlite3_errmsg \

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -6182,33 +6182,33 @@ void test_wdb_global_update_agent_groups_hash_empty_group_column_success(void **
     __real_cJSON_Delete(j_result);
 }
 
-/* Tests wdb_global_update_all_agents_groups_hash */
+/* Tests wdb_global_adjust_v4 */
 
-void test_wdb_global_update_all_agents_groups_hash_begin_failed(void **state) {
+void test_wdb_global_adjust_v4_begin_failed(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
 
     data->wdb->transaction = 0;
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
     will_return(__wrap_wdb_begin2, OS_INVALID);
 
-    int result = wdb_global_update_all_agents_groups_hash(data->wdb);
+    int result = wdb_global_adjust_v4(data->wdb);
 
     assert_int_equal(result, OS_INVALID);
 }
 
-void test_wdb_global_update_all_agents_groups_hash_cache_failed(void **state) {
+void test_wdb_global_adjust_v4_cache_failed(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
 
     data->wdb->transaction = 1;
     will_return(__wrap_wdb_stmt_cache, OS_INVALID);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    int result = wdb_global_update_all_agents_groups_hash(data->wdb);
+    int result = wdb_global_adjust_v4(data->wdb);
 
     assert_int_equal(result, OS_INVALID);
 }
 
-void test_wdb_global_update_all_agents_groups_hash_bind_failed(void **state) {
+void test_wdb_global_adjust_v4_bind_failed(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
 
     data->wdb->transaction = 1;
@@ -6219,12 +6219,12 @@ void test_wdb_global_update_all_agents_groups_hash_bind_failed(void **state) {
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    int result = wdb_global_update_all_agents_groups_hash(data->wdb);
+    int result = wdb_global_adjust_v4(data->wdb);
 
     assert_int_equal(result, OS_INVALID);
 }
 
-void test_wdb_global_update_all_agents_groups_hash_step_failed(void **state) {
+void test_wdb_global_adjust_v4_step_failed(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
 
     data->wdb->transaction = 1;
@@ -6236,12 +6236,12 @@ void test_wdb_global_update_all_agents_groups_hash_step_failed(void **state) {
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__mdebug1, formatted_msg, "SQLite: ERROR MESSAGE");
 
-    int result = wdb_global_update_all_agents_groups_hash(data->wdb);
+    int result = wdb_global_adjust_v4(data->wdb);
 
     assert_int_equal(result, OS_INVALID);
 }
 
-void test_wdb_global_update_all_agents_groups_hash_success(void **state) {
+void test_wdb_global_adjust_v4_success(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
 
@@ -6280,7 +6280,7 @@ void test_wdb_global_update_all_agents_groups_hash_success(void **state) {
 
     will_return(__wrap_wdb_step, SQLITE_DONE);
 
-    int result = wdb_global_update_all_agents_groups_hash(data->wdb);
+    int result = wdb_global_adjust_v4(data->wdb);
 
     assert_int_equal(result, OS_SUCCESS);
     __real_cJSON_Delete(j_result);
@@ -6599,12 +6599,12 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_groups_hash_success, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_groups_hash_groups_string_null_success, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_groups_hash_empty_group_column_success, test_setup, test_teardown),
-        /* Tests wdb_global_update_all_agents_groups_hash */
-        cmocka_unit_test_setup_teardown(test_wdb_global_update_all_agents_groups_hash_begin_failed, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_update_all_agents_groups_hash_cache_failed, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_update_all_agents_groups_hash_bind_failed, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_update_all_agents_groups_hash_step_failed, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_update_all_agents_groups_hash_success, test_setup, test_teardown),
+        /* Tests wdb_global_adjust_v4 */
+        cmocka_unit_test_setup_teardown(test_wdb_global_adjust_v4_begin_failed, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_adjust_v4_cache_failed, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_adjust_v4_bind_failed, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_adjust_v4_step_failed, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_adjust_v4_success, test_setup, test_teardown),
         /* Tests wdb_global_calculate_agent_group_csv */
         cmocka_unit_test_setup_teardown(test_wdb_global_calculate_agent_group_csv_unable_to_get_group, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_calculate_agent_group_csv_success, test_setup, test_teardown),

--- a/src/unit_tests/wazuh_db/test_wdb_upgrade.c
+++ b/src/unit_tests/wazuh_db/test_wdb_upgrade.c
@@ -20,6 +20,7 @@
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../wrappers/wazuh/wazuh_db/wdb_metadata_wrappers.h"
 #include "../wrappers/wazuh/wazuh_db/wdb_wrappers.h"
+#include "../wrappers/wazuh/wazuh_db/wdb_global_wrappers.h"
 #include "../wrappers/libc/stdio_wrappers.h"
 #include "../wrappers/posix/stat_wrappers.h"
 #include "../wrappers/posix/unistd_wrappers.h"
@@ -48,6 +49,7 @@ int setup_wdb(void **state) {
     os_strdup("global",init_data->wdb->id);
     os_calloc(256,sizeof(char),init_data->output);
     os_calloc(1,sizeof(sqlite3 *),init_data->wdb->db);
+    init_data->wdb->enabled = true;
     *state = init_data;
     return 0;
 }
@@ -63,396 +65,442 @@ int teardown_wdb(void **state) {
     return 0;
 }
 
+/* Tests test_wdb_recreate_global */
+
+void test_wdb_recreate_global_error_closing_wdb_struct(void **state)
+{
+    wdb_t *ret = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    // Error closing the wdb struct
+    will_return(__wrap_wdb_close, OS_INVALID);
+
+    ret = wdb_recreate_global(data->wdb);
+
+    assert_null(ret);
+}
+
+void test_wdb_recreate_global_error_creating_global_db(void **state)
+{
+    wdb_t *ret = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    // Closing the wdb struct and removing the current database file
+    will_return(__wrap_wdb_close, OS_SUCCESS);
+    expect_string(__wrap_unlink, file, "queue/db/global.db");
+    will_return(__wrap_unlink, 0);
+
+    // Error creating global.db
+    expect_string(__wrap_wdb_create_global, path, "queue/db/global.db");
+    will_return(__wrap_wdb_create_global, OS_INVALID);
+    expect_string(__wrap__merror, formatted_msg, "Couldn't create SQLite database 'queue/db/global.db'");
+
+    ret = wdb_recreate_global(data->wdb);
+
+    assert_null(ret);
+}
+
+void test_wdb_recreate_global_error_opening_global_db(void **state)
+{
+    wdb_t *ret = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    // Closing the wdb struct and removing the current database file
+    will_return(__wrap_wdb_close, OS_SUCCESS);
+    expect_string(__wrap_unlink, file, "queue/db/global.db");
+    will_return(__wrap_unlink, 0);
+
+    // Creating global.db
+    expect_string(__wrap_wdb_create_global, path, "queue/db/global.db");
+    will_return(__wrap_wdb_create_global, OS_SUCCESS);
+
+    // Error opening new global.db
+    expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/global.db");
+    expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE);
+    will_return(__wrap_sqlite3_open_v2, 1);
+    will_return(__wrap_sqlite3_open_v2, SQLITE_ERROR);
+    will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "Can't open SQLite backup database \
+'queue/db/global.db': ERROR MESSAGE");
+    will_return(__wrap_sqlite3_close_v2, OS_SUCCESS);
+
+    ret = wdb_recreate_global(data->wdb);
+
+    assert_null(ret);
+}
+
+void test_wdb_recreate_global_success(void **state)
+{
+    wdb_t *ret = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    // Closing the wdb struct and removing the current database file
+    will_return(__wrap_wdb_close, OS_SUCCESS);
+    expect_string(__wrap_unlink, file, "queue/db/global.db");
+    will_return(__wrap_unlink, 0);
+
+    // Creating global.db
+    expect_string(__wrap_wdb_create_global, path, "queue/db/global.db");
+    will_return(__wrap_wdb_create_global, OS_SUCCESS);
+
+    // Opening new global.db
+    expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/global.db");
+    expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE);
+    will_return(__wrap_sqlite3_open_v2, 1);
+    will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
+
+    // Initializing and adding to the pool
+    expect_string(__wrap_wdb_init, id, "global");
+    will_return(__wrap_wdb_init, (wdb_t*)1);
+    expect_value(__wrap_wdb_pool_append, wdb, (wdb_t*)1);
+
+    ret = wdb_recreate_global(data->wdb);
+
+    assert_non_null(ret);
+}
+
 /* Tests wdb_upgrade_global */
 
-void test_wdb_upgrade_global_table_fail(void **state)
+void test_wdb_upgrade_global_error_checking_metadata_table(void **state)
 {
     wdb_t *ret = NULL;
     test_struct_t *data  = (test_struct_t *)*state;
 
     expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
     will_return(__wrap_wdb_metadata_table_check, OS_INVALID);
-    expect_string(__wrap__mwarn, formatted_msg, "DB(global) Error trying to find metadata table");
-
-    //Global backup success
-    will_return(__wrap_wdb_close, 0);
-    expect_any_always(__wrap_fopen, path);
-    expect_any_always(__wrap_fopen, mode);
-    will_return(__wrap_fopen, 1);
-    will_return(__wrap_fopen, 1);
-    will_return(__wrap_fread, "");
-    will_return(__wrap_fread, 0);
-    expect_any_always(__wrap_fclose, _File);
-    will_return(__wrap_fclose, 0);
-    will_return(__wrap_fclose, 0);
-    expect_any_always(__wrap_chmod, path);
-    will_return(__wrap_chmod, 0);
-    expect_string(__wrap__mwarn, formatted_msg, "Creating Global DB backup and creating empty DB");
-    expect_string(__wrap_unlink, file, "queue/db/global.db");
-    will_return(__wrap_unlink, 0);
-    expect_string(__wrap_wdb_create_global, path, "queue/db/global.db");
-    will_return(__wrap_wdb_create_global, OS_SUCCESS);
-    expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/global.db");
-    expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE);
-    will_return(__wrap_sqlite3_open_v2, 1);
-    will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
-    expect_string(__wrap_wdb_init, id, "global");
-    will_return(__wrap_wdb_init, (wdb_t*)1);
-    expect_value(__wrap_wdb_pool_append, wdb, (wdb_t*)1);
+    expect_string(__wrap__merror, formatted_msg, "DB(global) Error trying to find metadata table");
 
     ret = wdb_upgrade_global(data->wdb);
 
-    assert_int_equal(ret, 1);
+    assert_ptr_equal(data->wdb, ret);
+    assert_false(ret->enabled);
 }
 
-void test_wdb_upgrade_global_update_success(void **state)
+void test_wdb_upgrade_global_error_backingup_legacy_db(void **state)
 {
     wdb_t *ret = NULL;
     test_struct_t *data  = (test_struct_t *)*state;
 
     expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
-    will_return(__wrap_wdb_metadata_table_check, 0);
-    expect_string(__wrap__mdebug2, formatted_msg, "Updating database 'global' to version 1");
-    expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v1_sql);
-    will_return(__wrap_wdb_sql_exec, 0);
-    expect_string(__wrap__mdebug2, formatted_msg, "Updating database 'global' to version 2");
-    expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v2_sql);
-    will_return(__wrap_wdb_sql_exec, 0);
-    expect_string(__wrap__mdebug2, formatted_msg, "Updating database 'global' to version 3");
-    expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v3_sql);
-    will_return(__wrap_wdb_sql_exec, 0);
+    will_return(__wrap_wdb_metadata_table_check, OS_SUCCESS);
 
-    // wdb_upgrade_check_manager_keepalive
-    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
-    expect_sqlite3_step_call(SQLITE_ROW);
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, 1);
-    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
-
-    ret = wdb_upgrade_global(data->wdb);
-
-    assert_int_equal(ret, data->wdb);
-}
-
-void test_wdb_upgrade_global_update_delete_old_version(void **state)
-{
-    wdb_t *ret = NULL;
-    test_struct_t *data  = (test_struct_t *)*state;
-
-    expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
-    will_return(__wrap_wdb_metadata_table_check, 0);
-
-    // wdb_upgrade_check_manager_keepalive
+    // wdb_upgrade_check_manager_keepalive (returns OS_SUCCESS
+    // to indicate that is a legacy database)
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
     expect_sqlite3_step_call(SQLITE_DONE);
     will_return(__wrap_sqlite3_finalize, SQLITE_OK);
 
-    //Global backup success
-    will_return(__wrap_wdb_close, 0);
-    expect_any_always(__wrap_fopen, path);
-    expect_any_always(__wrap_fopen, mode);
-    will_return(__wrap_fopen, 1);
-    will_return(__wrap_fopen, 1);
-    will_return(__wrap_fread, "");
-    will_return(__wrap_fread, 0);
-    expect_any_always(__wrap_fclose, _File);
-    will_return(__wrap_fclose, 0);
-    will_return(__wrap_fclose, 0);
-    expect_any_always(__wrap_chmod, path);
-    will_return(__wrap_chmod, 0);
-    expect_string(__wrap__mwarn, formatted_msg, "Creating Global DB backup and creating empty DB");
+    // Error backing up the database
+    will_return(__wrap_wdb_global_create_backup, "global.db");
+    will_return(__wrap_wdb_global_create_backup, OS_INVALID);
+    expect_string(__wrap__merror, formatted_msg, "Creating pre-upgrade \
+Global DB snapshot failed: global.db-pre_upgrade");
+
+    ret = wdb_upgrade_global(data->wdb);
+
+    assert_ptr_equal(data->wdb, ret);
+    assert_false(ret->enabled);
+}
+
+void test_wdb_upgrade_global_success_regenerating_legacy_db(void **state)
+{
+    wdb_t *ret = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
+    will_return(__wrap_wdb_metadata_table_check, OS_SUCCESS);
+
+    // wdb_upgrade_check_manager_keepalive (returns OS_SUCCESS
+    // to indicate that is a legacy database)
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+    expect_sqlite3_step_call(SQLITE_DONE);
+    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
+
+    // Success backing up the database
+    will_return(__wrap_wdb_global_create_backup, "global.db");
+    will_return(__wrap_wdb_global_create_backup, OS_SUCCESS);
+
+    // Recreating the database
+    // Closing the wdb struct and removing the current database file
+    will_return(__wrap_wdb_close, OS_SUCCESS);
     expect_string(__wrap_unlink, file, "queue/db/global.db");
     will_return(__wrap_unlink, 0);
+
+    // Creating global.db
     expect_string(__wrap_wdb_create_global, path, "queue/db/global.db");
     will_return(__wrap_wdb_create_global, OS_SUCCESS);
+
+    // Opening new global.db
     expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/global.db");
     expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE);
     will_return(__wrap_sqlite3_open_v2, 1);
     will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
+
+    // Initializing and adding to the pool
     expect_string(__wrap_wdb_init, id, "global");
     will_return(__wrap_wdb_init, (wdb_t*)1);
     expect_value(__wrap_wdb_pool_append, wdb, (wdb_t*)1);
 
     ret = wdb_upgrade_global(data->wdb);
 
-    assert_int_equal(ret, 1);
+    assert_ptr_equal(ret, (wdb_t*)1);
 }
 
-void test_wdb_upgrade_global_update_fail(void **state)
+void test_wdb_upgrade_global_error_getting_database_version(void **state)
 {
     wdb_t *ret = NULL;
     test_struct_t *data  = (test_struct_t *)*state;
 
     expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
-    will_return(__wrap_wdb_metadata_table_check, 0);
-    expect_string(__wrap__mdebug2, formatted_msg, "Updating database 'global' to version 1");
-    expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v1_sql);
-    will_return(__wrap_wdb_sql_exec, -1);
-    expect_string(__wrap__mwarn, formatted_msg, "Failed to update global.db to version 1");
+    will_return(__wrap_wdb_metadata_table_check, 1);
 
-    // wdb_upgrade_check_manager_keepalive
+    // Error getting database version
+    expect_string(__wrap_wdb_metadata_get_entry, key, "db_version");
+    will_return(__wrap_wdb_metadata_get_entry, "1");
+    will_return(__wrap_wdb_metadata_get_entry, -1);
+    expect_string(__wrap__mwarn, formatted_msg, "DB(global): Error trying to get DB version");
+
+    ret = wdb_upgrade_global(data->wdb);
+
+    assert_ptr_equal(data->wdb, ret);
+    assert_false(ret->enabled);
+}
+
+void test_wdb_upgrade_global_error_creating_pre_upgrade_backup(void **state)
+{
+    wdb_t *ret = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
+    will_return(__wrap_wdb_metadata_table_check, 1);
+
+    // Getting database version
+    expect_string(__wrap_wdb_metadata_get_entry, key, "db_version");
+    will_return(__wrap_wdb_metadata_get_entry, "1");
+    will_return(__wrap_wdb_metadata_get_entry, 1);
+
+    // Error creating pre upgrade backup
+    will_return(__wrap_wdb_global_create_backup, "global.db");
+    will_return(__wrap_wdb_global_create_backup, OS_INVALID);
+    expect_string(__wrap__merror, formatted_msg, "Creating pre-upgrade \
+Global DB snapshot failed: global.db-pre_upgrade");
+
+    ret = wdb_upgrade_global(data->wdb);
+
+    assert_ptr_equal(data->wdb, ret);
+    assert_false(ret->enabled);
+}
+
+void test_wdb_upgrade_global_error_restoring_database_and_getting_backup_name(void **state)
+{
+    wdb_t *ret = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
+    will_return(__wrap_wdb_metadata_table_check, 1);
+
+    // Getting database version
+    expect_string(__wrap_wdb_metadata_get_entry, key, "db_version");
+    will_return(__wrap_wdb_metadata_get_entry, "1");
+    will_return(__wrap_wdb_metadata_get_entry, 1);
+
+    // Creating pre upgrade backup
+    will_return(__wrap_wdb_global_create_backup, "global.db");
+    will_return(__wrap_wdb_global_create_backup, OS_SUCCESS);
+
+    // Error restoring database and getting the backup file name
+    expect_string(__wrap__mdebug2, formatted_msg, "Updating database 'global' to version 2");
+    expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v2_sql);
+    will_return(__wrap_wdb_sql_exec, OS_INVALID);
+    will_return(__wrap_wdb_global_get_most_recent_backup, NULL);
+    will_return(__wrap_wdb_global_get_most_recent_backup, OS_INVALID);
+    expect_string(__wrap__merror, formatted_msg, "Failed to update global.db to version 2.");
+
+    ret = wdb_upgrade_global(data->wdb);
+
+    assert_ptr_equal(data->wdb, ret);
+    assert_false(ret->enabled);
+}
+
+void test_wdb_upgrade_global_error_restoring_database(void **state)
+{
+    wdb_t *ret = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
+    will_return(__wrap_wdb_metadata_table_check, 1);
+
+    // Getting database version
+    expect_string(__wrap_wdb_metadata_get_entry, key, "db_version");
+    will_return(__wrap_wdb_metadata_get_entry, "1");
+    will_return(__wrap_wdb_metadata_get_entry, 1);
+
+    // Creating pre upgrade backup
+    will_return(__wrap_wdb_global_create_backup, "global.db");
+    will_return(__wrap_wdb_global_create_backup, OS_SUCCESS);
+
+    // Error restoring database
+    expect_string(__wrap__mdebug2, formatted_msg, "Updating database 'global' to version 2");
+    expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v2_sql);
+    will_return(__wrap_wdb_sql_exec, OS_INVALID);
+    will_return(__wrap_wdb_global_get_most_recent_backup, "test_backup_name");
+    will_return(__wrap_wdb_global_get_most_recent_backup, OS_INVALID);
+    expect_string(__wrap__merror, formatted_msg, "Failed to update global.db to version 2. \
+The global.db should be restored from test_backup_name.");
+
+    ret = wdb_upgrade_global(data->wdb);
+
+    assert_ptr_equal(data->wdb, ret);
+    assert_false(ret->enabled);
+}
+
+void test_wdb_upgrade_global_database_restored(void **state)
+{
+    wdb_t *ret = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
+    will_return(__wrap_wdb_metadata_table_check, 1);
+
+    // Getting database version
+    expect_string(__wrap_wdb_metadata_get_entry, key, "db_version");
+    will_return(__wrap_wdb_metadata_get_entry, "1");
+    will_return(__wrap_wdb_metadata_get_entry, 1);
+
+    // Creating pre upgrade backup
+    will_return(__wrap_wdb_global_create_backup, "global.db");
+    will_return(__wrap_wdb_global_create_backup, OS_SUCCESS);
+
+    // Error upgrading database
+    expect_string(__wrap__mdebug2, formatted_msg, "Updating database 'global' to version 2");
+    expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v2_sql);
+    will_return(__wrap_wdb_sql_exec, OS_INVALID);
+    will_return(__wrap_wdb_global_get_most_recent_backup, "test_backup_name");
+    will_return(__wrap_wdb_global_get_most_recent_backup, OS_SUCCESS);
+    expect_string(__wrap_wdb_global_restore_backup, snapshot, "test_backup_name");
+    expect_value(__wrap_wdb_global_restore_backup, save_pre_restore_state, false);
+    will_return(__wrap_wdb_global_restore_backup, OS_SUCCESS);
+    expect_string(__wrap__merror, formatted_msg, "Failed to update global.db to version 2. \
+The global.db was restored to the original state.");
+
+    ret = wdb_upgrade_global(data->wdb);
+
+    assert_ptr_equal(data->wdb, ret);
+    assert_true(ret->enabled);
+}
+
+void test_wdb_upgrade_global_intermediate_upgrade_error(void **state)
+{
+    wdb_t *ret = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
+    will_return(__wrap_wdb_metadata_table_check, 1);
+
+    // Getting database version
+    expect_string(__wrap_wdb_metadata_get_entry, key, "db_version");
+    will_return(__wrap_wdb_metadata_get_entry, "1");
+    will_return(__wrap_wdb_metadata_get_entry, 1);
+
+    // Creating pre upgrade backup
+    will_return(__wrap_wdb_global_create_backup, "global.db");
+    will_return(__wrap_wdb_global_create_backup, OS_SUCCESS);
+
+    // Error upgrading database
+    expect_string(__wrap__mdebug2, formatted_msg, "Updating database 'global' to version 2");
+    expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v2_sql);
+    will_return(__wrap_wdb_sql_exec, OS_SUCCESS);
+    expect_string(__wrap__mdebug2, formatted_msg, "Updating database 'global' to version 3");
+    expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v3_sql);
+    will_return(__wrap_wdb_sql_exec, OS_INVALID);
+    will_return(__wrap_wdb_global_get_most_recent_backup, "test_backup_name");
+    will_return(__wrap_wdb_global_get_most_recent_backup, OS_SUCCESS);
+    expect_string(__wrap_wdb_global_restore_backup, snapshot, "test_backup_name");
+    expect_value(__wrap_wdb_global_restore_backup, save_pre_restore_state, false);
+    will_return(__wrap_wdb_global_restore_backup, OS_SUCCESS);
+    expect_string(__wrap__merror, formatted_msg, "Failed to update global.db to version 3. \
+The global.db was restored to the original state.");
+
+    ret = wdb_upgrade_global(data->wdb);
+
+    assert_ptr_equal(data->wdb, ret);
+    assert_true(ret->enabled);
+}
+
+void test_wdb_upgrade_global_full_upgrade_success(void **state)
+{
+    wdb_t *ret = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
+    will_return(__wrap_wdb_metadata_table_check, 1);
+
+    // Getting database version
+    expect_string(__wrap_wdb_metadata_get_entry, key, "db_version");
+    will_return(__wrap_wdb_metadata_get_entry, "1");
+    will_return(__wrap_wdb_metadata_get_entry, 1);
+
+    // Creating pre upgrade backup
+    will_return(__wrap_wdb_global_create_backup, "global.db");
+    will_return(__wrap_wdb_global_create_backup, OS_SUCCESS);
+
+    // Upgrading database
+    expect_string(__wrap__mdebug2, formatted_msg, "Updating database 'global' to version 2");
+    expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v2_sql);
+    will_return(__wrap_wdb_sql_exec, OS_SUCCESS);
+    expect_string(__wrap__mdebug2, formatted_msg, "Updating database 'global' to version 3");
+    expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v3_sql);
+    will_return(__wrap_wdb_sql_exec, OS_SUCCESS);
+    expect_string(__wrap__mdebug2, formatted_msg, "Updating database 'global' to version 4");
+    expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v4_sql);
+    will_return(__wrap_wdb_sql_exec, OS_SUCCESS);
+    will_return(__wrap_wdb_global_update_all_agents_groups_hash, OS_SUCCESS);
+
+    ret = wdb_upgrade_global(data->wdb);
+
+    assert_ptr_equal(data->wdb, ret);
+    assert_true(ret->enabled);
+}
+
+void test_wdb_upgrade_global_full_upgrade_success_from_unversioned_db(void **state)
+{
+    wdb_t *ret = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
+    will_return(__wrap_wdb_metadata_table_check, OS_SUCCESS);
+
+    // wdb_upgrade_check_manager_keepalive (returns 1
+    // to indicate that is a legacy database greater than 3.10)
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
     expect_sqlite3_step_call(SQLITE_ROW);
     expect_value(__wrap_sqlite3_column_int, iCol, 0);
     will_return(__wrap_sqlite3_column_int, 1);
     will_return(__wrap_sqlite3_finalize, SQLITE_OK);
 
-    //Global backup success
-    will_return(__wrap_wdb_close, 0);
-    expect_any_always(__wrap_fopen, path);
-    expect_any_always(__wrap_fopen, mode);
-    will_return(__wrap_fopen, 1);
-    will_return(__wrap_fopen, 1);
-    will_return(__wrap_fread, "");
-    will_return(__wrap_fread, 0);
-    expect_any_always(__wrap_fclose, _File);
-    will_return(__wrap_fclose, 0);
-    will_return(__wrap_fclose, 0);
-    expect_any_always(__wrap_chmod, path);
-    will_return(__wrap_chmod, 0);
-    expect_string(__wrap__mwarn, formatted_msg, "Creating Global DB backup and creating empty DB");
-    expect_string(__wrap_unlink, file, "queue/db/global.db");
-    will_return(__wrap_unlink, 0);
-    expect_string(__wrap_wdb_create_global, path, "queue/db/global.db");
-    will_return(__wrap_wdb_create_global, OS_SUCCESS);
-    expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/global.db");
-    expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE);
-    will_return(__wrap_sqlite3_open_v2, 1);
-    will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
-    expect_string(__wrap_wdb_init, id, "global");
-    will_return(__wrap_wdb_init, (wdb_t*)1);
-    expect_value(__wrap_wdb_pool_append, wdb, (wdb_t*)1);
+    // Creating pre upgrade backup
+    will_return(__wrap_wdb_global_create_backup, "global.db");
+    will_return(__wrap_wdb_global_create_backup, OS_SUCCESS);
 
-    ret = wdb_upgrade_global(data->wdb);
-
-    assert_int_equal(ret, 1);
-}
-
-void test_wdb_upgrade_global_get_version_fail(void **state)
-{
-    wdb_t *ret = NULL;
-    test_struct_t *data  = (test_struct_t *)*state;
-
-    expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
-    will_return(__wrap_wdb_metadata_table_check, 1);
-
-    expect_string(__wrap_wdb_metadata_get_entry, key, "db_version");
-    will_return(__wrap_wdb_metadata_get_entry, "1");
-    will_return(__wrap_wdb_metadata_get_entry, -1);
-    expect_string(__wrap__mwarn, formatted_msg, "DB(global): Error trying to get DB version");
-
-    //Global backup success
-    will_return(__wrap_wdb_close, 0);
-    expect_any_always(__wrap_fopen, path);
-    expect_any_always(__wrap_fopen, mode);
-    will_return(__wrap_fopen, 1);
-    will_return(__wrap_fopen, 1);
-    will_return(__wrap_fread, "");
-    will_return(__wrap_fread, 0);
-    expect_any_always(__wrap_fclose, _File);
-    will_return(__wrap_fclose, 0);
-    will_return(__wrap_fclose, 0);
-    expect_any_always(__wrap_chmod, path);
-    will_return(__wrap_chmod, 0);
-    expect_string(__wrap__mwarn, formatted_msg, "Creating Global DB backup and creating empty DB");
-    expect_string(__wrap_unlink, file, "queue/db/global.db");
-    will_return(__wrap_unlink, 0);
-    expect_string(__wrap_wdb_create_global, path, "queue/db/global.db");
-    will_return(__wrap_wdb_create_global, OS_SUCCESS);
-    expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/global.db");
-    expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE);
-    will_return(__wrap_sqlite3_open_v2, 1);
-    will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
-    expect_string(__wrap_wdb_init, id, "global");
-    will_return(__wrap_wdb_init, (wdb_t*)1);
-    expect_value(__wrap_wdb_pool_append, wdb, (wdb_t*)1);
-
-    ret = wdb_upgrade_global(data->wdb);
-
-    assert_int_equal(ret, 1);
-}
-
-void test_wdb_upgrade_global_all_versions_upgrade(void **state)
-{
-    wdb_t *ret = NULL;
-    test_struct_t *data  = (test_struct_t *)*state;
-
-    expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
-    will_return(__wrap_wdb_metadata_table_check, 1);
-
-    expect_string(__wrap_wdb_metadata_get_entry, key, "db_version");
-    will_return(__wrap_wdb_metadata_get_entry, "0");
-    will_return(__wrap_wdb_metadata_get_entry, 1);
+    // Upgrading database
     expect_string(__wrap__mdebug2, formatted_msg, "Updating database 'global' to version 1");
     expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v1_sql);
-    will_return(__wrap_wdb_sql_exec, 0);
+    will_return(__wrap_wdb_sql_exec, OS_SUCCESS);
     expect_string(__wrap__mdebug2, formatted_msg, "Updating database 'global' to version 2");
     expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v2_sql);
-    will_return(__wrap_wdb_sql_exec, 0);
+    will_return(__wrap_wdb_sql_exec, OS_SUCCESS);
     expect_string(__wrap__mdebug2, formatted_msg, "Updating database 'global' to version 3");
     expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v3_sql);
-    will_return(__wrap_wdb_sql_exec, 0);
+    will_return(__wrap_wdb_sql_exec, OS_SUCCESS);
+    expect_string(__wrap__mdebug2, formatted_msg, "Updating database 'global' to version 4");
+    expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v4_sql);
+    will_return(__wrap_wdb_sql_exec, OS_SUCCESS);
+    will_return(__wrap_wdb_global_update_all_agents_groups_hash, OS_SUCCESS);
 
     ret = wdb_upgrade_global(data->wdb);
 
-    assert_int_equal(ret, data->wdb);
-}
-
-void test_wdb_upgrade_global_update_v1_to_v3_success(void **state)
-{
-    wdb_t *ret = NULL;
-    test_struct_t *data  = (test_struct_t *)*state;
-
-    expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
-    will_return(__wrap_wdb_metadata_table_check, 1);
-
-    expect_string(__wrap_wdb_metadata_get_entry, key, "db_version");
-    will_return(__wrap_wdb_metadata_get_entry, "1");
-    will_return(__wrap_wdb_metadata_get_entry, 1);
-    expect_string(__wrap__mdebug2, formatted_msg, "Updating database 'global' to version 2");
-    expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v2_sql);
-    will_return(__wrap_wdb_sql_exec, 0);
-    expect_string(__wrap__mdebug2, formatted_msg, "Updating database 'global' to version 3");
-    expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v3_sql);
-    will_return(__wrap_wdb_sql_exec, 0);
-
-    ret = wdb_upgrade_global(data->wdb);
-
-    assert_int_equal(ret, data->wdb);
-}
-
-void test_wdb_upgrade_global_update_v1_to_v3_fail(void **state)
-{
-    wdb_t *ret = NULL;
-    test_struct_t *data  = (test_struct_t *)*state;
-
-    expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
-    will_return(__wrap_wdb_metadata_table_check, 1);
-
-    expect_string(__wrap_wdb_metadata_get_entry, key, "db_version");
-    will_return(__wrap_wdb_metadata_get_entry, "1");
-    will_return(__wrap_wdb_metadata_get_entry, 1);
-    expect_string(__wrap__mdebug2, formatted_msg, "Updating database 'global' to version 2");
-    expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v2_sql);
-    will_return(__wrap_wdb_sql_exec, -1);
-    expect_string(__wrap__mwarn, formatted_msg, "Failed to update global.db to version 2");
-
-    //Global backup success
-    will_return(__wrap_wdb_close, 0);
-    expect_any_always(__wrap_fopen, path);
-    expect_any_always(__wrap_fopen, mode);
-    will_return(__wrap_fopen, 1);
-    will_return(__wrap_fopen, 1);
-    will_return(__wrap_fread, "");
-    will_return(__wrap_fread, 0);
-    expect_any_always(__wrap_fclose, _File);
-    will_return(__wrap_fclose, 0);
-    will_return(__wrap_fclose, 0);
-    expect_any_always(__wrap_chmod, path);
-    will_return(__wrap_chmod, 0);
-    expect_string(__wrap__mwarn, formatted_msg, "Creating Global DB backup and creating empty DB");
-    expect_string(__wrap_unlink, file, "queue/db/global.db");
-    will_return(__wrap_unlink, 0);
-    expect_string(__wrap_wdb_create_global, path, "queue/db/global.db");
-    will_return(__wrap_wdb_create_global, OS_SUCCESS);
-    expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/global.db");
-    expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE);
-    will_return(__wrap_sqlite3_open_v2, 1);
-    will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
-    expect_string(__wrap_wdb_init, id, "global");
-    will_return(__wrap_wdb_init, (wdb_t*)1);
-    expect_value(__wrap_wdb_pool_append, wdb, (wdb_t*)1);
-
-    ret = wdb_upgrade_global(data->wdb);
-
-    assert_int_equal(ret, 1);
-}
-
-void test_wdb_upgrade_global_update_v2_to_v3_success(void **state)
-{
-    wdb_t *ret = NULL;
-    test_struct_t *data  = (test_struct_t *)*state;
-
-    expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
-    will_return(__wrap_wdb_metadata_table_check, 2);
-
-    expect_string(__wrap_wdb_metadata_get_entry, key, "db_version");
-    will_return(__wrap_wdb_metadata_get_entry, "2");
-    will_return(__wrap_wdb_metadata_get_entry, 1);
-    expect_string(__wrap__mdebug2, formatted_msg, "Updating database 'global' to version 3");
-    expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v3_sql);
-    will_return(__wrap_wdb_sql_exec, 0);
-
-    ret = wdb_upgrade_global(data->wdb);
-
-    assert_int_equal(ret, data->wdb);
-}
-
-void test_wdb_upgrade_global_update_v2_to_v3_fail(void **state)
-{
-    wdb_t *ret = NULL;
-    test_struct_t *data  = (test_struct_t *)*state;
-
-    expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
-    will_return(__wrap_wdb_metadata_table_check, 2);
-
-    expect_string(__wrap_wdb_metadata_get_entry, key, "db_version");
-    will_return(__wrap_wdb_metadata_get_entry, "2");
-    will_return(__wrap_wdb_metadata_get_entry, 1);
-    expect_string(__wrap__mdebug2, formatted_msg, "Updating database 'global' to version 3");
-    expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v3_sql);
-    will_return(__wrap_wdb_sql_exec, -1);
-    expect_string(__wrap__mwarn, formatted_msg, "Failed to update global.db to version 3");
-
-    //Global backup success
-    will_return(__wrap_wdb_close, 0);
-    expect_any_always(__wrap_fopen, path);
-    expect_any_always(__wrap_fopen, mode);
-    will_return(__wrap_fopen, 1);
-    will_return(__wrap_fopen, 1);
-    will_return(__wrap_fread, "");
-    will_return(__wrap_fread, 0);
-    expect_any_always(__wrap_fclose, _File);
-    will_return(__wrap_fclose, 0);
-    will_return(__wrap_fclose, 0);
-    expect_any_always(__wrap_chmod, path);
-    will_return(__wrap_chmod, 0);
-    expect_string(__wrap__mwarn, formatted_msg, "Creating Global DB backup and creating empty DB");
-    expect_string(__wrap_unlink, file, "queue/db/global.db");
-    will_return(__wrap_unlink, 0);
-    expect_string(__wrap_wdb_create_global, path, "queue/db/global.db");
-    will_return(__wrap_wdb_create_global, OS_SUCCESS);
-    expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/global.db");
-    expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE);
-    will_return(__wrap_sqlite3_open_v2, 1);
-    will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
-    expect_string(__wrap_wdb_init, id, "global");
-    will_return(__wrap_wdb_init, (wdb_t*)1);
-    expect_value(__wrap_wdb_pool_append, wdb, (wdb_t*)1);
-
-    ret = wdb_upgrade_global(data->wdb);
-
-    assert_int_equal(ret, 1);
-}
-
-void test_wdb_upgrade_global_fail_backup_fail(void **state)
-{
-    wdb_t *ret = NULL;
-    test_struct_t *data  = (test_struct_t *)*state;
-
-    expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
-    will_return(__wrap_wdb_metadata_table_check, 1);
-
-    expect_string(__wrap_wdb_metadata_get_entry, key, "db_version");
-    will_return(__wrap_wdb_metadata_get_entry, "1");
-    will_return(__wrap_wdb_metadata_get_entry, -1);
-    expect_string(__wrap__mwarn, formatted_msg, "DB(global): Error trying to get DB version");
-    will_return(__wrap_wdb_close, -1);
-    expect_string(__wrap__merror, formatted_msg, "Couldn't create SQLite Global backup database.");
-
-    ret = wdb_upgrade_global(data->wdb);
-
-    assert_int_equal(ret, NULL);
+    assert_ptr_equal(data->wdb, ret);
+    assert_true(ret->enabled);
 }
 
 /* Tests wdb_upgrade_check_manager_keepalive */
@@ -505,17 +553,21 @@ int main()
 
     const struct CMUnitTest tests[] =
     {
-        cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_table_fail, setup_wdb, teardown_wdb),
-        cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_update_success, setup_wdb, teardown_wdb),
-        cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_update_delete_old_version, setup_wdb, teardown_wdb),
-        cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_update_fail, setup_wdb, teardown_wdb),
-        cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_get_version_fail, setup_wdb, teardown_wdb),
-        cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_all_versions_upgrade, setup_wdb, teardown_wdb),
-        cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_update_v1_to_v3_fail, setup_wdb, teardown_wdb),
-        cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_update_v1_to_v3_success, setup_wdb, teardown_wdb),
-        cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_update_v2_to_v3_fail, setup_wdb, teardown_wdb),
-        cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_update_v2_to_v3_success, setup_wdb, teardown_wdb),
-        cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_fail_backup_fail, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_recreate_global_error_closing_wdb_struct, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_recreate_global_error_creating_global_db, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_recreate_global_error_opening_global_db, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_recreate_global_success, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_error_checking_metadata_table, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_error_backingup_legacy_db, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_success_regenerating_legacy_db, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_error_getting_database_version, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_error_creating_pre_upgrade_backup, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_error_restoring_database_and_getting_backup_name, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_error_restoring_database, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_database_restored, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_intermediate_upgrade_error, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_full_upgrade_success, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_full_upgrade_success_from_unversioned_db, setup_wdb, teardown_wdb),
         cmocka_unit_test_setup_teardown(test_wdb_upgrade_check_manager_keepalive_prepare_error, setup_wdb, teardown_wdb),
         cmocka_unit_test_setup_teardown(test_wdb_upgrade_check_manager_keepalive_step_error, setup_wdb, teardown_wdb),
         cmocka_unit_test_setup_teardown(test_wdb_upgrade_check_manager_keepalive_step_nodata, setup_wdb, teardown_wdb),

--- a/src/unit_tests/wazuh_db/test_wdb_upgrade.c
+++ b/src/unit_tests/wazuh_db/test_wdb_upgrade.c
@@ -478,7 +478,7 @@ void test_wdb_upgrade_global_full_upgrade_success(void **state)
     expect_string(__wrap__mdebug2, formatted_msg, "Updating database 'global' to version 4");
     expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v4_sql);
     will_return(__wrap_wdb_sql_exec, OS_SUCCESS);
-    will_return(__wrap_wdb_global_update_all_agents_groups_hash, OS_SUCCESS);
+    will_return(__wrap_wdb_global_adjust_v4, OS_SUCCESS);
 
     ret = wdb_upgrade_global(data->wdb);
 
@@ -522,7 +522,7 @@ void test_wdb_upgrade_global_full_upgrade_success_from_unversioned_db(void **sta
     expect_string(__wrap__mdebug2, formatted_msg, "Updating database 'global' to version 4");
     expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v4_sql);
     will_return(__wrap_wdb_sql_exec, OS_SUCCESS);
-    will_return(__wrap_wdb_global_update_all_agents_groups_hash, OS_SUCCESS);
+    will_return(__wrap_wdb_global_adjust_v4, OS_SUCCESS);
 
     ret = wdb_upgrade_global(data->wdb);
 

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -268,7 +268,7 @@ int __wrap_wdb_global_agent_exists(wdb_t *wdb, int agent_id) {
     return mock();
 }
 
-int __wrap_wdb_global_update_all_agents_groups_hash(__attribute__((unused)) wdb_t* wdb) {
+int __wrap_wdb_global_adjust_v4(__attribute__((unused)) wdb_t* wdb) {
     return mock();
 }
 

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -268,8 +268,20 @@ int __wrap_wdb_global_agent_exists(wdb_t *wdb, int agent_id) {
     return mock();
 }
 
+int __wrap_wdb_global_update_all_agents_groups_hash(__attribute__((unused)) wdb_t* wdb) {
+    return mock();
+}
+
 cJSON* __wrap_wdb_global_get_backups() {
     return mock_ptr_type(cJSON*);
+}
+
+time_t __wrap_wdb_global_get_most_recent_backup(char **most_recent_backup_name) {
+    char *name = NULL;
+    if (name = mock_ptr_type(char*), name) {
+        os_strdup(name, *most_recent_backup_name);
+    }
+    return mock();
 }
 
 int __wrap_wdb_global_create_backup(__attribute__((unused)) wdb_t* wdb,

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -89,7 +89,11 @@ cJSON* __wrap_wdb_global_get_agents_to_disconnect(wdb_t *wdb, int last_agent_id,
 
 int __wrap_wdb_global_agent_exists(wdb_t *wdb, int agent_id);
 
+int __wrap_wdb_global_update_all_agents_groups_hash(wdb_t* wdb);
+
 cJSON* __wrap_wdb_global_get_backups();
+
+time_t __wrap_wdb_global_get_most_recent_backup(char **most_recent_backup_name);
 
 int __wrap_wdb_global_create_backup(wdb_t* wdb, char* output, const char* tag);
 

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -89,7 +89,7 @@ cJSON* __wrap_wdb_global_get_agents_to_disconnect(wdb_t *wdb, int last_agent_id,
 
 int __wrap_wdb_global_agent_exists(wdb_t *wdb, int agent_id);
 
-int __wrap_wdb_global_update_all_agents_groups_hash(wdb_t* wdb);
+int __wrap_wdb_global_adjust_v4(wdb_t* wdb);
 
 cJSON* __wrap_wdb_global_get_backups();
 

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_metadata_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_metadata_wrappers.c
@@ -19,11 +19,10 @@ int __wrap_wdb_metadata_table_check(__attribute__((unused)) wdb_t * wdb,
     return mock();
 }
 
-int __wrap_wdb_metadata_get_entry (__attribute__((unused)) wdb_t * wdb,
-                                   const char *key,
-                                   char *output) {
+int __wrap_wdb_metadata_get_entry(__attribute__((unused)) wdb_t * wdb,
+                                  const char *key,
+                                  char *output) {
     check_expected(key);
     snprintf(output, OS_SIZE_256 + 1, "%s", mock_ptr_type(char*));
     return mock();
 }
-

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -1244,15 +1244,15 @@ int wdb_close(wdb_t * wdb, bool commit) {
         if (result == SQLITE_OK) {
             wdb_pool_remove(wdb);
             wdb_destroy(wdb);
-            return 0;
+            return OS_SUCCESS;
         } else {
             merror("DB(%s) wdb_close(): %s", wdb->id, sqlite3_errmsg(wdb->db));
-            return -1;
+            return OS_INVALID;
         }
     } else {
         w_mutex_unlock(&wdb->mutex);
         mdebug1("Couldn't close database for agent %s: refcount = %u", wdb->id, wdb->refcount);
-        return -1;
+        return OS_INVALID;
     }
 }
 

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -1799,7 +1799,7 @@ int wdb_global_update_agent_groups_hash(wdb_t* wdb, int agent_id, char* groups_s
  * @param [in] wdb The Global struct database.
  * @return Returns 0 on success or -1 on error.
  */
-int wdb_global_update_all_agents_groups_hash(wdb_t* wdb);
+int wdb_global_adjust_v4(wdb_t* wdb);
 
 /**
  * @brief Function to get a group id using the group name.

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -621,7 +621,7 @@ int wdb_global_update_agent_groups_hash(wdb_t* wdb, int agent_id, char* groups_s
     return result;
 }
 
-int wdb_global_update_all_agents_groups_hash(wdb_t* wdb) {
+int wdb_global_adjust_v4(wdb_t* wdb) {
     int step_result = -1;
     int update_result = OS_SUCCESS;
     int result = OS_INVALID;

--- a/src/wazuh_db/wdb_metadata.c
+++ b/src/wazuh_db/wdb_metadata.c
@@ -146,7 +146,7 @@ int wdb_metadata_update_entry (wdb_t * wdb, const char *key, const char *value) 
     }
 }
 
-int wdb_metadata_get_entry (wdb_t * wdb, const char *key, char *output) {
+int wdb_metadata_get_entry(wdb_t * wdb, const char *key, char *output) {
     sqlite3_stmt *stmt = NULL;
 
     if (sqlite3_prepare_v2(wdb->db,

--- a/src/wazuh_db/wdb_upgrade.c
+++ b/src/wazuh_db/wdb_upgrade.c
@@ -296,9 +296,7 @@ int wdb_adjust_upgrade(wdb_t *wdb, int upgrade_step) {
 int wdb_adjust_global_upgrade(wdb_t *wdb, int upgrade_step) {
     switch (upgrade_step) {
         case 3:
-            // Migrating to the fourth version of the database: The groups_hash
-            // column is calculated with the hash of the group column
-            return wdb_global_update_all_agents_groups_hash(wdb);
+            return wdb_global_adjust_v4(wdb);
         default:
             return 0;
     }


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/11754 |

## Description

This pull request adds unit testing coverage for the next functions related to the upgrade of the global database.

- wdb_recreate_global()
- wdb_upgrade_global()
- wdb_adjust_global_upgrade()

The function `wdb_global_adjust_v4()` was deprecated as it just called the function `wdb_global_update_all_agents_groups_hash`. So all the calls to `wdb_global_adjust_v4()` were replaced by calls to `wdb_global_update_all_agents_groups_hash`.

**Note:** As the functions are a bit long to take screenshots of the coverage, I attached the coverage report file.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade


- Memory tests for Linux
  - [x] Scan-build report
![image](https://user-images.githubusercontent.com/5703274/151269581-b0e16650-6a73-4bd7-8868-57a693f8af86.png)
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer (included in the tests execution)

- [x] Added unit tests (for new features)
[coverage-report.zip](https://github.com/wazuh/wazuh/files/7946558/coverage-report.zip)
