### PR TITLE
Improve delay used after restart requests in the API integration tests

### DIFF
--- a/api/test/integration/common.yaml
+++ b/api/test/integration/common.yaml
@@ -18,7 +18,6 @@ variables:
 
   # delays
   reconnect_delay: 30
-  restart_delay: 45
   restart_delay_cluster: 150
   upgrade_delay: 60
   global_db_delay: 30

--- a/api/test/integration/env/tools/print_active_agents.py
+++ b/api/test/integration/env/tools/print_active_agents.py
@@ -1,3 +1,4 @@
 from wazuh import agent
 
-print(agent.get_agents(select=['status'], filters={'status': 'active'})._affected_items)
+if __name__ == '__main__':
+    print(agent.get_agents(select=['status'], filters={'status': 'active'}).affected_items)

--- a/api/test/integration/env/tools/print_active_agents.py
+++ b/api/test/integration/env/tools/print_active_agents.py
@@ -1,0 +1,3 @@
+from wazuh import agent
+
+print(agent.get_agents(select=['status'], filters={'status': 'active'})._affected_items)

--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -337,7 +337,7 @@ def test_validate_key_not_in_response(response, key):
 
 
 def check_agentd_started(response, agents_list):
-    """Wait until all the agents had their agentd process started correctly. This will avoid race conditions caused by
+    """Wait until all the agents have their agentd process started correctly. This will avoid race conditions caused by
     agents reconnections before restarting.
 
     Parameters

--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -263,12 +263,14 @@ def test_validate_restart_by_node(response, data):
             affected_items.append(item['id'])
     assert response.json()['data']['affected_items'] == affected_items
     assert not response.json()['data']['failed_items']
+    healthcheck_agent_restart(response, affected_items)
 
 
 def test_validate_restart_by_node_rbac(response, permitted_agents):
     data = response.json().get('data', None)
     if data:
         if data['affected_items']:
+            healthcheck_agent_restart(response, data['affected_items'])
             for agent in data['affected_items']:
                 assert agent in permitted_agents
         else:

--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -391,13 +391,12 @@ def check_agentd_started(response, agents_list):
             assert False, "The wazuh-agentd daemon was not started after requesting the restart"
 
 
-def check_agent_active_status(response, agents_list):
+def check_agent_active_status(agents_list):
     """Wait until all the agents have active status in the global.db. This will avoid race conditions caused by
     non-active agents in following test cases.
 
     Parameters
     ----------
-    response : Request response
     agents_list : list
         List of expected agents to be restarted.
     """
@@ -441,4 +440,4 @@ def healthcheck_agent_restart(response, agents_list):
     # Wait for cluster synchronization process (20 seconds)
     time.sleep(20)
     # Wait for active agent status (up to 25 seconds)
-    check_agent_active_status(response, agents_list)
+    check_agent_active_status(agents_list)

--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -411,7 +411,7 @@ def check_agent_active_status(agents_list):
             command.append(python_code)
             output = subprocess.check_output(command).decode().strip()
         except subprocess.CalledProcessError:
-            assert False, f"Error while trying to get agents"
+            assert False, "Error while trying to get agents"
 
         # Transform string representation of list to list and save agents id
         id_active_agents = [agent['id'] for agent in eval(output)]

--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -426,7 +426,7 @@ def check_agent_active_status(agents_list):
 
 
 def healthcheck_agent_restart(response, agents_list):
-    """Wait until the agent restart process of every agent in an agents list given is finished.
+    """Wait until the restart process is finished for every agent in the given list.
 
     Parameters
     ----------

--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -346,6 +346,8 @@ def check_agentd_started(response, agents_list):
     agents_list : list
         List of expected agents to be restarted.
     """
+    timestamp_regex = re.compile(r'^\d\d\d\d/\d\d/\d\d\s\d\d:\d\d:\d\d')
+    agentd_started_regex = re.compile(r'agentd.*Started')
 
     def get_timestamp(log):
         """Get timestamp from log.
