### PR TITLE
Dev agent groups ut fixes

### DIFF
--- a/src/config/wazuh_db-config.c
+++ b/src/config/wazuh_db-config.c
@@ -27,34 +27,36 @@ static short eval_bool(const char *str) {
     }
 }
 
-int Read_WazuhDB(const OS_XML *xml, XML_NODE chld_node) {
-    const char* xml_backup = "backup";
-    const char* xml_database = "database";
-    const char* xml_database_global = "global";
+int Read_WazuhDB(const OS_XML *xml, XML_NODE child_node) {
+    const char *xml_backup = "backup";
+    const char *xml_database = "database";
+    const char *xml_database_global = "global";
 
-    for(int i = 0; chld_node[i]; i++) {
-        if (!chld_node[i]->element) {
-            merror(XML_ELEMNULL);
-            return OS_INVALID;
-        } else if (!strcmp(chld_node[i]->element, xml_backup)) {
-            if(chld_node[i]->attributes && chld_node[i]->attributes[0] && !strcmp(chld_node[i]->attributes[0], xml_database)) {
-                if(chld_node[i]->values && chld_node[i]->values[0] && !strcmp(chld_node[i]->values[0], xml_database_global)) {
-                    return Read_WazuhDB_Backup(xml, chld_node[i], WDB_GLOBAL_BACKUP);
-                } else {
-                    merror(XML_VALUEERR, chld_node[i]->attributes[0], chld_node[i]->values && chld_node[i]->values[0] ? chld_node[i]->values[0] : "");
-                    return OS_INVALID;
-                }
-            } else {
-                merror(XML_INVATTR, chld_node[i]->attributes && chld_node[i]->attributes[0] ? chld_node[i]->attributes[0] : "", chld_node[i]->element);
-                return OS_INVALID;
-            }
-        } else {
-            merror(XML_INVELEM, chld_node[i]->element);
-            return OS_INVALID;
-        }
+    xml_node *node = *child_node;
+
+    if (node->element == NULL) {
+        merror(XML_ELEMNULL);
+        return OS_INVALID;
     }
 
-    return OS_SUCCESS;
+    if (strcmp(node->element, xml_backup) != 0) {
+        merror(XML_INVELEM, node->element);
+        return OS_INVALID;
+    }
+
+    char **attr = node->attributes;
+    if (attr == NULL || attr[0] == NULL || strcmp(attr[0], xml_database) != 0) {
+        merror(XML_INVATTR, attr && attr[0] ? attr[0] : "", node->element);
+        return OS_INVALID;
+    }
+
+    char **val = node->values;
+    if (val == NULL || val[0] == NULL || strcmp(val[0], xml_database_global) != 0) {
+        merror(XML_VALUEERR, node->attributes[0], val && val[0] ? val[0] : "");
+        return OS_INVALID;
+    }
+
+    return Read_WazuhDB_Backup(xml, node, WDB_GLOBAL_BACKUP);
 }
 
 int Read_WazuhDB_Backup(const OS_XML *xml, xml_node * node, int const BACKUP_NODE) {

--- a/src/os_crypto/sha1/sha1_op.h
+++ b/src/os_crypto/sha1/sha1_op.h
@@ -17,7 +17,9 @@
 #include <windef.h>
 #endif
 
-typedef char os_sha1[41];
+#define OS_SHA1_HEXDIGEST_SIZE (SHA_DIGEST_LENGTH * 2) // Sha1 digest len (20) * 2 (hex chars per byte)
+
+typedef char os_sha1[OS_SHA1_HEXDIGEST_SIZE + 1];
 
 int OS_SHA1_File(const char *fname, os_sha1 output, int mode) __attribute((nonnull));
 int OS_SHA1_Str(const char *str, ssize_t length, os_sha1 output) __attribute((nonnull));

--- a/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
@@ -118,7 +118,7 @@ int teardown_wdb_global_helpers_add_agent(void **state) {
 
 int teardown_wdb_global_helpers(void **state) {
     test_mode = 0;
-
+    errno = 0;
     return 0;
 }
 
@@ -218,8 +218,6 @@ void test_wdb_create_agent_db_error_opening_dest_profile(void **state)
     expect_string(__wrap_stat, __file, "var/db/agents/001-agent1.db");
     will_return(__wrap_stat, 0);
     will_return(__wrap_stat, OS_INVALID);
-    // reseting error number after last use
-    errno = 0;
     // profile database not found
     expect_string(__wrap_fopen, path, "var/db/.template.db");
     expect_string(__wrap_fopen, mode, "r");

--- a/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
@@ -164,9 +164,10 @@ void test_wdb_create_agent_db_error_creating_source_profile(void **state)
     will_return(__wrap_stat, 0);
     will_return(__wrap_stat, OS_INVALID);
     // profile database not found
-    expect_string(__wrap_stat, __file, "var/db/.template.db");
-    will_return(__wrap_stat, 0);
-    will_return(__wrap_stat, OS_INVALID);
+    errno = EACCES;
+    expect_string(__wrap_fopen, path, "var/db/.template.db");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
     // Creating profile
     expect_string(__wrap__mdebug1, formatted_msg, "Profile database not found, creating.");
     expect_string(__wrap_wdb_create_profile, path, "var/db/.template.db");
@@ -188,9 +189,10 @@ void test_wdb_create_agent_db_error_reopening_source_profile(void **state)
     will_return(__wrap_stat, 0);
     will_return(__wrap_stat, OS_INVALID);
     // profile database not found
-    expect_string(__wrap_stat, __file, "var/db/.template.db");
-    will_return(__wrap_stat, 0);
-    will_return(__wrap_stat, OS_INVALID);
+    errno = EACCES;
+    expect_string(__wrap_fopen, path, "var/db/.template.db");
+    expect_string(__wrap_fopen, mode, "r");
+    will_return(__wrap_fopen, 0);
     // Creating profile
     expect_string(__wrap__mdebug1, formatted_msg, "Profile database not found, creating.");
     expect_string(__wrap_wdb_create_profile, path, "var/db/.template.db");
@@ -216,11 +218,9 @@ void test_wdb_create_agent_db_error_opening_dest_profile(void **state)
     expect_string(__wrap_stat, __file, "var/db/agents/001-agent1.db");
     will_return(__wrap_stat, 0);
     will_return(__wrap_stat, OS_INVALID);
+    // reseting error number after last use
+    errno = 0;
     // profile database not found
-    expect_string(__wrap_stat, __file, "var/db/.template.db");
-    will_return(__wrap_stat, 0);
-    will_return(__wrap_stat, OS_SUCCESS);
-    // Opening source database file
     expect_string(__wrap_fopen, path, "var/db/.template.db");
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, 1);
@@ -248,10 +248,7 @@ void test_wdb_create_agent_db_error_writing_profile(void **state)
     will_return(__wrap_stat, 0);
     will_return(__wrap_stat, OS_INVALID);
     // profile database found
-    expect_string(__wrap_stat, __file, "var/db/.template.db");
-    will_return(__wrap_stat, 0);
-    will_return(__wrap_stat, OS_SUCCESS);
-    // Opening source database file
+
     expect_string(__wrap_fopen, path, "var/db/.template.db");
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, 1);
@@ -285,10 +282,6 @@ void test_wdb_create_agent_db_error_getting_ids(void **state)
     will_return(__wrap_stat, 0);
     will_return(__wrap_stat, OS_INVALID);
     // profile database not found
-    expect_string(__wrap_stat, __file, "var/db/.template.db");
-    will_return(__wrap_stat, 0);
-    will_return(__wrap_stat, OS_SUCCESS);
-    // Opening source database file
     expect_string(__wrap_fopen, path, "var/db/.template.db");
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, 1);
@@ -330,10 +323,6 @@ void test_wdb_create_agent_db_error_changing_owner(void **state)
     will_return(__wrap_stat, 0);
     will_return(__wrap_stat, OS_INVALID);
     // profile database not found
-    expect_string(__wrap_stat, __file, "var/db/.template.db");
-    will_return(__wrap_stat, 0);
-    will_return(__wrap_stat, OS_SUCCESS);
-    // Opening source database file
     expect_string(__wrap_fopen, path, "var/db/.template.db");
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, 1);
@@ -380,10 +369,6 @@ void test_wdb_create_agent_db_error_changing_mode(void **state)
     will_return(__wrap_stat, 0);
     will_return(__wrap_stat, OS_INVALID);
     // profile database not found
