### PR TITLE
Update DockerListener integration shebang

### DIFF
--- a/wodles/docker-listener/DockerListener.py
+++ b/wodles/docker-listener/DockerListener.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (C) 2015, Wazuh Inc.
 #
@@ -17,7 +17,7 @@ import time
 try:
     import docker
 except:
-    sys.stderr.write("'docker' module needs to be installed. Execute 'pip install docker' to do it.\n")
+    sys.stderr.write("'docker' module needs to be installed. Execute 'pip3 install docker' to do it.\n")
     exit(1)
 
 class DockerListener:


### PR DESCRIPTION
|Related issue|
|---|
|#9128|


## Description
This PR updates the `DockerListener.py` shebang to ensure Python3 is used when running the integration in Wazuh agents.

## Tests

Manual testing was performed to ensure everything works after the change. The tests were carried out using both a Wazuh manager and a Wazuh agent both using the following configuration:
```
<wodle name="docker-listener">
    <interval>30s</interval>
    <attempts>5</attempts>
    <run_on_start>yes</run_on_start>
    <disabled>no</disabled>
</wodle>
```

### Test cases

**Restart Wazuh and check ossec.log to verify the module is running**


<details><summary>ossec.log output</summary>

	2022/02/09 12:19:38 wazuh-modulesd[47536] main.c:94 at main(): DEBUG: Created new thread for the 'docker-listener' module.
	2022/02/09 12:19:38 wazuh-modulesd:docker-listener[47536] wm_docker.c:45 at wm_docker_main(): INFO: Module docker-listener started.
	2022/02/09 12:19:38 wazuh-modulesd:docker-listener[47536] wm_docker.c:54 at wm_docker_main(): DEBUG: Sleeping until: 2022/02/09 12:20:38
	2022/02/09 12:20:38 wazuh-modulesd:docker-listener[47536] wm_docker.c:58 at wm_docker_main(): INFO: Starting to listening Docker events.
	2022/02/09 12:20:38 wazuh-modulesd:docker-listener[47536] wm_docker.c:62 at wm_docker_main(): DEBUG: Launching command 'wodles/docker/DockerListener'	
</details>


**Run a container with no cache available**
```
docker run ubuntu
```

