### PR TITLE
Add agent ipv6 tests in agent API Integration Tests

### DIFF
--- a/api/test/integration/test_agent_POST_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_POST_endpoints.tavern.yaml
@@ -1,5 +1,5 @@
 ---
-test_name: POST /agents
+test_name: POST /agents (IPV6)
 
 marks:
   - base_tests
@@ -7,13 +7,103 @@ marks:
 stages:
 
     # POST /agents
-  - name: Try to create a new agent without body
+  - name: Create a new agent with a valid IPV6
     request: &agent_request
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
+      json:
+        name: "NewIPV6Agent"
+        ip: "fdb9:8d4a:1fc2:12a0:11aa:22ff:33eb:99cd"
+    response:
+      status_code: 200
+      json: &agent_create_response
+        error: !anyint
+        data:
+          id: !anystr
+          key: !anystr
+      save:
+        json:
+          agent1_id_ipv6: data.id
+
+    # POST /agents
+  - name: Create a new agent with a compressed IPV6
+    request:
+      verify: False
+      <<: *agent_request
+      json:
+        name: "NewCompressedIPV6Agent"
+        ip: "fdb9::99cd"
+    response:
+      status_code: 200
+      json:
+        <<: *agent_create_response
+      save:
+        json:
+          agent2_id_ipv6: data.id
+
+    # POST /agents
+  - name: Create a new agent with an invalid IPV6
+    request:
+      verify: False
+      <<: *agent_request
+      json:
+        name: "InvalidIPV6Agent"
+        ip: "fdb9:8d4a:1fc2:12a0:11aa:22ff:33eb:99gh"
+    response:
+      status_code: 400
+      json:
+        error: 1706
+
+    # POST /agents
+  - name: Create a new agent with an invalid compressed IPV6
+    request:
+      verify: False
+      <<: *agent_request
+      json:
+        name: "InvalidIPV6Agent"
+        ip: "fdb9::99gh"
+    response:
+      status_code: 400
+      json:
+        error: 1706
+    delay_after: !float "{global_db_delay}"
+
+    # GET /agents
+  - name: Check all registered IPV6 agents
+    request: &agent_list_response
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        agents_list: "{agent1_id_ipv6:s},{agent2_id_ipv6:s}"
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - id: "{agent1_id_ipv6:s}"
+              registerIP: !anystr
+              ip: !anystr
+            - id: "{agent2_id_ipv6:s}"
+              registerIP: !anystr
+              ip: !anystr
+
+---
+test_name: POST /agents
+
+stages:
+
+    # POST /agents
+  - name: Try to create a new agent without body
+    request:
+      verify: False
+      <<: *agent_request
     response:
       status_code: 400
       json: &error_spec
@@ -30,11 +120,8 @@ stages:
         ip: "any"
     response:
       status_code: 200
-      json: &agent_create_response
-        error: !anyint
-        data:
-          id: !anystr
-          key: !anystr
+      json:
+        <<: *agent_create_response
     delay_after: !float "{global_db_delay}"
 
     # POST /agents
@@ -193,10 +280,7 @@ stages:
   - name: Check that this agent has the IP 'any'
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
+      <<: *agent_list_response
       params:
         agents_list: "{agent_id_no_ip:s}"
     response:

--- a/api/test/integration/test_agent_POST_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_POST_endpoints.tavern.yaml
@@ -20,7 +20,7 @@ stages:
     response:
       status_code: 200
       json: &agent_create_response
-        error: !anyint
+        error: 0
         data:
           id: !anystr
           key: !anystr
@@ -73,7 +73,7 @@ stages:
 
     # GET /agents
   - name: Check all registered IPV6 agents
-    request: &agent_list_response
+    request: &agent_list_request
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: GET
@@ -84,7 +84,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: "{agent1_id_ipv6:s}"
@@ -280,13 +280,13 @@ stages:
   - name: Check that this agent has the IP 'any'
     request:
       verify: False
-      <<: *agent_list_response
+      <<: *agent_list_request
       params:
         agents_list: "{agent_id_no_ip:s}"
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: "{agent_id_no_ip:s}"
@@ -599,7 +599,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           id: !anystr
           key: !anystr


### PR DESCRIPTION
|Related issue|
|---|
|This PR closes #10930 |

## Description

Under this development I added a few new tests to verify the proper management of IPv6 agents.

## Test stages
* Create a new agent with a valid IPV6
* Create a new agent with a compressed IPV6
* Create a new agent with an invalid IPV6
* Create a new agent with an invalid compressed IPV6
* Check all registered IPV6 agents

In my opinion it's not necessary to test more functionality than the previously mentioned, since any other condition at the time we're registering agents is already being tested.
For example:
* Try to create a new agent with an already present name
* Try to create an agent with a duplicated IP
* Try to create agent with a name already present


## Results
```s
↪ ~/git/wazuh/api/test/integration ⊶ feature/10930-ipv6-ait ⨘ pytest -vv -x --disable-warnings test_agent_POST_endpoints.tavern.yaml
==================================== test session starts =====================================
platform linux -- Python 3.9.5, pytest-5.0.0, py-1.10.0, pluggy-0.13.1 -- /home/kondent/pythonEnv/inttest-env/bin/python3.9
cachedir: .pytest_cache
metadata: {'Python': '3.9.5', 'Platform': 'Linux-5.13.0-27-generic-x86_64-with-glibc2.31', 'Packages': {'pytest': '5.0.0', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'metadata': '1.11.0', 'tavern': '1.2.2'}}
rootdir: /home/kondent/git/wazuh/api/test/integration, inifile: pytest.ini
plugins: html-3.1.1, metadata-1.11.0, tavern-1.2.2
collected 6 items                                                                            

test_agent_POST_endpoints.tavern.yaml::POST /agents (IPV6) PASSED                                                                                                                      [ 16%]
test_agent_POST_endpoints.tavern.yaml::POST /agents PASSED                                                                                                                             [ 33%]
test_agent_POST_endpoints.tavern.yaml::POST /agents (no IP) PASSED                                                                                                                     [ 50%]
test_agent_POST_endpoints.tavern.yaml::POST /groups PASSED                                                                                                                             [ 66%]
test_agent_POST_endpoints.tavern.yaml::POST /agents/insert PASSED                                                                                                                      [ 83%]
test_agent_POST_endpoints.tavern.yaml::POST /agents/insert/quick PASSED                                                                                                                [100%]

=========================================================================== 6 passed, 1 warnings in 363.41 seconds ===========================================================================
```

Regards,
Alexis 
