### PR TITLE
Add authorization context hash to API logs

### DIFF
--- a/api/api/alogging.py
+++ b/api/api/alogging.py
@@ -52,34 +52,32 @@ class AccessLogger(AbstractAccessLogger):
         hash_auth_context : str, optional
             Hash representing the authorization context. Default: ''
         """
+        if not hash_auth_context:
+            log_info = f'{user} {remote} "{method} {path}" with parameters {json.dumps(query)} ' \
+                       f'and body {json.dumps(body)} done in {time:.3f}s: {status}'
+            json_info = {'user': user,
+                         'ip': remote,
+                         'http_method': method,
+                         'uri': f'{method} {path}',
+                         'parameters': query,
+                         'body': body,
+                         'time': f'{time:.3f}s',
+                         'status_code': status}
+        else:
+            log_info = f'{user} ({hash_auth_context}) {remote} "{method} {path}" with parameters {json.dumps(query)} ' \
+                       f'and body {json.dumps(body)} done in {time:.3f}s: {status}'
+            json_info = {'user': user,
+                         'hash_auth_context': hash_auth_context,
+                         'ip': remote,
+                         'http_method': method,
+                         'uri': f'{method} {path}',
+                         'parameters': query,
+                         'body': body,
+                         'time': f'{time:.3f}s',
+                         'status_code': status}
 
-        self.logger.info(f'{user} '
-                         f'{f"({hash_auth_context}) " if hash_auth_context else ""}'
-                         f'{remote} '
-                         f'"{method} {path}" '
-                         f'with parameters {json.dumps(query)} and body {json.dumps(body)} '
-                         f'done in {time:.3f}s: {status}',
-                         extra={'log_type': 'log'})
-
-        self.logger.info({'user': user,
-                          'ip': remote,
-                          'http_method': method,
-                          'uri': f'{method} {path}',
-                          'parameters': query,
-                          'body': body,
-                          'time': f'{time:.3f}s',
-                          'status_code': status
-                          } if not hash_auth_context else
-                         {'user': user,
-                          'hash_auth_context': hash_auth_context,
-                          'ip': remote,
-                          'http_method': method,
-                          'uri': f'{method} {path}',
-                          'parameters': query,
-                          'body': body,
-                          'time': f'{time:.3f}s',
-                          'status_code': status},
-                         extra={'log_type': 'json'})
+        self.logger.info(log_info, extra={'log_type': 'log'})
+        self.logger.info(json_info, extra={'log_type': 'json'})
 
     def log(self, request, response, time):
         query = dict(request.query)

--- a/api/api/alogging.py
+++ b/api/api/alogging.py
@@ -2,6 +2,7 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 import binascii
+import hashlib
 import json
 import logging
 import re
@@ -9,15 +10,17 @@ from base64 import b64decode
 
 from aiohttp.abc import AbstractAccessLogger
 from pythonjsonlogger import jsonlogger
+
 from wazuh.core.wlogging import WazuhLogger
 
-from api.configuration import api_conf
-
-# compile regex when the module is imported so it's not necessary to compile it everytime log.info is called
+# Compile regex when the module is imported so it's not necessary to compile it everytime log.info is called
 request_pattern = re.compile(r'\[.+]|\s+\*\s+')
 
 # Variable used to specify an unknown user
 UNKNOWN_USER_STRING = "unknown_user"
+
+# Run_as login endpoint path
+RUN_AS_LOGIN_ENDPOINT = "/security/user/authenticate/run_as"
 
 
 class AccessLogger(AbstractAccessLogger):
@@ -25,7 +28,7 @@ class AccessLogger(AbstractAccessLogger):
     Define the log writter used by aiohttp.
     """
 
