### PR TITLE
Changing from `merror` to `minfo` when Vulnerability Detector can't obtain the OS information of an agent to perform the scan

### DIFF
--- a/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
@@ -50,7 +50,7 @@ void test_wdb_get_sys_osinfo_error_sql_execution(void ** state)
     will_return(__wrap_wdbc_query_parse_json, NULL);
 
     // Handling result
-    expect_string(__wrap__minfo, formatted_msg, "Agents DB (1) Error querying Wazuh DB to get OS information");
+    expect_string(__wrap__minfo, formatted_msg, "Agents DB (1): No OS information available.");
 
     //Cleaning  memory
     expect_function_call(__wrap_cJSON_Delete);

--- a/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
@@ -50,7 +50,7 @@ void test_wdb_get_sys_osinfo_error_sql_execution(void ** state)
     will_return(__wrap_wdbc_query_parse_json, NULL);
 
     // Handling result
-    expect_string(__wrap__merror, formatted_msg, "Agents DB (1) Error querying Wazuh DB to get OS information");
+    expect_string(__wrap__minfo, formatted_msg, "Agents DB (1) Error querying Wazuh DB to get OS information");
 
     //Cleaning  memory
     expect_function_call(__wrap_cJSON_Delete);

--- a/src/wazuh_db/helpers/wdb_agents_helpers.c
+++ b/src/wazuh_db/helpers/wdb_agents_helpers.c
@@ -34,7 +34,7 @@ cJSON* wdb_get_agent_sys_osinfo(int id,
     cJSON* result = wdbc_query_parse_json(sock?sock:&aux_sock, wdbquery, wdboutput, WDBOUTPUT_SIZE);
 
     if (!result || !result->child) {
-        merror("Agents DB (%d) Error querying Wazuh DB to get OS information", id);
+        minfo("Agents DB (%d) Error querying Wazuh DB to get OS information", id);
         cJSON_Delete(result);
         result = NULL;
     }

--- a/src/wazuh_db/helpers/wdb_agents_helpers.c
+++ b/src/wazuh_db/helpers/wdb_agents_helpers.c
@@ -34,7 +34,7 @@ cJSON* wdb_get_agent_sys_osinfo(int id,
     cJSON* result = wdbc_query_parse_json(sock?sock:&aux_sock, wdbquery, wdboutput, WDBOUTPUT_SIZE);
 
     if (!result || !result->child) {
-        minfo("Agents DB (%d) Error querying Wazuh DB to get OS information", id);
+        minfo("Agents DB (%d): No OS information available.", id);
         cJSON_Delete(result);
         result = NULL;
     }


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/12068 |

## Description

This pull request fixes the log level for the case in which Vulnerability Detector module can't obtain the OS information to perform the scan of an agent.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation

- [x] Updated unit tests