### PR TITLE
Make agent_groups distributed

### DIFF
--- a/framework/scripts/agent_upgrade.py
+++ b/framework/scripts/agent_upgrade.py
@@ -211,6 +211,7 @@ if __name__ == "__main__":
     arg_parser.add_argument("-l", "--list_outdated", action="store_true",
                             help="Generates a list with all outdated agents.")
     arg_parser.add_argument("-f", "--file", type=str, help="Custom WPK filename.")
+    arg_parser.add_argument("-d", "--debug", action="store_true", help="Debug mode.")
     arg_parser.add_argument("-x", "--execute", type=str,
                             help="Executable filename in the WPK custom file. [Default: upgrade.sh]")
     arg_parser.add_argument("--http", action="store_true", help="Uses http protocol instead of https.")


### PR DESCRIPTION
|Related issue|
|---|
|#11789|

## Description

This closes #11789. In this pull request, we made the `agent_groups` binary distributed, meaning that it could be executed from not only the master but the workers too. The master will be in charge of creating, assigning and removing all the groups, and then sending this information to the workers. 