<details><summary>Archives.json output</summary>

	{"timestamp":"2022-02-09T12:21:07.466+0000","rule":{"level":3,"description":"Docker: Image or repository ubuntu pulled","id":"87932","firedtimes":1,"mail":false,"groups":["docker"],"pci_dss":["10.2.7"],"hipaa":["164.312.b"],"nist_800_53":["AU.14"],"tsc":["CC6.8","CC7.2","CC7.3"]},"agent":{"id":"000","name":"vagrant"},"manager":{"name":"vagrant"},"id":"1644409267.580573","full_log":"{\"integration\": \"docker\", \"docker\": {\"status\": \"pull\", \"id\": \"ubuntu:latest\", \"Type\": \"image\", \"Action\": \"pull\", \"Actor\": {\"ID\": \"ubuntu:latest\", \"Attributes\": {\"name\": \"ubuntu\"}}, \"scope\": \"local\", \"time\": 1644409267, \"timeNano\": 1644409267466011626}}","decoder":{"name":"json"},"data":{"integration":"docker","docker":{"status":"pull","id":"ubuntu:latest","Type":"image","Action":"pull","Actor":{"ID":"ubuntu:latest","Attributes":{"name":"ubuntu"}},"scope":"local","time":"1644409267","timeNano":"1644409267466011648.000000"}},"location":"Wazuh-Docker"}
	{"timestamp":"2022-02-09T12:21:07.648+0000","rule":{"level":3,"description":"Docker: Container angry_brahmagupta created","id":"87901","firedtimes":1,"mail":false,"groups":["docker"],"pci_dss":["10.2.7"],"hipaa":["164.312.b"],"nist_800_53":["AU.14"],"tsc":["CC6.8","CC7.2","CC7.3"]},"agent":{"id":"000","name":"vagrant"},"manager":{"name":"vagrant"},"id":"1644409267.581316","full_log":"{\"integration\": \"docker\", \"docker\": {\"status\": \"create\", \"id\": \"c56b09cfc0efae7b1a8684c6229d3f1ca456189632fb55b4e9463956360cdf7a\", \"from\": \"ubuntu\", \"Type\": \"container\", \"Action\": \"create\", \"Actor\": {\"ID\": \"c56b09cfc0efae7b1a8684c6229d3f1ca456189632fb55b4e9463956360cdf7a\", \"Attributes\": {\"image\": \"ubuntu\", \"name\": \"angry_brahmagupta\"}}, \"scope\": \"local\", \"time\": 1644409267, \"timeNano\": 1644409267646802213}}","decoder":{"name":"json"},"data":{"integration":"docker","docker":{"status":"create","id":"c56b09cfc0efae7b1a8684c6229d3f1ca456189632fb55b4e9463956360cdf7a","from":"ubuntu","Type":"container","Action":"create","Actor":{"ID":"c56b09cfc0efae7b1a8684c6229d3f1ca456189632fb55b4e9463956360cdf7a","Attributes":{"image":"ubuntu","name":"angry_brahmagupta"}},"scope":"local","time":"1644409267","timeNano":"1644409267646802176.000000"}},"location":"Wazuh-Docker"}
	{"timestamp":"2022-02-09T12:21:07.649+0000","rule":{"level":3,"description":"Docker: Attached local standard input, output, and error streams to container angry_brahmagupta","id":"87922","firedtimes":1,"mail":false,"groups":["docker"]},"agent":{"id":"000","name":"vagrant"},"manager":{"name":"vagrant"},"id":"1644409267.582398","full_log":"{\"integration\": \"docker\", \"docker\": {\"status\": \"attach\", \"id\": \"c56b09cfc0efae7b1a8684c6229d3f1ca456189632fb55b4e9463956360cdf7a\", \"from\": \"ubuntu\", \"Type\": \"container\", \"Action\": \"attach\", \"Actor\": {\"ID\": \"c56b09cfc0efae7b1a8684c6229d3f1ca456189632fb55b4e9463956360cdf7a\", \"Attributes\": {\"image\": \"ubuntu\", \"name\": \"angry_brahmagupta\"}}, \"scope\": \"local\", \"time\": 1644409267, \"timeNano\": 1644409267648985813}}","decoder":{"name":"json"},"data":{"integration":"docker","docker":{"status":"attach","id":"c56b09cfc0efae7b1a8684c6229d3f1ca456189632fb55b4e9463956360cdf7a","from":"ubuntu","Type":"container","Action":"attach","Actor":{"ID":"c56b09cfc0efae7b1a8684c6229d3f1ca456189632fb55b4e9463956360cdf7a","Attributes":{"image":"ubuntu","name":"angry_brahmagupta"}},"scope":"local","time":"1644409267","timeNano":"1644409267648985856.000000"}},"location":"Wazuh-Docker"}
	{"timestamp":"2022-02-09T12:21:07.699+0000","rule":{"level":3,"description":"Docker: Network bridge connected","id":"87928","firedtimes":1,"mail":false,"groups":["docker"]},"agent":{"id":"000","name":"vagrant"},"manager":{"name":"vagrant"},"id":"1644409267.583453","full_log":"{\"integration\": \"docker\", \"docker\": {\"Type\": \"network\", \"Action\": \"connect\", \"Actor\": {\"ID\": \"47eb8e0fa173ca139f4ed179d8a7ca07b0412a203f60e9bf56ab7edb5fcc781e\", \"Attributes\": {\"container\": \"c56b09cfc0efae7b1a8684c6229d3f1ca456189632fb55b4e9463956360cdf7a\", \"name\": \"bridge\", \"type\": \"bridge\"}}, \"scope\": \"local\", \"time\": 1644409267, \"timeNano\": 1644409267698604601}}","decoder":{"name":"json"},"data":{"integration":"docker","docker":{"Type":"network","Action":"connect","Actor":{"ID":"47eb8e0fa173ca139f4ed179d8a7ca07b0412a203f60e9bf56ab7edb5fcc781e","Attributes":{"container":"c56b09cfc0efae7b1a8684c6229d3f1ca456189632fb55b4e9463956360cdf7a","name":"bridge","type":"bridge"}},"scope":"local","time":"1644409267","timeNano":"1644409267698604544.000000"}},"location":"Wazuh-Docker"}
	{"timestamp":"2022-02-09T12:21:07.963+0000","rule":{"level":3,"description":"Docker: Container angry_brahmagupta started","id":"87903","firedtimes":1,"mail":false,"groups":["docker"]},"agent":{"id":"000","name":"vagrant"},"manager":{"name":"vagrant"},"id":"1644409267.584370","full_log":"{\"integration\": \"docker\", \"docker\": {\"status\": \"start\", \"id\": \"c56b09cfc0efae7b1a8684c6229d3f1ca456189632fb55b4e9463956360cdf7a\", \"from\": \"ubuntu\", \"Type\": \"container\", \"Action\": \"start\", \"Actor\": {\"ID\": \"c56b09cfc0efae7b1a8684c6229d3f1ca456189632fb55b4e9463956360cdf7a\", \"Attributes\": {\"image\": \"ubuntu\", \"name\": \"angry_brahmagupta\"}}, \"scope\": \"local\", \"time\": 1644409267, \"timeNano\": 1644409267963144623}}","decoder":{"name":"json"},"data":{"integration":"docker","docker":{"status":"start","id":"c56b09cfc0efae7b1a8684c6229d3f1ca456189632fb55b4e9463956360cdf7a","from":"ubuntu","Type":"container","Action":"start","Actor":{"ID":"c56b09cfc0efae7b1a8684c6229d3f1ca456189632fb55b4e9463956360cdf7a","Attributes":{"image":"ubuntu","name":"angry_brahmagupta"}},"scope":"local","time":"1644409267","timeNano":"1644409267963144704.000000"}},"location":"Wazuh-Docker"}
	{"timestamp":"2022-02-09T12:21:08.030+0000","rule":{"level":7,"description":"Docker: Container angry_brahmagupta received the action: die","id":"87924","firedtimes":1,"mail":false,"groups":["docker"],"gdpr":["IV_32.2"]},"agent":{"id":"000","name":"vagrant"},"manager":{"name":"vagrant"},"id":"1644409268.585369","full_log":"{\"integration\": \"docker\", \"docker\": {\"status\": \"die\", \"id\": \"c56b09cfc0efae7b1a8684c6229d3f1ca456189632fb55b4e9463956360cdf7a\", \"from\": \"ubuntu\", \"Type\": \"container\", \"Action\": \"die\", \"Actor\": {\"ID\": \"c56b09cfc0efae7b1a8684c6229d3f1ca456189632fb55b4e9463956360cdf7a\", \"Attributes\": {\"exitCode\": \"0\", \"image\": \"ubuntu\", \"name\": \"angry_brahmagupta\"}}, \"scope\": \"local\", \"time\": 1644409268, \"timeNano\": 1644409268028317451}}","decoder":{"name":"json"},"data":{"integration":"docker","docker":{"status":"die","id":"c56b09cfc0efae7b1a8684c6229d3f1ca456189632fb55b4e9463956360cdf7a","from":"ubuntu","Type":"container","Action":"die","Actor":{"ID":"c56b09cfc0efae7b1a8684c6229d3f1ca456189632fb55b4e9463956360cdf7a","Attributes":{"exitCode":"0","image":"ubuntu","name":"angry_brahmagupta"}},"scope":"local","time":"1644409268","timeNano":"1644409268028317440.000000"}},"location":"Wazuh-Docker"}
	{"timestamp":"2022-02-09T12:21:08.123+0000","rule":{"level":4,"description":"Docker: Network bridge disconnected","id":"87929","firedtimes":1,"mail":false,"groups":["docker"]},"agent":{"id":"000","name":"vagrant"},"manager":{"name":"vagrant"},"id":"1644409268.586443","full_log":"{\"integration\": \"docker\", \"docker\": {\"Type\": \"network\", \"Action\": \"disconnect\", \"Actor\": {\"ID\": \"47eb8e0fa173ca139f4ed179d8a7ca07b0412a203f60e9bf56ab7edb5fcc781e\", \"Attributes\": {\"container\": \"c56b09cfc0efae7b1a8684c6229d3f1ca456189632fb55b4e9463956360cdf7a\", \"name\": \"bridge\", \"type\": \"bridge\"}}, \"scope\": \"local\", \"time\": 1644409268, \"timeNano\": 1644409268120657302}}","decoder":{"name":"json"},"data":{"integration":"docker","docker":{"Type":"network","Action":"disconnect","Actor":{"ID":"47eb8e0fa173ca139f4ed179d8a7ca07b0412a203f60e9bf56ab7edb5fcc781e","Attributes":{"container":"c56b09cfc0efae7b1a8684c6229d3f1ca456189632fb55b4e9463956360cdf7a","name":"bridge","type":"bridge"}},"scope":"local","time":"1644409268","timeNano":"1644409268120657408.000000"}},"location":"Wazuh-Docker"}
