### PR TITLE
Remove unused `subprocess` imports in `core/utils.py` and `core/common.py`

### DIFF
--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -4,7 +4,6 @@
 
 import json
 import os
-import subprocess
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from contextvars import ContextVar
 from copy import deepcopy

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -20,7 +20,7 @@ from os import chmod, chown, listdir, mkdir, curdir, rename, utime, remove, walk
 from pyexpat import ExpatError
 from shutil import Error, copyfile, move
 from signal import signal, alarm, SIGALRM
-from xml.etree.ElementTree import ElementTree
+from subprocess import CalledProcessError, check_output
 
 from cachetools import cached, TTLCache
 from defusedxml.ElementTree import fromstring

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -20,7 +20,7 @@ from os import chmod, chown, listdir, mkdir, curdir, rename, utime, remove, walk
 from pyexpat import ExpatError
 from shutil import Error, copyfile, move
 from signal import signal, alarm, SIGALRM
-from subprocess import CalledProcessError, check_output
+from xml.etree.ElementTree import ElementTree
 
 from cachetools import cached, TTLCache
 from defusedxml.ElementTree import fromstring

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -20,7 +20,6 @@ from os import chmod, chown, listdir, mkdir, curdir, rename, utime, remove, walk
 from pyexpat import ExpatError
 from shutil import Error, copyfile, move
 from signal import signal, alarm, SIGALRM
-from subprocess import CalledProcessError, check_output
 
 from cachetools import cached, TTLCache
 from defusedxml.ElementTree import fromstring


### PR DESCRIPTION
This pull request is part of #10125.

As it was said in https://github.com/wazuh/wazuh-qa/issues/2330#issuecomment-1028275172, one of the required fixes has to do with a rebase conflict in some of the pull requests related to this epic.

In this case, this pull request removes the `from subprocess import CalledProcessError, check_output` line from `framework/wazuh/core/utils.py` since it's not being used and it's reported as a new framework flaw. It also removes `import subprocess from framework/wazuh/core/common.py` since it's not being used and it's known as a false positive.

