### PR TITLE
Adding unit test coverage for function `wdb_check_backup_enabled`

### DIFF
--- a/src/unit_tests/wazuh_db/test_wdb.c
+++ b/src/unit_tests/wazuh_db/test_wdb.c
@@ -85,6 +85,7 @@ int  wazuh_db_config_teardown() {
 
     return OS_SUCCESS;
 }
+
 /* Tests wdb_open_global */
 
 void test_wdb_open_tasks_pool_success(void **state)
@@ -737,6 +738,8 @@ void test_wdb_get_internal_config() {
     cJSON_Delete(ret);
 }
 
+/* Tests wdb_get_config */
+
 void test_wdb_get_config(){
     cJSON *ret = wdb_get_config();
 
@@ -763,7 +766,28 @@ void test_wdb_get_config(){
     cJSON_Delete(ret);
 }
 
-/* wdb_exec_stmt_single_column */
+/* Tests wdb_check_backup_enabled */
+
+void test_wdb_check_backup_enabled_enabled(void **state)
+{
+    bool ret = false;
+    wconfig.wdb_backup_settings[WDB_GLOBAL_BACKUP]->enabled = true;
+
+    ret = wdb_check_backup_enabled();
+    assert_true(ret);
+}
+
+void test_wdb_check_backup_enabled_disabled(void **state)
+{
+    bool ret = false;
+    wconfig.wdb_backup_settings[WDB_GLOBAL_BACKUP]->enabled = false;
+
+    ret = wdb_check_backup_enabled();
+    assert_false(ret);
+}
+
+/* Tests wdb_exec_stmt_single_column */
+
 void test_wdb_exec_single_column(){
     char col_text[4][16] = { 0 };
 
@@ -847,7 +871,8 @@ void test_wdb_finalize_all_statements(){
     assert_null(wdb.cache_list);
 }
 
-/* wdb_close*/
+/* Tests wdb_close*/
+
 void test_wdb_close_refcount_error(){
     wdb_t wdb = {0};
     wdb.refcount = 1;
@@ -940,6 +965,9 @@ int main() {
         cmocka_unit_test_setup_teardown(test_wdb_init_stmt_in_cache_invalid_statement, setup_wdb, teardown_wdb),
         // wdb_get_config
         cmocka_unit_test_setup_teardown(test_wdb_get_config, wazuh_db_config_setup, wazuh_db_config_teardown),
+        // wdb_check_backup_enabled
+        cmocka_unit_test_setup_teardown(test_wdb_check_backup_enabled_enabled, wazuh_db_config_setup, wazuh_db_config_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_check_backup_enabled_disabled, wazuh_db_config_setup, wazuh_db_config_teardown),
         // wdb_get_internal_config
         cmocka_unit_test(test_wdb_get_internal_config),
         // wdb_exec_single_conlumn

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -418,19 +418,6 @@ void * run_gc(__attribute__((unused)) void * args) {
     return NULL;
 }
 
-bool wdb_check_backup_enabled() {
-    bool result = false;
-
-    for (int i = 0; i < WDB_LAST_BACKUP; i++) {
-        if(wconfig.wdb_backup_settings[i]->enabled) {
-            result = true;
-            break;
-        }
-    }
-
-    return result;
-}
-
 void * run_backup(__attribute__((unused)) void * args) {
     time_t last_global_backup_time = wdb_global_get_most_recent_backup(NULL);
     char output[OS_MAXSTR + 1] = {0};

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -200,7 +200,7 @@ int main(int argc, char ** argv)
         goto failure;
     }
 
-    os_malloc(sizeof(pthread_t) * wconfig.worker_pool_size, worker_pool);
+    os_calloc(wconfig.worker_pool_size, sizeof(pthread_t), worker_pool);
 
     for (i = 0; i < wconfig.worker_pool_size; i++) {
         if (status = pthread_create(worker_pool + i, NULL, run_worker, NULL), status != 0) {

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -1535,3 +1535,16 @@ cJSON* wdb_get_config() {
 
     return root;
 }
+
+bool wdb_check_backup_enabled() {
+    bool result = false;
+
+    for (int i = 0; i < WDB_LAST_BACKUP; i++) {
+        if(wconfig.wdb_backup_settings[i]->enabled) {
+            result = true;
+            break;
+        }
+    }
+
+    return result;
+}


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/10771 |

## Description

This PR adds unit test cases to cover the function `wdb_check_backup_enabled`. In addition, it moves the function definition from the `main.c` file to the `wdb.c` file of `wazuh-db`.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade

- Memory tests for Linux
  - [x] Scan-build report
The scan reported an issue in the `main.c` file of `wazuh-db`.
[scan-build-wazuh_db_main.pdf](https://github.com/wazuh/wazuh/files/7954083/scan-build-wazuh_db_main.pdf)
After applying [this fix](https://github.com/wazuh/wazuh/pull/11999/commits/44dcccd098dcc36fdf037d49cb3a6e6810b743a0), the issue was removed.
![image](https://user-images.githubusercontent.com/5703274/151451163-775ee1d3-10e6-4d96-a865-f79cc2f9bb69.png)
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)
![image](https://user-images.githubusercontent.com/5703274/151447223-91b5c1fc-1c4a-43ea-aace-4bc583f588be.png)
