### PR TITLE
Fix regex for run_test.py

### DIFF
--- a/api/test/integration/run_tests.py
+++ b/api/test/integration/run_tests.py
@@ -14,7 +14,7 @@ def calculate_result(file_name):
     with open(file_name, 'r') as f:
         file = f.read()
     try:
-        result = re.search(r'={5,} (.+) in (.*) ={5,}', file).group(1)
+        result = re.search(r'= ((\d+ .+){1,}) in (.+) =', file).group(1)
         print(f'\t {result}\n')
     except AttributeError:
         print('\tCould not retrieve results from this test')


### PR DESCRIPTION
|Related issue|
|---|
|#10508|

## Description
Hello team,

This PR closes [#10508](https://github.com/wazuh/wazuh/issues/10508). It updates `api/test/integration/run_tests.py`. We have changed the regex that parses test results so that the script can match all AIT possible results properly. 

## Example

In cases like this where test results have some fails,

```
python3 run_tests.py -k agent_GET

Errors:
E   tavern.util.exceptions.TestFailError: Test 'Basic response agent' failed:
    - Status code was 200, expected 404
------------------------------ Captured log call -------------------------------
ERROR    tavern.response.base:base.py:43 Status code was 200, expected 404
=============================== warnings summary ===============================
-- Docs: https://docs.pytest.org/en/latest/warnings.html
- generated html file:
=== 1 failed, 88 passed, 1 xfailed, 1 xpassed, 1 warnings in 247.51 seconds ====

         1 failed, 88 passed, 1 xfailed, 1 xpassed, 1 warnings
```

The script will parse correclty the result obtained