### PR TITLE
Fix syscollector's delta send mechanism

### DIFF
--- a/src/wazuh_modules/wm_syscollector.c
+++ b/src/wazuh_modules/wm_syscollector.c
@@ -59,7 +59,7 @@ static void wm_sys_send_diff_message(const void* data) {
 }
 
 static void wm_sys_send_dbsync_message(const void* data) {
-    if(!os_iswait() && !is_shutdown_process_started()) {
+    if(!is_shutdown_process_started()) {
         const int eps = 1000000/syscollector_sync_max_eps;
         if (wm_sendmsg_ex(eps, queue_fd, data, WM_SYS_LOCATION, DBSYNC_MQ, &is_shutdown_process_started) < 0) {
 #ifdef CLIENT

--- a/src/wazuh_modules/wm_syscollector.c
+++ b/src/wazuh_modules/wm_syscollector.c
@@ -51,17 +51,10 @@ static bool is_shutdown_process_started() {
     return ret_val;
 }
 
-static void wm_sys_send_diff_message(const void* data) {
-    if(!os_iswait()) {
+static void wm_sys_send_message(const void* data, const char queue_id) {
+    if(!os_iswait() && !is_shutdown_process_started()) {
         const int eps = 1000000/syscollector_sync_max_eps;
-        wm_sendmsg(eps, queue_fd, data, WM_SYS_LOCATION, SYSCOLLECTOR_MQ);
-    }
-}
-
-static void wm_sys_send_dbsync_message(const void* data) {
-    if(!is_shutdown_process_started()) {
-        const int eps = 1000000/syscollector_sync_max_eps;
-        if (wm_sendmsg_ex(eps, queue_fd, data, WM_SYS_LOCATION, DBSYNC_MQ, &is_shutdown_process_started) < 0) {
+        if (wm_sendmsg_ex(eps, queue_fd, data, WM_SYS_LOCATION, queue_id, &is_shutdown_process_started) < 0) {
 #ifdef CLIENT
             mterror(WM_SYS_LOGTAG, "Unable to send message to '%s' (wazuh-agentd might be down). Attempting to reconnect.", DEFAULTQUEUE);
 #else
@@ -70,10 +63,10 @@ static void wm_sys_send_dbsync_message(const void* data) {
             // Since this method is beign called by multiple threads it's necessary this particular portion of code
             // to be mutually exclusive. When one thread is successfully reconnected, the other ones will make use of it.
             w_mutex_lock(&sys_reconnect_mutex);
-            if (!is_shutdown_process_started() && wm_sendmsg_ex(eps, queue_fd, data, WM_SYS_LOCATION, DBSYNC_MQ, &is_shutdown_process_started) < 0) {
+            if (!is_shutdown_process_started() && wm_sendmsg_ex(eps, queue_fd, data, WM_SYS_LOCATION, queue_id, &is_shutdown_process_started) < 0) {
                 if (queue_fd = MQReconnectPredicated(DEFAULTQUEUE, &is_shutdown_process_started), 0 <= queue_fd) {
                     mtinfo(WM_SYS_LOGTAG, "Successfully reconnected to '%s'", DEFAULTQUEUE);
-                    if (wm_sendmsg_ex(eps, queue_fd, data, WM_SYS_LOCATION, DBSYNC_MQ, &is_shutdown_process_started) < 0) {
+                    if (wm_sendmsg_ex(eps, queue_fd, data, WM_SYS_LOCATION, queue_id, &is_shutdown_process_started) < 0) {
                         mterror(WM_SYS_LOGTAG, "Unable to send message to '%s' after a successfull reconnection...", DEFAULTQUEUE);
                     }
                 }
@@ -81,6 +74,14 @@ static void wm_sys_send_dbsync_message(const void* data) {
             w_mutex_unlock(&sys_reconnect_mutex);
         }
     }
+}
+
+static void wm_sys_send_diff_message(const void* data) {
+    wm_sys_send_message(data, SYSCOLLECTOR_MQ);
+}
+
+static void wm_sys_send_dbsync_message(const void* data) {
+    wm_sys_send_message(data, DBSYNC_MQ);
 }
 
 static void wm_sys_log(const syscollector_log_level_t level, const char* log) {

--- a/src/wazuh_modules/wm_syscollector.c
+++ b/src/wazuh_modules/wm_syscollector.c
@@ -52,14 +52,14 @@ static bool is_shutdown_process_started() {
 }
 
 static void wm_sys_send_message(const void* data, const char queue_id) {
-    if(!os_iswait() && !is_shutdown_process_started()) {
+    if (!is_shutdown_process_started()) {
         const int eps = 1000000/syscollector_sync_max_eps;
         if (wm_sendmsg_ex(eps, queue_fd, data, WM_SYS_LOCATION, queue_id, &is_shutdown_process_started) < 0) {
-#ifdef CLIENT
+    #ifdef CLIENT
             mterror(WM_SYS_LOGTAG, "Unable to send message to '%s' (wazuh-agentd might be down). Attempting to reconnect.", DEFAULTQUEUE);
-#else
+    #else
             mterror(WM_SYS_LOGTAG, "Unable to send message to '%s' (wazuh-analysisd might be down). Attempting to reconnect.", DEFAULTQUEUE);
-#endif
+    #endif
             // Since this method is beign called by multiple threads it's necessary this particular portion of code
             // to be mutually exclusive. When one thread is successfully reconnected, the other ones will make use of it.
             w_mutex_lock(&sys_reconnect_mutex);
@@ -77,7 +77,9 @@ static void wm_sys_send_message(const void* data, const char queue_id) {
 }
 
 static void wm_sys_send_diff_message(const void* data) {
-    wm_sys_send_message(data, SYSCOLLECTOR_MQ);
+    if (!os_iswait()) {
+        wm_sys_send_message(data, SYSCOLLECTOR_MQ);
+    }
 }
 
 static void wm_sys_send_dbsync_message(const void* data) {


### PR DESCRIPTION
|Related issue|
|---|
|#12043|

## Description

Hi team!

This PR aims to improve syscollector deltas send mechanism by aligning it with dbsync criteria. Because both of them are quite similar, both mechanisms will be called a common function that does the job, but with different criteria

- Dbsync sync: aligned with #11949, sync will wait until the connection with manager was recovered.
- Delta messages: messages will be discarded if the connection to the manager has been lost. This decision was made to avoid applying historical differences in the manager (which could cause a flood), while the next sync step performed by dbsync will update all the information in a more efficient way.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors