### PR TITLE
UT for set-agent-groups parser

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -47,7 +47,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_open_global -Wl,--wrap,wdb_leave -Wl
                              -Wl,--wrap,wdb_global_get_agents_by_connection_status -Wl,--wrap,wdb_global_get_agents_to_disconnect \
                              -Wl,--wrap,sqlite3_step -Wl,--wrap,wdb_global_get_groups_integrity -Wl,--wrap,wdb_global_get_backups \
                              -Wl,--wrap,wdb_global_restore_backup -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_mutex_unlock \
-                             -Wl,--wrap,wdb_global_select_group_belong ${DEBUG_OP_WRAPPERS}")
+                             -Wl,--wrap,wdb_global_select_group_belong -Wl,--wrap,wdb_global_set_agent_groups ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_global")
 list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_begin2 -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,sqlite3_bind_int \

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -188,8 +188,8 @@ int __wrap_wdb_global_delete_group( __attribute__((unused)) wdb_t *wdb,
 
 wdbc_result __wrap_wdb_global_set_agent_groups(__attribute__((unused)) wdb_t *wdb,
                                                wdb_groups_set_mode_t mode,
-                                               char* sync_status,
-                                               cJSON* j_agents_group_info) {
+                                               char *sync_status,
+                                               cJSON *j_agents_group_info) {
     check_expected(mode);
     check_expected(sync_status);
     char *agents_group_info = cJSON_PrintUnformatted(j_agents_group_info);

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -186,6 +186,18 @@ int __wrap_wdb_global_delete_group( __attribute__((unused)) wdb_t *wdb,
     return mock();
 }
 
+wdbc_result __wrap_wdb_global_set_agent_groups(__attribute__((unused)) wdb_t *wdb,
+                                               wdb_groups_set_mode_t mode,
+                                               char* sync_status,
+                                               cJSON* j_agents_group_info) {
+    check_expected(mode);
+    check_expected(sync_status);
+    char *agents_group_info = cJSON_PrintUnformatted(j_agents_group_info);
+    check_expected(agents_group_info);
+    os_free(agents_group_info);
+    return mock();
+}
+
 cJSON* __wrap_wdb_global_select_groups(__attribute__((unused)) wdb_t *wdb) {
     return mock_ptr_type(cJSON*);
 }

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -67,7 +67,7 @@ int __wrap_wdb_global_insert_agent_belong(wdb_t *wdb, int id_group, int id_agent
 
 int __wrap_wdb_global_delete_group(wdb_t *wdb, char* group_name);
 
-wdbc_result __wrap_wdb_global_set_agent_groups(__attribute__((unused)) wdb_t *wdb, wdb_groups_set_mode_t mode, char* sync_status, cJSON* j_agents_group_info);
+wdbc_result __wrap_wdb_global_set_agent_groups(__attribute__((unused)) wdb_t *wdb, wdb_groups_set_mode_t mode, char *sync_status, cJSON *j_agents_group_info);
 
 cJSON* __wrap_wdb_global_select_groups(wdb_t *wdb);
 

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -67,6 +67,8 @@ int __wrap_wdb_global_insert_agent_belong(wdb_t *wdb, int id_group, int id_agent
 
 int __wrap_wdb_global_delete_group(wdb_t *wdb, char* group_name);
 
+wdbc_result __wrap_wdb_global_set_agent_groups(__attribute__((unused)) wdb_t *wdb, wdb_groups_set_mode_t mode, char* sync_status, cJSON* j_agents_group_info);
+
 cJSON* __wrap_wdb_global_select_groups(wdb_t *wdb);
 
 cJSON* __wrap_wdb_global_select_agent_keepalive(wdb_t *wdb, char* name, char* ip);

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -1939,6 +1939,7 @@ wdbc_result wdb_global_sync_agent_groups_get(wdb_t* wdb,
                                              bool set_synced,
                                              bool get_hash,
                                              cJSON** output);
+
 /**
  * @brief Function to update group_sync_status of a particular agent.
  *

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1247,15 +1247,13 @@ wdbc_result wdb_global_set_agent_groups(wdb_t *wdb, wdb_groups_set_mode_t mode, 
                     ret = WDBC_ERROR;
                     merror("There was an error un-assigning the groups to agent '%03d'", agent_id);
                 }
-            }
-            else {
+            } else {
                 if (mode == WDB_GROUP_OVERRIDE ) {
                     if (OS_INVALID == wdb_global_delete_agent_belong(wdb, agent_id)) {
                         ret = WDBC_ERROR;
                         merror("There was an error cleaning the previous agent groups");
                     }
-                }
-                else {
+                } else {
                     int last_group_priority = wdb_global_get_agent_max_group_priority(wdb, agent_id);
                     if (last_group_priority >= 0) {
                         if (mode == WDB_GROUP_EMPTY_ONLY) {
@@ -1282,13 +1280,11 @@ wdbc_result wdb_global_set_agent_groups(wdb_t *wdb, wdb_groups_set_mode_t mode, 
                 }
                 os_free(agent_groups_csv);
                 wdb_global_group_hash_cache(WDB_GLOBAL_GROUP_HASH_CLEAR, NULL);
-            }
-            else {
+            } else {
                 ret = WDBC_ERROR;
                 mdebug1("The agent groups where empty right after the set");
             }
-        }
-        else {
+        } else {
             ret = WDBC_ERROR;
             mdebug1("Invalid groups set information");
             continue;

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -860,7 +860,7 @@ int wdb_parse(char * input, char * output, int peer) {
             }
         } else if (strcmp(query, "set-agent-groups") == 0) {
             if (!next) {
-                mdebug1("Global DB Invalid DB query syntax for agent.");
+                mdebug1("Global DB Invalid DB query syntax for set-agent-groups.");
                 mdebug2("Global DB query error near: %s", query);
                 snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
                 result = OS_INVALID;
@@ -5220,7 +5220,7 @@ int wdb_parse_global_select_groups(wdb_t * wdb, char * output) {
 }
 
 int wdb_parse_global_set_agent_groups(wdb_t* wdb, char* input, char* output) {
-
+    int ret = OS_SUCCESS;
     const char *error = NULL;
     cJSON *args = cJSON_ParseWithOpts(input, &error, TRUE);
     if (args) {
@@ -5234,14 +5234,11 @@ int wdb_parse_global_set_agent_groups(wdb_t* wdb, char* input, char* output) {
             char* sync_status = "synced";
             if (0 == strcmp(j_mode->valuestring, "override")) {
                 mode = WDB_GROUP_OVERRIDE;
-            }
-            else if (0 == strcmp(j_mode->valuestring, "append")) {
+            } else if (0 == strcmp(j_mode->valuestring, "append")) {
                 mode = WDB_GROUP_APPEND;
-            }
-            else if (0 == strcmp(j_mode->valuestring, "empty_only")) {
+            } else if (0 == strcmp(j_mode->valuestring, "empty_only")) {
                 mode = WDB_GROUP_EMPTY_ONLY;
-            }
-            else if (0 == strcmp(j_mode->valuestring, "remove")) {
+            } else if (0 == strcmp(j_mode->valuestring, "remove")) {
                 mode = WDB_GROUP_REMOVE;
             }
 
@@ -5252,24 +5249,24 @@ int wdb_parse_global_set_agent_groups(wdb_t* wdb, char* input, char* output) {
             wdbc_result status = wdb_global_set_agent_groups(wdb, mode, sync_status, j_groups_data);
             if (status == WDBC_OK) {
                 snprintf(output, OS_MAXSTR + 1, "%s",  WDBC_RESULT[status]);
-            }
-            else {
+            } else {
                 snprintf(output, OS_MAXSTR + 1, "%s An error occurred during the set of the groups",  WDBC_RESULT[status]);
+                ret = OS_INVALID;
             }
-        }
-        else {
+        } else {
             mdebug1("Missing mandatory fields in set_agent_groups command.");
             snprintf(output, OS_MAXSTR + 1, "err Invalid JSON data, missing required fields");
+            ret = OS_INVALID;
         }
         cJSON_Delete(args);
-    }
-    else {
+    } else {
         mdebug1("Global DB Invalid JSON syntax when parsing set_agent_groups");
         mdebug2("Global DB JSON error near: %s", error);
         snprintf(output, OS_MAXSTR + 1, "err Invalid JSON syntax, near '%.32s'", input);
+        ret = OS_INVALID;
     }
 
-    return OS_SUCCESS;
+    return ret;
 }
 
 int wdb_parse_global_sync_agent_groups_get(wdb_t* wdb, char* input, char* output) {


### PR DESCRIPTION
|Related issue|
|---|
|#11754|

## Description

This PR adds UT for:

- set-agent-groups command.
- wdb_parse_global_set_agent_groups()

## Dod

![3](https://user-images.githubusercontent.com/13010397/151408412-3fef7661-f27f-4042-9eb7-ae3fb7db6375.png)
![1](https://user-images.githubusercontent.com/13010397/151408403-0a916c95-078c-4051-a981-406ca974d0c3.png)
![2](https://user-images.githubusercontent.com/13010397/151408408-c8aa6489-6bc1-4a5d-a26f-8fde97675b5a.png)

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)