### PR TITLE
Remove every mention to agent-groups in the integrity task

### DIFF
--- a/framework/wazuh/core/cluster/cluster.json
+++ b/framework/wazuh/core/cluster/cluster.json
@@ -66,17 +66,6 @@
             "description": "user CDB lists"
         },
 
-        "queue/agent-groups/": {
-            "permissions": "0o660",
-            "source": "master",
-            "files": ["all"],
-            "recursive": true,
-            "restart": false,
-            "remove_subdirs_if_empty": false,
-            "extra_valid": true,
-            "description": "agents group configuration"
-        },
-
         "excluded_files": [
             "ar.conf",
             "ossec.conf"

--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -172,10 +172,11 @@ def walk_dir(dirname, recursive, files, excluded_files, excluded_extensions, get
                             except KeyError:
                                 pass
                             # Create dict with metadata for the current file.
+                            # The TYPE string is a placeholder to define the type of merge performed.
                             file_metadata = {"mod_time": file_mod_time, 'cluster_item_key': get_cluster_item_key}
                             if '.merged' in file_:
                                 file_metadata['merged'] = True
-                                file_metadata['merge_type'] = 'agent-groups'
+                                file_metadata['merge_type'] = 'TYPE'
                                 file_metadata['merge_name'] = abs_file_path
                             else:
                                 file_metadata['merged'] = False
@@ -439,9 +440,10 @@ def compare_files(good_files, check_files, node_name):
     shared_e_v = list(shared_e_v)
     if shared_e_v:
         # Merge all shared extra valid files into a single one. Create a tuple (merged_filepath, {metadata_dict}).
-        shared_merged = [(merge_info(merge_type='agent-groups', files=shared_e_v, file_type='-shared',
+        # The TYPE and ITEM_KEY strings are placeholders for the merge type and the cluster item key.
+        shared_merged = [(merge_info(merge_type='TYPE', files=shared_e_v, file_type='-shared',
                                      node_name=node_name)[1],
-                          {'cluster_item_key': 'queue/agent-groups/', 'merged': True, 'merge-type': 'agent-groups'})]
+                          {'cluster_item_key': 'ITEM_KEY', 'merged': True, 'merge-type': 'TYPE'})]
 
         # Dict merging all 'shared' filepaths (keys) and the merged_filepath (key) created above.
         shared_files = dict(itertools.chain(shared_merged, ((key, good_files[key]) for key in shared)))

--- a/framework/wazuh/core/cluster/tests/test_cluster.py
+++ b/framework/wazuh/core/cluster/tests/test_cluster.py
@@ -153,7 +153,7 @@ def test_walk_dir(walk_mock, path_join_mock, md5_mock, getmtime_mock):
     assert cluster.walk_dir(dirname="/foo/bar", recursive=True, files=['all'], excluded_files=['ar.conf', 'spam'],
                             excluded_extensions=[".xml", ".txt"], get_cluster_item_key="",
                             previous_status={path_join_mock.return_value: {'mod_time': 35}}) == {
-               '/mock/foo/bar': {'mod_time': 45, 'cluster_item_key': '', 'merged': True, 'merge_type': 'agent-groups',
+               '/mock/foo/bar': {'mod_time': 45, 'cluster_item_key': '', 'merged': True, 'merge_type': 'TYPE',
                                  'merge_name': '/mock/foo/bar', 'md5': 'hash'}}
 
     walk_mock.assert_called_once_with(path_join_mock.return_value, topdown=True)
@@ -170,7 +170,7 @@ def test_walk_dir(walk_mock, path_join_mock, md5_mock, getmtime_mock):
     assert cluster.walk_dir(dirname="/foo/bar", recursive=True, files=['all'], excluded_files=['ar.conf', 'spam'],
                             excluded_extensions=[".xml", ".txt"], get_cluster_item_key="",
                             previous_status={path_join_mock.return_value: {'mod_mock_time': 35}}) == {
-               '/mock/foo/bar': {'mod_time': 45, 'cluster_item_key': '', 'merged': True, 'merge_type': 'agent-groups',
+               '/mock/foo/bar': {'mod_time': 45, 'cluster_item_key': '', 'merged': True, 'merge_type': 'TYPE',
                                  'merge_name': '/mock/foo/bar', 'md5': 'hash'}}
 
     walk_mock.assert_called_once_with(path_join_mock.return_value, topdown=True)

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -782,7 +782,9 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
             if data['merged']:  # worker nodes can only receive agent-groups files
                 # Split merged file into individual files inside zipdir (directory containing unzipped files),
                 # and then move each one to the destination directory (<wazuh_path>/filename).
-                for name, content, _ in cluster.unmerge_info('agent-groups', zip_path, filename):
+                # The TYPE string used in the 'unmerge_info' function is a placeholder. It corresponds to the
+                # directory inside '{wazuh_path}/queue/' path.
+                for name, content, _ in cluster.unmerge_info('TYPE', zip_path, filename):
                     full_unmerged_name = os.path.join(common.wazuh_path, name)
                     tmp_unmerged_path = full_unmerged_name + '.tmp'
                     with open(tmp_unmerged_path, 'wb') as f:


### PR DESCRIPTION
|Related issue|
|---|
|#11786|

## Description
This closes #11786. Every mention regarding the agent-groups was removed from the Integrity task, and the tests were updated accordingly.

