### PR TITLE
Fix exception regarding inactive agents at `/agents/reconnect`

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -147,7 +147,7 @@ def get_agents_summary_os(agent_list=None):
 
 
 @expose_resources(actions=["agent:reconnect"], resources=["agent:id:{agent_list}"],
-                  post_proc_kwargs={'exclude_codes': [1701, 1703, 1757]})
+                  post_proc_kwargs={'exclude_codes': [1701, 1703, 1707]})
 def reconnect_agents(agent_list: Union[list, str] = None) -> AffectedItemsWazuhResult:
     """Force reconnect a list of agents.
 

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -435,7 +435,7 @@ class Agent:
         ------
         WazuhError(1750)
             If the agent has active response disabled.
-        WazuhError(1757)
+        WazuhError(1707)
             If the agent to be reconnected is not active.
 
         Returns
@@ -446,7 +446,7 @@ class Agent:
         # Check if agent is active
         self.get_basic_information()
         if self.status.lower() != 'active':
-            raise WazuhError(1757)
+            raise WazuhError(1707)
 
         # Send force reconnect message to the WazuhQueue
         ret_msg = wq.send_msg_to_agent(WazuhQueue.HC_FORCE_RECONNECT, self.id)

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -608,7 +608,7 @@ def test_agent_reconnect(socket_mock, send_mock, mock_send_msg):
 def test_agent_reconnect_ko(socket_mock, send_mock, mock_queue):
     """Test if method reconnect raises exception."""
     # Assert exception is raised when status of agent is not 'active'
-    with pytest.raises(WazuhError, match='.* 1757 .*'):
+    with pytest.raises(WazuhError, match='.* 1707 .*'):
         agent = Agent(3)
         agent.reconnect(mock_queue)
 


### PR DESCRIPTION
|Related issue|
|---|
| This PR closes #11973 |

## Description
The raised exception at the `/agents/reconnect` endpoint related with an inactive agent was incorrect.

* Exception:
```json
"error": {
  "code": 1757,
  "message": "Error deleting an agent",
  "remediation": "Please check all data fields and try again"
}
```

I fixed it and reviewed several endpoints to verify that the raised exceptions regarding inactive agents are properly handled.

## Results

```s
curl -k -X PUT "https://localhost:55000/agents/reconnect?agents_list=001" -H "Authorization: Bearer $TOKEN"
```

```json
{
  "data": {
    "affected_items": [],
    "total_affected_items": 0,
    "total_failed_items": 1,
    "failed_items": [
      {
        "error": {
          "code": 1707,
          "message": "Cannot send request, agent is not active",
          "remediation": "Please, check non-active agents connection and try again. Visit https://documentation.wazuh.com/current/user-manual/registering/index.html and https://documentation.wazuh.com/current/user-manual/agents/agent-connection.html to obtain more information on registering and connecting agents"
        },
        "id": [
          "001"
        ]
      }
    ]
  },
  "message": "Force reconnect command was not sent to any agent",
  "error": 1
}
```