### PR TITLE
Dev 12130 ENOENT bugfix

### DIFF
--- a/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
@@ -188,7 +188,7 @@ void test_wdb_create_agent_db_error_creating_source_profile(void **state)
     will_return(__wrap_stat, 0);
     will_return(__wrap_stat, OS_INVALID);
     // Opening source database file
-    errno = EACCES;
+    errno = ENOENT;
     expect_string(__wrap_fopen, path, "var/db/.template.db");
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, 0);
@@ -213,7 +213,7 @@ void test_wdb_create_agent_db_error_reopening_source_profile(void **state)
     will_return(__wrap_stat, 0);
     will_return(__wrap_stat, OS_INVALID);
     // Opening source database file
-    errno = EACCES;
+    errno = ENOENT;
     expect_string(__wrap_fopen, path, "var/db/.template.db");
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, 0);

--- a/src/wazuh_db/helpers/wdb_global_helpers.c
+++ b/src/wazuh_db/helpers/wdb_global_helpers.c
@@ -1123,7 +1123,7 @@ int wdb_create_agent_db(int id, const char *name) {
 
     snprintf(src_path, OS_FLSIZE, "%s/%s", WDB_DIR, WDB_PROF_NAME);
     if (!(source = fopen(src_path, "r"))) {
-        if (errno != EACCES) // If we get any other error other than 'file does not exits'
+        if (errno != ENOENT) // If we get any other error other than 'file does not exits'
         {
             merror("Error accessing file (%s): (%s)", src_path, strerror(errno));
             return OS_INVALID;


### PR DESCRIPTION
|Related issue|
|---|
|#12130|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
When fixing previous coverity issues a bug was introduced in wdb_create_agent_db where EACCES was checked instead of ENOENT
<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report