### PR TITLE
Fix an integer overflow in the message counter at Remoted

### DIFF
--- a/src/remoted/netcounter.c
+++ b/src/remoted/netcounter.c
@@ -13,7 +13,7 @@
 #define SIZE_BLOCK 256
 
 typedef struct rem_fdlist_t {
-    int* list;
+    size_t* list;
     int size;
 } rem_fdlist_t;
 
@@ -23,7 +23,7 @@ static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
 
 
 void rem_initList(size_t initial_size) {
-    os_calloc(initial_size, sizeof(int), connections.list);
+    os_calloc(initial_size, sizeof(size_t), connections.list);
     connections.size = initial_size;
 }
 
@@ -33,8 +33,8 @@ void rem_setCounter(int fd, size_t counter) {
 
     w_mutex_lock(&lock);
     while (fd >= connections.size) {
-        os_realloc(connections.list, sizeof(int) * (connections.size + SIZE_BLOCK), connections.list);
-        memset(&connections.list[connections.size], 0, sizeof(int) * SIZE_BLOCK);
+        os_realloc(connections.list, sizeof(size_t) * (connections.size + SIZE_BLOCK), connections.list);
+        memset(&connections.list[connections.size], 0, sizeof(size_t) * SIZE_BLOCK);
         connections.size = connections.size + SIZE_BLOCK;
     }
     connections.list[fd] = counter;

--- a/src/remoted/netcounter.c
+++ b/src/remoted/netcounter.c
@@ -22,7 +22,7 @@ static rem_fdlist_t connections;
 static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
 
 
-void rem_initList(size_t initial_size) {
+void rem_initList(int initial_size) {
     os_calloc(initial_size, sizeof(size_t), connections.list);
     connections.size = initial_size;
 }

--- a/src/remoted/remoted.h
+++ b/src/remoted/remoted.h
@@ -167,7 +167,7 @@ int nb_recv(netbuffer_t * buffer, int sock);
 
 /* Network counter */
 
-void rem_initList(size_t initial_size);
+void rem_initList(int initial_size);
 void rem_setCounter(int fd, size_t counter);
 size_t rem_getCounter(int fd);
 


### PR DESCRIPTION
|Related issue|
|---|
|#11485|

As detailed on #11485, we found an integer overflow hazard in the Remoted's socket counter table, that helps to invalidate incoming messages if the source agent got disconnected at the moment to dispatch the message.

This is caused by a double value casting: `uint64` → `int32` → `uint64`.

### Bug unfixed

All these are valid messages (they must not be dropped as their counter is greater than their socket's counter:

```
Success: message_counter (1) > connection_counter (0)
Success: message_counter (2) > connection_counter (0)
Success: message_counter (3) > connection_counter (0)
Success: message_counter (4) > connection_counter (0)
Failure: message_counter (3000000002) <= connection_counter (18446744072414584321)
```

The bug made `3000000001` (`uint64`) be cast to `-1294967295` (`int32`) and then cast back to `18446744072414584321` (`uint64`).

### Bug fixed

```
Success: message_counter (3000000004) > connection_counter (3000000002)
```

## Tests

- [x] The bug addressed can't be longer reproduced.

Even setting the global message counter to 3.000.000.000, agents now connect without a problem:

```
2022/01/27 13:06:27 wazuh-agentd: INFO: Trying to connect to server (172.27.169.161:1514/tcp).
2022/01/27 13:06:27 wazuh-agentd: INFO: (4102): Connected to the server (172.27.169.161:1514/tcp).
```

- [x] Agent connection stress test: #11976.