### PR TITLE
Add wdb_remove_group_db, wdb_global_delete_tuple_belong, wdb_global_unassign_agent_group and wdb_global_assign_agent_group UT

### DIFF
--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -1847,7 +1847,7 @@ int wdb_global_insert_agent_belong(wdb_t *wdb, int id_group, int id_agent, int p
  * @param [in] id_agent The agent id.
  * @return Returns 0 on success or -1 on error.
  */
-int wdb_global_remove_tuple_belong(wdb_t *wdb, int id_group, int id_agent);
+int wdb_global_delete_tuple_belong(wdb_t *wdb, int id_group, int id_agent);
 
 /**
  * @brief Function to check if a group is empty.


### PR DESCRIPTION
|Related issue|
|---|
|#11754|

## Description
This PR adds the corresponding UT for the below methods:
- wdb_remove_group_db
- wdb_global_delete_tuple_belong
- wdb_global_unassign_agent_group
- wdb_global_assign_agent_group

## Tests
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Valgrind (memcheck and descriptor leaks check)