-    def custom_logging(self, user, remote, method, path, query, body, time, status):
+    def custom_logging(self, user, remote, method, path, query, body, time, status, hash_auth_context=''):
         """Provide the log entry structure depending on the logging format.
 
         Parameters
@@ -46,15 +49,17 @@ class AccessLogger(AbstractAccessLogger):
             Required time to compute the request.
         status : int
             Status code of the request.
+        hash_auth_context : str, optional
+            Hash representing the authorization context. Default: ''
         """
 
         self.logger.info(f'{user} '
+                         f'{f"({hash_auth_context}) " if hash_auth_context else ""}'
                          f'{remote} '
                          f'"{method} {path}" '
                          f'with parameters {json.dumps(query)} and body {json.dumps(body)} '
                          f'done in {time:.3f}s: {status}',
-                         extra={'log_type': 'log'}
-                         )
+                         extra={'log_type': 'log'})
 
         self.logger.info({'user': user,
                           'ip': remote,
@@ -64,9 +69,17 @@ class AccessLogger(AbstractAccessLogger):
                           'body': body,
                           'time': f'{time:.3f}s',
                           'status_code': status
-                          },
-                         extra={'log_type': 'json'}
-                         )
+                          } if not hash_auth_context else
+                         {'user': user,
+                          'hash_auth_context': hash_auth_context,
+                          'ip': remote,
+                          'http_method': method,
+                          'uri': f'{method} {path}',
+                          'parameters': query,
+                          'body': body,
+                          'time': f'{time:.3f}s',
+                          'status_code': status},
+                         extra={'log_type': 'json'})
 
     def log(self, request, response, time):
         query = dict(request.query)
@@ -77,6 +90,7 @@ class AccessLogger(AbstractAccessLogger):
             body['password'] = '****'
         if 'key' in body and '/agents' in request.path:
             body['key'] = '****'
+
         # With permanent redirect, not found responses or any response with no token information,
         # decode the JWT token to get the username
         user = request.get('user', '')
@@ -86,15 +100,17 @@ class AccessLogger(AbstractAccessLogger):
             except (KeyError, IndexError, binascii.Error):
                 user = UNKNOWN_USER_STRING
 
-        self.custom_logging(user,
-                            request.remote,
-                            request.method,
-                            request.path,
-                            query,
-                            body,
-                            time,
-                            response.status
-                            )
+        # Get or create authorization context hash
+        hash_auth_context = ''
+        # Get hash from token information
+        if 'token_info' in request:
+            hash_auth_context = request['token_info'].get('hash_auth_context', '')
+        # Create hash if run_as login
+        if not hash_auth_context and request.path == RUN_AS_LOGIN_ENDPOINT:
+            hash_auth_context = hashlib.blake2b(json.dumps(body).encode(), digest_size=16).hexdigest()
+
+        self.custom_logging(user, request.remote, request.method, request.path, query, body, time, response.status,
+                            hash_auth_context=hash_auth_context)
 
 
 class APILogger(WazuhLogger):
@@ -137,6 +153,7 @@ class WazuhJsonFormatter(jsonlogger.JsonFormatter):
     """
     Define the custom JSON log formatter used by wlogging.
     """
+
     def add_fields(self, log_record, record, message_dict):
         """Implement custom logic for adding fields in a log entry.
 
@@ -154,7 +171,7 @@ class WazuhJsonFormatter(jsonlogger.JsonFormatter):
             record.message = {
                 'type': 'request',
                 'payload': message_dict
-                }
+            }
         else:
             # Traceback handling
             traceback = message_dict.get('exc_info')
@@ -162,13 +179,13 @@ class WazuhJsonFormatter(jsonlogger.JsonFormatter):
                 record.message = {
                     'type': 'error',
                     'payload': f'{record.message}. {traceback}'
-                    }
+                }
             else:
                 # Plain text messages
                 record.message = {
                     'type': 'informative',
                     'payload': record.message
-                    }
+                }
         log_record['timestamp'] = self.formatTime(record, self.datefmt)
         log_record['levelname'] = record.levelname
         log_record['data'] = record.message

--- a/api/api/authentication.py
+++ b/api/api/authentication.py
@@ -3,6 +3,8 @@
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import asyncio
+import hashlib
+import json
 import logging
 import os
 from concurrent.futures import ThreadPoolExecutor
@@ -135,17 +137,17 @@ def get_security_conf():
     return conf.security_conf
 
 
-def generate_token(user_id=None, data=None, run_as=False):
-    """Generate an encoded jwt token. This method should be called once a user is properly logged on.
+def generate_token(user_id=None, data=None, auth_context=None):
+    """Generate an encoded JWT token. This method should be called once a user is properly logged on.
 
     Parameters
     ----------
     user_id : str
-        Unique username
+        Unique username.
     data : dict
-        Roles permissions for the user
-    run_as : bool
-        Indicate if the user has logged in with run_as or not
+        Roles permissions for the user.
+    auth_context : dict
+        Authorization context used in the run as login request.
 
     Returns
     -------
@@ -161,15 +163,16 @@ def generate_token(user_id=None, data=None, run_as=False):
     timestamp = int(core_utils.get_utc_now().timestamp())
 
     payload = {
-        "iss": JWT_ISSUER,
-        "aud": "Wazuh API REST",
-        "nbf": timestamp,
-        "exp": timestamp + result['auth_token_exp_timeout'],
-        "sub": str(user_id),
-        "run_as": run_as,
-        "rbac_roles": data['roles'],
-        "rbac_mode": result['rbac_mode']
-    }
+                  "iss": JWT_ISSUER,
+                  "aud": "Wazuh API REST",
+                  "nbf": timestamp,
+                  "exp": timestamp + result['auth_token_exp_timeout'],
+                  "sub": str(user_id),
+                  "run_as": auth_context is not None,
+                  "rbac_roles": data['roles'],
+                  "rbac_mode": result['rbac_mode']
+              } | ({"hash_auth_context": hashlib.blake2b(json.dumps(auth_context).encode(), digest_size=16).hexdigest()}
+                   if auth_context is not None else {})
 
     return jwt.encode(payload, generate_keypair()[0], algorithm=JWT_ALGORITHM)
 

--- a/api/api/controllers/security_controller.py
+++ b/api/api/controllers/security_controller.py
@@ -120,7 +120,8 @@ async def run_as_login(request, user: str, raw: bool = False) -> web.Response:
     web.Response
         Raw or JSON response with the generated access token.
     """
