### PR TITLE
Remove unused API integration tests marks

### DIFF
--- a/api/test/integration/conftest.py
+++ b/api/test/integration/conftest.py
@@ -70,8 +70,9 @@ def build_and_up(interval: int = 10, interval_build_env: int = 10, build: bool =
     dict
         Dict with healthchecks parameters.
     """
-    pwd = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'env')
-    os.chdir(pwd)
+    current_abspath = os.path.abspath(os.path.dirname(__file__))
+    env_dir_abspath = os.path.join(current_abspath, 'env')
+    os.chdir(env_dir_abspath)
     values = {
         'interval': interval,
         'max_retries': 60,
@@ -102,18 +103,21 @@ def build_and_up(interval: int = 10, interval_build_env: int = 10, build: bool =
             else:
                 time.sleep(values_build_env['interval'])
                 values_build_env['retries'] += 1
+    os.chdir(current_abspath)
 
     return values
 
 
 def down_env():
     """Stop all Docker environments for the current test."""
-    pwd = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'env')
-    os.chdir(pwd)
+    current_abspath = os.path.abspath(os.path.dirname(__file__))
+    env_dir_abspath = os.path.join(current_abspath, 'env')
+    os.chdir(env_dir_abspath)
     with open(docker_log_path, mode='a') as fdocker:
         current_process = subprocess.Popen(["docker-compose", "down", "-t", "0"],
                                            stdout=fdocker, stderr=subprocess.STDOUT, universal_newlines=True)
         current_process.wait()
+    os.chdir(current_abspath)
 
 
 def check_health(interval: int = 10, node_type: str = 'manager', agents: list = None):

--- a/api/test/integration/conftest.py
+++ b/api/test/integration/conftest.py
@@ -13,6 +13,7 @@ import yaml
 from py.xml import html
 
 current_path = os.path.dirname(os.path.abspath(__file__))
+env_path = os.path.join(current_path, 'env')
 test_logs_path = os.path.join(current_path, '_test_results', 'logs')
 docker_log_path = os.path.join(test_logs_path, 'docker.log')
 results = dict()
@@ -70,9 +71,7 @@ def build_and_up(interval: int = 10, interval_build_env: int = 10, build: bool =
     dict
         Dict with healthchecks parameters.
     """
-    current_abspath = os.path.abspath(os.path.dirname(__file__))
-    env_dir_abspath = os.path.join(current_abspath, 'env')
-    os.chdir(env_dir_abspath)
+    os.chdir(env_path)
     values = {
         'interval': interval,
         'max_retries': 60,
@@ -103,21 +102,19 @@ def build_and_up(interval: int = 10, interval_build_env: int = 10, build: bool =
             else:
                 time.sleep(values_build_env['interval'])
                 values_build_env['retries'] += 1
-    os.chdir(current_abspath)
+    os.chdir(current_path)
 
     return values
 
 
 def down_env():
     """Stop all Docker environments for the current test."""
-    current_abspath = os.path.abspath(os.path.dirname(__file__))
-    env_dir_abspath = os.path.join(current_abspath, 'env')
-    os.chdir(env_dir_abspath)
+    os.chdir(env_path)
     with open(docker_log_path, mode='a') as fdocker:
         current_process = subprocess.Popen(["docker-compose", "down", "-t", "0"],
                                            stdout=fdocker, stderr=subprocess.STDOUT, universal_newlines=True)
         current_process.wait()
-    os.chdir(current_abspath)
+    os.chdir(current_path)
 
 
 def check_health(interval: int = 10, node_type: str = 'manager', agents: list = None):
@@ -164,9 +161,9 @@ def general_procedure(module: str):
     module : str
         Name of the tested module
     """
-    base_content = os.path.join(current_path, 'env', 'configurations', 'base', '*')
-    module_content = os.path.join(current_path, 'env', 'configurations', module, '*')
-    tmp_content = os.path.join(current_path, 'env', 'configurations', 'tmp')
+    base_content = os.path.join(env_path, 'configurations', 'base', '*')
+    module_content = os.path.join(env_path, 'configurations', module, '*')
+    tmp_content = os.path.join(env_path, 'configurations', 'tmp')
     os.makedirs(tmp_content, exist_ok=True)
     os.popen(f'cp -rf {base_content} {tmp_content}').close()
     os.popen(f'cp -rf {module_content} {tmp_content}').close()
@@ -180,8 +177,8 @@ def change_rbac_mode(rbac_mode: str = 'white'):
     rbac_mode : str
         RBAC Mode: Black (by default: all allowed), White (by default: all denied)
     """
-    with open(os.path.join(current_path, 'env', 'configurations', 'base', 'manager', 'config', 'api', 'configuration',
-                           'security', 'security.yaml'), 'r+') as rbac_conf:
+    with open(os.path.join(env_path, 'configurations', 'base', 'manager', 'config', 'api', 'configuration', 'security',
+                           'security.yaml'), 'r+') as rbac_conf:
         content = rbac_conf.read()
         rbac_conf.seek(0)
         rbac_conf.write(re.sub(r'rbac_mode: (white|black)', f'rbac_mode: {rbac_mode}', content))
@@ -190,8 +187,8 @@ def change_rbac_mode(rbac_mode: str = 'white'):
 def enable_white_mode():
     """Set white mode for non-rbac integration tests
     """
-    with open(os.path.join(current_path, 'env', 'configurations', 'base', 'manager', 'config', 'api', 'configuration',
-                           'security', 'security.yaml'), '+r') as rbac_conf:
+    with open(os.path.join(env_path, 'configurations', 'base', 'manager', 'config', 'api', 'configuration', 'security',
+                           'security.yaml'), '+r') as rbac_conf:
         content = rbac_conf.read()
         rbac_conf.seek(0)
         rbac_conf.write(re.sub(r'rbac_mode: (white|black)', f'rbac_mode: white', content))
@@ -200,8 +197,8 @@ def enable_white_mode():
 def clean_tmp_folder():
     """Remove temporal folder used te configure the environment and set RBAC mode to Black.
     """
-    shutil.rmtree(os.path.join(current_path, 'env', 'configurations', 'tmp', 'manager'), ignore_errors=True)
-    shutil.rmtree(os.path.join(current_path, 'env', 'configurations', 'tmp', 'agent'), ignore_errors=True)
+    shutil.rmtree(os.path.join(env_path, 'configurations', 'tmp', 'manager'), ignore_errors=True)
+    shutil.rmtree(os.path.join(env_path, 'configurations', 'tmp', 'agent'), ignore_errors=True)
 
 
 def generate_rbac_pair(index: int, permission: dict):
@@ -239,11 +236,11 @@ def rbac_custom_config_generator(module: str, rbac_mode: str):
     rbac_mode : str
         RBAC Mode: Black (by default: all allowed), White (by default: all denied)
     """
-    custom_rbac_path = os.path.join(current_path, 'env', 'configurations', 'tmp', 'manager',
-                                    'configuration_files', 'custom_rbac_schema.sql')
+    custom_rbac_path = os.path.join(env_path, 'configurations', 'tmp', 'manager', 'configuration_files',
+                                    'custom_rbac_schema.sql')
 
     try:
-        with open(os.path.join(current_path, 'env', 'configurations', 'rbac', module,
+        with open(os.path.join(env_path, 'configurations', 'rbac', module,
                                f'{rbac_mode}_config.yaml')) as configuration_sentences:
             list_custom_policy = yaml.safe_load(configuration_sentences.read())
     except FileNotFoundError:

--- a/api/test/integration/test_active_response_endpoints.tavern.yaml
+++ b/api/test/integration/test_active_response_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: PUT /active-response/{:agent_id}
 
-marks:
-  - base_tests
-
 stages:
 
   - name: Runs an Active Response command on a specified agent with version >= 4.2.0

--- a/api/test/integration/test_agent_DELETE_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_DELETE_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: DELETE /agents/{agent_id}/group/{group_id}
 
-marks:
-  - base_tests
-
 stages:
 
     # DELETE /agents/000/group/group1

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /agents
 
-marks:
-  - base_tests
-
 stages:
 
   - name: Get all agents

--- a/api/test/integration/test_agent_POST_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_POST_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: POST /agents
 
-marks:
-  - base_tests
-
 stages:
 
     # POST /agents

--- a/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: PUT /agents/group
 
-marks:
-  - base_tests
-
 stages:
 
   # PUT /agents/group?group_id=wrong_group

--- a/api/test/integration/test_cdb_list_endpoints.tavern.yaml
+++ b/api/test/integration/test_cdb_list_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /lists
 
-marks:
-  - base_tests
-
 stages:
 
     # GET /lists

--- a/api/test/integration/test_ciscat_endpoints.tavern.yaml
+++ b/api/test/integration/test_ciscat_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /ciscat/{agent_id}/results
 
-marks:
-  - base_tests
-
 stages:
 
   # GET /ciscat/001/results

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /cluster/local/config
 
-marks:
-  - base_tests
-
 stages:
 
   - name: Get cluster config

--- a/api/test/integration/test_decoder_endpoints.tavern.yaml
+++ b/api/test/integration/test_decoder_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /decoders
 
-marks:
-  - base_tests
-
 stages:
 
     # GET /decoders

--- a/api/test/integration/test_default_endpoints.tavern.yaml
+++ b/api/test/integration/test_default_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /
 
-marks:
-  - base_tests
-
 stages:
 
     # GET /

--- a/api/test/integration/test_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_experimental_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: DELETE /experimental/rootcheck
 
-marks:
-  - base_tests
-
 stages:
 
   # DELETE /experimental/rootcheck

--- a/api/test/integration/test_logtest_endpoints.tavern.yaml
+++ b/api/test/integration/test_logtest_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: PUT /logtest
 
-marks:
-  - base_tests
-
 stages:
 
   - name: Run logtest with an invalid body (invalid key)

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /manager/status
 
-marks:
-  - base_tests
-
 stages:
 
   # GET /manager/status

--- a/api/test/integration/test_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_mitre_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /mitre/metadata
 
-marks:
-  - base_tests
-
 stages:
 
   # GET /mitre/metadata
@@ -30,9 +27,6 @@ stages:
 
 ---
 test_name: GET /mitre/mitigations
-
-marks:
-  - base_mitigation_tests
 
 stages:
 
@@ -351,9 +345,6 @@ stages:
 ---
 test_name: GET /mitre/references
 
-marks:
-  - base_reference_tests
-
 stages:
 
   - name: Show one reference
@@ -639,9 +630,6 @@ stages:
 
 ---
 test_name: GET /mitre/tactics
-
-marks:
-  - base_tactic_tests
 
 stages:
 
@@ -940,9 +928,6 @@ stages:
 
 ---
 test_name: GET /mitre/techniques
-
-marks:
-  - base_technique_tests
 
 stages:
 

--- a/api/test/integration/test_overview_endpoints.tavern.yaml
+++ b/api/test/integration/test_overview_endpoints.tavern.yaml
@@ -1,8 +1,5 @@
 test_name: GET /overview/agents
 
-marks:
-  - base_tests
-
 stages:
 
  - name: Get full agents overview

--- a/api/test/integration/test_rbac_black_active_response_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_active_response_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: PUT ACTIVE-RESPONSE OVER A LIST OF AGENTS
 
-marks:
-  - rbac_tests
-
 stages:
 
   - name: Runs an Active Response command on a specified agent (Deny)

--- a/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /agents
 
-marks:
-  - rbac_tests
-
 stages:
 
   - name: Get all agents (Partially allowed, user agnostic)

--- a/api/test/integration/test_rbac_black_cdb_list_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_cdb_list_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET LISTS RBAC
 
-marks:
-  - rbac_tests
-
 stages:
 
   - name: Show the lists of the system

--- a/api/test/integration/test_rbac_black_ciscat_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_ciscat_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /ciscat/agent_id/results
 
-marks:
-  - rbac_tests
-
 stages:
 
   - name: Get ciscat result for agent 001 (allowed)

--- a/api/test/integration/test_rbac_black_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_cluster_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: /cluster/local/config
 
-marks:
-  - rbac_tests
-
 stages:
 
   - name: Get cluster config

--- a/api/test/integration/test_rbac_black_decoder_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_decoder_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET DECODERS RBAC
 
-marks:
-  - rbac_tests
-
 stages:
 
   - name: Try to show the decoders of the system

--- a/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: DELETE /experimental/rootcheck
 
-marks:
-  - rbac_tests
-
 stages:
 
   - name: Delete rootcheck scans in agent 002 (Allow)

--- a/api/test/integration/test_rbac_black_logtest_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_logtest_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: PUT /logtest
 
-marks:
-  - rbac_tests
-
 stages:
 
   - name: Run logtest (deny)

--- a/api/test/integration/test_rbac_black_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_manager_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /manager/configuration
 
-marks:
-  - rbac_tests
-
 stages:
 
   - name: Request manager configuration (Allow)

--- a/api/test/integration/test_rbac_black_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_mitre_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /mitre/metadata
 
-marks:
-  - base_tests
-
 stages:
 
   # GET /mitre/metadata
@@ -23,9 +20,6 @@ stages:
 ---
 test_name: GET /mitre/mitigations
 
-marks:
-  - base_mitigation_tests
-
 stages:
 
   # GET /mitre/techniques
@@ -41,9 +35,6 @@ stages:
 
 ---
 test_name: GET /mitre/references
-
-marks:
-  - base_reference_tests
 
 stages:
 
@@ -61,9 +52,6 @@ stages:
 ---
 test_name: GET /mitre/techniques
 
-marks:
-  - base_technique_tests
-
 stages:
 
   # GET /mitre/techniques
@@ -79,9 +67,6 @@ stages:
 
 ---
 test_name: GET /mitre/tactics
-
-marks:
-  - base_tactic_tests
 
 stages:
 

--- a/api/test/integration/test_rbac_black_overview_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_overview_endpoints.tavern.yaml
@@ -1,8 +1,5 @@
 test_name: GET /overview/agents
 
-marks:
-  - rbac_tests
-
 stages:
 
  - name: Get full agents overview

--- a/api/test/integration/test_rbac_black_rootcheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_rootcheck_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /rootcheck
 
-marks:
-  - base_tests
-
 stages:
 
   - name: Try to get rootcheck scan results for agent 001 (Deny)

--- a/api/test/integration/test_rbac_black_rule_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_rule_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET RULES RBAC
 
-marks:
-  - rbac_tests
-
 stages:
 
   - name: Try to show the rules of the system

--- a/api/test/integration/test_rbac_black_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_sca_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /sca/{agent_id}
 
-marks:
-  - rbac_tests
-
 stages:
 
   - name: Request sca for agent 000 (Allowed)

--- a/api/test/integration/test_rbac_black_security_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_security_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET USERS RBAC
 
-marks:
-  - rbac_tests
-
 stages:
 
   - name: Get all users in the system

--- a/api/test/integration/test_rbac_black_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_syscheck_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /syscheck
 
-marks:
-  - base_tests
-
 stages:
 
   - name: Try to get syscheck scan results for agent 000 (Deny)

--- a/api/test/integration/test_rbac_black_syscollector_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_syscollector_endpoints.tavern.yaml
@@ -3,7 +3,6 @@ test_name: GET OS SYSCOLLECTOR RBAC
 
 marks:
   - xfail # Review and fix syscollector endpoints API integration tests - https://github.com/wazuh/wazuh/issues/10923
-  - base_tests
 
 stages:
 

--- a/api/test/integration/test_rbac_black_task_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_task_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /tasks/status
 
-marks:
-  - base_tests
-
 stages:
 
   - name: Get all existent tasks (At this point there is no task created)

--- a/api/test/integration/test_rbac_black_vulnerability_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_vulnerability_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /vulnerability/{agent_id}
 
-marks:
-  - rbac_tests
-
 stages:
 
   - name: Get vulnerabilities information for agent 001

--- a/api/test/integration/test_rbac_white_active_response_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_active_response_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: PUT ACTIVE-RESPONSE OVER A LIST OF AGENTS
 
-marks:
-  - rbac_tests
-
 stages:
 
   - name: Runs an Active Response command on a specified agent (Allow)

--- a/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /agents
 
-marks:
-  - rbac_tests
-
 stages:
 
   - name: Get all agents (Partially allowed, user agnostic)

--- a/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
@@ -11,9 +11,6 @@
 ---
 test_name: PUT /active-response
 
-marks:
-  - rbac_tests
-
 stages:
   - name: Try to run an Active Response command (generic)
     request:

--- a/api/test/integration/test_rbac_white_cdb_list_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_cdb_list_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET LISTS RBAC
 
-marks:
-  - rbac_tests
-
 stages:
 
   - name: Show the lists of the system

--- a/api/test/integration/test_rbac_white_ciscat_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_ciscat_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /ciscat/agent_id/results
 
-marks:
-  - rbac_tests
-
 stages:
 
   - name: Get ciscat result for agent 001 (allowed)

--- a/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: /cluster/local/config
 
-marks:
-  - rbac_tests
-
 stages:
 
   - name: Get cluster config

--- a/api/test/integration/test_rbac_white_decoder_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_decoder_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET DECODERS RBAC
 
-marks:
-  - rbac_tests
-
 stages:
 
   - name: Try to show the decoders of the system

--- a/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: DELETE /experimental/rootcheck
 
-marks:
-  - rbac_tests
-
 stages:
 
   - name: Delete rootcheck scans in agent 001 (Allow)

--- a/api/test/integration/test_rbac_white_logtest_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_logtest_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: PUT /logtest
 
-marks:
-  - rbac_tests
-
 stages:
 
   - name: Run logtest without token (allow)

--- a/api/test/integration/test_rbac_white_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_manager_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /manager/configuration
 
-marks:
-  - rbac_tests
-
 stages:
 
   - name: Request manager configuration (Denied)

--- a/api/test/integration/test_rbac_white_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_mitre_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /mitre/metadata
 
-marks:
-  - base_tests
-
 stages:
 
   # GET /mitre/metadata
@@ -21,9 +18,6 @@ stages:
 
 ---
 test_name: GET /mitre/mitigations
-
-marks:
-  - base_mitigation_tests
 
 stages:
 
@@ -43,9 +37,6 @@ stages:
 ---
 test_name: GET /mitre/references
 
-marks:
-  - base_reference_tests
-
 stages:
 
   # GET /mitre/references
@@ -64,9 +55,6 @@ stages:
 ---
 test_name: GET /mitre/techniques
 
-marks:
-  - base_technique_tests
-
 stages:
 
   # GET /mitre/techniques
@@ -84,9 +72,6 @@ stages:
 
 ---
 test_name: GET /mitre/tactics
-
-marks:
-  - base_tactic_tests
 
 stages:
 

--- a/api/test/integration/test_rbac_white_overview_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_overview_endpoints.tavern.yaml
@@ -1,8 +1,5 @@
 test_name: GET /overview/agents
 
-marks:
-  - rbac_tests
-
 stages:
 
  - name: Get full agents overview

--- a/api/test/integration/test_rbac_white_rootcheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_rootcheck_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /rootcheck
 
-marks:
-  - rbac_tests
-
 stages:
 
   - name: Get rootcheck scan results for agent 000 (Allow)

--- a/api/test/integration/test_rbac_white_rule_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_rule_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET RULES RBAC
 
-marks:
-  - rbac_tests
-
 stages:
 
   - name: Try to show the rules of the system

--- a/api/test/integration/test_rbac_white_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_sca_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /sca/{agent_id}
 
-marks:
-  - rbac_tests
-
 stages:
 
   - name: Request sca for agent 000 (Allowed)

--- a/api/test/integration/test_rbac_white_security_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_security_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET USERS RBAC
 
-marks:
-  - rbac_tests
-
 stages:
 
   - name: Get all users in the system

--- a/api/test/integration/test_rbac_white_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_syscheck_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /syscheck
 
-marks:
-  - rbac_tests
-
 stages:
 
   - name: Try to get syscheck scan results for agent 000 (Allow)

--- a/api/test/integration/test_rbac_white_syscollector_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_syscollector_endpoints.tavern.yaml
@@ -3,7 +3,6 @@ test_name: GET OS SYSCOLLECTOR RBAC
 
 marks:
   - xfail # Review and fix syscollector endpoints API integration tests - https://github.com/wazuh/wazuh/issues/10923
-  - rbac_tests
 
 stages:
 

--- a/api/test/integration/test_rbac_white_task_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_task_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /tasks/status
 
-marks:
-  - base_tests
-
 stages:
 
   - name: Get all existent tasks (At this point there is no task created)

--- a/api/test/integration/test_rbac_white_vulnerability_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_vulnerability_endpoints.tavern.yaml
@@ -2,9 +2,6 @@
 ---
 test_name: GET /vulnerability/{agent_id}
 
-marks:
-  - rbac_tests
-
 stages:
 
   - name: Try to get vulnerabilities information for agent 001

--- a/api/test/integration/test_rootcheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rootcheck_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /rootcheck/001
 
-marks:
-  - base_tests
-
 stages:
 
   # GET /rootcheck/001

--- a/api/test/integration/test_rule_endpoints.tavern.yaml
+++ b/api/test/integration/test_rule_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /rules
 
-marks:
-  - base_tests
-
 stages:
 
   - name: Try to show the rules of the system

--- a/api/test/integration/test_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_sca_endpoints.tavern.yaml
@@ -1,8 +1,5 @@
 test_name: GET /sca/{agent_id} for agents with Wazuh version >=4.2.0 (001) and <4.2.0 (006)
 
-marks:
-  - base_tests
-
 stages:
 
   # Testing GET /sca/001

--- a/api/test/integration/test_security_DELETE_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_DELETE_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: DELETE /security/roles/{role_id}
 
-marks:
-  - base_tests
-
 stages:
 
   # DELETE /security/roles/{role_id}

--- a/api/test/integration/test_security_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_GET_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /security/roles
 
-marks:
-  - base_tests
-
 stages:
 
   # GET /security/roles

--- a/api/test/integration/test_security_POST_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_POST_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: POST /security/roles
 
-marks:
-  - base_tests
-
 stages:
 
   # POST /security/roles

--- a/api/test/integration/test_security_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_PUT_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: PUT /security/roles
 
-marks:
-  - base_tests
-
 stages:
 
   # PUT /security/roles/{role_id}

--- a/api/test/integration/test_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_syscheck_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /syscheck/000
 
-marks:
-  - base_tests
-
 stages:
 
     # GET /syscheck/000

--- a/api/test/integration/test_syscollector_endpoints.tavern.yaml
+++ b/api/test/integration/test_syscollector_endpoints.tavern.yaml
@@ -2,7 +2,6 @@
 test_name: GET /syscollector/{agent_id}/os
 
 marks:
-  - base_tests
   - xfail # Review and fix syscollector endpoints API integration tests - https://github.com/wazuh/wazuh/issues/10923
 
 stages:

--- a/api/test/integration/test_task_endpoints.tavern.yaml
+++ b/api/test/integration/test_task_endpoints.tavern.yaml
@@ -1,9 +1,6 @@
 ---
 test_name: GET /tasks/status
 
-marks:
-  - base_tests
-
 stages:
 
   - name: Get all existent tasks (At this point there are no tasks created)

--- a/api/test/integration/test_vulnerability_endpoints.tavern.yaml
+++ b/api/test/integration/test_vulnerability_endpoints.tavern.yaml
@@ -2,7 +2,6 @@
 test_name: GET /vulnerability/{agent_id}
 
 marks:
-  - base_tests
   - xfail # Review and fix vulnerability endpoints API integration test - https://github.com/wazuh/wazuh/issues/10917
 
 stages:


### PR DESCRIPTION
|Related issue|
|---|
| #10869 |

This PR closes #10869.

In this pull request, I have deleted the unused API integration test marks.

I have also reviewed the `conftest.py` file since changes were needed after deleting the marks. When building and stopping docker containers, we were using a `chdir` call. After that, the `common.yaml` could not be found. With the marks, this error was not happening because the function used to load the `common.yaml` file is cached and used before building and stopping the containers. More information about this is in the related issue's comments.