### PR TITLE
Refactor `wdb_upgrade_global`

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -99,7 +99,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                              -Wl,--wrap,OS_SetSendTimeout -Wl,--wrap,time ${HASH_OP_WRAPPERS} ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_upgrade")
-list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_metadata_table_check \
+list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_count_tables_with_name \
                              -Wl,--wrap,wdb_sql_exec -Wl,--wrap,wdb_metadata_get_entry -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,fclose \
                              -Wl,--wrap,remove -Wl,--wrap,opendir -Wl,--wrap,readdir -Wl,--wrap,closedir -Wl,--wrap,fflush -Wl,--wrap,fseek -Wl,--wrap,fgets \
                              -Wl,--wrap,wdb_init -Wl,--wrap,wdb_close -Wl,--wrap,wdb_create_global -Wl,--wrap,wdb_pool_append -Wl,--wrap,chmod -Wl,--wrap,stat \

--- a/src/unit_tests/wazuh_db/test_wdb_metadata.c
+++ b/src/unit_tests/wazuh_db/test_wdb_metadata.c
@@ -46,7 +46,7 @@ static int test_teardown(void **state){
     return 0;
 }
 
-void test_wdb_metadata_table_check_prepare_fail(void **state)
+void test_wdb_count_tables_with_name_prepare_fail(void **state)
 {
     int ret = OS_INVALID;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -55,12 +55,14 @@ void test_wdb_metadata_table_check_prepare_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_prepare_v2(): ERROR MESSAGE");
 
-    ret = wdb_metadata_table_check(data->wdb, "metadata");
+    int count = 0;
+    ret = wdb_count_tables_with_name(data->wdb, "metadata", &count);
 
     assert_int_equal(ret, OS_INVALID);
+    assert_int_equal(count, 0);
 }
 
-void test_wdb_metadata_table_check_bind_fail(void **state)
+void test_wdb_count_tables_with_name_bind_fail(void **state)
 {
     int ret = OS_INVALID;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -74,12 +76,14 @@ void test_wdb_metadata_table_check_bind_fail(void **state)
 
     expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
 
-    ret = wdb_metadata_table_check(data->wdb, "metadata");
+    int count = 0;
+    ret = wdb_count_tables_with_name(data->wdb, "metadata", &count);
 
     assert_int_equal(ret, OS_INVALID);
+    assert_int_equal(count, 0);
 }
 
-void test_wdb_metadata_table_check_step_fail(void **state)
+void test_wdb_count_tables_with_name_step_fail(void **state)
 {
     int ret = OS_INVALID;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -95,12 +99,14 @@ void test_wdb_metadata_table_check_step_fail(void **state)
 
     expect_string(__wrap__mdebug1, formatted_msg, "DB(000) sqlite3_step(): ERROR MESSAGE");
 
-    ret = wdb_metadata_table_check(data->wdb, "metadata");
+    int count = 0;
+    ret = wdb_count_tables_with_name(data->wdb, "metadata", &count);
 
     assert_int_equal(ret, OS_INVALID);
+    assert_int_equal(count, 0);
 }
 
