### PR TITLE
Fix some info messages in fim_check_db_state

### DIFF
--- a/src/error_messages/information_messages.h
+++ b/src/error_messages/information_messages.h
@@ -52,8 +52,8 @@
 
 #define FIM_DB_NORMAL_ALERT_FILE            "(6036): The file database status returns to normal."
 #define FIM_DB_NORMAL_ALERT_REG             "(6037): The registry database status returns to normal."
-#define FIM_DB_80_PERCENTAGE_ALERT_FILE     "(6038): File database is 90%% full."
-#define FIM_DB_80_PERCENTAGE_ALERT_REG      "(6039): Registry database is 90%% full."
+#define FIM_DB_80_PERCENTAGE_ALERT_FILE     "(6038): File database is 80%% full."
+#define FIM_DB_80_PERCENTAGE_ALERT_REG      "(6039): Registry database is 80%% full."
 #define FIM_DB_90_PERCENTAGE_ALERT_FILE     "(6040): File database is 90%% full."
 #define FIM_DB_90_PERCENTAGE_ALERT_REG      "(6041): Registry database is 90%% full."
 

--- a/src/syscheckd/src/create_db.c
+++ b/src/syscheckd/src/create_db.c
@@ -805,22 +805,22 @@ void fim_check_db_state(int nodes_limit, int nodes_count, fim_state_db* db_state
     }
     else if (nodes_count >= nodes_limit * 0.9) {
         *db_state = FIM_STATE_DB_90_PERCENTAGE;
-        mwarn(strcmp(table_name, FIMDB_FILE_TABLE_NAME) ? FIM_DB_90_PERCENTAGE_ALERT_REG : FIM_DB_90_PERCENTAGE_ALERT_FILE);
+        minfo(strcmp(table_name, FIMDB_FILE_TABLE_NAME) ? FIM_DB_90_PERCENTAGE_ALERT_REG : FIM_DB_90_PERCENTAGE_ALERT_FILE);
         cJSON_AddStringToObject(json_event, "alert_type", "90_percentage");
     }
     else if (nodes_count >= nodes_limit * 0.8) {
         *db_state = FIM_STATE_DB_80_PERCENTAGE;
-        mwarn(strcmp(table_name, FIMDB_FILE_TABLE_NAME) ? FIM_DB_80_PERCENTAGE_ALERT_REG : FIM_DB_80_PERCENTAGE_ALERT_FILE);
+        minfo(strcmp(table_name, FIMDB_FILE_TABLE_NAME) ? FIM_DB_80_PERCENTAGE_ALERT_REG : FIM_DB_80_PERCENTAGE_ALERT_FILE);
         cJSON_AddStringToObject(json_event, "alert_type", "80_percentage");
     }
     else if (nodes_count > 0) {
         *db_state = FIM_STATE_DB_NORMAL;
-        mwarn(strcmp(table_name, FIMDB_FILE_TABLE_NAME) ? FIM_DB_NORMAL_ALERT_REG : FIM_DB_NORMAL_ALERT_FILE);
+        minfo(strcmp(table_name, FIMDB_FILE_TABLE_NAME) ? FIM_DB_NORMAL_ALERT_REG : FIM_DB_NORMAL_ALERT_FILE);
         cJSON_AddStringToObject(json_event, "alert_type", "normal");
     }
     else {
         *db_state = FIM_STATE_DB_EMPTY;
-        mwarn(strcmp(table_name, FIMDB_FILE_TABLE_NAME) ? FIM_DB_NORMAL_ALERT_REG : FIM_DB_NORMAL_ALERT_FILE);
+        minfo(strcmp(table_name, FIMDB_FILE_TABLE_NAME) ? FIM_DB_NORMAL_ALERT_REG : FIM_DB_NORMAL_ALERT_FILE);
         cJSON_AddStringToObject(json_event, "alert_type", "normal");
     }
 


### PR DESCRIPTION
|Related issue|
|---|
|[9103](https://github.com/wazuh/wazuh/issues/9103)|

### Description
This PR is to fix some bugs introduced in the main Epic branch of FIMDB. 
Some info messages have been introduced as warnings messages, and a small bug in one of them has been fixed.