### PR TITLE
Unit Tests fixes for wdb functions after coverity fixes

### DIFF
--- a/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
@@ -118,7 +118,7 @@ int teardown_wdb_global_helpers_add_agent(void **state) {
 
 int teardown_wdb_global_helpers(void **state) {
     test_mode = 0;
-
+    errno = 0;
     return 0;
 }
 
@@ -218,8 +218,6 @@ void test_wdb_create_agent_db_error_opening_dest_profile(void **state)
     expect_string(__wrap_stat, __file, "var/db/agents/001-agent1.db");
     will_return(__wrap_stat, 0);
     will_return(__wrap_stat, OS_INVALID);
-    // reseting error number after last use
-    errno = 0;
     // profile database not found
     expect_string(__wrap_fopen, path, "var/db/.template.db");
     expect_string(__wrap_fopen, mode, "r");

--- a/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
@@ -164,9 +164,10 @@ void test_wdb_create_agent_db_error_creating_source_profile(void **state)
     will_return(__wrap_stat, 0);
     will_return(__wrap_stat, OS_INVALID);
     // profile database not found
-    expect_string(__wrap_stat, __file, "var/db/.template.db");
-    will_return(__wrap_stat, 0);
-    will_return(__wrap_stat, OS_INVALID);
+    errno = EACCES;
+    expect_string(__wrap_fopen, path, "var/db/.template.db");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
     // Creating profile
     expect_string(__wrap__mdebug1, formatted_msg, "Profile database not found, creating.");
     expect_string(__wrap_wdb_create_profile, path, "var/db/.template.db");
@@ -188,9 +189,10 @@ void test_wdb_create_agent_db_error_reopening_source_profile(void **state)
     will_return(__wrap_stat, 0);
     will_return(__wrap_stat, OS_INVALID);
     // profile database not found
-    expect_string(__wrap_stat, __file, "var/db/.template.db");
-    will_return(__wrap_stat, 0);
-    will_return(__wrap_stat, OS_INVALID);
+    errno = EACCES;
+    expect_string(__wrap_fopen, path, "var/db/.template.db");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
     // Creating profile
     expect_string(__wrap__mdebug1, formatted_msg, "Profile database not found, creating.");
     expect_string(__wrap_wdb_create_profile, path, "var/db/.template.db");
@@ -216,11 +218,9 @@ void test_wdb_create_agent_db_error_opening_dest_profile(void **state)
     expect_string(__wrap_stat, __file, "var/db/agents/001-agent1.db");
     will_return(__wrap_stat, 0);
     will_return(__wrap_stat, OS_INVALID);
+    // reseting error number after last use
+    errno = 0;
     // profile database not found
-    expect_string(__wrap_stat, __file, "var/db/.template.db");
-    will_return(__wrap_stat, 0);
-    will_return(__wrap_stat, OS_SUCCESS);
-    // Opening source database file
     expect_string(__wrap_fopen, path, "var/db/.template.db");
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, 1);
@@ -248,10 +248,7 @@ void test_wdb_create_agent_db_error_writing_profile(void **state)
     will_return(__wrap_stat, 0);
     will_return(__wrap_stat, OS_INVALID);
     // profile database found
-    expect_string(__wrap_stat, __file, "var/db/.template.db");
-    will_return(__wrap_stat, 0);
-    will_return(__wrap_stat, OS_SUCCESS);
-    // Opening source database file
+
     expect_string(__wrap_fopen, path, "var/db/.template.db");
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, 1);
@@ -285,10 +282,6 @@ void test_wdb_create_agent_db_error_getting_ids(void **state)
     will_return(__wrap_stat, 0);
     will_return(__wrap_stat, OS_INVALID);
     // profile database not found
-    expect_string(__wrap_stat, __file, "var/db/.template.db");
-    will_return(__wrap_stat, 0);
-    will_return(__wrap_stat, OS_SUCCESS);
-    // Opening source database file
     expect_string(__wrap_fopen, path, "var/db/.template.db");
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, 1);
@@ -330,10 +323,6 @@ void test_wdb_create_agent_db_error_changing_owner(void **state)
     will_return(__wrap_stat, 0);
     will_return(__wrap_stat, OS_INVALID);
     // profile database not found
-    expect_string(__wrap_stat, __file, "var/db/.template.db");
-    will_return(__wrap_stat, 0);
-    will_return(__wrap_stat, OS_SUCCESS);
-    // Opening source database file
     expect_string(__wrap_fopen, path, "var/db/.template.db");
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, 1);
@@ -380,10 +369,6 @@ void test_wdb_create_agent_db_error_changing_mode(void **state)
     will_return(__wrap_stat, 0);
     will_return(__wrap_stat, OS_INVALID);
     // profile database not found
-    expect_string(__wrap_stat, __file, "var/db/.template.db");
-    will_return(__wrap_stat, 0);
-    will_return(__wrap_stat, OS_SUCCESS);
-    // Opening source database file
     expect_string(__wrap_fopen, path, "var/db/.template.db");
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, 1);
@@ -433,10 +418,6 @@ void test_wdb_create_agent_db_success(void **state)
     will_return(__wrap_stat, 0);
     will_return(__wrap_stat, OS_INVALID);
     // profile database not found
