### PR TITLE
Fix Windows agent crash due to segmentation fault at FIM Registry scan

### DIFF
--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -1116,10 +1116,10 @@ DWORD get_registry_permissions(HKEY hndl, cJSON **output_acl) {
     DWORD dwErrorCode = 0;
     DWORD lpcbSecurityDescriptor = 0;
 
-    if (RegGetKeySecurity(hndl, DACL_SECURITY_INFORMATION, NULL, &lpcbSecurityDescriptor) !=
-        ERROR_INSUFFICIENT_BUFFER) {
-        dwErrorCode = GetLastError();
-        return dwErrorCode;
+    dwRtnCode = RegGetKeySecurity(hndl, DACL_SECURITY_INFORMATION, NULL, &lpcbSecurityDescriptor);
+
+    if (dwRtnCode != ERROR_INSUFFICIENT_BUFFER) {
+        return dwRtnCode;
     }
 
     os_calloc(lpcbSecurityDescriptor, 1, pSecurityDescriptor);

--- a/src/unit_tests/shared/test_syscheck_op.c
+++ b/src/unit_tests/shared/test_syscheck_op.c
@@ -4040,7 +4040,6 @@ void test_get_registry_permissions_RegGetKeySecurity_insufficient_buffer(void **
     cJSON *permissions = NULL;
 
     expect_RegGetKeySecurity_call((LPDWORD)120, ERROR_ACCESS_DENIED);
-    expect_GetLastError_call(ERROR_ACCESS_DENIED);
 
     retval = get_registry_permissions(hndl, &permissions);
 


### PR DESCRIPTION
|Related issue|
|---|
|#12036|

## Description

As explained at https://github.com/wazuh/wazuh/issues/12036#issuecomment-1026069382, PR #11735 fixed a memory leak at `fim_registry_get_key_data()` because it was allocating a JSON object which is created again by `get_registry_permissions()`. There were some cases where `get_registry_permissions()` allocated the new object but did not assign it to the actual parameter.

However, this fix presents the opposite problem: there is a case where `get_registry_permissions()` is returning `0` (no error), but is not allocating the output parameter, as it is supposed to.

The fix consists of removing the call to `GetLastError()`, and taking the return value of `RegGetKeySecurity()` as an error code.

## Tests

- [x] Compile agent for Windows.
- [x] Fix and run the unit tests.
- [x] Launch stress tests:
  - [x] 4.3.0-RC3, set up files and Registry keys.
  - [x] 4.3.0-RC3, set up files only.
  - [x] This fixing branch, set up files and Registry keys.

### Stress test results

|Input|Fix|Result|Reference|
|---|---|---|---|
|Files + Registry keys|No|🔴|https://github.com/wazuh/wazuh/issues/11915#issuecomment-1025209665|
|Files|No|🟢|https://github.com/wazuh/wazuh/issues/11915#issuecomment-1025210370|
|Files + Registry keys|Yes|🟢|https://github.com/wazuh/wazuh/issues/11915#issuecomment-1025218751|