### PR TITLE
Improving the way in which Vulnerability Detector informs an agent discarded because of a lack of data and also the start of a scan

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2474,7 +2474,6 @@ int wm_vuldet_check_agent_vulnerabilities(wm_vuldet_t *vuldet) {
 
             if (agents_it->pending_attempts == 0) continue;
 
-            mtinfo(WM_VULNDETECTOR_LOGTAG, VU_START_AG_AN, scan_ctx.agent_id);
             time_t start = time(NULL);
 
             // Check if there are available vulnerabilities for this agent
@@ -2525,10 +2524,12 @@ int wm_vuldet_check_agent_vulnerabilities(wm_vuldet_t *vuldet) {
                     if (!first_fail_scan) first_fail_scan = time(NULL);
                 }
                 else {
-                    mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_GET_SOFTWARE_ERROR, scan_ctx.agent_id, WM_VULNDETECTOR_MAX_AGENT_SCAN_ATTEMPS);
+                    mtinfo(WM_VULNDETECTOR_LOGTAG, VU_GET_SOFTWARE_ERROR, scan_ctx.agent_id, WM_VULNDETECTOR_MAX_AGENT_SCAN_ATTEMPS);
                 }
                 continue;
             }
+
+            mtinfo(WM_VULNDETECTOR_LOGTAG, VU_START_AG_AN, scan_ctx.agent_id);
 
             // Find and report agent vulnerabilities
             if (OS_SUCCESS != wm_vuldet_find_agent_vulnerabilities(db, agents_it, &vuldet->flags, &scan_ctx)) {


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/12097 |

## Description

This pull request improves the Vulnerability Detector logs for two scenarios:

- When the Vulnerability Detector module fails to obtain the packages information of an agent to be scanned, after five attempts it will now log a WARNING message to inform the user about this situation.
- The log that informs the user that an agent is going to be scanned now will be logged once all the necessary information for the scan was properly obtained and the scan will actually happen.

## Logs/Alerts example

- Starting the scan
```
2022/02/08 19:44:13 wazuh-modulesd:vulnerability-detector: INFO: (5450): Analyzing agent '001' vulnerabilities.
```

- Warning after five attempts
```
2022/02/08 23:52:23 wazuh-modulesd:vulnerability-detector: INFO: (5507): The software of the agent '001' could not be obtained after 5 attempts. Skipping agent until the next scan.
```

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language