### PR TITLE
Enable Solaris packages inventory by default

### DIFF
--- a/etc/templates/config/sunos/wodle-syscollector.template
+++ b/etc/templates/config/sunos/wodle-syscollector.template
@@ -6,7 +6,7 @@
     <hardware>no</hardware>
     <os>yes</os>
     <network>no</network>
-    <packages>no</packages>
+    <packages>yes</packages>
     <ports all="no">no</ports>
     <processes>no</processes>
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #12157|

## Description

Hi team!

This PR aims to implement #12157 requirement, enabling by default packages collection for Solaris agents.

## Tests

- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Retrocompatibility with older Wazuh versions

Regards,
Nico