-    expect_string(__wrap_stat, __file, "var/db/.template.db");
-    will_return(__wrap_stat, 0);
-    will_return(__wrap_stat, OS_SUCCESS);
-    // Opening source database file
     expect_string(__wrap_fopen, path, "var/db/.template.db");
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, 1);

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -2055,7 +2055,7 @@ void test_wdb_parse_global_get_groups_integrity_syntax_error(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_parse_global_get_groups_integrity_query_error(void **state)
+void test_wdb_parse_global_get_groups_integrity_hash_length_expected_fail(void **state)
 {
     int ret = OS_SUCCESS;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -2063,7 +2063,23 @@ void test_wdb_parse_global_get_groups_integrity_query_error(void **state)
 
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-groups-integrity random_hash");
-    expect_string(__wrap_wdb_global_get_groups_integrity, hash, "random_hash");
+    expect_string(__wrap__mdebug1, formatted_msg, "Hash hex-digest does not have the expected length. Expected (40) got (11)");
+
+    ret = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "err Hash hex-digest does not have the expected length. Expected (40) got (11)");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_get_groups_integrity_query_error(void **state)
+{
+    int ret = OS_SUCCESS;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global get-groups-integrity xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-groups-integrity xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
+    expect_string(__wrap_wdb_global_get_groups_integrity, hash, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
     will_return(__wrap_wdb_global_get_groups_integrity, NULL);
     expect_string(__wrap__mdebug1, formatted_msg, "Error getting groups integrity information from global.db.");
 
@@ -2077,12 +2093,12 @@ void test_wdb_parse_global_get_groups_integrity_success_syncreq(void **state)
 {
     int ret = OS_SUCCESS;
     test_struct_t *data  = (test_struct_t *)*state;
-    char query[OS_BUFFER_SIZE] = "global get-groups-integrity random_hash";
+    char query[OS_BUFFER_SIZE] = "global get-groups-integrity xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
     cJSON* j_response = cJSON_Parse("[\"syncreq\"]");
 
     will_return(__wrap_wdb_open_global, data->wdb);
-    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-groups-integrity random_hash");
-    expect_string(__wrap_wdb_global_get_groups_integrity, hash, "random_hash");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-groups-integrity xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
+    expect_string(__wrap_wdb_global_get_groups_integrity, hash, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
     will_return(__wrap_wdb_global_get_groups_integrity, j_response);
 
     ret = wdb_parse(query, data->output, 0);
@@ -2095,12 +2111,12 @@ void test_wdb_parse_global_get_groups_integrity_success_synced(void **state)
 {
     int ret = OS_SUCCESS;
     test_struct_t *data  = (test_struct_t *)*state;
-    char query[OS_BUFFER_SIZE] = "global get-groups-integrity random_hash";
+    char query[OS_BUFFER_SIZE] = "global get-groups-integrity xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
     cJSON* j_response = cJSON_Parse("[\"synced\"]");
 
     will_return(__wrap_wdb_open_global, data->wdb);
-    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-groups-integrity random_hash");
-    expect_string(__wrap_wdb_global_get_groups_integrity, hash, "random_hash");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-groups-integrity xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
+    expect_string(__wrap_wdb_global_get_groups_integrity, hash, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
     will_return(__wrap_wdb_global_get_groups_integrity, j_response);
 
     ret = wdb_parse(query, data->output, 0);
@@ -2113,12 +2129,12 @@ void test_wdb_parse_global_get_groups_integrity_success_hash_mismatch(void **sta
 {
     int ret = OS_SUCCESS;
     test_struct_t *data  = (test_struct_t *)*state;
-    char query[OS_BUFFER_SIZE] = "global get-groups-integrity random_hash";
+    char query[OS_BUFFER_SIZE] = "global get-groups-integrity xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
     cJSON* j_response = cJSON_Parse("[\"hash_mismatch\"]");
 
     will_return(__wrap_wdb_open_global, data->wdb);
-    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-groups-integrity random_hash");
-    expect_string(__wrap_wdb_global_get_groups_integrity, hash, "random_hash");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-groups-integrity xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
+    expect_string(__wrap_wdb_global_get_groups_integrity, hash, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
     will_return(__wrap_wdb_global_get_groups_integrity, j_response);
 
     ret = wdb_parse(query, data->output, 0);
@@ -2741,6 +2757,7 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_groups_get_invalid_response, test_setup, test_teardown),
         /* Tests wdb_parse_global_get_groups_integrity */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_groups_integrity_syntax_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_groups_integrity_hash_length_expected_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_groups_integrity_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_groups_integrity_success_syncreq, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_groups_integrity_success_synced, test_setup, test_teardown),

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -2059,15 +2059,16 @@ void test_wdb_parse_global_get_groups_integrity_hash_length_expected_fail(void *
 {
     int ret = OS_SUCCESS;
     test_struct_t *data  = (test_struct_t *)*state;
-    char query[OS_BUFFER_SIZE] = "global get-groups-integrity random_hash";
+    char query[OS_BUFFER_SIZE] = "global get-groups-integrity small_hash";
 
     will_return(__wrap_wdb_open_global, data->wdb);
-    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-groups-integrity random_hash");
-    expect_string(__wrap__mdebug1, formatted_msg, "Hash hex-digest does not have the expected length. Expected (40) got (11)");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-groups-integrity small_hash");
+    // Expected hash should be OS_SHA1_HEXDIGEST_SIZE (40) characters long, and the received hash, "small_hash", is 10 characters long.
+    expect_string(__wrap__mdebug1, formatted_msg, "Hash hex-digest does not have the expected length. Expected (40) got (10)");
 
     ret = wdb_parse(query, data->output, 0);
 
-    assert_string_equal(data->output, "err Hash hex-digest does not have the expected length. Expected (40) got (11)");
+    assert_string_equal(data->output, "err Hash hex-digest does not have the expected length. Expected (40) got (10)");
     assert_int_equal(ret, OS_INVALID);
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|#10771|

## Description

<!--
Add a clear description of how the problem has been solved.
-->
Fixing Unit test due to changes after coverity exam over this functions:

```
wdb_parse_global_get_groups_integrity()
wdb_create_agent_db()
Read_WazuhDB()

```
## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux

- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Valgrind (memcheck and descriptor leaks check)

  - [x] Added unit testing files ".ini"
