### PR TITLE
Adding new command for Wazuh-DB to obtain all the agents' IDs that belong to a group

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -48,6 +48,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_open_global -Wl,--wrap,wdb_leave -Wl
                              -Wl,--wrap,sqlite3_step -Wl,--wrap,wdb_global_get_groups_integrity -Wl,--wrap,wdb_global_get_backups \
                              -Wl,--wrap,wdb_global_restore_backup -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_mutex_unlock \
                              -Wl,--wrap,wdb_global_select_group_belong -Wl,--wrap,wdb_global_set_agent_groups -Wl,--wrap,wdb_global_sync_agent_groups_get \
+                             -Wl,--wrap,wdb_global_get_group_agents \
                              ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_global")

--- a/src/unit_tests/wazuh_db/test_wdb_agents.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents.c
@@ -837,6 +837,7 @@ void test_wdb_agents_remove_vuln_cves_by_status_error_exec_stmt_sized(void **sta
 
     //Executing statement
     expect_value(__wrap_wdb_exec_stmt_sized, max_size, WDB_MAX_RESPONSE_SIZE);
+    expect_value(__wrap_wdb_exec_stmt_sized, column_mode, STMT_MULTI_COLUMN);
     will_return(__wrap_wdb_exec_stmt_sized, SQLITE_ERROR);
     will_return(__wrap_wdb_exec_stmt_sized, NULL);
     expect_string(__wrap__merror, formatted_msg, "Failed to retrieve vulnerabilities with status OBSOLETE from the database");
@@ -874,6 +875,7 @@ void test_wdb_agents_remove_vuln_cves_by_status_error_removing_cve(void **state)
 
     //Executing statement
     expect_value(__wrap_wdb_exec_stmt_sized, max_size, WDB_MAX_RESPONSE_SIZE);
+    expect_value(__wrap_wdb_exec_stmt_sized, column_mode, STMT_MULTI_COLUMN);
     will_return(__wrap_wdb_exec_stmt_sized, SQLITE_DONE);
     will_return(__wrap_wdb_exec_stmt_sized, root);
 
@@ -921,6 +923,7 @@ void test_wdb_agents_remove_vuln_cves_by_status_success(void **state) {
 
     //Executing statement
     expect_value(__wrap_wdb_exec_stmt_sized, max_size, WDB_MAX_RESPONSE_SIZE);
+    expect_value(__wrap_wdb_exec_stmt_sized, column_mode, STMT_MULTI_COLUMN);
     will_return(__wrap_wdb_exec_stmt_sized, SQLITE_DONE);
     will_return(__wrap_wdb_exec_stmt_sized, root);
 

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -140,6 +140,17 @@ cJSON* __wrap_wdb_global_select_agent_group(__attribute__((unused)) wdb_t *wdb,
     return mock_ptr_type(cJSON*);
 }
 
+cJSON* __wrap_wdb_global_get_group_agents(__attribute__((unused)) wdb_t *wdb,
+                                          wdbc_result* status,
+                                          char* group_name,
+                                          int last_agent_id) {
+
+    check_expected(group_name);
+    check_expected(last_agent_id);
+    *status = mock();
+    return mock_ptr_type(cJSON*);
+}
+
 int __wrap_wdb_global_delete_agent_belong(__attribute__((unused)) wdb_t *wdb,
                                           int id) {
     check_expected(id);

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -53,6 +53,8 @@ cJSON* __wrap_wdb_global_select_agent_name(wdb_t *wdb, int id);
 
 cJSON* __wrap_wdb_global_select_agent_group(wdb_t *wdb, int id);
 
+cJSON* __wrap_wdb_global_get_group_agents(wdb_t *wdb, wdbc_result* status, char* group_name, int last_agent_id);
+
 int __wrap_wdb_global_delete_agent_belong(wdb_t *wdb, int id);
 
 cJSON* __wrap_wdb_global_find_agent(wdb_t *wdb, const char *name, const char *ip);

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
@@ -100,14 +100,12 @@ cJSON * __wrap_wdb_exec_stmt(__attribute__((unused)) sqlite3_stmt *stmt) {
     return mock_ptr_type(cJSON *);
 }
 
-cJSON * __wrap_wdb_exec_stmt_single_column(__attribute__((unused)) sqlite3_stmt *stmt) {
-    return mock_ptr_type(cJSON *);
-}
-
 cJSON * __wrap_wdb_exec_stmt_sized(__attribute__((unused)) sqlite3_stmt *stmt,
                                    size_t max_size,
-                                   int* status) {
+                                   int* status,
+                                   bool column_mode) {
     check_expected(max_size);
+    check_expected(column_mode);
     *status = mock();
     return mock_ptr_type(cJSON *);
 }

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
@@ -47,9 +47,7 @@ int __wrap_wdb_syscheck_save2(wdb_t *wdb, const char *payload);
 
 cJSON * __wrap_wdb_exec_stmt(sqlite3_stmt *stmt);
 
-cJSON * __wrap_wdb_exec_stmt_single_column(sqlite3_stmt *stmt);
-
-cJSON * __wrap_wdb_exec_stmt_sized(sqlite3_stmt *stmt, size_t max_size, int* status);
+cJSON * __wrap_wdb_exec_stmt_sized(sqlite3_stmt *stmt, size_t max_size, int* status, bool column_mode);
 
 int __wrap_wdbc_parse_result(char *result, char **payload);
 

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -57,6 +57,10 @@
 #define VULN_CVES_TYPE_OS         "OS"
 #define VULN_CVES_TYPE_PACKAGE    "PACKAGE"
 
+/* wdb_exec_row_stmt modes */
+#define STMT_MULTI_COLUMN 0
+#define STMT_SINGLE_COLUMN 1
+
 /// Enumeration of agent groups sync conditions
 typedef enum wdb_groups_sync_condition_t {
         WDB_GROUP_SYNC_STATUS,      ///< Get groups by their sync status
@@ -214,6 +218,7 @@ typedef enum wdb_stmt {
     WDB_STMT_GLOBAL_DELETE_TUPLE_BELONG,
     WDB_STMT_GLOBAL_DELETE_GROUP,
     WDB_STMT_GLOBAL_GROUP_BELONG_FIND,
+    WDB_STMT_GLOBAL_GROUP_BELONG_GET,
     WDB_STMT_GLOBAL_SELECT_GROUPS,
     WDB_STMT_GLOBAL_SELECT_AGENT_KEEPALIVE,
     WDB_STMT_GLOBAL_SYNC_REQ_GET,
@@ -827,9 +832,31 @@ int wdb_remove_database(const char * agent_id);
  *
  * @param [in] stmt The SQL statement to be executed.
  * @param [out] status The status code of the statement execution. If NULL no value is written.
+ * @param [in] column_mode It could be STMT_SINGLE_COLUMN if the query returns only one column,
+ *                         or STMT_MULTI_COLUMN if the query returns more than one column.
  * @return JSON array with the statement execution results. NULL On error.
  */
-cJSON* wdb_exec_row_stmt(sqlite3_stmt * stmt, int* status);
+cJSON* wdb_exec_row_stmt(sqlite3_stmt * stmt, int* status, bool column_mode);
+
+/**
+ * @brief Function to execute one row of an SQL statement and save the result in a single JSON array without column name like:
+ *        ["column_value_1","column_value_2", ...]. The query should return only one column in every step.
+ *
+ * @param [in] stmt The SQL statement to be executed.
+ * @param [out] status The status code of the statement execution. If NULL no value is written.
+ * @return JSON array with the statement execution results. NULL On error.
+ */
+cJSON* wdb_exec_row_stmt_single_column(sqlite3_stmt * stmt, int* status);
+
+/**
+ * @brief Function to execute one row of an SQL statement and save the result in a single JSON array with column name like:
+ *        ["column_name_1":"column_value_1","column_name_2":"column_value_2", ...].
+ *
+ * @param [in] stmt The SQL statement to be executed.
+ * @param [out] status The status code of the statement execution. If NULL no value is written.
+ * @return JSON array with the statement execution results. NULL On error.
+ */
+cJSON* wdb_exec_row_stmt_multi_column(sqlite3_stmt * stmt, int* status);
 
 /**
  * @brief Function to execute an SQL statement without a response.
@@ -841,7 +868,7 @@ int wdb_exec_stmt_silent(sqlite3_stmt* stmt);
 
 /**
  * @brief Function to execute a SQL statement and save the result in a JSON array limited by size.
- *        Each step of the statemente will be printed to know the size.
+ *        Each step of the statement will be printed to know the size.
  *        The result of each step will be placed in returned result while fits.
  *
  * @param [in] stmt The SQL statement to be executed.
@@ -849,9 +876,11 @@ int wdb_exec_stmt_silent(sqlite3_stmt* stmt);
  *                     SQLITE_DONE means the statement is completed.
  *                     SQLITE_ROW means the statement has pending elements.
  *                     SQLITE_ERROR means an error occurred.
+ * @param [in] column_mode It could be STMT_SINGLE_COLUMN if the query returns only one column,
+ *                         or STMT_MULTI_COLUMN if the query returns more than one column.
  * @return JSON array with the statement execution results. NULL On error.
  */
-cJSON * wdb_exec_stmt_sized(sqlite3_stmt * stmt, const size_t max_size, int* status);
+cJSON * wdb_exec_stmt_sized(sqlite3_stmt * stmt, const size_t max_size, int* status, bool column_mode);
 
 /**
  * @brief Function to execute a SQL statement and send the result via TCP socket.
@@ -876,15 +905,6 @@ int wdb_exec_stmt_send(sqlite3_stmt* stmt, int peer);
  * @return JSON array with the statement execution results. NULL On error.
  */
 cJSON * wdb_exec_stmt(sqlite3_stmt * stmt);
-
-/**
- * @brief Function to execute a SQL statement and save the result in a single JSON array without column name like:
- *        ["column_value_1","column_value_2", ...]. The query should return only one column in every step.
- *
- * @param [in] stmt The SQL statement to be executed.
- * @return JSON array with the statement execution results. NULL On error.
- */
-cJSON * wdb_exec_stmt_single_column(sqlite3_stmt * stmt);
 
 /**
  * @brief Function to execute a SQL query and save the result in a JSON array.
@@ -1228,6 +1248,17 @@ int wdb_parse_global_delete_group(wdb_t * wdb, char * input, char * output);
  *        -1 On error: response contains "err" and an error description.
  */
 int wdb_parse_global_select_groups(wdb_t * wdb, char * output);
+
+/**
+ * @brief Function to parse the get group agents request.
+ *
+ * @param [in] wdb The global struct database.
+ * @param [in] input String with the group name.
+ * @param [out] output Response of the query.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
+ */
+int wdb_parse_global_get_group_agents(wdb_t * wdb, char * input, char * output);
 
 /**
  * @brief Function to parse the set agent groups request.
@@ -1876,6 +1907,17 @@ int wdb_global_delete_group(wdb_t *wdb, char* group_name);
  * @return JSON with all the groups on success. NULL on error.
  */
 cJSON* wdb_global_select_groups(wdb_t *wdb);
+
+/**
+ * @brief Function to get all agents that belong to a group
+ *
+ * @param [in] wdb The Global struct database.
+ * @param [out] status wdbc_result to represent if all agents has being obtained or any error occurred.
+ * @param [in] group_name The name of the group to get the agents from
+ * @param [in] last_agent_id ID where to start querying.
+ * @retval JSON with agents IDs on success, NULL on error.
+ */
+cJSON* wdb_global_get_group_agents(wdb_t *wdb,  wdbc_result* status, char* group_name, int last_agent_id);
 
 /**
  * @brief Function to get an agent keepalive using the agent name and register ip.

--- a/src/wazuh_db/wdb_agents.c
+++ b/src/wazuh_db/wdb_agents.c
@@ -215,7 +215,7 @@ wdbc_result wdb_agents_remove_vuln_cves_by_status(wdb_t *wdb, const char* status
 
     //Execute SQL query limited by size
     int sql_status = SQLITE_ERROR;
-    cJSON* cves = wdb_exec_stmt_sized(stmt, WDB_MAX_RESPONSE_SIZE, &sql_status);
+    cJSON* cves = wdb_exec_stmt_sized(stmt, WDB_MAX_RESPONSE_SIZE, &sql_status, STMT_MULTI_COLUMN);
 
     if (SQLITE_DONE == sql_status) wdb_res = WDBC_OK;
     else if (SQLITE_ROW == sql_status) wdb_res = WDBC_DUE;

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5214,7 +5214,7 @@ int wdb_parse_global_get_group_agents(wdb_t* wdb, char* input, char* output) {
     next = strtok_r(NULL, delim, &savedptr);
     if (next == NULL || strcmp(next, "last_id") != 0) {
         mdebug1("Invalid arguments, 'last_id' not found.");
-        snprintf(output, OS_MAXSTR + 1, "err Invalid arguments, 'last_id' not found");
+        snprintf(output, OS_MAXSTR + 1, "err Invalid arguments, 'last_id' not found.");
         return OS_INVALID;
     }
     next = strtok_r(NULL, delim, &savedptr);


### PR DESCRIPTION
|Related issue|
|---|
|#12132|

## Description

This PR creates the new `get-group-agents` command to obtain all the agents that belong to a group. 

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)

- [x] Added unit tests (for new features)