-    expect_string(__wrap_stat, __file, "var/db/.template.db");
-    will_return(__wrap_stat, 0);
-    will_return(__wrap_stat, OS_SUCCESS);
-    // Opening source database file
     expect_string(__wrap_fopen, path, "var/db/.template.db");
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, 1);
@@ -433,10 +418,6 @@ void test_wdb_create_agent_db_success(void **state)
     will_return(__wrap_stat, 0);
     will_return(__wrap_stat, OS_INVALID);
     // profile database not found
-    expect_string(__wrap_stat, __file, "var/db/.template.db");
-    will_return(__wrap_stat, 0);
-    will_return(__wrap_stat, OS_SUCCESS);
-    // Opening source database file
     expect_string(__wrap_fopen, path, "var/db/.template.db");
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, 1);

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -2055,7 +2055,7 @@ void test_wdb_parse_global_get_groups_integrity_syntax_error(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_parse_global_get_groups_integrity_query_error(void **state)
+void test_wdb_parse_global_get_groups_integrity_hash_length_expected_fail(void **state)
 {
     int ret = OS_SUCCESS;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -2063,7 +2063,23 @@ void test_wdb_parse_global_get_groups_integrity_query_error(void **state)
 
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-groups-integrity random_hash");
-    expect_string(__wrap_wdb_global_get_groups_integrity, hash, "random_hash");
+    expect_string(__wrap__mdebug1, formatted_msg, "Hash hex-digest does not have the expected length. Expected (40) got (11)");
+
+    ret = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "err Hash hex-digest does not have the expected length. Expected (40) got (11)");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_get_groups_integrity_query_error(void **state)
+{
+    int ret = OS_SUCCESS;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global get-groups-integrity xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-groups-integrity xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
+    expect_string(__wrap_wdb_global_get_groups_integrity, hash, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
     will_return(__wrap_wdb_global_get_groups_integrity, NULL);
     expect_string(__wrap__mdebug1, formatted_msg, "Error getting groups integrity information from global.db.");
 
@@ -2077,12 +2093,12 @@ void test_wdb_parse_global_get_groups_integrity_success_syncreq(void **state)
 {
     int ret = OS_SUCCESS;
     test_struct_t *data  = (test_struct_t *)*state;
-    char query[OS_BUFFER_SIZE] = "global get-groups-integrity random_hash";
+    char query[OS_BUFFER_SIZE] = "global get-groups-integrity xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
     cJSON* j_response = cJSON_Parse("[\"syncreq\"]");
 
     will_return(__wrap_wdb_open_global, data->wdb);
-    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-groups-integrity random_hash");
-    expect_string(__wrap_wdb_global_get_groups_integrity, hash, "random_hash");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-groups-integrity xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
+    expect_string(__wrap_wdb_global_get_groups_integrity, hash, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
     will_return(__wrap_wdb_global_get_groups_integrity, j_response);
 
     ret = wdb_parse(query, data->output, 0);
@@ -2095,12 +2111,12 @@ void test_wdb_parse_global_get_groups_integrity_success_synced(void **state)
 {
     int ret = OS_SUCCESS;
     test_struct_t *data  = (test_struct_t *)*state;
-    char query[OS_BUFFER_SIZE] = "global get-groups-integrity random_hash";
+    char query[OS_BUFFER_SIZE] = "global get-groups-integrity xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
     cJSON* j_response = cJSON_Parse("[\"synced\"]");
 
     will_return(__wrap_wdb_open_global, data->wdb);
-    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-groups-integrity random_hash");
-    expect_string(__wrap_wdb_global_get_groups_integrity, hash, "random_hash");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-groups-integrity xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
+    expect_string(__wrap_wdb_global_get_groups_integrity, hash, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
     will_return(__wrap_wdb_global_get_groups_integrity, j_response);
 
     ret = wdb_parse(query, data->output, 0);
@@ -2113,12 +2129,12 @@ void test_wdb_parse_global_get_groups_integrity_success_hash_mismatch(void **sta
 {
     int ret = OS_SUCCESS;
     test_struct_t *data  = (test_struct_t *)*state;
-    char query[OS_BUFFER_SIZE] = "global get-groups-integrity random_hash";
+    char query[OS_BUFFER_SIZE] = "global get-groups-integrity xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
     cJSON* j_response = cJSON_Parse("[\"hash_mismatch\"]");
 
     will_return(__wrap_wdb_open_global, data->wdb);
-    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-groups-integrity random_hash");
-    expect_string(__wrap_wdb_global_get_groups_integrity, hash, "random_hash");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-groups-integrity xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
+    expect_string(__wrap_wdb_global_get_groups_integrity, hash, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
     will_return(__wrap_wdb_global_get_groups_integrity, j_response);
 
     ret = wdb_parse(query, data->output, 0);
@@ -2741,6 +2757,7 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_groups_get_invalid_response, test_setup, test_teardown),
         /* Tests wdb_parse_global_get_groups_integrity */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_groups_integrity_syntax_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_groups_integrity_hash_length_expected_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_groups_integrity_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_groups_integrity_success_syncreq, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_groups_integrity_success_synced, test_setup, test_teardown),

--- a/src/wazuh_db/helpers/wdb_global_helpers.c
+++ b/src/wazuh_db/helpers/wdb_global_helpers.c
@@ -1122,17 +1122,23 @@ int wdb_create_agent_db(int id, const char *name) {
     }
 
     snprintf(src_path, OS_FLSIZE, "%s/%s", WDB_DIR, WDB_PROF_NAME);
-    if (OS_SUCCESS != stat(src_path, &st_buffer)) {
+    if (!(source = fopen(src_path, "r"))) {
+        if (errno != EACCES) // If we get any other error other than 'file does not exits'
+        {
+            merror("Error accessing file (%s): (%s)", src_path, strerror(errno));
+            return OS_INVALID;
+        }
+
         mdebug1("Profile database not found, creating.");
 
         if (wdb_create_profile(src_path) < 0) {
             return OS_INVALID;
         }
-    }
 
-    if (!(source = fopen(src_path, "r"))) {
-        merror("Couldn't open profile '%s'.", src_path);
-        return OS_INVALID;
+        if (!(source = fopen(src_path, "r"))) {
+            merror("Couldn't open profile '%s'.", src_path);
+            return OS_INVALID;
+        }
     }
 
     if (!(dest = fopen(dst_path, "w"))) {

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1857,9 +1857,15 @@ int wdb_global_restore_backup(wdb_t** wdb, char* snapshot, bool save_pre_restore
             *wdb = NULL;
 
             unlink(global_path);
-            rename(global_tmp_path, global_path);
-            snprintf(output, OS_MAXSTR + 1, "ok");
-            result = OS_SUCCESS;
+
+            if (rename(global_tmp_path, global_path) != OS_SUCCESS) {
+                merror("Renaming %s to %s: %s", global_tmp_path, global_path, strerror(errno));
+                result = OS_INVALID;
+            }
+            else {
+                snprintf(output, OS_MAXSTR + 1, "ok");
+                result = OS_SUCCESS;
+            }
         } else {
             mdebug1("Failed during backup decompression");
             snprintf(output, OS_MAXSTR + 1, "err Failed during backup decompression");


### PR DESCRIPTION
|Related issue|
|---|
|#10771|

## Description

<!--
Add a clear description of how the problem has been solved.
-->
Fixing Unit test due to changes after coverity exam over this functions:

```
wdb_parse_global_get_groups_integrity()
wdb_create_agent_db()
Read_WazuhDB()

```
## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux

- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)

  - [x] Added unit testing files ".ini"