-    f_kwargs = {'user_id': user, 'auth_context': await request.json()}
+    auth_context = await request.json()
+    f_kwargs = {'user_id': user, 'auth_context': auth_context}
 
     dapi = DistributedAPI(f=preprocessor.get_permissions,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -132,7 +133,7 @@ async def run_as_login(request, user: str, raw: bool = False) -> web.Response:
 
     token = None
     try:
-        token = generate_token(user_id=user, data=data.dikt, run_as=True)
+        token = generate_token(user_id=user, data=data.dikt, auth_context=auth_context)
     except WazuhException as e:
         raise_if_exc(e)
 

--- a/api/api/test/test_alogging.py
+++ b/api/api/test/test_alogging.py
@@ -54,8 +54,8 @@ def test_accesslogger_log_credentials():
     (None, 'wazuh')
 ])
 @patch('api.alogging.json.dumps')
-def test_accesslogger_log(mock_dumps, side_effect, user):
-    """Test expected methods are called when using log(). Also test that the user is logged properly.
+def test_accesslogger_log_user(mock_dumps, side_effect, user):
+    """Test that the user is logged properly when using log().
 
     Parameters
     ----------
@@ -100,7 +100,7 @@ def test_accesslogger_log(mock_dumps, side_effect, user):
     ('/security/user/authenticate', None, {})  # Test any other call without auth context does not log the hash
 ])
 def test_accesslogger_log_hash_auth_context(request_path, token_info, request_body):
-    """Test expected methods are called when using log(). Also test that the auth context hash is logged properly.
+    """Test that the authorization context hash is logged properly when using log().
 
     Parameters
     ----------

