### PR TITLE
Fixing global.db backup creation on startup if enabled

### DIFF
--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -425,10 +425,6 @@ void * run_backup(__attribute__((unused)) void * args) {
     int global_interval = wconfig.wdb_backup_settings[WDB_GLOBAL_BACKUP]->interval;
     bool global_enabled = wconfig.wdb_backup_settings[WDB_GLOBAL_BACKUP]->enabled;
 
-    if(OS_INVALID == last_global_backup_time) {
-        last_global_backup_time = time(NULL);
-    }
-
     mdebug2("Database backup thread started.");
 
     while(running) {


### PR DESCRIPTION
|Related issue|
|---|
|#12128|

## Description

At startup, Wazuh-DB tries to find an existing snapshot of **global.db**. If it doesn't exist and the backup mechanism is available, a backup should be created at that moment. 

This PR removes the conditional block that was preventing the immediate backup creation.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
