### PR TITLE
Improving strings used in the output of the settings request to the wazuh-db socket

### DIFF
--- a/src/unit_tests/wazuh_db/test_wdb.c
+++ b/src/unit_tests/wazuh_db/test_wdb.c
@@ -746,14 +746,14 @@ void test_wdb_get_config(){
     cJSON *root = cJSON_GetObjectItem(ret, "wdb");
     assert_true(cJSON_IsObject(root));
 
-    cJSON *cfg_array = cJSON_GetObjectItem(root, "backup_settings_nodes");
+    cJSON *cfg_array = cJSON_GetObjectItem(root, "backup");
     assert_true(cJSON_IsArray(cfg_array));
 
     cJSON *cfg = 0;
     cJSON_ArrayForEach(cfg, cfg_array){
         assert_true(cJSON_IsObject(cfg));
 
-        cJSON *c0 = cJSON_GetObjectItem(cfg, "node_name");
+        cJSON *c0 = cJSON_GetObjectItem(cfg, "database");
         assert_true(cJSON_IsString(c0));
         cJSON *c1 = cJSON_GetObjectItem(cfg, "enabled");
         assert_true(cJSON_IsBool(c1));

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -1510,14 +1510,14 @@ cJSON* wdb_get_internal_config() {
 cJSON* wdb_get_config() {
     cJSON *root = cJSON_CreateObject();
     cJSON* wdb_config = cJSON_CreateObject();
-    cJSON* j_wdb_backup_settings_nodes = cJSON_CreateArray();
+    cJSON* j_wdb_backup = cJSON_CreateArray();
 
     for (int i = 0; i < WDB_LAST_BACKUP; i++) {
         cJSON* j_wdb_backup_settings_node = cJSON_CreateObject();
 
         switch (i) {
             case WDB_GLOBAL_BACKUP:
-                cJSON_AddStringToObject(j_wdb_backup_settings_node, "node_name", "global");
+                cJSON_AddStringToObject(j_wdb_backup_settings_node, "database", "global");
                 break;
             default:
                 break;
@@ -1527,10 +1527,10 @@ cJSON* wdb_get_config() {
         cJSON_AddNumberToObject(j_wdb_backup_settings_node, "interval", wconfig.wdb_backup_settings[i]->interval);
         cJSON_AddNumberToObject(j_wdb_backup_settings_node, "max_files", wconfig.wdb_backup_settings[i]->max_files);
 
-        cJSON_AddItemToArray(j_wdb_backup_settings_nodes, j_wdb_backup_settings_node);
+        cJSON_AddItemToArray(j_wdb_backup, j_wdb_backup_settings_node);
     }
 
-    cJSON_AddItemToObject(wdb_config, "backup_settings_nodes", j_wdb_backup_settings_nodes);
+    cJSON_AddItemToObject(wdb_config, "backup", j_wdb_backup);
     cJSON_AddItemToObject(root, "wdb", wdb_config);
 
     return root;


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/11240 |

## Description

This pull request changes the strings used in the output of the request of the settings to the `wazuh-db` daemon. Now, the output looks like this:

![image](https://user-images.githubusercontent.com/5703274/152413101-936bda53-acc4-4e9f-9853-dad7a319c8ec.png)

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade

- Memory tests for Linux
  - [x] Scan-build report
  ![image](https://user-images.githubusercontent.com/5703274/152415127-aeff91e9-daf4-4bf8-96da-1ecd5bfefd1f.png)


- [x] Updated unit tests