### PR TITLE
Fix unique_lock out of context.

### DIFF
--- a/architecture/FIM/db/class.puml
+++ b/architecture/FIM/db/class.puml
@@ -133,7 +133,7 @@ class "FimDB"  <<(S,#FF7700) Singleton>> {
     + void stopIntegrity()
     + void logFunction(const modules_log_level_t, const string&)
     + DBSYNC_HANDLE DBSyncHandle()
-    + void loopRsync(lock)
+    + void loopRsync()
     + void removeItem(json)
     + void updateItem(json, callback)
     + void executeQuery(json, callback)

--- a/src/syscheckd/src/db/src/fimDB.hpp
+++ b/src/syscheckd/src/db/src/fimDB.hpp
@@ -307,7 +307,7 @@ class FIMDB
         /**
          * @brief Create the loop with the configured interval to do the periodical synchronization
          */
-        void loopRSync(std::unique_lock<std::mutex>& lock);
+        void loopRSync();
 
         /**
          * @brief Its the function in charge of starting the flow of synchronization

--- a/src/syscheckd/src/db/tests/db/FIMDB/fimDBTests/fimDBImpTests.cpp
+++ b/src/syscheckd/src/db/tests/db/FIMDB/fimDBTests/fimDBImpTests.cpp
@@ -281,8 +281,7 @@ TEST_F(FimDBWinFixture, loopWinRSyncSuccess)
     EXPECT_CALL(*mockRSync, startSync(mockDBSync->handle(), nlohmann::json::parse(FIM_REGISTRY_START_CONFIG_STATEMENT), testing::_));
     EXPECT_CALL(*mockLog, loggingFunction(LOG_INFO, "Finished FIM sync."));
 
-    std::unique_lock<std::mutex> lock{test_mutex};
-    std::thread syncThread(&FIMDB::loopRSync, &fimDBMock, std::ref(lock));
+    std::thread syncThread(&FIMDB::loopRSync, &fimDBMock);
 
     fimDBMock.stopIntegrity();
 
@@ -299,8 +298,7 @@ TEST_F(FimDBFixture, loopRSyncSuccess)
     EXPECT_CALL(*mockRSync, startSync(mockDBSync->handle(), nlohmann::json::parse(FIM_FILE_START_CONFIG_STATEMENT), testing::_));
     EXPECT_CALL(*mockLog, loggingFunction(LOG_INFO, "Finished FIM sync."));
 
-    std::unique_lock<std::mutex> lock{test_mutex};
-    std::thread syncThread(&FIMDB::loopRSync, &fimDBMock, std::ref(lock));
+    std::thread syncThread(&FIMDB::loopRSync, &fimDBMock);
 
     fimDBMock.stopIntegrity();
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #12107 |

## Description
Reviewing some of the PR checks we have found a bug that sometimes causes agents to crash just after starting the FIMDB synchronization. It is due to a unique_lock that goes out of context when launching the thread in which the synchronization is executed:
https://github.com/wazuh/wazuh/blob/a2597a10e56523ad04d7b488cfd1d941d322f312/src/syscheckd/src/db/src/fimDB.cpp#L129-L147

This causes the agent to crash when trying to access that lock.