</details>



**Run the same image, this time having the image in cache**

<details><summary>Archives.json output</summary>

	{"timestamp":"2022-02-09T12:22:01.411+0000","rule":{"level":3,"description":"Docker: Container serene_galileo created","id":"87901","firedtimes":2,"mail":false,"groups":["docker"],"pci_dss":["10.2.7"],"hipaa":["164.312.b"],"nist_800_53":["AU.14"],"tsc":["CC6.8","CC7.2","CC7.3"]},"agent":{"id":"000","name":"vagrant"},"manager":{"name":"vagrant"},"id":"1644409321.587369","full_log":"{\"integration\": \"docker\", \"docker\": {\"status\": \"create\", \"id\": \"82769682ea0e72e5830bfd4e06e9d07252cc5f7a94a1a82d4fd6f8b8e04729e3\", \"from\": \"ubuntu\", \"Type\": \"container\", \"Action\": \"create\", \"Actor\": {\"ID\": \"82769682ea0e72e5830bfd4e06e9d07252cc5f7a94a1a82d4fd6f8b8e04729e3\", \"Attributes\": {\"image\": \"ubuntu\", \"name\": \"serene_galileo\"}}, \"scope\": \"local\", \"time\": 1644409321, \"timeNano\": 1644409321410779805}}","decoder":{"name":"json"},"data":{"integration":"docker","docker":{"status":"create","id":"82769682ea0e72e5830bfd4e06e9d07252cc5f7a94a1a82d4fd6f8b8e04729e3","from":"ubuntu","Type":"container","Action":"create","Actor":{"ID":"82769682ea0e72e5830bfd4e06e9d07252cc5f7a94a1a82d4fd6f8b8e04729e3","Attributes":{"image":"ubuntu","name":"serene_galileo"}},"scope":"local","time":"1644409321","timeNano":"1644409321410779904.000000"}},"location":"Wazuh-Docker"}
	{"timestamp":"2022-02-09T12:22:01.412+0000","rule":{"level":3,"description":"Docker: Attached local standard input, output, and error streams to container serene_galileo","id":"87922","firedtimes":2,"mail":false,"groups":["docker"]},"agent":{"id":"000","name":"vagrant"},"manager":{"name":"vagrant"},"id":"1644409321.588442","full_log":"{\"integration\": \"docker\", \"docker\": {\"status\": \"attach\", \"id\": \"82769682ea0e72e5830bfd4e06e9d07252cc5f7a94a1a82d4fd6f8b8e04729e3\", \"from\": \"ubuntu\", \"Type\": \"container\", \"Action\": \"attach\", \"Actor\": {\"ID\": \"82769682ea0e72e5830bfd4e06e9d07252cc5f7a94a1a82d4fd6f8b8e04729e3\", \"Attributes\": {\"image\": \"ubuntu\", \"name\": \"serene_galileo\"}}, \"scope\": \"local\", \"time\": 1644409321, \"timeNano\": 1644409321412405843}}","decoder":{"name":"json"},"data":{"integration":"docker","docker":{"status":"attach","id":"82769682ea0e72e5830bfd4e06e9d07252cc5f7a94a1a82d4fd6f8b8e04729e3","from":"ubuntu","Type":"container","Action":"attach","Actor":{"ID":"82769682ea0e72e5830bfd4e06e9d07252cc5f7a94a1a82d4fd6f8b8e04729e3","Attributes":{"image":"ubuntu","name":"serene_galileo"}},"scope":"local","time":"1644409321","timeNano":"1644409321412405760.000000"}},"location":"Wazuh-Docker"}
	{"timestamp":"2022-02-09T12:22:01.442+0000","rule":{"level":3,"description":"Docker: Network bridge connected","id":"87928","firedtimes":2,"mail":false,"groups":["docker"]},"agent":{"id":"000","name":"vagrant"},"manager":{"name":"vagrant"},"id":"1644409321.589488","full_log":"{\"integration\": \"docker\", \"docker\": {\"Type\": \"network\", \"Action\": \"connect\", \"Actor\": {\"ID\": \"47eb8e0fa173ca139f4ed179d8a7ca07b0412a203f60e9bf56ab7edb5fcc781e\", \"Attributes\": {\"container\": \"82769682ea0e72e5830bfd4e06e9d07252cc5f7a94a1a82d4fd6f8b8e04729e3\", \"name\": \"bridge\", \"type\": \"bridge\"}}, \"scope\": \"local\", \"time\": 1644409321, \"timeNano\": 1644409321439470853}}","decoder":{"name":"json"},"data":{"integration":"docker","docker":{"Type":"network","Action":"connect","Actor":{"ID":"47eb8e0fa173ca139f4ed179d8a7ca07b0412a203f60e9bf56ab7edb5fcc781e","Attributes":{"container":"82769682ea0e72e5830bfd4e06e9d07252cc5f7a94a1a82d4fd6f8b8e04729e3","name":"bridge","type":"bridge"}},"scope":"local","time":"1644409321","timeNano":"1644409321439470848.000000"}},"location":"Wazuh-Docker"}
	{"timestamp":"2022-02-09T12:22:01.645+0000","rule":{"level":3,"description":"Docker: Container serene_galileo started","id":"87903","firedtimes":2,"mail":false,"groups":["docker"]},"agent":{"id":"000","name":"vagrant"},"manager":{"name":"vagrant"},"id":"1644409321.590405","full_log":"{\"integration\": \"docker\", \"docker\": {\"status\": \"start\", \"id\": \"82769682ea0e72e5830bfd4e06e9d07252cc5f7a94a1a82d4fd6f8b8e04729e3\", \"from\": \"ubuntu\", \"Type\": \"container\", \"Action\": \"start\", \"Actor\": {\"ID\": \"82769682ea0e72e5830bfd4e06e9d07252cc5f7a94a1a82d4fd6f8b8e04729e3\", \"Attributes\": {\"image\": \"ubuntu\", \"name\": \"serene_galileo\"}}, \"scope\": \"local\", \"time\": 1644409321, \"timeNano\": 1644409321645392199}}","decoder":{"name":"json"},"data":{"integration":"docker","docker":{"status":"start","id":"82769682ea0e72e5830bfd4e06e9d07252cc5f7a94a1a82d4fd6f8b8e04729e3","from":"ubuntu","Type":"container","Action":"start","Actor":{"ID":"82769682ea0e72e5830bfd4e06e9d07252cc5f7a94a1a82d4fd6f8b8e04729e3","Attributes":{"image":"ubuntu","name":"serene_galileo"}},"scope":"local","time":"1644409321","timeNano":"1644409321645392128.000000"}},"location":"Wazuh-Docker"}
	{"timestamp":"2022-02-09T12:22:01.666+0000","rule":{"level":7,"description":"Docker: Container serene_galileo received the action: die","id":"87924","firedtimes":2,"mail":false,"groups":["docker"],"gdpr":["IV_32.2"]},"agent":{"id":"000","name":"vagrant"},"manager":{"name":"vagrant"},"id":"1644409321.591395","full_log":"{\"integration\": \"docker\", \"docker\": {\"status\": \"die\", \"id\": \"82769682ea0e72e5830bfd4e06e9d07252cc5f7a94a1a82d4fd6f8b8e04729e3\", \"from\": \"ubuntu\", \"Type\": \"container\", \"Action\": \"die\", \"Actor\": {\"ID\": \"82769682ea0e72e5830bfd4e06e9d07252cc5f7a94a1a82d4fd6f8b8e04729e3\", \"Attributes\": {\"exitCode\": \"0\", \"image\": \"ubuntu\", \"name\": \"serene_galileo\"}}, \"scope\": \"local\", \"time\": 1644409321, \"timeNano\": 1644409321665613322}}","decoder":{"name":"json"},"data":{"integration":"docker","docker":{"status":"die","id":"82769682ea0e72e5830bfd4e06e9d07252cc5f7a94a1a82d4fd6f8b8e04729e3","from":"ubuntu","Type":"container","Action":"die","Actor":{"ID":"82769682ea0e72e5830bfd4e06e9d07252cc5f7a94a1a82d4fd6f8b8e04729e3","Attributes":{"exitCode":"0","image":"ubuntu","name":"serene_galileo"}},"scope":"local","time":"1644409321","timeNano":"1644409321665613312.000000"}},"location":"Wazuh-Docker"}
	{"timestamp":"2022-02-09T12:22:01.754+0000","rule":{"level":4,"description":"Docker: Network bridge disconnected","id":"87929","firedtimes":2,"mail":false,"groups":["docker"]},"agent":{"id":"000","name":"vagrant"},"manager":{"name":"vagrant"},"id":"1644409321.592460","full_log":"{\"integration\": \"docker\", \"docker\": {\"Type\": \"network\", \"Action\": \"disconnect\", \"Actor\": {\"ID\": \"47eb8e0fa173ca139f4ed179d8a7ca07b0412a203f60e9bf56ab7edb5fcc781e\", \"Attributes\": {\"container\": \"82769682ea0e72e5830bfd4e06e9d07252cc5f7a94a1a82d4fd6f8b8e04729e3\", \"name\": \"bridge\", \"type\": \"bridge\"}}, \"scope\": \"local\", \"time\": 1644409321, \"timeNano\": 1644409321752606001}}","decoder":{"name":"json"},"data":{"integration":"docker","docker":{"Type":"network","Action":"disconnect","Actor":{"ID":"47eb8e0fa173ca139f4ed179d8a7ca07b0412a203f60e9bf56ab7edb5fcc781e","Attributes":{"container":"82769682ea0e72e5830bfd4e06e9d07252cc5f7a94a1a82d4fd6f8b8e04729e3","name":"bridge","type":"bridge"}},"scope":"local","time":"1644409321","timeNano":"1644409321752605952.000000"}},"location":"Wazuh-Docker"}