@@ -360,7 +362,7 @@ def check_agentd_started(response, agents_list):
         datetime
             Datetime object representing the timestamp got.
         """
-        timestamp = re.search(r'^\d\d\d\d/\d\d/\d\d\s\d\d:\d\d:\d\d', log).group(0)
+        timestamp = timestamp_regex.search(string=log).group(0)
         return datetime.strptime(timestamp, "%Y/%m/%d %H:%M:%S")
 
     # Save the time when the restart command was sent
@@ -381,8 +383,7 @@ def check_agentd_started(response, agents_list):
                                   get_timestamp(agentd_log).timestamp() >= restart_request_time.timestamp()]
 
             # Check the log indicating agentd started is in the agent's ossec.log (after the restart request)
-            if any(re.search(pattern='agentd.*Started', string=agentd_log) for agentd_log in
-                   logs_after_restart):
+            if any(agentd_started_regex.search(string=agentd_log) for agentd_log in logs_after_restart):
                 break
 
             tries += 1

--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -347,7 +347,7 @@ def check_agentd_started(response, agents_list):
         List of expected agents to be restarted.
     """
     timestamp_regex = re.compile(r'^\d\d\d\d/\d\d/\d\d\s\d\d:\d\d:\d\d')
-    agentd_started_regex = re.compile(r'agentd.*Started')
+    agentd_started_regex = re.compile(r'agentd.+Started')
 
     def get_timestamp(log):
         """Get timestamp from log.
@@ -401,13 +401,14 @@ def check_agent_active_status(agents_list):
     agents_list : list
         List of expected agents to be restarted.
     """
+    active_agents_script_path = "/tools/print_active_agents.py"
     id_active_agents = []
     tries = 0
     while tries < 25:
         try:
             # Get active agents
-            output = subprocess.check_output("docker exec env_wazuh-master_1 /var/ossec/framework/python/bin/python3 "
-                                             "/tools/print_active_agents.py".split()).decode().strip()
+            output = subprocess.check_output(f"docker exec env_wazuh-master_1 /var/ossec/framework/python/bin/python3 "
+                                             f"{active_agents_script_path}".split()).decode().strip()
         except subprocess.SubprocessError as exc:
             raise subprocess.SubprocessError("Error while trying to get agents") from exc
 

--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -406,11 +406,8 @@ def check_agent_active_status(agents_list):
     while tries < 25:
         try:
             # Get active agents
-            python_code = "from wazuh import agent; print(agent.get_agents(select=['status'], " \
-                          "filters={'status': 'active'})._affected_items)"
-            command = "docker exec env_wazuh-master_1 /var/ossec/framework/python/bin/python3 -c ".split()
-            command.append(python_code)
-            output = subprocess.check_output(command).decode().strip()
+            output = subprocess.check_output("docker exec env_wazuh-master_1 /var/ossec/framework/python/bin/python3 "
+                                             "/tools/print_active_agents.py".split()).decode().strip()
         except subprocess.CalledProcessError:
             assert False, "Error while trying to get agents"
 

--- a/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
@@ -143,6 +143,10 @@ stages:
         agents_list: "003,004,005"
         group_id: group1
     response:
+      verify_response_with:
+        function: tavern_utils:healthcheck_agent_restart
+        extra_kwargs:
+          agents_list: ["003", "004"]
       status_code: 200
       json:
         error: 2
@@ -157,7 +161,6 @@ stages:
                 - "005"
           total_affected_items: 2
           total_failed_items: 1
-    delay_after: !float "{restart_delay}"
 
     # PUT /agents/group?group_id=group2
   - name: Assign all agents to group2
@@ -170,6 +173,10 @@ stages:
       params:
         group_id: group2
     response:
+      verify_response_with:
+        function: tavern_utils:healthcheck_agent_restart
+        extra_kwargs:
+          agents_list: ["001", "003", "004", "007"]  # 009 is not restarted as it is disconnected
       status_code: 200
       json:
         error: 0
@@ -181,7 +188,6 @@ stages:
             - "007"
             - "009"
           total_affected_items: 5
-    delay_after: !float "{restart_delay}"
 
     # PUT /agents/group?group_id=group2&force_single_group=true
   - name: Assign all agents to group2 with force_single_group