--- a/api/api/test/test_alogging.py
+++ b/api/api/test/test_alogging.py
@@ -139,14 +139,17 @@ def test_accesslogger_log_hash_auth_context(request_path, token_info, request_bo
         test_access_logger = alogging.AccessLogger(logger=logging.getLogger('test'), log_format=MagicMock())
         test_access_logger.log(request=request, response=MagicMock(), time=0.0)
 
-        log_message = mock_logger_info.call_args.args[0].split(" ")
+        message_api_log = mock_logger_info.call_args_list[0][0][0].split(" ")
+        message_api_json = mock_logger_info.call_args_list[1][0][0]
 
         # Test authorization context hash is being logged
         if (token_info and token_info.get('hash_auth_context')) or \
                 (request_path == "/security/user/authenticate/run_as" and request_body):
-            assert log_message[1] == f"({HASH_AUTH_CONTEXT_TEST})"
+            assert message_api_log[1] == f"({HASH_AUTH_CONTEXT_TEST})"
+            assert message_api_json.get('hash_auth_context') == HASH_AUTH_CONTEXT_TEST
         else:
-            assert log_message[1] == request.remote
+            assert message_api_log[1] == request.remote
+            assert 'hash_auth_context' not in message_api_json
 
 
 @pytest.mark.parametrize('json_log', [

--- a/api/api/test/test_alogging.py
+++ b/api/api/test/test_alogging.py
@@ -13,6 +13,9 @@ with patch('wazuh.core.common.wazuh_uid'):
     with patch('wazuh.core.common.wazuh_gid'):
         from api import alogging
 
+REQUEST_HEADERS_TEST = {'authorization': 'Basic d2F6dWg6cGFzc3dvcmQxMjM='}  # wazuh:password123
+AUTH_CONTEXT_TEST = {'auth_context': 'example'}
+HASH_AUTH_CONTEXT_TEST = '020efd3b53c1baf338cf143fad7131c3'
 
 def test_accesslogger_log_credentials():
     """Check AccessLogger is hiding confidential data from logs"""
@@ -52,7 +55,7 @@ def test_accesslogger_log_credentials():
 ])
 @patch('api.alogging.json.dumps')
 def test_accesslogger_log(mock_dumps, side_effect, user):
-    """Test expected methods are called when using log().
+    """Test expected methods are called when using log(). Also test that the user is logged properly.
 
     Parameters
     ----------
@@ -64,8 +67,7 @@ def test_accesslogger_log(mock_dumps, side_effect, user):
 
     # Create a class with a mocked get method for request
     class MockedRequest(MagicMock):
-        # wazuh:password123
-        headers = {'authorization': 'Basic d2F6dWg6cGFzc3dvcmQxMjM='} if side_effect is None else {}
+        headers = REQUEST_HEADERS_TEST if side_effect is None else {}
 
         def get(self, *args, **kwargs):
             return user
@@ -89,6 +91,62 @@ def test_accesslogger_log(mock_dumps, side_effect, user):
         else:
             assert json_call['user'] == user
             assert log_call.split(" ")[0] == user
+
+
+@pytest.mark.parametrize('request_path, token_info, request_body', [
+    ('/agents', {'hash_auth_context': HASH_AUTH_CONTEXT_TEST}, {}),  # Test a normal request logs the auth context hash
+    ('/security/user/authenticate/run_as', {'other_key': 'other_value'},
+     AUTH_CONTEXT_TEST),  # Test a login request generates and logs the auth context hash
+    ('/security/user/authenticate', None, {})  # Test any other call without auth context does not log the hash
+])
+def test_accesslogger_log_hash_auth_context(request_path, token_info, request_body):
+    """Test expected methods are called when using log(). Also test that the auth context hash is logged properly.
+
+    Parameters
+    ----------
+    request_path : str
+        Path used in the custom request.
+    token_info : dict
+        Dictionary corresponding to the token information. If token_info is None, we simulate that no token was given.
+    request_body : dict
+        Request body used in the custom request.
+    """
+
+    # Create a class with custom methods for request
+    class CustomRequest:
+        def __init__(self):
+            self.request_dict = {'token_info': token_info} if token_info else {}
+            self.path = request_path
+            self.body = request_body
+            self.query = {'q': 'test'}
+            self.remote = 'test'
+            self.method = 'test'
+            self.user = 'test'
+
+        def __contains__(self, key):
+            return key in self.request_dict
+
+        def __getitem__(self, key):
+            return self.request_dict[key]
+
+        def get(self, *args, **kwargs):
+            return getattr(self, args[0]) if args[0] in self.__dict__.keys() else args[1]
+
+    # Mock logger.info
+    with patch('logging.Logger.info') as mock_logger_info:
+        # Create an AccessLogger object and log a mocked call
+        request = CustomRequest()
+        test_access_logger = alogging.AccessLogger(logger=logging.getLogger('test'), log_format=MagicMock())
+        test_access_logger.log(request=request, response=MagicMock(), time=0.0)
+
+        log_message = mock_logger_info.call_args.args[0].split(" ")
+
+        # Test authorization context hash is being logged
+        if (token_info and token_info.get('hash_auth_context')) or \
+                (request_path == "/security/user/authenticate/run_as" and request_body):
+            assert log_message[1] == HASH_AUTH_CONTEXT_TEST
+        else:
+            assert log_message[1] == request.remote
 
 
 @pytest.mark.parametrize('json_log', [

--- a/api/api/test/test_alogging.py
+++ b/api/api/test/test_alogging.py
@@ -144,7 +144,7 @@ def test_accesslogger_log_hash_auth_context(request_path, token_info, request_bo
         # Test authorization context hash is being logged
         if (token_info and token_info.get('hash_auth_context')) or \
                 (request_path == "/security/user/authenticate/run_as" and request_body):
-            assert log_message[1] == HASH_AUTH_CONTEXT_TEST
+            assert log_message[1] == f"({HASH_AUTH_CONTEXT_TEST})"
         else:
             assert log_message[1] == request.remote
 

--- a/api/api/test/test_authentication.py
+++ b/api/api/test/test_authentication.py
@@ -44,8 +44,8 @@ decoded_payload = {
 }
 
 original_payload = {
-    "iss": 'wazuh',
-    "aud": 'Wazuh API REST',
+    "iss": "wazuh",
+    "aud": "Wazuh API REST",
     "nbf": 0,
     "exp": security_conf['auth_token_exp_timeout'],
     "sub": "001",

--- a/api/api/test/test_authentication.py
+++ b/api/api/test/test_authentication.py
@@ -2,6 +2,8 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
+import hashlib
+import json
 import os
 import sys
 from copy import deepcopy
@@ -46,8 +48,8 @@ original_payload = {
     "aud": 'Wazuh API REST',
     "nbf": 0,
     "exp": security_conf['auth_token_exp_timeout'],
-    "sub": '001',
-    'run_as': False,
+    "sub": "001",
+    "run_as": False,
     "rbac_roles": [1],
     "rbac_mode": security_conf['rbac_mode']
 }
@@ -124,6 +126,7 @@ def test_get_security_conf():
     assert all(x in result.keys() for x in ('auth_token_exp_timeout', 'rbac_mode'))
 
 
+@pytest.mark.parametrize('auth_context', [{'name': 'initial_auth'}, None])
 @patch('api.authentication.jwt.encode', return_value='test_token')
 @patch('api.authentication.generate_keypair', return_value=('-----BEGIN PRIVATE KEY-----',
                                                             '-----BEGIN PUBLIC KEY-----'))
@@ -132,7 +135,7 @@ def test_get_security_conf():
 @patch('concurrent.futures.ThreadPoolExecutor.submit', side_effect=None)
 @patch('api.authentication.raise_if_exc', side_effect=None)
 def test_generate_token(mock_raise_if_exc, mock_submit, mock_distribute_function, mock_dapi, mock_generate_keypair,
-                        mock_encode):
+                        mock_encode, auth_context):
     """Verify if result is as expected"""
 
     class NewDatetime:
@@ -141,7 +144,7 @@ def test_generate_token(mock_raise_if_exc, mock_submit, mock_distribute_function
 
     mock_raise_if_exc.return_value = security_conf
     with patch('api.authentication.core_utils.get_utc_now', return_value=NewDatetime()):
-        result = authentication.generate_token('001', {'roles': [1]})
+        result = authentication.generate_token(user_id='001', data={'roles': [1]}, auth_context=auth_context)
     assert result == 'test_token', 'Result is not as expected'
 
     # Check all functions are called with expected params
@@ -150,7 +153,10 @@ def test_generate_token(mock_raise_if_exc, mock_submit, mock_distribute_function
     mock_distribute_function.assert_called_once_with()
     mock_raise_if_exc.assert_called_once()
     mock_generate_keypair.assert_called_once()
-    mock_encode.assert_called_once_with(original_payload, '-----BEGIN PRIVATE KEY-----', algorithm='ES512')
+    expected_payload = original_payload | (
+        {"hash_auth_context": hashlib.blake2b(json.dumps(auth_context).encode(),
+                                              digest_size=16).hexdigest(), "run_as": True} if auth_context is not None else {})
+    mock_encode.assert_called_once_with(expected_payload, '-----BEGIN PRIVATE KEY-----', algorithm='ES512')
 
 
 @patch('api.authentication.TokenManager')


### PR DESCRIPTION
|Related issue|
|---|
| #11449 |

This PR closes #11449. 

In this pull request, I have added a hash that identifies the authorization context used in the run as login. This hash has been added to the API logs and it appears in the run as login requests and requests using tokens generated in run as login requests.

With this change, same Wazuh users using different permissions can be identified properly.

More investigation can be found in the related issue's comments.