</details>

**Remove the image**

<details><summary>Archives.json output</summary>

	{"timestamp":"2022-02-09T12:22:59.381+0000","rule":{"level":3,"description":"Docker: Image sha256:54c9d81cbb440897908abdcaa98674db83444636c300170cfd211e40a66f704f untagged","id":"87919","firedtimes":1,"mail":false,"groups":["docker"]},"agent":{"id":"000","name":"vagrant"},"manager":{"name":"vagrant"},"id":"1644409379.593386","full_log":"{\"integration\": \"docker\", \"docker\": {\"status\": \"untag\", \"id\": \"sha256:54c9d81cbb440897908abdcaa98674db83444636c300170cfd211e40a66f704f\", \"Type\": \"image\", \"Action\": \"untag\", \"Actor\": {\"ID\": \"sha256:54c9d81cbb440897908abdcaa98674db83444636c300170cfd211e40a66f704f\", \"Attributes\": {\"name\": \"sha256:54c9d81cbb440897908abdcaa98674db83444636c300170cfd211e40a66f704f\"}}, \"scope\": \"local\", \"time\": 1644409379, \"timeNano\": 1644409379380908813}}","decoder":{"name":"json"},"data":{"integration":"docker","docker":{"status":"untag","id":"sha256:54c9d81cbb440897908abdcaa98674db83444636c300170cfd211e40a66f704f","Type":"image","Action":"untag","Actor":{"ID":"sha256:54c9d81cbb440897908abdcaa98674db83444636c300170cfd211e40a66f704f","Attributes":{"name":"sha256:54c9d81cbb440897908abdcaa98674db83444636c300170cfd211e40a66f704f"}},"scope":"local","time":"1644409379","timeNano":"1644409379380908800.000000"}},"location":"Wazuh-Docker"}
	{"timestamp":"2022-02-09T12:22:59.385+0000","rule":{"level":7,"description":"Docker: Container sha256:54c9d81cbb440897908abdcaa98674db83444636c300170cfd211e40a66f704f deleted","id":"87921","mitre":{"id":["T1070.004","T1561.001"],"tactic":["Defense Evasion","Impact"],"technique":["File Deletion","Disk Content Wipe"]},"firedtimes":1,"mail":false,"groups":["docker"],"pci_dss":["10.2.7","11.5"],"hipaa":["164.312.b","164.312.c.1","164.312.c.2"],"nist_800_53":["AU.14","SI.7"],"tsc":["CC6.8","CC7.2","CC7.3","PI1.4","PI1.5","CC6.1"]},"agent":{"id":"000","name":"vagrant"},"manager":{"name":"vagrant"},"id":"1644409379.594469","full_log":"{\"integration\": \"docker\", \"docker\": {\"status\": \"delete\", \"id\": \"sha256:54c9d81cbb440897908abdcaa98674db83444636c300170cfd211e40a66f704f\", \"Type\": \"image\", \"Action\": \"delete\", \"Actor\": {\"ID\": \"sha256:54c9d81cbb440897908abdcaa98674db83444636c300170cfd211e40a66f704f\", \"Attributes\": {\"name\": \"sha256:54c9d81cbb440897908abdcaa98674db83444636c300170cfd211e40a66f704f\"}}, \"scope\": \"local\", \"time\": 1644409379, \"timeNano\": 1644409379384511682}}","decoder":{"name":"json"},"data":{"integration":"docker","docker":{"status":"delete","id":"sha256:54c9d81cbb440897908abdcaa98674db83444636c300170cfd211e40a66f704f","Type":"image","Action":"delete","Actor":{"ID":"sha256:54c9d81cbb440897908abdcaa98674db83444636c300170cfd211e40a66f704f","Attributes":{"name":"sha256:54c9d81cbb440897908abdcaa98674db83444636c300170cfd211e40a66f704f"}},"scope":"local","time":"1644409379","timeNano":"1644409379384511744.000000"}},"location":"Wazuh-Docker"}
