### PR TITLE
Add set_agent_group and set_agent_group_context UT

### DIFF
--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -6812,6 +6812,10 @@ void test_wdb_global_set_agent_group_context_exec_stmt_error(void **state)
 
 /* wdb_global_set_agent_groups */
 
+/**
+ * @brief Configure all the wrappers to simulate a successful call to wdb_global_delete_agent_belong() method
+ * @param agent_id The id of the agent whose groups are being deleted
+ */
 void create_wdb_global_delete_agent_belong_success_call(int agent_id) {
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
@@ -6821,6 +6825,13 @@ void create_wdb_global_delete_agent_belong_success_call(int agent_id) {
     will_return(__wrap_wdb_step, SQLITE_DONE);
 }
 
+/**
+ * @brief Configure all the wrappers to simulate a successful call to wdb_global_assign_agent_group() method
+ * @param agent_id The id of the agent being assigned in the belongs table
+ * @param group_id The id of the group being assigned in the belongs table
+ * @param group_name The name of the group being inserted in the group table
+ * @param find_group_resp The response of the find group query
+ */
 void create_wdb_global_assign_agent_group_success_call(int agent_id, int group_id, char* group_name, cJSON* find_group_resp) {
     int actual_priority = 0;
     // wdb_global_insert_agent_group
@@ -6853,6 +6864,13 @@ void create_wdb_global_assign_agent_group_success_call(int agent_id, int group_i
     will_return(__wrap_wdb_step, SQLITE_DONE);
 }
 
+/**
+ * @brief Configure all the wrappers to simulate a successful call to _wdb_global_unassign_agent_group() method
+ * @param agent_id The id of the agent being removed from the belongs table
+ * @param group_id The id of the group being removed from the the belongs table
+ * @param group_name The name of the group being searched for remove
+ * @param find_group_resp The response of the find group query
+ */
 void create_wdb_global_unassign_agent_group_success_call(int agent_id, int group_id, char* group_name, cJSON* find_group_resp) {
     // wdb_global_find_group
     will_return(__wrap_wdb_begin2, 1);
@@ -6874,6 +6892,11 @@ void create_wdb_global_unassign_agent_group_success_call(int agent_id, int group
     will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
 }
 
+/**
+ * @brief Configure all the wrappers to simulate a successful call to wdb_global_calculate_agent_group_csv() method
+ * @param agent_id The id of the agent to calculate its groups csv
+ * @param find_group_resp The response of the find select group query
+ */
 void create_wdb_global_calculate_agent_group_csv_success_call(int agent_id, cJSON* j_group_resp) {
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, OS_SUCCESS);
@@ -6884,6 +6907,13 @@ void create_wdb_global_calculate_agent_group_csv_success_call(int agent_id, cJSO
     expect_function_call(__wrap_cJSON_Delete);
 }
 
+/**
+ * @brief Configure all the wrappers to simulate a successful call to wdb_global_set_agent_group_context() method
+ * @param agent_id The id of the agent to set its group context
+ * @param csv The groups csv to be written in the groups column
+ * @param hash The hash to be written in the group_hash column
+ * @param sync_status The sync status to be written in the group_sync_status column
+ */
 void create_wdb_global_set_agent_group_context_success_call(int agent_id, char* csv, char* hash, char* sync_status) {
     expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_GLOBAL_GROUP_CTX_SET);
     will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1);
@@ -6902,6 +6932,11 @@ void create_wdb_global_set_agent_group_context_success_call(int agent_id, char* 
     will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
 }
 
+/**
+ * @brief Configure all the wrappers to simulate a successful call to wdb_global_get_agent_max_group_priority() method
+ * @param agent_id The id of the agent to get the max priority of its groups
+ * @param j_priority_resp The response of the priority query
+ */
 void create_wdb_global_get_agent_max_group_priority_success_call(int agent_id, cJSON* j_priority_resp) {
     expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_GLOBAL_GROUP_PRIORITY_GET);
     will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1);

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -7576,7 +7576,6 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_by_connection_status_ok, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_by_connection_status_due, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_by_connection_status_err, test_setup, test_teardown),
-        #if 0
         /* Tests wdb_global_create_backup */
         cmocka_unit_test_setup_teardown(test_wdb_global_create_backup_commit_failed, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_create_backup_prepare_failed, test_setup, test_teardown),
@@ -7584,7 +7583,6 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_global_create_backup_exec_failed, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_create_backup_compress_failed, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_create_backup_success, test_setup, test_teardown),
-        #endif
         /* Tests wdb_global_remove_old_backups */
         cmocka_unit_test_setup_teardown(test_wdb_global_remove_old_backups_opendir_failed, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_remove_old_backups_success_without_removing, test_setup, test_teardown),
@@ -7627,18 +7625,15 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_global_assign_agent_group_find_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_assign_agent_group_insert_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_assign_agent_group_invalid_json, test_setup, test_teardown),
-
         /* wdb_global_unassign_agent_group */
         cmocka_unit_test_setup_teardown(test_wdb_global_unassign_agent_group_success, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_unassign_agent_group_delete_tuple_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_unassign_agent_group_find_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_unassign_agent_group_invalid_json, test_setup, test_teardown),
-
         /* wdb_global_set_agent_group_context */
         cmocka_unit_test_setup_teardown(test_wdb_global_set_agent_group_context_success, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_set_agent_group_context_init_stmt_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_set_agent_group_context_exec_stmt_error, test_setup, test_teardown),
-
         /* wdb_global_set_agent_group */
         cmocka_unit_test_setup_teardown(test_wdb_global_set_agent_groups_override_success, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_set_agent_groups_override_delete_error, test_setup, test_teardown),

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1101,7 +1101,7 @@ char* wdb_global_calculate_agent_group_csv(wdb_t *wdb, int id) {
         cJSON_Delete(j_agent_groups);
     }
     else {
-        mdebug1("Unable to get groups of agent '%d'", id);
+        mdebug1("Unable to get groups of agent '%03d'", id);
     }
     return result;
 }
@@ -1168,7 +1168,7 @@ int wdb_global_get_agent_max_group_priority(wdb_t *wdb, int id) {
     int group_priority = OS_INVALID;
     cJSON* j_result = wdb_exec_stmt(stmt);
     if (j_result) {
-        if (j_result->child->child) {
+        if (j_result->child && j_result->child->child) {
             cJSON* j_priority = j_result->child->child;
             group_priority = j_priority->valueint;
         }
@@ -1269,7 +1269,7 @@ wdbc_result wdb_global_set_agent_groups(wdb_t *wdb, wdb_groups_set_mode_t mode, 
                     int last_group_priority = wdb_global_get_agent_max_group_priority(wdb, agent_id);
                     if (last_group_priority >= 0) {
                         if (mode == WDB_GROUP_EMPTY_ONLY) {
-                            mdebug2("Agent group set in empty_only mode ignored because the agent already contains groups");
+                            mdebug1("Agent group set in empty_only mode ignored because the agent already contains groups");
                             continue;
                         }
                         group_priority = last_group_priority+1;


### PR DESCRIPTION
|Related issue|
|---|
|#11754|

## Description
This PR adds UT for:
- **wdb_global_set_agent_group_context()**
- **wdb_global_set_agent_groups()**

It also fixes an incorrect comment block.


## Tests
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