@@ -195,6 +201,11 @@ stages:
         force_single_group: True
         group_id: group2
     response:
+      verify_response_with:
+        function: tavern_utils:healthcheck_agent_restart
+        extra_kwargs:
+          agents_list: ["001", "002", "003", "004", "005", "006", "007", "008"]  # 009 and 010 are not restarted as
+                                                                                 # they are disconnected
       status_code: 200
       json:
         error: 0
@@ -211,7 +222,6 @@ stages:
             - "009"
             - "010"
           total_affected_items: 10
-    delay_after: !float "{restart_delay}"
 
 ---
 test_name: PUT /groups/{group_id}/configuration
@@ -230,8 +240,12 @@ stages:
       data:
         "{file_xml:s}"
     response:
+      verify_response_with:
+        function: tavern_utils:healthcheck_agent_restart
+        extra_kwargs:
+          agents_list: ["001", "002", "003", "004", "005", "006", "007", "008"]  # 009 and 010 are not restarted as
+                                                                                 # they are disconnected
       status_code: 200
-    delay_after: !float "{restart_delay}"
 
     # PUT /groups/wrong_group/configuration
   - name: Try to update configuration of a non existing group
@@ -293,7 +307,7 @@ stages:
       json:
         error: 1114
 
-  - name: Try to update configuration using a complex configuration file
+  - name: Try to update configuration using a complex configuration file (no agents in group1)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/groups/group1/configuration"
@@ -305,7 +319,6 @@ stages:
         '{query_list_xml:s}'
     response:
       status_code: 200
-    delay_after: !float "{restart_delay}"
 
   - name: Ensure the config now has the expected value
     request:
@@ -379,7 +392,6 @@ stages:
             - "007"
             - "008"
           total_affected_items: 8
-    delay_after: !float "{restart_delay}"
 
   # PUT /groups/not_exists/restart (Group does not exist)
   - name: Restart all agents from a group which does not exist
@@ -601,7 +613,6 @@ stages:
                 - "999"
           total_affected_items: 2
           total_failed_items: 1
-    delay_after: !float "{restart_delay}"
 
     # PUT /agents/restart
   - name: Try to restart all agents
@@ -632,7 +643,6 @@ stages:
           failed_items: !anything
           total_affected_items: 8
           total_failed_items: 0
-    delay_after: !float "{restart_delay}"
 
 ---
 test_name: PUT /agents/{agent_id}/group/{group_id}
@@ -792,7 +802,6 @@ stages:
           affected_items:
             - "003"
           total_affected_items: 1
-    delay_after: !float "{restart_delay}"
 
 ---
 test_name: PUT /agents/node/{node_id}/restart
@@ -831,7 +840,6 @@ stages:
         - function: tavern_utils:test_validate_restart_by_node
           extra_kwargs:
             data: "{response_data}"
-    delay_after: !float "{restart_delay}"
 
   - name: Restart all agents belonging to a node (it does not exist)
     request:

--- a/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
@@ -361,6 +361,10 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
+      verify_response_with:
+        function: tavern_utils:healthcheck_agent_restart
+        extra_kwargs:
+          agents_list: ["001", "002", "003", "004", "005", "006", "007", "008"]
       status_code: 200
       json:
         error: 0
@@ -390,9 +394,6 @@ stages:
 
 ---
 test_name: PUT /agents/reconnect
-
-marks:
-  - xfail # Review and fix RBAC black agent API integration test - https://github.com/wazuh/wazuh/issues/10914
 
 stages:
 
@@ -582,6 +583,10 @@ stages:
       params:
         agents_list: "001,002,999"
     response:
+      verify_response_with:
+        function: tavern_utils:healthcheck_agent_restart
+        extra_kwargs:
+          agents_list: ["001", "002"]
       status_code: 200
       json:
         error: 2
@@ -607,6 +612,10 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
+      verify_response_with:
+        function: tavern_utils:healthcheck_agent_restart
+        extra_kwargs:
+          agents_list: ["001", "002", "003", "004", "005", "006", "007", "008"]
       status_code: 200
       json:
         error: 0
