### PR TITLE
Fix the exceed in the specified groups per agents

### DIFF
--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -743,7 +743,7 @@ class Agent:
             multigroup_name = f'{multigroup_name}{"," if multigroup_name else ""}{group_id}'
 
         # Check multigroup limit
-        if len(agent_groups) > common.max_groups_per_multigroup:
+        if len(agent_groups) >= common.max_groups_per_multigroup:
             raise WazuhError(1737)
 
         # Update group file

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -4,7 +4,8 @@
 
 
 from copy import deepcopy
-from wazuh.core.common import MAX_SOCKET_BUFFER_SIZE, wazuh_version as wazuh_full_version, agent_name_len_limit
+from wazuh.core.common import MAX_SOCKET_BUFFER_SIZE, wazuh_version as wazuh_full_version, agent_name_len_limit, \
+    max_groups_per_multigroup
 
 GENERIC_ERROR_MSG = "Wazuh Internal Error. See log for more detail"
 WAZUH_VERSION = 'current' if wazuh_full_version == '' else '.'.join(wazuh_full_version.split('.')[:2]).lstrip('v')
@@ -285,7 +286,7 @@ class WazuhException(Exception):
                'remediation': 'Please update the agent, in case the problem persists contact us at: https://github.com'
                               '/wazuh/wazuh/issues'
                },
-        1737: {'message': 'Maximum number of groups per multigroup is 256',
+        1737: {'message': f"Maximum number of groups per multigroup is {max_groups_per_multigroup}",
                'remediation': 'Please choose another group or remove an agent from the target group'
                },
         1738: {'message': 'Agent name is too long',


### PR DESCRIPTION
|Related issue|
|---|
|#11353|

## Description

This closes #11353. This pull request changes the hardcoded value in exception 1737, for a placeholder with the corresponding variable. Also, a change to avoid exceeding the maximum groups assigned to an agent was done.

