### PR TITLE
Invalidate in-memory database on every framework security unit test

### DIFF
--- a/framework/wazuh/tests/test_security.py
+++ b/framework/wazuh/tests/test_security.py
@@ -72,6 +72,12 @@ def db_setup():
             with patch('shutil.chown'), patch('os.chmod'):
                 with patch('api.constants.SECURITY_PATH', new=test_data_path):
                     import wazuh.rbac.orm as orm
+                    # Invalidate in-memory database
+                    conn = orm._engine.connect()
+                    orm._Session().close()
+                    conn.invalidate()
+                    orm._engine.dispose()
+
                     reload(orm)
                     orm.create_rbac_db()
                     import wazuh.rbac.decorators as decorators


### PR DESCRIPTION
|Related issue|
|---|
|closes #11957|

## Description

As it was described in the issue, one of the latest changes on the framework unit tests introduced a race condition for the RBAC database creation, probably when importing the module. To protect it when running any security or RBAC unit tests, we added an invalidation mechanism at the start of the main fixture, completely wiping the in-memory database before trying to create it again.

## Tests performed
### Framework unit tests

```shellsession
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.9.9, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /home/vicferpoy/venvs/unittest-env/bin/python3
cachedir: .pytest_cache
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: cov-2.12.0, asyncio-0.15.1
collected 1840 items                                                                                                                                                                        

wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI[kwargs0] PASSED                                                                                                       [  0%]
wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI[kwargs1] PASSED                                                                                                       [  0%]
wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_debug_log PASSED                                                                                                      [  0%]
wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_distribute_function[get_agents_summary_status-local_master-master-local-True-None] PASSED                             [  0%]
wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_distribute_function[restart_agents-distributed_master-master-forward-True-None] PASSED                                [  0%]
wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_distribute_function[get_node_wrapper-local_any-worker-local-True-token_nbf_time] PASSED                               [  0%]
wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_distribute_function[get_ciscat_results-distributed_master-worker-remote-True-None] PASSED                             [  0%]
wazuh/core/cluster/dapi/tests/test_dapi.py::test_DistributedAPI_distribute_function[status-local_master-worker-local-False-f_kwargs4] PASSED                                          [  0%]

(...)
                                                                         [ 99%]
wazuh/tests/test_vulnerability.py::test_get_agent_cve[params26-architecture-expected_items26] PASSED                                                                                  [ 99%]
wazuh/tests/test_vulnerability.py::test_get_agent_cve[params27-architecture-expected_items27] PASSED                                                                                  [ 99%]
wazuh/tests/test_vulnerability.py::test_get_agent_cve_select[params0-expected_fields0] PASSED                                                                                         [ 99%]
wazuh/tests/test_vulnerability.py::test_get_agent_cve_select[params1-expected_fields1] PASSED                                                                                         [ 99%]
wazuh/tests/test_vulnerability.py::test_get_agent_cve_select[params2-expected_fields2] PASSED                                                                                         [100%]

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================================= 1830 passed, 10 skipped, 42 warnings in 333.26s (0:05:33) =================================================================

```


Regards,
Víctor