@@ -772,6 +781,10 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
+      verify_response_with:
+        function: tavern_utils:healthcheck_agent_restart
+        extra_kwargs:
+          agents_list: ["003"]
       status_code: 200
       json:
         error: 0

--- a/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
@@ -658,6 +658,10 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
+      verify_response_with:
+        function: tavern_utils:healthcheck_agent_restart
+        extra_kwargs:
+          agents_list: ["001"]
       status_code: 200
       json:
         error: 0
@@ -712,6 +716,10 @@ stages:
       params:
         force_single_group: true
     response:
+      verify_response_with:
+        function: tavern_utils:healthcheck_agent_restart
+        extra_kwargs:
+          agents_list: ["002"]
       status_code: 200
       json:
         error: 0

--- a/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
@@ -693,10 +693,13 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
+      verify_response_with:
+        function: tavern_utils:healthcheck_agent_restart
+        extra_kwargs:
+          agents_list: ["005"]
       status_code: 200
       json:
-        message: "Agent '005' removed from 'group1'."
-    delay_after: !float "{global_db_delay}"
+        message: !anystr
 
 ---
 test_name: DELETE /agents/{agent_id}/group
@@ -1244,6 +1247,10 @@ stages:
         agents_list: '001,002,005'
         group_id: group1
     response:
+      verify_response_with:
+        function: tavern_utils:healthcheck_agent_restart
+        extra_kwargs:
+          agents_list: ["005"]
       status_code: 200
       json:
         error: 2
@@ -1295,6 +1302,10 @@ stages:
       data:
         "{file_xml:s}"
     response:
+      verify_response_with:
+        function: tavern_utils:healthcheck_agent_restart
+        extra_kwargs:
+          agents_list: ["005"]
       status_code: 200
 
   - name: Try to update group3 configuration (Denied)
@@ -1647,7 +1658,6 @@ stages:
         - function: tavern_utils:test_validate_restart_by_node_rbac
           extra_kwargs:
             permitted_agents: ['003','005','007'] # Agents '003', '005' and '007' can be restarted
-    delay_after: !float "{global_db_delay}"
 
   - name: Restart all agents belonging to worker1 (Allow node_id - Could deny agent_id)
     request:
@@ -1664,7 +1674,6 @@ stages:
         - function: tavern_utils:test_validate_restart_by_node_rbac
           extra_kwargs:
             permitted_agents: ['003','005','007'] # Agents '003', '005' and '007' can be restarted
-    delay_after: !float "{global_db_delay}"
 
   - name: Restart all agents belonging to worker2 (Allow node_id - Could deny agent_id)
     request:

--- a/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
@@ -1278,7 +1278,6 @@ stages:
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
-    delay_after: !float "{restart_delay}"
 
 ---
 test_name: PUT /groups/{group_id}/configuration
@@ -1351,7 +1350,6 @@ stages:
           total_affected_items: 1
           failed_items: []
           total_failed_items: 0
-    delay_after: !float "{restart_delay}"
 
 ---
 test_name: PUT /agents/reconnect
@@ -1464,7 +1462,6 @@ stages:
                 - '002'
           total_affected_items: 1
           total_failed_items: 3
-    delay_after: !float "{restart_delay}"
 
   - name: Try to restart all agents (Partially allowed, user agnostic)
     request:
@@ -1489,7 +1486,6 @@ stages:
           failed_items: []
           total_affected_items: 3
           total_failed_items: 0
-    delay_after: !float "{restart_delay}"
 
 ---
 test_name: PUT /agents/{agent_id}/group/{group_id}
@@ -1573,7 +1569,6 @@ stages:
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
-    delay_after: !float "{restart_delay}"
 
 ---
 test_name: PUT /agents/upgrade

--- a/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
@@ -1338,6 +1338,10 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
+      verify_response_with:
+        function: tavern_utils:healthcheck_agent_restart
+        extra_kwargs:
+          agents_list: ["005"]
       status_code: 200
       json:
         error: 0
