### PR TITLE
Update Vulnerability Detector remote configuration dump

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5541,7 +5541,7 @@ cJSON *wm_vuldet_dump(const wm_vuldet_t * vuldet){
     cJSON *providers = cJSON_CreateArray();
 
     for (i = 0; i < OS_SUPP_SIZE; i++) {
-        if (vuldet->updates[i] && i != CPE_WDIC && i != CVE_MSU) {
+        if (vuldet->updates[i] && i != CPE_WDIC) {
             cJSON *provider = cJSON_CreateObject();
             if (vuldet->updates[i]->dist) cJSON_AddStringToObject(provider,"name",vuldet->updates[i]->dist);
             if (vuldet->updates[i]->version) cJSON_AddStringToObject(provider,"version",vuldet->updates[i]->version);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5602,6 +5602,12 @@ cJSON *wm_vuldet_dump(const wm_vuldet_t * vuldet){
                 }
             }
 
+            // Skip JSON Redhat if not fetched from a custom location (it is not possible to disable it)
+            if (vuldet->updates[i]->dist_ref == FEED_JREDHAT && vuldet->updates[i]->custom_location == 0) {
+                cJSON_Delete(provider);
+                continue;
+            }
+
             cJSON_AddItemToArray(providers, provider);
         }
     }


### PR DESCRIPTION
|Related issue|
|---|
|#10839|

## Description

Hi team,

This _PR_ aims to modify the remote configuration dump for Vulnerability Detector, since it currently ignores the **MSU** vendor.

When enabled, the JSON configuration dump from now on will include a block like the next one: 

```json
{
    "name": "msu", 
    "url": "http://local_repo/msu-updates.json.gz", 
    "update_interval": 3600, 
    "download_timeout": 300
}
```

It also skip this provider
```js
{
    "name": "jredhat",
    "update_interval": 3600,
    "download_timeout": 0
},
```
when it is not included in the configuration.

Best regards.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
