### PR TITLE
Skip V9FS at Rootcheck system scan

### DIFF
--- a/src/shared/fs_op.c
+++ b/src/shared/fs_op.c
@@ -28,6 +28,7 @@
 #define OVERLAYFS   0x794c7630
 #define BTRFS       0x9123683E
 #define CIFS        0xFF534D42
+#define V9FS        0x01021997
 #define ST_NODEV    4
 #elif defined(__FreeBSD__)
 #define NFS         0x3a
@@ -54,6 +55,8 @@ const struct file_system_type skip_file_systems[] = {
     {.name="BTRFS", .f_type=BTRFS, .flag=1},
     {.name="AUFS", .f_type=AUFS, .flag=1},
     {.name="OVERLAYFS", .f_type=OVERLAYFS, .flag=1},
+    {.name="V9FS", .f_type=V9FS, .flag=1},
+
 #endif
     /*  The last entry must be name=NULL */
     {.name=NULL, .f_type=0, .flag=0}


### PR DESCRIPTION
|Related issue|
|---|
|#10336|

## Description

Rootcheck is producing a bunch of false positive alerts when running on WSL:

```
** Alert 1643808309.1711039: - ossec,rootcheck,pci_dss_10.6.1,gdpr_IV_35.7.d,
2022 Feb 02 14:25:09 Rocket->rootcheck
Rule: 510 (level 7) -> 'Host-based anomaly detection event (rootcheck).'
Files hidden inside directory '/usr/lib/wsl/drivers/displayoverride.inf_amd64_2a9c012705b571c0'. Link count does not match number of files (2,1).
title: Files hidden inside directory '/usr/lib/wsl/drivers/displayoverride.inf_amd64_2a9c012705b571c0'.
```

## Inspecting folder

```sh
$ ls -la /usr/lib/wsl/drivers/displayoverride.inf_amd64_2a9c012705b571c0
dr-xr-xr-x 1 root root 4096 Oct 10 03:01 .
dr-xr-xr-x 1 root root 4096 Jan 29 10:59 ..
-r-xr-xr-x 3 root root 3952 Jun  5  2021 displayoverride.inf

$ stat /usr/lib/wsl/drivers/displayoverride.inf_amd64_2a9c012705b571c0
  File: /usr/lib/wsl/drivers/displayoverride.inf_amd64_2a9c012705b571c0
  Size: 4096            Blocks: 0          IO Block: 4096   directory
Device: 3eh/62d Inode: 844424930214675  Links: 1
Access: (0555/dr-xr-xr-x)  Uid: (    0/    root)   Gid: (    0/    root)
Access: 2022-02-02 14:40:41.453322400 +0100
Modify: 2021-10-10 03:01:40.926064300 +0200
Change: 2021-10-10 03:01:40.926064300 +0200
 Birth: -

$ df /usr/lib/wsl/drivers/displayoverride.inf_amd64_2a9c012705b571c0
Filesystem     1K-blocks      Used Available Use% Mounted on
drivers        487640424 152531868 335108556  32% /usr/lib/wsl/drivers
```

[`statfs`](https://man7.org/linux/man-pages/man2/statfs.2.html) shows that the folder's file system magic number is:
```c
V9FS_MAGIC            0x01021997
```

### Conclusions

Folders mounted on a V9 file system won't count the number of links properly.

## Proposed fix

Let Rootcheck skip every folder mounted on a V9 file system, in order to prevent false positive alerts.

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->



<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

```xml
  <rootcheck>
    <disabled>no</disabled>
    <check_files>no</check_files>
    <check_trojans>no</check_trojans>
    <check_dev>no</check_dev>
    <check_sys>yes</check_sys>
    <check_pids>no</check_pids>
    <check_ports>no</check_ports>
    <check_if>no</check_if>
    <frequency>43200</frequency>
    <skip_nfs>yes</skip_nfs>
  </rootcheck>
```

## Alerts sample

While before this fix, Rootcheck produced about 800 alerts like the one above, after the fix there are no alerts related to link count from an agent running on WSL.