@@ -1351,9 +1355,6 @@ stages:
 
 ---
 test_name: PUT /agents/reconnect
-
-marks:
-  - xfail # Review and fix RBAC black agent API integration test - https://github.com/wazuh/wazuh/issues/10914
 
 stages:
 
@@ -1444,6 +1445,10 @@ stages:
       params:
         agents_list: "000,001,002,005"
     response:
+      verify_response_with:
+        function: tavern_utils:healthcheck_agent_restart
+        extra_kwargs:
+          agents_list: ["005"]
       status_code: 200
       json:
         error: 2
@@ -1469,6 +1474,10 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
+      verify_response_with:
+        function: tavern_utils:healthcheck_agent_restart
+        extra_kwargs:
+          agents_list: ["003", "005", "007"]
       status_code: 200
       json:
         error: 0
@@ -1551,6 +1560,10 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
+      verify_response_with:
+        function: tavern_utils:healthcheck_agent_restart
+        extra_kwargs:
+          agents_list: ["005"]
       status_code: 200
       json:
         error: 0

--- a/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
@@ -781,6 +781,10 @@ stages:
       params:
         groups_list: 'group1,group3,group2'
     response:
+      verify_response_with:
+        function: tavern_utils:healthcheck_agent_restart
+        extra_kwargs:
+          agents_list: ["007"]
       status_code: 200
       json:
         error: 2
@@ -798,7 +802,6 @@ stages:
                 - 'group1'
           total_affected_items: 1
           total_failed_items: 2
-    delay_after: !float "{global_db_delay}"
 
 ---
 test_name: DELETE /agents/group?group_id={group_id}
@@ -899,6 +902,10 @@ stages:
         agents_list: '001,008'
         group_id: 'default'
     response:
+      verify_response_with:
+        function: tavern_utils:healthcheck_agent_restart
+        extra_kwargs:
+          agents_list: ["001", "008"]
       status_code: 200
       json:
         error: 0
@@ -909,7 +916,6 @@ stages:
           failed_items: []
           total_affected_items: 2
           total_failed_items: 0
-    delay_after: !float "{global_db_delay}"
 
 ---
 test_name: DELETE /groups?groups_list={group_id}
@@ -1296,6 +1302,10 @@ stages:
         agents_list: '001,002,005'
         group_id: 'group2'
     response:
+      verify_response_with:
+        function: tavern_utils:healthcheck_agent_restart
+        extra_kwargs:
+          agents_list: ["002"]
       status_code: 200
       json:
         error: 2
@@ -1310,7 +1320,6 @@ stages:
                 - '005'
           total_affected_items: 1
           total_failed_items: 2
-    delay_after: !float "{global_db_delay}"
 
   - name: Try to assign all agents to group2 (Partially allowed, user agnostic)
     request:
@@ -1322,6 +1331,10 @@ stages:
       params:
         group_id: 'group2'
     response:
+      verify_response_with:
+        function: tavern_utils:healthcheck_agent_restart
+        extra_kwargs:
+          agents_list: ["006", "008"]
       status_code: 200
       json:
         error: 0
@@ -1332,7 +1345,6 @@ stages:
           failed_items: []
           total_affected_items: 2
           total_failed_items: 0
-    delay_after: !float "{global_db_delay}"
 
 ---
 test_name: PUT /groups/{group_id}/configuration
@@ -1350,6 +1362,10 @@ stages:
       data:
         "{file_xml:s}"
     response:
+      verify_response_with:
+        function: tavern_utils:healthcheck_agent_restart
+        extra_kwargs:
+          agents_list: ["002", "006", "008"]
       status_code: 200
 
   - name: Try to update group1 configuration (Denied)
@@ -1656,6 +1672,10 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
+      verify_response_with:
+        function: tavern_utils:healthcheck_agent_restart
+        extra_kwargs:
+          agents_list: ["008"]
       status_code: 200
       json:
         error: 0

--- a/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
@@ -1399,7 +1399,6 @@ stages:
                 - "010"
           total_failed_items: 3
         message: !anystr
-    delay_after: !float "{restart_delay}"
 
 ---
 test_name: PUT /agents/reconnect
@@ -1570,7 +1569,6 @@ stages:
                 - '002'
           total_affected_items: 1
           total_failed_items: 3
-    delay_after: !float "{restart_delay}"
 
   - name: Try to restart all agents (Partially allowed, user agnostic)
     request:
@@ -1593,7 +1591,6 @@ stages:
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
-    delay_after: !float "{restart_delay}"
 
 ---
 test_name: PUT /agents/{agent_id}/group/{group_id}
@@ -1726,7 +1723,6 @@ stages:
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
-    delay_after: !float "{restart_delay}"
 
 ---
 test_name: PUT /agents/upgrade

--- a/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
@@ -1379,6 +1379,10 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
+      verify_response_with:
+        function: tavern_utils:healthcheck_agent_restart
+        extra_kwargs:
+          agents_list: ["004"]
       status_code: 200
       json:
         error: 2
@@ -1399,9 +1403,6 @@ stages:
 
 ---
 test_name: PUT /agents/reconnect
-
-marks:
-  - xfail # Review and fix RBAC black agent API integration test - https://github.com/wazuh/wazuh/issues/10914
 
 stages:
 
@@ -1544,6 +1545,10 @@ stages:
         agents_list: "000,001,002,004"
         wait_for_complete: true  # Prevent error code 500
     response:
+      verify_response_with:
+        function: tavern_utils:healthcheck_agent_restart
+        extra_kwargs:
+          agents_list: ["004"]
       status_code: 200
       json:
         error: 2
@@ -1575,6 +1580,10 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
+      verify_response_with:
+        function: tavern_utils:healthcheck_agent_restart
+        extra_kwargs:
+          agents_list: ["004"]
       status_code: 200
       json:
         error: 0
@@ -1704,6 +1713,10 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
+      verify_response_with:
+        function: tavern_utils:healthcheck_agent_restart
+        extra_kwargs:
+          agents_list: ["004"]
       status_code: 200
       json:
         error: 0


### PR DESCRIPTION
|Related issue|
|---|
| #10914 |

This PR closes #10914.

In this pull request, I have implemented the dynamic delay mentioned in the related issue's comment for the agents restart requests.

This delay will be used to wait until the restart process has started. This way, we will avoid the race condition caused by possible agents reconnections.

The delay consists of a new function in `tavern_utils` that will be used for all API integration tests involving agents restart processes. The function is `healthcheck_agent_restart`.

In `healthcheck_agent_restart`, we save the time when the restart command was sent (with a `datetime.now` minus the time taken by the server to respond to the request (which is a little, but that can't be depreciated). After that, we take the `agentd` logs logged after that timestamp and we look for the "agentd terminated" log. 

If the specific log is not found in 80 seconds, the test fails.

Apart from this dynamic delay, the static delay we already have is maintained. This second delay is needed as, as we said in the related issue's comments, this first healthcheck covers the race condition caused by agents reconnections so we still need a delay for the restart process and cluster synchronization.

With these 2 delays, the time we expect the agent takes to restart is between 45 and 125 (best and worst case, respectively). These values are different from the ones shown in the table of the related issue (30-100), but it is OK to raise them since they were calculated theoretically and they can vary in real cases.

EDIT: as it was said [here](https://github.com/wazuh/wazuh/pull/11972#issuecomment-1024142433), the static delay has been deleted in favor of another dynamic one.


### Test results


```
test_agent_PUT_endpoints.tavern.yaml [1/2]
	 10 passed, 12 warnings

test_agent_PUT_endpoints.tavern.yaml [2/2]
	 10 passed, 12 warnings

test_rbac_black_agent_endpoints.tavern.yaml [1/2]
	 41 passed, 43 warnings

test_rbac_black_agent_endpoints.tavern.yaml [2/2]
	 41 passed, 43 warnings

test_rbac_white_agent_endpoints.tavern.yaml [1/2]
	 41 passed, 43 warnings

test_rbac_white_agent_endpoints.tavern.yaml [2/2]
	 41 passed, 43 warnings
```