</details>


**Kill the docker-listener process and check ossec.log**

The module should attempt to re-launch the process if the interval has been met.

<details><summary>ossec.log output</summary>

	2022/02/09 12:26:58 wazuh-modulesd[48471] main.c:94 at main(): DEBUG: Created new thread for the 'docker-listener' module.
	2022/02/09 12:26:58 wazuh-modulesd:docker-listener[48471] wm_docker.c:45 at wm_docker_main(): INFO: Module docker-listener started.
	2022/02/09 12:26:58 wazuh-modulesd:docker-listener[48471] wm_docker.c:58 at wm_docker_main(): INFO: Starting to listening Docker events.
	2022/02/09 12:26:58 wazuh-modulesd:docker-listener[48471] wm_docker.c:62 at wm_docker_main(): DEBUG: Launching command 'wodles/docker/DockerListener'
	2022/02/09 12:40:32 wazuh-modulesd:docker-listener[48471] wm_docker.c:87 at wm_docker_main(): ERROR: Killed
	2022/02/09 12:40:32 wazuh-modulesd:docker-listener[48471] wm_docker.c:111 at wm_docker_main(): WARNING: Docker-listener finished unexpectedly (code 137). Retrying to run in next scheduled time...
	2022/02/09 12:40:32 wazuh-modulesd:docker-listener[48471] schedule_scan.c:153 at _get_next_time(): WARNING: Interval overtaken.
	2022/02/09 12:40:32 wazuh-modulesd:docker-listener[48471] wm_docker.c:58 at wm_docker_main(): INFO: Starting to listening Docker events.
	2022/02/09 12:40:32 wazuh-modulesd:docker-listener[48471] wm_docker.c:62 at wm_docker_main(): DEBUG: Launching command 'wodles/docker/DockerListener'
