### PR TITLE
Fix segfault after global db restoration

### DIFF
--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -298,10 +298,14 @@ wdb_t * wdb_open_global() {
 
             wdb = wdb_init(db, WDB_GLOB_NAME);
             wdb_pool_append(wdb);
+            w_mutex_lock(&wdb->mutex);
+            wdb->refcount++;
         }
         else {
             wdb = wdb_init(db, WDB_GLOB_NAME);
             wdb_pool_append(wdb);
+            w_mutex_lock(&wdb->mutex);
+            wdb->refcount++;
             if (wdb = wdb_upgrade_global(wdb), !wdb) {
                 w_mutex_unlock(&pool_mutex);
                 return wdb;
@@ -310,10 +314,6 @@ wdb_t * wdb_open_global() {
 
         wdb_enable_foreign_keys(wdb->db);
     }
-
-    // The corresponding w_mutex_unlock(&wdb->mutex) is called in wdb_leave(wdb_t * wdb)
-    w_mutex_lock(&wdb->mutex);
-    wdb->refcount++;
 
     w_mutex_unlock(&pool_mutex);
     return wdb;

--- a/src/wazuh_db/wdb_upgrade.c
+++ b/src/wazuh_db/wdb_upgrade.c
@@ -139,7 +139,6 @@ wdb_t * wdb_upgrade_global(wdb_t *wdb) {
                         merror("Failed to update global.db to version %d. The global.db was "
                                "restored to the original state.",
                                i + 1);
-                        wdb->enabled = true;
                     }
                     else {
                         merror("Failed to update global.db to version %d.", i + 1);
@@ -201,6 +200,7 @@ wdb_t * wdb_recreate_global(wdb_t *wdb) {
 
     snprintf(path, PATH_MAX, "%s/%s.db", WDB2_DIR, WDB_GLOB_NAME);
 
+    wdb_leave(wdb);
     if (wdb_close(wdb, TRUE) != OS_INVALID) {
         unlink(path);
 
@@ -217,6 +217,8 @@ wdb_t * wdb_recreate_global(wdb_t *wdb) {
 
         new_wdb = wdb_init(db, WDB_GLOB_NAME);
         wdb_pool_append(new_wdb);
+        w_mutex_lock(&new_wdb->mutex);
+        new_wdb->refcount++;
     }
 
     return new_wdb;


### PR DESCRIPTION
|Related issue|
|---|
|#12104|

## Description

This PR fixes: 

- Segfault after restoring the global DB.
- Extra refcount decrementing causes wdb_close to fail during the restoration process.

## Dod

![image](https://user-images.githubusercontent.com/13010397/152863806-c24a5ebd-ab27-43a2-bdde-b5678bc19773.png)

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report