### PR TITLE
Fix xml tag in file limit config

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1585,7 +1585,6 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
     const char *xml_database = "database";
     const char *xml_scantime = "scan_time";
     const char *xml_file_limit = "file_limit"; // Deprecated
-    const char *xml_file_limit_enabled = "enabled"; // Deprecated
     const char *xml_file_limit_entries = "entries"; // Deprecated
     const char *xml_db_entry = "db_entry_limit";
     const char *xml_db_entry_enabled = "enabled";
@@ -1730,7 +1729,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
             }
             mwarn("file_limit block will be deprecated in future versions. Use db_entry_limit instead.");
             for(j = 0; children[j]; j++) {
-                if (strcmp(children[j]->element, xml_file_limit_enabled) == 0) {
+                if (strcmp(children[j]->element, xml_db_entry_enabled) == 0) {
                     if (strcmp(children[j]->content, "yes") == 0) {
                         syscheck->db_entry_limit_enabled = true;
                     }


### PR DESCRIPTION
|Related issue|
|---|
|[9103](https://github.com/wazuh/wazuh/issues/9103)|

### Description
This PR fixes a small bug in an xml tag of the file limit configuration, in the old block that was residual due to the compatibility with old agents. The old tag was still being used by mistake.