</details>


**Test the `attempts` parameter**

The DockerListener.py file was removed and the Wazuh service was restarted to force the script to fail and ensure the number of attempts was met.

<details><summary>ossec.log output</summary>

	2022/02/09 12:58:34 wazuh-modulesd[49399] main.c:94 at main(): DEBUG: Created new thread for the 'docker-listener' module.
	2022/02/09 12:58:34 wazuh-modulesd:docker-listener[49399] wm_docker.c:45 at wm_docker_main(): INFO: Module docker-listener started.
	2022/02/09 12:58:34 wazuh-modulesd:docker-listener[49399] wm_docker.c:58 at wm_docker_main(): INFO: Starting to listening Docker events.
	2022/02/09 12:58:34 wazuh-modulesd:docker-listener[49399] wm_docker.c:62 at wm_docker_main(): DEBUG: Launching command 'wodles/docker/DockerListener'
	2022/02/09 12:58:34 wazuh-modulesd:docker-listener[49399] wm_docker.c:87 at wm_docker_main(): ERROR: /var/ossec/framework/python/bin/python3: can't open file '/var/ossec/wodles/docker/DockerListener.py': [Errno 2] No such file or directory
	2022/02/09 12:58:34 wazuh-modulesd:docker-listener[49399] wm_docker.c:111 at wm_docker_main(): WARNING: Docker-listener finished unexpectedly (code 2). Retrying to run in next scheduled time...
	2022/02/09 12:58:34 wazuh-modulesd:docker-listener[49399] wm_docker.c:54 at wm_docker_main(): DEBUG: Sleeping until: 2022/02/09 12:58:49
	2022/02/09 12:58:49 wazuh-modulesd:docker-listener[49399] wm_docker.c:58 at wm_docker_main(): INFO: Starting to listening Docker events.
	2022/02/09 12:58:49 wazuh-modulesd:docker-listener[49399] wm_docker.c:62 at wm_docker_main(): DEBUG: Launching command 'wodles/docker/DockerListener'
	2022/02/09 12:58:49 wazuh-modulesd:docker-listener[49399] wm_docker.c:87 at wm_docker_main(): ERROR: /var/ossec/framework/python/bin/python3: can't open file '/var/ossec/wodles/docker/DockerListener.py': [Errno 2] No such file or directory
	2022/02/09 12:58:49 wazuh-modulesd:docker-listener[49399] wm_docker.c:111 at wm_docker_main(): WARNING: Docker-listener finished unexpectedly (code 2). Retrying to run in next scheduled time...
	2022/02/09 12:58:49 wazuh-modulesd:docker-listener[49399] wm_docker.c:54 at wm_docker_main(): DEBUG: Sleeping until: 2022/02/09 12:59:04
	2022/02/09 12:59:04 wazuh-modulesd:docker-listener[49399] wm_docker.c:58 at wm_docker_main(): INFO: Starting to listening Docker events.
	2022/02/09 12:59:04 wazuh-modulesd:docker-listener[49399] wm_docker.c:62 at wm_docker_main(): DEBUG: Launching command 'wodles/docker/DockerListener'
	2022/02/09 12:59:04 wazuh-modulesd:docker-listener[49399] wm_docker.c:87 at wm_docker_main(): ERROR: /var/ossec/framework/python/bin/python3: can't open file '/var/ossec/wodles/docker/DockerListener.py': [Errno 2] No such file or directory
	2022/02/09 12:59:04 wazuh-modulesd:docker-listener[49399] wm_docker.c:111 at wm_docker_main(): WARNING: Docker-listener finished unexpectedly (code 2). Retrying to run in next scheduled time...
	2022/02/09 12:59:04 wazuh-modulesd:docker-listener[49399] wm_docker.c:54 at wm_docker_main(): DEBUG: Sleeping until: 2022/02/09 12:59:19
	2022/02/09 12:59:19 wazuh-modulesd:docker-listener[49399] wm_docker.c:58 at wm_docker_main(): INFO: Starting to listening Docker events.
	2022/02/09 12:59:19 wazuh-modulesd:docker-listener[49399] wm_docker.c:62 at wm_docker_main(): DEBUG: Launching command 'wodles/docker/DockerListener'
	2022/02/09 12:59:19 wazuh-modulesd:docker-listener[49399] wm_docker.c:87 at wm_docker_main(): ERROR: /var/ossec/framework/python/bin/python3: can't open file '/var/ossec/wodles/docker/DockerListener.py': [Errno 2] No such file or directory
	2022/02/09 12:59:20 wazuh-modulesd:docker-listener[49399] wm_docker.c:111 at wm_docker_main(): WARNING: Docker-listener finished unexpectedly (code 2). Retrying to run in next scheduled time...
	2022/02/09 12:59:20 wazuh-modulesd:docker-listener[49399] wm_docker.c:54 at wm_docker_main(): DEBUG: Sleeping until: 2022/02/09 12:59:34
	2022/02/09 12:59:34 wazuh-modulesd:docker-listener[49399] wm_docker.c:58 at wm_docker_main(): INFO: Starting to listening Docker events.
	2022/02/09 12:59:34 wazuh-modulesd:docker-listener[49399] wm_docker.c:62 at wm_docker_main(): DEBUG: Launching command 'wodles/docker/DockerListener'
	2022/02/09 12:59:34 wazuh-modulesd:docker-listener[49399] wm_docker.c:87 at wm_docker_main(): ERROR: /var/ossec/framework/python/bin/python3: can't open file '/var/ossec/wodles/docker/DockerListener.py': [Errno 2] No such file or directory
	2022/02/09 12:59:34 wazuh-modulesd:docker-listener[49399] wm_docker.c:108 at wm_docker_main(): ERROR: Maximum attempts reached to run the listener. Exiting...
</details>

### Conclusions

Everything worked as expected