-void test_wdb_metadata_table_check_success(void **state)
+void test_wdb_count_tables_with_name_success(void **state)
 {
     int ret = OS_INVALID;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -115,18 +121,20 @@ void test_wdb_metadata_table_check_success(void **state)
     will_return(__wrap_sqlite3_column_int, 1);
     will_return(__wrap_sqlite3_finalize, SQLITE_OK);
 
-    ret = wdb_metadata_table_check(data->wdb, "metadata");
+    int count = 0;
+    ret = wdb_count_tables_with_name(data->wdb, "metadata", &count);
 
-    assert_int_equal(ret, 1);
+    assert_int_equal(ret, OS_SUCCESS);
+    assert_int_equal(count, 1);
 }
 
 int main()
 {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test_setup_teardown(test_wdb_metadata_table_check_prepare_fail, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_metadata_table_check_bind_fail, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_metadata_table_check_step_fail, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_metadata_table_check_success, test_setup, test_teardown)
+        cmocka_unit_test_setup_teardown(test_wdb_count_tables_with_name_prepare_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_count_tables_with_name_bind_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_count_tables_with_name_step_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_count_tables_with_name_success, test_setup, test_teardown)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_metadata_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_metadata_wrappers.c
@@ -13,9 +13,12 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-int __wrap_wdb_metadata_table_check(__attribute__((unused)) wdb_t * wdb,
-                                    const char * key) {
+int __wrap_wdb_count_tables_with_name(__attribute__((unused)) wdb_t *wdb,
+                                      const char *key,
+                                      __attribute__((unused)) int *counter) {
     check_expected(key);
+    assert_non_null(counter);
+    *counter = mock();
     return mock();
 }
 
@@ -24,5 +27,9 @@ int __wrap_wdb_metadata_get_entry(__attribute__((unused)) wdb_t * wdb,
                                   char *output) {
     check_expected(key);
     snprintf(output, OS_SIZE_256 + 1, "%s", mock_ptr_type(char*));
+    return mock();
+}
+
+int __wrap_wdb_is_older_than_v310(__attribute__((unused)) wdb_t *wdb) {
     return mock();
 }

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_metadata_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_metadata_wrappers.h
@@ -13,8 +13,10 @@
 
 #include "wazuh_db/wdb.h"
 
-int __wrap_wdb_metadata_table_check(wdb_t * wdb, const char * key);
+int __wrap_wdb_count_tables_with_name(wdb_t * wdb, const char * key, int* counter);
 
 int __wrap_wdb_metadata_get_entry (wdb_t * wdb, const char *key, char *output);
+
+int __wrap_wdb_is_older_than_v310(wdb_t *wdb);
 
 #endif

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -654,13 +654,14 @@ int wdb_metadata_fill_version(sqlite3 *db);
 int wdb_metadata_get_entry (wdb_t * wdb, const char *key, char *output);
 
 /**
- * @brief Checks if the table exists in the database.
+ * @brief Gets the count of the tables that match the provided name
  *
  * @param[in] wdb Database to query for the table existence.
  * @param[in] key Name of the table to find.
- * @return 1 if the table exists, 0 if the table doesn't exist or OS_INVALID on failure.
+ * @param[in] returns the count
+ * @return function success.
  */
- int wdb_metadata_table_check(wdb_t * wdb, const char * key);
+ int wdb_count_tables_with_name(wdb_t * wdb, const char * key, int* count);
 
 /* Update field date for specific fim_entry. */
 int wdb_fim_update_date_entry(wdb_t * wdb, const char *path);
@@ -1522,17 +1523,18 @@ int wdb_create_backup(const char * agent_id, int version);
 wdb_t * wdb_recreate_global(wdb_t *wdb);
 
 /**
- * @brief Check the agent 0 status in the global database
+ * @brief Check if the db version is older than 3.10
  *
- * The table "agent" must have a tuple with id=0 and last_keepalive=9999/12/31 23:59:59 UTC.
- * Otherwise, the database is either corrupt or old.
+ * This is a hacky way to check if the database version is older than 3.10
+ * For newer versions of the db the table "agent" must have a tuple with id=0(manager) and last_keepalive=9999/12/31 23:59:59 UTC.
+ * If this value is missing it means that the db is older than 3.10 or is corrupt
  *
- * @return Number of tuples matching that condition.
- * @retval 1 The agent 0 status is OK.
- * @retval 0 No tuple matching conditions exists.
- * @retval -1 The table "agent" is missing or an error occurred.
+ * @return Db version is older than 3.10.
+ * @retval 1 the db is older than 3.10
+ * @retval 0 the db is newer than 3.10.
+ * @retval 0 The table "agent" is missing or an error occurred.
  */
-int wdb_upgrade_check_manager_keepalive(wdb_t *wdb);
+bool wdb_is_older_than_v310(wdb_t *wdb);
 
 /**
  * @brief Query the checksum of a data range

--- a/src/wazuh_db/wdb_metadata.c
+++ b/src/wazuh_db/wdb_metadata.c
@@ -23,7 +23,7 @@ static const char *SQL_METADATA_STMT[] = {
     "INSERT INTO metadata (key, value) VALUES (?, ?);",
     "UPDATE metadata SET value = ? WHERE key = ?;",
     "SELECT value FROM metadata WHERE key = ?;",
-    "SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?;"
+    "SELECT count(name) FROM sqlite_master WHERE type='table' AND name=?;"
 };
 
 int wdb_fim_fill_metadata(wdb_t *wdb, char *data) {
@@ -150,42 +150,47 @@ int wdb_metadata_get_entry(wdb_t * wdb, const char *key, char *output) {
     sqlite3_stmt *stmt = NULL;
 
     if (sqlite3_prepare_v2(wdb->db,
-                            SQL_METADATA_STMT[WDB_STMT_METADATA_FIND],
-                            -1,
-                            &stmt,
-                            NULL) != SQLITE_OK) {
-        merror("DB(%s) sqlite3_prepare_v2(): %s", wdb->id, sqlite3_errmsg(wdb->db));
-        return -1;
+                           SQL_METADATA_STMT[WDB_STMT_METADATA_FIND],
+                           -1,
+                           &stmt,
+                           NULL) != SQLITE_OK) {
+        merror("DB(%s) sqlite3_prepare_v2(): %s",
+               wdb->id,
+               sqlite3_errmsg(wdb->db));
+        return OS_INVALID;
     }
 
     sqlite3_bind_text(stmt, 1, key, -1, NULL);
 
+    int ret = OS_INVALID;
     switch (sqlite3_step(stmt)) {
-        case SQLITE_ROW:
-            snprintf(output, OS_SIZE_256 + 1, "%s", (char *)sqlite3_column_text(stmt, 0));
-            sqlite3_finalize(stmt);
-            return 1;
+        case SQLITE_ROW: {
+            strncpy(output, (char *)sqlite3_column_text(stmt, 0), OS_SIZE_256);
+            ret = OS_SUCCESS;
             break;
-        case SQLITE_DONE:
-            sqlite3_finalize(stmt);
-            return 0;
+        }
+        case SQLITE_DONE: {
+            strncpy(output, "0", OS_SIZE_256);
+            ret = OS_NOTFOUND;
             break;
-        default:
-            mdebug1("DB(%s) sqlite3_step(): %s", wdb->id, sqlite3_errmsg(wdb->db));
-            sqlite3_finalize(stmt);
-            return -1;
+        }
+        default: {
+            mdebug1("DB(%s) sqlite3_step(): %s",
+                    wdb->id,
+                    sqlite3_errmsg(wdb->db));
+            ret = OS_INVALID;
+            break;
+        }
     }
+
+    sqlite3_finalize(stmt);
+    return ret;
 }
 
-int wdb_metadata_table_check(wdb_t * wdb, const char * key) {
+int wdb_count_tables_with_name(wdb_t * wdb, const char * key, int* count) {
     sqlite3_stmt *stmt = NULL;
-    int ret = OS_INVALID;
 
-    if (sqlite3_prepare_v2(wdb->db,
-                            SQL_METADATA_STMT[WDB_STMT_METADATA_TABLE_CHECK],
-                            -1,
-                            &stmt,
-                            NULL) != SQLITE_OK) {
+    if (sqlite3_prepare_v2(wdb->db, SQL_METADATA_STMT[WDB_STMT_METADATA_TABLE_CHECK], -1, &stmt, NULL) != SQLITE_OK) {
         merror("DB(%s) sqlite3_prepare_v2(): %s", wdb->id, sqlite3_errmsg(wdb->db));
         return OS_INVALID;
     }
@@ -196,15 +201,17 @@ int wdb_metadata_table_check(wdb_t * wdb, const char * key) {
         return OS_INVALID;
     }
 
+    int ret = OS_INVALID;
     switch (sqlite3_step(stmt)) {
-    case SQLITE_ROW:
-        ret = (int)sqlite3_column_int(stmt, 0);
-        sqlite3_finalize(stmt);
-        return ret;
-        break;
-    default:
-        mdebug1("DB(%s) sqlite3_step(): %s", wdb->id, sqlite3_errmsg(wdb->db));
-        sqlite3_finalize(stmt);
-        return OS_INVALID;
+        case SQLITE_ROW: {
+            *count = sqlite3_column_int(stmt, 0);
+            ret = OS_SUCCESS;
+        } break;
+        default: {
+            mdebug1("DB(%s) sqlite3_step(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+        }
     }
+
+    sqlite3_finalize(stmt);
+    return ret;
 }


### PR DESCRIPTION
|Related issue|
|---|
|#12120|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
- Refactor `wdb_upgrade_global`
- Changed `wdb_metadata_table_check' to `wdb_count_tables_with_name` and refactor the returns to make it clearer on what the function does
- Changed `wdb_upgrade_check_manager_keepalive` to `wdb_is_older_than_v310` to make it clear that this is just a hack-way to get the legacy version for the db
- Other minor changes and refactor
- Fixed Unit tests
<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report